### PR TITLE
fix: sanitize OSC title/pwd control chars to close a shell-injection sub-case

### DIFF
--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -119,6 +119,12 @@ paths:
 - **`{AGT_X}` tokens are substituted RAW into the `/bin/sh -c` line (`CommandContext.expand`).** This
   is the intended raw interpolation (convenient), NOT shell-quoted — so dynamic content like `{AGT_SELECTION}`
   can inject shell syntax.
+  `{AGT_SESSION_NAME}` and `{AGT_SESSION_PWD}` are equally unsafe, and worse than `{AGT_SELECTION}`
+  because they need no local interaction: a remote host sets the session title (OSC 0/1/2) and the
+  working directory (OSC 7), so either can carry attacker content silently.
+  OSC-reported title and pwd are stripped of control characters at ingestion (`TerminalText.sanitized`
+  in `GhosttySurfaceView.applyTitle`/`applyPwd`), so a newline can no longer split the `sh -c` line,
+  but visible metacharacters (`;`, `$()`, backticks) still pass through raw.
   The safe alternative is already provided: the same values are exported as `$AGT_X` env vars (`CommandContext.environment()`),
   naturally shell-quoted as `"$AGT_SELECTION"`.
   The starter `keymap.conf` comments + README recommend `$AGT_X` (quoted) for untrusted content.

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -281,10 +281,15 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
 
     // MARK: - Callback entry points
 
-    func applyPwd(_ pwd: String) {
+    func applyPwd(_ rawPwd: String) {
         // Already on the main actor (the callback hops via DispatchQueue.main.async).
         // `currentCwd` is observed, so the sidebar row refreshes live.
         //
+        // Strip control characters from the OSC 7 value first: it flows unquoted into a /bin/sh -c
+        // line via {AGT_SESSION_PWD} and into every cwd-inheriting spawn (split/overlay/restore), so a
+        // newline (an sh -c command separator) must never survive; a real path has no control chars.
+        let pwd = TerminalText.sanitized(rawPwd)
+
         // This deliberately does NOT save(): OSC 7 fires on every cd/prompt redraw,
         // so persisting here would thrash the disk. Live cwd is persisted on quit
         // and on structural mutations (add/close/move/rename/select), not on every
@@ -300,11 +305,16 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         }
     }
 
-    func applyTitle(_ title: String) {
+    func applyTitle(_ rawTitle: String) {
         // Already on the main actor (the callback hops via DispatchQueue.main.async).
         // `oscTitle`/`splitTitle` are observed, so the sidebar row and window title refresh live. Like
         // applyPwd, this deliberately does NOT save(): OSC set-title re-fires on every prompt redraw.
         //
+        // Strip control characters from the OSC 0/1/2 title first: it flows unquoted into a /bin/sh -c
+        // line via {AGT_SESSION_NAME}, so a newline (an sh -c command separator) must never survive; a
+        // real title has no control chars.
+        let title = TerminalText.sanitized(rawTitle)
+
         // Guard on a real value change so an equal re-emit doesn't notify observers and churn the sidebar.
         if isSplitPane {
             if session?.splitTitle != title { session?.splitTitle = title }

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -299,6 +299,7 @@ for untrusted content). A remote host can set the session title (OSC) and workin
 so `{AGT_SESSION_NAME}` and `{AGT_SESSION_PWD}` are as untrusted as `{AGT_SELECTION}`; use the quoted
 `$AGT_*` form for any of them:
 
+- `{AGT_SESSION_NAME}` / `$AGT_SESSION_NAME` — the session's display name (the focused pane's terminal title, remote-settable via OSC).
 - `{AGT_SESSION_PWD}` / `$AGT_SESSION_PWD` — the focused pane's working directory.
 - `{AGT_SELECTION}` / `$AGT_SELECTION` — the current selection.
 - Plus the other `$AGT_*` context vars the runner exports.

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -295,7 +295,9 @@ expressible as a parsed chord. Some chords are reserved (the Ctrl-Tab switcher, 
 and cannot be bound.
 
 Custom-command tokens (expanded into the `/bin/sh -c` line, raw — prefer the quoted `$AGT_*` env form
-for untrusted content):
+for untrusted content). A remote host can set the session title (OSC) and working directory (OSC 7),
+so `{AGT_SESSION_NAME}` and `{AGT_SESSION_PWD}` are as untrusted as `{AGT_SELECTION}`; use the quoted
+`$AGT_*` form for any of them:
 
 - `{AGT_SESSION_PWD}` / `$AGT_SESSION_PWD` — the focused pane's working directory.
 - `{AGT_SELECTION}` / `$AGT_SELECTION` — the current selection.

--- a/agtermCore/Sources/agtermCore/TerminalText.swift
+++ b/agtermCore/Sources/agtermCore/TerminalText.swift
@@ -14,7 +14,15 @@ import Foundation
 public enum TerminalText {
     /// Strip the C0 control range (U+0000–U+001F, including tab/newline/carriage-return) and DEL
     /// (U+007F) from an OSC-reported title or working directory; every other scalar is preserved.
+    /// The common case (no control characters, which is every real title/path) returns the input
+    /// unchanged with no allocation, since these callbacks run on every OSC redraw.
     public static func sanitized(_ value: String) -> String {
-        String(String.UnicodeScalarView(value.unicodeScalars.filter { $0.value >= 0x20 && $0.value != 0x7F }))
+        guard value.unicodeScalars.contains(where: { $0.value < 0x20 || $0.value == 0x7F })
+        else { return value }
+        var scalars = String.UnicodeScalarView()
+        for scalar in value.unicodeScalars where scalar.value >= 0x20 && scalar.value != 0x7F {
+            scalars.append(scalar)
+        }
+        return String(scalars)
     }
 }

--- a/agtermCore/Sources/agtermCore/TerminalText.swift
+++ b/agtermCore/Sources/agtermCore/TerminalText.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// TerminalText sanitizes strings a terminal program reports over OSC sequences — the window title
+/// (OSC 0/1/2) and the working directory (OSC 7) — before agterm stores them on a `Session`. Those
+/// values are attacker-influenceable (a remote SSH host or any program's output sets them) and flow,
+/// unquoted, into a `/bin/sh -c` line via the `{AGT_SESSION_NAME}`/`{AGT_SESSION_PWD}` custom-command
+/// tokens, so a control character — a newline above all, which `sh -c` reads as a command separator —
+/// must never survive into the stored value. A title or a directory path never legitimately contains
+/// a control character, so stripping the whole C0 range is lossless for real input.
+///
+/// This does NOT make raw `{AGT_X}` interpolation safe against visible shell metacharacters (`;`,
+/// `$()`, backticks); those are legitimate in titles/paths and are the caller's concern via the
+/// shell-quoted `$AGT_X` environment form. This closes only the invisible control-character vector.
+public enum TerminalText {
+    /// Strip the C0 control range (U+0000–U+001F, including tab/newline/carriage-return) and DEL
+    /// (U+007F) from an OSC-reported title or working directory; every other scalar is preserved.
+    public static func sanitized(_ value: String) -> String {
+        String(String.UnicodeScalarView(value.unicodeScalars.filter { $0.value >= 0x20 && $0.value != 0x7F }))
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/TerminalTextTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/TerminalTextTests.swift
@@ -1,0 +1,36 @@
+import Testing
+@testable import agtermCore
+
+struct TerminalTextTests {
+    @Test func cleanStringUnchanged() {
+        #expect(TerminalText.sanitized("user@host: ~/dev (main)") == "user@host: ~/dev (main)")
+    }
+
+    @Test func stripsNewlineAndCarriageReturn() {
+        // the security-relevant case: a newline in an unquoted {AGT_X} splice is an sh -c command separator.
+        #expect(TerminalText.sanitized("title\ninjected") == "titleinjected")
+        #expect(TerminalText.sanitized("a\rb") == "ab")
+        #expect(TerminalText.sanitized("a\r\nb") == "ab")
+    }
+
+    @Test func stripsTabNulEscAndDel() {
+        #expect(TerminalText.sanitized("a\tb") == "ab")
+        #expect(TerminalText.sanitized("a\u{00}b") == "ab")
+        #expect(TerminalText.sanitized("a\u{1B}[31mb") == "a[31mb")
+        #expect(TerminalText.sanitized("a\u{7F}b") == "ab")
+    }
+
+    @Test(arguments: 0..<0x20)
+    func stripsEveryC0ControlCharacter(_ code: Int) {
+        let scalar = Unicode.Scalar(code)!
+        #expect(TerminalText.sanitized("a\(scalar)b") == "ab")
+    }
+
+    @Test func preservesPrintableUnicodeAndSpace() {
+        #expect(TerminalText.sanitized("café 🚀 ~/项目") == "café 🚀 ~/项目")
+    }
+
+    @Test func emptyStaysEmpty() {
+        #expect(TerminalText.sanitized("") == "")
+    }
+}


### PR DESCRIPTION
Closes the one real finding from a full security review of the terminal surface: untrusted OSC-reported values reaching a shell.

**The issue.** OSC 0/1/2 titles and OSC 7 working dirs are set by untrusted terminal output (a remote SSH host, any program's stdout). Both flow unquoted into `/bin/sh -c` through the `{AGT_SESSION_NAME}`/`{AGT_SESSION_PWD}` custom-command tokens. A newline in such a value is an `sh -c` command separator, an invisible injection primitive that needs no visible shell metacharacter, only a token-using command being fired.

**The fix.** Sanitize both at the single OSC ingestion point (`GhosttySurfaceView.applyTitle`/`applyPwd`) via a host-free `TerminalText.sanitized` that strips the C0 range and DEL. A real title or path has no control characters, so this is lossless for legit input. It does not touch visible metacharacters (`;`, `$()`, backticks), which stay the caller's job via the quoted `$AGT_*` env form, by design.

**Scope.** This closes only the invisible control-char sub-case. A default install with no custom commands has no terminal-output to execution path at all: every escape-sequence action agterm handles is display-only, and terminal bytes can't inject keystrokes to fire a keybind.

The docs commit corrects `.claude/rules/keymap.md` and the bundled agent-skill reference to name `{AGT_SESSION_NAME}`/`{AGT_SESSION_PWD}` as remote-settable, not just `{AGT_SELECTION}`.

`TerminalText` has host-free unit coverage (full C0 sweep); `swift test` and `swiftlint --strict` pass.