### PR TITLE
chore: adopt swiftlint with a tailored, low-noise config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
               - "agterm/**"
               - "project.yml"
               - "scripts/**"
+              - ".swiftlint.yml"
               - ".github/workflows/ci.yml"
 
   test:
@@ -40,6 +41,18 @@ jobs:
       - name: swift test
         working-directory: agtermCore
         run: swift test
+
+  lint:
+    name: swiftlint
+    needs: changes
+    if: needs.changes.outputs.swift == 'true'
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install swiftlint
+        run: brew install swiftlint
+      - name: swiftlint (strict)
+        run: swiftlint lint --strict
 
   build:
     name: Build app

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,53 @@
+# swiftlint config for agterm — tailored, low-noise.
+# philosophy: disable only rules that fight deliberate project conventions; keep every
+# rule that surfaces a real, fixable finding on; grandfather size limits on big-by-design
+# files (refactoring them is out of scope) so only NEW growth warns.
+
+excluded:
+  - build                       # xcodebuild DerivedData
+  - .build                      # SwiftPM build (root)
+  - agtermCore/.build           # SwiftPM build + vendored checkouts
+  - GhosttyKit.xcframework
+  - agterm/Resources
+
+disabled_rules:
+  - identifier_name             # short local names (lmt, id, x, y) are deliberate — CLAUDE.md
+  - trailing_comma              # style preference, not a defect
+  - force_try                   # `try!` is idiomatic in tests; 0 in production code
+  - optional_data_string_conversion # we want lossy String(decoding:as:) for terminal/process bytes
+                                     # (best-effort, never nil), not the failable initializer
+
+type_name:
+  excluded:
+    - agtermApp                 # the @main App struct is deliberately brand-lowercase
+    - Go                        # the `session go` CLI subcommand type is short by design
+
+line_length:
+  warning: 200                  # code deliberately runs long; flag only genuinely long lines
+  error: 400
+  ignores_comments: true
+  ignores_urls: true
+
+# big-by-design: the 44-arm control dispatch, the eager-deck ContentView/surface views,
+# and the large XCUITest/unit suites. limits sit just above today's maxima so the repo is
+# clean now and only further growth warns.
+file_length:
+  warning: 2500
+  error: 3000
+type_body_length:
+  warning: 1800
+  error: 2500
+function_body_length:
+  warning: 250
+  error: 400
+cyclomatic_complexity:
+  warning: 25
+  error: 50
+  ignores_case_statements: true # a flat command-dispatch switch is not "complex"
+
+nesting:
+  type_level: 2                 # tightly-scoped private helper types nested 2 deep are idiomatic
+
+large_tuple:
+  warning: 3                    # 3-member named returns are fine; 4+ should become a struct
+  error: 5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,11 +69,21 @@ surface ownership, and the C-boundary concurrency contract before changing the b
 - `scripts/build.sh` — same but Release, no launch.
 - `cd agtermCore && swift test` — run the host-free unit tests (`scripts/test.sh` wraps this).
 - `Makefile` — a thin front door over the scripts: `make prep`/`build` (Debug,
-  no launch)/`run`/`release`/`deploy` (Release build + copy to `~/Applications`)/`test`/`dist VERSION=x.y.z [PUBLISH=1]`
+  no launch)/`run`/`release`/`deploy` (Release build + copy to `~/Applications`)/`test`/`lint`/`dist VERSION=x.y.z [PUBLISH=1]`
   (the `release.sh` DMG)/`clean`; a bare `make` lists them.
-  The scripts stay the source of truth — only `build` and `deploy` carry their own recipe.
+  The scripts stay the source of truth — only `build`, `deploy`, and `lint` carry their own recipe.
+- `make lint` runs `swiftlint lint --strict` over the tree, configured by `.swiftlint.yml` at the repo
+  root.
+  The config disables only rules that fight deliberate conventions (`identifier_name`,
+  `trailing_comma`, `force_try`, `optional_data_string_conversion` — the last keeps the lossy `String(decoding:as:)`
+  for terminal/process bytes), exempts the deliberately-named `agtermApp`/`Go` types,
+  tunes `line_length` (200) and `cyclomatic_complexity` (`ignores_case_statements`,
+  so the flat 44-arm command dispatch isn't "complex"), allows 2-deep type nesting,
+  and grandfathers the size limits on the big-by-design files (the control dispatch,
+  the eager-deck views, the large test suites) just above today's maxima — so only NEW growth warns.
+  `--strict` promotes warnings to failures, so the tree must stay swiftlint-clean (zero findings).
 
-The app must build and `swift test` must stay green after every change.
+The app must build, `swift test` must stay green, and `make lint` must pass after every change.
 
 - **Working in a git WORKTREE: SYMLINK the prebuilt artifacts, don't re-run setup.** A fresh `git worktree`
   does NOT contain the gitignored `GhosttyKit.xcframework`, `agterm/Resources/ghostty`,
@@ -157,17 +167,18 @@ The app must build and `swift test` must stay green after every change.
   verify the directory, don't trust a negative relative result.
 - **CI / release (`.github/workflows/`).**
   `ci.yml` runs on push/PR to `master`, gated by a `dorny/paths-filter` (`**/*.swift`,
-  `agtermCore/**`, `agterm/**`, `project.yml`, `scripts/**`, `ci.yml`): a `test` job (`swift test` in
-  `agtermCore`) and a `build` job (`brew install xcodegen` then `scripts/build.sh`,
+  `agtermCore/**`, `agterm/**`, `project.yml`, `scripts/**`, `.swiftlint.yml`, `ci.yml`): a `test` job
+  (`swift test` in `agtermCore`), a `lint` job (`brew install swiftlint` then `swiftlint lint --strict`
+  — no build, it only parses sources), and a `build` job (`brew install xcodegen` then `scripts/build.sh`,
   Release, with `GhosttyKit.xcframework` + ghostty/terminfo resources restored from an `actions/cache`
-  keyed on `scripts/setup.sh`), both on `macos-26`, concurrency cancel-in-progress.
+  keyed on `scripts/setup.sh`), all on `macos-26`, concurrency cancel-in-progress.
   **CI does NOT run the XCUITests** — it builds the app but never test-runs the app target;
   only the host-free `swift test` runs in CI.
+  The `lint` job is `--strict`, so any swiftlint warning fails the build (see the `make lint` note above).
   `release.yml` fires on `v*` tags: `scripts/release.sh <version> --publish` on `macos-26` builds an
   unsigned DMG (`AGTERM_ALLOW_UNSIGNED=1`), publishes the GitHub release,
   and bumps the Homebrew cask in `umputun/homebrew-apps` (needs the `HOMEBREW_TAP_PAT` secret,
   not the default token).
-  No swiftlint step yet.
 
 ## GhosttyKit.xcframework
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ INSTALL_DIR := $(HOME)/Applications
 RELEASE_APP := build/DerivedData/Build/Products/Release/agterm.app
 
 .DEFAULT_GOAL := help
-.PHONY: help prep generate build run release deploy test dist clean
+.PHONY: help prep generate build run release deploy test lint dist clean
 
 help: ## list targets
 	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | \
@@ -34,6 +34,9 @@ deploy: release ## release build + copy to ~/Applications
 
 test: ## host-free agtermCore unit tests (scripts/test.sh)
 	./scripts/test.sh
+
+lint: ## swiftlint over the tree (strict — warnings fail too)
+	swiftlint lint --strict --quiet
 
 dist: ## signed + notarized DMG — usage: make dist VERSION=x.y.z [PUBLISH=1]
 	@test -n "$(VERSION)" || { echo "usage: make dist VERSION=x.y.z [PUBLISH=1]" >&2; exit 1; }

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -613,10 +613,11 @@ final class AppActions {
         let current = settingsModel?.settings.theme
         func item(_ name: String?, title: String) -> PaletteItem {
             PaletteItem(id: themeID(name), title: title, badge: name == current ? "current" : nil,
-                        onSelect: { [weak self] in self?.previewTheme(name) }) { [weak self] in
-                self?.previewTheme(name)
-                self?.commitThemePreview()
-            }
+                        onSelect: { [weak self] in self?.previewTheme(name) },
+                        run: { [weak self] in
+                            self?.previewTheme(name)
+                            self?.commitThemePreview()
+                        })
         }
         // the nil row is ghostty's built-in default (no theme file); the app's own default is the
         // bundled "agterm" theme, which appears in the named list like any other.

--- a/agterm/ContentView.swift
+++ b/agterm/ContentView.swift
@@ -1156,7 +1156,6 @@ private struct WindowAccessor: NSViewRepresentable {
             }
         }
 
-
         /// Re-assert the window forward under XCUITest: the FB11763863 reopen can present it slightly
         /// after the view attaches, so keep ordering it front for a short schedule.
         private func scheduleUITestWindowForward(_ window: NSWindow) {

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -451,8 +451,8 @@ final class ControlServer {
             return focusSessionPane(request.target, window: request.args?.window, pane: request.args?.pane)
         case .sessionStatus:
             return setSessionStatus(request.target, window: request.args?.window,
-                                    status: request.args?.status, blink: request.args?.blink,
-                                    autoReset: request.args?.autoReset, sound: request.args?.sound)
+                                    update: StatusUpdate(status: request.args?.status, blink: request.args?.blink,
+                                                         autoReset: request.args?.autoReset, sound: request.args?.sound))
         case .sessionFlag:
             return flagSession(request.target, window: request.args?.window, mode: request.args?.mode)
         case .sessionCopy:
@@ -671,8 +671,16 @@ final class ControlServer {
     /// per-call `sound` is given and the session TRANSITIONS into `blocked`, the user's configured Settings
     /// "Blocked sound" (`blockedStatusSoundName`) plays as a best-effort default. The indicator is ephemeral
     /// and rendered on every non-idle session.
-    private func setSessionStatus(_ target: String?, window: String?, status: String?, blink: Bool?,
-                                  autoReset: Bool?, sound: String?) -> ControlResponse {
+    /// The per-call status payload for `setSessionStatus`; the addressing target/window stay separate.
+    private struct StatusUpdate {
+        let status: String?
+        let blink: Bool?
+        let autoReset: Bool?
+        let sound: String?
+    }
+
+    private func setSessionStatus(_ target: String?, window: String?, update: StatusUpdate) -> ControlResponse {
+        let status = update.status, blink = update.blink, autoReset = update.autoReset, sound = update.sound
         guard let parsed = AgentStatus(rawValue: status ?? "") else {
             return ControlResponse(ok: false, error: "invalid status")
         }

--- a/agterm/Ghostty/GhosttyApp.swift
+++ b/agterm/Ghostty/GhosttyApp.swift
@@ -315,7 +315,7 @@ final class GhosttyApp {
             }
         }
         // the theme file fills any selection color not set explicitly above.
-        if (selBg == nil || selFg == nil), let themeName, !themeName.isEmpty,
+        if selBg == nil || selFg == nil, let themeName, !themeName.isEmpty,
            let themesDir = Bundle.main.url(forResource: "ghostty", withExtension: nil)?
                .appendingPathComponent("themes", isDirectory: true) {
             for (key, value) in keyValues(ofFileAt: themesDir.appendingPathComponent(themeName).path) {

--- a/agterm/Views/SettingsView.swift
+++ b/agterm/Views/SettingsView.swift
@@ -99,7 +99,9 @@ private struct GeneralSettingsView: View {
             Section("Sessions") {
                 Toggle("Restore running commands on restart", isOn: restoreRunningCommand)
                     .accessibilityIdentifier("settings-restore-running-command")
-                Text("Re-runs each pane's foreground command when the app relaunches. Only single-process commands restore faithfully; programs listed in restore-denylist.conf (terminal multiplexers by default) start fresh.")
+                Text("Re-runs each pane's foreground command when the app relaunches. Only single-process "
+                    + "commands restore faithfully; programs listed in restore-denylist.conf (terminal "
+                    + "multiplexers by default) start fresh.")
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
             }
@@ -107,7 +109,9 @@ private struct GeneralSettingsView: View {
             Section("Ghostty Config") {
                 Toggle("Use my global Ghostty config", isOn: inheritGlobalGhosttyConfig)
                     .accessibilityIdentifier("settings-inherit-global-ghostty")
-                Text("Also load ~/.config/ghostty/config on top of agterm's own config. Off by default so agterm stays self-contained — a config written for Ghostty.app won't silently change agterm. To customize agterm, edit ~/.config/agterm/ghostty.conf (File ▸ Edit ghostty.conf…); it is always loaded.")
+                Text("Also load ~/.config/ghostty/config on top of agterm's own config. Off by default so agterm stays "
+                    + "self-contained — a config written for Ghostty.app won't silently change agterm. To customize agterm, "
+                    + "edit ~/.config/agterm/ghostty.conf (File ▸ Edit ghostty.conf…); it is always loaded.")
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
             }

--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -137,7 +137,7 @@ private final class StatusIconView: NSImageView {
         image = Self.icon(for: indicator.status)
         widthConstraint.constant = Self.glyphWidth
         setAccessibilityValue(indicator.status.rawValue)
-        indicator.blink ? startBlink() : stopBlink()
+        if indicator.blink { startBlink() } else { stopBlink() }
     }
 
     private func startBlink() {
@@ -180,6 +180,8 @@ private final class SidebarRowView: NSTableRowView {
 
     override var isEmphasized: Bool {
         get { window?.isKeyWindow ?? false }
+        // isEmphasized is derived from the window's key state; the setter only triggers a redraw.
+        // swiftlint:disable:next unused_setter_value
         set { needsDisplay = true }
     }
 
@@ -1293,14 +1295,21 @@ struct WorkspaceSidebar: NSViewRepresentable {
             return true
         }
 
+        /// The resolved session drop. `dropChildIndex` is the PRE-removal slot to highlight; `destination`
+        /// is the POST-removal index `moveSession` expects.
+        private struct SessionMove {
+            let sessionID: UUID
+            let workspace: UUID
+            let dropChildIndex: Int
+            let destination: Int
+        }
+
         /// Resolves a proposed session drop into the move it would perform, or nil when the drop is
         /// invalid or a no-op (so both `validateDrop` and `acceptDrop` agree exactly). Reads the pasteboard
         /// + store to map the dragged session and drop-target row to indices, then defers the index
         /// arithmetic (drop-on-row redirect, post-removal off-by-one, no-op detection) to the host-free
-        /// `SidebarDrop.resolveSession`. `dropChildIndex` is the PRE-removal slot to highlight; `destination`
-        /// is the POST-removal index `moveSession` expects.
-        private func resolveSessionMove(from info: NSDraggingInfo, item: Any?, childIndex index: Int)
-            -> (sessionID: UUID, workspace: UUID, dropChildIndex: Int, destination: Int)? {
+        /// `SidebarDrop.resolveSession`.
+        private func resolveSessionMove(from info: NSDraggingInfo, item: Any?, childIndex index: Int) -> SessionMove? {
             guard let sessionID = draggedSessionID(from: info), let node = item as? SidebarNode,
                   let source = store.sessionLocation(ofSession: sessionID) else { return nil }
 
@@ -1316,7 +1325,8 @@ struct WorkspaceSidebar: NSViewRepresentable {
 
             guard let move = SidebarDrop.resolveSession(sourceWorkspace: source.workspace, sourceIndex: source.index,
                                                         target: target, childIndex: index) else { return nil }
-            return (sessionID, move.workspace, move.dropChildIndex, move.destination)
+            return SessionMove(sessionID: sessionID, workspace: move.workspace,
+                               dropChildIndex: move.dropChildIndex, destination: move.destination)
         }
 
         /// Resolves a workspace drop into the top-level reorder it would perform, or nil when it is a no-op

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -636,7 +636,7 @@ struct agtermApp: App {
     /// hides + tears it down so the next show spawns fresh. Seeds from the session's current dir + env ids.
     @MainActor
     private static func makeScratchSurface(for session: Session, store: AppStore, env: [String: String],
-                                          suppressAutoFocus: Bool, library: WindowLibrary) -> GhosttySurfaceView {
+                                           suppressAutoFocus: Bool, library: WindowLibrary) -> GhosttySurfaceView {
         // autoFocus on creation gives the first show reliable focus — but suppress it when another
         // surface already owns focus above the scratch (a full overlay, or the window-level quick
         // terminal), so a scratch created under one can't steal first responder. Re-shows are focused

--- a/agtermCore/Sources/agtermctlKit/Commands.swift
+++ b/agtermCore/Sources/agtermctlKit/Commands.swift
@@ -205,7 +205,9 @@ struct Workspace: ParsableCommand {
 struct Session: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Session commands.",
-        subcommands: [New.self, Close.self, Select.self, Go.self, Rename.self, Move.self, TypeText.self, Split.self, Scratch.self, Focus.self, Copy.self, Status.self, FlagCommand.self, Search.self, Overlay.self]
+        subcommands: [New.self, Close.self, Select.self, Go.self, Rename.self, Move.self, TypeText.self,
+                      Split.self, Scratch.self, Focus.self, Copy.self, Status.self, FlagCommand.self,
+                      Search.self, Overlay.self]
     )
 
     struct New: RequestCommand {
@@ -373,7 +375,12 @@ struct Session: ParsableCommand {
         @Argument(help: "State: idle, active, completed, or blocked.") var state: String
         @Flag(name: .long, help: "Pulse the indicator for attention.") var blink = false
         @Flag(name: .long, help: "Reset the indicator to idle once the session is visited.") var autoReset = false
-        @Option(name: .long, help: "Play a sound when set: 'default' (or 'beep') for the system alert sound, or a system sound name (Basso, Blow, Bottle, Frog, Funk, Glass, Hero, Morse, Ping, Pop, Purr, Sosumi, Submarine, Tink).") var sound: String?
+        @Option(name: .long, help: """
+            Play a sound when set: 'default' (or 'beep') for the system alert sound, or a system sound \
+            name (Basso, Blow, Bottle, Frog, Funk, Glass, Hero, Morse, Ping, Pop, Purr, Sosumi, \
+            Submarine, Tink).
+            """)
+        var sound: String?
         @OptionGroup var target: TargetOptions
         @OptionGroup var options: ClientOptions
 


### PR DESCRIPTION
adopt swiftlint with a tailored config that respects the project's deliberate conventions and surfaces only real findings. Fix #37.

**config** (`.swiftlint.yml`, repo root). Disables only rules that fight conventions: `identifier_name` (short local names are deliberate), `trailing_comma`, `force_try` (all in tests, 0 in production), and `optional_data_string_conversion` (the terminal/process-byte sites want the lossy `String(decoding:as:)`, never nil). `type_name` exempts the deliberately-named `agtermApp` and `Go`. `line_length` is 200/400 with `ignores_comments`; `cyclomatic_complexity` uses `ignores_case_statements`, so the flat 44-arm control dispatch reads as 19 instead of 69. nesting is allowed 2 deep. The size limits on the big-by-design files (control dispatch, eager-deck views, large test suites) are grandfathered just above today's maxima, so only new growth warns. The default ruleset goes from 1054 violations to 0.

**code fixes** (real findings, fixed not suppressed). Redundant parens dropped, an explicit `run:` closure label, a double blank line collapsed, continuation params aligned, a void-returning ternary swapped for `if/else`, the deliberate `isEmphasized` setter inline-disabled with a reason, and two 4+-field groups folded into `SessionMove`/`StatusUpdate` structs (internal helper signatures, no protocol/CLI/wire change). Four over-long lines wrapped.

**tooling**. `make lint` runs `swiftlint lint --strict`; a new strict `swiftlint` CI job (`brew install swiftlint`, no app build needed) runs on the same swift paths-filter, with `.swiftlint.yml` added to it. CLAUDE.md build and CI notes updated.

verified: `swiftlint --strict` clean, `swift test` 805 green, app builds.
