### PR TITLE
fix: ⌘C/⌘V copy/paste on non-Latin keyboard layouts

### DIFF
--- a/agterm/Resources/agent-skill/troubleshooting.md
+++ b/agterm/Resources/agent-skill/troubleshooting.md
@@ -51,6 +51,17 @@ modifier); it only fires while a terminal pane has keyboard focus; it runs in a 
 non-zero exit posts a failure banner (meaning it DID fire and failed). Reload after edits:
 `agtermctl keymap reload`.
 
+### "⌘C/⌘V (or a shortcut) doesn't work on a non-Latin / alternative layout"
+
+⌘C/⌘V copy/paste on any layout by default — agterm's bundled ghostty defaults bind them to the physical
+key POSITIONS (`super+key_c`/`super+key_v`), matched by keycode regardless of the character the layout
+prints. (ghostty's own `super+c`/`super+v` match the produced CHARACTER, so they miss on a Russian/Greek/
+etc. layout where the physical V key yields `м`.) To remap any shortcut: a physical key name (`key_c`,
+`key_v`, …) matches by position on any layout; a bare letter (`c`, `v`) matches the produced character.
+A Dvorak/Colemak user who wants ⌘C/⌘V at their own letter positions overrides in
+`~/.config/agterm/ghostty.conf` (`super+key_c=unbind` + `super+c=copy_to_clipboard`, same for `v`), then
+`agtermctl config reload`.
+
 ## Reporting: decide bug vs unsupported FIRST
 
 - A **supported** thing misbehaves (a documented command/feature does the wrong thing, a crash, a parse

--- a/agterm/Resources/ghostty-defaults.conf
+++ b/agterm/Resources/ghostty-defaults.conf
@@ -16,3 +16,15 @@ window-padding-y = 6
 # the sidebar shows that — we just don't auto-title local shells with the path.
 cursor-style = block
 shell-integration-features = no-cursor,no-title
+
+# make ⌘C/⌘V copy/paste work on non-Latin keyboard layouts. libghostty's built-in
+# clipboard binds are unicode triggers (`super+c`/`super+v`), matched against the
+# character the active layout produces — so on a Russian/Greek/etc. layout the
+# physical V key yields `м`/etc. and the bind never fires. these physical-key
+# triggers match by keycode (the physical position) regardless of the produced
+# character, so copy/paste work on any layout. performable: keeps ghostty's default
+# fall-through (e.g. ⌘C does nothing when there is no selection). a Latin alternative
+# layout (Dvorak/Colemak) that wants its own letter positions can re-bind these in
+# ~/.config/agterm/ghostty.conf.
+keybind = performable:super+key_c=copy_to_clipboard
+keybind = performable:super+key_v=paste_from_clipboard

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -94,6 +94,28 @@ A reload applies most keys to your open terminals right away — colors, theme, 
 
 The full ghostty key reference is at <https://ghostty.org/docs/config>.
 
+## Copy/paste and shortcuts on a non-Latin or alternative layout
+
+⌘C and ⌘V copy and paste on any keyboard layout, non-Latin ones (Russian, Greek, and so on) included, because agterm binds them to the physical key positions rather than to the character a layout prints. The physical C and V keys then work no matter what those keys produce in the active layout.
+
+The reason is that ghostty's own copy/paste binds match the produced character: on a Russian layout the physical V key yields `м`, so the built-in `super+v` bind never fires. The bundled agterm defaults add physical-key binds (`super+key_c`, `super+key_v`) that match by position instead.
+
+The same distinction lets you remap any shortcut for your layout:
+
+- A physical key name (`key_c`, `key_v`, `key_a`, and so on) matches the key's position, whatever character it prints.
+- A bare letter (`c`, `v`) matches the character the active layout produces at that key.
+
+If you use a Latin alternative layout (Dvorak, Colemak, AZERTY) and want ⌘C/⌘V at your layout's own C and V letters instead of the QWERTY physical positions, override them in `~/.config/agterm/ghostty.conf` with character-based binds, and unbind the physical defaults so the QWERTY positions are freed:
+
+```
+keybind = super+key_c=unbind
+keybind = super+key_v=unbind
+keybind = super+c=copy_to_clipboard
+keybind = super+v=paste_from_clipboard
+```
+
+Reload with **File ▸ Reload Config** or `agtermctl config reload`. The keybind syntax is at <https://ghostty.org/docs/config/keybind/reference>.
+
 ## Other common issues
 
 - **`agtermctl: command not found`.** Install it from Help ▸ Install Command Line Tool… (it symlinks into `/usr/local/bin`). You can also call it by its full path inside the app bundle: `agterm.app/Contents/MacOS/agtermctl`.


### PR DESCRIPTION
libghostty's built-in clipboard binds (`super+c`/`super+v`) are unicode triggers, matched against the character the active layout produces. On a non-Latin layout (Russian, Greek, and so on) the physical C/V keys yield a non-Latin character, so the binds never match and ⌘C/⌘V do nothing (or, under the kitty keyboard protocol, leak the produced character to the pty).

Fix adds physical-key triggers to the bundled `ghostty-defaults.conf`:

```
keybind = performable:super+key_c=copy_to_clipboard
keybind = performable:super+key_v=paste_from_clipboard
```

Physical triggers match by keycode (the physical key position), so copy/paste work on any layout; agterm already passes the keycode through, so no change to the key path is needed. `performable:` keeps ghostty's default fall-through (⌘C with no selection does nothing). Verified on a Russian layout.

A Latin alternative layout (Dvorak/Colemak) that wants ⌘C/⌘V at its own letter positions can override them in `~/.config/agterm/ghostty.conf`. `docs/troubleshooting.md` and the bundled agent-skill now document the physical-vs-character distinction and that override.

Related to #30
