### PR TITLE
feat: split toolbar icon shows which pane is visible when collapsed

### DIFF
--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -154,8 +154,11 @@ paths:
   The detail `HSplitView` carries `.id("<session>-hsplit")` so its `NSSplitView`/divider can't leak across
   session switches.
   A session with a split shows a split-rectangle icon in the sidebar (`WorkspaceSidebar`,
-  keyed on `hasSplit` via `RowContent`) and a filled split icon in the title bar — both persist while
-  the split is hidden.
+  keyed on `hasSplit` via `RowContent`), which persists while the split is hidden.
+  The title-bar split button is a 4-state glyph: an outline when there is no split, a filled
+  split-rectangle (`rectangle.split.2x1.fill`) while the split is shown side-by-side, and a half-filled
+  glyph naming the visible pane once the split is collapsed to one pane
+  (`rectangle.lefthalf.filled` = primary, `rectangle.righthalf.filled` = split pane, driven by `splitFocused`).
 - `Close Session` is ⌘W (terminal-style).
   `AppActions.closeActiveSession()` first dismisses a focus-stealing cover in z-order — the frontmost
   window's quick terminal (`hide`), else the active session's open overlay (`closeOverlay`,

--- a/.claude/rules/sidebar.md
+++ b/.claude/rules/sidebar.md
@@ -88,9 +88,9 @@ paths:
   non-empty (skipped under the XCUITest launch, like the quit-confirm).
 - **Tree-mode flagged indicator (filled-icon variant).**
   In `.tree` mode a flagged session's row swaps its leading icon to the FILLED SF Symbol variant of its
-  base glyph — `terminal.fill` for a single session, `rectangle.split.2x1.fill` for a split (the SAME
-  filled split symbol the titlebar split button uses; outline = unflagged,
-  filled = flagged, mirroring the titlebar split indicator) — via the cached `flaggedSessionIcon`/`flaggedSplitSessionIcon`
+  base glyph — `terminal.fill` for a single session, `rectangle.split.2x1.fill` for a split (the same
+  filled split symbol the titlebar shows for a SHOWN split; outline = unflagged,
+  filled = flagged) — via the cached `flaggedSessionIcon`/`flaggedSplitSessionIcon`
   template images, tinted with the chrome/theme color.
   It is a pure SF Symbol swap (`Self.rowIcon(...)`), NOT a composited corner badge — same-size,
   so it is inherently layout-shift-free.

--- a/agterm/ContentView.swift
+++ b/agterm/ContentView.swift
@@ -716,16 +716,33 @@ private struct WindowContentView: View {
     private var splitButton: some View {
         let isSplit = store.activeSession?.isSplit ?? false
         let hasSplit = store.activeSession?.hasSplit ?? false
+        let splitFocused = store.activeSession?.splitFocused ?? false
+        // filled = pane visible, outline = hidden. No split: an empty two-pane outline. Split shown: both
+        // panes filled. Collapsed to a single pane (hasSplit but not shown): only the VISIBLE pane's half
+        // is filled — left for the primary, right for the split pane (`splitFocused` is the shown one when
+        // hidden) — so the glyph tells you which pane is up and that the other is parked. `a11y` mirrors the
+        // four states for XCUITest, which can't read the symbol name (like the attention bell's value).
+        let symbol: String
+        let a11y: String
+        if !hasSplit {
+            symbol = "rectangle.split.2x1"; a11y = "none"
+        } else if isSplit {
+            symbol = "rectangle.split.2x1.fill"; a11y = "both"
+        } else if splitFocused {
+            symbol = "rectangle.righthalf.filled"; a11y = "right"
+        } else {
+            symbol = "rectangle.lefthalf.filled"; a11y = "left"
+        }
         return Button {
             actions.toggleSplit()
         } label: {
             // a Label (icon + title) so the toolbar's "Icon and Text" mode has text to show; the title
-            // is hidden in the default icon-only mode. The filled variant marks a session that has a
-            // split (shown or hidden), matching the sidebar's split-session icon.
-            Label("Split", systemImage: hasSplit ? "rectangle.split.2x1.fill" : "rectangle.split.2x1")
+            // is hidden in the default icon-only mode.
+            Label("Split", systemImage: symbol)
         }
         .help(helpHint(isSplit ? "Hide split" : (hasSplit ? "Show split" : "Split right"), .toggleSplit))
         .disabled(store.activeSession == nil)
+        .accessibilityValue(a11y)
         .accessibilityIdentifier("split-toggle")
     }
 

--- a/agterm/ContentView.swift
+++ b/agterm/ContentView.swift
@@ -717,8 +717,8 @@ private struct WindowContentView: View {
         let isSplit = store.activeSession?.isSplit ?? false
         let hasSplit = store.activeSession?.hasSplit ?? false
         let splitFocused = store.activeSession?.splitFocused ?? false
-        // filled = pane visible, outline = hidden. No split: an empty two-pane outline. Split shown: both
-        // panes filled. Collapsed to a single pane (hasSplit but not shown): only the VISIBLE pane's half
+        // filled = pane visible, outline = hidden. no split: an empty two-pane outline. split shown: both
+        // panes filled. collapsed to a single pane (hasSplit but not shown): only the VISIBLE pane's half
         // is filled — left for the primary, right for the split pane (`splitFocused` is the shown one when
         // hidden) — so the glyph tells you which pane is up and that the other is parked. `a11y` mirrors the
         // four states for XCUITest, which can't read the symbol name (like the attention bell's value).

--- a/agtermUITests/SplitUITests.swift
+++ b/agtermUITests/SplitUITests.swift
@@ -226,6 +226,17 @@ final class SplitUITests: XCTestCase {
         // Ctrl-2 swaps the shown pane to the right → right half filled.
         app.typeKey("2", modifierFlags: .control)
         XCTAssertTrue(waitSplitValue(splitButton, "right"), "collapsed to the split pane fills the right half")
+
+        // re-showing the collapsed split fills both panes again (isSplit true).
+        splitButton.click()
+        XCTAssertTrue(waitSplitValue(splitButton, "both"), "re-showing a collapsed split fills both panes again")
+
+        // closing the split (exit the right pane's shell) collapses to a single non-split session → outline.
+        app.typeKey(.rightArrow, modifierFlags: [.command, .option]) // put terminal focus on the right pane
+        usleep(500_000)
+        app.typeText("exit")
+        app.typeKey(.return, modifierFlags: [])
+        XCTAssertTrue(waitSplitValue(splitButton, "none"), "closing the split returns the glyph to the no-split outline")
     }
 
     // exiting one pane of a split must keep the session alive (collapsed to the survivor) AND focus

--- a/agtermUITests/SplitUITests.swift
+++ b/agtermUITests/SplitUITests.swift
@@ -192,6 +192,42 @@ final class SplitUITests: XCTestCase {
                        "Ctrl-2 swaps the hidden split back to the right pane")
     }
 
+    // the split toolbar glyph encodes the split state via its accessibilityValue (the symbol name is not
+    // observable): none for a non-split session, both while shown side-by-side, and left/right when
+    // collapsed to a single pane — whichever pane is currently shown. Also pins the design choice that a
+    // SHOWN split stays "both" regardless of which pane holds focus (only a collapsed split distinguishes
+    // left vs right). Ctrl-1's effect is proven by the later "left" assertion: had it not registered,
+    // focus would still be on the right pane and the hide would collapse to "right", failing that check.
+    func testSplitButtonGlyphReflectsState() throws {
+        let row = app.staticTexts["session-row"]
+        XCTAssertTrue(row.waitForExistence(timeout: 20), "seeded session should exist")
+        row.click()
+        usleep(800_000)
+
+        let splitButton = app.buttons["split-toggle"]
+        XCTAssertTrue(splitButton.waitForExistence(timeout: 5), "split toolbar button should exist")
+
+        // non-split session → outline glyph.
+        XCTAssertTrue(waitSplitValue(splitButton, "none"), "a non-split session shows the outline glyph")
+
+        // open the split (both panes shown) → both halves filled.
+        splitButton.click()
+        XCTAssertTrue(waitSplitValue(splitButton, "both"), "a shown split fills both panes")
+
+        // a shown split stays "both" regardless of focus: focusing the primary must NOT flip the glyph.
+        app.typeKey("1", modifierFlags: .control)
+        usleep(500_000)
+        XCTAssertTrue(waitSplitValue(splitButton, "both"), "a shown split ignores which pane is focused")
+
+        // hide the split while the primary (left) pane is focused → collapsed to the left pane.
+        splitButton.click()
+        XCTAssertTrue(waitSplitValue(splitButton, "left"), "collapsed to the primary pane fills the left half")
+
+        // Ctrl-2 swaps the shown pane to the right → right half filled.
+        app.typeKey("2", modifierFlags: .control)
+        XCTAssertTrue(waitSplitValue(splitButton, "right"), "collapsed to the split pane fills the right half")
+    }
+
     // exiting one pane of a split must keep the session alive (collapsed to the survivor) AND focus
     // the surviving pane, so typing reaches it without a click. Verified by exiting the primary, then
     // typing WITHOUT focusing and checking the command landed in the surviving right shell.
@@ -285,5 +321,16 @@ final class SplitUITests: XCTestCase {
             usleep(150_000)
         }
         return nil
+    }
+
+    /// Polls the split button's accessibilityValue (none/both/left/right) until it equals `value`,
+    /// covering the observation lag between a state change and the title-bar re-render.
+    private func waitSplitValue(_ button: XCUIElement, _ value: String, timeout: TimeInterval = 8) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if (button.value as? String) == value { return true }
+            usleep(150_000)
+        }
+        return false
     }
 }


### PR DESCRIPTION
the split toolbar button used to be fully filled whenever a session had a split, so once the split collapsed to a single pane it no longer showed that the other pane was hidden, or which side you were looking at. This makes it a 4-state glyph:

- **no split**: `rectangle.split.2x1` (outline)
- **split shown** (both panes): `rectangle.split.2x1.fill`
- **collapsed to the primary/left pane**: `rectangle.lefthalf.filled`
- **collapsed to the split/right pane**: `rectangle.righthalf.filled`

filled = pane visible, outline = hidden. The collapsed half tracks `splitFocused` (the pane shown maximized when the split is hidden), so `Ctrl-1`/`Ctrl-2` flip the glyph live. A shown split stays fully filled regardless of focus; only a collapsed split distinguishes left vs right.

titlebar only; the sidebar's filled split icon keeps its own meaning (flagged). An `.accessibilityValue` (none/both/left/right) is added so the state is XCUITest-observable, covered by `testSplitButtonGlyphReflectsState` (all four states plus the reverse transitions back to both and none).

the second commit is a review cleanup pass: it fixes two now-stale rule-doc cross-refs about the titlebar glyph and lowercases an in-function comment to match the repo convention.
