### PR TITLE
feat: double-click window header to zoom

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -86,7 +86,7 @@ paths:
   The skill is a REFERENCE/knowledge skill (both user-invocable via `/agterm` and model-triggered,
   `allowed-tools: Bash(agtermctl *)`; the agent-neutral `description` carries the trigger nouns since
   Codex may ignore the extra `when_to_use` field — unknown frontmatter is harmless),
-  authored at `agterm/Resources/agent-skill/` (`SKILL.md` overview + model + addressing + 47-command
+  authored at `agterm/Resources/agent-skill/` (`SKILL.md` overview + model + addressing + 48-command
   summary + the image-display helper + a troubleshooting/reporting pointer;
   `reference.md` full per-command detail + keymap format; `examples.md` agtermctl recipes;
   `troubleshooting.md` diagnosing the common problems (keymap editor, custom actions,
@@ -156,7 +156,7 @@ paths:
   exact `uuidString` (case-insensitive), or a git-style unique prefix.
   Zero prefix hits → `notFound` error, ≥2 → `ambiguous` error listing the candidates.
   `--target` defaults to `active`, so scripts rarely type an id and never for "the current one".
-- **Command catalog (47 commands):**
+- **Command catalog (48 commands):**
   - `tree`
   - `workspace.new`/`workspace.rename`/`workspace.delete`/`workspace.select`/`workspace.move`/`workspace.focus`
   - `session.new`/`session.close`/`session.select`/`session.rename`/`session.move`/`session.type`/`session.split`/`session.scratch`/`session.focus`/`session.resize`/`session.go`/`session.copy`/`session.search`/`session.status`/`session.flag`/`session.overlay.open`/`session.overlay.close`/`session.overlay.result`
@@ -164,7 +164,7 @@ paths:
   - `sidebar`/`sidebar.mode`/`sidebar.expand`/`sidebar.collapse`
   - `notify`
   - `font.inc`/`font.dec`/`font.reset`
-  - `window.new`/`window.list`/`window.select`/`window.close`/`window.rename`/`window.delete`/`window.resize`/`window.move` (see the Windows section)
+  - `window.new`/`window.list`/`window.select`/`window.close`/`window.rename`/`window.delete`/`window.resize`/`window.move`/`window.zoom` (see the Windows section)
   - `keymap.reload` (see the Keymap section)
   - `config.reload` (see the Settings section)
   - `theme.set`/`theme.list` (see the Theme picker section)

--- a/.claude/rules/windows.md
+++ b/.claude/rules/windows.md
@@ -146,7 +146,32 @@ never two bundles in one window.
   `AGTERM_SOCKET` is the path `ControlServer` *actually bound* (`ControlServer.boundSocketPath`,
   nil before bind → the var is omitted), so a test-overridden `AGTERM_CONTROL_SOCKET` and the injected
   env agree.
-- **`window.*` control additions (eight commands).**
+- **`window.zoom` (maximize-to-screen toggle, control + double-click-header GUI).** `WindowRegistry.zoom(_:)`
+  drives the standard `NSWindow.zoom(nil)` — toggles between the normal frame and the screen's visible frame
+  (NOT native fullscreen); a second call restores.
+  Unlike `resize`/`move` it has a GUI surface: a custom-titlebar SwiftUI view can't receive the OS
+  double-click handling, so `WindowControlArea` (an `NSViewRepresentable` behind `customTitlebar`'s decorative
+  regions in `ContentView.swift`) handles `mouseDown` — `clickCount == 2` runs the user's configured title-bar
+  action, else `performDrag` (also making the FULL header draggable, not just the native top band);
+  `mouseDownCanMoveWindow = false` so our handler sees the double-click.
+  The double-click honors the macOS **Desktop & Dock ▸ "Double-click a window's title bar to"** setting
+  (`AppleActionOnDoubleClick` in `NSGlobalDomain`, read LIVE per click): Zoom/Fill → `window.zoom(nil)`,
+  Minimize → `performMiniaturize`, "Do Nothing" → no-op; the key is absent until the user changes it from the
+  macOS default (Zoom), so an untouched system still zooms (the prior behavior).
+  So the GUI double-click is NOT always-zoom — only the `window.zoom` control command unconditionally zooms.
+  A UITest env override (`AGTERM_UITEST_DOUBLECLICK_ACTION`, read ahead of the system default) pins the action
+  so the gesture tests are hermetic regardless of the host setting; it rides the environment, not launch
+  arguments (FB11763863 — see `ui-tests.md`).
+  The header's decorative parts (the traffic-light spacer, the divider gap, the title text) opt out via
+  `.allowsHitTesting(false)` so their region falls through to the layer; the buttons stay in front.
+  Requires the window OPEN (closed → the `window not open` error), like `resize`/`move`.
+  Four-point keep-in-sync audit: (1) `case windowZoom = "window.zoom"` in `ControlProtocol.swift`,
+  (2) the `.windowZoom` dispatch arm (`windowZoom`) in `ControlServer` → `WindowRegistry.shared.zoom`,
+  (3) the `window zoom <id>` subcommand in `agtermctlKit`, (4) `.windowZoom` in `windowCommandsRoundTrip`
+  (`ControlProtocolTests`) + the e2e `testWindowZoom` plus the gesture tests
+  `testDoubleClickHeaderZoomsAndRestores` / `testDoubleClickHeaderHonorsNoneSetting` /
+  `testHeaderButtonsStillReceiveClicksOverControlArea` / `testDragHeaderMovesWindow` in `ControlAPIUITests`.
+- **`window.*` control additions (eight commands, plus `window.zoom`).**
   `window.new` (returns the new id + opens its window), `window.list` (returns `windows` with each window's
   `open`/`active` flag), `window.select` (raise-or-open), `window.close` (`WindowRegistry.close` → standard
   teardown), `window.rename`, `window.delete` (`canRemoveWindow` keep-at-least-one → error,

--- a/agterm/ContentView.swift
+++ b/agterm/ContentView.swift
@@ -1238,9 +1238,16 @@ private struct WindowControlArea: NSViewRepresentable {
         /// Read live on each double-click so a setting change takes effect without an app relaunch.
         /// "Fill" maps to `zoom` (the closest standard NSWindow action; true Fill uses the newer
         /// window-tiling APIs). Zoom matches the green button and the `window.zoom` control command.
+        ///
+        /// A UITest env override (`AGTERM_UITEST_DOUBLECLICK_ACTION`) takes precedence so the gesture
+        /// tests are hermetic regardless of the host machine's setting; it rides the environment
+        /// because launch arguments trip the macOS 15+ no-window-at-launch bug (FB11763863, see
+        /// `ui-tests.md`). Production never sets it and falls through to the live system default.
         private func performTitlebarDoubleClickAction() {
             guard let window else { return }
-            switch UserDefaults.standard.string(forKey: "AppleActionOnDoubleClick") {
+            let action = ProcessInfo.processInfo.environment["AGTERM_UITEST_DOUBLECLICK_ACTION"]
+                ?? UserDefaults.standard.string(forKey: "AppleActionOnDoubleClick")
+            switch action {
             case "Minimize":
                 window.performMiniaturize(nil)
             case "None":

--- a/agterm/ContentView.swift
+++ b/agterm/ContentView.swift
@@ -639,19 +639,23 @@ private struct WindowContentView: View {
     /// traffic lights.
     private var customTitlebar: some View {
         HStack(spacing: 0) {
-            Color.clear.frame(width: 78) // system traffic lights
+            Color.clear.frame(width: 78).allowsHitTesting(false) // system traffic lights
             if store.sidebarVisible {
                 HStack(spacing: 0) {
                     Spacer(minLength: 0)
                     sidebarToggleButton.labelStyle(.iconOnly)
                 }
                 .frame(width: max(40, CGFloat(store.sidebarWidth) - 78))
-                Color.clear.frame(width: 11) // 1px divider + gap to the title
+                Color.clear.frame(width: 11).allowsHitTesting(false) // 1px divider + gap to the title
             } else {
                 sidebarToggleButton.labelStyle(.iconOnly)
                 Spacer().frame(width: 12)
             }
             titleLabel
+                // the title text falls through to the drag/zoom layer behind it (see `.background` below),
+                // so double-clicking it zooms and dragging it moves the window — the rest of the row is
+                // empty spacers (already non-hittable) and the buttons, which keep their own clicks.
+                .allowsHitTesting(false)
             if attentionButtonEnabled {
                 attentionButton.labelStyle(.iconOnly).padding(.leading, 10)
             }
@@ -674,6 +678,11 @@ private struct WindowContentView: View {
         .imageScale(compactToolbar ? .medium : .large)
         .frame(height: titlebarHeight)
         .frame(maxWidth: .infinity)
+        // make the header behave like a standard title bar: single-click drag moves the window, double-click
+        // zooms it (the maximize-to-screen toggle). The layer sits BEHIND the row, so the buttons render in
+        // front and keep their clicks; the empty spacers + the title text opt out of hit-testing (above) so
+        // their region falls through to it. Custom titlebar = no native double-click-to-zoom, hence this.
+        .background { WindowControlArea() }
     }
 
     /// Our own sidebar show/hide toggle (the custom split has no system one). Animated collapse.
@@ -1197,6 +1206,32 @@ private struct WindowAccessor: NSViewRepresentable {
     }
 }
 
+/// A transparent AppKit layer placed behind the custom titlebar's decorative regions (the title text and
+/// the empty spacers, which opt out of SwiftUI hit-testing) so the header behaves like a real title bar:
+/// a single-click drag moves the window (`performDrag`) and a double-click zooms it (`NSWindow.zoom`, the
+/// standard maximize-to-screen toggle — the same action as the green button and the `window.zoom` control
+/// command). The custom titlebar is a SwiftUI view, not AppKit's native title bar, so the OS double-click-
+/// to-zoom never reaches it; this restores it. The interactive header buttons render in front and keep
+/// their own clicks. `mouseDownCanMoveWindow` is off so our `mouseDown` — not AppKit's automatic move —
+/// sees the event and can tell a double-click apart from a drag.
+private struct WindowControlArea: NSViewRepresentable {
+    func makeNSView(context _: Context) -> TitlebarControlView { TitlebarControlView() }
+    func updateNSView(_: TitlebarControlView, context _: Context) {}
+
+    final class TitlebarControlView: NSView {
+        override var mouseDownCanMoveWindow: Bool { false }
+
+        override func mouseDown(with event: NSEvent) {
+            if event.clickCount == 2 {
+                window?.zoom(nil)
+                return
+            }
+            // a single click that turns into a drag moves the window; a plain click returns at once.
+            window?.performDrag(with: event)
+        }
+    }
+}
+
 /// App-side bridge mapping a `WindowInfo.ID` to its live `NSWindow`. `WindowLibrary` is host-free
 /// (no AppKit), so the NSWindow handles live here. `TitleProbeView` registers/unregisters on window
 /// attach/close; `raise(_:)` brings an already-open window forward (the dedup-by-id raise path) and
@@ -1289,6 +1324,17 @@ final class WindowRegistry {
         let origin = WindowGeometry.clampOrigin(requested, windowSize: WindowGeometry.Size(size),
                                                 displayFrame: WindowGeometry.Rect(screen.frame)).cgPoint
         window.setFrameOrigin(origin)
+        return true
+    }
+
+    /// Zooms (the maximize-to-screen toggle) the on-screen window for `id` if one is live, driving the
+    /// standard `NSWindow.zoom` — the same action as the green zoom button and the double-click-header
+    /// gesture. A second call restores the prior frame. Returns false if no window is registered for `id`
+    /// (not open). The control-channel `window.zoom` path.
+    @discardableResult
+    func zoom(_ id: WindowInfo.ID) -> Bool {
+        guard let window = windows[id] else { return false }
+        window.zoom(nil)
         return true
     }
 }

--- a/agterm/ContentView.swift
+++ b/agterm/ContentView.swift
@@ -679,9 +679,10 @@ private struct WindowContentView: View {
         .frame(height: titlebarHeight)
         .frame(maxWidth: .infinity)
         // make the header behave like a standard title bar: single-click drag moves the window, double-click
-        // zooms it (the maximize-to-screen toggle). The layer sits BEHIND the row, so the buttons render in
-        // front and keep their clicks; the empty spacers + the title text opt out of hit-testing (above) so
-        // their region falls through to it. Custom titlebar = no native double-click-to-zoom, hence this.
+        // runs the user's configured title-bar action (zoom/minimize/none). The layer sits BEHIND the row,
+        // so the buttons render in front and keep their clicks; the empty spacers + the title text opt out of
+        // hit-testing (above) so their region falls through to it. Custom titlebar = no native title-bar
+        // double-click handling, hence this.
         .background { WindowControlArea() }
     }
 
@@ -1208,12 +1209,11 @@ private struct WindowAccessor: NSViewRepresentable {
 
 /// A transparent AppKit layer placed behind the custom titlebar's decorative regions (the title text and
 /// the empty spacers, which opt out of SwiftUI hit-testing) so the header behaves like a real title bar:
-/// a single-click drag moves the window (`performDrag`) and a double-click zooms it (`NSWindow.zoom`, the
-/// standard maximize-to-screen toggle — the same action as the green button and the `window.zoom` control
-/// command). The custom titlebar is a SwiftUI view, not AppKit's native title bar, so the OS double-click-
-/// to-zoom never reaches it; this restores it. The interactive header buttons render in front and keep
-/// their own clicks. `mouseDownCanMoveWindow` is off so our `mouseDown` — not AppKit's automatic move —
-/// sees the event and can tell a double-click apart from a drag.
+/// a single-click drag moves the window (`performDrag`) and a double-click runs the user's configured
+/// title-bar double-click action. The custom titlebar is a SwiftUI view, not AppKit's native title bar,
+/// so the OS double-click handling never reaches it; this restores it. The interactive header buttons
+/// render in front and keep their own clicks. `mouseDownCanMoveWindow` is off so our `mouseDown` — not
+/// AppKit's automatic move — sees the event and can tell a double-click apart from a drag.
 private struct WindowControlArea: NSViewRepresentable {
     func makeNSView(context _: Context) -> TitlebarControlView { TitlebarControlView() }
     func updateNSView(_: TitlebarControlView, context _: Context) {}
@@ -1223,11 +1223,31 @@ private struct WindowControlArea: NSViewRepresentable {
 
         override func mouseDown(with event: NSEvent) {
             if event.clickCount == 2 {
-                window?.zoom(nil)
+                performTitlebarDoubleClickAction()
                 return
             }
             // a single click that turns into a drag moves the window; a plain click returns at once.
             window?.performDrag(with: event)
+        }
+
+        /// Mirror AppKit's native title-bar double-click by honoring the system setting at
+        /// Desktop & Dock ▸ "Double-click a window's title bar to" (`AppleActionOnDoubleClick`
+        /// in `NSGlobalDomain`): Zoom/Fill → zoom, Minimize → miniaturize, "Do Nothing" → no-op.
+        /// The key is absent until the user changes it from the macOS default (Zoom), so an
+        /// untouched system reads as `nil` here and still zooms — preserving the prior behavior.
+        /// Read live on each double-click so a setting change takes effect without an app relaunch.
+        /// "Fill" maps to `zoom` (the closest standard NSWindow action; true Fill uses the newer
+        /// window-tiling APIs). Zoom matches the green button and the `window.zoom` control command.
+        private func performTitlebarDoubleClickAction() {
+            guard let window else { return }
+            switch UserDefaults.standard.string(forKey: "AppleActionOnDoubleClick") {
+            case "Minimize":
+                window.performMiniaturize(nil)
+            case "None":
+                break
+            default: // "Maximize", "Fill", or unset (macOS default) → zoom
+                window.zoom(nil)
+            }
         }
     }
 }

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -544,6 +544,8 @@ final class ControlServer {
             return windowResize(request.target, width: request.args?.width, height: request.args?.height)
         case .windowMove:
             return windowMove(request.target, x: request.args?.x, y: request.args?.y, display: request.args?.display)
+        case .windowZoom:
+            return windowZoom(request.target)
         case .keymapReload:
             return reloadKeymap()
         case .configReload:
@@ -1373,6 +1375,18 @@ final class ControlServer {
         }
         return resolveWindowID(target) { id in
             guard WindowRegistry.shared.move(id, x: x, y: y, display: display) else {
+                return ControlResponse(ok: false, error: "window not open — window.select it first")
+            }
+            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
+        }
+    }
+
+    /// Resolve a window id and zoom (maximize-to-screen toggle) its on-screen window. The window must be
+    /// open; a closed window errors. The control half of the double-click-header gesture / the green zoom
+    /// button — drives the same `NSWindow.zoom` as `WindowRegistry.zoom`.
+    private func windowZoom(_ target: String?) -> ControlResponse {
+        return resolveWindowID(target) { id in
+            guard WindowRegistry.shared.zoom(id) else {
                 return ControlResponse(ok: false, error: "window not open — window.select it first")
             }
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -16,7 +16,7 @@ when_to_use: >
   Trigger on: agterm, agtermctl, agterm control socket, session.new, session.close, session.type,
   session.split, session.scratch, session.focus, session.resize, session.go, session.copy, session.search, session.status,
   session.flag, session.overlay, workspace.new, workspace.select, workspace.move, workspace.focus, window.new, window.list,
-  window.select, window.resize, window.move, quick terminal, sidebar, sidebar.mode, sidebar.expand, sidebar.collapse, flagged, notify, font.inc, keymap.reload, config.reload,
+  window.select, window.resize, window.move, window.zoom, quick terminal, sidebar, sidebar.mode, sidebar.expand, sidebar.collapse, flagged, notify, font.inc, keymap.reload, config.reload,
   theme.set, theme.list, select theme, edit keymap, show an image, display an image inline, show-image,
   AGTERM_SESSION_ID, AGTERM_SOCKET, and asks to drive or script agterm. Also: troubleshoot agterm,
   keymap editor won't open, custom action / custom command not working, agterm logs, file an agterm
@@ -88,7 +88,7 @@ a global `--window <id|prefix|active>` to operate on a specific window's tree (d
 
 Scripts rarely type ids: create with `*.new` (capture the returned id), or act on `active`.
 
-## Command summary (47 commands)
+## Command summary (48 commands)
 
 Run `agtermctl <area> <cmd> --help` for exact flags. Full detail in **reference.md**; recipes in
 **examples.md**.
@@ -130,7 +130,8 @@ via `session status`: `active`|`completed`|`blocked`, omitted when idle).
   `scripts/show-image.sh` (see below).
 
 **window** — `new [name]` · `list` · `select <id>` · `close <id>` · `rename <id> <name>` ·
-`delete <id>` · `resize <id> --width W --height H` · `move <id> --x X --y Y [--display N]`.
+`delete <id>` · `resize <id> --width W --height H` · `move <id> --x X --y Y [--display N]` ·
+`zoom <id>` (maximize-to-screen toggle, the double-click-header / green-button action).
 
 **quick** — `[show|hide|toggle]` — the window's quick terminal.
 

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -233,6 +233,7 @@ agtermctl session go --to next-attention  # jump to the next blocked/completed s
 w=$(agtermctl window new "scratch" --json | jq -r '.result.id')
 agtermctl window resize "$w" --width 1200 --height 800
 agtermctl window move "$w" --x 100 --y 100 --display 0
+agtermctl window zoom "$w"                 # maximize-to-screen toggle (call again to restore)
 agtermctl window select "$w"
 ```
 

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -172,6 +172,10 @@ shell (no controlling terminal — `/dev/tty` errors). See examples.md for usage
 - `window move <id> --x X --y Y [--display N]` — top-left position in points, relative to display `N`
   (default the window's current display; y measured from the display top). The window must be open. The
   origin is clamped so an off-screen request keeps a grabbable strip of the window on the target display.
+- `window zoom <id>` — toggle the window between its normal frame and a maximized (fill-screen, NOT
+  native fullscreen) frame, via the standard `NSWindow.zoom`. A second call restores the prior frame.
+  The window must be open. This is the control half of the double-click-on-header gesture (and the green
+  zoom button); `resize`/`move` are control-native, but `zoom` mirrors a GUI action.
 
 `window resize`/`move` are control-native (no GUI equivalent — the title bar already drags-to-resize).
 

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -46,6 +46,7 @@ public enum Command: String, Codable, Sendable {
     case windowDelete = "window.delete"
     case windowResize = "window.resize"
     case windowMove = "window.move"
+    case windowZoom = "window.zoom"
     case keymapReload = "keymap.reload"
     case configReload = "config.reload"
     case themeSet = "theme.set"

--- a/agtermCore/Sources/agtermctlKit/Commands.swift
+++ b/agtermCore/Sources/agtermctlKit/Commands.swift
@@ -565,7 +565,7 @@ struct Session: ParsableCommand {
 struct Window: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Window commands.",
-        subcommands: [New.self, List.self, Select.self, Close.self, Rename.self, Delete.self, Resize.self, Move.self]
+        subcommands: [New.self, List.self, Select.self, Close.self, Rename.self, Delete.self, Resize.self, Move.self, Zoom.self]
     )
 
     struct New: RequestCommand {
@@ -644,6 +644,14 @@ struct Window: ParsableCommand {
         func makeRequest() throws -> ControlRequest {
             ControlRequest(cmd: .windowMove, target: id, args: ControlArgs(x: x, y: y, display: display))
         }
+    }
+
+    struct Zoom: RequestCommand {
+        static let configuration = CommandConfiguration(abstract: "Zoom a window (maximize-to-screen toggle).")
+        @Argument(help: "Window id, unique prefix, or 'active'.") var id: String = "active"
+        @OptionGroup var options: BasicOptions
+
+        func makeRequest() throws -> ControlRequest { ControlRequest(cmd: .windowZoom, target: id) }
     }
 }
 

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -376,6 +376,7 @@ struct ControlProtocolTests {
             ControlRequest(cmd: .windowClose, target: "9f3c"),
             ControlRequest(cmd: .windowRename, target: "active", args: ControlArgs(name: "renamed")),
             ControlRequest(cmd: .windowDelete, target: "9f3c"),
+            ControlRequest(cmd: .windowZoom, target: "9f3c"),
         ]
         for request in cases {
             #expect(try roundTrip(request) == request)

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -28,6 +28,12 @@ final class ControlAPIUITests: XCTestCase {
         app = XCUIApplication()
         app.launchEnvironment["AGTERM_STATE_DIR"] = stateDir.path
         app.launchEnvironment["AGTERM_CONTROL_SOCKET"] = socketPath
+        // Pin the title-bar double-click action so the header gesture tests are hermetic regardless of
+        // the host's Desktop & Dock setting (the app honors this env override in
+        // performTitlebarDoubleClickAction; launch args can't carry it — FB11763863). Most tests never
+        // double-click, so the value is irrelevant to them; the no-op-case test opts into "None".
+        app.launchEnvironment["AGTERM_UITEST_DOUBLECLICK_ACTION"] =
+            name.contains("testDoubleClickHeaderHonorsNoneSetting") ? "None" : "Maximize"
         app.launchForUITest()
         // the seeded session row proves the window (and thus the control server's scene .task) is up.
         XCTAssertTrue(app.staticTexts["session-row"].waitForExistence(timeout: 30), "seeded session should exist")
@@ -1875,6 +1881,29 @@ final class ControlAPIUITests: XCTestCase {
         }
         XCTAssertEqual(window.frame.size.width, normal.width, accuracy: 40,
                        "a second header double-click should restore the window toward \(normal), got \(window.frame.size)")
+    }
+
+    // Locks in that the gesture HONORS the system setting rather than hardcoding zoom: pinned to "None"
+    // (Desktop & Dock ▸ "Do Nothing") via setUp's env override, a header double-click must be a no-op —
+    // the window's frame must not change. The complement of testDoubleClickHeaderZoomsAndRestores.
+    func testDoubleClickHeaderHonorsNoneSetting() throws {
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 5), "window should exist")
+        XCTAssertEqual(try sendCommand(#"{"cmd":"window.resize","args":{"width":800,"height":600}}"#)["ok"] as? Bool, true)
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline, !(abs(window.frame.size.width - 800) < 8 && abs(window.frame.size.height - 600) < 8) {
+            usleep(150_000)
+        }
+        let normal = window.frame.size
+        XCTAssertEqual(normal.width, 800, accuracy: 8, "window should settle near 800 wide before the gesture, got \(normal)")
+
+        emptyHeaderPoint(window).doubleClick()
+        // give any (erroneous) zoom time to land, then assert the frame never changed.
+        RunLoop.current.run(until: Date().addingTimeInterval(2))
+        XCTAssertEqual(window.frame.size.width, normal.width, accuracy: 8,
+                       "with 'None' set, a header double-click must not zoom (width): normal=\(normal) now=\(window.frame.size)")
+        XCTAssertEqual(window.frame.size.height, normal.height, accuracy: 8,
+                       "with 'None' set, a header double-click must not zoom (height): normal=\(normal) now=\(window.frame.size)")
     }
 
     // The `WindowControlArea` drag/zoom layer sits BEHIND the header; the toolbar buttons render in front

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -1832,6 +1832,97 @@ final class ControlAPIUITests: XCTestCase {
                        "window should restore toward \(normal) after a second window.zoom, got \(window.frame.size)")
     }
 
+    // A point 14pt below the top edge, horizontally centred: clears the top resize strip, lands inside the
+    // titlebar band (compact 30 / tall 48), and sits in the empty header (a Spacer) — clear of the traffic
+    // lights on the left and the toolbar buttons on the right, so the click falls through the decorative
+    // regions' `.allowsHitTesting(false)` to the `WindowControlArea` layer behind the custom header.
+    // Re-resolved at each interaction, so it stays in the header even after a zoom grows the window.
+    private func emptyHeaderPoint(_ window: XCUIElement) -> XCUICoordinate {
+        window.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0)).withOffset(CGVector(dx: 0, dy: 14))
+    }
+
+    // The double-click-header GESTURE (the actual mouse event, not the window.zoom control command) must
+    // zoom the window. Mirrors testWindowZoom's settle logic but drives the real cursor: resize to a known
+    // small frame, double-click the empty header centre, assert the window grows, then double-click again
+    // and assert it restores.
+    func testDoubleClickHeaderZoomsAndRestores() throws {
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 5), "window should exist")
+        XCTAssertEqual(try sendCommand(#"{"cmd":"window.resize","args":{"width":800,"height":600}}"#)["ok"] as? Bool, true)
+        var deadline = Date().addingTimeInterval(5)
+        while Date() < deadline, !(abs(window.frame.size.width - 800) < 8 && abs(window.frame.size.height - 600) < 8) {
+            usleep(150_000)
+        }
+        let normal = window.frame.size
+        XCTAssertEqual(normal.width, 800, accuracy: 8, "window should settle near 800 wide before the gesture, got \(normal)")
+
+        emptyHeaderPoint(window).doubleClick()
+        deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            let s = window.frame.size
+            if s.width > normal.width + 50 || s.height > normal.height + 50 { break }
+            usleep(150_000)
+        }
+        XCTAssertTrue(window.frame.size.width > normal.width + 50 || window.frame.size.height > normal.height + 50,
+                      "double-clicking the header should zoom (grow) the window: normal=\(normal) now=\(window.frame.size)")
+
+        emptyHeaderPoint(window).doubleClick()
+        deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            let s = window.frame.size
+            if abs(s.width - normal.width) < 40, abs(s.height - normal.height) < 40 { break }
+            usleep(150_000)
+        }
+        XCTAssertEqual(window.frame.size.width, normal.width, accuracy: 40,
+                       "a second header double-click should restore the window toward \(normal), got \(window.frame.size)")
+    }
+
+    // The `WindowControlArea` drag/zoom layer sits BEHIND the header; the toolbar buttons render in front
+    // and must keep their own clicks. A double-click on the empty header must zoom (not reach a button);
+    // a click on quick-terminal-toggle must still open the quick terminal cover despite the layer behind.
+    func testHeaderButtonsStillReceiveClicksOverControlArea() throws {
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 5), "window should exist")
+        let cover = app.descendants(matching: .any).matching(identifier: "quick-terminal").firstMatch
+
+        // double-clicking the empty header zooms the window; it must NOT open the quick terminal.
+        emptyHeaderPoint(window).doubleClick()
+        XCTAssertFalse(cover.waitForExistence(timeout: 2), "double-clicking the header must not open the quick terminal")
+
+        // the button itself still takes its click even though the control-area layer is behind the header.
+        let button = app.buttons["quick-terminal-toggle"]
+        XCTAssertTrue(button.waitForExistence(timeout: 5), "quick-terminal toolbar button should exist")
+        button.click()
+        XCTAssertTrue(cover.waitForExistence(timeout: 5), "clicking quick-terminal-toggle should open the quick terminal cover")
+    }
+
+    // A single-click-drag anywhere on the full custom header moves the window (performDrag), not just the
+    // native top band. Resize + position to a known on-screen frame so the drag stays on screen and the
+    // delta is unambiguous, record the origin, drag the empty header, and assert the window's origin moved.
+    func testDragHeaderMovesWindow() throws {
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 5), "window should exist")
+        XCTAssertEqual(try sendCommand(#"{"cmd":"window.resize","args":{"width":800,"height":600}}"#)["ok"] as? Bool, true)
+        XCTAssertEqual(try sendCommand(#"{"cmd":"window.move","args":{"x":140,"y":140}}"#)["ok"] as? Bool, true)
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline, abs(window.frame.size.width - 800) > 8 { usleep(150_000) }
+        let origin = window.frame.origin
+
+        let from = emptyHeaderPoint(window)
+        let to = from.withOffset(CGVector(dx: 90, dy: 70))
+        from.click(forDuration: 0.3, thenDragTo: to, withVelocity: 180, thenHoldForDuration: 0.25)
+
+        let settle = Date().addingTimeInterval(5)
+        while Date() < settle {
+            let o = window.frame.origin
+            if abs(o.x - origin.x) > 20 || abs(o.y - origin.y) > 20 { break }
+            usleep(150_000)
+        }
+        let moved = window.frame.origin
+        XCTAssertTrue(abs(moved.x - origin.x) > 20 || abs(moved.y - origin.y) > 20,
+                      "dragging the header should move the window: origin=\(origin) now=\(moved)")
+    }
+
     // window.close marks the window closed, after which a session command targeting it returns the
     // "window not open" error. (--window routing into the second window is exercised first to prove
     // the round-trip, then the close flips it to the error path.)

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -1794,6 +1794,44 @@ final class ControlAPIUITests: XCTestCase {
         XCTFail("window did not move right+down: first=\(first) now=\(window.frame.origin)")
     }
 
+    // window.zoom toggles the active window between its normal frame and a maximized (fill-screen) frame —
+    // the control half of the double-click-header gesture. From a known small frame the first zoom clearly
+    // enlarges; a second zoom restores it toward that frame.
+    func testWindowZoom() throws {
+        XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session")
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 5), "window should exist")
+        // start from a known un-maximized size so the first zoom unambiguously grows the window.
+        XCTAssertEqual(try sendCommand(#"{"cmd":"window.resize","args":{"width":800,"height":600}}"#)["ok"] as? Bool, true)
+        var deadline = Date().addingTimeInterval(5)
+        while Date() < deadline, !(abs(window.frame.size.width - 800) < 8 && abs(window.frame.size.height - 600) < 8) {
+            usleep(150_000)
+        }
+        let normal = window.frame.size
+        XCTAssertEqual(normal.width, 800, accuracy: 8, "window should settle near 800 wide before zoom, got \(normal)")
+
+        XCTAssertEqual(try sendCommand(#"{"cmd":"window.zoom"}"#)["ok"] as? Bool, true)
+        deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            let s = window.frame.size
+            if s.width > normal.width + 50 || s.height > normal.height + 50 { break }
+            usleep(150_000)
+        }
+        XCTAssertTrue(window.frame.size.width > normal.width + 50 || window.frame.size.height > normal.height + 50,
+                      "window should grow after window.zoom: normal=\(normal) now=\(window.frame.size)")
+
+        // a second zoom restores the window toward its previous (normal) frame.
+        XCTAssertEqual(try sendCommand(#"{"cmd":"window.zoom"}"#)["ok"] as? Bool, true)
+        deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            let s = window.frame.size
+            if abs(s.width - normal.width) < 40, abs(s.height - normal.height) < 40 { break }
+            usleep(150_000)
+        }
+        XCTAssertEqual(window.frame.size.width, normal.width, accuracy: 40,
+                       "window should restore toward \(normal) after a second window.zoom, got \(window.frame.size)")
+    }
+
     // window.close marks the window closed, after which a session command targeting it returns the
     // "window not open" error. (--window routing into the second window is exercised first to prove
     // the round-trip, then the close flips it to the error path.)


### PR DESCRIPTION
## What

Double-clicking the window header now zooms the window — the standard macOS maximize-to-screen toggle (fills the screen's visible frame, not native fullscreen; a second double-click restores the prior frame).

## Why

The custom titlebar is a SwiftUI view, not AppKit's native title bar, so the OS double-click-to-zoom never reached it. As a side effect the whole header was not draggable either (only the native ~28px band was).

## How

`WindowControlArea` — a transparent `NSViewRepresentable` placed behind `customTitlebar`'s decorative regions — handles `mouseDown`: `clickCount == 2` → `NSWindow.zoom(nil)`, otherwise `performDrag` (so the full header drags, not just the native band). `mouseDownCanMoveWindow = false` so our handler sees the double-click. The header's decorative parts (traffic-light spacer, divider gap, title text) opt out of hit-testing via `.allowsHitTesting(false)` so their region falls through to the layer; the buttons render in front and keep their clicks. It lives on `customTitlebar` (a top-level ZStack child), not in the `sessionDetail`/`NSSplitView` subtree, so it doesn't perturb the split.

Per the control-API keep-in-sync convention, the action is also drivable headless via a new **`window.zoom`** command:
- `windowZoom` case in `ControlProtocol`
- `.windowZoom` dispatch arm in `ControlServer` → `WindowRegistry.zoom`
- `agtermctl window zoom <id>` subcommand
- agent-skill + rule docs updated (command count 46 → 47)

## Test plan

- `cd agtermCore && swift test` — 770/770 pass (incl. the `window.zoom` protocol round-trip).
- `make build` — succeeds.
- New e2e `ControlAPIUITests.testWindowZoom` — first zoom enlarges the window, a second restores it; passes.
- Full XCUITest suite — green except two pre-existing failures unrelated to this change (`SettingsUITests.testCompactToolbarTogglePersists`, reproduced on master with this change stashed; `FocusWorkspaceUITests…` flaked once, passed on re-run).
- Manual: double-click the header (empty area / title text / traffic-light strip) zooms and restores; single-click-drag across the full header moves the window; header buttons still click.