### PR TITLE
refactor(palette): hoist fuzzy ranking

### DIFF
--- a/agterm/Views/Palette.swift
+++ b/agterm/Views/Palette.swift
@@ -109,17 +109,9 @@ struct CommandPalette: View {
             selection = filtered.isEmpty ? 0 : min(selection, filtered.count - 1)
             return
         }
-        let scored: [(item: PaletteItem, score: Int)] = allItems.compactMap { item in
-            let scores = [fuzzyScore(query: q, target: item.title),
-                          item.subtitle.flatMap { fuzzyScore(query: q, target: $0) }].compactMap { $0 }
-            guard let best = scores.min() else { return nil }
-            return (item, best)
+        filtered = fuzzyRank(query: q, items: allItems) { item in
+            item.subtitle.map { [item.title, $0] } ?? [item.title]
         }
-        filtered = scored.sorted {
-            $0.score != $1.score
-                ? $0.score < $1.score
-                : $0.item.title.localizedCaseInsensitiveCompare($1.item.title) == .orderedAscending
-        }.map(\.item)
         selection = filtered.isEmpty ? 0 : min(selection, filtered.count - 1)
     }
 

--- a/agtermCore/Sources/agtermCore/Fuzzy.swift
+++ b/agtermCore/Sources/agtermCore/Fuzzy.swift
@@ -21,6 +21,26 @@ public func fuzzyScore(query: String, target: String) -> Int? {
     return total
 }
 
+/// Ranks `items` against `query` for the command palettes: an item matches when any of its `keys`
+/// (for example, a title and optional subtitle) matches, scored by the best/lower score of those keys.
+/// Matches are sorted best-first with ties broken by the first key, case-insensitively.
+///
+/// Empty queries score every item at `0`, which makes this an alphabetical sort by first key. Callers
+/// that need an empty query to preserve natural input order should skip ranking for that case.
+public func fuzzyRank<Item>(query: String, items: [Item], keys: (Item) -> [String]) -> [Item] {
+    items.compactMap { item -> (item: Item, score: Int, label: String)? in
+        let itemKeys = keys(item)
+        guard let best = itemKeys.compactMap({ fuzzyScore(query: query, target: $0) }).min() else { return nil }
+        return (item, best, itemKeys.first ?? "")
+    }
+    .sorted {
+        $0.score != $1.score
+            ? $0.score < $1.score
+            : $0.label.localizedCaseInsensitiveCompare($1.label) == .orderedAscending
+    }
+    .map(\.item)
+}
+
 /// Scores a single whitespace-free `term` against the already-lowercased `target`: an exact prefix
 /// is `0`, a substring is `5 +` its start offset, a scattered subsequence is `40 +` the length gap,
 /// and `nil` when the term doesn't appear at all.

--- a/agtermCore/Tests/agtermCoreTests/FuzzyTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/FuzzyTests.swift
@@ -61,4 +61,47 @@ struct FuzzyTests {
     @Test func whitespaceOnlyQueryMatchesEverything() {
         #expect(fuzzyScore(query: "  \t ", target: "anything") == 0)
     }
+
+    @Test func fuzzyRankSortsBestMatchFirstAndDropsNonMatches() {
+        let items = ["New Workspace", "New Session", "Close Session"]
+        let ranked = fuzzyRank(query: "new", items: items, keys: { [$0] })
+
+        #expect(ranked == ["New Session", "New Workspace"])
+    }
+
+    @Test func fuzzyRankPrefersLowerScore() {
+        let items = ["New Session", "Session List"]
+
+        #expect(fuzzyRank(query: "sess", items: items, keys: { [$0] }) == ["Session List", "New Session"])
+    }
+
+    @Test func fuzzyRankMatchesAnyKeyUsingTheBestScore() {
+        struct Command: Equatable {
+            let title: String
+            let subtitle: String
+        }
+        let items = [
+            Command(title: "Toggle Split", subtitle: "panes"),
+            Command(title: "Reload", subtitle: "split config")
+        ]
+
+        let ranked = fuzzyRank(query: "split", items: items, keys: { [$0.title, $0.subtitle] })
+
+        #expect(ranked == [
+            Command(title: "Reload", subtitle: "split config"),
+            Command(title: "Toggle Split", subtitle: "panes")
+        ])
+    }
+
+    @Test func fuzzyRankEmptyQueryAlphabetizesByFirstKey() {
+        let items = ["beta", "Alpha", "gamma"]
+
+        #expect(fuzzyRank(query: "", items: items, keys: { [$0] }) == ["Alpha", "beta", "gamma"])
+    }
+
+    @Test func fuzzyRankTermCharactersMustMatchInOrder() {
+        let items = ["Split Pane", "Panel Split"]
+
+        #expect(fuzzyRank(query: "ps", items: items, keys: { [$0] }) == ["Panel Split"])
+    }
 }


### PR DESCRIPTION
Summary:
- Add `fuzzyRank` to `agtermCore` so palette ranking logic has one host-free helper.
- Rewire `CommandPalette` to use the shared ranker while preserving the attention palette empty-query order.
- Add focused core tests for ranking, no-match behavior, empty-query ordering, and order-sensitive subsequence matching.

Validation:
- `cd agtermCore && swift test --filter FuzzyTests`
- `cd agtermCore && swift test`
- `make lint`
- `make build`