### PR TITLE
feat: restore command sessions on relaunch

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -270,8 +270,11 @@ paths:
   `args.command` runs that command AS the session's process instead of the login shell (like kitty's
   `launch <cmd>` / ghostty's `command`) — NO echoed command line, and the session closes when the command
   exits (the normal single-pane `onExit` → `closePrimaryPane`).
-  It is transient + run-once: `Session.initialCommand` is `@ObservationIgnored` and absent from `SessionSnapshot`,
-  so a restored session is a plain shell.
+  `Session.initialCommand` is `@ObservationIgnored` but PERSISTED via `SessionSnapshot.initialCommand`, so it
+  re-runs on restore (through the same `config.command` exec path) when the **restore-running-command** opt-in
+  is on — gated via the transient `Session.wasRestored` so a fresh session always runs its command while a
+  restored one honors the toggle (default off → a restored session is a plain shell); a live captured
+  foreground preempts it, and `closePrimaryPane` clears it when a command pane exits into a promoted split.
   The arm threads `request.args?.command` into `AppStore.addSession(…, command:)`,
   which `makeSurface` passes to `GhosttySurfaceView(command:)` → `config.command` RAW (`strdup`,
   NO wrapper). libghostty tokenizes it into argv (shell-like word-splitting that RESPECTS quotes) and
@@ -559,10 +562,13 @@ paths:
   capture the restore-running-command feature uses (`ghostty_surface_foreground_pid` → `sysctl(KERN_PROCARGS2)`
   → host-free `CommandRestore`), populated in the tree builder per session so a script can read "what
   is each pane running".
-  `restore.clear` clears every open session's saved foreground command (`Session.foregroundCommand`/`splitForegroundCommand`)
-  and persists via `library.saveAllOpen()`, so the next restart restores plain shells instead of re-running
-  the captured commands (also closing the force-quit re-fire: the restored command is consumed in memory
-  but its on-disk copy lingers until the next save, which a force-quit skips).
+  `restore.clear` clears every open session's saved CAPTURED foreground command (`Session.foregroundCommand`/`splitForegroundCommand`)
+  and persists via `library.saveAllOpen()`, so the next restart restores plain shells for those panes instead
+  of re-running the captured commands (also closing the force-quit re-fire: the restored command is consumed
+  in memory but its on-disk copy lingers until the next save, which a force-quit skips).
+  It does NOT clear a `session.new --command` session's own `initialCommand` (the durable creation identity),
+  which still re-runs on restore when the setting is on — `restore.clear` is scoped to captured foreground
+  commands only.
   App-global like `keymap.reload` (clears all open windows, no `--window`).
   Four-point keep-in-sync audit for `restore.clear`: (1) `case restoreClear = "restore.clear"` in `ControlProtocol.swift`
   (no target/args; `foreground`/`splitForeground` added to `ControlSessionNode`),

--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -284,4 +284,7 @@ paths:
   `session.select`; only `theme.set`/`config.reload` touch settings over the socket).
   See the Notifications section for the bell's three states and the Menu/actions section for the `.attention`
   palette it opens.
+- **A Settings toggle's DESCRIPTION stays single-line short-form** — a terse hint, not a manual.
+  No detailed multi-line explanation of what the toggle does and no cross-refs to other toggles;
+  keep the minimal style (see also the flag-description convention).
 

--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -244,6 +244,15 @@ paths:
   the shell so exit returns to a prompt).
   The captured field is consumed run-once in the factory (read-then-nil,
   like `scratchCommand`) so a later structural save can't re-fire it.
+  The SAME toggle ALSO gates the OTHER restore path: a `session.new --command` session persists its command
+  (`SessionSnapshot.initialCommand`) and re-runs it on restore via `config.command` (the shell-replacing,
+  close-on-exit path — the opposite of the foreground path's `initial_input`), because a command that
+  exec-replaces the shell is invisible to the foreground-pid capture.
+  That path is gated by the transient `Session.wasRestored` (a fresh command session always runs; a restored
+  one honors the toggle), and a live captured foreground preempts the persisted `initialCommand`.
+  Unlike `foregroundCommand`, `initialCommand` is NOT consumed — it is the durable creation identity,
+  re-emitted by every `snapshot()`, so the opt-out is per-restart (re-enabling the toggle brings the command
+  session back); it is dropped only when the command pane exits into a promoted split (`closePrimaryPane`).
   All decision logic (parse/shell-detect/denylist/quote) is host-free in `CommandRestore` (unit-tested);
   the app target owns only the C-boundary + Darwin syscall.
   ONLY a single-process command restores faithfully — a typed pipeline/compound line captures one process.

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -35,7 +35,7 @@ file_length:
   warning: 2700
   error: 3000
 type_body_length:
-  warning: 1800
+  warning: 1850
   error: 2500
 function_body_length:
   warning: 250

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,14 @@ surface ownership, and the C-boundary concurrency contract before changing the b
 
 The app must build, `swift test` must stay green, and `make lint` must pass after every change.
 
+- **Manage file sizes for real — target under 1000 lines for source files (tests may run 2–3×).**
+  In OUR OWN work: when you touch a long file, PROPOSE splitting/relocating it toward that rather than
+  growing it further — but ALWAYS ask the user first, never restructure a file unprompted; and don't
+  reflexively bump the grandfathered swiftlint `file_length`/`type_body_length` limits to fit new code.
+  For a CONTRIBUTOR's PR: do NOT force this — a contributor shouldn't have to refactor a pre-existing long
+  file to land their change; NOTIFY that a file is getting long and SUGGEST keeping it under 1000, but
+  never make them address the line count or block the PR on it.
+
 - **Working in a git WORKTREE: SYMLINK the prebuilt artifacts, don't re-run setup.** A fresh `git worktree`
   does NOT contain the gitignored `GhosttyKit.xcframework`, `agterm/Resources/ghostty`,
   or `agterm/Resources/terminfo` (they're build outputs, never committed).

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -69,7 +69,9 @@ process — what it is running — omitted when the pane sits at its shell promp
   process instead of the login shell (no echoed command line; the session closes when the command
   exits). It runs argv-style (tokenized, quotes respected, but NO shell), so shell operators (`;`,
   `&&`, `$VAR`, redirects, globs) are not interpreted — wrap them yourself: `--command "sh -c '…'"`.
-  The command is run-once and not persisted (a restored session is a plain shell). `--name`
+  The command is persisted (`SessionSnapshot.initialCommand`) and re-runs on restore when **Restore
+  running commands on restart** is on (default off → a restored session is a plain shell); a live
+  captured foreground takes precedence over it. `--name`
   seeds the session's custom name (the sidebar label; blank/omitted leaves the auto basename),
   equivalent to a `session rename` right after create.
 - `session close [--target] [--window W]`.
@@ -301,8 +303,10 @@ the commit, with no preview.
 
 ## restore
 
-`agtermctl restore clear` — clear every session's saved foreground command and persist, so the next
-restart restores plain shells (not whatever each pane was running). This is the counterpart to the
+`agtermctl restore clear` — clear every session's saved CAPTURED foreground command and persist, so the
+next restart restores plain shells for those panes (not whatever each pane was running). It does NOT clear
+a `session.new --command` session's own command (`initialCommand`, the durable creation identity), which
+still re-runs on restore when the setting is on. This is the counterpart to the
 opt-in **Restore running commands on restart** setting: that setting captures each pane's foreground
 command at a clean quit and re-runs it on relaunch; `restore clear` wipes those saved commands now
 (also closing the force-quit re-fire window). App-global (no `--window`), prints `ok`.

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -464,22 +464,22 @@ struct agtermApp: App {
                                     library: WindowLibrary) -> GhosttySurfaceView {
         // `initialCommand` (from `session.new --command`) runs as the surface's process instead of the
         // login shell; on its exit the surface's onExit (below) closes the single session, like kitty.
-        // restore-running-command: feed the captured foreground command as `initial_input` (re-run inside
-        // the login shell, exits to a prompt). A live captured foreground TAKES PRECEDENCE over a persisted
-        // `initialCommand`: a command session (e.g. `--command ssh …`) whose command exec-replaces the shell
-        // isn't visible to libghostty's foreground pid, so it restores from `initialCommand`; but if that
-        // session had dropped to a shell and the user ran something else, the captured child wins so we
-        // restore what was ACTUALLY running, not the stale creation command. `command`/`initial_input` are
-        // mutually exclusive ways to seed a surface; both are consumed run-once, like `scratchCommand`.
+        // restore-running-command: `foregroundCommand` (a distinct child captured at quit) is consumed
+        // run-once here; the persisted `initialCommand` is the durable creation identity (re-emitted by every
+        // `snapshot()`). A command that exec-replaces the shell is invisible to libghostty's foreground pid
+        // (nil), so it is never captured and restores via the exec `command` path (preserving close-on-exit).
+        // The gate + precedence (fresh-always-runs, restored-honors-toggle, a captured foreground preempts
+        // `initialCommand` even when denylist-suppressed) is the host-free `CommandRestore.restorePlan`.
+        let hadForeground = session.foregroundCommand != nil
         let restoreInput = Self.restoreInitialInput(session.foregroundCommand)
         session.foregroundCommand = nil
-        // a FRESH command session always runs its command; a RESTORED one re-runs only when the
-        // restore-running-command opt-in is on (else it falls back to a plain shell, honoring the toggle).
-        let mayRunInitial = !session.wasRestored || GhosttyApp.shared.restoreRunningCommand
-        let command = (restoreInput == nil && mayRunInitial) ? session.initialCommand : nil
+        let plan = CommandRestore.restorePlan(wasRestored: session.wasRestored,
+                                              restoreEnabled: GhosttyApp.shared.restoreRunningCommand,
+                                              hadForeground: hadForeground, foregroundInput: restoreInput,
+                                              initialCommand: session.initialCommand)
         let view = GhosttySurfaceView(workingDirectory: session.initialCwd, fontSize: session.fontSize.map(Float.init),
-                                      command: command,
-                                      initialInput: command == nil ? restoreInput : nil, env: env)
+                                      command: plan.command,
+                                      initialInput: plan.initialInput, env: env)
         view.session = session
         let sessionID = session.id
         view.onExit = {

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -465,13 +465,21 @@ struct agtermApp: App {
         // `initialCommand` (from `session.new --command`) runs as the surface's process instead of the
         // login shell; on its exit the surface's onExit (below) closes the single session, like kitty.
         // restore-running-command: feed the captured foreground command as `initial_input` (re-run inside
-        // the login shell, exits to a prompt) — but only when there's no `initialCommand` (those are
-        // mutually exclusive ways to seed a surface). Consumed run-once, like `scratchCommand`.
+        // the login shell, exits to a prompt). A live captured foreground TAKES PRECEDENCE over a persisted
+        // `initialCommand`: a command session (e.g. `--command ssh …`) whose command exec-replaces the shell
+        // isn't visible to libghostty's foreground pid, so it restores from `initialCommand`; but if that
+        // session had dropped to a shell and the user ran something else, the captured child wins so we
+        // restore what was ACTUALLY running, not the stale creation command. `command`/`initial_input` are
+        // mutually exclusive ways to seed a surface; both are consumed run-once, like `scratchCommand`.
         let restoreInput = Self.restoreInitialInput(session.foregroundCommand)
         session.foregroundCommand = nil
+        // a FRESH command session always runs its command; a RESTORED one re-runs only when the
+        // restore-running-command opt-in is on (else it falls back to a plain shell, honoring the toggle).
+        let mayRunInitial = !session.wasRestored || GhosttyApp.shared.restoreRunningCommand
+        let command = (restoreInput == nil && mayRunInitial) ? session.initialCommand : nil
         let view = GhosttySurfaceView(workingDirectory: session.initialCwd, fontSize: session.fontSize.map(Float.init),
-                                      command: session.initialCommand,
-                                      initialInput: session.initialCommand == nil ? restoreInput : nil, env: env)
+                                      command: command,
+                                      initialInput: command == nil ? restoreInput : nil, env: env)
         view.session = session
         let sessionID = session.id
         view.onExit = {

--- a/agtermCore/Sources/agtermCore/AppSettings.swift
+++ b/agtermCore/Sources/agtermCore/AppSettings.swift
@@ -77,9 +77,10 @@ public struct AppSettings: Codable, Equatable, Sendable {
     /// SwiftUI wash behind the sidebar (see `sidebarShiftAmount`), NOT a ghostty key — it never appears
     /// in `ghosttyConfigLines()`.
     public var sidebarBackgroundShift: Int?
-    /// Whether, on app restart, each pane re-runs the command it had in the foreground at the last clean
-    /// quit (captured via `SessionSnapshot.foregroundCommand`). nil means the default (off). An app-level
-    /// behavior flag, NOT a ghostty key — it never appears in `ghosttyConfigLines()`.
+    /// Whether, on app restart, each pane re-runs the command it was running at the last clean quit: a
+    /// captured foreground command (`SessionSnapshot.foregroundCommand`) and a `session.new --command`
+    /// session's persisted `initialCommand`. nil means the default (off). An app-level behavior flag, NOT a
+    /// ghostty key — it never appears in `ghosttyConfigLines()`.
     public var restoreRunningCommand: Bool?
     /// Whether agterm also loads the user's GLOBAL ghostty config (`~/.config/ghostty/config`) on top of
     /// its bundled defaults. nil means the default (off): agterm is self-contained, so a config written

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -690,7 +690,8 @@ public final class AppStore {
                                 splitCwd: session.splitCwd ?? session.initialSplitCwd, splitRatio: session.splitRatio,
                                 flagged: session.flagged,
                                 foregroundCommand: session.foregroundCommand,
-                                splitForegroundCommand: session.splitForegroundCommand)
+                                splitForegroundCommand: session.splitForegroundCommand,
+                                initialCommand: session.initialCommand)
             })
         }
         return Snapshot(selectedSessionID: selectedSessionID, workspaces: workspaceSnapshots,
@@ -720,6 +721,8 @@ public final class AppStore {
                 session.flagged = sessionSnapshot.flagged ?? false
                 session.foregroundCommand = sessionSnapshot.foregroundCommand
                 session.splitForegroundCommand = sessionSnapshot.splitForegroundCommand
+                session.initialCommand = sessionSnapshot.initialCommand
+                session.wasRestored = true
                 return session
             }
             return Workspace(id: workspaceSnapshot.id, name: workspaceSnapshot.name, sessions: sessions)

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -362,6 +362,9 @@ public final class AppStore {
         session.hasSplit = false
         session.splitFocused = true
         session.splitRatio = nil // promoted to a single pane; a later split should open even, not stale
+        // the command pane is gone — the promoted survivor is a plain shell, so drop the creation command
+        // or a restart would resurrect the exited command instead of restoring the promoted shell.
+        session.initialCommand = nil
         if let cwd = session.splitCwd { session.currentCwd = cwd }
         // the primary surface (possibly the search owner) is torn down while the session survives as the
         // promoted split, so reset search rather than leave a stuck bar pinned to the gone primary.

--- a/agtermCore/Sources/agtermCore/CommandRestore.swift
+++ b/agtermCore/Sources/agtermCore/CommandRestore.swift
@@ -46,6 +46,35 @@ public enum CommandRestore {
         return !denylist.contains(basename(first))
     }
 
+    /// The mutually-exclusive surface seed a pane restores/creates with. `command` != nil → the exec path
+    /// (replaces the shell, closes on exit); else `initialInput` is typed into a login shell, or both nil =
+    /// a plain shell.
+    public struct RestorePlan: Equatable, Sendable {
+        public let command: String?
+        public let initialInput: String?
+        public init(command: String?, initialInput: String?) {
+            self.command = command
+            self.initialInput = initialInput
+        }
+    }
+
+    /// Decide a pane's seed on create/restore. Pure so the gate + precedence is unit-tested off the C
+    /// boundary; the app target owns only the libghostty seeding.
+    /// - `wasRestored`: the session came from a restore (a FRESH command session always runs its command; a
+    ///   RESTORED one only when the opt-in is on).
+    /// - `restoreEnabled`: the `restoreRunningCommand` opt-in.
+    /// - `hadForeground`: a foreground command was CAPTURED at the last quit. A captured foreground PREEMPTS
+    ///   `initialCommand` even when suppressed (denylisted/off → `foregroundInput` nil), yielding a plain
+    ///   shell rather than the stale creation command — so gate on capture, not on whether the input survived.
+    /// - `foregroundInput`: the rendered foreground command line to type, or nil (none / suppressed).
+    /// - `initialCommand`: the session's persisted `--command`.
+    public static func restorePlan(wasRestored: Bool, restoreEnabled: Bool, hadForeground: Bool,
+                                   foregroundInput: String?, initialCommand: String?) -> RestorePlan {
+        let mayRunInitial = !wasRestored || restoreEnabled
+        let command = (!hadForeground && mayRunInitial) ? initialCommand : nil
+        return RestorePlan(command: command, initialInput: command == nil ? foregroundInput : nil)
+    }
+
     /// Parse `restore-denylist.conf` into a set of program basenames NOT to re-run on restore: one entry
     /// per line, trimmed; blank lines and `#` comments ignored. There is NO built-in list — the file is
     /// the whole source (seeded with the terminal multiplexers on first launch).

--- a/agtermCore/Sources/agtermCore/Session.swift
+++ b/agtermCore/Sources/agtermCore/Session.swift
@@ -101,9 +101,17 @@ public final class Session: Identifiable {
     /// A command to run as the session's process instead of the login shell (like kitty's `launch
     /// <cmd>` / ghostty's `command`), set at creation via `session.new --command`. The surface factory
     /// reads it once; on the command exiting the session closes (the normal single-pane exit path).
-    /// `@ObservationIgnored` + absent from `snapshot()`: transient and run-once, never persisted, so a
-    /// restored session is a plain shell.
+    /// `@ObservationIgnored`. Persisted via `SessionSnapshot.initialCommand` so a command session — e.g.
+    /// an `ssh …` shortcut, which exec-replaces the shell and so is invisible to the foreground-pid
+    /// capture — re-runs its command on restore instead of coming back a plain shell. The restore re-run
+    /// is gated by `restoreRunningCommand` (via `wasRestored`); a fresh session always runs it.
     @ObservationIgnored public var initialCommand: String?
+
+    /// True when this session was rebuilt by `AppStore.restore(from:)` rather than freshly created. The
+    /// surface factory reads it to gate the `initialCommand` re-run: a FRESH command session always runs
+    /// its command, but a RESTORED one re-runs only when `restoreRunningCommand` is on (else a plain
+    /// shell). `@ObservationIgnored`; transient, never persisted.
+    @ObservationIgnored public var wasRestored = false
 
     /// The main pane's foreground command (full argv) captured at the last clean quit, for the
     /// restore-running-command feature. `@ObservationIgnored`: written imperatively by the quit-flush

--- a/agtermCore/Sources/agtermCore/Snapshot.swift
+++ b/agtermCore/Sources/agtermCore/Snapshot.swift
@@ -88,10 +88,16 @@ public struct SessionSnapshot: Codable, Equatable, Sendable {
     public var foregroundCommand: [String]?
     /// The split (right) pane's foreground command (full argv), the split analogue of `foregroundCommand`.
     public var splitForegroundCommand: [String]?
+    /// The command the session was created with (`session.new --command`), which exec-replaces the login
+    /// shell and so is invisible to libghostty's foreground pid — persisted here so a command session
+    /// (e.g. an `ssh …` shortcut) re-runs its command on restore instead of coming back a plain shell. A
+    /// live `foregroundCommand` takes precedence at restore. Optional for forward-compat like the fields above.
+    public var initialCommand: String?
 
     public init(id: UUID, customName: String?, cwd: String, isSplit: Bool? = nil, fontSize: Double? = nil,
                 splitCwd: String? = nil, splitRatio: Double? = nil, flagged: Bool? = nil,
-                foregroundCommand: [String]? = nil, splitForegroundCommand: [String]? = nil) {
+                foregroundCommand: [String]? = nil, splitForegroundCommand: [String]? = nil,
+                initialCommand: String? = nil) {
         self.id = id
         self.customName = customName
         self.cwd = cwd
@@ -102,5 +108,6 @@ public struct SessionSnapshot: Codable, Equatable, Sendable {
         self.flagged = flagged
         self.foregroundCommand = foregroundCommand
         self.splitForegroundCommand = splitForegroundCommand
+        self.initialCommand = initialCommand
     }
 }

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -648,7 +648,25 @@ struct AppStoreTests {
         let snap = try JSONDecoder().decode(SessionSnapshot.self, from: Data(json.utf8))
         #expect(snap.foregroundCommand == nil)
         #expect(snap.splitForegroundCommand == nil)
+        #expect(snap.initialCommand == nil)
         #expect(snap.cwd == "/tmp")
+    }
+
+    @Test func initialCommandRoundTripsThroughSnapshot() {
+        // a command session (e.g. `--command ssh …`) persists its creation command so it re-runs on
+        // restore instead of coming back a plain shell.
+        let store = Self.makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        session.initialCommand = "ssh user@host -t 'ssh inner'"
+        #expect(session.wasRestored == false) // a freshly created session always runs its command
+        let snap = store.snapshot()
+        #expect(snap.workspaces[0].sessions[0].initialCommand == "ssh user@host -t 'ssh inner'")
+        let restored = Self.makeStore()
+        restored.restore(from: snap)
+        let r = restored.workspaces[0].sessions[0]
+        #expect(r.initialCommand == "ssh user@host -t 'ssh inner'")
+        #expect(r.wasRestored == true) // a restored session gates its re-run on restoreRunningCommand
     }
 
     @Test func sidebarWidthAndVisibilityRoundTripThroughSnapshot() {

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -490,6 +490,7 @@ struct AppStoreTests {
         session.hasSplit = true
         session.splitCwd = "/var/log"
         session.splitRatio = 0.3
+        session.initialCommand = "ssh host" // a --command primary whose command has now exited
         store.closePrimaryPane(session.id)
         #expect(store.session(withID: session.id) != nil) // session survives
         #expect(primary.teardownCount == 1)               // the dead primary is torn down
@@ -501,6 +502,7 @@ struct AppStoreTests {
         #expect(session.splitFocused == true)             // the maximized survivor is shown
         #expect(session.splitRatio == nil)                // promoted to single, so a later split opens even
         #expect(session.currentCwd == "/var/log")         // the survivor's cwd is promoted
+        #expect(session.initialCommand == nil)            // the command pane is gone; a restart must NOT resurrect it
     }
 
     @Test func closePrimaryPaneWithoutSplitClosesSession() {
@@ -659,14 +661,14 @@ struct AppStoreTests {
         let ws = store.addWorkspace(name: "work")
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
         session.initialCommand = "ssh user@host -t 'ssh inner'"
-        #expect(session.wasRestored == false) // a freshly created session always runs its command
+        #expect(session.wasRestored == false) // a fresh session is not marked restored
         let snap = store.snapshot()
         #expect(snap.workspaces[0].sessions[0].initialCommand == "ssh user@host -t 'ssh inner'")
         let restored = Self.makeStore()
         restored.restore(from: snap)
         let r = restored.workspaces[0].sessions[0]
         #expect(r.initialCommand == "ssh user@host -t 'ssh inner'")
-        #expect(r.wasRestored == true) // a restored session gates its re-run on restoreRunningCommand
+        #expect(r.wasRestored == true) // restore marks the session, so the surface factory can gate its re-run
     }
 
     @Test func sidebarWidthAndVisibilityRoundTripThroughSnapshot() {

--- a/agtermCore/Tests/agtermCoreTests/CommandRestoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/CommandRestoreTests.swift
@@ -132,4 +132,45 @@ struct CommandRestoreTests {
         #expect(CommandRestore.basename("ssh") == "ssh")
         #expect(CommandRestore.basename("") == "")
     }
+
+    // MARK: - restorePlan (the surface-seed gate/precedence)
+
+    @Test func freshCommandSessionAlwaysRunsItsCommand() {
+        // a freshly created --command session runs its command via the exec path, toggle irrelevant
+        for enabled in [true, false] {
+            let plan = CommandRestore.restorePlan(wasRestored: false, restoreEnabled: enabled,
+                                                  hadForeground: false, foregroundInput: nil, initialCommand: "ssh host")
+            #expect(plan == CommandRestore.RestorePlan(command: "ssh host", initialInput: nil))
+        }
+    }
+
+    @Test func restoredCommandSessionRunsCommandOnlyWhenEnabled() {
+        let on = CommandRestore.restorePlan(wasRestored: true, restoreEnabled: true, hadForeground: false,
+                                            foregroundInput: nil, initialCommand: "ssh host")
+        #expect(on == CommandRestore.RestorePlan(command: "ssh host", initialInput: nil))
+        let off = CommandRestore.restorePlan(wasRestored: true, restoreEnabled: false, hadForeground: false,
+                                             foregroundInput: nil, initialCommand: "ssh host")
+        #expect(off == CommandRestore.RestorePlan(command: nil, initialInput: nil)) // opt-out → plain shell
+    }
+
+    @Test func capturedForegroundPreemptsInitialCommand() {
+        // a live child captured at quit wins over the persisted creation command (typed, not exec)
+        let plan = CommandRestore.restorePlan(wasRestored: true, restoreEnabled: true, hadForeground: true,
+                                              foregroundInput: "top\n", initialCommand: "ssh host")
+        #expect(plan == CommandRestore.RestorePlan(command: nil, initialInput: "top\n"))
+    }
+
+    @Test func suppressedForegroundYieldsPlainShellNotStaleCommand() {
+        // a foreground was captured but suppressed (denylisted/off → nil input): a plain shell, NOT a
+        // fall-through to the stale creation command
+        let plan = CommandRestore.restorePlan(wasRestored: true, restoreEnabled: true, hadForeground: true,
+                                              foregroundInput: nil, initialCommand: "ssh host")
+        #expect(plan == CommandRestore.RestorePlan(command: nil, initialInput: nil))
+    }
+
+    @Test func noCommandAndNoForegroundIsPlainShell() {
+        let plan = CommandRestore.restorePlan(wasRestored: true, restoreEnabled: true, hadForeground: false,
+                                              foregroundInput: nil, initialCommand: nil)
+        #expect(plan == CommandRestore.RestorePlan(command: nil, initialInput: nil))
+    }
 }

--- a/agtermUITests/RestoreCommandUITests.swift
+++ b/agtermUITests/RestoreCommandUITests.swift
@@ -202,6 +202,9 @@ final class RestoreCommandUITests: XCTestCase {
     }
 
     private func connect(to path: String) throws -> Int32 {
+        guard path.utf8.count < 104 else { // sun_path limit; guard before copying, like SocketClient.connect
+            throw posixError("socket path too long (\(path.utf8.count) bytes)", ENAMETOOLONG)
+        }
         let deadline = Date().addingTimeInterval(15)
         var lastErrno: Int32 = 0
         repeat {

--- a/agtermUITests/RestoreCommandUITests.swift
+++ b/agtermUITests/RestoreCommandUITests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import XCTest
 
 /// End-to-end for the restore-running-command feature: capture a pane's foreground command at quit and
@@ -9,6 +10,7 @@ final class RestoreCommandUITests: XCTestCase {
     private var app: XCUIApplication!
     private var stateDir: URL!
     private var marker: URL!
+    private var socketPath: String!
 
     override func setUp() async throws {
         continueAfterFailure = false
@@ -18,11 +20,18 @@ final class RestoreCommandUITests: XCTestCase {
         marker = stateDir.appendingPathComponent("restore-marker")
         app = XCUIApplication()
         app.launchEnvironment["AGTERM_STATE_DIR"] = stateDir.path
+        // short socket path in the runner's temp dir: under the ~104-byte sun_path limit AND inside the
+        // runner sandbox (the long per-test stateDir subdir + /tmp both fail); used to create a --command
+        // session over the control channel.
+        socketPath = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("agtermr-\(UUID().uuidString.prefix(8)).sock")
+        app.launchEnvironment["AGTERM_CONTROL_SOCKET"] = socketPath
     }
 
     override func tearDown() async throws {
         app?.terminate()
         if let stateDir { try? FileManager.default.removeItem(at: stateDir) }
+        if let socketPath { try? FileManager.default.removeItem(atPath: socketPath) }
     }
 
     func testRestoreReRunsForegroundCommand() throws {
@@ -88,6 +97,44 @@ final class RestoreCommandUITests: XCTestCase {
                       "an idle login-shell pane must not be captured as a foreground command, got \(capturedForegroundCommands())")
     }
 
+    // A `session.new --command` session persists its command and re-runs it via the EXEC path on restore
+    // when the feature is on — the command-session analogue of the foreground path. `tee <marker>` as the
+    // command exec-replaces the shell (so libghostty reports no foreground and NOTHING is captured), which
+    // proves the restore comes from the persisted `initialCommand`, not a captured foreground.
+    func testRestoreReRunsCommandSession() throws {
+        seedRestoreFlag(true)
+        app.launchForUITest()
+        XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 30), "control server up")
+        let created = try sendCommand(#"{"cmd":"session.new","args":{"command":"tee \#(marker.path)"}}"#)
+        XCTAssertEqual(created["ok"] as? Bool, true, "session.new --command should succeed: \(created)")
+        XCTAssertTrue(poll { FileManager.default.fileExists(atPath: self.marker.path) },
+                      "the --command `tee` should create its marker on start")
+
+        try FileManager.default.removeItem(at: marker)
+        gracefulQuit()
+        app.launchForUITest()
+        XCTAssertTrue(poll { FileManager.default.fileExists(atPath: self.marker.path) },
+                      "restore should re-run the persisted --command (via the exec path) and recreate the marker")
+    }
+
+    func testRestoreOffLeavesCommandSessionAPlainShell() throws {
+        seedRestoreFlag(false)
+        app.launchForUITest()
+        XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 30), "control server up")
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.new","args":{"command":"tee \#(marker.path)"}}"#)["ok"] as? Bool,
+                       true, "session.new --command should succeed")
+        XCTAssertTrue(poll { FileManager.default.fileExists(atPath: self.marker.path) }, "marker created on start")
+
+        try FileManager.default.removeItem(at: marker)
+        gracefulQuit()
+        app.launchForUITest()
+        // flag off → a restored --command session comes back a plain shell → tee is not re-run → marker gone.
+        XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "session restored")
+        RunLoop.current.run(until: Date().addingTimeInterval(2)) // give any (incorrect) re-run a chance to fire
+        XCTAssertFalse(FileManager.default.fileExists(atPath: marker.path),
+                       "with the flag off, a restored --command session must not re-run its command")
+    }
+
     // MARK: - Helpers
 
     /// Every persisted `foregroundCommand` across the window snapshots written at quit (the capture oracle).
@@ -140,5 +187,76 @@ final class RestoreCommandUITests: XCTestCase {
             usleep(200_000)
         }
         return condition()
+    }
+
+    /// Send one newline-delimited JSON request to the control socket and return the decoded response.
+    private func sendCommand(_ line: String) throws -> [String: Any] {
+        let fd = try connect(to: socketPath)
+        defer { close(fd) }
+        var payload = Data(line.utf8)
+        payload.append(UInt8(ascii: "\n"))
+        try writeAll(fd, payload)
+        let data = readResponseLine(fd)
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        return try XCTUnwrap(obj, "response should be a JSON object, got: \(String(data: data, encoding: .utf8) ?? "<binary>")")
+    }
+
+    private func connect(to path: String) throws -> Int32 {
+        let deadline = Date().addingTimeInterval(15)
+        var lastErrno: Int32 = 0
+        repeat {
+            let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+            guard fd >= 0 else { throw posixError("socket", errno) }
+            var addr = sockaddr_un()
+            addr.sun_family = sa_family_t(AF_UNIX)
+            let pathBytes = path.utf8CString
+            withUnsafeMutablePointer(to: &addr.sun_path) { dst in
+                dst.withMemoryRebound(to: CChar.self, capacity: pathBytes.count) { buf in
+                    pathBytes.withUnsafeBufferPointer { src in buf.update(from: src.baseAddress!, count: src.count) }
+                }
+            }
+            let result = withUnsafePointer(to: &addr) { ptr in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+                    Darwin.connect(fd, sa, socklen_t(MemoryLayout<sockaddr_un>.size))
+                }
+            }
+            if result == 0 { return fd }
+            lastErrno = errno
+            close(fd)
+            usleep(200_000)
+        } while Date() < deadline
+        throw posixError("connect(\(path))", lastErrno)
+    }
+
+    private func writeAll(_ fd: Int32, _ data: Data) throws {
+        try data.withUnsafeBytes { raw in
+            var offset = 0
+            let base = raw.bindMemory(to: UInt8.self).baseAddress!
+            while offset < data.count {
+                let n = write(fd, base + offset, data.count - offset)
+                if n <= 0 { throw posixError("write", errno) }
+                offset += n
+            }
+        }
+    }
+
+    private func readResponseLine(_ fd: Int32) -> Data {
+        var buffer = Data()
+        var byte: UInt8 = 0
+        while true {
+            let n = read(fd, &byte, 1)
+            if n < 0 {
+                if errno == EINTR { continue } // a signal interrupted the blocking read; retry
+                return buffer
+            }
+            if n == 0 { return buffer } // EOF
+            if byte == UInt8(ascii: "\n") { return buffer }
+            buffer.append(byte)
+        }
+    }
+
+    private func posixError(_ op: String, _ code: Int32) -> NSError {
+        NSError(domain: "control-socket", code: Int(code),
+                userInfo: [NSLocalizedDescriptionKey: "\(op) failed: \(String(cString: strerror(code)))"])
     }
 }


### PR DESCRIPTION
A session created with a command shortcut or `session.new --command` (an ssh session, say) exec-replaces the login shell, so its command is invisible to libghostty's foreground-pid capture and was never persisted. On restart it came back a plain shell in `$HOME` instead of reconnecting.

This persists `SessionSnapshot.initialCommand` and re-runs it on restore via the exec `command` path (so close-on-exit is kept), gated on the existing **Restore running commands on restart** opt-in through a transient `Session.wasRestored` flag: a freshly created command session always runs its command, a restored one honors the toggle. A live captured foreground command takes precedence over the persisted command, and `closePrimaryPane` clears it when a command pane exits into a promoted split so a restart can't resurrect a dead command.

The gate and precedence logic is the host-free `CommandRestore.restorePlan`; the surface factory just calls it.

Ran it through `/code-review-new` (6 role agents + codex + a verifier), which caught a split-promotion regression, a denylist edge, and stale keep-in-sync docs. All fixed and folded in.

**Tests**: `swift test` (823, including the `restorePlan` matrix and a `closePrimaryPane` regression), `RestoreCommandUITests` e2e (toggle on re-runs the command, off gives a plain shell), `make lint` clean.

*Also* two small project-norm doc notes captured during the work (file-size target, single-line Settings descriptions), orthogonal to the feature.
