### PR TITLE
feat: show unseen notification count as a Dock icon badge

### DIFF
--- a/.claude/rules/notifications.md
+++ b/.claude/rules/notifications.md
@@ -59,6 +59,30 @@ paths:
   reloads the rows).
   This gates ONLY the red count pill — the agent-status glyph (drawn just left of it by `StatusIconView`)
   is always on, never gated by this.
+- **Dock badge (`DockBadgeController`, app target).**
+  A `@MainActor` singleton (next to `NotificationManager`, wired in the scene `.task`) that shows the
+  app-wide unseen total on the Dock icon.
+  The total is the host-free `WindowLibrary.totalUnseenCount` (sum of every open window's sessions'
+  `unseenCount`, unit-tested); it's gated by the SAME `notificationBadgeEnabled` toggle as the sidebar
+  pill (badge count is 0 when off).
+  **Uses `UNUserNotificationCenter.setBadgeCount(_:)`, NOT `NSApp.dockTile.badgeLabel`.** For agterm the
+  legacy dock-tile label is silently suppressed — the value sets and persists on the tile but the Dock
+  never draws the pill — because it needs the `.badge` authorization option; `NotificationManager.start`
+  now requests `[.alert, .badge]`.
+  The modern UN badge renders correctly over the LIVE adaptive Icon Composer icon with no loss of
+  light/dark/tint/clear adaptivity, so there is NO `applicationIconImage` override.
+  Cleared to 0 on quit (`DockBadgeController.clear()` from `applicationWillTerminate`) — the OS badge
+  outlives the process and `unseenCount` is ephemeral, so without it a quit with unseen > 0 would leave a
+  stale count pinned on the Dock icon (the `willClose` poke can't do it: `isTerminating` makes `closeWindow`
+  no-op, so the total recomputes unchanged).
+  Reactivity is the Observation re-registration pattern (`apply()` reads `totalUnseenCount` inside
+  `withObservationTracking` and re-arms on change), with explicit `refresh()` pokes on the two
+  unobservable store mutations — a window CLOSE (`willClose` teardown in `ContentView`, `window.close` in
+  `ControlServer`) AND a window REOPEN (`ContentView.resolveStore` after `loadStore`, so a reopened
+  window's bumps aren't stale) — and an `.agtermAppearanceChanged` observer for the (non-`@Observable`)
+  toggle flip.
+  Keep-in-sync EXEMPT — pure derived chrome (`unseenCount` is already driven by `notify` / `session.select`),
+  nothing new to drive over the socket.
 - **Agent-status glyph.**
   Mirrors the `notify-badge` cell pattern (see the Control API `session.status`).
   `StatusIconView` (an `NSImageView` sibling of `BadgeView` in `WorkspaceSidebar`) draws the row's tinted

--- a/agterm/ContentView.swift
+++ b/agterm/ContentView.swift
@@ -1099,7 +1099,10 @@ private struct WindowAccessor: NSViewRepresentable {
                     library.closeWindow(windowID)
                     // closing a window drops its (unobserved) store, so the Dock badge's observation
                     // tracking won't fire — refresh it explicitly so the unseen total drops this window's.
-                    DockBadgeController.shared.refresh()
+                    // guard on isTerminating: on quit the willClose fires after applicationWillTerminate's
+                    // clear(), and closeWindow no-ops (stores stay loaded), so an unguarded refresh would
+                    // recompute the still-positive total and re-pin the badge clear() just zeroed.
+                    if !library.isTerminating { DockBadgeController.shared.refresh() }
                 }
             }
             titlebarObservers.append(closeToken)

--- a/agterm/ContentView.swift
+++ b/agterm/ContentView.swift
@@ -91,6 +91,9 @@ struct ContentView: View {
         }
         store = resolved
         resolvedID = id
+        // reopening a window loads an @ObservationIgnored store, which the Dock badge's observation can't
+        // see (symmetric to the willClose close poke) — recompute so a reopened window's unseen total counts.
+        DockBadgeController.shared.refresh()
     }
 
     /// The window id this view adopts: normally the next id in the library's claim queue. If the
@@ -1094,6 +1097,9 @@ private struct WindowAccessor: NSViewRepresentable {
                         session.scratchSurface?.teardown()
                     }
                     library.closeWindow(windowID)
+                    // closing a window drops its (unobserved) store, so the Dock badge's observation
+                    // tracking won't fire — refresh it explicitly so the unseen total drops this window's.
+                    DockBadgeController.shared.refresh()
                 }
             }
             titlebarObservers.append(closeToken)

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -1332,6 +1332,8 @@ final class ControlServer {
             if library.isOpen(id) {
                 library.closeWindow(id)
             }
+            // dropping a store is unobserved, so poke the Dock badge to drop this window's unseen total.
+            DockBadgeController.shared.refresh()
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
         }
     }

--- a/agterm/Notifications/DockBadgeController.swift
+++ b/agterm/Notifications/DockBadgeController.swift
@@ -1,0 +1,93 @@
+import agtermCore
+import Foundation
+import Observation
+import UserNotifications
+
+/// Drives the Dock icon's unseen-notification badge from the app-wide total of unseen terminal
+/// notifications — the same `Session.unseenCount` the sidebar's red pills show, summed across every open
+/// window by `WindowLibrary.totalUnseenCount`. Capped at 99 (mirrors the sidebar pill's `99+`), cleared at
+/// zero, gated by the SAME `GhosttyApp.notificationBadgeEnabled` ("Show notification badges") Settings
+/// toggle — one switch governs both surfaces.
+///
+/// **Uses the modern UserNotifications badge, NOT `NSApp.dockTile.badgeLabel`.** For agterm the legacy
+/// dock-tile label is silently suppressed — the value sets and persists on the tile, but the Dock never
+/// draws the pill — because it requires the `.badge` authorization option (which `NotificationManager` now
+/// requests alongside `.alert`). `UNUserNotificationCenter.setBadgeCount(_:)` renders the count correctly
+/// over the LIVE adaptive Icon Composer icon with no loss of light/dark/tint/clear adaptivity, so the badge
+/// is purely the number — no self-drawn icon, no `applicationIconImage` override.
+///
+/// `@MainActor` singleton like `NotificationManager`. Reactivity uses the Observation re-registration
+/// pattern: `apply()` reads the observable inputs inside `withObservationTracking` and re-arms itself on
+/// the next change, so a notification bump, a focus/select clear, and a session add/remove all refresh the
+/// badge. Changes that are NOT observable are poked explicitly: a window CLOSE drops, and a window REOPEN
+/// loads, an `@ObservationIgnored` store (`refresh()` on the `willClose` teardown / `window.close`, and on
+/// `ContentView.resolveStore`), and a badge-toggle flip lands in the non-`@Observable` `GhosttyApp` flag
+/// (it rides `.agtermAppearanceChanged`, the same channel the sidebar uses).
+@MainActor
+final class DockBadgeController {
+    static let shared = DockBadgeController()
+
+    /// The window library whose open sessions' unseen counts are summed. Weak, set at launch by
+    /// `agtermApp`; the library outlives the controller by app lifetime, matching `NotificationManager`.
+    weak var library: WindowLibrary?
+
+    /// The appearance-notification token, installed once so a badge-toggle flip refreshes the Dock badge.
+    private var appearanceObserver: NSObjectProtocol?
+
+    /// Coalesces the deferred re-applies an observation change schedules into one per runloop turn.
+    private var refreshScheduled = false
+
+    /// Begin driving the Dock badge. Idempotent — re-running just re-applies (the appearance observer is
+    /// installed once). Called from the scene `.task` alongside `NotificationManager.shared.start()`.
+    func start() {
+        if appearanceObserver == nil {
+            appearanceObserver = NotificationCenter.default.addObserver(
+                forName: .agtermAppearanceChanged, object: nil, queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated { self?.apply() }
+            }
+        }
+        apply()
+    }
+
+    /// Recompute and set the badge now — the explicit poke for a change the Observation tracking can't see
+    /// (a window close drops, or a reopen loads, an `@ObservationIgnored` store, leaving the tracked inputs
+    /// unchanged).
+    func refresh() { apply() }
+
+    /// Zero the Dock badge immediately — called from `applicationWillTerminate`. `setBadgeCount` writes an
+    /// OS-level badge that OUTLIVES the process, and `unseenCount` is ephemeral (never restored), so a quit
+    /// with unseen > 0 would otherwise leave a stale count pinned on the Dock icon until the next launch
+    /// recomputes it. The `willClose` `refresh()` poke can't cover this: the quit-flush sets
+    /// `library.isTerminating`, so `closeWindow` no-ops and the still-open stores recompute the same
+    /// positive total.
+    func clear() { UNUserNotificationCenter.current().setBadgeCount(0) }
+
+    /// Defer a single re-apply to the next runloop turn. An observation `onChange` fires at willSet (before
+    /// the new value is readable) and may fire from several live trackers at once, so this coalesces them
+    /// into one read-and-set after the mutation has landed.
+    private func scheduleRefresh() {
+        guard !refreshScheduled else { return }
+        refreshScheduled = true
+        DispatchQueue.main.async { [weak self] in
+            self?.refreshScheduled = false
+            self?.apply()
+        }
+    }
+
+    /// Read the observable inputs, set the Dock badge count, and re-arm tracking so the next change
+    /// re-fires. `GhosttyApp.notificationBadgeEnabled` is read but NOT `@Observable`, so its flips don't
+    /// re-arm here — they come through `start()`'s `.agtermAppearanceChanged` observer instead.
+    private func apply() {
+        let count = withObservationTracking { () -> Int in
+            guard GhosttyApp.shared.notificationBadgeEnabled else { return 0 }
+            return self.library?.totalUnseenCount ?? 0
+        } onChange: { [weak self] in
+            DispatchQueue.main.async { MainActor.assumeIsolated { self?.scheduleRefresh() } }
+        }
+        // setBadgeCount(0) clears the badge; a positive count shows the OS-rendered pill over the live
+        // adaptive icon (needs the `.badge` authorization `NotificationManager` requests). Capped at 99
+        // to mirror the sidebar pill's `99+` ceiling (the OS renders the raw Int, so this is the cap).
+        UNUserNotificationCenter.current().setBadgeCount(min(count, 99))
+    }
+}

--- a/agterm/Notifications/NotificationManager.swift
+++ b/agterm/Notifications/NotificationManager.swift
@@ -27,12 +27,14 @@ final class NotificationManager: NSObject, @preconcurrency UNUserNotificationCen
     /// suppressed but the sidebar badge still tracks unseen notifications. Set by `SettingsModel`.
     var bannersEnabled = true
 
-    /// Register as the notification delegate and request alert authorization. Idempotent; the
-    /// scene `.task` may re-run. Best-effort: a denial just means no banners.
+    /// Register as the notification delegate and request alert + badge authorization. Idempotent; the
+    /// scene `.task` may re-run. Best-effort: a denial just means no banners. The `.badge` option is what
+    /// lets `DockBadgeController` render the Dock count via `UNUserNotificationCenter.setBadgeCount` — the
+    /// legacy `NSApp.dockTile.badgeLabel` is silently suppressed for agterm without it.
     func start() {
         let center = UNUserNotificationCenter.current()
         center.delegate = self
-        center.requestAuthorization(options: [.alert]) { granted, error in
+        center.requestAuthorization(options: [.alert, .badge]) { granted, error in
             if !granted { logger.notice("notification authorization denied: \(String(describing: error), privacy: .public)") }
         }
     }

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -160,6 +160,10 @@ struct agtermApp: App {
                     NotificationManager.shared.actions = actions
                     NotificationManager.shared.library = library
                     NotificationManager.shared.start()
+                    // drive the Dock icon's count badge (via UNUserNotifications) from the app-wide unseen
+                    // total (the same Session.unseenCount the sidebar pills track, summed across windows).
+                    DockBadgeController.shared.library = library
+                    DockBadgeController.shared.start()
                     // surface keymap parse errors / conflicts loaded at SettingsModel init (too early to
                     // post then — before notification registration above). Only on the launch window:
                     // `hasReopened` is still false here for the first window's `.task` (reopenWindows()
@@ -722,7 +726,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // `AppIcon.icon`, which the system renders LIVE in the Dock with the current appearance
         // (light/dark/clear/tinted, Liquid Glass). applicationIconImage takes a STATIC NSImage, so
         // setting it (even from the compiled asset) freezes the Dock to one flat rendering and defeats
-        // the adaptive icon. Let LaunchServices render the bundle icon.
+        // the adaptive icon. Let LaunchServices render the bundle icon. (The Dock unseen-count badge is
+        // the modern `UNUserNotificationCenter.setBadgeCount` — see `DockBadgeController` — which renders
+        // over the live adaptive icon without touching `applicationIconImage`.)
         restoreObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.didFinishRestoringWindowsNotification,
             object: NSApp,
@@ -862,6 +868,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationWillTerminate(_: Notification) {
         controlServer?.stop()
         customCommandRunner?.stop()
+        // clear the OS-level Dock badge — it outlives the process, and unseenCount is ephemeral, so a quit
+        // with unseen > 0 would leave a stale count pinned on the Dock icon (the willClose refresh() poke
+        // can't: isTerminating below makes closeWindow no-op, so the total recomputes unchanged).
+        DockBadgeController.shared.clear()
         // mark terminating so the per-window willClose close-reporting can't zero the open-set as each
         // window tears down during quit — the set must survive for the next launch's reopen-all.
         library?.isTerminating = true

--- a/agtermCore/Sources/agtermCore/WindowLibrary.swift
+++ b/agtermCore/Sources/agtermCore/WindowLibrary.swift
@@ -169,6 +169,17 @@ public final class WindowLibrary {
         openIDs().compactMap { stores[$0] }.flatMap { $0.workspaces.flatMap(\.sessions) }
     }
 
+    /// The total unseen-notification count across every session in every OPEN window — the number the
+    /// Dock tile badge shows (`DockBadgeController`), the app-wide roll-up of the same `Session.unseenCount`
+    /// the sidebar's red pills track. Reads the observable `windows` list, each open store's `workspaces`,
+    /// and each session's `unseenCount`, so a `withObservationTracking` observer over this re-fires on a
+    /// notification bump, a focus/select clear, and a session add/remove. A window CLOSE drops a store
+    /// (`@ObservationIgnored stores`), which is NOT observable — the app refreshes the badge explicitly on
+    /// the `willClose` teardown for that case.
+    public var totalUnseenCount: Int {
+        allOpenSessions().reduce(0) { $0 + $1.unseenCount }
+    }
+
     /// The number of currently-open windows and the total number of sessions across them — the
     /// counts the quit confirmation reports. A window is open iff its store is loaded.
     public func openCounts() -> (windows: Int, sessions: Int) {

--- a/agtermCore/Tests/agtermCoreTests/WindowLibraryTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/WindowLibraryTests.swift
@@ -57,6 +57,23 @@ final class WindowLibraryTests {
         #expect(library.allOpenSessions().count == 3)
     }
 
+    @Test func totalUnseenCountSumsEverySessionAcrossWindows() {
+        let library = WindowLibrary(directory: directory)
+        #expect(library.totalUnseenCount == 0) // a fresh tree has nothing unseen
+        let firstStore = try! #require(library.store(for: library.windows[0].id))
+        firstStore.workspaces[0].sessions[0].unseenCount = 2
+        let second = library.newWindow(name: "work")
+        let secondStore = try! #require(library.store(for: second.id))
+        secondStore.workspaces[0].sessions[0].unseenCount = 3
+        let extra = try! #require(secondStore.addSession(toWorkspace: secondStore.workspaces[0].id, cwd: "/tmp"))
+        extra.unseenCount = 5
+        // 2 (window 1) + 3 + 5 (work) = 10 across both open windows.
+        #expect(library.totalUnseenCount == 10)
+        // closing a window drops its sessions from the roll-up.
+        library.closeWindow(second.id)
+        #expect(library.totalUnseenCount == 2)
+    }
+
     @Test func defaultWindowNameCountsUp() {
         let library = WindowLibrary(directory: directory)
         #expect(library.defaultWindowName == "window 2")


### PR DESCRIPTION
Closes #47.

## What

Show the app-wide unseen-notification total on the **Dock icon** as a count badge — the same `Session.unseenCount` the sidebar pills track, summed across every open window. Capped at 99, cleared at zero, gated by the existing **"Show notification badges"** Settings toggle (one switch governs both the sidebar pill and the Dock badge).

## How

Uses the modern **`UNUserNotificationCenter.setBadgeCount`**, which renders the pill over the live adaptive Icon Composer icon with full light/dark/tint/clear adaptivity — no `applicationIconImage`, no icon override. `NotificationManager` now requests `[.alert, .badge]` (the legacy `dockTile.badgeLabel` is silently suppressed without the badge grant).

## Changes

- `agtermCore`: `WindowLibrary.totalUnseenCount` (host-free, unit-tested).
- `DockBadgeController` (`@MainActor` singleton): Observation re-registration drives `apply()` on every notification bump / focus-clear / session add-remove; explicit `refresh()` pokes on the two unobservable store mutations — window **close** (`willClose` teardown in `ContentView`, `window.close` in `ControlServer`) and window **reopen** (`ContentView.resolveStore` after `loadStore`); `.agtermAppearanceChanged` observer for the (non-`@Observable`) toggle flip.
- `clear()` on `applicationWillTerminate` zeroes the OS-level badge on quit (it outlives the process, and `unseenCount` is ephemeral, so otherwise a quit with unseen > 0 leaves a stale count pinned on the Dock icon).
- `NotificationManager` requests `.badge`; controller wired in the scene `.task`.
- `.claude/rules/notifications.md` documents the subsystem.

Keep-in-sync **exempt**: pure derived chrome — `unseenCount` is already driven by `notify` / `session.select`, so there's nothing new to expose over the control socket.

## Note on existing installs

`setBadgeCount` needs the per-app **Badges** setting enabled. Fresh authorizations get it on by default; a bundle previously granted `[.alert]`-only keeps `badgeSetting == .disabled` until Badges is toggled on once in System Settings (standard UN behavior — no API to force it).

## Testing

- `swift test` (agtermCore): **825 tests pass**, incl. `totalUnseenCount`.
- App builds (Debug); swiftlint clean.
- Verified end-to-end on macOS 26.5.1: the pill renders over the live adaptive icon (icon stays adaptive, no static swap) with Badges enabled. Dock-tile rendering isn't XCUITest-coverable, so it's manually verified like the other AppKit chrome.
