### PR TITLE
refactor(control): backfill dispatcher session workspace routes

### DIFF
--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -118,6 +118,78 @@ extension ControlServer: ControlActions {
         }
     }
 
+    func selectSession(_ target: String?, window: String?) -> ControlResponse {
+        resolver.resolveSession(target, window: window) { store, id in
+            store.selectSession(id)
+            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
+        }
+    }
+
+    func goSession(window: String?, direction: SessionNavigation) -> ControlResponse {
+        // relative navigation acts on the store's current selection, so no session target -- just
+        // the frontmost-or-`--window` store.
+        resolver.resolvePlacementStore(window) { store in
+            store.navigateSession(direction)
+            guard let id = store.selectedSessionID else {
+                return ControlResponse(ok: false, error: "no session to navigate")
+            }
+            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
+        }
+    }
+
+    func closeSession(_ target: String?, window: String?) -> ControlResponse {
+        resolver.resolveSession(target, window: window) { store, id in
+            store.closeSession(id)
+            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
+        }
+    }
+
+    func renameSession(_ target: String?, window: String?, name: String) -> ControlResponse {
+        resolver.resolveSession(target, window: window) { store, id in
+            store.renameSession(id, to: name)
+            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
+        }
+    }
+
+    func createWorkspace(window: String?, name: String?) -> ControlResponse {
+        // placement target: the window's frontmost store (or `args.window`'s). name defaults to
+        // the auto-generated workspace name when none is given.
+        resolver.resolvePlacementStore(window) { store in
+            let name = trimmed(name) ?? store.defaultWorkspaceName
+            let workspace = store.addWorkspace(name: name)
+            return ControlResponse(ok: true, result: ControlResult(id: workspace.id.uuidString))
+        }
+    }
+
+    func selectWorkspace(_ target: String?, window: String?) -> ControlResponse {
+        // selecting a workspace selects its first session (workspace rows are not selectable on
+        // their own); an empty workspace just clears nothing and reports the workspace id.
+        resolver.resolveWorkspace(target, window: window) { store, id in
+            if let first = store.workspaces.first(where: { $0.id == id })?.sessions.first {
+                store.selectSession(first.id)
+            }
+            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
+        }
+    }
+
+    func renameWorkspace(_ target: String?, window: String?, name: String) -> ControlResponse {
+        resolver.resolveWorkspace(target, window: window) { store, id in
+            store.renameWorkspace(id, to: name)
+            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
+        }
+    }
+
+    func deleteWorkspace(_ target: String?, window: String?) -> ControlResponse {
+        // honors keep-at-least-one; returns an error rather than the GUI confirm alert.
+        resolver.resolveWorkspace(target, window: window) { store, id in
+            guard store.canRemoveWorkspace else {
+                return ControlResponse(ok: false, error: "cannot delete last workspace")
+            }
+            store.removeWorkspace(id)
+            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
+        }
+    }
+
     /// Resolve the target session and drive the split directly on its owning store (NOT the
     /// argument-less `AppActions.toggleSplit()`, which only acts on the active session). `mode` is
     /// `on|off|toggle`, computed against the session's current `isSplit` so `on`/`off` are

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -340,77 +340,14 @@ final class ControlServer {
             return response
         }
         switch request.cmd {
-        case .tree, .sessionNew, .sessionMove, .workspaceMove, .workspaceFocus, .sessionSplit,
-                .sessionScratch, .sessionFocus, .sessionResize, .sessionStatus, .sessionFlag,
-                .notify, .fontInc, .fontDec, .fontReset, .keymapReload, .configReload,
-                .themeSet, .themeList, .sidebar, .sidebarMode, .sidebarExpand, .sidebarCollapse,
-                .sessionType, .sessionCopy, .sessionOverlayOpen, .sessionOverlayClose, .sessionOverlayResult:
+        case .tree, .sessionNew, .sessionSelect, .sessionGo, .sessionClose, .sessionRename,
+                .workspaceNew, .workspaceSelect, .workspaceRename, .workspaceDelete,
+                .sessionMove, .workspaceMove, .workspaceFocus, .sessionSplit, .sessionScratch,
+                .sessionFocus, .sessionResize, .sessionStatus, .sessionFlag, .notify,
+                .fontInc, .fontDec, .fontReset, .keymapReload, .configReload, .themeSet, .themeList,
+                .sidebar, .sidebarMode, .sidebarExpand, .sidebarCollapse, .sessionType, .sessionCopy,
+                .sessionOverlayOpen, .sessionOverlayClose, .sessionOverlayResult:
             return ControlResponse(ok: false, error: "control dispatcher did not handle \(request.cmd.rawValue)")
-        case .sessionSelect:
-            return resolver.resolveSession(request.target, window: request.args?.window) { store, id in
-                store.selectSession(id)
-                return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
-            }
-        case .sessionGo:
-            // relative navigation acts on the store's current selection, so no session target — just
-            // the frontmost-or-`--window` store. unknown/missing `to` is a structured error.
-            guard let dir = (request.args?.to).flatMap(SessionNavigation.init(wire:)) else {
-                return ControlResponse(ok: false, error: "session.go requires --to next|prev|first|last|next-attention|prev-attention")
-            }
-            return resolver.resolvePlacementStore(request.args?.window) { store in
-                store.navigateSession(dir)
-                guard let id = store.selectedSessionID else {
-                    return ControlResponse(ok: false, error: "no session to navigate")
-                }
-                return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
-            }
-        case .workspaceSelect:
-            // selecting a workspace selects its first session (workspace rows are not selectable on
-            // their own); an empty workspace just clears nothing and reports the workspace id.
-            return resolver.resolveWorkspace(request.target, window: request.args?.window) { store, id in
-                if let first = store.workspaces.first(where: { $0.id == id })?.sessions.first {
-                    store.selectSession(first.id)
-                }
-                return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
-            }
-        case .workspaceNew:
-            // placement target: the window's frontmost store (or `args.window`'s). name defaults to
-            // the auto-generated workspace name when none is given.
-            return resolver.resolvePlacementStore(request.args?.window) { store in
-                let name = trimmed(request.args?.name) ?? store.defaultWorkspaceName
-                let workspace = store.addWorkspace(name: name)
-                return ControlResponse(ok: true, result: ControlResult(id: workspace.id.uuidString))
-            }
-        case .workspaceRename:
-            guard let name = trimmed(request.args?.name) else {
-                return ControlResponse(ok: false, error: "workspace.rename requires a name")
-            }
-            return resolver.resolveWorkspace(request.target, window: request.args?.window) { store, id in
-                store.renameWorkspace(id, to: name)
-                return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
-            }
-        case .workspaceDelete:
-            // honors keep-at-least-one; returns an error rather than the GUI confirm alert.
-            return resolver.resolveWorkspace(request.target, window: request.args?.window) { store, id in
-                guard store.canRemoveWorkspace else {
-                    return ControlResponse(ok: false, error: "cannot delete last workspace")
-                }
-                store.removeWorkspace(id)
-                return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
-            }
-        case .sessionClose:
-            return resolver.resolveSession(request.target, window: request.args?.window) { store, id in
-                store.closeSession(id)
-                return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
-            }
-        case .sessionRename:
-            guard let name = request.args?.name else {
-                return ControlResponse(ok: false, error: "session.rename requires a name")
-            }
-            return resolver.resolveSession(request.target, window: request.args?.window) { store, id in
-                store.renameSession(id, to: name)
-                return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
-            }
         case .sessionBackground:
             return setBackground(request.target, request.args)
         case .sessionText:

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -7,6 +7,14 @@ import Foundation
 public protocol ControlActions {
     func controlTree(window: String?) -> ControlResponse
     func createSession(_ options: ControlSessionCreateOptions) -> ControlResponse
+    func selectSession(_ target: String?, window: String?) -> ControlResponse
+    func goSession(window: String?, direction: SessionNavigation) -> ControlResponse
+    func closeSession(_ target: String?, window: String?) -> ControlResponse
+    func renameSession(_ target: String?, window: String?, name: String) -> ControlResponse
+    func createWorkspace(window: String?, name: String?) -> ControlResponse
+    func selectWorkspace(_ target: String?, window: String?) -> ControlResponse
+    func renameWorkspace(_ target: String?, window: String?, name: String) -> ControlResponse
+    func deleteWorkspace(_ target: String?, window: String?) -> ControlResponse
     func moveSession(_ target: String?, window: String?, move: ControlSessionMove) -> ControlResponse
     func moveWorkspace(_ target: String?, window: String?, direction: ReorderDirection) -> ControlResponse
     func focusWorkspace(_ target: String?, window: String?, mode: String?) -> ControlResponse
@@ -93,6 +101,33 @@ public struct ControlDispatcher {
                 command: args?.command,
                 name: args?.name
             ))
+        case .sessionSelect:
+            return actions.selectSession(request.target, window: request.args?.window)
+        case .sessionGo:
+            // unknown/missing `to` is a structured error.
+            guard let dir = (request.args?.to).flatMap(SessionNavigation.init(wire:)) else {
+                return ControlResponse(ok: false, error: "session.go requires --to next|prev|first|last|next-attention|prev-attention")
+            }
+            return actions.goSession(window: request.args?.window, direction: dir)
+        case .sessionClose:
+            return actions.closeSession(request.target, window: request.args?.window)
+        case .sessionRename:
+            guard let name = request.args?.name else {
+                return ControlResponse(ok: false, error: "session.rename requires a name")
+            }
+            return actions.renameSession(request.target, window: request.args?.window, name: name)
+        case .workspaceNew:
+            return actions.createWorkspace(window: request.args?.window, name: request.args?.name)
+        case .workspaceSelect:
+            return actions.selectWorkspace(request.target, window: request.args?.window)
+        case .workspaceRename:
+            guard let name = request.args?.name?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !name.isEmpty else {
+                return ControlResponse(ok: false, error: "workspace.rename requires a name")
+            }
+            return actions.renameWorkspace(request.target, window: request.args?.window, name: name)
+        case .workspaceDelete:
+            return actions.deleteWorkspace(request.target, window: request.args?.window)
         case .sessionMove:
             if request.args?.to != nil && request.args?.workspace != nil {
                 return ControlResponse(ok: false, error: "session.move takes either --to or a workspace, not both")

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -136,6 +136,109 @@ struct ControlDispatcherTests {
         #expect(actions.calls.isEmpty)
     }
 
+    @Test func sessionSelectGoCloseAndRenameRouteThroughActions() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let selected = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionSelect,
+            target: "session",
+            args: ControlArgs(window: "win")
+        ))
+        let navigated = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionGo,
+            args: ControlArgs(window: "win", to: "next-attention")
+        ))
+        let closed = await dispatcher.dispatch(ControlRequest(cmd: .sessionClose, target: "session"))
+        let renamed = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionRename,
+            target: "session",
+            args: ControlArgs(name: "api")
+        ))
+
+        #expect(selected == ControlResponse(ok: true))
+        #expect(navigated == ControlResponse(ok: true))
+        #expect(closed == ControlResponse(ok: true))
+        #expect(renamed == ControlResponse(ok: true))
+        #expect(actions.calls == [
+            .sessionSelect(target: "session", window: "win"),
+            .sessionGo(window: "win", .nextAttention),
+            .sessionClose(target: "session", window: nil),
+            .sessionRename(target: "session", window: nil, "api")
+        ])
+    }
+
+    @Test func sessionGoAndRenameRejectInvalidInputsWithoutCallingActions() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let missingDirection = await dispatcher.dispatch(ControlRequest(cmd: .sessionGo))
+        let badDirection = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionGo,
+            args: ControlArgs(to: "sideways")
+        ))
+        let missingName = await dispatcher.dispatch(ControlRequest(cmd: .sessionRename, target: "session"))
+
+        #expect(missingDirection == ControlResponse(
+            ok: false,
+            error: "session.go requires --to next|prev|first|last|next-attention|prev-attention"
+        ))
+        #expect(badDirection == ControlResponse(
+            ok: false,
+            error: "session.go requires --to next|prev|first|last|next-attention|prev-attention"
+        ))
+        #expect(missingName == ControlResponse(ok: false, error: "session.rename requires a name"))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test func workspaceCommandsRouteThroughActions() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let created = await dispatcher.dispatch(ControlRequest(
+            cmd: .workspaceNew,
+            args: ControlArgs(name: "api", window: "win")
+        ))
+        let selected = await dispatcher.dispatch(ControlRequest(
+            cmd: .workspaceSelect,
+            target: "workspace",
+            args: ControlArgs(window: "win")
+        ))
+        let renamed = await dispatcher.dispatch(ControlRequest(
+            cmd: .workspaceRename,
+            target: "workspace",
+            args: ControlArgs(name: "  renamed  ")
+        ))
+        let deleted = await dispatcher.dispatch(ControlRequest(cmd: .workspaceDelete, target: "workspace"))
+
+        #expect(created == ControlResponse(ok: true))
+        #expect(selected == ControlResponse(ok: true))
+        #expect(renamed == ControlResponse(ok: true))
+        #expect(deleted == ControlResponse(ok: true))
+        #expect(actions.calls == [
+            .workspaceNew(window: "win", "api"),
+            .workspaceSelect(target: "workspace", window: "win"),
+            .workspaceRename(target: "workspace", window: nil, "renamed"),
+            .workspaceDelete(target: "workspace", window: nil)
+        ])
+    }
+
+    @Test func workspaceRenameRejectsMissingOrBlankNameWithoutCallingActions() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let missing = await dispatcher.dispatch(ControlRequest(cmd: .workspaceRename, target: "workspace"))
+        let blank = await dispatcher.dispatch(ControlRequest(
+            cmd: .workspaceRename,
+            target: "workspace",
+            args: ControlArgs(name: "   ")
+        ))
+
+        #expect(missing == ControlResponse(ok: false, error: "workspace.rename requires a name"))
+        #expect(blank == ControlResponse(ok: false, error: "workspace.rename requires a name"))
+        #expect(actions.calls.isEmpty)
+    }
+
     @Test func sessionMoveRoutesReorderAndWorkspaceForms() async {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)
@@ -570,7 +673,7 @@ struct ControlDispatcherTests {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)
 
-        let response = await dispatcher.dispatch(ControlRequest(cmd: .sessionSelect))
+        let response = await dispatcher.dispatch(ControlRequest(cmd: .sessionText))
 
         #expect(response == nil)
         #expect(actions.calls.isEmpty)
@@ -582,6 +685,14 @@ private final class MockControlActions: ControlActions {
     enum Call: Equatable {
         case tree(window: String?)
         case sessionNew(ControlSessionCreateOptions)
+        case sessionSelect(target: String?, window: String?)
+        case sessionGo(window: String?, SessionNavigation)
+        case sessionClose(target: String?, window: String?)
+        case sessionRename(target: String?, window: String?, String)
+        case workspaceNew(window: String?, String?)
+        case workspaceSelect(target: String?, window: String?)
+        case workspaceRename(target: String?, window: String?, String)
+        case workspaceDelete(target: String?, window: String?)
         case sessionMove(target: String?, window: String?, ControlSessionMove)
         case workspaceMove(target: String?, window: String?, ReorderDirection)
         case workspaceFocus(target: String?, window: String?, String?)
@@ -635,6 +746,46 @@ private final class MockControlActions: ControlActions {
     func createSession(_ options: ControlSessionCreateOptions) -> ControlResponse {
         calls.append(.sessionNew(options))
         return nextSessionNewResponse
+    }
+
+    func selectSession(_ target: String?, window: String?) -> ControlResponse {
+        calls.append(.sessionSelect(target: target, window: window))
+        return ControlResponse(ok: true)
+    }
+
+    func goSession(window: String?, direction: SessionNavigation) -> ControlResponse {
+        calls.append(.sessionGo(window: window, direction))
+        return ControlResponse(ok: true)
+    }
+
+    func closeSession(_ target: String?, window: String?) -> ControlResponse {
+        calls.append(.sessionClose(target: target, window: window))
+        return ControlResponse(ok: true)
+    }
+
+    func renameSession(_ target: String?, window: String?, name: String) -> ControlResponse {
+        calls.append(.sessionRename(target: target, window: window, name))
+        return ControlResponse(ok: true)
+    }
+
+    func createWorkspace(window: String?, name: String?) -> ControlResponse {
+        calls.append(.workspaceNew(window: window, name))
+        return ControlResponse(ok: true)
+    }
+
+    func selectWorkspace(_ target: String?, window: String?) -> ControlResponse {
+        calls.append(.workspaceSelect(target: target, window: window))
+        return ControlResponse(ok: true)
+    }
+
+    func renameWorkspace(_ target: String?, window: String?, name: String) -> ControlResponse {
+        calls.append(.workspaceRename(target: target, window: window, name))
+        return ControlResponse(ok: true)
+    }
+
+    func deleteWorkspace(_ target: String?, window: String?) -> ControlResponse {
+        calls.append(.workspaceDelete(target: target, window: window))
+        return ControlResponse(ok: true)
     }
 
     func moveSession(_ target: String?, window: String?, move: ControlSessionMove) -> ControlResponse {


### PR DESCRIPTION
## Summary
- route remaining simple session/workspace control commands through `ControlDispatcher`
- keep app-side resolver/store behavior in the `ControlActions` adapter
- add focused dispatcher tests for migrated success paths and exact guard errors

## Scope
Migrated `session.select`, `session.go`, `session.close`, `session.rename`, `workspace.new`, `workspace.select`, `workspace.rename`, and `workspace.delete`.

Left surface/UI/global commands inline: `session.text`, `session.background`, `session.search`, `quick`, `restore.clear`, and `window.*`.

## Validation
- `make lint`
- `swift test`
- `make build`

## Notes
This is intended as a pure refactor: validation order, response strings, response shapes, resolver calls, and store mutations are preserved.