### PR TITLE
refactor: Move overlay capture contract into core

### DIFF
--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -727,7 +727,7 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         // tracks the surface. runs on every in-process teardown (natural exit, explicit close, force-close).
         if let f = overlayCodeFile {
             if let text = try? String(contentsOfFile: f, encoding: .utf8),
-               let code = Int(text.trimmingCharacters(in: .whitespacesAndNewlines)) {
+               let code = OverlayCapture.parseExitCode(text) {
                 onExitCodeCaptured?(code)
             } else {
                 NSLog("overlay exit-code file unreadable or empty: %@", f)

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -607,11 +607,8 @@ struct agtermApp: App {
     }
 
     /// The fixed wrapper that runs the overlay command and records its exit status to a temp file.
-    /// stdout/stderr are NOT redirected (so a TUI renders normally); only the status is captured —
-    /// libghostty's child-exited status reflects the login-shell wrapper, not the command. The real
-    /// command + the temp path ride in env (`AGTERM_OVL_CMD`/`AGTERM_OVL_CODE`), never interpolated, so
-    /// there is no shell-quoting of user data. The subshell makes an inline `exit N` propagate to `$?`.
-    private static let overlayExitWrapper = "sh -c '( eval \"$AGTERM_OVL_CMD\" ); echo $? > \"$AGTERM_OVL_CODE\"'"
+    /// stdout/stderr are NOT redirected (so a TUI renders normally); only the status is captured.
+    private static let overlayExitWrapper = "sh -c '\(OverlayCapture.shellLine)'"
 
     /// Overlay-terminal surface factory: an ephemeral surface running the session's `overlayCommand`
     /// as its process in `overlayCwd` (default the session's current dir). Like the split, it is NOT
@@ -625,8 +622,8 @@ struct agtermApp: App {
         // redirect — the program renders in the overlay as usual.
         let codeFile = (NSTemporaryDirectory() as NSString).appendingPathComponent("agterm-ovl-\(UUID().uuidString).code")
         var overlayEnv = env
-        overlayEnv["AGTERM_OVL_CMD"] = session.overlayCommand ?? ""
-        overlayEnv["AGTERM_OVL_CODE"] = codeFile
+        overlayEnv[OverlayCapture.cmdEnvKey] = session.overlayCommand ?? ""
+        overlayEnv[OverlayCapture.codeEnvKey] = codeFile
         let view = GhosttySurfaceView(workingDirectory: session.overlayCwd ?? session.effectiveCwd,
                                       fontSize: session.fontSize.map(Float.init), command: overlayExitWrapper,
                                       waitAfterCommand: session.overlayWait, autoFocus: true, env: overlayEnv)

--- a/agtermCore/Sources/agtermCore/OverlayCapture.swift
+++ b/agtermCore/Sources/agtermCore/OverlayCapture.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Shared contract for overlay command exit-status capture.
+///
+/// The real command and the status-file path are passed through environment variables so the wrapper
+/// never interpolates user command text. The wrapper does not redirect stdout or stderr, so terminal UI
+/// programs still render normally while only the exit status is captured.
+public enum OverlayCapture {
+    public static let cmdEnvKey = "AGTERM_OVL_CMD"
+    public static let codeEnvKey = "AGTERM_OVL_CODE"
+
+    public static let shellLine = #"( eval "$AGTERM_OVL_CMD" ); echo $? > "$AGTERM_OVL_CODE""#
+
+    public static func parseExitCode(_ text: String) -> Int? {
+        Int(text.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/OverlayCaptureTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/OverlayCaptureTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+struct OverlayCaptureTests {
+    @Test func constantsMatchOverlayContract() {
+        #expect(OverlayCapture.cmdEnvKey == "AGTERM_OVL_CMD")
+        #expect(OverlayCapture.codeEnvKey == "AGTERM_OVL_CODE")
+        #expect(OverlayCapture.shellLine == #"( eval "$AGTERM_OVL_CMD" ); echo $? > "$AGTERM_OVL_CODE""#)
+    }
+
+    @Test func shellLineRunsCommandAndWritesStatus() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agterm-overlay-capture-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/sh")
+        proc.arguments = ["-c", OverlayCapture.shellLine]
+        var env = ProcessInfo.processInfo.environment
+        env[OverlayCapture.cmdEnvKey] = "exit 7"
+        env[OverlayCapture.codeEnvKey] = tmp.path
+        proc.environment = env
+
+        try proc.run()
+        proc.waitUntilExit()
+
+        #expect(proc.terminationStatus == 0)
+        let text = try String(contentsOf: tmp, encoding: .utf8)
+        #expect(OverlayCapture.parseExitCode(text) == 7)
+    }
+
+    @Test func parseExitCodeTrimsWhitespaceAndRejectsInvalidText() {
+        #expect(OverlayCapture.parseExitCode("3\n") == 3)
+        #expect(OverlayCapture.parseExitCode("  0  ") == 0)
+        #expect(OverlayCapture.parseExitCode("") == nil)
+        #expect(OverlayCapture.parseExitCode("not a code") == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Hoists the overlay exit-status capture contract into `agtermCore` and rewires the macOS overlay setup to use the shared constants/parser.

## Validation

- `cd agtermCore && swift test`
- focused overlay XCUITests
- live `agtermctl session overlay open "sh -c 'exit 7'" --block` smoke
