### PR TITLE
feat: insert dropped file paths as text

### DIFF
--- a/agterm/Ghostty/GhosttyCallbacks.swift
+++ b/agterm/Ghostty/GhosttyCallbacks.swift
@@ -1,5 +1,6 @@
 // adapted from thdxg/macterm (MIT)
 
+import agtermCore
 import AppKit
 import GhosttyKit
 import os
@@ -122,18 +123,23 @@ final class GhosttyCallbacks: @unchecked Sendable {
         return true
     }
 
-    /// Returns pasted text from the pasteboard: file paths (Finder drag/copy)
-    /// fall back to plain string.
-    static func readPasteboardText() -> String? {
-        let pb = NSPasteboard.general
+    /// Returns the text for a pasteboard: file/web URLs (Finder copy, or a drag-drop) become shell-escaped
+    /// paths, space-joined for multiple, so a path with spaces lands as one argument; otherwise the plain
+    /// string verbatim (it may be a command the user means to run, so it is NOT escaped). Shared by the
+    /// clipboard paste path (`readPasteboardText`) and the drag-drop handler (`GhosttySurfaceView`), so a
+    /// dropped file inserts its path exactly like a pasted one.
+    static func pasteboardText(_ pb: NSPasteboard) -> String? {
         if let urls = pb.readObjects(forClasses: [NSURL.self]) as? [URL] {
-            let paths = urls
-                .map { url in url.isFileURL ? url.path(percentEncoded: false) : url.absoluteString }
+            let parts = urls
+                .map { ShellEscape.path($0.isFileURL ? $0.path(percentEncoded: false) : $0.absoluteString) }
                 .filter { !$0.isEmpty }
-            if !paths.isEmpty { return paths.joined(separator: " ") }
+            if !parts.isEmpty { return parts.joined(separator: " ") }
         }
         return pb.string(forType: .string).flatMap { !$0.isEmpty ? $0 : nil }
     }
+
+    /// Pasted text from the general clipboard (the libghostty paste callback).
+    static func readPasteboardText() -> String? { pasteboardText(.general) }
 
     func confirmReadClipboard(ud: UnsafeMutableRawPointer?, content: UnsafePointer<CChar>?, state: UnsafeMutableRawPointer?) {
         guard let content else { return }

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -316,6 +316,29 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         }
     }
 
+    // MARK: - Drag and drop (issue #51)
+
+    /// Accept the drag with a copy cursor when it carries something we can insert (a file/web URL or text),
+    /// reject it otherwise — so a session-row drag from the sidebar (a private pasteboard type) is ignored.
+    override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
+        dropText(from: sender) != nil ? .copy : []
+    }
+
+    /// Insert the dropped file's path (shell-escaped, space-joined for multiple) or text at the cursor,
+    /// using the SAME pasteboard logic as paste so a drop and a paste behave identically. Deferred to the
+    /// next runloop tick so the drag session fully unwinds before the terminal buffer is mutated.
+    override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+        guard let text = dropText(from: sender) else { return false }
+        DispatchQueue.main.async { [weak self] in self?.inject(text: text) }
+        return true
+    }
+
+    /// The text a drop would insert, via the shared `GhosttyCallbacks.pasteboardText` reader; nil when the
+    /// drag carries nothing usable (e.g. an internal sidebar row drag).
+    private func dropText(from sender: any NSDraggingInfo) -> String? {
+        GhosttyCallbacks.pasteboardText(sender.draggingPasteboard)
+    }
+
     /// Returns this surface's current selection text (the control channel's `session.copy`), or nil when
     /// there is no selection or the surface has not been created yet. The selection is a property of the
     /// surface's terminal state, independent of focus, so any realized session can be read. The libghostty
@@ -414,6 +437,9 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
 
     func createSurface() {
         guard !isDestroyed else { return }
+        // register as a file drop target (issue #51): dropping files inserts their paths. idempotent
+        // across re-entry (createSurface re-runs when a deferred surface finally gets a backing size).
+        registerForDraggedTypes([.fileURL, .string, .URL])
         guard surface == nil, let app = GhosttyApp.shared.app else { return }
         let backingSize = convertToBacking(bounds).size
         guard backingSize.width > 0, backingSize.height > 0 else {

--- a/agtermCore/Sources/agtermCore/ShellEscape.swift
+++ b/agtermCore/Sources/agtermCore/ShellEscape.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// ShellEscape backslash-escapes a filesystem path (or URL) for insertion into a terminal as literal text,
+/// the drag-drop / paste path-insertion case: a dropped path with spaces or parentheses lands as ONE shell
+/// argument, while a plain path with no shell-significant characters is returned UNCHANGED (no surrounding
+/// quotes), keeping the common case clean for a CLI agent that reads the path out of its prompt.
+///
+/// This differs from `CommandRestore.shellQuote`, which always single-quote-wraps an argv element for shell
+/// re-execution; that is the right choice for re-running a captured command, but wrong here because it would
+/// wrap even a clean `/path/image.png` in quotes.
+public enum ShellEscape {
+    /// The shell-significant characters that get a backslash prefix. Backslash is FIRST so the pass that
+    /// escapes it does not double-escape the backslashes added for the rest.
+    private static let significant: [Character] = Array("\\ ()[]{}<>\"'`!#$&;|*?\t")
+
+    /// Backslash-escape every shell-significant character in `path`; a path with none is returned unchanged.
+    public static func path(_ path: String) -> String {
+        var result = path
+        for character in significant {
+            result = result.replacingOccurrences(of: String(character), with: "\\" + String(character))
+        }
+        return result
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/ShellEscapeTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ShellEscapeTests.swift
@@ -1,0 +1,25 @@
+import Testing
+@testable import agtermCore
+
+struct ShellEscapeTests {
+    @Test func plainPathUnchanged() {
+        #expect(ShellEscape.path("/Users/me/image.png") == "/Users/me/image.png")
+    }
+
+    @Test func escapesSpacesAndParens() {
+        #expect(ShellEscape.path("/Users/me/My File (1).txt") == "/Users/me/My\\ File\\ \\(1\\).txt")
+    }
+
+    @Test func escapesBackslashFirstWithoutDoubleEscaping() {
+        // a literal backslash becomes \\, and a following space becomes \ (not re-escaped to \\ ).
+        #expect(ShellEscape.path("a\\b c") == "a\\\\b\\ c")
+    }
+
+    @Test func escapesShellMetacharacters() {
+        #expect(ShellEscape.path("a&b;c|d$e") == "a\\&b\\;c\\|d\\$e")
+    }
+
+    @Test func emptyStaysEmpty() {
+        #expect(ShellEscape.path("") == "")
+    }
+}


### PR DESCRIPTION
implements the drag-drop file-path request in #51: dropping a file onto a terminal now inserts its path at the cursor, like paste and like Kitty/iTerm/Terminal.

`GhosttySurfaceView` becomes an `NSDraggingDestination` (registers `.fileURL`/`.string`/`.URL`, shows the copy cursor when the drag is usable, and on drop injects the text via the existing `inject(text:)`, deferred a tick so the drag session unwinds). File/web URLs are shell-escaped (backslash style, so a clean path stays clean and only spaces or specials are escaped) and space-joined for multiple files; dropped plain text is inserted verbatim. Modeled on macterm's `GhosttyTerminalNSView` drop handling.

the escaper is a new host-free `agtermCore.ShellEscape.path` (5 unit tests). Drop and paste now share one `GhosttyCallbacks.pasteboardText` reader, so pasting a file path with spaces escapes consistently too (it didn't before, a latent bug). No new control command, the control-channel equivalent is the existing `session.type`.

**testing:** 799 host-free tests pass (including the ShellEscape suite) and the app builds; verified live by dropping files (with and without spaces) and selected text onto a dev instance. The drop interaction itself isn't XCUITest-able (a Finder file-drag onto an NSView can't be synthesized), so coverage is the host-free escaper tests plus manual verification.

**README:** intentionally left untouched, drag-drop is standard terminal behavior and the intro bullets cover agterm's distinctive features. Happy to add a line if you want one.

Fix #51
