### PR TITLE
refactor(input): hoist keystroke segmentation

### DIFF
--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -339,20 +339,16 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     /// created yet (a never-shown session); the caller realizes it first.
     func inject(text: String) {
         guard let surface else { return }
-        // normalize all line endings to \n so each becomes exactly one Return keypress.
-        let normalized = text.replacingOccurrences(of: "\r\n", with: "\n").replacingOccurrences(of: "\r", with: "\n")
-        let segments = normalized.components(separatedBy: "\n")
-        for (index, segment) in segments.enumerated() {
-            if !segment.isEmpty {
+        for segment in KeystrokeSegments.split(text) {
+            switch segment {
+            case let .text(segment):
                 segment.withCString { ptr in
                     var ke = ghostty_input_key_s()
                     ke.action = GHOSTTY_ACTION_PRESS
                     ke.text = ptr
                     _ = ghostty_surface_key(surface, ke)
                 }
-            }
-            // a newline separated this segment from the next → press Enter.
-            if index < segments.count - 1 {
+            case .returnKey:
                 sendReturn(to: surface)
             }
         }

--- a/agtermCore/Sources/agtermCore/KeystrokeSegments.swift
+++ b/agtermCore/Sources/agtermCore/KeystrokeSegments.swift
@@ -1,0 +1,28 @@
+/// A host-free description of the synthetic keystrokes used by `session.type`.
+public enum KeystrokeSegment: Equatable, Sendable {
+    case text(String)
+    case returnKey
+}
+
+/// Splits injected text into printable runs and Return keypresses.
+public enum KeystrokeSegments {
+    /// Normalizes CRLF and CR line endings to LF, then emits every line ending as exactly one Return.
+    public static func split(_ text: String) -> [KeystrokeSegment] {
+        let normalized = text
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        let parts = normalized.components(separatedBy: "\n")
+        var segments: [KeystrokeSegment] = []
+        segments.reserveCapacity(parts.count * 2)
+
+        for (index, part) in parts.enumerated() {
+            if !part.isEmpty {
+                segments.append(.text(part))
+            }
+            if index < parts.count - 1 {
+                segments.append(.returnKey)
+            }
+        }
+        return segments
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/KeystrokeSegmentsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/KeystrokeSegmentsTests.swift
@@ -1,0 +1,47 @@
+import Testing
+@testable import agtermCore
+
+struct KeystrokeSegmentsTests {
+    @Test func emptyTextProducesNoKeystrokes() {
+        #expect(KeystrokeSegments.split("") == [])
+    }
+
+    @Test func textWithoutLineEndingsStaysOneTextRun() {
+        #expect(KeystrokeSegments.split("echo hi") == [.text("echo hi")])
+    }
+
+    @Test func lineFeedsBecomeReturnKeystrokes() {
+        #expect(KeystrokeSegments.split("one\ntwo\n") == [
+            .text("one"),
+            .returnKey,
+            .text("two"),
+            .returnKey,
+        ])
+    }
+
+    @Test func carriageReturnsBecomeReturnKeystrokes() {
+        #expect(KeystrokeSegments.split("one\rtwo") == [
+            .text("one"),
+            .returnKey,
+            .text("two"),
+        ])
+    }
+
+    @Test func crlfBecomesOneReturnKeystroke() {
+        #expect(KeystrokeSegments.split("one\r\ntwo") == [
+            .text("one"),
+            .returnKey,
+            .text("two"),
+        ])
+    }
+
+    @Test func blankLinesStillSendReturns() {
+        #expect(KeystrokeSegments.split("\n\nmiddle\n\n") == [
+            .returnKey,
+            .returnKey,
+            .text("middle"),
+            .returnKey,
+            .returnKey,
+        ])
+    }
+}


### PR DESCRIPTION
## Summary
- Add a host-free `KeystrokeSegments` utility for `session.type` injection.
- Rewire `GhosttySurfaceView.inject(text:)` to use it without changing newline behavior.
- Add focused core tests for empty text, CR/LF/CRLF, trailing newlines, and blank lines.

## Validation
- `cd agtermCore && swift test --filter KeystrokeSegmentsTests`
- `cd agtermCore && swift test`
- `make lint`
- `make build`