### PR TITLE
feat: add --command to session scratch

### DIFF
--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -445,7 +445,8 @@ final class ControlServer {
         case .sessionSplit:
             return splitSession(request.target, window: request.args?.window, mode: request.args?.mode)
         case .sessionScratch:
-            return scratchSession(request.target, window: request.args?.window, mode: request.args?.mode)
+            return scratchSession(request.target, window: request.args?.window, mode: request.args?.mode,
+                                  command: request.args?.command)
         case .sessionFocus:
             return focusSessionPane(request.target, window: request.args?.window, pane: request.args?.pane)
         case .sessionStatus:
@@ -581,11 +582,14 @@ final class ControlServer {
         }
     }
 
-    /// Resolve the target session and show/hide its scratch terminal — a third, full-overlay login
-    /// shell. `mode` is `on|off|toggle`, computed against the session's current `scratchActive` so
-    /// `on`/`off` are idempotent. Like the split, hiding keeps the shell alive (`toggleScratch`);
-    /// `closeScratch` (tear down) is reserved for the shell's own `exit`.
-    private func scratchSession(_ target: String?, window: String?, mode: String?) -> ControlResponse {
+    /// Resolve the target session and show/hide its scratch terminal — a third, full-overlay shell.
+    /// `mode` is `on|off|toggle`, computed against the session's current `scratchActive` so `on`/`off`
+    /// are idempotent. Like the split, hiding keeps the shell alive (`toggleScratch`); `closeScratch`
+    /// (tear down) is reserved for the shell's own `exit`. `command` (only meaningful when showing) runs
+    /// that program as the scratch's process instead of a login shell, run-once like `session.new
+    /// --command`: a scratch is expendable, so if one is already alive it is torn down and respawned
+    /// with the command (otherwise the flag would be silently inert).
+    private func scratchSession(_ target: String?, window: String?, mode: String?, command: String?) -> ControlResponse {
         let mode = mode ?? "toggle"
         return resolveSession(target, window: window) { store, id in
             guard let session = store.session(withID: id) else {
@@ -597,6 +601,13 @@ final class ControlServer {
             case "off": want = false
             case "toggle": want = !session.scratchActive
             default: return ControlResponse(ok: false, error: "invalid scratch mode: \(mode)")
+            }
+            if want, let command, !command.isEmpty {
+                // run the command as the scratch process: respawn if one is already alive (a scratch is
+                // expendable), so the command is never silently ignored. closeScratch clears scratchActive,
+                // so the toggle below re-shows it and the factory consumes scratchCommand.
+                if session.scratchSurface != nil { store.closeScratch(id) }
+                session.scratchCommand = command
             }
             if want, store.selectedSessionID != id {
                 // the scratch is a full-coverage surface that grabs focus on show; it only makes sense on

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -112,7 +112,9 @@ Run `agtermctl <area> <cmd> --help` for exact flags. Full detail in **reference.
 - `copy` — print the session's selected text (does NOT touch the system clipboard).
 - `search [needle] [--next|--prev|--close]` — search the terminal scrollback; prints the "N of M" counter.
 - `split [on|off|toggle]` — side-by-side second shell (hide keeps it alive).
-- `scratch [on|off|toggle]` — full-coverage third shell (hide keeps it alive; `exit` recreates).
+- `scratch [on|off|toggle] [--command CMD]` — full-coverage third shell (hide keeps it alive; `exit`
+  recreates). `--command` (when showing) runs a program instead of a shell, run-once like `session new
+  --command` (respawns the scratch if one is open).
 - `focus [left|right|other]` — move focus between split panes.
 - `status <idle|active|completed|blocked> [--blink] [--auto-reset]` — set the sidebar agent glyph.
 - `flag [on|off|toggle|clear]` — flag a session for the flagged working-set view (`clear` unflags all).

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -112,6 +112,7 @@ A third per-session full-coverage shell. Hide keeps it alive; `exit` in it recre
 agtermctl session scratch on        # show (selects the target)
 agtermctl session scratch off       # hide, shell stays alive
 agtermctl session scratch toggle
+agtermctl session scratch on --command "lazygit"   # run a program instead of a shell (run-once)
 ```
 
 ## Flag a working set and view just the flagged sessions

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -99,11 +99,14 @@ flagged working-set). Workspace nodes carry `id`, `name`, `active`, `sessions`.
 - `session split [on|off|toggle] [--target] [--window W]` — side-by-side second shell. `off` HIDES it
   but keeps the shell alive (mirrors ⌘D); the pane's surface is torn down only when its shell exits.
   Unknown mode errors.
-- `session scratch [on|off|toggle] [--target] [--window W]` — a third, full-coverage shell that
-  renders like a full overlay but behaves like the split. `off` hides it keep-alive; typing `exit` in
-  it closes it and the next `on` spawns a fresh shell. `on` selects the target first (the scratch is
-  full-coverage and owns focus). Not persisted. Unknown mode errors. The tree's `scratch` flag tracks
-  visibility.
+- `session scratch [on|off|toggle] [--command CMD] [--target] [--window W]` — a third, full-coverage
+  shell that renders like a full overlay but behaves like the split. `off` hides it keep-alive; typing
+  `exit` in it closes it and the next `on` spawns a fresh shell. `on` selects the target first (the
+  scratch is full-coverage and owns focus). `--command` (only when showing) runs that program as the
+  scratch's process instead of a login shell — argv-style (no shell; wrap operators yourself as
+  `"sh -c '…'"`) and RUN-ONCE like `session new --command` (after it exits, the next `on` is a plain
+  shell). A scratch is expendable, so passing `--command` while one is already open respawns it. Not
+  persisted. Unknown mode errors. The tree's `scratch` flag tracks visibility.
 - `session focus [left|right|other] [--target] [--window W]` — move keyboard focus between the two
   split panes (`other` toggles, the default). Errors when the session has no split. Works whether the
   split is shown side-by-side or hidden (maximized) — when hidden, focusing a pane swaps which one shows.

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -580,12 +580,13 @@ struct agtermApp: App {
         return view
     }
 
-    /// Scratch-terminal surface factory: a third per-session login shell, full-overlay rendered. Like
-    /// the overlay it is NOT wired to the session (no `view.session`/`isSplitPane`), so its PWD/title
-    /// never clobber the session's sidebar name; unlike the overlay it runs a plain login shell (no
-    /// command) and is kept alive when hidden. `autoFocus` grabs first responder on show (winning the
-    /// SwiftUI/AppKit responder race); on the shell's `exit`, `closeScratch` hides + tears it down so
-    /// the next show spawns a fresh shell. Seeds from the session's current dir + inherits its env ids.
+    /// Scratch-terminal surface factory: a third per-session shell, full-overlay rendered. Like the
+    /// overlay it is NOT wired to the session (no `view.session`/`isSplitPane`), so its PWD/title never
+    /// clobber the session's sidebar name; unlike the overlay it is kept alive when hidden. Runs a plain
+    /// login shell, or `session.scratchCommand` when set (`session.scratch --command`) — RUN-ONCE: the
+    /// command is consumed here so a respawn after it exits is a plain shell. `autoFocus` grabs first
+    /// responder on show (winning the SwiftUI/AppKit responder race); on the shell's `exit`, `closeScratch`
+    /// hides + tears it down so the next show spawns fresh. Seeds from the session's current dir + env ids.
     @MainActor
     private static func makeScratchSurface(for session: Session, store: AppStore, env: [String: String],
                                           suppressAutoFocus: Bool, library: WindowLibrary) -> GhosttySurfaceView {
@@ -593,8 +594,12 @@ struct agtermApp: App {
         // surface already owns focus above the scratch (a full overlay, or the window-level quick
         // terminal), so a scratch created under one can't steal first responder. Re-shows are focused
         // via the `scratchActive` onChange (which also defers to those covers).
+        // scratchCommand is run-once: read it for this spawn, then clear so a post-exit respawn is a shell.
+        let command = session.scratchCommand
+        session.scratchCommand = nil
         let view = GhosttySurfaceView(workingDirectory: session.effectiveCwd,
                                       fontSize: session.fontSize.map(Float.init),
+                                      command: command,
                                       autoFocus: !suppressAutoFocus, env: env)
         let sessionID = session.id
         view.onExit = { store.closeScratch(sessionID) }

--- a/agtermCore/Sources/agtermCore/Session.swift
+++ b/agtermCore/Sources/agtermCore/Session.swift
@@ -142,11 +142,17 @@ public final class Session: Identifiable {
     /// hides the scratch. NOT persisted (absent from `snapshot()`), so it never survives a relaunch.
     public var scratchActive: Bool = false
 
-    /// The scratch terminal's surface: a plain login shell, lazily created on first show and kept
-    /// alive across hides (`scratchSurface != nil` is "alive but hidden"). Freed only on
-    /// `closeScratch` (an explicit close, the shell's own `exit`, or session/workspace/window
+    /// The scratch terminal's surface: a login shell (or `scratchCommand` when set), lazily created on
+    /// first show and kept alive across hides (`scratchSurface != nil` is "alive but hidden"). Freed only
+    /// on `closeScratch` (an explicit close, the shell's own `exit`, or session/workspace/window
     /// teardown) — after which the next show spawns a fresh shell. `@ObservationIgnored` like `surface`.
     @ObservationIgnored public var scratchSurface: (any TerminalSurface)?
+
+    /// A command to run as the scratch's process instead of a login shell (set via `session.scratch
+    /// --command`), the scratch analogue of `initialCommand`. RUN-ONCE: the scratch surface factory reads
+    /// it once when it spawns and clears it, so after the command exits the next show is a plain shell.
+    /// `@ObservationIgnored` + absent from `snapshot()`: transient like the scratch itself, never persisted.
+    @ObservationIgnored public var scratchCommand: String?
 
     /// Whether the in-terminal search bar is shown over this session's focused pane (⌘F). Observed,
     /// so the detail pane shows/hides the bar. Written directly (from the surface factory's search

--- a/agtermCore/Sources/agtermctlKit/Commands.swift
+++ b/agtermCore/Sources/agtermctlKit/Commands.swift
@@ -338,11 +338,12 @@ struct Session: ParsableCommand {
     struct Scratch: RequestCommand {
         static let configuration = CommandConfiguration(abstract: "Show or hide a session scratch terminal (on|off|toggle).")
         @Argument(help: "Mode: on (show), off (hide), or toggle (default). The hidden scratch shell stays alive.") var mode: String = "toggle"
+        @Option(name: .long, help: "When showing, run this command as the scratch's process instead of a login shell (run-once; respawns the scratch if one is already open).") var command: String?
         @OptionGroup var target: TargetOptions
         @OptionGroup var options: ClientOptions
 
         func makeRequest() throws -> ControlRequest {
-            ControlRequest(cmd: .sessionScratch, target: target.target, args: options.withWindow(ControlArgs(mode: mode)))
+            ControlRequest(cmd: .sessionScratch, target: target.target, args: options.withWindow(ControlArgs(mode: mode, command: command)))
         }
     }
 

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -106,6 +106,7 @@ struct ControlProtocolTests {
             ControlRequest(cmd: .sessionSplit, target: "active", args: ControlArgs(mode: "toggle")),
             ControlRequest(cmd: .sessionScratch, target: "active", args: ControlArgs(mode: "toggle")),
             ControlRequest(cmd: .sessionScratch, target: "9f3c", args: ControlArgs(mode: "on")),
+            ControlRequest(cmd: .sessionScratch, target: "active", args: ControlArgs(mode: "on", command: "htop")),
             ControlRequest(cmd: .quick, args: ControlArgs(mode: "show")),
             ControlRequest(cmd: .sidebar, args: ControlArgs(mode: "hide")),
             ControlRequest(cmd: .sessionFlag, target: "active", args: ControlArgs(mode: "toggle")),
@@ -120,6 +121,14 @@ struct ControlProtocolTests {
         for request in cases {
             #expect(try roundTrip(request) == request)
         }
+    }
+
+    @Test func sessionScratchRoundTripsWithCommand() throws {
+        let request = ControlRequest(cmd: .sessionScratch, target: "active", args: ControlArgs(mode: "on", command: "htop"))
+        let decoded = try roundTrip(request)
+        #expect(decoded == request)
+        #expect(decoded.args?.mode == "on")
+        #expect(decoded.args?.command == "htop")
     }
 
     @Test func sessionFlagRawStringMapsToCommandAndMode() throws {

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -926,6 +926,26 @@ final class ControlAPIUITests: XCTestCase {
         XCTAssertTrue((bad["error"] as? String ?? "").contains("invalid scratch mode"), "should report invalid mode: \(bad)")
     }
 
+    // session.scratch --command runs the command AS the scratch's process (not a shell): the command
+    // writes a marker file, proving it ran. It exits immediately (run-once), so the scratch then closes —
+    // the marker is the oracle. The command is argv-style (no shell), so the redirect is wrapped in sh -c.
+    func testSessionScratchCommandRunsAsProcess() throws {
+        let marker = NSTemporaryDirectory() + "agterm-scratchcmd-\(UUID().uuidString).txt"
+        let payload: [String: Any] = ["cmd": "session.scratch", "target": "active",
+                                      "args": ["mode": "on", "command": "sh -c 'printf SCRATCHRAN > \(marker)'"]]
+        let line = String(data: try JSONSerialization.data(withJSONObject: payload), encoding: .utf8)!
+        let resp = try sendCommand(line)
+        XCTAssertEqual(resp["ok"] as? Bool, true, "session.scratch --command should succeed: \(resp)")
+
+        var ran = false
+        for _ in 0..<40 {
+            if let s = try? String(contentsOfFile: marker, encoding: .utf8), s == "SCRATCHRAN" { ran = true; break }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+        }
+        XCTAssertTrue(ran, "the scratch command should run as the scratch's process")
+        try? FileManager.default.removeItem(atPath: marker)
+    }
+
     // session.scratch on a NON-active target selects it first (the scratch is full-coverage and grabs
     // focus on show, so it must be the visible session), then shows the scratch on it.
     func testSessionScratchOnSelectsTarget() throws {


### PR DESCRIPTION
`session scratch` only ever ran a login shell. This adds `--command` (control API + `agtermctl`) to run a custom program as the scratch's process instead, the scratch analogue of `session new --command`.

**Run-once:** the surface factory consumes `Session.scratchCommand` on spawn, so after the command exits the next show is a plain shell (same semantics as `session new --command`). Since a scratch is expendable, passing `--command` while one is already open respawns it, so the flag is never silently inert.

Why scratch and not just the overlay: the scratch is *kept alive when hidden*, so `session scratch on --command lazygit` gives a toggleable, persistent program layer (still running in the background when hidden) that the one-shot overlay can't provide.

Control/CLI-native, no GUI change (like `notify`/`session.type`). Covered by a protocol round-trip and an e2e (`testSessionScratchCommandRunsAsProcess`), documented across the bundled skill (SKILL.md + reference.md + examples.md). 748 host-free tests pass.