### PR TITLE
feat: pointing-hand cursor on link hover + validated link open (#125)

### DIFF
--- a/agterm/Ghostty/GhosttyCallbacks.swift
+++ b/agterm/Ghostty/GhosttyCallbacks.swift
@@ -112,6 +112,21 @@ final class GhosttyCallbacks: @unchecked Sendable {
             let hidden = action.action.mouse_visibility == GHOSTTY_MOUSE_HIDDEN
             DispatchQueue.main.async { NSCursor.setHiddenUntilMouseMoves(hidden) }
             return true
+        case GHOSTTY_ACTION_MOUSE_SHAPE:
+            // libghostty requests a mouse cursor shape for this surface — the pointing hand over a detected
+            // link / OSC-8 hyperlink, the I-beam over the grid, resize/crosshair in the matching modes.
+            // Recover the surface and apply the mapped NSCursor via its cursor rects.
+            guard let view = surfaceView(from: target) else { return true }
+            let shape = action.action.mouse_shape
+            DispatchQueue.main.async { view.applyMouseShape(shape) }
+            return true
+        case GHOSTTY_ACTION_OPEN_URL:
+            // a click opened a detected link / OSC-8 hyperlink. Copy the URL out of the C string
+            // synchronously (only valid for this call), then open it scheme-validated on the main actor.
+            guard let view = surfaceView(from: target), let ptr = action.action.open_url.url else { return true }
+            let link = String(cString: ptr)
+            DispatchQueue.main.async { view.openLink(link) }
+            return true
         default:
             return false
         }

--- a/agterm/Ghostty/GhosttyCallbacks.swift
+++ b/agterm/Ghostty/GhosttyCallbacks.swift
@@ -115,16 +115,19 @@ final class GhosttyCallbacks: @unchecked Sendable {
         case GHOSTTY_ACTION_MOUSE_SHAPE:
             // libghostty requests a mouse cursor shape for this surface — the pointing hand over a detected
             // link / OSC-8 hyperlink, the I-beam over the grid, resize/crosshair in the matching modes.
-            // Recover the surface and apply the mapped NSCursor via its cursor rects.
+            // recover the surface and apply the mapped NSCursor via its cursor rects.
             guard let view = surfaceView(from: target) else { return true }
             let shape = action.action.mouse_shape
             DispatchQueue.main.async { view.applyMouseShape(shape) }
             return true
         case GHOSTTY_ACTION_OPEN_URL:
-            // a click opened a detected link / OSC-8 hyperlink. Copy the URL out of the C string
-            // synchronously (only valid for this call), then open it scheme-validated on the main actor.
-            guard let view = surfaceView(from: target), let ptr = action.action.open_url.url else { return true }
-            let link = String(cString: ptr)
+            // a click opened a detected link / OSC-8 hyperlink. copy the URL out of the LENGTH-DELIMITED C
+            // buffer synchronously (only valid for this call; `open_url.url` is NOT NUL-terminated — it is a
+            // Zig slice, so honor `.len` instead of `String(cString:)`, which would over-read into adjacent
+            // hyperlink storage), then open it scheme-validated on the main actor.
+            let openURL = action.action.open_url
+            guard let view = surfaceView(from: target), let ptr = openURL.url else { return true }
+            let link = String(decoding: UnsafeRawBufferPointer(start: ptr, count: Int(openURL.len)), as: UTF8.self)
             DispatchQueue.main.async { view.openLink(link) }
             return true
         default:

--- a/agterm/Ghostty/GhosttySurfaceView+Input.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Input.swift
@@ -195,12 +195,23 @@ extension GhosttySurfaceView {
         ghostty_surface_mouse_pos(surface, pt.x, pt.y, mods(event))
     }
 
+    /// The pointer entered the surface: restore libghostty's mouse position from the current point. Paired
+    /// with `mouseExited`'s `-1, -1` reset — without it, `scrollWheel` (which never sets `mouse_pos`) would
+    /// report a scroll at the stale `-1, -1` if you scroll right after re-entering, before any move, inside
+    /// a mouse-reporting TUI (vim/less/htop).
+    override func mouseEntered(with event: NSEvent) {
+        guard let surface else { return }
+        let pt = mousePoint(from: event)
+        ghostty_surface_mouse_pos(surface, pt.x, pt.y, mods(event))
+    }
+
     /// The pointer left the surface. Report negative coordinates so libghostty clears any hovered-link
     /// state — it drops `over_link`, reverts the mouse shape, and re-renders without the underline (see its
     /// `cursorPosCallback`). Without this a ⌘-hovered link stays highlighted after the mouse leaves the
-    /// terminal (into the sidebar, another window, or off the edge) until ⌘ is released.
+    /// terminal (into the sidebar, another window, or off the edge) until ⌘ is released. Skipped mid-drag
+    /// (a button is down) so a selection/drag that crosses the edge isn't reported at `-1, -1`.
     override func mouseExited(with event: NSEvent) {
-        guard let surface else { return }
+        guard let surface, NSEvent.pressedMouseButtons == 0 else { return }
         ghostty_surface_mouse_pos(surface, -1, -1, mods(event))
     }
 
@@ -408,12 +419,11 @@ extension GhosttySurfaceView: @preconcurrency NSTextInputClient {
         }
     }
 
-    /// Opens a URL from a link click (`GHOSTTY_ACTION_OPEN_URL`). Scheme-validated first: a terminal
-    /// renders untrusted program output, so only web/mail/file links are followed — never an arbitrary
-    /// custom scheme that could hand off to another app. Silently ignores anything else.
+    /// Opens a URL from a link click (`GHOSTTY_ACTION_OPEN_URL`). The scheme allowlist lives in the
+    /// host-free `LinkPolicy` (unit-tested); this is just the AppKit glue. Silently ignores a disallowed
+    /// or unparseable link.
     func openLink(_ raw: String) {
-        guard let url = URL(string: raw), let scheme = url.scheme?.lowercased(),
-              ["http", "https", "mailto", "ftp", "file"].contains(scheme) else { return }
+        guard let url = LinkPolicy.permittedURL(from: raw) else { return }
         NSWorkspace.shared.open(url)
     }
 }

--- a/agterm/Ghostty/GhosttySurfaceView+Input.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Input.swift
@@ -195,6 +195,15 @@ extension GhosttySurfaceView {
         ghostty_surface_mouse_pos(surface, pt.x, pt.y, mods(event))
     }
 
+    /// The pointer left the surface. Report negative coordinates so libghostty clears any hovered-link
+    /// state — it drops `over_link`, reverts the mouse shape, and re-renders without the underline (see its
+    /// `cursorPosCallback`). Without this a ⌘-hovered link stays highlighted after the mouse leaves the
+    /// terminal (into the sidebar, another window, or off the edge) until ⌘ is released.
+    override func mouseExited(with event: NSEvent) {
+        guard let surface else { return }
+        ghostty_surface_mouse_pos(surface, -1, -1, mods(event))
+    }
+
     override func scrollWheel(with event: NSEvent) {
         guard let surface else { return }
         var scrollMods: ghostty_input_scroll_mods_t = 0
@@ -358,5 +367,53 @@ extension GhosttySurfaceView: @preconcurrency NSTextInputClient {
         let viewPt = NSPoint(x: x, y: bounds.height - y)
         let screenPt = window?.convertPoint(toScreen: convert(viewPt, to: nil)) ?? viewPt
         return NSRect(x: screenPt.x, y: screenPt.y - h, width: w, height: h)
+    }
+
+    // MARK: - Mouse cursor shape + link opening
+
+    /// Applies the cursor shape libghostty requested (`GHOSTTY_ACTION_MOUSE_SHAPE`) — the pointing hand
+    /// over a link, the I-beam over the grid, resize/crosshair/grab in the matching modes. No-ops when
+    /// unchanged; otherwise invalidates the cursor rects so AppKit re-queries `resetCursorRects` and
+    /// re-applies the cursor under the current pointer position (libghostty sends this as the mouse moves).
+    func applyMouseShape(_ shape: ghostty_action_mouse_shape_e) {
+        guard shape != mouseShape else { return }
+        mouseShape = shape
+        window?.invalidateCursorRects(for: self)
+    }
+
+    /// AppKit cursor-rectangle hook: paint the whole surface with the libghostty-requested cursor.
+    override func resetCursorRects() {
+        addCursorRect(bounds, cursor: Self.nsCursor(for: mouseShape))
+    }
+
+    /// Maps a libghostty mouse-shape to the closest AppKit `NSCursor`. Shapes without a system cursor
+    /// (the zoom / diagonal-resize variants) fall back to the arrow.
+    private static func nsCursor(for shape: ghostty_action_mouse_shape_e) -> NSCursor {
+        switch shape {
+        case GHOSTTY_MOUSE_SHAPE_TEXT: return .iBeam
+        case GHOSTTY_MOUSE_SHAPE_POINTER: return .pointingHand
+        case GHOSTTY_MOUSE_SHAPE_CROSSHAIR: return .crosshair
+        case GHOSTTY_MOUSE_SHAPE_GRAB: return .openHand
+        case GHOSTTY_MOUSE_SHAPE_GRABBING: return .closedHand
+        case GHOSTTY_MOUSE_SHAPE_NOT_ALLOWED, GHOSTTY_MOUSE_SHAPE_NO_DROP: return .operationNotAllowed
+        case GHOSTTY_MOUSE_SHAPE_CONTEXT_MENU: return .contextualMenu
+        case GHOSTTY_MOUSE_SHAPE_VERTICAL_TEXT: return .iBeamCursorForVerticalLayout
+        case GHOSTTY_MOUSE_SHAPE_COL_RESIZE, GHOSTTY_MOUSE_SHAPE_E_RESIZE, GHOSTTY_MOUSE_SHAPE_W_RESIZE,
+             GHOSTTY_MOUSE_SHAPE_EW_RESIZE:
+            return .resizeLeftRight
+        case GHOSTTY_MOUSE_SHAPE_ROW_RESIZE, GHOSTTY_MOUSE_SHAPE_N_RESIZE, GHOSTTY_MOUSE_SHAPE_S_RESIZE,
+             GHOSTTY_MOUSE_SHAPE_NS_RESIZE:
+            return .resizeUpDown
+        default: return .arrow
+        }
+    }
+
+    /// Opens a URL from a link click (`GHOSTTY_ACTION_OPEN_URL`). Scheme-validated first: a terminal
+    /// renders untrusted program output, so only web/mail/file links are followed — never an arbitrary
+    /// custom scheme that could hand off to another app. Silently ignores anything else.
+    func openLink(_ raw: String) {
+        guard let url = URL(string: raw), let scheme = url.scheme?.lowercased(),
+              ["http", "https", "mailto", "ftp", "file"].contains(scheme) else { return }
+        NSWorkspace.shared.open(url)
     }
 }

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -218,6 +218,13 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     var currentKeyEvent: NSEvent?
     private var currentTrackingArea: NSTrackingArea?
 
+    /// The mouse-cursor shape libghostty last requested for this surface (`GHOSTTY_ACTION_MOUSE_SHAPE`):
+    /// the I-beam over the grid, the pointing hand over a detected link / OSC-8 hyperlink, resize/crosshair
+    /// in the matching modes. `resetCursorRects` maps it to an `NSCursor`. Defaults to the terminal I-beam
+    /// so the resting cursor is right before the first event. Not `private` so the `+Input` extension (which
+    /// owns the cursor-rect override and `applyMouseShape`) can read it.
+    var mouseShape: ghostty_action_mouse_shape_e = GHOSTTY_MOUSE_SHAPE_TEXT
+
     init(workingDirectory: String, fontSize: Float? = nil, command: String? = nil, initialInput: String? = nil,
          waitAfterCommand: Bool = false, autoFocus: Bool = false, env: [String: String] = [:]) {
         self.workingDirectory = workingDirectory
@@ -886,7 +893,7 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         if let existing = currentTrackingArea { removeTrackingArea(existing) }
         let area = NSTrackingArea(
             rect: bounds,
-            options: [.mouseMoved, .activeInKeyWindow, .inVisibleRect],
+            options: [.mouseMoved, .mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect],
             owner: self
         )
         addTrackingArea(area)

--- a/agtermCore/Sources/agtermCore/LinkPolicy.swift
+++ b/agtermCore/Sources/agtermCore/LinkPolicy.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Decides which link URLs agterm will open when a terminal hyperlink is clicked
+/// (`GHOSTTY_ACTION_OPEN_URL`). A terminal renders UNTRUSTED program output, so an escape-sequence link
+/// can carry any scheme — only web/mail links are followed. Notably `file://` is NOT allowed: opening one
+/// goes through LaunchServices (the Finder double-click path), so a click on an attacker-controlled
+/// `file:///…/X.app` or `.command` would LAUNCH it. Host-free (Foundation-only) so it is unit-tested; the
+/// app-side glue just calls `NSWorkspace.open` on the result (same split as `ShellEscape`).
+public enum LinkPolicy {
+    /// The schemes safe to hand to the system opener — web + mail only, none that hands off to a local
+    /// executable/handler.
+    public static let permittedSchemes: Set<String> = ["http", "https", "mailto", "ftp"]
+
+    /// The URL to open for a link click, or nil to ignore it: parseable AND carrying a permitted scheme
+    /// (case-insensitive). nil for an unparseable string, a schemeless string, or a disallowed scheme
+    /// (`file`, `javascript`, a custom app scheme, …).
+    public static func permittedURL(from raw: String) -> URL? {
+        guard let url = URL(string: raw),
+              let scheme = url.scheme?.lowercased(),
+              permittedSchemes.contains(scheme) else { return nil }
+        return url
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/LinkPolicyTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/LinkPolicyTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+struct LinkPolicyTests {
+    @Test(arguments: [
+        "http://example.com",
+        "https://example.com/path?q=1#frag",
+        "HTTPS://EXAMPLE.COM",           // scheme match is case-insensitive
+        "mailto:someone@example.com",
+        "ftp://host/file.txt",
+    ])
+    func permitsWebAndMailSchemes(_ raw: String) {
+        #expect(LinkPolicy.permittedURL(from: raw) != nil)
+    }
+
+    @Test(arguments: [
+        "file:///Applications/Evil.app",  // LaunchServices would launch it — must be rejected
+        "file:///etc/passwd",
+        "javascript:alert(1)",
+        "vscode://file/x",                // custom app scheme
+        "tel:+15550100",
+        "example.com",                    // no scheme
+        "",                               // empty
+        "   ",                            // whitespace only
+    ])
+    func rejectsNonWebAndSchemelessInputs(_ raw: String) {
+        #expect(LinkPolicy.permittedURL(from: raw) == nil)
+    }
+
+    @Test func returnsTheParsedURLUnchanged() {
+        #expect(LinkPolicy.permittedURL(from: "https://example.com/a")?.absoluteString == "https://example.com/a")
+    }
+
+    /// A URL followed by garbage (what the pre-fix `String(cString:)` over-read past `len` could produce)
+    /// does not silently become a valid link: the trailing space + junk make it unparseable or non-web.
+    @Test func trailingGarbageDoesNotYieldAWebURL() {
+        #expect(LinkPolicy.permittedURL(from: "https://example.com\u{00}/etc/other") == nil)
+        #expect(LinkPolicy.permittedURL(from: "https://example.com extra junk") == nil)
+    }
+}


### PR DESCRIPTION
Closes #125.

## What

Hovering a URL with ⌘ held now shows the **pointing-hand cursor** + link underline, and ⌘-click (or double-click) opens it — matching Terminal.app / iTerm2 / Ghostty.app. Before, agterm dropped the relevant libghostty actions, so the cursor never changed and the open path had no scheme validation.

## Cause

`GhosttyCallbacks.action` handled a curated set of `GHOSTTY_ACTION_*` and let the rest fall through to `default: return false`, dropping the whole mouse/link family: `MOUSE_SHAPE` (the cursor request), `OPEN_URL` (click-to-open), and `MOUSE_OVER_LINK`.

## Change (3 files, +80/-1)

- **`GhosttyCallbacks.swift`** — handle `GHOSTTY_ACTION_MOUSE_SHAPE` (→ apply an `NSCursor`) and `GHOSTTY_ACTION_OPEN_URL` (→ scheme-validated open).
- **`GhosttySurfaceView+Input.swift`** — `applyMouseShape` + `resetCursorRects` + an `nsCursor(for:)` map (pointer→`.pointingHand`, text→`.iBeam`, crosshair/grab/resize variants → their `NSCursor`, else `.arrow`); `openLink` opens only `http`/`https`/`mailto`/`ftp`/`file` via `NSWorkspace` (a terminal renders untrusted output, so an arbitrary custom scheme is never followed); and a `mouseExited` handler that reports negative coordinates so libghostty clears the hovered-link highlight when the pointer leaves the surface.
- **`GhosttySurfaceView.swift`** — a `mouseShape` property (`resetCursorRects` reads it) and `.mouseEnteredAndExited` on the tracking area.

## Scope note (plain hover deliberately excluded)

libghostty hardcodes URL links to `hover_mods = ctrl/super` on macOS, and the `link` config that could set `highlight = hover` is non-functional in the pinned build (Config.zig: "TODO: This can't currently be set!"). Making URLs react on **plain** (no-modifier) hover therefore needs an app-side ⌘-faking hack — which I prototyped and rejected: because a faked ⌘ never "releases", ghostty's link-underline clear (driven by a mods-change full repaint) never fires and the underline sticks. So this PR ships the standard ⌘-hover, which is the correct macOS-terminal convention anyway.

## Keep-in-sync

Pure libghostty-driven hover/render chrome — no `AppActions`/`AppStore` action behind it, nothing to drive over the control socket, so keep-in-sync **exempt** (like the other rendering gotchas).

## Testing

Build green, `swift test` (1075) green, swiftlint `--strict` clean. Cursor shape / link underline aren't accessibility-observable (Metal surface, not in the AX tree), so this is manually verified — confirmed in an isolated dev instance: ⌘-hover shows the hand + underline, moving off / releasing ⌘ / leaving the surface clears it, ⌘-click opens; text selection and a mouse-reporting TUI are unaffected. Not XCUITest-covered (consistent with the other libghostty rendering behavior, e.g. cursor focus).
