### PR TITLE
feat: confirm before closing a session (opt-in)

### DIFF
--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -131,7 +131,8 @@ paths:
   instead of restoring the last-used tab.
   **General** (a **Mouse** section with the scroll-speed slider + the right-click-pastes toggle,
   a **Sessions** section with the new-session-directory picker (home / current session's directory / a
-  fixed custom folder, the last with a `Choose…` panel) + the restore-running-commands toggle,
+  fixed custom folder, the last with a `Choose…` panel) + the restore-running-commands toggle + the
+  confirm-before-closing-a-session toggle,
   and a **Ghostty Config** section with the inherit-global-config toggle).
   **Appearance** (a **Terminal** section — font/size/theme via `NSFontManager` monospaced families +
   the bundled `ghostty/themes` dir, `SettingsCatalog` — a **Window** section with the compact-toolbar

--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -338,7 +338,7 @@ paths:
   — which returns proceed-without-prompt when the setting is off OR under an XCUITest launch
   (`ContentView.isUITestLaunch`, a modal would hang the test, like the clear-flagged / quit confirms).
   It gates the two GUI close paths only: `AppActions.closeActiveSession()` (⌘W / File ▸ Close Session /
-  the ⌃⇧P palette) and the sidebar row's Close (routed through the new `AppActions.closeSession(_:)`);
+  the ⌃⇧P palette) and the sidebar row's Close (routed through the new `AppActions.closeSession(_:in:)`);
   the control channel's `session.close` calls `AppStore.closeSession` directly and stays silent.
   The General → Sessions `Toggle("Confirm before closing a session")` uses the default-OFF binding (get
   `?? false`, set `$0 ? true : nil`, like `restoreRunningCommand`).

--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -329,6 +329,22 @@ paths:
   `session.select`; only `theme.set`/`config.reload` touch settings over the socket).
   See the Notifications section for the bell's three states and the Menu/actions section for the `.attention`
   palette it opens.
+- **`confirmCloseSession` (confirm before closing a session, opt-in, General tab).**
+  `AppSettings.confirmCloseSession: Bool?` (nil = OFF, the default-off precedent like `restoreRunningCommand`)
+  gates a native `NSAlert` confirm before a GUI session close.
+  NOT a ghostty key (`SettingsModel.setConfirmCloseSession` is save-only, no config rewrite / surface reload).
+  Read ON DEMAND at close time by the private `AppActions.confirmCloseSession(_:)` — no `GhosttyApp` mirror
+  — which returns proceed-without-prompt when the setting is off OR under an XCUITest launch
+  (`ContentView.isUITestLaunch`, a modal would hang the test, like the clear-flagged / quit confirms).
+  It gates the two GUI close paths only: `AppActions.closeActiveSession()` (⌘W / File ▸ Close Session /
+  the ⌃⇧P palette) and the sidebar row's Close (routed through the new `AppActions.closeSession(_:)`);
+  the control channel's `session.close` calls `AppStore.closeSession` directly and stays silent.
+  The General → Sessions `Toggle("Confirm before closing a session")` uses the default-OFF binding (get
+  `?? false`, set `$0 ? true : nil`, like `restoreRunningCommand`).
+  GUI-only and keep-in-sync EXEMPT — a safety modal is meaningless to drive headless (`session.close`
+  must never prompt), like the quit-confirm.
+  Default-off + round-trip covered host-free in `AppSettingsTests`; the confirm itself is app-target
+  (manually/build verified, no app unit-test host, like `confirmDelete`/`confirmClearFlags`).
 - **A Settings toggle's DESCRIPTION stays single-line short-form** — a terse hint, not a manual.
   No detailed multi-line explanation of what the toggle does and no cross-refs to other toggles;
   keep the minimal style (see also the flag-description convention).

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ For jumping back to sessions you have been working in, a Ctrl-Tab switcher walks
 
 ## Settings
 
-Settings (Cmd+,) has three tabs. **General** covers notification banners and badges, scroll speed, how much the inactive split pane dims, where a new session opens, and an opt-in toggle to re-run each pane's foreground command on restart. **Appearance** sets the terminal font and theme (512 bundled themes), the window background opacity and blur, and the sidebar tint. **Key Mapping** points at the directory holding `keymap.conf`, lists any parse errors, and reloads it. Changes apply live to the open terminals.
+Settings (Cmd+,) has three tabs. **General** covers notification banners and badges, scroll speed, how much the inactive split pane dims, where a new session opens, an opt-in toggle to re-run each pane's foreground command on restart, and an opt-in confirmation before closing a session. **Appearance** sets the terminal font and theme (512 bundled themes), the window background opacity and blur, and the sidebar tint. **Key Mapping** points at the directory holding `keymap.conf`, lists any parse errors, and reloads it. Changes apply live to the open terminals.
 
 The theme picker (View ▸ Select Theme…, or the action palette) previews each bundled theme on the open terminals as you move through the list, so you see it before committing. Enter commits and syncs it to Settings; Esc reverts to the one you started on.
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ For jumping back to sessions you have been working in, a Ctrl-Tab switcher walks
 
 ## Settings
 
-Settings (Cmd+,) has three tabs. **General** covers notification banners and badges, scroll speed, how much the inactive split pane dims, where a new session opens, an opt-in toggle to re-run each pane's foreground command on restart, and an opt-in confirmation before closing a session. **Appearance** sets the terminal font and theme (512 bundled themes), the window background opacity and blur, and the sidebar tint. **Key Mapping** points at the directory holding `keymap.conf`, lists any parse errors, and reloads it. Changes apply live to the open terminals.
+Settings (Cmd+,) has five tabs. **General** covers mouse scroll speed and right-click-to-paste, where a new session opens, an opt-in toggle to re-run each pane's foreground command on restart, an opt-in confirmation before closing a session, and whether to load your global Ghostty config. **Appearance** sets the terminal font and theme (512 bundled themes), the window background opacity and blur, the sidebar tint, and how much the inactive split pane dims. **Notifications** toggles the banner, the unseen-count badge, and the title-bar attention indicator. **Agent Status** sets the status-glyph colors and the blocked-session sound. **Key Mapping** points at the directory holding `keymap.conf`, lists any parse errors, and reloads it. Changes apply live to the open terminals.
 
 The theme picker (View ▸ Select Theme…, or the action palette) previews each bundled theme on the open terminals as you move through the list, so you see it before committing. Enter commits and syncs it to Settings; Esc reverts to the one you started on.
 

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -124,11 +124,14 @@ final class AppActions {
         return true
     }
 
-    /// Close the session with `id` from a GUI surface (the sidebar row's Close), honoring the "Confirm
-    /// before closing a session" setting. The ⌘W/menu/palette path uses `closeActiveSession`; the control
-    /// channel's `session.close` closes directly, without a prompt.
-    func closeSession(_ id: UUID) {
-        guard let store, let session = store.session(withID: id) else { return }
+    /// Close the session with `id` in `store` from a GUI surface (the sidebar row's Close), honoring the
+    /// "Confirm before closing a session" setting. `store` is the caller's own window-local store — a
+    /// background window's sidebar must close ITS session, not the frontmost window's — so it is passed in
+    /// rather than resolved via the frontmost `activeStore`. The ⌘W/menu/palette path uses
+    /// `closeActiveSession` (which acts on the frontmost active session); the control channel's
+    /// `session.close` closes directly, without a prompt.
+    func closeSession(_ id: UUID, in store: AppStore) {
+        guard let session = store.session(withID: id) else { return }
         guard confirmCloseSession(session) else { return }
         store.closeSession(id)
     }

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -116,9 +116,35 @@ final class AppActions {
         guard let store, let session = store.activeSession else { return false }
         if session.overlayActive { store.closeOverlay(session.id); return true }
         if session.scratchActive { store.toggleScratch(session.id); return true }
+        // ⌘W was handled either way — on cancel we return true so the File menu doesn't fall back to
+        // closing the whole window.
+        guard confirmCloseSession(session) else { return true }
         store.closeSession(session.id)
         focusActiveSession()
         return true
+    }
+
+    /// Close the session with `id` from a GUI surface (the sidebar row's Close), honoring the "Confirm
+    /// before closing a session" setting. The ⌘W/menu/palette path uses `closeActiveSession`; the control
+    /// channel's `session.close` closes directly, without a prompt.
+    func closeSession(_ id: UUID) {
+        guard let store, let session = store.session(withID: id) else { return }
+        guard confirmCloseSession(session) else { return }
+        store.closeSession(id)
+    }
+
+    /// A native warning confirm before closing `session`, gated by `AppSettings.confirmCloseSession`.
+    /// Returns whether to proceed with the close: true immediately (no prompt) when the setting is off, or
+    /// under an XCUITest launch (a modal would hang the test, like the clear-flagged/quit confirms).
+    private func confirmCloseSession(_ session: Session) -> Bool {
+        guard settingsModel?.settings.confirmCloseSession == true, !ContentView.isUITestLaunch else { return true }
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Close “\(session.displayName)”?"
+        alert.informativeText = "The session and everything running in it will be closed."
+        alert.addButton(withTitle: "Close")
+        alert.addButton(withTitle: "Cancel")
+        return alert.runModal() == .alertFirstButtonReturn
     }
 
     /// Clear the active session's agent-status indicator back to idle (the same effect as `agtermctl

--- a/agterm/SettingsModel.swift
+++ b/agterm/SettingsModel.swift
@@ -117,6 +117,9 @@ final class SettingsModel {
     func setNewSessionDirectory(_ value: String?) { settings.newSessionDirectory = value; try? settingsStore.save(settings) }
     /// Persist the fixed directory used when `newSessionDirectory` is `custom` (nil/empty falls back to home).
     func setNewSessionCustomDirectory(_ value: String?) { settings.newSessionCustomDirectory = value; try? settingsStore.save(settings) }
+    /// Persist whether closing a session from the GUI first asks for confirmation (nil = off). Not a ghostty
+    /// key and nothing renders it continuously — `AppActions` reads it on demand at close time — so it just saves.
+    func setConfirmCloseSession(_ value: Bool?) { settings.confirmCloseSession = value; try? settingsStore.save(settings) }
 
     /// Apply a new background opacity live WITHOUT an immediate save — the live-drag half of the opacity
     /// slider. Updates translucency on every drag tick (apply-without-save) and schedules a debounced

--- a/agterm/Views/SettingsView.swift
+++ b/agterm/Views/SettingsView.swift
@@ -114,6 +114,9 @@ private struct GeneralSettingsView: View {
                 Toggle("Restore running commands on restart", isOn: restoreRunningCommand)
                     .accessibilityIdentifier("settings-restore-running-command")
                 SettingHint("Re-runs each pane's foreground command on relaunch; multiplexers start fresh.")
+                Toggle("Confirm before closing a session", isOn: confirmCloseSession)
+                    .accessibilityIdentifier("settings-confirm-close-session")
+                SettingHint("Asks before ⌘W closes a session and ends what's running in it.")
             }
 
             Section("Ghostty Config") {
@@ -131,6 +134,13 @@ private struct GeneralSettingsView: View {
     private var restoreRunningCommand: Binding<Bool> {
         Binding(get: { model.settings.restoreRunningCommand ?? false },
                 set: { model.setRestoreRunningCommand($0 ? true : nil) })
+    }
+
+    /// 1:1 with the toggle; nil (the default) reads as OFF, so on → true / off → nil keeps settings.json
+    /// minimal until the user opts into the close confirmation.
+    private var confirmCloseSession: Binding<Bool> {
+        Binding(get: { model.settings.confirmCloseSession ?? false },
+                set: { model.setConfirmCloseSession($0 ? true : nil) })
     }
 
     /// 1:1 with the toggle; nil (the default) reads as OFF, so on → true / off → nil keeps settings.json

--- a/agterm/Views/WorkspaceSidebar+ContextMenu.swift
+++ b/agterm/Views/WorkspaceSidebar+ContextMenu.swift
@@ -116,7 +116,7 @@ extension WorkspaceSidebar.Coordinator {
 
     @objc private func menuClose(_ sender: NSMenuItem) {
         guard let node = sender.representedObject as? SidebarNode else { return }
-        store.closeSession(node.id)
+        actions.closeSession(node.id)
     }
 
     @objc private func menuClearStatus(_ sender: NSMenuItem) {

--- a/agterm/Views/WorkspaceSidebar+ContextMenu.swift
+++ b/agterm/Views/WorkspaceSidebar+ContextMenu.swift
@@ -116,7 +116,9 @@ extension WorkspaceSidebar.Coordinator {
 
     @objc private func menuClose(_ sender: NSMenuItem) {
         guard let node = sender.representedObject as? SidebarNode else { return }
-        actions.closeSession(node.id)
+        // pass THIS sidebar's window-local store — a background window's Close must target its own
+        // session, not the frontmost window's (which `AppActions.store` would resolve to).
+        actions.closeSession(node.id, in: store)
     }
 
     @objc private func menuClearStatus(_ sender: NSMenuItem) {

--- a/agtermCore/Sources/agtermCore/AppSettings.swift
+++ b/agtermCore/Sources/agtermCore/AppSettings.swift
@@ -123,6 +123,11 @@ public struct AppSettings: Codable, Equatable, Sendable {
     /// The fixed directory a new session opens in when `newSessionDirectory` is `custom`; nil/empty falls
     /// back to home. Ignored for the `home`/`currentSession` modes. Set by the Settings directory picker.
     public var newSessionCustomDirectory: String?
+    /// Whether closing a session from the GUI (⌘W, the File/palette Close Session, the sidebar row's Close)
+    /// first asks for confirmation. nil means the default (off — the session closes immediately). An
+    /// app-level behavior flag read on demand by `AppActions`, NOT a ghostty key — it never appears in
+    /// `ghosttyConfigLines()`; the control channel's `session.close` closes without a prompt.
+    public var confirmCloseSession: Bool?
 
     public init(fontFamily: String? = nil, fontSize: Double? = nil, theme: String? = nil,
                 backgroundOpacity: Double? = nil, backgroundBlur: Int? = nil, notificationsEnabled: Bool? = nil,
@@ -133,7 +138,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
                 sidebarBackgroundShift: Int? = nil, restoreRunningCommand: Bool? = nil,
                 inheritGlobalGhosttyConfig: Bool? = nil, attentionButtonEnabled: Bool? = nil,
                 blockedStatusSoundName: String? = nil, rightClickPaste: Bool? = nil,
-                newSessionDirectory: String? = nil, newSessionCustomDirectory: String? = nil) {
+                newSessionDirectory: String? = nil, newSessionCustomDirectory: String? = nil,
+                confirmCloseSession: Bool? = nil) {
         self.fontFamily = fontFamily
         self.fontSize = fontSize
         self.theme = theme
@@ -156,6 +162,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.rightClickPaste = rightClickPaste
         self.newSessionDirectory = newSessionDirectory
         self.newSessionCustomDirectory = newSessionCustomDirectory
+        self.confirmCloseSession = confirmCloseSession
     }
 
     /// The working directory a new session should open in, resolving the `newSessionDirectory` mode

--- a/agtermCore/Tests/agtermCoreTests/AppSettingsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppSettingsTests.swift
@@ -111,6 +111,16 @@ struct AppSettingsTests {
         #expect(AppSettings(restoreRunningCommand: true).ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
+    @Test func confirmCloseSessionRoundTripsAndIsNotAConfigLine() throws {
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(AppSettings(confirmCloseSession: true)))
+        #expect(decoded.confirmCloseSession == true)
+        // absent in a legacy file decodes to nil (off — today's silent close).
+        let legacy = try JSONDecoder().decode(AppSettings.self, from: Data(#"{"theme":"Nord"}"#.utf8))
+        #expect(legacy.confirmCloseSession == nil)
+        // an app-level behavior flag, never a ghostty config key — only the always-on defaults (scroll + right-click) are emitted.
+        #expect(AppSettings(confirmCloseSession: true).ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
+    }
+
     @Test func blockedStatusSoundNameRoundTripsAndIsNotAConfigLine() throws {
         let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(AppSettings(blockedStatusSoundName: "Glass")))
         #expect(decoded.blockedStatusSoundName == "Glass")

--- a/agtermUITests/SettingsUITests.swift
+++ b/agtermUITests/SettingsUITests.swift
@@ -76,6 +76,14 @@ final class SettingsUITests: XCTestCase {
                       "turning restore-running-commands on should persist restoreRunningCommand=true")
     }
 
+    func testConfirmCloseSessionTogglePersists() throws {
+        let toggle = settingsControl(tab: "General", control: "settings-confirm-close-session")
+        toggle.click() // turn it on (default off)
+
+        XCTAssertTrue(poll { self.settingsBool("confirmCloseSession") == true },
+                      "turning confirm-before-closing on should persist confirmCloseSession=true")
+    }
+
     func testNewSessionDirectoryPickerPersists() throws {
         let picker = settingsControl(tab: "General", control: "settings-new-session-directory")
         picker.click()


### PR DESCRIPTION
closes the accidental-⌘W-kills-a-running-agent gap from #89. Adds a **"Confirm before closing a session"** toggle in Settings ▸ General ▸ Sessions, off by default. When on, a native confirm alert gates the GUI close paths before the session is torn down; off is today's silent close.

**what's gated:** ⌘W / File ▸ Close Session / the ⌃⇧P palette (via `closeActiveSession`) and the sidebar row's Close (via `AppActions.closeSession(_:in:)`, which takes the sidebar's own window-local store so a background window closes its own session). The control channel's `session.close` stays silent, so automation never hits a modal.

**design:** native `AppSettings.confirmCloseSession` flag, not ghostty's `confirm-close-surface` (agterm's own close path can't delegate to it). Always confirms when on, no "only when a process is running" gating. Reuses the existing `confirmDelete`/`confirmClearFlags` `NSAlert` pattern. Keep-in-sync exempt: a safety modal is meaningless to drive headless, like the quit-confirm.

**window close:** closing a whole window (red button / File ▸ Close) already confirms, always-on, via the pre-existing `WindowCloseDelegateProxy` (`window.close` control stays silent). So this leaves a coherent two-tier: window close (N sessions) always confirms, single-session ⌘W is the new opt-in.

the setting has a host-free round-trip test; the modal follows the manually-verified `confirmDelete` precedent (skipped under XCUITest so it can't hang the runner).

Fix #89
