### PR TITLE
refactor(control): hoist app store tree projection

### DIFF
--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -605,26 +605,19 @@ final class ControlServer {
     /// Project a window's workspace tree into the wire `ControlTree`, marking the active session and the
     /// active workspace (the one owning the selected session).
     private func buildTree(in store: AppStore) -> ControlTree {
-        let activeID = store.selectedSessionID
-        let activeWorkspaceID = activeID.flatMap { store.workspace(forSession: $0)?.id }
         let shellBasename = ProcessInfo.processInfo.environment["SHELL"].map(CommandRestore.basename)
-        let workspaces = store.workspaces.map { workspace in
-            let sessions = workspace.sessions.map { session in
-                let fg = (session.surface as? GhosttySurfaceView).flatMap { ForegroundProcess.command(for: $0, shellBasename: shellBasename) }
-                let splitFg = (session.splitSurface as? GhosttySurfaceView).flatMap { ForegroundProcess.command(for: $0, shellBasename: shellBasename) }
-                let status = session.agentIndicator.status == .idle ? nil : session.agentIndicator.status.rawValue
-                return ControlSessionNode(id: session.id.uuidString, name: session.displayName,
-                                          cwd: session.effectiveCwd, title: session.oscTitle,
-                                          active: session.id == activeID,
-                                          split: session.isSplit, overlay: session.overlayActive,
-                                          scratch: session.scratchActive, flagged: session.flagged,
-                                          foreground: fg, splitForeground: splitFg, status: status,
-                                          background: session.backgroundWatermark)
+        return store.controlTree(
+            foreground: { session in
+                (session.surface as? GhosttySurfaceView).flatMap {
+                    ForegroundProcess.command(for: $0, shellBasename: shellBasename)
+                }
+            },
+            splitForeground: { session in
+                (session.splitSurface as? GhosttySurfaceView).flatMap {
+                    ForegroundProcess.command(for: $0, shellBasename: shellBasename)
+                }
             }
-            return ControlWorkspaceNode(id: workspace.id.uuidString, name: workspace.name,
-                                        active: workspace.id == activeWorkspaceID, sessions: sessions)
-        }
-        return ControlTree(workspaces: workspaces)
+        )
     }
 
     /// Creates a session in `workspaceID` of `store` with the `session.new` args (cwd default $HOME,

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -120,6 +120,30 @@ public final class AppStore {
         "workspace \(workspaces.count + 1)"
     }
 
+    /// Projects this store's workspace/session model into the control-channel `tree` payload. Foreground
+    /// command lookup is supplied by the host because live process inspection is platform-specific.
+    public func controlTree(foreground: (Session) -> [String]? = { _ in nil },
+                            splitForeground: (Session) -> [String]? = { _ in nil }) -> ControlTree {
+        let activeID = selectedSessionID
+        let activeWorkspaceID = activeID.flatMap { workspace(forSession: $0)?.id }
+        let nodes = workspaces.map { workspace in
+            let sessions = workspace.sessions.map { session in
+                let status = session.agentIndicator.status == .idle ? nil : session.agentIndicator.status.rawValue
+                return ControlSessionNode(id: session.id.uuidString, name: session.displayName,
+                                          cwd: session.effectiveCwd, title: session.oscTitle,
+                                          active: session.id == activeID,
+                                          split: session.isSplit, overlay: session.overlayActive,
+                                          scratch: session.scratchActive, flagged: session.flagged,
+                                          foreground: foreground(session),
+                                          splitForeground: splitForeground(session), status: status,
+                                          background: session.backgroundWatermark)
+            }
+            return ControlWorkspaceNode(id: workspace.id.uuidString, name: workspace.name,
+                                        active: workspace.id == activeWorkspaceID, sessions: sessions)
+        }
+        return ControlTree(workspaces: nodes)
+    }
+
     /// Creates a workspace and appends it. Clears any active focus so the new (empty)
     /// workspace is immediately visible — without this `visibleWorkspaces` would still
     /// return only the focused one and the new workspace would be silently hidden until

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -738,4 +738,56 @@ struct AppStoreTests {
         #expect(!store.setBackgroundWatermark(nil, forSession: session.id))       // clear again: no change
         #expect(!store.setBackgroundWatermark(mark, forSession: UUID()))          // unknown id: no change
     }
+
+    @Test func controlTreeProjectsWorkspaceAndSessionShape() throws {
+        let store = makeStore()
+        let work = store.addWorkspace(name: "work")
+        let personal = store.addWorkspace(name: "personal")
+        let a = try #require(store.addSession(toWorkspace: work.id, cwd: "/repo/a", name: "alpha"))
+        let b = try #require(store.addSession(toWorkspace: personal.id, cwd: "/repo/b"))
+        b.currentCwd = "/live/b"
+        b.oscTitle = "remote:~/b"
+        b.isSplit = true
+        b.overlayActive = true
+        b.scratchActive = true
+        b.flagged = true
+        b.backgroundWatermark = BackgroundWatermark(kind: .text, text: "PROD")
+        store.setAgentIndicator(AgentIndicator(status: .blocked), forSession: b.id)
+        store.selectSession(b.id)
+
+        let tree = store.controlTree()
+
+        #expect(tree.workspaces.map(\.id) == [work.id.uuidString, personal.id.uuidString])
+        #expect(tree.workspaces.map(\.name) == ["work", "personal"])
+        #expect(tree.workspaces.map(\.active) == [false, true])
+        #expect(tree.workspaces[0].sessions == [
+            ControlSessionNode(id: a.id.uuidString, name: "alpha", cwd: "/repo/a",
+                               active: false, split: false)
+        ])
+        #expect(tree.workspaces[1].sessions == [
+            ControlSessionNode(id: b.id.uuidString, name: "remote:~/b", cwd: "/live/b",
+                               title: "remote:~/b", active: true, split: true,
+                               overlay: true, scratch: true, flagged: true,
+                               status: "blocked",
+                               background: BackgroundWatermark(kind: .text, text: "PROD"))
+        ])
+    }
+
+    @Test func controlTreeUsesForegroundLookups() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let active = try #require(store.addSession(toWorkspace: ws.id, cwd: "/active"))
+        let other = try #require(store.addSession(toWorkspace: ws.id, cwd: "/other"))
+        store.selectSession(active.id)
+
+        let tree = store.controlTree(
+            foreground: { session in session.id == active.id ? ["ssh", "host"] : nil },
+            splitForeground: { session in session.id == other.id ? ["tail", "-f", "app.log"] : nil }
+        )
+
+        #expect(tree.workspaces[0].sessions[0].foreground == ["ssh", "host"])
+        #expect(tree.workspaces[0].sessions[0].splitForeground == nil)
+        #expect(tree.workspaces[0].sessions[1].foreground == nil)
+        #expect(tree.workspaces[0].sessions[1].splitForeground == ["tail", "-f", "app.log"])
+    }
 }


### PR DESCRIPTION
## Summary
- hoist AppStore control tree projection into agtermCore
- keep ControlServer.buildTree(in:) as the macOS tree entry point
- pass foreground lookups from macOS via closures and cover the core projection with focused tests

## Validation
- cd agtermCore && swift test
- make lint
- make build
- xcodebuild -project agterm.xcodeproj -scheme agterm -configuration Debug -derivedDataPath build/DerivedData -only-testing:agtermUITests/ControlAPIUITests/testTreeReturnsSeededWorkspaceAndSession test