### PR TITLE
refactore: Route session text and restore controls through dispatcher

### DIFF
--- a/agterm/Control/ControlServer+SurfaceIO.swift
+++ b/agterm/Control/ControlServer+SurfaceIO.swift
@@ -38,29 +38,12 @@ extension ControlServer {
     /// `BackgroundWatermark` spec (nil for `clear`), persist it on the session (`AppStore`, so it rides
     /// `SessionSnapshot`), then apply it to the session's realized surface(s). A never-shown session keeps
     /// the spec and applies it itself when its surface is created. Returns the session id.
-    func setBackground(_ target: String?, _ args: ControlArgs?) -> ControlResponse {
-        // the args bag IS the option struct — unpack the watermark fields once so the arm stays a small
-        // fixed-arity signature (swiftlint function_parameter_count) rather than a 10-parameter dispatch.
-        let window = args?.window, mode = args?.mode, path = args?.path, text = args?.text
-        let color = args?.color, opacity = args?.opacity, fit = args?.fit
-        let position = args?.position, repeats = args?.repeats
-        if let fit, !WatermarkConfig.isValidFit(fit) {
-            return ControlResponse(ok: false, error: "invalid fit: \(fit) (contain|cover|stretch|none)")
-        }
-        if let position, !WatermarkConfig.isValidPosition(position) {
-            return ControlResponse(ok: false, error: "invalid position: \(position)")
-        }
-        if let opacity, !WatermarkConfig.isValidOpacity(opacity) {
-            return ControlResponse(ok: false, error: "invalid opacity: \(opacity) (0.0-1.0)")
-        }
-        let watermark: BackgroundWatermark?
-        switch mode {
-        case "image":
-            guard let path, !path.isEmpty else {
+    func setSessionBackground(_ target: String?, window: String?,
+                              options: ControlSessionBackgroundOptions) -> ControlResponse {
+        let watermark = options.watermark
+        if let watermark, watermark.kind == .image {
+            guard let path = watermark.imagePath, !path.isEmpty else {
                 return ControlResponse(ok: false, error: "session.background image requires a path")
-            }
-            guard WatermarkConfig.isValidImagePath(path) else {
-                return ControlResponse(ok: false, error: "image path must not contain control characters")
             }
             guard WatermarkRenderer.isSupportedImage(path) else {
                 return ControlResponse(ok: false, error: "unsupported image (PNG or JPEG only): \(path)")
@@ -68,39 +51,6 @@ extension ControlServer {
             guard FileManager.default.fileExists(atPath: path) else {
                 return ControlResponse(ok: false, error: "no such image file: \(path)")
             }
-            watermark = BackgroundWatermark(kind: .image, imagePath: path, opacity: opacity,
-                                            fit: fit.flatMap(BackgroundWatermark.Fit.init(rawValue:)),
-                                            position: position.flatMap(BackgroundWatermark.Position.init(rawValue:)),
-                                            repeats: repeats)
-        case "text":
-            guard let text, !text.isEmpty else {
-                return ControlResponse(ok: false, error: "session.background text requires text")
-            }
-            guard text.count <= WatermarkConfig.maxTextLength else {
-                return ControlResponse(ok: false,
-                                       error: "session.background text too long (max \(WatermarkConfig.maxTextLength) characters)")
-            }
-            if let color, !WatermarkConfig.isValidColorHex(color) {
-                return ControlResponse(ok: false, error: "invalid color: \(color) (#rrggbb)")
-            }
-            watermark = BackgroundWatermark(kind: .text, text: text, colorHex: color,
-                                            opacity: opacity,
-                                            fit: fit.flatMap(BackgroundWatermark.Fit.init(rawValue:)),
-                                            position: position.flatMap(BackgroundWatermark.Position.init(rawValue:)))
-        case "color":
-            // no per-call opacity: a solid color honors the window translucency set in Settings, applied at
-            // emit time via `WatermarkConfig.overlayText(windowOpacity:)` (see `GhosttySurfaceView`).
-            guard let color, !color.isEmpty else {
-                return ControlResponse(ok: false, error: "session.background color requires a color")
-            }
-            guard WatermarkConfig.isValidColorHex(color) else {
-                return ControlResponse(ok: false, error: "invalid color: \(color) (#rrggbb)")
-            }
-            watermark = BackgroundWatermark(kind: .color, colorHex: color)
-        case "clear", .none:
-            watermark = nil
-        default:
-            return ControlResponse(ok: false, error: "invalid background mode: \(mode ?? "") (image|text|color|clear)")
         }
         return resolver.resolveSession(target, window: window) { store, id in
             guard let session = store.session(withID: id) else {
@@ -136,8 +86,8 @@ extension ControlServer {
     /// here too, not only in the CLI `validate()`, so a raw socket client can't bypass it (an unchecked
     /// `lines <= 0` would silently fall through to the full buffer). A genuinely blank screen reads ok with
     /// an empty string; a failed surface read is an error, not a silent empty.
-    func readText(_ target: String?, window: String?, pane: String?,
-                  all: Bool, lines: Int?) -> ControlResponse {
+    func readSessionText(_ target: String?, window: String?, options: ControlSessionTextOptions) -> ControlResponse {
+        let pane = options.pane, all = options.all, lines = options.lines
         if all, lines != nil {
             return ControlResponse(ok: false, error: "use either --all or --lines, not both")
         }

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -346,13 +346,9 @@ final class ControlServer {
                 .sessionFocus, .sessionResize, .sessionStatus, .sessionFlag, .notify,
                 .fontInc, .fontDec, .fontReset, .keymapReload, .configReload, .themeSet, .themeList,
                 .sidebar, .sidebarMode, .sidebarExpand, .sidebarCollapse, .sessionType, .sessionCopy,
-                .sessionOverlayOpen, .sessionOverlayClose, .sessionOverlayResult:
+                .sessionOverlayOpen, .sessionOverlayClose, .sessionOverlayResult, .sessionBackground,
+                .sessionText, .restoreClear:
             return ControlResponse(ok: false, error: "control dispatcher did not handle \(request.cmd.rawValue)")
-        case .sessionBackground:
-            return setBackground(request.target, request.args)
-        case .sessionText:
-            return readText(request.target, window: request.args?.window, pane: request.args?.pane,
-                            all: request.args?.all ?? false, lines: request.args?.lines)
         case .sessionSearch:
             // resolve first (cross-window when no `args.window`), then select + realize the surface; the
             // realize path is async (bounded poll), so this can't go through the synchronous
@@ -383,8 +379,6 @@ final class ControlServer {
             return windowMove(request.target, x: request.args?.x, y: request.args?.y, display: request.args?.display)
         case .windowZoom:
             return windowZoom(request.target)
-        case .restoreClear:
-            return clearSavedCommands()
         }
     }
 
@@ -393,7 +387,7 @@ final class ControlServer {
     /// (consumed at restore); the SAVE is what wipes the on-disk copy from the last quit, also closing
     /// the force-quit re-fire window. Drives `restore.clear` / `agtermctl restore clear`. App-global like
     /// `keymap.reload` (no `--window` selector — it clears every open window).
-    private func clearSavedCommands() -> ControlResponse {
+    func clearRestoreCommands() -> ControlResponse {
         for session in library.allOpenSessions() {
             session.foregroundCommand = nil
             session.splitForegroundCommand = nil

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -40,6 +40,10 @@ public protocol ControlActions {
                             options: ControlSessionOverlayOpenOptions) -> ControlResponse
     func closeSessionOverlay(_ target: String?, window: String?) -> ControlResponse
     func sessionOverlayResult(_ target: String?, window: String?) -> ControlResponse
+    func setSessionBackground(_ target: String?, window: String?,
+                              options: ControlSessionBackgroundOptions) -> ControlResponse
+    func readSessionText(_ target: String?, window: String?, options: ControlSessionTextOptions) -> ControlResponse
+    func clearRestoreCommands() -> ControlResponse
 }
 
 public struct ControlSessionTypeOptions: Equatable, Sendable {
@@ -70,6 +74,26 @@ public struct ControlSessionOverlayOpenOptions: Equatable, Sendable {
     }
 }
 
+public struct ControlSessionBackgroundOptions: Equatable, Sendable {
+    public let watermark: BackgroundWatermark?
+
+    public init(watermark: BackgroundWatermark?) {
+        self.watermark = watermark
+    }
+}
+
+public struct ControlSessionTextOptions: Equatable, Sendable {
+    public let pane: String?
+    public let all: Bool
+    public let lines: Int?
+
+    public init(pane: String?, all: Bool, lines: Int?) {
+        self.pane = pane
+        self.all = all
+        self.lines = lines
+    }
+}
+
 /// Routes the command groups that have been hoisted from the app control switch. Commands outside this
 /// first migrated set return nil so the app can keep handling them in its existing switch.
 @MainActor
@@ -84,6 +108,27 @@ public struct ControlDispatcher {
         switch request.cmd {
         case .tree:
             return actions.controlTree(window: request.args?.window)
+        case .sessionNew, .sessionSelect, .sessionGo, .sessionClose, .sessionRename,
+                .sessionMove, .sessionFlag, .sessionStatus:
+            return dispatchSessionCommand(request)
+        case .sessionSplit, .sessionScratch, .sessionFocus, .sessionResize, .sessionType,
+                .sessionCopy, .sessionOverlayOpen, .sessionOverlayClose, .sessionOverlayResult,
+                .sessionBackground, .sessionText:
+            return await dispatchSessionSurfaceCommand(request)
+        case .workspaceNew, .workspaceSelect, .workspaceRename, .workspaceDelete,
+                .workspaceMove, .workspaceFocus:
+            return dispatchWorkspaceCommand(request)
+        case .fontInc, .fontDec, .fontReset, .keymapReload, .configReload, .notify,
+                .themeSet, .themeList, .sidebar, .sidebarMode, .sidebarExpand,
+                .sidebarCollapse, .restoreClear:
+            return dispatchAppCommand(request)
+        default:
+            return nil
+        }
+    }
+
+    private func dispatchSessionCommand(_ request: ControlRequest) -> ControlResponse {
+        switch request.cmd {
         case .sessionNew:
             let args = request.args
             if args?.workspace != nil, args?.workspaceName != nil {
@@ -116,18 +161,6 @@ public struct ControlDispatcher {
                 return ControlResponse(ok: false, error: "session.rename requires a name")
             }
             return actions.renameSession(request.target, window: request.args?.window, name: name)
-        case .workspaceNew:
-            return actions.createWorkspace(window: request.args?.window, name: request.args?.name)
-        case .workspaceSelect:
-            return actions.selectWorkspace(request.target, window: request.args?.window)
-        case .workspaceRename:
-            guard let name = request.args?.name?.trimmingCharacters(in: .whitespacesAndNewlines),
-                  !name.isEmpty else {
-                return ControlResponse(ok: false, error: "workspace.rename requires a name")
-            }
-            return actions.renameWorkspace(request.target, window: request.args?.window, name: name)
-        case .workspaceDelete:
-            return actions.deleteWorkspace(request.target, window: request.args?.window)
         case .sessionMove:
             if request.args?.to != nil && request.args?.workspace != nil {
                 return ControlResponse(ok: false, error: "session.move takes either --to or a workspace, not both")
@@ -142,16 +175,6 @@ public struct ControlDispatcher {
                 return ControlResponse(ok: false, error: "session.move requires --to or a workspace")
             }
             return actions.moveSession(request.target, window: request.args?.window, move: .workspace(workspace))
-        case .workspaceMove:
-            guard let to = request.args?.to else {
-                return ControlResponse(ok: false, error: "workspace.move requires --to")
-            }
-            guard let direction = ReorderDirection(rawValue: to) else {
-                return ControlResponse(ok: false, error: "workspace.move --to must be up|down|top|bottom")
-            }
-            return actions.moveWorkspace(request.target, window: request.args?.window, direction: direction)
-        case .workspaceFocus:
-            return actions.focusWorkspace(request.target, window: request.args?.window, mode: request.args?.mode)
         case .sessionFlag:
             return actions.setSessionFlag(request.target, window: request.args?.window, mode: request.args?.mode)
         case .sessionStatus:
@@ -162,6 +185,41 @@ public struct ControlDispatcher {
                                                     autoReset: request.args?.autoReset,
                                                     sound: request.args?.sound)
             return actions.setSessionStatus(request.target, window: request.args?.window, update: update)
+        default:
+            preconditionFailure("unexpected session command: \(request.cmd.rawValue)")
+        }
+    }
+
+    private func dispatchWorkspaceCommand(_ request: ControlRequest) -> ControlResponse {
+        switch request.cmd {
+        case .workspaceNew:
+            return actions.createWorkspace(window: request.args?.window, name: request.args?.name)
+        case .workspaceSelect:
+            return actions.selectWorkspace(request.target, window: request.args?.window)
+        case .workspaceRename:
+            guard let name = request.args?.name?.trimmedOrNil else {
+                return ControlResponse(ok: false, error: "workspace.rename requires a name")
+            }
+            return actions.renameWorkspace(request.target, window: request.args?.window, name: name)
+        case .workspaceDelete:
+            return actions.deleteWorkspace(request.target, window: request.args?.window)
+        case .workspaceMove:
+            guard let to = request.args?.to else {
+                return ControlResponse(ok: false, error: "workspace.move requires --to")
+            }
+            guard let direction = ReorderDirection(rawValue: to) else {
+                return ControlResponse(ok: false, error: "workspace.move --to must be up|down|top|bottom")
+            }
+            return actions.moveWorkspace(request.target, window: request.args?.window, direction: direction)
+        case .workspaceFocus:
+            return actions.focusWorkspace(request.target, window: request.args?.window, mode: request.args?.mode)
+        default:
+            preconditionFailure("unexpected workspace command: \(request.cmd.rawValue)")
+        }
+    }
+
+    private func dispatchSessionSurfaceCommand(_ request: ControlRequest) async -> ControlResponse {
+        switch request.cmd {
         case .sessionSplit:
             return actions.splitSession(request.target, window: request.args?.window, mode: request.args?.mode)
         case .sessionScratch:
@@ -180,6 +238,48 @@ public struct ControlDispatcher {
             case (nil, .some(let delta)):
                 return actions.resizeSplit(request.target, window: request.args?.window, resize: .delta(delta))
             }
+        case .sessionType:
+            guard let text = request.args?.text else {
+                return ControlResponse(ok: false, error: "session.type requires text")
+            }
+            return await actions.typeSession(request.target, window: request.args?.window,
+                                             options: ControlSessionTypeOptions(
+                                                text: text,
+                                                select: request.args?.select ?? false,
+                                                pane: request.args?.pane
+                                             ))
+        case .sessionCopy:
+            return actions.copySessionSelection(request.target, window: request.args?.window)
+        case .sessionOverlayOpen:
+            guard let command = request.args?.command, !command.isEmpty else {
+                return ControlResponse(ok: false, error: "session.overlay.open requires a command")
+            }
+            if let color = request.args?.color, !WatermarkConfig.isValidColorHex(color) {
+                return ControlResponse(ok: false, error: "invalid color: \(color) (#rrggbb)")
+            }
+            return actions.openSessionOverlay(request.target, window: request.args?.window,
+                                              options: ControlSessionOverlayOpenOptions(
+                                                command: command,
+                                                cwd: request.args?.cwd,
+                                                wait: request.args?.wait ?? false,
+                                                sizePercent: request.args?.sizePercent,
+                                                backgroundColor: request.args?.color
+                                              ))
+        case .sessionOverlayClose:
+            return actions.closeSessionOverlay(request.target, window: request.args?.window)
+        case .sessionOverlayResult:
+            return actions.sessionOverlayResult(request.target, window: request.args?.window)
+        case .sessionBackground:
+            return dispatchSessionBackground(request)
+        case .sessionText:
+            return dispatchSessionText(request)
+        default:
+            preconditionFailure("unexpected session surface command: \(request.cmd.rawValue)")
+        }
+    }
+
+    private func dispatchAppCommand(_ request: ControlRequest) -> ControlResponse {
+        switch request.cmd {
         case .fontInc:
             return actions.font(request.target, window: request.args?.window, action: "increase_font_size:1")
         case .fontDec:
@@ -214,39 +314,85 @@ public struct ControlDispatcher {
             return actions.expandSidebar(window: request.args?.window)
         case .sidebarCollapse:
             return actions.collapseSidebar(window: request.args?.window)
-        case .sessionType:
-            guard let text = request.args?.text else {
-                return ControlResponse(ok: false, error: "session.type requires text")
+        case .restoreClear:
+            return actions.clearRestoreCommands()
+        default:
+            preconditionFailure("unexpected app command: \(request.cmd.rawValue)")
+        }
+    }
+
+    private func dispatchSessionBackground(_ request: ControlRequest) -> ControlResponse {
+        // The args bag is normalized into the option struct here so the app-side adapter stays a small
+        // fixed-arity signature (swiftlint function_parameter_count) rather than a 10-parameter dispatch.
+        if let fit = request.args?.fit, !WatermarkConfig.isValidFit(fit) {
+            return ControlResponse(ok: false, error: "invalid fit: \(fit) (contain|cover|stretch|none)")
+        }
+        if let position = request.args?.position, !WatermarkConfig.isValidPosition(position) {
+            return ControlResponse(ok: false, error: "invalid position: \(position)")
+        }
+        if let opacity = request.args?.opacity, !WatermarkConfig.isValidOpacity(opacity) {
+            return ControlResponse(ok: false, error: "invalid opacity: \(opacity) (0.0-1.0)")
+        }
+        let watermark: BackgroundWatermark?
+        switch request.args?.mode {
+        case "image":
+            guard let path = request.args?.path, !path.isEmpty else {
+                return ControlResponse(ok: false, error: "session.background image requires a path")
             }
-            return await actions.typeSession(request.target, window: request.args?.window,
-                                             options: ControlSessionTypeOptions(
-                                                text: text,
-                                                select: request.args?.select ?? false,
-                                                pane: request.args?.pane
-                                             ))
-        case .sessionCopy:
-            return actions.copySessionSelection(request.target, window: request.args?.window)
-        case .sessionOverlayOpen:
-            guard let command = request.args?.command, !command.isEmpty else {
-                return ControlResponse(ok: false, error: "session.overlay.open requires a command")
+            guard WatermarkConfig.isValidImagePath(path) else {
+                return ControlResponse(ok: false, error: "image path must not contain control characters")
+            }
+            watermark = BackgroundWatermark(kind: .image, imagePath: path, opacity: request.args?.opacity,
+                                            fit: request.args?.fit.flatMap(BackgroundWatermark.Fit.init(rawValue:)),
+                                            position: request.args?.position.flatMap(BackgroundWatermark.Position.init(rawValue:)),
+                                            repeats: request.args?.repeats)
+        case "text":
+            guard let text = request.args?.text, !text.isEmpty else {
+                return ControlResponse(ok: false, error: "session.background text requires text")
+            }
+            guard text.count <= WatermarkConfig.maxTextLength else {
+                return ControlResponse(ok: false,
+                                       error: "session.background text too long (max \(WatermarkConfig.maxTextLength) characters)")
             }
             if let color = request.args?.color, !WatermarkConfig.isValidColorHex(color) {
                 return ControlResponse(ok: false, error: "invalid color: \(color) (#rrggbb)")
             }
-            return actions.openSessionOverlay(request.target, window: request.args?.window,
-                                              options: ControlSessionOverlayOpenOptions(
-                                                command: command,
-                                                cwd: request.args?.cwd,
-                                                wait: request.args?.wait ?? false,
-                                                sizePercent: request.args?.sizePercent,
-                                                backgroundColor: request.args?.color
-                                              ))
-        case .sessionOverlayClose:
-            return actions.closeSessionOverlay(request.target, window: request.args?.window)
-        case .sessionOverlayResult:
-            return actions.sessionOverlayResult(request.target, window: request.args?.window)
+            watermark = BackgroundWatermark(kind: .text, text: text, colorHex: request.args?.color,
+                                            opacity: request.args?.opacity,
+                                            fit: request.args?.fit.flatMap(BackgroundWatermark.Fit.init(rawValue:)),
+                                            position: request.args?.position.flatMap(BackgroundWatermark.Position.init(rawValue:)))
+        case "color":
+            // No per-call opacity: a solid color honors the window translucency set in Settings, applied at
+            // emit time via `WatermarkConfig.overlayText(windowOpacity:)` (see `GhosttySurfaceView`).
+            guard let color = request.args?.color, !color.isEmpty else {
+                return ControlResponse(ok: false, error: "session.background color requires a color")
+            }
+            guard WatermarkConfig.isValidColorHex(color) else {
+                return ControlResponse(ok: false, error: "invalid color: \(color) (#rrggbb)")
+            }
+            watermark = BackgroundWatermark(kind: .color, colorHex: color)
+        case "clear", .none:
+            watermark = nil
         default:
-            return nil
+            return ControlResponse(ok: false,
+                                   error: "invalid background mode: \(request.args?.mode ?? "") (image|text|color|clear)")
         }
+        return actions.setSessionBackground(request.target, window: request.args?.window,
+                                            options: ControlSessionBackgroundOptions(watermark: watermark))
+    }
+
+    private func dispatchSessionText(_ request: ControlRequest) -> ControlResponse {
+        let all = request.args?.all ?? false
+        let lines = request.args?.lines
+        if all, lines != nil {
+            return ControlResponse(ok: false, error: "use either --all or --lines, not both")
+        }
+        if let lines, lines <= 0 {
+            return ControlResponse(ok: false, error: "--lines must be greater than 0")
+        }
+        return actions.readSessionText(request.target, window: request.args?.window,
+                                       options: ControlSessionTextOptions(pane: request.args?.pane,
+                                                                          all: all,
+                                                                          lines: lines))
     }
 }

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -669,11 +669,173 @@ struct ControlDispatcherTests {
         #expect(actions.calls == [.overlayResult(target: "session", window: nil)])
     }
 
+    @Test func sessionBackgroundRoutesParsedTextImageColorAndClearForms() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextSessionBackgroundResponse = ControlResponse(ok: true, result: ControlResult(id: "session"))
+
+        let text = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionBackground,
+            target: "session",
+            args: ControlArgs(text: "DRAFT", mode: "text", window: "win", color: "#ff0000",
+                              opacity: 0.15, fit: "contain", position: "top-left")
+        ))
+        let image = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionBackground,
+            target: "session",
+            args: ControlArgs(mode: "image", path: "/tmp/bg.png", fit: "cover",
+                              position: "bottom-right", repeats: true)
+        ))
+        let color = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionBackground,
+            target: "session",
+            args: ControlArgs(mode: "color", color: "#102030")
+        ))
+        let clear = await dispatcher.dispatch(ControlRequest(cmd: .sessionBackground, target: "session"))
+
+        let textWatermark = BackgroundWatermark(kind: .text, text: "DRAFT", colorHex: "#ff0000",
+                                                opacity: 0.15, fit: .contain, position: .topLeft)
+        let imageWatermark = BackgroundWatermark(kind: .image, imagePath: "/tmp/bg.png",
+                                                 fit: .cover, position: .bottomRight, repeats: true)
+        let colorWatermark = BackgroundWatermark(kind: .color, colorHex: "#102030")
+        #expect(text == ControlResponse(ok: true, result: ControlResult(id: "session")))
+        #expect(image == ControlResponse(ok: true, result: ControlResult(id: "session")))
+        #expect(color == ControlResponse(ok: true, result: ControlResult(id: "session")))
+        #expect(clear == ControlResponse(ok: true, result: ControlResult(id: "session")))
+        #expect(actions.calls == [
+            .sessionBackground(target: "session", window: "win",
+                               ControlSessionBackgroundOptions(watermark: textWatermark)),
+            .sessionBackground(target: "session", window: nil,
+                               ControlSessionBackgroundOptions(watermark: imageWatermark)),
+            .sessionBackground(target: "session", window: nil,
+                               ControlSessionBackgroundOptions(watermark: colorWatermark)),
+            .sessionBackground(target: "session", window: nil,
+                               ControlSessionBackgroundOptions(watermark: nil))
+        ])
+    }
+
+    @Test func sessionBackgroundRejectsInvalidInputsBeforeCallingActions() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        let tooLong = String(repeating: "x", count: WatermarkConfig.maxTextLength + 1)
+
+        let badFit = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionBackground,
+            args: ControlArgs(mode: "image", path: "/tmp/bg.png", fit: "wide")
+        ))
+        let badPosition = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionBackground,
+            args: ControlArgs(mode: "image", path: "/tmp/bg.png", position: "middle")
+        ))
+        let badOpacity = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionBackground,
+            args: ControlArgs(mode: "image", path: "/tmp/bg.png", opacity: 1.5)
+        ))
+        let missingPath = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionBackground,
+            args: ControlArgs(mode: "image")
+        ))
+        let controlPath = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionBackground,
+            args: ControlArgs(mode: "image", path: "/tmp/bg\n.png")
+        ))
+        let missingText = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionBackground,
+            args: ControlArgs(mode: "text")
+        ))
+        let longText = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionBackground,
+            args: ControlArgs(text: tooLong, mode: "text")
+        ))
+        let badTextColor = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionBackground,
+            args: ControlArgs(text: "DRAFT", mode: "text", color: "red")
+        ))
+        let missingColor = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionBackground,
+            args: ControlArgs(mode: "color")
+        ))
+        let badColor = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionBackground,
+            args: ControlArgs(mode: "color", color: "blue")
+        ))
+        let badMode = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionBackground,
+            args: ControlArgs(mode: "pattern")
+        ))
+
+        #expect(badFit == ControlResponse(ok: false, error: "invalid fit: wide (contain|cover|stretch|none)"))
+        #expect(badPosition == ControlResponse(ok: false, error: "invalid position: middle"))
+        #expect(badOpacity == ControlResponse(ok: false, error: "invalid opacity: 1.5 (0.0-1.0)"))
+        #expect(missingPath == ControlResponse(ok: false, error: "session.background image requires a path"))
+        #expect(controlPath == ControlResponse(ok: false, error: "image path must not contain control characters"))
+        #expect(missingText == ControlResponse(ok: false, error: "session.background text requires text"))
+        #expect(longText == ControlResponse(
+            ok: false,
+            error: "session.background text too long (max \(WatermarkConfig.maxTextLength) characters)"
+        ))
+        #expect(badTextColor == ControlResponse(ok: false, error: "invalid color: red (#rrggbb)"))
+        #expect(missingColor == ControlResponse(ok: false, error: "session.background color requires a color"))
+        #expect(badColor == ControlResponse(ok: false, error: "invalid color: blue (#rrggbb)"))
+        #expect(badMode == ControlResponse(
+            ok: false,
+            error: "invalid background mode: pattern (image|text|color|clear)"
+        ))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test func sessionTextRoutesOptionsAndKeepsExactActionResponse() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextSessionTextResponse = ControlResponse(ok: true, result: ControlResult(text: "line\n"))
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionText,
+            target: "session",
+            args: ControlArgs(window: "win", pane: "scratch", lines: 10)
+        ))
+
+        #expect(response == ControlResponse(ok: true, result: ControlResult(text: "line\n")))
+        #expect(actions.calls == [
+            .sessionText(target: "session", window: "win",
+                         ControlSessionTextOptions(pane: "scratch", all: false, lines: 10))
+        ])
+    }
+
+    @Test func sessionTextRejectsInvalidLineOptionsBeforeCallingActions() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let both = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionText,
+            args: ControlArgs(all: true, lines: 5)
+        ))
+        let zero = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionText,
+            args: ControlArgs(lines: 0)
+        ))
+
+        #expect(both == ControlResponse(ok: false, error: "use either --all or --lines, not both"))
+        #expect(zero == ControlResponse(ok: false, error: "--lines must be greater than 0"))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test func restoreClearRoutesThroughActions() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextRestoreClearResponse = ControlResponse(ok: true)
+
+        let response = await dispatcher.dispatch(ControlRequest(cmd: .restoreClear))
+
+        #expect(response == ControlResponse(ok: true))
+        #expect(actions.calls == [.restoreClear])
+    }
+
     @Test func nonMigratedCommandFallsThrough() async {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)
 
-        let response = await dispatcher.dispatch(ControlRequest(cmd: .sessionText))
+        let response = await dispatcher.dispatch(ControlRequest(cmd: .sessionSearch))
 
         #expect(response == nil)
         #expect(actions.calls.isEmpty)
@@ -717,6 +879,9 @@ private final class MockControlActions: ControlActions {
         case overlayOpen(target: String?, window: String?, ControlSessionOverlayOpenOptions)
         case overlayClose(target: String?, window: String?)
         case overlayResult(target: String?, window: String?)
+        case sessionBackground(target: String?, window: String?, ControlSessionBackgroundOptions)
+        case sessionText(target: String?, window: String?, ControlSessionTextOptions)
+        case restoreClear
     }
 
     var calls: [Call] = []
@@ -737,6 +902,9 @@ private final class MockControlActions: ControlActions {
     var nextOverlayOpenResponse = ControlResponse(ok: true)
     var nextOverlayCloseResponse = ControlResponse(ok: true)
     var nextOverlayResultResponse = ControlResponse(ok: true)
+    var nextSessionBackgroundResponse = ControlResponse(ok: true)
+    var nextSessionTextResponse = ControlResponse(ok: true)
+    var nextRestoreClearResponse = ControlResponse(ok: true)
 
     func controlTree(window: String?) -> ControlResponse {
         calls.append(.tree(window: window))
@@ -911,5 +1079,21 @@ private final class MockControlActions: ControlActions {
     func sessionOverlayResult(_ target: String?, window: String?) -> ControlResponse {
         calls.append(.overlayResult(target: target, window: window))
         return nextOverlayResultResponse
+    }
+
+    func setSessionBackground(_ target: String?, window: String?,
+                              options: ControlSessionBackgroundOptions) -> ControlResponse {
+        calls.append(.sessionBackground(target: target, window: window, options))
+        return nextSessionBackgroundResponse
+    }
+
+    func readSessionText(_ target: String?, window: String?, options: ControlSessionTextOptions) -> ControlResponse {
+        calls.append(.sessionText(target: target, window: window, options))
+        return nextSessionTextResponse
+    }
+
+    func clearRestoreCommands() -> ControlResponse {
+        calls.append(.restoreClear)
+        return nextRestoreClearResponse
     }
 }


### PR DESCRIPTION
## Summary
- Route `session.text`, `session.background`, and `restore.clear` through `ControlDispatcher`.
- Keep live surface reads, watermark file checks/application, and restore clearing in the macOS adapter.
- Add focused dispatcher tests for success paths and exact validation errors.
- Preserve existing comments in their new locations and fold in the `workspace.rename` `trimmedOrNil` cleanup.

## Validation
- `swift test --filter ControlDispatcherTests`
- `make test`
- `make lint`
- `make build`
- UI partial: `ControlAPIUITests.testRestoreClearSucceeds` and `ControlAPIUITests.testSessionBackgroundSetClearAndValidation` passed.