### PR TITLE
feat: per-session solid background color for session.background

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -644,8 +644,8 @@ paths:
   within-range drag doesn't reload at all, so neither path alone keeps a color session tracking the slider.
   `BackgroundWatermark.fit`/`position` are typed `Fit`/`Position` `CaseIterable` enums (like `Kind`), not
   raw `String` — the raw values match ghostty's keys so they serialize identically, and a bad value can't
-  reach a config line (only `imagePath` stays free text, re-validated on emit by `overlayText`, closing the
-  restore-path injection as defense-in-depth). The spec is READ back on each `tree` node's `background` field.
+  reach a config line (`imagePath`/`colorHex` stay free text, re-validated on emit by `overlayText`, closing
+  the restore-path injection as defense-in-depth). The spec is READ back on each `tree` node's `background` field.
   Four-point keep-in-sync audit for `session.background`: (1) `case sessionBackground = "session.background"`
   + `ControlArgs.path`/`color`/`opacity`/`fit`/`position`/`repeats` in `ControlProtocol.swift` (+ `background`
   on `ControlSessionNode` for the read-back),

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -605,18 +605,27 @@ paths:
   (4) round-trip (`restoreClearRoundTrips` + `treeSessionNodeRoundTripsWithForeground`/`…OmitsForegroundWhenNil`)
   in `ControlProtocolTests` + the e2e (`testTreeExposesForegroundProcess`,
   `testRestoreClearSucceeds`) in `ControlAPIUITests`.
-  `session.background` (target = session) sets or clears a per-session background watermark composited
-  behind the terminal grid by libghostty `background-image*` keys — `args.mode` is `image`/`text`/`clear`:
+  `session.background` (target = session) sets or clears a per-session background composited behind the
+  terminal grid — `args.mode` is `image`/`text`/`color`/`clear`.
+  `image`/`text` are watermarks driven by libghostty `background-image*` keys:
   `image` needs `args.path` (PNG/JPEG, validated for format + existence + no control chars in the path),
   `text` needs `args.text` (capped at 256 chars; + optional `args.color` #rrggbb, default the terminal
-  foreground), and both accept `args.opacity` (0...1)/`args.fit`/`args.position`/`args.repeats` — opacity/color/fit/position
-  validated against the shared host-free `WatermarkConfig`, used by BOTH the CLI `validate()` and the server.
+  foreground), and both accept `args.opacity` (0...1)/`args.fit`/`args.position`/`args.repeats`.
+  `color` is a SOLID terminal background color driven by the `background` key: it needs `args.color` (#rrggbb)
+  and takes NO per-call opacity — it is drawn at the Settings WINDOW translucency (solid when off),
+  emitted as `background-opacity = <windowOpacity>` at apply time so the color honors the user's opacity/blur
+  instead of forcing itself opaque (unlike the image/text watermark, which pins `background-opacity = 1`
+  so the image shows).
+  opacity/color/fit/position validated against the shared host-free `WatermarkConfig`,
+  used by BOTH the CLI `validate()` and the server.
   The `BackgroundWatermark` spec (host-free, `Codable`) is persisted in `SessionSnapshot` (survives restart)
   via `AppStore.setBackgroundWatermark`, then applied to the session main + split surfaces as a PER-SURFACE
   ghostty config overlay: `GhosttyApp.configWithOverlay` builds the same base files + an overlay file
-  (`WatermarkConfig.overlayText`: the `background-image*` lines + `background-opacity = 1` so the image
-  shows even under window translucency, which pins the global `background-opacity` to 0, + a `font-size`
-  line so the per-session cmd-+/- zoom is not reset by the push), and `GhosttySurfaceView.applyWatermarkFromSession`
+  (`WatermarkConfig.overlayText`: for image/text the `background-image*` lines + `background-opacity = 1`
+  so the image shows even under window translucency, which pins the global `background-opacity` to 0;
+  for `color` a `background = <hex>` line + `background-opacity = <windowOpacity>` (passed in from
+  `GhosttyApp.shared.windowOpacity`) so the color honors translucency instead of forcing itself opaque;
+  plus a `font-size` line so the per-session cmd-+/- zoom is not reset by the push), and `GhosttySurfaceView.applyWatermarkFromSession`
   calls `ghostty_surface_update_config`, RETAINING each per-surface config in `ownedConfigs` and freeing
   it only on surface teardown (safe — the consumer is gone — unlike the never-freed app-wide config).
   libghostty auto-fits the image to the surface and RE-FITS on resize (no app-side resize code);
@@ -627,6 +636,12 @@ paths:
   `applyConfig`, WIPING any watermark — so `GhosttyApp.reloadConfig` re-resolves the theme colors and
   then calls `reapplyWatermarkIfNeeded` on each surface AFTER the broadcast to re-assert it (the theme
   colors first, so a default-tinted `.text` watermark re-renders with the new foreground, not the old).
+  A `.color` background bakes the window opacity into its `background-opacity` at apply time, so it must
+  RE-TRACK the Settings translucency slider: `SettingsModel.apply` re-asserts every `.color` surface
+  (`GhosttySurfaceView.reapplyColorBackgroundIfNeeded`, guarded to `.color` so image/text aren't rebuilt
+  per tick) right AFTER `applyWindowTranslucency` updates `GhosttyApp.windowOpacity`, on any opacity
+  change — the `reloadConfig` re-assert alone reads a STALE opacity (it runs before the update) and a
+  within-range drag doesn't reload at all, so neither path alone keeps a color session tracking the slider.
   `BackgroundWatermark.fit`/`position` are typed `Fit`/`Position` `CaseIterable` enums (like `Kind`), not
   raw `String` — the raw values match ghostty's keys so they serialize identically, and a bad value can't
   reach a config line (only `imagePath` stays free text, re-validated on emit by `overlayText`, closing the
@@ -636,10 +651,12 @@ paths:
   on `ControlSessionNode` for the read-back),
   (2) the `.sessionBackground` dispatch arm (`setBackground`, validating + building the spec, then `applyWatermark`
   to the realized surfaces) in `ControlServer` (+ `background:` populated in the tree builder), (3) the
-  `session background image|text|clear` subcommands in `agtermctlKit` (shared opacity/color/fit/position
-  `validate()`), (4) round-trip in `ControlProtocolTests` (incl. `treeSessionNodeRoundTripsWithBackground`)
-  + `WatermarkConfigTests` + `WatermarkStorageTests` + `CommandsTests` (CLI parse + bad-arg rejection)
-  + the e2e `testSessionBackgroundSetClearAndValidation` in `ControlAPIUITests` (set/clear + tree read-back).
+  `session background image|text|color|clear` subcommands in `agtermctlKit` (shared opacity/color/fit/position
+  `validate()`; `color` takes color only, no opacity), (4) round-trip in `ControlProtocolTests` (incl.
+  `treeSessionNodeRoundTripsWithBackground` + `backgroundWatermarkColorKindSerializes`)
+  + `WatermarkConfigTests` (incl. the `color*` overlay cases) + `WatermarkStorageTests` + `CommandsTests`
+  (CLI parse + bad-arg rejection) + the e2e `testSessionBackgroundSetClearAndValidation` in `ControlAPIUITests`
+  (image/text/color set/clear + tree read-back).
   **Agent-skill mirror (HARD keep-in-sync, 4th surface):** all commands are documented in the bundled
   `agterm/Resources/agent-skill/` (SKILL.md summary, reference.md detail,
   examples.md recipes) and the command count there is bumped to 50 to match.

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,6 +7,7 @@ excluded:
   - build                       # xcodebuild DerivedData
   - .build                      # SwiftPM build (root)
   - agtermCore/.build           # SwiftPM build + vendored checkouts
+  - .claude/worktrees           # concurrent git worktrees (gitignored) carry their own .build/checkouts
   - GhosttyKit.xcframework
   - agterm/Resources
 

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -1055,10 +1055,20 @@ final class ControlServer {
                                             opacity: opacity,
                                             fit: fit.flatMap(BackgroundWatermark.Fit.init(rawValue:)),
                                             position: position.flatMap(BackgroundWatermark.Position.init(rawValue:)))
+        case "color":
+            // no per-call opacity: a solid color honors the window translucency set in Settings, applied at
+            // emit time via `WatermarkConfig.overlayText(windowOpacity:)` (see `GhosttySurfaceView`).
+            guard let color, !color.isEmpty else {
+                return ControlResponse(ok: false, error: "session.background color requires a color")
+            }
+            guard WatermarkConfig.isValidColorHex(color) else {
+                return ControlResponse(ok: false, error: "invalid color: \(color) (#rrggbb)")
+            }
+            watermark = BackgroundWatermark(kind: .color, colorHex: color)
         case "clear", .none:
             watermark = nil
         default:
-            return ControlResponse(ok: false, error: "invalid background mode: \(mode ?? "") (image|text|clear)")
+            return ControlResponse(ok: false, error: "invalid background mode: \(mode ?? "") (image|text|color|clear)")
         }
         return resolveSession(target, window: window) { store, id in
             guard let session = store.session(withID: id) else {

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -497,7 +497,8 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         guard let surface, let session else { return }
         let resolvedImagePath = WatermarkRenderer.materialize(session.backgroundWatermark, sessionID: session.id)
         let overlay = WatermarkConfig.overlayText(watermark: session.backgroundWatermark,
-                                                  resolvedImagePath: resolvedImagePath, fontSize: session.fontSize)
+                                                  resolvedImagePath: resolvedImagePath, fontSize: session.fontSize,
+                                                  windowOpacity: GhosttyApp.shared.windowOpacity)
         guard let config = GhosttyApp.shared.configWithOverlay(overlay) else {
             NSLog("watermark: per-surface config build failed for session %@", session.id.uuidString)
             return
@@ -516,6 +517,16 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     /// a plain surface isn't needlessly rebuilt). Called from `GhosttyApp.reloadConfig`.
     func reapplyWatermarkIfNeeded() {
         guard session?.backgroundWatermark != nil else { return }
+        applyWatermarkFromSession()
+    }
+
+    /// Re-assert a SOLID-color session background after a window-opacity change. A `.color` background
+    /// bakes the current window opacity into its per-surface `background-opacity` at apply time (see
+    /// `WatermarkConfig.overlayText`), so a live opacity change must re-emit it to keep the color tracking
+    /// the slider. No-op unless the session carries a `.color` background — an image/text watermark has a
+    /// fixed opacity and must NOT re-render (a `.text` PNG rebuild) on every opacity tick.
+    func reapplyColorBackgroundIfNeeded() {
+        guard session?.backgroundWatermark?.kind == .color else { return }
         applyWatermarkFromSession()
     }
 

--- a/agterm/Ghostty/WatermarkRenderer.swift
+++ b/agterm/Ghostty/WatermarkRenderer.swift
@@ -19,12 +19,15 @@ enum WatermarkRenderer {
     /// The resolved PNG/JPEG path for `watermark`, rendering the `.text` PNG as a side effect:
     /// - `.image` → the user's file path (nil if missing or an unsupported format);
     /// - `.text` → a per-session PNG in `WatermarkStorage.directoryURL()` rendered from the string + color
-    ///   (nil if the text is empty/over-length or rendering fails).
+    ///   (nil if the text is empty/over-length or rendering fails);
+    /// - `.color` → nil (a solid color needs no image; `WatermarkConfig.overlayText` emits `background`).
     /// Returns nil for a nil watermark. Re-rendered on every call so a `.text` PNG always reflects the
     /// current string/color (cheap; called only on set/clear/reload, not per frame).
     static func materialize(_ watermark: BackgroundWatermark?, sessionID: UUID) -> String? {
         guard let watermark else { return nil }
         switch watermark.kind {
+        case .color:
+            return nil
         case .image:
             // re-validate the path (control-char guard) here too, not only at the control boundary — a
             // persisted spec restored from a hand-edited snapshot reaches this path without re-validation.

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -96,8 +96,8 @@ Run `agtermctl <area> <cmd> --help` for exact flags. Full detail in **reference.
 **tree** — print the workspace/session tree (`--json` for structured). Each session node carries
 `foreground`/`splitForeground` (the live argv of each pane's foreground process, omitted when the pane
 is at its shell prompt) — i.e. what each pane is currently running — `status` (the agent-status set
-via `session status`: `active`|`completed`|`blocked`, omitted when idle), and `background` (the watermark
-spec set via `session background`, omitted when none — the read side of set/clear).
+via `session status`: `active`|`completed`|`blocked`, omitted when idle), and `background` (the background
+spec — image/text watermark or solid color — set via `session background`, omitted when none — the read side of set/clear).
 
 **workspace** — `new [name]` · `rename <name>` · `delete` · `select` · `move --to up|down|top|bottom` ·
 `focus [on|off|toggle]` (collapse the sidebar tree to a single workspace).
@@ -129,9 +129,11 @@ spec set via `session background`, omitted when none — the read side of set/cl
 - `flag [on|off|toggle|clear]` — flag a session for the flagged working-set view (`clear` unflags all).
 - `background image <path> [--opacity F] [--fit contain|cover|stretch|none] [--position P] [--repeat]` ·
   `background text <text> [--color #rrggbb] [--opacity F] [--fit ...] [--position ...]` ·
-  `background clear` — composite an image (PNG/JPEG) or rasterized text behind the terminal as a
-  watermark, auto-fitting the window (re-fits on resize). Per session; survives restart. `--opacity`
-  0.0–1.0. (A watermark renders the pane opaque, overriding window translucency, so the image shows.)
+  `background color <#rrggbb>` · `background clear` — composite an image (PNG/JPEG) or rasterized text
+  behind the terminal as a watermark (auto-fitting the window, re-fits on resize), or set a solid
+  terminal background color. Per session; survives restart. `--opacity` 0.0–1.0. (An image/text watermark
+  renders the pane opaque, overriding window translucency, so it shows; a `color` takes no opacity and
+  honors the Settings window translucency instead.)
 - `overlay open <command> [--cwd DIR] [--wait] [--block] [--size-percent N]` · `overlay close` ·
   `overlay result` — run a program on top of a session; `--block` waits and exits with its status. An
   overlay is a real terminal (pty), which is also how you **display an image inline** — via the bundled

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -137,11 +137,11 @@ magick favicon.png -filter point -resize 256x256 /tmp/big.png
 
 Outside agterm (`AGTERM_ENABLED` unset) there is no overlay — fall back to `open img.png` (Preview).
 
-## Set a background watermark
+## Set a background watermark or color
 
 A persistent backdrop behind the terminal grid (distinct from `show-image.sh`, which is a transient
-overlay). Image or rasterized text, per session, auto-fitting the window (and re-fitting on resize);
-it survives a relaunch.
+overlay). An image or rasterized-text watermark (auto-fitting the window, re-fitting on resize), or a
+solid terminal background color — per session, surviving a relaunch.
 
 ```bash
 # rasterized text watermark on this session, faint
@@ -150,13 +150,17 @@ agtermctl session background text "STAGING" --color '#ff5500' --opacity 0.15 --t
 # an image (PNG/JPEG), scaled to cover the window
 agtermctl session background image /abs/logo.png --fit cover --opacity 0.2 --target "$AGTERM_SESSION_ID"
 
+# a solid background color — e.g. mark a PROD session so it can't be mistaken for a scratch one
+agtermctl session background color '#3a0d0d' --target "$AGTERM_SESSION_ID"
+
 # remove it
 agtermctl session background clear --target "$AGTERM_SESSION_ID"
 ```
 
 `--opacity` is 0.0–1.0; `--fit` is `contain` (default) / `cover` / `stretch` / `none`; `--position` is
-`center` (default) or an edge/corner anchor. A watermark renders the pane opaque (overriding window
-translucency), so the image is always visible.
+`center` (default) or an edge/corner anchor. An image/text watermark renders the pane opaque (overriding
+window translucency), so it is always visible; a `color` takes no opacity and honors the Settings window
+translucency (solid when off, blurred/translucent when on).
 
 ## Toggle the scratch terminal
 

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -37,8 +37,8 @@ when none reported; distinct from `name`, the derived sidebar label), `active` (
 flagged working-set), `status` (the agent-status — `active`|`completed`|`blocked` — omitted when
 idle), `foreground`/`splitForeground` (the live argv of each pane's foreground
 process — what it is running — omitted when the pane sits at its shell prompt), and `background` (the
-watermark spec set via `session background` — a `{kind, text?, imagePath?, colorHex?, opacity?, fit?,
-position?, repeats?}` object — omitted when no watermark is set). Workspace nodes carry
+background spec set via `session background` — a `{kind, text?, imagePath?, colorHex?, opacity?, fit?,
+position?, repeats?}` object; `kind` is `image`/`text`/`color` — omitted when none is set). Workspace nodes carry
 `id`, `name`, `active`, `sessions`.
 
 ## workspace
@@ -162,10 +162,17 @@ position?, repeats?}` object — omitted when no watermark is set). Workspace no
   — rasterize `text` to a watermark behind the terminal. `--color` defaults to the terminal foreground
   (must be a `#rrggbb` hex value); `--opacity`/`--fit`/`--position` as above. `text` is capped at 256
   characters (a watermark is a word or two).
-- `session background clear [--target] [--window W]` — remove the session's watermark.
-  Per session (applies to the session's pane(s)); persisted, so it survives a relaunch. A watermark makes
-  the pane render OPAQUE, overriding window translucency (an image is invisible at 0 background-opacity).
-  Read the current watermark back from a session's `background` field in `tree --json` (omitted when none).
+- `session background color <#rrggbb> [--target] [--window W]` — set a SOLID terminal background color
+  (the `background` key, not an image). Takes no opacity: the color is drawn at the Settings window
+  translucency (solid when translucency is off; blurred/translucent when on), so it honors your
+  opacity/blur instead of forcing the pane opaque like the image/text watermark. Errors on a malformed
+  color (must be a `#rrggbb` hex value).
+- `session background clear [--target] [--window W]` — remove the session's background.
+  Per session (applies to the session's pane(s)); persisted, so it survives a relaunch. An image/text
+  watermark makes the pane render OPAQUE, overriding window translucency (an image is invisible at 0
+  background-opacity); a `color` instead honors the Settings window translucency. Read the current
+  background back from a session's `background` field in `tree --json` (a `{kind, colorHex, …}` object,
+  omitted when none).
 - `session overlay open <command> [--cwd DIR] [--wait] [--block] [--size-percent N] [--target] [--window W]`
   — run `command` in an ephemeral terminal on top of the session; it closes when the command exits.
   Full-size by default (hides the session); `--size-percent N` (1–100) makes it a floating framed panel

--- a/agterm/SettingsModel.swift
+++ b/agterm/SettingsModel.swift
@@ -503,10 +503,20 @@ final class SettingsModel {
         // font size) when the generated config TEXT actually changed. A window-opacity drag within
         // the translucent range, or a blur change, leaves the config identical — re-syncing the
         // window alone is enough and avoids hammering surface rebuilds on every slider tick.
+        let opacityBefore = GhosttyApp.shared.windowOpacity
         if writeGhosttyConfig() {
             reloadConfigClearingSessionZoom()
         }
         applyWindowTranslucency()
+        // a `.color` session background bakes the window opacity into its per-surface `background-opacity`
+        // at apply time, so re-assert those surfaces whenever the opacity changed — reloadConfig's own
+        // re-assert (when the config text changed) runs BEFORE `applyWindowTranslucency` updates the
+        // opacity, and a within-range slider drag doesn't reload at all, so neither path alone keeps a
+        // color session tracking the slider. Guarded to `.color` surfaces so a plain/image/text session
+        // isn't rebuilt on every opacity tick (blur composites at the AppKit level and needs no re-emit).
+        if GhosttyApp.shared.windowOpacity != opacityBefore {
+            for surface in liveSurfaces() { surface.reapplyColorBackgroundIfNeeded() }
+        }
         applyNotificationsEnabled()
         applyCompactToolbar()
         applyNotificationBadgeEnabled()

--- a/agtermCore/Sources/agtermCore/BackgroundWatermark.swift
+++ b/agtermCore/Sources/agtermCore/BackgroundWatermark.swift
@@ -1,10 +1,11 @@
 import Foundation
 
-/// A per-session background watermark composited behind the terminal grid by libghostty's
-/// `background-image*` config keys: either a user-supplied image file (`.image`) or a string agterm
-/// rasterizes to a PNG (`.text`). Stored on `Session`, persisted in `SessionSnapshot`, and carried on
-/// the control wire. Host-free + `Codable`: the app target turns it into a per-surface ghostty config
-/// overlay (see `WatermarkConfig`) and, for `.text`, renders the PNG (the only step that needs AppKit).
+/// A per-session background composited behind the terminal grid: a user-supplied image file (`.image`)
+/// or a string agterm rasterizes to a PNG (`.text`), both via libghostty's `background-image*` keys, or
+/// a solid `#rrggbb` background color (`.color`) via the `background` key. Stored on `Session`, persisted
+/// in `SessionSnapshot`, and carried on the control wire. Host-free + `Codable`: the app target turns it
+/// into a per-surface ghostty config overlay (see `WatermarkConfig`) and, for `.text`, renders the PNG
+/// (the only step that needs AppKit).
 ///
 /// libghostty re-fits the image to the surface on every resize (`background-image-fit`), so the
 /// "auto-resize to the window" behavior needs no app-side resize handling.
@@ -14,6 +15,10 @@ public struct BackgroundWatermark: Codable, Sendable, Equatable {
         case image
         /// `text` is rasterized to a PNG by the app target; `colorHex` tints it.
         case text
+        /// `colorHex` is a solid `#rrggbb` terminal background color (no image). It is drawn at the window
+        /// translucency set in Settings (solid when translucency is off), applied at emit time by
+        /// `WatermarkConfig.overlayText(windowOpacity:)` — the spec carries no opacity of its own.
+        case color
     }
 
     /// libghostty `background-image-fit` (Config.zig `BackgroundImageFit`). A typed enum (like `Kind`)
@@ -37,6 +42,7 @@ public struct BackgroundWatermark: Codable, Sendable, Equatable {
     /// For `.text`: the watermark string.
     public var text: String?
     /// For `.text`: the text color as `#rrggbb`; nil = the terminal foreground color at render time.
+    /// For `.color`: the solid background color as `#rrggbb` (required).
     public var colorHex: String?
     /// `background-image-opacity` (relative to `background-opacity`); nil = ghostty's 1.0 default.
     public var opacity: Double?

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -81,11 +81,13 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     public var select: Bool?
     /// Mode for `session.split` / `quick` (`on|off|toggle`, `show|hide|toggle` for quick),
     /// `session.flag` (`on|off|toggle|clear`), `sidebar.mode` (`tree|flagged|toggle`),
-    /// `workspace.focus` (`on|off|toggle`), and `session.background` (`image|text|clear`).
+    /// `workspace.focus` (`on|off|toggle`), and `session.background` (`image|text|color|clear`).
     public var mode: String?
     /// The image file path for `session.background` mode `image` (PNG or JPEG).
     public var path: String?
-    /// The text color (`#rrggbb`) for `session.background` mode `text`; nil = the terminal foreground.
+    /// The color (`#rrggbb`) for `session.background`: the text tint for mode `text` (nil = the terminal
+    /// foreground), or the solid background color for mode `color` (required). Mode `color` takes no
+    /// opacity — it honors the Settings window translucency.
     public var color: String?
     /// The `background-image-opacity` for `session.background` (image + text), 0...1; nil = ghostty's 1.0.
     public var opacity: Double?

--- a/agtermCore/Sources/agtermCore/WatermarkConfig.swift
+++ b/agtermCore/Sources/agtermCore/WatermarkConfig.swift
@@ -65,8 +65,9 @@ public enum WatermarkConfig {
     /// - a `font-size` line preserving the session's cmd-+/- zoom (a per-surface `update_config` otherwise
     ///   resets font size to the config default).
     ///
-    /// A nil `watermark` (or a missing `resolvedImagePath`) yields ONLY the font-size line — clearing the
-    /// image while keeping zoom. Returns "" when there is nothing to override (no watermark, no zoom).
+    /// A nil `watermark` (or an `.image`/`.text` whose `resolvedImagePath` is missing) yields ONLY the
+    /// font-size line — clearing the image while keeping zoom; a `.color` still emits its `background`
+    /// lines (it needs no `resolvedImagePath`). Returns "" when there is nothing to override (no watermark, no zoom).
     /// Values are emitted RAW (no quotes): ghostty takes the whole line remainder as the value, so a path
     /// with spaces works unquoted — matching `AppSettings.ghosttyConfigLines()`.
     public static func overlayText(watermark: BackgroundWatermark?, resolvedImagePath: String?,

--- a/agtermCore/Sources/agtermCore/WatermarkConfig.swift
+++ b/agtermCore/Sources/agtermCore/WatermarkConfig.swift
@@ -52,9 +52,14 @@ public enum WatermarkConfig {
     }
 
     /// The per-surface ghostty config overlay (loaded LAST, so it wins) for `watermark` pointed at
-    /// `resolvedImagePath` (the user's file for `.image`, the rendered PNG for `.text`):
+    /// `resolvedImagePath` (the user's file for `.image`, the rendered PNG for `.text`, nil for `.color`):
     ///
-    /// - the `background-image*` lines for the watermark, plus `background-opacity = 1` so the image is
+    /// - for `.color`: a `background = <hex>` line plus `background-opacity = <windowOpacity>` so the color
+    ///   honors the window translucency the user set in Settings (the base config pins the global
+    ///   `background-opacity` to 0 under translucency, which would otherwise make the color invisible;
+    ///   `windowOpacity` = 1 when translucency is off = a solid color) — no image keys, and the window
+    ///   blur is composited at the AppKit level, so it shows through a translucent color unchanged;
+    /// - for `.image`/`.text`: the `background-image*` lines, plus `background-opacity = 1` so the image is
     ///   visible even when window translucency pins the global `background-opacity` to 0 (image opacity is
     ///   RELATIVE to it, so `0 × anything = 0` = invisible) — the user-chosen "auto-raise" behavior;
     /// - a `font-size` line preserving the session's cmd-+/- zoom (a per-surface `update_config` otherwise
@@ -65,13 +70,17 @@ public enum WatermarkConfig {
     /// Values are emitted RAW (no quotes): ghostty takes the whole line remainder as the value, so a path
     /// with spaces works unquoted — matching `AppSettings.ghosttyConfigLines()`.
     public static func overlayText(watermark: BackgroundWatermark?, resolvedImagePath: String?,
-                                   fontSize: Double?) -> String {
+                                   fontSize: Double?, windowOpacity: Double = 1) -> String {
         var lines: [String] = []
-        // re-validate the path on EMIT, not just at the control boundary: `AppStore.restore` assigns a
-        // persisted spec raw, so a hand-edited `workspaces.json` could carry a control-char path that would
-        // inject a ghostty key here. A poisoned path drops the image entirely (font-size still emitted).
-        // `fit`/`position` are typed enums now, so they can't carry an injection — only `imagePath` is free text.
-        if let watermark, let path = resolvedImagePath, isValidImagePath(path) {
+        // re-validate the free-text fields on EMIT, not just at the control boundary: `AppStore.restore`
+        // assigns a persisted spec raw, so a hand-edited `workspaces.json` could carry a control-char path
+        // or a malformed color that would inject a ghostty key here. A poisoned value drops the background
+        // entirely (font-size still emitted). `fit`/`position` are typed enums, so they can't inject.
+        if let watermark, watermark.kind == .color, let hex = watermark.colorHex, isValidColorHex(hex) {
+            let opacity = windowOpacity.isFinite ? min(max(windowOpacity, 0), 1) : 1
+            lines.append("background = \(hex)")
+            lines.append("background-opacity = \(formatted(opacity))")
+        } else if let watermark, watermark.kind != .color, let path = resolvedImagePath, isValidImagePath(path) {
             lines.append("background-opacity = 1")
             lines.append("background-image = \(path)")
             if let opacity = watermark.opacity { lines.append("background-image-opacity = \(formatted(opacity))") }

--- a/agtermCore/Sources/agtermctlKit/Commands.swift
+++ b/agtermCore/Sources/agtermctlKit/Commands.swift
@@ -590,7 +590,7 @@ struct Session: ParsableCommand {
         }
 
         struct Clear: RequestCommand {
-            static let configuration = CommandConfiguration(abstract: "Remove the session's background watermark.")
+            static let configuration = CommandConfiguration(abstract: "Remove the session's background (watermark or solid color).")
             @OptionGroup var target: TargetOptions
             @OptionGroup var options: ClientOptions
 

--- a/agtermCore/Sources/agtermctlKit/Commands.swift
+++ b/agtermCore/Sources/agtermctlKit/Commands.swift
@@ -504,8 +504,8 @@ struct Session: ParsableCommand {
     struct Background: ParsableCommand {
         static let configuration = CommandConfiguration(
             commandName: "background",
-            abstract: "Set or clear a session's background watermark (image or rasterized text).",
-            subcommands: [Image.self, Text.self, Clear.self]
+            abstract: "Set or clear a session's background (image, rasterized text, or solid color).",
+            subcommands: [Image.self, Text.self, Color.self, Clear.self]
         )
 
         /// Shared input validation against the host-free `WatermarkConfig`, so a bad value is a clean
@@ -571,6 +571,21 @@ struct Session: ParsableCommand {
                 ControlRequest(cmd: .sessionBackground, target: target.target,
                                args: options.withWindow(ControlArgs(text: text, mode: "text", color: color,
                                                                     opacity: opacity, fit: fit, position: position)))
+            }
+        }
+
+        struct Color: RequestCommand {
+            static let configuration = CommandConfiguration(
+                abstract: "Set a solid background color for the terminal (honors the Settings window translucency).")
+            @Argument(help: "Background color as #rrggbb.") var color: String
+            @OptionGroup var target: TargetOptions
+            @OptionGroup var options: ClientOptions
+
+            func validate() throws { try Background.validate(color: color) }
+
+            func makeRequest() throws -> ControlRequest {
+                ControlRequest(cmd: .sessionBackground, target: target.target,
+                               args: options.withWindow(ControlArgs(mode: "color", color: color)))
             }
         }
 

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -351,13 +351,21 @@ struct ControlProtocolTests {
 
     @Test func backgroundWatermarkColorKindSerializes() throws {
         // the `.color` kind serializes as "color" and carries only the hex (no opacity — a solid color
-        // honors the Settings window translucency at render time).
+        // honors the Settings window translucency at render time). Round-trip through ControlSessionNode too,
+        // so the actual `tree` wire path (not just the struct in isolation) covers the color read-back.
         let watermark = BackgroundWatermark(kind: .color, colorHex: "#112233")
         let json = String(decoding: try JSONEncoder().encode(watermark), as: UTF8.self)
         #expect(json.contains("\"kind\":\"color\""))
-        let decoded = try JSONDecoder().decode(BackgroundWatermark.self, from: Data(json.utf8))
-        #expect(decoded == watermark)
-        #expect(decoded.colorHex == "#112233")
+        #expect(try JSONDecoder().decode(BackgroundWatermark.self, from: Data(json.utf8)) == watermark)
+
+        let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false,
+                                         background: watermark)
+        let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(
+            workspaces: [ControlWorkspaceNode(id: "w1", name: "work", active: true, sessions: [session])])))
+        let node = try roundTrip(response).result?.tree?.workspaces.first?.sessions.first
+        #expect(node?.background == watermark)
+        #expect(node?.background?.kind == .color)
+        #expect(node?.background?.colorHex == "#112233")
     }
 
     @Test func restoreClearRoundTrips() throws {

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -229,6 +229,7 @@ struct ControlProtocolTests {
             ControlRequest(cmd: .sessionBackground, target: "9f3c",
                            args: ControlArgs(text: "DRAFT", mode: "text", color: "#ff0000",
                                              opacity: 0.15, fit: "contain", position: "center")),
+            ControlRequest(cmd: .sessionBackground, target: "active", args: ControlArgs(mode: "color", color: "#112233")),
             ControlRequest(cmd: .sessionBackground, target: "active", args: ControlArgs(mode: "clear")),
         ]
         for request in cases {
@@ -346,6 +347,17 @@ struct ControlProtocolTests {
         // a decoded-back value equals the original (rawValue mapping is lossless).
         let decoded = try JSONDecoder().decode(BackgroundWatermark.self, from: Data(json.utf8))
         #expect(decoded == watermark)
+    }
+
+    @Test func backgroundWatermarkColorKindSerializes() throws {
+        // the `.color` kind serializes as "color" and carries only the hex (no opacity — a solid color
+        // honors the Settings window translucency at render time).
+        let watermark = BackgroundWatermark(kind: .color, colorHex: "#112233")
+        let json = String(decoding: try JSONEncoder().encode(watermark), as: UTF8.self)
+        #expect(json.contains("\"kind\":\"color\""))
+        let decoded = try JSONDecoder().decode(BackgroundWatermark.self, from: Data(json.utf8))
+        #expect(decoded == watermark)
+        #expect(decoded.colorHex == "#112233")
     }
 
     @Test func restoreClearRoundTrips() throws {

--- a/agtermCore/Tests/agtermCoreTests/WatermarkConfigTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/WatermarkConfigTests.swift
@@ -81,6 +81,19 @@ struct WatermarkConfigTests {
         #expect(text.contains("font-size = 15\n"))
     }
 
+    @Test func colorOverlayClampsWindowOpacity() {
+        // windowOpacity traces back to a persisted, hand-editable AppSettings value, so a bad one must not
+        // emit nan/inf or an out-of-range opacity into the config: >1 clamps to 1, <0 to 0, non-finite to 1.
+        let watermark = BackgroundWatermark(kind: .color, colorHex: "#ff0000")
+        func overlay(_ windowOpacity: Double) -> String {
+            WatermarkConfig.overlayText(watermark: watermark, resolvedImagePath: nil, fontSize: nil, windowOpacity: windowOpacity)
+        }
+        #expect(overlay(1.5).contains("background-opacity = 1\n"))
+        #expect(overlay(-0.2).contains("background-opacity = 0\n"))
+        #expect(overlay(.nan).contains("background-opacity = 1\n"))
+        #expect(overlay(.infinity).contains("background-opacity = 1\n"))
+    }
+
     @Test func colorOverlayDropsMalformedHex() {
         // defense-in-depth on the restore path: a persisted `.color` spec with a malformed hex (only
         // reachable by hand-editing workspaces.json) must NOT emit a `background` line; font-size still emits.

--- a/agtermCore/Tests/agtermCoreTests/WatermarkConfigTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/WatermarkConfigTests.swift
@@ -63,6 +63,33 @@ struct WatermarkConfigTests {
         #expect(text == "font-size = 14\n")
     }
 
+    @Test func colorOverlayEmitsBackgroundAtWindowOpacity() {
+        let watermark = BackgroundWatermark(kind: .color, colorHex: "#ff0000")
+        let text = WatermarkConfig.overlayText(watermark: watermark, resolvedImagePath: nil, fontSize: nil)
+        #expect(text.contains("background = #ff0000\n"))
+        #expect(text.contains("background-opacity = 1\n"))   // default windowOpacity = solid
+        #expect(!text.contains("background-image"))          // a solid color emits no image keys
+    }
+
+    @Test func colorOverlayHonorsWindowTranslucency() {
+        // a solid color is drawn at the window translucency (Settings), not a per-call opacity, so the
+        // window blur shows through when translucency is on. font zoom is preserved alongside.
+        let watermark = BackgroundWatermark(kind: .color, colorHex: "#00ff88")
+        let text = WatermarkConfig.overlayText(watermark: watermark, resolvedImagePath: nil, fontSize: 15, windowOpacity: 0.8)
+        #expect(text.contains("background = #00ff88\n"))
+        #expect(text.contains("background-opacity = 0.8\n"))
+        #expect(text.contains("font-size = 15\n"))
+    }
+
+    @Test func colorOverlayDropsMalformedHex() {
+        // defense-in-depth on the restore path: a persisted `.color` spec with a malformed hex (only
+        // reachable by hand-editing workspaces.json) must NOT emit a `background` line; font-size still emits.
+        let watermark = BackgroundWatermark(kind: .color, colorHex: "not-a-color")
+        let text = WatermarkConfig.overlayText(watermark: watermark, resolvedImagePath: nil, fontSize: 14)
+        #expect(!text.contains("background ="))
+        #expect(text == "font-size = 14\n")
+    }
+
     @Test func formattedDropsTrailingZeroForIntegralValues() {
         #expect(WatermarkConfig.formatted(14) == "14")
         #expect(WatermarkConfig.formatted(14.0) == "14")

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -742,6 +742,17 @@ struct CommandsTests {
         #expect(try request(argv) == expected)
     }
 
+    @Test func sessionBackgroundColor() throws {
+        let expected = ControlRequest(cmd: .sessionBackground, target: "s1",
+                                      args: ControlArgs(mode: "color", color: "#112233"))
+        #expect(try request(["session", "background", "color", "#112233", "--target", "s1"]) == expected)
+    }
+
+    @Test func sessionBackgroundColorRejectsBadColor() {
+        #expect(validationMessage(["session", "background", "color", "red"]) != nil)
+        #expect(validationMessage(["session", "background", "color", "#fff"]) != nil)
+    }
+
     @Test func sessionBackgroundClear() throws {
         let expected = ControlRequest(cmd: .sessionBackground, target: "active", args: ControlArgs(mode: "clear"))
         #expect(try request(["session", "background", "clear"]) == expected)

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -749,8 +749,9 @@ struct CommandsTests {
     }
 
     @Test func sessionBackgroundColorRejectsBadColor() {
-        #expect(validationMessage(["session", "background", "color", "red"]) != nil)
-        #expect(validationMessage(["session", "background", "color", "#fff"]) != nil)
+        // assert the color validation (not some unrelated parse error) fired.
+        #expect(validationMessage(["session", "background", "color", "red"])?.contains("color") == true)
+        #expect(validationMessage(["session", "background", "color", "#fff"])?.contains("color") == true)
     }
 
     @Test func sessionBackgroundClear() throws {

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -192,6 +192,19 @@ final class ControlAPIUITests: XCTestCase {
         XCTAssertEqual(bg["kind"] as? String, "text", "the watermark kind should read back")
         XCTAssertEqual(bg["text"] as? String, "STAGING", "the watermark text should read back")
 
+        // a solid background color reads back with kind "color" and the hex. The spec carries no opacity —
+        // a color honors the Settings window translucency at render time.
+        let colorSet = try sendCommand(#"{"cmd":"session.background","target":"\#(sid)","args":{"mode":"color","color":"#ff0000"}}"#)
+        XCTAssertEqual(colorSet["ok"] as? Bool, true, "session.background color should succeed: \(colorSet)")
+        let afterColor = try sendCommand(#"{"cmd":"tree"}"#)
+        let colorNode = try XCTUnwrap(sessionNode(afterColor, id: sid), "the session should appear in the tree")
+        let colorBg = try XCTUnwrap(colorNode["background"] as? [String: Any], "tree should expose the color background")
+        XCTAssertEqual(colorBg["kind"] as? String, "color", "the color kind should read back")
+        XCTAssertEqual(colorBg["colorHex"] as? String, "#ff0000", "the color hex should read back")
+
+        let badColor = try sendCommand(#"{"cmd":"session.background","target":"\#(sid)","args":{"mode":"color","color":"red"}}"#)
+        XCTAssertEqual(badColor["ok"] as? Bool, false, "a malformed color should be rejected")
+
         let missing = try sendCommand(#"{"cmd":"session.background","target":"\#(sid)","args":{"mode":"image","path":"/no/such.png"}}"#)
         XCTAssertEqual(missing["ok"] as? Bool, false, "a missing image file should be rejected")
 

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -205,6 +205,13 @@ final class ControlAPIUITests: XCTestCase {
         let badColor = try sendCommand(#"{"cmd":"session.background","target":"\#(sid)","args":{"mode":"color","color":"red"}}"#)
         XCTAssertEqual(badColor["ok"] as? Bool, false, "a malformed color should be rejected")
 
+        // color mode with no color hits the "requires a color" guard (unreachable from the CLI, whose
+        // argument is required, so the raw-JSON e2e is the only cover for this arm).
+        let emptyColor = try sendCommand(#"{"cmd":"session.background","target":"\#(sid)","args":{"mode":"color"}}"#)
+        XCTAssertEqual(emptyColor["ok"] as? Bool, false, "color mode with no color should be rejected")
+        XCTAssertEqual(emptyColor["error"] as? String, "session.background color requires a color",
+                       "the empty-color guard should reject it")
+
         let missing = try sendCommand(#"{"cmd":"session.background","target":"\#(sid)","args":{"mode":"image","path":"/no/such.png"}}"#)
         XCTAssertEqual(missing["ok"] as? Bool, false, "a missing image file should be rejected")
 


### PR DESCRIPTION
Follow-up to #32 (per-session background watermark). Adds a `color` mode to `session.background`: a solid per-session terminal background color, set over the control socket and `agtermctl session background color <#rrggbb>`.

**Behavior.** The image/text watermark forces `background-opacity = 1` so the image shows over window translucency. A `color` is the opposite: it takes no per-call opacity and honors the Settings window translucency. The per-surface overlay emits `background-opacity = <window opacity>`, so the color is solid when translucency is off and translucent + blurred when it is on. A color session also re-tracks the opacity slider live, since `SettingsModel` re-asserts `.color` surfaces after the window opacity updates (guarded to `.color` so image/text watermarks are not rebuilt on every slider tick).

**Keep-in-sync surfaces.** `BackgroundWatermark.Kind.color` plus the `WatermarkConfig` overlay in `agtermCore`, the `ControlServer` dispatch arm, the `agtermctl session background color` subcommand, protocol/CLI/e2e tests, and the agent-skill + `control-api.md` docs.

**Tests.** `swift test` covers the overlay emission at window opacity, the opacity clamp, the malformed-hex drop on restore, the protocol round-trip through the tree wire path, and the CLI parse/validate; the control-API UI tests cover color set/read-back/reject end to end. Ran a multi-agent review pass (codex + 5 agents) with no critical or major findings.

A third commit excludes `.claude/worktrees` from swiftlint so a concurrent local worktree's vendored `.build` does not fail `make lint` (CI is unaffected, since worktrees are local-only).

Related to #32
