### PR TITLE
feat: per-overlay background color for session.overlay.open

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -358,8 +358,16 @@ paths:
   one program (`args.command`, e.g. a TUI); by default it is full single-pane size,
   hiding the single/split underneath, but `args.sizePercent` (1–100, clamped in `openOverlay`) makes
   it a *floating* opaque framed panel at that percent of the pane with the session still visible.
+  `args.color` (`#rrggbb`, REUSING the `session.background` field — no new arg — validated by the shared
+  `WatermarkConfig.isValidColorHex` at BOTH the CLI `validate()` and the server arm) gives the overlay
+  pane its OWN solid background color, independent of the session's `session.background color`;
+  the overlay is sessionless, so it is applied to the overlay SURFACE (not via the session) as the SAME
+  `.color` per-surface config overlay (`WatermarkConfig.overlayText` → `configWithOverlay`,
+  honoring window translucency), built in `GhosttySurfaceView.applyOverlayBackgroundColor` from the
+  view's `overlayBackgroundColorHex` in `createSurface` — works identically for the full + floating variants.
   `AppStore.openOverlay`/`closeOverlay` set non-persisted `Session.overlay*` state (incl.
-  `overlaySizePercent`, nil = full / non-nil = floating), and the surface runs `config.command` with
+  `overlaySizePercent`, nil = full / non-nil = floating; and `overlayBackgroundColor`,
+  set at open / cleared at close), and the surface runs `config.command` with
   `onExit → closeOverlay`.
   The two variants render in DIFFERENT places.
   The FULL overlay is an in-deck ZStack sibling in `WindowContentView.sessionDetail` (`.zIndex(1)` above the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,10 @@ The app must build, `swift test` must stay green, and `make lint` must pass afte
   unsigned DMG (`AGTERM_ALLOW_UNSIGNED=1`), publishes the GitHub release,
   and bumps the Homebrew cask in `umputun/homebrew-apps` (needs the `HOMEBREW_TAP_PAT` secret,
   not the default token).
+  **`CHANGELOG.md` is RELEASE-ONLY — never touch it in a feature PR.**
+  It is written only at release time (the `docs: update changelog for vX.Y.Z` commit / the release flow).
+  A feature's own doc updates go to `README.md`, the bundled `agterm/Resources/agent-skill/`,
+  and the relevant `.claude/rules/*.md` note — not the changelog.
 
 ## GhosttyKit.xcframework
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ With no selection it exits non-zero with `no selection`. The selection must be m
 agtermctl session overlay open "revdiff HEAD~3" --target 9f3c  # review the last 3 commits over session 9f3c
 agtermctl session overlay open "htop"                          # on the active session
 agtermctl session overlay open "htop" --size-percent 70        # a floating, framed panel at 70% of the pane
+agtermctl session overlay open "revdiff HEAD~3" --size-percent 80 --background-color "#2a1a3a"  # tint the overlay pane
 agtermctl session overlay open "make test" --wait              # keep the overlay open after exit (press a key to close)
 agtermctl session overlay open "make test" --block             # block until it exits; exit with its status
 agtermctl session overlay close --target 9f3c                  # close it from a script

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -498,10 +498,14 @@ final class ControlServer {
             guard let command = request.args?.command, !command.isEmpty else {
                 return ControlResponse(ok: false, error: "session.overlay.open requires a command")
             }
+            if let color = request.args?.color, !WatermarkConfig.isValidColorHex(color) {
+                return ControlResponse(ok: false, error: "invalid color: \(color) (#rrggbb)")
+            }
             return resolver.resolveSession(request.target, window: request.args?.window) { store, id in
                 guard store.openOverlay(id, command: command, cwd: request.args?.cwd,
                                         wait: request.args?.wait ?? false,
-                                        sizePercent: request.args?.sizePercent) else {
+                                        sizePercent: request.args?.sizePercent,
+                                        backgroundColor: request.args?.color) else {
                     return ControlResponse(ok: false, error: "overlay already open")
                 }
                 // a FLOATING overlay (sizePercent set) renders only for the ACTIVE session, so on a non-active

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -75,6 +75,12 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     /// nil for non-capturing surfaces.
     var overlayCodeFile: String?
 
+    /// For an OVERLAY surface: its own solid background color as `#rrggbb` (`session.overlay.open
+    /// --background-color`), or nil for the default theme background. Applied in `createSurface` once the
+    /// surface exists — the overlay carries no `session`, so the session-watermark path skips it. Set by
+    /// the overlay factory from `Session.overlayBackgroundColor`.
+    var overlayBackgroundColorHex: String?
+
     /// For a capturing overlay surface: receives the parsed exit status read from `overlayCodeFile` on
     /// teardown. Set by the overlay factory to record it onto the session for `session.overlay.result`.
     /// Called from `destroySurface` (main actor) on every in-process teardown, so the status is captured
@@ -507,6 +513,27 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         applyWatermarkFromSession()
     }
 
+    /// Applies a solid background color to a sessionless OVERLAY surface (`session.overlay.open
+    /// --background-color`). Mirrors `applyWatermarkFromSession`'s `.color` path but reads the overlay's
+    /// own `overlayBackgroundColorHex` + `initialFontSize` instead of a session — the overlay carries no
+    /// `session`, so that path skips it. Bakes the window translucency into `background-opacity` at open
+    /// time (the ephemeral overlay gets no live updates, so it does not re-track a later opacity change —
+    /// unlike a session `.color`). A no-op — or a malformed hex, rejected by the leading `isValidColorHex`
+    /// guard — leaves the plain base config. Retains the per-surface config in `ownedConfigs`, freed on teardown.
+    func applyOverlayBackgroundColor() {
+        guard let surface, let hex = overlayBackgroundColorHex, WatermarkConfig.isValidColorHex(hex) else { return }
+        let overlay = WatermarkConfig.overlayText(watermark: BackgroundWatermark(kind: .color, colorHex: hex),
+                                                  resolvedImagePath: nil, fontSize: initialFontSize.map(Double.init),
+                                                  windowOpacity: GhosttyApp.shared.windowOpacity)
+        guard let config = GhosttyApp.shared.configWithOverlay(overlay) else {
+            NSLog("overlay background: per-surface config build failed")
+            return
+        }
+        ghostty_surface_update_config(surface, config)
+        ownedConfigs.forEach { ghostty_config_free($0) }
+        ownedConfigs = [config]
+    }
+
     func reportFontSize() {
         // Already on the main actor (the CELL_SIZE callback hops via DispatchQueue.main.async).
         // inherited_config carries the surface's live font size (post cmd +/-); a zero means
@@ -616,6 +643,9 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         // a snapshot) applies it now that the surface exists — covering deferred-size creation, the eager
         // deck, and relaunch. No-op for the sessionless overlay/scratch/quick surfaces.
         if session?.backgroundWatermark != nil { applyWatermarkFromSession() }
+        // an overlay surface with its own background color (session.overlay.open --background-color) applies
+        // it here too — the overlay is sessionless, so the watermark path above skips it.
+        if overlayBackgroundColorHex != nil { applyOverlayBackgroundColor() }
 
         // the overlay grabs first responder itself (TerminalView's once-on-attach grab misses the
         // deferred overlay surface); a bounded run-loop retry beats the SwiftUI/AppKit responder race.

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -134,8 +134,10 @@ spec — image/text watermark or solid color — set via `session background`, o
   terminal background color. Per session; survives restart. `--opacity` 0.0–1.0. (An image/text watermark
   renders the pane opaque, overriding window translucency, so it shows; a `color` takes no opacity and
   honors the Settings window translucency instead.)
-- `overlay open <command> [--cwd DIR] [--wait] [--block] [--size-percent N]` · `overlay close` ·
-  `overlay result` — run a program on top of a session; `--block` waits and exits with its status. An
+- `overlay open <command> [--cwd DIR] [--wait] [--block] [--size-percent N] [--background-color #rrggbb]` ·
+  `overlay close` ·
+  `overlay result` — run a program on top of a session; `--block` waits and exits with its status.
+  `--background-color` gives the overlay pane its own solid color, independent of the session's. An
   overlay is a real terminal (pty), which is also how you **display an image inline** — via the bundled
   `scripts/show-image.sh` (see below).
 

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -100,6 +100,8 @@ Floating panel variant (session stays visible behind it):
 
 ```bash
 agtermctl session overlay open "htop" --target "$AGTERM_SESSION_ID" --size-percent 70   # this session
+# tint the overlay pane so it stands out from the session behind it:
+agtermctl session overlay open "revdiff HEAD~3" --target "$AGTERM_SESSION_ID" --size-percent 80 --background-color "#2a1a3a"
 # ... later
 agtermctl session overlay close
 ```

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -173,10 +173,12 @@ position?, repeats?}` object; `kind` is `image`/`text`/`color` — omitted when 
   background-opacity); a `color` instead honors the Settings window translucency. Read the current
   background back from a session's `background` field in `tree --json` (a `{kind, colorHex, …}` object,
   omitted when none).
-- `session overlay open <command> [--cwd DIR] [--wait] [--block] [--size-percent N] [--target] [--window W]`
+- `session overlay open <command> [--cwd DIR] [--wait] [--block] [--size-percent N] [--background-color #rrggbb] [--target] [--window W]`
   — run `command` in an ephemeral terminal on top of the session; it closes when the command exits.
   Full-size by default (hides the session); `--size-percent N` (1–100) makes it a floating framed panel
-  with the session visible behind. `--wait` keeps the overlay open after the command exits (press a key
+  with the session visible behind. `--background-color #rrggbb` gives the overlay pane its own solid
+  background color, independent of the session's own `session background color` (nil = the default theme
+  background); it honors the Settings window translucency, captured when the overlay opens. `--wait` keeps the overlay open after the command exits (press a key
   to close). `--block` waits for the command to exit and makes agtermctl exit with the command's status
   (cannot combine with `--wait`); the program renders normally — capture its OUTPUT via the program's
   own output file, not the control channel. Returns the overlay's session id. `--target` defaults to

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -340,6 +340,9 @@ struct agtermApp: App {
                                       fontSize: session.fontSize.map(Float.init), command: overlayExitWrapper,
                                       waitAfterCommand: session.overlayWait, autoFocus: true, env: overlayEnv)
         view.overlayCodeFile = codeFile
+        // the overlay's own background color (session.overlay.open --background-color), applied to the
+        // surface in createSurface — the overlay is sessionless, so it can't read it off the session there.
+        view.overlayBackgroundColorHex = session.overlayBackgroundColor
         // record the exit status on teardown (the surface always tears down through destroySurface), so
         // it survives an explicit session.overlay.close that bypasses onExit. a session/window force-close
         // removes the session first, so this no-ops there — but the result is unqueryable after that anyway.

--- a/agtermCore/Sources/agtermCore/AppStore+Panes.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Panes.swift
@@ -99,14 +99,19 @@ extension AppStore {
     /// `sizePercent` (clamped to 1...100) requests a *floating* overlay: an opaque, framed panel sized
     /// to that percent of the pane, with the session still visible behind it. nil gives the default
     /// full-pane overlay that hides the session.
+    ///
+    /// `backgroundColor` (`#rrggbb`) gives the overlay pane its own solid background, independent of the
+    /// session's; nil leaves the default theme background. Read by the overlay surface factory at creation.
     @discardableResult public func openOverlay(_ sessionID: UUID, command: String, cwd: String? = nil,
-                                               wait: Bool = false, sizePercent: Int? = nil) -> Bool {
+                                               wait: Bool = false, sizePercent: Int? = nil,
+                                               backgroundColor: String? = nil) -> Bool {
         guard let session = session(withID: sessionID), !session.overlayActive else { return false }
         session.overlayCommand = command
         session.overlayCwd = cwd
         session.overlayWait = wait
         session.overlayExitCode = nil
         session.overlaySizePercent = sizePercent.map { min(100, max(1, $0)) }
+        session.overlayBackgroundColor = backgroundColor
         session.overlayActive = true
         return true
     }
@@ -130,6 +135,7 @@ extension AppStore {
         session.overlayCwd = nil
         session.overlayWait = false
         session.overlaySizePercent = nil
+        session.overlayBackgroundColor = nil
         return true
     }
 

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -87,7 +87,9 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     public var path: String?
     /// The color (`#rrggbb`) for `session.background`: the text tint for mode `text` (nil = the terminal
     /// foreground), or the solid background color for mode `color` (required). Mode `color` takes no
-    /// opacity — it honors the Settings window translucency.
+    /// opacity — it honors the Settings window translucency. Also the optional solid background color for
+    /// `session.overlay.open` (the overlay pane's own color, independent of the session's); nil = the
+    /// default theme background, honoring the same window translucency.
     public var color: String?
     /// The `background-image-opacity` for `session.background` (image + text), 0...1; nil = ghostty's 1.0.
     public var opacity: Double?

--- a/agtermCore/Sources/agtermCore/Session.swift
+++ b/agtermCore/Sources/agtermCore/Session.swift
@@ -148,6 +148,12 @@ public final class Session: Identifiable {
     /// creation. `@ObservationIgnored`.
     @ObservationIgnored public var overlayCwd: String?
 
+    /// The overlay's own solid background color as `#rrggbb`, or nil for the default theme background.
+    /// Independent of the session's `backgroundWatermark` — the overlay surface is not wired to the
+    /// session, so it carries its own color, set via `session.overlay.open --background-color`. Read by
+    /// the factory at creation; set at open, cleared on close. `@ObservationIgnored`, never persisted.
+    @ObservationIgnored public var overlayBackgroundColor: String?
+
     /// Whether the overlay keeps its surface open after the command exits, showing libghostty's
     /// "press any key to close" prompt (useful to read a command's final output) instead of closing
     /// immediately. Read by the factory at creation. `@ObservationIgnored`.

--- a/agtermCore/Sources/agtermctlKit/SessionCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/SessionCommands.swift
@@ -416,19 +416,23 @@ struct Session: ParsableCommand {
             @Flag(name: .long, help: "Keep the overlay open after COMMAND exits (press any key to close).") var wait = false
             @Flag(name: .long, help: "Block until COMMAND exits and exit with its status (the program renders normally; capture its output via the program's own output file).") var block = false
             @Option(name: .long, help: "Render a floating, framed panel at PERCENT (1-100) of the pane instead of full-size.") var sizePercent: Int?
+            @Option(name: .long, help: "Solid background color (#rrggbb) for the overlay pane, independent of the session's own.") var backgroundColor: String?
             @OptionGroup var target: TargetOptions
             @OptionGroup var options: ClientOptions
 
-            // reject the mutually-exclusive combo at parse time (before any connection), so it's a clean
-            // usage error and is unit-testable without a socket.
+            // reject the mutually-exclusive combo + a malformed color at parse time (before any connection),
+            // so it's a clean usage error and is unit-testable without a socket.
             func validate() throws {
                 if block && wait { throw ValidationError("--block cannot be combined with --wait") }
+                if let backgroundColor, !WatermarkConfig.isValidColorHex(backgroundColor) {
+                    throw ValidationError("background-color must be a #rrggbb hex value")
+                }
             }
 
             func makeRequest() throws -> ControlRequest {
                 ControlRequest(cmd: .sessionOverlayOpen, target: target.target,
                                args: options.withWindow(ControlArgs(cwd: cwd, command: command, wait: wait ? true : nil,
-                                                                     sizePercent: sizePercent)))
+                                                                     sizePercent: sizePercent, color: backgroundColor)))
             }
 
             func run() throws {

--- a/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
@@ -214,6 +214,20 @@ struct AppStorePaneTests {
         #expect(session.overlayCommand == "revdiff")
     }
 
+    @Test func openOverlayCarriesBackgroundColorAndCloseClears() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        #expect(store.openOverlay(session.id, command: "revdiff", backgroundColor: "#2a1a3a") == true)
+        #expect(session.overlayBackgroundColor == "#2a1a3a")
+        // close clears the overlay's color back to nil, like the other ephemeral overlay fields.
+        store.closeOverlay(session.id)
+        #expect(session.overlayBackgroundColor == nil)
+        // omitting the color leaves it nil (default theme background, unchanged behavior).
+        #expect(store.openOverlay(session.id, command: "revdiff") == true)
+        #expect(session.overlayBackgroundColor == nil)
+    }
+
     @Test func overlayExitCodeRecordedAndSurvivesClose() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -44,6 +44,7 @@ struct ControlProtocolTests {
             ControlRequest(cmd: .sessionCopy, target: "9f3c"),
             ControlRequest(cmd: .sessionOverlayOpen, target: "9f3c", args: ControlArgs(cwd: "/b", command: "revdiff")),
             ControlRequest(cmd: .sessionOverlayOpen, target: "9f3c", args: ControlArgs(command: "htop", sizePercent: 70)),
+            ControlRequest(cmd: .sessionOverlayOpen, target: "9f3c", args: ControlArgs(command: "revdiff", color: "#2a1a3a")),
             ControlRequest(cmd: .sessionOverlayClose, target: "9f3c"),
             ControlRequest(cmd: .sessionOverlayResult, target: "9f3c"),
         ]

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -392,6 +392,20 @@ struct CommandsTests {
         #expect(try request(["session", "overlay", "open", "htop", "--size-percent", "70"]) == expected)
     }
 
+    @Test func sessionOverlayOpenWithBackgroundColor() throws {
+        // --background-color maps to ControlArgs.color (shared field, disambiguated by the command).
+        let expected = ControlRequest(cmd: .sessionOverlayOpen, target: "active",
+                                      args: ControlArgs(command: "revdiff", color: "#2a1a3a"))
+        #expect(try request(["session", "overlay", "open", "revdiff", "--background-color", "#2a1a3a"]) == expected)
+    }
+
+    @Test func sessionOverlayOpenRejectsBadBackgroundColor() {
+        // validate() rejects a malformed hex at parse time (before any connection).
+        #expect(throws: (any Error).self) {
+            try Agtermctl.parseAsRoot(["session", "overlay", "open", "cmd", "--background-color", "purple"])
+        }
+    }
+
     @Test func sessionOverlayClose() throws {
         #expect(try request(["session", "overlay", "close"]) == ControlRequest(cmd: .sessionOverlayClose, target: "active"))
     }

--- a/agtermUITests/ControlOverlaySplitUITests.swift
+++ b/agtermUITests/ControlOverlaySplitUITests.swift
@@ -36,6 +36,30 @@ final class ControlOverlaySplitUITests: ControlAPITestCase {
         XCTAssertEqual(closeAgain["error"] as? String, "no overlay", "\(closeAgain)")
     }
 
+    // session.overlay.open --background-color: a valid #rrggbb opens the overlay (the colored surface is
+    // a Metal layer, not in the AX tree, so the color is verified manually — this asserts the arm accepts
+    // and applies it via the lifecycle), and a malformed color is rejected before the overlay opens.
+    func testOverlayOpenWithBackgroundColorAndRejectsBadColor() throws {
+        let created = try sendCommand(#"{"cmd":"session.new"}"#)
+        let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
+        let id = try XCTUnwrap(result["id"] as? String, "session.new should return the new id")
+
+        // a malformed color is rejected up front; no overlay opens.
+        let bad = try sendCommand(#"{"cmd":"session.overlay.open","target":"\#(id)","args":{"command":"cat","color":"purple"}}"#)
+        XCTAssertEqual(bad["ok"] as? Bool, false, "a malformed color should be rejected: \(bad)")
+        XCTAssertEqual(bad["error"] as? String, "invalid color: purple (#rrggbb)", "\(bad)")
+        XCTAssertTrue(pollSessionOverlay(id: id, expected: false, timeout: 5), "the rejected open must not open an overlay")
+
+        // a valid color opens the overlay (cat is long-lived so it stays up); close tears it down.
+        // ##"…"## delimiters so the "#2a1a3a" value's leading "# doesn't close a #"…"# raw string.
+        let open = try sendCommand(##"{"cmd":"session.overlay.open","target":"\##(id)","args":{"command":"cat","color":"#2a1a3a"}}"##)
+        XCTAssertEqual(open["ok"] as? Bool, true, "overlay open with a valid color should succeed: \(open)")
+        XCTAssertTrue(pollSessionOverlay(id: id, expected: true, timeout: 10), "the colored overlay should be up")
+
+        let close = try sendCommand(#"{"cmd":"session.overlay.close","target":"\#(id)"}"#)
+        XCTAssertEqual(close["ok"] as? Bool, true, "overlay close should succeed: \(close)")
+    }
+
     // the overlay auto-closes when its command exits (the SHOW_CHILD_EXITED path): open an overlay
     // running a command that writes a marker then exits — the marker proves the command ran inside the
     // overlay, and the tree's overlay flag clearing proves the overlay vanished with no key press.


### PR DESCRIPTION
Adds an optional `--background-color <#rrggbb>` to `session overlay open`, giving an ephemeral overlay its own solid background color independent of the session's own `session background color` (#68). Default is unchanged: no flag means no color, current behavior.

It reuses the existing `ControlArgs.color` field (no new protocol arg or command), validated by the shared `WatermarkConfig.isValidColorHex` at both the CLI `validate()` and the `ControlServer` arm. The color is applied to the sessionless overlay surface via the same `.color` per-surface ghostty config overlay that `session background color` uses, so it works for both full and floating overlays and honors the window translucency (captured when the overlay opens; the ephemeral overlay gets no live updates).

Use case from the issue: visually distinguishing an overlay pane (running revdiff, a one-off command) from the session behind it, without changing the session's own color.

**Keep-in-sync surfaces:** protocol (reused field) + `ControlServer` arm + `agtermctl session overlay open --background-color` + tests + the bundled agent-skill docs and the `control-api` rule.

**Tests:** store set/clear (`AppStorePaneTests`), protocol round-trip (`ControlProtocolTests`), CLI parse + bad-color rejection (`CommandsTests`), and an e2e accept/reject in `ControlOverlaySplitUITests`. The rendered color is a Metal layer (not in the accessibility tree), so it is verified manually.

Fix #75
