### PR TITLE
refactor(control): hoist window list metadata

### DIFF
--- a/agterm/Control/ControlServer+WindowCommands.swift
+++ b/agterm/Control/ControlServer+WindowCommands.swift
@@ -17,11 +17,7 @@ extension ControlServer {
     /// Project the window library into the `window.list` response: every window with its open flag and
     /// whether it is the frontmost (active) window.
     func buildWindowList() -> [ControlWindowNode] {
-        let active = library.activeWindowID
-        return library.windows.map {
-            ControlWindowNode(id: $0.id.uuidString, name: $0.name,
-                              open: library.isOpen($0.id), active: $0.id == active)
-        }
+        library.controlWindowNodes()
     }
 
     /// Resolve a window id and surface it: raise an already-open window, or open a closed one (the

--- a/agtermCore/Sources/agtermCore/WindowLibrary.swift
+++ b/agtermCore/Sources/agtermCore/WindowLibrary.swift
@@ -157,6 +157,15 @@ public final class WindowLibrary {
         stores[id] != nil
     }
 
+    /// The window set projected into the `window.list` control payload (id/name + open/active flags),
+    /// in window order.
+    public func controlWindowNodes() -> [ControlWindowNode] {
+        let active = activeWindowID
+        return windows.map {
+            ControlWindowNode(id: $0.id.uuidString, name: $0.name, open: isOpen($0.id), active: $0.id == active)
+        }
+    }
+
     /// The persisted open-set in window order, for the launch reopen-all. A window is open iff
     /// its store is loaded.
     public func openIDs() -> [UUID] {

--- a/agtermCore/Tests/agtermCoreTests/WindowLibraryTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/WindowLibraryTests.swift
@@ -117,6 +117,31 @@ final class WindowLibraryTests {
         #expect(library.activeWindowID == info.id)
     }
 
+    @Test func controlWindowNodesProjectListMetadata() {
+        let library = WindowLibrary(directory: directory)
+        let first = library.windows[0]
+        let second = library.newWindow(name: "work")
+
+        #expect(library.controlWindowNodes() == [
+            ControlWindowNode(id: first.id.uuidString, name: first.name, open: true, active: false),
+            ControlWindowNode(id: second.id.uuidString, name: "work", open: true, active: true),
+        ])
+    }
+
+    @Test func controlWindowNodesUseActiveWindowFallback() {
+        let library = WindowLibrary(directory: directory)
+        let first = library.windows[0]
+        let second = library.newWindow(name: "work")
+
+        library.closeWindow(second.id)
+        library.frontmostWindowID = second.id
+
+        #expect(library.controlWindowNodes() == [
+            ControlWindowNode(id: first.id.uuidString, name: first.name, open: true, active: true),
+            ControlWindowNode(id: second.id.uuidString, name: "work", open: false, active: false),
+        ])
+    }
+
     @Test func newWindowBlankNameFallsBackToDefault() {
         let library = WindowLibrary(directory: directory)
         let info = library.newWindow(name: "   ")


### PR DESCRIPTION
Hoists the `window.list` metadata projection into `WindowLibrary.controlWindowNodes()` and keeps the macOS control server as a direct wrapper around that helper.

This is behavior-preserving: the helper uses the existing `activeWindowID` fallback, so a stale/closed `frontmostWindowID` still marks the first open window active.

Validation:
- `cd agtermCore && swift test --filter WindowLibraryTests/controlWindowNodes`
- `cd agtermCore && swift test`
- `make lint`
- `make build`
- `xcodebuild test -project agterm.xcodeproj -scheme agterm -configuration Debug -derivedDataPath build/DerivedData -only-testing:agtermUITests/ControlWindowUITests/testWindowNewAndList`








