### PR TITLE
refactor: route platform commands through dispatcher

### DIFF
--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -167,6 +167,52 @@ extension ControlServer: ControlActions {
         }
     }
 
+    // MARK: - Keymap
+
+    /// Re-read and re-parse `keymap.conf`, returning the count of parse diagnostics. The SAME
+    /// `reloadKeymap()` path the GUI's File ▸ Reload Keymap menu/palette item drives, so the menu/palette
+    /// and `keymap.reload` never diverge — control-native here only in the count it reports back.
+    func reloadKeymap() -> ControlResponse {
+        settingsModel.reloadKeymap()
+        return ControlResponse(ok: true, result: ControlResult(count: settingsModel.keymapDiagnostics.count))
+    }
+
+    // MARK: - Config
+
+    /// Re-read and apply the ghostty config, returning the config-diagnostic count (0 = clean), counted
+    /// across ALL config sources (bundled defaults, the global `~/.config/ghostty/config`, the agterm-scoped
+    /// `ghostty.conf`, and the UI settings conf) — libghostty diagnostics carry no source-file attribution.
+    /// The SAME `AppActions.reloadGhosttyConfig()` path the GUI's File ▸ Reload Config menu/palette item
+    /// drives (which posts the warning banner on diagnostics), so the GUI and `config.reload` never diverge
+    /// — control-native here only in the count it reports back. The count is the value the reload actually
+    /// produced (threaded back from the reload), not a separate re-read. App-global (one settings model +
+    /// one GhosttyApp), so no `--window` selector, like `keymap.reload`.
+    func reloadGhosttyConfig() -> ControlResponse {
+        ControlResponse(ok: true, result: ControlResult(count: actions.reloadGhosttyConfig()))
+    }
+
+    // MARK: - Theme
+
+    /// Set + persist a theme by name — the control half of the Settings picker / the `.themes` palette
+    /// commit (no live preview over the socket). A nil/empty name selects ghostty's built-in colors
+    /// ("default ghostty"), NOT the seeded `agterm` app default; any other name must be a bundled theme,
+    /// else an error (a typo silently doing nothing is worse than a fail). Returns the applied theme in
+    /// `result.theme` (nil = ghostty built-in). App-global: one `SettingsModel`, so no `--window` selector.
+    func setTheme(name: String?) -> ControlResponse {
+        let resolved = ThemeCatalog.resolvedName(name)
+        let catalog = ThemeCatalog(names: actions.availableThemes())
+        if let resolved, !catalog.contains(name: resolved) {
+            return ControlResponse(ok: false, error: "unknown theme: \(resolved)")
+        }
+        actions.setTheme(resolved)
+        return ControlResponse(ok: true, result: ControlResult(theme: resolved))
+    }
+
+    func listThemes() -> ControlResponse {
+        ControlResponse(ok: true, result: ControlResult(theme: actions.currentTheme,
+                                                        themes: actions.availableThemes()))
+    }
+
     /// Set the target session's agent-status indicator (control-native: no GUI/menu equivalent, like
     /// `notify`/`session.type`/`session.copy`). `status` is `idle|active|completed|blocked`; an unknown
     /// value is the structured `invalid status` error. `blink` (default false) pulses the glyph;
@@ -284,10 +330,7 @@ extension ControlServer: ControlActions {
     /// Post a desktop notification attributed to a session (default: the active session of the
     /// frontmost window, via `resolveSession`). `title` defaults to the session name; `body` is
     /// required. Errors when no open window owns the resolved session.
-    func sendNotification(_ target: String?, window: String?, title: String?, body: String?) -> ControlResponse {
-        guard let body, !body.isEmpty else {
-            return ControlResponse(ok: false, error: "notify requires a body")
-        }
+    func sendNotification(_ target: String?, window: String?, title: String?, body: String) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
             guard let session = store.session(withID: id) else {
                 return ControlResponse(ok: false, error: "no such session: \(target ?? "active")")

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -342,7 +342,8 @@ final class ControlServer {
         switch request.cmd {
         case .tree, .sessionNew, .sessionMove, .workspaceMove, .workspaceFocus, .sessionSplit,
                 .sessionScratch, .sessionFocus, .sessionResize, .sessionStatus, .sessionFlag,
-                .sidebar, .sidebarMode, .sidebarExpand, .sidebarCollapse:
+                .notify, .fontInc, .fontDec, .fontReset, .keymapReload, .configReload,
+                .themeSet, .themeList, .sidebar, .sidebarMode, .sidebarExpand, .sidebarCollapse:
             return ControlResponse(ok: false, error: "control dispatcher did not handle \(request.cmd.rawValue)")
         case .sessionSelect:
             return resolver.resolveSession(request.target, window: request.args?.window) { store, id in
@@ -485,15 +486,6 @@ final class ControlServer {
             }
         case .quick:
             return setQuickTerminal(mode: request.args?.mode)
-        case .notify:
-            return sendNotification(request.target, window: request.args?.window,
-                                    title: request.args?.title, body: request.args?.body)
-        case .fontInc:
-            return font(request.target, window: request.args?.window, action: "increase_font_size:1")
-        case .fontDec:
-            return font(request.target, window: request.args?.window, action: "decrease_font_size:1")
-        case .fontReset:
-            return font(request.target, window: request.args?.window, action: "reset_font_size")
         case .windowNew:
             return windowNew(name: request.args?.name)
         case .windowList:
@@ -512,15 +504,6 @@ final class ControlServer {
             return windowMove(request.target, x: request.args?.x, y: request.args?.y, display: request.args?.display)
         case .windowZoom:
             return windowZoom(request.target)
-        case .keymapReload:
-            return reloadKeymap()
-        case .configReload:
-            return reloadGhosttyConfig()
-        case .themeSet:
-            return setTheme(name: request.args?.name)
-        case .themeList:
-            return ControlResponse(ok: true, result: ControlResult(theme: actions.currentTheme,
-                                                                    themes: actions.availableThemes()))
         case .restoreClear:
             return clearSavedCommands()
         }
@@ -571,47 +554,6 @@ final class ControlServer {
         }
         if store === library.activeStore { actions.focusActiveSession() }
         return ControlResponse(ok: true, result: ControlResult(id: session.id.uuidString))
-    }
-
-    // MARK: - Keymap
-
-    /// Re-read and re-parse `keymap.conf`, returning the count of parse diagnostics. The SAME
-    /// `reloadKeymap()` path the GUI's File ▸ Reload Keymap menu/palette item drives, so the menu/palette
-    /// and `keymap.reload` never diverge — control-native here only in the count it reports back.
-    private func reloadKeymap() -> ControlResponse {
-        settingsModel.reloadKeymap()
-        return ControlResponse(ok: true, result: ControlResult(count: settingsModel.keymapDiagnostics.count))
-    }
-
-    // MARK: - Config
-
-    /// Re-read and apply the ghostty config, returning the config-diagnostic count (0 = clean), counted
-    /// across ALL config sources (bundled defaults, the global `~/.config/ghostty/config`, the agterm-scoped
-    /// `ghostty.conf`, and the UI settings conf) — libghostty diagnostics carry no source-file attribution.
-    /// The SAME `AppActions.reloadGhosttyConfig()` path the GUI's File ▸ Reload Config menu/palette item
-    /// drives (which posts the warning banner on diagnostics), so the GUI and `config.reload` never diverge
-    /// — control-native here only in the count it reports back. The count is the value the reload actually
-    /// produced (threaded back from the reload), not a separate re-read. App-global (one settings model +
-    /// one GhosttyApp), so no `--window` selector, like `keymap.reload`.
-    private func reloadGhosttyConfig() -> ControlResponse {
-        ControlResponse(ok: true, result: ControlResult(count: actions.reloadGhosttyConfig()))
-    }
-
-    // MARK: - Theme
-
-    /// Set + persist a theme by name — the control half of the Settings picker / the `.themes` palette
-    /// commit (no live preview over the socket). A nil/empty name selects ghostty's built-in colors
-    /// ("default ghostty"), NOT the seeded `agterm` app default; any other name must be a bundled theme,
-    /// else an error (a typo silently doing nothing is worse than a fail). Returns the applied theme in
-    /// `result.theme` (nil = ghostty built-in). App-global: one `SettingsModel`, so no `--window` selector.
-    private func setTheme(name: String?) -> ControlResponse {
-        let resolved = ThemeCatalog.resolvedName(name)
-        let catalog = ThemeCatalog(names: actions.availableThemes())
-        if let resolved, !catalog.contains(name: resolved) {
-            return ControlResponse(ok: false, error: "unknown theme: \(resolved)")
-        }
-        actions.setTheme(resolved)
-        return ControlResponse(ok: true, result: ControlResult(theme: resolved))
     }
 
     /// `value` trimmed of surrounding whitespace, or nil if absent or blank after trimming.

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -16,6 +16,12 @@ public protocol ControlActions {
     func scratchSession(_ target: String?, window: String?, mode: String?, command: String?) -> ControlResponse
     func focusSessionPane(_ target: String?, window: String?, pane: String?) -> ControlResponse
     func resizeSplit(_ target: String?, window: String?, resize: ControlSplitResize) -> ControlResponse
+    func font(_ target: String?, window: String?, action: String) -> ControlResponse
+    func reloadKeymap() -> ControlResponse
+    func reloadGhosttyConfig() -> ControlResponse
+    func sendNotification(_ target: String?, window: String?, title: String?, body: String) -> ControlResponse
+    func setTheme(name: String?) -> ControlResponse
+    func listThemes() -> ControlResponse
     func setSidebarVisibility(_ mode: ControlToggleMode) -> ControlResponse
     func setSidebarViewMode(_ mode: ControlSidebarViewMode) -> ControlResponse
     func expandSidebar(window: String?) -> ControlResponse
@@ -105,6 +111,26 @@ public struct ControlDispatcher {
             case (nil, .some(let delta)):
                 return actions.resizeSplit(request.target, window: request.args?.window, resize: .delta(delta))
             }
+        case .fontInc:
+            return actions.font(request.target, window: request.args?.window, action: "increase_font_size:1")
+        case .fontDec:
+            return actions.font(request.target, window: request.args?.window, action: "decrease_font_size:1")
+        case .fontReset:
+            return actions.font(request.target, window: request.args?.window, action: "reset_font_size")
+        case .keymapReload:
+            return actions.reloadKeymap()
+        case .configReload:
+            return actions.reloadGhosttyConfig()
+        case .notify:
+            guard let body = request.args?.body, !body.isEmpty else {
+                return ControlResponse(ok: false, error: "notify requires a body")
+            }
+            return actions.sendNotification(request.target, window: request.args?.window,
+                                            title: request.args?.title, body: body)
+        case .themeSet:
+            return actions.setTheme(name: request.args?.name)
+        case .themeList:
+            return actions.listThemes()
         case .sidebar:
             guard let mode = ControlToggleMode.parse(request.args?.mode, on: "show", off: "hide") else {
                 return ControlResponse(ok: false, error: "invalid sidebar mode: \(request.args?.mode ?? "toggle")")

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -319,11 +319,126 @@ struct ControlDispatcherTests {
         #expect(actions.calls.isEmpty)
     }
 
+    @Test func fontCommandsRouteActionsWithTargetAndWindow() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextFontResponse = ControlResponse(ok: true, result: ControlResult(id: "session"))
+
+        let inc = dispatcher.dispatch(ControlRequest(
+            cmd: .fontInc,
+            target: "session",
+            args: ControlArgs(window: "win")
+        ))
+        let dec = dispatcher.dispatch(ControlRequest(cmd: .fontDec, target: "session"))
+        let reset = dispatcher.dispatch(ControlRequest(cmd: .fontReset, target: "session"))
+
+        #expect(inc == ControlResponse(ok: true, result: ControlResult(id: "session")))
+        #expect(dec == ControlResponse(ok: true, result: ControlResult(id: "session")))
+        #expect(reset == ControlResponse(ok: true, result: ControlResult(id: "session")))
+        #expect(actions.calls == [
+            .font(target: "session", window: "win", "increase_font_size:1"),
+            .font(target: "session", window: nil, "decrease_font_size:1"),
+            .font(target: "session", window: nil, "reset_font_size")
+        ])
+    }
+
+    @Test func keymapAndConfigReloadWrapDiagnosticCounts() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextKeymapResponse = ControlResponse(ok: true, result: ControlResult(count: 2))
+        actions.nextConfigResponse = ControlResponse(ok: true, result: ControlResult(count: 3))
+
+        let keymap = dispatcher.dispatch(ControlRequest(cmd: .keymapReload))
+        let config = dispatcher.dispatch(ControlRequest(cmd: .configReload))
+
+        #expect(keymap == ControlResponse(ok: true, result: ControlResult(count: 2)))
+        #expect(config == ControlResponse(ok: true, result: ControlResult(count: 3)))
+        #expect(actions.calls == [.keymapReload, .configReload])
+    }
+
+    @Test func notifyRequiresBodyBeforeCallingActions() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let missing = dispatcher.dispatch(ControlRequest(cmd: .notify, target: "session"))
+        let empty = dispatcher.dispatch(ControlRequest(
+            cmd: .notify,
+            target: "session",
+            args: ControlArgs(body: "")
+        ))
+
+        #expect(missing == ControlResponse(ok: false, error: "notify requires a body"))
+        #expect(empty == ControlResponse(ok: false, error: "notify requires a body"))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test func notifyRoutesBodyTitleTargetAndWindow() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextNotifyResponse = ControlResponse(ok: true, result: ControlResult(id: "session"))
+
+        let response = dispatcher.dispatch(ControlRequest(
+            cmd: .notify,
+            target: "session",
+            args: ControlArgs(window: "win", title: "Build", body: "done")
+        ))
+
+        #expect(response == ControlResponse(ok: true, result: ControlResult(id: "session")))
+        #expect(actions.calls == [
+            .notify(target: "session", window: "win", title: "Build", body: "done")
+        ])
+    }
+
+    @Test func themeSetRoutesAndEchoesActionResponse() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextThemeSetResponse = ControlResponse(ok: true, result: ControlResult(theme: "Dracula"))
+
+        let set = dispatcher.dispatch(ControlRequest(
+            cmd: .themeSet,
+            args: ControlArgs(name: "Dracula")
+        ))
+
+        #expect(set == ControlResponse(ok: true, result: ControlResult(theme: "Dracula")))
+        #expect(actions.calls == [.themeSet("Dracula")])
+    }
+
+    @Test func themeSetKeepsExactActionErrorResponse() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextThemeSetResponse = ControlResponse(ok: false, error: "unknown theme: NotARealTheme")
+
+        let response = dispatcher.dispatch(ControlRequest(
+            cmd: .themeSet,
+            args: ControlArgs(name: "NotARealTheme")
+        ))
+
+        #expect(response == ControlResponse(ok: false, error: "unknown theme: NotARealTheme"))
+        #expect(actions.calls == [.themeSet("NotARealTheme")])
+    }
+
+    @Test func themeListReturnsCurrentThemeAndAvailableThemes() {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextThemeListResponse = ControlResponse(
+            ok: true,
+            result: ControlResult(theme: "Dracula", themes: ["Dracula", "Nord"])
+        )
+
+        let response = dispatcher.dispatch(ControlRequest(cmd: .themeList))
+
+        #expect(response == ControlResponse(
+            ok: true,
+            result: ControlResult(theme: "Dracula", themes: ["Dracula", "Nord"])
+        ))
+        #expect(actions.calls == [.themeList])
+    }
+
     @Test func nonMigratedCommandFallsThrough() {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)
 
-        let response = dispatcher.dispatch(ControlRequest(cmd: .sessionSelect))
+        let response = dispatcher.dispatch(ControlRequest(cmd: .sessionType))
 
         #expect(response == nil)
         #expect(actions.calls.isEmpty)
@@ -344,6 +459,12 @@ private final class MockControlActions: ControlActions {
         case sessionScratch(target: String?, window: String?, String?, command: String?)
         case sessionFocus(target: String?, window: String?, String?)
         case sessionResize(target: String?, window: String?, ControlSplitResize)
+        case font(target: String?, window: String?, String)
+        case keymapReload
+        case configReload
+        case notify(target: String?, window: String?, title: String?, body: String)
+        case themeSet(String?)
+        case themeList
         case sidebarVisibility(ControlToggleMode)
         case sidebarViewMode(ControlSidebarViewMode)
         case expand(window: String?)
@@ -357,6 +478,12 @@ private final class MockControlActions: ControlActions {
     var nextSidebarViewModeResponse = ControlResponse(ok: true)
     var nextExpandResponse = ControlResponse(ok: true)
     var nextCollapseResponse = ControlResponse(ok: true)
+    var nextFontResponse = ControlResponse(ok: true)
+    var nextNotifyResponse = ControlResponse(ok: true)
+    var nextKeymapResponse = ControlResponse(ok: true)
+    var nextConfigResponse = ControlResponse(ok: true)
+    var nextThemeSetResponse = ControlResponse(ok: true)
+    var nextThemeListResponse = ControlResponse(ok: true)
 
     func controlTree(window: String?) -> ControlResponse {
         calls.append(.tree(window: window))
@@ -413,6 +540,37 @@ private final class MockControlActions: ControlActions {
     func resizeSplit(_ target: String?, window: String?, resize: ControlSplitResize) -> ControlResponse {
         calls.append(.sessionResize(target: target, window: window, resize))
         return ControlResponse(ok: true)
+    }
+
+    func font(_ target: String?, window: String?, action: String) -> ControlResponse {
+        calls.append(.font(target: target, window: window, action))
+        return nextFontResponse
+    }
+
+    func reloadKeymap() -> ControlResponse {
+        calls.append(.keymapReload)
+        return nextKeymapResponse
+    }
+
+    func reloadGhosttyConfig() -> ControlResponse {
+        calls.append(.configReload)
+        return nextConfigResponse
+    }
+
+    func sendNotification(_ target: String?, window: String?,
+                          title: String?, body: String) -> ControlResponse {
+        calls.append(.notify(target: target, window: window, title: title, body: body))
+        return nextNotifyResponse
+    }
+
+    func setTheme(name: String?) -> ControlResponse {
+        calls.append(.themeSet(name))
+        return nextThemeSetResponse
+    }
+
+    func listThemes() -> ControlResponse {
+        calls.append(.themeList)
+        return nextThemeListResponse
     }
 
     func setSidebarVisibility(_ mode: ControlToggleMode) -> ControlResponse {


### PR DESCRIPTION
## Summary
- route lower-risk platform/control command families through `ControlDispatcher`
- keep macOS-only side effects in `ControlServer` adapter methods
- add focused core dispatcher tests for success routing and exact error responses

## Notes
Rebased onto current `master`; the PR diff is the group 3a dispatcher migration only.

Behavior audit: this is intended as a refactor-only slice. Exact control response strings are preserved for the migrated command paths, and heavier group 3b commands (`session.type`, `session.selection`, and `session.overlay.*`) stay out of scope.

## Validation
- `swift test --filter ControlDispatcherTests` in `agtermCore`
- `swift test` in `agtermCore`
- `make lint`
- `make build`
- `xcodebuild test -project agterm.xcodeproj -scheme agterm -destination 'platform=macOS' -only-testing:agtermUITests/ControlAPIUITests/testConfigReloadReportsDiagnosticsForMalformedFile -only-testing:agtermUITests/ControlAPIUITests/testConfigReloadSucceeds -only-testing:agtermUITests/ControlAPIUITests/testFontDecreaseAndResetSucceed -only-testing:agtermUITests/ControlAPIUITests/testFontIncreaseSucceeds -only-testing:agtermUITests/ControlAPIUITests/testKeymapReloadReportsDiagnosticsForBrokenFile -only-testing:agtermUITests/ControlAPIUITests/testKeymapReloadReportsZeroDiagnostics -only-testing:agtermUITests/ControlAPIUITests/testThemeListAndSet -only-testing:agtermUITests/ControlSidebarStatusUITests/testNotifySend`
