### PR TITLE
refactor: hoist control mode parsing helpers

### DIFF
--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -13,18 +13,14 @@ extension ControlServer {
     /// never tears the hidden pane's surface down (`closeSplit` stays the shell-exit-only path).
     /// Focus follows via `AppActions.focusSplitPane`.
     func splitSession(_ target: String?, window: String?, mode: String?) -> ControlResponse {
-        let mode = mode ?? "toggle"
         return resolver.resolveSession(target, window: window) { store, id in
             guard let session = store.session(withID: id) else {
                 return ControlResponse(ok: false, error: "no such session: \(target ?? "active")")
             }
-            let want: Bool
-            switch mode {
-            case "on": want = true
-            case "off": want = false
-            case "toggle": want = !session.isSplit
-            default: return ControlResponse(ok: false, error: "invalid split mode: \(mode)")
+            guard let parsedMode = ControlToggleMode.parse(mode) else {
+                return ControlResponse(ok: false, error: "invalid split mode: \(mode ?? "toggle")")
             }
+            let want = parsedMode.desiredValue(current: session.isSplit)
             if want != session.isSplit {
                 store.toggleSplit(id) // mirror ⌘D: keep-alive hide/show, never destroys the hidden pane
             }
@@ -41,18 +37,14 @@ extension ControlServer {
     /// --command`: a scratch is expendable, so if one is already alive it is torn down and respawned
     /// with the command (otherwise the flag would be silently inert).
     func scratchSession(_ target: String?, window: String?, mode: String?, command: String?) -> ControlResponse {
-        let mode = mode ?? "toggle"
         return resolver.resolveSession(target, window: window) { store, id in
             guard let session = store.session(withID: id) else {
                 return ControlResponse(ok: false, error: "no such session: \(target ?? "active")")
             }
-            let want: Bool
-            switch mode {
-            case "on": want = true
-            case "off": want = false
-            case "toggle": want = !session.scratchActive
-            default: return ControlResponse(ok: false, error: "invalid scratch mode: \(mode)")
+            guard let parsedMode = ControlToggleMode.parse(mode) else {
+                return ControlResponse(ok: false, error: "invalid scratch mode: \(mode ?? "toggle")")
             }
+            let want = parsedMode.desiredValue(current: session.scratchActive)
             if want, let command, !command.isEmpty {
                 // run the command as the scratch process: respawn if one is already alive (a scratch is
                 // expendable), so the command is never silently ignored. closeScratch clears scratchActive,
@@ -76,7 +68,6 @@ extension ControlServer {
     /// Move keyboard focus to a split session's left/right pane. `pane` is `left`|`right`|`other`
     /// (`other` toggles). Errors when the session isn't split or the pane value is unknown.
     func focusSessionPane(_ target: String?, window: String?, pane: String?) -> ControlResponse {
-        let pane = pane ?? "other"
         return resolver.resolveSession(target, window: window) { store, id in
             guard let session = store.session(withID: id) else {
                 return ControlResponse(ok: false, error: "no such session: \(target ?? "active")")
@@ -84,13 +75,10 @@ extension ControlServer {
             guard session.hasSplit else {
                 return ControlResponse(ok: false, error: "session has no split")
             }
-            let toSplit: Bool
-            switch pane {
-            case "left", "primary": toSplit = false
-            case "right", "split": toSplit = true
-            case "other", "toggle": toSplit = !session.splitFocused
-            default: return ControlResponse(ok: false, error: "invalid pane: \(pane)")
+            guard let parsedPane = ControlPaneFocusMode.parse(pane) else {
+                return ControlResponse(ok: false, error: "invalid pane: \(pane ?? "other")")
             }
+            let toSplit = parsedPane.wantsSplit(currentSplitFocused: session.splitFocused)
             actions.setSplitFocus(toSplit, of: session)
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
         }
@@ -289,17 +277,13 @@ extension ControlServer {
     /// flipping only when the requested state differs from the current `isVisible`. An unknown mode
     /// is an error, not a silent no-op; no open window is an error rather than a silent no-op.
     func setQuickTerminal(mode: String?) -> ControlResponse {
-        let mode = mode ?? "toggle"
         guard let controller = QuickTerminalRegistry.shared.controller(for: library.activeWindowID) else {
             return ControlResponse(ok: false, error: "no open window")
         }
-        let want: Bool
-        switch mode {
-        case "show": want = true
-        case "hide": want = false
-        case "toggle": want = !controller.isVisible
-        default: return ControlResponse(ok: false, error: "invalid quick mode: \(mode)")
+        guard let parsedMode = ControlToggleMode.parse(mode, on: "show", off: "hide") else {
+            return ControlResponse(ok: false, error: "invalid quick mode: \(mode ?? "toggle")")
         }
+        let want = parsedMode.desiredValue(current: controller.isVisible)
         if want != controller.isVisible {
             if want { controller.show() } else { controller.hide() }
         }
@@ -310,17 +294,13 @@ extension ControlServer {
     /// no system toggle). Flips only when the requested state differs; an unknown mode is an error, and no
     /// open window is an error rather than a silent no-op.
     func setSidebar(mode: String?) -> ControlResponse {
-        let mode = mode ?? "toggle"
         guard let store = library.activeStore else {
             return ControlResponse(ok: false, error: "no open window")
         }
-        let want: Bool
-        switch mode {
-        case "show": want = true
-        case "hide": want = false
-        case "toggle": want = !store.sidebarVisible
-        default: return ControlResponse(ok: false, error: "invalid sidebar mode: \(mode)")
+        guard let parsedMode = ControlToggleMode.parse(mode, on: "show", off: "hide") else {
+            return ControlResponse(ok: false, error: "invalid sidebar mode: \(mode ?? "toggle")")
         }
+        let want = parsedMode.desiredValue(current: store.sidebarVisible)
         if want != store.sidebarVisible {
             store.sidebarVisible = want
             store.save() // sidebarVisible is persisted per-window

--- a/agtermCore/Sources/agtermCore/ControlModes.swift
+++ b/agtermCore/Sources/agtermCore/ControlModes.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Parsed binary control mode with the shared default/toggle semantics used by mode-bearing commands.
+public enum ControlToggleMode: Equatable, Sendable {
+    case on
+    case off
+    case toggle
+
+    /// Parse a mode string, defaulting nil to `toggle`. Callers keep their command-specific tokens and
+    /// error strings by choosing the true/false spellings they already expose on the wire.
+    public static func parse(_ mode: String?, on onToken: String = "on", off offToken: String = "off") -> ControlToggleMode? {
+        let value = mode ?? "toggle"
+        if value == onToken { return .on }
+        if value == offToken { return .off }
+        if value == "toggle" { return .toggle }
+        return nil
+    }
+
+    public func desiredValue(current: Bool) -> Bool {
+        switch self {
+        case .on: return true
+        case .off: return false
+        case .toggle: return !current
+        }
+    }
+}
+
+/// Parsed pane selector for `session.focus`, including the default/toggle aliases.
+public enum ControlPaneFocusMode: Equatable, Sendable {
+    case primary
+    case split
+    case toggle
+
+    public static func parse(_ pane: String?) -> ControlPaneFocusMode? {
+        switch pane ?? "other" {
+        case "left", "primary": return .primary
+        case "right", "split": return .split
+        case "other", "toggle": return .toggle
+        default: return nil
+        }
+    }
+
+    public func wantsSplit(currentSplitFocused: Bool) -> Bool {
+        switch self {
+        case .primary: return false
+        case .split: return true
+        case .toggle: return !currentSplitFocused
+        }
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/ControlModesTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlModesTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+struct ControlModesTests {
+    @Test func toggleModeDefaultsToToggle() {
+        #expect(ControlToggleMode.parse(nil) == .toggle)
+        #expect(ControlToggleMode.parse(nil, on: "show", off: "hide") == .toggle)
+    }
+
+    @Test func toggleModeParsesDefaultTokens() {
+        #expect(ControlToggleMode.parse("on") == .on)
+        #expect(ControlToggleMode.parse("off") == .off)
+        #expect(ControlToggleMode.parse("toggle") == .toggle)
+    }
+
+    @Test func toggleModeParsesCustomTrueFalseTokens() {
+        #expect(ControlToggleMode.parse("show", on: "show", off: "hide") == .on)
+        #expect(ControlToggleMode.parse("hide", on: "show", off: "hide") == .off)
+        #expect(ControlToggleMode.parse("toggle", on: "show", off: "hide") == .toggle)
+    }
+
+    @Test func toggleModeRejectsUnknownToken() {
+        #expect(ControlToggleMode.parse("yes") == nil)
+        #expect(ControlToggleMode.parse("on", on: "show", off: "hide") == nil)
+    }
+
+    @Test func toggleModeComputesDesiredValue() {
+        #expect(ControlToggleMode.on.desiredValue(current: false))
+        #expect(ControlToggleMode.on.desiredValue(current: true))
+        #expect(!ControlToggleMode.off.desiredValue(current: false))
+        #expect(!ControlToggleMode.off.desiredValue(current: true))
+        #expect(ControlToggleMode.toggle.desiredValue(current: false))
+        #expect(!ControlToggleMode.toggle.desiredValue(current: true))
+    }
+
+    @Test func paneFocusModeDefaultsToOther() {
+        #expect(ControlPaneFocusMode.parse(nil) == .toggle)
+    }
+
+    @Test func paneFocusModeParsesAliases() {
+        #expect(ControlPaneFocusMode.parse("left") == .primary)
+        #expect(ControlPaneFocusMode.parse("primary") == .primary)
+        #expect(ControlPaneFocusMode.parse("right") == .split)
+        #expect(ControlPaneFocusMode.parse("split") == .split)
+        #expect(ControlPaneFocusMode.parse("other") == .toggle)
+        #expect(ControlPaneFocusMode.parse("toggle") == .toggle)
+    }
+
+    @Test func paneFocusModeRejectsUnknownPane() {
+        #expect(ControlPaneFocusMode.parse("center") == nil)
+    }
+
+    @Test func paneFocusModeComputesTargetPane() {
+        #expect(!ControlPaneFocusMode.primary.wantsSplit(currentSplitFocused: false))
+        #expect(!ControlPaneFocusMode.primary.wantsSplit(currentSplitFocused: true))
+        #expect(ControlPaneFocusMode.split.wantsSplit(currentSplitFocused: false))
+        #expect(ControlPaneFocusMode.split.wantsSplit(currentSplitFocused: true))
+        #expect(ControlPaneFocusMode.toggle.wantsSplit(currentSplitFocused: false))
+        #expect(!ControlPaneFocusMode.toggle.wantsSplit(currentSplitFocused: true))
+    }
+}


### PR DESCRIPTION
## Summary
- add host-free control toggle and pane-focus mode helpers in agtermCore
- reuse them in the macOS control session, quick, and sidebar mode arms
- keep command-specific error strings and non-binary mode commands app-side

## Validation
- cd agtermCore && swift test
- make lint
- xcodegen generate
- xcodebuild -project agterm.xcodeproj -scheme agterm -configuration Debug -derivedDataPath build/DerivedData -destination 'platform=macOS' -only-testing:agtermUITests/ControlSidebarStatusUITests/testSidebarShowHideToggle -only-testing:agtermUITests/ControlOverlaySplitUITests/testSessionSplitToggle -only-testing:agtermUITests/ControlOverlaySplitUITests/testSessionScratchToggle -only-testing:agtermUITests/ControlOverlaySplitUITests/testSessionFocusPane -only-testing:agtermUITests/ControlAPIUITests/testQuickTerminalToggle -only-testing:agtermUITests/ControlAPIUITests/testInvalidQuickModeErrors test