### PR TITLE
fix: unreadable selected session label on light themes (light:/dark: theme form)

### DIFF
--- a/agterm/Ghostty/GhosttyApp.swift
+++ b/agterm/Ghostty/GhosttyApp.swift
@@ -295,9 +295,9 @@ final class GhosttyApp {
             ?? selectionBackground.map(Self.contrastingText(for:))
     }
 
-    /// Whether the active appearance is dark, for resolving the `theme = light:…,dark:…` form. Uses
-    /// `NSApp` when available; `resolveThemeColors` runs from `init` before `NSApp` is set, so it falls
-    /// back to the system setting rather than force-unwrapping the nil `NSApp`.
+    /// Whether the active appearance is dark, for the `theme = light:…,dark:…` form.
+    /// `resolveThemeColors` runs from `init` before `NSApp` exists, so fall back to
+    /// the system setting instead of force-unwrapping nil `NSApp`.
     private static func currentAppearanceIsDark() -> Bool {
         if let appearance = NSApp?.effectiveAppearance {
             return appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
@@ -345,7 +345,7 @@ final class GhosttyApp {
         if selBg == nil || selFg == nil, let themeName, !themeName.isEmpty,
            let themesDir = Bundle.main.url(forResource: "ghostty", withExtension: nil)?
                .appendingPathComponent("themes", isDirectory: true) {
-            // `theme` may be the `light:…,dark:…` auto-switch form; reduce it to the active name.
+            // `theme` may be the `light:…,dark:…` form; reduce to the active name.
             let effectiveName = ThemeName.resolved(from: themeName, isDark: isDark)
             for (key, value) in keyValues(ofFileAt: themesDir.appendingPathComponent(effectiveName).path) {
                 if key == "selection-background", selBg == nil { selBg = parseHexColor(value) }

--- a/agterm/Ghostty/GhosttyApp.swift
+++ b/agterm/Ghostty/GhosttyApp.swift
@@ -288,23 +288,35 @@ final class GhosttyApp {
         terminalBackgroundColor = Self.color(from: config, key: "background")
         terminalForegroundColor = Self.color(from: config, key: "foreground")
         let (selectionBackground, selectionForeground) = Self.resolveSelectionColors(
-            ghosttyConfigPath: inputs.scopedURL.path, inheritGlobalConfig: inputs.inheritGlobalConfig)
+            ghosttyConfigPath: inputs.scopedURL.path, inheritGlobalConfig: inputs.inheritGlobalConfig,
+            isDark: Self.currentAppearanceIsDark())
         terminalSelectionBackgroundColor = selectionBackground
         terminalSelectionForegroundColor = selectionForeground
             ?? selectionBackground.map(Self.contrastingText(for:))
     }
 
+    /// Whether the active appearance is dark, for resolving the `theme = light:…,dark:…` form. Uses
+    /// `NSApp` when available; `resolveThemeColors` runs from `init` before `NSApp` is set, so it falls
+    /// back to the system setting rather than force-unwrapping the nil `NSApp`.
+    private static func currentAppearanceIsDark() -> Bool {
+        if let appearance = NSApp?.effectiveAppearance {
+            return appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        }
+        return UserDefaults.standard.string(forKey: "AppleInterfaceStyle") == "Dark"
+    }
+
     /// The selection colors can't be read back through `ghostty_config_get` (it doesn't expose the
     /// optional `selection-background`/`selection-foreground` keys), so resolve them by reading the
     /// same config sources `loadConfig` loads — in the same order — plus the active theme file. An
-    /// explicit `selection-*` line wins over the theme's; either color may be nil when unset.
+    /// explicit `selection-*` line wins over the theme's; either color may be nil when unset. The `theme`
+    /// value may be the `light:…,dark:…` auto-switch form, resolved to the active side via `isDark`.
     ///
     /// Known limitation: this scans only the top-level config files; it does NOT follow `config-file`
     /// includes that `ghostty_config_load_recursive_files` expands, so a `selection-*` delegated through
     /// an include is missed and the sidebar pill falls back. A known edge case (it pre-dates the
     /// agterm-scoped `ghostty.conf`). The user's global `~/.config/ghostty/config` is a source ONLY when
     /// `inheritGlobalConfig` is on, matching `loadConfig`'s gate.
-    private static func resolveSelectionColors(ghosttyConfigPath: String, inheritGlobalConfig: Bool) -> (NSColor?, NSColor?) {
+    private static func resolveSelectionColors(ghosttyConfigPath: String, inheritGlobalConfig: Bool, isDark: Bool) -> (NSColor?, NSColor?) {
         var sources: [String] = []
         if let defaults = Bundle.main.url(forResource: "ghostty-defaults", withExtension: "conf") {
             sources.append(defaults.path)
@@ -333,7 +345,9 @@ final class GhosttyApp {
         if selBg == nil || selFg == nil, let themeName, !themeName.isEmpty,
            let themesDir = Bundle.main.url(forResource: "ghostty", withExtension: nil)?
                .appendingPathComponent("themes", isDirectory: true) {
-            for (key, value) in keyValues(ofFileAt: themesDir.appendingPathComponent(themeName).path) {
+            // `theme` may be the `light:…,dark:…` auto-switch form; reduce it to the active name.
+            let effectiveName = ThemeName.resolved(from: themeName, isDark: isDark)
+            for (key, value) in keyValues(ofFileAt: themesDir.appendingPathComponent(effectiveName).path) {
                 if key == "selection-background", selBg == nil { selBg = parseHexColor(value) }
                 if key == "selection-foreground", selFg == nil { selFg = parseHexColor(value) }
             }

--- a/agtermCore/Sources/agtermCore/ThemeName.swift
+++ b/agtermCore/Sources/agtermCore/ThemeName.swift
@@ -1,41 +1,34 @@
 import Foundation
 
-/// Resolves a ghostty `theme` config value to the single theme name active for a given appearance.
+/// Reduces a ghostty `theme` value to the theme name active for the current appearance.
 ///
-/// ghostty accepts two forms (https://ghostty.org/docs/config/reference#theme): a plain name
-/// (`theme = Gruvbox Dark Hard`), or an appearance-split `theme = light:NameA,dark:NameB` that follows
-/// the system light/dark mode (order-independent, whitespace-trimmed). libghostty resolves
-/// `background`/`foreground` for both forms, but agterm parses the optional `selection-*` colors by hand
-/// from the theme file — so the split form must be reduced to ONE name before that file lookup, else the
-/// whole `light:…,dark:…` string is used as a filename, no theme file matches, and the sidebar selection
-/// pill falls back to an unreadable wash. Host-free (Foundation-only) so it is unit-tested; the app passes
-/// in the current appearance.
+/// The `light:…,dark:…` form must collapse to one name before agterm's by-hand `selection-*` lookup:
+/// the raw form matches no theme file, so the selected sidebar row falls back to an unreadable wash.
+/// Host-free so it is unit-tested.
 public enum ThemeName {
-    /// The theme name to load for `value` under the given appearance. A plain value is returned trimmed.
-    /// For the `light:…,dark:…` form the matching variant is returned, falling back to the other variant,
-    /// then to the trimmed raw value, if a side is missing.
+    /// The theme name for `value` under the appearance. Only a well-formed `light:…,dark:…` (both sides
+    /// present) resolves to a variant; a plain or malformed value is returned as-is.
     public static func resolved(from value: String, isDark: Bool) -> String {
         let trimmed = value.trimmingCharacters(in: .whitespaces)
         var light: String?
         var dark: String?
-        var sawPrefix = false
         for segment in trimmed.split(separator: ",") {
             let part = segment.trimmingCharacters(in: .whitespaces)
             if let name = variant("light:", in: part) {
                 light = name
-                sawPrefix = true
             } else if let name = variant("dark:", in: part) {
                 dark = name
-                sawPrefix = true
             }
         }
-        guard sawPrefix else { return trimmed }
-        return (isDark ? dark : light) ?? dark ?? light ?? trimmed
+        // The split form needs both sides; one-sided or malformed is a plain name.
+        guard let light, let dark else { return trimmed }
+        return isDark ? dark : light
     }
 
-    /// The name after a `light:`/`dark:` prefix (case-insensitive), trimmed; nil when the prefix is absent.
+    /// The trimmed name after a case-insensitive `light:`/`dark:` prefix; nil if absent or empty.
     private static func variant(_ prefix: String, in part: String) -> String? {
         guard part.lowercased().hasPrefix(prefix) else { return nil }
-        return String(part.dropFirst(prefix.count)).trimmingCharacters(in: .whitespaces)
+        let name = String(part.dropFirst(prefix.count)).trimmingCharacters(in: .whitespaces)
+        return name.isEmpty ? nil : name
     }
 }

--- a/agtermCore/Sources/agtermCore/ThemeName.swift
+++ b/agtermCore/Sources/agtermCore/ThemeName.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Resolves a ghostty `theme` config value to the single theme name active for a given appearance.
+///
+/// ghostty accepts two forms (https://ghostty.org/docs/config/reference#theme): a plain name
+/// (`theme = Gruvbox Dark Hard`), or an appearance-split `theme = light:NameA,dark:NameB` that follows
+/// the system light/dark mode (order-independent, whitespace-trimmed). libghostty resolves
+/// `background`/`foreground` for both forms, but agterm parses the optional `selection-*` colors by hand
+/// from the theme file — so the split form must be reduced to ONE name before that file lookup, else the
+/// whole `light:…,dark:…` string is used as a filename, no theme file matches, and the sidebar selection
+/// pill falls back to an unreadable wash. Host-free (Foundation-only) so it is unit-tested; the app passes
+/// in the current appearance.
+public enum ThemeName {
+    /// The theme name to load for `value` under the given appearance. A plain value is returned trimmed.
+    /// For the `light:…,dark:…` form the matching variant is returned, falling back to the other variant,
+    /// then to the trimmed raw value, if a side is missing.
+    public static func resolved(from value: String, isDark: Bool) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespaces)
+        var light: String?
+        var dark: String?
+        var sawPrefix = false
+        for segment in trimmed.split(separator: ",") {
+            let part = segment.trimmingCharacters(in: .whitespaces)
+            if let name = variant("light:", in: part) {
+                light = name
+                sawPrefix = true
+            } else if let name = variant("dark:", in: part) {
+                dark = name
+                sawPrefix = true
+            }
+        }
+        guard sawPrefix else { return trimmed }
+        return (isDark ? dark : light) ?? dark ?? light ?? trimmed
+    }
+
+    /// The name after a `light:`/`dark:` prefix (case-insensitive), trimmed; nil when the prefix is absent.
+    private static func variant(_ prefix: String, in part: String) -> String? {
+        guard part.lowercased().hasPrefix(prefix) else { return nil }
+        return String(part.dropFirst(prefix.count)).trimmingCharacters(in: .whitespaces)
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/ThemeNameTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ThemeNameTests.swift
@@ -37,8 +37,14 @@ struct ThemeNameTests {
         #expect(ThemeName.resolved(from: value, isDark: true) == "Gruvbox Dark Hard")
     }
 
-    @Test func missingSideFallsBackToTheOther() {
-        #expect(ThemeName.resolved(from: "light:Alabaster", isDark: true) == "Alabaster")
-        #expect(ThemeName.resolved(from: "dark:Gruvbox Dark Hard", isDark: false) == "Gruvbox Dark Hard")
+    @Test func oneSidedFormIsNotTreatedAsSplit() {
+        // ghostty requires both sides; a one-sided value is malformed and returned as-is.
+        #expect(ThemeName.resolved(from: "light:Alabaster", isDark: true) == "light:Alabaster")
+        #expect(ThemeName.resolved(from: "dark:Gruvbox Dark Hard", isDark: false) == "dark:Gruvbox Dark Hard")
+    }
+
+    @Test func emptyVariantIsNotTreatedAsSplit() {
+        #expect(ThemeName.resolved(from: "light:,dark:Gruvbox Dark Hard", isDark: false) == "light:,dark:Gruvbox Dark Hard")
+        #expect(ThemeName.resolved(from: "light:Alabaster,dark:", isDark: true) == "light:Alabaster,dark:")
     }
 }

--- a/agtermCore/Tests/agtermCoreTests/ThemeNameTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ThemeNameTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+struct ThemeNameTests {
+    @Test func plainNameIsReturnedForBothAppearances() {
+        #expect(ThemeName.resolved(from: "Gruvbox Dark Hard", isDark: true) == "Gruvbox Dark Hard")
+        #expect(ThemeName.resolved(from: "Gruvbox Dark Hard", isDark: false) == "Gruvbox Dark Hard")
+        #expect(ThemeName.resolved(from: "GitHub Light Default", isDark: false) == "GitHub Light Default")
+    }
+
+    @Test func plainNameIsTrimmed() {
+        #expect(ThemeName.resolved(from: "  Alabaster  ", isDark: false) == "Alabaster")
+    }
+
+    @Test func lightDarkFormPicksTheMatchingVariant() {
+        let value = "light:Alabaster,dark:Gruvbox Dark Hard"
+        #expect(ThemeName.resolved(from: value, isDark: false) == "Alabaster")
+        #expect(ThemeName.resolved(from: value, isDark: true) == "Gruvbox Dark Hard")
+    }
+
+    @Test func orderOfLightDarkDoesNotMatter() {
+        let value = "dark:Gruvbox Dark Hard,light:Alabaster"
+        #expect(ThemeName.resolved(from: value, isDark: false) == "Alabaster")
+        #expect(ThemeName.resolved(from: value, isDark: true) == "Gruvbox Dark Hard")
+    }
+
+    @Test func whitespaceAroundVariantsIsTrimmed() {
+        let value = "light: GitHub Light Default , dark: Gruvbox Dark Hard "
+        #expect(ThemeName.resolved(from: value, isDark: false) == "GitHub Light Default")
+        #expect(ThemeName.resolved(from: value, isDark: true) == "Gruvbox Dark Hard")
+    }
+
+    @Test func prefixMatchIsCaseInsensitive() {
+        let value = "LIGHT:Alabaster,DARK:Gruvbox Dark Hard"
+        #expect(ThemeName.resolved(from: value, isDark: false) == "Alabaster")
+        #expect(ThemeName.resolved(from: value, isDark: true) == "Gruvbox Dark Hard")
+    }
+
+    @Test func missingSideFallsBackToTheOther() {
+        #expect(ThemeName.resolved(from: "light:Alabaster", isDark: true) == "Alabaster")
+        #expect(ThemeName.resolved(from: "dark:Gruvbox Dark Hard", isDark: false) == "Gruvbox Dark Hard")
+    }
+}


### PR DESCRIPTION
Fixes #145.

`resolveSelectionColors` used the raw `theme` value as a theme-file name, so the `light:X,dark:Y` auto-switch form never matched a file → selection colors nil → selected sidebar row fell back to white-on-white on light themes. Resolve the active variant (new host-free `ThemeName.resolved`) before the lookup.

Tests: `ThemeNameTests` (7 cases), `agtermCore` green, `swiftlint --strict` clean. Verified live with `theme = light:Alabaster,dark:Gruvbox Dark Hard` in Light mode.

Screenshot:

<img width="233" height="206" alt="SCR-20260706-lomw" src="https://github.com/user-attachments/assets/13692247-0267-44a6-b188-84672fa415d5" />


