### PR TITLE
refactor: route remaining control commands through dispatcher

### DIFF
--- a/agterm/Control/ControlServer+SurfaceIO.swift
+++ b/agterm/Control/ControlServer+SurfaceIO.swift
@@ -146,6 +146,19 @@ extension ControlServer {
     /// via libghostty's SEARCH_TOTAL callback; `searchTotal`/`searchSelected` are cleared before the query so
     /// the bounded main-actor poll waits for the FRESH count (not a stale prior needle's), then `count` + the
     /// "N of M" display string are returned in `text`.
+    func searchSession(_ target: String?, window: String?, text: String?, to: String?) async -> ControlResponse {
+        // Resolve first (cross-window when no `window`), then select + realize the surface; the realize
+        // path is async (bounded poll), so this can't go through the synchronous `resolveSession`
+        // helper. Error strings stay in sync with `resolve(...)`, and target lookup preserves the
+        // pre-dispatcher error order by winning over `to` validation.
+        switch resolver.resolveSessionTarget(target, window: window) {
+        case .failure(let response):
+            return response
+        case .success(let (store, id)):
+            return await searchSession(id, store: store, text: text, to: to)
+        }
+    }
+
     func searchSession(_ id: UUID, store: AppStore, text: String?, to: String?) async -> ControlResponse {
         // validate `to` up front so a bad mode errors before touching the surface.
         if let to, !["next", "prev", "close"].contains(to) {

--- a/agterm/Control/ControlServer+WindowCommands.swift
+++ b/agterm/Control/ControlServer+WindowCommands.swift
@@ -20,6 +20,10 @@ extension ControlServer {
         library.controlWindowNodes()
     }
 
+    func windowList() -> ControlResponse {
+        ControlResponse(ok: true, result: ControlResult(windows: buildWindowList()))
+    }
+
     /// Resolve a window id and surface it: raise an already-open window, or open a closed one (the
     /// action hub's opener claims its id + spawns the window). A closed window's store loads only when
     /// its SwiftUI window appears, so this bounded-polls for it to open before replying — a script can

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -346,31 +346,11 @@ final class ControlServer {
                 .sessionFocus, .sessionResize, .sessionStatus, .sessionFlag, .notify,
                 .fontInc, .fontDec, .fontReset, .keymapReload, .configReload, .themeSet, .themeList,
                 .sidebar, .sidebarMode, .sidebarExpand, .sidebarCollapse, .sessionType, .sessionCopy,
-                .sessionOverlayOpen, .sessionOverlayClose, .sessionOverlayResult, .sessionBackground,
-                .sessionText, .windowRename, .windowResize, .windowMove, .windowZoom, .restoreClear:
+                .sessionSearch, .sessionOverlayOpen, .sessionOverlayClose, .sessionOverlayResult,
+                .sessionBackground, .sessionText, .quick, .windowNew, .windowList, .windowSelect,
+                .windowClose, .windowRename, .windowDelete, .windowResize, .windowMove, .windowZoom,
+                .restoreClear:
             return ControlResponse(ok: false, error: "control dispatcher did not handle \(request.cmd.rawValue)")
-        case .sessionSearch:
-            // resolve first (cross-window when no `args.window`), then select + realize the surface; the
-            // realize path is async (bounded poll), so this can't go through the synchronous
-            // `resolveSession` helper. error strings stay in sync with `resolve(...)`.
-            switch resolver.resolveSessionTarget(request.target, window: request.args?.window) {
-            case .failure(let response):
-                return response
-            case .success(let (store, id)):
-                return await searchSession(id, store: store, text: request.args?.text, to: request.args?.to)
-            }
-        case .quick:
-            return setQuickTerminal(mode: request.args?.mode)
-        case .windowNew:
-            return windowNew(name: request.args?.name)
-        case .windowList:
-            return ControlResponse(ok: true, result: ControlResult(windows: buildWindowList()))
-        case .windowSelect:
-            return await windowSelect(request.target)
-        case .windowClose:
-            return await windowClose(request.target)
-        case .windowDelete:
-            return windowDelete(request.target)
         }
     }
 

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -34,8 +34,11 @@ public protocol ControlActions {
     func setSidebarViewMode(_ mode: ControlSidebarViewMode) -> ControlResponse
     func expandSidebar(window: String?) -> ControlResponse
     func collapseSidebar(window: String?) -> ControlResponse
+    func setQuickTerminal(mode: String?) -> ControlResponse
     func typeSession(_ target: String?, window: String?, options: ControlSessionTypeOptions) async -> ControlResponse
     func copySessionSelection(_ target: String?, window: String?) -> ControlResponse
+    func searchSession(_ target: String?, window: String?,
+                       text: String?, to: String?) async -> ControlResponse
     func openSessionOverlay(_ target: String?, window: String?,
                             options: ControlSessionOverlayOpenOptions) -> ControlResponse
     func closeSessionOverlay(_ target: String?, window: String?) -> ControlResponse
@@ -43,7 +46,12 @@ public protocol ControlActions {
     func setSessionBackground(_ target: String?, window: String?,
                               options: ControlSessionBackgroundOptions) -> ControlResponse
     func readSessionText(_ target: String?, window: String?, options: ControlSessionTextOptions) -> ControlResponse
+    func windowNew(name: String?) -> ControlResponse
+    func windowList() -> ControlResponse
+    func windowSelect(_ target: String?) async -> ControlResponse
+    func windowClose(_ target: String?) async -> ControlResponse
     func windowRename(_ target: String?, name: String) -> ControlResponse
+    func windowDelete(_ target: String?) -> ControlResponse
     func windowResize(_ target: String?, width: Int, height: Int) -> ControlResponse
     func windowMove(_ target: String?, x: Int, y: Int, display: Int?) -> ControlResponse
     func windowZoom(_ target: String?) -> ControlResponse
@@ -98,8 +106,8 @@ public struct ControlSessionTextOptions: Equatable, Sendable {
     }
 }
 
-/// Routes the command groups that have been hoisted from the app control switch. Commands outside this
-/// first migrated set return nil so the app can keep handling them in its existing switch.
+/// Routes control commands through a host-provided action seam. The dispatcher owns command parsing and
+/// response shape; host actions keep target resolution, AppKit state, and terminal-surface side effects.
 @MainActor
 public struct ControlDispatcher {
     private let actions: any ControlActions
@@ -116,20 +124,19 @@ public struct ControlDispatcher {
                 .sessionMove, .sessionFlag, .sessionStatus:
             return dispatchSessionCommand(request)
         case .sessionSplit, .sessionScratch, .sessionFocus, .sessionResize, .sessionType,
-                .sessionCopy, .sessionOverlayOpen, .sessionOverlayClose, .sessionOverlayResult,
-                .sessionBackground, .sessionText:
+                .sessionCopy, .sessionSearch, .sessionOverlayOpen, .sessionOverlayClose,
+                .sessionOverlayResult, .sessionBackground, .sessionText:
             return await dispatchSessionSurfaceCommand(request)
         case .workspaceNew, .workspaceSelect, .workspaceRename, .workspaceDelete,
                 .workspaceMove, .workspaceFocus:
             return dispatchWorkspaceCommand(request)
-        case .fontInc, .fontDec, .fontReset, .keymapReload, .configReload, .notify,
+        case .quick, .fontInc, .fontDec, .fontReset, .keymapReload, .configReload, .notify,
                 .themeSet, .themeList, .sidebar, .sidebarMode, .sidebarExpand,
                 .sidebarCollapse, .restoreClear:
             return dispatchAppCommand(request)
-        case .windowRename, .windowResize, .windowMove, .windowZoom:
-            return dispatchWindowCommand(request)
-        default:
-            return nil
+        case .windowNew, .windowList, .windowSelect, .windowClose, .windowRename,
+                .windowDelete, .windowResize, .windowMove, .windowZoom:
+            return await dispatchWindowCommand(request)
         }
     }
 
@@ -291,6 +298,9 @@ public struct ControlDispatcher {
                                              ))
         case .sessionCopy:
             return actions.copySessionSelection(request.target, window: request.args?.window)
+        case .sessionSearch:
+            return await actions.searchSession(request.target, window: request.args?.window,
+                                               text: request.args?.text, to: request.args?.to)
         case .sessionOverlayOpen:
             guard let command = request.args?.command, !command.isEmpty else {
                 return ControlResponse(ok: false, error: "session.overlay.open requires a command")
@@ -327,6 +337,8 @@ public struct ControlDispatcher {
             return actions.font(request.target, window: request.args?.window, action: "decrease_font_size:1")
         case .fontReset:
             return actions.font(request.target, window: request.args?.window, action: "reset_font_size")
+        case .quick:
+            return actions.setQuickTerminal(mode: request.args?.mode)
         case .keymapReload:
             return actions.reloadKeymap()
         case .configReload:
@@ -437,13 +449,23 @@ public struct ControlDispatcher {
                                                                           lines: lines))
     }
 
-    private func dispatchWindowCommand(_ request: ControlRequest) -> ControlResponse {
+    private func dispatchWindowCommand(_ request: ControlRequest) async -> ControlResponse {
         switch request.cmd {
+        case .windowNew:
+            return actions.windowNew(name: request.args?.name)
+        case .windowList:
+            return actions.windowList()
+        case .windowSelect:
+            return await actions.windowSelect(request.target)
+        case .windowClose:
+            return await actions.windowClose(request.target)
         case .windowRename:
             guard let name = request.args?.name?.trimmedOrNil else {
                 return ControlResponse(ok: false, error: "window.rename requires a name")
             }
             return actions.windowRename(request.target, name: name)
+        case .windowDelete:
+            return actions.windowDelete(request.target)
         case .windowResize:
             guard let width = request.args?.width, let height = request.args?.height,
                   width > 0, height > 0 else {

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -1000,6 +1000,76 @@ struct ControlDispatcherTests {
         #expect(actions.calls == [.restoreClear])
     }
 
+    @Test func quickRoutesRawModeAndKeepsActionResponse() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextQuickResponse = ControlResponse(ok: false, error: "invalid quick mode: maybe")
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .quick,
+            args: ControlArgs(mode: "maybe")
+        ))
+
+        #expect(response == ControlResponse(ok: false, error: "invalid quick mode: maybe"))
+        #expect(actions.calls == [.quick("maybe")])
+    }
+
+    @Test func sessionSearchRoutesRawInputsAndKeepsActionResponse() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextSessionSearchResponse = ControlResponse(
+            ok: true,
+            result: ControlResult(text: "2 of 5", count: 5)
+        )
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionSearch,
+            target: "session",
+            args: ControlArgs(text: "needle", window: "win", to: "next")
+        ))
+
+        #expect(response == ControlResponse(ok: true, result: ControlResult(text: "2 of 5", count: 5)))
+        #expect(actions.calls == [
+            .sessionSearch(target: "session", window: "win", text: "needle", to: "next")
+        ])
+    }
+
+    @Test func windowLifecycleAndListCommandsRouteThroughActions() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        let windows = [
+            ControlWindowNode(id: "win-a", name: "Main", open: true, active: true),
+            ControlWindowNode(id: "win-b", name: "Build", open: false, active: false)
+        ]
+        actions.nextWindowNewResponse = ControlResponse(ok: true, result: ControlResult(id: "win-b"))
+        actions.nextWindowListResponse = ControlResponse(ok: true, result: ControlResult(windows: windows))
+        actions.nextWindowSelectResponse = ControlResponse(ok: true, result: ControlResult(id: "win-b"))
+        actions.nextWindowCloseResponse = ControlResponse(ok: true, result: ControlResult(id: "win-b"))
+        actions.nextWindowDeleteResponse = ControlResponse(ok: false, error: "cannot delete last window")
+
+        let created = await dispatcher.dispatch(ControlRequest(
+            cmd: .windowNew,
+            args: ControlArgs(name: "Build")
+        ))
+        let listed = await dispatcher.dispatch(ControlRequest(cmd: .windowList))
+        let selected = await dispatcher.dispatch(ControlRequest(cmd: .windowSelect, target: "win-b"))
+        let closed = await dispatcher.dispatch(ControlRequest(cmd: .windowClose, target: "win-b"))
+        let deleted = await dispatcher.dispatch(ControlRequest(cmd: .windowDelete, target: "win-b"))
+
+        #expect(created == ControlResponse(ok: true, result: ControlResult(id: "win-b")))
+        #expect(listed == ControlResponse(ok: true, result: ControlResult(windows: windows)))
+        #expect(selected == ControlResponse(ok: true, result: ControlResult(id: "win-b")))
+        #expect(closed == ControlResponse(ok: true, result: ControlResult(id: "win-b")))
+        #expect(deleted == ControlResponse(ok: false, error: "cannot delete last window"))
+        #expect(actions.calls == [
+            .windowNew("Build"),
+            .windowList,
+            .windowSelect(target: "win-b"),
+            .windowClose(target: "win-b"),
+            .windowDelete(target: "win-b")
+        ])
+    }
+
     @Test func windowCommandsRouteParsedInputsAndKeepActionResponses() async {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)
@@ -1096,15 +1166,6 @@ struct ControlDispatcherTests {
         ])
     }
 
-    @Test func nonMigratedCommandFallsThrough() async {
-        let actions = MockControlActions()
-        let dispatcher = ControlDispatcher(actions: actions)
-
-        let response = await dispatcher.dispatch(ControlRequest(cmd: .sessionSearch))
-
-        #expect(response == nil)
-        #expect(actions.calls.isEmpty)
-    }
 }
 
 @MainActor
@@ -1139,14 +1200,21 @@ private final class MockControlActions: ControlActions {
         case sidebarViewMode(ControlSidebarViewMode)
         case expand(window: String?)
         case collapse(window: String?)
+        case quick(String?)
         case sessionType(target: String?, window: String?, ControlSessionTypeOptions)
         case sessionCopy(target: String?, window: String?)
+        case sessionSearch(target: String?, window: String?, text: String?, to: String?)
         case overlayOpen(target: String?, window: String?, ControlSessionOverlayOpenOptions)
         case overlayClose(target: String?, window: String?)
         case overlayResult(target: String?, window: String?)
         case sessionBackground(target: String?, window: String?, ControlSessionBackgroundOptions)
         case sessionText(target: String?, window: String?, ControlSessionTextOptions)
+        case windowNew(String?)
+        case windowList
+        case windowSelect(target: String?)
+        case windowClose(target: String?)
         case windowRename(target: String?, String)
+        case windowDelete(target: String?)
         case windowResize(target: String?, width: Int, height: Int)
         case windowMove(target: String?, x: Int, y: Int, display: Int?)
         case windowZoom(target: String?)
@@ -1166,14 +1234,21 @@ private final class MockControlActions: ControlActions {
     var nextConfigResponse = ControlResponse(ok: true)
     var nextThemeSetResponse = ControlResponse(ok: true)
     var nextThemeListResponse = ControlResponse(ok: true)
+    var nextQuickResponse = ControlResponse(ok: true)
     var nextSessionTypeResponse = ControlResponse(ok: true)
     var nextSessionCopyResponse = ControlResponse(ok: true)
+    var nextSessionSearchResponse = ControlResponse(ok: true)
     var nextOverlayOpenResponse = ControlResponse(ok: true)
     var nextOverlayCloseResponse = ControlResponse(ok: true)
     var nextOverlayResultResponse = ControlResponse(ok: true)
     var nextSessionBackgroundResponse = ControlResponse(ok: true)
     var nextSessionTextResponse = ControlResponse(ok: true)
+    var nextWindowNewResponse = ControlResponse(ok: true)
+    var nextWindowListResponse = ControlResponse(ok: true)
+    var nextWindowSelectResponse = ControlResponse(ok: true)
+    var nextWindowCloseResponse = ControlResponse(ok: true)
     var nextWindowRenameResponse = ControlResponse(ok: true)
+    var nextWindowDeleteResponse = ControlResponse(ok: true)
     var nextWindowResizeResponse = ControlResponse(ok: true)
     var nextWindowMoveResponse = ControlResponse(ok: true)
     var nextWindowZoomResponse = ControlResponse(ok: true)
@@ -1327,6 +1402,11 @@ private final class MockControlActions: ControlActions {
         return nextCollapseResponse
     }
 
+    func setQuickTerminal(mode: String?) -> ControlResponse {
+        calls.append(.quick(mode))
+        return nextQuickResponse
+    }
+
     func typeSession(_ target: String?, window: String?,
                      options: ControlSessionTypeOptions) async -> ControlResponse {
         calls.append(.sessionType(target: target, window: window, options))
@@ -1336,6 +1416,12 @@ private final class MockControlActions: ControlActions {
     func copySessionSelection(_ target: String?, window: String?) -> ControlResponse {
         calls.append(.sessionCopy(target: target, window: window))
         return nextSessionCopyResponse
+    }
+
+    func searchSession(_ target: String?, window: String?,
+                       text: String?, to: String?) async -> ControlResponse {
+        calls.append(.sessionSearch(target: target, window: window, text: text, to: to))
+        return nextSessionSearchResponse
     }
 
     func openSessionOverlay(_ target: String?, window: String?,
@@ -1365,9 +1451,34 @@ private final class MockControlActions: ControlActions {
         return nextSessionTextResponse
     }
 
+    func windowNew(name: String?) -> ControlResponse {
+        calls.append(.windowNew(name))
+        return nextWindowNewResponse
+    }
+
+    func windowList() -> ControlResponse {
+        calls.append(.windowList)
+        return nextWindowListResponse
+    }
+
+    func windowSelect(_ target: String?) async -> ControlResponse {
+        calls.append(.windowSelect(target: target))
+        return nextWindowSelectResponse
+    }
+
+    func windowClose(_ target: String?) async -> ControlResponse {
+        calls.append(.windowClose(target: target))
+        return nextWindowCloseResponse
+    }
+
     func windowRename(_ target: String?, name: String) -> ControlResponse {
         calls.append(.windowRename(target: target, name))
         return nextWindowRenameResponse
+    }
+
+    func windowDelete(_ target: String?) -> ControlResponse {
+        calls.append(.windowDelete(target: target))
+        return nextWindowDeleteResponse
     }
 
     func windowResize(_ target: String?, width: Int, height: Int) -> ControlResponse {


### PR DESCRIPTION
## Summary
- Route the remaining `ControlServer.dispatch` command arms through `ControlDispatcher`: `window.new/list/select/close/delete`, `session.search`, and `quick`.
- Keep AppKit, SwiftUI, window-cache, target-resolution, quick-terminal, and terminal-search side effects in the macOS app-side adapters.
- Preserve the nonisolated cache fast path for `window.list` and `tree --window` closed-window errors.

## Behavior Notes
- `session.search` still resolves target/window before validating `--to`, preserving prior error ordering and exact response strings.
- `quick` still delegates mode parsing to the app-side action, preserving `no open window` versus invalid-mode ordering.
- Window lifecycle/list commands call the same app-side helpers as before; the dispatcher only routes them.

## Validation
- `swift test --filter ControlDispatcherTests`
- `make test` (967 tests)
- `make lint`
- `make build`

## Note to maintainer

Looks like this is the last piece of my Linux port. Next, I'm going to bring the port up to speed with the latest UI/UX changes you've introduced over the last couple of days and report back if `agtermCore` needs more work to properly support the UI abstraction.

Thanks for bearing with me through this series of PRs!