### PR TITLE
feat: read a session's buffer over the control API (session.text)

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -86,7 +86,7 @@ paths:
   The skill is a REFERENCE/knowledge skill (both user-invocable via `/agterm` and model-triggered,
   `allowed-tools: Bash(agtermctl *)`; the agent-neutral `description` carries the trigger nouns since
   Codex may ignore the extra `when_to_use` field — unknown frontmatter is harmless),
-  authored at `agterm/Resources/agent-skill/` (`SKILL.md` overview + model + addressing + 49-command
+  authored at `agterm/Resources/agent-skill/` (`SKILL.md` overview + model + addressing + 50-command
   summary + the image-display helper + a troubleshooting/reporting pointer;
   `reference.md` full per-command detail + keymap format; `examples.md` agtermctl recipes;
   `troubleshooting.md` diagnosing the common problems (keymap editor, custom actions,
@@ -156,10 +156,10 @@ paths:
   exact `uuidString` (case-insensitive), or a git-style unique prefix.
   Zero prefix hits → `notFound` error, ≥2 → `ambiguous` error listing the candidates.
   `--target` defaults to `active`, so scripts rarely type an id and never for "the current one".
-- **Command catalog (49 commands):**
+- **Command catalog (50 commands):**
   - `tree`
   - `workspace.new`/`workspace.rename`/`workspace.delete`/`workspace.select`/`workspace.move`/`workspace.focus`
-  - `session.new`/`session.close`/`session.select`/`session.rename`/`session.move`/`session.type`/`session.split`/`session.scratch`/`session.focus`/`session.resize`/`session.go`/`session.copy`/`session.search`/`session.status`/`session.flag`/`session.background`/`session.overlay.open`/`session.overlay.close`/`session.overlay.result`
+  - `session.new`/`session.close`/`session.select`/`session.rename`/`session.move`/`session.type`/`session.split`/`session.scratch`/`session.focus`/`session.resize`/`session.go`/`session.copy`/`session.text`/`session.search`/`session.status`/`session.flag`/`session.background`/`session.overlay.open`/`session.overlay.close`/`session.overlay.result`
   - `quick`
   - `sidebar`/`sidebar.mode`/`sidebar.expand`/`sidebar.collapse`
   - `notify`
@@ -305,6 +305,31 @@ paths:
   — it does NOT touch the system clipboard (automation pipes the returned text into another `session.type`);
   selection is surface state independent of focus, so any realized session can be read,
   and no/empty selection is a `no selection` error.
+  `session.text` reads the target surface's screen buffer as PLAIN TEXT (no ANSI) via `GhosttySurfaceView.readScreenText(all:lines:)`
+  (a `ghostty_selection_s` spanning VIEWPORT top-left→bottom-right by default,
+  SCREEN when `args.all || args.lines != nil`, `rectangle = false`;
+  `ghostty_surface_read_text` → copy out of `ghostty_text_s` → `ghostty_surface_free_text`) and returns it in `result.text`
+  — `args.all` adds scrollback, `args.lines N` keeps the last N CONTENT lines (trailing blank grid rows
+  trimmed so a non-scrolled screen returns content, not padding), and `args.pane` (`left`→main,
+  `right`→split-else-`session has no split` error, omitted→the ON-SCREEN surface via the shared
+  `Session.onScreenSurface` (scratch-when-covering else the focused pane, the SAME resolution `session.search`
+  uses), so a no-`pane` read returns what's visible, not a pane hidden under the scratch) picks the pane.
+  `args.all`+`args.lines` are mutually exclusive and `args.lines` must be > 0 — validated SERVER-SIDE in
+  `readText` (mirroring the CLI `validate()`), NOT only CLI-side, so a raw socket client can't bypass it
+  (an unchecked `lines ≤ 0` would otherwise fall through to the full buffer).
+  UNLIKE `session.focus`, the `pane` here is `left|right` ONLY (no `other`).
+  A genuinely BLANK screen reads `ok` with an empty string (NOT an error, on purpose — differs from `session.copy`'s
+  `no selection`), but a FAILED `ghostty_surface_read_text` is a `failed to read surface buffer` error:
+  `readScreenText` returns `""` for the empty read and nil ONLY for a real failure, which `readText` maps
+  to the error (so a caller can tell a blank terminal from a broken read).
+  Plain text only — the pinned libghostty exposes only `ghostty_surface_read_text` (no per-cell SGR),
+  so `--ansi` is out of scope until a styled surface read lands upstream and the pin is bumped.
+  Four-point keep-in-sync audit for `session.text`: (1) `case sessionText = "session.text"` + new `ControlArgs.all: Bool?`/`lines: Int?`
+  (reuses `pane` + `ControlResult.text`) in `ControlProtocol.swift`, (2) the `.sessionText` dispatch arm (`readText`)
+  in `ControlServer`, (3) the `session text [--all] [--lines N] [--pane left|right]` subcommand in `agtermctlKit`
+  (`validate()` guards the flag combos, re-enforced SERVER-SIDE in `readText`), (4) round-trip tests in
+  `ControlProtocolTests` + the e2e (`testSessionTextReturnsBuffer`, `testSessionTextSplitPaneWithoutSplitErrors`,
+  `testSessionTextRejectsInvalidArgsServerSide`) in `ControlAPIUITests`.
   `session.search` searches the target session's live scrollback (target = session) — it SELECTS the
   target (so the bar + match highlights render and the surface is realized,
   bounded-realize-polled like `session.type`), then drives the FOCUSED surface over `ghostty_surface_binding_action`:
@@ -616,5 +641,5 @@ paths:
   + the e2e `testSessionBackgroundSetClearAndValidation` in `ControlAPIUITests` (set/clear + tree read-back).
   **Agent-skill mirror (HARD keep-in-sync, 4th surface):** all commands are documented in the bundled
   `agterm/Resources/agent-skill/` (SKILL.md summary, reference.md detail,
-  examples.md recipes) and the command count there is bumped to 49 to match.
+  examples.md recipes) and the command count there is bumped to 50 to match.
 

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -329,7 +329,8 @@ paths:
   in `ControlServer`, (3) the `session text [--all] [--lines N] [--pane left|right]` subcommand in `agtermctlKit`
   (`validate()` guards the flag combos, re-enforced SERVER-SIDE in `readText`), (4) round-trip tests in
   `ControlProtocolTests` + the e2e (`testSessionTextReturnsBuffer`, `testSessionTextSplitPaneWithoutSplitErrors`,
-  `testSessionTextRejectsInvalidArgsServerSide`) in `ControlAPIUITests`.
+  `testSessionTextRejectsInvalidArgsServerSide`, `testSessionTextBlankScreenReturnsOkEmpty`) in `SessionTextUITests`
+  (a `ControlAPIUITests` extension split into its own file to keep that suite under the swiftlint file_length limit).
   `session.search` searches the target session's live scrollback (target = session) — it SELECTS the
   target (so the bar + match highlights render and the surface is realized,
   bounded-realize-polled like `session.type`), then drives the FOCUSED surface over `ghostty_surface_binding_action`:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -32,10 +32,10 @@ line_length:
 # and the large XCUITest/unit suites. limits sit just above today's maxima so the repo is
 # clean now and only further growth warns.
 file_length:
-  warning: 2800
+  warning: 2700
   error: 3000
 type_body_length:
-  warning: 1950
+  warning: 1850
   error: 2500
 function_body_length:
   warning: 250

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -32,10 +32,10 @@ line_length:
 # and the large XCUITest/unit suites. limits sit just above today's maxima so the repo is
 # clean now and only further growth warns.
 file_length:
-  warning: 2700
+  warning: 2800
   error: 3000
 type_body_length:
-  warning: 1850
+  warning: 1950
   error: 2500
 function_body_length:
   warning: 250

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -104,6 +104,13 @@ final class ControlServer {
     /// the total read time; a legit one-line request arrives in milliseconds, far under the cap.
     nonisolated private static let readDeadlineSeconds = 10
 
+    /// Overall seconds a single response write may take before it's abandoned. `SO_SNDTIMEO` only bounds
+    /// each `write()`, so a slow-drip reader draining a multi-MB `session.text --all` a few bytes per
+    /// interval keeps every write making progress and never trips the per-write timeout, parking the serial
+    /// accept loop. This caps the total write time, symmetric with `readDeadlineSeconds`; a normal reader
+    /// drains a response in milliseconds, far under the cap.
+    nonisolated private static let writeDeadlineSeconds = 10
+
     init(library: WindowLibrary, actions: AppActions, settingsModel: SettingsModel, socketPath: String? = nil) {
         self.library = library
         self.actions = actions
@@ -288,7 +295,11 @@ final class ControlServer {
         data.withUnsafeBytes { raw in
             var offset = 0
             let base = raw.bindMemory(to: UInt8.self).baseAddress!
+            // overall deadline: SO_SNDTIMEO bounds each write(), but a slow-drip reader making a few bytes
+            // of progress per interval never trips it, so cap the total write time like readLine's deadline.
+            let deadline = DispatchTime.now() + .seconds(writeDeadlineSeconds)
             while offset < data.count {
+                if DispatchTime.now() > deadline { return }
                 let n = write(conn, base + offset, data.count - offset)
                 if n < 0 {
                     if errno == EINTR { continue } // retry an interrupted write

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -93,6 +93,11 @@ final class ControlServer {
     /// stalled client can't park the serial accept loop forever.
     nonisolated private static let readTimeoutSeconds = 5
 
+    /// Seconds a blocking response `write()` may stall before it times out, so a client that stops reading
+    /// can't park the serial accept loop — `session.text --all` responses can be multi-MB and won't fit
+    /// the socket buffer in one write, so an unresponsive reader would otherwise block indefinitely.
+    nonisolated private static let writeTimeoutSeconds = 5
+
     /// Overall seconds a single connection's request read may take before it's abandoned. `readTimeoutSeconds`
     /// only bounds each `read()`, so a slow-loris client trickling one byte per interval (each under the
     /// per-read timeout) never sends a newline yet keeps the serial accept loop busy indefinitely. This caps
@@ -220,6 +225,11 @@ final class ControlServer {
         // timed-out read returns EAGAIN, which readLine treats as a read error and closes the connection.
         var readTimeout = timeval(tv_sec: readTimeoutSeconds, tv_usec: 0)
         setsockopt(conn, SOL_SOCKET, SO_RCVTIMEO, &readTimeout, socklen_t(MemoryLayout<timeval>.size))
+
+        // bound the blocking response write too — a large `session.text --all` reply may not fit the socket
+        // buffer in one write, so a client that stopped reading would otherwise wedge the accept loop.
+        var writeTimeout = timeval(tv_sec: writeTimeoutSeconds, tv_usec: 0)
+        setsockopt(conn, SOL_SOCKET, SO_SNDTIMEO, &writeTimeout, socklen_t(MemoryLayout<timeval>.size))
 
         guard let line = readLine(conn) else {
             writeResponse(conn, ControlResponse(ok: false, error: "request too large or read failed"))
@@ -462,6 +472,9 @@ final class ControlServer {
             return setBackground(request.target, request.args)
         case .sessionCopy:
             return copySelection(request.target, window: request.args?.window)
+        case .sessionText:
+            return readText(request.target, window: request.args?.window, pane: request.args?.pane,
+                            all: request.args?.all ?? false, lines: request.args?.lines)
         case .sessionSearch:
             // resolve first (cross-window when no `args.window`), then select + realize the surface; the
             // realize path is async (bounded poll), so this can't go through the synchronous
@@ -1061,6 +1074,53 @@ final class ControlServer {
         }
     }
 
+    /// Returns a pane's terminal buffer as plain text: the visible screen by default, the full screen plus
+    /// scrollback with `all`, or the last `lines` lines (reads the screen, then trims). `pane` picks the
+    /// surface (`left` main, `right` split, or the on-screen pane when omitted); `right` errors when the
+    /// session has no split. `all` and `lines` are mutually exclusive and `lines` must be > 0 — validated
+    /// here too, not only in the CLI `validate()`, so a raw socket client can't bypass it (an unchecked
+    /// `lines <= 0` would silently fall through to the full buffer). A genuinely blank screen reads ok with
+    /// an empty string; a failed surface read is an error, not a silent empty.
+    private func readText(_ target: String?, window: String?, pane: String?,
+                          all: Bool, lines: Int?) -> ControlResponse {
+        if all, lines != nil {
+            return ControlResponse(ok: false, error: "use either --all or --lines, not both")
+        }
+        if let lines, lines <= 0 {
+            return ControlResponse(ok: false, error: "--lines must be greater than 0")
+        }
+        return resolveSession(target, window: window) { store, id in
+            // resolveSession already resolved `id` from this store, so `session(withID:)` is non-nil.
+            guard let session = store.session(withID: id) else {
+                return ControlResponse(ok: false, error: "session not realized")
+            }
+            let chosen: (any TerminalSurface)?
+            switch pane {
+            case nil:
+                // omitted = the surface ON SCREEN (scratch-aware), the SAME `Session.onScreenSurface`
+                // resolution `session.search` uses, so a no-`--pane` read returns what's visible, not a
+                // pane hidden under the scratch.
+                chosen = session.onScreenSurface
+            case "left": chosen = session.surface
+            case "right":
+                guard let split = session.splitSurface else {
+                    return ControlResponse(ok: false, error: "session has no split pane")
+                }
+                chosen = split
+            // an unknown pane value errors here; `session.text` accepts left|right only, with no `other`
+            // toggle like `session.focus`.
+            case .some(let value): return ControlResponse(ok: false, error: "invalid pane: \(value)")
+            }
+            guard let surface = chosen as? GhosttySurfaceView else {
+                return ControlResponse(ok: false, error: "session not realized")
+            }
+            guard let text = surface.readScreenText(all: all, lines: lines) else {
+                return ControlResponse(ok: false, error: "failed to read surface buffer")
+            }
+            return ControlResponse(ok: true, result: ControlResult(text: text))
+        }
+    }
+
     /// Drive in-terminal search on the session `id`, mirroring the GUI bar and the
     /// `session.type`/floating-overlay arms. On the `close` path it drives the session's pinned
     /// `searchSurface` WITHOUT selecting (so closing a background session's bar never yanks the user's
@@ -1098,14 +1158,14 @@ final class ControlServer {
         // overlay) wins, mirroring AppActions.searchTarget(), else the focused pane; the factory pins it as
         // `searchSurface`, and once open needle/navigate target the pinned owner so they can't drift.
         store.selectSession(id)
-        // a covering scratch is searchable and sits above the pane, so drive it, not the hidden pane beneath.
-        let coverIsScratch = session.scratchActive && !session.overlayActive
-        var openSurface = (coverIsScratch ? session.topmostSurface : session.activeSurface) as? GhosttySurfaceView
+        // a covering scratch is searchable and sits above the pane, so drive it, not the hidden pane beneath
+        // (`onScreenSurface` is the shared pane-vs-scratch resolution, also used by `session.text`).
+        var openSurface = session.onScreenSurface as? GhosttySurfaceView
         if openSurface == nil {
             // a never-shown session realizes a beat after select — bounded poll like `injectText`.
             for _ in 0..<12 {
                 try? await Task.sleep(nanoseconds: 30_000_000)
-                if let realized = (coverIsScratch ? session.topmostSurface : session.activeSurface) as? GhosttySurfaceView {
+                if let realized = session.onScreenSurface as? GhosttySurfaceView {
                     openSurface = realized
                     break
                 }

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -388,6 +388,40 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         return String(decoding: UnsafeRawBufferPointer(start: ptr, count: Int(t.text_len)), as: UTF8.self)
     }
 
+    /// This surface's terminal buffer as plain text (the control channel's `session.text`). Returns nil only
+    /// on a FAILED read — the surface does not exist yet or `ghostty_surface_read_text` fails — so the caller
+    /// can distinguish that from a genuinely blank screen, which reads as an empty string. The region is the
+    /// visible screen by default, or the whole screen plus scrollback when `all` is true or `lines` is set;
+    /// `lines` keeps the last N CONTENT lines (trailing blank grid rows trimmed). Like `readSelection`, the
+    /// read ignores focus and the libghostty buffer is copied into a Swift `String` and freed before
+    /// returning. UTF-8 only: `ghostty_surface_read_text` carries no per-cell color or SGR. Covered by the
+    /// `session.text` XCUITest e2e rather than a unit test, since the call needs a live surface.
+    func readScreenText(all: Bool, lines: Int?) -> String? {
+        guard let surface else { return nil }
+        // A zero-init ghostty_point_s is GHOSTTY_POINT_ACTIVE / GHOSTTY_POINT_COORD_EXACT (both enum 0),
+        // not viewport/top-left, so set tag and coord on both endpoints.
+        let tag = (all || lines != nil) ? GHOSTTY_POINT_SCREEN : GHOSTTY_POINT_VIEWPORT
+        var sel = ghostty_selection_s()
+        sel.top_left = ghostty_point_s(tag: tag, coord: GHOSTTY_POINT_COORD_TOP_LEFT, x: 0, y: 0)
+        sel.bottom_right = ghostty_point_s(tag: tag, coord: GHOSTTY_POINT_COORD_BOTTOM_RIGHT, x: 0, y: 0)
+        sel.rectangle = false
+        var t = ghostty_text_s()
+        guard ghostty_surface_read_text(surface, sel, &t) else { return nil }
+        defer { ghostty_surface_free_text(surface, &t) }
+        // A successful read of a blank screen yields no bytes — that is an empty string, NOT a failure
+        // (nil is reserved for the guards above so `readText` can report a real read failure as an error).
+        guard let ptr = t.text, t.text_len > 0 else { return "" }
+        let full = String(decoding: UnsafeRawBufferPointer(start: ptr, count: Int(t.text_len)), as: UTF8.self)
+        guard let n = lines, n > 0 else { return full }
+        // Drop trailing blank/whitespace-only rows (the unused grid below a short screen) so `--lines N`
+        // returns the last N CONTENT lines instead of blank padding, then keep the last N.
+        var rows = full.components(separatedBy: "\n")
+        while let last = rows.last, last.trimmingCharacters(in: .whitespaces).isEmpty {
+            rows.removeLast()
+        }
+        return rows.suffix(n).joined(separator: "\n")
+    }
+
     /// This surface's foreground process pid (libghostty `ghostty_surface_foreground_pid`), or nil when
     /// the surface has not been created or the call returns 0. Read at quit by the restore-running-command
     /// capture (`ForegroundProcess.command(for:shellBasename:)`); not focus-dependent, like `readSelection`.

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -14,7 +14,7 @@ description: >
   feature request / question as a GitHub Discussion.
 when_to_use: >
   Trigger on: agterm, agtermctl, agterm control socket, session.new, session.close, session.type,
-  session.split, session.scratch, session.focus, session.resize, session.go, session.copy, session.search, session.status,
+  session.split, session.scratch, session.focus, session.resize, session.go, session.copy, session.text, session.search, session.status,
   session.flag, session.background, session.overlay, workspace.new, workspace.select, workspace.move, workspace.focus, window.new, window.list,
   window.select, window.resize, window.move, window.zoom, quick terminal, sidebar, sidebar.mode, sidebar.expand, sidebar.collapse, flagged, notify, font.inc, keymap.reload, config.reload,
   theme.set, theme.list, select theme, edit keymap, show an image, display an image inline, show-image,
@@ -88,7 +88,7 @@ a global `--window <id|prefix|active>` to operate on a specific window's tree (d
 
 Scripts rarely type ids: create with `*.new` (capture the returned id), or act on `active`.
 
-## Command summary (49 commands)
+## Command summary (50 commands)
 
 Run `agtermctl <area> <cmd> --help` for exact flags. Full detail in **reference.md**; recipes in
 **examples.md**.
@@ -113,6 +113,8 @@ spec set via `session background`, omitted when none — the read side of set/cl
 - `move <workspace>` (relocate) or `move --to up|down|top|bottom` (reorder within the workspace).
 - `type <text> [--stdin] [--select]` — inject keystrokes (real typing, Enter included).
 - `copy` — print the session's selected text (does NOT touch the system clipboard).
+- `text [--all] [--lines N] [--pane left|right]` — print the session buffer as plain text. Default is
+  the visible screen of the focused pane; `--all` adds scrollback; `--lines N` keeps the last N lines.
 - `search [needle] [--next|--prev|--close]` — search the terminal scrollback; prints the "N of M" counter.
 - `split [on|off|toggle]` — side-by-side second shell (hide keeps it alive).
 - `scratch [on|off|toggle] [--command CMD]` — full-coverage third shell (hide keeps it alive; `exit`

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -216,6 +216,20 @@ sel=$(agtermctl session copy --json | jq -r '.result.text')
 agtermctl session type "$sel" --target "$other"
 ```
 
+## Read a session's buffer as text
+
+`session text` returns the terminal buffer as plain text in `result.text` — the visible screen by
+default, the whole scrollback with `--all`, or the last N lines with `--lines N`. Pipe it into
+`grep`/`fzf` to extract URLs, paths, etc.
+
+```bash
+agtermctl session text                         # the visible screen of the focused pane
+agtermctl session text --lines 50              # the last 50 lines of the buffer
+agtermctl session text --pane right            # the split pane (errors if there is no split)
+# extract every URL from the full scrollback:
+agtermctl session text --all --json | jq -r '.result.text' | grep -oE 'https?://[^ ]+'
+```
+
 ## Search the terminal scrollback
 
 `session search` opens a search bar over the focused terminal and highlights matches in the live

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -12,7 +12,7 @@ Full detail for every `agtermctl` command. See `SKILL.md` for the model and addr
 - **`--json`**: prints the raw response object. Without it, mutations print `ok` and `tree`/`window
   list` print a human listing. Use `--json` when you need to read ids or values back.
 - **Response shape**: `{"ok": true, "result": {…}}` or `{"ok": false, "error": "<message>"}`.
-  `result` carries one of: `id` (affected/new session/workspace/window), `text` (session copy),
+  `result` carries one of: `id` (affected/new session/workspace/window), `text` (session copy/text),
   `exitCode` (overlay result), `count` (keymap diagnostics), `tree` (the tree), `windows` (window
   list). The process exit code is non-zero when `ok` is false.
 - **Options go after the subcommand**: `agtermctl session type "ls" --target active`, never before it.
@@ -95,6 +95,17 @@ position?, repeats?}` object — omitted when no watermark is set). Workspace no
 - `session copy [--target] [--window W]` — returns `result.text` with the session's current selection.
   Does NOT touch the system clipboard (pipe the returned text into another `session type`). No/empty
   selection → `no selection` error. Selection is readable on any realized session regardless of focus.
+- `session text [--all] [--lines N] [--pane left|right] [--target] [--window W]` — returns `result.text`
+  with the session's terminal buffer as PLAIN TEXT (no ANSI/color). By default it reads the VISIBLE
+  SCREEN of the on-screen pane. `--all` reads the whole buffer including scrollback; `--lines N` reads the
+  full buffer and keeps only the last N CONTENT lines (trailing blank rows trimmed; `--all` and `--lines`
+  are mutually exclusive and `--lines` must be > 0 — enforced server-side too). `--pane left` reads the
+  main pane, `--pane right` the split pane (errors if the session has no split); omit `--pane` for the
+  visible pane (the scratch terminal when it covers the session, else the focused pane). NOTE: unlike
+  `session focus`, `--pane` here has NO `other` value — only `left`/`right`. A genuinely BLANK screen is
+  NOT an error (returns `ok` with an empty string, unlike `session copy`'s `no selection`), but a failed
+  read IS an error (`failed to read surface buffer`). Pipe the text into `grep`/`fzf` to extract URLs,
+  paths, etc.
 - `session search [needle] [--next|--prev|--close] [--target] [--window W]` — search the target
   session's live terminal scrollback. Selects the target first (so the search bar and match highlights
   render). With a `needle` it sets the query (opening the bar if needed) and highlights matches; with no

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -26,6 +26,7 @@ public enum Command: String, Codable, Sendable {
     case sessionFocus = "session.focus"
     case sessionResize = "session.resize"
     case sessionCopy = "session.copy"
+    case sessionText = "session.text"
     case sessionSearch = "session.search"
     case sessionOverlayOpen = "session.overlay.open"
     case sessionOverlayClose = "session.overlay.close"
@@ -94,7 +95,8 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     public var position: String?
     /// The `background-image-repeat` flag for `session.background`; nil = false.
     public var repeats: Bool?
-    /// Which split pane to focus for `session.focus` (`left`|`right`|`other`; `other` toggles).
+    /// Which split pane to focus for `session.focus` (`left`|`right`|`other`; `other` toggles); also
+    /// which pane to read for `session.text` (`left`|`right`; omitted = the focused pane, no `other`).
     public var pane: String?
     /// Absolute left-pane split fraction (0...1) for `session.resize`, clamped server-side to
     /// `AppStore.splitRatioMin...splitRatioMax`. Mutually exclusive with `ratioDelta`.
@@ -103,6 +105,10 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     /// pane, negative grows the right (the CLI's `--grow-left`/`--grow-right`). Applied to the session's
     /// current fraction (0.5 when never moved). Mutually exclusive with `ratio`.
     public var ratioDelta: Double?
+    /// For `session.text`: read the full screen + scrollback instead of just the visible screen.
+    public var all: Bool?
+    /// For `session.text`: keep only the last N lines of the full buffer.
+    public var lines: Int?
     /// Direction for `session.go` (`next`|`prev`|`previous`|`first`|`last`), for the reorder form of
     /// `session.move` / `workspace.move` (`up`|`down`|`top`|`bottom`), and for `session.search`
     /// (`next`|`prev`|`close`).
@@ -151,7 +157,7 @@ public struct ControlArgs: Codable, Sendable, Equatable {
                 status: String? = nil, blink: Bool? = nil, autoReset: Bool? = nil, sound: String? = nil,
                 ratio: Double? = nil, ratioDelta: Double? = nil,
                 path: String? = nil, color: String? = nil, opacity: Double? = nil, fit: String? = nil,
-                position: String? = nil, repeats: Bool? = nil) {
+                position: String? = nil, repeats: Bool? = nil, all: Bool? = nil, lines: Int? = nil) {
         self.name = name
         self.cwd = cwd
         self.workspace = workspace
@@ -185,6 +191,8 @@ public struct ControlArgs: Codable, Sendable, Equatable {
         self.fit = fit
         self.position = position
         self.repeats = repeats
+        self.all = all
+        self.lines = lines
     }
 }
 

--- a/agtermCore/Sources/agtermCore/Session.swift
+++ b/agtermCore/Sources/agtermCore/Session.swift
@@ -288,6 +288,15 @@ public final class Session: Identifiable {
         return activeSurface
     }
 
+    /// The pane-or-scratch surface that is actually ON SCREEN: the scratch terminal when it covers the
+    /// panes (and no overlay is up), else the focused pane. The control arms that act on "what's visible"
+    /// — `session.text` with no `--pane` and `session.search` — resolve through this so they hit the
+    /// scratch rather than a pane hidden beneath it (an active overlay routes to its own surface via
+    /// `topmostSurface`; this stays the pane-vs-scratch choice those arms share, matching `searchTarget`).
+    public var onScreenSurface: (any TerminalSurface)? {
+        scratchActive && !overlayActive ? topmostSurface : activeSurface
+    }
+
     /// The match counter shown in the search bar and returned by `session.search`: empty before a
     /// query runs (`searchTotal` nil), `"no matches"` at zero, `"N matches"` while none is selected,
     /// and `"S of N"` once a match is selected. `selected` is clamped to `total` so a stale selected

--- a/agtermCore/Sources/agtermctlKit/Commands.swift
+++ b/agtermCore/Sources/agtermctlKit/Commands.swift
@@ -206,7 +206,7 @@ struct Session: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Session commands.",
         subcommands: [New.self, Close.self, Select.self, Go.self, Rename.self, Move.self, TypeText.self,
-                      Split.self, Scratch.self, Focus.self, Resize.self, Copy.self, Status.self, FlagCommand.self,
+                      Split.self, Scratch.self, Focus.self, Resize.self, Copy.self, Text.self, Status.self, FlagCommand.self,
                       Search.self, Background.self, Overlay.self]
     )
 
@@ -404,6 +404,32 @@ struct Session: ParsableCommand {
 
         func makeRequest() throws -> ControlRequest {
             ControlRequest(cmd: .sessionCopy, target: target.target, args: options.withWindow())
+        }
+    }
+
+    struct Text: RequestCommand {
+        static let configuration = CommandConfiguration(abstract: "Print a session's terminal buffer as plain text (does not touch the system clipboard).")
+        @Flag(name: .long, help: "Read the full screen + scrollback instead of just the visible screen.") var all = false
+        @Option(name: .long, help: "Keep only the last N lines of the full buffer.") var lines: Int?
+        @Option(name: .long, help: "Which pane to read: left (main) or right (split). Defaults to the focused pane.") var pane: String?
+        @OptionGroup var target: TargetOptions
+        @OptionGroup var options: ClientOptions
+
+        func validate() throws {
+            if all, lines != nil {
+                throw ValidationError("use either --all or --lines, not both")
+            }
+            if let lines, lines <= 0 {
+                throw ValidationError("--lines must be greater than 0")
+            }
+            if let pane, !["left", "right"].contains(pane) {
+                throw ValidationError("--pane must be left or right")
+            }
+        }
+
+        func makeRequest() throws -> ControlRequest {
+            ControlRequest(cmd: .sessionText, target: target.target,
+                           args: options.withWindow(ControlArgs(pane: pane, all: all ? true : nil, lines: lines)))
         }
     }
 

--- a/agtermCore/Sources/agtermctlKit/SocketClient.swift
+++ b/agtermCore/Sources/agtermctlKit/SocketClient.swift
@@ -14,8 +14,10 @@ struct SocketClientError: Error, CustomStringConvertible {
 struct SocketClient {
     let path: String
 
-    /// 1 MiB cap on a response line, mirroring the server's request cap.
-    private static let maxLineBytes = 1 << 20
+    /// 64 MiB cap on a response line. Requests stay small; a `session.text --all` response carries the
+    /// whole scrollback and can reach several MiB. It comes from our own server, so the cap only guards
+    /// against a runaway read (ghostty scrollback tops out near 10 MiB).
+    private static let maxLineBytes = 64 << 20
 
     /// Connect, send `request` as one newline-terminated JSON line, read the response line, decode it.
     func send(_ request: ControlRequest) throws -> ControlResponse {
@@ -82,16 +84,20 @@ struct SocketClient {
     }
 
     /// Read up to (and excluding) the first newline, capping at `maxLineBytes`. Returns nil on
-    /// EOF-before-newline, error, or cap exceeded.
+    /// EOF-before-newline, error, or cap exceeded. Reads in 64 KiB chunks so a multi-MB
+    /// `session.text --all` response takes a handful of syscalls instead of one per byte.
     private static func readLine(_ fd: Int32) -> Data? {
         var buffer = Data()
-        var byte: UInt8 = 0
+        var chunk = [UInt8](repeating: 0, count: 64 * 1024)
         while true {
-            let n = read(fd, &byte, 1)
+            let n = chunk.withUnsafeMutableBytes { read(fd, $0.baseAddress, $0.count) }
             if n == 0 { return buffer.isEmpty ? nil : buffer }
             if n < 0 { return nil }
-            if byte == UInt8(ascii: "\n") { return buffer }
-            buffer.append(byte)
+            if let idx = chunk[0..<n].firstIndex(of: UInt8(ascii: "\n")) {
+                buffer.append(contentsOf: chunk[0..<idx])
+                return buffer
+            }
+            buffer.append(contentsOf: chunk[0..<n])
             if buffer.count > maxLineBytes { return nil }
         }
     }

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -52,6 +52,26 @@ struct ControlProtocolTests {
         }
     }
 
+    @Test func sessionTextRoundTripsWithAllLinesAndPane() throws {
+        let request = ControlRequest(cmd: .sessionText, target: "9f3c",
+                                     args: ControlArgs(pane: "left", all: true, lines: 50))
+        let decoded = try roundTrip(request)
+        #expect(decoded == request)
+        #expect(decoded.cmd == .sessionText)
+        #expect(decoded.args?.all == true)
+        #expect(decoded.args?.lines == 50)
+        #expect(decoded.args?.pane == "left")
+    }
+
+    @Test func sessionTextBareRoundTrips() throws {
+        let request = ControlRequest(cmd: .sessionText)
+        let decoded = try roundTrip(request)
+        #expect(decoded == request)
+        #expect(decoded.args?.all == nil)
+        #expect(decoded.args?.lines == nil)
+        #expect(decoded.args?.pane == nil)
+    }
+
     @Test func sessionTypeWithSelectRoundTrips() throws {
         let request = ControlRequest(cmd: .sessionType, target: "9f3c", args: ControlArgs(text: "ls\n", select: true))
         #expect(try roundTrip(request) == request)

--- a/agtermCore/Tests/agtermCoreTests/SessionTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SessionTests.swift
@@ -354,6 +354,30 @@ struct SessionTests {
         session.scratchActive = false
         #expect(session.topmostSurface === primary)
     }
+
+    @Test func onScreenSurfaceIsCoveringScratchElseFocusedPane() {
+        // the "what's visible" surface for session.text (no --pane) / session.search: the scratch when it
+        // covers the panes (and no overlay is up), else the FOCUSED pane. An overlay falls back to the pane
+        // (search/text don't target the ephemeral overlay), matching AppActions.searchTarget.
+        let session = Session(initialCwd: "/repo")
+        let primary = FakeSurface(), split = FakeSurface(), scratch = FakeSurface(), overlay = FakeSurface()
+        session.surface = primary
+        session.splitSurface = split
+        session.scratchSurface = scratch
+        session.overlaySurface = overlay
+        // no cover, no split focus: the primary pane.
+        #expect(session.onScreenSurface === primary)
+        // split focused: the focused split pane, not the primary.
+        session.splitFocused = true
+        #expect(session.onScreenSurface === split)
+        session.splitFocused = false
+        // scratch shown (no overlay): the scratch is what's on screen.
+        session.scratchActive = true
+        #expect(session.onScreenSurface === scratch)
+        // an overlay over the scratch falls back to the pane beneath, not the scratch or the overlay.
+        session.overlayActive = true
+        #expect(session.onScreenSurface === primary)
+    }
 }
 
 private final class FakeSurface: TerminalSurface {

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -247,6 +247,40 @@ struct CommandsTests {
         #expect(try request(["session", "copy", "--target", "9f3c"]) == ControlRequest(cmd: .sessionCopy, target: "9f3c"))
     }
 
+    @Test func sessionTextDefaultsActive() throws {
+        // bare `session text` reads the visible screen of the focused pane (no args beyond the base bag).
+        #expect(try request(["session", "text"]) == ControlRequest(cmd: .sessionText, target: "active", args: ControlArgs()))
+    }
+
+    @Test func sessionTextWithAll() throws {
+        let expected = ControlRequest(cmd: .sessionText, target: "active", args: ControlArgs(all: true))
+        #expect(try request(["session", "text", "--all"]) == expected)
+    }
+
+    @Test func sessionTextWithLines() throws {
+        let expected = ControlRequest(cmd: .sessionText, target: "active", args: ControlArgs(lines: 50))
+        #expect(try request(["session", "text", "--lines", "50"]) == expected)
+    }
+
+    @Test func sessionTextWithPaneAndTarget() throws {
+        let expected = ControlRequest(cmd: .sessionText, target: "9f3c", args: ControlArgs(pane: "right"))
+        #expect(try request(["session", "text", "--pane", "right", "--target", "9f3c"]) == expected)
+    }
+
+    @Test func sessionTextRejectsAllWithLines() {
+        #expect(validationMessage(["session", "text", "--all", "--lines", "10"]) == "use either --all or --lines, not both")
+    }
+
+    @Test func sessionTextRejectsZeroLines() {
+        // a negative --lines (`-5`) is intercepted by ArgumentParser as a flag before validate() runs, so
+        // 0 is the CLI-reachable non-positive case the validation guards against.
+        #expect(validationMessage(["session", "text", "--lines", "0"]) == "--lines must be greater than 0")
+    }
+
+    @Test func sessionTextRejectsBadPane() {
+        #expect(validationMessage(["session", "text", "--pane", "other"]) == "--pane must be left or right")
+    }
+
     @Test func sessionStatusWithBlink() throws {
         let req = try request(["session", "status", "active", "--blink"])
         #expect(req.cmd == .sessionStatus)

--- a/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
@@ -39,6 +39,21 @@ struct SocketClientTests {
         #expect(response.error == "cannot delete last workspace")
     }
 
+    /// A `session.text --all` response can exceed the old 1 MiB cap (full scrollback). A >1 MiB text
+    /// payload must round-trip intact, not fail with "no response".
+    @Test func roundTripLargeResponse() throws {
+        let big = String(repeating: "scrollback line\n", count: 200_000) // ~3 MiB, well over 1 MiB
+        let server = StubServer(response: ControlResponse(ok: true, result: ControlResult(text: big)))
+        try server.start()
+        defer { server.stop() }
+
+        let client = SocketClient(path: server.path)
+        let response = try client.send(ControlRequest(cmd: .sessionText, target: "active"))
+
+        #expect(response.ok)
+        #expect(response.result?.text == big)
+    }
+
     @Test func connectFailureToMissingSocketThrows() {
         let client = SocketClient(path: NSTemporaryDirectory() + "agterm-missing-\(UUID().uuidString.prefix(8)).sock")
         #expect(throws: SocketClientError.self) { try client.send(ControlRequest(cmd: .tree)) }

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -7,7 +7,7 @@ import XCTest
 /// assert against the response and the `workspaces.json` file-polling oracle the sidebar tests use.
 @MainActor
 final class ControlAPIUITests: XCTestCase {
-    private var app: XCUIApplication!
+    var app: XCUIApplication!
     private var stateDir: URL!
     private var socketPath: String!
     private var markerDir: URL!
@@ -474,164 +474,6 @@ final class ControlAPIUITests: XCTestCase {
         let response = try sendCommand(#"{"cmd":"session.copy","target":"\#(newID)"}"#)
         XCTAssertEqual(response["ok"] as? Bool, false, "copy with no selection should fail: \(response)")
         XCTAssertEqual(response["error"] as? String, "no selection", "should report no selection: \(response)")
-    }
-
-    // session.text returns the session's terminal buffer in result.text. Type a command whose OUTPUT (not
-    // the echoed command line) is a unique marker — `echo <tag>-$((6*7))` prints `<tag>-42`, a string the
-    // typed line itself does NOT contain (it has `$((6*7))`) — so a match proves command output was
-    // captured, not merely the typed input echoed back. Poll until the rendered output lands (async).
-    func testSessionTextReturnsBuffer() throws {
-        let created = try sendCommand(#"{"cmd":"session.new"}"#)
-        let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
-        let newID = try XCTUnwrap(result["id"] as? String, "session.new should return the new id")
-
-        let tag = "AGTERM-TEXT-\(UUID().uuidString.prefix(8))"
-        let output = "\(tag)-42" // the shell evaluates $((6*7)); this string is absent from the typed line
-        let typed = try sendCommand(typeRequest(text: "echo \(tag)-$((6*7))\n", target: newID, select: true))
-        XCTAssertEqual(typed["ok"] as? Bool, true, "session.type should succeed: \(typed)")
-
-        var text: String?
-        for _ in 0..<40 {
-            let response = try sendCommand(#"{"cmd":"session.text","target":"\#(newID)"}"#)
-            XCTAssertEqual(response["ok"] as? Bool, true, "session.text should succeed: \(response)")
-            if let t = (response["result"] as? [String: Any])?["text"] as? String, t.contains(output) {
-                text = t
-                break
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
-        }
-        XCTAssertNotNil(text, "session.text should return a buffer containing the command OUTPUT \(output)")
-    }
-
-    // session.text --lines N keeps only the LAST N lines of the full buffer (the GhosttySurfaceView trim:
-    // strip one trailing newline, split on \n, suffix(N)). Print 50 distinctly-tagged numbered lines, then
-    // read --lines 5: assert exactly 5 lines come back, the LAST printed line (tag-50) is present, and an
-    // EARLY line (tag-1) is NOT — proving the suffix trim, which no other test exercises.
-    func testSessionTextLinesReturnsLastN() throws {
-        let created = try sendCommand(#"{"cmd":"session.new"}"#)
-        let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
-        let newID = try XCTUnwrap(result["id"] as? String, "session.new should return the new id")
-
-        // printf repeats its format over the seq args → tag-1-X, tag-2-X, … tag-50-X, each on its own line.
-        let tag = "LN-\(UUID().uuidString.prefix(8))"
-        let typed = try sendCommand(typeRequest(text: "printf '\(tag)-%s-X\\n' $(seq 1 50)\n", target: newID, select: true))
-        XCTAssertEqual(typed["ok"] as? Bool, true, "session.type should succeed: \(typed)")
-
-        var text: String?
-        for _ in 0..<40 {
-            let response = try sendCommand(#"{"cmd":"session.text","target":"\#(newID)","args":{"lines":5}}"#)
-            XCTAssertEqual(response["ok"] as? Bool, true, "session.text --lines 5 should succeed: \(response)")
-            if let t = (response["result"] as? [String: Any])?["text"] as? String, t.contains("\(tag)-50-X") {
-                text = t
-                break
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
-        }
-        let t = try XCTUnwrap(text, "--lines 5 should eventually contain the last printed line \(tag)-50-X")
-        XCTAssertEqual(t.components(separatedBy: "\n").count, 5, "--lines 5 should return exactly 5 lines: \(t)")
-        XCTAssertTrue(t.contains("\(tag)-50-X"), "the last printed line should be within the last 5: \(t)")
-        XCTAssertFalse(t.contains("\(tag)-1-X"), "an early line must be trimmed away by --lines 5: \(t)")
-    }
-
-    // session.text --all reads the whole SCREEN (visible + scrollback); the default read is the VIEWPORT
-    // only. Print far more lines than fit on screen, then assert --all returns an EARLY line that scrolled
-    // out of the viewport while the default read does NOT — a swapped VIEWPORT/SCREEN region would fail this
-    // (the default read is never otherwise distinguished from --all over the socket).
-    func testSessionTextAllIncludesScrollback() throws {
-        let created = try sendCommand(#"{"cmd":"session.new"}"#)
-        let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
-        let newID = try XCTUnwrap(result["id"] as? String, "session.new should return the new id")
-
-        // 400 lines far exceed any viewport, so tag-1-X is guaranteed to scroll out of the visible screen.
-        let tag = "SCR-\(UUID().uuidString.prefix(8))"
-        let typed = try sendCommand(typeRequest(text: "printf '\(tag)-%s-X\\n' $(seq 1 400)\n", target: newID, select: true))
-        XCTAssertEqual(typed["ok"] as? Bool, true, "session.type should succeed: \(typed)")
-
-        // poll --all until the last printed line lands (proves the output fully rendered to scrollback).
-        var allText: String?
-        for _ in 0..<60 {
-            let response = try sendCommand(#"{"cmd":"session.text","target":"\#(newID)","args":{"all":true}}"#)
-            XCTAssertEqual(response["ok"] as? Bool, true, "session.text --all should succeed: \(response)")
-            if let t = (response["result"] as? [String: Any])?["text"] as? String, t.contains("\(tag)-400-X") {
-                allText = t
-                break
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
-        }
-        let all = try XCTUnwrap(allText, "--all should eventually contain the last printed line \(tag)-400-X")
-        XCTAssertTrue(all.contains("\(tag)-1-X"), "--all (SCREEN) should include the early scrolled-out line: head of \(all.prefix(200))")
-
-        let viewportResp = try sendCommand(#"{"cmd":"session.text","target":"\#(newID)"}"#)
-        XCTAssertEqual(viewportResp["ok"] as? Bool, true, "session.text (viewport) should succeed: \(viewportResp)")
-        let viewport = try XCTUnwrap((viewportResp["result"] as? [String: Any])?["text"] as? String, "viewport read should carry text")
-        XCTAssertFalse(viewport.contains("\(tag)-1-X"), "the default (VIEWPORT) read must NOT include the scrolled-out line \(tag)-1-X")
-        XCTAssertTrue(viewport.contains("\(tag)-400-X"), "the default (VIEWPORT) read should still show the most recent line")
-    }
-
-    // session.text --pane left|right reads the matching pane of a split. session.type is main-only (it always
-    // injects into session.surface), so the LEFT marker goes in over the socket; the RIGHT pane is fed via
-    // the real keyboard after focusing it. Assert each pane read returns its OWN marker and NOT the other's —
-    // the --pane success mappings (left→surface, right→splitSurface) are otherwise only hit on the error path.
-    func testSessionTextPaneSelectsCorrectPane() throws {
-        let split = try sendCommand(#"{"cmd":"session.split","target":"active","args":{"mode":"on"}}"#)
-        XCTAssertEqual(split["ok"] as? Bool, true, "split on should succeed: \(split)")
-        XCTAssertTrue(pollActiveSessionSplit(true, timeout: 10), "the active session should report split:true")
-        let activeID = try activeSessionID()
-
-        // LEFT (main) pane: session.type injects into session.surface (main-only by design), so this marker
-        // lands in the left pane regardless of which pane holds focus.
-        let leftMarker = "LEFT-\(UUID().uuidString.prefix(8))"
-        XCTAssertNotNil(try pollPaneText(target: activeID, pane: "left", contains: leftMarker, retype: {
-            _ = try self.sendCommand(self.typeRequest(text: "echo \(leftMarker)\n", target: activeID, select: false))
-        }), "--pane left should read the marker typed into the main pane")
-
-        // RIGHT (split) pane: session.type can't reach it, so focus it and type via the real keyboard, which
-        // routes to the focused pane's first responder.
-        let rightMarker = "RIGHT-\(UUID().uuidString.prefix(8))"
-        XCTAssertEqual(try sendCommand(#"{"cmd":"session.focus","target":"\#(activeID)","args":{"pane":"right"}}"#)["ok"] as? Bool,
-                       true, "focus right should succeed")
-        app.activate()
-        XCTAssertNotNil(try pollPaneText(target: activeID, pane: "right", contains: rightMarker, retype: {
-            self.app.typeText("echo \(rightMarker)")
-            self.app.typeKey(.return, modifierFlags: [])
-        }), "--pane right should read the marker typed into the split pane")
-
-        // cross-check: each pane read carries ONLY its own marker (the two reads hit different surfaces).
-        let leftText = try XCTUnwrap((try sendCommand(#"{"cmd":"session.text","target":"\#(activeID)","args":{"pane":"left"}}"#)["result"] as? [String: Any])?["text"] as? String)
-        let rightText = try XCTUnwrap((try sendCommand(#"{"cmd":"session.text","target":"\#(activeID)","args":{"pane":"right"}}"#)["result"] as? [String: Any])?["text"] as? String)
-        XCTAssertTrue(leftText.contains(leftMarker), "--pane left should contain the left marker: \(leftText)")
-        XCTAssertFalse(leftText.contains(rightMarker), "--pane left must NOT contain the right pane's marker: \(leftText)")
-        XCTAssertTrue(rightText.contains(rightMarker), "--pane right should contain the right marker: \(rightText)")
-        XCTAssertFalse(rightText.contains(leftMarker), "--pane right must NOT contain the left pane's marker: \(rightText)")
-    }
-
-    // session.text --pane right on a non-split session errors. `right` is a valid pane value so it passes
-    // the CLI validate() and the request reaches the server, which rejects it (no split pane to read).
-    func testSessionTextSplitPaneWithoutSplitErrors() throws {
-        let created = try sendCommand(#"{"cmd":"session.new"}"#)
-        let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
-        let newID = try XCTUnwrap(result["id"] as? String, "session.new should return the new id")
-
-        let response = try sendCommand(#"{"cmd":"session.text","target":"\#(newID)","args":{"pane":"right"}}"#)
-        XCTAssertEqual(response["ok"] as? Bool, false, "session.text --pane right with no split should fail: \(response)")
-        XCTAssertEqual(response["error"] as? String, "session has no split pane", "should report no split pane: \(response)")
-    }
-
-    // session.text arg validation is enforced SERVER-SIDE, not only in the CLI `validate()`: a raw socket
-    // client bypasses the CLI, so `lines <= 0` and `all` + `lines` together must error here too (an unchecked
-    // `lines: 0` would otherwise fall through to the full buffer). sendCommand speaks raw JSON, so it is the
-    // bypassing client.
-    func testSessionTextRejectsInvalidArgsServerSide() throws {
-        let zero = try sendCommand(#"{"cmd":"session.text","target":"active","args":{"lines":0}}"#)
-        XCTAssertEqual(zero["ok"] as? Bool, false, "session.text lines:0 should fail server-side: \(zero)")
-        XCTAssertEqual(zero["error"] as? String, "--lines must be greater than 0", "should report the lines bound: \(zero)")
-
-        let negative = try sendCommand(#"{"cmd":"session.text","target":"active","args":{"lines":-1}}"#)
-        XCTAssertEqual(negative["ok"] as? Bool, false, "session.text lines:-1 should fail server-side: \(negative)")
-
-        let both = try sendCommand(#"{"cmd":"session.text","target":"active","args":{"all":true,"lines":5}}"#)
-        XCTAssertEqual(both["ok"] as? Bool, false, "session.text all+lines should fail server-side: \(both)")
-        XCTAssertEqual(both["error"] as? String, "use either --all or --lines, not both", "should report mutual exclusion: \(both)")
     }
 
     // session.search over the active session's scrollback: seed the screen with repeated needle text via
@@ -1184,7 +1026,7 @@ final class ControlAPIUITests: XCTestCase {
     }
 
     /// The id of the seeded (active) session from the tree.
-    private func activeSessionID() throws -> String {
+    func activeSessionID() throws -> String {
         let tree = try sendCommand(#"{"cmd":"tree"}"#)
         let result = try XCTUnwrap(tree["result"] as? [String: Any], "tree should carry a result")
         let t = try XCTUnwrap(result["tree"] as? [String: Any], "result should carry a tree")
@@ -2524,7 +2366,7 @@ final class ControlAPIUITests: XCTestCase {
     }
 
     /// Build a `session.type` request line with JSON-escaped `text` (covers the newline and the quoted path).
-    private func typeRequest(text: String, target: String? = nil, select: Bool) -> String {
+    func typeRequest(text: String, target: String? = nil, select: Bool) -> String {
         var obj: [String: Any] = ["cmd": "session.type", "args": ["text": text, "select": select]]
         if let target { obj["target"] = target }
         let data = try! JSONSerialization.data(withJSONObject: obj)
@@ -2579,26 +2421,6 @@ final class ControlAPIUITests: XCTestCase {
         return nil
     }
 
-    /// Polls `session.text --pane <pane>` of `target` until the returned buffer contains `contains`, re-running
-    /// `retype` (which re-injects the marker command — idempotent for an `echo` line) at the start of each
-    /// outer attempt to ride out shell/focus readiness. Returns the matching text, or nil on timeout.
-    @discardableResult
-    private func pollPaneText(target: String, pane: String, contains: String,
-                              attempts: Int = 8, perAttempt: Int = 8,
-                              retype: () throws -> Void) throws -> String? {
-        for _ in 0..<attempts {
-            try retype()
-            for _ in 0..<perAttempt {
-                let response = try sendCommand(#"{"cmd":"session.text","target":"\#(target)","args":{"pane":"\#(pane)"}}"#)
-                if let t = (response["result"] as? [String: Any])?["text"] as? String, t.contains(contains) {
-                    return t
-                }
-                RunLoop.current.run(until: Date().addingTimeInterval(0.4))
-            }
-        }
-        return nil
-    }
-
     // MARK: - Snapshot oracle
 
     /// Polls the hermetic snapshot file until the (single) seeded workspace holds `expected` sessions.
@@ -2619,7 +2441,7 @@ final class ControlAPIUITests: XCTestCase {
 
     /// Polls the hermetic snapshot file until the (single seeded workspace's) first session's `isSplit`
     /// equals `expected`.
-    private func pollActiveSessionSplit(_ expected: Bool, timeout: TimeInterval) -> Bool {
+    func pollActiveSessionSplit(_ expected: Bool, timeout: TimeInterval) -> Bool {
         stateDir.pollSnapshot(equals: expected, timeout: timeout) { obj in
             guard let workspaces = obj["workspaces"] as? [[String: Any]],
                   let sessions = workspaces.first?["sessions"] as? [[String: Any]] else { return nil }
@@ -2756,7 +2578,7 @@ final class ControlAPIUITests: XCTestCase {
     /// Connect to the app's control socket, send `line` (newline-terminated), read the single response
     /// line, and parse it as JSON. Retries the connect briefly since the server's scene `.task` may bind a
     /// beat after the window appears.
-    private func sendCommand(_ line: String) throws -> [String: Any] {
+    func sendCommand(_ line: String) throws -> [String: Any] {
         let fd = try connect(to: socketPath)
         defer { close(fd) }
 

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -476,6 +476,164 @@ final class ControlAPIUITests: XCTestCase {
         XCTAssertEqual(response["error"] as? String, "no selection", "should report no selection: \(response)")
     }
 
+    // session.text returns the session's terminal buffer in result.text. Type a command whose OUTPUT (not
+    // the echoed command line) is a unique marker — `echo <tag>-$((6*7))` prints `<tag>-42`, a string the
+    // typed line itself does NOT contain (it has `$((6*7))`) — so a match proves command output was
+    // captured, not merely the typed input echoed back. Poll until the rendered output lands (async).
+    func testSessionTextReturnsBuffer() throws {
+        let created = try sendCommand(#"{"cmd":"session.new"}"#)
+        let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
+        let newID = try XCTUnwrap(result["id"] as? String, "session.new should return the new id")
+
+        let tag = "AGTERM-TEXT-\(UUID().uuidString.prefix(8))"
+        let output = "\(tag)-42" // the shell evaluates $((6*7)); this string is absent from the typed line
+        let typed = try sendCommand(typeRequest(text: "echo \(tag)-$((6*7))\n", target: newID, select: true))
+        XCTAssertEqual(typed["ok"] as? Bool, true, "session.type should succeed: \(typed)")
+
+        var text: String?
+        for _ in 0..<40 {
+            let response = try sendCommand(#"{"cmd":"session.text","target":"\#(newID)"}"#)
+            XCTAssertEqual(response["ok"] as? Bool, true, "session.text should succeed: \(response)")
+            if let t = (response["result"] as? [String: Any])?["text"] as? String, t.contains(output) {
+                text = t
+                break
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+        }
+        XCTAssertNotNil(text, "session.text should return a buffer containing the command OUTPUT \(output)")
+    }
+
+    // session.text --lines N keeps only the LAST N lines of the full buffer (the GhosttySurfaceView trim:
+    // strip one trailing newline, split on \n, suffix(N)). Print 50 distinctly-tagged numbered lines, then
+    // read --lines 5: assert exactly 5 lines come back, the LAST printed line (tag-50) is present, and an
+    // EARLY line (tag-1) is NOT — proving the suffix trim, which no other test exercises.
+    func testSessionTextLinesReturnsLastN() throws {
+        let created = try sendCommand(#"{"cmd":"session.new"}"#)
+        let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
+        let newID = try XCTUnwrap(result["id"] as? String, "session.new should return the new id")
+
+        // printf repeats its format over the seq args → tag-1-X, tag-2-X, … tag-50-X, each on its own line.
+        let tag = "LN-\(UUID().uuidString.prefix(8))"
+        let typed = try sendCommand(typeRequest(text: "printf '\(tag)-%s-X\\n' $(seq 1 50)\n", target: newID, select: true))
+        XCTAssertEqual(typed["ok"] as? Bool, true, "session.type should succeed: \(typed)")
+
+        var text: String?
+        for _ in 0..<40 {
+            let response = try sendCommand(#"{"cmd":"session.text","target":"\#(newID)","args":{"lines":5}}"#)
+            XCTAssertEqual(response["ok"] as? Bool, true, "session.text --lines 5 should succeed: \(response)")
+            if let t = (response["result"] as? [String: Any])?["text"] as? String, t.contains("\(tag)-50-X") {
+                text = t
+                break
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+        }
+        let t = try XCTUnwrap(text, "--lines 5 should eventually contain the last printed line \(tag)-50-X")
+        XCTAssertEqual(t.components(separatedBy: "\n").count, 5, "--lines 5 should return exactly 5 lines: \(t)")
+        XCTAssertTrue(t.contains("\(tag)-50-X"), "the last printed line should be within the last 5: \(t)")
+        XCTAssertFalse(t.contains("\(tag)-1-X"), "an early line must be trimmed away by --lines 5: \(t)")
+    }
+
+    // session.text --all reads the whole SCREEN (visible + scrollback); the default read is the VIEWPORT
+    // only. Print far more lines than fit on screen, then assert --all returns an EARLY line that scrolled
+    // out of the viewport while the default read does NOT — a swapped VIEWPORT/SCREEN region would fail this
+    // (the default read is never otherwise distinguished from --all over the socket).
+    func testSessionTextAllIncludesScrollback() throws {
+        let created = try sendCommand(#"{"cmd":"session.new"}"#)
+        let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
+        let newID = try XCTUnwrap(result["id"] as? String, "session.new should return the new id")
+
+        // 400 lines far exceed any viewport, so tag-1-X is guaranteed to scroll out of the visible screen.
+        let tag = "SCR-\(UUID().uuidString.prefix(8))"
+        let typed = try sendCommand(typeRequest(text: "printf '\(tag)-%s-X\\n' $(seq 1 400)\n", target: newID, select: true))
+        XCTAssertEqual(typed["ok"] as? Bool, true, "session.type should succeed: \(typed)")
+
+        // poll --all until the last printed line lands (proves the output fully rendered to scrollback).
+        var allText: String?
+        for _ in 0..<60 {
+            let response = try sendCommand(#"{"cmd":"session.text","target":"\#(newID)","args":{"all":true}}"#)
+            XCTAssertEqual(response["ok"] as? Bool, true, "session.text --all should succeed: \(response)")
+            if let t = (response["result"] as? [String: Any])?["text"] as? String, t.contains("\(tag)-400-X") {
+                allText = t
+                break
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+        }
+        let all = try XCTUnwrap(allText, "--all should eventually contain the last printed line \(tag)-400-X")
+        XCTAssertTrue(all.contains("\(tag)-1-X"), "--all (SCREEN) should include the early scrolled-out line: head of \(all.prefix(200))")
+
+        let viewportResp = try sendCommand(#"{"cmd":"session.text","target":"\#(newID)"}"#)
+        XCTAssertEqual(viewportResp["ok"] as? Bool, true, "session.text (viewport) should succeed: \(viewportResp)")
+        let viewport = try XCTUnwrap((viewportResp["result"] as? [String: Any])?["text"] as? String, "viewport read should carry text")
+        XCTAssertFalse(viewport.contains("\(tag)-1-X"), "the default (VIEWPORT) read must NOT include the scrolled-out line \(tag)-1-X")
+        XCTAssertTrue(viewport.contains("\(tag)-400-X"), "the default (VIEWPORT) read should still show the most recent line")
+    }
+
+    // session.text --pane left|right reads the matching pane of a split. session.type is main-only (it always
+    // injects into session.surface), so the LEFT marker goes in over the socket; the RIGHT pane is fed via
+    // the real keyboard after focusing it. Assert each pane read returns its OWN marker and NOT the other's —
+    // the --pane success mappings (left→surface, right→splitSurface) are otherwise only hit on the error path.
+    func testSessionTextPaneSelectsCorrectPane() throws {
+        let split = try sendCommand(#"{"cmd":"session.split","target":"active","args":{"mode":"on"}}"#)
+        XCTAssertEqual(split["ok"] as? Bool, true, "split on should succeed: \(split)")
+        XCTAssertTrue(pollActiveSessionSplit(true, timeout: 10), "the active session should report split:true")
+        let activeID = try activeSessionID()
+
+        // LEFT (main) pane: session.type injects into session.surface (main-only by design), so this marker
+        // lands in the left pane regardless of which pane holds focus.
+        let leftMarker = "LEFT-\(UUID().uuidString.prefix(8))"
+        XCTAssertNotNil(try pollPaneText(target: activeID, pane: "left", contains: leftMarker, retype: {
+            _ = try self.sendCommand(self.typeRequest(text: "echo \(leftMarker)\n", target: activeID, select: false))
+        }), "--pane left should read the marker typed into the main pane")
+
+        // RIGHT (split) pane: session.type can't reach it, so focus it and type via the real keyboard, which
+        // routes to the focused pane's first responder.
+        let rightMarker = "RIGHT-\(UUID().uuidString.prefix(8))"
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.focus","target":"\#(activeID)","args":{"pane":"right"}}"#)["ok"] as? Bool,
+                       true, "focus right should succeed")
+        app.activate()
+        XCTAssertNotNil(try pollPaneText(target: activeID, pane: "right", contains: rightMarker, retype: {
+            self.app.typeText("echo \(rightMarker)")
+            self.app.typeKey(.return, modifierFlags: [])
+        }), "--pane right should read the marker typed into the split pane")
+
+        // cross-check: each pane read carries ONLY its own marker (the two reads hit different surfaces).
+        let leftText = try XCTUnwrap((try sendCommand(#"{"cmd":"session.text","target":"\#(activeID)","args":{"pane":"left"}}"#)["result"] as? [String: Any])?["text"] as? String)
+        let rightText = try XCTUnwrap((try sendCommand(#"{"cmd":"session.text","target":"\#(activeID)","args":{"pane":"right"}}"#)["result"] as? [String: Any])?["text"] as? String)
+        XCTAssertTrue(leftText.contains(leftMarker), "--pane left should contain the left marker: \(leftText)")
+        XCTAssertFalse(leftText.contains(rightMarker), "--pane left must NOT contain the right pane's marker: \(leftText)")
+        XCTAssertTrue(rightText.contains(rightMarker), "--pane right should contain the right marker: \(rightText)")
+        XCTAssertFalse(rightText.contains(leftMarker), "--pane right must NOT contain the left pane's marker: \(rightText)")
+    }
+
+    // session.text --pane right on a non-split session errors. `right` is a valid pane value so it passes
+    // the CLI validate() and the request reaches the server, which rejects it (no split pane to read).
+    func testSessionTextSplitPaneWithoutSplitErrors() throws {
+        let created = try sendCommand(#"{"cmd":"session.new"}"#)
+        let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
+        let newID = try XCTUnwrap(result["id"] as? String, "session.new should return the new id")
+
+        let response = try sendCommand(#"{"cmd":"session.text","target":"\#(newID)","args":{"pane":"right"}}"#)
+        XCTAssertEqual(response["ok"] as? Bool, false, "session.text --pane right with no split should fail: \(response)")
+        XCTAssertEqual(response["error"] as? String, "session has no split pane", "should report no split pane: \(response)")
+    }
+
+    // session.text arg validation is enforced SERVER-SIDE, not only in the CLI `validate()`: a raw socket
+    // client bypasses the CLI, so `lines <= 0` and `all` + `lines` together must error here too (an unchecked
+    // `lines: 0` would otherwise fall through to the full buffer). sendCommand speaks raw JSON, so it is the
+    // bypassing client.
+    func testSessionTextRejectsInvalidArgsServerSide() throws {
+        let zero = try sendCommand(#"{"cmd":"session.text","target":"active","args":{"lines":0}}"#)
+        XCTAssertEqual(zero["ok"] as? Bool, false, "session.text lines:0 should fail server-side: \(zero)")
+        XCTAssertEqual(zero["error"] as? String, "--lines must be greater than 0", "should report the lines bound: \(zero)")
+
+        let negative = try sendCommand(#"{"cmd":"session.text","target":"active","args":{"lines":-1}}"#)
+        XCTAssertEqual(negative["ok"] as? Bool, false, "session.text lines:-1 should fail server-side: \(negative)")
+
+        let both = try sendCommand(#"{"cmd":"session.text","target":"active","args":{"all":true,"lines":5}}"#)
+        XCTAssertEqual(both["ok"] as? Bool, false, "session.text all+lines should fail server-side: \(both)")
+        XCTAssertEqual(both["error"] as? String, "use either --all or --lines, not both", "should report mutual exclusion: \(both)")
+    }
+
     // session.search over the active session's scrollback: seed the screen with repeated needle text via
     // session.type (the surface's own shell renders it), then session.search "<needle>" reports a match
     // count + the "N of M" / "M matches" display string. --next/--prev step the selection and --close exits
@@ -2417,6 +2575,26 @@ final class ControlAPIUITests: XCTestCase {
             let typed = try sendCommand(typeRequest(text: command, target: target, select: select))
             XCTAssertEqual(typed["ok"] as? Bool, true, "typing the probe (attempt \(attempt)) should succeed: \(typed)")
             if let value = pollMarker(file, timeout: perAttempt) { return value }
+        }
+        return nil
+    }
+
+    /// Polls `session.text --pane <pane>` of `target` until the returned buffer contains `contains`, re-running
+    /// `retype` (which re-injects the marker command — idempotent for an `echo` line) at the start of each
+    /// outer attempt to ride out shell/focus readiness. Returns the matching text, or nil on timeout.
+    @discardableResult
+    private func pollPaneText(target: String, pane: String, contains: String,
+                              attempts: Int = 8, perAttempt: Int = 8,
+                              retype: () throws -> Void) throws -> String? {
+        for _ in 0..<attempts {
+            try retype()
+            for _ in 0..<perAttempt {
+                let response = try sendCommand(#"{"cmd":"session.text","target":"\#(target)","args":{"pane":"\#(pane)"}}"#)
+                if let t = (response["result"] as? [String: Any])?["text"] as? String, t.contains(contains) {
+                    return t
+                }
+                RunLoop.current.run(until: Date().addingTimeInterval(0.4))
+            }
         }
         return nil
     }

--- a/agtermUITests/SessionTextUITests.swift
+++ b/agtermUITests/SessionTextUITests.swift
@@ -1,0 +1,205 @@
+import Foundation
+import XCTest
+
+// session.text UI e2e. Split out of ControlAPIUITests so that file stays under the swiftlint
+// file_length limit; these are an extension over the SAME test class, reusing its helpers
+// (sendCommand / typeRequest / app / pollActiveSessionSplit / activeSessionID), so no
+// scaffolding is duplicated.
+extension ControlAPIUITests {
+    // session.text returns the session's terminal buffer in result.text. Type a command whose OUTPUT (not
+    // the echoed command line) is a unique marker — `echo <tag>-$((6*7))` prints `<tag>-42`, a string the
+    // typed line itself does NOT contain (it has `$((6*7))`) — so a match proves command output was
+    // captured, not merely the typed input echoed back. Poll until the rendered output lands (async).
+    func testSessionTextReturnsBuffer() throws {
+        let created = try sendCommand(#"{"cmd":"session.new"}"#)
+        let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
+        let newID = try XCTUnwrap(result["id"] as? String, "session.new should return the new id")
+
+        let tag = "AGTERM-TEXT-\(UUID().uuidString.prefix(8))"
+        let output = "\(tag)-42" // the shell evaluates $((6*7)); this string is absent from the typed line
+        let typed = try sendCommand(typeRequest(text: "echo \(tag)-$((6*7))\n", target: newID, select: true))
+        XCTAssertEqual(typed["ok"] as? Bool, true, "session.type should succeed: \(typed)")
+
+        var text: String?
+        for _ in 0..<40 {
+            let response = try sendCommand(#"{"cmd":"session.text","target":"\#(newID)"}"#)
+            XCTAssertEqual(response["ok"] as? Bool, true, "session.text should succeed: \(response)")
+            if let t = (response["result"] as? [String: Any])?["text"] as? String, t.contains(output) {
+                text = t
+                break
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+        }
+        XCTAssertNotNil(text, "session.text should return a buffer containing the command OUTPUT \(output)")
+    }
+
+    // session.text --lines N keeps only the LAST N lines of the full buffer (the GhosttySurfaceView trim:
+    // strip one trailing newline, split on \n, suffix(N)). Print 50 distinctly-tagged numbered lines, then
+    // read --lines 5: assert exactly 5 lines come back, the LAST printed line (tag-50) is present, and an
+    // EARLY line (tag-1) is NOT — proving the suffix trim, which no other test exercises.
+    func testSessionTextLinesReturnsLastN() throws {
+        let created = try sendCommand(#"{"cmd":"session.new"}"#)
+        let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
+        let newID = try XCTUnwrap(result["id"] as? String, "session.new should return the new id")
+
+        // printf repeats its format over the seq args → tag-1-X, tag-2-X, … tag-50-X, each on its own line.
+        let tag = "LN-\(UUID().uuidString.prefix(8))"
+        let typed = try sendCommand(typeRequest(text: "printf '\(tag)-%s-X\\n' $(seq 1 50)\n", target: newID, select: true))
+        XCTAssertEqual(typed["ok"] as? Bool, true, "session.type should succeed: \(typed)")
+
+        var text: String?
+        for _ in 0..<40 {
+            let response = try sendCommand(#"{"cmd":"session.text","target":"\#(newID)","args":{"lines":5}}"#)
+            XCTAssertEqual(response["ok"] as? Bool, true, "session.text --lines 5 should succeed: \(response)")
+            if let t = (response["result"] as? [String: Any])?["text"] as? String, t.contains("\(tag)-50-X") {
+                text = t
+                break
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+        }
+        let t = try XCTUnwrap(text, "--lines 5 should eventually contain the last printed line \(tag)-50-X")
+        XCTAssertEqual(t.components(separatedBy: "\n").count, 5, "--lines 5 should return exactly 5 lines: \(t)")
+        XCTAssertTrue(t.contains("\(tag)-50-X"), "the last printed line should be within the last 5: \(t)")
+        XCTAssertFalse(t.contains("\(tag)-1-X"), "an early line must be trimmed away by --lines 5: \(t)")
+    }
+
+    // session.text --all reads the whole SCREEN (visible + scrollback); the default read is the VIEWPORT
+    // only. Print far more lines than fit on screen, then assert --all returns an EARLY line that scrolled
+    // out of the viewport while the default read does NOT — a swapped VIEWPORT/SCREEN region would fail this
+    // (the default read is never otherwise distinguished from --all over the socket).
+    func testSessionTextAllIncludesScrollback() throws {
+        let created = try sendCommand(#"{"cmd":"session.new"}"#)
+        let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
+        let newID = try XCTUnwrap(result["id"] as? String, "session.new should return the new id")
+
+        // 400 lines far exceed any viewport, so tag-1-X is guaranteed to scroll out of the visible screen.
+        let tag = "SCR-\(UUID().uuidString.prefix(8))"
+        let typed = try sendCommand(typeRequest(text: "printf '\(tag)-%s-X\\n' $(seq 1 400)\n", target: newID, select: true))
+        XCTAssertEqual(typed["ok"] as? Bool, true, "session.type should succeed: \(typed)")
+
+        // poll --all until the last printed line lands (proves the output fully rendered to scrollback).
+        var allText: String?
+        for _ in 0..<60 {
+            let response = try sendCommand(#"{"cmd":"session.text","target":"\#(newID)","args":{"all":true}}"#)
+            XCTAssertEqual(response["ok"] as? Bool, true, "session.text --all should succeed: \(response)")
+            if let t = (response["result"] as? [String: Any])?["text"] as? String, t.contains("\(tag)-400-X") {
+                allText = t
+                break
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+        }
+        let all = try XCTUnwrap(allText, "--all should eventually contain the last printed line \(tag)-400-X")
+        XCTAssertTrue(all.contains("\(tag)-1-X"), "--all (SCREEN) should include the early scrolled-out line: head of \(all.prefix(200))")
+
+        let viewportResp = try sendCommand(#"{"cmd":"session.text","target":"\#(newID)"}"#)
+        XCTAssertEqual(viewportResp["ok"] as? Bool, true, "session.text (viewport) should succeed: \(viewportResp)")
+        let viewport = try XCTUnwrap((viewportResp["result"] as? [String: Any])?["text"] as? String, "viewport read should carry text")
+        XCTAssertFalse(viewport.contains("\(tag)-1-X"), "the default (VIEWPORT) read must NOT include the scrolled-out line \(tag)-1-X")
+        XCTAssertTrue(viewport.contains("\(tag)-400-X"), "the default (VIEWPORT) read should still show the most recent line")
+    }
+
+    // session.text --pane left|right reads the matching pane of a split. session.type is main-only (it always
+    // injects into session.surface), so the LEFT marker goes in over the socket; the RIGHT pane is fed via
+    // the real keyboard after focusing it. Assert each pane read returns its OWN marker and NOT the other's —
+    // the --pane success mappings (left→surface, right→splitSurface) are otherwise only hit on the error path.
+    func testSessionTextPaneSelectsCorrectPane() throws {
+        let split = try sendCommand(#"{"cmd":"session.split","target":"active","args":{"mode":"on"}}"#)
+        XCTAssertEqual(split["ok"] as? Bool, true, "split on should succeed: \(split)")
+        XCTAssertTrue(pollActiveSessionSplit(true, timeout: 10), "the active session should report split:true")
+        let activeID = try activeSessionID()
+
+        // LEFT (main) pane: session.type injects into session.surface (main-only by design), so this marker
+        // lands in the left pane regardless of which pane holds focus.
+        let leftMarker = "LEFT-\(UUID().uuidString.prefix(8))"
+        XCTAssertNotNil(try pollPaneText(target: activeID, pane: "left", contains: leftMarker, retype: {
+            _ = try self.sendCommand(self.typeRequest(text: "echo \(leftMarker)\n", target: activeID, select: false))
+        }), "--pane left should read the marker typed into the main pane")
+
+        // RIGHT (split) pane: session.type can't reach it, so focus it and type via the real keyboard, which
+        // routes to the focused pane's first responder.
+        let rightMarker = "RIGHT-\(UUID().uuidString.prefix(8))"
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.focus","target":"\#(activeID)","args":{"pane":"right"}}"#)["ok"] as? Bool,
+                       true, "focus right should succeed")
+        app.activate()
+        XCTAssertNotNil(try pollPaneText(target: activeID, pane: "right", contains: rightMarker, retype: {
+            self.app.typeText("echo \(rightMarker)")
+            self.app.typeKey(.return, modifierFlags: [])
+        }), "--pane right should read the marker typed into the split pane")
+
+        // cross-check: each pane read carries ONLY its own marker (the two reads hit different surfaces).
+        let leftText = try XCTUnwrap((try sendCommand(#"{"cmd":"session.text","target":"\#(activeID)","args":{"pane":"left"}}"#)["result"] as? [String: Any])?["text"] as? String)
+        let rightText = try XCTUnwrap((try sendCommand(#"{"cmd":"session.text","target":"\#(activeID)","args":{"pane":"right"}}"#)["result"] as? [String: Any])?["text"] as? String)
+        XCTAssertTrue(leftText.contains(leftMarker), "--pane left should contain the left marker: \(leftText)")
+        XCTAssertFalse(leftText.contains(rightMarker), "--pane left must NOT contain the right pane's marker: \(leftText)")
+        XCTAssertTrue(rightText.contains(rightMarker), "--pane right should contain the right marker: \(rightText)")
+        XCTAssertFalse(rightText.contains(leftMarker), "--pane right must NOT contain the left pane's marker: \(rightText)")
+    }
+
+    // session.text --pane right on a non-split session errors. `right` is a valid pane value so it passes
+    // the CLI validate() and the request reaches the server, which rejects it (no split pane to read).
+    func testSessionTextSplitPaneWithoutSplitErrors() throws {
+        let created = try sendCommand(#"{"cmd":"session.new"}"#)
+        let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
+        let newID = try XCTUnwrap(result["id"] as? String, "session.new should return the new id")
+
+        let response = try sendCommand(#"{"cmd":"session.text","target":"\#(newID)","args":{"pane":"right"}}"#)
+        XCTAssertEqual(response["ok"] as? Bool, false, "session.text --pane right with no split should fail: \(response)")
+        XCTAssertEqual(response["error"] as? String, "session has no split pane", "should report no split pane: \(response)")
+    }
+
+    // session.text arg validation is enforced SERVER-SIDE, not only in the CLI `validate()`: a raw socket
+    // client bypasses the CLI, so `lines <= 0` and `all` + `lines` together must error here too (an unchecked
+    // `lines: 0` would otherwise fall through to the full buffer). sendCommand speaks raw JSON, so it is the
+    // bypassing client.
+    func testSessionTextRejectsInvalidArgsServerSide() throws {
+        let zero = try sendCommand(#"{"cmd":"session.text","target":"active","args":{"lines":0}}"#)
+        XCTAssertEqual(zero["ok"] as? Bool, false, "session.text lines:0 should fail server-side: \(zero)")
+        XCTAssertEqual(zero["error"] as? String, "--lines must be greater than 0", "should report the lines bound: \(zero)")
+
+        let negative = try sendCommand(#"{"cmd":"session.text","target":"active","args":{"lines":-1}}"#)
+        XCTAssertEqual(negative["ok"] as? Bool, false, "session.text lines:-1 should fail server-side: \(negative)")
+
+        let both = try sendCommand(#"{"cmd":"session.text","target":"active","args":{"all":true,"lines":5}}"#)
+        XCTAssertEqual(both["ok"] as? Bool, false, "session.text all+lines should fail server-side: \(both)")
+        XCTAssertEqual(both["error"] as? String, "use either --all or --lines, not both", "should report mutual exclusion: \(both)")
+    }
+
+    // A genuinely BLANK screen reads ok with an EMPTY string, not an error (readScreenText returns "" for an
+    // empty read, nil only for a failed one). `session new --command "sleep 300"` execs sleep directly — no
+    // shell, so no prompt and no output — leaving the viewport blank; session.text returns ok + "".
+    func testSessionTextBlankScreenReturnsOkEmpty() throws {
+        let created = try sendCommand(#"{"cmd":"session.new","args":{"command":"sleep 300"}}"#)
+        let newID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "session.new should return the new id")
+
+        // poll for the surface to realize (a never-shown session realizes a beat after create).
+        var response: [String: Any] = [:]
+        for _ in 0..<40 {
+            response = try sendCommand(#"{"cmd":"session.text","target":"\#(newID)"}"#)
+            if response["ok"] as? Bool == true { break }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+        }
+        XCTAssertEqual(response["ok"] as? Bool, true, "session.text on a blank screen should be ok, not an error: \(response)")
+        let text = try XCTUnwrap((response["result"] as? [String: Any])?["text"] as? String, "a blank read still carries a text field: \(response)")
+        XCTAssertTrue(text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty, "a blank screen should read as empty, got: \(text)")
+    }
+
+    /// Polls `session.text --pane <pane>` of `target` until the returned buffer contains `contains`, re-running
+    /// `retype` (which re-injects the marker command — idempotent for an `echo` line) at the start of each
+    /// outer attempt to ride out shell/focus readiness. Returns the matching text, or nil on timeout.
+    @discardableResult
+    private func pollPaneText(target: String, pane: String, contains: String,
+                              attempts: Int = 8, perAttempt: Int = 8,
+                              retype: () throws -> Void) throws -> String? {
+        for _ in 0..<attempts {
+            try retype()
+            for _ in 0..<perAttempt {
+                let response = try sendCommand(#"{"cmd":"session.text","target":"\#(target)","args":{"pane":"\#(pane)"}}"#)
+                if let t = (response["result"] as? [String: Any])?["text"] as? String, t.contains(contains) {
+                    return t
+                }
+                RunLoop.current.run(until: Date().addingTimeInterval(0.4))
+            }
+        }
+        return nil
+    }
+}

--- a/docs/plans/completed/20260630-session-text-command.md
+++ b/docs/plans/completed/20260630-session-text-command.md
@@ -1,0 +1,274 @@
+# session.text — read a session's buffer over the control API
+
+Closes umputun/agterm#34.
+
+## Overview
+
+Add a `session.text` control command that returns a session's terminal buffer as
+plain text in `result.text`, so an external script can pull the whole screen (or
+scrollback) over the socket — today `session.copy` only returns an existing
+selection and there is no select-all over the control channel.
+
+Shape (settled with umputun in the issue, plus the maintainer's `--pane` addition):
+
+- `agtermctl session text` — the **visible screen** by default
+- `--all` — the full screen + scrollback
+- `--lines N` — the last N lines of the full buffer
+- `--pane left|right` — which pane to read; **default = the focused pane**.
+  Vocabulary matches `session.focus --pane left|right|other` (uniform across the app;
+  `session.type`/`session.copy` are intentionally left main-only, out of scope here).
+- text comes back in `result.text`, exactly like `session.copy`
+- **plain text only** — no `--ansi`. The pinned libghostty exposes only
+  `ghostty_surface_read_text` (UTF-8, no per-cell color/SGR), and that pin is
+  deliberate, so a styled dump is not possible against the pinned surface API.
+  Dropped from this change by design — but it is a clean future follow-up: ghostty's
+  core formatter already supports `vt` (SGR) output, and a surface-level styled read
+  (`ghostty_surface_read_text_styled`, same contract as `read_text` but `emit = .vt`
+  with palette resolved to direct RGB) was written as **closed-unmerged PR
+  ghostty-org/ghostty#12909** — watch/subscribe at
+  https://github.com/ghostty-org/ghostty/pull/12909 . It was auto-closed by the
+  contributor-vouch bot, not on technical merit. Once a styled surface read lands in
+  upstream `main` and the pin is bumped past it (the pin is also held pre-regression
+  for the font-increase scrollback bug), `--ansi` can be added by pointing the reader
+  at the styled call. Carrying the #12909 patch locally is the only other path and is
+  rejected here (breaks the self-owned, upstream@SHA-only build property).
+
+## Context (from discovery)
+
+Modeled end-to-end on `session.copy`. The four (five, with the skill) keep-in-sync
+surfaces and their exact spots:
+
+- **Protocol** — `agtermCore/Sources/agtermCore/ControlProtocol.swift`
+  - `Command` enum (line ~26, beside `case sessionCopy = "session.copy"`)
+  - `ControlArgs` (line 57): already has `pane` (reused) and the result already has
+    `text`; reuses the existing `pane` field (already `left|right|other` for
+    `session.focus`); need two NEW fields `all: Bool?` and `lines: Int?` (+ init params).
+- **Server** — `agterm/Control/ControlServer.swift`
+  - dispatch switch (line ~458, beside `case .sessionCopy`)
+  - `copySelection(_:window:)` (line 921) is the template for the new arm.
+- **Surface reader** — `agterm/Ghostty/GhosttySurfaceView.swift`
+  - `readSelection()` (line 323) is the near-clone; new reader uses
+    `ghostty_surface_read_text(surface, selection, &t)` with a `ghostty_selection_s`
+    instead of `ghostty_surface_read_selection`. Same `ghostty_text_s` +
+    `ghostty_surface_free_text` copy-out idiom.
+- **CLI** — `agtermCore/Sources/agtermctlKit/Commands.swift`
+  - `Session.subcommands` list (line 208) — register the new `Text` command
+  - `struct Copy: RequestCommand` (line 361) is the template.
+- **Tests**
+  - round-trip: `agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift` (line ~44)
+  - CLI parse: `agtermCore/Tests/agtermctlKitTests/CommandsTests.swift` (line ~213, the
+    `sessionCopy*` cases)
+  - e2e: `agtermUITests/ControlAPIUITests.swift` (line ~415, `testSessionCopy*`)
+- **Agent skill (HARD keep-in-sync, 5th surface)** — `agterm/Resources/agent-skill/`
+  - `SKILL.md` (command summary + the count, **46 → 47**)
+  - `reference.md` (per-command detail), `examples.md` (a recipe)
+- **Rules note** — `.claude/rules/control-api.md` documents the catalog and the
+  command count (46). Bump to 47 and add a `session.text` description sentence.
+
+Pane → surface map (from `Session.swift`), `left|right` to match `session.focus`:
+- `left` → `Session.surface` (the main pane)
+- `right` → `Session.splitSurface` (the split pane; nil when no split → error)
+- default (omitted) → `Session.activeSurface` (= split when `splitFocused` && a split
+  exists, else main) — "the focused pane".
+
+libghostty C API (`GhosttyKit.../Headers/ghostty.h`):
+- `ghostty_selection_s { ghostty_point_s top_left; ghostty_point_s bottom_right; bool rectangle; }`
+- `ghostty_point_s { ghostty_point_tag_e tag; ghostty_point_coord_e coord; uint32_t x; uint32_t y; }`
+- tags: `GHOSTTY_POINT_VIEWPORT` (visible screen) vs `GHOSTTY_POINT_SCREEN` (whole
+  buffer incl. scrollback); coords: `..._COORD_TOP_LEFT` / `..._COORD_BOTTOM_RIGHT`.
+- visible: VIEWPORT top-left → VIEWPORT bottom-right. full: SCREEN top-left → SCREEN
+  bottom-right. `rectangle = false` (line-wrapped, not block).
+
+## Development Approach
+
+- **Testing approach: Regular** (code first, then tests) per the maintainer's norm —
+  protocol/CLI logic is host-free and unit-tested in `swift test`; the surface read +
+  full wiring is covered by an XCUITest e2e (the only place a real surface exists).
+- The surface reader itself (`ghostty_surface_read_text`) is NOT host-free and is
+  exercised only through the e2e, like `readSelection`/`session.copy` — there is no
+  unit test for the libghostty call, by design (`agtermCore` is GhosttyKit-free).
+- Complete each task fully; `swift test` (in `agtermCore`) must stay green before the
+  next task. The app must build.
+- Small, focused changes. Backward compatible — purely additive.
+
+## Testing Strategy
+
+- **unit tests** (`agtermCore` `swift test`, host-free, run per task):
+  - `ControlProtocolTests` — `session.text` request encodes/decodes round-trip with
+    `all`/`lines`/`pane` args.
+  - `CommandsTests` — `session text` CLI parses to the right `ControlRequest`
+    (defaults; `--all`; `--lines N`; `--pane left|right`; and the mutual-exclusion /
+    bad-value `validate()` errors).
+- **e2e** (`agtermUITests/ControlAPIUITests.swift`, XCUITest — NOT run in CI, run
+  locally): `testSessionText*` — create a session, `session.type` a known marker,
+  then `session text` and assert the marker is in `result.text`; assert `--pane right`
+  on a non-split session errors. Mirror the existing `testSessionCopy*` style.
+
+## Solution Overview
+
+A pure clone of the `session.copy` pipeline with three behavioral deltas:
+
+1. The reader spans a screen region (`read_text`) instead of the selection
+   (`read_selection`); region = VIEWPORT (default) or SCREEN (`--all`/`--lines`).
+2. `--lines N` reads SCREEN then keeps the **last N lines** of the returned text
+   (split on `\n`, take suffix). Simple and correct; for personal scripting the cost
+   of reading the whole buffer then trimming is irrelevant. (Avoids fragile absolute-
+   row coordinate math on the Swift side.) `--lines` already reads the full SCREEN, so
+   `--all --lines N` is redundant rather than contradictory — rejecting the combo is a
+   deliberate UX choice (one clear meaning per flag), not a technical necessity.
+3. A `--pane left|right` selector picks the surface (`left`→main, `right`→split);
+   default = `activeSurface` (the focused pane). Reuses `session.focus`'s vocabulary.
+
+Empty/edge handling: an unrealized surface → `"session not realized"` error (same as
+copy). A nil/empty read → return `ok` with an **empty string** (not an error) —
+"read the screen" legitimately may be near-empty, and erroring is hostile to scripts
+(differs from `session.copy`'s `"no selection"` on purpose).
+
+Args reuse: `pane` (existing field, already `left|right|other`) carries `left|right`;
+`text` (existing result field) carries the dump. Only `all: Bool?` + `lines: Int?` are new.
+
+## Technical Details
+
+- New `Command` case: `case sessionText = "session.text"`.
+- New `ControlArgs` fields: `all: Bool?`, `lines: Int?` (added to the struct, the
+  `init`, and the `init` call site — keep `Equatable`/`Codable` synthesized).
+- Reader signature (app target, `GhosttySurfaceView`):
+  `func readScreenText(all: Bool, lines: Int?) -> String?`
+  - builds `ghostty_selection_s` (VIEWPORT vs SCREEN per `all || lines != nil`),
+    calls `ghostty_surface_read_text`, copies out of `ghostty_text_s`, frees with
+    `ghostty_surface_free_text` (defer), decodes UTF-8 — same shape as `readSelection`.
+  - when `lines` is set, returns the last N lines of the decoded text.
+- Server arm `readText(_ target:window:pane:all:lines:)`:
+  - `resolveSession(target, window:)`; inside, pick the surface by `pane`
+    (`left` → `surface`, `right` → `splitSurface` else `"session has no split pane"`
+    error, default → `activeSurface`), cast to `GhosttySurfaceView`,
+    `"session not realized"` if nil; call the reader; return `ControlResult(text:)`.
+- CLI `struct Text: RequestCommand` under `Session`:
+  - `@Flag --all`, `@Option --lines <n>`, `@Option --pane <left|right>`, the standard
+    `TargetOptions` + `ClientOptions`.
+  - `validate()`: reject `--all` together with `--lines`; reject `--lines` ≤ 0;
+    reject a `--pane` value other than `left`/`right`.
+  - `makeRequest()` → `ControlRequest(cmd: .sessionText, target: target.target,
+    args: options.withWindow(ControlArgs(all: all ? true : nil, lines: lines,
+    pane: pane)))`.
+
+## Progress Tracking
+
+- mark `[x]` immediately when done; ➕ for new tasks; ⚠️ for blockers.
+- if the design shifts during implementation, update this file.
+
+## What Goes Where
+
+- **Implementation Steps** (checkboxes): protocol, server, reader, CLI, tests, skill,
+  rules doc — all in-repo.
+- **Post-Completion** (no checkboxes): the branch is already `feat/session-text`;
+  manual smoke against a dev instance; PR back to umputun/agterm#34; the app build +
+  XCUITest e2e are run locally (CI does not run XCUITests).
+
+## Implementation Steps
+
+### Task 1: Protocol — add the `session.text` command + args
+
+**Files:**
+- Modify: `agtermCore/Sources/agtermCore/ControlProtocol.swift`
+- Modify: `agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift`
+
+- [x] add `case sessionText = "session.text"` to the `Command` enum (beside `sessionCopy`)
+- [x] add `public var all: Bool?` and `public var lines: Int?` to `ControlArgs`, with doc comments, plus matching `init` params (default `nil`) and assignments
+- [x] extend the `pane` doc comment to note it also carries `left|right` for `session.text`
+- [x] write a round-trip test: `ControlRequest(cmd: .sessionText, target: "9f3c", args: ControlArgs(all: true, lines: 50, pane: "left"))` encodes → decodes equal (success case)
+- [x] write a round-trip test for the bare/default form (`session.text` with no args) and `lines`-only (edge cases)
+- [x] run `cd agtermCore && swift test` — must pass before Task 2
+
+### Task 2: CLI — `session text` subcommand
+
+**Files:**
+- Modify: `agtermCore/Sources/agtermctlKit/Commands.swift`
+- Modify: `agtermCore/Tests/agtermctlKitTests/CommandsTests.swift`
+
+- [x] add `struct Text: RequestCommand` under `Session` (model on `Copy`), with `--all` flag, `--lines <n>` option, `--pane <left|right>` option, `TargetOptions`, `ClientOptions`, and an abstract help string
+- [x] implement `validate()`: error on `--all` + `--lines` together, on `--lines` ≤ 0, and on a `--pane` value not in `{left, right}`
+- [x] implement `makeRequest()` building the `.sessionText` `ControlRequest` (see Technical Details)
+- [x] register `Text.self` in the `Session` `subcommands` array (line ~208)
+- [x] write CLI-parse tests: defaults (`session text` → target `active`, no args); `--all`; `--lines 50`; `--pane right`; mirror the `sessionCopyDefaultsActive`/`…WithTarget` style
+- [x] write CLI-parse tests for the `validate()` errors (all+lines, lines≤0, bad pane) — note: negative `--lines` (`-5`) is intercepted by ArgumentParser as a flag before `validate()`, so the CLI-reachable non-positive case is `0`
+- [x] run `cd agtermCore && swift test` — must pass before Task 3
+
+### Task 3: Surface reader — `readScreenText` on `GhosttySurfaceView`
+
+**Files:**
+- Modify: `agterm/Ghostty/GhosttySurfaceView.swift`
+
+- [x] add `func readScreenText(all: Bool, lines: Int?) -> String?` beside `readSelection()`, with a doc comment explaining the VIEWPORT-vs-SCREEN region and the copy-out/free idiom
+- [x] build the `ghostty_selection_s` (VIEWPORT top-left→bottom-right by default; SCREEN when `all || lines != nil`; `rectangle = false`), call `ghostty_surface_read_text`, copy `ghostty_text_s` → Swift `String`, `defer ghostty_surface_free_text`
+- [x] set BOTH `tag` AND `coord` explicitly on each of `top_left`/`bottom_right` — a zero-init `ghostty_point_s` defaults to `GHOSTTY_POINT_ACTIVE`/`GHOSTTY_POINT_COORD_EXACT` (both enum 0), NOT viewport/top-left; do not rely on defaults
+- [x] guard the `Bool` return of `ghostty_surface_read_text` (return nil on `false`) and the nil/empty `ghostty_text_s.text`, exactly like `readSelection`
+- [x] when `lines` is set and > 0: strip a single trailing `\n` first (a buffer ending in newline would otherwise yield a trailing empty line), split on `\n`, return the last N lines
+- [x] (no unit test — exercised via the e2e in Task 5, like `readSelection`; note this in the doc comment)
+
+### Task 4: Server — `.sessionText` dispatch arm
+
+**Files:**
+- Modify: `agterm/Control/ControlServer.swift`
+
+- [x] add `case .sessionText: return readText(request.target, window: request.args?.window, pane: request.args?.pane, all: request.args?.all ?? false, lines: request.args?.lines)` to the dispatch switch (beside `.sessionCopy`)
+- [x] add `private func readText(_ target:window:pane:all:lines:)` modeled on `copySelection`: `resolveSession`, pick the surface by `pane` (`left`→`surface`, `right`→`splitSurface` else `"session has no split pane"` error, default→`activeSurface`), `"session not realized"` if not a `GhosttySurfaceView`, call `readScreenText`, return `ControlResult(text: text ?? "")`
+- [x] (no host-free test — covered by the e2e in Task 5)
+- [x] confirm the app target builds (`make build`)
+
+### Task 5: e2e test
+
+**Files:**
+- Modify: `agtermUITests/ControlAPIUITests.swift`
+
+- [x] add `testSessionTextReturnsBuffer`: create a session, `session.type` a unique marker string + Return, then `session.text` and assert `result.text` contains the marker (model on `testSessionCopyWithoutSelectionErrors` for the harness scaffolding)
+- [x] add `testSessionTextSplitPaneWithoutSplitErrors`: `session.text --pane right` on a non-split session returns `ok:false` (asserts the SERVER `"session has no split pane"` arm — `right` passes CLI `validate()`, so the request reaches the server, unlike an invalid pane value that would fail at parse)
+- [x] run the e2e locally (XCUITest; not in CI) — must pass before Task 6 (both tests passed: `Executed 2 tests, with 0 failures` in 8.9s)
+
+### Task 6: Agent skill + rules doc (HARD keep-in-sync)
+
+**Files:**
+- Modify: `agterm/Resources/agent-skill/SKILL.md`
+- Modify: `agterm/Resources/agent-skill/reference.md`
+- Modify: `agterm/Resources/agent-skill/examples.md`
+- Modify: `.claude/rules/control-api.md`
+
+- [x] add `session.text` to the `SKILL.md` command summary and bump the count **46 → 47** at `SKILL.md` line ~91 ("(46 commands)")
+- [x] add the full per-command entry to `reference.md` (args: `--all`, `--lines N`, `--pane left|right`; returns `result.text`; plain text only; default = visible screen / focused pane; note it reads the focused pane by default and `--pane` has NO `other` value, unlike `session.focus`)
+- [x] add an `examples.md` recipe (e.g. extract URLs: `session text --all | grep -oE 'https?://...'`)
+- [x] update `.claude/rules/control-api.md`: add a `session.text` sentence to the command catalog, and bump ALL THREE count sites — line 28 "46-command summary", line 32 "catalog (46 commands)", line 32 "bumped to 46" → 47
+- [x] grep the skill + rules for the old `46` count (`grep -rn "46" agterm/Resources/agent-skill/ .claude/rules/control-api.md`) to confirm none remain (safety net beyond the four enumerated sites) — confirmed: no matches
+- [x] run `cd agtermCore && swift test` (no-op for docs, but confirms nothing broke) — 809 tests passed
+
+### Task 7: Verify acceptance criteria
+
+- [x] `session text` (default) returns the visible screen; `--all` returns more (scrollback); `--lines N` returns ≤ N lines
+- [x] `--pane left` and `--pane right` read the correct pane; `--pane right` on a non-split session errors
+- [x] `--all` + `--lines` together is rejected at the CLI; bad `--pane` rejected
+- [x] run full `cd agtermCore && swift test`; build the app; run the new XCUITests locally
+- [x] all four control surfaces present (Command case, server arm, CLI subcommand, tests) + the skill mirror updated
+
+### Task 8: Final — docs + housekeeping
+
+- [x] confirm `README.md` needs no change (control commands aren't enumerated there) — confirmed — control commands not enumerated in README, no change needed (README shows usage examples like `session type`/`session copy`/`session overlay`, not a full command catalog)
+- [x] move this plan to `docs/plans/completed/`
+
+## Post-Completion
+*Manual / external — no checkboxes*
+
+**Manual verification:**
+- Smoke against an isolated dev instance: `make build`, launch with
+  `AGTERM_STATE_DIR`/`AGTERM_CONTROL_SOCKET` overrides, then
+  `agtermctl session text --socket <tmp>/agterm.sock` against a session with known
+  content; try `--all`, `--lines 5`, `--pane left|right`. Do NOT touch the deployed
+  daily-driver instance.
+- Sanity-check the umputun use cases from the issue: pipe `session text --all` into
+  `grep`/`fzf` to extract URLs / file paths.
+
+**External:**
+- Open the PR against `umputun/agterm` (branch `feat/session-text`) closing #34;
+  note in the PR that `--ansi` was intentionally dropped (plain text only, per the
+  maintainer's comment) — link the upstream follow-up
+  https://github.com/ghostty-org/ghostty/pull/12909 (`ghostty_surface_read_text_styled`,
+  closed-unmerged) as the path to a future styled dump — and that the
+  maintainer-requested `--pane` selector is included.


### PR DESCRIPTION
Closes #34.

`agtermctl session text` prints a session's buffer as plain text in `result.text`. `session.copy` only returns the current selection, so until now there was no way to grab the whole screen over the socket.

- default: the visible screen
- `--all`: screen plus scrollback
- `--lines N`: the last N lines
- `--pane left|right`: which pane (defaults to the focused one)

Plain text only. No `--ansi` support for now.
