### PR TITLE
refactor(control): hoist window target resolution

### DIFF
--- a/agterm/Control/ControlTargetResolver.swift
+++ b/agterm/Control/ControlTargetResolver.swift
@@ -44,7 +44,7 @@ final class ControlTargetResolver {
     /// else the closed-window error.
     private func resolveWindowStore(_ window: String?) -> Resolution<AppStore> {
         guard let window = trimmed(window) else { return .success(store) }
-        let resolution = ControlResolve.resolve(window, candidates: library.windows.map(\.id), active: library.activeWindowID)
+        let resolution = library.resolveWindow(window)
         guard case .resolved(let id) = resolution else {
             return .failure(resolutionError("window", target: window, resolution))
         }
@@ -152,10 +152,10 @@ final class ControlTargetResolver {
     /// error. Unlike the session/workspace resolvers, a window need not be open to be a target (select
     /// opens it, delete removes a closed one).
     func resolveWindowID(_ target: String?) -> Resolution<UUID> {
-        let resolution = ControlResolve.resolve(target ?? "active", candidates: library.windows.map(\.id),
-                                                active: library.activeWindowID)
+        let target = target ?? "active"
+        let resolution = library.resolveWindow(target)
         guard case .resolved(let id) = resolution else {
-            return .failure(resolutionError("window", target: target ?? "active", resolution))
+            return .failure(resolutionError("window", target: target, resolution))
         }
         return .success(id)
     }

--- a/agtermCore/Sources/agtermCore/WindowLibrary.swift
+++ b/agtermCore/Sources/agtermCore/WindowLibrary.swift
@@ -166,6 +166,13 @@ public final class WindowLibrary {
         }
     }
 
+    /// Resolve a control window target against the library's ordered window set. All known windows are
+    /// candidates, including closed windows; `active` resolves to the frontmost open window, with the
+    /// same fallback as `activeWindowID`.
+    public func resolveWindow(_ target: String) -> TargetResolution {
+        ControlResolve.resolve(target, candidates: windows.map(\.id), active: activeWindowID)
+    }
+
     /// The persisted open-set in window order, for the launch reopen-all. A window is open iff
     /// its store is loaded.
     public func openIDs() -> [UUID] {

--- a/agtermCore/Tests/agtermCoreTests/ControlResolveTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlResolveTests.swift
@@ -75,9 +75,8 @@ struct ControlResolveTests {
         #expect(ControlResolve.errorMessage(noun: "session", target: "active", resolution: .resolved(a)) == "no such session: active")
     }
 
-    // window-id targets reuse the same pure resolver: candidates are window ids, active is the
-    // frontmost window. No window-specific resolver function exists — the cross-window
-    // session->store mapping is app-side ControlServer logic (Task 7), not a resolve concern.
+    // window-id targets reuse the same pure matcher semantics. WindowLibrary wires those semantics to
+    // its own ordered window set and active-window fallback; these tests keep the raw matcher pinned.
     private let w1 = UUID(uuidString: "0A11AAAA-0000-0000-0000-000000000011")!
     private let w2 = UUID(uuidString: "0A22BBBB-0000-0000-0000-000000000012")!
     private let w3 = UUID(uuidString: "7B33CCCC-0000-0000-0000-000000000013")!

--- a/agtermCore/Tests/agtermCoreTests/WindowLibraryTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/WindowLibraryTests.swift
@@ -142,6 +142,58 @@ final class WindowLibraryTests {
         ])
     }
 
+    @Test func resolveWindowActiveUsesActiveWindowFallback() {
+        let library = WindowLibrary(directory: directory)
+        let first = library.windows[0].id
+        let second = library.newWindow(name: "work").id
+        library.frontmostWindowID = second
+
+        #expect(library.resolveWindow("active") == .resolved(second))
+
+        library.closeWindow(second)
+        #expect(library.resolveWindow("active") == .resolved(first))
+    }
+
+    @Test func resolveWindowMatchesExactAndUniquePrefix() throws {
+        let first = UUID(uuidString: "0A11AAAA-0000-0000-0000-000000000011")!
+        let second = UUID(uuidString: "7B33CCCC-0000-0000-0000-000000000013")!
+        try writeWindowFile(first, Snapshot(workspaces: [WorkspaceSnapshot(id: UUID(), name: "a", sessions: [])]))
+        try writeWindowFile(second, Snapshot(workspaces: [WorkspaceSnapshot(id: UUID(), name: "b", sessions: [])]))
+        try writeIndex(WindowsIndex(frontmost: second, windows: [
+            WindowEntry(id: first, name: "a", isOpen: true),
+            WindowEntry(id: second, name: "b", isOpen: true),
+        ]))
+
+        let library = WindowLibrary(directory: directory)
+
+        #expect(library.resolveWindow(first.uuidString.lowercased()) == .resolved(first))
+        #expect(library.resolveWindow("7b33") == .resolved(second))
+    }
+
+    @Test func resolveWindowReportsAmbiguousAndMissingTargets() throws {
+        let first = UUID(uuidString: "0A11AAAA-0000-0000-0000-000000000011")!
+        let second = UUID(uuidString: "0A22BBBB-0000-0000-0000-000000000012")!
+        try writeWindowFile(first, Snapshot(workspaces: [WorkspaceSnapshot(id: UUID(), name: "a", sessions: [])]))
+        try writeWindowFile(second, Snapshot(workspaces: [WorkspaceSnapshot(id: UUID(), name: "b", sessions: [])]))
+        try writeIndex(WindowsIndex(windows: [
+            WindowEntry(id: first, name: "a", isOpen: true),
+            WindowEntry(id: second, name: "b", isOpen: true),
+        ]))
+
+        let library = WindowLibrary(directory: directory)
+
+        #expect(library.resolveWindow("0a") == .ambiguous([first, second]))
+        #expect(library.resolveWindow("deadbeef") == .notFound)
+    }
+
+    @Test func resolveWindowIncludesClosedWindowsAsCandidates() {
+        let library = WindowLibrary(directory: directory)
+        let closed = library.newWindow(name: "closed").id
+        library.closeWindow(closed)
+
+        #expect(library.resolveWindow(closed.uuidString) == .resolved(closed))
+    }
+
     @Test func newWindowBlankNameFallsBackToDefault() {
         let library = WindowLibrary(directory: directory)
         let info = library.newWindow(name: "   ")


### PR DESCRIPTION
## Summary
- Add `WindowLibrary.resolveWindow(_:)` for the shared window target lookup.
- Rewire `ControlTargetResolver` to use the helper while preserving existing error strings and open-window checks.
- Add focused `WindowLibraryTests` for active, exact, prefix, ambiguous, missing, and closed-window resolution.

## Validation
- `swift test --filter WindowLibraryTests`
- `cd agtermCore && swift test`
- `make lint`
- `make build`
