### PR TITLE
feat: show the configured shortcut in toolbar and sidebar tooltips

### DIFF
--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -211,6 +211,15 @@ paths:
   The visible list is a `@State` array recomputed on query/mode change — NOT a computed property — so
   the rendered rows and the Enter target can't drift out of sync; results sort by score then title. ⌃P
   opens the session switcher, ⌃⇧P the action palette (the session/action shortcut split is deliberate).
+- **Built-in shortcut hints are one resolver, shared by the palette AND the toolbar/sidebar tooltips.**
+  `AppActions.shortcutGlyph(for:)` (formerly `paletteHint`) → the host-free `Keymap.glyphHint(for:)`
+  (`equivalent(for:)?.glyphString ?? BuiltinAction.arrowGlyphFallback`, nil = no shortcut) renders an
+  action's CURRENT chord as macOS glyphs (`⌃⌘S`), tracking a `keymap.conf` rebind live.
+  `paletteActions()` reads it for the right-aligned palette hint; `WindowContentView.helpHint(_:_:)`
+  appends `" (<glyph>)"` to the `.help(…)` tooltip of the 7 `BuiltinAction`-backed toolbar/sidebar buttons
+  (a button with no configured shortcut shows just its label). One resolver so the two surfaces can't
+  drift — the display analogue of the `defaultChord`-single-source-of-truth rule. Tooltip text is pure
+  visual chrome, so it is control-API keep-in-sync EXEMPT (no command, nothing to drive headless).
 - **Attention list (the `.attention` palette mode).**
   A fourth `PaletteMode` (`.attention`, placeholder "Go to a session that needs attention…") lists the
   window's NON-IDLE sessions — broader than the ⌃⌥↑/↓ attention-NAV, which steps only `needsAttention`

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -415,74 +415,63 @@ final class AppActions {
 
     // MARK: - Command palettes
 
-    /// The palette shortcut hint for a rebindable built-in: its currently-bound chord rendered as macOS
-    /// menu glyphs (so it tracks rebinds and reads like the menu equivalent), or `nil` when the action
-    /// has no chord. The arrow-bound actions fall back to their hardcoded arrow glyph when no override is
-    /// set — `defaultChord` is nil for them (arrows can't round-trip through `parseKeybind`), mirroring
-    /// `agtermApp.arrowShortcut(for:)`.
-    private func paletteHint(for action: BuiltinAction) -> String? {
-        if let chord = settingsModel?.keymap.equivalent(for: action) {
-            // macOS glyphs (⌘N, ⌃P) so a built-in reads like its menu item, NOT the raw kitty
-            // `displayString` (custom commands keep that).
-            return chord.glyphString
-        }
-        switch action {
-        case .focusLeftPane: return "⌥⌘←"
-        case .focusRightPane: return "⌥⌘→"
-        case .previousSession: return "⌥⌘↑"
-        case .nextSession: return "⌥⌘↓"
-        case .previousAttentionSession: return "⌃⌥↑"
-        case .nextAttentionSession: return "⌃⌥↓"
-        default: return nil
-        }
+    /// The macOS glyph string for a rebindable built-in's CURRENT shortcut (`⌘N`, `⌃⌘S`) — tracking
+    /// rebinds, reading like the menu equivalent — or `nil` when the action has no shortcut. The SINGLE
+    /// resolver behind both the action-palette hints and the toolbar/sidebar tooltips, so the two
+    /// surfaces can't drift. `glyphHint` resolves the live keymap (override else shipped default, with
+    /// the arrow-bound actions falling back to their hardcoded arrow glyph since arrows can't round-trip
+    /// through `parseKeybind`); before `settingsModel` is wired, fall back to the arrow glyph alone.
+    func shortcutGlyph(for action: BuiltinAction) -> String? {
+        guard let keymap = settingsModel?.keymap else { return action.arrowGlyphFallback }
+        return keymap.glyphHint(for: action)
     }
 
     /// The app's commands as palette items, sharing the same logic as the menu/buttons. Includes a
     /// "Move Session to …" item per other workspace (when there's an active session to move).
     func paletteActions() -> [PaletteItem] {
-        // built-in shortcut hints read the live keymap (`paletteHint`) so a rebind updates them too,
+        // built-in shortcut hints read the live keymap (`shortcutGlyph`) so a rebind updates them too,
         // matching the data-driven menu key-equivalents; custom commands show their raw shortcut below.
         var items: [PaletteItem] = [
-            PaletteItem(title: "New Session", shortcut: paletteHint(for: .newSession)) { [weak self] in self?.newSession() },
-            PaletteItem(title: "New Workspace", shortcut: paletteHint(for: .newWorkspace)) { [weak self] in self?.newWorkspace() },
-            PaletteItem(title: "Open Directory…", shortcut: paletteHint(for: .openDirectory)) { [weak self] in self?.openDirectory() },
-            PaletteItem(title: "Rename Session", shortcut: paletteHint(for: .renameSession)) { [weak self] in self?.renameActiveSession() },
-            PaletteItem(title: "Rename Workspace", shortcut: paletteHint(for: .renameWorkspace)) { [weak self] in self?.renameActiveWorkspace() },
-            PaletteItem(title: "Close Session", shortcut: paletteHint(for: .closeSession)) { [weak self] in self?.closeActiveSession() },
-            PaletteItem(title: "Clear Status", shortcut: paletteHint(for: .clearStatus)) { [weak self] in self?.clearActiveSessionStatus() },
-            PaletteItem(title: "Previous Session", shortcut: paletteHint(for: .previousSession)) { [weak self] in self?.selectPreviousSession() },
-            PaletteItem(title: "Next Session", shortcut: paletteHint(for: .nextSession)) { [weak self] in self?.selectNextSession() },
-            PaletteItem(title: "Previous Attention Session", shortcut: paletteHint(for: .previousAttentionSession)) { [weak self] in self?.selectPreviousAttentionSession() },
-            PaletteItem(title: "Next Attention Session", shortcut: paletteHint(for: .nextAttentionSession)) { [weak self] in self?.selectNextAttentionSession() },
-            PaletteItem(title: "First Session", shortcut: paletteHint(for: .firstSession)) { [weak self] in self?.selectFirstSession() },
-            PaletteItem(title: "Last Session", shortcut: paletteHint(for: .lastSession)) { [weak self] in self?.selectLastSession() },
-            PaletteItem(title: "Show Attention", shortcut: paletteHint(for: .showAttention)) { [weak self] in self?.openAttentionPalette() },
-            PaletteItem(title: "Toggle Split", shortcut: paletteHint(for: .toggleSplit)) { [weak self] in self?.toggleSplit() },
-            PaletteItem(title: "Toggle Scratch", shortcut: paletteHint(for: .toggleScratch)) { [weak self] in self?.toggleScratch() },
-            PaletteItem(title: "Toggle Sidebar", shortcut: paletteHint(for: .toggleSidebar)) { [weak self] in self?.toggleSidebar() },
+            PaletteItem(title: "New Session", shortcut: shortcutGlyph(for: .newSession)) { [weak self] in self?.newSession() },
+            PaletteItem(title: "New Workspace", shortcut: shortcutGlyph(for: .newWorkspace)) { [weak self] in self?.newWorkspace() },
+            PaletteItem(title: "Open Directory…", shortcut: shortcutGlyph(for: .openDirectory)) { [weak self] in self?.openDirectory() },
+            PaletteItem(title: "Rename Session", shortcut: shortcutGlyph(for: .renameSession)) { [weak self] in self?.renameActiveSession() },
+            PaletteItem(title: "Rename Workspace", shortcut: shortcutGlyph(for: .renameWorkspace)) { [weak self] in self?.renameActiveWorkspace() },
+            PaletteItem(title: "Close Session", shortcut: shortcutGlyph(for: .closeSession)) { [weak self] in self?.closeActiveSession() },
+            PaletteItem(title: "Clear Status", shortcut: shortcutGlyph(for: .clearStatus)) { [weak self] in self?.clearActiveSessionStatus() },
+            PaletteItem(title: "Previous Session", shortcut: shortcutGlyph(for: .previousSession)) { [weak self] in self?.selectPreviousSession() },
+            PaletteItem(title: "Next Session", shortcut: shortcutGlyph(for: .nextSession)) { [weak self] in self?.selectNextSession() },
+            PaletteItem(title: "Previous Attention Session", shortcut: shortcutGlyph(for: .previousAttentionSession)) { [weak self] in self?.selectPreviousAttentionSession() },
+            PaletteItem(title: "Next Attention Session", shortcut: shortcutGlyph(for: .nextAttentionSession)) { [weak self] in self?.selectNextAttentionSession() },
+            PaletteItem(title: "First Session", shortcut: shortcutGlyph(for: .firstSession)) { [weak self] in self?.selectFirstSession() },
+            PaletteItem(title: "Last Session", shortcut: shortcutGlyph(for: .lastSession)) { [weak self] in self?.selectLastSession() },
+            PaletteItem(title: "Show Attention", shortcut: shortcutGlyph(for: .showAttention)) { [weak self] in self?.openAttentionPalette() },
+            PaletteItem(title: "Toggle Split", shortcut: shortcutGlyph(for: .toggleSplit)) { [weak self] in self?.toggleSplit() },
+            PaletteItem(title: "Toggle Scratch", shortcut: shortcutGlyph(for: .toggleScratch)) { [weak self] in self?.toggleScratch() },
+            PaletteItem(title: "Toggle Sidebar", shortcut: shortcutGlyph(for: .toggleSidebar)) { [weak self] in self?.toggleSidebar() },
             PaletteItem(title: (store?.activeSession?.flagged == true) ? "Unflag Session" : "Flag Session",
-                        shortcut: paletteHint(for: .toggleFlag)) { [weak self] in self?.toggleFlagActiveSession() },
+                        shortcut: shortcutGlyph(for: .toggleFlag)) { [weak self] in self?.toggleFlagActiveSession() },
             PaletteItem(title: "Focus Workspace",
-                        shortcut: paletteHint(for: .focusWorkspace)) { [weak self] in self?.focusActiveWorkspace() },
-            PaletteItem(title: "Find…", shortcut: paletteHint(for: .toggleSearch)) { [weak self] in self?.toggleSearch() },
-            PaletteItem(title: "Quick Terminal", shortcut: paletteHint(for: .quickTerminal)) { [weak self] in self?.toggleQuickTerminal() },
-            PaletteItem(title: "Increase Font Size", shortcut: paletteHint(for: .increaseFontSize)) { [weak self] in self?.increaseFontSize() },
-            PaletteItem(title: "Decrease Font Size", shortcut: paletteHint(for: .decreaseFontSize)) { [weak self] in self?.decreaseFontSize() },
-            PaletteItem(title: "Actual Font Size", shortcut: paletteHint(for: .resetFontSize)) { [weak self] in self?.resetFontSize() },
-            PaletteItem(title: "Select Theme…", shortcut: paletteHint(for: .selectTheme)) { [weak self] in self?.openThemePalette() },
+                        shortcut: shortcutGlyph(for: .focusWorkspace)) { [weak self] in self?.focusActiveWorkspace() },
+            PaletteItem(title: "Find…", shortcut: shortcutGlyph(for: .toggleSearch)) { [weak self] in self?.toggleSearch() },
+            PaletteItem(title: "Quick Terminal", shortcut: shortcutGlyph(for: .quickTerminal)) { [weak self] in self?.toggleQuickTerminal() },
+            PaletteItem(title: "Increase Font Size", shortcut: shortcutGlyph(for: .increaseFontSize)) { [weak self] in self?.increaseFontSize() },
+            PaletteItem(title: "Decrease Font Size", shortcut: shortcutGlyph(for: .decreaseFontSize)) { [weak self] in self?.decreaseFontSize() },
+            PaletteItem(title: "Actual Font Size", shortcut: shortcutGlyph(for: .resetFontSize)) { [weak self] in self?.resetFontSize() },
+            PaletteItem(title: "Select Theme…", shortcut: shortcutGlyph(for: .selectTheme)) { [weak self] in self?.openThemePalette() },
             PaletteItem(title: "Edit Keymap") { [weak self] in self?.editKeymap() },
             PaletteItem(title: "Reload Keymap") { [weak self] in self?.reloadKeymap() },
             PaletteItem(title: "Edit ghostty.conf") { [weak self] in self?.editGhosttyConfig() },
             PaletteItem(title: "Reload Config") { [weak self] in self?.reloadGhosttyConfig() },
         ]
         if store?.canRemoveWorkspace == true {
-            items.append(PaletteItem(title: "Delete Workspace", shortcut: paletteHint(for: .deleteWorkspace)) { [weak self] in self?.deleteActiveWorkspace() })
+            items.append(PaletteItem(title: "Delete Workspace", shortcut: shortcutGlyph(for: .deleteWorkspace)) { [weak self] in self?.deleteActiveWorkspace() })
         }
         // the flagged-view toggle: omitted when there's nothing to show (tree mode + no flags); always
         // present in flagged mode so the palette can switch back to the tree.
         if store?.sidebarMode == .flagged || store?.flaggedSessions.isEmpty == false {
             items.append(PaletteItem(title: store?.sidebarMode == .flagged ? "Show All Sessions" : "Show Flagged Sessions",
-                                     shortcut: paletteHint(for: .toggleFlaggedView)) { [weak self] in self?.toggleFlaggedView() })
+                                     shortcut: shortcutGlyph(for: .toggleFlaggedView)) { [weak self] in self?.toggleFlaggedView() })
         }
         // plain (non-BuiltinAction) clear, shown only while the working-set is non-empty.
         if store?.flaggedSessions.isEmpty == false {
@@ -499,13 +488,13 @@ final class AppActions {
             items.append(PaletteItem(title: "Collapse Workspaces") { [weak self] in self?.collapseOtherWorkspaces() })
         }
         if store?.activeSession?.hasSplit == true {
-            items.append(PaletteItem(title: "Focus Left Pane", shortcut: paletteHint(for: .focusLeftPane)) { [weak self] in self?.focusPane(.main) })
-            items.append(PaletteItem(title: "Focus Right Pane", shortcut: paletteHint(for: .focusRightPane)) { [weak self] in self?.focusPane(.split) })
+            items.append(PaletteItem(title: "Focus Left Pane", shortcut: shortcutGlyph(for: .focusLeftPane)) { [weak self] in self?.focusPane(.main) })
+            items.append(PaletteItem(title: "Focus Right Pane", shortcut: shortcutGlyph(for: .focusRightPane)) { [weak self] in self?.focusPane(.split) })
         }
-        items.append(PaletteItem(title: "New Window", shortcut: paletteHint(for: .newWindow)) { [weak self] in self?.newWindow() })
-        items.append(PaletteItem(title: "Rename Window", shortcut: paletteHint(for: .renameWindow)) { [weak self] in self?.renameActiveWindow() })
+        items.append(PaletteItem(title: "New Window", shortcut: shortcutGlyph(for: .newWindow)) { [weak self] in self?.newWindow() })
+        items.append(PaletteItem(title: "Rename Window", shortcut: shortcutGlyph(for: .renameWindow)) { [weak self] in self?.renameActiveWindow() })
         if library.canRemoveWindow {
-            items.append(PaletteItem(title: "Delete Window", shortcut: paletteHint(for: .deleteWindow)) { [weak self] in self?.deleteActiveWindow() })
+            items.append(PaletteItem(title: "Delete Window", shortcut: shortcutGlyph(for: .deleteWindow)) { [weak self] in self?.deleteActiveWindow() })
         }
         // one "Open Window: <name>" per closed window — open ones are already on screen.
         for window in library.windows where !library.isOpen(window.id) {

--- a/agterm/ContentView.swift
+++ b/agterm/ContentView.swift
@@ -770,7 +770,7 @@ private struct WindowContentView: View {
         .foregroundStyle(blocked ? Color(nsColor: GhosttyApp.shared.blockedStatusColor) : chromeText)
         .opacity(empty ? 0.35 : 1)
         .disabled(empty)
-        .help(empty ? "No sessions need attention" : "Show sessions that need attention")
+        .help(helpHint(empty ? "No sessions need attention" : "Show sessions that need attention", .showAttention))
         .accessibilityIdentifier("attention-button")
         .accessibilityValue(empty ? "none" : (blocked ? "blocked" : "attention"))
     }

--- a/agterm/ContentView.swift
+++ b/agterm/ContentView.swift
@@ -686,6 +686,15 @@ private struct WindowContentView: View {
         .background { WindowControlArea() }
     }
 
+    /// A tooltip string with the action's current shortcut appended in parentheses (e.g. `Toggle
+    /// Sidebar (⌃⌘S)`), or just the base text when the action has no configured shortcut. Keeps the
+    /// toolbar/sidebar hints in lockstep with the keymap — a rebind shows the new chord, an unbound
+    /// action shows none — via the SAME `AppActions.shortcutGlyph` resolver the action palette uses.
+    private func helpHint(_ base: String, _ action: BuiltinAction) -> String {
+        guard let glyph = actions.shortcutGlyph(for: action) else { return base }
+        return "\(base) (\(glyph))"
+    }
+
     /// Our own sidebar show/hide toggle (the custom split has no system one). Animated collapse.
     private var sidebarToggleButton: some View {
         Button {
@@ -693,7 +702,7 @@ private struct WindowContentView: View {
         } label: {
             Label("Toggle Sidebar", systemImage: "sidebar.left")
         }
-        .help("Toggle Sidebar")
+        .help(helpHint("Toggle Sidebar", .toggleSidebar))
         .accessibilityIdentifier("sidebar-toggle-button")
     }
 
@@ -708,7 +717,7 @@ private struct WindowContentView: View {
             // split (shown or hidden), matching the sidebar's split-session icon.
             Label("Split", systemImage: hasSplit ? "rectangle.split.2x1.fill" : "rectangle.split.2x1")
         }
-        .help(isSplit ? "Hide split" : (hasSplit ? "Show split" : "Split right"))
+        .help(helpHint(isSplit ? "Hide split" : (hasSplit ? "Show split" : "Split right"), .toggleSplit))
         .disabled(store.activeSession == nil)
         .accessibilityIdentifier("split-toggle")
     }
@@ -723,7 +732,7 @@ private struct WindowContentView: View {
         } label: {
             Label("Scratch", systemImage: active ? "rectangle.inset.filled" : "rectangle")
         }
-        .help(active ? "Hide scratch terminal" : "Show scratch terminal")
+        .help(helpHint(active ? "Hide scratch terminal" : "Show scratch terminal", .toggleScratch))
         .disabled(store.activeSession == nil)
         .accessibilityIdentifier("scratch-toggle")
     }
@@ -737,7 +746,7 @@ private struct WindowContentView: View {
         } label: {
             Label("Quick Terminal", systemImage: "terminal")
         }
-        .help("Quick Terminal")
+        .help(helpHint("Quick Terminal", .quickTerminal))
         .accessibilityIdentifier("quick-terminal-toggle")
     }
 
@@ -853,7 +862,7 @@ private struct WindowContentView: View {
                     .contentShape(Rectangle())
             }
             .buttonStyle(.borderless)
-            .help("New Workspace")
+            .help(helpHint("New Workspace", .newWorkspace))
             .accessibilityLabel("New Workspace")
 
             Menu {
@@ -869,7 +878,7 @@ private struct WindowContentView: View {
             .tint(chromeText)
             .menuIndicator(.hidden)
             .fixedSize()
-            .help("New Session")
+            .help(helpHint("New Session", .newSession))
             .accessibilityLabel("Add session")
             .accessibilityIdentifier("add-session")
 
@@ -914,7 +923,7 @@ private struct WindowContentView: View {
             // chromeText foregroundStyle defeats SwiftUI's default disabled dimming, so mute it by hand.
             .disabled(store.sidebarMode == .tree && store.flaggedSessions.isEmpty)
             .opacity(store.sidebarMode == .tree && store.flaggedSessions.isEmpty ? 0.35 : 1)
-            .help(store.sidebarMode == .flagged ? "Show all sessions" : "Show flagged sessions")
+            .help(helpHint(store.sidebarMode == .flagged ? "Show all sessions" : "Show flagged sessions", .toggleFlaggedView))
             .accessibilityLabel("Toggle Flagged View")
             .accessibilityIdentifier("flagged-view-toggle")
         }

--- a/agterm/Views/Palette.swift
+++ b/agterm/Views/Palette.swift
@@ -8,7 +8,7 @@ struct PaletteItem: Identifiable {
     let title: String
     let subtitle: String?
     /// The action's keyboard shortcut hint shown right-aligned, nil for items with no shortcut.
-    /// Rebindable built-ins read the live keymap (`AppActions.paletteHint`) so it tracks rebinds;
+    /// Rebindable built-ins read the live keymap (`AppActions.shortcutGlyph`) so it tracks rebinds;
     /// custom commands show their raw kitty shortcut string. Both render in kitty syntax (e.g.
     /// `cmd+shift+e`), except the four arrow-bound actions which keep their glyph fallback.
     let shortcut: String?

--- a/agterm/Views/Palette.swift
+++ b/agterm/Views/Palette.swift
@@ -8,9 +8,10 @@ struct PaletteItem: Identifiable {
     let title: String
     let subtitle: String?
     /// The action's keyboard shortcut hint shown right-aligned, nil for items with no shortcut.
-    /// Rebindable built-ins read the live keymap (`AppActions.shortcutGlyph`) so it tracks rebinds;
-    /// custom commands show their raw kitty shortcut string. Both render in kitty syntax (e.g.
-    /// `cmd+shift+e`), except the four arrow-bound actions which keep their glyph fallback.
+    /// Rebindable built-ins read the live keymap (`AppActions.shortcutGlyph`) so it tracks rebinds and
+    /// render as macOS menu glyphs (e.g. `⌘⇧E`); custom commands show their raw kitty shortcut string
+    /// (e.g. `cmd+shift+e`). The six arrow-bound actions, not expressible as a `Chord`, keep their
+    /// hardcoded glyph fallback.
     let shortcut: String?
     /// A small trailing badge label (e.g. `custom` for user-defined keymap commands), nil for none.
     let badge: String?

--- a/agtermCore/Sources/agtermCore/BuiltinAction.swift
+++ b/agtermCore/Sources/agtermCore/BuiltinAction.swift
@@ -62,4 +62,21 @@ public enum BuiltinAction: String, CaseIterable, Sendable {
             return nil
         }
     }
+
+    /// The hardcoded macOS menu glyph for the six arrow-bound actions, whose default shortcut can't
+    /// round-trip through `Chord`/`keymap.conf` (so `defaultChord` is nil). `nil` for every other
+    /// action — a keyless action stays keyless until the user maps a chord. This is the display
+    /// counterpart of the menu's hardcoded arrow `.keyboardShortcut`, used by `Keymap.glyphHint(for:)`
+    /// to render an action's current shortcut in the action palette and the toolbar tooltips.
+    public var arrowGlyphFallback: String? {
+        switch self {
+        case .focusLeftPane: return "⌥⌘←"
+        case .focusRightPane: return "⌥⌘→"
+        case .previousSession: return "⌥⌘↑"
+        case .nextSession: return "⌥⌘↓"
+        case .previousAttentionSession: return "⌃⌥↑"
+        case .nextAttentionSession: return "⌃⌥↓"
+        default: return nil
+        }
+    }
 }

--- a/agtermCore/Sources/agtermCore/Keymap.swift
+++ b/agtermCore/Sources/agtermCore/Keymap.swift
@@ -20,6 +20,16 @@ public struct Keymap: Equatable, Sendable {
     public func equivalent(for action: BuiltinAction) -> Chord? {
         builtinOverrides[action] ?? action.defaultChord
     }
+
+    /// The action's current shortcut as a macOS menu glyph string (e.g. `⌘N`, `⌃⌘S`), or `nil` when
+    /// the action has no shortcut at all. Resolves the effective chord (`equivalent(for:)` — user
+    /// override else shipped default) and renders it via `Chord.glyphString`; for the arrow-bound
+    /// actions, which have no expressible default, it falls back to the hardcoded `arrowGlyphFallback`.
+    /// `nil` means "not configured" — the caller shows no shortcut. Drives both the action-palette
+    /// hints and the toolbar tooltips so the two surfaces can't drift.
+    public func glyphHint(for action: BuiltinAction) -> String? {
+        equivalent(for: action)?.glyphString ?? action.arrowGlyphFallback
+    }
 }
 
 /// A single problem found while parsing `keymap.conf`. `line` is 1-based; `0` is reserved for a

--- a/agtermCore/Tests/agtermCoreTests/BuiltinActionTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/BuiltinActionTests.swift
@@ -32,6 +32,24 @@ struct BuiltinActionTests {
         #expect(BuiltinAction(rawValue: "New_Window") == nil)
     }
 
+    @Test func arrowGlyphFallbackCoversTheSixArrowActions() {
+        // the six arrow-bound actions can't round-trip through Chord, so their menu glyph is hardcoded.
+        #expect(BuiltinAction.focusLeftPane.arrowGlyphFallback == "⌥⌘←")
+        #expect(BuiltinAction.focusRightPane.arrowGlyphFallback == "⌥⌘→")
+        #expect(BuiltinAction.previousSession.arrowGlyphFallback == "⌥⌘↑")
+        #expect(BuiltinAction.nextSession.arrowGlyphFallback == "⌥⌘↓")
+        #expect(BuiltinAction.previousAttentionSession.arrowGlyphFallback == "⌃⌥↑")
+        #expect(BuiltinAction.nextAttentionSession.arrowGlyphFallback == "⌃⌥↓")
+    }
+
+    @Test func nonArrowActionsHaveNoArrowGlyphFallback() {
+        // an action with an expressible default resolves through the keymap, not the fallback.
+        #expect(BuiltinAction.toggleSidebar.arrowGlyphFallback == nil)
+        #expect(BuiltinAction.newSession.arrowGlyphFallback == nil)
+        // a keyless, non-arrow action has nothing.
+        #expect(BuiltinAction.firstSession.arrowGlyphFallback == nil)
+    }
+
     @Test func defaultChordMatchesShippedTable() {
         let expected: [BuiltinAction: Chord?] = [
             .newWindow: Chord(mods: [.command, .option], key: "n"),

--- a/agtermCore/Tests/agtermCoreTests/KeymapTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/KeymapTests.swift
@@ -39,6 +39,41 @@ struct KeymapTests {
         #expect(keymap.commands.isEmpty)
     }
 
+    // MARK: glyphHint — the shortcut shown in the palette and toolbar tooltips
+
+    @Test func glyphHintRendersDefaultChordAsGlyphs() {
+        let keymap = Keymap(builtinOverrides: [:], commands: [])
+        #expect(keymap.glyphHint(for: .newSession) == "⌘N")
+        #expect(keymap.glyphHint(for: .toggleSidebar) == "⌃⌘S")
+        #expect(keymap.glyphHint(for: .toggleSplit) == "⌘D")
+    }
+
+    @Test func glyphHintUsesOverrideWhenPresent() {
+        let keymap = Keymap(builtinOverrides: [.toggleSidebar: Chord(mods: [.command], key: "k")], commands: [])
+        #expect(keymap.glyphHint(for: .toggleSidebar) == "⌘K")
+    }
+
+    @Test func glyphHintFallsBackToArrowGlyphForArrowActions() {
+        // arrow-bound actions have no expressible default chord, so the hint comes from the fallback.
+        let keymap = Keymap(builtinOverrides: [:], commands: [])
+        #expect(keymap.glyphHint(for: .previousSession) == "⌥⌘↑")
+        #expect(keymap.glyphHint(for: .focusLeftPane) == "⌥⌘←")
+    }
+
+    @Test func glyphHintOverrideWinsOverArrowFallback() {
+        // a user-mapped parseable chord beats the hardcoded arrow glyph.
+        let keymap = Keymap(builtinOverrides: [.previousSession: Chord(mods: [.command], key: "p")], commands: [])
+        #expect(keymap.glyphHint(for: .previousSession) == "⌘P")
+    }
+
+    @Test func glyphHintIsNilForUnconfiguredAction() {
+        // a keyless, non-arrow action shows nothing until the user maps a chord — the "if not
+        // configured, don't add" rule that keeps tooltips clean.
+        let keymap = Keymap(builtinOverrides: [:], commands: [])
+        #expect(keymap.glyphHint(for: .toggleFlaggedView) == nil)
+        #expect(keymap.glyphHint(for: .firstSession) == nil)
+    }
+
     @Test func rebindToggleSearchResolvesThroughGenericPath() {
         // toggle_search rebinds like any other built-in: the generic parse/resolve path (no per-action
         // special-casing) parses the chord, maps the raw name to .toggleSearch, and equivalent(for:)


### PR DESCRIPTION
## What

Toolbar and sidebar-bar button tooltips now include the button's current keyboard shortcut in parentheses — hovering **Toggle Sidebar** shows `Toggle Sidebar (⌃⌘S)`, **Split** shows `Split right (⌘D)`, etc. A button whose action has no configured shortcut (e.g. the flagged-view toggle) shows just its label, unchanged.

## Why

agterm is keyboard-first — every action has a shortcut — but the toolbar/sidebar buttons were the one surface that never revealed theirs. To learn or confirm a button's key you had to open the action palette or hunt through the menu bar. Both of *those* surfaces already show the shortcut as a macOS glyph; the tooltips were the gap. Surfacing it on hover teaches the shortcut in place, and because the tooltip reads the live keymap, a user who rebinds a built-in in `keymap.conf` sees the new chord rather than a stale default — reinforcing the customization story.

## How

The action→glyph resolution the action palette already used (`AppActions.paletteHint`) is lifted into a single host-free resolver in `agtermCore`, so the palette and the tooltips share one source of truth and can't drift:

- `Keymap.glyphHint(for:) -> String?` — the effective chord (`equivalent(for:)` = user override else shipped `defaultChord`) rendered via `Chord.glyphString`, falling back to `BuiltinAction.arrowGlyphFallback` for the six arrow-bound actions (whose shortcuts can't round-trip through `Chord`). `nil` = no shortcut, so the caller shows nothing.
- `BuiltinAction.arrowGlyphFallback: String?` — the hardcoded arrow glyphs (`⌥⌘↑` …) lifted out of the app target (they were duplicated inside `paletteHint`); `nil` for every other action. The display counterpart of the menu's hardcoded arrow `.keyboardShortcut`.
- `AppActions.paletteHint` → `AppActions.shortcutGlyph` — the shared entry point now, delegating to `glyphHint`; the palette call sites are renamed accordingly (mechanical).
- `WindowContentView.helpHint(_:_:)` (`ContentView`) composes `"<label> (<glyph>)"` when a glyph exists, else the bare label — wired into the 7 toolbar/sidebar buttons that map to a `BuiltinAction`. Buttons with no keymap action ("Clear focus", the search-bar controls) are left untouched, so they correctly show no shortcut.

### Keep-in-sync (control API): exempt

I checked whether this needs a control command, and it doesn't — it's the "pure visual chrome with nothing to drive" exemption (like `reveal`). It adds no user action to `AppActions`/`AppStore` and no new state: `shortcutGlyph`/`helpHint` are read-only formatters over the existing keymap, and a tooltip is hover-only OS chrome with nothing to invoke headless. The control command count stays 48; the keymap format, the window/workspace/session model, and the agent-skill docs are unchanged.

## Test plan

- `cd agtermCore && swift test` — **830/830 pass**, incl. 7 new cases: `Keymap.glyphHint` (default→glyph, override wins, arrow fallback, override beats arrow fallback, `nil` when unconfigured) and `BuiltinAction.arrowGlyphFallback` (covers the six arrows, `nil` otherwise).
- `swiftlint --config .swiftlint.yml` on the changed files — **0 violations**.
- `make build` — **succeeds**.
- Rebased onto current `master` (post-v0.4.1). The only merge-relevant overlap was keeping #35's "Show Attention" palette item on the renamed `shortcutGlyph`.
- Manual: hover each toolbar/sidebar button — bound ones show the glyph and track a `keymap.conf` rebind after Reload Keymap; the flagged-view toggle (no default shortcut) shows only its label.

Note: `helpHint` is a trivial formatter over the unit-tested `glyphHint`, and the SwiftUI `.help()` tooltip itself isn't practically XCUITest-observable, so it's covered by the resolver unit tests plus manual hover. Happy to extract the formatter into `agtermCore` for an explicit host-free test if you'd prefer belt-and-suspenders coverage.
