### PR TITLE
fix: drop text as bracketed paste to prevent accidental execution

### DIFF
--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -84,6 +84,22 @@ paths:
   when visible and `unregisterDraggedTypes` otherwise, so only the on-screen pane is ever a drop target.
   Not `hitTest` (AppKit drag ignores it) and not a `draggingEntered` reject (AppKit does not fall through
   to the sibling behind a rejecting target — the drop is simply lost).
+- **A drop inserts as a bracketed paste, never typed keystrokes.**
+  `performDragOperation` routes the dropped text through `GhosttySurfaceView.insertPasted(text:)` (`ghostty_surface_text`),
+  whose bracketed-paste wrapping makes the running program treat the payload as literal text, so a multi-line
+  drop lands at the cursor without auto-submitting — the same behavior as ⌘V paste.
+  The no-submit guarantee tracks the program's bracketed-paste mode: a program with mode 2004 OFF (a raw
+  prompt, some TUIs) still submits a trailing newline, exactly the caveat ⌘V has — closing that residual is
+  the separate unsafe-paste-confirmation work, not this change.
+  This is deliberately NOT `inject(text:)`, which turns each `\n`/`\r` into a Return: a drop is a paste,
+  while `session.type` is automation that WANTS newline→Return.
+  Drop USED to reuse `inject(text:)`; this change splits it off so drop uses the bracketed-paste call and
+  `session.type` keeps `inject` — do not re-unify them (the control-api note "do not simplify inject back to
+  `ghostty_surface_text`" is about `session.type` only).
+  (`pasteboardText`, the pasteboard reader, is shared by the drop path and the ⌘V clipboard-paste path
+  `readPasteboardText`, NOT by `session.type`, which takes its text from the control request.)
+  `ShellEscape.path` still escapes file-URL paths so a path with spaces lands as one shell token on Enter;
+  the newline-escaping from #96 is now belt-and-suspenders under bracketed paste.
 - **Search bar placement (NSSplitView-overrun rule).**
   `TerminalSearchBar` (`agterm/Views/`) is anchored on `detailPane` via `.overlay(alignment: .topTrailing) { searchBarLayer }`
   — the SAME level as `floatingOverlayLayer`, NEVER inside any session's `sessionDetail` HSplitView-hosting

--- a/agterm/Ghostty/GhosttySurfaceView+Input.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Input.swift
@@ -13,12 +13,13 @@ extension GhosttySurfaceView {
         dropText(from: sender) != nil ? .copy : []
     }
 
-    /// Insert the dropped file's path (shell-escaped, space-joined for multiple) or text at the cursor,
-    /// using the SAME pasteboard logic as paste so a drop and a paste behave identically. Deferred to the
-    /// next runloop tick so the drag session fully unwinds before the terminal buffer is mutated.
+    /// Insert the dropped file's path (shell-escaped, space-joined for multiple) or text at the cursor as a
+    /// bracketed paste — the same no-auto-submit behavior as ⌘V, so a multi-line drop lands as literal text
+    /// instead of executing each line. Deferred to the next runloop tick so the drag session fully unwinds
+    /// before the terminal buffer is mutated.
     override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
         guard let text = dropText(from: sender) else { return false }
-        DispatchQueue.main.async { [weak self] in self?.inject(text: text) }
+        DispatchQueue.main.async { [weak self] in self?.insertPasted(text: text) }
         return true
     }
 

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -358,6 +358,19 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         }
     }
 
+    /// Inserts `text` into this surface as a bracketed paste — the drag-drop path. Unlike `inject(text:)`,
+    /// which types keystrokes and turns each `\n`/`\r` into a Return, this routes through `ghostty_surface_text`,
+    /// whose bracketed-paste wrapping makes the running program treat the whole payload as literal text, so a
+    /// dropped multi-line selection lands at the cursor without auto-submitting — exactly like ⌘V paste. The
+    /// guarantee tracks the program's bracketed-paste mode (a raw prompt with mode 2004 off still submits, the
+    /// same caveat as ⌘V). A drop must behave like a paste, not like typing; `session.type` keeps `inject`
+    /// because automation DOES want newline→Return. The bytes are copied synchronously, so nothing must
+    /// outlive the call. A no-op when the surface has not been created yet (a never-shown session).
+    func insertPasted(text: String) {
+        guard let surface, !text.isEmpty else { return }
+        text.withCString { ghostty_surface_text(surface, $0, UInt(text.utf8.count)) }
+    }
+
     /// Returns this surface's current selection text (the control channel's `session.copy`), or nil when
     /// there is no selection or the surface has not been created yet. The selection is a property of the
     /// surface's terminal state, independent of focus, so any realized session can be read. The libghostty


### PR DESCRIPTION
Dragging a multi-line text selection onto the terminal auto-executed each line. `performDragOperation` fed the dropped text through `inject(text:)`, which turns every newline into a Return keypress, but a drop should insert text at the cursor like a paste, not submit it.

This routes the drop through a new `GhosttySurfaceView.insertPasted(text:)` that uses `ghostty_surface_text` (libghostty's bracketed-paste primitive), so a dropped payload is inserted as literal text and doesn't auto-submit, the same as ⌘V. `session.type` keeps `inject(text:)` since automation wants newline→Return; the two now use different libghostty calls.

The no-submit guarantee tracks the program's bracketed-paste mode, exactly like ⌘V: a program with mode 2004 off (a raw prompt, some TUIs) still submits a trailing newline. Closing that residual is separate unsafe-paste-confirmation work, not this change.

Builds on #96 (which escaped file-path newlines). `ShellEscape.path` still escapes file-URL paths so a path with spaces stays one shell token on Enter.

Verified manually: a multi-line text drop inserts without executing, and a single-line file-path drop is unchanged. No automated test, terminal drag-drop has no XCUITest harness and the behavior is a libghostty call with no host-free seam.

Related to #95.
