### PR TITLE
fix: keep '#' inside single-quoted custom-command shell args

### DIFF
--- a/agtermCore/Sources/agtermCore/Keymap.swift
+++ b/agtermCore/Sources/agtermCore/Keymap.swift
@@ -80,9 +80,10 @@ public struct KeymapStore: Sendable {
 ///
 /// Grammar (kitty-flavored): the file is line-based. Blank lines and lines whose first non-space
 /// character is `#` are ignored. A trailing inline comment is stripped when a `#` is preceded by
-/// whitespace AND lies outside any double-quoted span (so a `#` inside a `command "name"` or inside
-/// the shell line is kept) — this keeps `command "x" echo a#b` and `map cmd+a#` handling simple while
-/// allowing `map cmd+d toggle_split  # rebind`.
+/// whitespace AND lies outside any quoted span, single OR double (so a `#` inside a `command "name"`,
+/// inside a double-quoted shell arg, or inside a single-quoted one like `git commit -m 'fix #42'` is
+/// kept) — this keeps `command "x" echo a#b` and `map cmd+a#` handling simple while allowing
+/// `map cmd+d toggle_split  # rebind`.
 ///
 /// The first whitespace-token is the verb:
 /// - `map <chord> <action>`: `<chord>` is parsed via `parseKeybind` (a leader sequence, count > 1, is
@@ -306,21 +307,30 @@ private func validateCommands(_ commands: [CustomCommand], against keymap: Keyma
 }
 
 /// Strip a trailing inline comment: a `#` is a comment when it is preceded by whitespace AND sits
-/// outside a double-quoted span. A leading `#` (the whole-line comment) is handled by the caller, but
-/// it also falls out here since position 0 has no preceding whitespace only when the line starts with
-/// `#` after trimming — the caller trims and re-checks emptiness, so a `# ...` line becomes empty.
+/// outside a quoted span (single OR double). A leading `#` (the whole-line comment) is handled by the
+/// caller, but it also falls out here since position 0 has no preceding whitespace only when the line
+/// starts with `#` after trimming — the caller trims and re-checks emptiness, so a `# ...` line becomes
+/// empty. Single quotes matter because a shell line like `git commit -m 'fix #42'` must keep its `#`;
+/// the two quote states are mutually exclusive (a `"` inside `'...'` is literal, and vice versa).
 private func stripComment(_ line: String) -> String {
-    var inQuotes = false
+    var inSingleQuotes = false
+    var inDoubleQuotes = false
     var previousWasSpace = true // start-of-line counts as preceded-by-whitespace, so a leading `#` cuts
     var result = ""
     for ch in line {
-        if ch == "\"" {
-            inQuotes.toggle()
+        if ch == "\"" && !inSingleQuotes {
+            inDoubleQuotes.toggle()
             result.append(ch)
             previousWasSpace = false
             continue
         }
-        if ch == "#" && !inQuotes && previousWasSpace {
+        if ch == "'" && !inDoubleQuotes {
+            inSingleQuotes.toggle()
+            result.append(ch)
+            previousWasSpace = false
+            continue
+        }
+        if ch == "#" && !inSingleQuotes && !inDoubleQuotes && previousWasSpace {
             break
         }
         result.append(ch)

--- a/agtermCore/Tests/agtermCoreTests/KeymapTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/KeymapTests.swift
@@ -178,6 +178,30 @@ struct KeymapTests {
         #expect(keymap.commands[0].name == "name # not a comment")
     }
 
+    @Test func hashInsideSingleQuotedShellArgIsKept() {
+        // a `#` in a single-quoted arg (a commit message) must survive — it is not an inline comment.
+        let (keymap, diagnostics) = parseKeymap("command \"Commit\" cmd+shift+c git commit -m 'fix #42'")
+        #expect(diagnostics.isEmpty)
+        #expect(keymap.commands.count == 1)
+        #expect(keymap.commands[0].command == "git commit -m 'fix #42'")
+    }
+
+    @Test func trailingCommentAfterSingleQuotedArgIsStripped() {
+        // once the single quote closes, a whitespace-preceded `#` is still a real inline comment.
+        let (keymap, diagnostics) = parseKeymap("command \"X\" cmd+shift+x echo 'hi' # real comment")
+        #expect(diagnostics.isEmpty)
+        #expect(keymap.commands.count == 1)
+        #expect(keymap.commands[0].command == "echo 'hi'")
+    }
+
+    @Test func doubleQuoteInsideSingleQuotesDoesNotOpenAQuotedSpan() {
+        // a `"` inside `'...'` is literal, so the `#` after the single-quoted arg still starts a comment.
+        let (keymap, diagnostics) = parseKeymap("command \"Y\" cmd+shift+y echo 'a\"b' # c")
+        #expect(diagnostics.isEmpty)
+        #expect(keymap.commands.count == 1)
+        #expect(keymap.commands[0].command == "echo 'a\"b'")
+    }
+
     @Test func parseUnknownVerbDiagnostic() {
         let (keymap, diagnostics) = parseKeymap("bind cmd+d toggle_split")
         #expect(keymap.builtinOverrides.isEmpty)


### PR DESCRIPTION
Fixes #97.

### Problem

A custom command in `keymap.conf` whose shell line contained a `#` preceded by whitespace inside **single** quotes was silently truncated at parse time. `stripComment` only tracked double quotes, so:

```
command "Commit" cmd+shift+c git commit -m 'fix #42'
```

was stored as `git commit -m 'fix` (unterminated quote), **with 0 diagnostics** — the corruption was silent and surfaced only at fire time as a generic failure banner.

### Fix

Track single quotes in `stripComment` as well: a `#` is an inline comment only when preceded by whitespace and outside **both** single- and double-quoted spans. The two quote states are mutually exclusive (a `"` inside `'...'` is literal, and vice versa), which the implementation respects. Updated the grammar/`stripComment` doc comments to match.

### Tests

Added `KeymapTests` cases:
- `hashInsideSingleQuotedShellArgIsKept` — `'fix #42'` survives.
- `trailingCommentAfterSingleQuotedArgIsStripped` — a real `# comment` after a closed single quote is still stripped.
- `doubleQuoteInsideSingleQuotesDoesNotOpenAQuotedSpan` — a `"` inside `'...'` is literal, so a following `#` still starts a comment.

The existing `inlineCommentInsideQuotedNameIsKept` / `parseSkipsCommentsAndBlankLines` cases continue to pass.

### Verification

`swift test` — all tests pass (934). Longest changed line is 106 cols (limit 200).
