### PR TITLE
fix: right-click paste on by default and file-drop targeting

### DIFF
--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -67,6 +67,21 @@ paths:
   four `onSearch*`) at its END — AFTER `onExitCodeCaptured` is read for the overlay exit status (niling
   it earlier would silently break `session.overlay.result`/`--block`) — to break the `store → session → surface → closure → store`
   retain cycle on every window/session close.
+- **Drag-and-drop targets only the ON-SCREEN deck pane (`deckVisible` gates `registerForDraggedTypes`).**
+  Every session's surface is eagerly realized, so every one is a candidate file-drop target.
+  SwiftUI's `.opacity(0)` + `.allowsHitTesting(false)` on the inactive deck panes do NOT stop AppKit's
+  drag machinery: the NSView keeps `alphaValue == 1`, AND AppKit's drag-destination resolution does NOT
+  consult `hitTest` (verified: an off-screen surface whose `hitTest` returns nil STILL gets `draggingEntered`/`performDragOperation`).
+  So if every surface stayed registered, a file drop would land on whichever surface is topmost in z-order
+  (the ForEach/array order, NOT the selection) — an INVISIBLE background session — and inject the path
+  there, so the visible terminal shows nothing (single-session works, which is why #52 shipped with this
+  latent).
+  The fix is `GhosttySurfaceView.deckVisible` (set by `TerminalView` from the deck, = session selected
+  AND not hidden by a full overlay/scratch; NOT focus-gated, so BOTH panes of a visible split qualify —
+  unlike `deckActive`): its `didSet` calls `updateDropRegistration()` which `registerForDraggedTypes`
+  when visible and `unregisterDraggedTypes` otherwise, so only the on-screen pane is ever a drop target.
+  Not `hitTest` (AppKit drag ignores it) and not a `draggingEntered` reject (AppKit does not fall through
+  to the sibling behind a rejecting target — the drop is simply lost).
 - **Search bar placement (NSSplitView-overrun rule).**
   `TerminalSearchBar` (`agterm/Views/`) is anchored on `detailPane` via `.overlay(alignment: .topTrailing) { searchBarLayer }`
   — the SAME level as `floatingOverlayLayer`, NEVER inside any session's `sessionDetail` HSplitView-hosting

--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -24,7 +24,8 @@ paths:
   system orange/green; NOT ghostty keys) + `mouseScrollMultiplier` (ghostty `mouse-scroll-multiplier`)
   + `inactivePaneMuteStrength` (0...10 inactive-split-pane text mute, nil = default 5,
   NOT a ghostty key) + `sidebarBackgroundShift` (0...10 sidebar lighter/darker tint relative to the terminal,
-  nil = default 5 = neutral, NOT a ghostty key).
+  nil = default 5 = neutral, NOT a ghostty key)
+  + `rightClickPaste` (ghostty `right-click-action`, nil = on).
   The three `*StatusColorHex` (`#RRGGBB`, nil = active `#DBD9E6` muted lavender-grey + system amber/green)
   color the sidebar agent-status glyph: `SettingsModel` passes the hex to `GhosttyApp.setAgentStatusColors`
   which resolves to `NSColor` (so `SettingsModel` stays AppKit-free, the `NSColor`↔hex helper is `NSColor+AgtermHex`),
@@ -52,12 +53,21 @@ paths:
   `AppSettings.ghosttyConfigLines()` (host-free, unit-tested) emits `key = value` lines RAW — no quotes,
   because ghostty takes the whole line remainder as the value (confirmed against the bundled conf + theme
   files), so names with spaces (`3024 Night`) must not be quoted.
-  `mouseScrollMultiplier` is the ONE field always emitted: nil emits the default `mouse-scroll-multiplier = 3`
-  (a bare value applied to both the notched wheel and the trackpad) rather than being omitted,
-  so the default speed is effective rather than ghostty's per-device defaults (discrete 3 / precision
-  1) — a consequence is it overrides any `mouse-scroll-multiplier` in the user's own `~/.config/ghostty/config`.
-  The General → Scrolling stepper (1...10, default 3) maps 3 back to nil so `settings.json` stays minimal;
-  the emitted value is 3 either way.
+  TWO fields are always emitted (every other key is omitted when unset): `mouseScrollMultiplier` — nil
+  emits the default `mouse-scroll-multiplier = 3` (a bare value applied to both the notched wheel and
+  the trackpad) rather than being omitted, so the default speed is effective rather than ghostty's per-device
+  defaults (discrete 3 / precision 1) — a consequence is it overrides any `mouse-scroll-multiplier` in
+  the user's own `~/.config/ghostty/config`; and `rightClickPaste` — nil/on emits `right-click-action = paste`,
+  off emits `right-click-action = ignore`, so the toggle OWNS the key (the settings conf loads last, so
+  it wins over a `right-click-action` in the user's own `ghostty.conf` — for agterm, which has no terminal
+  context menu, paste-or-off is the whole meaningful choice).
+  The General → Mouse scroll-speed slider (1...10, default 3) maps 3 back to nil so `settings.json` stays
+  minimal; the emitted value is 3 either way.
+  The General → Mouse right-click toggle (default-ON binding, get `?? true` / set `$0 ? nil : false`,
+  like the other default-on toggles) drives `rightClickPaste` and is a real ghostty-key setter (`SettingsModel.setRightClickPaste`
+  → `persistAndApply` rewrites the conf and reloads surfaces live); GUI-only and keep-in-sync EXEMPT (only
+  `theme.set`/`config.reload` touch settings over the socket — the right-click FORWARDING itself is unconditional
+  in `GhosttySurfaceView`, this key only decides libghostty's action).
   The Appearance → Panes slider (0...10, default 5) maps 5 back to nil the same way;
   it drives `GhosttyApp.inactivePaneMuteStrength` (mirrored into `WindowContentView` view state on `.agtermAppearanceChanged`,
   like `compactToolbar`/`notificationBadgeEnabled`), and `ContentView.paneDim` washes the inactive split
@@ -117,8 +127,9 @@ paths:
   An explicit `TabView(selection:)` binding (`@State` default `.general`) suppresses SwiftUI's
   `com_apple_SwiftUI_Settings_selectedTabIndex` auto-persistence, so the window always opens on General
   instead of restoring the last-used tab.
-  **General** (a **Scrolling** section with the scroll-speed slider, a **Sessions** section with the
-  restore-running-commands toggle, and a **Ghostty Config** section with the inherit-global-config toggle).
+  **General** (a **Mouse** section with the scroll-speed slider + the right-click-pastes toggle,
+  a **Sessions** section with the restore-running-commands toggle,
+  and a **Ghostty Config** section with the inherit-global-config toggle).
   **Appearance** (a **Terminal** section — font/size/theme via `NSFontManager` monospaced families +
   the bundled `ghostty/themes` dir, `SettingsCatalog` — a **Window** section with the compact-toolbar
   toggle + background opacity/blur sliders + the Sidebar Tint slider, and a **Panes** section with the

--- a/agterm/ContentView.swift
+++ b/agterm/ContentView.swift
@@ -391,6 +391,10 @@ private struct WindowContentView: View {
         // this subtree's shape/hit-testing must not change when a floating overlay opens (NSSplitView overrun).
         let hideForOverlay = fullOverlay || session.scratchActive
         let overlaid = session.overlayActive || session.scratchActive
+        // on-screen = selected session, not hidden by a full overlay/scratch. Shared by BOTH split panes
+        // (unlike the focus-gated `isActive`), it drives each surface's `hitTest` so a file drop lands on
+        // the visible pane instead of an invisible background deck surface (matches the panes' hit-testing).
+        let visible = isActive && !hideForOverlay
         ZStack {
             // the session's pane(s), kept MOUNTED while an overlay is up — shells stay alive, like the deck
             // does for inactive sessions. a FULL overlay hides them (opacity 0) so its translucency reveals the
@@ -399,7 +403,7 @@ private struct WindowContentView: View {
                 if session.isSplit {
                     HSplitView {
                         TerminalView(session: session, surfaceKeyPath: \.surface, makeSurface: makeSurface,
-                                     isActive: isActive && !session.splitFocused && !overlaid)
+                                     isActive: isActive && !session.splitFocused && !overlaid, deckVisible: visible)
                             .overlay { paneDim(session.splitFocused) }
                             // introspects the AppKit NSSplitView to persist/restore the divider ratio AND to
                             // clip its divider out of the titlebar strip (see SplitRatioAccessor); a background
@@ -407,7 +411,7 @@ private struct WindowContentView: View {
                             .background { SplitRatioAccessor(session: session, titlebarHeight: titlebarHeight, onPersist: { store.save() }) }
                             .id(session.id)
                         TerminalView(session: session, surfaceKeyPath: \.splitSurface, makeSurface: makeSplitSurface,
-                                     isActive: isActive && session.splitFocused && !overlaid)
+                                     isActive: isActive && session.splitFocused && !overlaid, deckVisible: visible)
                             .overlay { paneDim(!session.splitFocused) }
                             .id("\(session.id.uuidString)-split")
                     }
@@ -417,11 +421,11 @@ private struct WindowContentView: View {
                 } else if session.splitFocused, session.splitSurface != nil {
                     // split hidden while the right pane had focus: show that pane maximized.
                     TerminalView(session: session, surfaceKeyPath: \.splitSurface, makeSurface: makeSplitSurface,
-                                 isActive: isActive && !overlaid)
+                                 isActive: isActive && !overlaid, deckVisible: visible)
                         .id("\(session.id.uuidString)-split")
                 } else {
                     TerminalView(session: session, surfaceKeyPath: \.surface, makeSurface: makeSurface,
-                                 isActive: isActive && !overlaid)
+                                 isActive: isActive && !overlaid, deckVisible: visible)
                         .id(session.id)
                 }
             }

--- a/agterm/ContentView.swift
+++ b/agterm/ContentView.swift
@@ -392,8 +392,8 @@ private struct WindowContentView: View {
         let hideForOverlay = fullOverlay || session.scratchActive
         let overlaid = session.overlayActive || session.scratchActive
         // on-screen = selected session, not hidden by a full overlay/scratch. Shared by BOTH split panes
-        // (unlike the focus-gated `isActive`), it drives each surface's `hitTest` so a file drop lands on
-        // the visible pane instead of an invisible background deck surface (matches the panes' hit-testing).
+        // (unlike the focus-gated `isActive`), it gates each surface's drag-type (un)registration so a file
+        // drop lands on the visible pane, not an invisible background deck surface (matches the panes' hit-testing).
         let visible = isActive && !hideForOverlay
         ZStack {
             // the session's pane(s), kept MOUNTED while an overlay is up — shells stay alive, like the deck

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -166,6 +166,30 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     /// for them; they take focus through `TerminalView.focusIfNeeded`, which is already active-gated.
     var deckActive = true
 
+    /// Whether this surface's deck slot is on-screen (its session is selected and not hidden by a full
+    /// overlay/scratch). UNLIKE `deckActive`, this is NOT focus-gated: both panes of a visible split are
+    /// `deckVisible`. `TerminalView` sets it from the deck. Load-bearing for drag-and-drop: every session's
+    /// surface is eagerly realized, and SwiftUI's `.opacity(0)`/`.allowsHitTesting(false)` on inactive deck
+    /// panes do NOT reach AppKit's drag machinery (the NSView keeps `alphaValue == 1`, and AppKit's
+    /// drag-destination resolution does NOT consult `hitTest`), so if every surface stayed a registered
+    /// drag target a file drop would land on whichever is topmost in z-order — an INVISIBLE background
+    /// session — instead of the one under the cursor. `didSet` (un)registers the drag types to fix that.
+    var deckVisible = true {
+        didSet { updateDropRegistration() }
+    }
+
+    /// Register the file/text drag types only while this surface is the on-screen deck pane; unregister
+    /// otherwise, so an eagerly-realized background surface is not a drag target and a drop can only reach
+    /// the visible pane. Called from `deckVisible`'s didSet and once from `createSurface` (didSet does not
+    /// fire for the initializer default).
+    private func updateDropRegistration() {
+        if deckVisible {
+            registerForDraggedTypes([.fileURL, .string, .URL])
+        } else {
+            unregisterDraggedTypes()
+        }
+    }
+
     private var _markedRange = NSRange(location: NSNotFound, length: 0)
     private var _selectedRange = NSRange(location: NSNotFound, length: 0)
     private var keyTextAccumulator: [String] = []
@@ -437,9 +461,10 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
 
     func createSurface() {
         guard !isDestroyed else { return }
-        // register as a file drop target (issue #51): dropping files inserts their paths. idempotent
-        // across re-entry (createSurface re-runs when a deferred surface finally gets a backing size).
-        registerForDraggedTypes([.fileURL, .string, .URL])
+        // register as a file drop target (issue #51) only while on-screen, so a background deck surface
+        // can't intercept the drop (see updateDropRegistration). idempotent across re-entry (createSurface
+        // re-runs when a deferred surface finally gets a backing size).
+        updateDropRegistration()
         guard surface == nil, let app = GhosttyApp.shared.app else { return }
         let backingSize = convertToBacking(bounds).size
         guard backingSize.width > 0, backingSize.height > 0 else {

--- a/agterm/SettingsModel.swift
+++ b/agterm/SettingsModel.swift
@@ -86,6 +86,8 @@ final class SettingsModel {
     func setCompactToolbar(_ value: Bool?) { settings.compactToolbar = value; persistAndApply() }
     func setNotificationBadgeEnabled(_ value: Bool?) { settings.notificationBadgeEnabled = value; persistAndApply() }
     func setMouseScrollMultiplier(_ value: Double?) { settings.mouseScrollMultiplier = value; persistAndApply() }
+    // ghostty key (right-click-action): persistAndApply() rewrites the conf and reloads surfaces live.
+    func setRightClickPaste(_ value: Bool?) { settings.rightClickPaste = value; persistAndApply() }
     func setInactivePaneMuteStrength(_ value: Int?) { settings.inactivePaneMuteStrength = value; persistAndApply() }
     func setSidebarBackgroundShift(_ value: Int?) { settings.sidebarBackgroundShift = value; persistAndApply() }
     // not a ghostty key, so persistAndApply()'s writeGhosttyConfig() no-ops and no surface reload fires.

--- a/agterm/Views/SettingsView.swift
+++ b/agterm/Views/SettingsView.swift
@@ -87,7 +87,7 @@ private struct GeneralSettingsView: View {
                 }
                 Toggle("Right-click pastes", isOn: rightClickPaste)
                     .accessibilityIdentifier("settings-right-click-paste")
-                SettingHint("Right-click (and middle-click) pastes the clipboard into the terminal.")
+                SettingHint("Right-click pastes the clipboard into the terminal.")
             }
 
             Section("Sessions") {

--- a/agterm/Views/SettingsView.swift
+++ b/agterm/Views/SettingsView.swift
@@ -2,7 +2,7 @@ import agtermCore
 import AppKit
 import SwiftUI
 
-/// The Settings window (Cmd+,): five tabs — General (scrolling, sessions, ghostty config),
+/// The Settings window (Cmd+,): five tabs — General (mouse, sessions, ghostty config),
 /// Appearance (font/theme + window translucency + pane dimming), Notifications (banner / badge /
 /// attention toggles), Agent Status (the sidebar glyph colors + blocked sound), and Key Mapping
 /// (the config directory + keymap diagnostics + Reload).
@@ -68,14 +68,15 @@ private struct SettingHint: View {
     }
 }
 
-/// General tab: scroll speed, the restore-running-commands toggle, and the inherit-global-ghostty-
-/// config toggle. The visual and notification settings live on their own tabs.
+/// General tab: a Mouse section (scroll speed + right-click-pastes toggle), the restore-running-commands
+/// toggle, and the inherit-global-ghostty-config toggle. The visual and notification settings live on
+/// their own tabs.
 private struct GeneralSettingsView: View {
     let model: SettingsModel
 
     var body: some View {
         Form {
-            Section("Scrolling") {
+            Section("Mouse") {
                 HStack {
                     Text("Scroll speed")
                     Slider(value: mouseScrollMultiplier, in: 1 ... 10, step: 1)
@@ -84,6 +85,9 @@ private struct GeneralSettingsView: View {
                         .monospacedDigit()
                         .frame(width: 42, alignment: .trailing)
                 }
+                Toggle("Right-click pastes", isOn: rightClickPaste)
+                    .accessibilityIdentifier("settings-right-click-paste")
+                SettingHint("Right-click (and middle-click) pastes the clipboard into the terminal.")
             }
 
             Section("Sessions") {
@@ -114,6 +118,13 @@ private struct GeneralSettingsView: View {
     private var inheritGlobalGhosttyConfig: Binding<Bool> {
         Binding(get: { model.settings.inheritGlobalGhosttyConfig ?? false },
                 set: { model.setInheritGlobalGhosttyConfig($0 ? true : nil) })
+    }
+
+    /// 1:1 with the toggle; nil (the default) reads as ON, so off → false / on → nil keeps settings.json
+    /// minimal. Drives the ghostty `right-click-action` key (paste when on, ignore when off).
+    private var rightClickPaste: Binding<Bool> {
+        Binding(get: { model.settings.rightClickPaste ?? true },
+                set: { model.setRightClickPaste($0 ? nil : false) })
     }
 
     /// nil (the default) reads as 3; stepping back to 3 stores nil so settings.json stays minimal. The

--- a/agterm/Views/TerminalView.swift
+++ b/agterm/Views/TerminalView.swift
@@ -27,7 +27,8 @@ struct TerminalView: NSViewRepresentable {
     var isActive = true
     /// Whether this pane is on-screen (its session is selected and not hidden by a full overlay/scratch).
     /// UNLIKE `isActive` this is NOT split-focus-gated: both panes of a visible split are `deckVisible`.
-    /// Drives `GhosttySurfaceView.hitTest` so a file drop can't land on an invisible background surface.
+    /// Drives `GhosttySurfaceView`'s drag-type (un)registration so a file drop can't land on an invisible
+    /// background surface.
     var deckVisible = true
 
     func makeCoordinator() -> Coordinator { Coordinator() }

--- a/agterm/Views/TerminalView.swift
+++ b/agterm/Views/TerminalView.swift
@@ -25,6 +25,10 @@ struct TerminalView: NSViewRepresentable {
     /// Whether this is the active (visible) pane in the deck. Every session's surface stays mounted, so
     /// a view only auto-grabs focus when active — otherwise every mounted pane would fight for it.
     var isActive = true
+    /// Whether this pane is on-screen (its session is selected and not hidden by a full overlay/scratch).
+    /// UNLIKE `isActive` this is NOT split-focus-gated: both panes of a visible split are `deckVisible`.
+    /// Drives `GhosttySurfaceView.hitTest` so a file drop can't land on an invisible background surface.
+    var deckVisible = true
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
@@ -34,6 +38,7 @@ struct TerminalView: NSViewRepresentable {
         // before the view attaches: gate the overlay/scratch auto-focus to the active slot so a background
         // session's overlay can't grab first responder during its initial createSurface.
         view.deckActive = isActive
+        view.deckVisible = deckVisible
         return view
     }
 
@@ -41,6 +46,7 @@ struct TerminalView: NSViewRepresentable {
         // keep the auto-focus gate in sync with selection, set BEFORE createSurface (which fires the overlay
         // auto-focus) so a background slot never starts the focus-grab retry.
         nsView.deckActive = isActive
+        nsView.deckVisible = deckVisible
         // makeNSView may have run before the view had a sized window; createSurface is idempotent
         // (guards surface == nil and a non-zero backing size), so calling it here is safe. Synchronous
         // on purpose: a deferred next-tick create races the layout and gives the surface a stale size.

--- a/agtermCore/Sources/agtermCore/AppSettings.swift
+++ b/agtermCore/Sources/agtermCore/AppSettings.swift
@@ -98,6 +98,13 @@ public struct AppSettings: Codable, Equatable, Sendable {
     /// overrides this. An app-level value played at the AppKit level, NOT a ghostty key — it never appears
     /// in `ghosttyConfigLines()`.
     public var blockedStatusSoundName: String?
+    /// Whether a right-click pastes the clipboard (ghostty `right-click-action`). nil means the default
+    /// (on): agterm forwards right-/middle-click to libghostty, so a right-click pastes out of the box.
+    /// UNLIKE most flags this IS a ghostty key — `ghosttyConfigLines()` emits `right-click-action = paste`
+    /// when on and `= ignore` when off, so the UI owns the key (the settings conf loads last and wins over
+    /// a `right-click-action` in the user's own `ghostty.conf`). agterm has no terminal context menu, so
+    /// paste-or-off is the whole meaningful choice.
+    public var rightClickPaste: Bool?
 
     public init(fontFamily: String? = nil, fontSize: Double? = nil, theme: String? = nil,
                 backgroundOpacity: Double? = nil, backgroundBlur: Int? = nil, notificationsEnabled: Bool? = nil,
@@ -107,7 +114,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
                 mouseScrollMultiplier: Double? = nil, inactivePaneMuteStrength: Int? = nil,
                 sidebarBackgroundShift: Int? = nil, restoreRunningCommand: Bool? = nil,
                 inheritGlobalGhosttyConfig: Bool? = nil, attentionButtonEnabled: Bool? = nil,
-                blockedStatusSoundName: String? = nil) {
+                blockedStatusSoundName: String? = nil, rightClickPaste: Bool? = nil) {
         self.fontFamily = fontFamily
         self.fontSize = fontSize
         self.theme = theme
@@ -127,6 +134,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.inheritGlobalGhosttyConfig = inheritGlobalGhosttyConfig
         self.attentionButtonEnabled = attentionButtonEnabled
         self.blockedStatusSoundName = blockedStatusSoundName
+        self.rightClickPaste = rightClickPaste
     }
 
     /// The SwiftUI overlay opacity for a given inactive-pane mute strength: the strength is clamped to
@@ -165,6 +173,10 @@ public struct AppSettings: Codable, Equatable, Sendable {
         // always emitted (nil = agterm's default of 3), so the default speed is effective rather than
         // ghostty's per-device defaults. a bare value sets both the wheel and the trackpad.
         lines.append("mouse-scroll-multiplier = \(Self.format(mouseScrollMultiplier ?? 3))")
+        // always emitted (nil = on): agterm forwards right-/middle-click to libghostty, so a right-click
+        // pastes by default. off emits `ignore` so the toggle hard-disables it (the settings conf loads
+        // last, so the UI owns the key over any `right-click-action` in the user's own ghostty.conf).
+        lines.append("right-click-action = \(rightClickPaste ?? true ? "paste" : "ignore")")
         return lines
     }
 

--- a/agtermCore/Sources/agtermCore/AppSettings.swift
+++ b/agtermCore/Sources/agtermCore/AppSettings.swift
@@ -176,7 +176,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         // always emitted (nil = on): agterm forwards right-/middle-click to libghostty, so a right-click
         // pastes by default. off emits `ignore` so the toggle hard-disables it (the settings conf loads
         // last, so the UI owns the key over any `right-click-action` in the user's own ghostty.conf).
-        lines.append("right-click-action = \(rightClickPaste ?? true ? "paste" : "ignore")")
+        lines.append("right-click-action = \((rightClickPaste ?? true) ? "paste" : "ignore")")
         return lines
     }
 

--- a/agtermCore/Tests/agtermCoreTests/AppSettingsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppSettingsTests.swift
@@ -19,10 +19,10 @@ struct AppSettingsTests {
         #expect(decoded.theme == nil)
     }
 
-    @Test func emptySettingsEmitOnlyScrollDefault() {
-        // every other field is unset (omitted); only mouse-scroll-multiplier is always emitted, at its
-        // default of 3.
-        #expect(AppSettings().ghosttyConfigLines() == ["mouse-scroll-multiplier = 3"])
+    @Test func emptySettingsEmitOnlyAlwaysOnDefaults() {
+        // every other field is unset (omitted); only the two always-on keys emit — mouse-scroll-multiplier
+        // at its default of 3 and right-click-action at its default of paste.
+        #expect(AppSettings().ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
     @Test func configLinesCoverSetFieldsRawNoQuoting() {
@@ -36,13 +36,13 @@ struct AppSettingsTests {
 
     @Test func configLinesOmitUnsetFields() {
         let lines = AppSettings(theme: "Alabaster").ghosttyConfigLines()
-        // theme is set; font lines omitted; the scroll default is always present.
-        #expect(lines == ["theme = Alabaster", "mouse-scroll-multiplier = 3"])
+        // theme is set; font lines omitted; the always-on defaults (scroll + right-click) trail.
+        #expect(lines == ["theme = Alabaster", "mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
     @Test func fractionalFontSizeKeepsDecimal() {
         let lines = AppSettings(fontSize: 13.5).ghosttyConfigLines()
-        #expect(lines == ["font-size = 13.5", "mouse-scroll-multiplier = 3"])
+        #expect(lines == ["font-size = 13.5", "mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
     @Test func backgroundFieldsRoundTrip() throws {
@@ -90,15 +90,15 @@ struct AppSettingsTests {
         let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(original))
         #expect(decoded == original)
         // the glyph colors are applied at the AppKit level, never as ghostty config keys — so the only
-        // line is the always-present scroll default.
-        #expect(decoded.ghosttyConfigLines() == ["mouse-scroll-multiplier = 3"])
+        // lines are the always-on defaults (scroll + right-click).
+        #expect(decoded.ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
     @Test func notificationsEnabledRoundTripsAndIsNotAConfigLine() throws {
         let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(AppSettings(notificationsEnabled: false)))
         #expect(decoded.notificationsEnabled == false)
-        // it's an app-level toggle, never a ghostty config key — only the scroll default is emitted.
-        #expect(AppSettings(notificationsEnabled: false).ghosttyConfigLines() == ["mouse-scroll-multiplier = 3"])
+        // it's an app-level toggle, never a ghostty config key — only the always-on defaults (scroll + right-click) are emitted.
+        #expect(AppSettings(notificationsEnabled: false).ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
     @Test func restoreRunningCommandRoundTripsAndIsNotAConfigLine() throws {
@@ -107,8 +107,8 @@ struct AppSettingsTests {
         // absent in a legacy file decodes to nil (off).
         let legacy = try JSONDecoder().decode(AppSettings.self, from: Data(#"{"theme":"Nord"}"#.utf8))
         #expect(legacy.restoreRunningCommand == nil)
-        // an app-level behavior flag, never a ghostty config key — only the scroll default is emitted.
-        #expect(AppSettings(restoreRunningCommand: true).ghosttyConfigLines() == ["mouse-scroll-multiplier = 3"])
+        // an app-level behavior flag, never a ghostty config key — only the always-on defaults (scroll + right-click) are emitted.
+        #expect(AppSettings(restoreRunningCommand: true).ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
     @Test func blockedStatusSoundNameRoundTripsAndIsNotAConfigLine() throws {
@@ -117,16 +117,16 @@ struct AppSettingsTests {
         // absent in a legacy file decodes to nil (no sound).
         let legacy = try JSONDecoder().decode(AppSettings.self, from: Data(#"{"theme":"Nord"}"#.utf8))
         #expect(legacy.blockedStatusSoundName == nil)
-        // an app-level value, never a ghostty config key — only the scroll default is emitted.
-        #expect(AppSettings(blockedStatusSoundName: "Glass").ghosttyConfigLines() == ["mouse-scroll-multiplier = 3"])
+        // an app-level value, never a ghostty config key — only the always-on defaults (scroll + right-click) are emitted.
+        #expect(AppSettings(blockedStatusSoundName: "Glass").ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
     @Test func compactToolbarRoundTripsAndIsNotAConfigLine() throws {
         let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(AppSettings(compactToolbar: true)))
         #expect(decoded.compactToolbar == true)
         // window-chrome toggle applied at the AppKit level, never a ghostty config key — only the
-        // scroll default is emitted.
-        #expect(AppSettings(compactToolbar: true).ghosttyConfigLines() == ["mouse-scroll-multiplier = 3"])
+        // always-on defaults (scroll + right-click) are emitted.
+        #expect(AppSettings(compactToolbar: true).ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
     @Test func notificationBadgeEnabledDefaultsNil() {
@@ -136,16 +136,16 @@ struct AppSettingsTests {
     @Test func notificationBadgeEnabledRoundTripsAndIsNotAConfigLine() throws {
         let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(AppSettings(notificationBadgeEnabled: false)))
         #expect(decoded.notificationBadgeEnabled == false)
-        // app-level sidebar render toggle, never a ghostty config key — only the scroll default is emitted.
-        #expect(AppSettings(notificationBadgeEnabled: false).ghosttyConfigLines() == ["mouse-scroll-multiplier = 3"])
+        // app-level sidebar render toggle, never a ghostty config key — only the always-on defaults (scroll + right-click) are emitted.
+        #expect(AppSettings(notificationBadgeEnabled: false).ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
     @Test func configDirectoryRoundTripsAndIsNotAConfigLine() throws {
         let original = AppSettings(configDirectory: "/tmp/agterm-config")
         let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(original))
         #expect(decoded.configDirectory == "/tmp/agterm-config")
-        // app-level path, never a ghostty config key — only the always-emitted scroll default appears.
-        #expect(decoded.ghosttyConfigLines() == ["mouse-scroll-multiplier = 3"])
+        // app-level path, never a ghostty config key — only the always-on defaults (scroll + right-click) appear.
+        #expect(decoded.ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
     @Test func configDirectoryDecodesNilWhenAbsent() throws {
@@ -159,7 +159,7 @@ struct AppSettingsTests {
         let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(AppSettings(inactivePaneMuteStrength: 7)))
         #expect(decoded.inactivePaneMuteStrength == 7)
         // SwiftUI overlay opacity applied in the app target, never a ghostty config key.
-        #expect(AppSettings(inactivePaneMuteStrength: 7).ghosttyConfigLines() == ["mouse-scroll-multiplier = 3"])
+        #expect(AppSettings(inactivePaneMuteStrength: 7).ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
     @Test func inactivePaneMuteStrengthDecodesNilWhenAbsent() throws {
@@ -181,7 +181,7 @@ struct AppSettingsTests {
         let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(AppSettings(sidebarBackgroundShift: 8)))
         #expect(decoded.sidebarBackgroundShift == 8)
         // AppKit-level sidebar tint applied in the app target, never a ghostty config key.
-        #expect(AppSettings(sidebarBackgroundShift: 8).ghosttyConfigLines() == ["mouse-scroll-multiplier = 3"])
+        #expect(AppSettings(sidebarBackgroundShift: 8).ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
     @Test func sidebarBackgroundShiftDecodesNilWhenAbsent() throws {
@@ -234,5 +234,21 @@ struct AppSettingsTests {
         }
         let legacy = try JSONDecoder().decode(AppSettings.self, from: Data(#"{ "fontSize": 16 }"#.utf8))
         #expect(legacy.attentionButtonEnabled == nil)
+    }
+
+    @Test func rightClickPasteDefaultsOnAndIsAGhosttyKey() throws {
+        // default (nil) = on → emits `right-click-action = paste`; off → `ignore`. UNLIKE the app-level
+        // flags this IS a ghostty key (the toggle owns it, always emitted).
+        #expect(AppSettings().rightClickPaste == nil)
+        #expect(AppSettings().ghosttyConfigLines().contains("right-click-action = paste"))
+        #expect(AppSettings(rightClickPaste: true).ghosttyConfigLines().contains("right-click-action = paste"))
+        #expect(AppSettings(rightClickPaste: false).ghosttyConfigLines().contains("right-click-action = ignore"))
+        // round-trips each state; a legacy settings.json without the key decodes to nil (on).
+        for value: Bool? in [nil, true, false] {
+            let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(AppSettings(rightClickPaste: value)))
+            #expect(decoded.rightClickPaste == value)
+        }
+        let legacy = try JSONDecoder().decode(AppSettings.self, from: Data(#"{ "fontSize": 16 }"#.utf8))
+        #expect(legacy.rightClickPaste == nil)
     }
 }


### PR DESCRIPTION
Two mouse-interaction fixes.

**Right-click paste on by default** (Fix #45). #53 added right-/middle-click forwarding to libghostty, but nothing set ghostty's `right-click-action`, so a right-click did nothing out of the box (agterm has no context menu). This defaults it to paste and adds a General -> Mouse toggle (`AppSettings.rightClickPaste`, on by default) that owns the `right-click-action` key (emits `paste` when on, `ignore` when off). The scroll-speed slider moved into the same Mouse section.

**File drops go to the visible session** (Fix #51). Every session's surface is eagerly realized and was registered as a file-drop target, so with more than one session a drop hit whichever surface was topmost in z-order (array order, not the selection), an invisible background session, and injected the path there while the visible terminal showed nothing. Single-session worked, which is why #52 shipped with this latent. SwiftUI's `opacity(0)`/`allowsHitTesting(false)` on inactive deck panes don't reach AppKit's drag machinery (alphaValue stays 1, and drag-destination resolution ignores `hitTest`), so `GhosttySurfaceView.deckVisible` now gates `registerForDraggedTypes`/`unregisterDraggedTypes`: only the on-screen pane is ever a drop target. Both split panes count as visible.

Verified live in a dev instance: single session, multi-session, and split panes all insert the dropped path into the pane under the cursor. 824 host-free tests pass, `swiftlint --strict` clean.

*Note on coverage: the drag-drop fix is manually verified only. An NSView file-drag isn't XCUITest-synthesizable and the register/unregister behavior isn't accessibility-observable, so no unit test guards it (same limitation #52 called out for the drop feature itself).*
