### PR TITLE
refactor: hoist static command catalog

### DIFF
--- a/agterm/AppActions+Palette.swift
+++ b/agterm/AppActions+Palette.swift
@@ -19,71 +19,77 @@ extension AppActions {
         return keymap.glyphHint(for: action)
     }
 
+    private var paletteContext: PaletteContext {
+        let activeStore = store
+        return PaletteContext(
+            canRemoveWorkspace: activeStore?.canRemoveWorkspace == true,
+            hasFlaggedSessions: activeStore?.flaggedSessions.isEmpty == false,
+            sidebarShowsWorkspaceTree: activeStore?.sidebarMode == .tree,
+            sidebarShowsFlaggedOnly: activeStore?.sidebarMode == .flagged,
+            activeSessionFlagged: activeStore?.activeSession?.flagged == true,
+            hasFocusedWorkspace: activeStore?.focusedWorkspaceID != nil,
+            activeSessionHasSplit: activeStore?.activeSession?.hasSplit == true
+        )
+    }
+
+    private func paletteItem(for command: PaletteCommand, context: PaletteContext) -> PaletteItem {
+        PaletteItem(title: command.title(in: context),
+                    shortcut: command.builtinAction.flatMap { shortcutGlyph(for: $0) }) { [weak self] in
+            self?.runPaletteCommand(command)
+        }
+    }
+
+    private func runPaletteCommand(_ command: PaletteCommand) {
+        switch command {
+        case .newSession: newSession()
+        case .newWorkspace: newWorkspace()
+        case .openDirectory: openDirectory()
+        case .renameSession: renameActiveSession()
+        case .renameWorkspace: renameActiveWorkspace()
+        case .closeSession: closeActiveSession()
+        case .clearStatus: clearActiveSessionStatus()
+        case .previousSession: selectPreviousSession()
+        case .nextSession: selectNextSession()
+        case .previousAttentionSession: selectPreviousAttentionSession()
+        case .nextAttentionSession: selectNextAttentionSession()
+        case .firstSession: selectFirstSession()
+        case .lastSession: selectLastSession()
+        case .showAttention: openAttentionPalette()
+        case .toggleSplit: toggleSplit()
+        case .toggleScratch: toggleScratch()
+        case .toggleSidebar: toggleSidebar()
+        case .toggleFlag: toggleFlagActiveSession()
+        case .focusWorkspace: focusActiveWorkspace()
+        case .find: toggleSearch()
+        case .quickTerminal: toggleQuickTerminal()
+        case .increaseFontSize: increaseFontSize()
+        case .decreaseFontSize: decreaseFontSize()
+        case .resetFontSize: resetFontSize()
+        case .selectTheme: openThemePalette()
+        case .editKeymap: editKeymap()
+        case .reloadKeymap: reloadKeymap()
+        case .editGhosttyConfig: editGhosttyConfig()
+        case .reloadConfig: reloadGhosttyConfig()
+        case .deleteWorkspace: deleteActiveWorkspace()
+        case .toggleFlaggedView: toggleFlaggedView()
+        case .clearFlagged: clearFlags()
+        case .clearFocus: clearFocus()
+        case .expandWorkspaces: expandAllWorkspaces()
+        case .collapseWorkspaces: collapseOtherWorkspaces()
+        case .focusLeftPane: focusPane(.main)
+        case .focusRightPane: focusPane(.split)
+        }
+    }
+
     /// The app's commands as palette items, sharing the same logic as the menu/buttons. Includes a
     /// "Move Session to …" item per other workspace (when there's an active session to move).
     func paletteActions() -> [PaletteItem] {
         // built-in shortcut hints read the live keymap (`shortcutGlyph`) so a rebind updates them too,
         // matching the data-driven menu key-equivalents; custom commands show their raw shortcut below.
-        var items: [PaletteItem] = [
-            PaletteItem(title: "New Session", shortcut: shortcutGlyph(for: .newSession)) { [weak self] in self?.newSession() },
-            PaletteItem(title: "New Workspace", shortcut: shortcutGlyph(for: .newWorkspace)) { [weak self] in self?.newWorkspace() },
-            PaletteItem(title: "Open Directory…", shortcut: shortcutGlyph(for: .openDirectory)) { [weak self] in self?.openDirectory() },
-            PaletteItem(title: "Rename Session", shortcut: shortcutGlyph(for: .renameSession)) { [weak self] in self?.renameActiveSession() },
-            PaletteItem(title: "Rename Workspace", shortcut: shortcutGlyph(for: .renameWorkspace)) { [weak self] in self?.renameActiveWorkspace() },
-            PaletteItem(title: "Close Session", shortcut: shortcutGlyph(for: .closeSession)) { [weak self] in self?.closeActiveSession() },
-            PaletteItem(title: "Clear Status", shortcut: shortcutGlyph(for: .clearStatus)) { [weak self] in self?.clearActiveSessionStatus() },
-            PaletteItem(title: "Previous Session", shortcut: shortcutGlyph(for: .previousSession)) { [weak self] in self?.selectPreviousSession() },
-            PaletteItem(title: "Next Session", shortcut: shortcutGlyph(for: .nextSession)) { [weak self] in self?.selectNextSession() },
-            PaletteItem(title: "Previous Attention Session", shortcut: shortcutGlyph(for: .previousAttentionSession)) { [weak self] in self?.selectPreviousAttentionSession() },
-            PaletteItem(title: "Next Attention Session", shortcut: shortcutGlyph(for: .nextAttentionSession)) { [weak self] in self?.selectNextAttentionSession() },
-            PaletteItem(title: "First Session", shortcut: shortcutGlyph(for: .firstSession)) { [weak self] in self?.selectFirstSession() },
-            PaletteItem(title: "Last Session", shortcut: shortcutGlyph(for: .lastSession)) { [weak self] in self?.selectLastSession() },
-            PaletteItem(title: "Show Attention", shortcut: shortcutGlyph(for: .showAttention)) { [weak self] in self?.openAttentionPalette() },
-            PaletteItem(title: "Toggle Split", shortcut: shortcutGlyph(for: .toggleSplit)) { [weak self] in self?.toggleSplit() },
-            PaletteItem(title: "Toggle Scratch", shortcut: shortcutGlyph(for: .toggleScratch)) { [weak self] in self?.toggleScratch() },
-            PaletteItem(title: "Toggle Sidebar", shortcut: shortcutGlyph(for: .toggleSidebar)) { [weak self] in self?.toggleSidebar() },
-            PaletteItem(title: (store?.activeSession?.flagged == true) ? "Unflag Session" : "Flag Session",
-                        shortcut: shortcutGlyph(for: .toggleFlag)) { [weak self] in self?.toggleFlagActiveSession() },
-            PaletteItem(title: "Focus Workspace",
-                        shortcut: shortcutGlyph(for: .focusWorkspace)) { [weak self] in self?.focusActiveWorkspace() },
-            PaletteItem(title: "Find…", shortcut: shortcutGlyph(for: .toggleSearch)) { [weak self] in self?.toggleSearch() },
-            PaletteItem(title: "Quick Terminal", shortcut: shortcutGlyph(for: .quickTerminal)) { [weak self] in self?.toggleQuickTerminal() },
-            PaletteItem(title: "Increase Font Size", shortcut: shortcutGlyph(for: .increaseFontSize)) { [weak self] in self?.increaseFontSize() },
-            PaletteItem(title: "Decrease Font Size", shortcut: shortcutGlyph(for: .decreaseFontSize)) { [weak self] in self?.decreaseFontSize() },
-            PaletteItem(title: "Actual Font Size", shortcut: shortcutGlyph(for: .resetFontSize)) { [weak self] in self?.resetFontSize() },
-            PaletteItem(title: "Select Theme…", shortcut: shortcutGlyph(for: .selectTheme)) { [weak self] in self?.openThemePalette() },
-            PaletteItem(title: "Edit Keymap") { [weak self] in self?.editKeymap() },
-            PaletteItem(title: "Reload Keymap") { [weak self] in self?.reloadKeymap() },
-            PaletteItem(title: "Edit ghostty.conf") { [weak self] in self?.editGhosttyConfig() },
-            PaletteItem(title: "Reload Config") { [weak self] in self?.reloadGhosttyConfig() },
-        ]
-        if store?.canRemoveWorkspace == true {
-            items.append(PaletteItem(title: "Delete Workspace", shortcut: shortcutGlyph(for: .deleteWorkspace)) { [weak self] in self?.deleteActiveWorkspace() })
-        }
-        // the flagged-view toggle: omitted when there's nothing to show (tree mode + no flags); always
-        // present in flagged mode so the palette can switch back to the tree.
-        if store?.sidebarMode == .flagged || store?.flaggedSessions.isEmpty == false {
-            items.append(PaletteItem(title: store?.sidebarMode == .flagged ? "Show All Sessions" : "Show Flagged Sessions",
-                                     shortcut: shortcutGlyph(for: .toggleFlaggedView)) { [weak self] in self?.toggleFlaggedView() })
-        }
-        // plain (non-BuiltinAction) clear, shown only while the working-set is non-empty.
-        if store?.flaggedSessions.isEmpty == false {
-            items.append(PaletteItem(title: "Clear Flagged") { [weak self] in self?.clearFlags() })
-        }
-        // plain (non-BuiltinAction) unfocus, shown only while a workspace is focused.
-        if store?.focusedWorkspaceID != nil {
-            items.append(PaletteItem(title: "Clear Focus") { [weak self] in self?.clearFocus() })
-        }
-        // plain (non-BuiltinAction) sidebar tree expand/collapse, tree mode only (no workspace rows in
-        // flagged mode), like the disabled-in-flagged menu items.
-        if store?.sidebarMode == .tree {
-            items.append(PaletteItem(title: "Expand Workspaces") { [weak self] in self?.expandAllWorkspaces() })
-            items.append(PaletteItem(title: "Collapse Workspaces") { [weak self] in self?.collapseOtherWorkspaces() })
-        }
-        if store?.activeSession?.hasSplit == true {
-            items.append(PaletteItem(title: "Focus Left Pane", shortcut: shortcutGlyph(for: .focusLeftPane)) { [weak self] in self?.focusPane(.main) })
-            items.append(PaletteItem(title: "Focus Right Pane", shortcut: shortcutGlyph(for: .focusRightPane)) { [weak self] in self?.focusPane(.split) })
-        }
+        let context = paletteContext
+        var items = PaletteCommand.allCases
+            .filter { $0.isVisible(in: context) }
+            .map { paletteItem(for: $0, context: context) }
         items.append(PaletteItem(title: "New Window", shortcut: shortcutGlyph(for: .newWindow)) { [weak self] in self?.newWindow() })
         items.append(PaletteItem(title: "Rename Window", shortcut: shortcutGlyph(for: .renameWindow)) { [weak self] in self?.renameActiveWindow() })
         if library.canRemoveWindow {

--- a/agtermCore/Sources/agtermCore/PaletteCatalog.swift
+++ b/agtermCore/Sources/agtermCore/PaletteCatalog.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+/// The UI facts needed to decide which static action-palette rows are relevant right now.
+public struct PaletteContext: Sendable, Equatable {
+    public let canRemoveWorkspace: Bool
+    public let hasFlaggedSessions: Bool
+    public let sidebarShowsWorkspaceTree: Bool
+    public let sidebarShowsFlaggedOnly: Bool
+    public let activeSessionFlagged: Bool
+    public let hasFocusedWorkspace: Bool
+    public let activeSessionHasSplit: Bool
+
+    public init(canRemoveWorkspace: Bool = false,
+                hasFlaggedSessions: Bool = false,
+                sidebarShowsWorkspaceTree: Bool = false,
+                sidebarShowsFlaggedOnly: Bool = false,
+                activeSessionFlagged: Bool = false,
+                hasFocusedWorkspace: Bool = false,
+                activeSessionHasSplit: Bool = false) {
+        self.canRemoveWorkspace = canRemoveWorkspace
+        self.hasFlaggedSessions = hasFlaggedSessions
+        self.sidebarShowsWorkspaceTree = sidebarShowsWorkspaceTree
+        self.sidebarShowsFlaggedOnly = sidebarShowsFlaggedOnly
+        self.activeSessionFlagged = activeSessionFlagged
+        self.hasFocusedWorkspace = hasFocusedWorkspace
+        self.activeSessionHasSplit = activeSessionHasSplit
+    }
+}
+
+/// Static action-palette rows, in the same order the macOS palette presents them before dynamic rows.
+public enum PaletteCommand: String, CaseIterable, Sendable {
+    case newSession, newWorkspace, openDirectory
+    case renameSession, renameWorkspace, closeSession, clearStatus
+    case previousSession, nextSession, previousAttentionSession, nextAttentionSession
+    case firstSession, lastSession, showAttention
+    case toggleSplit, toggleScratch, toggleSidebar, toggleFlag, focusWorkspace
+    case find, quickTerminal
+    case increaseFontSize, decreaseFontSize, resetFontSize, selectTheme
+    case editKeymap, reloadKeymap, editGhosttyConfig, reloadConfig
+    case deleteWorkspace, toggleFlaggedView, clearFlagged, clearFocus
+    case expandWorkspaces, collapseWorkspaces, focusLeftPane, focusRightPane
+
+    public func isVisible(in context: PaletteContext) -> Bool {
+        switch self {
+        case .deleteWorkspace:
+            return context.canRemoveWorkspace
+        case .toggleFlaggedView:
+            return context.sidebarShowsFlaggedOnly || context.hasFlaggedSessions
+        case .clearFlagged:
+            return context.hasFlaggedSessions
+        case .clearFocus:
+            return context.hasFocusedWorkspace
+        case .expandWorkspaces, .collapseWorkspaces:
+            return context.sidebarShowsWorkspaceTree
+        case .focusLeftPane, .focusRightPane:
+            return context.activeSessionHasSplit
+        default:
+            return true
+        }
+    }
+
+    public var title: String {
+        title(in: PaletteContext())
+    }
+
+    public func title(in context: PaletteContext) -> String {
+        switch self {
+        case .newSession: return "New Session"
+        case .newWorkspace: return "New Workspace"
+        case .openDirectory: return "Open Directory…"
+        case .renameSession: return "Rename Session"
+        case .renameWorkspace: return "Rename Workspace"
+        case .closeSession: return "Close Session"
+        case .clearStatus: return "Clear Status"
+        case .previousSession: return "Previous Session"
+        case .nextSession: return "Next Session"
+        case .previousAttentionSession: return "Previous Attention Session"
+        case .nextAttentionSession: return "Next Attention Session"
+        case .firstSession: return "First Session"
+        case .lastSession: return "Last Session"
+        case .showAttention: return "Show Attention"
+        case .toggleSplit: return "Toggle Split"
+        case .toggleScratch: return "Toggle Scratch"
+        case .toggleSidebar: return "Toggle Sidebar"
+        case .toggleFlag: return context.activeSessionFlagged ? "Unflag Session" : "Flag Session"
+        case .focusWorkspace: return "Focus Workspace"
+        case .find: return "Find…"
+        case .quickTerminal: return "Quick Terminal"
+        case .increaseFontSize: return "Increase Font Size"
+        case .decreaseFontSize: return "Decrease Font Size"
+        case .resetFontSize: return "Actual Font Size"
+        case .selectTheme: return "Select Theme…"
+        case .editKeymap: return "Edit Keymap"
+        case .reloadKeymap: return "Reload Keymap"
+        case .editGhosttyConfig: return "Edit ghostty.conf"
+        case .reloadConfig: return "Reload Config"
+        case .deleteWorkspace: return "Delete Workspace"
+        case .toggleFlaggedView: return context.sidebarShowsFlaggedOnly ? "Show All Sessions" : "Show Flagged Sessions"
+        case .clearFlagged: return "Clear Flagged"
+        case .clearFocus: return "Clear Focus"
+        case .expandWorkspaces: return "Expand Workspaces"
+        case .collapseWorkspaces: return "Collapse Workspaces"
+        case .focusLeftPane: return "Focus Left Pane"
+        case .focusRightPane: return "Focus Right Pane"
+        }
+    }
+
+    public var builtinAction: BuiltinAction? {
+        switch self {
+        case .newSession: return .newSession
+        case .newWorkspace: return .newWorkspace
+        case .openDirectory: return .openDirectory
+        case .renameSession: return .renameSession
+        case .renameWorkspace: return .renameWorkspace
+        case .closeSession: return .closeSession
+        case .clearStatus: return .clearStatus
+        case .previousSession: return .previousSession
+        case .nextSession: return .nextSession
+        case .previousAttentionSession: return .previousAttentionSession
+        case .nextAttentionSession: return .nextAttentionSession
+        case .firstSession: return .firstSession
+        case .lastSession: return .lastSession
+        case .showAttention: return .showAttention
+        case .toggleSplit: return .toggleSplit
+        case .toggleScratch: return .toggleScratch
+        case .toggleSidebar: return .toggleSidebar
+        case .toggleFlag: return .toggleFlag
+        case .focusWorkspace: return .focusWorkspace
+        case .find: return .toggleSearch
+        case .quickTerminal: return .quickTerminal
+        case .increaseFontSize: return .increaseFontSize
+        case .decreaseFontSize: return .decreaseFontSize
+        case .resetFontSize: return .resetFontSize
+        case .selectTheme: return .selectTheme
+        case .deleteWorkspace: return .deleteWorkspace
+        case .toggleFlaggedView: return .toggleFlaggedView
+        case .focusLeftPane: return .focusLeftPane
+        case .focusRightPane: return .focusRightPane
+        case .editKeymap, .reloadKeymap, .editGhosttyConfig, .reloadConfig,
+             .clearFlagged, .clearFocus, .expandWorkspaces, .collapseWorkspaces:
+            return nil
+        }
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/PaletteCatalogTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/PaletteCatalogTests.swift
@@ -1,0 +1,98 @@
+import Testing
+@testable import agtermCore
+
+struct PaletteCatalogTests {
+    @Test func titlesMatchThePaletteSourceOrder() {
+        #expect(PaletteCommand.allCases.map(\.title) == [
+            "New Session",
+            "New Workspace",
+            "Open Directory…",
+            "Rename Session",
+            "Rename Workspace",
+            "Close Session",
+            "Clear Status",
+            "Previous Session",
+            "Next Session",
+            "Previous Attention Session",
+            "Next Attention Session",
+            "First Session",
+            "Last Session",
+            "Show Attention",
+            "Toggle Split",
+            "Toggle Scratch",
+            "Toggle Sidebar",
+            "Flag Session",
+            "Focus Workspace",
+            "Find…",
+            "Quick Terminal",
+            "Increase Font Size",
+            "Decrease Font Size",
+            "Actual Font Size",
+            "Select Theme…",
+            "Edit Keymap",
+            "Reload Keymap",
+            "Edit ghostty.conf",
+            "Reload Config",
+            "Delete Workspace",
+            "Show Flagged Sessions",
+            "Clear Flagged",
+            "Clear Focus",
+            "Expand Workspaces",
+            "Collapse Workspaces",
+            "Focus Left Pane",
+            "Focus Right Pane",
+        ])
+    }
+
+    @Test func catalogHasTheExpectedStaticCommandCount() {
+        #expect(PaletteCommand.allCases.count == 37)
+    }
+
+    @Test func idsRoundTripThroughRawValue() {
+        for command in PaletteCommand.allCases {
+            #expect(PaletteCommand(rawValue: command.rawValue) == command)
+        }
+    }
+
+    @Test func contextTitlesMatchToggleState() {
+        #expect(PaletteCommand.toggleFlag.title(in: PaletteContext(activeSessionFlagged: false)) == "Flag Session")
+        #expect(PaletteCommand.toggleFlag.title(in: PaletteContext(activeSessionFlagged: true)) == "Unflag Session")
+        #expect(PaletteCommand.toggleFlaggedView.title(in: PaletteContext(sidebarShowsFlaggedOnly: false)) == "Show Flagged Sessions")
+        #expect(PaletteCommand.toggleFlaggedView.title(in: PaletteContext(sidebarShowsFlaggedOnly: true)) == "Show All Sessions")
+    }
+
+    @Test func clearFlaggedVisibleOnlyWhenSomethingIsFlagged() {
+        #expect(!PaletteCommand.clearFlagged.isVisible(in: PaletteContext(hasFlaggedSessions: false)))
+        #expect(PaletteCommand.clearFlagged.isVisible(in: PaletteContext(hasFlaggedSessions: true)))
+    }
+
+    @Test func flaggedToggleVisibleWithFlagsOrWhileAlreadyInFlaggedView() {
+        #expect(!PaletteCommand.toggleFlaggedView.isVisible(in: PaletteContext()))
+        #expect(PaletteCommand.toggleFlaggedView.isVisible(in: PaletteContext(hasFlaggedSessions: true)))
+        #expect(PaletteCommand.toggleFlaggedView.isVisible(in: PaletteContext(sidebarShowsFlaggedOnly: true)))
+    }
+
+    @Test func treeExpansionCommandsShowOnlyInWorkspaceTreeMode() {
+        #expect(PaletteCommand.expandWorkspaces.isVisible(in: PaletteContext(sidebarShowsWorkspaceTree: true)))
+        #expect(PaletteCommand.collapseWorkspaces.isVisible(in: PaletteContext(sidebarShowsWorkspaceTree: true)))
+        #expect(!PaletteCommand.expandWorkspaces.isVisible(in: PaletteContext(sidebarShowsWorkspaceTree: false)))
+        #expect(!PaletteCommand.collapseWorkspaces.isVisible(in: PaletteContext(sidebarShowsWorkspaceTree: false)))
+    }
+
+    @Test func workspaceAndSplitCommandsFollowTheirPredicates() {
+        #expect(!PaletteCommand.deleteWorkspace.isVisible(in: PaletteContext(canRemoveWorkspace: false)))
+        #expect(PaletteCommand.deleteWorkspace.isVisible(in: PaletteContext(canRemoveWorkspace: true)))
+        #expect(!PaletteCommand.clearFocus.isVisible(in: PaletteContext(hasFocusedWorkspace: false)))
+        #expect(PaletteCommand.clearFocus.isVisible(in: PaletteContext(hasFocusedWorkspace: true)))
+        #expect(!PaletteCommand.focusLeftPane.isVisible(in: PaletteContext(activeSessionHasSplit: false)))
+        #expect(PaletteCommand.focusRightPane.isVisible(in: PaletteContext(activeSessionHasSplit: true)))
+    }
+
+    @Test func builtinMappingsCoverRebindableCommands() {
+        #expect(PaletteCommand.newSession.builtinAction == .newSession)
+        #expect(PaletteCommand.find.builtinAction == .toggleSearch)
+        #expect(PaletteCommand.resetFontSize.builtinAction == .resetFontSize)
+        #expect(PaletteCommand.clearFlagged.builtinAction == nil)
+        #expect(PaletteCommand.expandWorkspaces.builtinAction == nil)
+    }
+}

--- a/agtermUITests/PaletteUITests.swift
+++ b/agtermUITests/PaletteUITests.swift
@@ -123,6 +123,42 @@ final class PaletteUITests: XCTestCase {
         app.typeKey(.escape, modifierFlags: []) // revert the preview
     }
 
+    func testActionPaletteClearFlaggedVisibilityTracksFlagState() throws {
+        openPalette("Command Palette")
+        typeIntoPalette("Clear Flagged")
+        XCTAssertFalse(app.staticTexts["Clear Flagged"].waitForExistence(timeout: 1),
+                       "Clear Flagged should be omitted while no session is flagged")
+        app.typeKey(.escape, modifierFlags: [])
+
+        invokeViewMenuItem("Flag Session")
+        openPalette("Command Palette")
+        typeIntoPalette("Clear Flagged")
+        XCTAssertTrue(app.staticTexts["Clear Flagged"].waitForExistence(timeout: 5),
+                      "Clear Flagged should appear once a session is flagged")
+    }
+
+    func testActionPaletteHidesExpandCollapseInFlaggedView() throws {
+        invokeViewMenuItem("Flag Session")
+
+        openPalette("Command Palette")
+        typeIntoPalette("Expand Workspaces")
+        XCTAssertTrue(app.staticTexts["Expand Workspaces"].waitForExistence(timeout: 5),
+                      "Expand Workspaces should appear in the normal workspace tree")
+        app.typeKey(.escape, modifierFlags: [])
+
+        invokeViewMenuItem("Show Flagged Sessions")
+        openPalette("Command Palette")
+        typeIntoPalette("Expand Workspaces")
+        XCTAssertFalse(app.staticTexts["Expand Workspaces"].waitForExistence(timeout: 1),
+                       "Expand Workspaces should be omitted in the flat flagged view")
+        app.typeKey(.escape, modifierFlags: [])
+
+        openPalette("Command Palette")
+        typeIntoPalette("Collapse Workspaces")
+        XCTAssertFalse(app.staticTexts["Collapse Workspaces"].waitForExistence(timeout: 1),
+                       "Collapse Workspaces should be omitted in the flat flagged view")
+    }
+
     // MARK: - Helpers
 
     /// The theme line the live config currently applies, read from <stateDir>/ghostty-settings.conf
@@ -154,6 +190,13 @@ final class PaletteUITests: XCTestCase {
         app.menuBars.menuBarItems["Navigate"].click()
         let item = app.menuItems[menuTitle]
         XCTAssertTrue(item.waitForExistence(timeout: 5), "Navigate menu should offer \(menuTitle)")
+        item.click()
+    }
+
+    private func invokeViewMenuItem(_ title: String) {
+        app.menuBars.menuBarItems["View"].click()
+        let item = app.menuItems[title].firstMatch
+        XCTAssertTrue(item.waitForExistence(timeout: 5), "View menu should offer \(title)")
         item.click()
     }
 


### PR DESCRIPTION
## Summary
- add a host-free `PaletteCommand` catalog and `PaletteContext` visibility predicates in `agtermCore`
- rewire macOS `paletteActions()` to build static rows from the core catalog with an exhaustive command switch
- keep window, move-session, and custom-command rows in macOS code
- add focused core and palette UI coverage for titles/order and visibility predicates

## Validation
- `swift test --filter PaletteCatalogTests`
- `cd agtermCore && swift test`
- `make lint`
- `./scripts/setup.sh`
- `xcodegen generate`
- `xcodebuild -project agterm.xcodeproj -scheme agterm -configuration Debug -derivedDataPath build/DerivedData build`
- `xcodebuild -project agterm.xcodeproj -scheme agterm -configuration Debug -derivedDataPath build/DerivedData test -only-testing:agtermUITests/PaletteUITests/testActionPaletteClearFlaggedVisibilityTracksFlagState -only-testing:agtermUITests/PaletteUITests/testActionPaletteHidesExpandCollapseInFlaggedView`