### PR TITLE
fix: single-quote-escape paths in show-image.sh overlay command

### DIFF
--- a/agterm/Resources/agent-skill/scripts/show-image.sh
+++ b/agterm/Resources/agent-skill/scripts/show-image.sh
@@ -45,5 +45,10 @@ command -v agtermctl >/dev/null 2>&1 || { echo "show-image.sh: agtermctl not on 
 self=$(cd "$(dirname "$0")" && pwd)/$(basename "$0")
 abs=$(cd "$(dirname "$img")" && pwd)/$(basename "$img")
 
+# POSIX single-quote a string for safe embedding in the command below: wrap in '...' and replace each
+# embedded ' with the '\'' sequence, so a path containing a quote can't break out of the quoting. The
+# overlay command is run via `sh -c`, so an unescaped ' in the path would otherwise abort it.
+sq() { printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"; }
+
 # open an overlay that re-invokes this script in --emit mode inside the overlay's pty.
-agtermctl session overlay open "/bin/bash '$self' --emit '$abs'" --size-percent "$size"
+agtermctl session overlay open "/bin/bash $(sq "$self") --emit $(sq "$abs")" --size-percent "$size"


### PR DESCRIPTION
Fixes #99.

### Problem

`show-image.sh` built the overlay command by embedding `$self` and `$abs` single-quoted with no escaping:

```sh
agtermctl session overlay open "/bin/bash '$self' --emit '$abs'" --size-percent "$size"
```

`agtermctl session overlay open` runs the command via `sh -c`, so an image path containing a single quote (e.g. `/tmp/it's a pic.png`) closed the quote early and aborted with `unexpected EOF while looking for matching '`. The image never displayed.

### Fix

Add a POSIX single-quote helper and quote both paths through it:

```sh
sq() { printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"; }
agtermctl session overlay open "/bin/bash $(sq "$self") --emit $(sq "$abs")" --size-percent "$size"
```

### Verification

- `bash -n` — no syntax errors.
- Simulated the `sh -c` parse the overlay performs: a path like `/tmp/it's a "weird" pic.png` is now passed through as a single intact argument (`arg[/tmp/it's a "weird" pic.png]`), where before it aborted the command.

Only the single source of truth at `agterm/Resources/agent-skill/scripts/show-image.sh` is changed; installed copies are regenerated by Help ▸ Install Agent Skill.
