### PR TITLE
docs: reflow .claude/rules and CLAUDE.md into semantic line breaks

### DIFF
--- a/.claude/rules/app-icon.md
+++ b/.claude/rules/app-icon.md
@@ -6,8 +6,38 @@ paths:
 
 ## App icon
 
-- The icon is an **adaptive Icon Composer document** at `agterm/AppIcon.icon` (macOS 26 `.icon` format — layered, with Liquid Glass + light/dark/clear/tinted appearances the system renders LIVE). `ASSETCATALOG_COMPILER_APPICON_NAME` is `AppIcon`; `CFBundleIconName` ends up `AppIcon` (actool writes it). actool compiles the `.icon` into `Assets.car` (the adaptive data) plus a legacy `AppIcon.icns` fallback for macOS < 26 — no hand-made `.appiconset`/`.icns` needed.
-- **The `.icon` MUST be a target FILE, NOT nested inside `Assets.xcassets` (load-bearing).** actool only compiles a `.icon` passed as a DIRECT input; a `.icon` dropped inside an `.xcassets` is treated as an opaque folder and actool **silently emits nothing** (no error, no `Assets.car` — the app ends up icon-less). So `AppIcon.icon` lives at the top of the `agterm/` source dir (Xcode types it `wrapper.icon` and routes it to actool alongside the catalog: `actool …/AppIcon.icon …/Assets.xcassets --compile …`). To swap the design, replace `agterm/AppIcon.icon` (re-export from Icon Composer; `xattr -cr` it first — the source carries quarantine/provenance). A CONTENT swap recompiles on an incremental `make build`; but a STRUCTURAL asset-catalog change (adding/removing the icon, or the appiconset↔`.icon` swap) can make xcodebuild SKIP actool entirely — a "BUILD SUCCEEDED" with a STALE `Assets.car` and no new icon. Force it with `make clean` and confirm `Contents/Resources/AppIcon.icns`'s mtime actually updated.
-- **xcodegen also lists the `.icon` in Copy Bundle Resources**, dropping a redundant LOOSE `AppIcon.icon` in the bundle. The `Bundle agtermctl CLI` postBuildScript `rm -rf`s it before the re-seal: a loose source `.icon` renders as the generic Icon-Composer **placeholder grid** (so it must not win over the compiled icon), and its source xattrs would trip `codesign --deep`.
-- **Do NOT set `NSApp.applicationIconImage`.** `applicationIconImage` takes a STATIC `NSImage`, so setting it (even from the compiled asset) FREEZES the Dock to one flat rendering and defeats the adaptive icon — the symptom is a flat, non-glass, non-tinted Dock tile. The shipped app lets LaunchServices render the bundle `.icon` live. (An earlier `applicationWillFinishLaunching` override that set it for the ad-hoc Debug Dock tile was removed for exactly this reason.)
-- **Debug builds from DerivedData may show a STALE Dock/Finder tile.** Icon Services caches by bundle PATH and the DerivedData path is reused across rebuilds, so a rebuilt dev app can show the prior (or placeholder) icon — NOT a bug. The deployed app (fresh install path) renders correctly. To verify a dev build's icon, copy the `.app` to a fresh path + `lsregister -f` it (or read `Contents/Resources/AppIcon.icns` directly).
+- The icon is an **adaptive Icon Composer document** at `agterm/AppIcon.icon` (macOS 26 `.icon` format
+  — layered, with Liquid Glass + light/dark/clear/tinted appearances the system renders LIVE).
+  `ASSETCATALOG_COMPILER_APPICON_NAME` is `AppIcon`; `CFBundleIconName` ends up `AppIcon` (actool writes
+  it). actool compiles the `.icon` into `Assets.car` (the adaptive data) plus a legacy `AppIcon.icns`
+  fallback for macOS < 26 — no hand-made `.appiconset`/`.icns` needed.
+- **The `.icon` MUST be a target FILE, NOT nested inside `Assets.xcassets` (load-bearing).** actool only
+  compiles a `.icon` passed as a DIRECT input; a `.icon` dropped inside an `.xcassets` is treated as
+  an opaque folder and actool **silently emits nothing** (no error, no `Assets.car` — the app ends up
+  icon-less).
+  So `AppIcon.icon` lives at the top of the `agterm/` source dir (Xcode types it `wrapper.icon` and routes
+  it to actool alongside the catalog: `actool …/AppIcon.icon …/Assets.xcassets --compile …`).
+  To swap the design, replace `agterm/AppIcon.icon` (re-export from Icon Composer;
+  `xattr -cr` it first — the source carries quarantine/provenance).
+  A CONTENT swap recompiles on an incremental `make build`; but a STRUCTURAL asset-catalog change (adding/removing
+  the icon, or the appiconset↔`.icon` swap) can make xcodebuild SKIP actool entirely — a "BUILD SUCCEEDED"
+  with a STALE `Assets.car` and no new icon.
+  Force it with `make clean` and confirm `Contents/Resources/AppIcon.icns`'s mtime actually updated.
+- **xcodegen also lists the `.icon` in Copy Bundle Resources**, dropping a redundant LOOSE `AppIcon.icon`
+  in the bundle.
+  The `Bundle agtermctl CLI` postBuildScript `rm -rf`s it before the re-seal:
+  a loose source `.icon` renders as the generic Icon-Composer **placeholder grid** (so it must not win
+  over the compiled icon), and its source xattrs would trip `codesign --deep`.
+- **Do NOT set `NSApp.applicationIconImage`.**
+  `applicationIconImage` takes a STATIC `NSImage`, so setting it (even from the compiled asset) FREEZES
+  the Dock to one flat rendering and defeats the adaptive icon — the symptom is a flat,
+  non-glass, non-tinted Dock tile.
+  The shipped app lets LaunchServices render the bundle `.icon` live.
+  (An earlier `applicationWillFinishLaunching` override that set it for the ad-hoc Debug Dock tile was
+  removed for exactly this reason.)
+- **Debug builds from DerivedData may show a STALE Dock/Finder tile.**
+  Icon Services caches by bundle PATH and the DerivedData path is reused across rebuilds,
+  so a rebuilt dev app can show the prior (or placeholder) icon — NOT a bug.
+  The deployed app (fresh install path) renders correctly.
+  To verify a dev build's icon, copy the `.app` to a fresh path + `lsregister -f` it (or read `Contents/Resources/AppIcon.icns`
+  directly).

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -18,16 +18,540 @@ paths:
 
 ## Control API
 
-- A programmatic control channel lets an external script drive `agterm` over a local unix-domain socket, via the companion `agtermctl` CLI. It is a thin dispatcher onto the existing `AppActions`/`AppStore` seam — the third caller of that seam, alongside the toolbar/bottom bar and the menu bar — so no business logic is duplicated. Scope is personal scripting: fire-and-forget commands, no terminal-output/scrollback streaming and no event subscription (out of scope by design).
+- A programmatic control channel lets an external script drive `agterm` over a local unix-domain socket,
+  via the companion `agtermctl` CLI.
+  It is a thin dispatcher onto the existing `AppActions`/`AppStore` seam — the third caller of that seam,
+  alongside the toolbar/bottom bar and the menu bar — so no business logic is duplicated.
+  Scope is personal scripting: fire-and-forget commands, no terminal-output/scrollback streaming and
+  no event subscription (out of scope by design).
 - **Three layers, matching the core/app split:**
-  1. **Protocol + pure logic in `agtermCore`** (Foundation-only, `Codable`, `Sendable`): `ControlProtocol.swift` holds the `Command` enum, `ControlArgs`, `ControlRequest`, the tree node types (`ControlSessionNode`/`ControlWorkspaceNode`/`ControlTree`), `ControlResult`, and `ControlResponse`. `ControlResolve.swift` holds the pure target resolver (`resolve(_:candidates:active:) -> TargetResolution`) and the socket-path resolver (`socketPath(stateDir:appSupport:)`). Shared by both the app and the CLI so the wire contract cannot drift.
-  2. **`ControlServer` in the app target** (`agterm/Control/ControlServer.swift`, `@MainActor`): owns the POSIX unix socket. The blocking accept/read loop runs on a background `DispatchQueue`; each newline-delimited `ControlRequest` is decoded, hopped to `@MainActor`, dispatched onto `AppActions`/`AppStore` (plus a thin `GhosttySurfaceView.inject(text:)` for input), and the `ControlResponse` written back before the connection closes.
-  3. **`agtermctl` CLI** in the `agtermCore` SwiftPM package: an `agtermctlKit` library (the `ParsableCommand` tree in `Commands.swift` + the socket client in `SocketClient.swift`) plus a thin `agtermctl` executable. It links `swift-argument-parser`; the `agtermCore` library target stays dependency-free. Builds with `swift build`, needs no Xcode/GhosttyKit.
-- **Bundling + install.** The `agterm` target's `Bundle agtermctl CLI` postBuildScript (`project.yml`) runs `swift build -c release --product agtermctl`, copies it to `agterm.app/Contents/MacOS/agtermctl`, ad-hoc signs the helper, then **re-signs the whole app `--deep`** — the phase can run AFTER Xcode's own code-sign on incremental builds, so without the re-seal the injected helper breaks the signature (and a shallow re-sign chokes on the Debug `agterm.debug.dylib`). **Help ▸ Install Command Line Tool…** (`agtermApp` `CommandGroup(replacing: .help)` → `CLIInstaller.run()`) symlinks the bundled binary into `/usr/local/bin` (first entry in macOS's default `/etc/paths`, unlike `~/.local/bin`): a direct `FileManager` symlink when the dir is user-writable, else a one-time GUI admin prompt via `osascript … with administrator privileges`. Pure path/quote logic is `agtermCore.CLIInstall` (host-free, unit-tested); the AppKit FS + auth glue is `CLIInstaller` (app-side, manually verified like the directory picker). Install is GUI-only and keep-in-sync EXEMPT — driving it over the socket is meaningless (you'd need `agtermctl` already installed to call it).
-- **Agent-status hooks install.** A second Help entry, **Help ▸ Install Agent Status Hooks…** (`AgentHooksInstaller.run()`), wires coding agents to `session.status`. The hooks scripts bundle at `agterm/Resources/agent-status/` (`agterm-agent-status.sh` wrapper + `shell/integration.sh` + `codex-notify.sh`, a `project.yml` Contents/Resources folder mirroring `Resources/ghostty`). The installer copies them to `~/.config/agterm/agent-status/`, bakes the bundled `agtermctl`'s absolute path (`Bundle.main.url(forAuxiliaryExecutable:)`) into the wrapper so the hooks fire even without the CLI on PATH, appends a marker-guarded `source` line to `~/.zshrc` + `~/.bashrc`, merges four Claude Code hooks into `~/.claude/settings.json` with a `.bak` (UserPromptSubmit→`active --blink`, PostToolUse→`active --blink`, Stop→`completed --auto-reset`, Notification[`permission_prompt`]→`blocked`; the unmatched PostToolUse re-asserts `active` after every tool so a `blocked` permission prompt clears back to active when work resumes — Claude Code has no "permission answered" event, and the gated tool's own PreToolUse fires BEFORE `blocked` is set, so the approved tool's PostToolUse is the first hook afterwards), and PRINTS the Codex `~/.codex/config.toml` `notify` line (never auto-edits TOML). Idempotent + re-runnable (re-run refreshes the baked path). Like the CLI installer, the host-free JSON-merge / shell-rc-marker / backup-path logic is `agtermCore.AgentHooksInstall` (unit-tested); `AgentHooksInstaller` (app-side) owns the AppKit FS glue, manually verified.
-- **Agent skill install (Claude Code + Codex).** A third Help entry, **Help ▸ Install Agent Skill…** (`SkillInstaller.run()`), copies a bundled, personal-scope Agent Skill to `~/.claude/skills/agterm/` AND `~/.codex/skills/agterm/` so a coding agent running INSIDE an agterm session knows how to drive the app over the control channel. Claude Code and Codex use the SAME SKILL.md Agent-Skill format (`name`/`description`/`allowed-tools` frontmatter + optional reference files; verified against the user's `~/.codex/skills/`), so one authored skill serves both. The skill is a REFERENCE/knowledge skill (both user-invocable via `/agterm` and model-triggered, `allowed-tools: Bash(agtermctl *)`; the agent-neutral `description` carries the trigger nouns since Codex may ignore the extra `when_to_use` field — unknown frontmatter is harmless), authored at `agterm/Resources/agent-skill/` (`SKILL.md` overview + model + addressing + 46-command summary + the image-display helper + a troubleshooting/reporting pointer; `reference.md` full per-command detail + keymap format; `examples.md` agtermctl recipes; `troubleshooting.md` diagnosing the common problems (keymap editor, custom actions, logs) + the bug-issue / feature-Discussion reporting workflow (draft-first, scrub, never run `gh` without explicit user approval); `scripts/show-image.sh` the bundled image-display helper), bundled via a `project.yml` Contents/Resources FOLDER reference like `agent-status` (the whole dir, INCLUDING the `scripts/` subdir, copies verbatim; `SkillInstaller` uses `FileManager.copyItem` so the subdir reaches both installs). **Image display is NOT a control command** — it's a bundled shell helper: `show-image.sh <image> [size%]` opens an overlay (a real pty) and renders the image via the kitty graphics protocol, which the pinned ghostty draws NATIVELY — pure `base64` + chunked `\e_G` APC frames, NO kitty binary and NO external image tool. (The pinned ghostty renders ONLY the kitty graphics protocol; iTerm2 OSC-1337 inline images and sixel are `unimplemented` in that build — verified in upstream `src/terminal/osc/parsers/iterm2.zig`, the `.File`/`.FilePart`/`.FileEnd`/`.MultipartFile` keys land in the `unimplemented OSC 1337` bucket. The agent CANNOT print graphics escapes to its own tool stdout — the harness escapes the control bytes — nor run a viewer in its tool shell — no `/dev/tty`; the overlay sidesteps both, so the method is agent-harness-agnostic and works identically for Codex.) It is invoked by absolute install path (`~/.claude/skills/agterm/scripts/show-image.sh` or `~/.codex/...`), NOT `${CLAUDE_SKILL_DIR}` — that token is Claude-Code-only and would not expand in the Codex copy of the SAME authored `SKILL.md`. **Install policy:** write to each agent base that EXISTS (`~/.claude` and/or `~/.codex`); if neither, fall back to creating `~/.claude` (`SkillInstall.installTargets`). Pure file-drop (no manifest): per-target remove-then-copy for a clean reinstall, best-effort per agent (one failing doesn't abort the other), but it REFUSES to clobber a same-named skill the user authored (one whose `SKILL.md` lacks the `<!-- agterm-skill -->` marker — `SkillInstall.mayOverwrite`). Host-free path/target/marker logic is `agtermCore.SkillInstall` (unit-tested); `SkillInstaller` (app-side) owns the AppKit copy, manually verified. Install is GUI-only and keep-in-sync EXEMPT (a skill that documents the socket isn't itself driven over it). **KEEP-IN-SYNC (HARD): the bundled skill is a documentation mirror of the control surface — whenever you change the Control API (commands/args/returns), the keymap format, or the window/workspace/session/pane model, update `agterm/Resources/agent-skill/` (SKILL.md + reference.md + examples.md + `troubleshooting.md` + `scripts/`, incl. the command count) so the installed agent-driver doc stays accurate. It is the fourth keep-in-sync surface alongside the GUI/menu/CLI. The skill's `troubleshooting.md` mirrors the user-facing `docs/troubleshooting.md`; keep the two in step when a diagnostic path or the reporting workflow changes.**
-- **Socket path / lifecycle.** The path is `<AGTERM_STATE_DIR>/agterm.sock` when `AGTERM_STATE_DIR` is set (state isolation), else `<app support>/agterm.sock` (`~/Library/Application Support/agterm`), via `ControlResolve.socketPath`. `ControlServer.defaultSocketPath()` adds an `AGTERM_CONTROL_SOCKET` env override that takes precedence (used by XCUITests, whose sandboxed `AGTERM_STATE_DIR` container path exceeds the `sun_path` ~104-byte limit); the CLI's `--socket` flag is the user-facing equivalent. The socket is `chmod 0600`. Each accepted connection sets `SO_RCVTIMEO` (5 s, alongside `SO_NOSIGPIPE`) so a stalled client can't wedge the serial accept loop — a timed-out `read()` returns `EAGAIN`, which `readLine` (any non-`EINTR` `n < 0` = end-of-read) maps to nil → close → `accept()` resumes. `start()` is idempotent (the scene `.task` may re-run) and unlinks any stale path before binding; it is best-effort (a bind failure logs and the app still launches). Lifecycle is asymmetric: started from the scene `.task`, stopped from `AppDelegate.applicationWillTerminate`; a force-quit that skips that leaves a stale socket file, which the next launch's unlink-first handles.
-- **Protocol shape.** One request per connection, newline-delimited JSON: `{"cmd":…,"target":…,"args":{…}}` → one `{"ok":…,"result":…|"error":…}` → close. Mutating commands return the affected/new id in `result.id` (create-then-use without a second round-trip); `tree` returns `result.tree`. An unknown `cmd` fails to decode and comes back as a structured error, never a crash; a 1 MiB max-line cap bounds the read buffer. In `agtermctl`'s human (non-`--json`) output, `result.id` is echoed ONLY for the create commands (`session/workspace/window new`, via `RequestCommand.echoesResultID`) where the new id isn't known yet; every other mutation prints `ok` (the id you already named is noise). The id is always present under `--json`.
-- **Addressing.** UUID is canonical, with sugar: `active` (the selected session / current workspace), exact `uuidString` (case-insensitive), or a git-style unique prefix. Zero prefix hits → `notFound` error, ≥2 → `ambiguous` error listing the candidates. `--target` defaults to `active`, so scripts rarely type an id and never for "the current one".
-- **Command catalog (46 commands):** `tree`; `workspace.new`/`workspace.rename`/`workspace.delete`/`workspace.select`/`workspace.move`/`workspace.focus`; `session.new`/`session.close`/`session.select`/`session.rename`/`session.move`/`session.type`/`session.split`/`session.scratch`/`session.focus`/`session.go`/`session.copy`/`session.search`/`session.status`/`session.flag`/`session.overlay.open`/`session.overlay.close`/`session.overlay.result`; `quick`; `sidebar`/`sidebar.mode`/`sidebar.expand`/`sidebar.collapse`; `notify`; `font.inc`/`font.dec`/`font.reset`; `window.new`/`window.list`/`window.select`/`window.close`/`window.rename`/`window.delete`/`window.resize`/`window.move` (see the Windows section); `keymap.reload` (see the Keymap section); `config.reload` (see the Settings section); `theme.set`/`theme.list` (see the Theme picker section); `restore.clear` (see the Settings section). `workspace.delete` honors keep-at-least-one and returns an error instead of the GUI confirm alert (nothing blocks on a modal). `session.move` is MODE-BEARING: `args.to` (`up`|`down`|`top`|`bottom`) REORDERS the session within its own workspace (parses `ReorderDirection`, drives `AppStore.reorderSession` → the existing `moveSession(at:)` primitive, returns the session id), while `args.workspace` RELOCATES it to another workspace (unchanged — still appends at the end); both-set and neither-set are errors, and an invalid direction is an error. `workspace.move` is the workspace REORDER (control-native, no separate verb): `args.to` (`up`|`down`|`top`|`bottom`) resolves the workspace target via the shared `resolveWorkspace` (honoring the global `--window` selector like other workspace commands), drives `AppStore.reorderWorkspace`, and returns the workspace id; a missing or invalid `to` is an error. Drag-and-drop stays the precise (drop-between-rows) surface; the control path is relative-only, mirroring `session.go --to`. Four-point keep-in-sync audit for `workspace.move`: (1) `case workspaceMove = "workspace.move"` in `ControlProtocol.swift` (reuses `ControlArgs.to`, no new field), (2) the `.workspaceMove` dispatch arm in `ControlServer`, (3) the `workspace move --to` subcommand in `agtermctlKit`, (4) round-trip tests in `ControlProtocolTests` plus the e2e in `ControlAPIUITests`. NOTE on `workspace.move --target active`: `active` for a workspace resolves to `AppStore.currentWorkspaceID`, which with NO selected session falls back to `workspaces.last` — so repeated `workspace.move --to top --target active` on a session-less window targets a DIFFERENT (newly-last) workspace each call (consistent with the `currentWorkspaceID` fallback contract; address a specific workspace by id/prefix to step the same one). `session.split` resolves the target id and drives `AppStore.toggleSplit` directly (NOT the argument-less `AppActions.toggleSplit()`, which only acts on the active session) — `off` HIDES the split keep-alive, mirroring ⌘D (the pane's surface is NOT torn down; `closeSplit` stays the shell-exit-only path, so there is no on-demand destroy over the control channel, matching the GUI). `session.scratch` (mode `on`|`off`|`toggle`, mirrors `session.split` exactly) shows/hides the **scratch terminal** — a THIRD per-session login shell (alongside main + split) that RENDERS like a full overlay (full-pane, hides the session, translucent) but BEHAVES like the split: lazily spawned on first show, kept alive when hidden (`off` is `AppStore.toggleScratch` keep-alive, never a teardown), recreated fresh after its shell's own `exit`. NOT persisted (absent from `SessionSnapshot`, like the overlay) — `Session.scratchActive`/`scratchSurface`, `AppStore.toggleScratch`/`closeScratch` (the latter only on `exit` + session/workspace/window teardown). Full-overlay rendering only (never floating) so it's a structural clone of the proven `if fullOverlay` ZStack sibling at `.zIndex(1)`, BELOW the ephemeral overlay (`.zIndex(2)` — a normal overlay launched over the scratch sits on top); the panes' opacity/hit-testing gate is `hideForOverlay = fullOverlay || scratchActive` (still false for a FLOATING overlay, preserving the NSSplitView-overrun invariant). GUI half: ⌘J (`BuiltinAction.toggleScratch`), title-bar `scratch-toggle` button, View ▸ Show/Hide Scratch, the ⌃⇧P palette "Toggle Scratch" — all through `AppActions.toggleScratch()`. The scratch surface is NOT wired to the session (no `view.session`, like the overlay) so its PWD/title never clobber the sidebar name; `autoFocus` grabs first responder on show, the detail pane's `.onChange(of: scratchActive)` reclaims it on hide. Four-point keep-in-sync audit: (1) `case sessionScratch = "session.scratch"` + the new `ControlSessionNode.scratch` flag in `ControlProtocol.swift` (reuses `ControlArgs.mode`), (2) the `.sessionScratch` dispatch arm (`scratchSession`) in `ControlServer` + `scratch:` in the tree builder, (3) the `session scratch` subcommand in `agtermctlKit`, (4) round-trip in `ControlProtocolTests` + the e2e `testSessionScratchToggle` in `ControlAPIUITests`. `session.focus` moves keyboard focus between the two split panes — `args.pane` is `left`|`right`|`other` (`other` toggles, the default); it errors when the session has no split (works whether the split is shown side-by-side or hidden — when hidden, focusing a pane swaps which one shows maximized), drives `AppActions.setSplitFocus(_:of:)`, and is the control half of the ⌘⌥←/→ keyboard nav + the "Focus Left/Right Pane" menu/palette items. `session.go` navigates BETWEEN sessions — `args.to` is `next`|`prev`|`first`|`last`|`next-attention`|`prev-attention` and acts on the target store's CURRENT selection (it is RELATIVE, so it resolves the placement store via `resolvePlacementStore` rather than a session target — there is NO `--target`), stops at the ends on next/prev (no wrap), jumps to the ends for first/last, and for `next-attention`/`prev-attention` steps through ONLY the sessions needing attention (`AgentStatus.needsAttention` = `blocked`/`completed`) WRAPPING around (skipping idle/active), drives `AppStore.navigateSession`, and returns the newly-selected id in `result.id`. It mirrors the `session.focus --pane` one-command-with-arg precedent and is the control half of the ⌥⌘↑/⌥⌘↓ session-nav + ⌃⌥↑/⌃⌥↓ attention-nav menu/palette items (First/Last have no hotkey). `notify` posts a desktop notification attributed to a session (default: the active session of the frontmost window via `resolveSession`): `args.body` is required, `args.title` defaults to the session name. It is control-NATIVE (no GUI/menu equivalent, like `session.type`/`session.copy`) and goes through `NotificationManager.send(toSession:title:body:)` — which, unlike the OSC 9/777 path, does NOT focus-suppress (the caller asked for it) but still bumps the badge + carries the `<windowID>:<sessionID>:main` click-to-reveal identity. It is the ONLY app-level way to post a banner; the terminal OSC path remains the other source. `session.new` creates a session. The destination workspace is addressed one of two MUTUALLY-EXCLUSIVE ways: `args.workspace` (id / unique prefix / `active`, the default) OR `args.workspaceName` (the sidebar label, name-matched first-exact-trimmed via `AppStore.workspace(named:)`) — the latter optionally with `args.createWorkspace` to reuse-or-create the named workspace (idempotent; `AppStore.ensureWorkspace(named:)`). A `workspaceName` with no match and no `createWorkspace` errors, both addressing modes set is an error, and `createWorkspace` without `workspaceName` is an error (nothing to create by id); the same two rules are pre-validated CLI-side by `session new`'s `validate()`. `args.command` runs that command AS the session's process instead of the login shell (like kitty's `launch <cmd>` / ghostty's `command`) — NO echoed command line, and the session closes when the command exits (the normal single-pane `onExit` → `closePrimaryPane`). It is transient + run-once: `Session.initialCommand` is `@ObservationIgnored` and absent from `SessionSnapshot`, so a restored session is a plain shell. The arm threads `request.args?.command` into `AppStore.addSession(…, command:)`, which `makeSurface` passes to `GhosttySurfaceView(command:)` → `config.command` RAW (`strdup`, NO wrapper). libghostty tokenizes it into argv (shell-like word-splitting that RESPECTS quotes) and execs argv[0] DIRECTLY — there is NO `sh -c`, so shell operators (`;`, `&&`, `|`, `$VAR`, redirects, globs) are NOT interpreted: `ssh host -p 22 -t "ssh inner"` works (the nested command rides as one quoted arg, runs with no echo — verified empirically), but `clear; ssh …` execs a program literally named `clear;` and fails. This is NOT the overlay's path — `makeOverlaySurface` explicitly wraps its command in `sh -c '…'` (so the overlay DOES get shell semantics); a session `--command` that needs shell features must wrap ITSELF, e.g. `--command "sh -c '…'"`. Keep-in-sync: the `.sessionNew` case carries `ControlArgs.command` plus `ControlArgs.name` (custom name) and `ControlArgs.workspaceName` + `ControlArgs.createWorkspace` (name-addressing + ensure); the arm pre-validates the mutual-exclusion / create-needs-name rules and shares `makeSessionResponse` across the id- and name-addressed paths; the `session new` CLI carries `--command`/`--name`/`--workspace-name`/`--create-workspace` (the last two also `validate()`-guarded); and round-trip + e2e (`testSessionNewWithCommandRunsAsProcess`, `testSessionNewWithName`, `testSessionNewWorkspaceNameCreatesThenReuses`) cover them. `session.type` injects into the target surface. Every session is realized eagerly (the deck mounts all at startup), so any session is normally typable WITHOUT `select`; `select:true` remains for the brief window before a just-created session is mounted (select, then a bounded poll, the `focusSplitPane` idiom), with `session not realized` the fallback if the surface still isn't up. `GhosttySurfaceView.inject(text:)` types via `ghostty_surface_key` keystrokes (printable runs as key-with-`text`, each `\n`/`\r`/`\r\n` as a Return keypress, keycode 36) — NOT `ghostty_surface_text`, whose bracketed-paste wrapping suppresses Enter and leaks `\e[200~`/`\e[201~` markers when fired rapidly. Do not "simplify" it back to `ghostty_surface_text`. `session.copy` reads the target surface's selection via `GhosttySurfaceView.readSelection()` (`ghostty_surface_has_selection` + `ghostty_surface_read_selection`, freed with `ghostty_surface_free_text`) and returns it in `result.text` — it does NOT touch the system clipboard (automation pipes the returned text into another `session.type`); selection is surface state independent of focus, so any realized session can be read, and no/empty selection is a `no selection` error. `session.search` searches the target session's live scrollback (target = session) — it SELECTS the target (so the bar + match highlights render and the surface is realized, bounded-realize-polled like `session.type`), then drives the FOCUSED surface over `ghostty_surface_binding_action`: `args.text` is the needle (`sendSearchQuery`, opening search first via `startSearch` if not already `searchActive`), `args.to` is `next`|`prev`|`close` (`navigateSearch(.next/.previous)`; `close` → `endSearch()` returns ok with no counter). The match count lands ASYNC via libghostty's `SEARCH_TOTAL` callback, so the arm bounded-polls `session.searchTotal` (the overlay-result idiom) before returning `result.count` = total matches + `result.text` = the "N of M" / "M matches" / "no matches" display string (`Session.searchDisplayText`, host-free; an empty display maps to nil `text` so the CLI prints `ok`). No needle + no `to` opens the empty bar. The four search state fields (`searchActive`/`searchNeedle`/`searchTotal`/`searchSelected`) are ephemeral on `Session`, absent from `SessionSnapshot`; the GUI bar (see the Menu/actions + ContentView placement notes) and the control channel read/write the SAME fields so they can't drift. Four-point keep-in-sync audit for `session.search`: (1) `case sessionSearch = "session.search"` in `ControlProtocol.swift` (reuses `ControlArgs.text` = needle + `ControlArgs.to` = next|prev|close, and `ControlResult.count` + `text` — no new field), (2) the `.sessionSearch` dispatch arm (`searchSession`) in `ControlServer`, (3) the `session search [needle] --next|--prev|--close` subcommand in `agtermctlKit` (`validate()` rejects flag combos), (4) round-trip tests in `ControlProtocolTests` + the e2e `testSessionSearch` in `ControlAPIUITests`. `session.overlay.open`/`session.overlay.close` run an ephemeral terminal on top of a session executing one program (`args.command`, e.g. a TUI); by default it is full single-pane size, hiding the single/split underneath, but `args.sizePercent` (1–100, clamped in `openOverlay`) makes it a *floating* opaque framed panel at that percent of the pane with the session still visible. `AppStore.openOverlay`/`closeOverlay` set non-persisted `Session.overlay*` state (incl. `overlaySizePercent`, nil = full / non-nil = floating), and the surface runs `config.command` with `onExit → closeOverlay`. The two variants render in DIFFERENT places. The FULL overlay is an in-deck ZStack sibling in `ContentView.sessionDetail` (`.zIndex(1)` above the pane(s), gated on `fullOverlay`): it draws translucent + blurred (NO opaque backing) with the pane(s) behind hidden at `.opacity(0)` + `.allowsHitTesting(false)` (kept MOUNTED, shells alive like the deck's inactive sessions), so its transparency reveals the window backing (desktop, tint + blur), not the session. The FLOATING overlay (`overlaySizePercent` set) is rendered OUTSIDE `sessionDetail` — as `.overlay { floatingOverlayLayer }` on `detailPane` — so `sessionDetail` for the floating case adds NO sibling to its ZStack: just the pane(s) at opacity 1, the same SHAPE as no-overlay (which is what keeps the NSSplitView from moving). Hit-testing stays gated on `.allowsHitTesting(!fullOverlay)` and must NOT flip when a floating overlay opens: changing the panes' OWN `allowsHitTesting` on overlay-open (e.g. to `!session.overlayActive`) ALSO triggers the NSSplitView titlebar-overrun — the SAME class of perturbation as adding a sibling, even though it looks like a pure interaction change (Codex insisted hit-testing was layout-inert; a review-loop regression proved otherwise). So the floating panes stay hit-testable, and the overlay's focus is protected OUTSIDE `sessionDetail`: a transparent `Color.clear.contentShape(Rectangle())` catcher in `floatingOverlayLayer` (on `detailPane`) absorbs clicks AROUND the panel so they can't reach the panes and steal the overlay program's first responder. (Generalize the rule: ANYTHING in `sessionDetail`'s HSplitView-hosting subtree that CHANGES when `overlayActive` flips — a sibling, a flattened ZStack, or a toggled pane modifier — overruns the split into the titlebar; keep that subtree identical for the floating case and do everything else at the `detailPane` level.) This separation is load-bearing: adding a conditional sibling INSIDE `sessionDetail`'s ZStack (the HSplitView-hosting subtree) made SwiftUI re-host it and the AppKit `NSSplitView` overrun UP into the transparent titlebar, painting the split over the header (Codex-confirmed; the quick terminal renders at this level for the same reason and never hit it). Anchoring on `detailPane` also means `floatingOverlayLayer`'s `GeometryReader` reports the terminal area EXACTLY — no manual sidebar/titlebar insets (computing those at the window level mis-centered the panel one line low) — so it sizes the opaque framed panel (`terminalColor` backing + hairline frame + shadow, quick-terminal styling) to `sizePercent`% and centers it in the detail area, the pane(s) visible around it. Only the active session's floating overlay shows, so `ControlServer` SELECTS the target when a floating overlay (`sizePercent` set) opens — its surface only mounts for the active session, so without the select a non-active target's program would never run and a `--block` open would poll forever (the full overlay needs no select; it mounts in the eager deck regardless). On close an `.onChange(of: session.overlayActive)` drives `focusAfterReparent()` on the session's `activeSurface` so first responder returns to the underlying terminal — the pane re-activating only does a single `makeFirstResponder`, which loses the teardown/re-host race (same reason the open path needs the `autoFocus` retry). Two libghostty gotchas (confirmed against cmux/macterm, see the gotchas section): the surface must **handle `GHOSTTY_ACTION_SHOW_CHILD_EXITED`** (in `GhosttyCallbacks.action`) and return `true` to suppress ghostty's "Process exited. Press any key" prompt and close immediately — `config.wait_after_command` does NOT suppress it; and the overlay must grab focus via a **bounded run-loop `makeFirstResponder` retry** (`autoFocus`), since a single-shot loses the SwiftUI/AppKit responder race. `--wait`/`overlayWait` keeps the prompt (returns `false` from the action so `close_surface_cb` closes after a keypress). `handleProcessExit` is idempotent (both the action and `close_surface_cb` can fire). The overlay is rendered only for the *active* session, so the caller selects the session first. **Exit-status capture (`session.overlay.result` + `agtermctl … --block`).** `makeOverlaySurface` wraps the command in a FIXED `sh -c '( eval "$AGTERM_OVL_CMD" ); echo $? > "$AGTERM_OVL_CODE"'` — the real command + a per-surface temp path ride in env (`AGTERM_OVL_CMD`/`AGTERM_OVL_CODE`, never interpolated), and crucially there is **NO stdout/stderr redirect** so a TUI renders normally; only the exit status is captured. (libghostty's `GHOSTTY_ACTION_SHOW_CHILD_EXITED.exit_code` reflects the login-shell wrapper — always 0 — so the status is taken from the wrapper's `echo $?`, NOT libghostty; the subshell makes an inline `exit N` propagate.) the surface's teardown reads the temp file → `AppStore.recordOverlayExit` (sets the non-persisted `Session.overlayExitCode`) → then deletes it, all in `GhosttySurfaceView.destroySurface` (via `onExitCodeCaptured`), so EVERY in-process close path — natural exit, explicit `session.overlay.close`, force-close (session/workspace/window) — captures the status before the file is removed, and the file's lifetime tracks the surface (no registry/sweep); `onExit` itself just drives `closeOverlay`. `session.overlay.result` (target = session) returns `result.exitCode` once the overlay has closed (`OverlayResultError.stillRunning` while up, `noResult` if none ran — both shared constants so the CLI poll matches exactly). `agtermctl session overlay open <command> … --block` wraps open → poll `session.overlay.result` (retry while still running; targets the returned id with NO window scope, so a frontmost-window change can't desync the poll) → exit with the captured status into ONE blocking command (rejects `--block` + `--wait` at parse via `validate()`); the program's OUTPUT is its own concern — a TUI like revdiff renders in the overlay and writes results to its own `--output` file, which the caller reads (the control channel does NOT capture stdout). Mode-bearing commands (`session.split`/`quick`) compute the delta against current state so `on`/`off`/`show`/`hide` are idempotent, and an unknown mode is an error. `session.status` flags a per-session agent status on the sidebar row — `args.status` is `idle`|`active`|`completed`|`blocked` (`AgentStatus(rawValue:)` → an `invalid status` error on anything else), `args.blink` pulses the glyph, and `args.autoReset` (status-agnostic, caller-set, symmetrical with `blink`) makes it clear back to idle once the session is visited. `args.sound` plays a ONE-SHOT sound when the status is applied (caller-driven, NOT stored on `AgentIndicator` — `default`/`beep` = `NSSound.beep()`, any other value = the named system sound via `NSSound(named:)`, which also resolves custom sounds in `~/Library/Sounds`); it is validated UP-FRONT against the app-side `StatusSoundPlayer.shared` (a singleton that caches resolved `NSSound`s so a short clip isn't cut off when the local goes out of scope — also reused by the Settings picker preview), so an unknown name is an `unknown sound: X` error that leaves the status UNCHANGED, and the fire is inside `resolveSession` so a bad target still errors `notFound` without playing. When NO per-call `args.sound` is given and a session TRANSITIONS into `blocked`, the user's **Settings ▸ Appearance ▸ Agent Status ▸ Blocked sound** (`AppSettings.blockedStatusSoundName`, GUI-only, default None) plays as a best-effort default. The transition is gated by a `wasBlocked` read of the session's current status BEFORE `setAgentIndicator`, so a REPEATED `blocked` set does not replay the default (and an empty per-call `args.sound` counts as unset); the precedence is the host-free `AgentStatus.effectiveSound(perCall:blockedDefault:)` (explicit per-call wins; the default is blocked-only), with the transition gate itself in the server. That setting is keep-in-sync EXEMPT like the status colors, since the per-status sound already has full control coverage via `--sound`. Setting a non-idle status is control-driven (the hooks/agents call it; no GUI sets active/completed/blocked), but clearing to idle ALSO has a GUI — the **Clear Status** action (see the Agent-status glyph note) — so the idle case is keep-in-sync covered by `session.status idle`. Cross-window via the shared `resolveSession` (the install's Stop hook targets its own `$AGTERM_SESSION_ID`, which may live in a non-frontmost window). The arm (`setSessionStatus`) builds an `AgentIndicator{status, blink, autoReset}` (host-free, ephemeral — never in `SessionSnapshot`) and drives the single `AppStore.setAgentIndicator(_:forSession:)` mutation point (unknown id = clean no-op), returning the id. Visibility is keep-state vs one-time, decided by `autoReset` alone: `AppStore.selectSession` resets an `autoReset` indicator (the `completed` flash) to idle on BOTH the session visited AND the one left (right after `clearUnseen`), so it never lingers on a row you switch away from, and leaves a non-`autoReset` one untouched. The glyph is NOT gated by selection — it shows on every non-idle session, the selected one included (see below). `keymap.reload` re-reads `keymap.conf` and returns the parse-diagnostic count in `result.count` (0 reads as a clean reload; `agtermctl keymap reload` prints `ok` then, else `N diagnostic(s)`). It is the SAME `SettingsModel.reloadKeymap()` path the GUI's File ▸ Reload Keymap menu/palette item drives, so the GUI half and the control half can't diverge — control-native only in the count it reports back; no `--window` selector (the keymap is app-global — a single app-wide `SettingsModel`, constructed once in `agtermApp.init` and shared with `ControlServer`). Four-point keep-in-sync audit for `keymap.reload`: (1) `case keymapReload = "keymap.reload"` in `ControlProtocol.swift` (returns the new `ControlResult.count: Int?`, no target/args), (2) the `.keymapReload` dispatch arm in `ControlServer`, (3) the `keymap reload` subcommand in `agtermctlKit`, (4) round-trip tests in `ControlProtocolTests` plus the e2e in `ControlAPIUITests`. See the Keymap section for the parser/menu/monitor design. `config.reload` re-reads the agterm-scoped `ghostty.conf` and returns the ghostty config-diagnostic count in `result.count` (0 reads as a clean reload; `agtermctl config reload` prints `ok` then, else `N diagnostic(s)`). It is the SAME `AppActions.reloadGhosttyConfig()` path the GUI's File ▸ Reload Config menu/palette item + the Edit-ghostty overlay close drive (which posts the warning banner on a malformed file), so the GUI half and the control half can't diverge — control-native only in the count it reports back; no `--window` selector (the config is app-global — one `SettingsModel` + one `GhosttyApp`, shared with `ControlServer`). The arm calls `actions.reloadGhosttyConfig()` then returns `GhosttyApp.shared.lastConfigDiagnosticsCount`. Four-point keep-in-sync audit for `config.reload`: (1) `case configReload = "config.reload"` in `ControlProtocol.swift` (reuses `ControlResult.count`, no target/args), (2) the `.configReload` dispatch arm (`reloadGhosttyConfig`) in `ControlServer`, (3) the `config reload` subcommand in `agtermctlKit`, (4) round-trip tests in `ControlProtocolTests` plus the e2e in `ControlAPIUITests`. See the Settings section for the config layer + Edit/Reload. `sidebar` (mode `show`|`hide`|`toggle`, default toggle, frontmost window — mirrors `quick`, delta-computed so it's idempotent, unknown mode + no-open-window are errors) shows/hides the custom-split sidebar — the per-window `AppStore.sidebarVisible` (persisted per-window in `Snapshot`, restored on relaunch alongside `AppStore.sidebarWidth`; `toggleSidebar`/`setSidebar` call `save()`; the custom split replaced `NavigationSplitView`, so there is no system toggle). `AppActions.toggleSidebar()` flips `library.activeStore?.sidebarVisible` and `ContentView` animates it (`splitRoot`'s `.animation(value:)`, so every caller animates uniformly — the toolbar button no longer wraps its own `withAnimation`); shared by the title-bar `sidebar-toggle-button`, View ▸ Show/Hide Sidebar, the ⌃⇧P palette "Toggle Sidebar", and the ⌃⌘S keymap action (`BuiltinAction.toggleSidebar`, expressible so pure-`defaultChord`-driven). Four-point keep-in-sync audit: (1) `case sidebar` in `ControlProtocol.swift` (reuses `ControlArgs.mode`), (2) the `.sidebar` dispatch arm (`setSidebar`) in `ControlServer`, (3) the `sidebar` subcommand in `agtermctlKit`, (4) round-trip in `ControlProtocolTests` + the e2e `testSidebarShowHideToggle` (sidebar hide removes the `session-row`s from the AX tree) in `ControlAPIUITests`. `theme.set` sets + persists a theme by name (`args.name`; nil/empty = ghostty's built-in / "default ghostty", NOT the seeded `agterm` app default — see the Theme picker section) — the control half of the Settings picker / the `.themes` palette commit, the SAME `SettingsModel.setTheme` persist+apply path (NO live preview over the socket — preview is interactive-only). An unknown name (not in `SettingsCatalog.themeNames()`) is an `unknown theme: X` error (a typo silently doing nothing is worse than a fail); the applied name echoes in `result.theme` (nil = ghostty built-in). `theme.list` returns `result.themes` = the bundled names + `result.theme` = the current one (nil = ghostty built-in; absent on a fresh install means the seeded `agterm` is current); `agtermctl theme list` prints one name per line with a leading "default ghostty" row, the current marked `* `, and `theme.set` prints `ok` (non-create mutation). App-global like `keymap.reload` (one `SettingsModel`), so NO `--window` selector. Four-point keep-in-sync audit: (1) `case themeSet = "theme.set"` + `case themeList = "theme.list"` in `ControlProtocol.swift` (reuse `ControlArgs.name`; add `ControlResult.theme`/`themes`), (2) the `.themeSet` (`setTheme`, with name validation) + `.themeList` dispatch arms in `ControlServer`, (3) the `theme set [name]` / `theme list` subcommands in `agtermctlKit` (+ `SocketClient.formatThemes`), (4) round-trip in `ControlProtocolTests` + the e2e `testThemeListAndSet` in `ControlAPIUITests`. See the Theme picker section for the GUI/preview half. `session.flag` (target = session) flags/unflags a session for the flagged working-set view — `args.mode` is `on`|`off`|`toggle`|`clear` (`clear` IGNORES the target and unflags every session in the resolved store via `AppStore.clearFlags()`, mirroring `session.scratch`/`session.split`'s mode-bearing shape), drives `AppStore.setFlag(_:forSession:)` (idempotent — no-op + no save when unchanged), surfaces the `flagged` bool on `ControlSessionNode` in the `tree` builder, and returns the session id; an unknown mode is an error. It is the control half of the row context-menu Flag/Unflag + the View-menu/palette Flag Session/Clear Flagged. Pair with `sidebar.mode flagged` to view just the flagged sessions. Four-point keep-in-sync audit for `session.flag`: (1) `case sessionFlag = "session.flag"` in `ControlProtocol.swift` (reuses `ControlArgs.mode`; adds `flagged` to `ControlSessionNode`), (2) the `.sessionFlag` dispatch arm (`flagSession`) in `ControlServer`, (3) the `session flag on|off|toggle|clear` subcommand (`FlagCommand`) in `agtermctlKit`, (4) round-trip in `ControlProtocolTests` + the e2e `testSessionFlagAndSidebarModeFlagged` in `ControlAPIUITests`. `sidebar.mode` (frontmost window) flips the sidebar VIEW between the workspace tree and the flat flagged working-set list — `args.mode` is `tree`|`flagged`|`toggle` (delta-computed against `AppStore.sidebarMode` so it's idempotent, unknown mode = error), drives `setSidebarViewMode` → `AppStore.setSidebarMode`. It is the control half of the bottom-bar `flagged-view-toggle` + the View-menu Show Flagged/Show All + `BuiltinAction.toggleFlaggedView`; the existing `sidebar [show|hide|toggle]` is now the default `sidebar visibility` subcommand alongside `sidebar mode`. Four-point keep-in-sync audit: (1) `case sidebarMode = "sidebar.mode"` in `ControlProtocol.swift` (reuses `ControlArgs.mode`), (2) the `.sidebarMode` dispatch arm (`setSidebarViewMode`) in `ControlServer`, (3) the `sidebar mode tree|flagged|toggle` subcommand (`Mode`, alongside the `Visibility` default) in `agtermctlKit`, (4) round-trip in `ControlProtocolTests` + the e2e `testSessionFlagAndSidebarModeFlagged` in `ControlAPIUITests`. `sidebar.expand`/`sidebar.collapse` expand every workspace / collapse all but the active one in a window's sidebar TREE — `expand` drives `AppActions.expandAllWorkspaces(in:)`, `collapse` drives `collapseOtherWorkspaces(in:)` (collapse keeps the ACTIVE session's workspace expanded and scrolls its row into view). UNLIKE `sidebar`/`sidebar.mode` (frontmost-only, no selector), these honor the global `--window` selector (`ControlArgs.window`): the arm resolves the target store via `resolvePlacementStore(window)` (frontmost by default; a named window must be OPEN, else the closed-window error; no open window at all → `no open window`), then posts a notification (`.agtermExpandWorkspaces`/`.agtermCollapseWorkspaces`) carrying THAT `AppStore` as the object. `WorkspaceSidebar.Coordinator` registers its observer with `object: store`, so NotificationCenter delivers ONLY to that window's sidebar Coordinator — this object-scoping (the rename notifications self-scope via the selected-session guard; expand/collapse have no such natural guard) is exactly what lets the control path target a specific (even background) window while the GUI menu/palette use the frontmost. A graceful no-op in `flagged` mode (no workspace rows: `expandWorkspacesNotified` gates on tree mode, `collapseOthers` gates internally); idempotent. GUI half (frontmost only): View ▸ Expand/Collapse Workspaces (plain keyless items, disabled with no active store or in flagged mode) + the ⌃⇧P palette "Expand Workspaces"/"Collapse Workspaces" (tree-mode only). Four-point keep-in-sync audit: (1) `case sidebarExpand = "sidebar.expand"` + `case sidebarCollapse = "sidebar.collapse"` in `ControlProtocol.swift` (reuse `ControlArgs.window`, no new field), (2) the `.sidebarExpand`/`.sidebarCollapse` dispatch arms (`expandWorkspaces(window:)`/`collapseWorkspaces(window:)`) in `ControlServer`, (3) the `sidebar expand`/`sidebar collapse` subcommands (`Expand`/`Collapse` on `ClientOptions` for `--window`, alongside the `Visibility` default + `Mode`) in `agtermctlKit`, (4) round-trip (incl. the windowed variant) in `ControlProtocolTests` + the e2e `testSidebarExpandCollapse` in `ControlAPIUITests`. `workspace.focus` (target = workspace) collapses the sidebar tree to a single workspace — `args.mode` is `on`|`off`|`toggle` (`off` unfocuses only when the target is the currently focused one, `toggle` flips; delta-computed against `AppStore.focusedWorkspaceID` so it's idempotent, unknown mode = error), drives `focusWorkspace` → `AppStore.setFocusedWorkspace`, honors the global `--window` selector, and returns the workspace id. Per-window + persisted, orthogonal to `sidebar.mode` (the flat flagged list ignores focus); selecting a session outside the focused workspace auto-unfocuses (see the Sidebar section). It is the control half of the workspace-row Focus/Unfocus + the `focus-pill` ✕ + `BuiltinAction.focusWorkspace`/`focusActiveWorkspace` + the Clear Focus menu/palette item. Four-point keep-in-sync audit: (1) `case workspaceFocus = "workspace.focus"` in `ControlProtocol.swift` (reuses `ControlArgs.mode`), (2) the `.workspaceFocus` dispatch arm (`focusWorkspace`) in `ControlServer`, (3) the `workspace focus on|off|toggle` subcommand (`Focus`) in `agtermctlKit`, (4) round-trip in `ControlProtocolTests` + the e2e `testWorkspaceFocusHidesOtherWorkspaces` in `ControlAPIUITests` plus the `FocusWorkspaceUITests` XCUITest. `tree` now also surfaces, on each `ControlSessionNode`, `foreground`/`splitForeground` — the LIVE foreground-process argv of the main + split panes (nil/omitted at the shell prompt), the SAME `ForegroundProcess.command(for:shellBasename:)` capture the restore-running-command feature uses (`ghostty_surface_foreground_pid` → `sysctl(KERN_PROCARGS2)` → host-free `CommandRestore`), populated in the tree builder per session so a script can read "what is each pane running". `restore.clear` clears every open session's saved foreground command (`Session.foregroundCommand`/`splitForegroundCommand`) and persists via `library.saveAllOpen()`, so the next restart restores plain shells instead of re-running the captured commands (also closing the force-quit re-fire: the restored command is consumed in memory but its on-disk copy lingers until the next save, which a force-quit skips). App-global like `keymap.reload` (clears all open windows, no `--window`). Four-point keep-in-sync audit for `restore.clear`: (1) `case restoreClear = "restore.clear"` in `ControlProtocol.swift` (no target/args; `foreground`/`splitForeground` added to `ControlSessionNode`), (2) the `.restoreClear` dispatch arm (`clearSavedCommands`) in `ControlServer` + the foreground population in the tree builder, (3) the `restore clear` subcommand (`Restore`) in `agtermctlKit`, (4) round-trip (`restoreClearRoundTrips` + `treeSessionNodeRoundTripsWithForeground`/`…OmitsForegroundWhenNil`) in `ControlProtocolTests` + the e2e (`testTreeExposesForegroundProcess`, `testRestoreClearSucceeds`) in `ControlAPIUITests`. **Agent-skill mirror (HARD keep-in-sync, 4th surface):** all commands are documented in the bundled `agterm/Resources/agent-skill/` (SKILL.md summary, reference.md detail, examples.md recipes) and the command count there is bumped to 46 to match.
+  1. **Protocol + pure logic in `agtermCore`**
+     (Foundation-only, `Codable`, `Sendable`): `ControlProtocol.swift` holds the `Command` enum,
+     `ControlArgs`, `ControlRequest`, the tree node types (`ControlSessionNode`/`ControlWorkspaceNode`/`ControlTree`),
+     `ControlResult`, and `ControlResponse`.
+     `ControlResolve.swift` holds the pure target resolver (`resolve(_:candidates:active:) -> TargetResolution`)
+     and the socket-path resolver (`socketPath(stateDir:appSupport:)`).
+     Shared by both the app and the CLI so the wire contract cannot drift.
+  2. **`ControlServer` in the app target**
+     (`agterm/Control/ControlServer.swift`, `@MainActor`): owns the POSIX unix socket.
+     The blocking accept/read loop runs on a background `DispatchQueue`;
+     each newline-delimited `ControlRequest` is decoded, hopped to `@MainActor`,
+     dispatched onto `AppActions`/`AppStore` (plus a thin `GhosttySurfaceView.inject(text:)` for input),
+     and the `ControlResponse` written back before the connection closes.
+  3. **`agtermctl` CLI**
+     in the `agtermCore` SwiftPM package: an `agtermctlKit` library (the `ParsableCommand` tree in `Commands.swift`
+     + the socket client in `SocketClient.swift`) plus a thin `agtermctl` executable.
+     It links `swift-argument-parser`; the `agtermCore` library target stays dependency-free.
+     Builds with `swift build`, needs no Xcode/GhosttyKit.
+- **Bundling + install.**
+  The `agterm` target's `Bundle agtermctl CLI` postBuildScript (`project.yml`) runs `swift build -c release --product agtermctl`,
+  copies it to `agterm.app/Contents/MacOS/agtermctl`, ad-hoc signs the helper,
+  then **re-signs the whole app `--deep`** — the phase can run AFTER Xcode's own code-sign on incremental
+  builds, so without the re-seal the injected helper breaks the signature (and a shallow re-sign chokes
+  on the Debug `agterm.debug.dylib`).
+  **Help ▸ Install Command Line Tool…** (`agtermApp` `CommandGroup(replacing: .help)` → `CLIInstaller.run()`)
+  symlinks the bundled binary into `/usr/local/bin` (first entry in macOS's default `/etc/paths`,
+  unlike `~/.local/bin`): a direct `FileManager` symlink when the dir is user-writable,
+  else a one-time GUI admin prompt via `osascript … with administrator privileges`.
+  Pure path/quote logic is `agtermCore.CLIInstall` (host-free, unit-tested);
+  the AppKit FS + auth glue is `CLIInstaller` (app-side, manually verified like the directory picker).
+  Install is GUI-only and keep-in-sync EXEMPT — driving it over the socket is meaningless (you'd need
+  `agtermctl` already installed to call it).
+- **Agent-status hooks install.**
+  A second Help entry, **Help ▸ Install Agent Status Hooks…** (`AgentHooksInstaller.run()`),
+  wires coding agents to `session.status`.
+  The hooks scripts bundle at `agterm/Resources/agent-status/` (`agterm-agent-status.sh` wrapper + `shell/integration.sh`
+  + `codex-notify.sh`, a `project.yml` Contents/Resources folder mirroring `Resources/ghostty`).
+  The installer copies them to `~/.config/agterm/agent-status/`, bakes the bundled `agtermctl`'s absolute
+  path (`Bundle.main.url(forAuxiliaryExecutable:)`) into the wrapper so the hooks fire even without the
+  CLI on PATH, appends a marker-guarded `source` line to `~/.zshrc` + `~/.bashrc`,
+  merges four Claude Code hooks into `~/.claude/settings.json` with a `.bak` (UserPromptSubmit→`active --blink`,
+  PostToolUse→`active --blink`, Stop→`completed --auto-reset`, Notification[`permission_prompt`]→`blocked`;
+  the unmatched PostToolUse re-asserts `active` after every tool so a `blocked` permission prompt clears
+  back to active when work resumes — Claude Code has no "permission answered" event,
+  and the gated tool's own PreToolUse fires BEFORE `blocked` is set, so the approved tool's PostToolUse
+  is the first hook afterwards), and PRINTS the Codex `~/.codex/config.toml` `notify` line (never auto-edits
+  TOML).
+  Idempotent + re-runnable (re-run refreshes the baked path).
+  Like the CLI installer, the host-free JSON-merge / shell-rc-marker / backup-path logic is `agtermCore.AgentHooksInstall`
+  (unit-tested); `AgentHooksInstaller` (app-side) owns the AppKit FS glue,
+  manually verified.
+- **Agent skill install (Claude Code + Codex).**
+  A third Help entry, **Help ▸ Install Agent Skill…** (`SkillInstaller.run()`),
+  copies a bundled, personal-scope Agent Skill to `~/.claude/skills/agterm/` AND `~/.codex/skills/agterm/`
+  so a coding agent running INSIDE an agterm session knows how to drive the app over the control channel.
+  Claude Code and Codex use the SAME SKILL.md Agent-Skill format (`name`/`description`/`allowed-tools`
+  frontmatter + optional reference files; verified against the user's `~/.codex/skills/`),
+  so one authored skill serves both.
+  The skill is a REFERENCE/knowledge skill (both user-invocable via `/agterm` and model-triggered,
+  `allowed-tools: Bash(agtermctl *)`; the agent-neutral `description` carries the trigger nouns since
+  Codex may ignore the extra `when_to_use` field — unknown frontmatter is harmless),
+  authored at `agterm/Resources/agent-skill/` (`SKILL.md` overview + model + addressing + 46-command
+  summary + the image-display helper + a troubleshooting/reporting pointer;
+  `reference.md` full per-command detail + keymap format; `examples.md` agtermctl recipes;
+  `troubleshooting.md` diagnosing the common problems (keymap editor, custom actions,
+  logs) + the bug-issue / feature-Discussion reporting workflow (draft-first,
+  scrub, never run `gh` without explicit user approval); `scripts/show-image.sh` the bundled image-display
+  helper), bundled via a `project.yml` Contents/Resources FOLDER reference like `agent-status` (the whole
+  dir, INCLUDING the `scripts/` subdir, copies verbatim; `SkillInstaller` uses `FileManager.copyItem`
+  so the subdir reaches both installs).
+  **Image display is NOT a control command** — it's a bundled shell helper:
+  `show-image.sh <image> [size%]` opens an overlay (a real pty) and renders the image via the kitty graphics
+  protocol, which the pinned ghostty draws NATIVELY — pure `base64` + chunked `\e_G` APC frames,
+  NO kitty binary and NO external image tool.
+  (The pinned ghostty renders ONLY the kitty graphics protocol; iTerm2 OSC-1337 inline images and sixel
+  are `unimplemented` in that build — verified in upstream `src/terminal/osc/parsers/iterm2.zig`,
+  the `.File`/`.FilePart`/`.FileEnd`/`.MultipartFile` keys land in the `unimplemented OSC 1337` bucket.
+  The agent CANNOT print graphics escapes to its own tool stdout — the harness escapes the control bytes
+  — nor run a viewer in its tool shell — no `/dev/tty`; the overlay sidesteps both,
+  so the method is agent-harness-agnostic and works identically for Codex.) It is invoked by absolute
+  install path (`~/.claude/skills/agterm/scripts/show-image.sh` or `~/.codex/...`),
+  NOT `${CLAUDE_SKILL_DIR}` — that token is Claude-Code-only and would not expand in the Codex copy of
+  the SAME authored `SKILL.md`.
+  **Install policy:** write to each agent base that EXISTS (`~/.claude` and/or `~/.codex`);
+  if neither, fall back to creating `~/.claude` (`SkillInstall.installTargets`).
+  Pure file-drop (no manifest): per-target remove-then-copy for a clean reinstall,
+  best-effort per agent (one failing doesn't abort the other), but it REFUSES to clobber a same-named
+  skill the user authored (one whose `SKILL.md` lacks the `<!-- agterm-skill -->` marker — `SkillInstall.mayOverwrite`).
+  Host-free path/target/marker logic is `agtermCore.SkillInstall` (unit-tested);
+  `SkillInstaller` (app-side) owns the AppKit copy, manually verified.
+  Install is GUI-only and keep-in-sync EXEMPT (a skill that documents the socket isn't itself driven
+  over it).
+  **KEEP-IN-SYNC (HARD): the bundled skill is a documentation mirror of the control surface — whenever
+  you change the Control API (commands/args/returns), the keymap format,
+  or the window/workspace/session/pane model, update `agterm/Resources/agent-skill/` (SKILL.md + reference.md
+  + examples.md + `troubleshooting.md` + `scripts/`, incl. the command count) so the installed agent-driver
+  doc stays accurate.
+  It is the fourth keep-in-sync surface alongside the GUI/menu/CLI.
+  The skill's `troubleshooting.md` mirrors the user-facing `docs/troubleshooting.md`;
+  keep the two in step when a diagnostic path or the reporting workflow changes.**
+- **Socket path / lifecycle.**
+  The path is `<AGTERM_STATE_DIR>/agterm.sock` when `AGTERM_STATE_DIR` is set (state isolation),
+  else `<app support>/agterm.sock` (`~/Library/Application Support/agterm`),
+  via `ControlResolve.socketPath`.
+  `ControlServer.defaultSocketPath()` adds an `AGTERM_CONTROL_SOCKET` env override that takes precedence
+  (used by XCUITests, whose sandboxed `AGTERM_STATE_DIR` container path exceeds the `sun_path` ~104-byte
+  limit); the CLI's `--socket` flag is the user-facing equivalent.
+  The socket is `chmod 0600`.
+  Each accepted connection sets `SO_RCVTIMEO` (5 s, alongside `SO_NOSIGPIPE`) so a stalled client can't
+  wedge the serial accept loop — a timed-out `read()` returns `EAGAIN`, which `readLine` (any non-`EINTR`
+  `n < 0` = end-of-read) maps to nil → close → `accept()` resumes.
+  `start()` is idempotent (the scene `.task` may re-run) and unlinks any stale path before binding;
+  it is best-effort (a bind failure logs and the app still launches).
+  Lifecycle is asymmetric: started from the scene `.task`, stopped from `AppDelegate.applicationWillTerminate`;
+  a force-quit that skips that leaves a stale socket file, which the next launch's unlink-first handles.
+- **Protocol shape.**
+  One request per connection, newline-delimited JSON: `{"cmd":…,"target":…,"args":{…}}` → one `{"ok":…,"result":…|"error":…}`
+  → close.
+  Mutating commands return the affected/new id in `result.id` (create-then-use without a second round-trip);
+  `tree` returns `result.tree`.
+  An unknown `cmd` fails to decode and comes back as a structured error,
+  never a crash; a 1 MiB max-line cap bounds the read buffer.
+  In `agtermctl`'s human (non-`--json`) output, `result.id` is echoed ONLY for the create commands (`session/workspace/window new`,
+  via `RequestCommand.echoesResultID`) where the new id isn't known yet;
+  every other mutation prints `ok` (the id you already named is noise).
+  The id is always present under `--json`.
+- **Addressing.**
+  UUID is canonical, with sugar: `active` (the selected session / current workspace),
+  exact `uuidString` (case-insensitive), or a git-style unique prefix.
+  Zero prefix hits → `notFound` error, ≥2 → `ambiguous` error listing the candidates.
+  `--target` defaults to `active`, so scripts rarely type an id and never for "the current one".
+- **Command catalog (46 commands):**
+  - `tree`
+  - `workspace.new`/`workspace.rename`/`workspace.delete`/`workspace.select`/`workspace.move`/`workspace.focus`
+  - `session.new`/`session.close`/`session.select`/`session.rename`/`session.move`/`session.type`/`session.split`/`session.scratch`/`session.focus`/`session.go`/`session.copy`/`session.search`/`session.status`/`session.flag`/`session.overlay.open`/`session.overlay.close`/`session.overlay.result`
+  - `quick`
+  - `sidebar`/`sidebar.mode`/`sidebar.expand`/`sidebar.collapse`
+  - `notify`
+  - `font.inc`/`font.dec`/`font.reset`
+  - `window.new`/`window.list`/`window.select`/`window.close`/`window.rename`/`window.delete`/`window.resize`/`window.move` (see the Windows section)
+  - `keymap.reload` (see the Keymap section)
+  - `config.reload` (see the Settings section)
+  - `theme.set`/`theme.list` (see the Theme picker section)
+  - `restore.clear` (see the Settings section)
+
+  `workspace.delete` honors keep-at-least-one and returns an error instead of the GUI confirm alert (nothing
+  blocks on a modal).
+  `session.move` is MODE-BEARING: `args.to` (`up`|`down`|`top`|`bottom`) REORDERS the session within
+  its own workspace (parses `ReorderDirection`, drives `AppStore.reorderSession` → the existing `moveSession(at:)`
+  primitive, returns the session id), while `args.workspace` RELOCATES it to another workspace (unchanged
+  — still appends at the end); both-set and neither-set are errors, and an invalid direction is an error.
+  `workspace.move` is the workspace REORDER (control-native, no separate verb):
+  `args.to` (`up`|`down`|`top`|`bottom`) resolves the workspace target via the shared `resolveWorkspace`
+  (honoring the global `--window` selector like other workspace commands),
+  drives `AppStore.reorderWorkspace`, and returns the workspace id; a missing or invalid `to` is an error.
+  Drag-and-drop stays the precise (drop-between-rows) surface; the control path is relative-only,
+  mirroring `session.go --to`.
+  Four-point keep-in-sync audit for `workspace.move`: (1) `case workspaceMove = "workspace.move"` in
+  `ControlProtocol.swift` (reuses `ControlArgs.to`, no new field), (2) the `.workspaceMove` dispatch
+  arm in `ControlServer`, (3) the `workspace move --to` subcommand in `agtermctlKit`,
+  (4) round-trip tests in `ControlProtocolTests` plus the e2e in `ControlAPIUITests`.
+  NOTE on `workspace.move --target active`: `active` for a workspace resolves to `AppStore.currentWorkspaceID`,
+  which with NO selected session falls back to `workspaces.last` — so repeated `workspace.move --to top --target active`
+  on a session-less window targets a DIFFERENT (newly-last) workspace each call (consistent with the
+  `currentWorkspaceID` fallback contract; address a specific workspace by id/prefix to step the same
+  one).
+  `session.split` resolves the target id and drives `AppStore.toggleSplit` directly (NOT the argument-less
+  `AppActions.toggleSplit()`, which only acts on the active session) — `off` HIDES the split keep-alive,
+  mirroring ⌘D (the pane's surface is NOT torn down; `closeSplit` stays the shell-exit-only path,
+  so there is no on-demand destroy over the control channel, matching the GUI).
+  `session.scratch` (mode `on`|`off`|`toggle`, mirrors `session.split` exactly) shows/hides the **scratch
+  terminal** — a THIRD per-session login shell (alongside main + split) that RENDERS like a full overlay
+  (full-pane, hides the session, translucent) but BEHAVES like the split:
+  lazily spawned on first show, kept alive when hidden (`off` is `AppStore.toggleScratch` keep-alive,
+  never a teardown), recreated fresh after its shell's own `exit`.
+  NOT persisted (absent from `SessionSnapshot`, like the overlay) — `Session.scratchActive`/`scratchSurface`,
+  `AppStore.toggleScratch`/`closeScratch` (the latter only on `exit` + session/workspace/window teardown).
+  Full-overlay rendering only (never floating) so it's a structural clone of the proven `if fullOverlay`
+  ZStack sibling at `.zIndex(1)`, BELOW the ephemeral overlay (`.zIndex(2)` — a normal overlay launched
+  over the scratch sits on top); the panes' opacity/hit-testing gate is `hideForOverlay = fullOverlay || scratchActive`
+  (still false for a FLOATING overlay, preserving the NSSplitView-overrun invariant).
+  GUI half: ⌘J (`BuiltinAction.toggleScratch`), title-bar `scratch-toggle` button,
+  View ▸ Show/Hide Scratch, the ⌃⇧P palette "Toggle Scratch" — all through `AppActions.toggleScratch()`.
+  The scratch surface is NOT wired to the session (no `view.session`, like the overlay) so its PWD/title
+  never clobber the sidebar name; `autoFocus` grabs first responder on show,
+  the detail pane's `.onChange(of: scratchActive)` reclaims it on hide.
+  Four-point keep-in-sync audit: (1) `case sessionScratch = "session.scratch"` + the new `ControlSessionNode.scratch`
+  flag in `ControlProtocol.swift` (reuses `ControlArgs.mode`), (2) the `.sessionScratch` dispatch arm
+  (`scratchSession`) in `ControlServer` + `scratch:` in the tree builder,
+  (3) the `session scratch` subcommand in `agtermctlKit`, (4) round-trip in `ControlProtocolTests` +
+  the e2e `testSessionScratchToggle` in `ControlAPIUITests`.
+  `session.focus` moves keyboard focus between the two split panes — `args.pane` is `left`|`right`|`other`
+  (`other` toggles, the default); it errors when the session has no split (works whether the split is
+  shown side-by-side or hidden — when hidden, focusing a pane swaps which one shows maximized),
+  drives `AppActions.setSplitFocus(_:of:)`, and is the control half of the ⌘⌥←/→ keyboard nav + the "Focus
+  Left/Right Pane" menu/palette items.
+  `session.go` navigates BETWEEN sessions — `args.to` is `next`|`prev`|`first`|`last`|`next-attention`|`prev-attention`
+  and acts on the target store's CURRENT selection (it is RELATIVE, so it resolves the placement store
+  via `resolvePlacementStore` rather than a session target — there is NO `--target`),
+  stops at the ends on next/prev (no wrap), jumps to the ends for first/last,
+  and for `next-attention`/`prev-attention` steps through ONLY the sessions needing attention (`AgentStatus.needsAttention`
+  = `blocked`/`completed`) WRAPPING around (skipping idle/active), drives `AppStore.navigateSession`,
+  and returns the newly-selected id in `result.id`.
+  It mirrors the `session.focus --pane` one-command-with-arg precedent and is the control half of the
+  ⌥⌘↑/⌥⌘↓ session-nav + ⌃⌥↑/⌃⌥↓ attention-nav menu/palette items (First/Last have no hotkey).
+  `notify` posts a desktop notification attributed to a session (default:
+  the active session of the frontmost window via `resolveSession`): `args.body` is required,
+  `args.title` defaults to the session name.
+  It is control-NATIVE (no GUI/menu equivalent, like `session.type`/`session.copy`) and goes through
+  `NotificationManager.send(toSession:title:body:)` — which, unlike the OSC 9/777 path,
+  does NOT focus-suppress (the caller asked for it) but still bumps the badge + carries the `<windowID>:<sessionID>:main`
+  click-to-reveal identity.
+  It is the ONLY app-level way to post a banner; the terminal OSC path remains the other source.
+  `session.new` creates a session.
+  The destination workspace is addressed one of two MUTUALLY-EXCLUSIVE ways:
+  `args.workspace` (id / unique prefix / `active`, the default) OR `args.workspaceName` (the sidebar
+  label, name-matched first-exact-trimmed via `AppStore.workspace(named:)`) — the latter optionally with
+  `args.createWorkspace` to reuse-or-create the named workspace (idempotent;
+  `AppStore.ensureWorkspace(named:)`).
+  A `workspaceName` with no match and no `createWorkspace` errors, both addressing modes set is an error,
+  and `createWorkspace` without `workspaceName` is an error (nothing to create by id);
+  the same two rules are pre-validated CLI-side by `session new`'s `validate()`.
+  `args.command` runs that command AS the session's process instead of the login shell (like kitty's
+  `launch <cmd>` / ghostty's `command`) — NO echoed command line, and the session closes when the command
+  exits (the normal single-pane `onExit` → `closePrimaryPane`).
+  It is transient + run-once: `Session.initialCommand` is `@ObservationIgnored` and absent from `SessionSnapshot`,
+  so a restored session is a plain shell.
+  The arm threads `request.args?.command` into `AppStore.addSession(…, command:)`,
+  which `makeSurface` passes to `GhosttySurfaceView(command:)` → `config.command` RAW (`strdup`,
+  NO wrapper). libghostty tokenizes it into argv (shell-like word-splitting that RESPECTS quotes) and
+  execs argv[0] DIRECTLY — there is NO `sh -c`, so shell operators (`;`,
+  `&&`, `|`, `$VAR`, redirects, globs) are NOT interpreted: `ssh host -p 22 -t "ssh inner"` works (the
+  nested command rides as one quoted arg, runs with no echo — verified empirically),
+  but `clear; ssh …` execs a program literally named `clear;` and fails.
+  This is NOT the overlay's path — `makeOverlaySurface` explicitly wraps its command in `sh -c '…'` (so
+  the overlay DOES get shell semantics); a session `--command` that needs shell features must wrap ITSELF,
+  e.g. `--command "sh -c '…'"`.
+  Keep-in-sync: the `.sessionNew` case carries `ControlArgs.command` plus `ControlArgs.name` (custom
+  name) and `ControlArgs.workspaceName` + `ControlArgs.createWorkspace` (name-addressing + ensure);
+  the arm pre-validates the mutual-exclusion / create-needs-name rules and shares `makeSessionResponse`
+  across the id- and name-addressed paths; the `session new` CLI carries `--command`/`--name`/`--workspace-name`/`--create-workspace`
+  (the last two also `validate()`-guarded); and round-trip + e2e (`testSessionNewWithCommandRunsAsProcess`,
+  `testSessionNewWithName`, `testSessionNewWorkspaceNameCreatesThenReuses`) cover them.
+  `session.type` injects into the target surface.
+  Every session is realized eagerly (the deck mounts all at startup), so any session is normally typable
+  WITHOUT `select`; `select:true` remains for the brief window before a just-created session is mounted
+  (select, then a bounded poll, the `focusSplitPane` idiom), with `session not realized` the fallback
+  if the surface still isn't up.
+  `GhosttySurfaceView.inject(text:)` types via `ghostty_surface_key` keystrokes (printable runs as key-with-`text`,
+  each `\n`/`\r`/`\r\n` as a Return keypress, keycode 36) — NOT `ghostty_surface_text`,
+  whose bracketed-paste wrapping suppresses Enter and leaks `\e[200~`/`\e[201~` markers when fired rapidly.
+  Do not "simplify" it back to `ghostty_surface_text`.
+  `session.copy` reads the target surface's selection via `GhosttySurfaceView.readSelection()` (`ghostty_surface_has_selection`
+  + `ghostty_surface_read_selection`, freed with `ghostty_surface_free_text`) and returns it in `result.text`
+  — it does NOT touch the system clipboard (automation pipes the returned text into another `session.type`);
+  selection is surface state independent of focus, so any realized session can be read,
+  and no/empty selection is a `no selection` error.
+  `session.search` searches the target session's live scrollback (target = session) — it SELECTS the
+  target (so the bar + match highlights render and the surface is realized,
+  bounded-realize-polled like `session.type`), then drives the FOCUSED surface over `ghostty_surface_binding_action`:
+  `args.text` is the needle (`sendSearchQuery`, opening search first via `startSearch` if not already
+  `searchActive`), `args.to` is `next`|`prev`|`close` (`navigateSearch(.next/.previous)`;
+  `close` → `endSearch()` returns ok with no counter).
+  The match count lands ASYNC via libghostty's `SEARCH_TOTAL` callback, so the arm bounded-polls `session.searchTotal`
+  (the overlay-result idiom) before returning `result.count` = total matches + `result.text` = the "N
+  of M" / "M matches" / "no matches" display string (`Session.searchDisplayText`,
+  host-free; an empty display maps to nil `text` so the CLI prints `ok`).
+  No needle + no `to` opens the empty bar.
+  The four search state fields (`searchActive`/`searchNeedle`/`searchTotal`/`searchSelected`) are ephemeral
+  on `Session`, absent from `SessionSnapshot`; the GUI bar (see the Menu/actions + ContentView placement
+  notes) and the control channel read/write the SAME fields so they can't drift.
+  Four-point keep-in-sync audit for `session.search`: (1) `case sessionSearch = "session.search"` in
+  `ControlProtocol.swift` (reuses `ControlArgs.text` = needle + `ControlArgs.to` = next|prev|close,
+  and `ControlResult.count` + `text` — no new field), (2) the `.sessionSearch` dispatch arm (`searchSession`)
+  in `ControlServer`, (3) the `session search [needle] --next|--prev|--close` subcommand in `agtermctlKit`
+  (`validate()` rejects flag combos), (4) round-trip tests in `ControlProtocolTests` + the e2e `testSessionSearch`
+  in `ControlAPIUITests`.
+  `session.overlay.open`/`session.overlay.close` run an ephemeral terminal on top of a session executing
+  one program (`args.command`, e.g. a TUI); by default it is full single-pane size,
+  hiding the single/split underneath, but `args.sizePercent` (1–100, clamped in `openOverlay`) makes
+  it a *floating* opaque framed panel at that percent of the pane with the session still visible.
+  `AppStore.openOverlay`/`closeOverlay` set non-persisted `Session.overlay*` state (incl.
+  `overlaySizePercent`, nil = full / non-nil = floating), and the surface runs `config.command` with
+  `onExit → closeOverlay`.
+  The two variants render in DIFFERENT places.
+  The FULL overlay is an in-deck ZStack sibling in `ContentView.sessionDetail` (`.zIndex(1)` above the
+  pane(s), gated on `fullOverlay`): it draws translucent + blurred (NO opaque backing) with the pane(s)
+  behind hidden at `.opacity(0)` + `.allowsHitTesting(false)` (kept MOUNTED,
+  shells alive like the deck's inactive sessions), so its transparency reveals the window backing (desktop,
+  tint + blur), not the session.
+  The FLOATING overlay (`overlaySizePercent` set) is rendered OUTSIDE `sessionDetail` — as `.overlay { floatingOverlayLayer }`
+  on `detailPane` — so `sessionDetail` for the floating case adds NO sibling to its ZStack:
+  just the pane(s) at opacity 1, the same SHAPE as no-overlay (which is what keeps the NSSplitView from
+  moving).
+  Hit-testing stays gated on `.allowsHitTesting(!fullOverlay)` and must NOT flip when a floating overlay
+  opens: changing the panes' OWN `allowsHitTesting` on overlay-open (e.g. to `!session.overlayActive`)
+  ALSO triggers the NSSplitView titlebar-overrun — the SAME class of perturbation as adding a sibling,
+  even though it looks like a pure interaction change (Codex insisted hit-testing was layout-inert;
+  a review-loop regression proved otherwise).
+  So the floating panes stay hit-testable, and the overlay's focus is protected OUTSIDE `sessionDetail`:
+  a transparent `Color.clear.contentShape(Rectangle())` catcher in `floatingOverlayLayer` (on `detailPane`)
+  absorbs clicks AROUND the panel so they can't reach the panes and steal the overlay program's first
+  responder.
+  (Generalize the rule: ANYTHING in `sessionDetail`'s HSplitView-hosting subtree that CHANGES when `overlayActive`
+  flips — a sibling, a flattened ZStack, or a toggled pane modifier — overruns the split into the titlebar;
+  keep that subtree identical for the floating case and do everything else at the `detailPane` level.)
+  This separation is load-bearing: adding a conditional sibling INSIDE `sessionDetail`'s ZStack (the
+  HSplitView-hosting subtree) made SwiftUI re-host it and the AppKit `NSSplitView` overrun UP into the
+  transparent titlebar, painting the split over the header (Codex-confirmed;
+  the quick terminal renders at this level for the same reason and never hit it).
+  Anchoring on `detailPane` also means `floatingOverlayLayer`'s `GeometryReader` reports the terminal
+  area EXACTLY — no manual sidebar/titlebar insets (computing those at the window level mis-centered
+  the panel one line low) — so it sizes the opaque framed panel (`terminalColor` backing + hairline frame
+  + shadow, quick-terminal styling) to `sizePercent`% and centers it in the detail area,
+  the pane(s) visible around it.
+  Only the active session's floating overlay shows, so `ControlServer` SELECTS the target when a floating
+  overlay (`sizePercent` set) opens — its surface only mounts for the active session,
+  so without the select a non-active target's program would never run and a `--block` open would poll
+  forever (the full overlay needs no select; it mounts in the eager deck regardless).
+  On close an `.onChange(of: session.overlayActive)` drives `focusAfterReparent()` on the session's `activeSurface`
+  so first responder returns to the underlying terminal — the pane re-activating only does a single `makeFirstResponder`,
+  which loses the teardown/re-host race (same reason the open path needs the `autoFocus` retry).
+  Two libghostty gotchas (confirmed against cmux/macterm, see the gotchas section):
+  the surface must **handle `GHOSTTY_ACTION_SHOW_CHILD_EXITED`** (in `GhosttyCallbacks.action`) and return
+  `true` to suppress ghostty's "Process exited.
+  Press any key" prompt and close immediately — `config.wait_after_command` does NOT suppress it;
+  and the overlay must grab focus via a **bounded run-loop `makeFirstResponder` retry** (`autoFocus`),
+  since a single-shot loses the SwiftUI/AppKit responder race.
+  `--wait`/`overlayWait` keeps the prompt (returns `false` from the action so `close_surface_cb` closes
+  after a keypress).
+  `handleProcessExit` is idempotent (both the action and `close_surface_cb` can fire).
+  The overlay is rendered only for the *active* session, so the caller selects the session first.
+  **Exit-status capture (`session.overlay.result` + `agtermctl … --block`).** `makeOverlaySurface` wraps
+  the command in a FIXED `sh -c '( eval "$AGTERM_OVL_CMD" ); echo $? > "$AGTERM_OVL_CODE"'` — the real
+  command + a per-surface temp path ride in env (`AGTERM_OVL_CMD`/`AGTERM_OVL_CODE`,
+  never interpolated), and crucially there is **NO stdout/stderr redirect** so a TUI renders normally;
+  only the exit status is captured.
+  (libghostty's `GHOSTTY_ACTION_SHOW_CHILD_EXITED.exit_code` reflects the login-shell wrapper — always
+  0 — so the status is taken from the wrapper's `echo $?`, NOT libghostty;
+  the subshell makes an inline `exit N` propagate.) the surface's teardown reads the temp file → `AppStore.recordOverlayExit`
+  (sets the non-persisted `Session.overlayExitCode`) → then deletes it, all in `GhosttySurfaceView.destroySurface`
+  (via `onExitCodeCaptured`), so EVERY in-process close path — natural exit,
+  explicit `session.overlay.close`, force-close (session/workspace/window) — captures the status before
+  the file is removed, and the file's lifetime tracks the surface (no registry/sweep);
+  `onExit` itself just drives `closeOverlay`.
+  `session.overlay.result` (target = session) returns `result.exitCode` once the overlay has closed (`OverlayResultError.stillRunning`
+  while up, `noResult` if none ran — both shared constants so the CLI poll matches exactly).
+  `agtermctl session overlay open <command> … --block` wraps open → poll `session.overlay.result` (retry
+  while still running; targets the returned id with NO window scope, so a frontmost-window change can't
+  desync the poll) → exit with the captured status into ONE blocking command (rejects `--block` + `--wait`
+  at parse via `validate()`); the program's OUTPUT is its own concern — a TUI like revdiff renders in
+  the overlay and writes results to its own `--output` file, which the caller reads (the control channel
+  does NOT capture stdout).
+  Mode-bearing commands (`session.split`/`quick`) compute the delta against current state so `on`/`off`/`show`/`hide`
+  are idempotent, and an unknown mode is an error.
+  `session.status` flags a per-session agent status on the sidebar row — `args.status` is `idle`|`active`|`completed`|`blocked`
+  (`AgentStatus(rawValue:)` → an `invalid status` error on anything else),
+  `args.blink` pulses the glyph, and `args.autoReset` (status-agnostic, caller-set,
+  symmetrical with `blink`) makes it clear back to idle once the session is visited.
+  `args.sound` plays a ONE-SHOT sound when the status is applied (caller-driven,
+  NOT stored on `AgentIndicator` — `default`/`beep` = `NSSound.beep()`, any other value = the named system
+  sound via `NSSound(named:)`, which also resolves custom sounds in `~/Library/Sounds`);
+  it is validated UP-FRONT against the app-side `StatusSoundPlayer.shared` (a singleton that caches resolved
+  `NSSound`s so a short clip isn't cut off when the local goes out of scope — also reused by the Settings
+  picker preview), so an unknown name is an `unknown sound: X` error that leaves the status UNCHANGED,
+  and the fire is inside `resolveSession` so a bad target still errors `notFound` without playing.
+  When NO per-call `args.sound` is given and a session TRANSITIONS into `blocked`,
+  the user's **Settings ▸ Appearance ▸ Agent Status ▸ Blocked sound** (`AppSettings.blockedStatusSoundName`,
+  GUI-only, default None) plays as a best-effort default.
+  The transition is gated by a `wasBlocked` read of the session's current status BEFORE `setAgentIndicator`,
+  so a REPEATED `blocked` set does not replay the default (and an empty per-call `args.sound` counts
+  as unset); the precedence is the host-free `AgentStatus.effectiveSound(perCall:blockedDefault:)` (explicit
+  per-call wins; the default is blocked-only), with the transition gate itself in the server.
+  That setting is keep-in-sync EXEMPT like the status colors, since the per-status sound already has
+  full control coverage via `--sound`.
+  Setting a non-idle status is control-driven (the hooks/agents call it;
+  no GUI sets active/completed/blocked), but clearing to idle ALSO has a GUI — the **Clear Status** action
+  (see the Agent-status glyph note) — so the idle case is keep-in-sync covered by `session.status idle`.
+  Cross-window via the shared `resolveSession` (the install's Stop hook targets its own `$AGTERM_SESSION_ID`,
+  which may live in a non-frontmost window).
+  The arm (`setSessionStatus`) builds an `AgentIndicator{status, blink, autoReset}` (host-free,
+  ephemeral — never in `SessionSnapshot`) and drives the single `AppStore.setAgentIndicator(_:forSession:)`
+  mutation point (unknown id = clean no-op), returning the id.
+  Visibility is keep-state vs one-time, decided by `autoReset` alone: `AppStore.selectSession` resets
+  an `autoReset` indicator (the `completed` flash) to idle on BOTH the session visited AND the one left
+  (right after `clearUnseen`), so it never lingers on a row you switch away from,
+  and leaves a non-`autoReset` one untouched.
+  The glyph is NOT gated by selection — it shows on every non-idle session,
+  the selected one included (see below).
+  `keymap.reload` re-reads `keymap.conf` and returns the parse-diagnostic count in `result.count` (0
+  reads as a clean reload; `agtermctl keymap reload` prints `ok` then, else `N diagnostic(s)`).
+  It is the SAME `SettingsModel.reloadKeymap()` path the GUI's File ▸ Reload Keymap menu/palette item
+  drives, so the GUI half and the control half can't diverge — control-native only in the count it reports
+  back; no `--window` selector (the keymap is app-global — a single app-wide `SettingsModel`,
+  constructed once in `agtermApp.init` and shared with `ControlServer`).
+  Four-point keep-in-sync audit for `keymap.reload`: (1) `case keymapReload = "keymap.reload"` in `ControlProtocol.swift`
+  (returns the new `ControlResult.count: Int?`, no target/args), (2) the `.keymapReload` dispatch arm
+  in `ControlServer`, (3) the `keymap reload` subcommand in `agtermctlKit`,
+  (4) round-trip tests in `ControlProtocolTests` plus the e2e in `ControlAPIUITests`.
+  See the Keymap section for the parser/menu/monitor design.
+  `config.reload` re-reads the agterm-scoped `ghostty.conf` and returns the ghostty config-diagnostic
+  count in `result.count` (0 reads as a clean reload; `agtermctl config reload` prints `ok` then,
+  else `N diagnostic(s)`).
+  It is the SAME `AppActions.reloadGhosttyConfig()` path the GUI's File ▸ Reload Config menu/palette
+  item + the Edit-ghostty overlay close drive (which posts the warning banner on a malformed file),
+  so the GUI half and the control half can't diverge — control-native only in the count it reports back;
+  no `--window` selector (the config is app-global — one `SettingsModel` + one `GhosttyApp`,
+  shared with `ControlServer`).
+  The arm calls `actions.reloadGhosttyConfig()` then returns `GhosttyApp.shared.lastConfigDiagnosticsCount`.
+  Four-point keep-in-sync audit for `config.reload`: (1) `case configReload = "config.reload"` in `ControlProtocol.swift`
+  (reuses `ControlResult.count`, no target/args), (2) the `.configReload` dispatch arm (`reloadGhosttyConfig`)
+  in `ControlServer`, (3) the `config reload` subcommand in `agtermctlKit`,
+  (4) round-trip tests in `ControlProtocolTests` plus the e2e in `ControlAPIUITests`.
+  See the Settings section for the config layer + Edit/Reload.
+  `sidebar` (mode `show`|`hide`|`toggle`, default toggle, frontmost window — mirrors `quick`,
+  delta-computed so it's idempotent, unknown mode + no-open-window are errors) shows/hides the custom-split
+  sidebar — the per-window `AppStore.sidebarVisible` (persisted per-window in `Snapshot`,
+  restored on relaunch alongside `AppStore.sidebarWidth`; `toggleSidebar`/`setSidebar` call `save()`;
+  the custom split replaced `NavigationSplitView`, so there is no system toggle).
+  `AppActions.toggleSidebar()` flips `library.activeStore?.sidebarVisible` and `ContentView` animates
+  it (`splitRoot`'s `.animation(value:)`, so every caller animates uniformly — the toolbar button no
+  longer wraps its own `withAnimation`); shared by the title-bar `sidebar-toggle-button`,
+  View ▸ Show/Hide Sidebar, the ⌃⇧P palette "Toggle Sidebar", and the ⌃⌘S keymap action (`BuiltinAction.toggleSidebar`,
+  expressible so pure-`defaultChord`-driven).
+  Four-point keep-in-sync audit: (1) `case sidebar` in `ControlProtocol.swift` (reuses `ControlArgs.mode`),
+  (2) the `.sidebar` dispatch arm (`setSidebar`) in `ControlServer`, (3) the `sidebar` subcommand in
+  `agtermctlKit`, (4) round-trip in `ControlProtocolTests` + the e2e `testSidebarShowHideToggle` (sidebar
+  hide removes the `session-row`s from the AX tree) in `ControlAPIUITests`.
+  `theme.set` sets + persists a theme by name (`args.name`; nil/empty = ghostty's built-in / "default
+  ghostty", NOT the seeded `agterm` app default — see the Theme picker section) — the control half of
+  the Settings picker / the `.themes` palette commit, the SAME `SettingsModel.setTheme` persist+apply
+  path (NO live preview over the socket — preview is interactive-only).
+  An unknown name (not in `SettingsCatalog.themeNames()`) is an `unknown theme: X` error (a typo silently
+  doing nothing is worse than a fail); the applied name echoes in `result.theme` (nil = ghostty built-in).
+  `theme.list` returns `result.themes` = the bundled names + `result.theme` = the current one (nil =
+  ghostty built-in; absent on a fresh install means the seeded `agterm` is current);
+  `agtermctl theme list` prints one name per line with a leading "default ghostty" row,
+  the current marked `* `, and `theme.set` prints `ok` (non-create mutation).
+  App-global like `keymap.reload` (one `SettingsModel`), so NO `--window` selector.
+  Four-point keep-in-sync audit: (1) `case themeSet = "theme.set"` + `case themeList = "theme.list"`
+  in `ControlProtocol.swift` (reuse `ControlArgs.name`; add `ControlResult.theme`/`themes`),
+  (2) the `.themeSet` (`setTheme`, with name validation) + `.themeList` dispatch arms in `ControlServer`,
+  (3) the `theme set [name]` / `theme list` subcommands in `agtermctlKit` (+ `SocketClient.formatThemes`),
+  (4) round-trip in `ControlProtocolTests` + the e2e `testThemeListAndSet` in `ControlAPIUITests`.
+  See the Theme picker section for the GUI/preview half.
+  `session.flag` (target = session) flags/unflags a session for the flagged working-set view — `args.mode`
+  is `on`|`off`|`toggle`|`clear` (`clear` IGNORES the target and unflags every session in the resolved
+  store via `AppStore.clearFlags()`, mirroring `session.scratch`/`session.split`'s mode-bearing shape),
+  drives `AppStore.setFlag(_:forSession:)` (idempotent — no-op + no save when unchanged),
+  surfaces the `flagged` bool on `ControlSessionNode` in the `tree` builder,
+  and returns the session id; an unknown mode is an error.
+  It is the control half of the row context-menu Flag/Unflag + the View-menu/palette Flag Session/Clear
+  Flagged.
+  Pair with `sidebar.mode flagged` to view just the flagged sessions.
+  Four-point keep-in-sync audit for `session.flag`: (1) `case sessionFlag = "session.flag"` in `ControlProtocol.swift`
+  (reuses `ControlArgs.mode`; adds `flagged` to `ControlSessionNode`), (2) the `.sessionFlag` dispatch
+  arm (`flagSession`) in `ControlServer`, (3) the `session flag on|off|toggle|clear` subcommand (`FlagCommand`)
+  in `agtermctlKit`, (4) round-trip in `ControlProtocolTests` + the e2e `testSessionFlagAndSidebarModeFlagged`
+  in `ControlAPIUITests`.
+  `sidebar.mode` (frontmost window) flips the sidebar VIEW between the workspace tree and the flat flagged
+  working-set list — `args.mode` is `tree`|`flagged`|`toggle` (delta-computed against `AppStore.sidebarMode`
+  so it's idempotent, unknown mode = error), drives `setSidebarViewMode` → `AppStore.setSidebarMode`.
+  It is the control half of the bottom-bar `flagged-view-toggle` + the View-menu Show Flagged/Show All
+  + `BuiltinAction.toggleFlaggedView`; the existing `sidebar [show|hide|toggle]` is now the default `sidebar visibility`
+  subcommand alongside `sidebar mode`.
+  Four-point keep-in-sync audit: (1) `case sidebarMode = "sidebar.mode"` in `ControlProtocol.swift` (reuses
+  `ControlArgs.mode`), (2) the `.sidebarMode` dispatch arm (`setSidebarViewMode`) in `ControlServer`,
+  (3) the `sidebar mode tree|flagged|toggle` subcommand (`Mode`, alongside the `Visibility` default)
+  in `agtermctlKit`, (4) round-trip in `ControlProtocolTests` + the e2e `testSessionFlagAndSidebarModeFlagged`
+  in `ControlAPIUITests`.
+  `sidebar.expand`/`sidebar.collapse` expand every workspace / collapse all but the active one in a window's
+  sidebar TREE — `expand` drives `AppActions.expandAllWorkspaces(in:)`, `collapse` drives `collapseOtherWorkspaces(in:)`
+  (collapse keeps the ACTIVE session's workspace expanded and scrolls its row into view).
+  UNLIKE `sidebar`/`sidebar.mode` (frontmost-only, no selector), these honor the global `--window` selector
+  (`ControlArgs.window`): the arm resolves the target store via `resolvePlacementStore(window)` (frontmost
+  by default; a named window must be OPEN, else the closed-window error;
+  no open window at all → `no open window`), then posts a notification (`.agtermExpandWorkspaces`/`.agtermCollapseWorkspaces`)
+  carrying THAT `AppStore` as the object.
+  `WorkspaceSidebar.Coordinator` registers its observer with `object: store`,
+  so NotificationCenter delivers ONLY to that window's sidebar Coordinator — this object-scoping (the
+  rename notifications self-scope via the selected-session guard; expand/collapse have no such natural
+  guard) is exactly what lets the control path target a specific (even background) window while the GUI
+  menu/palette use the frontmost.
+  A graceful no-op in `flagged` mode (no workspace rows: `expandWorkspacesNotified` gates on tree mode,
+  `collapseOthers` gates internally); idempotent.
+  GUI half (frontmost only): View ▸ Expand/Collapse Workspaces (plain keyless items,
+  disabled with no active store or in flagged mode) + the ⌃⇧P palette "Expand Workspaces"/"Collapse Workspaces"
+  (tree-mode only).
+  Four-point keep-in-sync audit: (1) `case sidebarExpand = "sidebar.expand"` + `case sidebarCollapse = "sidebar.collapse"`
+  in `ControlProtocol.swift` (reuse `ControlArgs.window`, no new field),
+  (2) the `.sidebarExpand`/`.sidebarCollapse` dispatch arms (`expandWorkspaces(window:)`/`collapseWorkspaces(window:)`)
+  in `ControlServer`, (3) the `sidebar expand`/`sidebar collapse` subcommands (`Expand`/`Collapse` on
+  `ClientOptions` for `--window`, alongside the `Visibility` default + `Mode`) in `agtermctlKit`,
+  (4) round-trip (incl. the windowed variant) in `ControlProtocolTests` + the e2e `testSidebarExpandCollapse`
+  in `ControlAPIUITests`.
+  `workspace.focus` (target = workspace) collapses the sidebar tree to a single workspace — `args.mode`
+  is `on`|`off`|`toggle` (`off` unfocuses only when the target is the currently focused one,
+  `toggle` flips; delta-computed against `AppStore.focusedWorkspaceID` so it's idempotent,
+  unknown mode = error), drives `focusWorkspace` → `AppStore.setFocusedWorkspace`,
+  honors the global `--window` selector, and returns the workspace id.
+  Per-window + persisted, orthogonal to `sidebar.mode` (the flat flagged list ignores focus);
+  selecting a session outside the focused workspace auto-unfocuses (see the Sidebar section).
+  It is the control half of the workspace-row Focus/Unfocus + the `focus-pill` ✕ + `BuiltinAction.focusWorkspace`/`focusActiveWorkspace`
+  + the Clear Focus menu/palette item.
+  Four-point keep-in-sync audit: (1) `case workspaceFocus = "workspace.focus"` in `ControlProtocol.swift`
+  (reuses `ControlArgs.mode`), (2) the `.workspaceFocus` dispatch arm (`focusWorkspace`) in `ControlServer`,
+  (3) the `workspace focus on|off|toggle` subcommand (`Focus`) in `agtermctlKit`,
+  (4) round-trip in `ControlProtocolTests` + the e2e `testWorkspaceFocusHidesOtherWorkspaces` in `ControlAPIUITests`
+  plus the `FocusWorkspaceUITests` XCUITest.
+  `tree` now also surfaces, on each `ControlSessionNode`, `foreground`/`splitForeground` — the LIVE foreground-process
+  argv of the main + split panes (nil/omitted at the shell prompt), the SAME `ForegroundProcess.command(for:shellBasename:)`
+  capture the restore-running-command feature uses (`ghostty_surface_foreground_pid` → `sysctl(KERN_PROCARGS2)`
+  → host-free `CommandRestore`), populated in the tree builder per session so a script can read "what
+  is each pane running".
+  `restore.clear` clears every open session's saved foreground command (`Session.foregroundCommand`/`splitForegroundCommand`)
+  and persists via `library.saveAllOpen()`, so the next restart restores plain shells instead of re-running
+  the captured commands (also closing the force-quit re-fire: the restored command is consumed in memory
+  but its on-disk copy lingers until the next save, which a force-quit skips).
+  App-global like `keymap.reload` (clears all open windows, no `--window`).
+  Four-point keep-in-sync audit for `restore.clear`: (1) `case restoreClear = "restore.clear"` in `ControlProtocol.swift`
+  (no target/args; `foreground`/`splitForeground` added to `ControlSessionNode`),
+  (2) the `.restoreClear` dispatch arm (`clearSavedCommands`) in `ControlServer` + the foreground population
+  in the tree builder, (3) the `restore clear` subcommand (`Restore`) in `agtermctlKit`,
+  (4) round-trip (`restoreClearRoundTrips` + `treeSessionNodeRoundTripsWithForeground`/`…OmitsForegroundWhenNil`)
+  in `ControlProtocolTests` + the e2e (`testTreeExposesForegroundProcess`,
+  `testRestoreClearSucceeds`) in `ControlAPIUITests`.
+  **Agent-skill mirror (HARD keep-in-sync, 4th surface):** all commands are documented in the bundled
+  `agterm/Resources/agent-skill/` (SKILL.md summary, reference.md detail,
+  examples.md recipes) and the command count there is bumped to 46 to match.
 

--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -12,14 +12,146 @@ paths:
 
 ## Keymap
 
-- A user-editable, kitty-flavored keymap file (`<configDir>/keymap.conf`, default `~/.config/agterm`) lets the user (1) **rebind built-in menu shortcuts** and (2) **define custom shell commands** bound to keys, the latter listed in the action palette marked `custom`. Like the Control API, the pure logic lives host-free in `agtermCore` and the app target wires it. The feature is the keymap analogue of the toolbar/menu/control seam: the SAME parsed `Keymap` drives the menu shortcuts, the custom-command monitor, and the palette, so the three can't drift.
-- **Two-section verb-based format (`parseKeymap`, host-free, never throws).** `map <chord> <action>` overrides a built-in's shortcut (single chord only — a leader is a diagnostic); `command "<name>" [chord] <shell...>` defines a custom command (quoted name with spaces; the post-name token is the chord IFF `parseKeybind` accepts it AND it carries a modifier — a bare modifier-less key is rejected with a diagnostic and the line falls back to palette-only, so a custom shortcut can't shadow a plain terminal key and a palette-only shell line starting with a single-char token isn't silently swallowed as a binding; else palette-only; the shell remainder keeps `{AGT_X}` tokens verbatim — an EMPTY shell line is a diagnostic, not a no-op binding). Both verbs tokenize on GENERAL whitespace (space OR tab). Blank lines and `#` comments are skipped (an inline `#` is a comment only when preceded by whitespace AND outside a double-quoted span). A malformed line becomes a `KeymapDiagnostic{line, message}` and is skipped — a bad line never discards the rest of the file. Pure types: `Modifier`/`Chord`/`Keybind`/`parseKeybind`/`keybindConflicts`/`reservedMonitorChords` (`Keybind.swift`), `KeybindMatcher` (leader state machine), `CustomCommand`/`CommandContext` (the `{AGT_X}` token table — single source of truth for both `{AGT_X}` expansion and the `$AGT_X` env), `BuiltinAction` (the 35 rebindable actions + `defaultChord`), `Keymap`/`parseKeymap` (`Keymap.swift`), `ConfigPaths` (the path resolver). All unit-tested under `agtermCoreTests`.
-- **MENU-driven built-in override vs MONITOR-driven custom commands — two different mechanisms.** Built-ins ride AppKit menu-key-equivalents: each built-in `Button` in `agtermApp`'s `.commands` reads `settingsModel.keymap.equivalent(for: .action)` via the `shortcut(for:)` helper (`Chord` → SwiftUI `KeyboardShortcut?`, applied only when non-nil so a keyless action stays keyless until mapped). Because `keymap` is `@Observable` and `.commands` reads it, the menu shortcuts re-render on reload — no notification needed for the menu. Custom commands ride an app-wide `NSEvent` local `.keyDown` monitor in `CustomCommandRunner` (the same monitor pattern as the Ctrl-Tab switcher and Ctrl-1/2): it maps `NSEvent` → `Chord`, feeds a `KeybindMatcher` (firing simple chords + leader sequences like `ctrl+a>g`, 1.5 s leader timeout, key-repeat ignored), and on `.fired` spawns a detached `/bin/sh -c` with the focused pane's `CommandContext` (cwd + selection + `$AGT_*` env); a non-zero exit posts a failure banner via `NotificationManager.notifyCommandFailure`. It only fires when a `GhosttySurfaceView` holds first responder (so a bound chord never eats keystrokes in a text field) and rebuilds its matcher on `.agtermKeymapChanged`. The runner also exposes a public `run(_:)` for the palette items, which resolve context from the active session (no first responder to key off).
-- **Built-in override resolution is ORDER-INDEPENDENT, decided against the FINAL state (`resolveBuiltinOverrides`).** Overrides are NOT folded incrementally against a partially-built map (that was order-sensitive — it would reject `map cmd+d new_session` when toggle_split still owned cmd+d "so far", even if a later line moved toggle_split off cmd+d). Instead: (1) fold all overrides last-wins into a candidate map; (2) compute each action's final resolved chord (override else `defaultChord`); (3) a chord that TWO DISTINCT actions resolve to is the only real conflict — an override colliding with another action's UNMOVED default loses (the default owner keeps the chord), two colliding OVERRIDES → the later-in-file one loses, each with a diagnostic naming the kept owner. So `map cmd+d new_session` + `map cmd+shift+d toggle_split` both succeed in EITHER order. The dropped-override diagnostics are emitted sorted by file line for deterministic order.
-- **Cross-section validation + ownership-by-disjoint-registration (why there is NO precedence fight).** `parseKeymap` runs a SINGLE final validation pass AFTER every line is parsed (NOT incremental — a custom line parsed before a later keyless-built-in `map` must still be checked against the override that `map` installs): it computes the active built-in chord set (`equivalent(for:)` over every `BuiltinAction`, overrides applied) and drops a custom keybind whose FIRST chord collides with a built-in OR whose ANY chord is a reserved monitor chord (the monitor consumes its chord wherever it lands in a leader, so a later reserved chord like `ctrl+a>ctrl+1` is just as dead as a leading one) — clearing the command's `shortcut` to `""`, keeping the palette entry, + a diagnostic — then drops both keybinds of any custom-vs-custom conflict via `keybindConflicts`. The reserved set is the PREDICATE `isReservedMonitorChord(_:)` (NOT a fixed list): control+tab with ANY modifiers (the Ctrl-Tab switcher consumes Tab whenever Control is held — `ctrl+tab` / `ctrl+shift+tab` / `ctrl+opt+tab` / `ctrl+cmd+tab`), plus control+1 / control+2 with Control as the SOLE modifier (the Ctrl-1/2 pane monitor) — so all of these are un-rebindable. The SAME predicate also rejects a built-in `map` line whose (single) chord is reserved (`parseMapLine`), so neither a built-in nor a custom command can steal a monitor chord. The reasoning: the NSEvent monitor only consumes chords registered in its matcher, and validation guarantees those registered chords are disjoint from the active built-in (menu) chords AND the reserved monitor chords. So every physical chord is owned by exactly one mechanism — the menu OR a monitor, never both — regardless of AppKit's menu-key-equivalent-vs-local-monitor dispatch order (the design does NOT rely on asserting that order). Caveat: validation covers agterm's own built-ins + reserved monitor chords, NOT system/standard menu items (⌘Q/⌘C/⌘,); binding a custom command to one of those resolves by AppKit's own dispatch — documented, not validated.
-- **`BuiltinAction.defaultChord` is the single source of truth for the built-in shortcuts (keep-in-sync surface).** Task 9 collapsed the old `BuiltinAction` ↔ menu keep-in-sync convention: 29 of the 35 built-in menu items now read `equivalent(for:)` (override else `defaultChord`) with NO hardcoded `.keyboardShortcut` literal, so adding/changing a default chord happens in `defaultChord` alone (`toggle_search` ⌘F, `toggle_sidebar` ⌃⌘S, `custom_command_palette` ⌃⇧O, and `show_attention` ⌃⇧I are among these — expressible, so pure-`defaultChord`-driven, not arrow exceptions). The EXCEPTION is the six arrow-bound actions (`focus_left_pane` ⌘⌥←, `focus_right_pane` ⌘⌥→, `previous_session` ⌥⌘↑, `next_session` ⌥⌘↓, `previous_attention_session` ⌃⌥↑, `next_attention_session` ⌃⌥↓): `parseKeybind` accepts only single-char keys or `tab`/`space`/`return`/`delete` — arrows are not expressible as a parsed `Chord`, so `defaultChord` returns nil for them and the menu keeps its hardcoded arrow `.keyboardShortcut` as the FALLBACK when `equivalent(for:)` is nil (a user can still `map` these to a parseable chord, which then wins). So the six arrow actions are NOT pure-`defaultChord`-driven by design; the other 29 are.
-- **v1 scope cut (confirmed).** Built-in rebinds are single-chord only (leaders only for custom commands); keys that clash with the grammar separators aren't expressible in the file — the arrows (the four arrow actions above keep their defaults unless mapped to a parseable chord), `+` (the chord-joiner, so `increase_font_size`'s default ⌘+ can't be written — `chordSyntax` renders it as `(not expressible)` in the starter and verifies the round-trip), and `>` (the leader separator). The Ctrl-Tab MRU switcher and Ctrl-1/Ctrl-2 pane focus are NOT rebindable (they are monitor-driven, not menu items — folding them in would reintroduce a monitor-vs-monitor precedence question; a custom command bound to one is dropped via `reservedMonitorChords`). The palette shows a custom command's chord as raw kitty syntax (`cmd+shift+e`), not the ⌘⇧E glyphs built-ins use.
-- **`{AGT_X}` tokens are substituted RAW into the `/bin/sh -c` line (`CommandContext.expand`).** This is the intended raw interpolation (convenient), NOT shell-quoted — so dynamic content like `{AGT_SELECTION}` can inject shell syntax. The safe alternative is already provided: the same values are exported as `$AGT_X` env vars (`CommandContext.environment()`), naturally shell-quoted as `"$AGT_SELECTION"`. The starter `keymap.conf` comments + README recommend `$AGT_X` (quoted) for untrusted content. Do NOT add quoting to the `{AGT_X}` expansion — by design.
-- **Reload + control.** `AppActions.reloadKeymap()` → `SettingsModel.reloadKeymap()` (re-read + re-parse + post `.agtermKeymapChanged`) is exposed as File ▸ Reload Keymap, an action-palette entry, AND the `keymap.reload` control command — all ONE path. See the Control API catalog for the `keymap.reload` four-point audit.
-- **Edit Keymap (GUI-only).** `AppActions.editKeymap()` (File ▸ Edit Keymap… + the ⌃⇧P palette) opens `keymap.conf` in the user's editor inside a 95% FLOATING overlay over the active session via `AppStore.openOverlay(…, sizePercent: 95)`. The command is the host-free, unit-tested `ConfigPaths.editorCommand(forPath:)` → `${SHELL:-/bin/zsh} -ilc 'exec /bin/sh -c '\''${VISUAL:-${EDITOR:-vi}} "$1"'\'' agterm-config-edit '<single-quoted path>''` (the path comes from `SettingsModel.keymapPath`). The user's INTERACTIVE login shell (`$SHELL -ilc`) runs first so it sources its rc and EXPORTS `$EDITOR`/`$VISUAL`, then `exec`s a POSIX `/bin/sh` that does the actual `${VISUAL:-${EDITOR:-vi}} "$1"` resolution + launch (the path is the inner `/bin/sh`'s positional `$1`, embedded single-quoted so spaces/quotes survive — NOT passed positionally to `$SHELL`, which fish has no `$1` for). TWO LOAD-BEARING reasons for the shape: (1) the `-ilc` sourcing — the overlay's own process is a bare non-interactive `/bin/sh` (libghostty runs `config.command` via `sh -c`, NOT the user's interactive shell) that sources none of the user's shell config, so a direct `${EDITOR:-vi}` there always fell back to `vi`; (2) the inner-`/bin/sh` hop — `$SHELL` may NOT be a POSIX shell (fish), which can't parse POSIX `${VAR:-default}` and died with `fish: ${ is not a valid variable` (exit 127, overlay just flashed) when the resolution ran directly under `$SHELL` — the POSIX text now rides inside single quotes that fish (and POSIX shells) pass through verbatim to `/bin/sh`. Two known limits: it assumes `$SHELL` accepts `-ilc` and passes single-quoted text verbatim (true for sh/bash/zsh/fish, NOT csh/tcsh, which reject `-ilc`); and it resolves `$EDITOR`/`$VISUAL` only when EXPORTED (their entire convention) — a non-exported, shell-local value does not survive the `exec` and falls to `vi`. Cross-shell behavior is unit-tested (`ConfigPathsTests` runs the built command under zsh + fish-when-present with a fake recorder editor, plus VISUAL-precedence and rc-sourcing cases). On the editor exiting the keymap reloads automatically: `editKeymap` records the target in `AppActions.keymapEditOverlaySession` and `WindowContentView`'s overlay-close `onChange` calls `reloadKeymap()` for it (then clears it). NO control command — a script can already `agtermctl session overlay open "$EDITOR <path>" --size-percent 95` (keep-in-sync exempt, like `reveal`, since it composes the controllable `session.overlay.open`).
+- A user-editable, kitty-flavored keymap file (`<configDir>/keymap.conf`,
+  default `~/.config/agterm`) lets the user (1) **rebind built-in menu shortcuts** and (2) **define custom
+  shell commands** bound to keys, the latter listed in the action palette marked `custom`.
+  Like the Control API, the pure logic lives host-free in `agtermCore` and the app target wires it.
+  The feature is the keymap analogue of the toolbar/menu/control seam: the SAME parsed `Keymap` drives
+  the menu shortcuts, the custom-command monitor, and the palette, so the three can't drift.
+- **Two-section verb-based format (`parseKeymap`, host-free, never throws).**
+  `map <chord> <action>` overrides a built-in's shortcut (single chord only — a leader is a diagnostic);
+  `command "<name>" [chord] <shell...>` defines a custom command (quoted name with spaces;
+  the post-name token is the chord IFF `parseKeybind` accepts it AND it carries a modifier — a bare modifier-less
+  key is rejected with a diagnostic and the line falls back to palette-only,
+  so a custom shortcut can't shadow a plain terminal key and a palette-only shell line starting with
+  a single-char token isn't silently swallowed as a binding; else palette-only;
+  the shell remainder keeps `{AGT_X}` tokens verbatim — an EMPTY shell line is a diagnostic,
+  not a no-op binding).
+  Both verbs tokenize on GENERAL whitespace (space OR tab).
+  Blank lines and `#` comments are skipped (an inline `#` is a comment only when preceded by whitespace
+  AND outside a double-quoted span).
+  A malformed line becomes a `KeymapDiagnostic{line, message}` and is skipped — a bad line never discards
+  the rest of the file.
+  Pure types: `Modifier`/`Chord`/`Keybind`/`parseKeybind`/`keybindConflicts`/`reservedMonitorChords`
+  (`Keybind.swift`), `KeybindMatcher` (leader state machine), `CustomCommand`/`CommandContext` (the `{AGT_X}`
+  token table — single source of truth for both `{AGT_X}` expansion and the `$AGT_X` env),
+  `BuiltinAction` (the 35 rebindable actions + `defaultChord`), `Keymap`/`parseKeymap` (`Keymap.swift`),
+  `ConfigPaths` (the path resolver).
+  All unit-tested under `agtermCoreTests`.
+- **MENU-driven built-in override vs MONITOR-driven custom commands — two different mechanisms.** Built-ins
+  ride AppKit menu-key-equivalents: each built-in `Button` in `agtermApp`'s `.commands` reads `settingsModel.keymap.equivalent(for: .action)`
+  via the `shortcut(for:)` helper (`Chord` → SwiftUI `KeyboardShortcut?`,
+  applied only when non-nil so a keyless action stays keyless until mapped).
+  Because `keymap` is `@Observable` and `.commands` reads it, the menu shortcuts re-render on reload
+  — no notification needed for the menu.
+  Custom commands ride an app-wide `NSEvent` local `.keyDown` monitor in `CustomCommandRunner` (the same
+  monitor pattern as the Ctrl-Tab switcher and Ctrl-1/2): it maps `NSEvent` → `Chord`,
+  feeds a `KeybindMatcher` (firing simple chords + leader sequences like `ctrl+a>g`,
+  1.5 s leader timeout, key-repeat ignored), and on `.fired` spawns a detached `/bin/sh -c` with the
+  focused pane's `CommandContext` (cwd + selection + `$AGT_*` env); a non-zero exit posts a failure banner
+  via `NotificationManager.notifyCommandFailure`.
+  It only fires when a `GhosttySurfaceView` holds first responder (so a bound chord never eats keystrokes
+  in a text field) and rebuilds its matcher on `.agtermKeymapChanged`.
+  The runner also exposes a public `run(_:)` for the palette items, which resolve context from the active
+  session (no first responder to key off).
+- **Built-in override resolution is ORDER-INDEPENDENT, decided against the FINAL state (`resolveBuiltinOverrides`).**
+  Overrides are NOT folded incrementally against a partially-built map (that was order-sensitive — it
+  would reject `map cmd+d new_session` when toggle_split still owned cmd+d "so far",
+  even if a later line moved toggle_split off cmd+d).
+  Instead: (1) fold all overrides last-wins into a candidate map; (2) compute each action's final resolved
+  chord (override else `defaultChord`); (3) a chord that TWO DISTINCT actions resolve to is the only
+  real conflict — an override colliding with another action's UNMOVED default loses (the default owner
+  keeps the chord), two colliding OVERRIDES → the later-in-file one loses,
+  each with a diagnostic naming the kept owner.
+  So `map cmd+d new_session` + `map cmd+shift+d toggle_split` both succeed in EITHER order.
+  The dropped-override diagnostics are emitted sorted by file line for deterministic order.
+- **Cross-section validation + ownership-by-disjoint-registration (why there is NO precedence fight).**
+  `parseKeymap` runs a SINGLE final validation pass AFTER every line is parsed (NOT incremental — a custom
+  line parsed before a later keyless-built-in `map` must still be checked against the override that `map`
+  installs): it computes the active built-in chord set (`equivalent(for:)` over every `BuiltinAction`,
+  overrides applied) and drops a custom keybind whose FIRST chord collides with a built-in OR whose ANY
+  chord is a reserved monitor chord (the monitor consumes its chord wherever it lands in a leader,
+  so a later reserved chord like `ctrl+a>ctrl+1` is just as dead as a leading one) — clearing the command's
+  `shortcut` to `""`, keeping the palette entry, + a diagnostic — then drops both keybinds of any custom-vs-custom
+  conflict via `keybindConflicts`.
+  The reserved set is the PREDICATE `isReservedMonitorChord(_:)` (NOT a fixed list):
+  control+tab with ANY modifiers (the Ctrl-Tab switcher consumes Tab whenever Control is held — `ctrl+tab`
+  / `ctrl+shift+tab` / `ctrl+opt+tab` / `ctrl+cmd+tab`), plus control+1 / control+2 with Control as the
+  SOLE modifier (the Ctrl-1/2 pane monitor) — so all of these are un-rebindable.
+  The SAME predicate also rejects a built-in `map` line whose (single) chord is reserved (`parseMapLine`),
+  so neither a built-in nor a custom command can steal a monitor chord.
+  The reasoning: the NSEvent monitor only consumes chords registered in its matcher,
+  and validation guarantees those registered chords are disjoint from the active built-in (menu) chords
+  AND the reserved monitor chords.
+  So every physical chord is owned by exactly one mechanism — the menu OR a monitor,
+  never both — regardless of AppKit's menu-key-equivalent-vs-local-monitor dispatch order (the design
+  does NOT rely on asserting that order).
+  Caveat: validation covers agterm's own built-ins + reserved monitor chords,
+  NOT system/standard menu items (⌘Q/⌘C/⌘,); binding a custom command to one of those resolves by AppKit's
+  own dispatch — documented, not validated.
+- **`BuiltinAction.defaultChord` is the single source of truth for the built-in shortcuts (keep-in-sync
+  surface).** Task 9 collapsed the old `BuiltinAction` ↔ menu keep-in-sync convention:
+  29 of the 35 built-in menu items now read `equivalent(for:)` (override else `defaultChord`) with NO
+  hardcoded `.keyboardShortcut` literal, so adding/changing a default chord happens in `defaultChord`
+  alone (`toggle_search` ⌘F, `toggle_sidebar` ⌃⌘S, `custom_command_palette` ⌃⇧O,
+  and `show_attention` ⌃⇧I are among these — expressible, so pure-`defaultChord`-driven,
+  not arrow exceptions).
+  The EXCEPTION is the six arrow-bound actions (`focus_left_pane` ⌘⌥←, `focus_right_pane` ⌘⌥→,
+  `previous_session` ⌥⌘↑, `next_session` ⌥⌘↓, `previous_attention_session` ⌃⌥↑,
+  `next_attention_session` ⌃⌥↓): `parseKeybind` accepts only single-char keys or `tab`/`space`/`return`/`delete`
+  — arrows are not expressible as a parsed `Chord`, so `defaultChord` returns nil for them and the menu
+  keeps its hardcoded arrow `.keyboardShortcut` as the FALLBACK when `equivalent(for:)` is nil (a user
+  can still `map` these to a parseable chord, which then wins).
+  So the six arrow actions are NOT pure-`defaultChord`-driven by design;
+  the other 29 are.
+- **v1 scope cut (confirmed).**
+  Built-in rebinds are single-chord only (leaders only for custom commands);
+  keys that clash with the grammar separators aren't expressible in the file — the arrows (the four arrow
+  actions above keep their defaults unless mapped to a parseable chord),
+  `+` (the chord-joiner, so `increase_font_size`'s default ⌘+ can't be written — `chordSyntax` renders
+  it as `(not expressible)` in the starter and verifies the round-trip),
+  and `>` (the leader separator).
+  The Ctrl-Tab MRU switcher and Ctrl-1/Ctrl-2 pane focus are NOT rebindable (they are monitor-driven,
+  not menu items — folding them in would reintroduce a monitor-vs-monitor precedence question;
+  a custom command bound to one is dropped via `reservedMonitorChords`).
+  The palette shows a custom command's chord as raw kitty syntax (`cmd+shift+e`),
+  not the ⌘⇧E glyphs built-ins use.
+- **`{AGT_X}` tokens are substituted RAW into the `/bin/sh -c` line (`CommandContext.expand`).** This
+  is the intended raw interpolation (convenient), NOT shell-quoted — so dynamic content like `{AGT_SELECTION}`
+  can inject shell syntax.
+  The safe alternative is already provided: the same values are exported as `$AGT_X` env vars (`CommandContext.environment()`),
+  naturally shell-quoted as `"$AGT_SELECTION"`.
+  The starter `keymap.conf` comments + README recommend `$AGT_X` (quoted) for untrusted content.
+  Do NOT add quoting to the `{AGT_X}` expansion — by design.
+- **Reload + control.**
+  `AppActions.reloadKeymap()` → `SettingsModel.reloadKeymap()` (re-read + re-parse + post `.agtermKeymapChanged`)
+  is exposed as File ▸ Reload Keymap, an action-palette entry, AND the `keymap.reload` control command
+  — all ONE path.
+  See the Control API catalog for the `keymap.reload` four-point audit.
+- **Edit Keymap (GUI-only).**
+  `AppActions.editKeymap()` (File ▸ Edit Keymap… + the ⌃⇧P palette) opens `keymap.conf` in the user's
+  editor inside a 95% FLOATING overlay over the active session via `AppStore.openOverlay(…, sizePercent: 95)`.
+  The command is the host-free, unit-tested `ConfigPaths.editorCommand(forPath:)` → `${SHELL:-/bin/zsh} -ilc 'exec /bin/sh -c '\''${VISUAL:-${EDITOR:-vi}} "$1"'\'' agterm-config-edit '<single-quoted path>''`
+  (the path comes from `SettingsModel.keymapPath`).
+  The user's INTERACTIVE login shell (`$SHELL -ilc`) runs first so it sources its rc and EXPORTS `$EDITOR`/`$VISUAL`,
+  then `exec`s a POSIX `/bin/sh` that does the actual `${VISUAL:-${EDITOR:-vi}} "$1"` resolution + launch
+  (the path is the inner `/bin/sh`'s positional `$1`, embedded single-quoted so spaces/quotes survive
+  — NOT passed positionally to `$SHELL`, which fish has no `$1` for).
+  TWO LOAD-BEARING reasons for the shape: (1) the `-ilc` sourcing — the overlay's own process is a bare
+  non-interactive `/bin/sh` (libghostty runs `config.command` via `sh -c`,
+  NOT the user's interactive shell) that sources none of the user's shell config,
+  so a direct `${EDITOR:-vi}` there always fell back to `vi`; (2) the inner-`/bin/sh` hop — `$SHELL`
+  may NOT be a POSIX shell (fish), which can't parse POSIX `${VAR:-default}` and died with `fish: ${ is not a valid variable`
+  (exit 127, overlay just flashed) when the resolution ran directly under `$SHELL` — the POSIX text now
+  rides inside single quotes that fish (and POSIX shells) pass through verbatim to `/bin/sh`.
+  Two known limits: it assumes `$SHELL` accepts `-ilc` and passes single-quoted text verbatim (true for
+  sh/bash/zsh/fish, NOT csh/tcsh, which reject `-ilc`); and it resolves `$EDITOR`/`$VISUAL` only when
+  EXPORTED (their entire convention) — a non-exported, shell-local value does not survive the `exec`
+  and falls to `vi`.
+  Cross-shell behavior is unit-tested (`ConfigPathsTests` runs the built command under zsh + fish-when-present
+  with a fake recorder editor, plus VISUAL-precedence and rc-sourcing cases).
+  On the editor exiting the keymap reloads automatically: `editKeymap` records the target in `AppActions.keymapEditOverlaySession`
+  and `WindowContentView`'s overlay-close `onChange` calls `reloadKeymap()` for it (then clears it).
+  NO control command — a script can already `agtermctl session overlay open "$EDITOR <path>" --size-percent 95`
+  (keep-in-sync exempt, like `reveal`, since it composes the controllable `session.overlay.open`).
 

--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -11,15 +11,153 @@ paths:
 
 ## libghostty gotchas
 
-- **Chrome colors track the terminal theme; `config_get` can't read the optional `selection-*` keys.** The non-terminal chrome (sidebar row text + icons, title-bar text + buttons, the bottom add-buttons) uses the theme's colors instead of system label colors: `GhosttyApp.resolveThemeColors` reads `background`/`foreground` via `ghostty_config_get` and mirrors `terminalForegroundColor` into the views (refreshed on `.agtermAppearanceChanged`, like `terminalColor`). But `ghostty_config_get` returns the non-optional `background`/`foreground` and **returns false for the optional `selection-background`/`selection-foreground`** (verified: `selBg=false` even when the theme sets them). So the selection colors are resolved by `resolveSelectionColors()` — parsing the same config sources `loadConfig` loads (defaults → `~/.config/ghostty/config` → the agterm settings conf, last-wins) for `theme`/explicit `selection-*`, then reading the named theme file under `Bundle.main/ghostty/themes/<name>`. The selected sidebar row draws the theme's `selection-background` pill with `selection-foreground` text (a luminance-contrast black/white fallback when only the background is set). The borderless New-Session `Menu` glyph ignores `foregroundStyle` on its label, so it's tinted via `.tint(chromeText)`.
-- **Sidebar selection is drawn entirely by `SidebarRowView`, not AppKit.** `outline.selectionHighlightStyle = .none` (set right after `style = .sourceList`, which would otherwise reset it) so AppKit draws no selection of its own — otherwise it paints a gray *unemphasized* capsule whenever the sidebar isn't first responder (the normal case, since focus lives in the terminal), overriding any custom `drawSelection`. The row draws the themed pill in `drawBackground(in:)` for every state, and the Coordinator's `refreshSelectionAppearance()` repaints the pills + re-tints the row text on selection change (AppKit won't redraw rows on its own with `.none`) and on `.agtermAppearanceChanged`. **`SidebarOutlineView.acceptsFirstResponder` is `false`** so a mouse click selects without stealing first responder from the terminal — that responder bounce (terminal → outline → terminal, via `mouseDown`'s `focusActiveTerminal`) otherwise makes AppKit re-set `SidebarRowView.isEmphasized`, whose setter forces `needsDisplay`, and flicks the pill on every click (programmatic selection from the palette/Ctrl-Tab never bounces, so it was already smooth). **Reconcile splits SHAPE from CONTENT** (`TreeShape` ids/order → full `rebuildAndReload`; `RowContent` name/icon/badge → per-row `reloadItem`) so a cwd-driven `displayName` change reloads only its row instead of a full `reloadData` + re-expand that re-lays-out and horizontally jitters every source-list row. **Inline rename** paints the edit field with the terminal theme's foreground-on-background (the row's selection-foreground would be dark-on-dark in the system edit box), and `restore` re-applies the row's selection-aware color when editing ends (a same-name commit doesn't reload the row).
-- **terminfo sibling dir.** `GHOSTTY_RESOURCES_DIR` points at `Contents/Resources/ghostty`; libghostty derives `TERMINFO` as `dirname(...)/terminfo` at shell spawn, so the compiled terminfo database must be a sibling at `Contents/Resources/terminfo`. `GhosttyResources` sets only `GHOSTTY_RESOURCES_DIR` and never `TERMINFO` (libghostty overwrites it at spawn). If this layout breaks, `TERM=xterm-ghostty` fails and keys break.
-- **Surface lifecycle (EAGER deck).** `Session` owns its `GhosttySurfaceView` (`@ObservationIgnored`). The detail pane is a *deck* — `ContentView.detailPane` is a `ZStack` over EVERY session (`store.workspaces.flatMap(\.sessions)`), each session's `TerminalView` mounted at once, with only the selected one at `opacity 1` + hit-testable. So every session's shell spawns at startup (eager realization, not lazy-on-first-select), and switching is a visibility + `isActive` flip, never an `.id` swap — re-hosting a surface invalidates its Metal drawable and flickers the window. `dismantleNSView` is a no-op; `ghostty_surface_free` runs only in `destroySurface()` (reached via `teardown()` on close or pane-exit). This single-owner, single-free rule is what makes passing the view as unretained `userdata` safe. `destroySurface()` ALSO nils every `store`-capturing callback (`onExit`/`onExitCodeCaptured`/`onFocusChange`/`onUserInputClearsStatus`/`onFontSizeChange`/the four `onSearch*`) at its END — AFTER `onExitCodeCaptured` is read for the overlay exit status (niling it earlier would silently break `session.overlay.result`/`--block`) — to break the `store → session → surface → closure → store` retain cycle on every window/session close.
-- **Search bar placement (NSSplitView-overrun rule).** `TerminalSearchBar` (`agterm/Views/`) is anchored on `detailPane` via `.overlay(alignment: .topTrailing) { searchBarLayer }` — the SAME level as `floatingOverlayLayer`, NEVER inside any session's `sessionDetail` HSplitView-hosting subtree. This is the same hard-won rule as the floating overlay: adding a conditional sibling (or flipping a pane modifier) inside `sessionDetail`'s ZStack when `searchActive` flips would re-host the `NSSplitView` and overrun it UP into the transparent titlebar. The bar reads `store.activeSession?.searchActive` and shows only when set, so the split subtree's SHAPE is constant whether or not the bar is shown. Because it is a `detailPane` `.overlay`, it renders ABOVE the in-deck scratch (zIndex 1 inside `sessionDetail`) and the FULL overlay (zIndex 2) without any layout change — so search-over-scratch shows the bar on top of the scratch with no `sessionDetail`/HSplitView perturbation.
-- **Window overlays sit BELOW the custom titlebar, NOT as a body-level `.overlay` (transparent-titlebar-scrim rule).** The quick terminal, command palettes, and Ctrl-Tab switcher render via `windowOverlayLayer` — a ZStack sibling INSIDE the body's root ZStack, inset by `titlebarHeight` (`.padding(.top, titlebarHeight)`) and at `.zIndex(1)`, with `customTitlebar` at `.zIndex(2)` ABOVE it. They are NOT body-level `.overlay { … }` (which layer above EVERYTHING). Reason: `customTitlebar` is transparent (no backing) AND AppKit's native titlebar backing is deliberately hidden for translucency (`WindowAppearance`); a full-window overlay's dim scrim (`Color.black.opacity(0.2)`) attached as a body `.overlay` composites OVER the titlebar and darkens/seams it — visible only in the TALL non-compact (48px) titlebar (the cwd-subtitle strip lives in the content area below the native titlebar band; the 30px compact bar stays within the band and hides it). Keeping the titlebar at the highest zIndex means a scrim can never cover it; insetting the overlays by `titlebarHeight` keeps them off the titlebar entirely. The empty `windowOverlayLayer` (all three conditionals false) is a bare `.frame`-sized `ZStack` — an empty frame is NOT hit-testable, so the terminal below stays interactive (do NOT put a `Color`/`contentShape` at that level). Diagnosed by codex; the fix preserves translucency (titlebar stays backing-free) and keeps the overlays outside `detailPane`/`sessionDetail`/`HSplitView` (no split perturbation). Do NOT "fix" this with a permanent `.background(terminalColor)` on `customTitlebar` — it masks the symptom but breaks the opacity/blur chrome.
-- **Non-zero backing size.** Create the surface only when the view has a non-zero backing size, else the Metal layer renders blank. `pendingSurfaceCreation` defers creation until `setFrameSize` reports a real size.
-- **Re-parent invalidates the drawable → force a repaint.** The split toggle re-hosts a surface between the `HSplitView` and a standalone host, detaching/re-attaching the `NSView` and invalidating its Metal drawable. `ghostty_app_tick` (demand-driven, coalesced on wakeup) only draws surfaces flagged dirty, and `ghostty_surface_set_size` to an UNCHANGED grid is a no-op, so a re-attached pane keeps a blank drawable even though its terminal buffer is intact (verified: `ghostty_surface_read_text` returns the full screen while the pane shows blank). `updateMetalLayerSize` calls `ghostty_surface_refresh` after every size push to force the redraw. This is a DISPLAY fix, not a buffer fix. The parked font-increase blank is ALSO buffer-intact (a `read_text` probe returns the full screen), but is harder: it is NOT fixed by `refresh` or a forced `set_size` jitter, and a font change doesn't resize the view so this `updateMetalLayerSize` path never fires for it — still parked.
-- **strdup buffer lifetime.** `working_directory` (and `initial_input`) `const char*` buffers must outlive `ghostty_surface_new`; they are held in a `nonisolated(unsafe)` array and freed only in `destroySurface()`.
-- **Cursor shape is a config default, not set in code.** `agterm/Resources/ghostty-defaults.conf` (loaded first in `GhosttyApp.loadConfig`, so a user's `~/.config/ghostty/config` still overrides it) pins a steady block cursor with `cursor-style = block` + `shell-integration-features = no-cursor,no-title`. The shell-integration `cursor` feature re-emits a DECSCUSR bar (`\e[5 q`) on every prompt and resets to the config default while a command runs, so setting `cursor-style` alone can't stop the bar-at-prompt — disabling the feature with `no-cursor` is what keeps the cursor a block everywhere. `no-title` disables the integration's auto-title (zsh `%(4~|…/%3~|%~)` / bash `\w`), which would emit OSC 2 with the abbreviated cwd on every prompt and — since `Session.displayName` prefers `oscTitle` over the cwd basename — always override the sidebar name with a noisy `…/a/b/c` path. Explicit titles still win: a remote host over SSH or a user `PROMPT_COMMAND` emitting OSC 2 sets `oscTitle`, and only local auto-titling is suppressed (OSC 7 pwd reporting is a separate feature, unaffected). **Caveat — a title is only kept while a foreground process HOLDS the local shell.** A one-shot local `printf` OSC 2 sets `oscTitle`, but the shell immediately returns to its prompt where the title is cleared again (the prompt cycle), so the sidebar name reverts to the cwd basename. A real `ssh` keeps its title precisely because it BLOCKS the local prompt cycle (and its remote re-emits each prompt); to reproduce that locally — e.g. in a test — hold the shell after setting the title: `printf '\033]2;X\007'; cat`. So a remote session's `oscTitle` (and the `subtitleDetail` second line that prefers it) is reliable, but a quick local printf "looks broken" only because it isn't held. See [[ui-tests]] for the test pattern.
-- **Cursor focus = window-key AND first-responder (`GhosttySurfaceView.liveFocus`).** libghostty draws a solid (blinking) cursor only on a surface told it is focused via `ghostty_surface_set_focus`, a hollow outline otherwise. agterm reports `liveFocus = window.isKeyWindow && window.firstResponder === self` (the LIVE responder, NOT a cached flag), pushed through `updateGhosttyFocus()`. The key-window gate is LOAD-BEARING: AppKit's first responder is PER-WINDOW and does NOT resign when a window merely loses key, so without it EVERY window's active surface would keep a blinking cursor at once. Each surface observes `NSWindow.didBecomeKey/didResignKeyNotification` (`object: nil`, re-evaluating its OWN `isKeyWindow` on any window's key change) and re-pushes focus, so a background window goes hollow and the new key window's active surface goes solid. `becomeFirstResponder`/`resignFirstResponder` push DIRECTLY (become gated on `isKeyWindow`), because `window.firstResponder` is not yet self inside those calls; `createSurface`/`viewDidMoveToWindow`/the auto-focus + reparent grabs read `liveFocus`, so a re-hosted pane reports its TRUE (non-)focus instead of a stale latch — which is what left BOTH split panes solid on open before this. `onFocusChange` (the `splitFocused` model tracking) stays tied to first-responder transitions, NOT key state, so a session keeps its focused pane while its window is inactive. The observers are removed in `destroySurface`/`deinit`; `focusObservers` is `nonisolated(unsafe)` for the deinit read. Cursor solid/hollow is not accessibility-observable, so it is NOT unit/UI-testable — verified by instrumenting `set_focus` and reading `log show` across split-open + multi-window key switches (exactly one focused surface app-wide in every case).
+- **Chrome colors track the terminal theme; `config_get` can't read the optional `selection-*` keys.**
+  The non-terminal chrome (sidebar row text + icons, title-bar text + buttons,
+  the bottom add-buttons) uses the theme's colors instead of system label colors:
+  `GhosttyApp.resolveThemeColors` reads `background`/`foreground` via `ghostty_config_get` and mirrors
+  `terminalForegroundColor` into the views (refreshed on `.agtermAppearanceChanged`,
+  like `terminalColor`).
+  But `ghostty_config_get` returns the non-optional `background`/`foreground` and **returns false for
+  the optional `selection-background`/`selection-foreground`** (verified:
+  `selBg=false` even when the theme sets them).
+  So the selection colors are resolved by `resolveSelectionColors()` — parsing the same config sources
+  `loadConfig` loads (defaults → `~/.config/ghostty/config` → the agterm settings conf,
+  last-wins) for `theme`/explicit `selection-*`, then reading the named theme file under `Bundle.main/ghostty/themes/<name>`.
+  The selected sidebar row draws the theme's `selection-background` pill with `selection-foreground`
+  text (a luminance-contrast black/white fallback when only the background is set).
+  The borderless New-Session `Menu` glyph ignores `foregroundStyle` on its label,
+  so it's tinted via `.tint(chromeText)`.
+- **Sidebar selection is drawn entirely by `SidebarRowView`, not AppKit.**
+  `outline.selectionHighlightStyle = .none` (set right after `style = .sourceList`,
+  which would otherwise reset it) so AppKit draws no selection of its own — otherwise it paints a gray
+  *unemphasized* capsule whenever the sidebar isn't first responder (the normal case,
+  since focus lives in the terminal), overriding any custom `drawSelection`.
+  The row draws the themed pill in `drawBackground(in:)` for every state,
+  and the Coordinator's `refreshSelectionAppearance()` repaints the pills + re-tints the row text on
+  selection change (AppKit won't redraw rows on its own with `.none`) and on `.agtermAppearanceChanged`.
+  **`SidebarOutlineView.acceptsFirstResponder` is `false`** so a mouse click selects without stealing
+  first responder from the terminal — that responder bounce (terminal → outline → terminal,
+  via `mouseDown`'s `focusActiveTerminal`) otherwise makes AppKit re-set `SidebarRowView.isEmphasized`,
+  whose setter forces `needsDisplay`, and flicks the pill on every click (programmatic selection from
+  the palette/Ctrl-Tab never bounces, so it was already smooth).
+  **Reconcile splits SHAPE from CONTENT** (`TreeShape` ids/order → full `rebuildAndReload`;
+  `RowContent` name/icon/badge → per-row `reloadItem`) so a cwd-driven `displayName` change reloads only
+  its row instead of a full `reloadData` + re-expand that re-lays-out and horizontally jitters every
+  source-list row.
+  **Inline rename** paints the edit field with the terminal theme's foreground-on-background (the row's
+  selection-foreground would be dark-on-dark in the system edit box), and `restore` re-applies the row's
+  selection-aware color when editing ends (a same-name commit doesn't reload the row).
+- **terminfo sibling dir.**
+  `GHOSTTY_RESOURCES_DIR` points at `Contents/Resources/ghostty`; libghostty derives `TERMINFO` as `dirname(...)/terminfo`
+  at shell spawn, so the compiled terminfo database must be a sibling at `Contents/Resources/terminfo`.
+  `GhosttyResources` sets only `GHOSTTY_RESOURCES_DIR` and never `TERMINFO` (libghostty overwrites it
+  at spawn).
+  If this layout breaks, `TERM=xterm-ghostty` fails and keys break.
+- **Surface lifecycle (EAGER deck).**
+  `Session` owns its `GhosttySurfaceView` (`@ObservationIgnored`).
+  The detail pane is a *deck* — `ContentView.detailPane` is a `ZStack` over EVERY session (`store.workspaces.flatMap(\.sessions)`),
+  each session's `TerminalView` mounted at once, with only the selected one at `opacity 1` + hit-testable.
+  So every session's shell spawns at startup (eager realization, not lazy-on-first-select),
+  and switching is a visibility + `isActive` flip, never an `.id` swap — re-hosting a surface invalidates
+  its Metal drawable and flickers the window.
+  `dismantleNSView` is a no-op; `ghostty_surface_free` runs only in `destroySurface()` (reached via `teardown()`
+  on close or pane-exit).
+  This single-owner, single-free rule is what makes passing the view as unretained `userdata` safe.
+  `destroySurface()` ALSO nils every `store`-capturing callback (`onExit`/`onExitCodeCaptured`/`onFocusChange`/`onUserInputClearsStatus`/`onFontSizeChange`/the
+  four `onSearch*`) at its END — AFTER `onExitCodeCaptured` is read for the overlay exit status (niling
+  it earlier would silently break `session.overlay.result`/`--block`) — to break the `store → session → surface → closure → store`
+  retain cycle on every window/session close.
+- **Search bar placement (NSSplitView-overrun rule).**
+  `TerminalSearchBar` (`agterm/Views/`) is anchored on `detailPane` via `.overlay(alignment: .topTrailing) { searchBarLayer }`
+  — the SAME level as `floatingOverlayLayer`, NEVER inside any session's `sessionDetail` HSplitView-hosting
+  subtree.
+  This is the same hard-won rule as the floating overlay: adding a conditional sibling (or flipping a
+  pane modifier) inside `sessionDetail`'s ZStack when `searchActive` flips would re-host the `NSSplitView`
+  and overrun it UP into the transparent titlebar.
+  The bar reads `store.activeSession?.searchActive` and shows only when set,
+  so the split subtree's SHAPE is constant whether or not the bar is shown.
+  Because it is a `detailPane` `.overlay`, it renders ABOVE the in-deck scratch (zIndex 1 inside `sessionDetail`)
+  and the FULL overlay (zIndex 2) without any layout change — so search-over-scratch shows the bar on
+  top of the scratch with no `sessionDetail`/HSplitView perturbation.
+- **Window overlays sit BELOW the custom titlebar, NOT as a body-level `.overlay` (transparent-titlebar-scrim
+  rule).** The quick terminal, command palettes, and Ctrl-Tab switcher render via `windowOverlayLayer`
+  — a ZStack sibling INSIDE the body's root ZStack, inset by `titlebarHeight` (`.padding(.top, titlebarHeight)`)
+  and at `.zIndex(1)`, with `customTitlebar` at `.zIndex(2)` ABOVE it.
+  They are NOT body-level `.overlay { … }` (which layer above EVERYTHING).
+  Reason: `customTitlebar` is transparent (no backing) AND AppKit's native titlebar backing is deliberately
+  hidden for translucency (`WindowAppearance`); a full-window overlay's dim scrim (`Color.black.opacity(0.2)`)
+  attached as a body `.overlay` composites OVER the titlebar and darkens/seams it — visible only in the
+  TALL non-compact (48px) titlebar (the cwd-subtitle strip lives in the content area below the native
+  titlebar band; the 30px compact bar stays within the band and hides it).
+  Keeping the titlebar at the highest zIndex means a scrim can never cover it;
+  insetting the overlays by `titlebarHeight` keeps them off the titlebar entirely.
+  The empty `windowOverlayLayer` (all three conditionals false) is a bare `.frame`-sized `ZStack` — an
+  empty frame is NOT hit-testable, so the terminal below stays interactive (do NOT put a `Color`/`contentShape`
+  at that level).
+  Diagnosed by codex; the fix preserves translucency (titlebar stays backing-free) and keeps the overlays
+  outside `detailPane`/`sessionDetail`/`HSplitView` (no split perturbation).
+  Do NOT "fix" this with a permanent `.background(terminalColor)` on `customTitlebar` — it masks the
+  symptom but breaks the opacity/blur chrome.
+- **Non-zero backing size.**
+  Create the surface only when the view has a non-zero backing size, else the Metal layer renders blank.
+  `pendingSurfaceCreation` defers creation until `setFrameSize` reports a real size.
+- **Re-parent invalidates the drawable → force a repaint.**
+  The split toggle re-hosts a surface between the `HSplitView` and a standalone host,
+  detaching/re-attaching the `NSView` and invalidating its Metal drawable.
+  `ghostty_app_tick` (demand-driven, coalesced on wakeup) only draws surfaces flagged dirty,
+  and `ghostty_surface_set_size` to an UNCHANGED grid is a no-op, so a re-attached pane keeps a blank
+  drawable even though its terminal buffer is intact (verified: `ghostty_surface_read_text` returns the
+  full screen while the pane shows blank).
+  `updateMetalLayerSize` calls `ghostty_surface_refresh` after every size push to force the redraw.
+  This is a DISPLAY fix, not a buffer fix.
+  The parked font-increase blank is ALSO buffer-intact (a `read_text` probe returns the full screen),
+  but is harder: it is NOT fixed by `refresh` or a forced `set_size` jitter,
+  and a font change doesn't resize the view so this `updateMetalLayerSize` path never fires for it —
+  still parked.
+- **strdup buffer lifetime.**
+  `working_directory` (and `initial_input`) `const char*` buffers must outlive `ghostty_surface_new`;
+  they are held in a `nonisolated(unsafe)` array and freed only in `destroySurface()`.
+- **Cursor shape is a config default, not set in code.**
+  `agterm/Resources/ghostty-defaults.conf` (loaded first in `GhosttyApp.loadConfig`,
+  so a user's `~/.config/ghostty/config` still overrides it) pins a steady block cursor with `cursor-style = block`
+  + `shell-integration-features = no-cursor,no-title`.
+  The shell-integration `cursor` feature re-emits a DECSCUSR bar (`\e[5 q`) on every prompt and resets
+  to the config default while a command runs, so setting `cursor-style` alone can't stop the bar-at-prompt
+  — disabling the feature with `no-cursor` is what keeps the cursor a block everywhere.
+  `no-title` disables the integration's auto-title (zsh `%(4~|…/%3~|%~)` / bash `\w`),
+  which would emit OSC 2 with the abbreviated cwd on every prompt and — since `Session.displayName` prefers
+  `oscTitle` over the cwd basename — always override the sidebar name with a noisy `…/a/b/c` path.
+  Explicit titles still win: a remote host over SSH or a user `PROMPT_COMMAND` emitting OSC 2 sets `oscTitle`,
+  and only local auto-titling is suppressed (OSC 7 pwd reporting is a separate feature,
+  unaffected).
+  **Caveat — a title is only kept while a foreground process HOLDS the local shell.** A one-shot local
+  `printf` OSC 2 sets `oscTitle`, but the shell immediately returns to its prompt where the title is
+  cleared again (the prompt cycle), so the sidebar name reverts to the cwd basename.
+  A real `ssh` keeps its title precisely because it BLOCKS the local prompt cycle (and its remote re-emits
+  each prompt); to reproduce that locally — e.g. in a test — hold the shell after setting the title:
+  `printf '\033]2;X\007'; cat`.
+  So a remote session's `oscTitle` (and the `subtitleDetail` second line that prefers it) is reliable,
+  but a quick local printf "looks broken" only because it isn't held.
+  See [[ui-tests]] for the test pattern.
+- **Cursor focus = window-key AND first-responder (`GhosttySurfaceView.liveFocus`).** libghostty draws
+  a solid (blinking) cursor only on a surface told it is focused via `ghostty_surface_set_focus`,
+  a hollow outline otherwise. agterm reports `liveFocus = window.isKeyWindow && window.firstResponder === self`
+  (the LIVE responder, NOT a cached flag), pushed through `updateGhosttyFocus()`.
+  The key-window gate is LOAD-BEARING: AppKit's first responder is PER-WINDOW and does NOT resign when
+  a window merely loses key, so without it EVERY window's active surface would keep a blinking cursor
+  at once.
+  Each surface observes `NSWindow.didBecomeKey/didResignKeyNotification` (`object: nil`,
+  re-evaluating its OWN `isKeyWindow` on any window's key change) and re-pushes focus,
+  so a background window goes hollow and the new key window's active surface goes solid.
+  `becomeFirstResponder`/`resignFirstResponder` push DIRECTLY (become gated on `isKeyWindow`),
+  because `window.firstResponder` is not yet self inside those calls; `createSurface`/`viewDidMoveToWindow`/the
+  auto-focus + reparent grabs read `liveFocus`, so a re-hosted pane reports its TRUE (non-)focus instead
+  of a stale latch — which is what left BOTH split panes solid on open before this.
+  `onFocusChange` (the `splitFocused` model tracking) stays tied to first-responder transitions,
+  NOT key state, so a session keeps its focused pane while its window is inactive.
+  The observers are removed in `destroySurface`/`deinit`; `focusObservers` is `nonisolated(unsafe)` for
+  the deinit read.
+  Cursor solid/hollow is not accessibility-observable, so it is NOT unit/UI-testable — verified by instrumenting
+  `set_focus` and reading `log show` across split-open + multi-window key switches (exactly one focused
+  surface app-wide in every case).
 

--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -16,17 +16,240 @@ paths:
 
 ## Menu bar and actions
 
-- User actions live in `AppActions` (app target, `@MainActor`), shared by the toolbar/bottom-bar buttons (`ContentView`), the menu bar (`agtermApp`'s `.commands`), and the control channel (`ControlServer`) so the three never drift. Trivial one-liners (quick-terminal toggle) call the controller/store directly; `AppActions` owns the ones with real logic — new-session placement, the directory picker, split + focus, and font.
-- **Menu split: View vs Navigate.** The menu bar has TWO custom menus (besides File/Help). **View** (`CommandGroup(after: .toolbar)`) holds appearance + what-is-shown: font/theme, sidebar show-hide + expand/collapse, the flagged-view + Flag/Clear-Flagged + Focus Workspace items, and the surface toggles (Split/Scratch/Find/Quick Terminal). **Navigate** (a separate top-level `CommandMenu("Navigate")`, placed right after the View group so AppKit renders it after View) holds moving the selection/focus: the two palettes (Go to Session / Command Palette), session stepping (Previous/Next, Previous/Next Attention, First/Last), and Focus Left/Right Pane. This is a pure menu-PLACEMENT split — every item still drives the SAME `AppActions`, and the control/palette/keymap surfaces are untouched (so it is NOT a keep-in-sync change). When adding a menu item, file it by intent: display state → View, moving between things → Navigate. XCUITest helpers that open a menu by title must target the menu the item actually lives in (the `PaletteUITests`/`KeymapUITests` `openPalette` helpers open **Navigate** for the palette items).
-- **Keep-in-sync convention (HARD).** Any new user action added to `AppActions`/`AppStore` is not "done" until it is also drivable from the control socket. Shipping a new action requires all four of: (1) a `Command` case (plus any args) in `agtermCore`'s control protocol, (2) a dispatch arm in `ControlServer`, (3) an `agtermctl` subcommand, (4) protocol round-trip plus end-to-end tests for it. This extends the toolbar/menu-bar "never drift" rule to the third surface — the control channel. See the Control API section below.
-- Font menu items (⌘+/⌘−/⌘0) drive libghostty on the *focused* surface via `GhosttySurfaceView.performBindingAction("increase_font_size:1"/"decrease_font_size:1"/"reset_font_size")`. `focusedSurface()` is the key window's first responder (main pane, split pane, or quick terminal), else the active session's surface. A menu-driven font change still rides the CELL_SIZE → persist path, like the keybind.
-- **In-terminal search (⌘F).** `BuiltinAction.toggleSearch` (`defaultChord` = ⌘F, expressible/rebindable — NOT one of the arrow-bound exceptions) drives `AppActions.toggleSearch()` → `focusedSurface().startSearch()` (the `start_search` binding action). It is a real View ▸ Find… menu item (reading `equivalent(for: .toggleSearch)`, no hardcoded shortcut) plus a ⌃⇧P palette "Find…" entry. libghostty replies with a `START_SEARCH` action; the surface's `onSearchStart` closure TOGGLES — if the owning session's bar is already visible it calls `endSearch()` (sends `end_search`, so libghostty actually exits search mode, never just flips the flag), else opens the bar (`searchActive = true`, seeds any returned needle) and focuses the field. The `onSearchEnd` closure clears the four search fields and returns first responder to the terminal (`focusAfterReparent`); `onSearchTotal`/`onSearchSelected` set `searchTotal`/`searchSelected` (negative `ssize_t` → nil). The four `GhosttySurfaceView` methods (`startSearch`/`sendSearchQuery`/`navigateSearch`/`endSearch`) are thin wrappers over `performBindingAction`, the four callbacks are wired by ALL THREE in-tree surface factories — `makeSurface`/`makeSplitSurface`/`makeScratchSurface` via the shared `wireSearchCallbacks` helper (the `splitFocused` direct-write precedent) — and the four `GHOSTTY_ACTION_START_SEARCH`/`END_SEARCH`/`SEARCH_TOTAL`/`SEARCH_SELECTED` arms in `GhosttyCallbacks.action` copy the needle to a `String` before the main hop and return `true`. `AppActions` also owns `updateSearchNeedle(_:)`/`navigateSearch(_:)`/`endSearch()` for the bar. The state is the four ephemeral `Session` fields + `searchDisplayText` (the "N of M" / "M matches" / "no matches" computed), shared with the `session.search` control half (see the Control API catalog) so the GUI and control surfaces can't drift. **The SCRATCH terminal is searchable (the quick terminal + full overlay are NOT).** Wiring `makeScratchSurface` makes the scratch `isSearchable`, so ⌘F over a shown scratch opens the bar on the scratch itself: `coverHidesActiveSession` (the ⌘F open gate) blocks only the quick terminal + a FULL overlay (both unsearchable, focus-stealing over a hidden pane) — NOT the scratch; and `searchTarget()` checks the scratch-covers case FIRST (returns `topmostSurface` = the scratch when `scratchActive && !overlayActive`, BEFORE consulting `focusedSurface()`), so a ⌘F while the scratch covers the session never opens on the pane underneath — even when key-window focus sits off the surface (e.g. the sidebar), where `focusedSurface()` would otherwise fall back to the hidden `activeSurface`. A FLOATING overlay leaves the pane visible, so search there still targets the pane behind it (not the unsearchable overlay surface). Teardown: `AppStore.closeScratch` (the scratch shell's `exit`) clears search via `session.clearSearch()` ONLY when the bar is pinned to the scratch being torn down (`searchSurface === scratchSurface`) — so a search owned by the main/split pane survives the scratch teardown — mirroring the closeSplit/closePrimaryPane clear; the full session/workspace/window teardowns destroy the session entirely so no surviving bar can stick.
-- **Split panes (one session, two shells).** Three observed flags on `Session`: `isSplit` = the split is shown side-by-side; `hasSplit` = the session HAS a split pane at all (stays true while hidden, cleared only by `closeSplit`); `splitFocused` = which pane holds focus. The split (right) surface is wired to the session as `isSplitPane`, so its PWD/title go to `splitCwd`/`splitTitle`, and the focus-aware `Session.displayName`/`focusedCwd` make the sidebar row AND the title bar track whichever pane is focused — guarded on `splitFocused` alone (NOT `isSplit`), so it follows a hidden-but-focused split pane. `effectiveCwd` stays the PRIMARY pane's (non-focus-aware) for seeding new panes + the `AGTERM_SESSION_PWD` token; `Session.activeSurface` is the focused pane's surface (the focus helpers + the collapsed detail pane target it). **Opening a split moves focus to the new (right) pane** (`AppStore.toggleSplit` sets `splitFocused = true` on open; hiding leaves it set so the focused pane is the one shown maximized). **Hiding the split (the toolbar toggle) keeps BOTH shells alive** and shows the focused pane maximized — `detailPane`'s collapsed branch renders `\.splitSurface` when `splitFocused`, else `\.surface` — so reopening restores the two panes in place; nothing is destroyed (`closeSplit` only runs when the split shell exits). **Exiting a pane's shell keeps the session, collapsed to the survivor:** the primary's `onExit` is `AppStore.closePrimaryPane` (promotes the split pane to a single non-split session, its cwd promoted to the session's) and the split's is `closeSplitPane` (collapses to the primary, or closes the session if the primary already exited). Only a single (non-split) session's exit closes it. The collapse re-hosts the survivor (HSplitView → standalone), which drops focus, so `GhosttySurfaceView.focusAfterReparent` re-grabs first responder until it sticks past the re-host. `⌘⌥←`/`⌘⌥→` (+ the "Focus Left/Right Pane" menu items and palette entries, + `session.focus`) move focus via `AppActions.focusPane(_:)`/`setSplitFocus(_:of:)` — ALL gated on `hasSplit`, NOT `isSplit` (the menu items' `.disabled`, the palette gate, the `setSplitFocus` guard, `revealSession`, and the `session.focus` control arm), so pane navigation works whether the split is shown side-by-side OR hidden (maximized). When hidden, focusing the other pane just flips `splitFocused`, which swaps which pane the collapsed `detailPane` shows maximized (the "switch the zoomed pane with the other" behavior); the single-pane (no-split) state still disables/no-ops them. `⌃1`/`⌃2` are a direct-switch alias for the same `focusPane(.main)`/`focusPane(.split)` actions, caught by `PaneShortcuts` (an app-wide `NSEvent` local monitor, like the Ctrl-Tab switcher — NOT a SwiftUI shortcut, so they aren't duplicate menu items). The monitor ALWAYS consumes `⌃1`/`⌃2` (reserved app shortcuts) so they never leak to the shell — on a non-split session `focusPane` is a no-op rather than the terminal printing a literal "1" (the bug from the first cut, which only consumed when split). No new control command — `session.focus` already covers it. Each pane persists its OWN cwd: `SessionSnapshot.splitCwd` + `Session.initialSplitCwd` seed the split shell on restore. The split's DIVIDER RATIO persists per-session too: `SessionSnapshot.splitRatio` (a 0...1 left-pane fraction) is captured by `SplitRatioAccessor` (`ContentView.swift`) — a `.background` `NSViewRepresentable` on the PRIMARY pane (a background, not a third arranged pane; unconditional so it never perturbs the split shape) that introspects the AppKit `NSSplitView` under the SwiftUI `HSplitView`, since no SwiftUI API exposes the divider position. It `setPosition`s the divider once the split has a real width (retried per `layout()` pass) and writes the current fraction back to `Session.splitRatio` (`@ObservationIgnored`) on each `NSSplitView.didResizeSubviewsNotification`. Persisted by a debounced `save()` ~0.4 s after the drag settles (coalescing one drag's resize ticks via a cancel-and-reschedule `DispatchWorkItem`), plus the usual save points and the quit-flush, so a force-quit keeps it too, symmetric with the sidebar WIDTH (which saves on the drag's `.onEnded`). **`SplitRatioAccessor` ALSO clips the split's divider out of the titlebar strip (`updateDividerClip`).** In COMPACT mode (`titlebarHeight` = 30) the SwiftUI `.padding(.top, titlebarHeight)` lands inside the window's safe-area band, so the AppKit `NSSplitView` IGNORES it and grows to the FULL window height (verified: its frame + both arranged panes span pt 0..windowHeight; the 48px non-compact inset clears the band so normal mode is already bounded). The panes' top strip is then empty terminal-bg (invisible against the window bg), but the divider draws BLACK through it — a streak up through the transparent titlebar (only the DIVIDER shows; the panes' content still starts at the content top because the terminal grid respects the safe area). The fix is a **CALayer mask on the `NSSplitView`** hiding its overrun strip — the overrun is computed LIVE (`titlebarHeight - splitTopFromContentTop`, ~30 in compact, 0 in normal → mask dropped) so normal mode is untouched and the clip tracks window resize. Use a layer mask, NOT SwiftUI `.mask`/`.clipped()`: those reflow the terminal grid (scroll the top row away — confirmed twice), while a layer mask is render-only; and NOT an opaque cover (would break translucency — the mask reveals the window backing). The detail `HSplitView` carries `.id("<session>-hsplit")` so its `NSSplitView`/divider can't leak across session switches. A session with a split shows a split-rectangle icon in the sidebar (`WorkspaceSidebar`, keyed on `hasSplit` via `RowContent`) and a filled split icon in the title bar — both persist while the split is hidden.
-- `Close Session` is ⌘W (terminal-style). `AppActions.closeActiveSession()` first dismisses a focus-stealing cover in z-order — the frontmost window's quick terminal (`hide`), else the active session's open overlay (`closeOverlay`, full OR floating), else a shown scratch (`toggleScratch`) — and only closes the active session when no cover is up; it returns whether it handled the keystroke, and the File ▸ Close Session menu item falls back to `performClose` on the window ONLY when it returns false (no cover and no session, e.g. a window emptied to zero sessions). The cover guard lives in `closeActiveSession` rather than the menu on purpose: the menu's old `if activeSession != nil` gate skipped the guard when a window had no session but the quick terminal was up, closing the window instead of the cover. `AppStore.currentWorkspaceID`/`defaultWorkspaceName` are the host-free placement/naming helpers behind New Session / New Workspace.
-- **Session navigation (between sessions).** Previous/Next Session sit on ⌥⌘↑/⌥⌘↓; First/Last Session have NO hotkey (menu + palette + `session.go` only). The keys deliberately AVOID the bare ⌘+arrow cluster: as always-enabled menu key-equivalents, bare ⌘←/→/↑/↓ shadow standard text-field caret nav (line/doc start/end) in the inline rename field, the palette search field, and Settings fields. ⌥⌘+arrows is not a text-field caret binding, so it doesn't shadow editing; ⌥⌘↑/↓ for sessions also complements the existing ⌥⌘←/→ "Focus Left/Right Pane" (left/right = panes, up/down = sessions), and first/last need no dedicated key. They are real menu items (the Navigate menu — see the menu-split note below), so AppKit menu dispatch swallows the shortcut before libghostty and nothing leaks to the shell. The pure logic is `AppStore.navigateSession(_:)` (host-free, unit-tested): it flattens the tree (`workspaces.flatMap(\.sessions)`), stops at the ends on next/prev (no wrap), jumps to the ends for first/last, falls to first on no/invalid selection, no-ops on an empty tree, and routes through `selectSession` (recency + badge + persist + workspace-derivation). It is shared by the menu, the action palette, and the control channel (`session.go`) so the three can't drift. Each GUI action (`AppActions.select{Next,Previous,First,Last}Session`) calls `focusActiveSession()` after the move so first responder follows into the moved-to terminal (the sidebar never steals focus); `WorkspaceSidebar.syncSelection()` expands the owning workspace if collapsed and `scrollRowToVisible`s the target so an off-screen row is revealed. Distinct from the ⌃Tab MRU switcher (recency order) and the ⌃P fuzzy palette (search) — this is predictable spatial stepping in the sidebar's visual order. **Attention navigation** (⌃⌥↑/⌃⌥↓ — the SAME arrow-fallback as the session nav, since arrows aren't keymap-expressible) is the variant that steps through ONLY the sessions needing attention (`AgentStatus.needsAttention` = `blocked`/`completed`), WRAPPING around and skipping idle/active. It reuses `AppStore.navigateSession` (the `.nextAttention`/`.previousAttention` cases — host-free, unit-tested) and is driven by Navigate ▸ Previous/Next Attention Session, the action palette, and `session.go next-attention|prev-attention`; the two new `BuiltinAction`s (`previous_attention_session`/`next_attention_session`) join the arrow-bound set (nil `defaultChord`, hardcoded ⌃⌥↑/↓ via `arrowShortcut`).
-- `Delete Workspace` lives once in `AppActions.deleteWorkspace(_:)` (confirm alert when the workspace still has sessions, then `AppStore.removeWorkspace`) and is invoked from all three surfaces — the sidebar workspace row's context menu, the menu bar, and the action palette (the latter two via `deleteActiveWorkspace()`, which targets `currentWorkspaceID`). `AppStore.removeWorkspace` tears down each session's surfaces, prunes recency, and reselects; `canRemoveWorkspace` (count > 1) enforces keep-at-least-one and gates the menu item / palette entry. The sidebar Coordinator takes `AppActions` so the row menu routes through it rather than duplicating the confirm.
-- The command palettes (`Palette.swift`: `PaletteController` + `CommandPalette`) feed off `AppActions.paletteActions()`/`paletteSessions()` and the host-free `fuzzyScore` (agtermCore, unit-tested). The visible list is a `@State` array recomputed on query/mode change — NOT a computed property — so the rendered rows and the Enter target can't drift out of sync; results sort by score then title. ⌃P opens the session switcher, ⌃⇧P the action palette (the session/action shortcut split is deliberate).
-- **Attention list (the `.attention` palette mode).** A fourth `PaletteMode` (`.attention`, placeholder "Go to a session that needs attention…") lists the window's NON-IDLE sessions — broader than the ⌃⌥↑/↓ attention-NAV, which steps only `needsAttention` (blocked/completed). `AppActions.paletteAttention()` maps `AppStore.attentionSessions` (host-free, per-window: all non-idle, sorted blocked→active→completed then `statusChangedAt` newest-first, nil last) to `PaletteItem`s mirroring `paletteSessions()` (title=`displayName`, subtitle="workspace · detail"), with the new `PaletteItem.status: AgentStatus?` set so `CommandPalette.row` renders a leading `StatusGlyph` (the shared `AgentStatus.symbolName` + `GhosttyApp.statusColor(for:)` mapping the sidebar's `StatusIconView` also uses); `run` = `store.selectSession(id)`. Empty-query order is the `attentionSessions` order (the palette re-sorts by fuzzy score only once the user types); `.attention` needs no theme-preview wiring (`syncThemeSession` guards on `.themes`). Opened three keyboard/menu ways: `BuiltinAction.showAttention` (rawValue `show_attention`, `defaultChord` ⌃⇧I — a distinct chord swallowed before the terminal like ⌃⇧P/⌃⇧O, expressible/pure-`defaultChord`, NOT an arrow exception) → `AppActions.toggleAttentionPalette()` → `palette.toggle(.attention)`, the **Navigate ▸ "Go to Attention…"** menu item (reading `equivalent(for: .showAttention)`), and a **"Show Attention"** entry in `paletteActions()` (the ⌃⇧P launcher). The fourth opener is the title-bar bell (see the Notifications section). Opening a palette is interactive-only → keep-in-sync EXEMPT, like every other palette open. **Button-open focus fix (`CommandPalette.onAppear`):** a palette opened from a title-bar BUTTON (the bell) mounts while that button still holds first responder, so `onAppear`'s synchronous `fieldFocused = true` loses the race and the field never takes the keyboard; the fix re-asserts `fieldFocused = true` on the next runloop tick via `DispatchQueue.main.async` — a no-op for the already-focused menu/hotkey/⌃P opens (no competing responder).
-- Inline rename has no direct handle from the menu/palette into the sidebar's editor, so `AppActions.renameActive{Session,Workspace}()` post `.agtermBeginRenameSession`/`.agtermBeginRenameWorkspace`; `WorkspaceSidebar.Coordinator` observes them and calls `beginEditing` on the selected row (async, so the row is on screen after any palette overlay closes). `AppActions.renamePending` keeps `focusActiveSession` (the palette/quick-terminal close focus-restore) off the rename field for ~0.6 s.
-- The Ctrl-Tab session switcher (`SessionSwitcher` + `SessionSwitcherOverlay`) cycles a most-recently-used list. `AppStore.sessionRecency` (`RecencyStack<UUID>` in agtermCore — host-free, unit-tested, NOT persisted) is pushed on every selection and pruned on close; the switcher snapshots it on `begin()` so cycling never reorders it (only the commit does, via `selectSession`). Keys come from app-wide `NSEvent` local monitors (`.keyDown` for Ctrl+Tab / Ctrl+Shift+Tab / Esc, `.flagsChanged` to detect the Ctrl release = commit), NOT SwiftUI shortcuts — the interaction needs Tab-while-Ctrl-held plus the modifier-release signal. The overlay has no focusable control, so the terminal keeps first responder and selection-on-commit re-focuses via `TerminalView`.
+- User actions live in `AppActions` (app target, `@MainActor`), shared by the toolbar/bottom-bar buttons
+  (`ContentView`), the menu bar (`agtermApp`'s `.commands`), and the control channel (`ControlServer`)
+  so the three never drift.
+  Trivial one-liners (quick-terminal toggle) call the controller/store directly;
+  `AppActions` owns the ones with real logic — new-session placement, the directory picker,
+  split + focus, and font.
+- **Menu split: View vs Navigate.**
+  The menu bar has TWO custom menus (besides File/Help).
+  **View** (`CommandGroup(after: .toolbar)`) holds appearance + what-is-shown:
+  font/theme, sidebar show-hide + expand/collapse, the flagged-view + Flag/Clear-Flagged + Focus Workspace
+  items, and the surface toggles (Split/Scratch/Find/Quick Terminal).
+  **Navigate** (a separate top-level `CommandMenu("Navigate")`, placed right after the View group so
+  AppKit renders it after View) holds moving the selection/focus: the two palettes (Go to Session / Command
+  Palette), session stepping (Previous/Next, Previous/Next Attention, First/Last),
+  and Focus Left/Right Pane.
+  This is a pure menu-PLACEMENT split — every item still drives the SAME `AppActions`,
+  and the control/palette/keymap surfaces are untouched (so it is NOT a keep-in-sync change).
+  When adding a menu item, file it by intent: display state → View, moving between things → Navigate.
+  XCUITest helpers that open a menu by title must target the menu the item actually lives in (the `PaletteUITests`/`KeymapUITests`
+  `openPalette` helpers open **Navigate** for the palette items).
+- **Keep-in-sync convention (HARD).**
+  Any new user action added to `AppActions`/`AppStore` is not "done" until it is also drivable from the
+  control socket.
+  Shipping a new action requires all four of: (1) a `Command` case (plus any args) in `agtermCore`'s
+  control protocol, (2) a dispatch arm in `ControlServer`, (3) an `agtermctl` subcommand,
+  (4) protocol round-trip plus end-to-end tests for it.
+  This extends the toolbar/menu-bar "never drift" rule to the third surface — the control channel.
+  See the Control API section below.
+- Font menu items (⌘+/⌘−/⌘0) drive libghostty on the *focused* surface via `GhosttySurfaceView.performBindingAction("increase_font_size:1"/"decrease_font_size:1"/"reset_font_size")`.
+  `focusedSurface()` is the key window's first responder (main pane, split pane,
+  or quick terminal), else the active session's surface.
+  A menu-driven font change still rides the CELL_SIZE → persist path, like the keybind.
+- **In-terminal search (⌘F).**
+  `BuiltinAction.toggleSearch` (`defaultChord` = ⌘F, expressible/rebindable — NOT one of the arrow-bound
+  exceptions) drives `AppActions.toggleSearch()` → `focusedSurface().startSearch()` (the `start_search`
+  binding action).
+  It is a real View ▸ Find… menu item (reading `equivalent(for: .toggleSearch)`,
+  no hardcoded shortcut) plus a ⌃⇧P palette "Find…" entry. libghostty replies with a `START_SEARCH` action;
+  the surface's `onSearchStart` closure TOGGLES — if the owning session's bar is already visible it calls
+  `endSearch()` (sends `end_search`, so libghostty actually exits search mode,
+  never just flips the flag), else opens the bar (`searchActive = true`,
+  seeds any returned needle) and focuses the field.
+  The `onSearchEnd` closure clears the four search fields and returns first responder to the terminal
+  (`focusAfterReparent`); `onSearchTotal`/`onSearchSelected` set `searchTotal`/`searchSelected` (negative
+  `ssize_t` → nil).
+  The four `GhosttySurfaceView` methods (`startSearch`/`sendSearchQuery`/`navigateSearch`/`endSearch`)
+  are thin wrappers over `performBindingAction`, the four callbacks are wired by ALL THREE in-tree surface
+  factories — `makeSurface`/`makeSplitSurface`/`makeScratchSurface` via the shared `wireSearchCallbacks`
+  helper (the `splitFocused` direct-write precedent) — and the four `GHOSTTY_ACTION_START_SEARCH`/`END_SEARCH`/`SEARCH_TOTAL`/`SEARCH_SELECTED`
+  arms in `GhosttyCallbacks.action` copy the needle to a `String` before the main hop and return `true`.
+  `AppActions` also owns `updateSearchNeedle(_:)`/`navigateSearch(_:)`/`endSearch()` for the bar.
+  The state is the four ephemeral `Session` fields + `searchDisplayText` (the "N of M" / "M matches"
+  / "no matches" computed), shared with the `session.search` control half (see the Control API catalog)
+  so the GUI and control surfaces can't drift.
+  **The SCRATCH terminal is searchable (the quick terminal + full overlay are NOT).** Wiring `makeScratchSurface`
+  makes the scratch `isSearchable`, so ⌘F over a shown scratch opens the bar on the scratch itself:
+  `coverHidesActiveSession` (the ⌘F open gate) blocks only the quick terminal + a FULL overlay (both
+  unsearchable, focus-stealing over a hidden pane) — NOT the scratch; and `searchTarget()` checks the
+  scratch-covers case FIRST (returns `topmostSurface` = the scratch when `scratchActive && !overlayActive`,
+  BEFORE consulting `focusedSurface()`), so a ⌘F while the scratch covers the session never opens on
+  the pane underneath — even when key-window focus sits off the surface (e.g. the sidebar),
+  where `focusedSurface()` would otherwise fall back to the hidden `activeSurface`.
+  A FLOATING overlay leaves the pane visible, so search there still targets the pane behind it (not the
+  unsearchable overlay surface).
+  Teardown: `AppStore.closeScratch` (the scratch shell's `exit`) clears search via `session.clearSearch()`
+  ONLY when the bar is pinned to the scratch being torn down (`searchSurface === scratchSurface`) — so
+  a search owned by the main/split pane survives the scratch teardown — mirroring the closeSplit/closePrimaryPane
+  clear; the full session/workspace/window teardowns destroy the session entirely so no surviving bar
+  can stick.
+- **Split panes (one session, two shells).**
+  Three observed flags on `Session`: `isSplit` = the split is shown side-by-side;
+  `hasSplit` = the session HAS a split pane at all (stays true while hidden,
+  cleared only by `closeSplit`); `splitFocused` = which pane holds focus.
+  The split (right) surface is wired to the session as `isSplitPane`, so its PWD/title go to `splitCwd`/`splitTitle`,
+  and the focus-aware `Session.displayName`/`focusedCwd` make the sidebar row AND the title bar track
+  whichever pane is focused — guarded on `splitFocused` alone (NOT `isSplit`),
+  so it follows a hidden-but-focused split pane.
+  `effectiveCwd` stays the PRIMARY pane's (non-focus-aware) for seeding new panes + the `AGTERM_SESSION_PWD`
+  token; `Session.activeSurface` is the focused pane's surface (the focus helpers + the collapsed detail
+  pane target it).
+  **Opening a split moves focus to the new (right) pane** (`AppStore.toggleSplit` sets `splitFocused = true`
+  on open; hiding leaves it set so the focused pane is the one shown maximized).
+  **Hiding the split (the toolbar toggle) keeps BOTH shells alive** and shows the focused pane maximized
+  — `detailPane`'s collapsed branch renders `\.splitSurface` when `splitFocused`,
+  else `\.surface` — so reopening restores the two panes in place; nothing is destroyed (`closeSplit`
+  only runs when the split shell exits).
+  **Exiting a pane's shell keeps the session, collapsed to the survivor:** the primary's `onExit` is
+  `AppStore.closePrimaryPane` (promotes the split pane to a single non-split session,
+  its cwd promoted to the session's) and the split's is `closeSplitPane` (collapses to the primary,
+  or closes the session if the primary already exited).
+  Only a single (non-split) session's exit closes it.
+  The collapse re-hosts the survivor (HSplitView → standalone), which drops focus,
+  so `GhosttySurfaceView.focusAfterReparent` re-grabs first responder until it sticks past the re-host.
+  `⌘⌥←`/`⌘⌥→` (+ the "Focus Left/Right Pane" menu items and palette entries,
+  + `session.focus`) move focus via `AppActions.focusPane(_:)`/`setSplitFocus(_:of:)` — ALL gated on
+  `hasSplit`, NOT `isSplit` (the menu items' `.disabled`, the palette gate,
+  the `setSplitFocus` guard, `revealSession`, and the `session.focus` control arm),
+  so pane navigation works whether the split is shown side-by-side OR hidden (maximized).
+  When hidden, focusing the other pane just flips `splitFocused`, which swaps which pane the collapsed
+  `detailPane` shows maximized (the "switch the zoomed pane with the other" behavior);
+  the single-pane (no-split) state still disables/no-ops them.
+  `⌃1`/`⌃2` are a direct-switch alias for the same `focusPane(.main)`/`focusPane(.split)` actions,
+  caught by `PaneShortcuts` (an app-wide `NSEvent` local monitor, like the Ctrl-Tab switcher — NOT a
+  SwiftUI shortcut, so they aren't duplicate menu items).
+  The monitor ALWAYS consumes `⌃1`/`⌃2` (reserved app shortcuts) so they never leak to the shell — on
+  a non-split session `focusPane` is a no-op rather than the terminal printing a literal "1" (the bug
+  from the first cut, which only consumed when split).
+  No new control command — `session.focus` already covers it.
+  Each pane persists its OWN cwd: `SessionSnapshot.splitCwd` + `Session.initialSplitCwd` seed the split
+  shell on restore.
+  The split's DIVIDER RATIO persists per-session too: `SessionSnapshot.splitRatio` (a 0...1 left-pane
+  fraction) is captured by `SplitRatioAccessor` (`ContentView.swift`) — a `.background` `NSViewRepresentable`
+  on the PRIMARY pane (a background, not a third arranged pane; unconditional so it never perturbs the
+  split shape) that introspects the AppKit `NSSplitView` under the SwiftUI `HSplitView`,
+  since no SwiftUI API exposes the divider position.
+  It `setPosition`s the divider once the split has a real width (retried per `layout()` pass) and writes
+  the current fraction back to `Session.splitRatio` (`@ObservationIgnored`) on each `NSSplitView.didResizeSubviewsNotification`.
+  Persisted by a debounced `save()` ~0.4 s after the drag settles (coalescing one drag's resize ticks
+  via a cancel-and-reschedule `DispatchWorkItem`), plus the usual save points and the quit-flush,
+  so a force-quit keeps it too, symmetric with the sidebar WIDTH (which saves on the drag's `.onEnded`).
+  **`SplitRatioAccessor` ALSO clips the split's divider out of the titlebar strip (`updateDividerClip`).**
+  In COMPACT mode (`titlebarHeight` = 30) the SwiftUI `.padding(.top, titlebarHeight)` lands inside the
+  window's safe-area band, so the AppKit `NSSplitView` IGNORES it and grows to the FULL window height
+  (verified: its frame + both arranged panes span pt 0..windowHeight; the 48px non-compact inset clears
+  the band so normal mode is already bounded).
+  The panes' top strip is then empty terminal-bg (invisible against the window bg),
+  but the divider draws BLACK through it — a streak up through the transparent titlebar (only the DIVIDER
+  shows; the panes' content still starts at the content top because the terminal grid respects the safe
+  area).
+  The fix is a **CALayer mask on the `NSSplitView`** hiding its overrun strip — the overrun is computed
+  LIVE (`titlebarHeight - splitTopFromContentTop`, ~30 in compact, 0 in normal → mask dropped) so normal
+  mode is untouched and the clip tracks window resize.
+  Use a layer mask, NOT SwiftUI `.mask`/`.clipped()`: those reflow the terminal grid (scroll the top
+  row away — confirmed twice), while a layer mask is render-only; and NOT an opaque cover (would break
+  translucency — the mask reveals the window backing).
+  The detail `HSplitView` carries `.id("<session>-hsplit")` so its `NSSplitView`/divider can't leak across
+  session switches.
+  A session with a split shows a split-rectangle icon in the sidebar (`WorkspaceSidebar`,
+  keyed on `hasSplit` via `RowContent`) and a filled split icon in the title bar — both persist while
+  the split is hidden.
+- `Close Session` is ⌘W (terminal-style).
+  `AppActions.closeActiveSession()` first dismisses a focus-stealing cover in z-order — the frontmost
+  window's quick terminal (`hide`), else the active session's open overlay (`closeOverlay`,
+  full OR floating), else a shown scratch (`toggleScratch`) — and only closes the active session when
+  no cover is up; it returns whether it handled the keystroke, and the File ▸ Close Session menu item
+  falls back to `performClose` on the window ONLY when it returns false (no cover and no session,
+  e.g. a window emptied to zero sessions).
+  The cover guard lives in `closeActiveSession` rather than the menu on purpose:
+  the menu's old `if activeSession != nil` gate skipped the guard when a window had no session but the
+  quick terminal was up, closing the window instead of the cover.
+  `AppStore.currentWorkspaceID`/`defaultWorkspaceName` are the host-free placement/naming helpers behind
+  New Session / New Workspace.
+- **Session navigation (between sessions).**
+  Previous/Next Session sit on ⌥⌘↑/⌥⌘↓; First/Last Session have NO hotkey (menu + palette + `session.go`
+  only).
+  The keys deliberately AVOID the bare ⌘+arrow cluster: as always-enabled menu key-equivalents,
+  bare ⌘←/→/↑/↓ shadow standard text-field caret nav (line/doc start/end) in the inline rename field,
+  the palette search field, and Settings fields. ⌥⌘+arrows is not a text-field caret binding,
+  so it doesn't shadow editing; ⌥⌘↑/↓ for sessions also complements the existing ⌥⌘←/→ "Focus Left/Right
+  Pane" (left/right = panes, up/down = sessions), and first/last need no dedicated key.
+  They are real menu items (the Navigate menu — see the menu-split note below),
+  so AppKit menu dispatch swallows the shortcut before libghostty and nothing leaks to the shell.
+  The pure logic is `AppStore.navigateSession(_:)` (host-free, unit-tested):
+  it flattens the tree (`workspaces.flatMap(\.sessions)`), stops at the ends on next/prev (no wrap),
+  jumps to the ends for first/last, falls to first on no/invalid selection,
+  no-ops on an empty tree, and routes through `selectSession` (recency + badge + persist + workspace-derivation).
+  It is shared by the menu, the action palette, and the control channel (`session.go`) so the three can't
+  drift.
+  Each GUI action (`AppActions.select{Next,Previous,First,Last}Session`) calls `focusActiveSession()`
+  after the move so first responder follows into the moved-to terminal (the sidebar never steals focus);
+  `WorkspaceSidebar.syncSelection()` expands the owning workspace if collapsed and `scrollRowToVisible`s
+  the target so an off-screen row is revealed.
+  Distinct from the ⌃Tab MRU switcher (recency order) and the ⌃P fuzzy palette (search) — this is predictable
+  spatial stepping in the sidebar's visual order.
+  **Attention navigation** (⌃⌥↑/⌃⌥↓ — the SAME arrow-fallback as the session nav,
+  since arrows aren't keymap-expressible) is the variant that steps through ONLY the sessions needing
+  attention (`AgentStatus.needsAttention` = `blocked`/`completed`), WRAPPING around and skipping idle/active.
+  It reuses `AppStore.navigateSession` (the `.nextAttention`/`.previousAttention` cases — host-free,
+  unit-tested) and is driven by Navigate ▸ Previous/Next Attention Session,
+  the action palette, and `session.go next-attention|prev-attention`; the two new `BuiltinAction`s (`previous_attention_session`/`next_attention_session`)
+  join the arrow-bound set (nil `defaultChord`, hardcoded ⌃⌥↑/↓ via `arrowShortcut`).
+- `Delete Workspace` lives once in `AppActions.deleteWorkspace(_:)` (confirm alert when the workspace
+  still has sessions, then `AppStore.removeWorkspace`) and is invoked from all three surfaces — the sidebar
+  workspace row's context menu, the menu bar, and the action palette (the latter two via `deleteActiveWorkspace()`,
+  which targets `currentWorkspaceID`).
+  `AppStore.removeWorkspace` tears down each session's surfaces, prunes recency,
+  and reselects; `canRemoveWorkspace` (count > 1) enforces keep-at-least-one and gates the menu item
+  / palette entry.
+  The sidebar Coordinator takes `AppActions` so the row menu routes through it rather than duplicating
+  the confirm.
+- The command palettes (`Palette.swift`: `PaletteController` + `CommandPalette`) feed off `AppActions.paletteActions()`/`paletteSessions()`
+  and the host-free `fuzzyScore` (agtermCore, unit-tested).
+  The visible list is a `@State` array recomputed on query/mode change — NOT a computed property — so
+  the rendered rows and the Enter target can't drift out of sync; results sort by score then title. ⌃P
+  opens the session switcher, ⌃⇧P the action palette (the session/action shortcut split is deliberate).
+- **Attention list (the `.attention` palette mode).**
+  A fourth `PaletteMode` (`.attention`, placeholder "Go to a session that needs attention…") lists the
+  window's NON-IDLE sessions — broader than the ⌃⌥↑/↓ attention-NAV, which steps only `needsAttention`
+  (blocked/completed).
+  `AppActions.paletteAttention()` maps `AppStore.attentionSessions` (host-free,
+  per-window: all non-idle, sorted blocked→active→completed then `statusChangedAt` newest-first,
+  nil last) to `PaletteItem`s mirroring `paletteSessions()` (title=`displayName`,
+  subtitle="workspace · detail"), with the new `PaletteItem.status: AgentStatus?` set so `CommandPalette.row`
+  renders a leading `StatusGlyph` (the shared `AgentStatus.symbolName` + `GhosttyApp.statusColor(for:)`
+  mapping the sidebar's `StatusIconView` also uses); `run` = `store.selectSession(id)`.
+  Empty-query order is the `attentionSessions` order (the palette re-sorts by fuzzy score only once the
+  user types); `.attention` needs no theme-preview wiring (`syncThemeSession` guards on `.themes`).
+  Opened three keyboard/menu ways: `BuiltinAction.showAttention` (rawValue `show_attention`,
+  `defaultChord` ⌃⇧I — a distinct chord swallowed before the terminal like ⌃⇧P/⌃⇧O,
+  expressible/pure-`defaultChord`, NOT an arrow exception) → `AppActions.toggleAttentionPalette()` →
+  `palette.toggle(.attention)`, the **Navigate ▸ "Go to Attention…"** menu item (reading `equivalent(for: .showAttention)`),
+  and a **"Show Attention"** entry in `paletteActions()` (the ⌃⇧P launcher).
+  The fourth opener is the title-bar bell (see the Notifications section).
+  Opening a palette is interactive-only → keep-in-sync EXEMPT, like every other palette open.
+  **Button-open focus fix (`CommandPalette.onAppear`):** a palette opened from a title-bar BUTTON (the
+  bell) mounts while that button still holds first responder, so `onAppear`'s synchronous `fieldFocused = true`
+  loses the race and the field never takes the keyboard; the fix re-asserts `fieldFocused = true` on
+  the next runloop tick via `DispatchQueue.main.async` — a no-op for the already-focused menu/hotkey/⌃P
+  opens (no competing responder).
+- Inline rename has no direct handle from the menu/palette into the sidebar's editor,
+  so `AppActions.renameActive{Session,Workspace}()` post `.agtermBeginRenameSession`/`.agtermBeginRenameWorkspace`;
+  `WorkspaceSidebar.Coordinator` observes them and calls `beginEditing` on the selected row (async,
+  so the row is on screen after any palette overlay closes).
+  `AppActions.renamePending` keeps `focusActiveSession` (the palette/quick-terminal close focus-restore)
+  off the rename field for ~0.6 s.
+- The Ctrl-Tab session switcher (`SessionSwitcher` + `SessionSwitcherOverlay`) cycles a most-recently-used
+  list.
+  `AppStore.sessionRecency` (`RecencyStack<UUID>` in agtermCore — host-free,
+  unit-tested, NOT persisted) is pushed on every selection and pruned on close;
+  the switcher snapshots it on `begin()` so cycling never reorders it (only the commit does,
+  via `selectSession`).
+  Keys come from app-wide `NSEvent` local monitors (`.keyDown` for Ctrl+Tab / Ctrl+Shift+Tab / Esc,
+  `.flagsChanged` to detect the Ctrl release = commit), NOT SwiftUI shortcuts — the interaction needs
+  Tab-while-Ctrl-held plus the modifier-release signal.
+  The overlay has no focusable control, so the terminal keeps first responder and selection-on-commit
+  re-focuses via `TerminalView`.
 

--- a/.claude/rules/notifications.md
+++ b/.claude/rules/notifications.md
@@ -7,11 +7,130 @@ paths:
 
 ## Notifications
 
-- Terminal desktop notifications (OSC 9 / 777). `GhosttyCallbacks.action` handles `GHOSTTY_ACTION_DESKTOP_NOTIFICATION` — copies the `title`/`body` C strings synchronously (only valid for the call), recovers the firing `GhosttySurfaceView` via the existing `surfaceView(from:)`, and hops to `NotificationManager.shared.notify(surface:title:body:)`. (The bell, `GHOSTTY_ACTION_RING_BELL`, is intentionally NOT a notification source.)
-- `NotificationManager` (`agterm/Notifications/`, `@MainActor` singleton + `UNUserNotificationCenterDelegate`, `@preconcurrency` conformance like macterm) owns the macOS surface. `notify` resolves the owning `Session` (the view's `weak var session`) + `PaneRole` (identity-compare the view to the session's `surface`/`splitSurface`/`overlaySurface`), applies suppression, **always bumps `session.unseenCount`** (the badge), then posts a `UNNotificationRequest` ONLY if `bannersEnabled` (the General toggle) — so turning banners off still tracks the badge. Registered + `requestAuthorization([.alert])` from the scene `.task` (alongside `controlServer.start()`); auth is best-effort — the badge works even when banners are denied. `willPresent` returns `[.banner, .list]` so banners show even while agterm is frontmost (the focused-pane case is dropped at delivery, NOT in `willPresent`). `clearDelivered(sessionID:)` removes a session's delivered banners (all three pane identifiers) when you focus it, so a notification you've navigated to doesn't linger in Notification Center. `send(toSession:title:body:)` is the control channel's entry point (the `notify` command / `agtermctl notify`): same badge + banner + reveal-identity machinery, but NO focus-suppression (the caller asked for it) and attributed to the `.main` pane.
-- **Suppression** is the pure, agtermCore-tested `TerminalNotification.shouldDeliver(firingIsFocused:appActive:)`: drop entirely only when the firing surface is the key window's first responder AND `NSApp.isActive` (you're already looking at it). The manager uses the strict first-responder check (NOT `AppActions.focusedSurface()`, whose active-session fallback would wrongly count a sidebar-focused window as "looking at the pane").
-- **Identity / navigation.** `TerminalNotification.identity`/`parseIdentity` (agtermCore) make the request identifier `"<sessionID>:<paneRole>"` — it both coalesces repeats from the same pane (the OS replaces, doesn't stack) and carries the click target (no `userInfo` needed). `didReceive` parses it, `NSApp.activate`s, and calls `AppActions.reveal(sessionID:pane:)`: `selectSession` (which clears the badge + derives the workspace) then `focusSplitPane` for the pane, stale-safe (unknown session → just activate; a `.split` no longer split → primary). `reveal` is internal click-routing (not on toolbar/menu/palette) composing the already-controllable `session.select`, so it has NO control command (keep-in-sync exempt, by user decision).
-- **Badge.** `Session.unseenCount` (observed; ephemeral — `SessionSnapshot` doesn't capture it, so it never persists). `SidebarCellView.badge` is a custom-drawn `BadgeView` (an accent capsule, count capped `99+`, accessibility role `.staticText` with id `notify-badge`) at the row's trailing edge, with a `Workspace.unseenCount` roll-up on the workspace row so an unseen badge stays visible when the workspace is collapsed. `unseenCount` is folded into the sidebar's `updateNSView` dependency read, and `reloadChangedBadgeRows`/`snapshotBadges` reload only the changed session + workspace rows. Cleared by `AppStore.selectSession` and by a pane's `onFocusChange(true)` (which also calls `clearDelivered` — focusing a pane means you've seen the session). **The count pill rendering is gated by the `notificationBadgeEnabled` Settings toggle** (see the Settings section): the Coordinator's `effectiveUnseen(_:)` returns 0 when the flag is off, applied to BOTH the session badge and the workspace roll-up (and to `RowContent.unseen` so a toggle reloads the rows). This gates ONLY the red count pill — the agent-status glyph (drawn just left of it by `StatusIconView`) is always on, never gated by this.
-- **Agent-status glyph.** Mirrors the `notify-badge` cell pattern (see the Control API `session.status`). `StatusIconView` (an `NSImageView` sibling of `BadgeView` in `WorkspaceSidebar`) draws the row's tinted SF Symbol just LEFT of the count badge — `active`=`ellipsis.circle.fill`, `blocked`=`exclamationmark.circle.fill`, `completed`=`checkmark.circle.fill`, `.idle`=hidden, each tinted with its configurable Settings color (`GhosttyApp.{active,blocked,completed}StatusColor`, default `#DBD9E6` muted lavender-grey / system amber / system green; see the Settings section) — with accessibility role `.staticText`, id `agent-status`, value = the state name (so XCUITest matches `app.staticTexts["agent-status"]`), and a `CABasicAnimation` `opacity` pulse added only while visible AND `blink` (the install's `UserPromptSubmit→active --blink` hook pulses the in-progress glyph). The glyph shows on EVERY non-idle session, the selected one INCLUDED — there is NO visibility gate. (An earlier `isFrontmostWindow`-driven hide-on-the-selected-session gate was removed: blanking the status on the row you're viewing read as confusing, since every other row carried a state; the `isFrontmostWindow` plumbing went with it.) `effectiveIndicator(forSession:)` is just the session's own `agentIndicator`; it rides in `RowContent` (Equatable) so a status/blink change reloads only that row, and `agentIndicator` is folded into the `updateNSView` dependency read. A one-time `completed --auto-reset` is cleared by `AppStore.selectSession` on BOTH the session visited AND the one left (`clearAutoResetIndicator(new)` + `clearAutoResetIndicator(previous)`) so it never lingers on the row you switch away from — a Claude Code hook can't do this, it has no notion of the agterm selection. `StatusIconView` owns its OWN width constraint (0 when `.idle`, glyph-width otherwise, toggled in `apply`) so an idle row collapses the slot and reads full-width; `BadgeView.intrinsicContentSize` likewise collapses to zero width at `count == 0` (so a hidden OSC badge reserves no trailing slot and the glyph sits flush-right), with the glyph-to-badge gap baked into the badge's leading edge so it only appears when the badge does. **Clear Status** forces a session's indicator back to idle from the GUI: the sidebar row's right-click menu (first item, only when non-idle), the menu bar, and the ⌃⇧P palette — the row menu targets the clicked node id, the menu bar + palette go through `AppActions.clearActiveSessionStatus` (the active session); all route to `AppStore.setAgentIndicator(AgentIndicator(), forSession:)`, the GUI half of `session.status idle`. **Typing also clears an attention glyph:** `GhosttySurfaceView.keyDown` calls `AgentStatus.clearedByKeystroke(isEscape:)` on the owning session's `agentIndicator.status` and, when it returns true, fires `onUserInputClearsStatus` (wired by the main/split surface factories to the same `setAgentIndicator(AgentIndicator(), …)` → idle). The decision is host-free + unit-tested in `agtermCore`: `blocked`/`completed` clear on ANY key (you've engaged with the prompt / finished result); `active` clears ONLY on Escape — the interrupt key (`keyCode == 53`) — so ordinary typing while the agent works does NOT wipe the "working" glyph, but cancelling a prompt with Esc does; `idle` has no glyph. This is the ONE input-driven clear (status is otherwise control-driven). It covers the Esc-decline/interrupt case Claude Code fires NO hook for — the keystroke flows through the surface's `keyDown` on its way to the agent's PTY, so it clears the stale glyph the moment you deal with the prompt — and clears the `completed` flash once you re-engage. The `active`-on-Esc arm is load-bearing for the QUICK-Esc case: a pending question can still read `active` when you cancel it, because Claude Code's `blocked` (`Notification[permission_prompt]`) fires on a DELAY (~tens of seconds — its idle-notification timer, `messageIdleNotifThresholdMs`, default 60000), so a fast Esc lands while the glyph is still `active`, and the interrupt itself fires no hook (verified by a status-hook probe: an Esc-cancel logs no hook at all; a manual decline fires neither `Stop` nor `PostToolUse`) — the keystroke clear is the only signal. The `PostToolUse→active --blink` install hook covers the answer-then-resume case (the agent's next tool re-asserts `active`). Peer terminals get the decline case for free by different means agterm avoids: cmux owns the permission decision UI (a blocking hook round-trip captures accept/deny), herdr scrapes the PTY (the prompt chrome leaving the screen clears it).
-- **Titlebar attention bell (opt-in, window-wide aggregate of the glyph).** When `attentionButtonEnabled` is on (Settings ▸ General, default OFF — see the Settings section), `customTitlebar` (`ContentView`) shows a bell icon just after the title that recovers the per-session attention signal when the sidebar is hidden. It derives THREE states from the window's `AppStore.attentionSessions` (the host-free per-window set — ALL non-idle sessions, broader than `needsAttention`): empty → `bell`, ~0.35 opacity, `.disabled(true)`; non-empty no-blocked → `bell`, `chromeText`, enabled; any `.blocked` → `bell.fill` tinted `GhosttyApp.shared.blockedStatusColor`, enabled. No count, no pulse. Reading `attentionSessions` registers the `agentIndicator` observation, so the icon updates LIVE on status change. Click → `AppActions.toggleAttentionPalette()` (the `.attention` palette — see the Menu/actions section). It carries `.accessibilityIdentifier("attention-button")`, a `.help` string, and an `.accessibilityValue` of `none`|`attention`|`blocked` — mirroring `StatusIconView`'s state-name value so XCUITest can read the otherwise-unobservable `bell`↔`bell.fill` highlight. `WindowContentView` mirrors the chrome flag into `@State` (seeded from `GhosttyApp.shared.attentionButtonEnabled`, refreshed on `.agtermAppearanceChanged`), NOT from `model.settings`. The bell is pure visual chrome (it opens the already-controllable attention palette / `session.select`) — keep-in-sync EXEMPT, like the other titlebar buttons.
+- Terminal desktop notifications (OSC 9 / 777).
+  `GhosttyCallbacks.action` handles `GHOSTTY_ACTION_DESKTOP_NOTIFICATION` — copies the `title`/`body`
+  C strings synchronously (only valid for the call), recovers the firing `GhosttySurfaceView` via the
+  existing `surfaceView(from:)`, and hops to `NotificationManager.shared.notify(surface:title:body:)`.
+  (The bell, `GHOSTTY_ACTION_RING_BELL`, is intentionally NOT a notification source.)
+- `NotificationManager` (`agterm/Notifications/`, `@MainActor` singleton + `UNUserNotificationCenterDelegate`,
+  `@preconcurrency` conformance like macterm) owns the macOS surface.
+  `notify` resolves the owning `Session` (the view's `weak var session`) + `PaneRole` (identity-compare
+  the view to the session's `surface`/`splitSurface`/`overlaySurface`), applies suppression,
+  **always bumps `session.unseenCount`** (the badge), then posts a `UNNotificationRequest` ONLY if `bannersEnabled`
+  (the General toggle) — so turning banners off still tracks the badge.
+  Registered + `requestAuthorization([.alert])` from the scene `.task` (alongside `controlServer.start()`);
+  auth is best-effort — the badge works even when banners are denied.
+  `willPresent` returns `[.banner, .list]` so banners show even while agterm is frontmost (the focused-pane
+  case is dropped at delivery, NOT in `willPresent`).
+  `clearDelivered(sessionID:)` removes a session's delivered banners (all three pane identifiers) when
+  you focus it, so a notification you've navigated to doesn't linger in Notification Center.
+  `send(toSession:title:body:)` is the control channel's entry point (the `notify` command / `agtermctl notify`):
+  same badge + banner + reveal-identity machinery, but NO focus-suppression (the caller asked for it)
+  and attributed to the `.main` pane.
+- **Suppression**
+  is the pure, agtermCore-tested `TerminalNotification.shouldDeliver(firingIsFocused:appActive:)`:
+  drop entirely only when the firing surface is the key window's first responder AND `NSApp.isActive`
+  (you're already looking at it).
+  The manager uses the strict first-responder check (NOT `AppActions.focusedSurface()`,
+  whose active-session fallback would wrongly count a sidebar-focused window as "looking at the pane").
+- **Identity / navigation.**
+  `TerminalNotification.identity`/`parseIdentity` (agtermCore) make the request identifier `"<sessionID>:<paneRole>"`
+  — it both coalesces repeats from the same pane (the OS replaces, doesn't stack) and carries the click
+  target (no `userInfo` needed).
+  `didReceive` parses it, `NSApp.activate`s, and calls `AppActions.reveal(sessionID:pane:)`:
+  `selectSession` (which clears the badge + derives the workspace) then `focusSplitPane` for the pane,
+  stale-safe (unknown session → just activate; a `.split` no longer split → primary).
+  `reveal` is internal click-routing (not on toolbar/menu/palette) composing the already-controllable
+  `session.select`, so it has NO control command (keep-in-sync exempt, by user decision).
+- **Badge.**
+  `Session.unseenCount` (observed; ephemeral — `SessionSnapshot` doesn't capture it,
+  so it never persists).
+  `SidebarCellView.badge` is a custom-drawn `BadgeView` (an accent capsule,
+  count capped `99+`, accessibility role `.staticText` with id `notify-badge`) at the row's trailing
+  edge, with a `Workspace.unseenCount` roll-up on the workspace row so an unseen badge stays visible
+  when the workspace is collapsed.
+  `unseenCount` is folded into the sidebar's `updateNSView` dependency read,
+  and `reloadChangedBadgeRows`/`snapshotBadges` reload only the changed session + workspace rows.
+  Cleared by `AppStore.selectSession` and by a pane's `onFocusChange(true)` (which also calls `clearDelivered`
+  — focusing a pane means you've seen the session).
+  **The count pill rendering is gated by the `notificationBadgeEnabled` Settings toggle** (see the Settings
+  section): the Coordinator's `effectiveUnseen(_:)` returns 0 when the flag is off,
+  applied to BOTH the session badge and the workspace roll-up (and to `RowContent.unseen` so a toggle
+  reloads the rows).
+  This gates ONLY the red count pill — the agent-status glyph (drawn just left of it by `StatusIconView`)
+  is always on, never gated by this.
+- **Agent-status glyph.**
+  Mirrors the `notify-badge` cell pattern (see the Control API `session.status`).
+  `StatusIconView` (an `NSImageView` sibling of `BadgeView` in `WorkspaceSidebar`) draws the row's tinted
+  SF Symbol just LEFT of the count badge — `active`=`ellipsis.circle.fill`,
+  `blocked`=`exclamationmark.circle.fill`, `completed`=`checkmark.circle.fill`,
+  `.idle`=hidden, each tinted with its configurable Settings color (`GhosttyApp.{active,blocked,completed}StatusColor`,
+  default `#DBD9E6` muted lavender-grey / system amber / system green; see the Settings section) — with
+  accessibility role `.staticText`, id `agent-status`, value = the state name (so XCUITest matches `app.staticTexts["agent-status"]`),
+  and a `CABasicAnimation` `opacity` pulse added only while visible AND `blink` (the install's `UserPromptSubmit→active --blink`
+  hook pulses the in-progress glyph).
+  The glyph shows on EVERY non-idle session, the selected one INCLUDED — there is NO visibility gate.
+  (An earlier `isFrontmostWindow`-driven hide-on-the-selected-session gate was removed:
+  blanking the status on the row you're viewing read as confusing, since every other row carried a state;
+  the `isFrontmostWindow` plumbing went with it.) `effectiveIndicator(forSession:)` is just the session's
+  own `agentIndicator`; it rides in `RowContent` (Equatable) so a status/blink change reloads only that
+  row, and `agentIndicator` is folded into the `updateNSView` dependency read.
+  A one-time `completed --auto-reset` is cleared by `AppStore.selectSession` on BOTH the session visited
+  AND the one left (`clearAutoResetIndicator(new)` + `clearAutoResetIndicator(previous)`) so it never
+  lingers on the row you switch away from — a Claude Code hook can't do this,
+  it has no notion of the agterm selection.
+  `StatusIconView` owns its OWN width constraint (0 when `.idle`, glyph-width otherwise,
+  toggled in `apply`) so an idle row collapses the slot and reads full-width;
+  `BadgeView.intrinsicContentSize` likewise collapses to zero width at `count == 0` (so a hidden OSC
+  badge reserves no trailing slot and the glyph sits flush-right), with the glyph-to-badge gap baked
+  into the badge's leading edge so it only appears when the badge does.
+  **Clear Status** forces a session's indicator back to idle from the GUI:
+  the sidebar row's right-click menu (first item, only when non-idle), the menu bar,
+  and the ⌃⇧P palette — the row menu targets the clicked node id, the menu bar + palette go through `AppActions.clearActiveSessionStatus`
+  (the active session); all route to `AppStore.setAgentIndicator(AgentIndicator(), forSession:)`,
+  the GUI half of `session.status idle`.
+  **Typing also clears an attention glyph:** `GhosttySurfaceView.keyDown` calls `AgentStatus.clearedByKeystroke(isEscape:)`
+  on the owning session's `agentIndicator.status` and, when it returns true,
+  fires `onUserInputClearsStatus` (wired by the main/split surface factories to the same `setAgentIndicator(AgentIndicator(), …)`
+  → idle).
+  The decision is host-free + unit-tested in `agtermCore`: `blocked`/`completed` clear on ANY key (you've
+  engaged with the prompt / finished result); `active` clears ONLY on Escape — the interrupt key (`keyCode == 53`)
+  — so ordinary typing while the agent works does NOT wipe the "working" glyph,
+  but cancelling a prompt with Esc does; `idle` has no glyph.
+  This is the ONE input-driven clear (status is otherwise control-driven).
+  It covers the Esc-decline/interrupt case Claude Code fires NO hook for — the keystroke flows through
+  the surface's `keyDown` on its way to the agent's PTY, so it clears the stale glyph the moment you
+  deal with the prompt — and clears the `completed` flash once you re-engage.
+  The `active`-on-Esc arm is load-bearing for the QUICK-Esc case: a pending question can still read `active`
+  when you cancel it, because Claude Code's `blocked` (`Notification[permission_prompt]`) fires on a
+  DELAY (~tens of seconds — its idle-notification timer, `messageIdleNotifThresholdMs`,
+  default 60000), so a fast Esc lands while the glyph is still `active`,
+  and the interrupt itself fires no hook (verified by a status-hook probe:
+  an Esc-cancel logs no hook at all; a manual decline fires neither `Stop` nor `PostToolUse`) — the keystroke
+  clear is the only signal.
+  The `PostToolUse→active --blink` install hook covers the answer-then-resume case (the agent's next
+  tool re-asserts `active`).
+  Peer terminals get the decline case for free by different means agterm avoids:
+  cmux owns the permission decision UI (a blocking hook round-trip captures accept/deny),
+  herdr scrapes the PTY (the prompt chrome leaving the screen clears it).
+- **Titlebar attention bell (opt-in, window-wide aggregate of the glyph).**
+  When `attentionButtonEnabled` is on (Settings ▸ General, default OFF — see the Settings section),
+  `customTitlebar` (`ContentView`) shows a bell icon just after the title that recovers the per-session
+  attention signal when the sidebar is hidden.
+  It derives THREE states from the window's `AppStore.attentionSessions` (the host-free per-window set
+  — ALL non-idle sessions, broader than `needsAttention`): empty → `bell`,
+  ~0.35 opacity, `.disabled(true)`; non-empty no-blocked → `bell`, `chromeText`,
+  enabled; any `.blocked` → `bell.fill` tinted `GhosttyApp.shared.blockedStatusColor`,
+  enabled.
+  No count, no pulse.
+  Reading `attentionSessions` registers the `agentIndicator` observation,
+  so the icon updates LIVE on status change.
+  Click → `AppActions.toggleAttentionPalette()` (the `.attention` palette — see the Menu/actions section).
+  It carries `.accessibilityIdentifier("attention-button")`, a `.help` string,
+  and an `.accessibilityValue` of `none`|`attention`|`blocked` — mirroring `StatusIconView`'s state-name
+  value so XCUITest can read the otherwise-unobservable `bell`↔`bell.fill` highlight.
+  `WindowContentView` mirrors the chrome flag into `@State` (seeded from `GhosttyApp.shared.attentionButtonEnabled`,
+  refreshed on `.agtermAppearanceChanged`), NOT from `model.settings`.
+  The bell is pure visual chrome (it opens the already-controllable attention palette / `session.select`)
+  — keep-in-sync EXEMPT, like the other titlebar buttons.
 

--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -12,14 +12,265 @@ paths:
 
 ## Settings
 
-- Settings persist in agtermCore: `AppSettings` (Codable value type, optional fields, NO version field — optionality is the forward-compat) + `SettingsStore` (JSON at `<stateDir>/settings.json`, `AGTERM_STATE_DIR`-isolated, mirrors `PersistenceStore`). Fields: `fontFamily`/`fontSize`/`theme` + `backgroundOpacity` (0...1) / `backgroundBlur` (CGS radius) + `notificationsEnabled` / `compactToolbar` / `notificationBadgeEnabled` / `attentionButtonEnabled` + the agent-status glyph colors `activeStatusColorHex`/`blockedStatusColorHex`/`completedStatusColorHex` (nil defaults: `notificationsEnabled`/`notificationBadgeEnabled` = on, `compactToolbar` = compact [the app default — `?? true`; an explicit `false` is the tall non-compact bar], `attentionButtonEnabled` = off, the `*ColorHex` = default tint, active `#DBD9E6` + blocked/completed system orange/green; NOT ghostty keys) + `mouseScrollMultiplier` (ghostty `mouse-scroll-multiplier`) + `inactivePaneMuteStrength` (0...10 inactive-split-pane text mute, nil = default 5, NOT a ghostty key) + `sidebarBackgroundShift` (0...10 sidebar lighter/darker tint relative to the terminal, nil = default 5 = neutral, NOT a ghostty key). The three `*StatusColorHex` (`#RRGGBB`, nil = active `#DBD9E6` muted lavender-grey + system amber/green) color the sidebar agent-status glyph: `SettingsModel` passes the hex to `GhosttyApp.setAgentStatusColors` which resolves to `NSColor` (so `SettingsModel` stays AppKit-free, the `NSColor`↔hex helper is `NSColor+AgtermHex`), `StatusIconView` reads it when drawing, and a change rides `.agtermAppearanceChanged` → the Coordinator's `reapplyStatusGlyphs()` sweep (the colors are global, not per-row, so `reconcile`'s diff can't see them). Settings → Appearance → Agent Status drives them with a Reset-to-defaults button (clears all three to nil), plus a **Blocked sound** picker bound to `AppSettings.blockedStatusSoundName` (nil/"None" = no sound, the default; else a system sound name). `SettingsModel.setBlockedStatusSoundName` only SAVES (not a ghostty key, nothing renders it continuously); `ControlServer.setSessionStatus` reads `settingsModel.settings.blockedStatusSoundName` on demand and plays it via `StatusSoundPlayer.shared` ONLY when a session TRANSITIONS into `blocked` (a `wasBlocked` read of the session's current status BEFORE the mutation gates it, so a repeated `blocked` set does NOT replay the default) and no per-call `--sound` was given — the precedence is the host-free `AgentStatus.effectiveSound(perCall:blockedDefault:)` (explicit per-call wins; an empty per-call value counts as unset; the default is blocked-only and the transition gate lives in the server). The picker previews the sound on selection (plays it via `StatusSoundPlayer.shared`). GUI-only and keep-in-sync EXEMPT, same as the status colors (only `theme.set`/`config.reload` touch settings over the socket); the per-status sound already has full control coverage via `session.status --sound`. `notificationBadgeEnabled` (nil = on) gates the sidebar's red unseen-count pill (session rows + workspace roll-up), render-only — `unseenCount` keeps tracking so re-enabling instantly shows current counts; distinct from `notificationsEnabled` (which gates the OS banner) and does NOT gate the always-on agent-status glyph. `AppSettings.ghosttyConfigLines()` (host-free, unit-tested) emits `key = value` lines RAW — no quotes, because ghostty takes the whole line remainder as the value (confirmed against the bundled conf + theme files), so names with spaces (`3024 Night`) must not be quoted. `mouseScrollMultiplier` is the ONE field always emitted: nil emits the default `mouse-scroll-multiplier = 3` (a bare value applied to both the notched wheel and the trackpad) rather than being omitted, so the default speed is effective rather than ghostty's per-device defaults (discrete 3 / precision 1) — a consequence is it overrides any `mouse-scroll-multiplier` in the user's own `~/.config/ghostty/config`. The General → Scrolling stepper (1...10, default 3) maps 3 back to nil so `settings.json` stays minimal; the emitted value is 3 either way. The General → Panes slider (0...10, default 5) maps 5 back to nil the same way; it drives `GhosttyApp.inactivePaneMuteStrength` (mirrored into `WindowContentView` view state on `.agtermAppearanceChanged`, like `compactToolbar`/`notificationBadgeEnabled`), and `ContentView.paneDim` washes the inactive split pane with `terminalColor` at `AppSettings.muteOpacity(strength:)` (host-free, unit-tested: 0→0 renders nothing, 5→0.4 = the historical default, 10→0.8) so the inactive pane's TEXT mutes toward the background (`bg→bg` unchanged, `text→bg` dimmer) while the background stays put — the way other terminals dim an inactive pane. NOT a ghostty key, so `writeGhosttyConfig` no-ops and no surface reload fires (only the `.agtermAppearanceChanged` re-render). Caveat: in translucent-window mode the surface background is transparent, so the wash tints the inactive pane's see-through area slightly toward the theme color (the old `Color.black` dim darkened it instead — not a regression). The Appearance → Window → Sidebar Tint slider (0...10, default 5 = neutral) maps 5 back to nil the same way; it drives `GhosttyApp.sidebarBackgroundShift` (mirrored into `WindowContentView.sidebarShift` on `.agtermAppearanceChanged`, like `inactivePaneMuteStrength`), and `ContentView.sidebarTintWash` washes the sidebar column with black (darker, >5) or white (lighter, <5) at `abs(AppSettings.sidebarShiftAmount(strength:))` (host-free, unit-tested: signed, ±0.30 at the ends, 5→0) — a `.background` BEHIND the transparent outline + bottom bar, so the whole column (NOT the title strip, deliberately left uniform with the terminal) reads as one surface a touch lighter/darker WITHOUT tinting row text. Compositing the wash over the window background equals blending the terminal color toward black/white and works identically over an opaque OR a translucent+blurred backdrop, so it composes with opacity/blur instead of fighting it; `WindowAppearance.syncSidebarBackground` keeps the sidebar see-through (no AppKit fill — the wash is the single tint layer). NOT a ghostty key (only the `.agtermAppearanceChanged` re-render). Translucency is composited at the AppKit window level, NOT by the renderer: when `backgroundOpacity < 1`, `ghosttyConfigLines()` pins `background-opacity = 0` + `background-blur = 0` so ghostty draws fully transparent and the window's tinted background is the single translucent layer (no double-tint); at full opacity those lines are omitted and the renderer paints its own background as before.
-- The app target's `SettingsModel` (`@Observable`) loads `AppSettings`, and on every change: saves (the opacity/blur sliders are the exception — see the end of this bullet), writes `ghostty-settings.conf` (loaded LAST in `GhosttyApp.loadConfig`, so the UI wins over the user's `~/.config/ghostty/config` for the keys it manages). It calls `GhosttyApp.reloadConfig` (rebuild + `ghostty_app_update_config` + `ghostty_surface_update_config` on every live surface) + `AppStore.resetSessionFontSizes()` ONLY when the generated config TEXT actually changed — a window-opacity drag within the translucent range, or a blur change, leaves the config identical, so it skips the surface rebuild (and the zoom reset) and just re-syncs the window. The shared config resets every surface to the default size, so when it does reload, per-session cmd-+/- overrides are cleared to match (user-approved simplification — no per-surface config / zoom preservation). Opacity/blur are NOT ghostty-resolved, so `SettingsModel` mirrors them into `GhosttyApp.windowOpacity`/`windowBlurRadius` (the shared channel the window chrome reads) at launch and on every change. The opacity/blur Settings sliders are the one exception to save-on-every-change: their bindings call `previewBackgroundOpacity`/`previewBackgroundBlur` (apply WITHOUT save) on every drag tick and DEBOUNCE the `settings.json` write (~0.3 s), so a drag coalesces to a single write on settle — which also persists keyboard arrow adjustments that never fire the slider's `onEditingChanged`; a mouse release flushes it immediately via `commitBackgroundSettings()`.
-- `GhosttyApp.reloadConfig` keeps the new config as `self.config` and does NOT free the previous one: `update_config` has no documented ownership contract and the existing code never frees on success, so this matches that (crash-safe over a negligible leak on a rare settings change).
-- The terminal color isn't observable, so a settings change posts `.agtermAppearanceChanged`: `ContentView` mirrors the color into `terminalColor` view state (the quick terminal's opaque backing re-renders with the new color) and `TitleProbeView` re-applies the window appearance. Without this the chrome only refreshed when the window next re-keyed. UI is the standard SwiftUI `Settings` scene (Cmd+,) with a 3-tab `TabView`: **General** (the notification-banner toggle + the notification-badge toggle + a **Scrolling** section with the scroll-speed stepper), **Appearance** (a **Terminal** section — font/size/theme via `NSFontManager` monospaced families + the bundled `ghostty/themes` dir, `SettingsCatalog` — and a **Window** section with background opacity + blur sliders + the Sidebar Tint slider), and **Key Mapping** (the config directory holding `keymap.conf` + a read-only diagnostics list + a Reload button — see the Keymap section). The notification toggle (`AppSettings.notificationsEnabled`, nil = on) is mirrored to `NotificationManager.bannersEnabled` by `SettingsModel`; it gates only the OS banner, never the badge, and is NOT a ghostty config key (no reload). The badge toggle (`AppSettings.notificationBadgeEnabled`, nil = on) is mirrored into the non-observable `GhosttyApp.notificationBadgeEnabled` flag by `SettingsModel.applyNotificationBadgeEnabled`; because that flag isn't `@Observable`, a flip rides the `.agtermAppearanceChanged` notification the same way `compactToolbar` does — the sidebar Coordinator's `appearanceChanged` calls `reconcile()`, and the gated `RowContent.unseen` (0 when off via `effectiveUnseen`) reloads the affected badge rows. NOT a ghostty config key.
-- **Window translucency (`WindowAppearance.sync`).** Below full opacity the window goes `isOpaque = false` with `backgroundColor = terminalColor.withAlphaComponent(opacity)` (the single tinted layer), applies the blur via the private `CGSSetWindowBackgroundBlurRadius` SPI (`dlsym`-resolved once, no-op if absent — adapted from macterm, its `fatalError` softened to a graceful return), and hides `NSTitlebarBackgroundView` so the tint runs continuously under the titlebar; at full opacity it restores the original opaque/solid path and clears the blur. The macOS-26 `NavigationSplitView` sidebar is a Liquid Glass container (`NSContainerConcentricGlassEffectView : NSGlassEffectView`) that WRAPS the sidebar content (an ancestor, so it can't be hidden), and is NOT flattenable to the window tint; `sidebarGlass(in:)` finds it by walking up from the tagged `agterm-sidebar-scroll` view, and when translucent sets its `style = .clear` (the see-through variant) + `tintColor = terminalColor.withAlphaComponent(opacity)` so the sidebar reads as the same translucent surface (its blur stays Liquid Glass, not the window CGS blur — close, not pixel-identical). All of this re-applies on every `sync`, which `TitleProbeView` already drives on window key/main/fullscreen transitions + `.agtermAppearanceChanged`.
-- **`configDirectory` + the keymap (see the Keymap section).** `AppSettings.configDirectory: String?` (nil = the default) holds the directory that contains `keymap.conf`. `SettingsModel` resolves it through the host-free `ConfigPaths.configDirectory(setting:stateDir:home:)` (explicit setting → `<AGTERM_STATE_DIR>/config` for test isolation → `~/.config/agterm`) and `ConfigPaths.keymapPath(...)` (`<dir>/keymap.conf`), loads + `parseKeymap`s it at init into the `@Observable` `keymap`/`keymapDiagnostics`, and on first launch writes a fully-commented starter `keymap.conf` (`ensureStarterKeymap` — never overwrites an existing file; documents every `BuiltinAction` raw name + default chord and the `{AGT_X}` token list, so a fresh file rebinds nothing). `setConfigDirectory(_:)` persists + reloads; the Key Mapping tab's directory picker drives it. Unlike the other settings, a keymap change is NOT a ghostty config rewrite (no `persistAndApply`/surface reload) — it posts `.agtermKeymapChanged` (co-located in `GhosttyApp.swift`'s `Notification.Name` extension) and the `@Observable keymap` drives the rest.
-- **`<configDir>/ghostty.conf` (agterm-scoped ghostty config, co-located with `keymap.conf`).** A config layer between the (opt-in) global ghostty config and agterm's UI settings, and the agterm customization point: `GhosttyApp.loadConfig` loads `ghostty-defaults.conf` → `~/.config/ghostty/config` (ONLY when `inheritGlobalGhosttyConfig` is on — OFF by default; see that field) → `<configDir>/ghostty.conf` → `ghostty-settings.conf` (UI), each overriding the last, so `ghostty.conf` overrides the bundled defaults (and the global config when inherited) for ANY key, but agterm's UI-managed keys (font/theme/opacity/blur/scroll) still WIN because the settings conf loads LAST. The scoped `ghostty.conf` is ALWAYS loaded; skipped only when absent (the starter is comment-only, so a fresh install is a no-op). Scoped to agterm only — the standalone Ghostty.app never reads it. `GhosttyApp.resolveConfigInputs()` (a FUNCTION, not a computed property, since it reads `settings.json` via `SettingsStore().load()`) returns `ConfigInputs{scopedURL, inheritGlobalConfig}` — resolving the scoped path SELF-CONTAINED (`configDirectory` + `ConfigPaths.configDirectory(setting:stateDir:home:)` + the `ConfigPaths.ghosttyConfigPath` helper) AND the inherit flag in ONE settings load, because `loadConfig` runs before any `SettingsModel` exists (its first `GhosttyApp.shared` touch is inside `SettingsModel.init`). It is resolved ONCE per config build and THREADED to `loadConfig(_:)` and `resolveSelectionColors(ghosttyConfigPath:inheritGlobalConfig:)` (whose `sources` array gets the global path ONLY when inherited, then the scoped path, then the settings conf), so a single reload reads `settings.json` at most once. `SettingsModel.ensureStarterGhosttyConfig` (mirrors `ensureStarterKeymap`) seeds a comment-only starter on first launch (header link to `https://ghostty.org/docs/config`, a commented `# macos-option-as-alt = true`, a note that the UI keys win) — never overwrites an existing file, seeded at `SettingsModel.init` AFTER `loadConfig` already ran (harmless, all comments). **Edit/Reload mirror the keymap surfaces** (the keymap's `editorCommand(forKeymapPath:)` was generalized to `editorCommand(forPath:)`, `$0` label `agterm-config-edit`, shared by both). `AppActions.editGhosttyConfig` (File ▸ Edit ghostty.conf… + the ⌃⇧P palette, GUI-only, keep-in-sync EXEMPT like Edit Keymap) opens `ghostty.conf` in `$EDITOR` via a 95% overlay; the target + the file's opening contents ride `ghosttyEditOverlaySession`/`ghosttyEditOverlaySnapshot` and `WindowContentView`'s overlay-close `onChange` calls `reloadGhosttyConfigIfEdited` on close (reloads only when the file CHANGED since the editor opened, so a no-op editor session keeps per-session font zoom) then clears it. `AppActions.reloadGhosttyConfig` (`@discardableResult -> Int`, returning the diagnostic count; File ▸ Reload Config + the palette + the overlay close + the `config.reload` control command) → `SettingsModel.reloadGhosttyConfig` → `GhosttyApp.reloadConfig(surfaces:)` (`@discardableResult -> Int`, returning + caching `lastConfigDiagnosticsCount`) + `resetSessionFontSizesAllWindows()` + `.agtermAppearanceChanged`; a non-zero count posts `NotificationManager.notifyConfigDiagnostics(count:)` from `SettingsModel.reloadGhosttyConfig` (mirroring `reloadKeymap`, so EVERY caller surfaces it — incl. a Key Mapping directory change via `setConfigDirectory`, which now reloads BOTH co-located files). The count spans ALL config sources (libghostty diagnostics carry NO source-file attribution), NOT just `ghostty.conf`, so the banner/godoc/`config.reload` say "ghostty config", not "ghostty.conf". The EXPLICIT Reload Config / `config.reload` reload is UNCONDITIONAL (`ghostty.conf` is edited externally, so there is always something to re-read) and clears per-session ⌘+/⌘− zoom like any config reload; only the editor round-trip is guarded by the unchanged-file check. The whole-config diagnostics banner ALSO fires at launch (`agtermApp` posts `notifyConfigDiagnostics` when `GhosttyApp.shared.lastConfigDiagnosticsCount > 0` after the first config build). See the Control API catalog for the `config.reload` four-point audit.
-- **`restoreRunningCommand` (re-run the foreground command on restart, opt-in, General tab).** `AppSettings.restoreRunningCommand: Bool?` (nil = off) gates capturing each pane's foreground command at clean quit and re-running it on the next launch. NOT a ghostty key (`writeGhosttyConfig` no-ops, no surface reload). CAPTURE: `AppDelegate.applicationWillTerminate` — only when the flag is on — walks every open store's session surfaces and sets `Session.foregroundCommand`/`splitForegroundCommand` (persisted on `SessionSnapshot`) BEFORE `saveAllOpen()`, via `ForegroundProcess.command(for:shellBasename:)` (`ghostty_surface_foreground_pid` → `sysctl(KERN_PROCARGS2)` → host-free `CommandRestore.parseProcArgs`; returns nil only for an IDLE shell-at-prompt via `CommandRestore.isIdleShell` — a known shell with NO payload argument after argv0, only option flags. A shell RUNNING a script is NOT idle and IS captured: a `#!/bin/sh` wrapper like the `cld` claude-code launcher has foreground argv `['/bin/sh', '/usr/local/bin/cld', …]`, which earlier was wrongly skipped because `basename('/bin/sh')` is `sh` — `isIdleShell` keeps it because of the script-path argument). The walk uses `WindowLibrary.allOpenSessions()` and captures the SPLIT command ONLY when `session.isSplit` (a hidden split isn't recreated at restore, so capturing it would leave a stale command to fire on the next manual ⌘D — `clearSavedCommands` shares the same `allOpenSessions` walk). A login shell's argv0 is dash-decorated (`/usr/bin/login … exec -l /bin/zsh` → argv0 `-/bin/zsh`, whose basename splits on `/` to `zsh`; `isKnownShell` ALSO strips a leading `-` so a bare `-zsh` form is recognized too), so an idle pane captures nil and stays a plain shell — verified via `tree --json`. A force-quit/crash skips `applicationWillTerminate`, so it loses commands (sessions + cwd still restore from the debounced snapshot) — best-effort by design. RESTORE: the surface factories (`makeSurface`/`makeSplitSurface`) read the persisted command, gate on `GhosttyApp.shared.restoreRunningCommand` (mirrored by `SettingsModel.applyRestoreRunningCommand`, like `notificationBadgeEnabled`) + the host-free `CommandRestore.shouldRestore(argv:denylist:)` check against the user-editable `restore-denylist.conf` (NO built-in list — `SettingsModel.loadRestoreDenylist` parses `<configDir>/restore-denylist.conf` at launch via `CommandRestore.parseDenylist` and mirrors it into `GhosttyApp.shared.restoreDenylist`, seeded with the terminal multiplexers `tmux`/`screen`/`zellij` by `ensureStarterRestoreDenylist`; everything not listed — `python manage.py runserver`, `node server.js`, a REPL — restores), and feed it to the login shell via `config.initial_input` = `CommandRestore.shellQuotedLine(argv) + "\n"` (NOT `config.command`, which would replace the shell + close on exit; `initial_input` re-runs inside the shell so exit returns to a prompt). The captured field is consumed run-once in the factory (read-then-nil, like `scratchCommand`) so a later structural save can't re-fire it. All decision logic (parse/shell-detect/denylist/quote) is host-free in `CommandRestore` (unit-tested); the app target owns only the C-boundary + Darwin syscall. ONLY a single-process command restores faithfully — a typed pipeline/compound line captures one process. The SETTINGS TOGGLE is GUI-only (no `settings.*` control surface; only `theme.set`/`config.reload` touch settings), but the feature DOES have a control surface: `restore.clear` clears the saved commands and live `foreground`/`splitForeground` ride `tree`/`ControlSessionNode` (see the Control API catalog's `restore.clear` four-point audit) — the agent-skill was updated accordingly.
-- **`inheritGlobalGhosttyConfig` (load the user's global `~/.config/ghostty/config`, opt-in, General tab).** `AppSettings.inheritGlobalGhosttyConfig: Bool?` (nil = OFF) gates whether `loadConfig` reads the user's GLOBAL ghostty config (see the `<configDir>/ghostty.conf` bullet for the layering). OFF by default so agterm is self-contained: a config written for the standalone Ghostty.app does NOT silently change agterm, which also keeps bug reports legible (the colors a user sees are agterm's own unless they opt in). The agterm-scoped `<configDir>/ghostty.conf` is ALWAYS loaded regardless and is the documented customization point. Resolved at config-LOAD time (via `resolveConfigInputs`), NOT a live `GhosttyApp` mirror and NOT a `ghosttyConfigLines()` key — so `setInheritGlobalGhosttyConfig` saves `settings.json` then calls `reloadGhosttyConfig()` UNCONDITIONALLY (like `setConfigDirectory`), because it changes WHICH files load and `persistAndApply`'s text-diff guard would otherwise skip the reload. The SETTINGS TOGGLE is GUI-only and keep-in-sync EXEMPT (like `restoreRunningCommand`'s toggle — only `theme.set`/`config.reload` touch settings over the socket). Default-off + round-trip covered host-free in `AppSettingsTests`; the file-gating itself is app-target (manually/build verified, no app unit-test host).
-- **`attentionButtonEnabled` (titlebar attention bell, opt-in, General tab).** `AppSettings.attentionButtonEnabled: Bool?` (nil = OFF, the default-off precedent like `restoreRunningCommand`/`inheritGlobalGhosttyConfig`, NOT `notificationBadgeEnabled`'s default-ON) gates the title-bar bell icon that reflects the window's `AppStore.attentionSessions` at a glance (empty → dimmed/disabled, non-empty → enabled, any blocked → filled-amber). NOT a ghostty key (`writeGhosttyConfig` no-ops, no surface reload). It is the non-observable chrome-mirror pattern: `SettingsModel.setAttentionButtonEnabled` saves + `applyAttentionButtonEnabled` pushes `settings.attentionButtonEnabled ?? false` into the `GhosttyApp.attentionButtonEnabled` flag (alongside `applyCompactToolbar`/`applyNotificationBadgeEnabled`), so a flip rides `.agtermAppearanceChanged` and `WindowContentView` re-reads the mirror to re-render the titlebar live — exactly like `compactToolbar`/`notificationBadgeEnabled`. The General ▸ Notifications `Toggle("Show attention indicator")` uses the default-OFF binding (get `?? false`, set `$0 ? true : nil`, mirroring `restoreRunningCommand`/`inheritGlobalGhosttyConfig`, NOT `notificationBadgeEnabled`). GUI-only and keep-in-sync EXEMPT (the bell just opens the already-controllable attention palette / `session.select`; only `theme.set`/`config.reload` touch settings over the socket). See the Notifications section for the bell's three states and the Menu/actions section for the `.attention` palette it opens.
+- Settings persist in agtermCore: `AppSettings` (Codable value type, optional fields,
+  NO version field — optionality is the forward-compat) + `SettingsStore` (JSON at `<stateDir>/settings.json`,
+  `AGTERM_STATE_DIR`-isolated, mirrors `PersistenceStore`).
+  Fields: `fontFamily`/`fontSize`/`theme` + `backgroundOpacity` (0...1) / `backgroundBlur` (CGS radius)
+  + `notificationsEnabled` / `compactToolbar` / `notificationBadgeEnabled` / `attentionButtonEnabled`
+  + the agent-status glyph colors `activeStatusColorHex`/`blockedStatusColorHex`/`completedStatusColorHex`
+  (nil defaults: `notificationsEnabled`/`notificationBadgeEnabled` = on,
+  `compactToolbar` = compact [the app default — `?? true`; an explicit `false` is the tall non-compact
+  bar], `attentionButtonEnabled` = off, the `*ColorHex` = default tint, active `#DBD9E6` + blocked/completed
+  system orange/green; NOT ghostty keys) + `mouseScrollMultiplier` (ghostty `mouse-scroll-multiplier`)
+  + `inactivePaneMuteStrength` (0...10 inactive-split-pane text mute, nil = default 5,
+  NOT a ghostty key) + `sidebarBackgroundShift` (0...10 sidebar lighter/darker tint relative to the terminal,
+  nil = default 5 = neutral, NOT a ghostty key).
+  The three `*StatusColorHex` (`#RRGGBB`, nil = active `#DBD9E6` muted lavender-grey + system amber/green)
+  color the sidebar agent-status glyph: `SettingsModel` passes the hex to `GhosttyApp.setAgentStatusColors`
+  which resolves to `NSColor` (so `SettingsModel` stays AppKit-free, the `NSColor`↔hex helper is `NSColor+AgtermHex`),
+  `StatusIconView` reads it when drawing, and a change rides `.agtermAppearanceChanged` → the Coordinator's
+  `reapplyStatusGlyphs()` sweep (the colors are global, not per-row, so `reconcile`'s diff can't see
+  them).
+  Settings → Appearance → Agent Status drives them with a Reset-to-defaults button (clears all three
+  to nil), plus a **Blocked sound** picker bound to `AppSettings.blockedStatusSoundName` (nil/"None"
+  = no sound, the default; else a system sound name).
+  `SettingsModel.setBlockedStatusSoundName` only SAVES (not a ghostty key,
+  nothing renders it continuously); `ControlServer.setSessionStatus` reads `settingsModel.settings.blockedStatusSoundName`
+  on demand and plays it via `StatusSoundPlayer.shared` ONLY when a session TRANSITIONS into `blocked`
+  (a `wasBlocked` read of the session's current status BEFORE the mutation gates it,
+  so a repeated `blocked` set does NOT replay the default) and no per-call `--sound` was given — the
+  precedence is the host-free `AgentStatus.effectiveSound(perCall:blockedDefault:)` (explicit per-call
+  wins; an empty per-call value counts as unset; the default is blocked-only and the transition gate
+  lives in the server).
+  The picker previews the sound on selection (plays it via `StatusSoundPlayer.shared`).
+  GUI-only and keep-in-sync EXEMPT, same as the status colors (only `theme.set`/`config.reload` touch
+  settings over the socket); the per-status sound already has full control coverage via `session.status --sound`.
+  `notificationBadgeEnabled` (nil = on) gates the sidebar's red unseen-count pill (session rows + workspace
+  roll-up), render-only — `unseenCount` keeps tracking so re-enabling instantly shows current counts;
+  distinct from `notificationsEnabled` (which gates the OS banner) and does NOT gate the always-on agent-status
+  glyph.
+  `AppSettings.ghosttyConfigLines()` (host-free, unit-tested) emits `key = value` lines RAW — no quotes,
+  because ghostty takes the whole line remainder as the value (confirmed against the bundled conf + theme
+  files), so names with spaces (`3024 Night`) must not be quoted.
+  `mouseScrollMultiplier` is the ONE field always emitted: nil emits the default `mouse-scroll-multiplier = 3`
+  (a bare value applied to both the notched wheel and the trackpad) rather than being omitted,
+  so the default speed is effective rather than ghostty's per-device defaults (discrete 3 / precision
+  1) — a consequence is it overrides any `mouse-scroll-multiplier` in the user's own `~/.config/ghostty/config`.
+  The General → Scrolling stepper (1...10, default 3) maps 3 back to nil so `settings.json` stays minimal;
+  the emitted value is 3 either way.
+  The General → Panes slider (0...10, default 5) maps 5 back to nil the same way;
+  it drives `GhosttyApp.inactivePaneMuteStrength` (mirrored into `WindowContentView` view state on `.agtermAppearanceChanged`,
+  like `compactToolbar`/`notificationBadgeEnabled`), and `ContentView.paneDim` washes the inactive split
+  pane with `terminalColor` at `AppSettings.muteOpacity(strength:)` (host-free,
+  unit-tested: 0→0 renders nothing, 5→0.4 = the historical default, 10→0.8) so the inactive pane's TEXT
+  mutes toward the background (`bg→bg` unchanged, `text→bg` dimmer) while the background stays put —
+  the way other terminals dim an inactive pane.
+  NOT a ghostty key, so `writeGhosttyConfig` no-ops and no surface reload fires (only the `.agtermAppearanceChanged`
+  re-render).
+  Caveat: in translucent-window mode the surface background is transparent,
+  so the wash tints the inactive pane's see-through area slightly toward the theme color (the old `Color.black`
+  dim darkened it instead — not a regression).
+  The Appearance → Window → Sidebar Tint slider (0...10, default 5 = neutral) maps 5 back to nil the
+  same way; it drives `GhosttyApp.sidebarBackgroundShift` (mirrored into `WindowContentView.sidebarShift`
+  on `.agtermAppearanceChanged`, like `inactivePaneMuteStrength`), and `ContentView.sidebarTintWash`
+  washes the sidebar column with black (darker, >5) or white (lighter, <5) at `abs(AppSettings.sidebarShiftAmount(strength:))`
+  (host-free, unit-tested: signed, ±0.30 at the ends, 5→0) — a `.background` BEHIND the transparent outline
+  + bottom bar, so the whole column (NOT the title strip, deliberately left uniform with the terminal)
+  reads as one surface a touch lighter/darker WITHOUT tinting row text.
+  Compositing the wash over the window background equals blending the terminal color toward black/white
+  and works identically over an opaque OR a translucent+blurred backdrop,
+  so it composes with opacity/blur instead of fighting it; `WindowAppearance.syncSidebarBackground` keeps
+  the sidebar see-through (no AppKit fill — the wash is the single tint layer).
+  NOT a ghostty key (only the `.agtermAppearanceChanged` re-render).
+  Translucency is composited at the AppKit window level, NOT by the renderer:
+  when `backgroundOpacity < 1`, `ghosttyConfigLines()` pins `background-opacity = 0` + `background-blur = 0`
+  so ghostty draws fully transparent and the window's tinted background is the single translucent layer
+  (no double-tint); at full opacity those lines are omitted and the renderer paints its own background
+  as before.
+- The app target's `SettingsModel` (`@Observable`) loads `AppSettings`, and on every change:
+  saves (the opacity/blur sliders are the exception — see the end of this bullet),
+  writes `ghostty-settings.conf` (loaded LAST in `GhosttyApp.loadConfig`,
+  so the UI wins over the user's `~/.config/ghostty/config` for the keys it manages).
+  It calls `GhosttyApp.reloadConfig` (rebuild + `ghostty_app_update_config` + `ghostty_surface_update_config`
+  on every live surface) + `AppStore.resetSessionFontSizes()` ONLY when the generated config TEXT actually
+  changed — a window-opacity drag within the translucent range, or a blur change,
+  leaves the config identical, so it skips the surface rebuild (and the zoom reset) and just re-syncs
+  the window.
+  The shared config resets every surface to the default size, so when it does reload,
+  per-session cmd-+/- overrides are cleared to match (user-approved simplification — no per-surface config
+  / zoom preservation).
+  Opacity/blur are NOT ghostty-resolved, so `SettingsModel` mirrors them into `GhosttyApp.windowOpacity`/`windowBlurRadius`
+  (the shared channel the window chrome reads) at launch and on every change.
+  The opacity/blur Settings sliders are the one exception to save-on-every-change:
+  their bindings call `previewBackgroundOpacity`/`previewBackgroundBlur` (apply WITHOUT save) on every
+  drag tick and DEBOUNCE the `settings.json` write (~0.3 s), so a drag coalesces to a single write on
+  settle — which also persists keyboard arrow adjustments that never fire the slider's `onEditingChanged`;
+  a mouse release flushes it immediately via `commitBackgroundSettings()`.
+- `GhosttyApp.reloadConfig` keeps the new config as `self.config` and does NOT free the previous one:
+  `update_config` has no documented ownership contract and the existing code never frees on success,
+  so this matches that (crash-safe over a negligible leak on a rare settings change).
+- The terminal color isn't observable, so a settings change posts `.agtermAppearanceChanged`:
+  `ContentView` mirrors the color into `terminalColor` view state (the quick terminal's opaque backing
+  re-renders with the new color) and `TitleProbeView` re-applies the window appearance.
+  Without this the chrome only refreshed when the window next re-keyed.
+  UI is the standard SwiftUI `Settings` scene (Cmd+,) with a 3-tab `TabView`:
+  **General** (the notification-banner toggle + the notification-badge toggle + a **Scrolling** section
+  with the scroll-speed stepper), **Appearance** (a **Terminal** section — font/size/theme via `NSFontManager`
+  monospaced families + the bundled `ghostty/themes` dir, `SettingsCatalog` — and a **Window** section
+  with background opacity + blur sliders + the Sidebar Tint slider), and **Key Mapping** (the config
+  directory holding `keymap.conf` + a read-only diagnostics list + a Reload button — see the Keymap section).
+  The notification toggle (`AppSettings.notificationsEnabled`, nil = on) is mirrored to `NotificationManager.bannersEnabled`
+  by `SettingsModel`; it gates only the OS banner, never the badge, and is NOT a ghostty config key (no
+  reload).
+  The badge toggle (`AppSettings.notificationBadgeEnabled`, nil = on) is mirrored into the non-observable
+  `GhosttyApp.notificationBadgeEnabled` flag by `SettingsModel.applyNotificationBadgeEnabled`;
+  because that flag isn't `@Observable`, a flip rides the `.agtermAppearanceChanged` notification the
+  same way `compactToolbar` does — the sidebar Coordinator's `appearanceChanged` calls `reconcile()`,
+  and the gated `RowContent.unseen` (0 when off via `effectiveUnseen`) reloads the affected badge rows.
+  NOT a ghostty config key.
+- **Window translucency (`WindowAppearance.sync`).**
+  Below full opacity the window goes `isOpaque = false` with `backgroundColor = terminalColor.withAlphaComponent(opacity)`
+  (the single tinted layer), applies the blur via the private `CGSSetWindowBackgroundBlurRadius` SPI
+  (`dlsym`-resolved once, no-op if absent — adapted from macterm, its `fatalError` softened to a graceful
+  return), and hides `NSTitlebarBackgroundView` so the tint runs continuously under the titlebar;
+  at full opacity it restores the original opaque/solid path and clears the blur.
+  The macOS-26 `NavigationSplitView` sidebar is a Liquid Glass container (`NSContainerConcentricGlassEffectView : NSGlassEffectView`)
+  that WRAPS the sidebar content (an ancestor, so it can't be hidden), and is NOT flattenable to the
+  window tint; `sidebarGlass(in:)` finds it by walking up from the tagged `agterm-sidebar-scroll` view,
+  and when translucent sets its `style = .clear` (the see-through variant) + `tintColor = terminalColor.withAlphaComponent(opacity)`
+  so the sidebar reads as the same translucent surface (its blur stays Liquid Glass,
+  not the window CGS blur — close, not pixel-identical).
+  All of this re-applies on every `sync`, which `TitleProbeView` already drives on window key/main/fullscreen
+  transitions + `.agtermAppearanceChanged`.
+- **`configDirectory` + the keymap (see the Keymap section).**
+  `AppSettings.configDirectory: String?` (nil = the default) holds the directory that contains `keymap.conf`.
+  `SettingsModel` resolves it through the host-free `ConfigPaths.configDirectory(setting:stateDir:home:)`
+  (explicit setting → `<AGTERM_STATE_DIR>/config` for test isolation → `~/.config/agterm`) and `ConfigPaths.keymapPath(...)`
+  (`<dir>/keymap.conf`), loads + `parseKeymap`s it at init into the `@Observable` `keymap`/`keymapDiagnostics`,
+  and on first launch writes a fully-commented starter `keymap.conf` (`ensureStarterKeymap` — never overwrites
+  an existing file; documents every `BuiltinAction` raw name + default chord and the `{AGT_X}` token
+  list, so a fresh file rebinds nothing).
+  `setConfigDirectory(_:)` persists + reloads; the Key Mapping tab's directory picker drives it.
+  Unlike the other settings, a keymap change is NOT a ghostty config rewrite (no `persistAndApply`/surface
+  reload) — it posts `.agtermKeymapChanged` (co-located in `GhosttyApp.swift`'s `Notification.Name` extension)
+  and the `@Observable keymap` drives the rest.
+- **`<configDir>/ghostty.conf` (agterm-scoped ghostty config, co-located with `keymap.conf`).** A config
+  layer between the (opt-in) global ghostty config and agterm's UI settings,
+  and the agterm customization point: `GhosttyApp.loadConfig` loads `ghostty-defaults.conf` → `~/.config/ghostty/config`
+  (ONLY when `inheritGlobalGhosttyConfig` is on — OFF by default; see that field) → `<configDir>/ghostty.conf`
+  → `ghostty-settings.conf` (UI), each overriding the last, so `ghostty.conf` overrides the bundled defaults
+  (and the global config when inherited) for ANY key, but agterm's UI-managed keys (font/theme/opacity/blur/scroll)
+  still WIN because the settings conf loads LAST.
+  The scoped `ghostty.conf` is ALWAYS loaded; skipped only when absent (the starter is comment-only,
+  so a fresh install is a no-op).
+  Scoped to agterm only — the standalone Ghostty.app never reads it.
+  `GhosttyApp.resolveConfigInputs()` (a FUNCTION, not a computed property,
+  since it reads `settings.json` via `SettingsStore().load()`) returns `ConfigInputs{scopedURL, inheritGlobalConfig}`
+  — resolving the scoped path SELF-CONTAINED (`configDirectory` + `ConfigPaths.configDirectory(setting:stateDir:home:)`
+  + the `ConfigPaths.ghosttyConfigPath` helper) AND the inherit flag in ONE settings load,
+  because `loadConfig` runs before any `SettingsModel` exists (its first `GhosttyApp.shared` touch is
+  inside `SettingsModel.init`).
+  It is resolved ONCE per config build and THREADED to `loadConfig(_:)` and `resolveSelectionColors(ghosttyConfigPath:inheritGlobalConfig:)`
+  (whose `sources` array gets the global path ONLY when inherited, then the scoped path,
+  then the settings conf), so a single reload reads `settings.json` at most once.
+  `SettingsModel.ensureStarterGhosttyConfig` (mirrors `ensureStarterKeymap`) seeds a comment-only starter
+  on first launch (header link to `https://ghostty.org/docs/config`, a commented `# macos-option-as-alt = true`,
+  a note that the UI keys win) — never overwrites an existing file, seeded at `SettingsModel.init` AFTER
+  `loadConfig` already ran (harmless, all comments).
+  **Edit/Reload mirror the keymap surfaces** (the keymap's `editorCommand(forKeymapPath:)` was generalized
+  to `editorCommand(forPath:)`, `$0` label `agterm-config-edit`, shared by both).
+  `AppActions.editGhosttyConfig` (File ▸ Edit ghostty.conf… + the ⌃⇧P palette,
+  GUI-only, keep-in-sync EXEMPT like Edit Keymap) opens `ghostty.conf` in `$EDITOR` via a 95% overlay;
+  the target + the file's opening contents ride `ghosttyEditOverlaySession`/`ghosttyEditOverlaySnapshot`
+  and `WindowContentView`'s overlay-close `onChange` calls `reloadGhosttyConfigIfEdited` on close (reloads
+  only when the file CHANGED since the editor opened, so a no-op editor session keeps per-session font
+  zoom) then clears it.
+  `AppActions.reloadGhosttyConfig` (`@discardableResult -> Int`, returning the diagnostic count;
+  File ▸ Reload Config + the palette + the overlay close + the `config.reload` control command) → `SettingsModel.reloadGhosttyConfig`
+  → `GhosttyApp.reloadConfig(surfaces:)` (`@discardableResult -> Int`, returning + caching `lastConfigDiagnosticsCount`)
+  + `resetSessionFontSizesAllWindows()` + `.agtermAppearanceChanged`; a non-zero count posts `NotificationManager.notifyConfigDiagnostics(count:)`
+  from `SettingsModel.reloadGhosttyConfig` (mirroring `reloadKeymap`, so EVERY caller surfaces it — incl.
+  a Key Mapping directory change via `setConfigDirectory`, which now reloads BOTH co-located files).
+  The count spans ALL config sources (libghostty diagnostics carry NO source-file attribution),
+  NOT just `ghostty.conf`, so the banner/godoc/`config.reload` say "ghostty config",
+  not "ghostty.conf".
+  The EXPLICIT Reload Config / `config.reload` reload is UNCONDITIONAL (`ghostty.conf` is edited externally,
+  so there is always something to re-read) and clears per-session ⌘+/⌘− zoom like any config reload;
+  only the editor round-trip is guarded by the unchanged-file check.
+  The whole-config diagnostics banner ALSO fires at launch (`agtermApp` posts `notifyConfigDiagnostics`
+  when `GhosttyApp.shared.lastConfigDiagnosticsCount > 0` after the first config build).
+  See the Control API catalog for the `config.reload` four-point audit.
+- **`restoreRunningCommand` (re-run the foreground command on restart, opt-in,
+  General tab).** `AppSettings.restoreRunningCommand: Bool?` (nil = off) gates capturing each pane's
+  foreground command at clean quit and re-running it on the next launch.
+  NOT a ghostty key (`writeGhosttyConfig` no-ops, no surface reload).
+  CAPTURE: `AppDelegate.applicationWillTerminate` — only when the flag is on — walks every open store's
+  session surfaces and sets `Session.foregroundCommand`/`splitForegroundCommand` (persisted on `SessionSnapshot`)
+  BEFORE `saveAllOpen()`, via `ForegroundProcess.command(for:shellBasename:)` (`ghostty_surface_foreground_pid`
+  → `sysctl(KERN_PROCARGS2)` → host-free `CommandRestore.parseProcArgs`;
+  returns nil only for an IDLE shell-at-prompt via `CommandRestore.isIdleShell` — a known shell with
+  NO payload argument after argv0, only option flags.
+  A shell RUNNING a script is NOT idle and IS captured: a `#!/bin/sh` wrapper like the `cld` claude-code
+  launcher has foreground argv `['/bin/sh', '/usr/local/bin/cld', …]`, which earlier was wrongly skipped
+  because `basename('/bin/sh')` is `sh` — `isIdleShell` keeps it because of the script-path argument).
+  The walk uses `WindowLibrary.allOpenSessions()` and captures the SPLIT command ONLY when `session.isSplit`
+  (a hidden split isn't recreated at restore, so capturing it would leave a stale command to fire on
+  the next manual ⌘D — `clearSavedCommands` shares the same `allOpenSessions` walk).
+  A login shell's argv0 is dash-decorated (`/usr/bin/login … exec -l /bin/zsh` → argv0 `-/bin/zsh`,
+  whose basename splits on `/` to `zsh`; `isKnownShell` ALSO strips a leading `-` so a bare `-zsh` form
+  is recognized too), so an idle pane captures nil and stays a plain shell — verified via `tree --json`.
+  A force-quit/crash skips `applicationWillTerminate`, so it loses commands (sessions + cwd still restore
+  from the debounced snapshot) — best-effort by design.
+  RESTORE: the surface factories (`makeSurface`/`makeSplitSurface`) read the persisted command,
+  gate on `GhosttyApp.shared.restoreRunningCommand` (mirrored by `SettingsModel.applyRestoreRunningCommand`,
+  like `notificationBadgeEnabled`) + the host-free `CommandRestore.shouldRestore(argv:denylist:)` check
+  against the user-editable `restore-denylist.conf` (NO built-in list — `SettingsModel.loadRestoreDenylist`
+  parses `<configDir>/restore-denylist.conf` at launch via `CommandRestore.parseDenylist` and mirrors
+  it into `GhosttyApp.shared.restoreDenylist`, seeded with the terminal multiplexers `tmux`/`screen`/`zellij`
+  by `ensureStarterRestoreDenylist`; everything not listed — `python manage.py runserver`,
+  `node server.js`, a REPL — restores), and feed it to the login shell via `config.initial_input` = `CommandRestore.shellQuotedLine(argv) + "\n"`
+  (NOT `config.command`, which would replace the shell + close on exit; `initial_input` re-runs inside
+  the shell so exit returns to a prompt).
+  The captured field is consumed run-once in the factory (read-then-nil,
+  like `scratchCommand`) so a later structural save can't re-fire it.
+  All decision logic (parse/shell-detect/denylist/quote) is host-free in `CommandRestore` (unit-tested);
+  the app target owns only the C-boundary + Darwin syscall.
+  ONLY a single-process command restores faithfully — a typed pipeline/compound line captures one process.
+  The SETTINGS TOGGLE is GUI-only (no `settings.*` control surface; only `theme.set`/`config.reload`
+  touch settings), but the feature DOES have a control surface: `restore.clear` clears the saved commands
+  and live `foreground`/`splitForeground` ride `tree`/`ControlSessionNode` (see the Control API catalog's
+  `restore.clear` four-point audit) — the agent-skill was updated accordingly.
+- **`inheritGlobalGhosttyConfig` (load the user's global `~/.config/ghostty/config`,
+  opt-in, General tab).** `AppSettings.inheritGlobalGhosttyConfig: Bool?` (nil = OFF) gates whether `loadConfig`
+  reads the user's GLOBAL ghostty config (see the `<configDir>/ghostty.conf` bullet for the layering).
+  OFF by default so agterm is self-contained: a config written for the standalone Ghostty.app does NOT
+  silently change agterm, which also keeps bug reports legible (the colors a user sees are agterm's own
+  unless they opt in).
+  The agterm-scoped `<configDir>/ghostty.conf` is ALWAYS loaded regardless and is the documented customization
+  point.
+  Resolved at config-LOAD time (via `resolveConfigInputs`), NOT a live `GhosttyApp` mirror and NOT a
+  `ghosttyConfigLines()` key — so `setInheritGlobalGhosttyConfig` saves `settings.json` then calls `reloadGhosttyConfig()`
+  UNCONDITIONALLY (like `setConfigDirectory`), because it changes WHICH files load and `persistAndApply`'s
+  text-diff guard would otherwise skip the reload.
+  The SETTINGS TOGGLE is GUI-only and keep-in-sync EXEMPT (like `restoreRunningCommand`'s toggle — only
+  `theme.set`/`config.reload` touch settings over the socket).
+  Default-off + round-trip covered host-free in `AppSettingsTests`; the file-gating itself is app-target
+  (manually/build verified, no app unit-test host).
+- **`attentionButtonEnabled` (titlebar attention bell, opt-in, General tab).**
+  `AppSettings.attentionButtonEnabled: Bool?` (nil = OFF, the default-off precedent like `restoreRunningCommand`/`inheritGlobalGhosttyConfig`,
+  NOT `notificationBadgeEnabled`'s default-ON) gates the title-bar bell icon that reflects the window's
+  `AppStore.attentionSessions` at a glance (empty → dimmed/disabled, non-empty → enabled,
+  any blocked → filled-amber).
+  NOT a ghostty key (`writeGhosttyConfig` no-ops, no surface reload).
+  It is the non-observable chrome-mirror pattern: `SettingsModel.setAttentionButtonEnabled` saves + `applyAttentionButtonEnabled`
+  pushes `settings.attentionButtonEnabled ?? false` into the `GhosttyApp.attentionButtonEnabled` flag
+  (alongside `applyCompactToolbar`/`applyNotificationBadgeEnabled`), so a flip rides `.agtermAppearanceChanged`
+  and `WindowContentView` re-reads the mirror to re-render the titlebar live — exactly like `compactToolbar`/`notificationBadgeEnabled`.
+  The General ▸ Notifications `Toggle("Show attention indicator")` uses the default-OFF binding (get
+  `?? false`, set `$0 ? true : nil`, mirroring `restoreRunningCommand`/`inheritGlobalGhosttyConfig`,
+  NOT `notificationBadgeEnabled`).
+  GUI-only and keep-in-sync EXEMPT (the bell just opens the already-controllable attention palette /
+  `session.select`; only `theme.set`/`config.reload` touch settings over the socket).
+  See the Notifications section for the bell's three states and the Menu/actions section for the `.attention`
+  palette it opens.
 

--- a/.claude/rules/sidebar.md
+++ b/.claude/rules/sidebar.md
@@ -12,16 +12,178 @@ paths:
 
 ## Sidebar
 
-- The sidebar is an AppKit `NSOutlineView` (`WorkspaceSidebar`, an `NSViewRepresentable`), not a SwiftUI `List` — chosen for native cross-workspace drag-and-drop. Its `@MainActor` `Coordinator` is the data source/delegate, backed by `AppStore`. Outline items are cached reference-type `SidebarNode`s, reused across reloads for stable identity (expansion/selection survive `reloadData`).
-- **Drag reorder (sessions AND workspaces).** The Coordinator's `validateDrop`/`acceptDrop` now HONOR `proposedChildIndex` (via the shared `resolveSessionMove`/`resolveWorkspaceMove` helpers that compute target + insert index + no-op detection in ONE place so validate and accept agree exactly) instead of force-retargeting every drop to `NSOutlineViewDropOnItemIndex` — enabling intra-workspace SESSION reorder (drop between rows for a precise slot) AND precise cross-workspace placement (a cross-workspace drag now lands at the drop position, no longer always-append). Workspace ROWS are draggable too: a second pasteboard type `com.umputun.agterm.workspace` is added to `registerForDraggedTypes` (LOAD-BEARING — without it AppKit never delivers validate/accept for workspace drags) and `pasteboardWriterForItem` emits it (carrying the workspace UUID) for workspace nodes. **Workspace reorder is a TOP-LEVEL move, but it does NOT use AppKit's proposed `item`/`childIndex`.** With workspaces expanded their sessions fill the gaps between workspace rows, so `NSOutlineView` only ever proposes drops INTO a workspace's children (`proposedItem != nil`) — never the clean root between-rows slot — so the old `proposedItem == nil`-only gate rejected EVERY drop and made workspace drag impossible once any workspace held sessions (the real-world state). `resolveWorkspaceMove` therefore IGNORES the proposed item/index and derives the insert slot from the CURSOR Y against the workspace ROWS' midpoints (`info.draggingLocation` → `rect(ofRow:).midY`, sessions ignored): the slot is the count of workspace rows whose midpoint sits above the cursor, so the top half of a row drops before it and the bottom half after it — reachable everywhere. It still feeds that slot to the host-free `SidebarDrop.resolveWorkspace` for the post-removal/no-op math, and `validateDrop` highlights it via `setDropItem(nil, dropChildIndex:)`. Covered by `ReorderUITests.testReorderWorkspaceOntoSessionRow` (drag a workspace onto a session row — the case the `proposedItem == nil` gate broke). The session helper still HONORS `proposedChildIndex` (sessions are real same-level siblings, so the outline proposes precise between-rows slots). Both feed `SidebarDrop`, which applies the same-parent downward `childIndex - 1` post-removal adjustment (only when `sourceIndex < childIndex`), since `moveSession`/`moveWorkspace` remove-then-insert so `at:` is a POST-removal index while the fed insert slot is PRE-removal. The PURE index arithmetic (drop-on-row `sessionIndex + 1` redirect, the downward `-1`, cross-workspace vs same-parent index spaces, and a CLAMPED same-workspace no-op check that also catches re-appending an already-last element) lives host-free in `agtermCore.SidebarDrop` (`resolveSession`/`resolveWorkspace`), table-tested in `SidebarDropTests`; the two Coordinator helpers only do the AppKit/store glue (read the pasteboard, resolve ids → indices via `AppStore.sessionLocation(ofSession:)`) and feed `SidebarDrop`, so the trickiest part is unit-covered without the fragile XCUITest drag.
-- Add affordances live in a bottom bar in `ContentView`: a workspace button and a session menu (New Session / Open Directory…). The two session actions are also on each workspace row's right-click menu.
-- Accessibility identifiers `session-row`, `workspace-row`, `edit-field`, and `add-session` back the XCUITests. Note the rename field surfaces as a `TextField` for sessions and a `StaticText` for workspaces, so UI tests match `edit-field` by identifier across element types.
-- **Flagged working-set view (`AppStore.sidebarMode` `.tree`/`.flagged`).** `SidebarMode` (`agtermCore/SidebarMode.swift`, `String`-backed `Codable`/`Sendable`) drives a per-window MODE toggle between the normal two-level tree and a FLAT list of just the flagged sessions. A session is flagged via the observed `Session.flagged: Bool`; the flat list is the PURE derived projection `AppStore.flaggedSessions` (`workspaces.flatMap(\.sessions).filter(\.flagged)`, already in tree order — workspace-then-session). No second container: a session always has exactly one home workspace, the flag dies with the session and survives a workspace move (the projection re-sorts). The ONE `NSOutlineView` renders either source — `numberOfChildrenOfItem`/`child`/`isItemExpandable` branch on `store.sidebarMode`; in `.flagged` the root's children are `flaggedSessions` as flat, non-expandable rows labeled `session : workspace` (the session `displayName`, then the owning workspace name) with the base leading icon — a plain terminal for a single session, the split-rectangle for a split one so a split stays distinguishable (the FILLED flag variant is suppressed; every row here is flagged) — plus the usual `StatusIconView` + `BadgeView`. A row click routes through the existing `selectSession`; the mode switch is VIEW-ONLY (never re-selects/refocuses). Drag-reorder is DISABLED in `.flagged` mode. An empty flagged set shows a centered, non-scrolling empty-state hint ("No flagged sessions. / Right-click a session → Flag.") overlaid in the scroll view, re-tinted on `.agtermAppearanceChanged` and toggled by `updateEmptyStateHint` (visible only in `.flagged` with `flaggedSessions.isEmpty`). Mutators: `AppStore.setFlag(_:forSession:)` (clean no-op + no save on unknown id or unchanged value), `clearFlags()` (single save), `setSidebarMode(_:)` (save). GUI half: the bottom-bar `flagged-view-toggle` button (right of the trailing `Spacer()`, 2-state flag/checkmark glyph, tinted `chromeText`, flips `sidebarMode` and animates via `ContentView`'s `.animation(value:)`), the row context-menu Flag/Unflag → `AppActions.toggleFlag(_:)`, the View-menu Show Flagged/Show All + Flag Session + Clear Flagged, the ⌃⇧P palette entries, and the two `BuiltinAction`s `toggleFlaggedView`/`toggleFlag` (expressible/keyless). **Clear Flagged** is a plain menu/palette item (NOT a `BuiltinAction`, mirroring Reload/Edit Keymap) → `AppActions.clearFlags()` with a light confirm alert when the set is non-empty (skipped under the XCUITest launch, like the quit-confirm).
-- **Tree-mode flagged indicator (filled-icon variant).** In `.tree` mode a flagged session's row swaps its leading icon to the FILLED SF Symbol variant of its base glyph — `terminal.fill` for a single session, `rectangle.split.2x1.fill` for a split (the SAME filled split symbol the titlebar split button uses; outline = unflagged, filled = flagged, mirroring the titlebar split indicator) — via the cached `flaggedSessionIcon`/`flaggedSplitSessionIcon` template images, tinted with the chrome/theme color. It is a pure SF Symbol swap (`Self.rowIcon(...)`), NOT a composited corner badge — same-size, so it is inherently layout-shift-free. `flagged` is folded into the row's `RowContent` (Equatable), so a flag/unflag re-renders ONLY that row (per-row `reloadItem`). The filled variant is tree-mode only — the flat flagged view shows the unfilled base icon, so a split session still gets the split-rectangle to stay distinguishable; only the FILLED flag variant is suppressed there (every row is flagged).
-- **Focus filter (`AppStore.focusedWorkspaceID`).** A per-workspace toggle collapses the `.tree` to a single root: `visibleWorkspaces` is the focused workspace when `focusedWorkspaceID` is set AND still present, else ALL workspaces — the source of truth the tree filters on (the data source maps `store.visibleWorkspaces` in `.tree`). Focus is ORTHOGONAL to flagged: the flat flagged view ignores focus (it always shows the full cross-workspace set). `setFocusedWorkspace(_:)` (delta-guarded so callers stay idempotent, nil unfocuses, saves) is driven by the workspace-row context-menu Focus/Unfocus → `AppActions.focusWorkspace(_:)`, the bottom-bar `focus-pill` ("<name> ✕" — the focused workspace name with no "Focused:" prefix, shown only while focused, ✕ unfocuses), `AppActions.focusActiveWorkspace()` (targets `currentWorkspaceID`, analogous to `deleteActiveWorkspace`) wired to `BuiltinAction.focusWorkspace` + a View-menu/palette "Focus Workspace", and `AppActions.clearFocus()` (a plain menu/palette "Clear Focus", NOT a `BuiltinAction`). `removeWorkspace` clears focus when the removed workspace was the focused one.
-- **Scoped session navigation (the VISIBLE/FILTERED set).** Session navigation operates over `AppStore.navigableSessions`, NOT the whole tree: `sidebarMode == .flagged ? flaggedSessions : visibleWorkspaces.flatMap(\.sessions)` — i.e. the flagged set in `.flagged` mode, the focused workspace's sessions when a workspace is focused (tree mode), else ALL sessions. Computed LIVE (`visibleWorkspaces` already collapses to the focused workspace or the full tree, including the stale-focus-id fallback), so clearing the flag/focus naturally restores the full set. `navigateSession(_:)` flattens `navigableSessions` for EVERY direction — next/prev/first/last AND attention-nav (next-attention/prev-attention scope to the filtered set too) — keeping the same "no/invalid selection → first of the filtered list", "stop at ends, no wrap (attention wraps)" semantics over the filtered list. This is shared by `session.go` (control, no ControlServer change — it already routes through `navigateSession`), the ⌥⌘↑/↓ + ⌃⌥↑/↓ menu/palette nav, the Ctrl-Tab MRU switcher (`SessionSwitcher.begin()` scopes its candidate set to `store.navigableSessions.map(\.id)`; the MRU ORDER still comes from `sessionRecency`), AND the ⌃P fuzzy session palette (`AppActions.paletteSessions()` lists `store.navigableSessions`, so the searchable set matches the visible sidebar — in a focused workspace ⌃P shows only that workspace's sessions, in flagged mode only the flagged ones). This SUPERSEDES the earlier "global nav reveals its target" behavior.
-- **Focus×selection auto-unfocus contract (load-bearing, now the cross-set safety net).** Because nav is scoped, its targets are ALWAYS in-set, so nav never crosses the focus boundary. `selectSession` still AUTO-CLEARS focus when the newly selected session is NOT in the focused workspace (`workspace(forSession:)?.id != focusedWorkspaceID` → `focusedWorkspaceID = nil`) — but this now only fires for an EXPLICIT cross-set select: `session.select <id>` of a hidden session, a notification reveal, or a move/close that reselects elsewhere. This keeps the active session inside the visible set for those cases, which also keeps `currentWorkspaceID` (new-session placement) consistent with NO special-case. No-op when unfocused or nothing selected. The contract is ONE-DIRECTIONAL by design: an explicit cross-set select auto-unfocuses (reveal), but focusing a workspace that does NOT contain the active session deliberately does NOT reselect or switch the active terminal — focus is a pure view filter, never a terminal switch, so the active session's terminal keeps rendering while the sidebar shows no selection until the next select (the focus pill signals the state, and it self-heals on the next `selectSession`/`addSession`). This stranded-selection state is intentional, not a bug.
-- **Mode/focus-aware reconcile signal.** The reconcile `TreeShape` is computed from the MODE-selected/filtered roots: in `.tree` it is `visibleWorkspaces` → `(workspaceID, sessionIDs)` (so a focus flip re-shapes), in `.flagged` it is a SINGLE flat group keyed on a stable pseudo-id (`flaggedShapeID`, so within flagged mode only a change to the flagged list — not a fresh per-call id — rebuilds). A `lastMode` flip swaps the whole data source and forces a `rebuildAndReload` regardless of the shape diff; `sidebarMode`, `focusedWorkspaceID`, and each session's `flagged` are folded into the `updateNSView` dependency read so a mode/focus/flag change is seen. **Task 9 expansion-restore fix:** `NSOutlineView` discards the expansion state of items DROPPED from the data source during a flagged-mode reload, so expanded workspace ids are tracked independently in `expandedWorkspaceIDs` via the `outlineViewItemDidExpand`/`outlineViewItemDidCollapse` delegate callbacks (and `expandAll`) and re-applied in `rebuildAndReload` (`expandItem` for each tracked id), surviving the round-trip through flagged mode.
-- **Expand / collapse all workspaces (per-window).** Two sidebar tree operations: **Expand Workspaces** (`AppActions.expandAllWorkspaces(in:)` → the Coordinator's existing `expandAll`, every workspace open) and **Collapse Workspaces** (`collapseOtherWorkspaces(in:)` → the Coordinator's `collapseOthers`, every workspace collapsed EXCEPT the active session's `currentWorkspaceID`, kept expanded + `scrollRowToVisible`'d). Both keep `expandedWorkspaceIDs` in sync (so the state survives a flagged-mode round-trip). Per-window scoping rides a notification (`.agtermExpandWorkspaces`/`.agtermCollapseWorkspaces`) posted with the TARGET window's `AppStore` as the object; each Coordinator registers its observer with `object: store`, so only the matching window's sidebar acts (unlike the rename notifications, which self-scope via the selected-session guard). This object-scoping is what lets the control path target ANY open window. Graceful no-op in `flagged` mode (no workspace rows). GUI surfaces (frontmost window): View ▸ Expand/Collapse Workspaces (plain keyless items, disabled with no store or in flagged mode) + the ⌃⇧P palette (tree-mode only). Control: `sidebar.expand`/`sidebar.collapse` resolve the target store via `resolvePlacementStore(window)` (frontmost by default, the global `--window` selector for any open window) and call the `(in:)` variants — so unlike the frontmost-only `sidebar`/`sidebar.mode`, these can drive a background window's tree (see the Control API catalog).
-- **Persistence (per-window, no version bump).** `Session.flagged` persists via `SessionSnapshot.flagged: Bool?` (decode → `false`), `sidebarMode` via `Snapshot.sidebarMode: SidebarMode?` (→ `.tree`), `focusedWorkspaceID` via `Snapshot.focusedWorkspaceID: UUID?` (naturally Optional → nil). All three Optional fields, so legacy JSON with none of the keys decodes to the unflagged / `.tree` / unfocused defaults without throwing (the load-fresh-on-decode-failure contract) — no `Snapshot` version bump. Round-trips + legacy-decode covered in `PersistenceTests`, mutations/derived-list/focus-clear/auto-unfocus in `AppStoreTests`.
+- The sidebar is an AppKit `NSOutlineView` (`WorkspaceSidebar`, an `NSViewRepresentable`),
+  not a SwiftUI `List` — chosen for native cross-workspace drag-and-drop.
+  Its `@MainActor` `Coordinator` is the data source/delegate, backed by `AppStore`.
+  Outline items are cached reference-type `SidebarNode`s, reused across reloads for stable identity (expansion/selection
+  survive `reloadData`).
+- **Drag reorder (sessions AND workspaces).**
+  The Coordinator's `validateDrop`/`acceptDrop` now HONOR `proposedChildIndex` (via the shared `resolveSessionMove`/`resolveWorkspaceMove`
+  helpers that compute target + insert index + no-op detection in ONE place so validate and accept agree
+  exactly) instead of force-retargeting every drop to `NSOutlineViewDropOnItemIndex` — enabling intra-workspace
+  SESSION reorder (drop between rows for a precise slot) AND precise cross-workspace placement (a cross-workspace
+  drag now lands at the drop position, no longer always-append).
+  Workspace ROWS are draggable too: a second pasteboard type `com.umputun.agterm.workspace` is added
+  to `registerForDraggedTypes` (LOAD-BEARING — without it AppKit never delivers validate/accept for workspace
+  drags) and `pasteboardWriterForItem` emits it (carrying the workspace UUID) for workspace nodes.
+  **Workspace reorder is a TOP-LEVEL move, but it does NOT use AppKit's proposed `item`/`childIndex`.**
+  With workspaces expanded their sessions fill the gaps between workspace rows,
+  so `NSOutlineView` only ever proposes drops INTO a workspace's children (`proposedItem != nil`) — never
+  the clean root between-rows slot — so the old `proposedItem == nil`-only gate rejected EVERY drop and
+  made workspace drag impossible once any workspace held sessions (the real-world state).
+  `resolveWorkspaceMove` therefore IGNORES the proposed item/index and derives the insert slot from the
+  CURSOR Y against the workspace ROWS' midpoints (`info.draggingLocation` → `rect(ofRow:).midY`,
+  sessions ignored): the slot is the count of workspace rows whose midpoint sits above the cursor,
+  so the top half of a row drops before it and the bottom half after it — reachable everywhere.
+  It still feeds that slot to the host-free `SidebarDrop.resolveWorkspace` for the post-removal/no-op
+  math, and `validateDrop` highlights it via `setDropItem(nil, dropChildIndex:)`.
+  Covered by `ReorderUITests.testReorderWorkspaceOntoSessionRow` (drag a workspace onto a session row
+  — the case the `proposedItem == nil` gate broke).
+  The session helper still HONORS `proposedChildIndex` (sessions are real same-level siblings,
+  so the outline proposes precise between-rows slots).
+  Both feed `SidebarDrop`, which applies the same-parent downward `childIndex - 1` post-removal adjustment
+  (only when `sourceIndex < childIndex`), since `moveSession`/`moveWorkspace` remove-then-insert so `at:`
+  is a POST-removal index while the fed insert slot is PRE-removal.
+  The PURE index arithmetic (drop-on-row `sessionIndex + 1` redirect, the downward `-1`,
+  cross-workspace vs same-parent index spaces, and a CLAMPED same-workspace no-op check that also catches
+  re-appending an already-last element) lives host-free in `agtermCore.SidebarDrop` (`resolveSession`/`resolveWorkspace`),
+  table-tested in `SidebarDropTests`; the two Coordinator helpers only do the AppKit/store glue (read
+  the pasteboard, resolve ids → indices via `AppStore.sessionLocation(ofSession:)`) and feed `SidebarDrop`,
+  so the trickiest part is unit-covered without the fragile XCUITest drag.
+- Add affordances live in a bottom bar in `ContentView`: a workspace button and a session menu (New Session
+  / Open Directory…).
+  The two session actions are also on each workspace row's right-click menu.
+- Accessibility identifiers `session-row`, `workspace-row`, `edit-field`,
+  and `add-session` back the XCUITests.
+  Note the rename field surfaces as a `TextField` for sessions and a `StaticText` for workspaces,
+  so UI tests match `edit-field` by identifier across element types.
+- **Flagged working-set view (`AppStore.sidebarMode` `.tree`/`.flagged`).**
+  `SidebarMode` (`agtermCore/SidebarMode.swift`, `String`-backed `Codable`/`Sendable`) drives a per-window
+  MODE toggle between the normal two-level tree and a FLAT list of just the flagged sessions.
+  A session is flagged via the observed `Session.flagged: Bool`; the flat list is the PURE derived projection
+  `AppStore.flaggedSessions` (`workspaces.flatMap(\.sessions).filter(\.flagged)`,
+  already in tree order — workspace-then-session).
+  No second container: a session always has exactly one home workspace, the flag dies with the session
+  and survives a workspace move (the projection re-sorts).
+  The ONE `NSOutlineView` renders either source — `numberOfChildrenOfItem`/`child`/`isItemExpandable`
+  branch on `store.sidebarMode`; in `.flagged` the root's children are `flaggedSessions` as flat,
+  non-expandable rows labeled `session : workspace` (the session `displayName`,
+  then the owning workspace name) with the base leading icon — a plain terminal for a single session,
+  the split-rectangle for a split one so a split stays distinguishable (the FILLED flag variant is suppressed;
+  every row here is flagged) — plus the usual `StatusIconView` + `BadgeView`.
+  A row click routes through the existing `selectSession`; the mode switch is VIEW-ONLY (never re-selects/refocuses).
+  Drag-reorder is DISABLED in `.flagged` mode.
+  An empty flagged set shows a centered, non-scrolling empty-state hint ("No flagged sessions. / Right-click
+  a session → Flag.") overlaid in the scroll view, re-tinted on `.agtermAppearanceChanged` and toggled
+  by `updateEmptyStateHint` (visible only in `.flagged` with `flaggedSessions.isEmpty`).
+  Mutators: `AppStore.setFlag(_:forSession:)` (clean no-op + no save on unknown id or unchanged value),
+  `clearFlags()` (single save), `setSidebarMode(_:)` (save).
+  GUI half: the bottom-bar `flagged-view-toggle` button (right of the trailing `Spacer()`,
+  2-state flag/checkmark glyph, tinted `chromeText`, flips `sidebarMode` and animates via `ContentView`'s
+  `.animation(value:)`), the row context-menu Flag/Unflag → `AppActions.toggleFlag(_:)`,
+  the View-menu Show Flagged/Show All + Flag Session + Clear Flagged, the ⌃⇧P palette entries,
+  and the two `BuiltinAction`s `toggleFlaggedView`/`toggleFlag` (expressible/keyless).
+  **Clear Flagged** is a plain menu/palette item (NOT a `BuiltinAction`,
+  mirroring Reload/Edit Keymap) → `AppActions.clearFlags()` with a light confirm alert when the set is
+  non-empty (skipped under the XCUITest launch, like the quit-confirm).
+- **Tree-mode flagged indicator (filled-icon variant).**
+  In `.tree` mode a flagged session's row swaps its leading icon to the FILLED SF Symbol variant of its
+  base glyph — `terminal.fill` for a single session, `rectangle.split.2x1.fill` for a split (the SAME
+  filled split symbol the titlebar split button uses; outline = unflagged,
+  filled = flagged, mirroring the titlebar split indicator) — via the cached `flaggedSessionIcon`/`flaggedSplitSessionIcon`
+  template images, tinted with the chrome/theme color.
+  It is a pure SF Symbol swap (`Self.rowIcon(...)`), NOT a composited corner badge — same-size,
+  so it is inherently layout-shift-free.
+  `flagged` is folded into the row's `RowContent` (Equatable), so a flag/unflag re-renders ONLY that
+  row (per-row `reloadItem`).
+  The filled variant is tree-mode only — the flat flagged view shows the unfilled base icon,
+  so a split session still gets the split-rectangle to stay distinguishable;
+  only the FILLED flag variant is suppressed there (every row is flagged).
+- **Focus filter (`AppStore.focusedWorkspaceID`).**
+  A per-workspace toggle collapses the `.tree` to a single root: `visibleWorkspaces` is the focused workspace
+  when `focusedWorkspaceID` is set AND still present, else ALL workspaces — the source of truth the tree
+  filters on (the data source maps `store.visibleWorkspaces` in `.tree`).
+  Focus is ORTHOGONAL to flagged: the flat flagged view ignores focus (it always shows the full cross-workspace
+  set).
+  `setFocusedWorkspace(_:)` (delta-guarded so callers stay idempotent, nil unfocuses,
+  saves) is driven by the workspace-row context-menu Focus/Unfocus → `AppActions.focusWorkspace(_:)`,
+  the bottom-bar `focus-pill` ("<name> ✕" — the focused workspace name with no "Focused:" prefix,
+  shown only while focused, ✕ unfocuses), `AppActions.focusActiveWorkspace()` (targets `currentWorkspaceID`,
+  analogous to `deleteActiveWorkspace`) wired to `BuiltinAction.focusWorkspace` + a View-menu/palette
+  "Focus Workspace", and `AppActions.clearFocus()` (a plain menu/palette "Clear Focus",
+  NOT a `BuiltinAction`).
+  `removeWorkspace` clears focus when the removed workspace was the focused one.
+- **Scoped session navigation (the VISIBLE/FILTERED set).**
+  Session navigation operates over `AppStore.navigableSessions`, NOT the whole tree:
+  `sidebarMode == .flagged ? flaggedSessions : visibleWorkspaces.flatMap(\.sessions)` — i.e. the flagged
+  set in `.flagged` mode, the focused workspace's sessions when a workspace is focused (tree mode),
+  else ALL sessions.
+  Computed LIVE (`visibleWorkspaces` already collapses to the focused workspace or the full tree,
+  including the stale-focus-id fallback), so clearing the flag/focus naturally restores the full set.
+  `navigateSession(_:)` flattens `navigableSessions` for EVERY direction — next/prev/first/last AND attention-nav
+  (next-attention/prev-attention scope to the filtered set too) — keeping the same "no/invalid selection
+  → first of the filtered list", "stop at ends, no wrap (attention wraps)" semantics over the filtered
+  list.
+  This is shared by `session.go` (control, no ControlServer change — it already routes through `navigateSession`),
+  the ⌥⌘↑/↓ + ⌃⌥↑/↓ menu/palette nav, the Ctrl-Tab MRU switcher (`SessionSwitcher.begin()` scopes its
+  candidate set to `store.navigableSessions.map(\.id)`; the MRU ORDER still comes from `sessionRecency`),
+  AND the ⌃P fuzzy session palette (`AppActions.paletteSessions()` lists `store.navigableSessions`,
+  so the searchable set matches the visible sidebar — in a focused workspace ⌃P shows only that workspace's
+  sessions, in flagged mode only the flagged ones).
+  This SUPERSEDES the earlier "global nav reveals its target" behavior.
+- **Focus×selection auto-unfocus contract (load-bearing, now the cross-set safety net).** Because nav
+  is scoped, its targets are ALWAYS in-set, so nav never crosses the focus boundary.
+  `selectSession` still AUTO-CLEARS focus when the newly selected session is NOT in the focused workspace
+  (`workspace(forSession:)?.id != focusedWorkspaceID` → `focusedWorkspaceID = nil`) — but this now only
+  fires for an EXPLICIT cross-set select: `session.select <id>` of a hidden session,
+  a notification reveal, or a move/close that reselects elsewhere.
+  This keeps the active session inside the visible set for those cases, which also keeps `currentWorkspaceID`
+  (new-session placement) consistent with NO special-case.
+  No-op when unfocused or nothing selected.
+  The contract is ONE-DIRECTIONAL by design: an explicit cross-set select auto-unfocuses (reveal),
+  but focusing a workspace that does NOT contain the active session deliberately does NOT reselect or
+  switch the active terminal — focus is a pure view filter, never a terminal switch,
+  so the active session's terminal keeps rendering while the sidebar shows no selection until the next
+  select (the focus pill signals the state, and it self-heals on the next `selectSession`/`addSession`).
+  This stranded-selection state is intentional, not a bug.
+- **Mode/focus-aware reconcile signal.**
+  The reconcile `TreeShape` is computed from the MODE-selected/filtered roots:
+  in `.tree` it is `visibleWorkspaces` → `(workspaceID, sessionIDs)` (so a focus flip re-shapes),
+  in `.flagged` it is a SINGLE flat group keyed on a stable pseudo-id (`flaggedShapeID`,
+  so within flagged mode only a change to the flagged list — not a fresh per-call id — rebuilds).
+  A `lastMode` flip swaps the whole data source and forces a `rebuildAndReload` regardless of the shape
+  diff; `sidebarMode`, `focusedWorkspaceID`, and each session's `flagged` are folded into the `updateNSView`
+  dependency read so a mode/focus/flag change is seen.
+  **Task 9 expansion-restore fix:** `NSOutlineView` discards the expansion state of items DROPPED from
+  the data source during a flagged-mode reload, so expanded workspace ids are tracked independently in
+  `expandedWorkspaceIDs` via the `outlineViewItemDidExpand`/`outlineViewItemDidCollapse` delegate callbacks
+  (and `expandAll`) and re-applied in `rebuildAndReload` (`expandItem` for each tracked id),
+  surviving the round-trip through flagged mode.
+- **Expand / collapse all workspaces (per-window).**
+  Two sidebar tree operations: **Expand Workspaces** (`AppActions.expandAllWorkspaces(in:)` → the Coordinator's
+  existing `expandAll`, every workspace open) and **Collapse Workspaces** (`collapseOtherWorkspaces(in:)`
+  → the Coordinator's `collapseOthers`, every workspace collapsed EXCEPT the active session's `currentWorkspaceID`,
+  kept expanded + `scrollRowToVisible`'d).
+  Both keep `expandedWorkspaceIDs` in sync (so the state survives a flagged-mode round-trip).
+  Per-window scoping rides a notification (`.agtermExpandWorkspaces`/`.agtermCollapseWorkspaces`) posted
+  with the TARGET window's `AppStore` as the object; each Coordinator registers its observer with `object: store`,
+  so only the matching window's sidebar acts (unlike the rename notifications,
+  which self-scope via the selected-session guard).
+  This object-scoping is what lets the control path target ANY open window.
+  Graceful no-op in `flagged` mode (no workspace rows).
+  GUI surfaces (frontmost window): View ▸ Expand/Collapse Workspaces (plain keyless items,
+  disabled with no store or in flagged mode) + the ⌃⇧P palette (tree-mode only).
+  Control: `sidebar.expand`/`sidebar.collapse` resolve the target store via `resolvePlacementStore(window)`
+  (frontmost by default, the global `--window` selector for any open window) and call the `(in:)` variants
+  — so unlike the frontmost-only `sidebar`/`sidebar.mode`, these can drive a background window's tree
+  (see the Control API catalog).
+- **Persistence (per-window, no version bump).**
+  `Session.flagged` persists via `SessionSnapshot.flagged: Bool?` (decode → `false`),
+  `sidebarMode` via `Snapshot.sidebarMode: SidebarMode?` (→ `.tree`), `focusedWorkspaceID` via `Snapshot.focusedWorkspaceID: UUID?`
+  (naturally Optional → nil).
+  All three Optional fields, so legacy JSON with none of the keys decodes to the unflagged / `.tree`
+  / unfocused defaults without throwing (the load-fresh-on-decode-failure contract) — no `Snapshot` version
+  bump.
+  Round-trips + legacy-decode covered in `PersistenceTests`, mutations/derived-list/focus-clear/auto-unfocus
+  in `AppStoreTests`.
 

--- a/.claude/rules/theme-picker.md
+++ b/.claude/rules/theme-picker.md
@@ -8,9 +8,67 @@ paths:
 
 ## Theme picker
 
-- **A live-preview theme picker as a third command-palette mode.** The `.themes` `PaletteMode` (alongside `.actions`/`.sessions`, `Palette.swift`) reuses the SAME `CommandPalette` fuzzy-search/list/nav view; only theme mode carries the live preview. Its rows = `AppActions.paletteThemes()` (a leading "default ghostty" = nil/no-theme + one per `SettingsCatalog.themeNames()`, the current one badged `current`). The theme NAMES never pollute the action palette — only a single **"Select Theme…"** launcher item appears in `paletteActions()` (and the View ▸ Select Theme… menu item + the keyless `BuiltinAction.selectTheme`). The launcher opens the picker via `AppActions.openThemePalette()` → `palette.open(.themes)` dispatched ASYNC (the launcher runs inside the action palette's `runItem`, which closes that palette right after; the async open lets `.themes` re-open a tick later as a FRESH view — empty query, not the launcher's search text).
-- **Preview/commit/cancel, themes-only.** Two optional hooks the View invokes ONLY when `mode == .themes`: `PaletteItem.onSelect` (fired on selection change → `AppActions.previewTheme(name)`) and a mode-level cancel. `previewTheme` = `SettingsModel.previewTheme` sets `settings.theme = name` immediately but DEBOUNCES the live `apply()` (~0.07 s) so a burst of nav/typing previews coalesces to one surface reload — applied WITHOUT `settingsStore.save` (`persistAndApply` was split into `save(); apply()` so preview can apply-without-persist). Enter/click commits via `commitThemePreview()` → `SettingsModel.commitTheme()`, which FLUSHES the pending debounced apply (so the latest theme is live NOW) then `save()`s. Any dismiss without a commit — Esc, scrim tap, switch to another palette mode, unmount — reverts via `cancelThemePreview()` → `previewThemeImmediate(original)`, which CANCELS the pending debounce and re-applies the theme captured on open SYNCHRONOUSLY (no debounce lag, no stuck last-preview). `AppActions` owns the session state (`themePreviewActive` + `themePreviewOriginal`); `SettingsModel` stays stateless about it. The View wires it through `syncThemeSession()` (begin + select the current theme's row on enter, cancel on leave — called from `.onAppear`/`.onChange(of: mode)`) + `.onDisappear { cancelThemePreview() }` + the `onChange(of: selection)` preview call. The picker opens with the CURRENT theme's row selected (via `currentThemeID`), so it doesn't preview-jump to "default ghostty". **Typing also previews:** `onChange(of: query)` resets `selection = 0` then calls `previewSelected()` — because a filter re-orders the list so the item AT index 0 changes while `selection` STAYS 0, `onChange(of: selection)` doesn't fire, so the new top match would never preview on filtering alone (only on arrow-nav). `previewSelected()` fires `filtered[selection].onSelect?()` explicitly (a no-op for non-theme palettes, whose items carry no `onSelect`).
-- **Focus invariant (load-bearing).** `AppActions.focusActiveSession` early-returns when `palette?.mode != nil` — NEVER grab terminal first responder while a palette is open. Without it, the launcher path breaks: closing the action palette fires `ContentView`'s close-restore (`onChange(palette.mode == nil) { focusActiveSession() }`), whose ~12×0.03s `makeFirstResponder(terminal)` RETRY loop out-races the just-opened picker's field focus, so the picker can't be typed into (the terminal behind it eats the keys). The guard also kills the retry the instant `.themes` opens AND blocks any focus steal during a live preview reload.
-- **Default theme = the bundled `agterm` theme (NOT ghostty's built-in).** `AppSettings.defaultTheme = "agterm"` (host-free), and `SettingsStore.load()` seeds it on a fresh install (missing/corrupt `settings.json` → `AppSettings(theme: defaultTheme)`). It is NOT baked into the `AppSettings()` memberwise default — that stays `theme == nil` so `ghosttyConfigLines()`'s "nil = no theme line" invariant (and its tests) hold; the seed lives ONLY in the fresh-load path. So `theme == nil` means ghostty's built-in (the picker's "default ghostty" row); the agterm default is a real seeded value, and the picker opens on the "agterm" row for a fresh install. An EXISTING `settings.json` with `theme` absent decodes to nil (ghostty built-in) — an existing user is never silently re-themed. `theme.set` with no name still sets nil (ghostty built-in / "default ghostty"), distinct from the seeded app default.
-- **Control parity = the commit, not the preview** (preview is interactive-only): `theme.set`/`theme.list` (see the Control API catalog for the four-point audit). The font-zoom reset on a theme change (any `apply()` that changes the config text runs `resetSessionFontSizesAllWindows`) applies to the preview too — navigating the picker clears per-session ⌘+/⌘− zoom and Esc does not bring it back; accepted (matches the Settings-picker behavior, a colors-only reload isn't cheaply available from libghostty).
+- **A live-preview theme picker as a third command-palette mode.**
+  The `.themes` `PaletteMode` (alongside `.actions`/`.sessions`, `Palette.swift`) reuses the SAME `CommandPalette`
+  fuzzy-search/list/nav view; only theme mode carries the live preview.
+  Its rows = `AppActions.paletteThemes()` (a leading "default ghostty" = nil/no-theme + one per `SettingsCatalog.themeNames()`,
+  the current one badged `current`).
+  The theme NAMES never pollute the action palette — only a single **"Select Theme…"** launcher item
+  appears in `paletteActions()` (and the View ▸ Select Theme… menu item + the keyless `BuiltinAction.selectTheme`).
+  The launcher opens the picker via `AppActions.openThemePalette()` → `palette.open(.themes)` dispatched
+  ASYNC (the launcher runs inside the action palette's `runItem`, which closes that palette right after;
+  the async open lets `.themes` re-open a tick later as a FRESH view — empty query,
+  not the launcher's search text).
+- **Preview/commit/cancel, themes-only.**
+  Two optional hooks the View invokes ONLY when `mode == .themes`: `PaletteItem.onSelect` (fired on selection
+  change → `AppActions.previewTheme(name)`) and a mode-level cancel.
+  `previewTheme` = `SettingsModel.previewTheme` sets `settings.theme = name` immediately but DEBOUNCES
+  the live `apply()` (~0.07 s) so a burst of nav/typing previews coalesces to one surface reload — applied
+  WITHOUT `settingsStore.save` (`persistAndApply` was split into `save(); apply()` so preview can apply-without-persist).
+  Enter/click commits via `commitThemePreview()` → `SettingsModel.commitTheme()`,
+  which FLUSHES the pending debounced apply (so the latest theme is live NOW) then `save()`s.
+  Any dismiss without a commit — Esc, scrim tap, switch to another palette mode,
+  unmount — reverts via `cancelThemePreview()` → `previewThemeImmediate(original)`,
+  which CANCELS the pending debounce and re-applies the theme captured on open SYNCHRONOUSLY (no debounce
+  lag, no stuck last-preview).
+  `AppActions` owns the session state (`themePreviewActive` + `themePreviewOriginal`);
+  `SettingsModel` stays stateless about it.
+  The View wires it through `syncThemeSession()` (begin + select the current theme's row on enter,
+  cancel on leave — called from `.onAppear`/`.onChange(of: mode)`) + `.onDisappear { cancelThemePreview() }`
+  + the `onChange(of: selection)` preview call.
+  The picker opens with the CURRENT theme's row selected (via `currentThemeID`),
+  so it doesn't preview-jump to "default ghostty".
+  **Typing also previews:** `onChange(of: query)` resets `selection = 0` then calls `previewSelected()`
+  — because a filter re-orders the list so the item AT index 0 changes while `selection` STAYS 0,
+  `onChange(of: selection)` doesn't fire, so the new top match would never preview on filtering alone
+  (only on arrow-nav).
+  `previewSelected()` fires `filtered[selection].onSelect?()` explicitly (a no-op for non-theme palettes,
+  whose items carry no `onSelect`).
+- **Focus invariant (load-bearing).**
+  `AppActions.focusActiveSession` early-returns when `palette?.mode != nil` — NEVER grab terminal first
+  responder while a palette is open.
+  Without it, the launcher path breaks: closing the action palette fires `ContentView`'s close-restore
+  (`onChange(palette.mode == nil) { focusActiveSession() }`), whose ~12×0.03s `makeFirstResponder(terminal)`
+  RETRY loop out-races the just-opened picker's field focus, so the picker can't be typed into (the terminal
+  behind it eats the keys).
+  The guard also kills the retry the instant `.themes` opens AND blocks any focus steal during a live
+  preview reload.
+- **Default theme = the bundled `agterm` theme (NOT ghostty's built-in).**
+  `AppSettings.defaultTheme = "agterm"` (host-free), and `SettingsStore.load()` seeds it on a fresh install
+  (missing/corrupt `settings.json` → `AppSettings(theme: defaultTheme)`).
+  It is NOT baked into the `AppSettings()` memberwise default — that stays `theme == nil` so `ghosttyConfigLines()`'s
+  "nil = no theme line" invariant (and its tests) hold; the seed lives ONLY in the fresh-load path.
+  So `theme == nil` means ghostty's built-in (the picker's "default ghostty" row);
+  the agterm default is a real seeded value, and the picker opens on the "agterm" row for a fresh install.
+  An EXISTING `settings.json` with `theme` absent decodes to nil (ghostty built-in) — an existing user
+  is never silently re-themed.
+  `theme.set` with no name still sets nil (ghostty built-in / "default ghostty"),
+  distinct from the seeded app default.
+- **Control parity = the commit, not the preview**
+  (preview is interactive-only): `theme.set`/`theme.list` (see the Control API catalog for the four-point
+  audit).
+  The font-zoom reset on a theme change (any `apply()` that changes the config text runs `resetSessionFontSizesAllWindows`)
+  applies to the preview too — navigating the picker clears per-session ⌘+/⌘− zoom and Esc does not bring
+  it back; accepted (matches the Settings-picker behavior, a colors-only reload isn't cheaply available
+  from libghostty).
 

--- a/.claude/rules/ui-tests.md
+++ b/.claude/rules/ui-tests.md
@@ -5,16 +5,141 @@ paths:
 
 ## UI tests
 
-- `agtermUITests/` is an XCUITest target that launches the real app and drives the sidebar (rename, close, move, drag, add-session) through the accessibility API — the coverage the host-free `agtermCore` unit tests can't provide. Run with `xcodebuild test -project agterm.xcodeproj -scheme agterm -destination 'platform=macOS'`.
-- Tests pass `AGTERM_STATE_DIR` (a temp dir) via launch environment to isolate persistence; the app honors it in `agtermApp.restoredStore()`. The native `Open Directory…` panel is system UI, verified manually rather than in XCUITest.
-- **Launch the app with `app.launchForUITest()` — never bare `app.launch()`.** Apple bug **FB11763863**: on macOS 15+/Xcode 16+ (incl. 26) a SwiftUI `WindowGroup` app launched by another process (XCUITest, launchd) frequently **never auto-presents its window** — dock icon shows, no window, the scene's `.task`/`.onAppear` never fire, `NSApp.windows` stays empty, so elements exist in the AX tree (`waitForExistence` passes) but are un-hittable and every interaction silently no-ops. It is OS-version dependent, so the SAME app code "worked before" a macOS upgrade and breaks after. The fix lives in `AppDelegate.bringUITestWindowsForward` (UITest path): when no real window exists it fires a programmatic **reopen** — `NSWorkspace.shared.open(Bundle.main.bundleURL)`, the same event a dock click sends — and SwiftUI then creates the window. `XCUIApplication.activate()` / `NSApp.activate()` / `orderFrontRegardless()` / `.defaultLaunchBehavior(.presented)` do NOT help (the window is never created, not just un-focused). `launchForUITest()` (in `XCUIApplicationSidebarIsolation.swift`) feeds the `AGTERM_UITEST_FORCE_SIDEBAR_VISIBLE` sentinel via launch **environment** (NOT `launchArguments` — args trip a related variant), launches, and `activate()`s. The reopen re-triggers macOS state restoration, so the `Settings` window is marked **non-restorable** (`SettingsView`'s `NonRestorableWindow`) or a stale Settings window resurrects and steals key focus. To diagnose this class of bug, `NSLog` `NSApp.windows.count` on a timer and read it via `log show --predicate 'eventMessage CONTAINS "…"'`; `total=0` for seconds = "never created". See [[reference_swiftui-windowgroup-no-window-xcuitest]].
-- **Open a Settings tab via the retrying `settingsControl(tab:control:)` helper, not a one-shot `app.buttons[tab].click()`.** The reopen can leave a half-open/non-key Settings window that silently drops the first tab click; `settingsControl` re-clicks each tick until the expected control is hittable, which is what makes the Settings tests non-flaky.
-- **Add a UI test when you add UI functionality** — don't ship UI behavior with only `agtermCore` model-level unit tests. For behavior the accessibility tree can't observe (the Metal `GhosttySurfaceView`, transient non-persisted state), drive it through an observable side effect: e.g. the split test types `tty > <file>` into the focused pane and compares the written tty to verify which shell received the keystrokes and that focus follows.
-- **Driving an OSC terminal title in a test (and reading it back).** `Session.oscTitle`/`subtitleDetail` are ephemeral (never persisted) and the second line renders as a SwiftUI `Text`, so test through observable side effects, not the snapshot. Set a title by typing/injecting `printf '\033]2;TITLE\007'; cat` into the session — the trailing `; cat` is **LOAD-BEARING**: a one-shot printf sets the title but the local shell returns to its prompt where the title is cleared again (the prompt cycle), so it reverts to the cwd basename; `cat` holds the foreground so no prompt redraw fires, mirroring why a real `ssh` keeps its title but a quick local printf "looks broken" (see [[libghostty]]). Type **LITERAL** `\033`/`\007` (Swift `"printf '\\033]2;…\\007'"`) so the SESSION shell's printf expands them — do NOT pre-expand to raw ESC/BEL bytes (e.g. a host-side `printf` building the string), which injects control bytes the shell's line editor reads as keystrokes and garbles the command (it can even fire history/ZLE widgets and run an unrelated history command). Read the result through an observable: **line 1** (displayName) via the `session-row` static-text **VALUE** (not label — see `SidebarUITests`); **line 2** (`subtitleDetail`) via the `palette-subtitle` AX id read as VALUE in the Go-to-Session palette. Gotcha: `FileManager.default.homeDirectoryForCurrentUser` resolves DIFFERENTLY in the XCUITest runner process vs the app, so assert a cwd second line against a stable marker like `/Users/`, NOT the runner's own home. (`agtermctl session.type` is the control-channel equivalent of the typed injection; `agtermctl tree --json` now carries the raw `title`, which an e2e can poll instead of reading the AX tree. See `SessionSubtitleUITests` + `ControlAPIUITests.testTreeExposesOscTitle`.)
-- **Driving an `NSOutlineView` row drag from XCUITest needs three things, ALL load-bearing (see `ReorderUITests.dragRow`).** Getting any one wrong means the drag silently does nothing — `validateDrop`/`acceptDrop` never fire and the model never mutates: (1) **SELECT the source row first** (`from.click()` + a short run-loop drain) — the outline only begins a drag from the *selected* row, so dragging an unselected row (e.g. a middle row that wasn't the last one touched) never starts a drag session at all. This was the actual cause of a "downward drag doesn't work" red herring — the up-drag happened to drag the just-renamed (hence selected) row, the down-drag dragged an unselected one. (2) **Drag via `coordinate(withNormalizedOffset:)`, NOT element-to-element** — a row's AX element is the recycled `NSTextField` inside the cell, while the drag tracking lives in the outline; a coordinate drag targets the outline machinery directly. (3) **Use the mouse-native `click(forDuration:thenDragTo:withVelocity:thenHoldForDuration:)`, NOT the touch `press(forDuration:thenDragTo:)`** — `pressForDuration:` is the touch-events API and delivers an `NSDraggingInfo` only intermittently to AppKit. One drag per test launch is the reliable unit — a *second chained* native drag in the same method does not reliably re-start a drag session (it ends up testing XCTest's event injector, not the drop delegate), so cover a second direction in a separate `func test…` (fresh launch), never by chaining. To diagnose a non-delivering drag, `NSLog` from `validateDrop`/`acceptDrop` and read it with `log show --last 90s --predicate 'eventMessage CONTAINS "…"'`: *zero* events = the drag never started (selection/gesture problem); events present but the wrong `dest` = a drop-resolution bug in the delegate.
-- **NEVER run XCUITests while the user is interacting with a handed-off dev build — it HIJACKS their screen.** XCUITest launches/activates app instances and synthesizes REAL keyboard + mouse events on the live screen (`typeText`/`typeKey`/`click` drive the actual cursor and focus), so a UI run while the user is trying a build types into their windows and steals focus — it interrupts their work, hard. When you hand the user a build to try ("try it", a launched demo instance), do NOT start any `xcodebuild test` (UI target) until they say they're done. Run UI tests BEFORE handing off, or AFTER the user is finished — never concurrently with their hands-on testing, and never "in parallel/background" (background only hides the output, not the on-screen event synthesis). Host-free `swift test` is fine anytime (no screen interaction).
-- **Test cadence — ASK before a full UI run; don't default to it.** The host-free `cd agtermCore && swift test` is fast (~0.2 s) — always run it. The XCUITest suite is SLOW (~75 s for one class, ~460 s for all 77) and re-runs unaffected tests, so a full UI run is NOT a default pre-commit gate. For an isolated change, run ONLY the affected target/case (`xcodebuild test … -only-testing:agtermUITests/SplitUITests`, or a single method like `…/SidebarUITests/testRenameSession`). Before committing UI-affecting work, ASK which UI-test scope is wanted and RECOMMEND one: focused for self-contained changes; full only for foundational/cross-concern work (app launch, signing/bundle, the eager deck, window/scene wiring, shared chrome). Don't burn minutes re-running the whole suite when the change is self-contained.
-- **A screen-occluding overlay app (HazeOver) makes `app.typeText`/`typeKey` fail with `Failed to synthesize event: Timed out while synthesizing event`** — a ~90 s hang that ends the test with NO `XCTAssert` failure (the keyboard event never reaches the covered window; the run log shows `Synthesize event` → `Failed: Timed out` ~64 s apart). It is ENVIRONMENTAL, not a test-logic or app bug: the SAME test passes in ~13 s once HazeOver is quit. Treat a `synthesize event` / `Unable to find hit point` timeout (as opposed to a real assertion failure) as an occlusion symptom — quit HazeOver and clear covered/minimized/Spaces windows, then re-run before suspecting the test or the fix. Distinct from FB11763863 (window never created → AX tree empty); here the window exists but is covered.
-- **`XCUIApplication.terminate()` HARD-KILLS — it does NOT fire `applicationWillTerminate`.** A test that needs the app's graceful-quit path (anything in `applicationWillTerminate`: the restore-running-command capture, a quit-flush write) must quit with **⌘Q** (`app.typeKey("q", modifierFlags: .command)` then `app.wait(for: .notRunning, timeout:)`), NOT `terminate()`. The quit-confirm modal is auto-skipped under XCUITest (`ContentView.isUITestLaunch` → `.terminateNow`), so ⌘Q quits cleanly AND runs `applicationWillTerminate`. Verified by instrumenting the top of `applicationWillTerminate` to a `/tmp` file: empty under `terminate()`, written under ⌘Q. (`MultiWindowUITests` survives `terminate()` only because the open-set is also saved by in-session structural saves, NOT because the quit-flush ran.) This is the same write-to-a-temp-FILE diagnostic the project uses for launch-time values — `NSLog` doesn't reach the unified log from an `open -n`/XCUITest dev build.
-- **`ghostty_surface_foreground_pid` returns the actual FOREGROUND process, not the session's shell.** Confirmed empirically (`tee <file>` → the captured pid/argv is `tee`, not `zsh`). The restore-running-command capture skips ONLY an IDLE shell-at-prompt (`CommandRestore.isIdleShell`: a known-shell argv0 with no payload argument, only `-flags`). A shell RUNNING something IS captured: a `#!/bin/sh` wrapper script (its foreground is `/bin/sh <script>`, the real-world `cld` claude-code bug) and a `sh -c '…'` BOTH carry a payload argument and are captured — only a bare `-zsh`/`/bin/zsh` prompt is dropped. `tee <file>` is still the cleanest e2e marker: it creates its output file on start and blocks reading the pty, so it's the live foreground at quit, and re-running it recreates the file (a delete-then-relaunch-then-exists cycle is the observable proof). `RestoreCommandUITests.testRestoreReRunsShellScriptWrapper` covers the shell-with-payload case via `sh -c 'tee …; true'` (a compound list keeps `sh` the foreground) — NOT an executable script file, since the runner writes its sandboxed temp dir and the app can't exec a script from there (a plain `tee` marker writes there fine, but exec is blocked).
+- `agtermUITests/` is an XCUITest target that launches the real app and drives the sidebar (rename,
+  close, move, drag, add-session) through the accessibility API — the coverage the host-free `agtermCore`
+  unit tests can't provide.
+  Run with `xcodebuild test -project agterm.xcodeproj -scheme agterm -destination 'platform=macOS'`.
+- Tests pass `AGTERM_STATE_DIR` (a temp dir) via launch environment to isolate persistence;
+  the app honors it in `agtermApp.restoredStore()`.
+  The native `Open Directory…` panel is system UI, verified manually rather than in XCUITest.
+- **Launch the app with `app.launchForUITest()` — never bare `app.launch()`.**
+  Apple bug **FB11763863**: on macOS 15+/Xcode 16+ (incl.
+  26) a SwiftUI `WindowGroup` app launched by another process (XCUITest,
+  launchd) frequently **never auto-presents its window** — dock icon shows,
+  no window, the scene's `.task`/`.onAppear` never fire, `NSApp.windows` stays empty,
+  so elements exist in the AX tree (`waitForExistence` passes) but are un-hittable and every interaction
+  silently no-ops.
+  It is OS-version dependent, so the SAME app code "worked before" a macOS upgrade and breaks after.
+  The fix lives in `AppDelegate.bringUITestWindowsForward` (UITest path):
+  when no real window exists it fires a programmatic **reopen** — `NSWorkspace.shared.open(Bundle.main.bundleURL)`,
+  the same event a dock click sends — and SwiftUI then creates the window.
+  `XCUIApplication.activate()` / `NSApp.activate()` / `orderFrontRegardless()` / `.defaultLaunchBehavior(.presented)`
+  do NOT help (the window is never created, not just un-focused).
+  `launchForUITest()` (in `XCUIApplicationSidebarIsolation.swift`) feeds the `AGTERM_UITEST_FORCE_SIDEBAR_VISIBLE`
+  sentinel via launch **environment** (NOT `launchArguments` — args trip a related variant),
+  launches, and `activate()`s.
+  The reopen re-triggers macOS state restoration, so the `Settings` window is marked **non-restorable**
+  (`SettingsView`'s `NonRestorableWindow`) or a stale Settings window resurrects and steals key focus.
+  To diagnose this class of bug, `NSLog` `NSApp.windows.count` on a timer and read it via `log show --predicate 'eventMessage CONTAINS "…"'`;
+  `total=0` for seconds = "never created".
+  See [[reference_swiftui-windowgroup-no-window-xcuitest]].
+- **Open a Settings tab via the retrying `settingsControl(tab:control:)` helper,
+  not a one-shot `app.buttons[tab].click()`.** The reopen can leave a half-open/non-key Settings window
+  that silently drops the first tab click; `settingsControl` re-clicks each tick until the expected control
+  is hittable, which is what makes the Settings tests non-flaky.
+- **Add a UI test when you add UI functionality**
+  — don't ship UI behavior with only `agtermCore` model-level unit tests.
+  For behavior the accessibility tree can't observe (the Metal `GhosttySurfaceView`,
+  transient non-persisted state), drive it through an observable side effect:
+  e.g. the split test types `tty > <file>` into the focused pane and compares the written tty to verify
+  which shell received the keystrokes and that focus follows.
+- **Driving an OSC terminal title in a test (and reading it back).**
+  `Session.oscTitle`/`subtitleDetail` are ephemeral (never persisted) and the second line renders as
+  a SwiftUI `Text`, so test through observable side effects, not the snapshot.
+  Set a title by typing/injecting `printf '\033]2;TITLE\007'; cat` into the session — the trailing `; cat`
+  is **LOAD-BEARING**: a one-shot printf sets the title but the local shell returns to its prompt where
+  the title is cleared again (the prompt cycle), so it reverts to the cwd basename;
+  `cat` holds the foreground so no prompt redraw fires, mirroring why a real `ssh` keeps its title but
+  a quick local printf "looks broken" (see [[libghostty]]).
+  Type **LITERAL** `\033`/`\007` (Swift `"printf '\\033]2;…\\007'"`) so the SESSION shell's printf expands
+  them — do NOT pre-expand to raw ESC/BEL bytes (e.g. a host-side `printf` building the string),
+  which injects control bytes the shell's line editor reads as keystrokes and garbles the command (it
+  can even fire history/ZLE widgets and run an unrelated history command).
+  Read the result through an observable: **line 1** (displayName) via the `session-row` static-text **VALUE**
+  (not label — see `SidebarUITests`); **line 2** (`subtitleDetail`) via the `palette-subtitle` AX id
+  read as VALUE in the Go-to-Session palette.
+  Gotcha: `FileManager.default.homeDirectoryForCurrentUser` resolves DIFFERENTLY in the XCUITest runner
+  process vs the app, so assert a cwd second line against a stable marker like `/Users/`,
+  NOT the runner's own home.
+  (`agtermctl session.type` is the control-channel equivalent of the typed injection;
+  `agtermctl tree --json` now carries the raw `title`, which an e2e can poll instead of reading the AX
+  tree.
+  See `SessionSubtitleUITests` + `ControlAPIUITests.testTreeExposesOscTitle`.)
+- **Driving an `NSOutlineView` row drag from XCUITest needs three things,
+  ALL load-bearing (see `ReorderUITests.dragRow`).** Getting any one wrong means the drag silently does
+  nothing — `validateDrop`/`acceptDrop` never fire and the model never mutates:
+  (1) **SELECT the source row first** (`from.click()` + a short run-loop drain) — the outline only begins
+  a drag from the *selected* row, so dragging an unselected row (e.g. a middle row that wasn't the last
+  one touched) never starts a drag session at all.
+  This was the actual cause of a "downward drag doesn't work" red herring — the up-drag happened to drag
+  the just-renamed (hence selected) row, the down-drag dragged an unselected one.
+  (2) **Drag via `coordinate(withNormalizedOffset:)`, NOT element-to-element** — a row's AX element is
+  the recycled `NSTextField` inside the cell, while the drag tracking lives in the outline;
+  a coordinate drag targets the outline machinery directly.
+  (3) **Use the mouse-native `click(forDuration:thenDragTo:withVelocity:thenHoldForDuration:)`,
+  NOT the touch `press(forDuration:thenDragTo:)`** — `pressForDuration:` is the touch-events API and
+  delivers an `NSDraggingInfo` only intermittently to AppKit.
+  One drag per test launch is the reliable unit — a *second chained* native drag in the same method does
+  not reliably re-start a drag session (it ends up testing XCTest's event injector,
+  not the drop delegate), so cover a second direction in a separate `func test…` (fresh launch),
+  never by chaining.
+  To diagnose a non-delivering drag, `NSLog` from `validateDrop`/`acceptDrop` and read it with `log show --last 90s --predicate 'eventMessage CONTAINS "…"'`:
+  *zero* events = the drag never started (selection/gesture problem); events present but the wrong `dest`
+  = a drop-resolution bug in the delegate.
+- **NEVER run XCUITests while the user is interacting with a handed-off dev build — it HIJACKS their
+  screen.** XCUITest launches/activates app instances and synthesizes REAL keyboard + mouse events on
+  the live screen (`typeText`/`typeKey`/`click` drive the actual cursor and focus),
+  so a UI run while the user is trying a build types into their windows and steals focus — it interrupts
+  their work, hard.
+  When you hand the user a build to try ("try it", a launched demo instance),
+  do NOT start any `xcodebuild test` (UI target) until they say they're done.
+  Run UI tests BEFORE handing off, or AFTER the user is finished — never concurrently with their hands-on
+  testing, and never "in parallel/background" (background only hides the output,
+  not the on-screen event synthesis).
+  Host-free `swift test` is fine anytime (no screen interaction).
+- **Test cadence — ASK before a full UI run; don't default to it.**
+  The host-free `cd agtermCore && swift test` is fast (~0.2 s) — always run it.
+  The XCUITest suite is SLOW (~75 s for one class, ~460 s for all 77) and re-runs unaffected tests,
+  so a full UI run is NOT a default pre-commit gate.
+  For an isolated change, run ONLY the affected target/case (`xcodebuild test … -only-testing:agtermUITests/SplitUITests`,
+  or a single method like `…/SidebarUITests/testRenameSession`).
+  Before committing UI-affecting work, ASK which UI-test scope is wanted and RECOMMEND one:
+  focused for self-contained changes; full only for foundational/cross-concern work (app launch,
+  signing/bundle, the eager deck, window/scene wiring, shared chrome).
+  Don't burn minutes re-running the whole suite when the change is self-contained.
+- **A screen-occluding overlay app (HazeOver) makes `app.typeText`/`typeKey` fail with `Failed to synthesize event: Timed out while synthesizing event`**
+  — a ~90 s hang that ends the test with NO `XCTAssert` failure (the keyboard event never reaches the
+  covered window; the run log shows `Synthesize event` → `Failed: Timed out` ~64 s apart).
+  It is ENVIRONMENTAL, not a test-logic or app bug: the SAME test passes in ~13 s once HazeOver is quit.
+  Treat a `synthesize event` / `Unable to find hit point` timeout (as opposed to a real assertion failure)
+  as an occlusion symptom — quit HazeOver and clear covered/minimized/Spaces windows,
+  then re-run before suspecting the test or the fix.
+  Distinct from FB11763863 (window never created → AX tree empty); here the window exists but is covered.
+- **`XCUIApplication.terminate()` HARD-KILLS — it does NOT fire `applicationWillTerminate`.** A test
+  that needs the app's graceful-quit path (anything in `applicationWillTerminate`:
+  the restore-running-command capture, a quit-flush write) must quit with **⌘Q** (`app.typeKey("q", modifierFlags: .command)`
+  then `app.wait(for: .notRunning, timeout:)`), NOT `terminate()`.
+  The quit-confirm modal is auto-skipped under XCUITest (`ContentView.isUITestLaunch` → `.terminateNow`),
+  so ⌘Q quits cleanly AND runs `applicationWillTerminate`.
+  Verified by instrumenting the top of `applicationWillTerminate` to a `/tmp` file:
+  empty under `terminate()`, written under ⌘Q.
+  (`MultiWindowUITests` survives `terminate()` only because the open-set is also saved by in-session
+  structural saves, NOT because the quit-flush ran.) This is the same write-to-a-temp-FILE diagnostic
+  the project uses for launch-time values — `NSLog` doesn't reach the unified log from an `open -n`/XCUITest
+  dev build.
+- **`ghostty_surface_foreground_pid` returns the actual FOREGROUND process,
+  not the session's shell.** Confirmed empirically (`tee <file>` → the captured pid/argv is `tee`,
+  not `zsh`).
+  The restore-running-command capture skips ONLY an IDLE shell-at-prompt (`CommandRestore.isIdleShell`:
+  a known-shell argv0 with no payload argument, only `-flags`).
+  A shell RUNNING something IS captured: a `#!/bin/sh` wrapper script (its foreground is `/bin/sh <script>`,
+  the real-world `cld` claude-code bug) and a `sh -c '…'` BOTH carry a payload argument and are captured
+  — only a bare `-zsh`/`/bin/zsh` prompt is dropped.
+  `tee <file>` is still the cleanest e2e marker: it creates its output file on start and blocks reading
+  the pty, so it's the live foreground at quit, and re-running it recreates the file (a delete-then-relaunch-then-exists
+  cycle is the observable proof).
+  `RestoreCommandUITests.testRestoreReRunsShellScriptWrapper` covers the shell-with-payload case via
+  `sh -c 'tee …; true'` (a compound list keeps `sh` the foreground) — NOT an executable script file,
+  since the runner writes its sandboxed temp dir and the app can't exec a script from there (a plain
+  `tee` marker writes there fine, but exec is blocked).
 

--- a/.claude/rules/windows.md
+++ b/.claude/rules/windows.md
@@ -10,18 +10,163 @@ paths:
 
 ## Windows (multi-window)
 
-A **window** is the top level above the workspace tree: a named, persisted bundle of workspaces + sessions, each rendered in its own on-screen macOS window. The user keeps a library of windows (e.g. "work", "personal"), opens one per on-screen window, and the set open at quit reopens on next launch. Strict 1:1 — a bundle shows in exactly one on-screen window, never two windows for one bundle, never two bundles in one window. **No** shared/cross-window live state and **no** cross-window session drag (out of scope by the 1:1 model).
+A **window** is the top level above the workspace tree: a named, persisted bundle of workspaces + sessions,
+each rendered in its own on-screen macOS window.
+The user keeps a library of windows (e.g. "work", "personal"), opens one per on-screen window,
+and the set open at quit reopens on next launch.
+Strict 1:1 — a bundle shows in exactly one on-screen window, never two windows for one bundle,
+never two bundles in one window.
+**No** shared/cross-window live state and **no** cross-window session drag (out of scope by the 1:1 model).
 
-- **Model (`agtermCore`, host-free).** `WindowLibrary.swift` holds `WindowInfo {id: UUID, name: String}` (named `WindowInfo`, NOT `Window`, to avoid the SwiftUI/AppKit clash) and the persisted Codables `WindowsIndex {version, frontmost: UUID?, windows: [WindowEntry]}` / `WindowEntry {id, name, isOpen}` (the index carries its OWN `version`, independent of `Snapshot.version`). `WindowLibrary` is `@Observable @MainActor` like `AppStore`: it owns the ordered `windows: [WindowInfo]`, the live per-window `stores: [UUID: AppStore]` (`@ObservationIgnored`), `frontmostWindowID`, and per-window + index persistence. A window is "open" iff its `AppStore` is loaded (`stores[id] != nil`).
-- **`AppStore` stays the per-window unit** — it already is one tree + one selection, so internals are unchanged; `WindowLibrary` just owns one store per open window, lazily loaded. `store(for:)` returns an open window's store; `loadStore(for:)` lazily builds/caches it from `windows/<id>.json`; `newWindow(name:)` seeds a fresh window (one "workspace 1" + one `$HOME` session — the seeding that used to live in the dropped `agtermApp.restoredStore()`); `closeWindow`/`renameWindow`/`removeWindow` (`canRemoveWindow` = count > 1, keep-at-least-one) mutate + persist; `openIDs()` is the persisted open-set for launch reopen.
-- **Persistence layout** under `<stateDir>` (`AGTERM_STATE_DIR`-aware, else `~/Library/Application Support/agterm`): `windows.json` is the index, `windows/<uuid>.json` is each window's `Snapshot` (the same shape `workspaces.json` had), and the legacy `workspaces.json` is left dormant after migration. `PersistenceStore` gained an optional `fileName:` init param (default `workspaces.json`) so a per-window store targets `windows/<id>.json` without breaking existing callers. A per-mutation `saveIndex()` rewrites only `windows.json`; each store's own `save()` rewrites only its file.
-- **Migration + recovery (on `WindowLibrary` init `bootstrap()`; never throws, mirrors `PersistenceStore.load()`):** valid `windows.json` → load it; absent index but legacy `workspaces.json` present → wrap it into one window ("window 1", marked open/frontmost); neither → seed one empty window. A corrupt or `version`-mismatched `windows.json` is treated as absent, but BEFORE the legacy-else-seed fallback `recoverOrphanedWindows()` (run in `bootstrap()` between `loadIndex()` and `migrateLegacy()`) enumerates any `windows/<uuid>.json` files (skipping non-UUID names), appends them ALL to `windows` FIRST (`loadStore` guards on `windows.contains(id)`), default-names them (`window N`), `loadStore`s each, and marks them all open with the first frontmost — so a future index schema bump RECOVERS the user's sessions instead of resurrecting stale `workspaces.json` or seeding empty; only with NO per-window files does the migrate-from-legacy-else-seed path run. A missing/corrupt `windows/<id>.json` opens that window with an empty `Snapshot` (one default workspace + session). Net: the app always reaches a valid, non-empty window set, never windowless at launch.
-- **Scene + restoration — ⚠️ deviates from the planned `WindowGroup(for:)`.** A *value-based* `WindowGroup(for:)` does NOT auto-open any window at launch when SwiftUI window restoration is off (the scene `.task` never runs, so `openWindow(value:)` can't bootstrap). The scene is therefore a **plain `WindowGroup(id: "terminal")`** (auto-opens one window at launch + one per `openWindow(id:)`). `WindowLibrary` is the single source of truth for the open-set; each appearing SwiftUI window claims the next id from a FIFO **claim queue** (`consumeReopen()` seeds it launch-window-first, `claimNextWindowID()` pops, `enqueueClaim(_:)` appends for a brand-new window), and a window beyond the open set (a SwiftUI-restored stray) gets no id and `dismiss()`es itself. **No `.restorationBehavior`:** it is macOS 15+ and `SceneBuilder` rejects `if #available` entirely (verified — `@ViewBuilder` accepts it, `@SceneBuilder` does not, and there is no `AnyScene` eraser), and the deployment floor is macOS 14, so the mechanism is **dedup-by-id only** (claim queue + dismiss-stray), uniform across 14 and 15. `reopenWindows()` in the scene `.task` opens one window per *remaining* open id (SwiftUI auto-opened the first), once via the `hasReopened` latch. `TitleProbeView` sets `frameAutosaveName("agterm-window-<id>")` so AppKit restores geometry per window.
-- **Frontmost-store resolution + quit-flush.** `AppActions` takes the `WindowLibrary`, not a fixed store: its mutating methods resolve `library.activeStore` (the frontmost open store, falling back to the first open store; backed by `activeWindowID`, the same resolution the quick terminal uses) and no-op when nil. The app `.commands` builder and `paletteActions()` build-time reads go through the same accessor — reactive because `WindowLibrary` is `@Observable`. `ControlServer`/`SettingsModel`/`SessionSwitcher` are likewise wired to the library. `TitleProbeView` reports frontmost (`didBecomeKey/Main` → `library.frontmostWindowID` + `saveIndex()`) and close (`willClose` → tear down that window's surfaces + `library.closeWindow`). The quit-flush replaces the dropped single-store `AppDelegate.store.save()`: `applicationWillTerminate` sets `library.isTerminating` (so the per-window `willClose` close-reporting can't zero the open-set as windows tear down on quit) then `library.saveAllOpen()` + `library.saveIndex()` — load-bearing because `AppStore` does NOT save on a live `cd`, so cwd changes since the last structural mutation are flushed here. `selectSession`/`setFontSize` also persist via a debounced `scheduleSave()` (~0.3 s, host-free `Debouncer`) instead of an immediate `save()` — structural mutations (add/close/move/rename/addWorkspace) still `save()` synchronously, and `save()` cancels any pending scheduled save so this quit-flush captures the latest selection/font (same lose-last-change-on-SIGKILL tradeoff as the split-ratio debounce).
-- **Quit confirmation.** `AppDelegate.applicationShouldTerminate` gates a menu/⌘Q quit behind a standard warning `NSAlert` (Quit / Cancel → `.terminateNow`/`.terminateCancel`), reporting how many windows + sessions the quit closes (closing them ends every shell, the same loss `deleteWorkspace`/`deleteActiveWindow` confirm). Counts come from the host-free `WindowLibrary.openCounts()` (open windows + total sessions across them) and the message from the host-free `QuitPrompt.message(windows:sessions:)` (both unit-tested); the AppKit alert is the app-side glue, manually verified like the other `confirmDelete` alerts. Skips the prompt (`.terminateNow`) when nothing is open (the auto-quit after the last window closed — `applicationShouldTerminateAfterLastWindowClosed` already gates that on the model open-set) OR under an XCUITest launch (`ContentView.isUITestLaunch` — a modal would hang the test's terminate; the dialog is therefore manually verified, not XCUITest-covered). `let library else .terminateNow` is a safety fallback: a quit before the scene `.task` wired the library (sub-~4 s after launch) allows termination rather than deadlocking. Keep-in-sync EXEMPT — a quit-confirm modal is GUI-only chrome with nothing to drive over the socket (there is no `app.quit` control command).
-- **`WindowRegistry`** (`ContentView.swift`, app-side, `@MainActor` singleton) maps a `WindowInfo.ID` to its live `NSWindow` — `WindowLibrary` is host-free (no AppKit), so the NSWindow handles live app-side. `TitleProbeView` registers/unregisters on attach/close; `raise(_:)` brings an already-open window forward (the dedup-by-id raise path), `close(_:)` runs `performClose` (driving the standard `willClose` teardown, used by `window.close`).
-- **Per-window quick terminal.** `QuickTerminalController` is no longer a `static let shared` singleton — it is a per-window instance owned by `WindowContentView` (as `@State`), registered in the app-side `QuickTerminalRegistry` (`Views/QuickTerminal.swift`, `@MainActor` singleton) keyed by `WindowInfo.ID` on appear, unregistered on disappear. Its `cwdProvider`/`envProvider` bind to that window's active session. The frontmost-window call sites resolve via `QuickTerminalRegistry.controller(for: library.activeWindowID)` (the toggle goes through `AppActions.toggleQuickTerminal()`; `ControlServer`'s `quick` arm errors with `no open window` when none is open); the settings broadcast reaches every window's quick terminal via `allControllers()`. Zero `QuickTerminalController.shared` references remain.
-- **Cross-window notification reveal.** The notification identity (`TerminalNotification.identity`/`parseIdentity` in agtermCore) is now `"<windowID>:<sessionID>:<paneRole>"` — the windowID lets a banner clicked after its window closed know which window to reopen. The capture side (`NotificationManager.notify`/`clearDelivered`) resolves the firing window via `library.windowID(forSession:)`. `AppActions.reveal(windowID:sessionID:pane:)` uses `library.store(forSession:)`; if the owning window is closed it reopens it via the `actions.openWindow` closure (`agtermApp` wires it to `WindowRegistry.raise` else `enqueueClaim` + `openWindow(id:)`), polls for the store to load, then `selectSession` + focus the pane (stale-safe: unknown window/session → just activate). `reveal` stays a keep-in-sync exemption (internal click-routing, not on toolbar/menu/palette).
-- **Spawned-shell `AGTERM_*` env (per surface).** `GhosttySurfaceView.init` takes `env: [String: String] = [:]`; it strdups each key/value into the existing `configCStrings` and builds a `nonisolated(unsafe) var envVars: [ghostty_env_var_s]` field set as `config.env_vars`/`config.env_var_count` — the struct array must outlive `ghostty_surface_new` and can't live in `configCStrings` (wrong element type), so `ghostty_surface_new` is called *inside* the `envVars.withUnsafeMutableBufferPointer` closure (no env → plain path) and the array is cleared in `destroySurface`/`deinit` alongside the strdup frees. Tree surfaces (main/split/overlay, via `agtermApp.surfaceEnv(for:)`) inject `AGTERM_ENABLED=1`, `AGTERM_WINDOW_ID` (`library.windowID(forSession:)`), `AGTERM_WORKSPACE_ID` (`store.workspace(forSession:)`), `AGTERM_SESSION_ID`, `AGTERM_SOCKET`; split/overlay inherit the parent session's ids. The quick terminal (`quickTerminalEnv(for:)`) gets only `AGTERM_ENABLED` + `AGTERM_WINDOW_ID` + `AGTERM_SOCKET` (scratch, not in the tree). `AGTERM_SOCKET` is the path `ControlServer` *actually bound* (`ControlServer.boundSocketPath`, nil before bind → the var is omitted), so a test-overridden `AGTERM_CONTROL_SOCKET` and the injected env agree.
-- **`window.*` control additions (eight commands).** `window.new` (returns the new id + opens its window), `window.list` (returns `windows` with each window's `open`/`active` flag), `window.select` (raise-or-open), `window.close` (`WindowRegistry.close` → standard teardown), `window.rename`, `window.delete` (`canRemoveWindow` keep-at-least-one → error, not a GUI confirm). `window.resize` (`args.width`/`height` → the window's frame size in points) and `window.move` (`args.x`/`y` → the top-left relative to display `args.display`, default the window's current display; y from the display top, so multiple displays are addressed by index) drive the app-side `WindowRegistry.resize`/`move` (the NSWindow handles, since `WindowLibrary` is host-free); both require the window OPEN (a closed window errors) and are control-NATIVE (no GUI surface — the native title bar already drags-to-resize). Both CLAMP the request via the host-free `WindowGeometry` (`clampSize` into `[window.minSize, screen.visibleFrame]`, `clampOrigin` keeps a grabbable on-screen strip) applied INSIDE `WindowRegistry` (the only place with the live `NSWindow`/`NSScreen`); `ControlServer` keeps only the `>0` guard. `WindowGeometry` is agtermCore's first CoreGraphics types (CG ≠ AppKit/Metal, Foundation-provided on Darwin). Window-id resolution reuses the pure `ControlResolve.resolve` over `library.windows` (active=frontmost / exact / prefix / ambiguous / not-found); a window need NOT be open to be a `window.*` target. The global `--window <id>` selector (`ControlArgs.window`) targets a session/workspace command at a *specific* window's tree: with `args.window` set, the window must be open (else `window not open — window.select it first`); without it, `active`/placement default to the frontmost store, but an id/prefix session/workspace target is matched across ALL open stores (`resolveTargetAcrossWindows`) and mapped back to its owning `AppStore`. See the Control API section for the catalog and the keep-in-sync four-point audit (all eight window commands satisfy it).
+- **Model (`agtermCore`, host-free).**
+  `WindowLibrary.swift` holds `WindowInfo {id: UUID, name: String}` (named `WindowInfo`,
+  NOT `Window`, to avoid the SwiftUI/AppKit clash) and the persisted Codables `WindowsIndex {version, frontmost: UUID?, windows: [WindowEntry]}`
+  / `WindowEntry {id, name, isOpen}` (the index carries its OWN `version`,
+  independent of `Snapshot.version`).
+  `WindowLibrary` is `@Observable @MainActor` like `AppStore`: it owns the ordered `windows: [WindowInfo]`,
+  the live per-window `stores: [UUID: AppStore]` (`@ObservationIgnored`),
+  `frontmostWindowID`, and per-window + index persistence.
+  A window is "open" iff its `AppStore` is loaded (`stores[id] != nil`).
+- **`AppStore` stays the per-window unit**
+  — it already is one tree + one selection, so internals are unchanged; `WindowLibrary` just owns one
+  store per open window, lazily loaded.
+  `store(for:)` returns an open window's store; `loadStore(for:)` lazily builds/caches it from `windows/<id>.json`;
+  `newWindow(name:)` seeds a fresh window (one "workspace 1" + one `$HOME` session — the seeding that
+  used to live in the dropped `agtermApp.restoredStore()`); `closeWindow`/`renameWindow`/`removeWindow`
+  (`canRemoveWindow` = count > 1, keep-at-least-one) mutate + persist; `openIDs()` is the persisted open-set
+  for launch reopen.
+- **Persistence layout**
+  under `<stateDir>` (`AGTERM_STATE_DIR`-aware, else `~/Library/Application Support/agterm`):
+  `windows.json` is the index, `windows/<uuid>.json` is each window's `Snapshot` (the same shape `workspaces.json`
+  had), and the legacy `workspaces.json` is left dormant after migration.
+  `PersistenceStore` gained an optional `fileName:` init param (default `workspaces.json`) so a per-window
+  store targets `windows/<id>.json` without breaking existing callers.
+  A per-mutation `saveIndex()` rewrites only `windows.json`; each store's own `save()` rewrites only
+  its file.
+- **Migration + recovery (on `WindowLibrary` init `bootstrap()`; never throws,
+  mirrors `PersistenceStore.load()`):** valid `windows.json` → load it; absent index but legacy `workspaces.json`
+  present → wrap it into one window ("window 1", marked open/frontmost);
+  neither → seed one empty window.
+  A corrupt or `version`-mismatched `windows.json` is treated as absent,
+  but BEFORE the legacy-else-seed fallback `recoverOrphanedWindows()` (run in `bootstrap()` between `loadIndex()`
+  and `migrateLegacy()`) enumerates any `windows/<uuid>.json` files (skipping non-UUID names),
+  appends them ALL to `windows` FIRST (`loadStore` guards on `windows.contains(id)`),
+  default-names them (`window N`), `loadStore`s each, and marks them all open with the first frontmost
+  — so a future index schema bump RECOVERS the user's sessions instead of resurrecting stale `workspaces.json`
+  or seeding empty; only with NO per-window files does the migrate-from-legacy-else-seed path run.
+  A missing/corrupt `windows/<id>.json` opens that window with an empty `Snapshot` (one default workspace
+  + session).
+  Net: the app always reaches a valid, non-empty window set, never windowless at launch.
+- **Scene + restoration — ⚠️ deviates from the planned `WindowGroup(for:)`.**
+  A *value-based* `WindowGroup(for:)` does NOT auto-open any window at launch when SwiftUI window restoration
+  is off (the scene `.task` never runs, so `openWindow(value:)` can't bootstrap).
+  The scene is therefore a **plain `WindowGroup(id: "terminal")`** (auto-opens one window at launch +
+  one per `openWindow(id:)`).
+  `WindowLibrary` is the single source of truth for the open-set; each appearing SwiftUI window claims
+  the next id from a FIFO **claim queue** (`consumeReopen()` seeds it launch-window-first,
+  `claimNextWindowID()` pops, `enqueueClaim(_:)` appends for a brand-new window),
+  and a window beyond the open set (a SwiftUI-restored stray) gets no id and `dismiss()`es itself.
+  **No `.restorationBehavior`:** it is macOS 15+ and `SceneBuilder` rejects `if #available` entirely
+  (verified — `@ViewBuilder` accepts it, `@SceneBuilder` does not, and there is no `AnyScene` eraser),
+  and the deployment floor is macOS 14, so the mechanism is **dedup-by-id only** (claim queue + dismiss-stray),
+  uniform across 14 and 15.
+  `reopenWindows()` in the scene `.task` opens one window per *remaining* open id (SwiftUI auto-opened
+  the first), once via the `hasReopened` latch.
+  `TitleProbeView` sets `frameAutosaveName("agterm-window-<id>")` so AppKit restores geometry per window.
+- **Frontmost-store resolution + quit-flush.**
+  `AppActions` takes the `WindowLibrary`, not a fixed store: its mutating methods resolve `library.activeStore`
+  (the frontmost open store, falling back to the first open store; backed by `activeWindowID`,
+  the same resolution the quick terminal uses) and no-op when nil.
+  The app `.commands` builder and `paletteActions()` build-time reads go through the same accessor —
+  reactive because `WindowLibrary` is `@Observable`.
+  `ControlServer`/`SettingsModel`/`SessionSwitcher` are likewise wired to the library.
+  `TitleProbeView` reports frontmost (`didBecomeKey/Main` → `library.frontmostWindowID` + `saveIndex()`)
+  and close (`willClose` → tear down that window's surfaces + `library.closeWindow`).
+  The quit-flush replaces the dropped single-store `AppDelegate.store.save()`:
+  `applicationWillTerminate` sets `library.isTerminating` (so the per-window `willClose` close-reporting
+  can't zero the open-set as windows tear down on quit) then `library.saveAllOpen()` + `library.saveIndex()`
+  — load-bearing because `AppStore` does NOT save on a live `cd`, so cwd changes since the last structural
+  mutation are flushed here.
+  `selectSession`/`setFontSize` also persist via a debounced `scheduleSave()` (~0.3 s,
+  host-free `Debouncer`) instead of an immediate `save()` — structural mutations (add/close/move/rename/addWorkspace)
+  still `save()` synchronously, and `save()` cancels any pending scheduled save so this quit-flush captures
+  the latest selection/font (same lose-last-change-on-SIGKILL tradeoff as the split-ratio debounce).
+- **Quit confirmation.**
+  `AppDelegate.applicationShouldTerminate` gates a menu/⌘Q quit behind a standard warning `NSAlert` (Quit
+  / Cancel → `.terminateNow`/`.terminateCancel`), reporting how many windows + sessions the quit closes
+  (closing them ends every shell, the same loss `deleteWorkspace`/`deleteActiveWindow` confirm).
+  Counts come from the host-free `WindowLibrary.openCounts()` (open windows + total sessions across them)
+  and the message from the host-free `QuitPrompt.message(windows:sessions:)` (both unit-tested);
+  the AppKit alert is the app-side glue, manually verified like the other `confirmDelete` alerts.
+  Skips the prompt (`.terminateNow`) when nothing is open (the auto-quit after the last window closed
+  — `applicationShouldTerminateAfterLastWindowClosed` already gates that on the model open-set) OR under
+  an XCUITest launch (`ContentView.isUITestLaunch` — a modal would hang the test's terminate;
+  the dialog is therefore manually verified, not XCUITest-covered).
+  `let library else .terminateNow` is a safety fallback: a quit before the scene `.task` wired the library
+  (sub-~4 s after launch) allows termination rather than deadlocking.
+  Keep-in-sync EXEMPT — a quit-confirm modal is GUI-only chrome with nothing to drive over the socket
+  (there is no `app.quit` control command).
+- **`WindowRegistry`**
+  (`ContentView.swift`, app-side, `@MainActor` singleton) maps a `WindowInfo.ID` to its live `NSWindow`
+  — `WindowLibrary` is host-free (no AppKit), so the NSWindow handles live app-side.
+  `TitleProbeView` registers/unregisters on attach/close; `raise(_:)` brings an already-open window forward
+  (the dedup-by-id raise path), `close(_:)` runs `performClose` (driving the standard `willClose` teardown,
+  used by `window.close`).
+- **Per-window quick terminal.**
+  `QuickTerminalController` is no longer a `static let shared` singleton — it is a per-window instance
+  owned by `WindowContentView` (as `@State`), registered in the app-side `QuickTerminalRegistry` (`Views/QuickTerminal.swift`,
+  `@MainActor` singleton) keyed by `WindowInfo.ID` on appear, unregistered on disappear.
+  Its `cwdProvider`/`envProvider` bind to that window's active session.
+  The frontmost-window call sites resolve via `QuickTerminalRegistry.controller(for: library.activeWindowID)`
+  (the toggle goes through `AppActions.toggleQuickTerminal()`; `ControlServer`'s `quick` arm errors with
+  `no open window` when none is open); the settings broadcast reaches every window's quick terminal via
+  `allControllers()`.
+  Zero `QuickTerminalController.shared` references remain.
+- **Cross-window notification reveal.**
+  The notification identity (`TerminalNotification.identity`/`parseIdentity` in agtermCore) is now `"<windowID>:<sessionID>:<paneRole>"`
+  — the windowID lets a banner clicked after its window closed know which window to reopen.
+  The capture side (`NotificationManager.notify`/`clearDelivered`) resolves the firing window via `library.windowID(forSession:)`.
+  `AppActions.reveal(windowID:sessionID:pane:)` uses `library.store(forSession:)`;
+  if the owning window is closed it reopens it via the `actions.openWindow` closure (`agtermApp` wires
+  it to `WindowRegistry.raise` else `enqueueClaim` + `openWindow(id:)`),
+  polls for the store to load, then `selectSession` + focus the pane (stale-safe:
+  unknown window/session → just activate).
+  `reveal` stays a keep-in-sync exemption (internal click-routing, not on toolbar/menu/palette).
+- **Spawned-shell `AGTERM_*` env (per surface).**
+  `GhosttySurfaceView.init` takes `env: [String: String] = [:]`; it strdups each key/value into the existing
+  `configCStrings` and builds a `nonisolated(unsafe) var envVars: [ghostty_env_var_s]` field set as `config.env_vars`/`config.env_var_count`
+  — the struct array must outlive `ghostty_surface_new` and can't live in `configCStrings` (wrong element
+  type), so `ghostty_surface_new` is called *inside* the `envVars.withUnsafeMutableBufferPointer` closure
+  (no env → plain path) and the array is cleared in `destroySurface`/`deinit` alongside the strdup frees.
+  Tree surfaces (main/split/overlay, via `agtermApp.surfaceEnv(for:)`) inject `AGTERM_ENABLED=1`,
+  `AGTERM_WINDOW_ID` (`library.windowID(forSession:)`), `AGTERM_WORKSPACE_ID` (`store.workspace(forSession:)`),
+  `AGTERM_SESSION_ID`, `AGTERM_SOCKET`; split/overlay inherit the parent session's ids.
+  The quick terminal (`quickTerminalEnv(for:)`) gets only `AGTERM_ENABLED` + `AGTERM_WINDOW_ID` + `AGTERM_SOCKET`
+  (scratch, not in the tree).
+  `AGTERM_SOCKET` is the path `ControlServer` *actually bound* (`ControlServer.boundSocketPath`,
+  nil before bind → the var is omitted), so a test-overridden `AGTERM_CONTROL_SOCKET` and the injected
+  env agree.
+- **`window.*` control additions (eight commands).**
+  `window.new` (returns the new id + opens its window), `window.list` (returns `windows` with each window's
+  `open`/`active` flag), `window.select` (raise-or-open), `window.close` (`WindowRegistry.close` → standard
+  teardown), `window.rename`, `window.delete` (`canRemoveWindow` keep-at-least-one → error,
+  not a GUI confirm).
+  `window.resize` (`args.width`/`height` → the window's frame size in points) and `window.move` (`args.x`/`y`
+  → the top-left relative to display `args.display`, default the window's current display;
+  y from the display top, so multiple displays are addressed by index) drive the app-side `WindowRegistry.resize`/`move`
+  (the NSWindow handles, since `WindowLibrary` is host-free); both require the window OPEN (a closed
+  window errors) and are control-NATIVE (no GUI surface — the native title bar already drags-to-resize).
+  Both CLAMP the request via the host-free `WindowGeometry` (`clampSize` into `[window.minSize, screen.visibleFrame]`,
+  `clampOrigin` keeps a grabbable on-screen strip) applied INSIDE `WindowRegistry` (the only place with
+  the live `NSWindow`/`NSScreen`); `ControlServer` keeps only the `>0` guard.
+  `WindowGeometry` is agtermCore's first CoreGraphics types (CG ≠ AppKit/Metal,
+  Foundation-provided on Darwin).
+  Window-id resolution reuses the pure `ControlResolve.resolve` over `library.windows` (active=frontmost
+  / exact / prefix / ambiguous / not-found); a window need NOT be open to be a `window.*` target.
+  The global `--window <id>` selector (`ControlArgs.window`) targets a session/workspace command at a
+  *specific* window's tree: with `args.window` set, the window must be open (else `window not open — window.select it first`);
+  without it, `active`/placement default to the frontmost store, but an id/prefix session/workspace target
+  is matched across ALL open stores (`resolveTargetAcrossWindows`) and mapped back to its owning `AppStore`.
+  See the Control API section for the catalog and the keep-in-sync four-point audit (all eight window
+  commands satisfy it).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,79 +1,301 @@
 # agterm — project notes
 
-`agterm` is a native macOS SwiftUI terminal on libghostty, with a two-level workspace -> session vertical sidebar. Read `README.md` for the overview and `ARCHITECTURE.md` for the module split, surface ownership, and the C-boundary concurrency contract before changing the bridge.
+`agterm` is a native macOS SwiftUI terminal on libghostty, with a two-level workspace -> session vertical
+sidebar.
+Read `README.md` for the overview and `ARCHITECTURE.md` for the module split,
+surface ownership, and the C-boundary concurrency contract before changing the bridge.
 
 ## Working norms
 
-- The maintainer and most expected contributors are NOT SwiftUI / macOS UI-UX experts. When a UI request is non-standard, risky, or trickier than it sounds (custom window chrome, fighting `NavigationSplitView`, reaching into private AppKit views, layout-direction hacks, etc.), push back gently FIRST: explain what it actually takes and the trade-offs, and offer the simpler/standard alternative. If the user still wants it after that, do it — the user is the boss.
-- **Propose control-API/CLI coverage for every new feature (aim for completeness).** When adding ANY feature or capability, evaluate what of it makes sense to drive over the control channel and PROACTIVELY propose adding it — a `Command` case + `ControlServer` arm + `agtermctl` subcommand + round-trip/e2e tests. The goal is the most complete control-API coverage possible (the API is a first-class surface, not an afterthought), not merely parity with the GUI. This generalizes the HARD keep-in-sync convention (which covers GUI actions in `AppActions`/`AppStore`) to features with NO GUI surface at all — `notify`/`session.copy`/`session.type` are control-native. Only skip when exposure is genuinely meaningless (pure rendering/visual chrome with nothing to drive).
-- **Use the Swift skills for Swift/SwiftUI work — proactively, from the START, not only when stuck.** agterm is Swift 6 + SwiftUI + AppKit; activate the relevant skill before/while working: `swiftui-expert` for any SwiftUI/AppKit view, layout, `@Observable`/state, focus, animation, or rendering work (this whole `ContentView`/window-chrome/overlay surface); `swift-testing-expert` for writing or modernizing Swift tests; `swift-concurrency` for actor / `@MainActor` / `Sendable` / async work (esp. across the C-callback boundary). Don't wait for a failure to reach for them.
-- **"Show me" / "show it" for a UI feature = BUILD + RUN the app for the user to look at, NOT a screenshot.** When the user asks to see a visual change, `make build` then launch an ISOLATED dev instance (`open -n --env AGTERM_STATE_DIR=<tmp> --env AGTERM_CONTROL_SOCKET=<tmp>/agterm.sock build/DerivedData/.../Debug/agterm.app`) so it coexists with the deployed daily-driver and never touches the real `workspaces.json` — then leave it running and tell the user how to reach the feature. Do NOT take a screenshot (`screencapture`) or capture an image via XCUITest (`XCUIScreen.screenshot`/`XCTAttachment`) — the user wants to interact with the running app themselves. The XCUITest runner is sandboxed and can't write `/tmp` anyway.
-- **After launching a dev instance for the user to test, default to HANDS-OFF.** For the user's MANUAL test (the common case — "run it for me to test", "I'll test manually"), do NOT touch the running instance after launch: no `agtermctl` calls, no `session status` pokes, no state changes — poking it mid-test corrupts what the user is observing. For an ASSISTED experiment (you drive part of it — e.g. set a session's status via `agtermctl` so the user can then act on it), acting is fine, but ANNOUNCE each action as you do it so the user can follow and help. When in doubt, treat it as manual and ask before touching.
+- The maintainer and most expected contributors are NOT SwiftUI / macOS UI-UX experts.
+  When a UI request is non-standard, risky, or trickier than it sounds (custom window chrome,
+  fighting `NavigationSplitView`, reaching into private AppKit views, layout-direction hacks,
+  etc.), push back gently FIRST: explain what it actually takes and the trade-offs,
+  and offer the simpler/standard alternative.
+  If the user still wants it after that, do it — the user is the boss.
+- **Propose control-API/CLI coverage for every new feature (aim for completeness).** When adding ANY
+  feature or capability, evaluate what of it makes sense to drive over the control channel and PROACTIVELY
+  propose adding it — a `Command` case + `ControlServer` arm + `agtermctl` subcommand + round-trip/e2e
+  tests.
+  The goal is the most complete control-API coverage possible (the API is a first-class surface,
+  not an afterthought), not merely parity with the GUI.
+  This generalizes the HARD keep-in-sync convention (which covers GUI actions in `AppActions`/`AppStore`)
+  to features with NO GUI surface at all — `notify`/`session.copy`/`session.type` are control-native.
+  Only skip when exposure is genuinely meaningless (pure rendering/visual chrome with nothing to drive).
+- **Use the Swift skills for Swift/SwiftUI work — proactively, from the START,
+  not only when stuck.** agterm is Swift 6 + SwiftUI + AppKit; activate the relevant skill before/while
+  working: `swiftui-expert` for any SwiftUI/AppKit view, layout, `@Observable`/state,
+  focus, animation, or rendering work (this whole `ContentView`/window-chrome/overlay surface);
+  `swift-testing-expert` for writing or modernizing Swift tests; `swift-concurrency` for actor / `@MainActor`
+  / `Sendable` / async work (esp. across the C-callback boundary).
+  Don't wait for a failure to reach for them.
+- **"Show me" / "show it" for a UI feature = BUILD + RUN the app for the user to look at,
+  NOT a screenshot.** When the user asks to see a visual change, `make build` then launch an ISOLATED
+  dev instance (`open -n --env AGTERM_STATE_DIR=<tmp> --env AGTERM_CONTROL_SOCKET=<tmp>/agterm.sock build/DerivedData/.../Debug/agterm.app`)
+  so it coexists with the deployed daily-driver and never touches the real `workspaces.json` — then leave
+  it running and tell the user how to reach the feature.
+  Do NOT take a screenshot (`screencapture`) or capture an image via XCUITest (`XCUIScreen.screenshot`/`XCTAttachment`)
+  — the user wants to interact with the running app themselves.
+  The XCUITest runner is sandboxed and can't write `/tmp` anyway.
+- **After launching a dev instance for the user to test, default to HANDS-OFF.**
+  For the user's MANUAL test (the common case — "run it for me to test",
+  "I'll test manually"), do NOT touch the running instance after launch:
+  no `agtermctl` calls, no `session status` pokes, no state changes — poking it mid-test corrupts what
+  the user is observing.
+  For an ASSISTED experiment (you drive part of it — e.g. set a session's status via `agtermctl` so the
+  user can then act on it), acting is fine, but ANNOUNCE each action as you do it so the user can follow
+  and help.
+  When in doubt, treat it as manual and ask before touching.
 
 ## Toolchain
 
-- The app target is generated with `xcodegen` and built with `xcodebuild` (Xcode 26). `mise` is not used; call `xcodegen`, `xcodebuild`, and `swift` directly through the scripts.
-- The `agtermCore` package is built and tested with `swift test` (Swift 6, strict concurrency `complete`). It is independent of Xcode and libghostty.
-- `scripts/setup.sh` builds libghostty from upstream ghostty source, so it needs `git`, Homebrew (for the `zig@0.15` keg = zig 0.15.2, what ghostty pins), and Xcode's Metal Toolchain (auto-downloaded on first run via `xcodebuild -downloadComponent MetalToolchain`). The build is one-time — cached by the present-check — so day-to-day work pays nothing.
+- The app target is generated with `xcodegen` and built with `xcodebuild` (Xcode 26).
+  `mise` is not used; call `xcodegen`, `xcodebuild`, and `swift` directly through the scripts.
+- The `agtermCore` package is built and tested with `swift test` (Swift 6,
+  strict concurrency `complete`).
+  It is independent of Xcode and libghostty.
+- `scripts/setup.sh` builds libghostty from upstream ghostty source, so it needs `git`,
+  Homebrew (for the `zig@0.15` keg = zig 0.15.2, what ghostty pins), and Xcode's Metal Toolchain (auto-downloaded
+  on first run via `xcodebuild -downloadComponent MetalToolchain`).
+  The build is one-time — cached by the present-check — so day-to-day work pays nothing.
 
 ## Build and test commands
 
-- `scripts/setup.sh` — build `GhosttyKit.xcframework` and the ghostty resources from upstream ghostty source (pinned SHA, zig 0.15.2). Idempotent; skips the build if both are already present. First run takes a few minutes plus a one-time Metal Toolchain download.
+- `scripts/setup.sh` — build `GhosttyKit.xcframework` and the ghostty resources from upstream ghostty
+  source (pinned SHA, zig 0.15.2).
+  Idempotent; skips the build if both are already present.
+  First run takes a few minutes plus a one-time Metal Toolchain download.
 - `scripts/run.sh` — setup, `xcodegen generate`, `xcodebuild` Debug, then launch.
 - `scripts/build.sh` — same but Release, no launch.
 - `cd agtermCore && swift test` — run the host-free unit tests (`scripts/test.sh` wraps this).
-- `Makefile` — a thin front door over the scripts: `make prep`/`build` (Debug, no launch)/`run`/`release`/`deploy` (Release build + copy to `~/Applications`)/`test`/`dist VERSION=x.y.z [PUBLISH=1]` (the `release.sh` DMG)/`clean`; a bare `make` lists them. The scripts stay the source of truth — only `build` and `deploy` carry their own recipe.
+- `Makefile` — a thin front door over the scripts: `make prep`/`build` (Debug,
+  no launch)/`run`/`release`/`deploy` (Release build + copy to `~/Applications`)/`test`/`dist VERSION=x.y.z [PUBLISH=1]`
+  (the `release.sh` DMG)/`clean`; a bare `make` lists them.
+  The scripts stay the source of truth — only `build` and `deploy` carry their own recipe.
 
 The app must build and `swift test` must stay green after every change.
 
-- **Working in a git WORKTREE: SYMLINK the prebuilt artifacts, don't re-run setup.** A fresh `git worktree` does NOT contain the gitignored `GhosttyKit.xcframework`, `agterm/Resources/ghostty`, or `agterm/Resources/terminfo` (they're build outputs, never committed). Running `scripts/setup.sh` there would REBUILD libghostty from upstream (a few minutes + the Metal Toolchain). Instead symlink all three from the main worktree, then `setup.sh`'s present-check skips the rebuild (prints `GhosttyKit and resources already present`): `ln -s <main>/GhosttyKit.xcframework GhosttyKit.xcframework` and `ln -s <main>/agterm/Resources/{ghostty,terminfo}` into the worktree's `agterm/Resources/`. **Use ABSOLUTE targets for the two Resources symlinks** — the relative depth from `<wt>/agterm/Resources/` is easy to miscount (`../../` lands inside the worktree, not the sibling). The symlinks show as untracked (`??`) in the worktree and never need committing; `git worktree remove --force <wt>` removes the worktree + its symlinks WITHOUT touching the symlink targets in the main repo. Build with the same `xcodegen generate` + `xcodebuild … -derivedDataPath build/DerivedData` as usual.
-- **Debug build code lives in `agterm.debug.dylib`, NOT the main `agterm` executable.** Xcode Debug builds emit the Swift code (and its string literals) into a sibling `…/Contents/MacOS/agterm.debug.dylib`; the main `agterm` binary is a thin stub. So to verify that an edit/instrumentation actually compiled into the running app, `grep -a` the **dylib** (or the per-file `…/Objects-normal/arm64/<File>.o`), not the main executable — grepping `agterm` for a string you added will falsely come back empty.
-- **For launch-time value capture, write to a temp FILE, not `NSLog`.** `NSLog` from a dev build launched via `open -n` does NOT reliably reach the unified log (`log show` showed only the `log show` command's own echoes, never the app's lines, even with the string confirmed present in the dylib and a window on screen). A tiny file appender (`FileHandle` append to `/tmp/<tag>.log`) is bulletproof and independent of unified-log capture — the reliable way to read what a value resolved to at `init` / first view render. (`os.Logger` with a subsystem is the production channel; this is just for throwaway investigation.)
-- **`run.sh` re-activates a stale instance.** `scripts/run.sh` ends in `open agterm.app` with no kill, so if an instance is already running macOS just brings it to front — the freshly built binary is NOT loaded. To actually test a rebuild, fully quit the running app first (then `open`, or launch `…/Debug/agterm.app` directly / `open -n`); otherwise visual verification runs against the old build and a real fix looks like it failed.
-- **A `make deploy`'d copy in `~/Applications` SHADOWS the dev build — for the CLI, the hooks, AND the app.** This machine has agterm installed via `make deploy` (Release → `~/Applications/agterm.app`), and the Help-menu installers run off that copy point `/usr/local/bin/agtermctl` and the agent-status hooks' baked `AGTERMCTL` (in `~/.config/agterm/agent-status/agterm-agent-status.sh`) at it. So once deployed, a bare `agtermctl …` on PATH, the agent-status hooks, AND a plain launch/activate (LaunchServices resolves `com.umputun.agterm` to `~/Applications`) all hit the DEPLOYED build — NOT whatever you just rebuilt into `build/DerivedData`. When iterating on `agtermctl` or the hook scripts, the change is therefore NOT exercised by the PATH CLI / the hooks until you either (a) invoke the fresh binary by full path — `build/DerivedData/Build/Products/Debug/agterm.app/Contents/MacOS/agtermctl …` (or `export AGTERMCTL=` to it for the hooks), or (b) `make deploy` again and re-run Help ▸ Install Command Line Tool… + Install Agent Status Hooks… to re-point PATH and the hooks at the new build. For APP-code changes, do NOT quit the deployed app (see the next note — it is the user's live daily driver); Debug builds carry a DISTINCT bundle id (`com.umputun.agterm.debug`, project.yml per-config) so they run as a SEPARATE instance alongside the deployed Release. The XCUITests no longer collide either: the `.debug` bundle id means XCUITest's launch-time terminate hits only the `.debug` instance, not the deployed `com.umputun.agterm`, and they still use an isolated `AGTERM_STATE_DIR`/socket.
-- **NEVER kill or relaunch the deployed `~/Applications/agterm.app` — it is the user's REAL, in-use daily terminal with LIVE sessions.** BANNED: `pkill agterm` / `pkill -x agterm`, `osascript -e 'tell application "agterm" to quit'`, and ANY quit-then-relaunch of the deployed app (including the quit+`open` after `make deploy`). After `make deploy` the Release build is COPIED into `~/Applications`, but the RUNNING instance keeps the old code until the USER relaunches it on their own schedule (so their live sessions survive) — just report it's installed; do NOT relaunch it. For dev-build UI acceptance / socket probes, open a SEPARATE ISOLATED instance that coexists with the deployed app: `open -n --env AGTERM_STATE_DIR=<tmp> --env AGTERM_CONTROL_SOCKET=<tmp>/agterm.sock build/DerivedData/Build/Products/Debug/agterm.app` (verified: launches a second instance with the deployed app untouched and its socket not stolen). Probe via the temp socket (`agtermctl tree --socket <tmp>/agterm.sock` — `--socket` is a per-subcommand option, so it goes AFTER the subcommand, never before it) and quit ONLY that instance BY PID (`kill <pid>`, never `pkill`). The Debug bundle id (`com.umputun.agterm.debug`) makes the dev/test build a distinct LaunchServices identity from the deployed `com.umputun.agterm`, which is what lets XCUITest (it terminates the app-under-test's bundle-id instance on launch) run WITHOUT killing the deployed app — verified, the e2e leaves it alive. But state + socket are PATH-based (NOT bundle-id-derived, both default to `~/Library/Application Support/agterm/`), so the `AGTERM_STATE_DIR`/`AGTERM_CONTROL_SOCKET` env overrides are STILL required for a manual dev launch even with the distinct id — otherwise the dev instance reads/writes the user's real `workspaces.json` AND steals the deployed app's socket (its `start()` unlinks-then-binds the default path).
-- **Anchor path/existence checks at an ABSOLUTE repo-root path — the Bash cwd DRIFTS.** The shell working directory persists across tool calls and silently drifts (e.g. a `cd agtermCore` for `swift test` leaves you there), so a later relative `find .github`/`ls`/`cd` runs from the WRONG place and returns a FALSE negative. NEVER assert "file/dir X doesn't exist" from a relative `find`/`ls` — confirm with an absolute path (`/Users/umputun/dev.umputun/agterm/...`) or `git -C <root> ls-files`, especially before claiming infra facts (CI presence, config files). The repo root vs the `agtermCore` SwiftPM subpackage makes root-vs-subdir confusion easy; verify the directory, don't trust a negative relative result.
-- **CI / release (`.github/workflows/`).** `ci.yml` runs on push/PR to `master`, gated by a `dorny/paths-filter` (`**/*.swift`, `agtermCore/**`, `agterm/**`, `project.yml`, `scripts/**`, `ci.yml`): a `test` job (`swift test` in `agtermCore`) and a `build` job (`brew install xcodegen` then `scripts/build.sh`, Release, with `GhosttyKit.xcframework` + ghostty/terminfo resources restored from an `actions/cache` keyed on `scripts/setup.sh`), both on `macos-26`, concurrency cancel-in-progress. **CI does NOT run the XCUITests** — it builds the app but never test-runs the app target; only the host-free `swift test` runs in CI. `release.yml` fires on `v*` tags: `scripts/release.sh <version> --publish` on `macos-26` builds an unsigned DMG (`AGTERM_ALLOW_UNSIGNED=1`), publishes the GitHub release, and bumps the Homebrew cask in `umputun/homebrew-apps` (needs the `HOMEBREW_TAP_PAT` secret, not the default token). No swiftlint step yet.
+- **Working in a git WORKTREE: SYMLINK the prebuilt artifacts, don't re-run setup.** A fresh `git worktree`
+  does NOT contain the gitignored `GhosttyKit.xcframework`, `agterm/Resources/ghostty`,
+  or `agterm/Resources/terminfo` (they're build outputs, never committed).
+  Running `scripts/setup.sh` there would REBUILD libghostty from upstream (a few minutes + the Metal
+  Toolchain).
+  Instead symlink all three from the main worktree, then `setup.sh`'s present-check skips the rebuild
+  (prints `GhosttyKit and resources already present`): `ln -s <main>/GhosttyKit.xcframework GhosttyKit.xcframework`
+  and `ln -s <main>/agterm/Resources/{ghostty,terminfo}` into the worktree's `agterm/Resources/`.
+  **Use ABSOLUTE targets for the two Resources symlinks** — the relative depth from `<wt>/agterm/Resources/`
+  is easy to miscount (`../../` lands inside the worktree, not the sibling).
+  The symlinks show as untracked (`??`) in the worktree and never need committing;
+  `git worktree remove --force <wt>` removes the worktree + its symlinks WITHOUT touching the symlink
+  targets in the main repo.
+  Build with the same `xcodegen generate` + `xcodebuild … -derivedDataPath build/DerivedData` as usual.
+- **Debug build code lives in `agterm.debug.dylib`, NOT the main `agterm` executable.** Xcode Debug builds
+  emit the Swift code (and its string literals) into a sibling `…/Contents/MacOS/agterm.debug.dylib`;
+  the main `agterm` binary is a thin stub.
+  So to verify that an edit/instrumentation actually compiled into the running app,
+  `grep -a` the **dylib** (or the per-file `…/Objects-normal/arm64/<File>.o`),
+  not the main executable — grepping `agterm` for a string you added will falsely come back empty.
+- **For launch-time value capture, write to a temp FILE, not `NSLog`.**
+  `NSLog` from a dev build launched via `open -n` does NOT reliably reach the unified log (`log show`
+  showed only the `log show` command's own echoes, never the app's lines,
+  even with the string confirmed present in the dylib and a window on screen).
+  A tiny file appender (`FileHandle` append to `/tmp/<tag>.log`) is bulletproof and independent of unified-log
+  capture — the reliable way to read what a value resolved to at `init` / first view render.
+  (`os.Logger` with a subsystem is the production channel; this is just for throwaway investigation.)
+- **`run.sh` re-activates a stale instance.**
+  `scripts/run.sh` ends in `open agterm.app` with no kill, so if an instance is already running macOS
+  just brings it to front — the freshly built binary is NOT loaded.
+  To actually test a rebuild, fully quit the running app first (then `open`,
+  or launch `…/Debug/agterm.app` directly / `open -n`); otherwise visual verification runs against the
+  old build and a real fix looks like it failed.
+- **A `make deploy`'d copy in `~/Applications` SHADOWS the dev build — for the CLI,
+  the hooks, AND the app.** This machine has agterm installed via `make deploy` (Release → `~/Applications/agterm.app`),
+  and the Help-menu installers run off that copy point `/usr/local/bin/agtermctl` and the agent-status
+  hooks' baked `AGTERMCTL` (in `~/.config/agterm/agent-status/agterm-agent-status.sh`) at it.
+  So once deployed, a bare `agtermctl …` on PATH, the agent-status hooks,
+  AND a plain launch/activate (LaunchServices resolves `com.umputun.agterm` to `~/Applications`) all
+  hit the DEPLOYED build — NOT whatever you just rebuilt into `build/DerivedData`.
+  When iterating on `agtermctl` or the hook scripts, the change is therefore NOT exercised by the PATH
+  CLI / the hooks until you either (a) invoke the fresh binary by full path — `build/DerivedData/Build/Products/Debug/agterm.app/Contents/MacOS/agtermctl …`
+  (or `export AGTERMCTL=` to it for the hooks), or (b) `make deploy` again and re-run Help ▸ Install
+  Command Line Tool… + Install Agent Status Hooks… to re-point PATH and the hooks at the new build.
+  For APP-code changes, do NOT quit the deployed app (see the next note — it is the user's live daily
+  driver); Debug builds carry a DISTINCT bundle id (`com.umputun.agterm.debug`,
+  project.yml per-config) so they run as a SEPARATE instance alongside the deployed Release.
+  The XCUITests no longer collide either: the `.debug` bundle id means XCUITest's launch-time terminate
+  hits only the `.debug` instance, not the deployed `com.umputun.agterm`,
+  and they still use an isolated `AGTERM_STATE_DIR`/socket.
+- **NEVER kill or relaunch the deployed `~/Applications/agterm.app` — it is the user's REAL,
+  in-use daily terminal with LIVE sessions.** BANNED: `pkill agterm` / `pkill -x agterm`,
+  `osascript -e 'tell application "agterm" to quit'`, and ANY quit-then-relaunch of the deployed app
+  (including the quit+`open` after `make deploy`).
+  After `make deploy` the Release build is COPIED into `~/Applications`,
+  but the RUNNING instance keeps the old code until the USER relaunches it on their own schedule (so
+  their live sessions survive) — just report it's installed; do NOT relaunch it.
+  For dev-build UI acceptance / socket probes, open a SEPARATE ISOLATED instance that coexists with the
+  deployed app: `open -n --env AGTERM_STATE_DIR=<tmp> --env AGTERM_CONTROL_SOCKET=<tmp>/agterm.sock build/DerivedData/Build/Products/Debug/agterm.app`
+  (verified: launches a second instance with the deployed app untouched and its socket not stolen).
+  Probe via the temp socket (`agtermctl tree --socket <tmp>/agterm.sock` — `--socket` is a per-subcommand
+  option, so it goes AFTER the subcommand, never before it) and quit ONLY that instance BY PID (`kill <pid>`,
+  never `pkill`).
+  The Debug bundle id (`com.umputun.agterm.debug`) makes the dev/test build a distinct LaunchServices
+  identity from the deployed `com.umputun.agterm`, which is what lets XCUITest (it terminates the app-under-test's
+  bundle-id instance on launch) run WITHOUT killing the deployed app — verified,
+  the e2e leaves it alive.
+  But state + socket are PATH-based (NOT bundle-id-derived, both default to `~/Library/Application Support/agterm/`),
+  so the `AGTERM_STATE_DIR`/`AGTERM_CONTROL_SOCKET` env overrides are STILL required for a manual dev
+  launch even with the distinct id — otherwise the dev instance reads/writes the user's real `workspaces.json`
+  AND steals the deployed app's socket (its `start()` unlinks-then-binds the default path).
+- **Anchor path/existence checks at an ABSOLUTE repo-root path — the Bash cwd DRIFTS.** The shell working
+  directory persists across tool calls and silently drifts (e.g. a `cd agtermCore` for `swift test` leaves
+  you there), so a later relative `find .github`/`ls`/`cd` runs from the WRONG place and returns a FALSE
+  negative.
+  NEVER assert "file/dir X doesn't exist" from a relative `find`/`ls` — confirm with an absolute path
+  (`/Users/umputun/dev.umputun/agterm/...`) or `git -C <root> ls-files`,
+  especially before claiming infra facts (CI presence, config files).
+  The repo root vs the `agtermCore` SwiftPM subpackage makes root-vs-subdir confusion easy;
+  verify the directory, don't trust a negative relative result.
+- **CI / release (`.github/workflows/`).**
+  `ci.yml` runs on push/PR to `master`, gated by a `dorny/paths-filter` (`**/*.swift`,
+  `agtermCore/**`, `agterm/**`, `project.yml`, `scripts/**`, `ci.yml`): a `test` job (`swift test` in
+  `agtermCore`) and a `build` job (`brew install xcodegen` then `scripts/build.sh`,
+  Release, with `GhosttyKit.xcframework` + ghostty/terminfo resources restored from an `actions/cache`
+  keyed on `scripts/setup.sh`), both on `macos-26`, concurrency cancel-in-progress.
+  **CI does NOT run the XCUITests** — it builds the app but never test-runs the app target;
+  only the host-free `swift test` runs in CI.
+  `release.yml` fires on `v*` tags: `scripts/release.sh <version> --publish` on `macos-26` builds an
+  unsigned DMG (`AGTERM_ALLOW_UNSIGNED=1`), publishes the GitHub release,
+  and bumps the Homebrew cask in `umputun/homebrew-apps` (needs the `HOMEBREW_TAP_PAT` secret,
+  not the default token).
+  No swiftlint step yet.
 
 ## GhosttyKit.xcframework
 
-- Source: **built from upstream `ghostty-org/ghostty` source** by `scripts/setup.sh`, pinned to the `GHOSTTY_REV` SHA (`zig build -Demit-xcframework=true -Dxcframework-target=native …` with zig 0.15.2). Self-owned: the only inputs are upstream ghostty at a pinned commit and the zig/Metal toolchains — no third-party fork, no daily-build release that can be pruned. Bump `GHOSTTY_REV` deliberately when adopting a newer libghostty.
-- **The pin is a pre-regression commit on purpose.** A libghostty `main` renderer regression introduced after `4dcb09ada` (2026-04-30) blanks the scrollback on a font-size *increase* (decrease is fine); it is NOT an agterm bug and no app-side change fixes it. Every thdxg/ghostty daily build (which agterm used to download) has it. Re-test the font-increase case before bumping past it.
-- `setup.sh` stages the freshly-built `macos/GhosttyKit.xcframework` plus `zig-out/share/{ghostty,terminfo}` resources. The xcframework, `agterm/Resources/ghostty`, and `agterm/Resources/terminfo` are gitignored and never committed.
-- The xcframework is linked with `embed: false` in `project.yml`. Never embed it; embedding breaks the signature on non-Developer-ID builds.
+- Source: **built from upstream `ghostty-org/ghostty` source** by `scripts/setup.sh`,
+  pinned to the `GHOSTTY_REV` SHA (`zig build -Demit-xcframework=true -Dxcframework-target=native …`
+  with zig 0.15.2).
+  Self-owned: the only inputs are upstream ghostty at a pinned commit and the zig/Metal toolchains —
+  no third-party fork, no daily-build release that can be pruned.
+  Bump `GHOSTTY_REV` deliberately when adopting a newer libghostty.
+- **The pin is a pre-regression commit on purpose.**
+  A libghostty `main` renderer regression introduced after `4dcb09ada` (2026-04-30) blanks the scrollback
+  on a font-size *increase* (decrease is fine); it is NOT an agterm bug and no app-side change fixes
+  it.
+  Every thdxg/ghostty daily build (which agterm used to download) has it.
+  Re-test the font-increase case before bumping past it.
+- `setup.sh` stages the freshly-built `macos/GhosttyKit.xcframework` plus `zig-out/share/{ghostty,terminfo}`
+  resources.
+  The xcframework, `agterm/Resources/ghostty`, and `agterm/Resources/terminfo` are gitignored and never
+  committed.
+- The xcframework is linked with `embed: false` in `project.yml`.
+  Never embed it; embedding breaks the signature on non-Developer-ID builds.
 
 ## Module boundary
 
-- `agtermCore` must not import GhosttyKit, AppKit, or Metal. Keeping it host-free is what lets `swift test` run with no app host. Model, persistence, and naming logic go here; the surface contract is the `TerminalSurface` protocol, which the app target's `GhosttySurfaceView` conforms to.
+- `agtermCore` must not import GhosttyKit, AppKit, or Metal.
+  Keeping it host-free is what lets `swift test` run with no app host.
+  Model, persistence, and naming logic go here; the surface contract is the `TerminalSurface` protocol,
+  which the app target's `GhosttySurfaceView` conforms to.
 - The app target owns all SwiftUI and libghostty code.
-- **Also keep `agtermCore` CoreGraphics-free — no `CGSize`/`CGPoint`/`CGRect`/`CGFloat`.** They're Foundation-reachable on Darwin and compile + `swift test` fine, but a CoreGraphics member reference (e.g. `CGSize.width`) in a Foundation-only module serializes as an unresolvable cross-reference that crashes the app target's **release** whole-module-optimizer SIL deserializer (`*** DESERIALIZATION FAILURE *** Cross-reference to module 'CoreFoundation'`, Xcode 26.5) — so it passes Debug + tests but breaks `make release`/`make deploy`. Use plain `Double`-backed structs in `agtermCore` (see `WindowGeometry.Size`/`Point`/`Rect`) and convert to/from CG at the app-target call site. Treat CoreGraphics geometry types as if they were on the banned list above.
+- **Also keep `agtermCore` CoreGraphics-free — no `CGSize`/`CGPoint`/`CGRect`/`CGFloat`.** They're Foundation-reachable
+  on Darwin and compile + `swift test` fine, but a CoreGraphics member reference (e.g. `CGSize.width`)
+  in a Foundation-only module serializes as an unresolvable cross-reference that crashes the app target's
+  **release** whole-module-optimizer SIL deserializer (`*** DESERIALIZATION FAILURE *** Cross-reference to module 'CoreFoundation'`,
+  Xcode 26.5) — so it passes Debug + tests but breaks `make release`/`make deploy`.
+  Use plain `Double`-backed structs in `agtermCore` (see `WindowGeometry.Size`/`Point`/`Rect`) and convert
+  to/from CG at the app-target call site.
+  Treat CoreGraphics geometry types as if they were on the banned list above.
 
 ## C-callback isolation
 
-- `GhosttyCallbacks` is `@unchecked Sendable`, not `@MainActor`. C closures capture nothing and reach Swift via `GhosttyApp.shared`.
+- `GhosttyCallbacks` is `@unchecked Sendable`, not `@MainActor`.
+  C closures capture nothing and reach Swift via `GhosttyApp.shared`.
 - Copy any `char*` into a Swift `String` before hopping; every `@MainActor` touch goes through `DispatchQueue.main.async`.
-- **Rendering is demand-driven, no poll timer.** `GhosttyCallbacks.wakeup` coalesces libghostty wakeups into one `DispatchQueue.main.async` `ghostty_app_tick` (an `OSAllocatedUnfairLock` flag dedupes the wakeup storm), and `GHOSTTY_ACTION_RENDER` draws the surface via `renderNow()` (`ghostty_surface_draw`). Mirrors Ghostty.app/conterm — an idle terminal does no work (the old 120Hz poll ticked continuously). The C callbacks never use `assumeIsolated`; every `@MainActor` touch hops through `DispatchQueue.main.async`.
-- `close_surface_cb` only recovers the view and dispatches to the main actor; it never frees synchronously.
+- **Rendering is demand-driven, no poll timer.**
+  `GhosttyCallbacks.wakeup` coalesces libghostty wakeups into one `DispatchQueue.main.async` `ghostty_app_tick`
+  (an `OSAllocatedUnfairLock` flag dedupes the wakeup storm), and `GHOSTTY_ACTION_RENDER` draws the surface
+  via `renderNow()` (`ghostty_surface_draw`).
+  Mirrors Ghostty.app/conterm — an idle terminal does no work (the old 120Hz poll ticked continuously).
+  The C callbacks never use `assumeIsolated`; every `@MainActor` touch hops through `DispatchQueue.main.async`.
+- `close_surface_cb` only recovers the view and dispatches to the main actor;
+  it never frees synchronously.
 
 ## Keep-in-sync conventions (HARD)
 
-These cross-subsystem contracts apply when editing ANY feature, not just the files that own them. They are restated in detail in the relevant path-scoped rules, but the principle lives here so it is always in context:
+These cross-subsystem contracts apply when editing ANY feature, not just the files that own them.
+They are restated in detail in the relevant path-scoped rules, but the principle lives here so it is
+always in context:
 
-- **A new user action is not "done" until it is drivable from the control socket.** Any action added to `AppActions`/`AppStore` requires all four: (1) a `Command` case (+ args) in `agtermCore`'s `ControlProtocol`, (2) a dispatch arm in `ControlServer`, (3) an `agtermctl` subcommand, (4) protocol round-trip + end-to-end tests. The toolbar/bottom-bar, the menu bar, and the control channel are three callers of the SAME `AppActions`/`AppStore` seam and must never drift. (The Working-norms bullet above generalizes this to control-native features with no GUI surface.) Genuinely meaningless exposure (pure visual chrome with nothing to drive — quit-confirm, CLI/skill installers, click-routing `reveal`) is the only exemption, and must be called out as such.
-- **The bundled agent skill is the fourth keep-in-sync surface.** Whenever you change the Control API (commands/args/returns), the keymap format, or the window/workspace/session/pane model, update `agterm/Resources/agent-skill/` (SKILL.md + reference.md + examples.md + troubleshooting.md + scripts, incl. the command count) so the installed agent-driver doc stays accurate. The app-repo `agterm/Resources/agent-skill/` is the SINGLE source of truth — edit ONLY there. NEVER edit, copy into, or "mirror" the installed copies at `~/.claude/skills/agterm/` or `~/.codex/skills/agterm/`; they are install OUTPUTS that Help ▸ Install Agent Skill (`SkillInstaller`) regenerates from the bundle, so a manual edit there is wrong and must never even be offered (`~/.claude/skills/agterm/` is snapshotted in the dot-files repo, but that does not make it a source).
+- **A new user action is not "done" until it is drivable from the control socket.** Any action added
+  to `AppActions`/`AppStore` requires all four: (1) a `Command` case (+ args) in `agtermCore`'s `ControlProtocol`,
+  (2) a dispatch arm in `ControlServer`, (3) an `agtermctl` subcommand, (4) protocol round-trip + end-to-end
+  tests.
+  The toolbar/bottom-bar, the menu bar, and the control channel are three callers of the SAME `AppActions`/`AppStore`
+  seam and must never drift.
+  (The Working-norms bullet above generalizes this to control-native features with no GUI surface.) Genuinely
+  meaningless exposure (pure visual chrome with nothing to drive — quit-confirm,
+  CLI/skill installers, click-routing `reveal`) is the only exemption, and must be called out as such.
+- **The bundled agent skill is the fourth keep-in-sync surface.**
+  Whenever you change the Control API (commands/args/returns), the keymap format,
+  or the window/workspace/session/pane model, update `agterm/Resources/agent-skill/` (SKILL.md + reference.md
+  + examples.md + troubleshooting.md + scripts, incl. the command count) so the installed agent-driver
+  doc stays accurate.
+  The app-repo `agterm/Resources/agent-skill/` is the SINGLE source of truth — edit ONLY there.
+  NEVER edit, copy into, or "mirror" the installed copies at `~/.claude/skills/agterm/` or `~/.codex/skills/agterm/`;
+  they are install OUTPUTS that Help ▸ Install Agent Skill (`SkillInstaller`) regenerates from the bundle,
+  so a manual edit there is wrong and must never even be offered (`~/.claude/skills/agterm/` is snapshotted
+  in the dot-files repo, but that does not make it a source).
 
 ## Subsystem notes (path-scoped rules)
 
-Detailed per-subsystem engineering notes live in `.claude/rules/*.md`, each scoped with `paths:` frontmatter so it loads into context only when you read a matching source file — that is what keeps this root file lean. When starting work on a subsystem, read its rule first: the auto-trigger covers the subsystem-owned files, but a cross-cutting edit that touches only a hub file (`AppStore.swift`, `ContentView.swift`, `agtermApp.swift`) may not match a glob, so consult this index and open the rule yourself.
+Detailed per-subsystem engineering notes live in `.claude/rules/*.md`, each scoped with `paths:` frontmatter
+so it loads into context only when you read a matching source file — that is what keeps this root file
+lean.
+When starting work on a subsystem, read its rule first: the auto-trigger covers the subsystem-owned files,
+but a cross-cutting edit that touches only a hub file (`AppStore.swift`,
+`ContentView.swift`, `agtermApp.swift`) may not match a glob, so consult this index and open the rule
+yourself.
 
-- `sidebar.md` — `NSOutlineView` sidebar: drag-reorder (sessions + workspaces), flagged working-set view, focus filter, scoped session nav, reconcile signal, persistence. Triggers on `WorkspaceSidebar.swift`, `SidebarDrop`/`SidebarMode`/`Reorder`, and the sidebar/reorder/flagged/focus UI tests.
-- `menu-actions.md` — the `AppActions` seam: View vs Navigate menu split, split panes (one session two shells), session navigation, command palettes, Ctrl-Tab MRU switcher, inline rename, font/in-terminal-search. Triggers on `AppActions.swift`, `agtermApp.swift`, `Palette`/`PaneShortcuts`/`SessionSwitcher`, `RecencyStack`/`Fuzzy`, and the menu/palette/nav/switcher/split UI tests.
-- `windows.md` — multi-window model: `WindowLibrary`, scene + claim-queue restoration, per-window quick terminal, frontmost-store resolution + quit-flush, quit confirmation, `window.*` control. Triggers on `WindowLibrary`/`WindowGeometry`/`QuitPrompt`, `QuickTerminal.swift`, and the multi-window/quick-terminal UI tests.
-- `control-api.md` — the full 44-command control catalog, the three protocol layers, addressing, and the CLI/hooks/skill installers. Triggers on `ControlServer.swift`, `ControlProtocol`/`ControlResolve`, `agtermctlKit`/`agtermctl`, the three installers + their host-free `*Install` logic, `Resources/agent-skill/`, and the control UI tests.
-- `settings.md` — `AppSettings`/`SettingsModel`, the 3-tab Settings scene, ghostty-config emission, window translucency. Triggers on `SettingsModel.swift`, `SettingsView`/`SettingsCatalog`/`WindowAppearance`/`NSColor+AgtermHex`, `AppSettings`/`SettingsStore`, and the settings UI tests.
-- `theme-picker.md` — the live-preview theme palette mode, preview/commit/cancel, the seeded default theme. Triggers on `Palette.swift`, `SettingsModel`/`SettingsCatalog`, `AppActions.swift`.
-- `keymap.md` — the kitty-flavored `keymap.conf` parser, built-in-override resolution, custom-command monitor, `{AGT_X}` tokens, reload + Edit Keymap. Triggers on `Keybind`/`KeybindMatcher`/`Keymap`/`BuiltinAction`/`CustomCommand`/`ConfigPaths`, `CustomCommandRunner.swift`, and the keymap UI tests.
-- `notifications.md` — terminal OSC 9/777 + control `notify`, suppression, click-to-reveal identity, the unseen badge, the agent-status glyph. Triggers on `NotificationManager.swift`, `Notifications`/`AgentStatus`.
-- `ui-tests.md` — XCUITest patterns: `launchForUITest` (FB11763863), Settings-tab retry helper, driving an `NSOutlineView` drag, the occlusion-timeout symptom, test cadence. Triggers on any `agtermUITests/` file.
-- `libghostty.md` — rendering / AppKit gotchas: the eager-deck surface lifecycle, the NSSplitView-titlebar-overrun rule, cursor focus, theme-tracking chrome colors, search-bar / overlay placement, reparent repaint. Triggers on the `Ghostty/` surfaces, `ContentView.swift`, `TerminalView`/`TerminalSearchBar`.
-- `app-icon.md` — the adaptive Icon Composer `.icon` build rules. Triggers on `AppIcon.icon/`, `project.yml`.
+- `sidebar.md` — `NSOutlineView` sidebar: drag-reorder (sessions + workspaces),
+  flagged working-set view, focus filter, scoped session nav, reconcile signal,
+  persistence.
+  Triggers on `WorkspaceSidebar.swift`, `SidebarDrop`/`SidebarMode`/`Reorder`,
+  and the sidebar/reorder/flagged/focus UI tests.
+- `menu-actions.md` — the `AppActions` seam: View vs Navigate menu split,
+  split panes (one session two shells), session navigation, command palettes,
+  Ctrl-Tab MRU switcher, inline rename, font/in-terminal-search.
+  Triggers on `AppActions.swift`, `agtermApp.swift`, `Palette`/`PaneShortcuts`/`SessionSwitcher`,
+  `RecencyStack`/`Fuzzy`, and the menu/palette/nav/switcher/split UI tests.
+- `windows.md` — multi-window model: `WindowLibrary`, scene + claim-queue restoration,
+  per-window quick terminal, frontmost-store resolution + quit-flush, quit confirmation,
+  `window.*` control.
+  Triggers on `WindowLibrary`/`WindowGeometry`/`QuitPrompt`, `QuickTerminal.swift`,
+  and the multi-window/quick-terminal UI tests.
+- `control-api.md` — the full 44-command control catalog, the three protocol layers,
+  addressing, and the CLI/hooks/skill installers.
+  Triggers on `ControlServer.swift`, `ControlProtocol`/`ControlResolve`,
+  `agtermctlKit`/`agtermctl`, the three installers + their host-free `*Install` logic,
+  `Resources/agent-skill/`, and the control UI tests.
+- `settings.md` — `AppSettings`/`SettingsModel`, the 3-tab Settings scene,
+  ghostty-config emission, window translucency.
+  Triggers on `SettingsModel.swift`, `SettingsView`/`SettingsCatalog`/`WindowAppearance`/`NSColor+AgtermHex`,
+  `AppSettings`/`SettingsStore`, and the settings UI tests.
+- `theme-picker.md` — the live-preview theme palette mode, preview/commit/cancel,
+  the seeded default theme.
+  Triggers on `Palette.swift`, `SettingsModel`/`SettingsCatalog`, `AppActions.swift`.
+- `keymap.md` — the kitty-flavored `keymap.conf` parser, built-in-override resolution,
+  custom-command monitor, `{AGT_X}` tokens, reload + Edit Keymap.
+  Triggers on `Keybind`/`KeybindMatcher`/`Keymap`/`BuiltinAction`/`CustomCommand`/`ConfigPaths`,
+  `CustomCommandRunner.swift`, and the keymap UI tests.
+- `notifications.md` — terminal OSC 9/777 + control `notify`, suppression,
+  click-to-reveal identity, the unseen badge, the agent-status glyph.
+  Triggers on `NotificationManager.swift`, `Notifications`/`AgentStatus`.
+- `ui-tests.md` — XCUITest patterns: `launchForUITest` (FB11763863), Settings-tab retry helper,
+  driving an `NSOutlineView` drag, the occlusion-timeout symptom, test cadence.
+  Triggers on any `agtermUITests/` file.
+- `libghostty.md` — rendering / AppKit gotchas: the eager-deck surface lifecycle,
+  the NSSplitView-titlebar-overrun rule, cursor focus, theme-tracking chrome colors,
+  search-bar / overlay placement, reparent repaint.
+  Triggers on the `Ghostty/` surfaces, `ContentView.swift`, `TerminalView`/`TerminalSearchBar`.
+- `app-icon.md` — the adaptive Icon Composer `.icon` build rules.
+  Triggers on `AppIcon.icon/`, `project.yml`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,10 @@ but a cross-cutting edit that touches only a hub file (`AppStore.swift`,
 `ContentView.swift`, `agtermApp.swift`) may not match a glob, so consult this index and open the rule
 yourself.
 
+**When writing or editing these notes — this file and `.claude/rules/*.md` — use semantic line breaks: one sentence per line, never a giant single-line bullet.**
+Break after every sentence (split a long sentence further at clause boundaries, around 100 columns), keep inline-code spans intact, and render any long enumeration (e.g. a command catalog) as a real markdown list rather than one inline run.
+This only changes raw-text line breaks — the rendered markdown is identical — but it keeps a diff scoped to the sentence that changed and stops two branches that edit the same note from conflicting on the whole paragraph.
+
 - `sidebar.md` — `NSOutlineView` sidebar: drag-reorder (sessions + workspaces),
   flagged working-set view, focus filter, scoped session nav, reconcile signal,
   persistence.


### PR DESCRIPTION
the `.claude/rules/*.md` notes and CLAUDE.md's long bullets were written as huge single-line bullets. The worst, control-api.md's command catalog, was a single 35,001-char line - unmergeable (two branches editing it conflict on the whole line) and unreviewable (no per-line comments, no useful wrap).

reflowed every rule file and CLAUDE.md to semantic line breaks: one sentence per line, long sentences split at clause boundaries near 100 cols, inline-code spans kept intact. The inline command catalog in control-api.md is now a real markdown list, and the longest line dropped from 35,001 to ~295.

pure reformatting: 11 of 12 files are byte-identical after whitespace normalization, all 46 catalog command names are preserved, and every `paths:` frontmatter block is byte-identical, so rule auto-loading is unaffected. Also added a CLAUDE.md convention so the giant single-line bullets don't come back.

the open PRs touching these files (#46/#33/#32 on control-api.md, #48 on notifications.md, #33 on windows.md, #32 on CLAUDE.md) will need a rebase after this, but each then conflicts on a sentence-scoped line instead of the 35K line.

Fix #39
