### PR TITLE
refactor: route session mutations through dispatcher

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -556,7 +556,7 @@ paths:
   Pair with `sidebar.mode flagged` to view just the flagged sessions.
   Four-point keep-in-sync audit for `session.flag`: (1) `case sessionFlag = "session.flag"` in `ControlProtocol.swift`
   (reuses `ControlArgs.mode`; adds `flagged` to `ControlSessionNode`), (2) the `.sessionFlag` dispatch
-  arm (`flagSession`) in `ControlServer`, (3) the `session flag on|off|toggle|clear` subcommand (`FlagCommand`)
+  arm (`setSessionFlag`) in `ControlServer`, (3) the `session flag on|off|toggle|clear` subcommand (`FlagCommand`)
   in `agtermctlKit`, (4) round-trip in `ControlProtocolTests` + the e2e `testSessionFlagAndSidebarModeFlagged`
   in `ControlSidebarStatusUITests`.
   `sidebar.mode` (frontmost window) flips the sidebar VIEW between the workspace tree and the flat flagged

--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -1,10 +1,10 @@
 import Foundation
 import agtermCore
 
-/// `ControlServer` session/workspace/sidebar action arms — the first half of the flat command dispatch
-/// (splits, scratch, focus, status, flag, move, notify, quick terminal, sidebar). Each resolves its target
-/// through `resolver` and drives the `AppActions`/`AppStore` seam. Split out of `ControlServer.swift` to
-/// keep that file under the swiftlint size limit.
+/// `ControlServer` session/workspace/sidebar action adapter arms. Dispatcher-routed commands parse in
+/// agtermCore when that preserves the old response order; target-dependent parsing stays here with
+/// `resolver`. App-owned commands still call nearby helpers. Split out of `ControlServer.swift` to keep
+/// that file under the swiftlint size limit.
 extension ControlServer: ControlActions {
     func controlTree(window: String?) -> ControlResponse {
         resolver.resolvePlacementStore(window) { store in
@@ -26,6 +26,36 @@ extension ControlServer: ControlActions {
 
     func collapseSidebar(window: String?) -> ControlResponse {
         collapseWorkspaces(window: window)
+    }
+
+    /// The destination workspace is addressed one of two mutually-exclusive ways: `workspace`
+    /// (id / unique prefix / `active`, the default) or `workspaceName` (the sidebar label),
+    /// the latter optionally with `createWorkspace` to add it when absent. create needs a name —
+    /// there is nothing to create by id. cwd/command/name are applied in makeSessionResponse.
+    func createSession(_ options: ControlSessionCreateOptions) -> ControlResponse {
+        resolver.resolvePlacementStore(options.window) { store in
+            // name addressing: reuse-or-create with `createWorkspace`, else require an existing match.
+            if let name = options.workspaceName {
+                // a blank name can neither be found NOR created — report that directly rather than
+                // suggesting --create-workspace (which would also reject a blank name).
+                guard !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                    return ControlResponse(ok: false, error: "workspace name must not be blank")
+                }
+                let workspace = options.createWorkspace == true
+                    ? store.ensureWorkspace(named: name)
+                    : store.workspace(named: name)
+                guard let workspace else {
+                    return ControlResponse(ok: false, error: "no workspace named \"\(name)\" (pass --create-workspace to add it)")
+                }
+                return makeSessionResponse(in: store, workspaceID: workspace.id, options: options)
+            }
+            // id addressing (default `active`): the canonical prefix/active resolver.
+            let target = options.workspace ?? "active"
+            return resolver.resolve(target, candidates: store.workspaces.map(\.id),
+                           active: store.currentWorkspaceID, noun: "workspace") { workspaceID in
+                makeSessionResponse(in: store, workspaceID: workspaceID, options: options)
+            }
+        }
     }
 
     /// Resolve the target session and drive the split directly on its owning store (NOT the
@@ -58,7 +88,8 @@ extension ControlServer: ControlActions {
     /// that program as the scratch's process instead of a login shell, run-once like `session.new
     /// --command`: a scratch is expendable, so if one is already alive it is torn down and respawned
     /// with the command (otherwise the flag would be silently inert).
-    func scratchSession(_ target: String?, window: String?, mode: String?, command: String?) -> ControlResponse {
+    func scratchSession(_ target: String?, window: String?, mode: String?,
+                        command: String?) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
             guard let session = store.session(withID: id) else {
                 return ControlResponse(ok: false, error: "no such session: \(target ?? "active")")
@@ -113,15 +144,7 @@ extension ControlServer: ControlActions {
     /// then `.agtermApplySplitRatio` pokes the session's `SplitProbeView` to move the live divider (a no-op
     /// when the split is hidden — the stored value applies on next show). Errors when the session has no
     /// split, mirroring `session.focus`. Echoes the applied (clamped) fraction in `result.ratio`.
-    func resizeSplit(_ target: String?, window: String?, ratio: Double?, delta: Double?) -> ControlResponse {
-        switch (ratio, delta) {
-        case (nil, nil):
-            return ControlResponse(ok: false, error: "session.resize requires --split-ratio, --grow-left, or --grow-right")
-        case (.some, .some):
-            return ControlResponse(ok: false, error: "session.resize: --split-ratio is mutually exclusive with --grow-left/--grow-right")
-        default:
-            break
-        }
+    func resizeSplit(_ target: String?, window: String?, resize: ControlSplitResize) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
             guard let session = store.session(withID: id) else {
                 return ControlResponse(ok: false, error: "no such session: \(target ?? "active")")
@@ -129,7 +152,13 @@ extension ControlServer: ControlActions {
             guard session.hasSplit else {
                 return ControlResponse(ok: false, error: "session has no split")
             }
-            let requested = ratio ?? ((session.splitRatio ?? AppStore.splitRatioDefault) + (delta ?? 0))
+            let requested: Double
+            switch resize {
+            case .ratio(let ratio):
+                requested = ratio
+            case .delta(let delta):
+                requested = (session.splitRatio ?? AppStore.splitRatioDefault) + delta
+            }
             guard let applied = store.applySplitRatio(requested, forSession: id) else {
                 return ControlResponse(ok: false, error: "no such session: \(target ?? "active")")
             }
@@ -148,34 +177,22 @@ extension ControlServer: ControlActions {
     /// per-call `sound` is given and the session TRANSITIONS into `blocked`, the user's configured Settings
     /// "Blocked sound" (`blockedStatusSoundName`) plays as a best-effort default. The indicator is ephemeral
     /// and rendered on every non-idle session.
-    /// The per-call status payload for `setSessionStatus`; the addressing target/window stay separate.
-    struct StatusUpdate {
-        let status: String?
-        let blink: Bool?
-        let autoReset: Bool?
-        let sound: String?
-    }
-
-    func setSessionStatus(_ target: String?, window: String?, update: StatusUpdate) -> ControlResponse {
-        let status = update.status, blink = update.blink, autoReset = update.autoReset, sound = update.sound
-        guard let parsed = AgentStatus(rawValue: status ?? "") else {
-            return ControlResponse(ok: false, error: "invalid status")
-        }
+    func setSessionStatus(_ target: String?, window: String?, update: ControlSessionStatusUpdate) -> ControlResponse {
         // an explicit per-call sound is validated up-front: an unknown name errors without changing status.
         // an empty value is treated as no per-call sound, matching `AgentStatus.effectiveSound`.
-        if let sound, !sound.isEmpty, StatusSoundPlayer.shared.action(for: sound) == nil {
+        if let sound = update.sound, !sound.isEmpty, StatusSoundPlayer.shared.action(for: sound) == nil {
             let hint = StatusSoundPlayer.standardNames.joined(separator: ", ")
             return ControlResponse(ok: false, error: "unknown sound: \(sound) (use 'default', 'beep', or one of: \(hint))")
         }
         return resolver.resolveSession(target, window: window) { store, id in
             // capture the status BEFORE mutating so the Settings default plays only on a real transition.
             let wasBlocked = store.session(withID: id)?.agentIndicator.status == .blocked
-            store.setAgentIndicator(AgentIndicator(status: parsed, blink: blink ?? false,
-                                                   autoReset: autoReset ?? false), forSession: id)
+            store.setAgentIndicator(AgentIndicator(status: update.status, blink: update.blink ?? false,
+                                                   autoReset: update.autoReset ?? false), forSession: id)
             // explicit per-call sound wins on any status; the Settings default plays only when a session
             // newly enters `blocked`, not on a repeated `blocked` set.
             let blockedDefault = wasBlocked ? nil : self.settingsModel.settings.blockedStatusSoundName
-            if let name = parsed.effectiveSound(perCall: sound, blockedDefault: blockedDefault) {
+            if let name = update.status.effectiveSound(perCall: update.sound, blockedDefault: blockedDefault) {
                 StatusSoundPlayer.shared.play(name)
             }
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
@@ -187,7 +204,7 @@ extension ControlServer: ControlActions {
     /// session's current `flagged` so `on`/`off` are idempotent. `clear` ignores the target and unflags
     /// every session in the resolved store (frontmost or `--window`), via `AppStore.clearFlags()` — it
     /// reports ok with no id. An unknown mode is an error.
-    func flagSession(_ target: String?, window: String?, mode: String?) -> ControlResponse {
+    func setSessionFlag(_ target: String?, window: String?, mode: String?) -> ControlResponse {
         let mode = mode ?? "toggle"
         if mode == "clear" {
             return resolver.resolvePlacementStore(window) { store in
@@ -214,29 +231,22 @@ extension ControlServer: ControlActions {
     /// Mode-bearing `session.move`: `to` reorders the session within its own workspace
     /// (`up`|`down`|`top`|`bottom`), `workspace` relocates it to another workspace (appending). Exactly
     /// one of the two is required; both set or neither set is an error. An invalid `to` direction errors.
-    func moveSession(_ target: String?, window: String?, to: String?, workspace: String?) -> ControlResponse {
-        if to != nil && workspace != nil {
-            return ControlResponse(ok: false, error: "session.move takes either --to or a workspace, not both")
-        }
-        if let to {
-            guard let dir = ReorderDirection(rawValue: to) else {
-                return ControlResponse(ok: false, error: "session.move --to must be up|down|top|bottom")
-            }
+    func moveSession(_ target: String?, window: String?, move: ControlSessionMove) -> ControlResponse {
+        switch move {
+        case .reorder(let dir):
             return resolver.resolveSession(target, window: window) { store, id in
                 store.reorderSession(id, dir)
                 return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
             }
-        }
-        guard let workspace else {
-            return ControlResponse(ok: false, error: "session.move requires --to or a workspace")
-        }
-        // the session and the destination workspace must live in the same store: resolve the
-        // session first (which fixes the store), then the workspace within that same store.
-        return resolver.resolveSession(target, window: window) { store, sessionID in
-            resolver.resolve(workspace, candidates: store.workspaces.map(\.id),
-                    active: store.currentWorkspaceID, noun: "workspace") { workspaceID in
-                store.moveSession(sessionID, toWorkspace: workspaceID)
-                return ControlResponse(ok: true, result: ControlResult(id: sessionID.uuidString))
+        case .workspace(let workspace):
+            // the session and the destination workspace must live in the same store: resolve the
+            // session first (which fixes the store), then the workspace within that same store.
+            return resolver.resolveSession(target, window: window) { store, sessionID in
+                resolver.resolve(workspace, candidates: store.workspaces.map(\.id),
+                        active: store.currentWorkspaceID, noun: "workspace") { workspaceID in
+                    store.moveSession(sessionID, toWorkspace: workspaceID)
+                    return ControlResponse(ok: true, result: ControlResult(id: sessionID.uuidString))
+                }
             }
         }
     }
@@ -244,13 +254,7 @@ extension ControlServer: ControlActions {
     /// `workspace.move`: reorder a workspace among its siblings (`up`|`down`|`top`|`bottom`). `to` is
     /// required; an invalid direction errors. Resolves the workspace target via `resolveWorkspace`
     /// (honoring the global `--window` selector like other workspace commands).
-    func moveWorkspace(_ target: String?, window: String?, to: String?) -> ControlResponse {
-        guard let to else {
-            return ControlResponse(ok: false, error: "workspace.move requires --to")
-        }
-        guard let dir = ReorderDirection(rawValue: to) else {
-            return ControlResponse(ok: false, error: "workspace.move --to must be up|down|top|bottom")
-        }
+    func moveWorkspace(_ target: String?, window: String?, direction dir: ReorderDirection) -> ControlResponse {
         return resolver.resolveWorkspace(target, window: window) { store, id in
             store.reorderWorkspace(id, dir)
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -340,7 +340,9 @@ final class ControlServer {
             return response
         }
         switch request.cmd {
-        case .tree, .sidebar, .sidebarMode, .sidebarExpand, .sidebarCollapse:
+        case .tree, .sessionNew, .sessionMove, .workspaceMove, .workspaceFocus, .sessionSplit,
+                .sessionScratch, .sessionFocus, .sessionResize, .sessionStatus, .sessionFlag,
+                .sidebar, .sidebarMode, .sidebarExpand, .sidebarCollapse:
             return ControlResponse(ok: false, error: "control dispatcher did not handle \(request.cmd.rawValue)")
         case .sessionSelect:
             return resolver.resolveSession(request.target, window: request.args?.window) { store, id in
@@ -394,41 +396,6 @@ final class ControlServer {
                 store.removeWorkspace(id)
                 return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
             }
-        case .sessionNew:
-            // the destination workspace is addressed one of two mutually-exclusive ways: `workspace`
-            // (id / unique prefix / `active`, the default) or `workspaceName` (the sidebar label),
-            // the latter optionally with `createWorkspace` to add it when absent. create needs a name —
-            // there is nothing to create by id. cwd/command/name are applied in makeSessionResponse.
-            let args = request.args
-            if args?.workspace != nil, args?.workspaceName != nil {
-                return ControlResponse(ok: false, error: "use either --workspace or --workspace-name, not both")
-            }
-            if args?.createWorkspace == true, args?.workspaceName == nil {
-                return ControlResponse(ok: false, error: "--create-workspace requires --workspace-name")
-            }
-            return resolver.resolvePlacementStore(args?.window) { store in
-                // name addressing: reuse-or-create with `createWorkspace`, else require an existing match.
-                if let name = args?.workspaceName {
-                    // a blank name can neither be found NOR created — report that directly rather than
-                    // suggesting --create-workspace (which would also reject a blank name).
-                    guard !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-                        return ControlResponse(ok: false, error: "workspace name must not be blank")
-                    }
-                    let workspace = args?.createWorkspace == true
-                        ? store.ensureWorkspace(named: name)
-                        : store.workspace(named: name)
-                    guard let workspace else {
-                        return ControlResponse(ok: false, error: "no workspace named \"\(name)\" (pass --create-workspace to add it)")
-                    }
-                    return makeSessionResponse(in: store, workspaceID: workspace.id, args: args)
-                }
-                // id addressing (default `active`): the canonical prefix/active resolver.
-                let target = args?.workspace ?? "active"
-                return resolver.resolve(target, candidates: store.workspaces.map(\.id),
-                               active: store.currentWorkspaceID, noun: "workspace") { workspaceID in
-                    makeSessionResponse(in: store, workspaceID: workspaceID, args: args)
-                }
-            }
         case .sessionClose:
             return resolver.resolveSession(request.target, window: request.args?.window) { store, id in
                 store.closeSession(id)
@@ -442,13 +409,6 @@ final class ControlServer {
                 store.renameSession(id, to: name)
                 return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
             }
-        case .sessionMove:
-            return moveSession(request.target, window: request.args?.window,
-                               to: request.args?.to, workspace: request.args?.workspace)
-        case .workspaceMove:
-            return moveWorkspace(request.target, window: request.args?.window, to: request.args?.to)
-        case .workspaceFocus:
-            return focusWorkspace(request.target, window: request.args?.window, mode: request.args?.mode)
         case .sessionType:
             guard let text = request.args?.text else {
                 return ControlResponse(ok: false, error: "session.type requires text")
@@ -463,22 +423,6 @@ final class ControlServer {
                 return await injectText(text, into: id, store: store, select: request.args?.select ?? false,
                                         pane: request.args?.pane)
             }
-        case .sessionSplit:
-            return splitSession(request.target, window: request.args?.window, mode: request.args?.mode)
-        case .sessionScratch:
-            return scratchSession(request.target, window: request.args?.window, mode: request.args?.mode,
-                                  command: request.args?.command)
-        case .sessionFocus:
-            return focusSessionPane(request.target, window: request.args?.window, pane: request.args?.pane)
-        case .sessionResize:
-            return resizeSplit(request.target, window: request.args?.window,
-                               ratio: request.args?.ratio, delta: request.args?.ratioDelta)
-        case .sessionStatus:
-            return setSessionStatus(request.target, window: request.args?.window,
-                                    update: StatusUpdate(status: request.args?.status, blink: request.args?.blink,
-                                                         autoReset: request.args?.autoReset, sound: request.args?.sound))
-        case .sessionFlag:
-            return flagSession(request.target, window: request.args?.window, mode: request.args?.mode)
         case .sessionBackground:
             return setBackground(request.target, request.args)
         case .sessionCopy:
@@ -618,10 +562,11 @@ final class ControlServer {
     /// optional command/name), focuses it when it lands in the frontmost window (so a keymap `session new`
     /// opens focused like the GUI New Session; a background `--window` target keeps focus), and returns the
     /// new id. Shared by the id- and name-addressed paths of the `.sessionNew` arm.
-    private func makeSessionResponse(in store: AppStore, workspaceID: UUID, args: ControlArgs?) -> ControlResponse {
-        let cwd = args?.cwd ?? FileManager.default.homeDirectoryForCurrentUser.path
+    func makeSessionResponse(in store: AppStore, workspaceID: UUID,
+                             options: ControlSessionCreateOptions) -> ControlResponse {
+        let cwd = options.cwd ?? FileManager.default.homeDirectoryForCurrentUser.path
         guard let session = store.addSession(toWorkspace: workspaceID, cwd: cwd,
-                                             command: args?.command, name: args?.name) else {
+                                             command: options.command, name: options.name) else {
             return ControlResponse(ok: false, error: "could not create session")
         }
         if store === library.activeStore { actions.focusActiveSession() }

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -6,6 +6,16 @@ import Foundation
 @MainActor
 public protocol ControlActions {
     func controlTree(window: String?) -> ControlResponse
+    func createSession(_ options: ControlSessionCreateOptions) -> ControlResponse
+    func moveSession(_ target: String?, window: String?, move: ControlSessionMove) -> ControlResponse
+    func moveWorkspace(_ target: String?, window: String?, direction: ReorderDirection) -> ControlResponse
+    func focusWorkspace(_ target: String?, window: String?, mode: String?) -> ControlResponse
+    func setSessionFlag(_ target: String?, window: String?, mode: String?) -> ControlResponse
+    func setSessionStatus(_ target: String?, window: String?, update: ControlSessionStatusUpdate) -> ControlResponse
+    func splitSession(_ target: String?, window: String?, mode: String?) -> ControlResponse
+    func scratchSession(_ target: String?, window: String?, mode: String?, command: String?) -> ControlResponse
+    func focusSessionPane(_ target: String?, window: String?, pane: String?) -> ControlResponse
+    func resizeSplit(_ target: String?, window: String?, resize: ControlSplitResize) -> ControlResponse
     func setSidebarVisibility(_ mode: ControlToggleMode) -> ControlResponse
     func setSidebarViewMode(_ mode: ControlSidebarViewMode) -> ControlResponse
     func expandSidebar(window: String?) -> ControlResponse
@@ -26,6 +36,75 @@ public struct ControlDispatcher {
         switch request.cmd {
         case .tree:
             return actions.controlTree(window: request.args?.window)
+        case .sessionNew:
+            let args = request.args
+            if args?.workspace != nil, args?.workspaceName != nil {
+                return ControlResponse(ok: false, error: "use either --workspace or --workspace-name, not both")
+            }
+            if args?.createWorkspace == true, args?.workspaceName == nil {
+                return ControlResponse(ok: false, error: "--create-workspace requires --workspace-name")
+            }
+            return actions.createSession(ControlSessionCreateOptions(
+                window: args?.window,
+                cwd: args?.cwd,
+                workspace: args?.workspace,
+                workspaceName: args?.workspaceName,
+                createWorkspace: args?.createWorkspace,
+                command: args?.command,
+                name: args?.name
+            ))
+        case .sessionMove:
+            if request.args?.to != nil && request.args?.workspace != nil {
+                return ControlResponse(ok: false, error: "session.move takes either --to or a workspace, not both")
+            }
+            if let to = request.args?.to {
+                guard let direction = ReorderDirection(rawValue: to) else {
+                    return ControlResponse(ok: false, error: "session.move --to must be up|down|top|bottom")
+                }
+                return actions.moveSession(request.target, window: request.args?.window, move: .reorder(direction))
+            }
+            guard let workspace = request.args?.workspace else {
+                return ControlResponse(ok: false, error: "session.move requires --to or a workspace")
+            }
+            return actions.moveSession(request.target, window: request.args?.window, move: .workspace(workspace))
+        case .workspaceMove:
+            guard let to = request.args?.to else {
+                return ControlResponse(ok: false, error: "workspace.move requires --to")
+            }
+            guard let direction = ReorderDirection(rawValue: to) else {
+                return ControlResponse(ok: false, error: "workspace.move --to must be up|down|top|bottom")
+            }
+            return actions.moveWorkspace(request.target, window: request.args?.window, direction: direction)
+        case .workspaceFocus:
+            return actions.focusWorkspace(request.target, window: request.args?.window, mode: request.args?.mode)
+        case .sessionFlag:
+            return actions.setSessionFlag(request.target, window: request.args?.window, mode: request.args?.mode)
+        case .sessionStatus:
+            guard let status = AgentStatus(rawValue: request.args?.status ?? "") else {
+                return ControlResponse(ok: false, error: "invalid status")
+            }
+            let update = ControlSessionStatusUpdate(status: status, blink: request.args?.blink,
+                                                    autoReset: request.args?.autoReset,
+                                                    sound: request.args?.sound)
+            return actions.setSessionStatus(request.target, window: request.args?.window, update: update)
+        case .sessionSplit:
+            return actions.splitSession(request.target, window: request.args?.window, mode: request.args?.mode)
+        case .sessionScratch:
+            return actions.scratchSession(request.target, window: request.args?.window, mode: request.args?.mode,
+                                          command: request.args?.command)
+        case .sessionFocus:
+            return actions.focusSessionPane(request.target, window: request.args?.window, pane: request.args?.pane)
+        case .sessionResize:
+            switch (request.args?.ratio, request.args?.ratioDelta) {
+            case (nil, nil):
+                return ControlResponse(ok: false, error: "session.resize requires --split-ratio, --grow-left, or --grow-right")
+            case (.some, .some):
+                return ControlResponse(ok: false, error: "session.resize: --split-ratio is mutually exclusive with --grow-left/--grow-right")
+            case (.some(let ratio), nil):
+                return actions.resizeSplit(request.target, window: request.args?.window, resize: .ratio(ratio))
+            case (nil, .some(let delta)):
+                return actions.resizeSplit(request.target, window: request.args?.window, resize: .delta(delta))
+            }
         case .sidebar:
             guard let mode = ControlToggleMode.parse(request.args?.mode, on: "show", off: "hide") else {
                 return ControlResponse(ok: false, error: "invalid sidebar mode: \(request.args?.mode ?? "toggle")")

--- a/agtermCore/Sources/agtermCore/ControlModes.swift
+++ b/agtermCore/Sources/agtermCore/ControlModes.swift
@@ -64,3 +64,52 @@ public enum ControlSidebarViewMode: Equatable, Sendable {
         }
     }
 }
+
+/// The mutually exclusive move forms accepted by `session.move`.
+public enum ControlSessionMove: Equatable, Sendable {
+    case reorder(ReorderDirection)
+    case workspace(String)
+}
+
+/// Parsed resize request for `session.resize`.
+public enum ControlSplitResize: Equatable, Sendable {
+    case ratio(Double)
+    case delta(Double)
+}
+
+/// Host-facing `session.new` options after dispatcher-level guard validation.
+public struct ControlSessionCreateOptions: Equatable, Sendable {
+    public let window: String?
+    public let cwd: String?
+    public let workspace: String?
+    public let workspaceName: String?
+    public let createWorkspace: Bool?
+    public let command: String?
+    public let name: String?
+
+    public init(window: String?, cwd: String?, workspace: String?, workspaceName: String?,
+                createWorkspace: Bool?, command: String?, name: String?) {
+        self.window = window
+        self.cwd = cwd
+        self.workspace = workspace
+        self.workspaceName = workspaceName
+        self.createWorkspace = createWorkspace
+        self.command = command
+        self.name = name
+    }
+}
+
+/// Parsed `session.status` payload. Sound validation and playback stay host-side.
+public struct ControlSessionStatusUpdate: Equatable, Sendable {
+    public let status: AgentStatus
+    public let blink: Bool?
+    public let autoReset: Bool?
+    public let sound: String?
+
+    public init(status: AgentStatus, blink: Bool?, autoReset: Bool?, sound: String?) {
+        self.status = status
+        self.blink = blink
+        self.autoReset = autoReset
+        self.sound = sound
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -92,6 +92,233 @@ struct ControlDispatcherTests {
         #expect(actions.calls == [.expand(window: "win"), .collapse(window: "win")])
     }
 
+    @Test func sessionNewRoutesValidatedOptions() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextSessionNewResponse = ControlResponse(ok: true, result: ControlResult(id: "new-session"))
+
+        let response = dispatcher.dispatch(ControlRequest(
+            cmd: .sessionNew,
+            args: ControlArgs(name: "api", cwd: "/tmp", workspaceName: "servers", createWorkspace: true,
+                              command: "top", window: "win")
+        ))
+
+        let options = ControlSessionCreateOptions(window: "win", cwd: "/tmp", workspace: nil,
+                                                  workspaceName: "servers", createWorkspace: true,
+                                                  command: "top", name: "api")
+        #expect(response == ControlResponse(ok: true, result: ControlResult(id: "new-session")))
+        #expect(actions.calls == [.sessionNew(options)])
+    }
+
+    @Test func sessionNewRejectsAmbiguousWorkspaceArguments() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let response = dispatcher.dispatch(ControlRequest(
+            cmd: .sessionNew,
+            args: ControlArgs(workspace: "active", workspaceName: "servers")
+        ))
+
+        #expect(response == ControlResponse(ok: false, error: "use either --workspace or --workspace-name, not both"))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test func sessionNewRejectsCreateWorkspaceWithoutName() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let response = dispatcher.dispatch(ControlRequest(
+            cmd: .sessionNew,
+            args: ControlArgs(createWorkspace: true)
+        ))
+
+        #expect(response == ControlResponse(ok: false, error: "--create-workspace requires --workspace-name"))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test func sessionMoveRoutesReorderAndWorkspaceForms() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let reorder = dispatcher.dispatch(ControlRequest(
+            cmd: .sessionMove,
+            target: "session",
+            args: ControlArgs(window: "win", to: "top")
+        ))
+        let workspace = dispatcher.dispatch(ControlRequest(
+            cmd: .sessionMove,
+            target: "session",
+            args: ControlArgs(workspace: "dest")
+        ))
+
+        #expect(reorder == ControlResponse(ok: true))
+        #expect(workspace == ControlResponse(ok: true))
+        #expect(actions.calls == [
+            .sessionMove(target: "session", window: "win", .reorder(.top)),
+            .sessionMove(target: "session", window: nil, .workspace("dest"))
+        ])
+    }
+
+    @Test func sessionMoveRejectsInvalidForms() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let missing = dispatcher.dispatch(ControlRequest(cmd: .sessionMove, target: "active"))
+        let both = dispatcher.dispatch(ControlRequest(
+            cmd: .sessionMove,
+            target: "active",
+            args: ControlArgs(workspace: "active", to: "up")
+        ))
+        let badDirection = dispatcher.dispatch(ControlRequest(
+            cmd: .sessionMove,
+            target: "active",
+            args: ControlArgs(to: "sideways")
+        ))
+
+        #expect(missing == ControlResponse(ok: false, error: "session.move requires --to or a workspace"))
+        #expect(both == ControlResponse(ok: false, error: "session.move takes either --to or a workspace, not both"))
+        #expect(badDirection == ControlResponse(ok: false, error: "session.move --to must be up|down|top|bottom"))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test func workspaceMoveRoutesDirectionAndRejectsInvalidForms() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let moved = dispatcher.dispatch(ControlRequest(
+            cmd: .workspaceMove,
+            target: "workspace",
+            args: ControlArgs(window: "win", to: "bottom")
+        ))
+        let missing = dispatcher.dispatch(ControlRequest(cmd: .workspaceMove, target: "workspace"))
+        let bad = dispatcher.dispatch(ControlRequest(
+            cmd: .workspaceMove,
+            target: "workspace",
+            args: ControlArgs(to: "sideways")
+        ))
+
+        #expect(moved == ControlResponse(ok: true))
+        #expect(missing == ControlResponse(ok: false, error: "workspace.move requires --to"))
+        #expect(bad == ControlResponse(ok: false, error: "workspace.move --to must be up|down|top|bottom"))
+        #expect(actions.calls == [.workspaceMove(target: "workspace", window: "win", .bottom)])
+    }
+
+    @Test func workspaceFocusRoutesModeForHostSideValidation() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let focused = dispatcher.dispatch(ControlRequest(
+            cmd: .workspaceFocus,
+            target: "workspace",
+            args: ControlArgs(mode: "on", window: "win")
+        ))
+
+        #expect(focused == ControlResponse(ok: true))
+        #expect(actions.calls == [.workspaceFocus(target: "workspace", window: "win", "on")])
+    }
+
+    @Test func sessionFlagRoutesModeForHostSideValidation() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let flagged = dispatcher.dispatch(ControlRequest(
+            cmd: .sessionFlag,
+            target: "session",
+            args: ControlArgs(mode: "on", window: "win")
+        ))
+        let cleared = dispatcher.dispatch(ControlRequest(cmd: .sessionFlag, args: ControlArgs(mode: "clear")))
+
+        #expect(flagged == ControlResponse(ok: true))
+        #expect(cleared == ControlResponse(ok: true))
+        #expect(actions.calls == [
+            .sessionFlag(target: "session", window: "win", "on"),
+            .sessionFlag(target: nil, window: nil, "clear")
+        ])
+    }
+
+    @Test func sessionStatusRoutesParsedStatusAndRejectsInvalidStatus() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let status = dispatcher.dispatch(ControlRequest(
+            cmd: .sessionStatus,
+            target: "session",
+            args: ControlArgs(window: "win", status: "blocked", blink: true,
+                              autoReset: true, sound: "default")
+        ))
+        let bad = dispatcher.dispatch(ControlRequest(
+            cmd: .sessionStatus,
+            target: "session",
+            args: ControlArgs(status: "bogus")
+        ))
+
+        #expect(status == ControlResponse(ok: true))
+        #expect(bad == ControlResponse(ok: false, error: "invalid status"))
+        #expect(actions.calls == [
+            .sessionStatus(target: "session", window: "win",
+                           ControlSessionStatusUpdate(status: .blocked, blink: true,
+                                                      autoReset: true, sound: "default"))
+        ])
+    }
+
+    @Test func splitScratchFocusAndResizeRouteParsedInputs() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let split = dispatcher.dispatch(ControlRequest(
+            cmd: .sessionSplit,
+            target: "session",
+            args: ControlArgs(mode: "off", window: "win")
+        ))
+        let scratch = dispatcher.dispatch(ControlRequest(
+            cmd: .sessionScratch,
+            target: "session",
+            args: ControlArgs(mode: "on", command: "htop")
+        ))
+        let focus = dispatcher.dispatch(ControlRequest(
+            cmd: .sessionFocus,
+            target: "session",
+            args: ControlArgs(pane: "right")
+        ))
+        let resize = dispatcher.dispatch(ControlRequest(
+            cmd: .sessionResize,
+            target: "session",
+            args: ControlArgs(window: "win", ratioDelta: -0.1)
+        ))
+
+        #expect(split == ControlResponse(ok: true))
+        #expect(scratch == ControlResponse(ok: true))
+        #expect(focus == ControlResponse(ok: true))
+        #expect(resize == ControlResponse(ok: true))
+        #expect(actions.calls == [
+            .sessionSplit(target: "session", window: "win", "off"),
+            .sessionScratch(target: "session", window: nil, "on", command: "htop"),
+            .sessionFocus(target: "session", window: nil, "right"),
+            .sessionResize(target: "session", window: "win", .delta(-0.1))
+        ])
+    }
+
+    @Test func resizeRejectsInvalidInputs() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let missingResize = dispatcher.dispatch(ControlRequest(cmd: .sessionResize, args: ControlArgs()))
+        let bothResize = dispatcher.dispatch(ControlRequest(
+            cmd: .sessionResize,
+            args: ControlArgs(ratio: 0.7, ratioDelta: 0.1)
+        ))
+
+        #expect(missingResize == ControlResponse(
+            ok: false,
+            error: "session.resize requires --split-ratio, --grow-left, or --grow-right"
+        ))
+        #expect(bothResize == ControlResponse(
+            ok: false,
+            error: "session.resize: --split-ratio is mutually exclusive with --grow-left/--grow-right"
+        ))
+        #expect(actions.calls.isEmpty)
+    }
+
     @Test func nonMigratedCommandFallsThrough() {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)
@@ -107,6 +334,16 @@ struct ControlDispatcherTests {
 private final class MockControlActions: ControlActions {
     enum Call: Equatable {
         case tree(window: String?)
+        case sessionNew(ControlSessionCreateOptions)
+        case sessionMove(target: String?, window: String?, ControlSessionMove)
+        case workspaceMove(target: String?, window: String?, ReorderDirection)
+        case workspaceFocus(target: String?, window: String?, String?)
+        case sessionFlag(target: String?, window: String?, String?)
+        case sessionStatus(target: String?, window: String?, ControlSessionStatusUpdate)
+        case sessionSplit(target: String?, window: String?, String?)
+        case sessionScratch(target: String?, window: String?, String?, command: String?)
+        case sessionFocus(target: String?, window: String?, String?)
+        case sessionResize(target: String?, window: String?, ControlSplitResize)
         case sidebarVisibility(ControlToggleMode)
         case sidebarViewMode(ControlSidebarViewMode)
         case expand(window: String?)
@@ -115,6 +352,7 @@ private final class MockControlActions: ControlActions {
 
     var calls: [Call] = []
     var nextTreeResponse = ControlResponse(ok: false, error: "tree not stubbed")
+    var nextSessionNewResponse = ControlResponse(ok: true)
     var nextSidebarVisibilityResponse = ControlResponse(ok: true)
     var nextSidebarViewModeResponse = ControlResponse(ok: true)
     var nextExpandResponse = ControlResponse(ok: true)
@@ -123,6 +361,58 @@ private final class MockControlActions: ControlActions {
     func controlTree(window: String?) -> ControlResponse {
         calls.append(.tree(window: window))
         return nextTreeResponse
+    }
+
+    func createSession(_ options: ControlSessionCreateOptions) -> ControlResponse {
+        calls.append(.sessionNew(options))
+        return nextSessionNewResponse
+    }
+
+    func moveSession(_ target: String?, window: String?, move: ControlSessionMove) -> ControlResponse {
+        calls.append(.sessionMove(target: target, window: window, move))
+        return ControlResponse(ok: true)
+    }
+
+    func moveWorkspace(_ target: String?, window: String?, direction: ReorderDirection) -> ControlResponse {
+        calls.append(.workspaceMove(target: target, window: window, direction))
+        return ControlResponse(ok: true)
+    }
+
+    func focusWorkspace(_ target: String?, window: String?, mode: String?) -> ControlResponse {
+        calls.append(.workspaceFocus(target: target, window: window, mode))
+        return ControlResponse(ok: true)
+    }
+
+    func setSessionFlag(_ target: String?, window: String?, mode: String?) -> ControlResponse {
+        calls.append(.sessionFlag(target: target, window: window, mode))
+        return ControlResponse(ok: true)
+    }
+
+    func setSessionStatus(_ target: String?, window: String?,
+                          update: ControlSessionStatusUpdate) -> ControlResponse {
+        calls.append(.sessionStatus(target: target, window: window, update))
+        return ControlResponse(ok: true)
+    }
+
+    func splitSession(_ target: String?, window: String?, mode: String?) -> ControlResponse {
+        calls.append(.sessionSplit(target: target, window: window, mode))
+        return ControlResponse(ok: true)
+    }
+
+    func scratchSession(_ target: String?, window: String?, mode: String?,
+                        command: String?) -> ControlResponse {
+        calls.append(.sessionScratch(target: target, window: window, mode, command: command))
+        return ControlResponse(ok: true)
+    }
+
+    func focusSessionPane(_ target: String?, window: String?, pane: String?) -> ControlResponse {
+        calls.append(.sessionFocus(target: target, window: window, pane))
+        return ControlResponse(ok: true)
+    }
+
+    func resizeSplit(_ target: String?, window: String?, resize: ControlSplitResize) -> ControlResponse {
+        calls.append(.sessionResize(target: target, window: window, resize))
+        return ControlResponse(ok: true)
     }
 
     func setSidebarVisibility(_ mode: ControlToggleMode) -> ControlResponse {


### PR DESCRIPTION
## Summary
- route session/workspace mutation command families through `ControlDispatcher`
- keep target resolution, target-dependent parse order, and macOS-only side effects in `ControlServer` adapter methods
- add focused core dispatcher tests for success routing and dispatcher-owned validation errors

## Notes
Rebased after #105 merged; the PR diff is now only the group 2 dispatcher migration against `master`.

Behavior audit: this is intended as a refactor-only slice. Exact control response strings are preserved, and target-dependent mode/pane parsing remains adapter-side where the old code resolved targets first.

## Validation
- `swift test --filter ControlDispatcherTests`
- `swift test` in `agtermCore`
- `make lint`
- `make build`
- `~/.codex/skills/codex-review/scripts/codex-review --mode branch --base origin/master`
