### PR TITLE
fix: escape newlines in ShellEscape to prevent drag-drop command injection

### DIFF
--- a/agtermCore/Sources/agtermCore/ShellEscape.swift
+++ b/agtermCore/Sources/agtermCore/ShellEscape.swift
@@ -10,8 +10,9 @@ import Foundation
 /// wrap even a clean `/path/image.png` in quotes.
 public enum ShellEscape {
     /// The shell-significant characters that get a backslash prefix. Backslash is FIRST so the pass that
-    /// escapes it does not double-escape the backslashes added for the rest.
-    private static let significant: [Character] = Array("\\ ()[]{}<>\"'`!#$&;|*?\t")
+    /// escapes it does not double-escape the backslashes added for the rest. `\n`/`\r` are escaped so a
+    /// dropped filename with a newline can't inject a command via `inject(text:)` (bare newline → Return).
+    private static let significant: [Character] = Array("\\ ()[]{}<>\"'`!#$&;|*?\t\n\r")
 
     /// Backslash-escape every shell-significant character in `path`; a path with none is returned unchanged.
     public static func path(_ path: String) -> String {

--- a/agtermCore/Tests/agtermCoreTests/ShellEscapeTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ShellEscapeTests.swift
@@ -19,6 +19,14 @@ struct ShellEscapeTests {
         #expect(ShellEscape.path("a&b;c|d$e") == "a\\&b\\;c\\|d\\$e")
     }
 
+    @Test func escapesNewlinesSoADroppedNameCannotInjectACommand() {
+        // a filename may contain a newline; unescaped it would submit the rest as a shell command via
+        // inject(text:). Backslash-escaped, the line terminator can't terminate a command.
+        #expect(ShellEscape.path("report.txt\ndate") == "report.txt\\\ndate")
+        #expect(ShellEscape.path("a\rb") == "a\\\rb")
+        #expect(ShellEscape.path("a\r\nb") == "a\\\r\\\nb")
+    }
+
     @Test func emptyStaysEmpty() {
         #expect(ShellEscape.path("") == "")
     }


### PR DESCRIPTION
Fixes #95.

### Problem

Dropping a file whose name contains a newline executed shell commands embedded in the filename. `ShellEscape.path` did not escape `\n`/`\r`, and the drop path feeds the escaped path through `GhosttySurfaceView.inject(text:)`, which converts a bare newline into a Return keypress — so any newline in the filename submitted the following text to the shell.

### Fix

Add `\n` and `\r` to `ShellEscape.significant` so a line terminator is backslash-escaped into a shell line-continuation instead of a command terminator. This is contained to the host-free `ShellEscape` and does not touch the shared `inject(text:)` newline→Return behavior that `session.type` relies on.

### Test

Added `escapesNewlinesSoADroppedNameCannotInjectACommand` to `ShellEscapeTests`, covering `\n`, `\r`, and `\r\n`.

### Verification

- `swift test` — all 899 tests pass.
- Longest changed line is 109 cols (limit 200); no file-size limits affected.

### Safe manual repro

`ShellEscape` escapes spaces, so only a no-argument command survives — this demonstrates the bug harmlessly:

```sh
OUT="$(mktemp -d)/drop-poc"; mkdir -p "$OUT"
touch "$OUT/$(printf 'report.txt\ndate\n')"
ls -1b "$OUT"
```

Before this change, dragging `report.txt␊date` in ran `date`; after, the path is inserted without executing.
