### PR TITLE
refactor(surface): hoist environment builders

### DIFF
--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -385,22 +385,22 @@ struct agtermApp: App {
     /// `start()` binds still sees it), honoring a test's `AGTERM_CONTROL_SOCKET` override.
     @MainActor
     private func surfaceEnv(for session: Session) -> [String: String] {
-        var env = ["AGTERM_ENABLED": "1", "AGTERM_SESSION_ID": session.id.uuidString,
-                   "AGTERM_SOCKET": controlServer.resolvedSocketPath]
-        if let windowID = library.windowID(forSession: session.id) {
-            env["AGTERM_WINDOW_ID"] = windowID.uuidString
-            if let workspace = library.store(for: windowID)?.workspace(forSession: session.id) {
-                env["AGTERM_WORKSPACE_ID"] = workspace.id.uuidString
+        var windowID: WindowInfo.ID?
+        var workspaceID: UUID?
+        if let resolvedWindowID = library.windowID(forSession: session.id) {
+            windowID = resolvedWindowID
+            if let workspace = library.store(for: resolvedWindowID)?.workspace(forSession: session.id) {
+                workspaceID = workspace.id
             }
         }
-        return env
+        return SurfaceEnvironment.session(sessionID: session.id, windowID: windowID,
+                                          workspaceID: workspaceID, socketPath: controlServer.resolvedSocketPath)
     }
 
     /// The `AGTERM_*` environment a window's quick terminal exposes — scratch, not in the tree, so it
     /// carries only `AGTERM_ENABLED`, `AGTERM_WINDOW_ID`, and `AGTERM_SOCKET` (no workspace/session ids).
     @MainActor
     func quickTerminalEnv(for windowID: WindowInfo.ID) -> [String: String] {
-        ["AGTERM_ENABLED": "1", "AGTERM_WINDOW_ID": windowID.uuidString,
-         "AGTERM_SOCKET": controlServer.resolvedSocketPath]
+        SurfaceEnvironment.quickTerminal(windowID: windowID, socketPath: controlServer.resolvedSocketPath)
     }
 }

--- a/agtermCore/Sources/agtermCore/SurfaceEnvironment.swift
+++ b/agtermCore/Sources/agtermCore/SurfaceEnvironment.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Pure builders for the `AGTERM_*` environment values injected into spawned shells.
+/// The platform surface owns shell creation; this keeps the variable set testable.
+public enum SurfaceEnvironment {
+    /// Environment for a session-owned surface: main pane, split pane, overlay, or scratch.
+    public static func session(sessionID: UUID, windowID: UUID?, workspaceID: UUID?,
+                               socketPath: String) -> [String: String] {
+        var env = [
+            "AGTERM_ENABLED": "1",
+            "AGTERM_SESSION_ID": sessionID.uuidString,
+            "AGTERM_SOCKET": socketPath,
+        ]
+        if let windowID {
+            env["AGTERM_WINDOW_ID"] = windowID.uuidString
+        }
+        if let workspaceID {
+            env["AGTERM_WORKSPACE_ID"] = workspaceID.uuidString
+        }
+        return env
+    }
+
+    /// Environment for a window's quick terminal, which is not part of the session tree.
+    public static func quickTerminal(windowID: UUID, socketPath: String) -> [String: String] {
+        [
+            "AGTERM_ENABLED": "1",
+            "AGTERM_WINDOW_ID": windowID.uuidString,
+            "AGTERM_SOCKET": socketPath,
+        ]
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/SurfaceEnvironmentTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SurfaceEnvironmentTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+struct SurfaceEnvironmentTests {
+    @Test func sessionEnvironmentCarriesAllKnownIdentifiers() {
+        let sessionID = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+        let windowID = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+        let workspaceID = UUID(uuidString: "33333333-3333-3333-3333-333333333333")!
+
+        let env = SurfaceEnvironment.session(
+            sessionID: sessionID,
+            windowID: windowID,
+            workspaceID: workspaceID,
+            socketPath: "/tmp/agterm.sock"
+        )
+
+        #expect(env == [
+            "AGTERM_ENABLED": "1",
+            "AGTERM_SESSION_ID": "11111111-1111-1111-1111-111111111111",
+            "AGTERM_WINDOW_ID": "22222222-2222-2222-2222-222222222222",
+            "AGTERM_WORKSPACE_ID": "33333333-3333-3333-3333-333333333333",
+            "AGTERM_SOCKET": "/tmp/agterm.sock",
+        ])
+    }
+
+    @Test func sessionEnvironmentOmitsUnknownWindowAndWorkspace() {
+        let sessionID = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+
+        let env = SurfaceEnvironment.session(
+            sessionID: sessionID,
+            windowID: nil,
+            workspaceID: nil,
+            socketPath: "/tmp/agterm.sock"
+        )
+
+        #expect(env == [
+            "AGTERM_ENABLED": "1",
+            "AGTERM_SESSION_ID": "11111111-1111-1111-1111-111111111111",
+            "AGTERM_SOCKET": "/tmp/agterm.sock",
+        ])
+    }
+
+    @Test func quickTerminalEnvironmentCarriesOnlyWindowAndSocketFacts() {
+        let windowID = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+
+        let env = SurfaceEnvironment.quickTerminal(windowID: windowID, socketPath: "/tmp/agterm.sock")
+
+        #expect(env == [
+            "AGTERM_ENABLED": "1",
+            "AGTERM_WINDOW_ID": "22222222-2222-2222-2222-222222222222",
+            "AGTERM_SOCKET": "/tmp/agterm.sock",
+        ])
+        #expect(env["AGTERM_SESSION_ID"] == nil)
+        #expect(env["AGTERM_WORKSPACE_ID"] == nil)
+    }
+
+    @Test func emptySocketPathIsStillEmitted() {
+        let sessionID = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+
+        let env = SurfaceEnvironment.session(
+            sessionID: sessionID,
+            windowID: nil,
+            workspaceID: nil,
+            socketPath: ""
+        )
+
+        #expect(env["AGTERM_SOCKET"] == "")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a host-free `SurfaceEnvironment` helper for session and quick-terminal `AGTERM_*` dictionaries.
- Rewires the macOS surface env builders to use the shared core helper without changing emitted keys or values.
- Adds focused core tests for full, partial, quick-terminal, and empty-socket cases.

## Validation
- `cd agtermCore && swift test --filter SurfaceEnvironmentTests`
- `cd agtermCore && swift test`
- `make lint`
- `make build`