### PR TITLE
feat: de-bounce repeated identical status sounds

### DIFF
--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -691,7 +691,7 @@ final class ControlServer {
             // newly enters `blocked`, not on a repeated `blocked` set.
             let blockedDefault = wasBlocked ? nil : self.settingsModel.settings.blockedStatusSoundName
             if let name = parsed.effectiveSound(perCall: sound, blockedDefault: blockedDefault) {
-                StatusSoundPlayer.shared.action(for: name)?()
+                StatusSoundPlayer.shared.play(name)
             }
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
         }

--- a/agterm/Control/StatusSoundPlayer.swift
+++ b/agterm/Control/StatusSoundPlayer.swift
@@ -1,4 +1,5 @@
 import AppKit
+import agtermCore
 
 /// StatusSoundPlayer plays the one-shot sound requested by `session.status --sound`. It is a thin AppKit
 /// wrapper over `NSSound`, owned by `ControlServer` for the app's lifetime.
@@ -6,7 +7,9 @@ import AppKit
 /// `action(for:)` resolves a sound name to its play closure (or nil when a named sound can't be found),
 /// so the caller can validate before mutating the indicator and surface an `unknown sound` error. The
 /// `default`/`beep` value maps to the system alert sound; any other value is a named system sound via
-/// `NSSound(named:)`, which also resolves custom sounds in `~/Library/Sounds`.
+/// `NSSound(named:)`, which also resolves custom sounds in `~/Library/Sounds`. `play(_:)` resolves AND
+/// plays, but de-bounces a replay of the same sound within a short window (`SoundThrottle`) so a burst of
+/// rapid status sets can't machine-gun an identical clip.
 ///
 /// Resolved `NSSound` instances are cached and thus retained for the app's lifetime — both to skip
 /// reloading and to avoid the AppKit gotcha where a locally-scoped `NSSound` is deallocated mid-play and
@@ -18,6 +21,10 @@ final class StatusSoundPlayer {
     static let shared = StatusSoundPlayer()
 
     private var cache: [String: NSSound] = [:]
+
+    /// De-bounce identical replays so a rapid run of `session.status --sound` (or repeated `blocked`
+    /// transitions) doesn't stutter the same clip; the Settings preview bypasses this and always sounds.
+    private var throttle = SoundThrottle(window: .milliseconds(200))
 
     /// The standard macOS system sound names, used only to suggest valid values in the `unknown sound`
     /// error; any name `NSSound(named:)` can resolve is accepted, not just these.
@@ -32,5 +39,17 @@ final class StatusSoundPlayer {
         guard let sound = NSSound(named: NSSound.Name(name)) else { return nil }
         cache[name] = sound
         return { sound.stop(); sound.play() }
+    }
+
+    /// Resolve and play `name`, suppressing a replay of the SAME sound within the throttle window so a
+    /// burst of rapid status sets doesn't machine-gun an identical clip. Returns false ONLY when the name
+    /// can't be resolved (so the caller can surface `unknown sound`); a throttled replay returns true
+    /// (resolvable, just intentionally silent). The control server's play path uses this; the Settings
+    /// picker preview calls `action(for:)` directly so a deliberate preview click always sounds.
+    @discardableResult
+    func play(_ name: String) -> Bool {
+        guard let action = action(for: name) else { return false }
+        if throttle.allow(name, at: ContinuousClock().now) { action() }
+        return true
     }
 }

--- a/agtermCore/Sources/agtermCore/SoundThrottle.swift
+++ b/agtermCore/Sources/agtermCore/SoundThrottle.swift
@@ -1,0 +1,22 @@
+/// SoundThrottle suppresses a replay of the SAME sound within a short window, so a burst of rapid
+/// `session.status --sound` calls (or repeated `blocked` transitions) can't machine-gun an identical
+/// clip. It tracks the last play time per sound name; a DIFFERENT sound is never suppressed. Host-free
+/// and clock-injected (the caller passes a monotonic `now`) so the window decision is unit-testable
+/// without real time.
+public struct SoundThrottle: Sendable {
+    /// Minimum gap before the same sound name may play again.
+    private let window: Duration
+    private var lastPlayed: [String: ContinuousClock.Instant] = [:]
+
+    public init(window: Duration) { self.window = window }
+
+    /// Whether `name` may play at `now`, recording the play when it may. Returns false WITHOUT changing
+    /// state for a same-sound replay still inside `window` (so the window is always measured from the last
+    /// ALLOWED play, not the last attempt); otherwise records `now` and returns true — including the first
+    /// play of a name and any play at or past the window boundary.
+    public mutating func allow(_ name: String, at now: ContinuousClock.Instant) -> Bool {
+        if let last = lastPlayed[name], now - last < window { return false }
+        lastPlayed[name] = now
+        return true
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/SoundThrottleTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SoundThrottleTests.swift
@@ -1,0 +1,60 @@
+import Testing
+@testable import agtermCore
+
+// `allow` is mutating, and the #expect macro captures its argument immutably, so each call is bound to a
+// `let` before asserting rather than invoked inline.
+struct SoundThrottleTests {
+    @Test func firstPlayOfANameIsAllowed() {
+        var throttle = SoundThrottle(window: .milliseconds(200))
+        let first = throttle.allow("Ping", at: ContinuousClock().now)
+        #expect(first)
+    }
+
+    @Test func sameSoundSuppressedWithinWindow() {
+        var throttle = SoundThrottle(window: .milliseconds(200))
+        let t0 = ContinuousClock().now
+        let first = throttle.allow("Ping", at: t0)
+        let early = throttle.allow("Ping", at: t0 + .milliseconds(1))
+        let nearEdge = throttle.allow("Ping", at: t0 + .milliseconds(199))
+        #expect(first)
+        #expect(!early)
+        #expect(!nearEdge)
+    }
+
+    @Test func sameSoundAllowedAtOrPastWindowBoundary() {
+        var throttle = SoundThrottle(window: .milliseconds(200))
+        let t0 = ContinuousClock().now
+        let first = throttle.allow("Ping", at: t0)
+        let atBoundary = throttle.allow("Ping", at: t0 + .milliseconds(200)) // >= window plays
+        let wellPast = throttle.allow("Ping", at: t0 + .milliseconds(450))
+        #expect(first)
+        #expect(atBoundary)
+        #expect(wellPast)
+    }
+
+    @Test func differentSoundsThrottleIndependently() {
+        var throttle = SoundThrottle(window: .milliseconds(200))
+        let t0 = ContinuousClock().now
+        let ping = throttle.allow("Ping", at: t0)
+        let hero = throttle.allow("Hero", at: t0 + .milliseconds(10))  // different name, not suppressed
+        let pingAgain = throttle.allow("Ping", at: t0 + .milliseconds(20)) // Ping still inside its window
+        let heroAgain = throttle.allow("Hero", at: t0 + .milliseconds(30)) // Hero now inside its window
+        #expect(ping)
+        #expect(hero)
+        #expect(!pingAgain)
+        #expect(!heroAgain)
+    }
+
+    @Test func suppressedReplayDoesNotAdvanceTheWindow() {
+        // the window is measured from the last ALLOWED play, not the last attempt — a suppressed call
+        // must not re-stamp, else a steady stream just under the window would never play.
+        var throttle = SoundThrottle(window: .milliseconds(200))
+        let t0 = ContinuousClock().now
+        let first = throttle.allow("Ping", at: t0)
+        let suppressed = throttle.allow("Ping", at: t0 + .milliseconds(150)) // must not re-stamp
+        let atBoundary = throttle.allow("Ping", at: t0 + .milliseconds(200)) // 200ms since ALLOWED play → plays
+        #expect(first)
+        #expect(!suppressed)
+        #expect(atBoundary)
+    }
+}


### PR DESCRIPTION
session.status --sound (and the Settings blocked-default) fired on every apply, so a rapid burst of the same status could machine-gun an identical clip. This adds a small host-free `SoundThrottle` (per-name last-play time, 200ms window) and routes the control play path through `StatusSoundPlayer.play`, which suppresses a same-sound replay still inside the window.

different sounds are independent, and the Settings picker preview bypasses the throttle so a deliberate click always sounds. It's internal to playback only, with no command/arg/CLI change, and a single `session.status --sound` call still plays once as documented.

covered by `SoundThrottleTests`: first-play, within-window suppression, the window boundary, per-name independence, and that a suppressed call doesn't advance the window.
