### PR TITLE
refactor(appstore): hoist sidebar visibility operation

### DIFF
--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -474,12 +474,12 @@ final class AppActions {
     }
 
     /// Show/hide the frontmost window's sidebar. The custom split owns visibility (no system toggle), so
-    /// this flips the active store's `sidebarVisible`; the view animates the change. Shared by the toolbar
-    /// button, the View menu item, the palette, and the `sidebar` control command.
+    /// this flips the active store's per-window `sidebarVisible`; the view animates the change and
+    /// `AppStore` persists it. Shared by the toolbar button, the View menu item, the palette, and the
+    /// `sidebar` control command.
     func toggleSidebar() {
         guard let store else { return }
-        store.sidebarVisible.toggle()
-        store.save() // sidebarVisible is persisted per-window
+        store.toggleSidebarVisible()
     }
 
     /// Move keyboard focus to a pane of the active session's split: `.split` -> the right pane,

--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -301,10 +301,7 @@ extension ControlServer {
             return ControlResponse(ok: false, error: "invalid sidebar mode: \(mode ?? "toggle")")
         }
         let want = parsedMode.desiredValue(current: store.sidebarVisible)
-        if want != store.sidebarVisible {
-            store.sidebarVisible = want
-            store.save() // sidebarVisible is persisted per-window
-        }
+        store.setSidebarVisible(want) // no-op + no save when unchanged (idempotent)
         return ControlResponse(ok: true)
     }
 

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -434,6 +434,21 @@ public final class AppStore {
         if changed { save() }
     }
 
+    /// Sets this window's sidebar visibility and persists it. Clean no-op (no write) when unchanged, so
+    /// menu, toolbar, palette, and control callers can delta-compute their desired state without
+    /// duplicating the persistence gate. `sidebarVisible` is per-window state saved in this store's
+    /// snapshot.
+    public func setSidebarVisible(_ visible: Bool) {
+        guard sidebarVisible != visible else { return }
+        sidebarVisible = visible
+        save()
+    }
+
+    /// Flips this window's sidebar visibility and persists the new state.
+    public func toggleSidebarVisible() {
+        setSidebarVisible(!sidebarVisible)
+    }
+
     /// Sets the sidebar mode and persists it. Clean no-op (no write) when the mode is unchanged, so the
     /// delta-computed control/menu callers stay idempotent.
     public func setSidebarMode(_ mode: SidebarMode) {

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -14,8 +14,12 @@ struct AppStoreTests {
     @Test func sidebarVisibleDefaultsTrueAndToggles() {
         let store = makeStore()
         #expect(store.sidebarVisible)
-        store.sidebarVisible.toggle()
+        store.toggleSidebarVisible()
         #expect(!store.sidebarVisible)
+        store.setSidebarVisible(true)
+        #expect(store.sidebarVisible)
+        store.setSidebarVisible(true) // unchanged: clean no-op
+        #expect(store.sidebarVisible)
     }
 
     @Test func defaultWorkspaceNameCountsUp() {

--- a/agtermCore/Tests/agtermCoreTests/PersistenceTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/PersistenceTests.swift
@@ -204,6 +204,23 @@ final class PersistenceTests {
         #expect(restoredTree.sidebarMode == .tree)
     }
 
+    @Test func sidebarVisibilityPersistsAndRestoresThroughHelper() {
+        let app = AppStore(persistence: store)
+        _ = app.addWorkspace(name: "work")
+        #expect(store.load().sidebarVisible == true)
+        app.setSidebarVisible(false)
+        #expect(store.load().sidebarVisible == false)
+
+        let restored = AppStore(persistence: store)
+        restored.restore(from: store.load())
+        #expect(restored.sidebarVisible == false)
+
+        app.toggleSidebarVisible()
+        let restoredShown = AppStore(persistence: store)
+        restoredShown.restore(from: store.load())
+        #expect(restoredShown.sidebarVisible == true)
+    }
+
     @Test func legacySnapshotWithoutSidebarModeDecodesTree() throws {
         // a workspaces.json written before `sidebarMode` existed has no key; it must decode (not throw
         // and wipe the tree) and restore to `.tree`.


### PR DESCRIPTION
## Summary
- Add AppStore helpers for per-window sidebar visibility so persistence is owned by the store.
- Rewire the app action and control sidebar command to use the helper while preserving existing behavior and comments.
- Add focused core coverage for toggling, setting, and persistence/restore.

## Validation
- cd agtermCore && swift test
- make lint
- make build
- xcodebuild -project agterm.xcodeproj -scheme agterm -configuration Debug -derivedDataPath build/DerivedData -only-testing:agtermUITests/ControlSidebarStatusUITests/testSidebarShowHideToggle test