### PR TITLE
feat: pane-addressable session.type and the AGT_PANE keymap token

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -295,10 +295,25 @@ paths:
   (the last two also `validate()`-guarded); and round-trip + e2e (`testSessionNewWithCommandRunsAsProcess`,
   `testSessionNewWithName`, `testSessionNewWorkspaceNameCreatesThenReuses`) cover them.
   `session.type` injects into the target surface.
+  `args.pane` picks the pane like `session.text` (`left`|`right` only, no `other`):
+  omitted/`left` is the MAIN pane (omitted deliberately keeps the pre-pane behavior — always the main
+  pane, NOT the focused/on-screen one, so existing automation is unaffected);
+  `right` injects into the split surface, `session has no split pane` without one,
+  and an unknown value is an `invalid pane` error — all validated SERVER-SIDE in `injectText`
+  (mirroring the CLI `validate()`), so a raw socket client can't bypass it.
   Every session is realized eagerly (the deck mounts all at startup), so any session is normally typable
   WITHOUT `select`; `select:true` remains for the brief window before a just-created session is mounted
   (select, then a bounded poll, the `focusSplitPane` idiom), with `session not realized` the fallback
   if the surface still isn't up.
+  The realize/select path applies to the MAIN pane only — a split pane is never created by selecting,
+  so `pane:right` injects into the existing split surface or errors.
+  Four-point keep-in-sync audit for `session.type --pane`: (1) reuses `ControlArgs.pane` in
+  `ControlProtocol.swift` (no new field), (2) the pane switch in `injectText`
+  (`ControlServer+SurfaceIO.swift`), (3) the `session type --pane left|right` option
+  (`validate()`-guarded) in `agtermctlKit`, (4) round-trip in `ControlProtocolTests` + CLI mapping in
+  `CommandsTests` + the e2e (`testSessionTypePaneRightReachesSplitPane`,
+  `testSessionTypePaneRightWithoutSplitErrors`, `testSessionTypeRejectsInvalidPaneServerSide`) in
+  `SessionTypePaneUITests` (a `ControlAPITestCase` subclass like `SessionTextUITests`).
   `GhosttySurfaceView.inject(text:)` types via `ghostty_surface_key` keystrokes (printable runs as key-with-`text`,
   each `\n`/`\r`/`\r\n` as a Return keypress, keycode 36) — NOT `ghostty_surface_text`,
   whose bracketed-paste wrapping suppresses Enter and leaks `\e[200~`/`\e[201~` markers when fired rapidly.

--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -54,11 +54,16 @@ paths:
   in a text field) and rebuilds its matcher on `.agtermKeymapChanged`.
   The runner also exposes a public `run(_:)` for the palette items, which resolve context from the active
   session (no first responder to key off).
-  `CommandContext.pane` (the `{AGT_PANE}`/`$AGT_PANE` token, `left`|`right`, `left` without a split)
+  `CommandContext.pane` (the `{AGT_PANE}`/`$AGT_PANE` token, `left`|`right`)
   carries the fired-from pane: the keybind path derives it from the focused SURFACE's identity
   (`splitSurface === focusedSurface`), the palette path from `session.splitFocused` —
   so a script can feed it back as `agtermctl session type --pane "$AGT_PANE"` to type into the very
   pane the shortcut was pressed in.
+  It reflects the pane's PHYSICAL surface slot, not `hasSplit`: a promoted split survivor (the primary
+  pane exited and the split pane took over) reports `right` even though the session no longer shows a
+  split, because that survivor still lives in the `splitSurface` slot — which is exactly where
+  `session.type --pane right` reaches it, so the round-trip stays correct (a `left` there would name a
+  pane `session.type` can't type into, since the promoted session's `surface` slot is nil).
 - **Built-in override resolution is ORDER-INDEPENDENT, decided against the FINAL state (`resolveBuiltinOverrides`).**
   Overrides are NOT folded incrementally against a partially-built map (that was order-sensitive — it
   would reject `map cmd+d new_session` when toggle_split still owned cmd+d "so far",

--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -54,6 +54,11 @@ paths:
   in a text field) and rebuilds its matcher on `.agtermKeymapChanged`.
   The runner also exposes a public `run(_:)` for the palette items, which resolve context from the active
   session (no first responder to key off).
+  `CommandContext.pane` (the `{AGT_PANE}`/`$AGT_PANE` token, `left`|`right`, `left` without a split)
+  carries the fired-from pane: the keybind path derives it from the focused SURFACE's identity
+  (`splitSurface === focusedSurface`), the palette path from `session.splitFocused` —
+  so a script can feed it back as `agtermctl session type --pane "$AGT_PANE"` to type into the very
+  pane the shortcut was pressed in.
 - **Built-in override resolution is ORDER-INDEPENDENT, decided against the FINAL state (`resolveBuiltinOverrides`).**
   Overrides are NOT folded incrementally against a partially-built map (that was order-sensitive — it
   would reject `map cmd+d new_session` when toggle_split still owned cmd+d "so far",

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ agtermctl quick toggle                           # toggle the quick terminal
 agtermctl font inc                               # increase the active surface's font size
 ```
 
-`session type` types the text as real keystrokes, and every newline is a real Return press — so a trailing newline submits the command, and a multi-line payload runs line by line (a multi-line shell construct like a `for` loop is entered across the shell's continuation prompts and runs as one command). Note the `$'…\n'` quoting: a literal `\n` inside plain single quotes reaches the CLI as two characters, not a newline; use `$'…\n'` or pipe a real newline via `--stdin`.
+`session type` types the text as real keystrokes, and every newline is a real Return press — so a trailing newline submits the command, and a multi-line payload runs line by line (a multi-line shell construct like a `for` loop is entered across the shell's continuation prompts and runs as one command). Note the `$'…\n'` quoting: a literal `\n` inside plain single quotes reaches the CLI as two characters, not a newline; use `$'…\n'` or pipe a real newline via `--stdin`. Typing goes to the session's left (main) pane by default; `--pane right` types into the split pane instead (an error when the session has no split).
 
 `session copy` returns the target session's selected text in the response (it does not touch the system clipboard), so a script can move a selection from one session to another:
 
@@ -301,10 +301,10 @@ The shell line of a `command` may use these `{AGT_X}` tokens, expanded at fire t
 {AGT_SESSION_ID}   {AGT_SESSION_NAME}   {AGT_SESSION_PWD}
 {AGT_WORKSPACE_ID} {AGT_WORKSPACE_NAME}
 {AGT_WINDOW_ID}    {AGT_WINDOW_NAME}
-{AGT_SELECTION}    {AGT_SOCKET}
+{AGT_PANE}         {AGT_SELECTION}      {AGT_SOCKET}
 ```
 
-The context is resolved from the focused pane's session, so a custom command runs in that session's working directory and can read its current selection. A custom command runs as a detached `/bin/sh -c`; a non-zero exit (or a spawn failure) posts a notification banner.
+The context is resolved from the focused pane's session, so a custom command runs in that session's working directory and can read its current selection. `{AGT_PANE}` is the pane the shortcut fired from — `left` (main) or `right` (split), always `left` without a split — so a script can route a follow-up `agtermctl session type --pane "$AGT_PANE"` back into the very pane it was invoked in. A custom command runs as a detached `/bin/sh -c`; a non-zero exit (or a spawn failure) posts a notification banner.
 
 Because it runs detached with no controlling terminal, a custom command suits fire-and-forget launches — GUI apps (`open -a …`), scripts, one-off shell lines — not interactive or full-screen programs: a TUI like `lazygit` run bare has no TTY to draw into and exits immediately. The `Lazygit` example above launches it the right way, in an overlay terminal that *does* have a TTY (`agtermctl session overlay open`, passing `{AGT_SOCKET}` so the CLI reaches this very app; add `--size-percent 80` for a floating panel instead of full-size). A per-session scratch terminal (`agtermctl session scratch on --command lazygit`) works too.
 

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ The shell line of a `command` may use these `{AGT_X}` tokens, expanded at fire t
 {AGT_PANE}         {AGT_SELECTION}      {AGT_SOCKET}
 ```
 
-The context is resolved from the focused pane's session, so a custom command runs in that session's working directory and can read its current selection. `{AGT_PANE}` is the pane the shortcut fired from — `left` (main) or `right` (split), always `left` without a split — so a script can route a follow-up `agtermctl session type --pane "$AGT_PANE"` back into the very pane it was invoked in. A custom command runs as a detached `/bin/sh -c`; a non-zero exit (or a spawn failure) posts a notification banner.
+The context is resolved from the focused pane's session, so a custom command runs in that session's working directory and can read its current selection. `{AGT_PANE}` is the pane the shortcut fired from — `left` (main) or `right` (split) — so a script can route a follow-up `agtermctl session type --pane "$AGT_PANE"` back into the very pane it was invoked in. A custom command runs as a detached `/bin/sh -c`; a non-zero exit (or a spawn failure) posts a notification banner.
 
 Because it runs detached with no controlling terminal, a custom command suits fire-and-forget launches — GUI apps (`open -a …`), scripts, one-off shell lines — not interactive or full-screen programs: a TUI like `lazygit` run bare has no TTY to draw into and exits immediately. The `Lazygit` example above launches it the right way, in an overlay terminal that *does* have a TTY (`agtermctl session overlay open`, passing `{AGT_SOCKET}` so the CLI reaches this very app; add `--size-percent 80` for a floating panel instead of full-size). A per-session scratch terminal (`agtermctl session scratch on --command lazygit`) works too.
 

--- a/agterm/Commands/CustomCommandRunner.swift
+++ b/agterm/Commands/CustomCommandRunner.swift
@@ -176,12 +176,17 @@ final class CustomCommandRunner {
             logger.notice("custom command \"\(command.name, privacy: .public)\" fired with no active session; ignored")
             return
         }
-        // palette path: selection + pane both come from the active session's focused pane (split if it
-        // holds focus). the palette has no fired-from surface to key off, so the focus flag is the source.
-        let splitFocused = session.splitFocused
-        let selectionSurface = (splitFocused ? session.splitSurface : session.surface) as? GhosttySurfaceView
+        // palette path: selection + pane both come from the active session's focused pane. the palette has
+        // no fired-from surface to key off, so the focus flag is the source — but gated on the split surface
+        // EXISTING (the `Session.onScreenSurface` idiom, `splitFocused && splitSurface != nil`): in the
+        // window right after `session split on`, `splitFocused` is already true while `splitSurface` is
+        // still nil, so a bare flag would report `.right` (and read the selection from the nil split
+        // surface) when `session.type --pane right` still errors "no split pane". A promoted survivor keeps
+        // `splitSurface` non-nil, so it still reports `.right` — the pane `--pane right` reaches.
+        let onSplit = session.splitFocused && session.splitSurface != nil
+        let selectionSurface = (onSplit ? session.splitSurface : session.surface) as? GhosttySurfaceView
         let context = self.context(for: session, in: store, selectionSurface: selectionSurface,
-                                   pane: splitFocused ? .right : .left)
+                                   pane: onSplit ? .right : .left)
         spawn(command, context: context)
     }
 

--- a/agterm/Commands/CustomCommandRunner.swift
+++ b/agterm/Commands/CustomCommandRunner.swift
@@ -178,7 +178,8 @@ final class CustomCommandRunner {
         }
         // palette path: selection comes from the active session's focused pane (split if it holds focus).
         let selectionSurface = (session.splitFocused ? session.splitSurface : session.surface) as? GhosttySurfaceView
-        let context = self.context(for: session, in: store, selectionSurface: selectionSurface)
+        let context = self.context(for: session, in: store, selectionSurface: selectionSurface,
+                                   pane: session.splitFocused ? "right" : "left")
         spawn(command, context: context)
     }
 
@@ -196,14 +197,18 @@ final class CustomCommandRunner {
             run(command)
             return
         }
-        let context = self.context(for: session, in: store, selectionSurface: focusedSurface)
+        // the fired-from pane is the surface's identity, not the session's focus flag — a chord fired
+        // from a pane the focus flag hasn't caught up to still reports the pane it was typed in.
+        let pane = (session.splitSurface as? GhosttySurfaceView) === focusedSurface ? "right" : "left"
+        let context = self.context(for: session, in: store, selectionSurface: focusedSurface, pane: pane)
         spawn(command, context: context)
     }
 
     /// Resolve every `{AGT_X}` token for the given session: ids + cwd from the model, the names from
     /// the owning workspace/window, the selection from `selectionSurface` (the exact focused surface),
-    /// and the socket from the control server.
-    private func context(for session: Session, in store: AppStore, selectionSurface: GhosttySurfaceView?) -> CommandContext {
+    /// the fired-from pane (`left`|`right`) from the caller, and the socket from the control server.
+    private func context(for session: Session, in store: AppStore, selectionSurface: GhosttySurfaceView?,
+                         pane: String) -> CommandContext {
         let workspace = store.workspace(forSession: session.id)
         let windowID = library.windowID(forSession: session.id)
         let windowName = windowID.flatMap { id in library.windows.first { $0.id == id }?.name } ?? ""
@@ -215,6 +220,7 @@ final class CustomCommandRunner {
             workspaceName: workspace?.name ?? "",
             windowID: windowID?.uuidString ?? "",
             windowName: windowName,
+            pane: pane,
             selection: selectionSurface?.readSelection() ?? "",
             socket: socketProvider()
         )

--- a/agterm/Commands/CustomCommandRunner.swift
+++ b/agterm/Commands/CustomCommandRunner.swift
@@ -176,10 +176,12 @@ final class CustomCommandRunner {
             logger.notice("custom command \"\(command.name, privacy: .public)\" fired with no active session; ignored")
             return
         }
-        // palette path: selection comes from the active session's focused pane (split if it holds focus).
-        let selectionSurface = (session.splitFocused ? session.splitSurface : session.surface) as? GhosttySurfaceView
+        // palette path: selection + pane both come from the active session's focused pane (split if it
+        // holds focus). the palette has no fired-from surface to key off, so the focus flag is the source.
+        let splitFocused = session.splitFocused
+        let selectionSurface = (splitFocused ? session.splitSurface : session.surface) as? GhosttySurfaceView
         let context = self.context(for: session, in: store, selectionSurface: selectionSurface,
-                                   pane: session.splitFocused ? "right" : "left")
+                                   pane: splitFocused ? .right : .left)
         spawn(command, context: context)
     }
 
@@ -199,7 +201,7 @@ final class CustomCommandRunner {
         }
         // the fired-from pane is the surface's identity, not the session's focus flag — a chord fired
         // from a pane the focus flag hasn't caught up to still reports the pane it was typed in.
-        let pane = (session.splitSurface as? GhosttySurfaceView) === focusedSurface ? "right" : "left"
+        let pane: CommandContext.Pane = (session.splitSurface as? GhosttySurfaceView) === focusedSurface ? .right : .left
         let context = self.context(for: session, in: store, selectionSurface: focusedSurface, pane: pane)
         spawn(command, context: context)
     }
@@ -208,7 +210,7 @@ final class CustomCommandRunner {
     /// the owning workspace/window, the selection from `selectionSurface` (the exact focused surface),
     /// the fired-from pane (`left`|`right`) from the caller, and the socket from the control server.
     private func context(for session: Session, in store: AppStore, selectionSurface: GhosttySurfaceView?,
-                         pane: String) -> CommandContext {
+                         pane: CommandContext.Pane) -> CommandContext {
         let workspace = store.workspace(forSession: session.id)
         let windowID = library.windowID(forSession: session.id)
         let windowName = windowID.flatMap { id in library.windows.first { $0.id == id }?.name } ?? ""

--- a/agterm/Control/ControlServer+SurfaceIO.swift
+++ b/agterm/Control/ControlServer+SurfaceIO.swift
@@ -281,8 +281,10 @@ extension ControlServer {
     }
 
     /// Inject `text` into the session `id`'s surface. A session's surface is created lazily (deferred until
-    /// it has a non-zero backing size — a never-shown session has `surface == nil`). `ghostty_surface_text`
-    /// writes to the child pty, which the kernel buffers, so text is never lost even before the first prompt.
+    /// it has a non-zero backing size — a never-shown session has `surface == nil`). `inject(text:)` sends
+    /// the text as `ghostty_surface_key` keystrokes (NOT `ghostty_surface_text` — see its doc for why),
+    /// which write to the child pty; the kernel buffers the pty, so text is never lost even before the
+    /// first prompt.
     /// `pane` picks the pane like `session.text` (`left`|`right` only, no `other`): omitted/`left` is the
     /// main pane (omitted keeps the pre-pane behavior — always the main pane, NOT the focused one, so
     /// existing automation is unaffected); `right` is the split pane, `session has no split pane` without

--- a/agterm/Control/ControlServer+SurfaceIO.swift
+++ b/agterm/Control/ControlServer+SurfaceIO.swift
@@ -283,12 +283,34 @@ extension ControlServer {
     /// Inject `text` into the session `id`'s surface. A session's surface is created lazily (deferred until
     /// it has a non-zero backing size — a never-shown session has `surface == nil`). `ghostty_surface_text`
     /// writes to the child pty, which the kernel buffers, so text is never lost even before the first prompt.
+    /// `pane` picks the pane like `session.text` (`left`|`right` only, no `other`): omitted/`left` is the
+    /// main pane (omitted keeps the pre-pane behavior — always the main pane, NOT the focused one, so
+    /// existing automation is unaffected); `right` is the split pane, `session has no split pane` without
+    /// one. The realize/select path below applies to the main pane only — a split pane is never created by
+    /// selecting, so `right` injects into the existing split surface or errors.
     /// - surface already realized → inject immediately, ok.
     /// - never realized, `select:true` → select it, then poll for the surface (bounded: 12 × 0.03 s, the
     ///   `focusSplitPane` idiom) and inject on the first realized attempt; never realized → error (never a
     ///   false ok).
     /// - never realized, no select → an immediate "use select" error.
-    func injectText(_ text: String, into id: UUID, store: AppStore, select: Bool) async -> ControlResponse {
+    func injectText(_ text: String, into id: UUID, store: AppStore, select: Bool, pane: String?) async -> ControlResponse {
+        switch pane {
+        case nil, "left":
+            break
+        case "right":
+            guard let split = store.session(withID: id)?.splitSurface else {
+                return ControlResponse(ok: false, error: "session has no split pane")
+            }
+            guard let surface = split as? GhosttySurfaceView else {
+                return ControlResponse(ok: false, error: "session not realized")
+            }
+            surface.inject(text: text)
+            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
+        // an unknown pane value errors here; `session.type` accepts left|right only, with no `other`
+        // toggle like `session.focus` (mirroring `session.text`).
+        case .some(let value):
+            return ControlResponse(ok: false, error: "invalid pane: \(value)")
+        }
         if let surface = store.session(withID: id)?.surface as? GhosttySurfaceView {
             surface.inject(text: text)
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -459,7 +459,8 @@ final class ControlServer {
             case .failure(let response):
                 return response
             case .success(let (store, id)):
-                return await injectText(text, into: id, store: store, select: request.args?.select ?? false)
+                return await injectText(text, into: id, store: store, select: request.args?.select ?? false,
+                                        pane: request.args?.pane)
             }
         case .sessionSplit:
             return splitSession(request.target, window: request.args?.window, mode: request.args?.mode)

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -111,7 +111,8 @@ spec — image/text watermark or solid color — set via `session background`, o
 - `close` · `select` · `rename <name>`.
 - `go --to next|prev|first|last|next-attention|prev-attention` — move the selection between sessions.
 - `move <workspace>` (relocate) or `move --to up|down|top|bottom` (reorder within the workspace).
-- `type <text> [--stdin] [--select]` — inject keystrokes (real typing, Enter included).
+- `type <text> [--stdin] [--select] [--pane left|right]` — inject keystrokes (real typing, Enter
+  included) into the main pane, or the split pane with `--pane right`.
 - `copy` — print the session's selected text (does NOT touch the system clipboard).
 - `text [--all] [--lines N] [--pane left|right]` — print the session buffer as plain text. Default is
   the visible screen of the focused pane; `--all` adds scrollback; `--lines N` keeps the last N lines.

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -31,7 +31,12 @@ realized eagerly, so no `--select` is needed.
 sid=$(agtermctl session new --cwd "$HOME/project" --json | jq -r '.result.id')
 agtermctl session type "git status" --target "$sid"
 agtermctl session type $'\n' --target "$sid"     # send Return (or include it in the text)
+agtermctl session type $'ls\n' --target "$sid" --pane right   # type into the split pane instead
 ```
+
+Typing goes to the session's main (left) pane by default; `--pane right` targets the split pane and
+errors with `session has no split pane` when there is none. In a custom keymap command, `$AGT_PANE`
+holds the pane the shortcut fired from, so `session type --pane "$AGT_PANE"` types back into it.
 
 Run a command AS the session's process (closes when it exits, no echoed command line):
 

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -31,7 +31,8 @@ realized eagerly, so no `--select` is needed.
 sid=$(agtermctl session new --cwd "$HOME/project" --json | jq -r '.result.id')
 agtermctl session type "git status" --target "$sid"
 agtermctl session type $'\n' --target "$sid"     # send Return (or include it in the text)
-agtermctl session type $'ls\n' --target "$sid" --pane right   # type into the split pane instead
+agtermctl session split on --target "$sid"                    # open a split first
+agtermctl session type $'ls\n' --target "$sid" --pane right   # then type into the split pane
 ```
 
 Typing goes to the session's main (left) pane by default; `--pane right` targets the split pane and

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -305,9 +305,8 @@ so `{AGT_SESSION_NAME}` and `{AGT_SESSION_PWD}` are as untrusted as `{AGT_SELECT
 - `{AGT_SESSION_NAME}` / `$AGT_SESSION_NAME` — the session's display name (the focused pane's terminal title, remote-settable via OSC).
 - `{AGT_SESSION_PWD}` / `$AGT_SESSION_PWD` — the focused pane's working directory.
 - `{AGT_SELECTION}` / `$AGT_SELECTION` — the current selection.
-- `{AGT_PANE}` / `$AGT_PANE` — the pane the command fired from: `left` (main) or `right` (split),
-  always `left` without a split. Feed it back as `session type --pane "$AGT_PANE"` to type into the
-  very pane the shortcut was pressed in.
+- `{AGT_PANE}` / `$AGT_PANE` — the pane the command fired from: `left` (main) or `right` (split). Feed
+  it back as `session type --pane "$AGT_PANE"` to type into the very pane the shortcut was pressed in.
 - Plus the other `$AGT_*` context vars the runner exports.
 
 Built-in action names for `map` include: `new_window`, `new_workspace`, `new_session`,

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -88,10 +88,13 @@ position?, repeats?}` object; `kind` is `image`/`text`/`color` — omitted when 
 - `session move <workspace> [--target] [--window W]` — relocate the session to another workspace
   (appends). OR `session move --to up|down|top|bottom [--target]` — reorder within its workspace.
   Exactly one of the positional workspace or `--to` is required.
-- `session type <text> [--stdin] [--select] [--target] [--window W]` — inject text as real keystrokes
-  (printable runs plus Return for each newline; no bracketed-paste markers). `--stdin` reads the text
-  from stdin instead of the argument. `--select` selects (and realizes) a never-shown session before
-  injecting. Any realized session is normally typable without `--select`.
+- `session type <text> [--stdin] [--select] [--pane left|right] [--target] [--window W]` — inject text
+  as real keystrokes (printable runs plus Return for each newline; no bracketed-paste markers).
+  `--stdin` reads the text from stdin instead of the argument. `--select` selects (and realizes) a
+  never-shown session before injecting. Any realized session is normally typable without `--select`.
+  `--pane left` types into the main pane (the default when omitted), `--pane right` into the split pane
+  (errors with `session has no split pane` when the session has no split); like `session text`, no
+  `other` value. `--select` realizes the MAIN pane only — a split pane must already exist.
 - `session copy [--target] [--window W]` — returns `result.text` with the session's current selection.
   Does NOT touch the system clipboard (pipe the returned text into another `session type`). No/empty
   selection → `no selection` error. Selection is readable on any realized session regardless of focus.
@@ -302,6 +305,9 @@ so `{AGT_SESSION_NAME}` and `{AGT_SESSION_PWD}` are as untrusted as `{AGT_SELECT
 - `{AGT_SESSION_NAME}` / `$AGT_SESSION_NAME` — the session's display name (the focused pane's terminal title, remote-settable via OSC).
 - `{AGT_SESSION_PWD}` / `$AGT_SESSION_PWD` — the focused pane's working directory.
 - `{AGT_SELECTION}` / `$AGT_SELECTION` — the current selection.
+- `{AGT_PANE}` / `$AGT_PANE` — the pane the command fired from: `left` (main) or `right` (split),
+  always `left` without a split. Feed it back as `session type --pane "$AGT_PANE"` to type into the
+  very pane the shortcut was pressed in.
 - Plus the other `$AGT_*` context vars the runner exports.
 
 Built-in action names for `map` include: `new_window`, `new_workspace`, `new_session`,

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -100,7 +100,9 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     /// The `background-image-repeat` flag for `session.background`; nil = false.
     public var repeats: Bool?
     /// Which split pane to focus for `session.focus` (`left`|`right`|`other`; `other` toggles); also
-    /// which pane to read for `session.text` (`left`|`right`; omitted = the focused pane, no `other`).
+    /// which pane to read for `session.text` (`left`|`right`; omitted = the focused pane, no `other`),
+    /// and which pane `session.type` injects into (`left`|`right`; omitted = the left/main pane, the
+    /// pre-pane behavior).
     public var pane: String?
     /// Absolute left-pane split fraction (0...1) for `session.resize`, clamped server-side to
     /// `AppStore.splitRatioMin...splitRatioMax`. Mutually exclusive with `ratioDelta`.

--- a/agtermCore/Sources/agtermCore/CustomCommand.swift
+++ b/agtermCore/Sources/agtermCore/CustomCommand.swift
@@ -47,8 +47,9 @@ public struct CommandContext: Equatable, Sendable {
     /// physical surface slot: a session that has only ever had a main pane reports `.left`, but a promoted
     /// split survivor (the primary pane exited and the split pane took over) reports `.right`, since that
     /// surface still lives in the `splitSurface` slot and is where `session.type --pane` reaches it. Typed
-    /// (not a raw `String`) so the "always a valid `--pane` value" invariant is guaranteed by construction,
-    /// not by call-site discipline.
+    /// (not a raw `String`) so `rawValue` can only be `left`/`right`; it is consumed as the `$AGT_PANE` env
+    /// var a script feeds back through `session type --pane` (re-validated CLI- AND server-side — the enum
+    /// pins the token this emits, not the shell round-trip).
     public var pane: Pane
     public var selection: String
     public var socket: String

--- a/agtermCore/Sources/agtermCore/CustomCommand.swift
+++ b/agtermCore/Sources/agtermCore/CustomCommand.swift
@@ -36,12 +36,15 @@ public struct CommandContext: Equatable, Sendable {
     public var workspaceName: String
     public var windowID: String
     public var windowName: String
+    /// The pane that had focus at fire time: `left` (main) or `right` (split). `left` for a session
+    /// with no split, so the value is always a valid `--pane` argument for `session.type`/`session.text`.
+    public var pane: String
     public var selection: String
     public var socket: String
 
     public init(sessionID: String = "", sessionName: String = "", sessionPWD: String = "",
                 workspaceID: String = "", workspaceName: String = "", windowID: String = "",
-                windowName: String = "", selection: String = "", socket: String = "") {
+                windowName: String = "", pane: String = "left", selection: String = "", socket: String = "") {
         self.sessionID = sessionID
         self.sessionName = sessionName
         self.sessionPWD = sessionPWD
@@ -49,6 +52,7 @@ public struct CommandContext: Equatable, Sendable {
         self.workspaceName = workspaceName
         self.windowID = windowID
         self.windowName = windowName
+        self.pane = pane
         self.selection = selection
         self.socket = socket
     }
@@ -64,6 +68,7 @@ public struct CommandContext: Equatable, Sendable {
          ("AGT_WORKSPACE_NAME", workspaceName),
          ("AGT_WINDOW_ID", windowID),
          ("AGT_WINDOW_NAME", windowName),
+         ("AGT_PANE", pane),
          ("AGT_SELECTION", selection),
          ("AGT_SOCKET", socket)]
     }

--- a/agtermCore/Sources/agtermCore/CustomCommand.swift
+++ b/agtermCore/Sources/agtermCore/CustomCommand.swift
@@ -29,6 +29,13 @@ public struct CustomCommand: Codable, Equatable, Sendable, Identifiable {
 /// the token substitutions (`expand`) and the environment dictionary (`environment`). Both derive
 /// from the single `tokens` table, so the `{AGT_X}` set and the `$AGT_X` set can never drift.
 public struct CommandContext: Equatable, Sendable {
+    /// Which pane a command fired from. The raw values are exactly the `--pane` argument strings, so
+    /// `pane.rawValue` is always a valid `session.type`/`session.text --pane` value.
+    public enum Pane: String, Equatable, Sendable {
+        case left
+        case right
+    }
+
     public var sessionID: String
     public var sessionName: String
     public var sessionPWD: String
@@ -36,15 +43,19 @@ public struct CommandContext: Equatable, Sendable {
     public var workspaceName: String
     public var windowID: String
     public var windowName: String
-    /// The pane that had focus at fire time: `left` (main) or `right` (split). `left` for a session
-    /// with no split, so the value is always a valid `--pane` argument for `session.type`/`session.text`.
-    public var pane: String
+    /// The pane that had focus at fire time — `.left` (main) or `.right` (split). Reflects the pane's
+    /// physical surface slot: a session that has only ever had a main pane reports `.left`, but a promoted
+    /// split survivor (the primary pane exited and the split pane took over) reports `.right`, since that
+    /// surface still lives in the `splitSurface` slot and is where `session.type --pane` reaches it. Typed
+    /// (not a raw `String`) so the "always a valid `--pane` value" invariant is guaranteed by construction,
+    /// not by call-site discipline.
+    public var pane: Pane
     public var selection: String
     public var socket: String
 
     public init(sessionID: String = "", sessionName: String = "", sessionPWD: String = "",
                 workspaceID: String = "", workspaceName: String = "", windowID: String = "",
-                windowName: String = "", pane: String = "left", selection: String = "", socket: String = "") {
+                windowName: String = "", pane: Pane = .left, selection: String = "", socket: String = "") {
         self.sessionID = sessionID
         self.sessionName = sessionName
         self.sessionPWD = sessionPWD
@@ -68,7 +79,7 @@ public struct CommandContext: Equatable, Sendable {
          ("AGT_WORKSPACE_NAME", workspaceName),
          ("AGT_WINDOW_ID", windowID),
          ("AGT_WINDOW_NAME", windowName),
-         ("AGT_PANE", pane),
+         ("AGT_PANE", pane.rawValue),
          ("AGT_SELECTION", selection),
          ("AGT_SOCKET", socket)]
     }

--- a/agtermCore/Sources/agtermctlKit/SessionCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/SessionCommands.swift
@@ -2,6 +2,15 @@ import ArgumentParser
 import Foundation
 import agtermCore
 
+/// Shared `--pane` validation for the session commands that accept `left|right` (type, text). Rejects any
+/// other value with a clean usage error before the socket round-trip, matching the server-side switch (so
+/// the CLI and server can't drift, and a raw socket client still hits the same check server-side).
+func validatePaneArgument(_ pane: String?) throws {
+    if let pane, !["left", "right"].contains(pane) {
+        throw ValidationError("--pane must be left or right")
+    }
+}
+
 // MARK: - session
 
 struct Session: ParsableCommand {
@@ -108,16 +117,12 @@ struct Session: ParsableCommand {
         static let configuration = CommandConfiguration(commandName: "type", abstract: "Inject text into a session.")
         @Argument(help: "Text to inject (omit with --stdin).") var text: String?
         @Flag(name: .long, help: "Read the text from stdin instead of an argument.") var stdin = false
-        @Flag(name: .long, help: "Select (and realize) a never-shown session before injecting.") var select = false
+        @Flag(name: .long, help: "Select (and realize) a never-shown session before injecting (main pane only; a split pane must already exist).") var select = false
         @Option(name: .long, help: "Which pane to type into: left (main) or right (split). Defaults to the left pane.") var pane: String?
         @OptionGroup var target: TargetOptions
         @OptionGroup var options: ClientOptions
 
-        func validate() throws {
-            if let pane, !["left", "right"].contains(pane) {
-                throw ValidationError("--pane must be left or right")
-            }
-        }
+        func validate() throws { try validatePaneArgument(pane) }
 
         func makeRequest() throws -> ControlRequest {
             let payload: String
@@ -231,9 +236,7 @@ struct Session: ParsableCommand {
             if let lines, lines <= 0 {
                 throw ValidationError("--lines must be greater than 0")
             }
-            if let pane, !["left", "right"].contains(pane) {
-                throw ValidationError("--pane must be left or right")
-            }
+            try validatePaneArgument(pane)
         }
 
         func makeRequest() throws -> ControlRequest {

--- a/agtermCore/Sources/agtermctlKit/SessionCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/SessionCommands.swift
@@ -109,8 +109,15 @@ struct Session: ParsableCommand {
         @Argument(help: "Text to inject (omit with --stdin).") var text: String?
         @Flag(name: .long, help: "Read the text from stdin instead of an argument.") var stdin = false
         @Flag(name: .long, help: "Select (and realize) a never-shown session before injecting.") var select = false
+        @Option(name: .long, help: "Which pane to type into: left (main) or right (split). Defaults to the left pane.") var pane: String?
         @OptionGroup var target: TargetOptions
         @OptionGroup var options: ClientOptions
+
+        func validate() throws {
+            if let pane, !["left", "right"].contains(pane) {
+                throw ValidationError("--pane must be left or right")
+            }
+        }
 
         func makeRequest() throws -> ControlRequest {
             let payload: String
@@ -124,7 +131,7 @@ struct Session: ParsableCommand {
                 throw ValidationError("provide TEXT or --stdin")
             }
             return ControlRequest(cmd: .sessionType, target: target.target,
-                                  args: options.withWindow(ControlArgs(text: payload, select: select)))
+                                  args: options.withWindow(ControlArgs(text: payload, select: select, pane: pane)))
         }
     }
 

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -85,6 +85,14 @@ struct ControlProtocolTests {
         #expect(decoded.args?.select == nil)
     }
 
+    @Test func sessionTypeWithPaneRoundTrips() throws {
+        let request = ControlRequest(cmd: .sessionType, target: "9f3c",
+                                     args: ControlArgs(text: "ls\n", pane: "right"))
+        let decoded = try roundTrip(request)
+        #expect(decoded == request)
+        #expect(decoded.args?.pane == "right")
+    }
+
     @Test func sessionStatusRoundTripsWithStateAndBlink() throws {
         let request = ControlRequest(cmd: .sessionStatus, target: "9f3c",
                                      args: ControlArgs(status: "active", blink: true, autoReset: true))

--- a/agtermCore/Tests/agtermCoreTests/CustomCommandTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/CustomCommandTests.swift
@@ -6,7 +6,7 @@ struct CustomCommandTests {
     private func sampleContext() -> CommandContext {
         CommandContext(sessionID: "sess-1", sessionName: "shell", sessionPWD: "/tmp/work",
                        workspaceID: "ws-1", workspaceName: "main", windowID: "win-1",
-                       windowName: "work", selection: "hello", socket: "/tmp/agt.sock")
+                       windowName: "work", pane: "right", selection: "hello", socket: "/tmp/agt.sock")
     }
 
     @Test func expandSubstitutesKnownTokens() {
@@ -61,9 +61,18 @@ struct CustomCommandTests {
         #expect(env["AGT_WORKSPACE_NAME"] == "main")
         #expect(env["AGT_WINDOW_ID"] == "win-1")
         #expect(env["AGT_WINDOW_NAME"] == "work")
+        #expect(env["AGT_PANE"] == "right")
         #expect(env["AGT_SELECTION"] == "hello")
         #expect(env["AGT_SOCKET"] == "/tmp/agt.sock")
-        #expect(env.count == 9)
+        #expect(env.count == 10)
+    }
+
+    @Test func paneDefaultsToLeft() {
+        // an unspecified pane is the main pane — always a valid `session.type --pane` argument, so a
+        // split-less session's context still round-trips into a pane-addressed control call.
+        #expect(CommandContext().pane == "left")
+        #expect(CommandContext().environment()["AGT_PANE"] == "left")
+        #expect(CommandContext().expand("{AGT_PANE}") == "left")
     }
 
     @Test func environmentKeySetMatchesTheTokensExpandSubstitutes() {
@@ -77,7 +86,7 @@ struct CustomCommandTests {
         // and there is no extra token expand handles that environment omits.
         let expected: Set<String> = ["AGT_SESSION_ID", "AGT_SESSION_NAME", "AGT_SESSION_PWD",
                                      "AGT_WORKSPACE_ID", "AGT_WORKSPACE_NAME", "AGT_WINDOW_ID",
-                                     "AGT_WINDOW_NAME", "AGT_SELECTION", "AGT_SOCKET"]
+                                     "AGT_WINDOW_NAME", "AGT_PANE", "AGT_SELECTION", "AGT_SOCKET"]
         #expect(envKeys == expected)
     }
 

--- a/agtermCore/Tests/agtermCoreTests/CustomCommandTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/CustomCommandTests.swift
@@ -6,7 +6,7 @@ struct CustomCommandTests {
     private func sampleContext() -> CommandContext {
         CommandContext(sessionID: "sess-1", sessionName: "shell", sessionPWD: "/tmp/work",
                        workspaceID: "ws-1", workspaceName: "main", windowID: "win-1",
-                       windowName: "work", pane: "right", selection: "hello", socket: "/tmp/agt.sock")
+                       windowName: "work", pane: .right, selection: "hello", socket: "/tmp/agt.sock")
     }
 
     @Test func expandSubstitutesKnownTokens() {
@@ -69,10 +69,12 @@ struct CustomCommandTests {
 
     @Test func paneDefaultsToLeft() {
         // an unspecified pane is the main pane — always a valid `session.type --pane` argument, so a
-        // split-less session's context still round-trips into a pane-addressed control call.
-        #expect(CommandContext().pane == "left")
+        // split-less session's context still round-trips into a pane-addressed control call. The typed
+        // `Pane` enum guarantees the value is left/right by construction; its rawValue feeds the token.
+        #expect(CommandContext().pane == .left)
         #expect(CommandContext().environment()["AGT_PANE"] == "left")
         #expect(CommandContext().expand("{AGT_PANE}") == "left")
+        #expect(CommandContext(pane: .right).expand("{AGT_PANE}") == "right")
     }
 
     @Test func environmentKeySetMatchesTheTokensExpandSubstitutes() {

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -150,6 +150,22 @@ struct CommandsTests {
         #expect(command.target.target == "s1")
     }
 
+    @Test func sessionTypeWithPane() throws {
+        let expected = ControlRequest(cmd: .sessionType, target: "s1",
+                                      args: ControlArgs(text: "ls\n", select: false, pane: "right"))
+        #expect(try request(["session", "type", "ls\n", "--pane", "right", "--target", "s1"]) == expected)
+    }
+
+    @Test func sessionTypeWithoutPaneOmitsIt() throws {
+        let req = try request(["session", "type", "ls\n"])
+        #expect(req.args?.pane == nil)
+    }
+
+    @Test func sessionTypeRejectsBadPane() {
+        // `other` is a session.focus mode, not a typable pane — type accepts left|right only.
+        #expect(validationMessage(["session", "type", "x", "--pane", "other"]) == "--pane must be left or right")
+    }
+
     @Test func sessionSplitDefaultsToggle() throws {
         let expected = ControlRequest(cmd: .sessionSplit, target: "active", args: ControlArgs(mode: "toggle"))
         #expect(try request(["session", "split"]) == expected)

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -161,6 +161,13 @@ struct CommandsTests {
         #expect(req.args?.pane == nil)
     }
 
+    @Test func sessionTypeWithPaneLeft() throws {
+        // explicit --pane left is forwarded as "left"; the server treats nil and "left" identically (both
+        // the main pane), but the CLI still passes the value through rather than dropping it.
+        let req = try request(["session", "type", "ls\n", "--pane", "left"])
+        #expect(req.args?.pane == "left")
+    }
+
     @Test func sessionTypeRejectsBadPane() {
         // `other` is a session.focus mode, not a typable pane — type accepts left|right only.
         #expect(validationMessage(["session", "type", "x", "--pane", "other"]) == "--pane must be left or right")

--- a/agtermUITests/ControlAPITestCase.swift
+++ b/agtermUITests/ControlAPITestCase.swift
@@ -110,9 +110,12 @@ class ControlAPITestCase: XCTestCase {
         XCTAssertTrue(app.staticTexts["session-row"].waitForExistence(timeout: 30), "seeded session should exist")
     }
 
-    /// Build a `session.type` request line with JSON-escaped `text` (covers the newline and the quoted path).
-    func typeRequest(text: String, target: String? = nil, select: Bool) -> String {
-        var obj: [String: Any] = ["cmd": "session.type", "args": ["text": text, "select": select]]
+    /// Build a `session.type` request line with JSON-escaped `text` (covers the newline and the quoted
+    /// path); `pane` addresses a split pane (`left`|`right`, nil = the main pane).
+    func typeRequest(text: String, target: String? = nil, select: Bool, pane: String? = nil) -> String {
+        var args: [String: Any] = ["text": text, "select": select]
+        if let pane { args["pane"] = pane }
+        var obj: [String: Any] = ["cmd": "session.type", "args": args]
         if let target { obj["target"] = target }
         let data = try! JSONSerialization.data(withJSONObject: obj)
         return String(data: data, encoding: .utf8)!

--- a/agtermUITests/ControlAPITestCase.swift
+++ b/agtermUITests/ControlAPITestCase.swift
@@ -153,6 +153,27 @@ class ControlAPITestCase: XCTestCase {
         return nil
     }
 
+    /// Polls `session.text --pane <pane>` of `target` until the returned buffer contains `contains`, re-running
+    /// `retype` (which re-injects the marker command — idempotent for an `echo` line) at the start of each
+    /// outer attempt to ride out shell/focus readiness. Returns the matching text, or nil on timeout. Shared
+    /// by the pane-addressed suites (`SessionTextUITests`, `SessionTypePaneUITests`).
+    @discardableResult
+    func pollPaneText(target: String, pane: String, contains: String,
+                      attempts: Int = 8, perAttempt: Int = 8,
+                      retype: () throws -> Void) throws -> String? {
+        for _ in 0..<attempts {
+            try retype()
+            for _ in 0..<perAttempt {
+                let response = try sendCommand(#"{"cmd":"session.text","target":"\#(target)","args":{"pane":"\#(pane)"}}"#)
+                if let t = (response["result"] as? [String: Any])?["text"] as? String, t.contains(contains) {
+                    return t
+                }
+                RunLoop.current.run(until: Date().addingTimeInterval(0.4))
+            }
+        }
+        return nil
+    }
+
     // MARK: - Snapshot oracle
 
     /// Polls the hermetic snapshot file until the (single) seeded workspace holds `expected` sessions.

--- a/agtermUITests/CustomCommandPaneTokenUITests.swift
+++ b/agtermUITests/CustomCommandPaneTokenUITests.swift
@@ -81,6 +81,49 @@ final class CustomCommandPaneTokenUITests: ControlAPITestCase {
                        "a command run from the palette with no split should report $AGT_PANE=left")
     }
 
+    // promoted single-pane: split on, then exit the PRIMARY (main/left) shell so `closePrimaryPane`
+    // promotes the survivor into the `splitSurface` slot (hasSplit=false, splitFocused=true, surface=nil).
+    // {AGT_PANE} must report "right": the survivor physically lives in splitSurface, so that's the pane
+    // `session.type --pane` reaches — a "left" here would name the torn-down main surface. Then prove the
+    // round-trip the token exists for: `session.type --pane <reported>` lands in the survivor's own buffer.
+    // This is the edge the review went back and forth on (reword-not-gate).
+    func testAgtPanePromotedSurvivorReportsRight() throws {
+        let marker = markerDir.appendingPathComponent("agt-pane-promoted")
+        try relaunch(withKeymap: "command \"Pane Probe\" printf %s \"$AGT_PANE\" > \"\(marker.path)\"\n")
+
+        let split = try sendCommand(#"{"cmd":"session.split","target":"active","args":{"mode":"on"}}"#)
+        XCTAssertEqual(split["ok"] as? Bool, true, "split on should succeed: \(split)")
+        XCTAssertTrue(pollActiveSessionSplit(true, timeout: 10), "the active session should report split:true")
+        let activeID = try activeSessionID()
+
+        // a no-pane session.type injects into the main (left) surface regardless of focus, so `exit` closes
+        // the primary pane; with a live split pane, `closePrimaryPane` promotes the survivor rather than
+        // closing the session. Retry the exit until the split flag drops (the shell may not be at a prompt
+        // for the first keystrokes — the same readiness idiom the pane-text polls use).
+        var promoted = false
+        for _ in 0..<5 {
+            _ = try sendCommand(typeRequest(text: "exit\n", target: activeID, select: false))
+            if pollActiveSessionSplit(false, timeout: 4) { promoted = true; break }
+        }
+        XCTAssertTrue(promoted, "exiting the primary pane should promote the survivor to a single (non-split) pane")
+
+        // palette path: the promoted survivor has splitFocused=true AND splitSurface != nil, so run() reports right.
+        try? FileManager.default.removeItem(at: marker)
+        runFromCustomCommandsPalette("Pane Probe")
+        let reported = pollMarker(marker, timeout: 5)
+        XCTAssertEqual(reported, "right", "a promoted split survivor should report $AGT_PANE=right")
+
+        // round-trip: session.type --pane <reported> must reach THAT pane's buffer (the survivor). Typed as
+        // `$((6*7))` arithmetic so a match proves the survivor's shell RAN the line, not merely echoed it.
+        let pane = try XCTUnwrap(reported)
+        let tag = "PROMO-\(UUID().uuidString.prefix(8))"
+        let text = try pollPaneText(target: activeID, pane: pane, contains: "\(tag)-42", retype: {
+            _ = try self.sendCommand(self.typeRequest(text: "echo \(tag)-$((6*7))\n", target: activeID,
+                                                      select: false, pane: pane))
+        })
+        XCTAssertNotNil(text, "session.type --pane \(pane) should reach the promoted survivor")
+    }
+
     // MARK: - Helpers
 
     /// Click the seeded session row so the main terminal surface is first responder (the custom-command

--- a/agtermUITests/CustomCommandPaneTokenUITests.swift
+++ b/agtermUITests/CustomCommandPaneTokenUITests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import XCTest
+
+// Verifies the `CustomCommandRunner` pane derivation that populates `{AGT_PANE}`/`$AGT_PANE`: a custom
+// command reports the pane it fired FROM — "left" (main) or "right" (split). This is the only test that
+// pins that logic. The keybind path derives the pane from the focused SURFACE's identity (NOT the
+// session's `splitFocused` flag), and the palette path from the flag. The probe command writes
+// `$AGT_PANE` to a marker file, which the test reads back. A `ControlAPITestCase` subclass so it can
+// split/focus panes over the control socket while firing real keystrokes for the keybind path.
+@MainActor
+final class CustomCommandPaneTokenUITests: ControlAPITestCase {
+    // keybind path: fire the SAME chord from the main pane and then from the split's right pane; $AGT_PANE
+    // must be "left" then "right", proving `runFromKeybind` keys off the focused surface's identity rather
+    // than a shared flag (a plain `splitFocused`-based derivation would report "right" for both once split).
+    func testAgtPaneKeybindReflectsFiredFromPane() throws {
+        let marker = markerDir.appendingPathComponent("agt-pane-keybind")
+        // ⌘⇧E → write $AGT_PANE to the marker. The runner already wraps the line in `/bin/sh -c`, so
+        // `$AGT_PANE` expands from the exported env; no inner `sh -c` is needed.
+        try relaunch(withKeymap: "command \"Pane Probe\" cmd+shift+e printf %s \"$AGT_PANE\" > \"\(marker.path)\"\n")
+
+        // MAIN pane (no split yet): focus the seeded terminal, fire the chord → "left".
+        focusMainTerminal()
+        XCTAssertEqual(firePaneProbe(marker) { self.app.typeKey("e", modifierFlags: [.command, .shift]) }, "left",
+                       "a chord fired from the main pane should report $AGT_PANE=left")
+
+        // SPLIT right pane: split on, move keyboard focus to the right pane, fire the SAME chord → "right".
+        let split = try sendCommand(#"{"cmd":"session.split","target":"active","args":{"mode":"on"}}"#)
+        XCTAssertEqual(split["ok"] as? Bool, true, "split on should succeed: \(split)")
+        XCTAssertTrue(pollActiveSessionSplit(true, timeout: 10), "the active session should report split:true")
+        let activeID = try activeSessionID()
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.focus","target":"\#(activeID)","args":{"pane":"right"}}"#)["ok"] as? Bool,
+                       true, "focus right should succeed")
+        app.activate()
+        XCTAssertEqual(firePaneProbe(marker) { self.app.typeKey("e", modifierFlags: [.command, .shift]) }, "right",
+                       "a chord fired from the split's right pane should report $AGT_PANE=right")
+    }
+
+    // palette path: the runner's `run(_:)` (no fired-from surface to key off) derives the pane from the
+    // active session's `splitFocused` flag. Split on + focus right, then run the command from the Custom
+    // Commands palette; opening the menu doesn't touch `splitFocused`, so the flag stays true → "right".
+    func testAgtPanePaletteUsesFocusedPane() throws {
+        let marker = markerDir.appendingPathComponent("agt-pane-palette")
+        // no chord → palette-only (the `printf` token is not a valid chord, so the whole remainder is the
+        // shell line).
+        try relaunch(withKeymap: "command \"Pane Probe\" printf %s \"$AGT_PANE\" > \"\(marker.path)\"\n")
+
+        let split = try sendCommand(#"{"cmd":"session.split","target":"active","args":{"mode":"on"}}"#)
+        XCTAssertEqual(split["ok"] as? Bool, true, "split on should succeed: \(split)")
+        XCTAssertTrue(pollActiveSessionSplit(true, timeout: 10), "the active session should report split:true")
+        let activeID = try activeSessionID()
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.focus","target":"\#(activeID)","args":{"pane":"right"}}"#)["ok"] as? Bool,
+                       true, "focus right should succeed")
+
+        try? FileManager.default.removeItem(at: marker)
+        runFromCustomCommandsPalette("Pane Probe")
+        XCTAssertEqual(pollMarker(marker, timeout: 5), "right",
+                       "a command run from the palette while the right pane is focused should report $AGT_PANE=right")
+    }
+
+    // palette path, default (no split): the seeded session has no split, so `run(_:)`'s
+    // `splitFocused ? .right : .left` takes the `.left` branch — the common case, and the half of that
+    // ternary the split+focus-right test above never exercises through the real runner. Pins that a
+    // swapped ternary or a hardcoded `.right` in the palette path would be caught.
+    func testAgtPanePaletteDefaultsToLeftWithoutSplit() throws {
+        let marker = markerDir.appendingPathComponent("agt-pane-palette-left")
+        try relaunch(withKeymap: "command \"Pane Probe\" printf %s \"$AGT_PANE\" > \"\(marker.path)\"\n")
+
+        // no split on the seeded session → the active pane is the main pane, so the palette path reports left.
+        try? FileManager.default.removeItem(at: marker)
+        runFromCustomCommandsPalette("Pane Probe")
+        XCTAssertEqual(pollMarker(marker, timeout: 5), "left",
+                       "a command run from the palette with no split should report $AGT_PANE=left")
+    }
+
+    // MARK: - Helpers
+
+    /// Click the seeded session row so the main terminal surface is first responder (the custom-command
+    /// monitor only fires when a `GhosttySurfaceView` holds first responder). Drains until the row reports
+    /// selected so the responder bounce settles before a chord is pressed.
+    private func focusMainTerminal() {
+        let row = app.staticTexts["session-row"].firstMatch
+        XCTAssertTrue(row.waitForHittable(timeout: 20), "seeded session should be hittable")
+        row.click()
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline, row.isSelected == false {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+    }
+
+    /// Fire `press` and read the marker back, retrying: a chord can land before the surface is genuinely
+    /// first responder (focus return is async) and be dropped. Clears the marker before each attempt so a
+    /// prior attempt's write can't be misread. Returns the trimmed value, or nil on timeout.
+    private func firePaneProbe(_ marker: URL, attempts: Int = 8, perAttempt: TimeInterval = 2,
+                               press: () -> Void) -> String? {
+        for _ in 0..<attempts {
+            try? FileManager.default.removeItem(at: marker)
+            press()
+            if let value = pollMarker(marker, timeout: perAttempt) { return value }
+        }
+        return nil
+    }
+
+    /// Open Navigate ▸ Custom Commands, filter to `name`, and run the top match (Return).
+    private func runFromCustomCommandsPalette(_ name: String) {
+        app.menuBars.menuBarItems["Navigate"].click()
+        let item = app.menuItems["Custom Commands"]
+        XCTAssertTrue(item.waitForExistence(timeout: 5), "Navigate menu should offer Custom Commands")
+        item.click()
+        let field = app.textFields.firstMatch
+        XCTAssertTrue(field.waitForExistence(timeout: 5), "palette search field should appear")
+        field.click()
+        field.typeText(name)
+        app.typeKey(.return, modifierFlags: [])
+    }
+}

--- a/agtermUITests/CustomCommandPaneTokenUITests.swift
+++ b/agtermUITests/CustomCommandPaneTokenUITests.swift
@@ -9,9 +9,18 @@ import XCTest
 // split/focus panes over the control socket while firing real keystrokes for the keybind path.
 @MainActor
 final class CustomCommandPaneTokenUITests: ControlAPITestCase {
-    // keybind path: fire the SAME chord from the main pane and then from the split's right pane; $AGT_PANE
-    // must be "left" then "right", proving `runFromKeybind` keys off the focused surface's identity rather
-    // than a shared flag (a plain `splitFocused`-based derivation would report "right" for both once split).
+    // keybind path: fire the SAME chord from the main pane (no split) and then from the split's focused
+    // right pane; $AGT_PANE must be "left" then "right", exercising both branches of `runFromKeybind`'s
+    // surface-identity derivation end-to-end through the real NSEvent monitor.
+    //
+    // NOTE: this does NOT isolate "surface identity" from "the splitFocused flag" — in both fired states
+    // the flag and the actual first responder AGREE (the surfaces' onFocusChange closures keep splitFocused
+    // synced to real focus), so a regression deriving the pane from splitFocused would pass here too. A
+    // flag-vs-focus divergence isn't deterministically reproducible: the only way to set the flag without a
+    // focus change is `session.split on` over the socket, after which the main surface is re-hosted into the
+    // HSplitView and holds no reliable first responder — so the chord's "a GhosttySurfaceView must hold
+    // first responder" gate can't be pinned. The surface-identity choice itself is covered by inspection
+    // (`CustomCommandRunner.runFromKeybind`) plus the promoted-survivor reasoning in keymap.md.
     func testAgtPaneKeybindReflectsFiredFromPane() throws {
         let marker = markerDir.appendingPathComponent("agt-pane-keybind")
         // ⌘⇧E → write $AGT_PANE to the marker. The runner already wraps the line in `/bin/sh -c`, so

--- a/agtermUITests/SessionTextUITests.swift
+++ b/agtermUITests/SessionTextUITests.swift
@@ -98,25 +98,27 @@ final class SessionTextUITests: ControlAPITestCase {
         XCTAssertTrue(viewport.contains("\(tag)-400-X"), "the default (VIEWPORT) read should still show the most recent line")
     }
 
-    // session.text --pane left|right reads the matching pane of a split. session.type is main-only (it always
-    // injects into session.surface), so the LEFT marker goes in over the socket; the RIGHT pane is fed via
-    // the real keyboard after focusing it. Assert each pane read returns its OWN marker and NOT the other's —
-    // the --pane success mappings (left→surface, right→splitSurface) are otherwise only hit on the error path.
+    // session.text --pane left|right reads the matching pane of a split. The LEFT marker goes in over the
+    // socket (a no-pane session.type injects into the main pane); the RIGHT pane is fed via the real
+    // keyboard after focusing it — deliberately NOT via `session.type --pane right` (that route has its own
+    // e2e in SessionTypePaneUITests), so this test also proves the focus→keyboard first-responder routing.
+    // Assert each pane read returns its OWN marker and NOT the other's — the --pane success mappings
+    // (left→surface, right→splitSurface) are otherwise only hit on the error path.
     func testSessionTextPaneSelectsCorrectPane() throws {
         let split = try sendCommand(#"{"cmd":"session.split","target":"active","args":{"mode":"on"}}"#)
         XCTAssertEqual(split["ok"] as? Bool, true, "split on should succeed: \(split)")
         XCTAssertTrue(pollActiveSessionSplit(true, timeout: 10), "the active session should report split:true")
         let activeID = try activeSessionID()
 
-        // LEFT (main) pane: session.type injects into session.surface (main-only by design), so this marker
-        // lands in the left pane regardless of which pane holds focus.
+        // LEFT (main) pane: a no-pane session.type injects into session.surface (the main pane), so this
+        // marker lands in the left pane regardless of which pane holds focus.
         let leftMarker = "LEFT-\(UUID().uuidString.prefix(8))"
         XCTAssertNotNil(try pollPaneText(target: activeID, pane: "left", contains: leftMarker, retype: {
             _ = try self.sendCommand(self.typeRequest(text: "echo \(leftMarker)\n", target: activeID, select: false))
         }), "--pane left should read the marker typed into the main pane")
 
-        // RIGHT (split) pane: session.type can't reach it, so focus it and type via the real keyboard, which
-        // routes to the focused pane's first responder.
+        // RIGHT (split) pane: focus it and type via the real keyboard, which routes to the focused pane's
+        // first responder.
         let rightMarker = "RIGHT-\(UUID().uuidString.prefix(8))"
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.focus","target":"\#(activeID)","args":{"pane":"right"}}"#)["ok"] as? Bool,
                        true, "focus right should succeed")

--- a/agtermUITests/SessionTextUITests.swift
+++ b/agtermUITests/SessionTextUITests.swift
@@ -184,24 +184,4 @@ final class SessionTextUITests: ControlAPITestCase {
         let text = try XCTUnwrap((response["result"] as? [String: Any])?["text"] as? String, "a blank read still carries a text field: \(response)")
         XCTAssertTrue(text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty, "a blank screen should read as empty, got: \(text)")
     }
-
-    /// Polls `session.text --pane <pane>` of `target` until the returned buffer contains `contains`, re-running
-    /// `retype` (which re-injects the marker command — idempotent for an `echo` line) at the start of each
-    /// outer attempt to ride out shell/focus readiness. Returns the matching text, or nil on timeout.
-    @discardableResult
-    private func pollPaneText(target: String, pane: String, contains: String,
-                              attempts: Int = 8, perAttempt: Int = 8,
-                              retype: () throws -> Void) throws -> String? {
-        for _ in 0..<attempts {
-            try retype()
-            for _ in 0..<perAttempt {
-                let response = try sendCommand(#"{"cmd":"session.text","target":"\#(target)","args":{"pane":"\#(pane)"}}"#)
-                if let t = (response["result"] as? [String: Any])?["text"] as? String, t.contains(contains) {
-                    return t
-                }
-                RunLoop.current.run(until: Date().addingTimeInterval(0.4))
-            }
-        }
-        return nil
-    }
 }

--- a/agtermUITests/SessionTypePaneUITests.swift
+++ b/agtermUITests/SessionTypePaneUITests.swift
@@ -60,25 +60,4 @@ final class SessionTypePaneUITests: ControlAPITestCase {
         XCTAssertEqual(response["ok"] as? Bool, false, "session.type pane:middle should fail server-side: \(response)")
         XCTAssertEqual(response["error"] as? String, "invalid pane: middle", "should report the invalid pane: \(response)")
     }
-
-    /// Polls `session.text --pane <pane>` of `target` until the returned buffer contains `contains`,
-    /// re-running `retype` at the start of each outer attempt (idempotent `echo` markers) to ride out
-    /// shell/pty readiness. Returns the matching text, or nil on timeout. (The same idiom as
-    /// `SessionTextUITests.pollPaneText`, private there.)
-    @discardableResult
-    private func pollPaneText(target: String, pane: String, contains: String,
-                              attempts: Int = 8, perAttempt: Int = 8,
-                              retype: () throws -> Void) throws -> String? {
-        for _ in 0..<attempts {
-            try retype()
-            for _ in 0..<perAttempt {
-                let response = try sendCommand(#"{"cmd":"session.text","target":"\#(target)","args":{"pane":"\#(pane)"}}"#)
-                if let t = (response["result"] as? [String: Any])?["text"] as? String, t.contains(contains) {
-                    return t
-                }
-                RunLoop.current.run(until: Date().addingTimeInterval(0.4))
-            }
-        }
-        return nil
-    }
 }

--- a/agtermUITests/SessionTypePaneUITests.swift
+++ b/agtermUITests/SessionTypePaneUITests.swift
@@ -28,10 +28,13 @@ final class SessionTypePaneUITests: ControlAPITestCase {
         })
         XCTAssertNotNil(leftText, "the default (no pane) injection should land in the main pane")
 
+        // NB: no inner `ok == true` assert here (unlike a one-shot check) — the base class sets
+        // continueAfterFailure = false, so a transient ok:false on a not-yet-ready split would abort the
+        // whole test instead of letting the retry loop ride it out. Success is asserted once, below, via
+        // the marker actually landing (the left closure omits the inner assert for the same reason).
         let rightText = try pollPaneText(target: activeID, pane: "right", contains: "\(rightTag)-42", retype: {
-            let typed = try self.sendCommand(self.typeRequest(text: "echo \(rightTag)-$((6*7))\n",
-                                                              target: activeID, select: false, pane: "right"))
-            XCTAssertEqual(typed["ok"] as? Bool, true, "session.type --pane right should succeed: \(typed)")
+            _ = try self.sendCommand(self.typeRequest(text: "echo \(rightTag)-$((6*7))\n",
+                                                      target: activeID, select: false, pane: "right"))
         })
         XCTAssertNotNil(rightText, "--pane right should land in the split pane")
 
@@ -42,8 +45,9 @@ final class SessionTypePaneUITests: ControlAPITestCase {
                        "the split pane must NOT contain the main pane's marker: \(rightText ?? "")")
     }
 
-    // session.type --pane right on a non-split session errors. `right` passes the CLI validate(), so the
-    // request reaches the server, which rejects it (no split pane to type into) — mirroring session.text.
+    // session.type --pane right on a non-split session errors. The request is sent directly over the socket
+    // (sendCommand bypasses the CLI entirely), so the SERVER itself rejects it (no split pane to type into)
+    // — mirroring session.text.
     func testSessionTypePaneRightWithoutSplitErrors() throws {
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
         let newID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "session.new should return the new id")

--- a/agtermUITests/SessionTypePaneUITests.swift
+++ b/agtermUITests/SessionTypePaneUITests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import XCTest
+
+// session.type --pane UI e2e: pane-addressed text injection into a split. A `ControlAPITestCase`
+// subclass like `SessionTextUITests`, reusing the shared harness (sendCommand / typeRequest /
+// pollActiveSessionSplit / activeSessionID). The read-back oracle is `session.text --pane`, whose own
+// pane routing is proven independently in `SessionTextUITests.testSessionTextPaneSelectsCorrectPane`.
+@MainActor
+final class SessionTypePaneUITests: ControlAPITestCase {
+    // session.type --pane right injects into the SPLIT pane's pty while the default (no pane) keeps
+    // injecting into the main pane — each marker must come back from its own pane's buffer and NOT the
+    // other's, proving the two injections hit different surfaces. Markers are echo OUTPUT tags typed as
+    // `$((6*7))` arithmetic so a match proves the shell in that pane RAN the line, not merely echoed it.
+    func testSessionTypePaneRightReachesSplitPane() throws {
+        let split = try sendCommand(#"{"cmd":"session.split","target":"active","args":{"mode":"on"}}"#)
+        XCTAssertEqual(split["ok"] as? Bool, true, "split on should succeed: \(split)")
+        XCTAssertTrue(pollActiveSessionSplit(true, timeout: 10), "the active session should report split:true")
+        let activeID = try activeSessionID()
+
+        let leftTag = "TYPEL-\(UUID().uuidString.prefix(8))"
+        let rightTag = "TYPER-\(UUID().uuidString.prefix(8))"
+
+        // default (no pane) lands in the main pane; --pane right lands in the split pane. Re-inject per
+        // attempt: a freshly-spawned pane's shell may not be ready for its first keystrokes (the
+        // typeUntilMarker readiness idiom), and an `echo` line is idempotent.
+        let leftText = try pollPaneText(target: activeID, pane: "left", contains: "\(leftTag)-42", retype: {
+            _ = try self.sendCommand(self.typeRequest(text: "echo \(leftTag)-$((6*7))\n", target: activeID, select: false))
+        })
+        XCTAssertNotNil(leftText, "the default (no pane) injection should land in the main pane")
+
+        let rightText = try pollPaneText(target: activeID, pane: "right", contains: "\(rightTag)-42", retype: {
+            let typed = try self.sendCommand(self.typeRequest(text: "echo \(rightTag)-$((6*7))\n",
+                                                              target: activeID, select: false, pane: "right"))
+            XCTAssertEqual(typed["ok"] as? Bool, true, "session.type --pane right should succeed: \(typed)")
+        })
+        XCTAssertNotNil(rightText, "--pane right should land in the split pane")
+
+        // cross-check: each pane's buffer carries ONLY its own marker.
+        XCTAssertFalse(try XCTUnwrap(leftText).contains("\(rightTag)-42"),
+                       "the main pane must NOT contain the split pane's marker: \(leftText ?? "")")
+        XCTAssertFalse(try XCTUnwrap(rightText).contains("\(leftTag)-42"),
+                       "the split pane must NOT contain the main pane's marker: \(rightText ?? "")")
+    }
+
+    // session.type --pane right on a non-split session errors. `right` passes the CLI validate(), so the
+    // request reaches the server, which rejects it (no split pane to type into) — mirroring session.text.
+    func testSessionTypePaneRightWithoutSplitErrors() throws {
+        let created = try sendCommand(#"{"cmd":"session.new"}"#)
+        let newID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "session.new should return the new id")
+
+        let response = try sendCommand(typeRequest(text: "echo nope\n", target: newID, select: true, pane: "right"))
+        XCTAssertEqual(response["ok"] as? Bool, false, "session.type --pane right with no split should fail: \(response)")
+        XCTAssertEqual(response["error"] as? String, "session has no split pane", "should report no split pane: \(response)")
+    }
+
+    // pane validation is enforced SERVER-SIDE, not only in the CLI `validate()`: a raw socket client
+    // bypasses the CLI, so an unknown pane value must error here too (sendCommand is that raw client).
+    func testSessionTypeRejectsInvalidPaneServerSide() throws {
+        let response = try sendCommand(#"{"cmd":"session.type","target":"active","args":{"text":"x","pane":"middle"}}"#)
+        XCTAssertEqual(response["ok"] as? Bool, false, "session.type pane:middle should fail server-side: \(response)")
+        XCTAssertEqual(response["error"] as? String, "invalid pane: middle", "should report the invalid pane: \(response)")
+    }
+
+    /// Polls `session.text --pane <pane>` of `target` until the returned buffer contains `contains`,
+    /// re-running `retype` at the start of each outer attempt (idempotent `echo` markers) to ride out
+    /// shell/pty readiness. Returns the matching text, or nil on timeout. (The same idiom as
+    /// `SessionTextUITests.pollPaneText`, private there.)
+    @discardableResult
+    private func pollPaneText(target: String, pane: String, contains: String,
+                              attempts: Int = 8, perAttempt: Int = 8,
+                              retype: () throws -> Void) throws -> String? {
+        for _ in 0..<attempts {
+            try retype()
+            for _ in 0..<perAttempt {
+                let response = try sendCommand(#"{"cmd":"session.text","target":"\#(target)","args":{"pane":"\#(pane)"}}"#)
+                if let t = (response["result"] as? [String: Any])?["text"] as? String, t.contains(contains) {
+                    return t
+                }
+                RunLoop.current.run(until: Date().addingTimeInterval(0.4))
+            }
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
## What

Two small, paired additions that make split panes reachable from automation:

1. **`session.type` gains `--pane left|right`** (protocol: `args.pane`, reused field — no new `ControlArgs` member). Omitted/`left` is the main pane; `right` injects into the split surface. Mirrors `session.text`'s pane semantics and error strings.
2. **Custom keymap commands get `{AGT_PANE}` / `$AGT_PANE`** (`left`|`right`, always `left` without a split): the pane the shortcut fired from. Keybind path derives it from the focused surface's identity; palette path from `splitFocused`.

Together they close a loop that was previously impossible: a hotkey script can now type back into the exact pane it was invoked from — `agtermctl session type --pane "$AGT_PANE"`.

## Why

`session.type` always injected into `session.surface` (the main pane), so any control-channel automation invoked from a split pane landed its keystrokes in the wrong shell. Concrete case: a keymap-bound popup menu (overlay TUI) that types the picked command into the invoking session — invoked from the right pane, the command lands in the left one. Nothing on the control surface could express "the split pane", and nothing told the fired script which pane it came from; this PR adds both halves.

## Design notes

- **Omitted `--pane` keeps the exact pre-pane behavior (main pane), NOT the focused/on-screen pane.** That's deliberately asymmetric with `session.text` (whose no-pane read is the on-screen surface): changing the injection default would silently redirect existing automation's keystrokes. Happy to flip it to `onScreenSurface` if you prefer consistency over compatibility here.
- `right` requires an existing split surface — the realize/`--select` path stays main-pane-only, since selecting never creates a split. No split → `session has no split pane` (same string as `session.text`).
- Pane validation is enforced server-side in `injectText` (raw socket clients can't bypass the CLI `validate()`), mirroring the `session.text` precedent.
- `SessionTextUITests.testSessionTextPaneSelectsCorrectPane` still feeds the right pane via the real keyboard on purpose (it also proves focus→first-responder routing); the new `SessionTypePaneUITests` covers the `--pane right` injection route.

## Keep-in-sync audit (four surfaces)

1. `ControlProtocol.swift` — reuses `ControlArgs.pane`, doc updated.
2. `ControlServer` — pane switch in `injectText` (`ControlServer+SurfaceIO.swift`).
3. `agtermctl` — `session type --pane left|right`, `validate()`-guarded.
4. Tests — round-trip (`ControlProtocolTests`), CLI mapping + rejection (`CommandsTests`), token/env symmetry incl. the new `AGT_PANE` (`CustomCommandTests`), e2e (`SessionTypePaneUITests`: `--pane right` reaches the split pane and only it, no-split errors, invalid pane rejected server-side).

Plus the doc mirrors: `agterm/Resources/agent-skill/` (SKILL.md, reference.md, examples.md — command count unchanged, no new command), README (token table + `session type` note), `.claude/rules/control-api.md` + `.claude/rules/keymap.md`.

## Verification

- `swift test`: 906 tests green.
- `make lint` (`--strict`): clean.
- `make build` (Debug): green.
- XCUITest: `SessionTypePaneUITests` (3/3) and `SessionTextUITests/testSessionTextPaneSelectsCorrectPane` pass locally.
