### PR TITLE
feat: add session.resize control command to move the split divider

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -86,7 +86,7 @@ paths:
   The skill is a REFERENCE/knowledge skill (both user-invocable via `/agterm` and model-triggered,
   `allowed-tools: Bash(agtermctl *)`; the agent-neutral `description` carries the trigger nouns since
   Codex may ignore the extra `when_to_use` field — unknown frontmatter is harmless),
-  authored at `agterm/Resources/agent-skill/` (`SKILL.md` overview + model + addressing + 46-command
+  authored at `agterm/Resources/agent-skill/` (`SKILL.md` overview + model + addressing + 47-command
   summary + the image-display helper + a troubleshooting/reporting pointer;
   `reference.md` full per-command detail + keymap format; `examples.md` agtermctl recipes;
   `troubleshooting.md` diagnosing the common problems (keymap editor, custom actions,
@@ -156,10 +156,10 @@ paths:
   exact `uuidString` (case-insensitive), or a git-style unique prefix.
   Zero prefix hits → `notFound` error, ≥2 → `ambiguous` error listing the candidates.
   `--target` defaults to `active`, so scripts rarely type an id and never for "the current one".
-- **Command catalog (46 commands):**
+- **Command catalog (47 commands):**
   - `tree`
   - `workspace.new`/`workspace.rename`/`workspace.delete`/`workspace.select`/`workspace.move`/`workspace.focus`
-  - `session.new`/`session.close`/`session.select`/`session.rename`/`session.move`/`session.type`/`session.split`/`session.scratch`/`session.focus`/`session.go`/`session.copy`/`session.search`/`session.status`/`session.flag`/`session.overlay.open`/`session.overlay.close`/`session.overlay.result`
+  - `session.new`/`session.close`/`session.select`/`session.rename`/`session.move`/`session.type`/`session.split`/`session.scratch`/`session.focus`/`session.resize`/`session.go`/`session.copy`/`session.search`/`session.status`/`session.flag`/`session.overlay.open`/`session.overlay.close`/`session.overlay.result`
   - `quick`
   - `sidebar`/`sidebar.mode`/`sidebar.expand`/`sidebar.collapse`
   - `notify`
@@ -221,6 +221,26 @@ paths:
   shown side-by-side or hidden — when hidden, focusing a pane swaps which one shows maximized),
   drives `AppActions.setSplitFocus(_:of:)`, and is the control half of the ⌘⌥←/→ keyboard nav + the "Focus
   Left/Right Pane" menu/palette items.
+  `session.resize` moves the split DIVIDER — it is control-NATIVE (the divider is otherwise mouse-drag
+  only; NO GUI/menu/keymap action, so a key is bound by mapping a `command "agtermctl session resize …"`
+  custom action).
+  `args.ratio` sets the absolute left-pane fraction; `args.ratioDelta` is a signed relative nudge (the
+  CLI's `--grow-left`/`--grow-right` map to ±`ratioDelta`, applied to the current fraction,
+  `AppStore.splitRatioDefault` = 0.5 when never moved); exactly one must be set (neither/both error).
+  It errors when the session has no split (mirroring `session.focus`), clamps + persists via the host-free
+  `AppStore.applySplitRatio` (→ `AppStore.clampSplitRatio`, `splitRatioMin...splitRatioMax`),
+  then posts the object-scoped `.agtermApplySplitRatio` (object = the `Session`) so the matching `SplitProbeView`
+  (`ContentView`) moves the LIVE divider via `setPosition` — a no-op when the split is hidden (no live
+  `NSSplitView`; the stored fraction applies on next show).
+  It echoes the applied (clamped) fraction in the new `ControlResult.ratio` (the CLI prints it as a bare
+  `%.3f` number, scriptable).
+  Four-point keep-in-sync audit for `session.resize`: (1) `case sessionResize = "session.resize"` +
+  `ControlArgs.ratio`/`ratioDelta` + `ControlResult.ratio` in `ControlProtocol.swift`,
+  (2) the `.sessionResize` dispatch arm (`resizeSplit`) in `ControlServer` (+ the `SplitProbeView` re-apply
+  observer in `ContentView`), (3) the `session resize --split-ratio|--grow-left|--grow-right` subcommand
+  (`Resize`, `validate()`-guarded exactly-one) in `agtermctlKit` + the `result.ratio` format arm in `SocketClient`,
+  (4) round-trip in `ControlProtocolTests` + `AppStoreTests` (clamp/apply) + `CommandsTests` (validate/mapping)
+  + `SocketClientTests` (format) + the e2e `testSessionResizeSplitDivider` in `ControlAPIUITests`.
   `session.go` navigates BETWEEN sessions — `args.to` is `next`|`prev`|`first`|`last`|`next-attention`|`prev-attention`
   and acts on the target store's CURRENT selection (it is RELATIVE, so it resolves the placement store
   via `resolvePlacementStore` rather than a session target — there is NO `--target`),
@@ -553,5 +573,5 @@ paths:
   `testRestoreClearSucceeds`) in `ControlAPIUITests`.
   **Agent-skill mirror (HARD keep-in-sync, 4th surface):** all commands are documented in the bundled
   `agterm/Resources/agent-skill/` (SKILL.md summary, reference.md detail,
-  examples.md recipes) and the command count there is bumped to 46 to match.
+  examples.md recipes) and the command count there is bumped to 47 to match.
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ agtermctl session move --to up                   # reorder the active session wi
 agtermctl session move "$ws"                      # relocate the active session to another workspace (appends)
 agtermctl workspace move --to top                # reorder a workspace among its siblings (up|down|top|bottom)
 agtermctl session split toggle                   # split the active session
+agtermctl session resize --split-ratio 0.7       # set the split divider (left-pane fraction); or --grow-left/--grow-right D
 agtermctl session scratch toggle                 # show/hide the active session's scratch terminal (on|off|toggle)
 agtermctl session flag on                        # flag the active session for the flagged working-set view (on|off|toggle|clear)
 agtermctl sidebar mode flagged                   # show only the flagged sessions as a flat list (tree|flagged|toggle)

--- a/agterm/ContentView.swift
+++ b/agterm/ContentView.swift
@@ -1410,6 +1410,7 @@ private struct SplitRatioAccessor: NSViewRepresentable {
         /// Top strip (in points) to clip the split's divider out of; updated on a compact-toolbar toggle.
         var titlebarHeight: CGFloat = 0 { didSet { if titlebarHeight != oldValue { updateDividerClip() } } }
         nonisolated(unsafe) private var resizeObserver: NSObjectProtocol?
+        nonisolated(unsafe) private var applyObserver: NSObjectProtocol?
         nonisolated(unsafe) private var saveWorkItem: DispatchWorkItem?
         private weak var splitView: NSSplitView?
         private var dividerClipMask: CALayer?
@@ -1446,6 +1447,25 @@ private struct SplitRatioAccessor: NSViewRepresentable {
                 // `capture()`, matching the codebase's notification-closure pattern (e.g. ControlServer).
                 MainActor.assumeIsolated { self?.capture() }
             }
+            // `session.resize` stores a new fraction on the session and posts this (object-scoped to the
+            // session) to move the LIVE divider — the programmatic analogue of a user drag. Unlike the
+            // one-shot restore in `layout()`, it fires on every resize command.
+            applyObserver = NotificationCenter.default.addObserver(
+                forName: .agtermApplySplitRatio, object: session, queue: .main) { [weak self] _ in
+                MainActor.assumeIsolated { self?.applyRatio() }
+            }
+        }
+
+        /// Move the live divider to the session's stored `splitRatio` (set by `session.resize` just before
+        /// it posts `.agtermApplySplitRatio`). The follow-on `didResizeSubviews` → `capture()` is a no-op:
+        /// the captured fraction equals the value we just set, so `capture()`'s near-equal guard skips it.
+        private func applyRatio() {
+            guard let split = splitView, let ratio = session.splitRatio else { return }
+            let total = split.bounds.width
+            // no real width yet (mid-relayout): re-arm the one-shot `layout()` restore so it applies the
+            // new fraction on the next pass instead of leaving the model ahead of the divider.
+            guard total > 1 else { restored = false; return }
+            split.setPosition(total * CGFloat(ratio), ofDividerAt: 0)
         }
 
         /// Mask the split's divider out of the titlebar zone — the strip ABOVE the window's titlebar boundary
@@ -1515,6 +1535,7 @@ private struct SplitRatioAccessor: NSViewRepresentable {
         deinit {
             saveWorkItem?.cancel()
             if let resizeObserver { NotificationCenter.default.removeObserver(resizeObserver) }
+            if let applyObserver { NotificationCenter.default.removeObserver(applyObserver) }
         }
     }
 }

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -449,6 +449,9 @@ final class ControlServer {
                                   command: request.args?.command)
         case .sessionFocus:
             return focusSessionPane(request.target, window: request.args?.window, pane: request.args?.pane)
+        case .sessionResize:
+            return resizeSplit(request.target, window: request.args?.window,
+                               ratio: request.args?.ratio, delta: request.args?.ratioDelta)
         case .sessionStatus:
             return setSessionStatus(request.target, window: request.args?.window,
                                     update: StatusUpdate(status: request.args?.status, blink: request.args?.blink,
@@ -658,6 +661,38 @@ final class ControlServer {
             }
             actions.setSplitFocus(toSplit, of: session)
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
+        }
+    }
+
+    /// Resize a split session's divider (control-native: no GUI/menu equivalent — the GUI resizes by
+    /// dragging the divider). `ratio` is an absolute left-pane fraction; `delta` is a signed relative nudge
+    /// (positive grows the left pane) applied to the session's current fraction (0.5 when never moved).
+    /// Exactly one must be set. The clamped fraction is stored + persisted via `AppStore.applySplitRatio`,
+    /// then `.agtermApplySplitRatio` pokes the session's `SplitProbeView` to move the live divider (a no-op
+    /// when the split is hidden — the stored value applies on next show). Errors when the session has no
+    /// split, mirroring `session.focus`. Echoes the applied (clamped) fraction in `result.ratio`.
+    private func resizeSplit(_ target: String?, window: String?, ratio: Double?, delta: Double?) -> ControlResponse {
+        switch (ratio, delta) {
+        case (nil, nil):
+            return ControlResponse(ok: false, error: "session.resize requires --split-ratio, --grow-left, or --grow-right")
+        case (.some, .some):
+            return ControlResponse(ok: false, error: "session.resize: --split-ratio is mutually exclusive with --grow-left/--grow-right")
+        default:
+            break
+        }
+        return resolveSession(target, window: window) { store, id in
+            guard let session = store.session(withID: id) else {
+                return ControlResponse(ok: false, error: "no such session: \(target ?? "active")")
+            }
+            guard session.hasSplit else {
+                return ControlResponse(ok: false, error: "session has no split")
+            }
+            let requested = ratio ?? ((session.splitRatio ?? AppStore.splitRatioDefault) + (delta ?? 0))
+            guard let applied = store.applySplitRatio(requested, forSession: id) else {
+                return ControlResponse(ok: false, error: "no such session: \(target ?? "active")")
+            }
+            NotificationCenter.default.post(name: .agtermApplySplitRatio, object: session)
+            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString, ratio: applied))
         }
     }
 

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -14,7 +14,7 @@ description: >
   feature request / question as a GitHub Discussion.
 when_to_use: >
   Trigger on: agterm, agtermctl, agterm control socket, session.new, session.close, session.type,
-  session.split, session.scratch, session.focus, session.go, session.copy, session.search, session.status,
+  session.split, session.scratch, session.focus, session.resize, session.go, session.copy, session.search, session.status,
   session.flag, session.overlay, workspace.new, workspace.select, workspace.move, workspace.focus, window.new, window.list,
   window.select, window.resize, window.move, quick terminal, sidebar, sidebar.mode, sidebar.expand, sidebar.collapse, flagged, notify, font.inc, keymap.reload, config.reload,
   theme.set, theme.list, select theme, edit keymap, show an image, display an image inline, show-image,
@@ -88,7 +88,7 @@ a global `--window <id|prefix|active>` to operate on a specific window's tree (d
 
 Scripts rarely type ids: create with `*.new` (capture the returned id), or act on `active`.
 
-## Command summary (46 commands)
+## Command summary (47 commands)
 
 Run `agtermctl <area> <cmd> --help` for exact flags. Full detail in **reference.md**; recipes in
 **examples.md**.
@@ -118,6 +118,10 @@ via `session status`: `active`|`completed`|`blocked`, omitted when idle).
   recreates). `--command` (when showing) runs a program instead of a shell, run-once like `session new
   --command` (respawns the scratch if one is open).
 - `focus [left|right|other]` — move focus between split panes.
+- `resize --split-ratio R | --grow-left D | --grow-right D` — move the split divider (no GUI/keymap
+  equivalent — bind it via a `command "agtermctl session resize …"` custom action). `--split-ratio` sets
+  the absolute left-pane fraction (0..1, clamped to 0.05..0.95); `--grow-left`/`--grow-right` nudge it by
+  a fraction. Prints the applied (clamped) fraction.
 - `status <idle|active|completed|blocked> [--blink] [--auto-reset] [--sound NAME]` — set the sidebar agent glyph (`--sound default` or a system sound name plays a one-shot sound).
 - `flag [on|off|toggle|clear]` — flag a session for the flagged working-set view (`clear` unflags all).
 - `overlay open <command> [--cwd DIR] [--wait] [--block] [--size-percent N]` · `overlay close` ·

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -60,9 +60,25 @@ ws=$(agtermctl workspace new "build" --json | jq -r '.result.id')
 a=$(agtermctl session new --workspace "$ws" --cwd "$HOME/proj" --json | jq -r '.result.id')
 agtermctl session rename "server" --target "$a"
 agtermctl session split on --target "$a"          # second shell side by side
+agtermctl session resize --split-ratio 0.7 --target "$a"   # left pane gets 70% (prints 0.700)
 b=$(agtermctl session new --workspace "$ws" --json | jq -r '.result.id')
 agtermctl session rename "logs" --target "$b"
 ```
+
+## Resize the split divider from a keybinding
+
+The divider is otherwise mouse-drag only — there is no built-in resize action, so bind keys to the CLI
+with `command "<name>" <chord> <shell…>` custom actions in `keymap.conf` (then `agtermctl keymap reload`):
+
+```conf
+# grow/shrink the left pane by 5% per press; cmd+ctrl+0 resets to an even split
+command "grow left pane"  cmd+ctrl+l agtermctl session resize --grow-left 0.05
+command "grow right pane" cmd+ctrl+h agtermctl session resize --grow-right 0.05
+command "even split"      cmd+ctrl+0 agtermctl session resize --split-ratio 0.5
+```
+
+`--split-ratio` is absolute (0..1); `--grow-left`/`--grow-right` are relative nudges. All clamp to
+0.05..0.95 and print the applied fraction.
 
 ## Run a program in a blocking overlay and read its status
 

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -113,6 +113,14 @@ process — what it is running — omitted when the pane sits at its shell promp
 - `session focus [left|right|other] [--target] [--window W]` — move keyboard focus between the two
   split panes (`other` toggles, the default). Errors when the session has no split. Works whether the
   split is shown side-by-side or hidden (maximized) — when hidden, focusing a pane swaps which one shows.
+- `session resize (--split-ratio R | --grow-left D | --grow-right D) [--target] [--window W]` — move the
+  split DIVIDER (the divider is otherwise mouse-drag only; there is no GUI/menu/keymap action, so bind a
+  key by mapping a `command "agtermctl session resize …"` custom action). Provide exactly one form:
+  `--split-ratio` sets the absolute left-pane fraction (`0..1`); `--grow-left D` / `--grow-right D` nudge
+  it by the fraction `D` (grow-left shrinks the right pane and vice-versa). The result is clamped to
+  `0.05..0.95` and persisted, and the applied (clamped) fraction is printed (and returned as `result.ratio`
+  under `--json`). Errors when the session has no split. Resizing a hidden split updates the stored
+  fraction; it takes effect when the split is next shown.
 - `session status <idle|active|completed|blocked> [--blink] [--auto-reset] [--sound NAME] [--target] [--window W]` —
   set the sidebar agent-status glyph. `--blink` pulses it (for attention). `--auto-reset` clears it
   back to idle once the session is visited (use for a one-shot completion flash). `--sound` plays a

--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -1411,4 +1411,9 @@ extension Notification.Name {
     /// `WorkspaceSidebar.Coordinator` observes them scoped to that one window's sidebar.
     static let agtermExpandWorkspaces = Notification.Name("agterm.expandWorkspaces")
     static let agtermCollapseWorkspaces = Notification.Name("agterm.collapseWorkspaces")
+    /// Posted by the `session.resize` control arm after it stores a new split-divider fraction, with the
+    /// target `Session` as the object so the matching `SplitProbeView` (in `ContentView`) moves the live
+    /// divider to `Session.splitRatio`. Object-scoped like the expand/collapse pokes, so only the one
+    /// session's pane view reacts.
+    static let agtermApplySplitRatio = Notification.Name("agterm.applySplitRatio")
 }

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -68,6 +68,14 @@ public final class AppStore {
     /// outside this range and `restore()` clamps to it, so the on-disk ratio is always within bounds.
     public static let splitRatioMin: Double = 0.05
     public static let splitRatioMax: Double = 0.95
+    /// The even split fraction a never-moved divider renders at (the `HSplitView` default); the base for a
+    /// relative `session.resize` when `Session.splitRatio` is still nil.
+    public static let splitRatioDefault: Double = 0.5
+
+    /// Clamp a left-pane split fraction to `splitRatioMin...splitRatioMax`.
+    public static func clampSplitRatio(_ ratio: Double) -> Double {
+        min(splitRatioMax, max(splitRatioMin, ratio))
+    }
 
     /// Most-recently-selected session ids, front = current. Drives the Ctrl-Tab switcher
     /// (`items[1]` is the previous session). `@ObservationIgnored`: read imperatively by the
@@ -302,6 +310,19 @@ public final class AppStore {
             session.splitFocused = true
         }
         save()
+    }
+
+    /// Sets a session's split-divider left-pane fraction to `ratio`, clamped to the bounds, and persists.
+    /// Returns the applied (clamped) fraction, or nil when the id is unknown. Moving the LIVE divider is
+    /// driven separately by the caller (`session.resize` posts `.agtermApplySplitRatio` to the pane view) —
+    /// this is control-native, so there is no GUI surface that goes through `AppActions`.
+    @discardableResult
+    public func applySplitRatio(_ ratio: Double, forSession id: UUID) -> Double? {
+        guard let session = session(withID: id) else { return nil }
+        let applied = AppStore.clampSplitRatio(ratio)
+        session.splitRatio = applied
+        save()
+        return applied
     }
 
     /// Closes the split pane: hides it AND tears down its surface, so a subsequent split

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -23,6 +23,7 @@ public enum Command: String, Codable, Sendable {
     case sessionSplit = "session.split"
     case sessionScratch = "session.scratch"
     case sessionFocus = "session.focus"
+    case sessionResize = "session.resize"
     case sessionCopy = "session.copy"
     case sessionSearch = "session.search"
     case sessionOverlayOpen = "session.overlay.open"
@@ -81,6 +82,13 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     public var mode: String?
     /// Which split pane to focus for `session.focus` (`left`|`right`|`other`; `other` toggles).
     public var pane: String?
+    /// Absolute left-pane split fraction (0...1) for `session.resize`, clamped server-side to
+    /// `AppStore.splitRatioMin...splitRatioMax`. Mutually exclusive with `ratioDelta`.
+    public var ratio: Double?
+    /// Signed relative split-divider nudge for `session.resize`: a positive fraction grows the LEFT
+    /// pane, negative grows the right (the CLI's `--grow-left`/`--grow-right`). Applied to the session's
+    /// current fraction (0.5 when never moved). Mutually exclusive with `ratio`.
+    public var ratioDelta: Double?
     /// Direction for `session.go` (`next`|`prev`|`previous`|`first`|`last`), for the reorder form of
     /// `session.move` / `workspace.move` (`up`|`down`|`top`|`bottom`), and for `session.search`
     /// (`next`|`prev`|`close`).
@@ -126,7 +134,8 @@ public struct ControlArgs: Codable, Sendable, Equatable {
                 command: String? = nil, wait: Bool? = nil, sizePercent: Int? = nil, window: String? = nil,
                 pane: String? = nil, to: String? = nil, title: String? = nil, body: String? = nil,
                 width: Int? = nil, height: Int? = nil, x: Int? = nil, y: Int? = nil, display: Int? = nil,
-                status: String? = nil, blink: Bool? = nil, autoReset: Bool? = nil, sound: String? = nil) {
+                status: String? = nil, blink: Bool? = nil, autoReset: Bool? = nil, sound: String? = nil,
+                ratio: Double? = nil, ratioDelta: Double? = nil) {
         self.name = name
         self.cwd = cwd
         self.workspace = workspace
@@ -152,6 +161,8 @@ public struct ControlArgs: Codable, Sendable, Equatable {
         self.blink = blink
         self.autoReset = autoReset
         self.sound = sound
+        self.ratio = ratio
+        self.ratioDelta = ratioDelta
     }
 }
 
@@ -272,10 +283,13 @@ public struct ControlResult: Codable, Sendable, Equatable {
     public var theme: String?
     /// The available bundled theme names for `theme.list`.
     public var themes: [String]?
+    /// The applied (clamped) left-pane split fraction echoed by `session.resize`, so a script can see
+    /// where the divider landed after clamping / a relative nudge.
+    public var ratio: Double?
 
     public init(id: String? = nil, tree: ControlTree? = nil, text: String? = nil,
                 windows: [ControlWindowNode]? = nil, exitCode: Int? = nil, count: Int? = nil,
-                theme: String? = nil, themes: [String]? = nil) {
+                theme: String? = nil, themes: [String]? = nil, ratio: Double? = nil) {
         self.id = id
         self.tree = tree
         self.text = text
@@ -284,6 +298,7 @@ public struct ControlResult: Codable, Sendable, Equatable {
         self.count = count
         self.theme = theme
         self.themes = themes
+        self.ratio = ratio
     }
 }
 

--- a/agtermCore/Sources/agtermctlKit/Commands.swift
+++ b/agtermCore/Sources/agtermctlKit/Commands.swift
@@ -206,7 +206,7 @@ struct Session: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Session commands.",
         subcommands: [New.self, Close.self, Select.self, Go.self, Rename.self, Move.self, TypeText.self,
-                      Split.self, Scratch.self, Focus.self, Copy.self, Status.self, FlagCommand.self,
+                      Split.self, Scratch.self, Focus.self, Resize.self, Copy.self, Status.self, FlagCommand.self,
                       Search.self, Overlay.self]
     )
 
@@ -357,6 +357,43 @@ struct Session: ParsableCommand {
 
         func makeRequest() throws -> ControlRequest {
             ControlRequest(cmd: .sessionFocus, target: target.target, args: options.withWindow(ControlArgs(pane: pane)))
+        }
+    }
+
+    struct Resize: RequestCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Resize a split session's divider (set or nudge the left-pane fraction).")
+        @Option(name: .customLong("split-ratio"), help: "Absolute left-pane fraction 0..1 (e.g. 0.7). Clamped to 0.05..0.95.") var splitRatio: Double?
+        @Option(name: .customLong("grow-left"), help: "Grow the left pane by this fraction (e.g. 0.05); shrinks the right.") var growLeft: Double?
+        @Option(name: .customLong("grow-right"), help: "Grow the right pane by this fraction (e.g. 0.05); shrinks the left.") var growRight: Double?
+        @OptionGroup var target: TargetOptions
+        @OptionGroup var options: ClientOptions
+
+        // exactly one of the three forms must be set; reject neither/multiple at parse time so it's a clean
+        // usage error, unit-testable without a socket. Prints the applied (clamped) fraction.
+        func validate() throws {
+            let values = [splitRatio, growLeft, growRight].compactMap { $0 }
+            guard values.count == 1 else {
+                throw ValidationError("provide exactly one of --split-ratio, --grow-left, or --grow-right")
+            }
+            // nan/inf parse as Double but fail to JSON-encode (a generic error after the socket opens), so
+            // reject non-finite input here with a clean usage error.
+            guard values[0].isFinite else {
+                throw ValidationError("the resize value must be a finite number")
+            }
+        }
+
+        func makeRequest() throws -> ControlRequest {
+            // grow-left/grow-right map to a signed wire delta (+ grows the left pane); split-ratio is absolute.
+            let args: ControlArgs
+            if let splitRatio {
+                args = ControlArgs(ratio: splitRatio)
+            } else if let growLeft {
+                args = ControlArgs(ratioDelta: growLeft)
+            } else {
+                args = ControlArgs(ratioDelta: -(growRight ?? 0))
+            }
+            return ControlRequest(cmd: .sessionResize, target: target.target, args: options.withWindow(args))
         }
     }
 

--- a/agtermCore/Sources/agtermctlKit/SocketClient.swift
+++ b/agtermCore/Sources/agtermctlKit/SocketClient.swift
@@ -139,6 +139,10 @@ struct SocketClient {
             // keymap.reload reports its parse-diagnostic count; 0 reads as a clean reload.
             return count == 0 ? "ok" : "\(count) diagnostic(s)"
         }
+        if let ratio = response.result?.ratio {
+            // session.resize echoes the applied (clamped) left-pane fraction, scriptable as a bare number.
+            return String(format: "%.3f", ratio)
+        }
         if echoID, let id = response.result?.id {
             return id
         }

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -456,6 +456,30 @@ struct AppStoreTests {
         #expect(split.teardownCount == 1)
     }
 
+    @Test func clampSplitRatioBoundsValue() {
+        #expect(AppStore.clampSplitRatio(0.7) == 0.7)
+        #expect(AppStore.clampSplitRatio(2.0) == AppStore.splitRatioMax)   // above the cap
+        #expect(AppStore.clampSplitRatio(-1.0) == AppStore.splitRatioMin)  // below the floor
+        #expect(AppStore.clampSplitRatio(AppStore.splitRatioMin) == AppStore.splitRatioMin)
+        #expect(AppStore.clampSplitRatio(AppStore.splitRatioMax) == AppStore.splitRatioMax)
+    }
+
+    @Test func applySplitRatioClampsSetsAndReturns() {
+        let store = Self.makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        #expect(store.applySplitRatio(0.7, forSession: session.id) == 0.7)
+        #expect(session.splitRatio == 0.7)
+        // out-of-range clamps to the cap, on both the return and the stored value.
+        #expect(store.applySplitRatio(2.0, forSession: session.id) == AppStore.splitRatioMax)
+        #expect(session.splitRatio == AppStore.splitRatioMax)
+    }
+
+    @Test func applySplitRatioUnknownSessionReturnsNil() {
+        let store = Self.makeStore()
+        #expect(store.applySplitRatio(0.5, forSession: UUID()) == nil)
+    }
+
     @Test func closePrimaryPaneWithSplitKeepsSessionAndPromotesSurvivor() {
         let store = Self.makeStore()
         let ws = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -153,6 +153,32 @@ struct ControlProtocolTests {
         #expect(decoded.args?.command == "htop")
     }
 
+    @Test func sessionResizeRoundTrips() throws {
+        let cases: [ControlRequest] = [
+            ControlRequest(cmd: .sessionResize, target: "active", args: ControlArgs(ratio: 0.7)),
+            ControlRequest(cmd: .sessionResize, target: "9f3c", args: ControlArgs(ratioDelta: 0.05)),
+            ControlRequest(cmd: .sessionResize, args: ControlArgs(ratioDelta: -0.05)),
+        ]
+        for request in cases {
+            #expect(try roundTrip(request) == request)
+        }
+    }
+
+    @Test func sessionResizeRawStringMapsToCommandAndArgs() throws {
+        let raw = #"{"cmd":"session.resize","target":"active","args":{"ratio":0.7}}"#
+        let decoded = try JSONDecoder().decode(ControlRequest.self, from: Data(raw.utf8))
+        #expect(decoded.cmd == .sessionResize)
+        #expect(decoded.args?.ratio == 0.7)
+        #expect(decoded.args?.ratioDelta == nil)
+    }
+
+    @Test func sessionResizeResultRoundTripsRatio() throws {
+        let response = ControlResponse(ok: true, result: ControlResult(id: "9f3c", ratio: 0.85))
+        let decoded = try roundTrip(response)
+        #expect(decoded == response)
+        #expect(decoded.result?.ratio == 0.85)
+    }
+
     @Test func sessionFlagRawStringMapsToCommandAndMode() throws {
         let raw = #"{"cmd":"session.flag","target":"active","args":{"mode":"on"}}"#
         let decoded = try JSONDecoder().decode(ControlRequest.self, from: Data(raw.utf8))

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -180,6 +180,35 @@ struct CommandsTests {
         #expect(try request(["session", "focus", "right"]) == expected)
     }
 
+    @Test func sessionResizeAbsolute() throws {
+        let expected = ControlRequest(cmd: .sessionResize, target: "active", args: ControlArgs(ratio: 0.7))
+        #expect(try request(["session", "resize", "--split-ratio", "0.7"]) == expected)
+    }
+
+    @Test func sessionResizeGrowLeftIsPositiveDelta() throws {
+        let expected = ControlRequest(cmd: .sessionResize, target: "active", args: ControlArgs(ratioDelta: 0.05))
+        #expect(try request(["session", "resize", "--grow-left", "0.05"]) == expected)
+    }
+
+    @Test func sessionResizeGrowRightIsNegativeDelta() throws {
+        let expected = ControlRequest(cmd: .sessionResize, target: "active", args: ControlArgs(ratioDelta: -0.05))
+        #expect(try request(["session", "resize", "--grow-right", "0.05"]) == expected)
+    }
+
+    @Test func sessionResizeRequiresExactlyOneForm() {
+        // neither form set, and two forms set — validate() rejects both with the same usage message.
+        #expect(validationMessage(["session", "resize"])?.contains("exactly one") == true)
+        #expect(validationMessage(["session", "resize", "--split-ratio", "0.7", "--grow-left", "0.1"])?
+            .contains("exactly one") == true)
+    }
+
+    @Test func sessionResizeRejectsNonFinite() {
+        // nan/inf parse as Double but can't JSON-encode; validate() rejects them with a clean usage error.
+        #expect(validationMessage(["session", "resize", "--split-ratio", "nan"])?.contains("finite") == true)
+        #expect(validationMessage(["session", "resize", "--grow-left", "inf"])?.contains("finite") == true)
+        #expect(validationMessage(["session", "resize", "--split-ratio", "1e999"])?.contains("finite") == true)
+    }
+
     @Test func sessionGoNext() throws {
         let expected = ControlRequest(cmd: .sessionGo, args: ControlArgs(to: "next"))
         #expect(try request(["session", "go", "--to", "next"]) == expected)

--- a/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
@@ -169,6 +169,12 @@ struct SocketClientTests {
         #expect(SocketClient.formatResponse(ControlResponse(ok: false, error: "boom"), json: false) == "error: boom")
     }
 
+    @Test func formatResponseRatio() {
+        // session.resize echoes the applied (clamped) left-pane fraction as a bare 3-decimal number.
+        let response = ControlResponse(ok: true, result: ControlResult(id: "9f3c", ratio: 0.85))
+        #expect(SocketClient.formatResponse(response, json: false) == "0.850")
+    }
+
     @Test func formatResponseErrorFallback() {
         // an error response with no message falls back to a generic line.
         #expect(SocketClient.formatResponse(ControlResponse(ok: false), json: false) == "error: unknown error")

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -1158,6 +1158,52 @@ final class ControlAPIUITests: XCTestCase {
         XCTAssertTrue((bad["error"] as? String ?? "").contains("invalid pane"), "should report invalid pane: \(bad)")
     }
 
+    // session.resize errors on a non-split session, sets an absolute fraction (clamped) and a relative
+    // nudge on a split, persists it to workspaces.json, and rejects a request carrying no fraction.
+    func testSessionResizeSplitDivider() throws {
+        let notSplit = try sendCommand(#"{"cmd":"session.resize","target":"active","args":{"ratio":0.7}}"#)
+        XCTAssertEqual(notSplit["ok"] as? Bool, false, "resize on a non-split session should fail: \(notSplit)")
+        XCTAssertTrue((notSplit["error"] as? String ?? "").contains("no split"), "should report no split: \(notSplit)")
+
+        let split = try sendCommand(#"{"cmd":"session.split","target":"active","args":{"mode":"on"}}"#)
+        XCTAssertEqual(split["ok"] as? Bool, true, "split on should succeed: \(split)")
+        XCTAssertTrue(pollActiveSessionSplit(true, timeout: 10), "the active session should report split:true")
+
+        // relative nudge from the nil base (0.5 default) before any absolute set: grow-left 0.1 -> 0.6.
+        let fromDefault = try sendCommand(#"{"cmd":"session.resize","target":"active","args":{"ratioDelta":0.1}}"#)
+        XCTAssertEqual(fromDefault["ok"] as? Bool, true, "nudge from default should succeed: \(fromDefault)")
+        XCTAssertEqual((fromDefault["result"] as? [String: Any])?["ratio"] as? Double ?? -1, 0.6, accuracy: 0.0001,
+                       "0.5 default + 0.1 = 0.6: \(fromDefault)")
+
+        // server rejects both fraction forms at once — the CLI's validate() blocks this, but a raw client can send it.
+        let both = try sendCommand(#"{"cmd":"session.resize","target":"active","args":{"ratio":0.7,"ratioDelta":0.1}}"#)
+        XCTAssertEqual(both["ok"] as? Bool, false, "both ratio and delta should fail: \(both)")
+        XCTAssertTrue((both["error"] as? String ?? "").contains("mutually exclusive"), "should report mutual exclusion: \(both)")
+
+        // absolute fraction: echoed in result.ratio and persisted to the snapshot.
+        let abs = try sendCommand(#"{"cmd":"session.resize","target":"active","args":{"ratio":0.7}}"#)
+        XCTAssertEqual(abs["ok"] as? Bool, true, "absolute resize should succeed: \(abs)")
+        XCTAssertEqual((abs["result"] as? [String: Any])?["ratio"] as? Double ?? -1, 0.7, accuracy: 0.0001,
+                       "should echo the applied ratio: \(abs)")
+        XCTAssertTrue(pollSplitRatio(0.7, timeout: 10), "0.7 should land in workspaces.json")
+
+        // out-of-range absolute clamps to the cap (0.95).
+        let clamped = try sendCommand(#"{"cmd":"session.resize","target":"active","args":{"ratio":2.0}}"#)
+        XCTAssertEqual(clamped["ok"] as? Bool, true, "clamped resize should succeed: \(clamped)")
+        XCTAssertEqual((clamped["result"] as? [String: Any])?["ratio"] as? Double ?? -1, 0.95, accuracy: 0.0001,
+                       "2.0 should clamp to 0.95: \(clamped)")
+
+        // relative nudge: grow-right 0.1 (a negative delta) from 0.95 lands at 0.85.
+        let nudged = try sendCommand(#"{"cmd":"session.resize","target":"active","args":{"ratioDelta":-0.1}}"#)
+        XCTAssertEqual(nudged["ok"] as? Bool, true, "relative resize should succeed: \(nudged)")
+        XCTAssertEqual((nudged["result"] as? [String: Any])?["ratio"] as? Double ?? -1, 0.85, accuracy: 0.0001,
+                       "0.95 - 0.1 = 0.85: \(nudged)")
+
+        // neither a ratio nor a delta is a usage error.
+        let empty = try sendCommand(#"{"cmd":"session.resize","target":"active","args":{}}"#)
+        XCTAssertEqual(empty["ok"] as? Bool, false, "resize with no fraction should fail: \(empty)")
+    }
+
     // session.status sets a session's agent indicator: a valid state returns ok + the resolved id, an
     // unknown state returns the literal `invalid status` error, and an unknown target is not-found.
     func testSessionStatusSetsIndicator() throws {
@@ -2274,6 +2320,16 @@ final class ControlAPIUITests: XCTestCase {
             guard let workspaces = obj["workspaces"] as? [[String: Any]],
                   let sessions = workspaces.first?["sessions"] as? [[String: Any]] else { return nil }
             return sessions.first?["customName"] as? String
+        }
+    }
+
+    /// Polls the hermetic snapshot file until the (single seeded workspace's) first session's `splitRatio`
+    /// equals `expected` — the persisted side effect of `session.resize`.
+    private func pollSplitRatio(_ expected: Double, timeout: TimeInterval) -> Bool {
+        stateDir.pollSnapshot(equals: expected, timeout: timeout) { obj in
+            guard let workspaces = obj["workspaces"] as? [[String: Any]],
+                  let sessions = workspaces.first?["sessions"] as? [[String: Any]] else { return nil }
+            return sessions.first?["splitRatio"] as? Double
         }
     }
 


### PR DESCRIPTION
Resolves the request in #50: a keyboard/CLI way to resize a split session's divider, which was previously mouse-drag only.

**What.** Adds a control-native `session.resize` command. `agtermctl session resize --split-ratio R` sets the absolute left-pane fraction; `--grow-left D` / `--grow-right D` nudge it relatively. Clamped to `0.05..0.95`, persisted, and echoes the applied fraction.

**Scope.** CLI/control only, no GUI/menu/keymap action (mirrors `window resize`). Bind a key by mapping a `command "agtermctl session resize ..."` custom action in `keymap.conf`. Errors on a non-split session.

**Implementation.** Reuses the existing `Session.splitRatio` persistence and `SplitProbeView`. The arm clamps and persists via `AppStore.applySplitRatio`, then posts an object-scoped `.agtermApplySplitRatio` so the session's pane view moves the live divider (a no-op for a hidden split, where the stored fraction applies on next show).

**Keep-in-sync.** The `Command` plus `ControlArgs`/`ControlResult` in `agtermCore`, the `ControlServer` arm, the `agtermctl` subcommand, and the agent-skill docs (command count bumped to 47).

**Tests.** Host-free round-trip / clamp-apply / CLI validate-and-mapping / format, plus the `testSessionResizeSplitDivider` e2e (absolute, clamp, relative-from-default, both-set and neither-set rejection, persistence). `--split-ratio nan|inf` fails with a clean usage error.

Fix #50
