### PR TITLE
fix: use title-case app name in the macOS menu bar

### DIFF
--- a/agterm/AppDelegate.swift
+++ b/agterm/AppDelegate.swift
@@ -134,7 +134,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let className = NSStringFromClass(type(of: window))
         return className.contains("SwiftUI")
-            && window.title == "agterm"
+            && window.title == "Agterm"
             && window.styleMask.contains(.titled)
             && window.canBecomeKey
     }
@@ -163,7 +163,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard counts.windows > 0 else { return .terminateNow }
         let alert = NSAlert()
         alert.alertStyle = .warning
-        alert.messageText = "Quit agterm?"
+        alert.messageText = "Quit Agterm?"
         alert.informativeText = QuitPrompt.message(windows: counts.windows, sessions: counts.sessions)
         alert.addButton(withTitle: "Quit")
         alert.addButton(withTitle: "Cancel")

--- a/agterm/Info.plist
+++ b/agterm/Info.plist
@@ -7,9 +7,9 @@
 	<key>CFBundleExecutable</key>
 	<string>agterm</string>
 	<key>CFBundleName</key>
-	<string>agterm</string>
+	<string>Agterm</string>
 	<key>CFBundleDisplayName</key>
-	<string>agterm</string>
+	<string>Agterm</string>
 	<key>CFBundleIconName</key>
 	<string>AppIcon</string>
 	<key>CFBundlePackageType</key>

--- a/agterm/Resources/agent-skill/troubleshooting.md
+++ b/agterm/Resources/agent-skill/troubleshooting.md
@@ -94,7 +94,7 @@ anthropics/claude-code#72188 (mouse-click variant #72273). Workaround: answer be
    hostnames/IPs, usernames embedded in absolute paths (replace with `~` or `<user>`), private repo
    names, and the contents of a selection / `session.copy` / clipboard. When unsure, ask.
 5. **Gather the repro facts yourself** where you can: agterm version (the user reads it from
-   agterm ▸ About agterm), `agtermctl tree --json` shape, a scrubbed `keymap.conf` excerpt, a scrubbed
+   Agterm ▸ About Agterm), `agtermctl tree --json` shape, a scrubbed `keymap.conf` excerpt, a scrubbed
    `log show` excerpt.
 
 ## Issue template (bug)

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -476,9 +476,9 @@ struct WindowContentView: View {
 
     /// The titlebar title (first line): the active session's display name, suffixed with the window
     /// name as "session — window" when the window has a custom (user-set) name, so a renamed window
-    /// is identifiable at a glance. Auto "window N" names are omitted. "agterm" when nothing is selected.
+    /// is identifiable at a glance. Auto "window N" names are omitted. "Agterm" when nothing is selected.
     private var windowTitle: String {
-        let session = store.activeSession?.displayName ?? "agterm"
+        let session = store.activeSession?.displayName ?? "Agterm"
         guard let info = library.windows.first(where: { $0.id == windowID }), info.hasCustomName else {
             return session
         }

--- a/agterm/agtermApp+Menus.swift
+++ b/agterm/agtermApp+Menus.swift
@@ -52,10 +52,10 @@ extension agtermApp {
 
     @CommandsBuilder
     var appCommands: some Commands {
-            // App menu: replace the default "About agterm" with one that opens the standard
+            // App menu: replace the default "About Agterm" with one that opens the standard
             // panel enriched with a clickable repo link and, on release builds, the build commit.
             CommandGroup(replacing: .appInfo) {
-                Button("About agterm") { showAboutPanel() }
+                Button("About Agterm") { showAboutPanel() }
             }
             // File: replace the default "New" group with all of agterm's creation/management actions,
             // grouped by entity into three sections — Window, then Workspace, then Session. The

--- a/agtermCore/Sources/agtermCore/QuitPrompt.swift
+++ b/agtermCore/Sources/agtermCore/QuitPrompt.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Pure builder for the quit-confirmation alert text. Host-free so the pluralization is unit-tested
 /// without an app host; the AppKit `NSAlert` lives in the app target's `AppDelegate`.
 public enum QuitPrompt {
-    /// The informative line for "Quit agterm?", reporting how many windows and sessions the quit
+    /// The informative line for "Quit Agterm?", reporting how many windows and sessions the quit
     /// closes so the loss is explicit (matching the workspace/window delete confirmations). Singular
     /// and plural agree per count.
     public static func message(windows: Int, sessions: Int) -> String {

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -136,7 +136,7 @@ Workaround until the upstream fix: answer the prompt before switching away, or i
 
 Collect this before filing:
 
-- agterm version (agterm ▸ About agterm).
+- agterm version (Agterm ▸ About Agterm).
 - macOS version.
 - The exact steps, what you expected, and what happened instead.
 - A log excerpt from the `log show` command above, covering the moment you reproduced it.


### PR DESCRIPTION
the macOS app menu, the About/Hide/Quit items, and the Dock/Finder name come from `CFBundleName`/`CFBundleDisplayName`, which were lowercase `agterm`. Set both to `Agterm` so the menu bar follows platform title-style capitalization.

**identity stays lowercase**: the executable and `agterm.app`, the bundle id `com.umputun.agterm`, `~/Library/Application Support/agterm`, `~/.config/agterm`, the control socket, the `agterm` CLI, and the Homebrew cask are all unchanged. Only the display name flips.

also updates every spot that referenced the old lowercase name: the custom About menu item, the quit-confirm alert, the stray-restored-window title guard in `AppDelegate`, and the session-less window-title fallback, plus the two `troubleshooting.md` menu-path references and a `QuitPrompt` godoc comment.

Fix #115
