### PR TITLE
feat: promote split survivor into the main pane on primary exit

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -419,7 +419,8 @@ paths:
   re-runs on restore (through the same `config.command` exec path) when the **restore-running-command** opt-in
   is on — gated via the transient `Session.wasRestored` so a fresh session always runs its command while a
   restored one honors the toggle (default off → a restored session is a plain shell); a live captured
-  foreground preempts it, and `closePrimaryPane` clears it when a command pane exits into a promoted split.
+  foreground preempts it, and `closePrimaryPane` clears it when a command pane exits and its split
+  survivor is promoted to the session's single pane.
   The arm threads `request.args?.command` into `AppStore.addSession(…, command:)`,
   which `makeSurface` passes to `GhosttySurfaceView(command:)` → `config.command` RAW (`strdup`,
   NO wrapper). libghostty tokenizes it into argv (shell-like word-splitting that RESPECTS quotes) and

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -542,10 +542,11 @@ paths:
   (and so does `font.*`'s omitted/`left` default — its `right`/`scratch` panes resolve `splitSurface`/`scratchSurface`
   instead, via its own pane switch rather than `surfaceBindingAction`),
   and `addressableSurface` is `surface ?? splitSurface`: identical to `surface` for every ordinary or split
-  session, but falling back to a PROMOTED SPLIT SURVIVOR whose primary shell exited (`closePrimaryPane` nils
-  `surface` and keeps the live shell in `splitSurface`, asserted by `AppStorePaneTests`).
-  Resolving through `surface` alone returned `session not realized` for a session the user was actively typing
-  in. It is deliberately NOT focus-aware (unlike `activeSurface`) — a shown split keeps addressing the main
+  session — including a PROMOTED SPLIT SURVIVOR, which `closePrimaryPane` moves into the main slot
+  (`AppStorePaneTests` asserts `splitSurface == nil` after promotion).
+  The `?? splitSurface` term is a defensive fallback only, kept so the arms answer (instead of
+  `session not realized`) should `surface` ever be nil while a split shell is still alive.
+  It is deliberately NOT focus-aware (unlike `activeSurface`) — a shown split keeps addressing the main
   pane, which is what keeps `session.selectall` and its `session.copy` read-back on the SAME surface.
   READ-BACK: neither adds a `ControlSessionNode` field — `session.selectall`'s read-back is `session.copy`
   (reads the resulting selection) and `session.paste`'s is `session.text` (reads the inserted buffer), the

--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -59,11 +59,12 @@ paths:
   (`splitSurface === focusedSurface`), the palette path from `session.splitFocused` —
   so a script can feed it back as `agtermctl session type --pane "$AGT_PANE"` to type into the very
   pane the shortcut was pressed in.
-  It reflects the pane's PHYSICAL surface slot, not `hasSplit`: a promoted split survivor (the primary
-  pane exited and the split pane took over) reports `right` even though the session no longer shows a
-  split, because that survivor still lives in the `splitSurface` slot — which is exactly where
-  `session.type --pane right` reaches it, so the round-trip stays correct (a `left` there would name a
-  pane `session.type` can't type into, since the promoted session's `surface` slot is nil).
+  It reflects the pane's physical surface slot: `left` for any single-pane session, including a promoted
+  split survivor.
+  When the primary pane's shell exits, `closePrimaryPane` MOVES the surviving split pane from
+  `splitSurface` into the `surface` (main) slot and flips its `isSplitPane` flag off, so a
+  collapsed-to-single session reports `left` and `session.type --pane left` reaches it —
+  the survivor is no longer addressable as `right`, and a later split opens a fresh right pane beside it.
 - **Built-in override resolution is ORDER-INDEPENDENT, decided against the FINAL state (`resolveBuiltinOverrides`).**
   Overrides are NOT folded incrementally against a partially-built map (that was order-sensitive — it
   would reject `map cmd+d new_session` when toggle_split still owned cmd+d "so far",

--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -112,9 +112,10 @@ paths:
   else `\.surface` — so reopening restores the two panes in place; nothing is destroyed (`closeSplit`
   only runs when the split shell exits).
   **Exiting a pane's shell keeps the session, collapsed to the survivor:** the primary's `onExit` is
-  `AppStore.closePrimaryPane` (promotes the split pane to a single non-split session,
-  its cwd promoted to the session's) and the split's is `closeSplitPane` (collapses to the primary,
-  or closes the session if the primary already exited).
+  `AppStore.closePrimaryPane` (promotes the surviving split pane INTO the main slot as a single non-split
+  session — its cwd/title/foreground command migrate up) and the split's is `closeSplitPane` (collapses
+  to the primary only for a genuine two-pane split, else closes the session — the primary already exited,
+  or the promoted survivor's own exit, `splitSurface == nil`).
   Only a single (non-split) session's exit closes it.
   The collapse re-hosts the survivor (HSplitView → standalone), which drops focus,
   so `GhosttySurfaceView.focusAfterReparent` re-grabs first responder until it sticks past the re-host.

--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -213,8 +213,10 @@ paths:
   EVERY user-initiated GUI selection now REVEALS the blocked PANE, not just the session: the shared
   `AppActions.revealActiveBlockedPane()` (formerly private, now called on all selection paths) reads the
   landed session's `agentIndicator.statusPane` and focuses that pane — for `right`, the split surface via
-  `focusSplitPane(_:wantSplit: true)` (a FIXED target, UNGATED on `hasSplit`, so a promoted split survivor
-  is still focused, and its `onFocusChange` re-asserts `splitFocused` to win the shown-split re-render race);
+  `focusSplitPane(_:wantSplit: true)` (a FIXED target gated on `splitSurface != nil`, and its `onFocusChange`
+  re-asserts `splitFocused` to win the shown-split re-render race). A promoted split survivor is NOT covered
+  by this branch — promotion moves it into `surface` with `splitSurface == nil` (and re-tags a `.right` block
+  to `.left`), so it falls through to `focusActiveSession` as the session's sole main pane, which is correct;
   for `scratch`, shows a hidden scratch via `AppStore.toggleScratch` then focuses it;
   for `left`/nil, the main pane; and it is a no-op (plain `focusActiveSession`) for an IDLE session
   (no status set), so ordinary selections are unaffected (the idle gate is what keeps a plain nav to a

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -842,10 +842,11 @@ final class AppActions {
     /// `focusActiveSession`: a SHOWN (side-by-side) split's deck re-render churns first responder onto the
     /// main pane, whose `onFocusChange` writes `splitFocused = false`, and a follow-the-flag focus target
     /// then chases the wrong pane; re-asserting the split surface directly wins the race (its `onFocusChange`
-    /// re-sets `splitFocused = true`). The gate is `splitSurface != nil` (NOT `hasSplit`), so it still covers
-    /// a promoted split survivor (primary exited, survivor in `splitSurface`, `hasSplit` false — still
-    /// focused), while a STALE `right` tag on a genuinely single-pane session (a manual `session.status
-    /// --pane right`, or after the split collapsed) falls through to `focusActiveSession` instead of setting
+    /// re-sets `splitFocused = true`). The gate is `splitSurface != nil` (NOT `hasSplit`). A promoted split
+    /// survivor is NOT covered here — promotion moves it into `surface` with `splitSurface == nil` and re-tags
+    /// its `.right` status to `.left`, so it falls through to `focusActiveSession` as the session's sole main
+    /// pane (correct). A STALE `right` tag on a genuinely single-pane session (a manual `session.status
+    /// --pane right`, or after the split collapsed) likewise falls through instead of setting
     /// `splitFocused = true` with no split surface (the `splitFocused` invariant is "true only while the
     /// split pane exists"). `.scratch` shows the
     /// scratch only when hidden (a show-if-hidden guard, never a bare toggle that could HIDE a shown one) so

--- a/agterm/Commands/CustomCommandRunner.swift
+++ b/agterm/Commands/CustomCommandRunner.swift
@@ -186,8 +186,9 @@ final class CustomCommandRunner {
         // EXISTING (the `Session.onScreenSurface` idiom, `splitFocused && splitSurface != nil`): in the
         // window right after `session split on`, `splitFocused` is already true while `splitSurface` is
         // still nil, so a bare flag would report `.right` (and read the selection from the nil split
-        // surface) when `session.type --pane right` still errors "no split pane". A promoted survivor keeps
-        // `splitSurface` non-nil, so it still reports `.right` — the pane `--pane right` reaches.
+        // surface) when `session.type --pane right` still errors "no split pane". A promoted survivor now
+        // lives in the `surface` slot with `splitSurface == nil` and `splitFocused == false`, so `onSplit`
+        // is false and it reports `.left` — the pane `--pane left` reaches.
         let onSplit = session.splitFocused && session.splitSurface != nil
         let selectionSurface = (onSplit ? session.splitSurface : session.surface) as? GhosttySurfaceView
         let context = self.context(for: session, in: store, selectionSurface: selectionSurface,

--- a/agterm/Ghostty/GhosttySurfaceView+Panes.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Panes.swift
@@ -1,0 +1,11 @@
+extension GhosttySurfaceView {
+    // MARK: - Pane role
+
+    /// `TerminalSurface` conformance: the model calls this when the primary pane exits and this split
+    /// (right) pane is promoted to the session's sole pane. Clears `isSplitPane` so subsequent
+    /// `applyPwd`/`applyTitle` reports route to `session.currentCwd`/`oscTitle` (the main fields) rather
+    /// than `splitCwd`/`splitTitle`.
+    func promoteToPrimaryPane() {
+        isSplitPane = false
+    }
+}

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -875,6 +875,14 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         destroySurface()
     }
 
+    /// `TerminalSurface` conformance: the model calls this when the primary pane exits and this split
+    /// (right) pane is promoted to the session's sole pane. Clears `isSplitPane` so subsequent
+    /// `applyPwd`/`applyTitle` reports route to `session.currentCwd`/`oscTitle` (the main fields) rather
+    /// than `splitCwd`/`splitTitle`.
+    func promoteToPrimaryPane() {
+        isSplitPane = false
+    }
+
     // MARK: - Window / size
 
     override func viewDidMoveToWindow() {

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -875,14 +875,6 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         destroySurface()
     }
 
-    /// `TerminalSurface` conformance: the model calls this when the primary pane exits and this split
-    /// (right) pane is promoted to the session's sole pane. Clears `isSplitPane` so subsequent
-    /// `applyPwd`/`applyTitle` reports route to `session.currentCwd`/`oscTitle` (the main fields) rather
-    /// than `splitCwd`/`splitTitle`.
-    func promoteToPrimaryPane() {
-        isSplitPane = false
-    }
-
     // MARK: - Window / size
 
     override func viewDidMoveToWindow() {

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -229,7 +229,7 @@ struct agtermApp: App {
             store.clearUnseen(sessionID)
             NotificationManager.shared.clearDelivered(sessionID: sessionID)
         }
-        Self.wireStatusClear(view, store: store, sessionID: sessionID, pane: .left)
+        Self.wireStatusClear(view, store: store, sessionID: sessionID)
         view.onUserInput = { store.noteUserActivity() }
         view.onFontSizeChange = { store.setFontSize(sessionID, $0) }
         Self.wireSearchCallbacks(view, store: store, sessionID: sessionID, library: library)
@@ -333,12 +333,17 @@ struct agtermApp: App {
     /// Wire the pane-scoped keystroke-clear: `keyDown` fires `onUserInputClearsStatus` unconditionally, and
     /// this closure clears the status back to idle ONLY when the host-free `AgentIndicator.clearedBy(pane:isInterrupt:)`
     /// says the keystroke's OWN pane owns the current status — so a block set from a background pane survives
-    /// foreground typing in another pane. Wired by all three surface factories with only the pane differing
-    /// (main=`.left`, split=`.right`, scratch=`.scratch`), like `wireSearchCallbacks`; the scratch has no
-    /// `view.session`, so the decision must live in this closure rather than `keyDown`.
+    /// foreground typing in another pane. The main/split panes resolve their pane from the surface's LIVE role
+    /// (`isSplitPane`) at keystroke time, NOT statically: a promoted split survivor (a split surface whose
+    /// `isSplitPane` was cleared) then clears as `.left`, matching its migrated status identity and `tree`
+    /// addressing — a statically-captured `.right` would keep clearing the wrong pane after promotion, and a
+    /// re-split would leave both panes `.right`-wired (mirrors the role-aware `onFocusChange`). The scratch pane
+    /// passes `fixedPane: .scratch` (never promoted, and it has no `view.session` to read a role from).
     @MainActor
-    private static func wireStatusClear(_ view: GhosttySurfaceView, store: AppStore, sessionID: UUID, pane: StatusPane) {
-        view.onUserInputClearsStatus = { isInterrupt in
+    private static func wireStatusClear(_ view: GhosttySurfaceView, store: AppStore, sessionID: UUID,
+                                        fixedPane: StatusPane? = nil) {
+        view.onUserInputClearsStatus = { [weak view] isInterrupt in
+            let pane = fixedPane ?? ((view?.isSplitPane ?? false) ? .right : .left)
             if store.session(withID: sessionID)?.agentIndicator.clearedBy(pane: pane, isInterrupt: isInterrupt) == true {
                 store.setAgentIndicator(AgentIndicator(), forSession: sessionID)
             }
@@ -383,7 +388,7 @@ struct agtermApp: App {
             store.clearUnseen(sessionID)
             NotificationManager.shared.clearDelivered(sessionID: sessionID)
         }
-        Self.wireStatusClear(view, store: store, sessionID: sessionID, pane: .right)
+        Self.wireStatusClear(view, store: store, sessionID: sessionID)
         view.onUserInput = { store.noteUserActivity() }
         Self.wireSearchCallbacks(view, store: store, sessionID: sessionID, library: library)
         return view
@@ -449,7 +454,7 @@ struct agtermApp: App {
                                       autoFocus: !suppressAutoFocus, env: env)
         let sessionID = session.id
         view.onExit = { store.closeScratch(sessionID) }
-        Self.wireStatusClear(view, store: store, sessionID: sessionID, pane: .scratch)
+        Self.wireStatusClear(view, store: store, sessionID: sessionID, fixedPane: .scratch)
         // typing in the scratch counts as user activity: reset the window's auto-follow idle timer so an
         // idle fire can't change the underlying selection (hiding the per-session scratch) while you type
         // in it. destroySurface nils this, breaking the store -> surface -> closure retain cycle.

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -212,20 +212,9 @@ struct agtermApp: App {
                                       initialInput: plan.initialInput, env: env)
         view.session = session
         let sessionID = session.id
-        view.onExit = {
-            store.closePrimaryPane(sessionID)
-            // a promoted survivor was built by makeSplitSurface (which omits onFontSizeChange); as the
-            // session's now-sole pane it should persist its own cmd +/- like a real primary, so adopt that
-            // wiring. no-op when the session closed instead (single pane) — `surface` is then nil.
-            if let promoted = store.session(withID: sessionID)?.surface as? GhosttySurfaceView {
-                promoted.onFontSizeChange = { store.setFontSize(sessionID, $0) }
-            }
-            // focus the surviving (now maximized) pane; if the whole (single) session closed instead,
-            // focus the session it reselected to. the collapse/switch re-hosts the target, so use the retry.
-            // resolve through `topmostSurface`, so a pane exiting under an overlay or scratch hands focus to
-            // the cover on top rather than to the pane it hides.
-            let target = store.session(withID: sessionID)?.topmostSurface ?? store.activeSession?.topmostSurface
-            (target as? GhosttySurfaceView)?.focusAfterReparent()
+        view.onExit = { [weak view] in
+            guard let view else { return }
+            Self.handlePaneExit(view, store: store, sessionID: sessionID)
         }
         view.onFocusChange = { focused in
             guard focused else { return }
@@ -245,6 +234,33 @@ struct agtermApp: App {
         view.onFontSizeChange = { store.setFontSize(sessionID, $0) }
         Self.wireSearchCallbacks(view, store: store, sessionID: sessionID, library: library)
         return view
+    }
+
+    /// Shell-exit handler shared by BOTH pane factories, dispatched on the surface's CURRENT role rather
+    /// than the factory that built it: a promoted split survivor (built by `makeSplitSurface`, then moved
+    /// into the main slot with `isSplitPane` cleared) must run `closePrimaryPane` on its own exit — else
+    /// a re-split followed by exiting the main pane fires the stale `closeSplitPane`, whose guard now
+    /// passes (both slots live) and tears down the fresh right pane, stranding the session on the dead
+    /// left one. Mirrors the role-aware `onFocusChange` so fresh and promoted panes route the same way.
+    @MainActor
+    private static func handlePaneExit(_ view: GhosttySurfaceView, store: AppStore, sessionID: UUID) {
+        if view.isSplitPane {
+            store.closeSplitPane(sessionID)
+        } else {
+            store.closePrimaryPane(sessionID)
+            // a promoted survivor was built by makeSplitSurface (which omits onFontSizeChange); as the
+            // session's now-sole pane it should persist its own cmd +/- like a real primary, so adopt that
+            // wiring. no-op when the session closed instead (single pane) — `surface` is then nil.
+            if let promoted = store.session(withID: sessionID)?.surface as? GhosttySurfaceView {
+                promoted.onFontSizeChange = { store.setFontSize(sessionID, $0) }
+            }
+        }
+        // focus the surviving (now maximized) pane; if the whole session closed instead, focus the session
+        // it reselected to. the collapse/switch re-hosts the target, so use the retry.
+        // resolve through `topmostSurface`, so a pane exiting under an overlay or scratch hands focus to
+        // the cover on top rather than to the pane it hides.
+        let target = store.session(withID: sessionID)?.topmostSurface ?? store.activeSession?.topmostSurface
+        (target as? GhosttySurfaceView)?.focusAfterReparent()
     }
 
     /// The `initial_input` for a restored pane: the captured foreground argv re-rendered as a shell
@@ -349,14 +365,9 @@ struct agtermApp: App {
         view.session = session
         view.isSplitPane = true
         let sessionID = session.id
-        view.onExit = {
-            store.closeSplitPane(sessionID)
-            // focus the surviving (now maximized) pane; if the whole session closed (primary already
-            // exited), focus the session it reselected to. the collapse/switch re-hosts it, so retry.
-            // resolve through `topmostSurface`, so a pane exiting under an overlay or scratch hands focus to
-            // the cover on top rather than to the pane it hides.
-            let target = store.session(withID: sessionID)?.topmostSurface ?? store.activeSession?.topmostSurface
-            (target as? GhosttySurfaceView)?.focusAfterReparent()
+        view.onExit = { [weak view] in
+            guard let view else { return }
+            Self.handlePaneExit(view, store: store, sessionID: sessionID)
         }
         view.onFocusChange = { [weak view] focused in
             guard focused else { return }

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -214,6 +214,12 @@ struct agtermApp: App {
         let sessionID = session.id
         view.onExit = {
             store.closePrimaryPane(sessionID)
+            // a promoted survivor was built by makeSplitSurface (which omits onFontSizeChange); as the
+            // session's now-sole pane it should persist its own cmd +/- like a real primary, so adopt that
+            // wiring. no-op when the session closed instead (single pane) — `surface` is then nil.
+            if let promoted = store.session(withID: sessionID)?.surface as? GhosttySurfaceView {
+                promoted.onFontSizeChange = { store.setFontSize(sessionID, $0) }
+            }
             // focus the surviving (now maximized) pane; if the whole (single) session closed instead,
             // focus the session it reselected to. the collapse/switch re-hosts the target, so use the retry.
             // resolve through `topmostSurface`, so a pane exiting under an overlay or scratch hands focus to
@@ -352,9 +358,12 @@ struct agtermApp: App {
             let target = store.session(withID: sessionID)?.topmostSurface ?? store.activeSession?.topmostSurface
             (target as? GhosttySurfaceView)?.focusAfterReparent()
         }
-        view.onFocusChange = { focused in
+        view.onFocusChange = { [weak view] focused in
             guard focused else { return }
-            store.session(withID: sessionID)?.splitFocused = true
+            // a promoted survivor keeps this split-factory closure but has had `isSplitPane` cleared, so
+            // honor the view's CURRENT role: once it is the main pane it must NOT re-raise `splitFocused`
+            // (which would mask its migrated title and mis-route focus after a later re-split).
+            store.session(withID: sessionID)?.splitFocused = view?.isSplitPane ?? false
             store.clearUnseen(sessionID)
             NotificationManager.shared.clearDelivered(sessionID: sessionID)
         }

--- a/agtermCore/Sources/agtermCore/AppStore+Panes.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Panes.swift
@@ -118,11 +118,21 @@ extension AppStore {
         if session.searchSurface == nil || session.searchSurface === priorPrimary {
             session.clearSearch()
         }
-        // the exited primary owned any `.left`/nil-tagged agent-status block; clear it (the dead pane is gone).
-        // a `.right`-tagged block belongs to the promoted survivor, which keeps its `.right`-wired
-        // keystroke-clear (wireStatusClear binds the pane at factory time, not by live role), so it stays and
-        // remains clearable — the mirror of closeSplit's `.right` clear when the OTHER pane exits.
-        clearIndicatorOwnedByPane(.left, of: session)
+        // migrate the agent-status identity like the cwd/title above: the exited primary owned any
+        // `.left`/nil-tagged block, which dies with it (clear); a `.right`-tagged block belonged to the
+        // promoted survivor and FOLLOWS it into the main slot — re-tag to `.left` so the `tree` (which now
+        // reports `split:false`) and the survivor's now-`.left`-role-aware keystroke-clear agree, instead of
+        // a self-contradictory `split:false` + `statusPane:"right"`. A `.scratch` block is untouched.
+        if session.agentIndicator.status != .idle {
+            switch session.agentIndicator.statusPane ?? .left {
+            case .left: setAgentIndicator(AgentIndicator(), forSession: session.id)
+            case .right:
+                var promoted = session.agentIndicator
+                promoted.statusPane = .left
+                setAgentIndicator(promoted, forSession: session.id)
+            case .scratch: break
+            }
+        }
         save()
     }
 

--- a/agtermCore/Sources/agtermCore/AppStore+Panes.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Panes.swift
@@ -86,7 +86,7 @@ extension AppStore {
         }
         let priorPrimary = session.surface // the exiting pane, torn down below; scopes the search reset
         priorPrimary?.teardown()
-        // Promote the surviving split pane into the primary slot. `promoteToPrimaryPane` flips the
+        // promote the surviving split pane into the primary slot. `promoteToPrimaryPane` flips the
         // surface's split-role flag so its future pwd/title reports write to the main fields.
         survivor.promoteToPrimaryPane()
         session.surface = survivor
@@ -100,11 +100,13 @@ extension AppStore {
         session.initialCommand = nil
         // migrate the split pane's live/persisted metadata up to the session (main) fields, then clear the
         // now-meaningless split fields so nothing still describes a pane that no longer exists.
-        if let cwd = session.splitCwd { session.currentCwd = cwd }
-        if let title = session.splitTitle { session.oscTitle = title }
-        // cwd/title fall back to the exited primary's value when the split reported none (a sane default —
-        // a fresh split seeds its cwd from the primary anyway); foregroundCommand does NOT — it is replaced
-        // outright (nil clears it) so the dead primary's captured command can never linger on the survivor.
+        // cwd prefers the split's live PWD, then its restore-seed (`initialSplitCwd`, set for a restored
+        // split whose shell hasn't emitted OSC yet), and only falls back to the exited primary's cwd when
+        // the split has none at all (a fresh split seeds its cwd from the primary anyway). title is replaced
+        // OUTRIGHT from the split's (nil clears it) so the dead primary's title can never linger on the
+        // survivor — likewise foregroundCommand, so the exited primary's captured command can't either.
+        session.currentCwd = session.splitCwd ?? session.initialSplitCwd ?? session.currentCwd
+        session.oscTitle = session.splitTitle
         session.foregroundCommand = session.splitForegroundCommand
         session.splitCwd = nil
         session.splitTitle = nil

--- a/agtermCore/Sources/agtermCore/AppStore+Panes.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Panes.swift
@@ -69,42 +69,72 @@ extension AppStore {
         save()
     }
 
-    /// The primary pane's shell exited. If a split pane is alive it becomes the session's single
-    /// (non-split) pane and the session survives; otherwise the session is closed. The survivor stays
-    /// in the `splitSurface` slot, shown maximized via `splitFocused`, and its cwd is promoted to the
-    /// session's so a restart restores the single session in the right directory. Called by the primary
-    /// surface's `onExit`.
+    /// The primary pane's shell exited. If a split pane is alive it is PROMOTED into the primary slot
+    /// and the session survives as a single (non-split) pane; otherwise the session is closed. The
+    /// survivor MOVES from `splitSurface` into `surface` (its surface, cwd, title, and foreground command
+    /// migrate to the main fields, and its split-role reporting is turned off via `promoteToPrimaryPane`),
+    /// so the session becomes indistinguishable from a fresh single pane: `surface != nil`,
+    /// `splitSurface == nil`, `hasSplit == false`, `splitFocused == false`. That is what makes the
+    /// promoted pane addressable as the MAIN/left pane everywhere — `session.type`/`session.text --pane
+    /// left` (and omitted) reach it, `{AGT_PANE}` reports `left`, and a later `session.split` opens a
+    /// fresh RIGHT pane instead of displacing the survivor. Called by the primary surface's `onExit`.
     public func closePrimaryPane(_ sessionID: UUID) {
         guard let session = session(withID: sessionID) else { return }
-        guard session.splitSurface != nil else {
+        guard let survivor = session.splitSurface else {
             closeSession(sessionID)
             return
         }
-        session.surface?.teardown()
-        session.surface = nil
+        let priorPrimary = session.surface // the exiting pane, torn down below; scopes the search reset
+        priorPrimary?.teardown()
+        // Promote the surviving split pane into the primary slot. `promoteToPrimaryPane` flips the
+        // surface's split-role flag so its future pwd/title reports write to the main fields.
+        survivor.promoteToPrimaryPane()
+        session.surface = survivor
+        session.splitSurface = nil
         session.isSplit = false
         session.hasSplit = false
-        session.splitFocused = true
+        session.splitFocused = false
         session.splitRatio = nil // promoted to a single pane; a later split should open even, not stale
         // the command pane is gone — the promoted survivor is a plain shell, so drop the creation command
         // or a restart would resurrect the exited command instead of restoring the promoted shell.
         session.initialCommand = nil
+        // migrate the split pane's live/persisted metadata up to the session (main) fields, then clear the
+        // now-meaningless split fields so nothing still describes a pane that no longer exists.
         if let cwd = session.splitCwd { session.currentCwd = cwd }
-        // the primary surface (possibly the search owner) is torn down while the session survives as the
-        // promoted split, so reset search rather than leave a stuck bar pinned to the gone primary.
-        session.clearSearch()
-        // the gone primary owned any `.left`/nil-tagged block; the promoted (right-wired) survivor can never
-        // keystroke-clear a `.left` tag, so clear it here (a `.right` tag stays — the survivor still owns it).
+        if let title = session.splitTitle { session.oscTitle = title }
+        // cwd/title fall back to the exited primary's value when the split reported none (a sane default —
+        // a fresh split seeds its cwd from the primary anyway); foregroundCommand does NOT — it is replaced
+        // outright (nil clears it) so the dead primary's captured command can never linger on the survivor.
+        session.foregroundCommand = session.splitForegroundCommand
+        session.splitCwd = nil
+        session.splitTitle = nil
+        session.initialSplitCwd = nil
+        session.splitForegroundCommand = nil
+        // reset search only if the torn-down primary owned the bar (or the weak ref already dangled), so a
+        // search owned by the SURVIVING pane stays valid across promotion — matching closeScratch's
+        // identity guard rather than clearing unconditionally and dropping a still-valid search.
+        if session.searchSurface == nil || session.searchSurface === priorPrimary {
+            session.clearSearch()
+        }
+        // the exited primary owned any `.left`/nil-tagged agent-status block; clear it (the dead pane is gone).
+        // a `.right`-tagged block belongs to the promoted survivor, which keeps its `.right`-wired
+        // keystroke-clear (wireStatusClear binds the pane at factory time, not by live role), so it stays and
+        // remains clearable — the mirror of closeSplit's `.right` clear when the OTHER pane exits.
         clearIndicatorOwnedByPane(.left, of: session)
         save()
     }
 
-    /// The split pane's shell exited. If the primary is alive the split collapses to it (`closeSplit`);
-    /// otherwise the primary already exited, so this was the last pane and the session is closed. Called
-    /// by the split surface's `onExit`.
+    /// The split pane's shell exited. It collapses to the primary (`closeSplit`) ONLY when a genuine
+    /// two-pane split is live — BOTH `surface` and `splitSurface` set. Otherwise this was the session's
+    /// last pane and the session is closed: the surface has been PROMOTED into the primary slot
+    /// (`splitSurface == nil`) — a promoted survivor keeps the split pane's `onExit`, so its own exit still
+    /// routes here, and closing (not collapsing a split that no longer exists) is what keeps it from
+    /// leaving a zombie session. (The `surface == nil` half of the guard is defensive: `closePrimaryPane`
+    /// now always promotes the survivor INTO `surface`, so a live `splitSurface` implies a live `surface`.)
+    /// Called by the split surface's `onExit`.
     public func closeSplitPane(_ sessionID: UUID) {
         guard let session = session(withID: sessionID) else { return }
-        guard session.surface != nil else {
+        guard session.surface != nil, session.splitSurface != nil else {
             closeSession(sessionID)
             return
         }

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -342,13 +342,19 @@ public final class AppStore {
     public func setAgentIndicator(_ indicator: AgentIndicator, forSession id: UUID) {
         guard let session = session(withID: id) else { return }
         var indicator = indicator
-        // normalize a `.right` tag to `.left` when the session has NO live split pane. A promoted survivor's
+        // normalize a `.right` tag to `.left` when the session has NO split. A promoted survivor's
         // shell keeps its baked `AGTERM_PANE=right`, so the agent-status hook re-emits `--pane right` after
         // promotion even though there is no right pane — left unnormalized that re-creates the
         // `split:false` + `statusPane:"right"` contradiction the round-3 re-tag fixed, and the sole
-        // (`.left`-role-aware) pane could never keystroke-clear it. A hidden-but-LIVE split keeps its
-        // `splitSurface`, so `.right` stays valid there. `.left`/`.scratch` are untouched.
-        if indicator.statusPane == .right, session.splitSurface == nil {
+        // (`.left`-role-aware) pane could never keystroke-clear it. A hidden-but-LIVE split keeps
+        // `hasSplit`, so `.right` stays valid there. `.left`/`.scratch` are untouched.
+        // gated on `hasSplit`, NOT `splitSurface == nil`: `toggleSplit`/restore set `hasSplit`
+        // synchronously while the deck creates `splitSurface` a render pass later, so a scripted
+        // `session.split` + immediate `session.status --pane right` lands in that realization window —
+        // there `.right` is the correct forward tag and must NOT be rewritten. `splitSurface != nil`
+        // implies `hasSplit` (only `closeSplit`/`closePrimaryPane` clear it, tearing the surface down
+        // with it), so `!hasSplit` still covers every genuinely splitless session.
+        if indicator.statusPane == .right, !session.hasSplit {
             indicator.statusPane = .left
         }
         session.agentIndicator = indicator

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -341,6 +341,16 @@ public final class AppStore {
     /// unknown id. Not persisted (the indicator is ephemeral), so it never triggers a `save()`.
     public func setAgentIndicator(_ indicator: AgentIndicator, forSession id: UUID) {
         guard let session = session(withID: id) else { return }
+        var indicator = indicator
+        // normalize a `.right` tag to `.left` when the session has NO live split pane. A promoted survivor's
+        // shell keeps its baked `AGTERM_PANE=right`, so the agent-status hook re-emits `--pane right` after
+        // promotion even though there is no right pane — left unnormalized that re-creates the
+        // `split:false` + `statusPane:"right"` contradiction the round-3 re-tag fixed, and the sole
+        // (`.left`-role-aware) pane could never keystroke-clear it. A hidden-but-LIVE split keeps its
+        // `splitSurface`, so `.right` stays valid there. `.left`/`.scratch` are untouched.
+        if indicator.statusPane == .right, session.splitSurface == nil {
+            indicator.statusPane = .left
+        }
         session.agentIndicator = indicator
         session.statusChangedAt = indicator.status == .idle ? nil : Date()
     }

--- a/agtermCore/Sources/agtermCore/CustomCommand.swift
+++ b/agtermCore/Sources/agtermCore/CustomCommand.swift
@@ -43,13 +43,13 @@ public struct CommandContext: Equatable, Sendable {
     public var workspaceName: String
     public var windowID: String
     public var windowName: String
-    /// The pane that had focus at fire time — `.left` (main) or `.right` (split). Reflects the pane's
-    /// physical surface slot: a session that has only ever had a main pane reports `.left`, but a promoted
-    /// split survivor (the primary pane exited and the split pane took over) reports `.right`, since that
-    /// surface still lives in the `splitSurface` slot and is where `session.type --pane` reaches it. Typed
-    /// (not a raw `String`) so `rawValue` can only be `left`/`right`; it is consumed as the `$AGT_PANE` env
-    /// var a script feeds back through `session type --pane` (re-validated CLI- AND server-side — the enum
-    /// pins the token this emits, not the shell round-trip).
+    /// The pane that had focus at fire time — `.left` (main) or `.right` (split). `.left` for any
+    /// single-pane session, including a promoted split survivor: when the primary pane exits,
+    /// `closePrimaryPane` moves the surviving split pane into the main slot, so it reports `.left` and
+    /// `session.type --pane left` reaches it. Typed (not a raw `String`) so `rawValue` can only be
+    /// `left`/`right`; it is consumed as the `$AGT_PANE` env var a script feeds back through
+    /// `session type --pane` (re-validated CLI- AND server-side — the enum pins the token this emits,
+    /// not the shell round-trip).
     public var pane: Pane
     public var selection: String
     public var socket: String

--- a/agtermCore/Sources/agtermCore/Session.swift
+++ b/agtermCore/Sources/agtermCore/Session.swift
@@ -259,15 +259,18 @@ public final class Session: Identifiable {
     /// the split is shown side-by-side OR hidden and maximized), otherwise the primary's; falls back
     /// to the primary cwd then `initialCwd`. The sidebar and title bar use this so they track whichever
     /// pane has focus, while `effectiveCwd` (below) stays the primary's for seeding new panes and the
-    /// `AGTERM_SESSION_PWD` token. Guarded on `splitFocused` alone (not `isSplit`): `closeSplit` resets
-    /// the flag, so `splitFocused` is true only while the split pane actually exists.
+    /// `AGTERM_SESSION_PWD` token. Guarded on `splitFocused && splitSurface != nil` — the same idiom as
+    /// `activeSurface`: the split fields describe the split pane only while it exists, so a promoted
+    /// survivor that momentarily re-raised `splitFocused` after moving into the main slot can't mask the
+    /// migrated main-pane cwd/title.
     public var focusedCwd: String {
-        if splitFocused, let cwd = splitCwd { return cwd }
+        if splitFocused, splitSurface != nil, let cwd = splitCwd { return cwd }
         return currentCwd ?? initialCwd
     }
 
-    /// The terminal title of the focused pane: the split pane's while it has focus, else the primary's.
-    private var focusedOscTitle: String? { splitFocused ? splitTitle : oscTitle }
+    /// The terminal title of the focused pane: the split pane's while it has focus AND exists, else the
+    /// primary's (see `focusedCwd` for why the split-existence guard).
+    private var focusedOscTitle: String? { splitFocused && splitSurface != nil ? splitTitle : oscTitle }
 
     /// The detail shown after the workspace name on the second line of the session palette, the Ctrl-Tab
     /// switcher, and the title bar: the focused pane's terminal title when it isn't already the

--- a/agtermCore/Sources/agtermCore/Session.swift
+++ b/agtermCore/Sources/agtermCore/Session.swift
@@ -302,11 +302,11 @@ public final class Session: Identifiable {
 
     /// The session's one addressable pane for the control arms that act on "the session" rather than on a
     /// named `--pane`: `session.copy`, `session.paste`, `session.selectall`, and `font.*`. Normally the main
-    /// pane, and IDENTICAL to `surface` for every ordinary or split session. It differs only for a promoted
-    /// split survivor: when the primary pane's shell exits, `closePrimaryPane` tears that surface down and
-    /// nils `surface`, leaving the session's only live shell in `splitSurface`. Resolving through `surface`
-    /// alone reports `session not realized` for a session the user is actively typing in, so those arms fall
-    /// back to the survivor. Deliberately NOT focus-aware (unlike `activeSurface`): a shown split keeps
+    /// pane, and IDENTICAL to `surface` for every ordinary or split session — including a promoted split
+    /// survivor, which `closePrimaryPane` moves INTO the main slot (`surface`) and whose `splitSurface` it
+    /// nils. The `?? splitSurface` term is a defensive fallback only: it keeps the arms answering (instead
+    /// of `session not realized`) should `surface` ever be nil while a split shell is still alive.
+    /// Deliberately NOT focus-aware (unlike `activeSurface`): a shown split keeps
     /// addressing the main pane, which is what keeps `session.selectall` and its `session.copy` read-back
     /// pointed at the same surface.
     public var addressableSurface: (any TerminalSurface)? { surface ?? splitSurface }

--- a/agtermCore/Sources/agtermCore/TerminalSurface.swift
+++ b/agtermCore/Sources/agtermCore/TerminalSurface.swift
@@ -12,6 +12,12 @@ public protocol TerminalSurface: AnyObject {
     /// Frees the underlying libghostty surface and shell. Called when the
     /// owning session is closed.
     func teardown()
+
+    /// Reassigns this surface from the split (right) pane role to the primary pane, so its live
+    /// pwd/title reports flow to the session's main fields (`currentCwd`/`oscTitle`) instead of the
+    /// split fields (`splitCwd`/`splitTitle`). Called by `closePrimaryPane` when the primary pane's
+    /// shell exits and the surviving split pane is promoted to the session's sole pane.
+    func promoteToPrimaryPane()
 }
 
 /// The direction the search selection steps, in agterm's natural convention:

--- a/agtermCore/Sources/agtermCore/TerminalSurface.swift
+++ b/agtermCore/Sources/agtermCore/TerminalSurface.swift
@@ -16,15 +16,10 @@ public protocol TerminalSurface: AnyObject {
     /// Reassigns this surface from the split (right) pane role to the primary pane, so its live
     /// pwd/title reports flow to the session's main fields (`currentCwd`/`oscTitle`) instead of the
     /// split fields (`splitCwd`/`splitTitle`). Called by `closePrimaryPane` when the primary pane's
-    /// shell exits and the surviving split pane is promoted to the session's sole pane.
+    /// shell exits and the surviving split pane is promoted to the session's sole pane. A hard
+    /// requirement (no default) like `teardown()`: a conformer that routes pwd/title by role MUST
+    /// reassign here, so a future surface fails to compile rather than silently mis-reporting.
     func promoteToPrimaryPane()
-}
-
-public extension TerminalSurface {
-    /// Default no-op so adding this requirement stays source-compatible for conformers that route
-    /// pwd/title reports role-agnostically and have nothing to reassign. `GhosttySurfaceView` overrides
-    /// it (dynamically dispatched via the witness table) to clear its split-role flag.
-    func promoteToPrimaryPane() {}
 }
 
 /// The direction the search selection steps, in agterm's natural convention:

--- a/agtermCore/Sources/agtermCore/TerminalSurface.swift
+++ b/agtermCore/Sources/agtermCore/TerminalSurface.swift
@@ -20,6 +20,13 @@ public protocol TerminalSurface: AnyObject {
     func promoteToPrimaryPane()
 }
 
+public extension TerminalSurface {
+    /// Default no-op so adding this requirement stays source-compatible for conformers that route
+    /// pwd/title reports role-agnostically and have nothing to reassign. `GhosttySurfaceView` overrides
+    /// it (dynamically dispatched via the witness table) to clear its split-role flag.
+    func promoteToPrimaryPane() {}
+}
+
 /// The direction the search selection steps, in agterm's natural convention:
 /// `next` = forward = visually DOWN the screen (toward newer output), `previous` = back = visually UP
 /// (toward older scrollback). Host-free so the inversion to libghostty's own `navigate_search` strings is

--- a/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
@@ -770,17 +770,19 @@ struct AppStorePaneTests {
         }
     }
 
-    @Test func closePrimaryPaneLeavesRightTaggedStatus() {
+    @Test func closePrimaryPaneMigratesRightTaggedStatusToLeft() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
         session.surface = SpySurface(); session.splitSurface = SpySurface()
         session.isSplit = true; session.hasSplit = true
-        // the `.right` block is owned by the split, which becomes the promoted survivor — still clearable, keep it.
+        // the `.right` block is owned by the split, which is PROMOTED into the main slot — its status follows,
+        // re-tagged to `.left` (like the cwd/title migration) so `tree` (now split:false) and the survivor's
+        // left-role-aware keystroke-clear agree, instead of a self-contradictory split:false + statusPane:right.
         store.setAgentIndicator(AgentIndicator(status: .blocked, statusPane: .right), forSession: session.id)
         store.closePrimaryPane(session.id)
-        #expect(session.agentIndicator.status == .blocked)
-        #expect(session.agentIndicator.statusPane == .right)
+        #expect(session.agentIndicator.status == .blocked)   // the survivor's block persists across promotion
+        #expect(session.agentIndicator.statusPane == .left)  // re-tagged to the (now sole) main pane
     }
 
     @Test func closeScratchClearsScratchTaggedStatus() {

--- a/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
@@ -93,24 +93,35 @@ struct AppStorePaneTests {
         let split = SpySurface(); session.splitSurface = split
         session.isSplit = true
         session.hasSplit = true
+        session.splitFocused = true
         session.splitCwd = "/var/log"
+        session.splitTitle = "remote-host"
+        session.splitForegroundCommand = ["ssh", "host"]
         session.splitRatio = 0.3
         session.initialCommand = "ssh host" // a --command primary whose command has now exited
         store.closePrimaryPane(session.id)
         #expect(store.session(withID: session.id) != nil) // session survives
         #expect(primary.teardownCount == 1)               // the dead primary is torn down
         #expect(split.teardownCount == 0)                 // the survivor is kept
-        #expect(session.surface == nil)
-        #expect(session.splitSurface != nil)
+        #expect(split.promotedCount == 1)                 // the survivor is promoted to the primary role
+        // the survivor MOVES into the primary slot — the session is now a plain single pane
+        #expect(session.surface === split)
+        #expect(session.splitSurface == nil)
         #expect(session.isSplit == false)
         #expect(session.hasSplit == false)
-        #expect(session.splitFocused == true)             // the maximized survivor is shown
+        #expect(session.splitFocused == false)            // no split anymore; the survivor is the main pane
         #expect(session.splitRatio == nil)                // promoted to single, so a later split opens even
-        #expect(session.currentCwd == "/var/log")         // the survivor's cwd is promoted
         #expect(session.initialCommand == nil)            // the command pane is gone; a restart must NOT resurrect it
+        // the survivor's metadata migrates up to the session (main) fields, and the split fields clear
+        #expect(session.currentCwd == "/var/log")
+        #expect(session.oscTitle == "remote-host")
+        #expect(session.foregroundCommand == ["ssh", "host"])
+        #expect(session.splitCwd == nil)
+        #expect(session.splitTitle == nil)
+        #expect(session.splitForegroundCommand == nil)
         // the session-scoped control arms (session.copy/paste/selectall, font.*) must still reach the live
-        // shell: `surface` is nil here, so resolving through it alone would report "session not realized"
-        // for a session the user is actively typing in.
+        // shell: the survivor now sits IN `surface`, so `addressableSurface` resolves it through the primary
+        // slot (the `?? splitSurface` fallback is for a shown split pre-collapse, not for promotion).
         #expect(session.addressableSurface === split)
     }
 
@@ -135,6 +146,57 @@ struct AppStorePaneTests {
         let ws = store.addWorkspace(name: "work")
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
         #expect(session.addressableSurface == nil)        // never-shown session still errors "session not realized"
+    }
+
+    @Test func closePrimaryPaneKeepsSearchOwnedBySurvivor() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        let primary = SpySurface(); session.surface = primary
+        let split = SpySurface(); session.splitSurface = split
+        session.isSplit = true
+        session.hasSplit = true
+        session.searchActive = true       // the SURVIVING (split) pane owns an open search bar
+        session.searchSurface = split
+        store.closePrimaryPane(session.id)
+        #expect(session.searchActive)              // the survivor's search stays valid across promotion
+        #expect(session.searchSurface === split)
+    }
+
+    @Test func closePrimaryPaneClearsSearchOwnedByExitingPrimary() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        let primary = SpySurface(); session.surface = primary
+        let split = SpySurface(); session.splitSurface = split
+        session.isSplit = true
+        session.hasSplit = true
+        session.searchActive = true       // the EXITING primary owns the bar → reset it (no stuck bar)
+        session.searchSurface = primary
+        store.closePrimaryPane(session.id)
+        #expect(session.searchActive == false)
+        #expect(session.searchSurface == nil)
+    }
+
+    // Regression: after the primary exits and the split is promoted into the main slot, the promoted
+    // surface still carries the split pane's `onExit` (→ `closeSplitPane`). Since it is now the session's
+    // sole pane, that exit must CLOSE the session — not collapse a split that no longer exists, which left
+    // a zombie session with a torn-down surface before `closeSplitPane`'s guard was tightened.
+    @Test func closeSplitPaneAfterPromotionClosesSession() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        let primary = SpySurface(); session.surface = primary
+        let split = SpySurface(); session.splitSurface = split
+        session.isSplit = true
+        session.hasSplit = true
+        session.splitFocused = true
+        store.closePrimaryPane(session.id)                 // primary exits → split promoted into the main slot
+        #expect(session.surface === split)                 // precondition: the survivor is now the sole pane
+        #expect(session.splitSurface == nil)
+        store.closeSplitPane(session.id)                   // the survivor's stale split `onExit` fires
+        #expect(store.session(withID: session.id) == nil)  // last pane → session closed, no zombie
+        #expect(split.teardownCount == 1)                  // the promoted surface is torn down exactly once
     }
 
     @Test func closePrimaryPaneWithoutSplitClosesSession() {

--- a/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
@@ -199,6 +199,36 @@ struct AppStorePaneTests {
         #expect(split.teardownCount == 1)                  // the promoted surface is torn down exactly once
     }
 
+    // Regression (the fix `handlePaneExit` routes to): promote a survivor into the main slot, split AGAIN,
+    // then exit the (promoted) MAIN pane. Because the survivor's role is now primary, its exit runs
+    // `closePrimaryPane` — which must collapse onto the FRESH right pane (promote it, tear down the exited
+    // main), not the stale `closeSplitPane` that would tear down the new split and strand the dead main.
+    @Test func closePrimaryPaneAfterPromotionAndResplitCollapsesToNewSplit() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        let primary = SpySurface(); session.surface = primary
+        let firstSplit = SpySurface(); session.splitSurface = firstSplit
+        session.isSplit = true
+        session.hasSplit = true
+        session.splitFocused = true
+        store.closePrimaryPane(session.id)                 // primary exits → firstSplit promoted into main
+        #expect(session.surface === firstSplit)            // precondition: firstSplit is now the sole pane
+        #expect(session.splitSurface == nil)
+        // re-split the promoted single pane: a fresh right pane mounts beside the survivor.
+        let secondSplit = SpySurface(); session.splitSurface = secondSplit
+        session.isSplit = true
+        session.hasSplit = true
+        session.splitFocused = true
+        store.closePrimaryPane(session.id)                 // the promoted MAIN pane's own exit routes here
+        #expect(store.session(withID: session.id) != nil)  // session survives — the split is promoted, not lost
+        #expect(session.surface === secondSplit)           // the FRESH right pane took over the main slot
+        #expect(session.splitSurface == nil)
+        #expect(secondSplit.promotedCount == 1)            // it was promoted, not torn down
+        #expect(secondSplit.teardownCount == 0)
+        #expect(firstSplit.teardownCount == 1)             // the exited (promoted) main pane is torn down
+    }
+
     @Test func closePrimaryPaneWithoutSplitClosesSession() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
@@ -148,6 +148,27 @@ struct AppStorePaneTests {
         #expect(session.addressableSurface == nil)        // never-shown session still errors "session not realized"
     }
 
+    @Test func closePrimaryPaneUsesRestoredSplitCwdAndClearsTitleWhenSplitHasNoOSCYet() {
+        // a RESTORED split whose shell hasn't emitted OSC yet: `initialSplitCwd` is seeded but the live
+        // `splitCwd`/`splitTitle` are still nil. Exiting the primary must promote the survivor showing ITS
+        // restore-seed cwd and NO title — not the exited primary's cwd/title lingering until the survivor's
+        // next report.
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        session.surface = SpySurface()
+        session.splitSurface = SpySurface()
+        session.isSplit = true
+        session.hasSplit = true
+        session.currentCwd = "/primary"             // the exited primary's live cwd on the main field
+        session.oscTitle = "primary-title"          // the exited primary's title
+        session.initialSplitCwd = "/restored-split" // the survivor's restore-seed; no live splitCwd/splitTitle yet
+        store.closePrimaryPane(session.id)
+        #expect(session.currentCwd == "/restored-split") // the survivor's restore-seed cwd, not the primary's
+        #expect(session.oscTitle == nil)                 // the primary's title must NOT linger on the survivor
+        #expect(session.initialSplitCwd == nil)          // split fields cleared after promotion
+    }
+
     @Test func closePrimaryPaneKeepsSearchOwnedBySurvivor() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
@@ -788,9 +788,10 @@ struct AppStorePaneTests {
     @Test func setAgentIndicatorCoercesRightToLeftWithoutLiveSplit() {
         // a promoted survivor's shell keeps its baked `AGTERM_PANE=right`, so the agent-status hook re-emits
         // `--pane right` on every status AFTER promotion — but there is no right pane. `setAgentIndicator`
-        // coerces `.right` to `.left` when the session has no live `splitSurface`, so a post-promotion status
-        // can't re-create the `split:false` + `statusPane:"right"` contradiction and the sole `.left`-role-aware
-        // pane can still keystroke-clear it. (Drives what the agent-status wrapper does; host-free, CI-covered.)
+        // coerces `.right` to `.left` when the session has no split (`hasSplit` false), so a post-promotion
+        // status can't re-create the `split:false` + `statusPane:"right"` contradiction and the sole
+        // `.left`-role-aware pane can still keystroke-clear it. (Drives what the agent-status wrapper does;
+        // host-free, CI-covered.)
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         // an actual PROMOTED SURVIVOR: split, exit the primary (survivor promotes), then the still-.right-baked
@@ -798,7 +799,7 @@ struct AppStorePaneTests {
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
         session.surface = SpySurface(); session.splitSurface = SpySurface()
         session.isSplit = true; session.hasSplit = true
-        store.closePrimaryPane(session.id) // primary exits → survivor promoted, splitSurface == nil
+        store.closePrimaryPane(session.id) // primary exits → survivor promoted, hasSplit/splitSurface cleared
         store.setAgentIndicator(AgentIndicator(status: .blocked, statusPane: .right), forSession: session.id)
         #expect(session.agentIndicator.statusPane == .left)                      // coerced — no live split
         #expect(session.agentIndicator.clearedBy(pane: .left, isInterrupt: false))  // the sole (left) pane clears it
@@ -808,9 +809,34 @@ struct AppStorePaneTests {
         #expect(node?.statusPane == "left")
         // a session with a LIVE split keeps `.right` — the right pane really exists (incl. a hidden-but-live split).
         let split = store.addSession(toWorkspace: ws.id, cwd: "/b")!
-        split.splitSurface = SpySurface()
+        split.hasSplit = true; split.splitSurface = SpySurface()
         store.setAgentIndicator(AgentIndicator(status: .blocked, statusPane: .right), forSession: split.id)
         #expect(split.agentIndicator.statusPane == .right)                    // kept — a live split owns it
+    }
+
+    @Test func setAgentIndicatorKeepsRightDuringSplitRealization() {
+        // the realization window: `toggleSplit` sets `hasSplit` synchronously while the deck creates
+        // `splitSurface` a render pass later — so a scripted `session.split` + immediate
+        // `session.status --pane right` arrives with `hasSplit == true` but `splitSurface == nil`.
+        // `.right` is the correct forward tag there and must NOT be coerced to `.left`, or the realized
+        // split reports `split:true` + `statusPane:"left"` and only the LEFT pane could clear a block the
+        // RIGHT pane owns — the mirror of the promoted-survivor bug. Guards the `!hasSplit` predicate:
+        // the old `splitSurface == nil` gate rewrites this tag and fails the test.
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        session.surface = SpySurface()
+        store.toggleSplit(session.id) // hasSplit set synchronously; splitSurface not yet realized
+        #expect(session.hasSplit == true)
+        #expect(session.splitSurface == nil)
+        store.setAgentIndicator(AgentIndicator(status: .blocked, statusPane: .right), forSession: session.id)
+        #expect(session.agentIndicator.statusPane == .right)                  // kept — the split is coming up
+        // once the deck realizes the surface, the block is exactly where the right pane can clear it.
+        session.splitSurface = SpySurface()
+        #expect(session.agentIndicator.clearedBy(pane: .right, isInterrupt: false))
+        let node = store.controlTree().workspaces[0].sessions.first
+        #expect(node?.split == true)
+        #expect(node?.statusPane == "right")
     }
 
     @Test func closeScratchClearsScratchTaggedStatus() {

--- a/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
@@ -785,6 +785,34 @@ struct AppStorePaneTests {
         #expect(session.agentIndicator.statusPane == .left)  // re-tagged to the (now sole) main pane
     }
 
+    @Test func setAgentIndicatorCoercesRightToLeftWithoutLiveSplit() {
+        // a promoted survivor's shell keeps its baked `AGTERM_PANE=right`, so the agent-status hook re-emits
+        // `--pane right` on every status AFTER promotion — but there is no right pane. `setAgentIndicator`
+        // coerces `.right` to `.left` when the session has no live `splitSurface`, so a post-promotion status
+        // can't re-create the `split:false` + `statusPane:"right"` contradiction and the sole `.left`-role-aware
+        // pane can still keystroke-clear it. (Drives what the agent-status wrapper does; host-free, CI-covered.)
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        // an actual PROMOTED SURVIVOR: split, exit the primary (survivor promotes), then the still-.right-baked
+        // hook fires the next status — the reviewer's exact scenario.
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        session.surface = SpySurface(); session.splitSurface = SpySurface()
+        session.isSplit = true; session.hasSplit = true
+        store.closePrimaryPane(session.id) // primary exits → survivor promoted, splitSurface == nil
+        store.setAgentIndicator(AgentIndicator(status: .blocked, statusPane: .right), forSession: session.id)
+        #expect(session.agentIndicator.statusPane == .left)                      // coerced — no live split
+        #expect(session.agentIndicator.clearedBy(pane: .left, isInterrupt: false))  // the sole (left) pane clears it
+        // and the tree agrees: split:false with statusPane "left", never the contradictory "right".
+        let node = store.controlTree().workspaces[0].sessions.first
+        #expect(node?.split == false)
+        #expect(node?.statusPane == "left")
+        // a session with a LIVE split keeps `.right` — the right pane really exists (incl. a hidden-but-live split).
+        let split = store.addSession(toWorkspace: ws.id, cwd: "/b")!
+        split.splitSurface = SpySurface()
+        store.setAgentIndicator(AgentIndicator(status: .blocked, statusPane: .right), forSession: split.id)
+        #expect(split.agentIndicator.statusPane == .right)                    // kept — a live split owns it
+    }
+
     @Test func closeScratchClearsScratchTaggedStatus() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
@@ -522,25 +522,32 @@ struct AppStorePaneTests {
 
     @Test func controlTreeFontSizeReadsPromotedSurvivorViaAddressableSurface() throws {
         // regression: after the primary pane exits, the fontSize read-back must resolve through
-        // addressableSurface (the promoted split survivor) — the same surface the font default/left
-        // WRITE path targets — not bare `surface`, which is nil in that state. A closure over `surface`
-        // would report nothing for a session the user is actively typing in.
+        // addressableSurface — the same surface the font default/left WRITE path targets. With true
+        // promotion the survivor MOVES into `surface`, so addressableSurface === surface and the
+        // read-back keeps reporting the live shell across the collapse.
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
         session.surface = SpySurface()
-        session.splitSurface = SpySurface()
+        let survivor = SpySurface()
+        session.splitSurface = survivor
         session.isSplit = true
         session.hasSplit = true
-        store.closePrimaryPane(session.id)                 // primary exits -> surface nil, survivor promoted
-        #expect(session.surface == nil)
-        #expect(session.addressableSurface != nil)
-        // the app wires fontSize off addressableSurface: it reports the survivor's size here...
+        store.closePrimaryPane(session.id)                 // primary exits -> survivor promoted into `surface`
+        #expect(session.surface === survivor)
+        #expect(session.addressableSurface === survivor)
+        let promoted = store.controlTree(fontSize: { $0.addressableSurface != nil ? 13 : nil })
+        #expect(promoted.workspaces[0].sessions.first?.fontSize == 13)
+        // the `?? splitSurface` term is a defensive fallback now — hand-build the surface-less state it
+        // covers and keep the addressable-vs-bare-`surface` distinction guarded: a closure over bare
+        // `surface` reports nothing there, the addressable one still finds the live split shell.
+        let fallback = store.addSession(toWorkspace: ws.id, cwd: "/b")!
+        fallback.hasSplit = true
+        fallback.splitSurface = SpySurface()
         let viaAddressable = store.controlTree(fontSize: { $0.addressableSurface != nil ? 13 : nil })
-        #expect(viaAddressable.workspaces[0].sessions.first?.fontSize == 13)
-        // ...whereas the old wiring over the (now nil) `surface` would report nothing.
+        #expect(viaAddressable.workspaces[0].sessions.last?.fontSize == 13)
         let viaSurface = store.controlTree(fontSize: { $0.surface != nil ? 13 : nil })
-        #expect(viaSurface.workspaces[0].sessions.first?.fontSize == nil)
+        #expect(viaSurface.workspaces[0].sessions.last?.fontSize == nil)
     }
 
     @Test func controlTreeReportsSplitFocused() throws {

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTestFixtures.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTestFixtures.swift
@@ -20,5 +20,7 @@ import Foundation
 
 final class SpySurface: TerminalSurface {
     var teardownCount = 0
+    var promotedCount = 0
     func teardown() { teardownCount += 1 }
+    func promoteToPrimaryPane() { promotedCount += 1 }
 }

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -1459,6 +1459,7 @@ struct AppStoreTests {
         b.oscTitle = "remote:~/b"
         b.isSplit = true
         b.hasSplit = true
+        b.splitSurface = SpySurface() // a live split pane, so the `.right` status below stays valid
         b.overlayActive = true
         b.scratchActive = true
         b.flagged = true
@@ -1597,6 +1598,7 @@ struct AppStoreTests {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let session = try #require(store.addSession(toWorkspace: ws.id, cwd: "/repo"))
+        session.splitSurface = SpySurface() // a live split, so a `.right` status is valid (not coerced to `.left`)
         store.setAgentIndicator(AgentIndicator(status: .blocked, statusPane: .right), forSession: session.id)
 
         let node = try #require(store.controlTree().workspaces[0].sessions.first)

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -1598,6 +1598,7 @@ struct AppStoreTests {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let session = try #require(store.addSession(toWorkspace: ws.id, cwd: "/repo"))
+        session.hasSplit = true
         session.splitSurface = SpySurface() // a live split, so a `.right` status is valid (not coerced to `.left`)
         store.setAgentIndicator(AgentIndicator(status: .blocked, statusPane: .right), forSession: session.id)
 

--- a/agtermCore/Tests/agtermCoreTests/SessionTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SessionTests.swift
@@ -96,6 +96,22 @@ struct SessionTests {
         #expect(session.subtitleDetail == "user@web1: ~")
     }
 
+    @Test func promotedSurvivorTitleNotMaskedByStaleSplitFocused() {
+        // regression: a promoted survivor can momentarily carry `splitFocused == true` while it is the
+        // session's SOLE pane (`splitSurface == nil`, split fields cleared) — the split factory's focus
+        // callback keeps firing on it. The focus-aware readers must ignore that stale flag and surface the
+        // MIGRATED main-pane title/cwd, not the nil'd split fields (which would drop the SSH title).
+        let session = Session(initialCwd: "/Users/user", customName: "web1")
+        session.currentCwd = "/Users/user"
+        session.oscTitle = "user@web1: ~" // migrated up from the split on promotion
+        session.splitFocused = true        // stale — no split exists
+        session.splitSurface = nil
+        session.splitTitle = nil
+        session.splitCwd = nil
+        #expect(session.subtitleDetail == "user@web1: ~") // the migrated title, not the cwd
+        #expect(session.focusedCwd == "/Users/user")       // the main cwd, not an initialCwd fallback
+    }
+
     @Test func subtitleDetailUsesCwdForNamedSessionWithoutTitle() {
         // named local session: local auto-title is suppressed so oscTitle is nil; the second line is the cwd.
         let session = Session(initialCwd: "/Users/user/dev/foo", customName: "build")
@@ -138,6 +154,7 @@ struct SessionTests {
         // title (the split pane's while it has focus, else the primary's).
         let session = Session(initialCwd: "/repo", customName: "build")
         session.isSplit = true
+        session.splitSurface = FakeSurface() // a focused split always has a live split surface
         session.oscTitle = "primary-title"
         session.splitTitle = "split-title"
         #expect(session.subtitleDetail == "primary-title")
@@ -162,6 +179,7 @@ struct SessionTests {
         let session = Session(initialCwd: "/Users/user/dev/foo")
         session.currentCwd = "/Users/user/dev/foo"
         session.isSplit = true
+        session.splitSurface = FakeSurface() // a focused split always has a live split surface
         session.splitCwd = "/var/log"
         // split not focused: the primary pane drives name + cwd.
         #expect(session.displayName == "foo")
@@ -175,6 +193,7 @@ struct SessionTests {
     @Test func focusedPaneTitleWins() {
         let session = Session(initialCwd: "/repo")
         session.isSplit = true
+        session.splitSurface = FakeSurface() // a focused split always has a live split surface
         session.oscTitle = "primary-title"
         session.splitTitle = "split-title"
         #expect(session.displayName == "primary-title")
@@ -205,10 +224,13 @@ struct SessionTests {
     }
 
     @Test func focusedCwdFallsBackUntilSplitReports() {
-        // split focused but the split pane hasn't reported a cwd yet: fall back to the primary's.
+        // split focused and ALIVE, but the split pane hasn't reported a cwd yet: fall back to the primary's.
+        // splitSurface must be set (else the split-existence guard alone short-circuits) so this exercises
+        // the `let cwd = splitCwd` nil-fallback branch, not the missing-surface one.
         let session = Session(initialCwd: "/repo")
         session.currentCwd = "/repo/primary"
         session.isSplit = true
+        session.splitSurface = FakeSurface()
         session.splitFocused = true
         #expect(session.focusedCwd == "/repo/primary")
         #expect(session.displayName == "primary")
@@ -399,4 +421,5 @@ struct SessionTests {
 
 private final class FakeSurface: TerminalSurface {
     func teardown() {}
+    func promoteToPrimaryPane() {}
 }

--- a/agtermCore/Tests/agtermCoreTests/TerminalZoomTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/TerminalZoomTests.swift
@@ -35,7 +35,7 @@ struct TerminalZoomTests {
         #expect(!TerminalZoomController.isTargetValid(.session(session.id, .primary), in: store, quickTerminalVisible: false))
     }
 
-    @Test func splitTargetStaysValidWhenHiddenOrPromotedAndClearsWhenClosed() {
+    @Test func splitTargetStaysValidWhenHiddenAndClearsWhenPromotedOrClosed() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
@@ -48,35 +48,43 @@ struct TerminalZoomTests {
         #expect(session.hasSplit == true)
         #expect(TerminalZoomController.isTargetValid(.session(session.id, .split), in: store, quickTerminalVisible: false))
 
+        // the primary exits: the survivor is PROMOTED into the main slot, so no right pane exists
+        // anymore — a zoom on the split target must end, not keep covering the promoted main pane.
         session.surface = SpySurface()
         session.splitSurface = SpySurface()
         store.closePrimaryPane(session.id)
         #expect(session.hasSplit == false)
-        #expect(session.splitSurface != nil)
-        #expect(TerminalZoomController.isTargetValid(.session(session.id, .split), in: store, quickTerminalVisible: false))
+        #expect(session.splitSurface == nil)
+        #expect(!TerminalZoomController.isTargetValid(.session(session.id, .split), in: store, quickTerminalVisible: false))
 
+        // closing a live split clears the target the ordinary way too.
+        store.toggleSplit(session.id)
+        #expect(TerminalZoomController.isTargetValid(.session(session.id, .split), in: store, quickTerminalVisible: false))
         store.closeSplit(session.id)
         #expect(!TerminalZoomController.isTargetValid(.session(session.id, .split), in: store, quickTerminalVisible: false))
     }
 
-    @Test func primaryTargetClearsWhenPrimaryExitsAndSplitIsPromoted() {
+    @Test func primaryTargetStaysValidWhenPrimaryExitsAndSplitIsPromoted() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
 
         #expect(TerminalZoomController.isTargetValid(.session(session.id, .primary), in: store, quickTerminalVisible: false))
 
+        let survivor = SpySurface()
         session.surface = SpySurface()
-        session.splitSurface = SpySurface()
+        session.splitSurface = survivor
         session.isSplit = true
         session.hasSplit = true
         store.closePrimaryPane(session.id)
 
-        #expect(session.surface == nil)
-        #expect(session.splitSurface != nil)
-        #expect(session.splitFocused == true)
-        #expect(!TerminalZoomController.isTargetValid(.session(session.id, .primary), in: store, quickTerminalVisible: false))
-        #expect(TerminalZoomController.isTargetValid(.session(session.id, .split), in: store, quickTerminalVisible: false))
+        // the survivor MOVES into the primary slot: the primary target keeps pointing at the live
+        // shell (now the survivor), and the split target dies with the vacated right pane.
+        #expect(session.surface === survivor)
+        #expect(session.splitSurface == nil)
+        #expect(session.splitFocused == false)
+        #expect(TerminalZoomController.isTargetValid(.session(session.id, .primary), in: store, quickTerminalVisible: false))
+        #expect(!TerminalZoomController.isTargetValid(.session(session.id, .split), in: store, quickTerminalVisible: false))
     }
 
     @Test func scratchAndOverlayTargetsFollowActiveFlags() {

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -372,6 +372,47 @@ final class ControlAPIUITests: ControlAPITestCase {
         try? FileManager.default.removeItem(atPath: marker)
     }
 
+    // promote → re-split keystroke-clear: after the primary exits and the split survivor is promoted into
+    // the main slot, then a fresh split opens, typing a REAL keystroke in the promoted MAIN pane must NOT
+    // clear a `.right` block owned by the fresh split — the promoted survivor is the main (`.left`) pane now.
+    // Before the role-aware wireStatusClear fix the survivor stayed statically `.right`-wired, so main-pane
+    // typing wrongly cleared the split's `.right` block. Real keystrokes (not session.type inject) drive the
+    // onUserInputClearsStatus path; the socket sets + reads the status. Guards the role-aware clear + re-tag.
+    func testPromotedMainPaneDoesNotClearSplitRightStatus() throws {
+        let sid = try activeSessionID()
+
+        // open a split, focus the primary (left), and exit its shell so the right pane PROMOTES to main.
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.split","target":"\#(sid)","args":{"mode":"on"}}"#)["ok"] as? Bool, true)
+        RunLoop.current.run(until: Date().addingTimeInterval(1))
+        app.typeKey(.leftArrow, modifierFlags: [.command, .option])
+        RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+        app.typeText("exit")
+        app.typeKey(.return, modifierFlags: [])
+        RunLoop.current.run(until: Date().addingTimeInterval(2)) // shell exit + promotion + auto-focus
+
+        // re-split → a fresh right pane opens; block it (.right).
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.split","target":"\#(sid)","args":{"mode":"on"}}"#)["ok"] as? Bool, true)
+        RunLoop.current.run(until: Date().addingTimeInterval(1))
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.status","target":"\#(sid)","args":{"status":"blocked","pane":"right"}}"#)["ok"] as? Bool, true)
+        // sanity: the block is set before we test that typing elsewhere doesn't clear it.
+        var set = false
+        for _ in 0..<10 {
+            if (sessionNode(try sendCommand(#"{"cmd":"tree"}"#), id: sid)?["status"] as? String) == "blocked" { set = true; break }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+        }
+        XCTAssertTrue(set, "the .right block should be set before the keystroke test")
+
+        // type a REAL keystroke in the promoted MAIN (left) pane — must NOT clear the split's .right block.
+        app.typeKey(.leftArrow, modifierFlags: [.command, .option])
+        RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+        app.typeText("x")
+        RunLoop.current.run(until: Date().addingTimeInterval(1))
+
+        let tree = try sendCommand(#"{"cmd":"tree"}"#)
+        XCTAssertEqual(sessionNode(tree, id: sid)?["status"] as? String, "blocked",
+                       "typing in the promoted main pane must not clear the split pane's .right block")
+    }
+
     // session.new --name seeds the new session's custom name at creation (open a session already labeled,
     // without a follow-up rename). Verify the returned id carries the given name in the persisted snapshot.
     func testSessionNewWithName() throws {

--- a/agtermUITests/CustomCommandPaneTokenUITests.swift
+++ b/agtermUITests/CustomCommandPaneTokenUITests.swift
@@ -82,12 +82,11 @@ final class CustomCommandPaneTokenUITests: ControlAPITestCase {
     }
 
     // promoted single-pane: split on, then exit the PRIMARY (main/left) shell so `closePrimaryPane`
-    // promotes the survivor into the `splitSurface` slot (hasSplit=false, splitFocused=true, surface=nil).
-    // {AGT_PANE} must report "right": the survivor physically lives in splitSurface, so that's the pane
-    // `session.type --pane` reaches — a "left" here would name the torn-down main surface. Then prove the
-    // round-trip the token exists for: `session.type --pane <reported>` lands in the survivor's own buffer.
-    // This is the edge the review went back and forth on (reword-not-gate).
-    func testAgtPanePromotedSurvivorReportsRight() throws {
+    // promotes the survivor INTO the main slot (surface=survivor, splitSurface=nil, hasSplit=false,
+    // splitFocused=false — a plain single pane). {AGT_PANE} must report "left": the survivor is now the
+    // main pane, and `session.type --pane left` reaches it. Then prove the round-trip the token exists
+    // for: `session.type --pane <reported>` lands in the promoted pane's own buffer.
+    func testAgtPanePromotedSurvivorReportsLeft() throws {
         let marker = markerDir.appendingPathComponent("agt-pane-promoted")
         try relaunch(withKeymap: "command \"Pane Probe\" printf %s \"$AGT_PANE\" > \"\(marker.path)\"\n")
 
@@ -107,11 +106,12 @@ final class CustomCommandPaneTokenUITests: ControlAPITestCase {
         }
         XCTAssertTrue(promoted, "exiting the primary pane should promote the survivor to a single (non-split) pane")
 
-        // palette path: the promoted survivor has splitFocused=true AND splitSurface != nil, so run() reports right.
+        // palette path: the promoted survivor is now the main pane (splitSurface == nil, splitFocused ==
+        // false), so run() reports left.
         try? FileManager.default.removeItem(at: marker)
         runFromCustomCommandsPalette("Pane Probe")
         let reported = pollMarker(marker, timeout: 5)
-        XCTAssertEqual(reported, "right", "a promoted split survivor should report $AGT_PANE=right")
+        XCTAssertEqual(reported, "left", "a promoted split survivor is the main pane, so $AGT_PANE=left")
 
         // round-trip: session.type --pane <reported> must reach THAT pane's buffer (the survivor). Typed as
         // `$((6*7))` arithmetic so a match proves the survivor's shell RAN the line, not merely echoed it.

--- a/agtermUITests/SplitUITests.swift
+++ b/agtermUITests/SplitUITests.swift
@@ -274,6 +274,64 @@ final class SplitUITests: XCTestCase {
         XCTAssertEqual(survivorTTY, rightTTY, "after exiting the primary, the surviving right pane is focused")
     }
 
+    // promote → re-split → exit-main: the round-1 zombie scenario, driven through the REAL pane-exit
+    // routing (typing `exit`, not calling closePrimaryPane directly like the host-free test). After the
+    // primary exits, the right pane promotes into the sole/main slot; a fresh split then opens a new right
+    // pane; exiting the promoted MAIN pane must route through closePrimaryPane (dispatched on the surface's
+    // LIVE role, now primary) and collapse onto the FRESH right pane — not through the survivor's stale
+    // split onExit, which would tear the fresh right down and strand the dead main. The tell: the final
+    // command reaches the fresh right shell. This is the only test that guards the role-aware dispatch;
+    // reverting it strands the session, failing the last assertion.
+    func testPromoteThenResplitThenExitMainCollapsesToFreshSplit() throws {
+        let row = app.staticTexts["session-row"]
+        XCTAssertTrue(row.waitForExistence(timeout: 20), "seeded session should exist")
+        row.click()
+        usleep(800_000)
+
+        let splitButton = app.buttons["split-toggle"]
+        XCTAssertTrue(splitButton.waitForExistence(timeout: 5), "split toolbar button should exist")
+
+        // open the split, focus the right pane, record its tty — this is the survivor that promotes.
+        splitButton.click()
+        usleep(800_000)
+        app.typeKey(.rightArrow, modifierFlags: [.command, .option])
+        usleep(500_000)
+        let promotedTTY = ttyAfterCommand(named: "promoted")
+        XCTAssertNotNil(promotedTTY, "right shell should write its tty")
+
+        // exit the primary (left) shell → the right pane promotes into the sole/main pane and holds focus.
+        app.typeKey(.leftArrow, modifierFlags: [.command, .option])
+        usleep(500_000)
+        app.typeText("exit")
+        app.typeKey(.return, modifierFlags: [])
+        usleep(1_500_000) // shell exit + promotion + auto-focus retry
+        XCTAssertTrue(row.waitForExistence(timeout: 5), "exiting the primary must keep the session (promoted survivor)")
+        XCTAssertEqual(ttyAfterCommand(named: "after-promote"), promotedTTY,
+                       "the promoted survivor is the session's sole pane and holds focus")
+
+        // split AGAIN → a fresh right pane opens and takes focus (a separate shell from the promoted main).
+        splitButton.click()
+        usleep(800_000)
+        let freshRightTTY = ttyAfterCommand(named: "fresh-right")
+        XCTAssertNotNil(freshRightTTY, "the re-split's fresh right shell should write its tty")
+        XCTAssertNotEqual(freshRightTTY, promotedTTY, "re-split opens a fresh right pane, distinct from the promoted main")
+
+        // focus the promoted MAIN (left) pane and exit its shell. Its exit must route through
+        // closePrimaryPane (live role = primary after promotion) and collapse onto the FRESH right pane —
+        // NOT closeSplitPane, which would tear the fresh right down and strand the dead main (round-1 bug).
+        app.typeKey(.leftArrow, modifierFlags: [.command, .option])
+        usleep(500_000)
+        app.typeText("exit")
+        app.typeKey(.return, modifierFlags: [])
+        usleep(1_500_000)
+
+        XCTAssertTrue(row.waitForExistence(timeout: 5), "exiting the promoted main pane must keep the session")
+        // type WITHOUT focusing — the fresh right pane must be the survivor and hold focus, so the command
+        // reaches its shell (a torn-down fresh right / stranded dead main would fail this).
+        XCTAssertEqual(ttyAfterCommand(named: "final"), freshRightTTY,
+                       "exiting the promoted main collapses onto the fresh right pane, not tears it down")
+    }
+
     // mirror of the above for exiting the split (right) pane: the session survives, collapsed to the
     // primary, and the primary holds focus.
     func testExitSplitPaneKeepsSessionAndFocusesSurvivor() throws {


### PR DESCRIPTION
### Background

#90 made split panes addressable as `left`/`right` (`session.type --pane`, the `{AGT_PANE}` keymap token). It shipped an **interim contract**: when the primary (left) pane's shell exited and the split survived, the survivor stayed parked in the `splitSurface` slot, so `{AGT_PANE}` reported `right` and `session.type --pane right` reached it — a `left` there would have named the torn-down main surface. Correct, but leaky: the session showed a single maximized pane yet answered to `right`, and a later `session.split` would displace the survivor instead of opening beside it.

This PR removes that wart. `closePrimaryPane` now **moves** the survivor into the main slot, so a collapsed-to-single session is indistinguishable from a fresh single pane.

### What changed

On primary exit with a live split:
- `survivor.promoteToPrimaryPane()` — new `TerminalSurface` method — flips the surface's split-role flag so its pwd/title reports route to the main fields.
- `surface = survivor`, `splitSurface = nil`, `splitFocused = false`, `hasSplit = false`, `splitRatio = nil`.
- `splitCwd`/`splitTitle`/`splitForegroundCommand` migrate up to `currentCwd`/`oscTitle`/`foregroundCommand`; the split fields clear. `foregroundCommand` is replaced outright (never falls back) so the dead primary's captured command can't linger.

Result: `session.type`/`session.text --pane left` (and omitted) reach the survivor, `{AGT_PANE}` reports `left`, `session.focus` errors (no split), and a later `session.split` opens a fresh right pane beside it. Supersedes the interim "promoted survivor reports `right`" contract from #90.

### Correctness fixes (found in review)

- **Zombie-session leak** — a promoted survivor keeps the split pane's `onExit` (→ `closeSplitPane`), so its own exit routed there. Tightened the guard (`surface != nil && splitSurface != nil`) to close the session rather than collapse a split that no longer exists.
- **Stale `splitFocused`** — `makeSplitSurface.onFocusChange` now sets `splitFocused = view.isSplitPane` (was hardcoded `true`), so a promoted survivor stops re-raising the flag, which otherwise masked its migrated title and mis-routed focus after a re-split.
- `focusedCwd`/`focusedOscTitle` now guard on `splitFocused && splitSurface != nil` (the `activeSurface` idiom) — robust to a stale/creation-race flag.
- The survivor adopts `onFontSizeChange` so its font persists like a real primary; a survivor-owned search bar is preserved across promotion (only a primary-owned bar resets).

### Tests

- Host-free (`swift test`): promotion migrates metadata + clears split fields; search kept when survivor-owned / cleared when primary-owned; `closeSplitPane` after promotion closes the session (no zombie); promoted survivor's title not masked by stale `splitFocused`.
- e2e: `testAgtPanePromotedSurvivorReportsLeft` (was `…ReportsRight`) — split, exit primary, assert `$AGT_PANE=left`, prove `session.type --pane left` lands in the survivor's buffer.

### Docs

`CustomCommand.pane`, `keymap.md`, `control-api.md`, `menu-actions.md` updated to the new `left` contract.
