### PR TITLE
fix: hide scratch under full overlay so it can't show through

### DIFF
--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -131,6 +131,18 @@ paths:
   outside `detailPane`/`sessionDetail`/`HSplitView` (no split perturbation).
   Do NOT "fix" this with a permanent `.background(terminalColor)` on `customTitlebar` — it masks the
   symptom but breaks the opacity/blur chrome.
+- **Under window translucency every surface renders a fully transparent background — never leave a
+  surface visible beneath the FULL overlay.**
+  The translucency setting pins `background-opacity = 0` for every ghostty surface (the window's AppKit
+  backing supplies the tint), and the FULL overlay deliberately has no opaque SwiftUI backing.
+  Any surface left mounted at opacity 1 below it shows straight through — an "the overlay opened under
+  the scratch" report is SEE-THROUGH, not a z-order inversion (the layer compositing order was verified
+  correct in every open sequence: the overlay's layer sits above the scratch's).
+  `sessionDetail` therefore hides EVERY covered surface when `session.fullOverlayActive`:
+  the pane(s) via `hideForOverlay`, the scratch via its own `opacity(0)` + `allowsHitTesting(false)` +
+  a `deckVisible` gate (so a covered scratch is also not a file-drop target).
+  The FLOATING (sized) overlay and the quick terminal need none of this — both draw an opaque
+  `terminalColor`-backed panel, so nothing shows through them.
 - **Non-zero backing size.**
   Create the surface only when the view has a non-zero backing size, else the Metal layer renders blank.
   `pendingSurfaceCreation` defers creation until `setFrameSize` reports a real size.

--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -135,7 +135,7 @@ paths:
   surface visible beneath the FULL overlay.**
   The translucency setting pins `background-opacity = 0` for every ghostty surface (the window's AppKit
   backing supplies the tint), and the FULL overlay deliberately has no opaque SwiftUI backing.
-  Any surface left mounted at opacity 1 below it shows straight through — an "the overlay opened under
+  Any surface left mounted at opacity 1 below it shows straight through — a "the overlay opened under
   the scratch" report is SEE-THROUGH, not a z-order inversion (the layer compositing order was verified
   correct in every open sequence: the overlay's layer sits above the scratch's).
   `sessionDetail` therefore hides EVERY covered surface when `session.fullOverlayActive`:

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -537,9 +537,8 @@ final class AppActions {
     private var coverHidesActiveSession: Bool {
         if frontmostQuickTerminal?.isVisible == true { return true }
         guard let session = store?.activeSession else { return false }
-        // a FLOATING overlay (overlaySizePercent != nil) leaves the session visible, so only a FULL
-        // overlay hides it (and is not searchable).
-        return session.overlayActive && session.overlaySizePercent == nil
+        // a FLOATING overlay leaves the session visible, so only a FULL overlay hides it (and is not searchable).
+        return session.fullOverlayActive
     }
 
     /// Toggle the search bar for the active session. CLOSE branch (search already active): send

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -244,7 +244,7 @@ struct WindowContentView: View {
         // a FULL overlay (no size) hides the session beneath it (opacity 0) and draws translucent; a
         // FLOATING overlay (overlaySizePercent set) leaves the session VISIBLE and draws a smaller
         // opaque framed panel on top. Either way the pane(s) stay non-interactive while an overlay is up.
-        let fullOverlay = session.overlayActive && session.overlaySizePercent == nil
+        let fullOverlay = session.fullOverlayActive
         // the scratch terminal is a full-coverage overlay too, so it hides the pane(s) exactly like a
         // FULL overlay; `hideForOverlay` drives opacity + hit-testing. `overlaid` (any overlay OR scratch)
         // is what owns focus, so it gates the pane(s)' `isActive` (focus goes to the overlay/scratch, not
@@ -299,16 +299,23 @@ struct WindowContentView: View {
             .allowsHitTesting(!hideForOverlay)
             // the scratch terminal renders here, in-deck, above the (hidden) pane(s) — like the FULL overlay,
             // a full-coverage sibling is safe (the panes go opacity 0, the split's frame is hidden). It sits
-            // BELOW the ephemeral overlay (zIndex 1 vs 2) so a normal overlay launched over the scratch is on
-            // top. The FLOATING overlay is deliberately NOT a sibling here (it renders as a `detailPane`
-            // `.overlay`), since adding a child while the panes stay VISIBLE overruns the NSSplitView.
+            // BELOW the ephemeral overlay (zIndex 1 vs 2) AND goes hidden while a full overlay is up, exactly
+            // like the pane(s): under window translucency every surface's background renders fully transparent,
+            // so a scratch left visible below would show through the overlay (reading as "the overlay opened
+            // under the scratch"). The FLOATING overlay is deliberately NOT a sibling here (it renders as a
+            // `detailPane` `.overlay`), since adding a child while the panes stay VISIBLE overruns the
+            // NSSplitView — and its opaque panel needs no hiding of the scratch behind it.
             if session.scratchActive {
                 // gate focus on every surface that covers the scratch — a full overlay (renders above it,
                 // zIndex 2) AND the window-level quick terminal — so the deck's focusIfNeeded can't grab the
                 // scratch behind them. When the cover goes away, isActive flips true and the deck re-grabs it.
-                // (matches the autoFocus suppression in makeScratchSurface.)
+                // (matches the autoFocus suppression in makeScratchSurface.) `deckVisible` mirrors the panes'
+                // rule so only an on-screen scratch is a file-drop target.
                 TerminalView(session: session, surfaceKeyPath: \.scratchSurface, makeSurface: makeScratchSurface,
-                             isActive: isActive && !session.overlayActive && !quickTerminal.isVisible)
+                             isActive: isActive && !session.overlayActive && !quickTerminal.isVisible,
+                             deckVisible: isActive && !fullOverlay)
+                    .opacity(fullOverlay ? 0 : 1)
+                    .allowsHitTesting(!fullOverlay)
                     .id("\(session.id.uuidString)-scratch")
                     .zIndex(1)
             }

--- a/agtermCore/Sources/agtermCore/Session.swift
+++ b/agtermCore/Sources/agtermCore/Session.swift
@@ -172,6 +172,13 @@ public final class Session: Identifiable {
     /// Set at open, cleared on close; never persisted.
     public var overlaySizePercent: Int?
 
+    /// Whether a FULL-coverage overlay is up: `overlayActive` with no size percent. A full overlay hides
+    /// the session content beneath it — the pane(s) AND a shown scratch — so its translucent background
+    /// reveals the window backing, never a covered surface (under window translucency every surface
+    /// renders a fully transparent background, so anything left visible below would bleed through).
+    /// A floating (sized) overlay is not a cover: it draws an opaque panel over still-visible content.
+    public var fullOverlayActive: Bool { overlayActive && overlaySizePercent == nil }
+
     /// Whether the scratch terminal is shown on top of this session (full single-pane size, hiding
     /// the single/split content underneath, like a full overlay). The scratch is a third per-session
     /// shell that — unlike the ephemeral overlay — behaves like the split: hiding it keeps the shell

--- a/agtermCore/Tests/agtermCoreTests/SessionTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SessionTests.swift
@@ -378,6 +378,24 @@ struct SessionTests {
         session.overlayActive = true
         #expect(session.onScreenSurface === primary)
     }
+
+    @Test func fullOverlayActiveOnlyForFullCoverageOverlay() {
+        // the full-coverage overlay (no size) hides the session content beneath it — panes AND scratch —
+        // so its translucent background reveals the window backing, never the covered surfaces.
+        let session = Session(initialCwd: "/repo")
+        // no overlay: nothing to hide behind.
+        #expect(session.fullOverlayActive == false)
+        // full-coverage overlay (no size percent): active.
+        session.overlayActive = true
+        #expect(session.fullOverlayActive == true)
+        // floating (sized) overlay: draws an opaque panel over visible content, not a full cover.
+        session.overlaySizePercent = 80
+        #expect(session.fullOverlayActive == false)
+        // no overlay at all: a stale size percent alone is not a cover.
+        session.overlayActive = false
+        session.overlaySizePercent = nil
+        #expect(session.fullOverlayActive == false)
+    }
 }
 
 private final class FakeSurface: TerminalSurface {

--- a/agtermCore/Tests/agtermCoreTests/SessionTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SessionTests.swift
@@ -391,9 +391,8 @@ struct SessionTests {
         // floating (sized) overlay: draws an opaque panel over visible content, not a full cover.
         session.overlaySizePercent = 80
         #expect(session.fullOverlayActive == false)
-        // no overlay at all: a stale size percent alone is not a cover.
+        // overlay closed with a stale size percent lingering: still not a cover.
         session.overlayActive = false
-        session.overlaySizePercent = nil
         #expect(session.fullOverlayActive == false)
     }
 }


### PR DESCRIPTION
the per-session scratch was visible through a full-screen overlay when window translucency is on. Translucency pins background-opacity to 0 for every surface and the full overlay has no opaque backing of its own, so a scratch left mounted at opacity 1 below it showed straight through, reading as "the overlay opened under the scratch". Compositing order was verified correct with layer-tree instrumentation - this was see-through, not a z-order inversion. The sized (floating) overlay was never affected, it draws an opaque panel.

the fix hides the scratch exactly like the panes while a full overlay is up: opacity 0, hit-testing off, and the drop-target registration (`deckVisible`) gated the same way. The predicate is a new host-free `Session.fullOverlayActive` (unit-tested); `coverHidesActiveSession` reuses it instead of inlining the same expression. The scratch surface stays alive, reappears and regains focus when the overlay closes.
