### PR TITLE
refactor: hoist theme catalog facts

### DIFF
--- a/agterm/AppActions+Palette.swift
+++ b/agterm/AppActions+Palette.swift
@@ -199,8 +199,9 @@ extension AppActions {
     /// the current one badged. Navigating a row previews it live (`onSelect`); Enter/click commits it.
     func paletteThemes() -> [PaletteItem] {
         let current = settingsModel?.settings.theme
-        func item(_ name: String?, title: String) -> PaletteItem {
-            PaletteItem(id: themeID(name), title: title, badge: name == current ? "current" : nil,
+        func item(_ entry: ThemeCatalog.Entry) -> PaletteItem {
+            let name = entry.name
+            return PaletteItem(id: entry.id, title: entry.title, badge: name == current ? "current" : nil,
                         onSelect: { [weak self] in self?.previewTheme(name) },
                         run: { [weak self] in
                             self?.previewTheme(name)
@@ -209,16 +210,12 @@ extension AppActions {
         }
         // the nil row is ghostty's built-in default (no theme file); the app's own default is the
         // bundled "agterm" theme, which appears in the named list like any other.
-        var items = [item(nil, title: "default ghostty")]
-        items.append(contentsOf: SettingsCatalog.themeNames().map { item($0, title: $0) })
-        return items
+        return ThemeCatalog(names: SettingsCatalog.themeNames()).entries.map(item)
     }
 
     /// The palette-item id of the currently-applied theme, so the picker opens with that row selected
     /// (and previews it — a no-op — rather than jumping to "Default").
-    var currentThemeID: String { themeID(settingsModel?.settings.theme) }
-
-    private func themeID(_ name: String?) -> String { name.map { "theme:\($0)" } ?? "theme:__default__" }
+    var currentThemeID: String { ThemeCatalog.id(for: settingsModel?.settings.theme) }
 
     /// Capture the live theme so Esc/cancel can restore it. Idempotent while a preview is active.
     func beginThemePreview() {

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -673,9 +673,9 @@ final class ControlServer {
     /// else an error (a typo silently doing nothing is worse than a fail). Returns the applied theme in
     /// `result.theme` (nil = ghostty built-in). App-global: one `SettingsModel`, so no `--window` selector.
     private func setTheme(name: String?) -> ControlResponse {
-        let trimmed = name?.trimmingCharacters(in: .whitespaces)
-        let resolved = (trimmed?.isEmpty ?? true) ? nil : trimmed
-        if let resolved, !actions.availableThemes().contains(resolved) {
+        let resolved = ThemeCatalog.resolvedName(name)
+        let catalog = ThemeCatalog(names: actions.availableThemes())
+        if let resolved, !catalog.contains(name: resolved) {
             return ControlResponse(ok: false, error: "unknown theme: \(resolved)")
         }
         actions.setTheme(resolved)

--- a/agterm/SettingsCatalog.swift
+++ b/agterm/SettingsCatalog.swift
@@ -1,4 +1,5 @@
 import AppKit
+import agtermCore
 
 /// Read-only catalogs for the Appearance settings pickers: the bundled ghostty themes and the
 /// system's monospaced font families. Pure lookups against the bundle / font manager.
@@ -10,7 +11,7 @@ enum SettingsCatalog {
             .appendingPathComponent("themes", isDirectory: true),
             let names = try? FileManager.default.contentsOfDirectory(atPath: themesDir.path)
         else { return [] }
-        return names.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+        return ThemeCatalog(names: names).names
     }
 
     /// Monospaced font family names available on the system, sorted. Filters to families whose

--- a/agtermCore/Sources/agtermCore/ThemeCatalog.swift
+++ b/agtermCore/Sources/agtermCore/ThemeCatalog.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Host-free facts for agterm's theme picker and control API. The app target still owns locating the
+/// bundled ghostty themes directory; this catalog owns ordering, display rows, ids, and default-theme
+/// resolution so the Settings picker, palette, and control path stay aligned.
+public struct ThemeCatalog: Sendable, Equatable {
+    public struct Entry: Sendable, Equatable {
+        public let id: String
+        public let name: String?
+        public let title: String
+
+        public var isDefault: Bool { name == nil }
+    }
+
+    public static let defaultTitle = "default ghostty"
+    public static let defaultID = "theme:__default__"
+
+    public let names: [String]
+
+    public init(names: [String]) {
+        self.names = Self.sorted(names)
+    }
+
+    /// The theme names in `directory` (one file per theme), sorted case-insensitively. Empty when the
+    /// directory is absent or empty.
+    public static func names(in directory: String) -> [String] {
+        guard let items = try? FileManager.default.contentsOfDirectory(atPath: directory), !items.isEmpty else {
+            return []
+        }
+        return sorted(items)
+    }
+
+    public var entries: [Entry] {
+        [Entry(id: Self.defaultID, name: nil, title: Self.defaultTitle)] + names.map {
+            Entry(id: Self.id(for: $0), name: $0, title: $0)
+        }
+    }
+
+    public static func id(for name: String?) -> String {
+        name.map { "theme:\($0)" } ?? defaultID
+    }
+
+    /// A nil or whitespace-only input selects ghostty's built-in default; otherwise the trimmed theme
+    /// name is returned for exact matching against `names`.
+    public static func resolvedName(_ name: String?) -> String? {
+        guard let trimmed = name?.trimmingCharacters(in: .whitespaces), !trimmed.isEmpty else { return nil }
+        return trimmed
+    }
+
+    public func contains(name: String) -> Bool {
+        names.contains(name)
+    }
+
+    private static func sorted(_ names: [String]) -> [String] {
+        names.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/ThemeCatalogTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ThemeCatalogTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+struct ThemeCatalogTests {
+    @Test func namesInDirectorySortCaseInsensitively() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("agterm-themes-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        for name in ["Nord", "alabaster", "Zenburn"] {
+            try "".write(to: dir.appendingPathComponent(name), atomically: true, encoding: .utf8)
+        }
+
+        #expect(ThemeCatalog.names(in: dir.path) == ["alabaster", "Nord", "Zenburn"])
+        #expect(ThemeCatalog.names(in: "/no/such/dir") == [])
+    }
+
+    @Test func entriesPutGhosttyDefaultBeforeNamedThemes() {
+        let catalog = ThemeCatalog(names: ["Nord", "agterm", "Adwaita Dark"])
+
+        #expect(catalog.names == ["Adwaita Dark", "agterm", "Nord"])
+        #expect(catalog.entries == [
+            ThemeCatalog.Entry(id: "theme:__default__", name: nil, title: "default ghostty"),
+            ThemeCatalog.Entry(id: "theme:Adwaita Dark", name: "Adwaita Dark", title: "Adwaita Dark"),
+            ThemeCatalog.Entry(id: "theme:agterm", name: "agterm", title: "agterm"),
+            ThemeCatalog.Entry(id: "theme:Nord", name: "Nord", title: "Nord"),
+        ])
+        #expect(catalog.entries.first?.isDefault == true)
+    }
+
+    @Test func idsRepresentDefaultAndNamedThemes() {
+        #expect(ThemeCatalog.id(for: nil) == "theme:__default__")
+        #expect(ThemeCatalog.id(for: "agterm") == "theme:agterm")
+    }
+
+    @Test func resolvedNameTreatsNilAndBlankAsDefault() {
+        #expect(ThemeCatalog.resolvedName(nil) == nil)
+        #expect(ThemeCatalog.resolvedName("") == nil)
+        #expect(ThemeCatalog.resolvedName("   ") == nil)
+        #expect(ThemeCatalog.resolvedName("  Nord  ") == "Nord")
+    }
+
+    @Test func containsMatchesBundledNamesExactly() {
+        let catalog = ThemeCatalog(names: ["agterm", "Nord"])
+
+        #expect(catalog.contains(name: "agterm"))
+        #expect(catalog.contains(name: "Nord"))
+        #expect(!catalog.contains(name: "nord"))
+    }
+}


### PR DESCRIPTION
Summary:
- Add a small host-free ThemeCatalog for theme ordering, default-row metadata, picker IDs, and control-name resolution.
- Rewire the macOS Settings/theme palette/control validation call sites to consume the shared catalog.
- Add focused core tests for ordering, ids, default behavior, and exact name matching.

Validation:
- cd agtermCore && swift test
- make lint
- make build

Note:
- Confirmed the earlier WindowAccessor.swift strong-capture build warnings are not from this PR: that file is unchanged in the branch.