### PR TITLE
fix: source builds show 0.0.0 in About — derive version from git tag in build.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,6 +6,12 @@ cd "$(dirname "$0")/.."
 ./scripts/setup.sh
 xcodegen generate
 GIT_COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+# version = latest reachable v-tag (About panel / CFBundleShortVersionString);
+# builds past the tag keep its version and the GitCommit parenthetical
+# disambiguates. Falls back to 0.0.0 when no tag is reachable (shallow CI).
+VERSION="$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null | sed 's/^v//')"
+[ -n "$VERSION" ] || VERSION="0.0.0"
 xcodebuild -project agterm.xcodeproj -scheme agterm -configuration Release \
-  -derivedDataPath build/DerivedData GIT_COMMIT="$GIT_COMMIT" build
+  -derivedDataPath build/DerivedData \
+  MARKETING_VERSION="$VERSION" CURRENT_PROJECT_VERSION="$VERSION" GIT_COMMIT="$GIT_COMMIT" build
 echo "built: build/DerivedData/Build/Products/Release/agterm.app"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,7 +9,10 @@ GIT_COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
 # version = latest reachable v-tag (About panel / CFBundleShortVersionString);
 # builds past the tag keep its version and the GitCommit parenthetical
 # disambiguates. Falls back to 0.0.0 when no tag is reachable (shallow CI).
-VERSION="$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null | sed 's/^v//')"
+# `|| true` inside the substitution: `git describe` exits 128 with no tags, which
+# under `set -e` would abort before the fallback below — swallow it so the empty
+# result reaches the `-n` check.
+VERSION="$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null | sed 's/^v//' || true)"
 [ -n "$VERSION" ] || VERSION="0.0.0"
 xcodebuild -project agterm.xcodeproj -scheme agterm -configuration Release \
   -derivedDataPath build/DerivedData \


### PR DESCRIPTION
## Problem

Building agterm from source (`make release` / `make deploy`, i.e. `scripts/build.sh`) produces an app whose **About panel shows `0.0.0 (<sha>)`** instead of the real version:

- `project.yml` defaults `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` to `0.0.0`.
- Only `scripts/release.sh` overrides them (it takes the version as an explicit argument), so the DMG/tag path was always correct.
- `scripts/build.sh` passed just `GIT_COMMIT`, so every source build shipped with `CFBundleShortVersionString = 0.0.0` — and since `GitCommit` *was* baked, About rendered the worst of both: `0.0.0 (fbe18d3)`.

**Who is affected:** anyone building from source and installing via `make deploy`. **Not affected:** Homebrew cask / GitHub release users — verified by mounting the published `agterm-0.5.2.dmg` and reading its Info.plist (`0.5.2` / `f98de51`, correct).

## Fix

`scripts/build.sh` now derives the version from git and passes it to xcodebuild alongside the existing `GIT_COMMIT`:

- `git describe --tags --abbrev=0 --match 'v[0-9]*'` with the `v` prefix stripped — builds between tags keep the last tag's version, and the `GitCommit` parenthetical in About disambiguates which commit it actually is.
- Falls back to `0.0.0` when no tag is reachable — this keeps CI's `build` job working, since `actions/checkout` is shallow and fetches no tags.

Deliberately untouched:

- `scripts/release.sh` — its explicit version argument stays authoritative for tagged releases.
- Debug builds (`make build` / `scripts/run.sh`) — they keep the plain `0.0.0` dev fallback, matching the About-panel comment in `agtermApp.swift` (dev builds have no baked commit and fall back to the plain version).

## Verification

- `scripts/build.sh` on a checkout at `v0.5.0`: built app's Info.plist reads `CFBundleShortVersionString = 0.5.0`, `CFBundleVersion = 0.5.0`, `GitCommit = fbe18d3`; About panel visually confirmed showing **0.5.0 (fbe18d3)**.
- `swift test` in `agtermCore`: 898 tests pass (no Swift changes in this PR).
- Published-release path confirmed unaffected (see above).
