### PR TITLE
refactor: Move custom command matcher into core

### DIFF
--- a/agterm/Commands/CustomCommandRunner.swift
+++ b/agterm/Commands/CustomCommandRunner.swift
@@ -5,7 +5,7 @@ import os
 private let logger = Logger(subsystem: "com.umputun.agterm", category: "CustomCommandRunner")
 
 /// Drives user-defined custom commands: an app-wide `NSEvent` local key monitor turns key presses
-/// into chords, a `KeybindMatcher` resolves them to a command (firing simple chords and leader
+/// into chords, a `CustomCommandEngine` resolves them to a command (firing simple chords and leader
 /// sequences like `ctrl+a > g`), and a fired command is run as a detached `/bin/sh -c` with the
 /// active session's context available as both `{AGT_X}` template tokens and `$AGT_X` environment.
 ///
@@ -21,9 +21,7 @@ final class CustomCommandRunner {
     private let settings: SettingsModel
     private let socketProvider: () -> String
 
-    private var matcher = KeybindMatcher([])
-    /// The commands keyed by id, so a `.fired(id)` resolves back to the command to run.
-    private var commandsByID: [UUID: CustomCommand] = [:]
+    private var commandEngine = CustomCommandEngine(commands: [])
 
     private var keyMonitor: Any?
     private var leaderTimer: Timer?
@@ -70,17 +68,12 @@ final class CustomCommandRunner {
     /// so a conflicted bind arrives here with an empty shortcut and is dropped from the matcher.
     private func rebuild() {
         let commands = settings.keymap.commands
-        commandsByID = Dictionary(uniqueKeysWithValues: commands.map { ($0.id, $0) })
-
-        var binds: [(Keybind, UUID)] = []
         for command in commands where !command.shortcut.isEmpty {
-            guard let keybind = parseKeybind(command.shortcut) else {
+            if parseKeybind(command.shortcut) == nil {
                 logger.notice("custom command \"\(command.name, privacy: .public)\" has invalid shortcut \"\(command.shortcut, privacy: .public)\"; skipping keybind")
-                continue
             }
-            binds.append((keybind, command.id))
         }
-        matcher = KeybindMatcher(binds)
+        commandEngine = CustomCommandEngine(commands: commands)
         cancelLeaderTimer()
     }
 
@@ -99,8 +92,8 @@ final class CustomCommandRunner {
         guard !event.isARepeat else { return false }
         guard let focused = NSApp.keyWindow?.firstResponder as? GhosttySurfaceView else {
             // focus is on a text field / non-terminal; drop any half-typed leader and pass through.
-            if matcher.isArmed {
-                matcher.reset()
+            if commandEngine.isArmed {
+                commandEngine.reset()
                 cancelLeaderTimer()
             }
             return false
@@ -108,8 +101,8 @@ final class CustomCommandRunner {
         // Esc abandons a half-typed leader sequence (the same call the timeout makes); it never
         // advances the matcher (Esc is not a bindable base key), so handle it before deriving a chord.
         if event.keyCode == Self.escapeKeyCode {
-            guard matcher.isArmed else { return false }
-            matcher.reset()
+            guard commandEngine.isArmed else { return false }
+            commandEngine.reset()
             cancelLeaderTimer()
             return true
         }
@@ -117,13 +110,13 @@ final class CustomCommandRunner {
             // a key with no usable base (e.g. a bare modifier) can't advance; while armed, keep waiting.
             return false
         }
-        switch matcher.advance(chord) {
-        case .fired(let id):
+        switch commandEngine.advance(chord) {
+        case .fired(let command):
             cancelLeaderTimer()
             // resolve context from the surface that actually had focus at key-down time, NOT the
             // frontmost active session — firing from a split/overlay/quick terminal (or during a
             // window-switch race) must run against THAT surface's session/cwd/selection.
-            if let command = commandsByID[id] { runFromKeybind(command, focusedSurface: focused) }
+            runFromKeybind(command, focusedSurface: focused)
             return true
         case .armed:
             startLeaderTimer()
@@ -164,7 +157,7 @@ final class CustomCommandRunner {
         leaderTimer = Timer.scheduledTimer(withTimeInterval: Self.leaderTimeout, repeats: false) { [weak self] _ in
             MainActor.assumeIsolated {
                 guard let self else { return }
-                self.matcher.reset()
+                self.commandEngine.reset()
                 self.leaderTimer = nil
             }
         }

--- a/agtermCore/Sources/agtermCore/CustomCommandEngine.swift
+++ b/agtermCore/Sources/agtermCore/CustomCommandEngine.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Host-free custom-command matcher: indexes parsed commands by id, builds a keybind matcher for the
+/// commands with shortcuts, and resolves each chord to the command that should run.
+public struct CustomCommandEngine: Sendable {
+    private var matcher: KeybindMatcher
+    private let commandsByID: [UUID: CustomCommand]
+
+    public init(commands: [CustomCommand]) {
+        commandsByID = Dictionary(commands.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        let binds: [(Keybind, UUID)] = commands.compactMap { command in
+            guard !command.shortcut.isEmpty, let keybind = parseKeybind(command.shortcut) else { return nil }
+            return (keybind, command.id)
+        }
+        matcher = KeybindMatcher(binds)
+    }
+
+    public enum Outcome: Equatable, Sendable {
+        case fired(CustomCommand)
+        case armed
+        case unmatched
+    }
+
+    public mutating func advance(_ chord: Chord) -> Outcome {
+        switch matcher.advance(chord) {
+        case .fired(let id):
+            commandsByID[id].map(Outcome.fired) ?? .unmatched
+        case .armed:
+            .armed
+        case .unmatched:
+            .unmatched
+        }
+    }
+
+    public var isArmed: Bool { matcher.isArmed }
+
+    public mutating func reset() {
+        matcher.reset()
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/CustomCommandEngineTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/CustomCommandEngineTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+struct CustomCommandEngineTests {
+    private let ctrlA = Chord(mods: .control, key: "a")
+    private let g = Chord(mods: [], key: "g")
+    private let x = Chord(mods: [], key: "x")
+    private let cmdShiftE = Chord(mods: [.command, .shift], key: "e")
+
+    @Test func firesSimpleCommand() {
+        let command = CustomCommand(name: "edit", command: "zed {AGT_SESSION_PWD}", shortcut: "cmd+shift+e")
+        var engine = CustomCommandEngine(commands: [command])
+
+        #expect(engine.advance(cmdShiftE) == .fired(command))
+        #expect(!engine.isArmed)
+    }
+
+    @Test func armsThenFiresLeaderCommand() {
+        let command = CustomCommand(name: "git", command: "git status", shortcut: "ctrl+a>g")
+        var engine = CustomCommandEngine(commands: [command])
+
+        #expect(engine.advance(ctrlA) == .armed)
+        #expect(engine.isArmed)
+        #expect(engine.advance(g) == .fired(command))
+        #expect(!engine.isArmed)
+    }
+
+    @Test func unmatchedChordPassesThrough() {
+        let command = CustomCommand(name: "edit", command: "zed", shortcut: "cmd+shift+e")
+        var engine = CustomCommandEngine(commands: [command])
+
+        #expect(engine.advance(ctrlA) == .unmatched)
+        #expect(!engine.isArmed)
+    }
+
+    @Test func resetAbandonsLeaderSequence() {
+        let command = CustomCommand(name: "git", command: "git status", shortcut: "ctrl+a>g")
+        var engine = CustomCommandEngine(commands: [command])
+
+        #expect(engine.advance(ctrlA) == .armed)
+        engine.reset()
+        #expect(!engine.isArmed)
+        #expect(engine.advance(g) == .unmatched)
+    }
+
+    @Test func paletteOnlyCommandNeverMatchesAChord() {
+        let command = CustomCommand(name: "palette", command: "touch /tmp/x", shortcut: "")
+        var engine = CustomCommandEngine(commands: [command])
+
+        #expect(engine.advance(cmdShiftE) == .unmatched)
+        #expect(engine.advance(ctrlA) == .unmatched)
+    }
+
+    @Test func invalidShortcutCommandNeverMatchesAChord() {
+        let command = CustomCommand(name: "bad", command: "echo bad", shortcut: "ctrl+missing")
+        var engine = CustomCommandEngine(commands: [command])
+
+        #expect(engine.advance(ctrlA) == .unmatched)
+    }
+
+    @Test func wrongLeaderContinuationCanRestartAsFreshLeader() {
+        let command = CustomCommand(name: "git", command: "git status", shortcut: "ctrl+a>g")
+        var engine = CustomCommandEngine(commands: [command])
+
+        #expect(engine.advance(ctrlA) == .armed)
+        #expect(engine.advance(ctrlA) == .armed)
+        #expect(engine.advance(g) == .fired(command))
+    }
+
+    @Test func wrongLeaderContinuationCanFireSimpleCommand() {
+        let sequence = CustomCommand(name: "git", command: "git status", shortcut: "ctrl+a>g")
+        let simple = CustomCommand(name: "edit", command: "zed", shortcut: "cmd+shift+e")
+        var engine = CustomCommandEngine(commands: [sequence, simple])
+
+        #expect(engine.advance(ctrlA) == .armed)
+        #expect(engine.advance(cmdShiftE) == .fired(simple))
+        #expect(!engine.isArmed)
+    }
+
+    @Test func emptyEngineUnmatches() {
+        var engine = CustomCommandEngine(commands: [])
+
+        #expect(engine.advance(x) == .unmatched)
+        #expect(!engine.isArmed)
+    }
+}


### PR DESCRIPTION
## Summary

Hoists the custom-command keybind matcher into `agtermCore` and rewires the macOS runner to use the shared engine while keeping AppKit event handling, leader timers, context resolution, and process spawning app-side.

## Validation

- `cd agtermCore && swift test`
- `make lint`
- Debug `xcodebuild`
- focused `KeymapUITests`
- `codex review --base upstream/master`
