### PR TITLE
fix: Esc cancels inline rename and focus returns to the terminal

### DIFF
--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -325,6 +325,13 @@ struct WorkspaceSidebar: NSViewRepresentable {
         /// from under the in-progress edit. `committing` covers only the end-editing
         /// instant; this covers the whole typing window.
         private var editing = false
+        /// Set by the Esc handler (`doCommandBy` cancelOperation) so the end-editing that the
+        /// manual resign triggers is treated as a cancel — the typed value is discarded.
+        private var cancellingRename = false
+        /// The row's pre-edit label, captured in `beginEditing` so an Esc-cancel can restore the
+        /// displayed text (a manual resign keeps the edited stringValue, and a cancel makes no model
+        /// change so no reload refreshes the row).
+        private var renameOriginalValue: String?
         /// Guards `syncSelection` against the selection-change delegate callback it
         /// itself triggers (which would otherwise re-enter the store).
         private var applyingSelection = false
@@ -1000,6 +1007,7 @@ struct WorkspaceSidebar: NSViewRepresentable {
             let row = outline.row(forItem: node)
             guard row >= 0, let cell = outline.view(atColumn: 0, row: row, makeIfNecessary: true) as? NSTableCellView,
                   let field = cell.textField else { return }
+            renameOriginalValue = field.stringValue
             field.isEditable = true
             field.isBordered = true
             field.drawsBackground = true
@@ -1015,6 +1023,19 @@ struct WorkspaceSidebar: NSViewRepresentable {
             editing = true
         }
 
+        /// Intercepts Esc during an inline rename. The field is focused via `makeFirstResponder`
+        /// (not the outline's edit session), so AppKit never delivers the cancel text-movement for
+        /// Esc — `cancelOperation:` would otherwise do nothing and leave the field stuck in edit
+        /// mode. Flag the cancel, resign so `controlTextDidEndEditing` fires, and consume the
+        /// command so the default (no-op) handling doesn't run.
+        func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+            guard editing, commandSelector == #selector(NSResponder.cancelOperation(_:)),
+                  let field = control as? NSTextField else { return false }
+            cancellingRename = true
+            field.window?.makeFirstResponder(outlineView)
+            return true
+        }
+
         func controlTextDidEndEditing(_ notification: Notification) {
             guard !committing, let field = notification.object as? NSTextField, let outline = outlineView else { return }
             committing = true
@@ -1024,11 +1045,16 @@ struct WorkspaceSidebar: NSViewRepresentable {
             let row = outline.row(for: field)
             let node = row >= 0 ? outline.item(atRow: row) as? SidebarNode : nil
 
-            // Escape cancels: AppKit reports it via the text-movement key in userInfo.
+            // Escape cancels: via AppKit's cancel text-movement, or via our Esc handler's flag (the
+            // manual-resign path the rename field needs, since it never gets the cancel movement).
             let movement = (notification.userInfo?["NSTextMovement"] as? Int) ?? 0
-            let cancelled = movement == NSTextMovement.cancel.rawValue
+            let cancelled = movement == NSTextMovement.cancel.rawValue || cancellingRename
+            cancellingRename = false
 
             let newValue = field.stringValue
+            // a manual-resign cancel keeps the edited stringValue and makes no model change (no row
+            // reload), so restore the pre-edit label before flipping the field back to a plain label.
+            if cancelled, let original = renameOriginalValue { field.stringValue = original }
             restore(field: field, kind: node?.kind)
             guard let node, !cancelled else { return }
 

--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -1056,6 +1056,10 @@ struct WorkspaceSidebar: NSViewRepresentable {
             // reload), so restore the pre-edit label before flipping the field back to a plain label.
             if cancelled, let original = renameOriginalValue { field.stringValue = original }
             restore(field: field, kind: node?.kind)
+            // a rename ends with focus on the field editor; hand it back to the active terminal so the
+            // sidebar never keeps keyboard focus (the design contract). deferred so the editor's resign
+            // settles first — focusActiveTerminal bails while an NSText field editor is first responder.
+            DispatchQueue.main.async { [weak self] in self?.focusActiveTerminal() }
             guard let node, !cancelled else { return }
 
             switch node.kind {

--- a/agtermUITests/SidebarUITests.swift
+++ b/agtermUITests/SidebarUITests.swift
@@ -90,6 +90,26 @@ final class SidebarUITests: XCTestCase {
                       "workspace header should show the new name after rename")
     }
 
+    // issue #41: Esc must cancel the inline rename — close edit mode and discard the typed change.
+    func testRenameSessionEscCancels() throws {
+        let row = sessionRow()
+        XCTAssertTrue(row.waitForExistence(timeout: 20), "session row should exist")
+        let original = row.value as? String
+        row.rightClick()
+        let rename = app.menuItems["Rename"]
+        XCTAssertTrue(rename.waitForExistence(timeout: 5), "Rename menu item should appear")
+        rename.click()
+        let field = app.descendants(matching: .any).matching(identifier: "edit-field").firstMatch
+        XCTAssertTrue(field.waitForExistence(timeout: 5), "rename did not enter edit mode (field never appeared)")
+        app.typeKey("a", modifierFlags: .command)
+        app.typeText("should-be-discarded")
+        app.typeKey(XCUIKeyboardKey.escape, modifierFlags: [])
+        // edit mode closes: on restore the field's identifier reverts from edit-field to session-row.
+        XCTAssertTrue(field.waitForNonExistence(timeout: 5), "Esc should close rename edit mode")
+        // and the name is unchanged: the rename was discarded, not committed.
+        XCTAssertEqual(sessionRow().value as? String, original, "Esc should discard the rename")
+    }
+
     func testCloseSession() throws {
         let row = sessionRow()
         XCTAssertTrue(row.waitForExistence(timeout: 20))

--- a/agtermUITests/SidebarUITests.swift
+++ b/agtermUITests/SidebarUITests.swift
@@ -13,6 +13,7 @@ import XCTest
 final class SidebarUITests: XCTestCase {
     private var app: XCUIApplication!
     private var stateDir: URL!
+    private var markerDir: URL!
 
     override func setUp() async throws {
         continueAfterFailure = false
@@ -20,6 +21,9 @@ final class SidebarUITests: XCTestCase {
         // "workspace 1" + one session, and we never touch the real workspaces.json.
         stateDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("agterm-uitest-\(UUID().uuidString)", isDirectory: true)
+        markerDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agterm-sidebar-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: markerDir, withIntermediateDirectories: true)
         app = XCUIApplication()
         app.launchEnvironment["AGTERM_STATE_DIR"] = stateDir.path
         app.launchForUITest()
@@ -28,6 +32,26 @@ final class SidebarUITests: XCTestCase {
     override func tearDown() async throws {
         app?.terminate()
         if let stateDir { try? FileManager.default.removeItem(at: stateDir) }
+        if let markerDir { try? FileManager.default.removeItem(at: markerDir) }
+    }
+
+    /// Focus oracle: types `tty > file` into whatever currently holds keyboard focus, then Return.
+    /// The marker file gets written only if the keystrokes reached the session's shell — i.e. the
+    /// terminal has focus. If the sidebar kept focus the text drives outline type-select instead and
+    /// the file stays absent, so a nil return means "focus did NOT return to the terminal".
+    private func terminalReceivedTyping(named name: String) -> Bool {
+        let file = markerDir.appendingPathComponent(name)
+        app.typeText("tty > '\(file.path)'")
+        app.typeKey(.return, modifierFlags: [])
+        let deadline = Date().addingTimeInterval(8)
+        while Date() < deadline {
+            if let contents = try? String(contentsOf: file, encoding: .utf8),
+               !contents.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return true
+            }
+            usleep(150_000)
+        }
+        return false
     }
 
     /// The (single, seeded) session row, matched by its stable accessibility
@@ -108,6 +132,20 @@ final class SidebarUITests: XCTestCase {
         XCTAssertTrue(field.waitForNonExistence(timeout: 5), "Esc should close rename edit mode")
         // and the name is unchanged: the rename was discarded, not committed.
         XCTAssertEqual(sessionRow().value as? String, original, "Esc should discard the rename")
+        // focus returns to the terminal: the sidebar must not keep focus after the rename ends.
+        usleep(800_000)
+        XCTAssertTrue(terminalReceivedTyping(named: "after-esc"),
+                      "Esc should return focus to the session terminal, not keep it on the sidebar")
+    }
+
+    // ending a rename with Return must also hand focus back to the terminal (not keep it on the sidebar).
+    func testRenameSessionCommitReturnsFocus() throws {
+        let row = sessionRow()
+        rename(row, to: "renamed-focus")
+        XCTAssertTrue(waitForValue(row, "renamed-focus", timeout: 5), "rename should commit")
+        usleep(800_000)
+        XCTAssertTrue(terminalReceivedTyping(named: "after-commit"),
+                      "committing a rename should return focus to the session terminal")
     }
 
     func testCloseSession() throws {


### PR DESCRIPTION
two fixes for inline session/workspace rename in the sidebar, both from #41.

**Esc cancels the rename.** The rename field is focused via `makeFirstResponder` (not the outline's edit session), so AppKit never delivered the cancel text-movement for Esc. `cancelOperation:` was swallowed and the field stayed stuck in edit mode. A `control(_:textView:doCommandBy:)` handler now intercepts Esc, flags a cancel, and resigns so the existing `controlTextDidEndEditing` cancel path runs: restore the pre-edit label, skip the rename.

**focus returns to the terminal when a rename ends.** Ending a rename left first responder on the sidebar outline. This was visible on the new Esc-cancel path and on Enter-commit too, a pre-existing gap. Both paths now call the existing `focusActiveTerminal()` after the edit ends, deferred one runloop tick so the field editor's resign settles first (it bails while an `NSText` field editor still holds focus).

app-target only, no `agtermCore` / control-API / agent-skill change: Esc-cancel and the focus hand-off are keyboard interactions inside an open GUI edit, with nothing to drive over the socket.

**tests.** `SidebarUITests` gets a focus assertion on `testRenameSessionEscCancels` (Esc closes the edit, discards the change, returns focus) plus a new `testRenameSessionCommitReturnsFocus`. Focus is checked with the same tty-marker oracle `SplitUITests` uses. Both focus assertions were confirmed to fail without the focus fix and pass with it.

Fix #41
