### PR TITLE
fix: declare NSMicrophoneUsageDescription for hosted CLI mic access

### DIFF
--- a/agterm/Info.plist
+++ b/agterm/Info.plist
@@ -34,5 +34,7 @@
 	<string>public.app-category.developer-tools</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2026 Umputun</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Command-line tools you run inside agterm (for example, voice dictation in Claude Code) request microphone access through agterm.</string>
 </dict>
 </plist>


### PR DESCRIPTION
a terminal is the *responsible process* for the CLI tools it hosts, so macOS attributes a microphone request from a child process to agterm. With no `NSMicrophoneUsageDescription` in the bundle `Info.plist`, the OS refuses the request before it can prompt and never creates a TCC entry, so voice features in a hosted CLI agent (Claude Code's `/voice`) get no permission dialog and agterm never appears in **Privacy & Security > Microphone**, regardless of `tccutil reset`.

adds the missing key to `agterm/Info.plist`:

```xml
<key>NSMicrophoneUsageDescription</key>
<string>Command-line tools you run inside agterm (for example, voice dictation in Claude Code) request microphone access through agterm.</string>
```

the app is non-sandboxed under hardened runtime, so the usage-description string is all that's required, no `com.apple.security.device.audio-input` entitlement needed.

verified on an isolated dev build: a CLI child requesting the mic now triggers the permission dialog and `authorizationStatus` goes notDetermined -> authorized after allow; before the change the request was refused with no dialog.

Fix #142
