### PR TITLE
refactor: hoist resolution error messages

### DIFF
--- a/agterm/Control/ControlTargetResolver.swift
+++ b/agterm/Control/ControlTargetResolver.swift
@@ -144,11 +144,8 @@ final class ControlTargetResolver {
     /// "no such <noun>: …" / "ambiguous <noun> prefix '…' → <prefix8 list>" strings, which tests pin).
     /// `.resolved` maps to the not-found string too, covering the across-windows owner-lookup miss.
     private func resolutionError(_ noun: String, target: String, _ resolution: TargetResolution) -> ControlResponse {
-        guard case .ambiguous(let hits) = resolution else {
-            return ControlResponse(ok: false, error: "no such \(noun): \(target)")
-        }
-        let listed = hits.map { String($0.uuidString.prefix(8)) }.joined(separator: ", ")
-        return ControlResponse(ok: false, error: "ambiguous \(noun) prefix '\(target)' → \(listed)")
+        let message = ControlResolve.errorMessage(noun: noun, target: target, resolution: resolution)
+        return ControlResponse(ok: false, error: message)
     }
 
     /// Resolve a window `target` (defaulting to `active` = frontmost) to a window id, or the structured

--- a/agtermCore/Sources/agtermCore/ControlResolve.swift
+++ b/agtermCore/Sources/agtermCore/ControlResolve.swift
@@ -40,6 +40,26 @@ public enum ControlResolve {
         }
     }
 
+    /// The canonical not-found control error for a target resolution miss.
+    public static func notFoundMessage(noun: String, target: String) -> String {
+        "no such \(noun): \(target)"
+    }
+
+    /// The canonical ambiguous-prefix control error, listing matching ids by their first 8 characters.
+    public static func ambiguousMessage(noun: String, target: String, hits: [UUID]) -> String {
+        let listed = hits.map { String($0.uuidString.prefix(8)) }.joined(separator: ", ")
+        return "ambiguous \(noun) prefix '\(target)' → \(listed)"
+    }
+
+    /// The canonical control error for an unresolved target. `.resolved` maps to not-found so callers
+    /// that resolve an id but cannot find its owner keep the same wire contract as a normal miss.
+    public static func errorMessage(noun: String, target: String, resolution: TargetResolution) -> String {
+        guard case .ambiguous(let hits) = resolution else {
+            return notFoundMessage(noun: noun, target: target)
+        }
+        return ambiguousMessage(noun: noun, target: target, hits: hits)
+    }
+
     /// Derive the control socket path. With `stateDir` (the `AGTERM_STATE_DIR` value, if set) it is
     /// `<stateDir>/agterm.sock`; otherwise `<appSupport>/agterm.sock`. The app and the CLI both call this
     /// with the same inputs, so they always rendezvous on the same path.

--- a/agtermCore/Tests/agtermCoreTests/ControlResolveTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlResolveTests.swift
@@ -55,6 +55,26 @@ struct ControlResolveTests {
         #expect(ControlResolve.resolve("", candidates: [a], active: nil) == .notFound)
     }
 
+    @Test func notFoundMessageUsesControlWireString() {
+        let message = ControlResolve.notFoundMessage(noun: "session", target: "deadbeef")
+        #expect(message == "no such session: deadbeef")
+    }
+
+    @Test func ambiguousMessageUsesControlWireStringWithPrefix8List() {
+        let message = ControlResolve.ambiguousMessage(noun: "window", target: "9f", hits: [a, b])
+        #expect(message == "ambiguous window prefix '9f' → 9F3CAAAA, 9FABBBBB")
+    }
+
+    @Test func errorMessageUsesAmbiguousWireString() {
+        let message = ControlResolve.errorMessage(noun: "workspace", target: "9f", resolution: .ambiguous([a, b]))
+        #expect(message == "ambiguous workspace prefix '9f' → 9F3CAAAA, 9FABBBBB")
+    }
+
+    @Test func errorMessageMapsNonAmbiguousResultsToNotFoundWireString() {
+        #expect(ControlResolve.errorMessage(noun: "session", target: "active", resolution: .notFound) == "no such session: active")
+        #expect(ControlResolve.errorMessage(noun: "session", target: "active", resolution: .resolved(a)) == "no such session: active")
+    }
+
     // window-id targets reuse the same pure resolver: candidates are window ids, active is the
     // frontmost window. No window-specific resolver function exists — the cross-window
     // session->store mapping is app-side ControlServer logic (Task 7), not a resolve concern.

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -722,8 +722,8 @@ final class ControlAPIUITests: ControlAPITestCase {
     // an ambiguous-prefix request returns the `ambiguous` error listing the candidate ids and changes nothing:
     // seed two sessions whose ids share a prefix, then select by that shared prefix.
     func testSessionSelectAmbiguousPrefixErrors() throws {
-        let firstID = UUID(uuidString: "ABCD0000-0000-0000-0000-000000000001")!
-        let secondID = UUID(uuidString: "ABCD0000-0000-0000-0000-000000000002")!
+        let firstID = UUID(uuidString: "ABCD1111-0000-0000-0000-000000000001")!
+        let secondID = UUID(uuidString: "ABCD2222-0000-0000-0000-000000000002")!
         let snapshot = """
         {"version":1,"selectedSessionID":"\(firstID.uuidString)","workspaces":[\
         {"id":"\(UUID().uuidString)","name":"workspace 1","sessions":[\
@@ -736,12 +736,8 @@ final class ControlAPIUITests: ControlAPITestCase {
         let response = try sendCommand(#"{"cmd":"session.select","target":"abcd"}"#)
         XCTAssertEqual(response["ok"] as? Bool, false, "an ambiguous prefix should fail")
         let error = try XCTUnwrap(response["error"] as? String, "an ambiguous prefix should carry an error")
-        XCTAssertTrue(error.hasPrefix("ambiguous session prefix 'abcd'"), "should report the ambiguous prefix, got: \(error)")
-        // both 8-char candidate prefixes must be listed.
-        XCTAssertTrue(error.contains(String(firstID.uuidString.prefix(8)).lowercased())
-                      || error.contains(String(firstID.uuidString.prefix(8))), "should list the first candidate, got: \(error)")
-        XCTAssertTrue(error.contains(String(secondID.uuidString.prefix(8)).lowercased())
-                      || error.contains(String(secondID.uuidString.prefix(8))), "should list the second candidate, got: \(error)")
+        XCTAssertEqual(error, "ambiguous session prefix 'abcd' → ABCD1111, ABCD2222",
+                       "should report the exact ambiguous-prefix wire string")
         // selection must be unchanged (the originally-selected first session stays active).
         XCTAssertTrue(pollActiveSessionID(firstID, timeout: 5), "an ambiguous select must not change the active session")
     }


### PR DESCRIPTION
## Summary
- add pure control resolution error-message helpers in agtermCore
- route the macOS ControlServer resolution errors through the core helper
- pin exact not-found and ambiguous wire strings in core tests and focused UI coverage

## Validation
- `cd agtermCore && swift test --filter ControlResolveTests`
- `cd agtermCore && swift test`
- `make lint`
- `make build`
- `xcodebuild test -project agterm.xcodeproj -scheme agterm -destination 'platform=macOS' -only-testing:agtermUITests/ControlAPIUITests/testSessionSelectAmbiguousPrefixErrors -only-testing:agtermUITests/ControlAPIUITests/testCrossWindowUnknownIDErrors`