### PR TITLE
feat: persist workspace expand/collapse state across relaunch

### DIFF
--- a/.claude/rules/sidebar.md
+++ b/.claude/rules/sidebar.md
@@ -206,10 +206,30 @@ paths:
 - **Persistence (per-window, no version bump).**
   `Session.flagged` persists via `SessionSnapshot.flagged: Bool?` (decode → `false`),
   `sidebarMode` via `Snapshot.sidebarMode: SidebarMode?` (→ `.tree`), `focusedWorkspaceID` via `Snapshot.focusedWorkspaceID: UUID?`
-  (naturally Optional → nil).
-  All three Optional fields, so legacy JSON with none of the keys decodes to the unflagged / `.tree`
-  / unfocused defaults without throwing (the load-fresh-on-decode-failure contract) — no `Snapshot` version
-  bump.
-  Round-trips + legacy-decode covered in `PersistenceTests`, mutations/derived-list/focus-clear/auto-unfocus
-  in `AppStoreTests`.
+  (naturally Optional → nil), and each workspace's expand/collapse state via `WorkspaceSnapshot.collapsed: Bool?`
+  (decode → `false` → expanded).
+  All four Optional fields, so legacy JSON with none of the keys decodes to the unflagged / `.tree`
+  / unfocused / expanded defaults without throwing (the load-fresh-on-decode-failure contract) — no `Snapshot`
+  version bump.
+  `collapsed` is stored as the INVERSE of `Workspace.isExpanded` and only WRITTEN when collapsed (`true`);
+  an expanded workspace omits it, so an all-expanded tree serializes byte-identically to a legacy snapshot,
+  and "lack of the field = expanded" holds.
+  The sidebar Coordinator seeds `expandedWorkspaceIDs` from `Workspace.isExpanded` in `makeNSView`
+  (`seedExpansionFromModel`, replacing the old unconditional `expandAll`) so a collapsed workspace restores
+  collapsed.
+  **Only a GENUINE user toggle persists.**
+  The `outlineViewItemDidExpand`/`DidCollapse` callbacks write back via `AppStore.setWorkspaceExpanded(_:expanded:)`
+  (a PER-workspace mutator, so toggling one row never rewrites another's saved state), and `expandAll`/`collapseOthers`
+  persist the whole tree once via `setWorkspacesExpanded(_:)`.
+  A `suppressExpansionPersist` flag is set around every PROGRAMMATIC `expandItem`/`collapseItem` — the launch/`rebuildAndReload`
+  re-apply, the `syncSelection` reveal, and the focused-workspace force-expand — so those update the VISUAL
+  `expandedWorkspaceIDs` (needed for the flagged-mode round-trip) WITHOUT touching the persisted `isExpanded`.
+  This is what makes a deliberate collapse durable: revealing a session inside a collapsed workspace (nav,
+  notification click, or the launch-time active-session reveal) or focusing it shows the row but does NOT
+  un-collapse it on disk — the collapse survives until the user expands the row themselves.
+  The active session is still force-revealed on launch (`syncSelection`), so it is never hidden inside a
+  collapsed workspace; the row just re-collapses on the next launch (its persisted state is untouched).
+  Round-trips + legacy-decode (incl. explicit `collapsed:false`) covered in `PersistenceTests`,
+  per-workspace + whole-tree mutators / no-op-no-write in `AppStoreOrganizationTests`, and the
+  collapse-survives-relaunch + reveal-does-not-repersist end-to-end cases in `SidebarUITests`.
 

--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -58,8 +58,11 @@ struct WorkspaceSidebar: NSViewRepresentable {
 
         context.coordinator.outlineView = outline
         context.coordinator.renameController.outlineView = outline
+        // seed the tracked expansion from the persisted per-workspace state BEFORE the reload, so
+        // rebuildAndReload restores each workspace's saved open/collapsed state (a collapsed workspace
+        // stays collapsed across relaunch) instead of force-expanding every row.
+        context.coordinator.seedExpansionFromModel()
         context.coordinator.rebuildAndReload()
-        context.coordinator.expandAll()
         context.coordinator.syncSelection()
         // on launch AppKit makes the sidebar the window's initial first responder; hand
         // focus to the terminal once the window + surface are attached (retries internally).
@@ -138,6 +141,13 @@ struct WorkspaceSidebar: NSViewRepresentable {
         /// discards its own expansion state for items it no longer renders, so on the way back to the tree
         /// this set is the only record of which workspaces were open.
         private var expandedWorkspaceIDs = Set<UUID>()
+        /// Set true around PROGRAMMATIC `expandItem`/`collapseItem` (the launch/rebuild re-apply, the
+        /// `syncSelection` reveal, the focus force-expand). While set, the didExpand/DidCollapse callbacks
+        /// still update the visual `expandedWorkspaceIDs` but SKIP the persist write-back, so a view-only
+        /// reveal or focus zoom-in never burns a workspace's deliberately-persisted collapse. Only a genuine
+        /// user toggle (row click / disclosure triangle) — which fires the callback with this false —
+        /// persists. `expandAll`/`collapseOthers` set it too and persist once explicitly at the end.
+        private var suppressExpansionPersist = false
         /// Scheduled single-click workspace expand/collapse, deferred by the double-click interval so a
         /// double-click (rename) can cancel it — otherwise the first click of a rename double-click would
         /// flip the workspace open/closed on its way into edit mode. See `handleSingleClick`.
@@ -404,18 +414,26 @@ struct WorkspaceSidebar: NSViewRepresentable {
             nodeCache = nodeCache.filter { seen.contains($0.key) }
             roots = newRoots
 
-            // prune expansion tracking for workspaces that no longer exist, so a removed-then-re-added id
-            // can't carry stale expansion.
+            // keep the tracked set in step with the model: drop ids for workspaces that no longer exist,
+            // then pick up any the model reports expanded but that aren't tracked yet — a workspace added
+            // at runtime defaults `isExpanded == true`, so this renders it open rather than collapsed. A
+            // user-collapsed workspace has `isExpanded == false` (so it's excluded) and a programmatic
+            // reveal keeps its already-present id (formUnion only adds), so neither is disturbed.
             expandedWorkspaceIDs.formIntersection(Set(store.workspaces.map(\.id)))
+            expandedWorkspaceIDs.formUnion(store.workspaces.filter(\.isExpanded).map(\.id))
 
             // restore expansion from the tracked set rather than the live outline state: a flagged-mode
             // reload drops the workspace nodes, so the outline forgets they were expanded, but the tracked
             // set remembers across the interlude. A freshly-focused workspace is expanded unconditionally —
-            // focus is a "zoom in", so its sessions must show even if the workspace was collapsed.
+            // focus is a "zoom in", so its sessions must show even if the workspace was collapsed. This
+            // re-apply is a VIEW restore, not a user action, so suppress the persist: a focused-but-collapsed
+            // workspace must keep its persisted collapse (the zoom-in shows it, but doesn't un-collapse it).
             outline.reloadData()
+            suppressExpansionPersist = true
             for node in roots where expandedWorkspaceIDs.contains(node.id) || node.id == store.focusedWorkspaceID {
                 outline.expandItem(node)
             }
+            suppressExpansionPersist = false
             updateEmptyState()
         }
 
@@ -451,33 +469,51 @@ struct WorkspaceSidebar: NSViewRepresentable {
             label.textColor = (GhosttyApp.shared.terminalForegroundColor ?? .secondaryLabelColor).withAlphaComponent(0.6)
         }
 
-        /// Expands every workspace row (new workspaces start open). Seeds the tracked expansion from the
-        /// live workspaces — NOT the current `roots`, which are session nodes when launched in flagged mode
-        /// or a single subtree when launched focused — so a later switch back to the full tree remembers
-        /// every workspace as expanded instead of collapsing them all.
+        /// Seeds the tracked expansion set from the persisted per-workspace state (`Workspace.isExpanded`),
+        /// so the launch reload restores each workspace's saved open/collapsed state. Sets only the tracked
+        /// set — `rebuildAndReload` applies it to the outline. Called once from `makeNSView`.
+        func seedExpansionFromModel() {
+            expandedWorkspaceIDs = Set(store.workspaces.filter(\.isExpanded).map(\.id))
+        }
+
+        /// Expands every workspace row — the "Expand Workspaces" user action. Seeds the tracked expansion
+        /// from the live `store.workspaces`, NOT the current `roots` (a single subtree when a workspace is
+        /// focused), so unfocusing back to the full tree remembers every workspace as expanded. The
+        /// per-item callbacks are suppressed; the whole-tree state is persisted once via
+        /// `setWorkspacesExpanded` since this is a deliberate all-workspace command.
         func expandAll() {
             guard let outline = outlineView else { return }
             for workspace in store.workspaces { expandedWorkspaceIDs.insert(workspace.id) }
+            suppressExpansionPersist = true
             for node in roots where node.kind == .workspace { outline.expandItem(node) }
+            suppressExpansionPersist = false
+            store.setWorkspacesExpanded(expandedWorkspaceIDs)
         }
 
         /// Collapses every workspace except the active one (the workspace of the active session,
         /// `store.currentWorkspaceID`), keeping that one expanded and scrolling its row into view so it
-        /// stays visible. Updates the tracked expansion set to match (the expand/collapse delegate
-        /// callbacks also fire, but the explicit update keeps the set correct even if a state is unchanged).
-        /// Tree-mode only — no workspace rows exist in flagged mode, so it is a graceful no-op there.
+        /// stays visible. Tree-mode only — no workspace rows exist in flagged mode, so it is a graceful
+        /// no-op there.
         func collapseOthers() {
             guard let outline = outlineView, store.sidebarMode == .tree else { return }
             let keepID = store.currentWorkspaceID
+            // this command targets ALL workspaces, not just the visible `roots`: reduce the tracked set to
+            // exactly the active workspace so a focus filter that hides some workspaces can't leave them in
+            // the set and get them persisted expanded by the batch write below. The outline expand/collapse
+            // only touches the rows currently on screen.
+            if let keepID { expandedWorkspaceIDs = [keepID] } else { expandedWorkspaceIDs = [] }
+            suppressExpansionPersist = true
             for node in roots where node.kind == .workspace {
                 if node.id == keepID {
                     if !outline.isItemExpanded(node) { outline.expandItem(node) }
-                    expandedWorkspaceIDs.insert(node.id)
-                } else {
-                    if outline.isItemExpanded(node) { outline.collapseItem(node) }
-                    expandedWorkspaceIDs.remove(node.id)
+                } else if outline.isItemExpanded(node) {
+                    outline.collapseItem(node)
                 }
             }
+            suppressExpansionPersist = false
+            // persist the whole-tree collapse state once — this is a deliberate command, so it writes every
+            // workspace (only the active one expanded), unlike the per-toggle callback path.
+            store.setWorkspacesExpanded(expandedWorkspaceIDs)
             // keep the active workspace's row on screen (mirrors syncSelection's scroll-into-view).
             guard let keepID, let node = nodeCache[keepID] else { return }
             let row = outline.row(forItem: node)
@@ -488,12 +524,18 @@ struct WorkspaceSidebar: NSViewRepresentable {
             guard let node = notification.userInfo?[Self.outlineItemUserInfoKey] as? SidebarNode,
                   node.kind == .workspace else { return }
             expandedWorkspaceIDs.insert(node.id)
+            // persist ONLY a genuine user expand (row click / disclosure triangle). A programmatic reveal or
+            // rebuild re-apply sets suppressExpansionPersist, so it updates the visual set above without
+            // burning the persisted collapse intent.
+            if !suppressExpansionPersist { store.setWorkspaceExpanded(node.id, expanded: true) }
         }
 
         func outlineViewItemDidCollapse(_ notification: Notification) {
             guard let node = notification.userInfo?[Self.outlineItemUserInfoKey] as? SidebarNode,
                   node.kind == .workspace else { return }
             expandedWorkspaceIDs.remove(node.id)
+            // persist only a genuine user collapse; programmatic collapses are suppressed (see didExpand).
+            if !suppressExpansionPersist { store.setWorkspaceExpanded(node.id, expanded: false) }
         }
 
         private func node(for id: UUID, kind: SidebarNode.Kind) -> SidebarNode {
@@ -522,9 +564,13 @@ struct WorkspaceSidebar: NSViewRepresentable {
             // session leave a user-collapsed workspace and a user-moved scroll position alone.
             let selectionChanged = selectedID != lastRevealedSelection
             // a session selected by keyboard nav may live in a collapsed workspace, whose row is -1
-            // until expanded; expand its owner first so the row resolves.
+            // until expanded; expand its owner first so the row resolves. This reveal is a VIEW action,
+            // not a user expand, so suppress the persist: navigating into (or launching with the selection
+            // inside) a deliberately-collapsed workspace shows the session without un-collapsing it on disk.
             if selectionChanged, let owner = ownerWorkspaceNode(ofSession: selectedID), !outline.isItemExpanded(owner) {
+                suppressExpansionPersist = true
                 outline.expandItem(owner)
+                suppressExpansionPersist = false
             }
             let row = outline.row(forItem: node)
             guard row >= 0 else { return }

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -530,6 +530,33 @@ public final class AppStore {
         save()
     }
 
+    /// Sets one workspace's expand/collapse state and persists it. Clean no-op (no write) for an unknown id
+    /// or when unchanged. The sidebar calls this for a GENUINE per-row user toggle only (a row click or the
+    /// disclosure triangle), never for a programmatic reveal — so a deliberate collapse survives a later
+    /// reveal of a session inside the workspace, and toggling one workspace never touches another's saved
+    /// state (unlike `setWorkspacesExpanded`, which rewrites the whole tree).
+    public func setWorkspaceExpanded(_ id: UUID, expanded: Bool) {
+        guard let index = workspaces.firstIndex(where: { $0.id == id }), workspaces[index].isExpanded != expanded else { return }
+        workspaces[index].isExpanded = expanded
+        save()
+    }
+
+    /// Marks each workspace expanded iff its id is in `expandedIDs` and persists the collapse state so it
+    /// survives a relaunch. One `save()` for the whole diff; a clean no-op (no write) when nothing changed.
+    /// Backs the deliberate all-workspace commands (Expand Workspaces / Collapse Workspaces), which set
+    /// every workspace at once; per-row toggles use `setWorkspaceExpanded` instead.
+    public func setWorkspacesExpanded(_ expandedIDs: Set<UUID>) {
+        var changed = false
+        for index in workspaces.indices {
+            let expanded = expandedIDs.contains(workspaces[index].id)
+            if workspaces[index].isExpanded != expanded {
+                workspaces[index].isExpanded = expanded
+                changed = true
+            }
+        }
+        if changed { save() }
+    }
+
     /// The focused workspace, resolved from `focusedWorkspaceID` — nil when unfocused OR when the id is
     /// stale (its workspace no longer exists). The single id→workspace lookup the tree filter and the
     /// bottom-bar focus pill both read, so they can't drift.
@@ -636,7 +663,7 @@ public final class AppStore {
     /// `@MainActor`; the resulting value is `Sendable` and safe to hand to a writer.
     public func snapshot() -> Snapshot {
         let workspaceSnapshots = workspaces.map { workspace in
-            WorkspaceSnapshot(id: workspace.id, name: workspace.name, sessions: workspace.sessions.map { session in
+            let sessions = workspace.sessions.map { session in
                 SessionSnapshot(id: session.id, customName: session.customName, cwd: session.currentCwd ?? session.initialCwd,
                                 isSplit: session.isSplit, fontSize: session.fontSize,
                                 splitCwd: session.splitCwd ?? session.initialSplitCwd, splitRatio: session.splitRatio,
@@ -645,7 +672,11 @@ public final class AppStore {
                                 splitForegroundCommand: session.splitForegroundCommand,
                                 initialCommand: session.initialCommand,
                                 backgroundWatermark: session.backgroundWatermark)
-            })
+            }
+            // only a collapsed workspace writes the flag; an expanded one omits it (nil) so an all-expanded
+            // tree serializes identically to a legacy snapshot.
+            return WorkspaceSnapshot(id: workspace.id, name: workspace.name, sessions: sessions,
+                                     collapsed: workspace.isExpanded ? nil : true)
         }
         return Snapshot(selectedSessionID: selectedSessionID, workspaces: workspaceSnapshots,
                         sidebarWidth: sidebarWidth, sidebarVisible: sidebarVisible, sidebarMode: sidebarMode,
@@ -679,7 +710,9 @@ public final class AppStore {
                 session.backgroundWatermark = sessionSnapshot.backgroundWatermark
                 return session
             }
-            return Workspace(id: workspaceSnapshot.id, name: workspaceSnapshot.name, sessions: sessions)
+            // absent/nil collapsed → expanded (back-compat with snapshots written before the field existed).
+            return Workspace(id: workspaceSnapshot.id, name: workspaceSnapshot.name, sessions: sessions,
+                             isExpanded: !(workspaceSnapshot.collapsed ?? false))
         }
         // clamp on restore (not just nil-default) so a corrupt or hand-edited snapshot can't drive an
         // out-of-range frame width; the drag path clamps to the same bounds.

--- a/agtermCore/Sources/agtermCore/Snapshot.swift
+++ b/agtermCore/Sources/agtermCore/Snapshot.swift
@@ -73,11 +73,18 @@ public struct WorkspaceSnapshot: Codable, Equatable, Sendable {
     public var id: UUID
     public var name: String
     public var sessions: [SessionSnapshot]
+    /// Whether the sidebar row was collapsed. Optional AND stored as the inverse of `isExpanded` so a
+    /// snapshot already on disk before this field was added still decodes (missing → nil → not collapsed
+    /// → expanded, the default) instead of failing the load and wiping the saved tree, like the fields on
+    /// `SessionSnapshot`. Only a collapsed workspace writes it (`true`); an expanded one omits it, so an
+    /// all-expanded tree serializes byte-identically to a legacy snapshot.
+    public var collapsed: Bool?
 
-    public init(id: UUID, name: String, sessions: [SessionSnapshot]) {
+    public init(id: UUID, name: String, sessions: [SessionSnapshot], collapsed: Bool? = nil) {
         self.id = id
         self.name = name
         self.sessions = sessions
+        self.collapsed = collapsed
     }
 }
 

--- a/agtermCore/Sources/agtermCore/Workspace.swift
+++ b/agtermCore/Sources/agtermCore/Workspace.swift
@@ -7,17 +7,22 @@ public struct Workspace: Identifiable {
     public let id: UUID
     public var name: String
     public var sessions: [Session]
+    /// Whether the sidebar row is expanded (its session rows shown). Defaults true so a freshly created
+    /// workspace opens; persisted per workspace so the collapse state survives a relaunch.
+    public var isExpanded: Bool
 
-    public init(name: String, sessions: [Session] = []) {
+    public init(name: String, sessions: [Session] = [], isExpanded: Bool = true) {
         id = UUID()
         self.name = name
         self.sessions = sessions
+        self.isExpanded = isExpanded
     }
 
-    public init(id: UUID, name: String, sessions: [Session] = []) {
+    public init(id: UUID, name: String, sessions: [Session] = [], isExpanded: Bool = true) {
         self.id = id
         self.name = name
         self.sessions = sessions
+        self.isExpanded = isExpanded
     }
 
     /// Total unseen-notification count across this workspace's sessions, for the badge on a

--- a/agtermCore/Tests/agtermCoreTests/AppStoreOrganizationTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreOrganizationTests.swift
@@ -165,6 +165,68 @@ struct AppStoreOrganizationTests {
         #expect(store.focusedWorkspaceID == work.id)
     }
 
+    @Test func newWorkspaceStartsExpanded() {
+        let store = makeStore()
+        let work = store.addWorkspace(name: "work")
+        #expect(work.isExpanded)
+        #expect(store.workspaces[0].isExpanded)
+    }
+
+    @Test func setWorkspacesExpandedTogglesAndPersists() {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("agterm-tests-\(UUID().uuidString)")
+        let persistence = PersistenceStore(directory: dir)
+        let store = AppStore(persistence: persistence)
+        let a = store.addWorkspace(name: "a")
+        let b = store.addWorkspace(name: "b")
+        // only `a` stays expanded; `b` collapses.
+        store.setWorkspacesExpanded([a.id])
+        #expect(store.workspaces[0].isExpanded)
+        #expect(!store.workspaces[1].isExpanded)
+        let loaded = persistence.load()
+        #expect(loaded.workspaces[0].collapsed == nil)   // expanded → omitted
+        #expect(loaded.workspaces[1].collapsed == true)  // collapsed → written
+        _ = b
+    }
+
+    @Test func setWorkspacesExpandedUnchangedDoesNotWrite() {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("agterm-tests-\(UUID().uuidString)")
+        let persistence = PersistenceStore(directory: dir)
+        let store = AppStore(persistence: persistence)
+        let a = store.addWorkspace(name: "a")
+        // collapse a, flush to disk, then hand-edit the on-disk file to a sentinel and re-issue the SAME
+        // state: a no-op mutator must not overwrite the sentinel (proving it skipped save()).
+        store.setWorkspacesExpanded([]) // a collapsed, saved
+        let sentinelURL = dir.appendingPathComponent("workspaces.json")
+        try! Data("{ not json }".utf8).write(to: sentinelURL)
+        store.setWorkspacesExpanded([]) // same state → no save, sentinel survives
+        #expect(try! Data(contentsOf: sentinelURL) == Data("{ not json }".utf8))
+        _ = a
+    }
+
+    @Test func setWorkspaceExpandedTogglesSingleWorkspaceAndPersists() {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("agterm-tests-\(UUID().uuidString)")
+        let persistence = PersistenceStore(directory: dir)
+        let store = AppStore(persistence: persistence)
+        let a = store.addWorkspace(name: "a")
+        let b = store.addWorkspace(name: "b")
+        store.setWorkspaceExpanded(a.id, expanded: false)
+        #expect(!store.workspaces[0].isExpanded)
+        #expect(store.workspaces[1].isExpanded) // b untouched — per-workspace, not whole-tree
+        let loaded = persistence.load()
+        #expect(loaded.workspaces[0].collapsed == true)
+        #expect(loaded.workspaces[1].collapsed == nil)
+        _ = b
+    }
+
+    @Test func setWorkspaceExpandedUnknownOrUnchangedIsNoOp() {
+        let store = makeStore()
+        let a = store.addWorkspace(name: "a")
+        store.setWorkspaceExpanded(UUID(), expanded: false) // unknown id
+        #expect(store.workspaces[0].isExpanded)
+        store.setWorkspaceExpanded(a.id, expanded: true) // already expanded
+        #expect(store.workspaces[0].isExpanded)
+    }
+
     @Test func visibleWorkspacesReturnsAllWhenUnfocused() {
         let store = makeStore()
         let work = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/PersistenceTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/PersistenceTests.swift
@@ -375,6 +375,55 @@ final class PersistenceTests {
         #expect(restored.workspaces[0].sessions[0].fontSize == 17.5)
     }
 
+    @Test func workspaceCollapsePersistsAndRestores() {
+        let app = AppStore(persistence: store)
+        let a = app.addWorkspace(name: "a")
+        let b = app.addWorkspace(name: "b")
+        app.setWorkspacesExpanded([a.id]) // collapse b, keep a expanded
+        let disk = store.load()
+        #expect(disk.workspaces[0].collapsed == nil)  // expanded → omitted
+        #expect(disk.workspaces[1].collapsed == true) // collapsed → written
+
+        let restored = AppStore(persistence: store)
+        restored.restore(from: disk)
+        #expect(restored.workspaces[0].isExpanded)     // a
+        #expect(!restored.workspaces[1].isExpanded)    // b
+        _ = b
+    }
+
+    @Test func legacyWorkspaceWithoutCollapsedDecodesExpanded() throws {
+        // a workspaces.json written before `collapsed` existed has no key; it must decode (not throw and
+        // wipe the tree) and restore expanded — lack of the field means expanded, for back-compat.
+        let ws = UUID()
+        let session = UUID()
+        let json = #"{ "version": 1, "workspaces": "# +
+            #"[ { "id": "\#(ws.uuidString)", "name": "work", "sessions": [ { "id": "\#(session.uuidString)", "cwd": "/a" } ] } ] }"#
+        try Data(json.utf8).write(to: fileURL)
+        let loaded = store.load()
+        #expect(loaded.workspaces.map(\.id) == [ws])
+        #expect(loaded.workspaces[0].collapsed == nil)
+
+        let app = AppStore(persistence: store)
+        app.restore(from: loaded)
+        #expect(app.workspaces[0].isExpanded)
+    }
+
+    @Test func explicitCollapsedFalseDecodesExpanded() throws {
+        // an explicit `collapsed: false` (a hand-edit, or a snapshot from a future build that always writes
+        // the field) must decode to expanded, same as an absent key — `!(false ?? false)` == expanded.
+        let ws = UUID()
+        let session = UUID()
+        let json = #"{ "version": 1, "workspaces": [ { "id": "\#(ws.uuidString)", "name": "work", "# +
+            #""collapsed": false, "sessions": [ { "id": "\#(session.uuidString)", "cwd": "/a" } ] } ] }"#
+        try Data(json.utf8).write(to: fileURL)
+        let loaded = store.load()
+        #expect(loaded.workspaces[0].collapsed == false)
+
+        let app = AppStore(persistence: store)
+        app.restore(from: loaded)
+        #expect(app.workspaces[0].isExpanded)
+    }
+
     @Test func selectSessionPersistsSelectionToDisk() {
         let app = AppStore(persistence: store)
         let work = app.addWorkspace(name: "work")

--- a/agtermUITests/SidebarUITests.swift
+++ b/agtermUITests/SidebarUITests.swift
@@ -73,6 +73,18 @@ final class SidebarUITests: XCTestCase {
         return app.menuItems[title].firstMatch
     }
 
+    /// Polls until the number of visible `session-row` static texts equals `expected`. Used by the
+    /// collapse-persistence test, where the observable is how many session rows show under the
+    /// expanded-vs-collapsed workspaces.
+    private func pollSessionRowCount(_ expected: Int, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if app.staticTexts.matching(identifier: "session-row").count == expected { return true }
+            usleep(150_000)
+        }
+        return app.staticTexts.matching(identifier: "session-row").count == expected
+    }
+
     /// Polls an element's `value` until it equals `expected`.
     private func waitForValue(_ element: XCUIElement, _ expected: String, timeout: TimeInterval) -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
@@ -130,6 +142,126 @@ final class SidebarUITests: XCTestCase {
         // click again → expand → the session row comes back.
         ws.click()
         XCTAssertTrue(session.waitForExistence(timeout: 5), "expanding the workspace should show its session row again")
+    }
+
+    /// A workspace's collapsed state persists per window and restores on relaunch. Collapse a workspace
+    /// whose session is NOT the selected one (so the launch-time reveal of the active session can't
+    /// re-expand it), confirm the snapshot records it, then relaunch and confirm it comes back collapsed.
+    func testWorkspaceCollapsePersistsAcrossRelaunch() throws {
+        XCTAssertTrue(app.staticTexts["workspace 1"].waitForExistence(timeout: 20), "seeded workspace should exist")
+        XCTAssertTrue(pollSessionRowCount(1, timeout: 10), "seeded session A should be visible")
+
+        // add a second workspace and give it its own session B (created via the workspace-row menu so it
+        // lands in workspace 2); B becomes the selected/active session.
+        app.buttons["New Workspace"].click()
+        let ws2 = app.staticTexts["workspace 2"]
+        XCTAssertTrue(ws2.waitForExistence(timeout: 5), "second workspace should appear")
+        ws2.rightClick()
+        presentedMenuItem("New Session").click()
+        XCTAssertTrue(pollSessionRowCount(2, timeout: 10), "workspace 2 should now show its own session B")
+
+        // collapse workspace 1 (NOT the active workspace) → its session A hides, leaving only B.
+        app.staticTexts["workspace 1"].click()
+        XCTAssertTrue(pollSessionRowCount(1, timeout: 8), "collapsing workspace 1 should hide session A")
+        XCTAssertTrue(stateDir.pollSnapshot(equals: true, timeout: 8) { snapshot in
+            (snapshot["workspaces"] as? [[String: Any]])?
+                .first(where: { $0["name"] as? String == "workspace 1" })?["collapsed"] as? Bool
+        }, "collapsing workspace 1 should persist collapsed=true")
+
+        // relaunch with the same state dir: workspace 1 must restore COLLAPSED. The active session B's
+        // workspace (2) is revealed on launch, so exactly one session row (B) shows; A stays hidden under
+        // the restored-collapsed workspace 1.
+        app.terminate()
+        app = XCUIApplication()
+        app.launchEnvironment["AGTERM_STATE_DIR"] = stateDir.path
+        app.launchForUITest()
+        XCTAssertTrue(app.staticTexts["workspace 1"].waitForExistence(timeout: 20), "workspace 1 should restore")
+        XCTAssertTrue(pollSessionRowCount(1, timeout: 10),
+                      "workspace 1 should restore collapsed (session A hidden); only the active session B shows")
+
+        // expanding workspace 1 again brings A back and clears the persisted collapse.
+        app.staticTexts["workspace 1"].click()
+        XCTAssertTrue(pollSessionRowCount(2, timeout: 8), "expanding workspace 1 should reveal session A again")
+    }
+
+    /// Collapsing the workspace that OWNS the active session must persist that collapse even though the
+    /// active session is force-revealed on relaunch: the reveal shows the session but is a view action, so
+    /// it must NOT re-persist the workspace as expanded. Guards the reveal-must-not-burn-collapse fix.
+    func testActiveWorkspaceCollapsePersistsDespiteReveal() throws {
+        XCTAssertTrue(app.staticTexts["workspace 1"].waitForExistence(timeout: 20), "seeded workspace should exist")
+        XCTAssertTrue(pollSessionRowCount(1, timeout: 10), "seeded active session should be visible")
+
+        // collapse the active session's own workspace → its row hides, snapshot records collapsed=true.
+        app.staticTexts["workspace 1"].click()
+        XCTAssertTrue(pollSessionRowCount(0, timeout: 8), "collapsing the active workspace should hide its session row")
+        XCTAssertTrue(stateDir.pollSnapshot(equals: true, timeout: 8) { snapshot in
+            (snapshot["workspaces"] as? [[String: Any]])?.first?["collapsed"] as? Bool
+        }, "collapsing the active workspace should persist collapsed=true")
+
+        // relaunch: the active session is revealed (its row shows again), but the persisted collapse must
+        // survive — the reveal must not have flipped the snapshot back to expanded.
+        app.terminate()
+        app = XCUIApplication()
+        app.launchEnvironment["AGTERM_STATE_DIR"] = stateDir.path
+        app.launchForUITest()
+        XCTAssertTrue(pollSessionRowCount(1, timeout: 20), "the active session should be force-revealed on relaunch")
+        XCTAssertTrue(stateDir.pollSnapshot(equals: true, timeout: 8) { snapshot in
+            (snapshot["workspaces"] as? [[String: Any]])?.first?["collapsed"] as? Bool
+        }, "the launch reveal must not re-persist the workspace as expanded (still collapsed=true)")
+    }
+
+    /// Collapse Workspaces while a workspace is FOCUSED must still collapse the focus-hidden workspaces,
+    /// not just the one visible row. Guards the focused-mode collapseOthers fix (it reduces the tracked set
+    /// to the active workspace across ALL workspaces, so hidden ones are persisted collapsed too).
+    func testCollapseWorkspacesWhileFocusedCollapsesHiddenWorkspaces() throws {
+        XCTAssertTrue(app.staticTexts["workspace 1"].waitForExistence(timeout: 20), "seeded workspace should exist")
+        // give workspace 2 its own session B (via its row menu) so it becomes the active workspace.
+        app.buttons["New Workspace"].click()
+        let ws2 = app.staticTexts["workspace 2"]
+        XCTAssertTrue(ws2.waitForExistence(timeout: 5), "second workspace should appear")
+        ws2.rightClick()
+        presentedMenuItem("New Session").click()
+        XCTAssertTrue(pollSessionRowCount(2, timeout: 10), "workspace 2 should show its own active session B")
+
+        // focus workspace 2 → workspace 1 (holding the non-active session A) is now hidden from the tree.
+        ws2.rightClick()
+        presentedMenuItem("Focus").click()
+        XCTAssertTrue(pollSessionRowCount(1, timeout: 8), "focusing workspace 2 should hide workspace 1's session")
+
+        // Collapse Workspaces (View menu) must collapse workspace 1 even though it is hidden by the focus.
+        app.menuBars.menuBarItems["View"].click()
+        let collapse = app.menuItems["Collapse Workspaces"]
+        XCTAssertTrue(collapse.waitForExistence(timeout: 5), "Collapse Workspaces menu item should appear")
+        collapse.click()
+        XCTAssertTrue(stateDir.pollSnapshot(equals: true, timeout: 8) { snapshot in
+            (snapshot["workspaces"] as? [[String: Any]])?
+                .first(where: { $0["name"] as? String == "workspace 1" })?["collapsed"] as? Bool
+        }, "Collapse Workspaces must persist the focus-hidden workspace 1 as collapsed")
+    }
+
+    /// Moving the active session into a freshly created workspace must keep it visible: a runtime-added
+    /// workspace defaults expanded, so its rows show without a manual expand. The move does not change the
+    /// selection, so nothing reveals the workspace — only the model-expanded-default (picked up by the
+    /// rebuild's formUnion) renders it open. Guards that fix.
+    func testMovingActiveSessionIntoNewWorkspaceKeepsItVisible() throws {
+        let row = sessionRow()
+        XCTAssertTrue(row.waitForExistence(timeout: 20), "seeded active session should exist")
+        app.buttons["New Workspace"].click()
+        XCTAssertTrue(app.staticTexts["workspace 2"].waitForExistence(timeout: 5), "second workspace should appear")
+
+        // move the active session into the new (never-revealed) workspace 2 via its context menu.
+        row.rightClick()
+        let moveTo = app.menuItems["Move to"]
+        XCTAssertTrue(moveTo.waitForExistence(timeout: 5), "Move to submenu should appear")
+        moveTo.hover()
+        let target = app.menuItems["workspace 2"]
+        XCTAssertTrue(target.waitForExistence(timeout: 5), "target workspace in submenu should appear")
+        target.click()
+
+        // the moved session stays selected (no reveal fires), so it only shows if workspace 2 renders
+        // expanded from its isExpanded=true default; without that it would be hidden under a collapsed row.
+        XCTAssertTrue(pollSessionRowCount(1, timeout: 8),
+                      "the active session should stay visible in the new workspace (rendered expanded by default)")
     }
 
     // issue #41: Esc must cancel the inline rename — close edit mode and discard the typed change.


### PR DESCRIPTION
Each workspace's sidebar expand/collapse state now survives a relaunch. Previously every workspace re-expanded on launch; now a workspace you collapse stays collapsed.

**Model and persistence.** Adds `Workspace.isExpanded` (default true), persisted as the optional inverse `WorkspaceSnapshot.collapsed`. Only a collapsed workspace writes the field, so an all-expanded tree is byte-identical to a legacy snapshot and any `workspaces.json` written before this change (no `collapsed` key) decodes as expanded. Back-compatible, no snapshot version bump.

**Only deliberate toggles persist.** The sidebar seeds expansion from the model on launch and writes back per-workspace from the row-toggle callbacks. A `suppressExpansionPersist` guard wraps all programmatic expansion (the launch/rebuild re-apply, the active-session reveal, and the focus zoom-in) so revealing or focusing a collapsed workspace shows it without un-collapsing it on disk. The active session is still revealed on launch, it just re-collapses on the next launch. `expandAll`/`collapseOthers` persist the whole tree, and `collapseOthers` works while a focus filter is active.

**Tests.** Host-free round-trip, back-compat (absent and explicit `collapsed:false`), and per-workspace/whole-tree mutator tests, plus SidebarUITests for relaunch persistence, reveal-does-not-repersist, focused-mode collapse, and runtime-add rendering.
