### PR TITLE
refactor: Route window controls through dispatcher

### DIFF
--- a/agterm/Control/ControlServer+WindowCommands.swift
+++ b/agterm/Control/ControlServer+WindowCommands.swift
@@ -75,10 +75,7 @@ extension ControlServer {
     /// Resolve a window id and resize its on-screen window to `width` x `height` points (frame size).
     /// The window must be open; a closed window errors (resize it after `window.select`). Control-native
     /// (no GUI surface — the native title bar already drags-to-resize).
-    func windowResize(_ target: String?, width: Int?, height: Int?) -> ControlResponse {
-        guard let width, let height, width > 0, height > 0 else {
-            return ControlResponse(ok: false, error: "window.resize requires positive width and height")
-        }
+    func windowResize(_ target: String?, width: Int, height: Int) -> ControlResponse {
         return resolver.resolveWindowID(target) { id in
             guard WindowRegistry.shared.resize(id, width: width, height: height) else {
                 return ControlResponse(ok: false, error: "window not open — window.select it first")
@@ -90,10 +87,7 @@ extension ControlServer {
     /// Resolve a window id and move its on-screen window so its top-left corner is at (`x`, `y`) points in
     /// the global top-left space (origin = the primary display's top-left, spanning all displays). The
     /// window must be open; a closed window errors. Control-native (no GUI surface).
-    func windowMove(_ target: String?, x: Int?, y: Int?, display: Int?) -> ControlResponse {
-        guard let x, let y else {
-            return ControlResponse(ok: false, error: "window.move requires x and y")
-        }
+    func windowMove(_ target: String?, x: Int, y: Int, display: Int?) -> ControlResponse {
         if let display, display < 0 || display >= NSScreen.screens.count {
             return ControlResponse(ok: false, error: "display \(display) out of range (have \(NSScreen.screens.count))")
         }
@@ -118,10 +112,7 @@ extension ControlServer {
     }
 
     /// Resolve a window id and rename it (the name lives in the index). Requires a name. Returns the id.
-    func windowRename(_ target: String?, name: String?) -> ControlResponse {
-        guard let name = trimmed(name) else {
-            return ControlResponse(ok: false, error: "window.rename requires a name")
-        }
+    func windowRename(_ target: String?, name: String) -> ControlResponse {
         return resolver.resolveWindowID(target) { id in
             library.renameWindow(id, to: name)
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -347,7 +347,7 @@ final class ControlServer {
                 .fontInc, .fontDec, .fontReset, .keymapReload, .configReload, .themeSet, .themeList,
                 .sidebar, .sidebarMode, .sidebarExpand, .sidebarCollapse, .sessionType, .sessionCopy,
                 .sessionOverlayOpen, .sessionOverlayClose, .sessionOverlayResult, .sessionBackground,
-                .sessionText, .restoreClear:
+                .sessionText, .windowRename, .windowResize, .windowMove, .windowZoom, .restoreClear:
             return ControlResponse(ok: false, error: "control dispatcher did not handle \(request.cmd.rawValue)")
         case .sessionSearch:
             // resolve first (cross-window when no `args.window`), then select + realize the surface; the
@@ -369,16 +369,8 @@ final class ControlServer {
             return await windowSelect(request.target)
         case .windowClose:
             return await windowClose(request.target)
-        case .windowRename:
-            return windowRename(request.target, name: request.args?.name)
         case .windowDelete:
             return windowDelete(request.target)
-        case .windowResize:
-            return windowResize(request.target, width: request.args?.width, height: request.args?.height)
-        case .windowMove:
-            return windowMove(request.target, x: request.args?.x, y: request.args?.y, display: request.args?.display)
-        case .windowZoom:
-            return windowZoom(request.target)
         }
     }
 

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -43,6 +43,10 @@ public protocol ControlActions {
     func setSessionBackground(_ target: String?, window: String?,
                               options: ControlSessionBackgroundOptions) -> ControlResponse
     func readSessionText(_ target: String?, window: String?, options: ControlSessionTextOptions) -> ControlResponse
+    func windowRename(_ target: String?, name: String) -> ControlResponse
+    func windowResize(_ target: String?, width: Int, height: Int) -> ControlResponse
+    func windowMove(_ target: String?, x: Int, y: Int, display: Int?) -> ControlResponse
+    func windowZoom(_ target: String?) -> ControlResponse
     func clearRestoreCommands() -> ControlResponse
 }
 
@@ -122,6 +126,8 @@ public struct ControlDispatcher {
                 .themeSet, .themeList, .sidebar, .sidebarMode, .sidebarExpand,
                 .sidebarCollapse, .restoreClear:
             return dispatchAppCommand(request)
+        case .windowRename, .windowResize, .windowMove, .windowZoom:
+            return dispatchWindowCommand(request)
         default:
             return nil
         }
@@ -404,5 +410,30 @@ public struct ControlDispatcher {
                                        options: ControlSessionTextOptions(pane: request.args?.pane,
                                                                           all: all,
                                                                           lines: lines))
+    }
+
+    private func dispatchWindowCommand(_ request: ControlRequest) -> ControlResponse {
+        switch request.cmd {
+        case .windowRename:
+            guard let name = request.args?.name?.trimmedOrNil else {
+                return ControlResponse(ok: false, error: "window.rename requires a name")
+            }
+            return actions.windowRename(request.target, name: name)
+        case .windowResize:
+            guard let width = request.args?.width, let height = request.args?.height,
+                  width > 0, height > 0 else {
+                return ControlResponse(ok: false, error: "window.resize requires positive width and height")
+            }
+            return actions.windowResize(request.target, width: width, height: height)
+        case .windowMove:
+            guard let x = request.args?.x, let y = request.args?.y else {
+                return ControlResponse(ok: false, error: "window.move requires x and y")
+            }
+            return actions.windowMove(request.target, x: x, y: y, display: request.args?.display)
+        case .windowZoom:
+            return actions.windowZoom(request.target)
+        default:
+            preconditionFailure("unexpected window command: \(request.cmd.rawValue)")
+        }
     }
 }

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -900,6 +900,102 @@ struct ControlDispatcherTests {
         #expect(actions.calls == [.restoreClear])
     }
 
+    @Test func windowCommandsRouteParsedInputsAndKeepActionResponses() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextWindowRenameResponse = ControlResponse(ok: true, result: ControlResult(id: "win"))
+        actions.nextWindowResizeResponse = ControlResponse(ok: true, result: ControlResult(id: "win"))
+        actions.nextWindowMoveResponse = ControlResponse(ok: true, result: ControlResult(id: "win"))
+        actions.nextWindowZoomResponse = ControlResponse(ok: false, error: "window not open — window.select it first")
+
+        let renamed = await dispatcher.dispatch(ControlRequest(
+            cmd: .windowRename,
+            target: "9f3c",
+            args: ControlArgs(name: "  Renamed  ")
+        ))
+        let resized = await dispatcher.dispatch(ControlRequest(
+            cmd: .windowResize,
+            target: "9f3c",
+            args: ControlArgs(width: 1200, height: 800)
+        ))
+        let moved = await dispatcher.dispatch(ControlRequest(
+            cmd: .windowMove,
+            target: "9f3c",
+            args: ControlArgs(x: 100, y: 50, display: 1)
+        ))
+        let zoomed = await dispatcher.dispatch(ControlRequest(cmd: .windowZoom, target: "9f3c"))
+
+        #expect(renamed == ControlResponse(ok: true, result: ControlResult(id: "win")))
+        #expect(resized == ControlResponse(ok: true, result: ControlResult(id: "win")))
+        #expect(moved == ControlResponse(ok: true, result: ControlResult(id: "win")))
+        #expect(zoomed == ControlResponse(ok: false, error: "window not open — window.select it first"))
+        #expect(actions.calls == [
+            .windowRename(target: "9f3c", "Renamed"),
+            .windowResize(target: "9f3c", width: 1200, height: 800),
+            .windowMove(target: "9f3c", x: 100, y: 50, display: 1),
+            .windowZoom(target: "9f3c")
+        ])
+    }
+
+    @Test func windowCommandsRejectInvalidInputsBeforeCallingActions() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let missingName = await dispatcher.dispatch(ControlRequest(cmd: .windowRename, target: "win"))
+        let blankName = await dispatcher.dispatch(ControlRequest(
+            cmd: .windowRename,
+            target: "win",
+            args: ControlArgs(name: "   ")
+        ))
+        let missingResize = await dispatcher.dispatch(ControlRequest(
+            cmd: .windowResize,
+            target: "win",
+            args: ControlArgs(width: 1200)
+        ))
+        let badResize = await dispatcher.dispatch(ControlRequest(
+            cmd: .windowResize,
+            target: "win",
+            args: ControlArgs(width: 0, height: 800)
+        ))
+        let missingMoveY = await dispatcher.dispatch(ControlRequest(
+            cmd: .windowMove,
+            target: "win",
+            args: ControlArgs(x: 100)
+        ))
+
+        #expect(missingName == ControlResponse(ok: false, error: "window.rename requires a name"))
+        #expect(blankName == ControlResponse(ok: false, error: "window.rename requires a name"))
+        #expect(missingResize == ControlResponse(ok: false, error: "window.resize requires positive width and height"))
+        #expect(badResize == ControlResponse(ok: false, error: "window.resize requires positive width and height"))
+        #expect(missingMoveY == ControlResponse(ok: false, error: "window.move requires x and y"))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test func windowCommandsKeepHostSideLookupAndPlatformErrors() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextWindowRenameResponse = ControlResponse(ok: false, error: "no such window: missing")
+        actions.nextWindowMoveResponse = ControlResponse(ok: false, error: "display 3 out of range (have 1)")
+
+        let missingWindow = await dispatcher.dispatch(ControlRequest(
+            cmd: .windowRename,
+            target: "missing",
+            args: ControlArgs(name: "Renamed")
+        ))
+        let badDisplay = await dispatcher.dispatch(ControlRequest(
+            cmd: .windowMove,
+            target: "win",
+            args: ControlArgs(x: 100, y: 50, display: 3)
+        ))
+
+        #expect(missingWindow == ControlResponse(ok: false, error: "no such window: missing"))
+        #expect(badDisplay == ControlResponse(ok: false, error: "display 3 out of range (have 1)"))
+        #expect(actions.calls == [
+            .windowRename(target: "missing", "Renamed"),
+            .windowMove(target: "win", x: 100, y: 50, display: 3)
+        ])
+    }
+
     @Test func nonMigratedCommandFallsThrough() async {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)
@@ -950,6 +1046,10 @@ private final class MockControlActions: ControlActions {
         case overlayResult(target: String?, window: String?)
         case sessionBackground(target: String?, window: String?, ControlSessionBackgroundOptions)
         case sessionText(target: String?, window: String?, ControlSessionTextOptions)
+        case windowRename(target: String?, String)
+        case windowResize(target: String?, width: Int, height: Int)
+        case windowMove(target: String?, x: Int, y: Int, display: Int?)
+        case windowZoom(target: String?)
         case restoreClear
     }
 
@@ -973,6 +1073,10 @@ private final class MockControlActions: ControlActions {
     var nextOverlayResultResponse = ControlResponse(ok: true)
     var nextSessionBackgroundResponse = ControlResponse(ok: true)
     var nextSessionTextResponse = ControlResponse(ok: true)
+    var nextWindowRenameResponse = ControlResponse(ok: true)
+    var nextWindowResizeResponse = ControlResponse(ok: true)
+    var nextWindowMoveResponse = ControlResponse(ok: true)
+    var nextWindowZoomResponse = ControlResponse(ok: true)
     var nextRestoreClearResponse = ControlResponse(ok: true)
 
     func controlTree(window: String?) -> ControlResponse {
@@ -1159,6 +1263,26 @@ private final class MockControlActions: ControlActions {
     func readSessionText(_ target: String?, window: String?, options: ControlSessionTextOptions) -> ControlResponse {
         calls.append(.sessionText(target: target, window: window, options))
         return nextSessionTextResponse
+    }
+
+    func windowRename(_ target: String?, name: String) -> ControlResponse {
+        calls.append(.windowRename(target: target, name))
+        return nextWindowRenameResponse
+    }
+
+    func windowResize(_ target: String?, width: Int, height: Int) -> ControlResponse {
+        calls.append(.windowResize(target: target, width: width, height: height))
+        return nextWindowResizeResponse
+    }
+
+    func windowMove(_ target: String?, x: Int, y: Int, display: Int?) -> ControlResponse {
+        calls.append(.windowMove(target: target, x: x, y: y, display: display))
+        return nextWindowMoveResponse
+    }
+
+    func windowZoom(_ target: String?) -> ControlResponse {
+        calls.append(.windowZoom(target: target))
+        return nextWindowZoomResponse
     }
 
     func clearRestoreCommands() -> ControlResponse {


### PR DESCRIPTION
## Summary
- route `window.rename`, `window.resize`, `window.move`, and `window.zoom` through `ControlDispatcher`
- keep `window.new`, `window.list`, `window.select`, `window.close`, and `window.delete` on the existing app-side path
- keep AppKit/window registry effects in `ControlServer` and add focused dispatcher tests for validation and response passthrough

## Validation
- `swift test --package-path agtermCore --filter ControlDispatcherTests`
- `swift test --package-path agtermCore`
- `make lint`
- `make build`
- `xcodebuild -project agterm.xcodeproj -scheme agterm -derivedDataPath build/DerivedData -only-testing:agtermUITests/ControlWindowUITests test` partially failed in unrelated header interaction tests; migrated command-specific tests in that class passed (`testWindowMove`, `testWindowResize`, `testWindowZoom`, targeting/list cases).

## Notes
- `window.new` and `window.list` behavior are intentionally unchanged.
- No comment-only lines were removed or changed in the production diff.