### PR TITLE
fix: forward right- and middle-click to libghostty

### DIFF
--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -854,6 +854,40 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, mods(event))
     }
 
+    // forward right- and middle-button press/release to libghostty so its mouse bindings fire (e.g.
+    // `right-click-action = paste`). mirrors the left handlers — `mouse_pos` before `mouse_button` — but
+    // does NOT grab focus (a right/middle click on macOS doesn't move first responder). agterm has no
+    // terminal context menu, so the return value is discarded like the left handler.
+    override func rightMouseDown(with event: NSEvent) {
+        guard let surface else { return }
+        let pt = mousePoint(from: event)
+        ghostty_surface_mouse_pos(surface, pt.x, pt.y, mods(event))
+        _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_RIGHT, mods(event))
+    }
+
+    override func rightMouseUp(with event: NSEvent) {
+        guard let surface else { return }
+        let pt = mousePoint(from: event)
+        ghostty_surface_mouse_pos(surface, pt.x, pt.y, mods(event))
+        _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_RIGHT, mods(event))
+    }
+
+    // only the middle button (buttonNumber 2) maps to GHOSTTY_MOUSE_MIDDLE; any other extra button
+    // (back/forward, etc.) falls through to the responder chain via super.
+    override func otherMouseDown(with event: NSEvent) {
+        guard event.buttonNumber == 2, let surface else { super.otherMouseDown(with: event); return }
+        let pt = mousePoint(from: event)
+        ghostty_surface_mouse_pos(surface, pt.x, pt.y, mods(event))
+        _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_MIDDLE, mods(event))
+    }
+
+    override func otherMouseUp(with event: NSEvent) {
+        guard event.buttonNumber == 2, let surface else { super.otherMouseUp(with: event); return }
+        let pt = mousePoint(from: event)
+        ghostty_surface_mouse_pos(surface, pt.x, pt.y, mods(event))
+        _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_MIDDLE, mods(event))
+    }
+
     override func mouseDragged(with event: NSEvent) { mouseMoved(with: event) }
     override func rightMouseDragged(with event: NSEvent) { mouseMoved(with: event) }
     override func otherMouseDragged(with event: NSEvent) { mouseMoved(with: event) }


### PR DESCRIPTION
right- and middle-button clicks were never forwarded to libghostty (only left was): `GhosttySurfaceView` sent `GHOSTTY_MOUSE_LEFT` from `mouseDown`/`mouseUp` but had no `rightMouseDown`/`rightMouseUp` or `otherMouseDown`/`otherMouseUp`, so `right-click-action = paste` in `ghostty.conf` did nothing because the right-click event never reached the engine.

adds `rightMouseDown`/`rightMouseUp` forwarding `GHOSTTY_MOUSE_RIGHT` and `otherMouseDown`/`otherMouseUp` forwarding `GHOSTTY_MOUSE_MIDDLE` (middle button only, `buttonNumber == 2`; back/forward and other extra buttons fall through to `super`), mirroring the existing left handlers (`mouse_pos` before `mouse_button`, `mods(event)`) but without the focus grab, since a right or middle click on macOS doesn't move first responder. Modeled on macterm's `GhosttyTerminalNSView` right-click forwarding; agterm has no terminal context menu, so the return value is discarded like the left handler rather than driving a menu fallback.

**testing:** no automated test, mouse-button forwarding into libghostty isn't host-free or XCUITest-able (same class as cursor focus). Verified manually: with `right-click-action = paste` set, right-click now pastes the clipboard, and middle-click pastes too.

Fix #45
