### PR TITLE
refactor(control): add dispatcher foundation

### DIFF
--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -5,7 +5,29 @@ import agtermCore
 /// (splits, scratch, focus, status, flag, move, notify, quick terminal, sidebar). Each resolves its target
 /// through `resolver` and drives the `AppActions`/`AppStore` seam. Split out of `ControlServer.swift` to
 /// keep that file under the swiftlint size limit.
-extension ControlServer {
+extension ControlServer: ControlActions {
+    func controlTree(window: String?) -> ControlResponse {
+        resolver.resolvePlacementStore(window) { store in
+            ControlResponse(ok: true, result: ControlResult(tree: buildTree(in: store)))
+        }
+    }
+
+    func setSidebarVisibility(_ mode: ControlToggleMode) -> ControlResponse {
+        setSidebar(mode: mode)
+    }
+
+    func setSidebarViewMode(_ mode: ControlSidebarViewMode) -> ControlResponse {
+        setSidebarViewMode(mode: mode)
+    }
+
+    func expandSidebar(window: String?) -> ControlResponse {
+        expandWorkspaces(window: window)
+    }
+
+    func collapseSidebar(window: String?) -> ControlResponse {
+        collapseWorkspaces(window: window)
+    }
+
     /// Resolve the target session and drive the split directly on its owning store (NOT the
     /// argument-less `AppActions.toggleSplit()`, which only acts on the active session). `mode` is
     /// `on|off|toggle`, computed against the session's current `isSplit` so `on`/`off` are
@@ -293,14 +315,11 @@ extension ControlServer {
     /// Show / hide / toggle the frontmost window's sidebar (the custom split owns visibility, so there's
     /// no system toggle). Flips only when the requested state differs; an unknown mode is an error, and no
     /// open window is an error rather than a silent no-op.
-    func setSidebar(mode: String?) -> ControlResponse {
+    func setSidebar(mode: ControlToggleMode) -> ControlResponse {
         guard let store = library.activeStore else {
             return ControlResponse(ok: false, error: "no open window")
         }
-        guard let parsedMode = ControlToggleMode.parse(mode, on: "show", off: "hide") else {
-            return ControlResponse(ok: false, error: "invalid sidebar mode: \(mode ?? "toggle")")
-        }
-        let want = parsedMode.desiredValue(current: store.sidebarVisible)
+        let want = mode.desiredValue(current: store.sidebarVisible)
         store.setSidebarVisible(want) // no-op + no save when unchanged (idempotent)
         return ControlResponse(ok: true)
     }
@@ -308,17 +327,15 @@ extension ControlServer {
     /// Set the frontmost window's sidebar VIEW mode (the tree vs the flat flagged list) — distinct from
     /// `setSidebar` (visibility). `mode` is `tree|flagged|toggle`, delta-computed so a no-op mode skips
     /// the write (idempotent), via `AppStore.setSidebarMode`. An unknown mode + no-open-window are errors.
-    func setSidebarViewMode(mode: String?) -> ControlResponse {
-        let mode = mode ?? "toggle"
+    func setSidebarViewMode(mode: ControlSidebarViewMode) -> ControlResponse {
         guard let store = library.activeStore else {
             return ControlResponse(ok: false, error: "no open window")
         }
         let want: SidebarMode
         switch mode {
-        case "tree": want = .tree
-        case "flagged": want = .flagged
-        case "toggle": want = store.sidebarMode == .tree ? .flagged : .tree
-        default: return ControlResponse(ok: false, error: "invalid sidebar mode: \(mode)")
+        case .tree: want = .tree
+        case .flagged: want = .flagged
+        case .toggle: want = store.sidebarMode == .tree ? .flagged : .tree
         }
         store.setSidebarMode(want) // no-op + no save when unchanged (idempotent)
         return ControlResponse(ok: true)

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -336,11 +336,12 @@ final class ControlServer {
         // refresh the read cache within this same main-actor execution (a window mutation just ran), so
         // the background fast path sees the new state without a separate hop that could stall.
         defer { refreshWindowCache() }
+        if let response = ControlDispatcher(actions: self).dispatch(request) {
+            return response
+        }
         switch request.cmd {
-        case .tree:
-            return resolver.resolvePlacementStore(request.args?.window) { store in
-                ControlResponse(ok: true, result: ControlResult(tree: buildTree(in: store)))
-            }
+        case .tree, .sidebar, .sidebarMode, .sidebarExpand, .sidebarCollapse:
+            return ControlResponse(ok: false, error: "control dispatcher did not handle \(request.cmd.rawValue)")
         case .sessionSelect:
             return resolver.resolveSession(request.target, window: request.args?.window) { store, id in
                 store.selectSession(id)
@@ -539,14 +540,6 @@ final class ControlServer {
             }
         case .quick:
             return setQuickTerminal(mode: request.args?.mode)
-        case .sidebar:
-            return setSidebar(mode: request.args?.mode)
-        case .sidebarMode:
-            return setSidebarViewMode(mode: request.args?.mode)
-        case .sidebarExpand:
-            return expandWorkspaces(window: request.args?.window)
-        case .sidebarCollapse:
-            return collapseWorkspaces(window: request.args?.window)
         case .notify:
             return sendNotification(request.target, window: request.args?.window,
                                     title: request.args?.title, body: request.args?.body)
@@ -604,7 +597,7 @@ final class ControlServer {
 
     /// Project a window's workspace tree into the wire `ControlTree`, marking the active session and the
     /// active workspace (the one owning the selected session).
-    private func buildTree(in store: AppStore) -> ControlTree {
+    func buildTree(in store: AppStore) -> ControlTree {
         let shellBasename = ProcessInfo.processInfo.environment["SHELL"].map(CommandRestore.basename)
         return store.controlTree(
             foreground: { session in

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// App-facing operations a host must provide for commands routed through `ControlDispatcher`.
+/// The dispatcher owns command parsing and response shape; the host keeps target resolution and
+/// platform-specific side effects.
+@MainActor
+public protocol ControlActions {
+    func controlTree(window: String?) -> ControlResponse
+    func setSidebarVisibility(_ mode: ControlToggleMode) -> ControlResponse
+    func setSidebarViewMode(_ mode: ControlSidebarViewMode) -> ControlResponse
+    func expandSidebar(window: String?) -> ControlResponse
+    func collapseSidebar(window: String?) -> ControlResponse
+}
+
+/// Routes the command groups that have been hoisted from the app control switch. Commands outside this
+/// first migrated set return nil so the app can keep handling them in its existing switch.
+@MainActor
+public struct ControlDispatcher {
+    private let actions: any ControlActions
+
+    public init(actions: any ControlActions) {
+        self.actions = actions
+    }
+
+    public func dispatch(_ request: ControlRequest) -> ControlResponse? {
+        switch request.cmd {
+        case .tree:
+            return actions.controlTree(window: request.args?.window)
+        case .sidebar:
+            guard let mode = ControlToggleMode.parse(request.args?.mode, on: "show", off: "hide") else {
+                return ControlResponse(ok: false, error: "invalid sidebar mode: \(request.args?.mode ?? "toggle")")
+            }
+            return actions.setSidebarVisibility(mode)
+        case .sidebarMode:
+            guard let mode = ControlSidebarViewMode.parse(request.args?.mode) else {
+                return ControlResponse(ok: false, error: "invalid sidebar mode: \(request.args?.mode ?? "toggle")")
+            }
+            return actions.setSidebarViewMode(mode)
+        case .sidebarExpand:
+            return actions.expandSidebar(window: request.args?.window)
+        case .sidebarCollapse:
+            return actions.collapseSidebar(window: request.args?.window)
+        default:
+            return nil
+        }
+    }
+}

--- a/agtermCore/Sources/agtermCore/ControlModes.swift
+++ b/agtermCore/Sources/agtermCore/ControlModes.swift
@@ -48,3 +48,19 @@ public enum ControlPaneFocusMode: Equatable, Sendable {
         }
     }
 }
+
+/// Parsed view mode for `sidebar.mode`.
+public enum ControlSidebarViewMode: Equatable, Sendable {
+    case tree
+    case flagged
+    case toggle
+
+    public static func parse(_ mode: String?) -> ControlSidebarViewMode? {
+        switch mode ?? "toggle" {
+        case "tree": return .tree
+        case "flagged": return .flagged
+        case "toggle": return .toggle
+        default: return nil
+        }
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -1,0 +1,147 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+@MainActor
+struct ControlDispatcherTests {
+    @Test func treeRoutesThroughActionsWithWindowArgument() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        let tree = ControlTree(workspaces: [
+            ControlWorkspaceNode(id: "workspace", name: "Workspace", active: true, sessions: [])
+        ])
+        actions.nextTreeResponse = ControlResponse(ok: true, result: ControlResult(tree: tree))
+
+        let response = dispatcher.dispatch(ControlRequest(cmd: .tree, args: ControlArgs(window: "abc")))
+
+        #expect(response == ControlResponse(ok: true, result: ControlResult(tree: tree)))
+        #expect(actions.calls == [.tree(window: "abc")])
+    }
+
+    @Test func sidebarVisibilityParsesModesAndKeepsExactResponse() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextSidebarVisibilityResponse = ControlResponse(ok: true)
+
+        let response = dispatcher.dispatch(ControlRequest(cmd: .sidebar, args: ControlArgs(mode: "hide")))
+
+        #expect(response == ControlResponse(ok: true))
+        #expect(actions.calls == [.sidebarVisibility(.off)])
+    }
+
+    @Test func sidebarVisibilityDefaultsToToggle() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        _ = dispatcher.dispatch(ControlRequest(cmd: .sidebar))
+
+        #expect(actions.calls == [.sidebarVisibility(.toggle)])
+    }
+
+    @Test func sidebarVisibilityRejectsInvalidModeWithoutCallingActions() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let response = dispatcher.dispatch(ControlRequest(cmd: .sidebar, args: ControlArgs(mode: "yes")))
+
+        #expect(response == ControlResponse(ok: false, error: "invalid sidebar mode: yes"))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test func sidebarViewModeParsesModesAndKeepsExactResponse() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextSidebarViewModeResponse = ControlResponse(ok: true)
+
+        let response = dispatcher.dispatch(ControlRequest(cmd: .sidebarMode, args: ControlArgs(mode: "flagged")))
+
+        #expect(response == ControlResponse(ok: true))
+        #expect(actions.calls == [.sidebarViewMode(.flagged)])
+    }
+
+    @Test func sidebarViewModeDefaultsToToggle() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        _ = dispatcher.dispatch(ControlRequest(cmd: .sidebarMode))
+
+        #expect(actions.calls == [.sidebarViewMode(.toggle)])
+    }
+
+    @Test func sidebarViewModeRejectsInvalidModeWithoutCallingActions() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let response = dispatcher.dispatch(ControlRequest(cmd: .sidebarMode, args: ControlArgs(mode: "wide")))
+
+        #expect(response == ControlResponse(ok: false, error: "invalid sidebar mode: wide"))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test func sidebarExpandAndCollapseRouteWithWindowArgument() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextExpandResponse = ControlResponse(ok: true)
+        actions.nextCollapseResponse = ControlResponse(ok: false, error: "window not open - window.select it first")
+
+        let expand = dispatcher.dispatch(ControlRequest(cmd: .sidebarExpand, args: ControlArgs(window: "win")))
+        let collapse = dispatcher.dispatch(ControlRequest(cmd: .sidebarCollapse, args: ControlArgs(window: "win")))
+
+        #expect(expand == ControlResponse(ok: true))
+        #expect(collapse == ControlResponse(ok: false, error: "window not open - window.select it first"))
+        #expect(actions.calls == [.expand(window: "win"), .collapse(window: "win")])
+    }
+
+    @Test func nonMigratedCommandFallsThrough() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let response = dispatcher.dispatch(ControlRequest(cmd: .sessionSelect))
+
+        #expect(response == nil)
+        #expect(actions.calls.isEmpty)
+    }
+}
+
+@MainActor
+private final class MockControlActions: ControlActions {
+    enum Call: Equatable {
+        case tree(window: String?)
+        case sidebarVisibility(ControlToggleMode)
+        case sidebarViewMode(ControlSidebarViewMode)
+        case expand(window: String?)
+        case collapse(window: String?)
+    }
+
+    var calls: [Call] = []
+    var nextTreeResponse = ControlResponse(ok: false, error: "tree not stubbed")
+    var nextSidebarVisibilityResponse = ControlResponse(ok: true)
+    var nextSidebarViewModeResponse = ControlResponse(ok: true)
+    var nextExpandResponse = ControlResponse(ok: true)
+    var nextCollapseResponse = ControlResponse(ok: true)
+
+    func controlTree(window: String?) -> ControlResponse {
+        calls.append(.tree(window: window))
+        return nextTreeResponse
+    }
+
+    func setSidebarVisibility(_ mode: ControlToggleMode) -> ControlResponse {
+        calls.append(.sidebarVisibility(mode))
+        return nextSidebarVisibilityResponse
+    }
+
+    func setSidebarViewMode(_ mode: ControlSidebarViewMode) -> ControlResponse {
+        calls.append(.sidebarViewMode(mode))
+        return nextSidebarViewModeResponse
+    }
+
+    func expandSidebar(window: String?) -> ControlResponse {
+        calls.append(.expand(window: window))
+        return nextExpandResponse
+    }
+
+    func collapseSidebar(window: String?) -> ControlResponse {
+        calls.append(.collapse(window: window))
+        return nextCollapseResponse
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/ControlModesTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlModesTests.swift
@@ -59,4 +59,12 @@ struct ControlModesTests {
         #expect(ControlPaneFocusMode.toggle.wantsSplit(currentSplitFocused: false))
         #expect(!ControlPaneFocusMode.toggle.wantsSplit(currentSplitFocused: true))
     }
+
+    @Test func sidebarViewModeParsesModes() {
+        #expect(ControlSidebarViewMode.parse(nil) == .toggle)
+        #expect(ControlSidebarViewMode.parse("tree") == .tree)
+        #expect(ControlSidebarViewMode.parse("flagged") == .flagged)
+        #expect(ControlSidebarViewMode.parse("toggle") == .toggle)
+        #expect(ControlSidebarViewMode.parse("wide") == nil)
+    }
 }


### PR DESCRIPTION
Summary:
- Add a small agtermCore ControlDispatcher/ControlActions seam for routed control commands.
- Migrate only tree and sidebar visibility/mode/expand/collapse through the dispatcher.
- Keep all other ControlServer command arms inline as fallback and cover routed behavior with core mock-action tests.

Validation:
- cd agtermCore && swift test
- make lint
- make build
- xcodebuild focused UI tests for tree, sidebar show/hide, sidebar.mode, and sidebar expand/collapse