### PR TITLE
fix: persist Ctrl-Tab MRU order across relaunch

### DIFF
--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -256,9 +256,14 @@ paths:
 - The Ctrl-Tab session switcher (`SessionSwitcher` + `SessionSwitcherOverlay`) cycles a most-recently-used
   list.
   `AppStore.sessionRecency` (`RecencyStack<UUID>` in agtermCore — host-free,
-  unit-tested, NOT persisted) is pushed on every selection and pruned on close;
+  unit-tested) is pushed on every selection and pruned on close;
   the switcher snapshots it on `begin()` so cycling never reorders it (only the commit does,
   via `selectSession`).
+  The order is persisted (`Snapshot.sessionRecency`, an optional field like the other post-v1 additions)
+  and re-seeded on restore — stale ids dropped, the restored selection floated to the front — so the
+  switcher works right after a relaunch instead of starting empty (#110).
+  Persistence is pure model/restore behavior with no new user action,
+  so it is control-API keep-in-sync EXEMPT.
   Keys come from app-wide `NSEvent` local monitors (`.keyDown` for Ctrl+Tab / Ctrl+Shift+Tab / Esc,
   `.flagsChanged` to detect the Ctrl release = commit), NOT SwiftUI shortcuts — the interaction needs
   Tab-while-Ctrl-held plus the modifier-release signal.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,10 @@ The app must build, `swift test` must stay green, and `make lint` must pass afte
   so the `AGTERM_STATE_DIR`/`AGTERM_CONTROL_SOCKET` env overrides are STILL required for a manual dev
   launch even with the distinct id — otherwise the dev instance reads/writes the user's real `workspaces.json`
   AND steals the deployed app's socket (its `start()` unlinks-then-binds the default path).
+  **The socket override must be a SHORT path** (unix sockets cap the path at ~104 bytes):
+  a long temp dir (e.g. a Claude session scratchpad) fails with `socket path too long` and the control
+  server never binds, while the app itself launches fine — so keep the state dir wherever,
+  but point the socket at something like `/tmp/<name>.sock`.
 - **Anchor path/existence checks at an ABSOLUTE repo-root path — the Bash cwd DRIFTS.** The shell working
   directory persists across tool calls and silently drifts (e.g. a `cd agtermCore` for `swift test` leaves
   you there), so a later relative `find .github`/`ls`/`cd` runs from the WRONG place and returns a FALSE

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ agterm is built to run from the keyboard. Every action has a shortcut and appear
 - the **action palette** (Ctrl-Shift-P) runs any command by name (new, rename, close, split, toggle scratch, move a session, change font size, and so on);
 - the **custom-commands palette** (Ctrl-Shift-O) lists the shell commands you define in `keymap.conf`.
 
-For jumping back to sessions you have been working in, a Ctrl-Tab switcher walks a most-recently-used list across every workspace, macOS app-switcher style: hold Ctrl and tap Tab to move through it, release to switch, and a single tap flips straight back to the session you were just in. Shortcuts also step between adjacent sessions, panes, and windows.
+For jumping back to sessions you have been working in, a Ctrl-Tab switcher walks a most-recently-used list across every workspace, macOS app-switcher style: hold Ctrl and tap Tab to move through it, release to switch, and a single tap flips straight back to the session you were just in. The list survives a relaunch, so the switcher works right after your sessions restore. Shortcuts also step between adjacent sessions, panes, and windows.
 
 ## Settings
 

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -79,7 +79,8 @@ public final class AppStore {
 
     /// Most-recently-selected session ids, front = current. Drives the Ctrl-Tab switcher
     /// (`items[1]` is the previous session). `@ObservationIgnored`: read imperatively by the
-    /// switcher, not by any SwiftUI view, and not persisted.
+    /// switcher, not by any SwiftUI view. Persisted in the snapshot so the switcher's order
+    /// survives a relaunch.
     @ObservationIgnored public private(set) var sessionRecency = RecencyStack<UUID>()
 
     @ObservationIgnored private let persistence: PersistenceStore
@@ -607,7 +608,7 @@ public final class AppStore {
         }
         return Snapshot(selectedSessionID: selectedSessionID, workspaces: workspaceSnapshots,
                         sidebarWidth: sidebarWidth, sidebarVisible: sidebarVisible, sidebarMode: sidebarMode,
-                        focusedWorkspaceID: focusedWorkspaceID)
+                        focusedWorkspaceID: focusedWorkspaceID, sessionRecency: sessionRecency.items)
     }
 
     /// Rebuilds the tree from a snapshot: fresh `Session`s (surfaces and shells
@@ -652,7 +653,11 @@ public final class AppStore {
         } else {
             selectedSessionID = snapshot.selectedSessionID
         }
-        sessionRecency = RecencyStack<UUID>()
+        // re-seed the Ctrl-Tab order from the persisted list (dropping ids not in the restored
+        // tree) so the switcher works right after relaunch; the restored selection floats to the
+        // front, keeping the "previous session" slot truthful.
+        let restoredIDs = Set(workspaces.flatMap(\.sessions).map(\.id))
+        sessionRecency = RecencyStack(items: (snapshot.sessionRecency ?? []).filter { restoredIDs.contains($0) })
         recordRecency()
     }
 

--- a/agtermCore/Sources/agtermCore/RecencyStack.swift
+++ b/agtermCore/Sources/agtermCore/RecencyStack.swift
@@ -7,9 +7,12 @@ public struct RecencyStack<ID: Hashable>: Equatable {
     public private(set) var items: [ID] = []
     public let limit: Int
 
+    /// Seeds the list from `items`, keeping the first occurrence of each id (the list is unique by
+    /// contract, but a persisted/hand-edited seed may not be) and truncating to `limit`.
     public init(limit: Int = 100, items: [ID] = []) {
         self.limit = limit
-        self.items = Array(items.prefix(limit))
+        var seen = Set<ID>()
+        self.items = Array(items.filter { seen.insert($0).inserted }.prefix(limit))
     }
 
     /// Move `id` to the front. No-op if it's already there.

--- a/agtermCore/Sources/agtermCore/Snapshot.swift
+++ b/agtermCore/Sources/agtermCore/Snapshot.swift
@@ -43,6 +43,29 @@ public struct Snapshot: Codable, Equatable, Sendable {
         self.focusedWorkspaceID = focusedWorkspaceID
         self.sessionRecency = sessionRecency
     }
+
+    enum CodingKeys: String, CodingKey {
+        case version, selectedSessionID, workspaces, sidebarWidth, sidebarVisible, sidebarMode
+        case focusedWorkspaceID, sessionRecency
+    }
+
+    /// Custom decode so `sessionRecency` is LOSSY: a present-but-invalid list (a malformed UUID
+    /// string or a wrong JSON type after a hand edit) drops to nil instead of throwing. Without
+    /// this, `Optional` tolerates only a MISSING key, so one bad MRU entry would fail the entire
+    /// `Snapshot` and `PersistenceStore.load` would start fresh — wiping every workspace and
+    /// session over a non-essential field. Mirrors `SessionSnapshot`'s `backgroundWatermark`
+    /// handling below; every other field keeps its strict/`decodeIfPresent` behavior.
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        version = try c.decode(Int.self, forKey: .version)
+        selectedSessionID = try c.decodeIfPresent(UUID.self, forKey: .selectedSessionID)
+        workspaces = try c.decode([WorkspaceSnapshot].self, forKey: .workspaces)
+        sidebarWidth = try c.decodeIfPresent(Double.self, forKey: .sidebarWidth)
+        sidebarVisible = try c.decodeIfPresent(Bool.self, forKey: .sidebarVisible)
+        sidebarMode = try c.decodeIfPresent(SidebarMode.self, forKey: .sidebarMode)
+        focusedWorkspaceID = try c.decodeIfPresent(UUID.self, forKey: .focusedWorkspaceID)
+        sessionRecency = (try? c.decodeIfPresent([UUID].self, forKey: .sessionRecency)) ?? nil
+    }
 }
 
 /// One persisted workspace: its identity, name, and ordered sessions.

--- a/agtermCore/Sources/agtermCore/Snapshot.swift
+++ b/agtermCore/Sources/agtermCore/Snapshot.swift
@@ -26,10 +26,14 @@ public struct Snapshot: Codable, Equatable, Sendable {
     /// snapshot already on disk before this field was added decodes (as nil → unfocused) instead of
     /// failing the load and wiping the saved tree.
     public var focusedWorkspaceID: UUID?
+    /// Most-recently-selected session ids, front = current, so the Ctrl-Tab switcher's order survives
+    /// a relaunch. Restore drops ids no longer in the tree. Optional so a snapshot already on disk
+    /// before this field was added still decodes (as nil → selection only), like the fields above.
+    public var sessionRecency: [UUID]?
 
     public init(version: Int = Snapshot.currentVersion, selectedSessionID: UUID? = nil,
                 workspaces: [WorkspaceSnapshot] = [], sidebarWidth: Double? = nil, sidebarVisible: Bool? = nil,
-                sidebarMode: SidebarMode? = nil, focusedWorkspaceID: UUID? = nil) {
+                sidebarMode: SidebarMode? = nil, focusedWorkspaceID: UUID? = nil, sessionRecency: [UUID]? = nil) {
         self.version = version
         self.selectedSessionID = selectedSessionID
         self.workspaces = workspaces
@@ -37,6 +41,7 @@ public struct Snapshot: Codable, Equatable, Sendable {
         self.sidebarVisible = sidebarVisible
         self.sidebarMode = sidebarMode
         self.focusedWorkspaceID = focusedWorkspaceID
+        self.sessionRecency = sessionRecency
     }
 }
 

--- a/agtermCore/Tests/agtermCoreTests/PersistenceTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/PersistenceTests.swift
@@ -313,6 +313,39 @@ final class PersistenceTests {
         #expect(app.sessionRecency.items == [b, a])
     }
 
+    @Test func malformedRecencyDropsToNilKeepingTree() throws {
+        // a present-but-invalid sessionRecency (hand-edit typo, wrong type) must drop to nil
+        // lossily — never fail the whole Snapshot decode and wipe the tree on the next save.
+        let ws = UUID()
+        let session = UUID()
+        let tree = #""selectedSessionID": "\#(session.uuidString)", "workspaces": "# +
+            #"[ { "id": "\#(ws.uuidString)", "name": "work", "sessions": [ { "id": "\#(session.uuidString)", "cwd": "/a" } ] } ]"#
+        for bad in [#""sessionRecency": ["not-a-uuid"]"#, #""sessionRecency": 42"#] {
+            try Data(#"{ "version": 1, \#(bad), \#(tree) }"#.utf8).write(to: fileURL)
+            let loaded = store.load()
+            #expect(loaded.workspaces.map(\.id) == [ws])
+            #expect(loaded.selectedSessionID == session)
+            #expect(loaded.sessionRecency == nil)
+        }
+    }
+
+    @Test func restoreInsertsAbsentSelectionAtFront() {
+        let a = UUID()
+        let b = UUID()
+        let c = UUID()
+        let snapshot = Snapshot(selectedSessionID: c, workspaces: [
+            WorkspaceSnapshot(id: UUID(), name: "work", sessions: [
+                SessionSnapshot(id: a, customName: nil, cwd: "/a"),
+                SessionSnapshot(id: b, customName: nil, cwd: "/b"),
+                SessionSnapshot(id: c, customName: nil, cwd: "/c"),
+            ]),
+        ], sessionRecency: [a, b])
+        let app = AppStore(persistence: store)
+        app.restore(from: snapshot)
+        // a selection missing from the persisted seed is inserted at the FRONT, not appended.
+        #expect(app.sessionRecency.items == [c, a, b])
+    }
+
     @Test func legacySnapshotWithoutRecencyDecodesSelectionOnly() throws {
         // a workspaces.json written before `sessionRecency` existed has no key; it must decode (not
         // throw and wipe the tree) and restore with just the selection in the Ctrl-Tab order.

--- a/agtermCore/Tests/agtermCoreTests/PersistenceTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/PersistenceTests.swift
@@ -268,6 +268,67 @@ final class PersistenceTests {
         #expect(app.focusedWorkspaceID == nil)
     }
 
+    @Test func sessionRecencyPersistsAndRestores() {
+        let app = AppStore(persistence: store)
+        let work = app.addWorkspace(name: "work")
+        let a = try! #require(app.addSession(toWorkspace: work.id, cwd: "/a"))
+        let b = try! #require(app.addSession(toWorkspace: work.id, cwd: "/b"))
+        let c = try! #require(app.addSession(toWorkspace: work.id, cwd: "/c"))
+        app.selectSession(a.id)
+        app.selectSession(b.id)
+        app.save() // selection saves are debounced; flush so the write lands before reading back
+        #expect(store.load().sessionRecency == [b.id, a.id, c.id])
+
+        let restored = AppStore(persistence: store)
+        restored.restore(from: store.load())
+        #expect(restored.sessionRecency.items == [b.id, a.id, c.id])
+    }
+
+    @Test func restoreDropsStaleRecencyIds() {
+        let id = UUID()
+        let stale = UUID()
+        let snapshot = Snapshot(selectedSessionID: id, workspaces: [
+            WorkspaceSnapshot(id: UUID(), name: "work", sessions: [
+                SessionSnapshot(id: id, customName: nil, cwd: "/a"),
+            ]),
+        ], sessionRecency: [stale, id])
+        let app = AppStore(persistence: store)
+        app.restore(from: snapshot)
+        // the stale id points at no restored session; it must never reach the switcher.
+        #expect(app.sessionRecency.items == [id])
+    }
+
+    @Test func restoreFloatsSelectionToRecencyFront() {
+        let a = UUID()
+        let b = UUID()
+        let snapshot = Snapshot(selectedSessionID: b, workspaces: [
+            WorkspaceSnapshot(id: UUID(), name: "work", sessions: [
+                SessionSnapshot(id: a, customName: nil, cwd: "/a"),
+                SessionSnapshot(id: b, customName: nil, cwd: "/b"),
+            ]),
+        ], sessionRecency: [a, b])
+        let app = AppStore(persistence: store)
+        app.restore(from: snapshot)
+        // a hand-edited/out-of-sync order still puts the restored selection first.
+        #expect(app.sessionRecency.items == [b, a])
+    }
+
+    @Test func legacySnapshotWithoutRecencyDecodesSelectionOnly() throws {
+        // a workspaces.json written before `sessionRecency` existed has no key; it must decode (not
+        // throw and wipe the tree) and restore with just the selection in the Ctrl-Tab order.
+        let ws = UUID()
+        let session = UUID()
+        let json = #"{ "version": 1, "selectedSessionID": "\#(session.uuidString)", "workspaces": "# +
+            #"[ { "id": "\#(ws.uuidString)", "name": "work", "sessions": [ { "id": "\#(session.uuidString)", "cwd": "/a" } ] } ] }"#
+        try Data(json.utf8).write(to: fileURL)
+        let loaded = store.load()
+        #expect(loaded.sessionRecency == nil)
+
+        let app = AppStore(persistence: store)
+        app.restore(from: loaded)
+        #expect(app.sessionRecency.items == [session])
+    }
+
     @Test func sessionFontSizePersistsAndRestores() {
         let app = AppStore(persistence: store)
         let work = app.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/RecencyStackTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/RecencyStackTests.swift
@@ -29,6 +29,12 @@ struct RecencyStackTests {
         #expect(stack.items == [1, 2, 3])
     }
 
+    @Test func initDedupsBeforeTruncatingToLimit() {
+        // dedup must run before the limit cut: prefix-then-dedup would yield [1] here.
+        let stack = RecencyStack<Int>(limit: 2, items: [1, 1, 2, 3])
+        #expect(stack.items == [1, 2])
+    }
+
     @Test func limitBoundsTheList() {
         var stack = RecencyStack<Int>(limit: 2)
         stack.push(1); stack.push(2); stack.push(3)

--- a/agtermCore/Tests/agtermCoreTests/RecencyStackTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/RecencyStackTests.swift
@@ -23,6 +23,12 @@ struct RecencyStackTests {
         #expect(stack.items == [3, 1])
     }
 
+    @Test func initDropsDuplicateSeedIds() {
+        // a persisted/hand-edited seed may carry duplicates; the first occurrence wins.
+        let stack = RecencyStack<Int>(items: [1, 2, 1, 3, 2])
+        #expect(stack.items == [1, 2, 3])
+    }
+
     @Test func limitBoundsTheList() {
         var stack = RecencyStack<Int>(limit: 2)
         stack.push(1); stack.push(2); stack.push(3)


### PR DESCRIPTION
after a relaunch the Ctrl-Tab switcher knew only the restored selection, so it did nothing until other sessions were visited by hand (the recency stack was in-memory only, reset on restore).

this persists the order as an optional `sessionRecency` field in the per-window snapshot and re-seeds it on restore: ids not in the restored tree are dropped, duplicate seed ids collapse to the first occurrence, and the restored selection floats to the front so a single tap still flips to the actual previous session. The field decodes lossily: a present-but-malformed value (hand-edit typo, wrong JSON type) drops to nil instead of failing the whole snapshot decode and wiping the tree, same defense as `backgroundWatermark`. Old `workspaces.json` files load unchanged (missing key decodes nil, version stays 1).

no control-API changes: pure model/restore behavior with no new user action, so keep-in-sync exempt. Covered by eight new tests (round-trip, legacy and malformed decode, stale-id drop, selection float for present and absent ids, init dedup and limit ordering); also verified end-to-end against an isolated dev instance: quit/relaunch preserves the order, corrupt and legacy snapshots degrade gracefully.

Fix #110
