### PR TITLE
refactor: Move keymap store into core

### DIFF
--- a/agterm/SettingsModel.swift
+++ b/agterm/SettingsModel.swift
@@ -341,21 +341,9 @@ final class SettingsModel {
     /// file that EXISTS but can't be read (permissions, invalid UTF-8) is surfaced as a single line-0
     /// diagnostic so the warning banner fires, rather than being silently treated as missing.
     private func loadKeymap() {
-        let url = keymapURL()
-        do {
-            let text = try String(contentsOf: url, encoding: .utf8)
-            let parsed = parseKeymap(text)
-            keymap = parsed.keymap
-            keymapDiagnostics = parsed.diagnostics
-        } catch {
-            keymap = Keymap(builtinOverrides: [:], commands: [])
-            guard FileManager.default.fileExists(atPath: url.path) else {
-                // truly missing — not an error.
-                keymapDiagnostics = []
-                return
-            }
-            keymapDiagnostics = [KeymapDiagnostic(line: 0, message: "could not read keymap.conf: \(error.localizedDescription)")]
-        }
+        let loaded = KeymapStore(configDirectory: configDirectoryURL()).load()
+        keymap = loaded.keymap
+        keymapDiagnostics = loaded.diagnostics
     }
 
     /// On first launch, if `keymap.conf` does not exist, create the config directory and write a
@@ -367,7 +355,7 @@ final class SettingsModel {
         do {
             try FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
                                                     withIntermediateDirectories: true)
-            try starterKeymapText().write(to: url, atomically: true, encoding: .utf8)
+            try ConfigPaths.starterKeymapConf().write(to: url, atomically: true, encoding: .utf8)
         } catch {
             logger.notice("could not write starter keymap at \(url.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
@@ -410,88 +398,6 @@ final class SettingsModel {
         # in Settings and always win over this file — set those in Settings, everything else here.
 
         """
-    }
-
-    /// The commented starter `keymap.conf`: the two-verb syntax, every `BuiltinAction` raw name with
-    /// its shipped default chord (or "no default"), and the `{AGT_X}` token list. Every line is a
-    /// comment so a fresh file rebinds nothing.
-    private func starterKeymapText() -> String {
-        // pad the action name column to the longest raw name (+ a 2-space gutter) so a future action
-        // longer than any current one can never silently truncate.
-        let nameColumnWidth = (BuiltinAction.allCases.map { $0.rawValue.count }.max() ?? 0) + 2
-        let actionLines = BuiltinAction.allCases.map { action -> String in
-            // a default whose key can't round-trip through the keymap grammar (e.g. increase_font_size's
-            // `+`, which clashes with the `+` separator) is documented as not file-expressible rather
-            // than printed as an unparseable token like `cmd++`.
-            let chord = action.defaultChord.map(chordSyntax) ?? "(no default)"
-            return "#   \(action.rawValue.padding(toLength: nameColumnWidth, withPad: " ", startingAt: 0))\(chord)"
-        }.joined(separator: "\n")
-        let tokenLines = CommandContext.tokenNames.map { "#   {\($0)}" }.joined(separator: "\n")
-
-        return """
-        # agterm keymap — a kitty-flavored config for rebinding built-in shortcuts and defining
-        # custom shell commands. Edit this file and run File ▸ Reload Keymap (or `agtermctl keymap
-        # reload`) to apply. Blank lines and lines starting with `#` are ignored.
-        #
-        # Two verbs:
-        #
-        #   map <chord> <action>
-        #       Rebind a built-in action to a single chord (no leader sequences for built-ins).
-        #       Chords use kitty syntax: mods joined by `+`, e.g. `cmd+shift+d`, `ctrl+\\``.
-        #       Mods: ctrl, cmd, opt, shift. Example:
-        #
-        #           map cmd+shift+d  toggle_split
-        #
-        #   command "<name>" [chord] <shell...>
-        #       Define a custom command, shown in the action palette marked `custom`. The quoted
-        #       name may contain spaces. An optional chord (single chord OR a leader like `ctrl+a>g`)
-        #       binds it to a key; the chord MUST include a modifier (a bare key is rejected and the
-        #       line becomes palette-only). Omit the chord for a palette-only command. The rest of the
-        #       line is run via `/bin/sh -c`, detached with no terminal — so it suits fire-and-forget
-        #       launches (GUI apps, scripts), NOT a bare interactive or full-screen TUI program, which
-        #       has no TTY and exits at once. Launch a TUI over a session through an overlay terminal,
-        #       as the Lazygit example does. Examples:
-        #
-        #           command "Open in Zed"  cmd+shift+e  open -a Zed "$AGT_SESSION_PWD"
-        #           command "Lazygit"      ctrl+a>g     agtermctl session overlay open lazygit --socket "$AGT_SOCKET"
-        #           command "Deploy"                    ./deploy.sh
-        #
-        # Built-in actions (raw name → shipped default chord):
-        #
-        \(actionLines)
-        #
-        # Custom-command tokens (expanded in the shell line and exported as $AGT_X env vars):
-        #
-        \(tokenLines)
-        #
-        # NOTE: a {AGT_X} token is substituted RAW into the /bin/sh line — convenient, but unsafe for
-        # content you don't control. {AGT_SELECTION} is the obvious case, but a remote host can also set
-        # the session title (OSC) and the working directory (OSC 7), so {AGT_SESSION_NAME} and
-        # {AGT_SESSION_PWD} are equally unsafe raw. For any such content prefer the matching $AGT_X
-        # environment variable, QUOTED, e.g. "$AGT_SELECTION".
-        #
-        # Uncomment and edit a line below to start.
-        # map cmd+shift+d toggle_split
-
-        """
-    }
-
-    /// Render a `Chord` back into the kitty syntax the user writes (`cmd+shift+d`), for the starter
-    /// file's documentation of the default shortcuts. Mods are ordered ctrl, cmd, opt, shift. Returns
-    /// `(not expressible)` when the chord's key is a grammar separator (`+`/`>`) that can't round-trip
-    /// through `parseKeybind` — e.g. increase_font_size's `+`, which would render as the unparseable
-    /// `cmd++`.
-    private func chordSyntax(_ chord: Chord) -> String {
-        var parts: [String] = []
-        if chord.mods.contains(.control) { parts.append("ctrl") }
-        if chord.mods.contains(.command) { parts.append("cmd") }
-        if chord.mods.contains(.option) { parts.append("opt") }
-        if chord.mods.contains(.shift) { parts.append("shift") }
-        parts.append(chord.key)
-        let rendered = parts.joined(separator: "+")
-        // verify the rendered string round-trips: a key like `+`/`>` produces an unparseable token.
-        guard parseKeybind(rendered) == [chord] else { return "(not expressible)" }
-        return rendered
     }
 
     private func persistAndApply() {

--- a/agtermCore/Sources/agtermCore/ConfigPaths.swift
+++ b/agtermCore/Sources/agtermCore/ConfigPaths.swift
@@ -21,6 +21,44 @@ public enum ConfigPaths {
         configDirectory.appendingPathComponent("keymap.conf")
     }
 
+    /// A fully-commented starter `keymap.conf`: documents the two-verb format, the `{AGT_*}` tokens,
+    /// and lists every rebindable built-in action with its shipped default chord. Fully commented, so
+    /// a fresh install rebinds nothing.
+    public static func starterKeymapConf() -> String {
+        let nameColumnWidth = (BuiltinAction.allCases.map { $0.rawValue.count }.max() ?? 0) + 2
+        let actions = BuiltinAction.allCases.map { action -> String in
+            let chord = action.defaultChord.map(starterChordSyntax) ?? "(no default)"
+            return "#   \(action.rawValue.padding(toLength: nameColumnWidth, withPad: " ", startingAt: 0))\(chord)"
+        }.joined(separator: "\n")
+        let tokenLines = CommandContext.tokenNames.map { "#   {\($0)}" }.joined(separator: "\n")
+        return """
+        # agterm keymap.conf - rebind built-in shortcuts and define custom shell commands.
+        #
+        # Fully commented: a fresh install rebinds NOTHING. Uncomment and edit a line to override,
+        # then reload via the command palette's "Reload Keymap" or Settings > Key Mapping > Reload.
+        #
+        # Override a built-in shortcut:
+        #   map <chord> <action>                  e.g.  map ctrl+shift+t new_session
+        #   chord = modifiers + key, e.g. cmd+shift+p (ctrl / control / cmd / command / opt / option / alt / shift)
+        #
+        # Define a custom command (also shown in the palette, marked "custom"):
+        #   command "<name>" [chord] <shell...>   e.g.  command "Git status" ctrl+shift+g git status
+        #   Tokens substituted into the shell line and exported as $AGT_* env vars:
+        \(tokenLines)
+        #   For untrusted content prefer the QUOTED env form, e.g. "$AGT_SELECTION".
+        #
+        # Rebindable built-in actions:
+        \(actions)
+
+        """
+    }
+
+    private static func starterChordSyntax(_ chord: Chord) -> String {
+        let rendered = chord.displayString
+        guard parseKeybind(rendered) == [chord] else { return "(not expressible)" }
+        return rendered
+    }
+
     /// The agterm-scoped ghostty config file path within a resolved config directory: `<dir>/ghostty.conf`.
     /// Co-located with `keymap.conf` so a user-set custom config dir holds both.
     public static func ghosttyConfigPath(configDirectory: URL) -> URL {

--- a/agtermCore/Sources/agtermCore/ConfigPaths.swift
+++ b/agtermCore/Sources/agtermCore/ConfigPaths.swift
@@ -21,34 +21,66 @@ public enum ConfigPaths {
         configDirectory.appendingPathComponent("keymap.conf")
     }
 
-    /// A fully-commented starter `keymap.conf`: documents the two-verb format, the `{AGT_*}` tokens,
-    /// and lists every rebindable built-in action with its shipped default chord. Fully commented, so
-    /// a fresh install rebinds nothing.
+    /// The commented starter `keymap.conf`: the two-verb syntax, every `BuiltinAction` raw name with
+    /// its shipped default chord (or "no default"), and the `{AGT_X}` token list. Every line is a
+    /// comment so a fresh file rebinds nothing.
     public static func starterKeymapConf() -> String {
+        // pad the action name column to the longest raw name (+ a 2-space gutter) so a future action
+        // longer than any current one can never silently truncate.
         let nameColumnWidth = (BuiltinAction.allCases.map { $0.rawValue.count }.max() ?? 0) + 2
-        let actions = BuiltinAction.allCases.map { action -> String in
+        let actionLines = BuiltinAction.allCases.map { action -> String in
+            // a default whose key can't round-trip through the keymap grammar (e.g. increase_font_size's
+            // `+`, which clashes with the `+` separator) is documented as not file-expressible rather
+            // than printed as an unparseable token like `cmd++`.
             let chord = action.defaultChord.map(starterChordSyntax) ?? "(no default)"
             return "#   \(action.rawValue.padding(toLength: nameColumnWidth, withPad: " ", startingAt: 0))\(chord)"
         }.joined(separator: "\n")
         let tokenLines = CommandContext.tokenNames.map { "#   {\($0)}" }.joined(separator: "\n")
+
         return """
-        # agterm keymap.conf - rebind built-in shortcuts and define custom shell commands.
+        # agterm keymap — a kitty-flavored config for rebinding built-in shortcuts and defining
+        # custom shell commands. Edit this file and run File ▸ Reload Keymap (or `agtermctl keymap
+        # reload`) to apply. Blank lines and lines starting with `#` are ignored.
         #
-        # Fully commented: a fresh install rebinds NOTHING. Uncomment and edit a line to override,
-        # then reload via the command palette's "Reload Keymap" or Settings > Key Mapping > Reload.
+        # Two verbs:
         #
-        # Override a built-in shortcut:
-        #   map <chord> <action>                  e.g.  map ctrl+shift+t new_session
-        #   chord = modifiers + key, e.g. cmd+shift+p (ctrl / control / cmd / command / opt / option / alt / shift)
+        #   map <chord> <action>
+        #       Rebind a built-in action to a single chord (no leader sequences for built-ins).
+        #       Chords use kitty syntax: mods joined by `+`, e.g. `cmd+shift+d`, `ctrl+\\``.
+        #       Mods: ctrl, cmd, opt, shift. Example:
         #
-        # Define a custom command (also shown in the palette, marked "custom"):
-        #   command "<name>" [chord] <shell...>   e.g.  command "Git status" ctrl+shift+g git status
-        #   Tokens substituted into the shell line and exported as $AGT_* env vars:
+        #           map cmd+shift+d  toggle_split
+        #
+        #   command "<name>" [chord] <shell...>
+        #       Define a custom command, shown in the action palette marked `custom`. The quoted
+        #       name may contain spaces. An optional chord (single chord OR a leader like `ctrl+a>g`)
+        #       binds it to a key; the chord MUST include a modifier (a bare key is rejected and the
+        #       line becomes palette-only). Omit the chord for a palette-only command. The rest of the
+        #       line is run via `/bin/sh -c`, detached with no terminal — so it suits fire-and-forget
+        #       launches (GUI apps, scripts), NOT a bare interactive or full-screen TUI program, which
+        #       has no TTY and exits at once. Launch a TUI over a session through an overlay terminal,
+        #       as the Lazygit example does. Examples:
+        #
+        #           command "Open in Zed"  cmd+shift+e  open -a Zed "$AGT_SESSION_PWD"
+        #           command "Lazygit"      ctrl+a>g     agtermctl session overlay open lazygit --socket "$AGT_SOCKET"
+        #           command "Deploy"                    ./deploy.sh
+        #
+        # Built-in actions (raw name → shipped default chord):
+        #
+        \(actionLines)
+        #
+        # Custom-command tokens (expanded in the shell line and exported as $AGT_X env vars):
+        #
         \(tokenLines)
-        #   For untrusted content prefer the QUOTED env form, e.g. "$AGT_SELECTION".
         #
-        # Rebindable built-in actions:
-        \(actions)
+        # NOTE: a {AGT_X} token is substituted RAW into the /bin/sh line — convenient, but unsafe for
+        # content you don't control. {AGT_SELECTION} is the obvious case, but a remote host can also set
+        # the session title (OSC) and the working directory (OSC 7), so {AGT_SESSION_NAME} and
+        # {AGT_SESSION_PWD} are equally unsafe raw. For any such content prefer the matching $AGT_X
+        # environment variable, QUOTED, e.g. "$AGT_SELECTION".
+        #
+        # Uncomment and edit a line below to start.
+        # map cmd+shift+d toggle_split
 
         """
     }

--- a/agtermCore/Sources/agtermCore/Keymap.swift
+++ b/agtermCore/Sources/agtermCore/Keymap.swift
@@ -44,6 +44,36 @@ public struct KeymapDiagnostic: Equatable, Sendable {
     }
 }
 
+/// Host-free loader for the user keymap file. Missing files recover as an empty keymap with no
+/// diagnostics; existing unreadable or invalid-UTF8 files recover with a single line-0 diagnostic.
+public struct KeymapStore: Sendable {
+    public let configDirectory: URL
+
+    public init(configDirectory: URL) {
+        self.configDirectory = configDirectory
+    }
+
+    public var path: URL {
+        ConfigPaths.keymapPath(configDirectory: configDirectory)
+    }
+
+    public func load() -> (keymap: Keymap, diagnostics: [KeymapDiagnostic]) {
+        do {
+            let text = try String(contentsOf: path, encoding: .utf8)
+            return parseKeymap(text)
+        } catch {
+            let empty = Keymap(builtinOverrides: [:], commands: [])
+            guard FileManager.default.fileExists(atPath: path.path) else {
+                return (empty, [])
+            }
+            let diagnostic = KeymapDiagnostic(
+                line: 0,
+                message: "could not read keymap.conf: \(error.localizedDescription)")
+            return (empty, [diagnostic])
+        }
+    }
+}
+
 /// Parse the text of a `keymap.conf` into a `Keymap` plus a list of diagnostics. Never throws: a bad
 /// line becomes a diagnostic and is skipped, so a single malformed line never discards the rest of
 /// the file.

--- a/agtermCore/Tests/agtermCoreTests/ConfigPathsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ConfigPathsTests.swift
@@ -33,9 +33,14 @@ struct ConfigPathsTests {
 
     @Test func starterKeymapConfIsCommentedAndListsActions() {
         let starter = ConfigPaths.starterKeymapConf()
+        #expect(starter.contains("agterm keymap — a kitty-flavored config"))
         #expect(starter.contains("map <chord> <action>"))
         #expect(starter.contains("command \"<name>\" [chord] <shell...>"))
-        #expect(starter.contains("cmd+shift+p"))
+        #expect(starter.contains("single chord OR a leader like `ctrl+a>g`"))
+        #expect(starter.contains("command \"Open in Zed\"  cmd+shift+e  open -a Zed \"$AGT_SESSION_PWD\""))
+        #expect(starter.contains("command \"Lazygit\"      ctrl+a>g     agtermctl session overlay open lazygit --socket \"$AGT_SOCKET\""))
+        #expect(starter.contains("command \"Deploy\"                    ./deploy.sh"))
+        #expect(starter.contains("ctrl+shift+p"))
         #expect(!starter.contains("super"))
         for action in BuiltinAction.allCases {
             #expect(starter.contains("#   \(action.rawValue)"))
@@ -52,6 +57,12 @@ struct ConfigPathsTests {
         #expect(!starter.contains("{AGT_SESSION}"))
         #expect(!starter.contains("{AGT_WINDOW}"))
         #expect(!starter.contains("{AGT_CWD}"))
+        #expect(starter.contains("a {AGT_X} token is substituted RAW into the /bin/sh line"))
+        #expect(starter.contains("a remote host can also set"))
+        #expect(starter.contains("the session title (OSC) and the working directory (OSC 7)"))
+        #expect(starter.contains("{AGT_SESSION_NAME} and"))
+        #expect(starter.contains("{AGT_SESSION_PWD} are equally unsafe raw"))
+        #expect(starter.contains("environment variable, QUOTED, e.g. \"$AGT_SELECTION\""))
         let parsed = parseKeymap(starter)
         #expect(parsed.keymap.builtinOverrides.isEmpty)
         #expect(parsed.keymap.commands.isEmpty)

--- a/agtermCore/Tests/agtermCoreTests/ConfigPathsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ConfigPathsTests.swift
@@ -31,6 +31,33 @@ struct ConfigPathsTests {
         #expect(ConfigPaths.keymapPath(configDirectory: dir).path == "/Users/test/.config/agterm/keymap.conf")
     }
 
+    @Test func starterKeymapConfIsCommentedAndListsActions() {
+        let starter = ConfigPaths.starterKeymapConf()
+        #expect(starter.contains("map <chord> <action>"))
+        #expect(starter.contains("command \"<name>\" [chord] <shell...>"))
+        #expect(starter.contains("cmd+shift+p"))
+        #expect(!starter.contains("super"))
+        for action in BuiltinAction.allCases {
+            #expect(starter.contains("#   \(action.rawValue)"))
+        }
+        #expect(starter.contains("#   new_session"))
+        #expect(starter.contains("cmd+n"))
+        #expect(starter.contains("#   increase_font_size"))
+        #expect(starter.contains("(not expressible)"))
+        #expect(starter.contains("#   rename_session"))
+        #expect(starter.contains("(no default)"))
+        for token in CommandContext.tokenNames {
+            #expect(starter.contains("#   {\(token)}"))
+        }
+        #expect(!starter.contains("{AGT_SESSION}"))
+        #expect(!starter.contains("{AGT_WINDOW}"))
+        #expect(!starter.contains("{AGT_CWD}"))
+        let parsed = parseKeymap(starter)
+        #expect(parsed.keymap.builtinOverrides.isEmpty)
+        #expect(parsed.keymap.commands.isEmpty)
+        #expect(parsed.diagnostics.isEmpty)
+    }
+
     @Test func ghosttyConfigPathIsGhosttyConfInDir() {
         let dir = URL(fileURLWithPath: "/Users/test/.config/agterm")
         #expect(ConfigPaths.ghosttyConfigPath(configDirectory: dir).path == "/Users/test/.config/agterm/ghostty.conf")

--- a/agtermCore/Tests/agtermCoreTests/KeymapTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/KeymapTests.swift
@@ -514,4 +514,49 @@ struct KeymapTests {
         #expect(diagnostics.contains { $0.message.contains("'Lead'") && $0.message.contains("'Leader'") })
         #expect(diagnostics.contains { $0.message.contains("'Leader'") && $0.message.contains("'Lead'") })
     }
+
+    @Test func keymapStoreLoadsFileAndRecoversWhenMissing() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("agterm-keymap-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = KeymapStore(configDirectory: dir)
+
+        #expect(store.path == ConfigPaths.keymapPath(configDirectory: dir))
+        #expect(store.load().keymap.commands.isEmpty)
+        #expect(store.load().diagnostics.isEmpty)
+
+        try "command \"Greet\" ctrl+shift+y echo hi\n".write(to: store.path, atomically: true, encoding: .utf8)
+        let loaded = store.load()
+        #expect(loaded.keymap.commands.contains { $0.name == "Greet" })
+        #expect(loaded.diagnostics.isEmpty)
+    }
+
+    @Test func keymapStoreReportsMalformedKeymapDiagnostics() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("agterm-keymap-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = KeymapStore(configDirectory: dir)
+
+        try "map cmd+d not_an_action\ncommand \"Good\" ctrl+shift+y echo ok\n"
+            .write(to: store.path, atomically: true, encoding: .utf8)
+        let loaded = store.load()
+
+        #expect(loaded.keymap.commands.contains { $0.name == "Good" })
+        #expect(loaded.diagnostics.contains { $0.line == 1 && $0.message.contains("unknown action") })
+    }
+
+    @Test func keymapStoreReportsUnreadableTextFile() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("agterm-keymap-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = KeymapStore(configDirectory: dir)
+
+        try Data([0xff, 0xfe, 0xfd]).write(to: store.path)
+        let loaded = store.load()
+
+        #expect(loaded.keymap == Keymap(builtinOverrides: [:], commands: []))
+        #expect(loaded.diagnostics.count == 1)
+        #expect(loaded.diagnostics[0].line == 0)
+        #expect(loaded.diagnostics[0].message.contains("could not read keymap.conf"))
+    }
 }


### PR DESCRIPTION
## Summary
- move keymap loading and starter keymap generation into `agtermCore`
- keep startup behavior the same: missing files are clean, unreadable/invalid UTF-8 files report one diagnostic
- preserve starter keymap default-chord docs, including `(not expressible)` and `(no default)` entries

## Validation
- `make lint`
- `cd agtermCore && swift test`
- `xcodebuild -project agterm.xcodeproj -scheme agterm -configuration Debug -derivedDataPath build/DerivedData build CODE_SIGNING_ALLOWED=NO`
- `xcodebuild -project agterm.xcodeproj -scheme agterm -configuration Debug -destination 'platform=macOS' -derivedDataPath build/DerivedData -only-testing:agtermUITests/KeymapUITests test`\n- manual app launch with isolated keymap configs: starter/valid reload `0`, malformed reload `1`, invalid UTF-8 reload `1`, clean reload `0`