### PR TITLE
fix: wire mouse-hide-while-typing, document ghostty.conf reload limits

### DIFF
--- a/agterm/Ghostty/GhosttyCallbacks.swift
+++ b/agterm/Ghostty/GhosttyCallbacks.swift
@@ -104,6 +104,13 @@ final class GhosttyCallbacks: @unchecked Sendable {
             let value = raw < 0 ? nil : Int(raw)
             DispatchQueue.main.async { view.onSearchSelected?(value) }
             return true
+        case GHOSTTY_ACTION_MOUSE_VISIBILITY:
+            // libghostty asks the host to hide/show the pointer — the mechanism behind
+            // mouse-hide-while-typing (the core never touches the cursor itself). setHiddenUntilMouseMoves
+            // auto-reveals on the next mouse move, so the hidden case is all that needs acting on; show resets it.
+            let hidden = action.action.mouse_visibility == GHOSTTY_MOUSE_HIDDEN
+            DispatchQueue.main.async { NSCursor.setHiddenUntilMouseMoves(hidden) }
+            return true
         default:
             return false
         }

--- a/agterm/Resources/agent-skill/troubleshooting.md
+++ b/agterm/Resources/agent-skill/troubleshooting.md
@@ -19,7 +19,9 @@ You are inside agterm (`AGTERM_ENABLED=1`). Use:
   record which file a diagnostic came from), so check the Console log for the offending line. `ghostty.conf`
   (next to `keymap.conf`) overrides the bundled defaults and the global `~/.config/ghostty/config`; agterm's
   Settings (font/theme/opacity/scroll) still win. Use it for keys the UI does not expose, e.g.
-  `macos-option-as-alt`. Full reference: https://ghostty.org/docs/config
+  `macos-option-as-alt`. Most keys apply to open panes on reload, but layout keys (`window-padding-*`)
+  and spawn-time keys (`term`, `shell-integration-features`) only take effect in a new session/window
+  or after a relaunch. Full reference: https://ghostty.org/docs/config
 - **Logs** (unified logging, subsystem `com.umputun.agterm`):
   ```bash
   log show --predicate 'subsystem == "com.umputun.agterm"' --info --last 30m

--- a/agterm/SettingsModel.swift
+++ b/agterm/SettingsModel.swift
@@ -302,7 +302,9 @@ final class SettingsModel {
         # ~/.config/ghostty/config. Full key reference: https://ghostty.org/docs/config
         #
         # Edit this file and run File ▸ Reload Config (or relaunch) to apply. Blank lines and lines
-        # starting with `#` are ignored.
+        # starting with `#` are ignored. Most keys apply to open terminals on reload, but layout keys
+        # (window-padding-*) and shell-spawn keys (term, shell-integration-features) only take effect in
+        # a new session/window or after a relaunch.
         #
         # Example — make the macOS Option key send Alt (uncomment to enable):
         # macos-option-as-alt = true

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -87,6 +87,11 @@ ghostty's bundled defaults  →  ~/.config/ghostty/config  →  <config dir>/gho
 
 Edit `ghostty.conf` with **File ▸ Edit ghostty.conf…** (or the ⌃⇧P palette), which opens it in `$EDITOR` and reloads on exit, the same as Edit Keymap. After editing it elsewhere, apply it with **File ▸ Reload Config**, the action palette, or `agtermctl config reload`. A malformed line is skipped while the good ones still apply. The diagnostic count (shown in a banner and printed by `config.reload`, where `0` means a clean reload) covers every ghostty config source, not just `ghostty.conf`, because the diagnostics do not record which file they came from. Check the Console log for the offending line.
 
+A reload applies most keys to your open terminals right away — colors, theme, `cursor-style`, `macos-option-as-alt`, and the mouse and clipboard keys all take effect on the visible pane. Two kinds of key cannot change for a terminal that is already running, though:
+
+- **Layout keys** — `window-padding-x`, `window-padding-y`, and other size-affecting keys — do not re-apply to an open pane. libghostty re-derives a surface's padding only when it is first laid out, so a reload (and even resizing the window) leaves existing panes on their old padding. Open a new session or new window to pick up the change; the panes that were already open need a relaunch.
+- **Spawn-time keys** — `term` and `shell-integration-features` — are read once when the shell starts, so a reload cannot change them for a shell that is already running. Open a new session, whose shell is spawned fresh, to apply them.
+
 The full ghostty key reference is at <https://ghostty.org/docs/config>.
 
 ## Other common issues


### PR DESCRIPTION
two things, both from chasing a "ghostty.conf reload doesn't apply" report.

**the bug.** `mouse-hide-while-typing` never worked in agterm. The cause is upstream: libghostty doesn't touch the pointer itself, and on each keystroke `Surface.zig`'s `hideMouse()` fires the apprt action `GHOSTTY_ACTION_MOUSE_VISIBILITY` asking the host to hide it. `GhosttyCallbacks.action` had no case for it, so the request fell through to the no-op `default` and nothing happened. Added the case, mirroring Ghostty.app: `NSCursor.setHiddenUntilMouseMoves`, which auto-reveals on the next mouse move. Cursor visibility isn't accessibility-observable, so there's no unit/UI test; verified by typing in an isolated dev instance.

**the docs.** The reload itself is fine. Renderer/input keys (colors, theme, `cursor-style`, `macos-option-as-alt`, mouse/clipboard keys) apply live to open panes. But two key classes can't re-apply to a terminal that's already running: layout keys (`window-padding-*`), which libghostty re-derives only on a fresh surface, and spawn-time keys (`term`, `shell-integration-features`), baked into the shell at startup. A new session/window or relaunch picks those up. `troubleshooting.md` over-promised ("the good ones still apply"); corrected there, in the bundled agent-skill mirror, and in the starter `ghostty.conf` comment.
