### PR TITLE
fix(core): support agtermctl tests on Linux

### DIFF
--- a/agtermCore/Sources/agtermctlKit/SocketClient.swift
+++ b/agtermCore/Sources/agtermctlKit/SocketClient.swift
@@ -1,4 +1,8 @@
+#if canImport(Darwin)
 import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
 import Foundation
 import agtermCore
 
@@ -40,13 +44,18 @@ struct SocketClient {
 
     /// Open and connect a `AF_UNIX` stream socket to `path`.
     private func connect() throws -> Int32 {
-        guard path.utf8.count < 104 else {
+        var addr = sockaddr_un()
+        let pathCapacity = MemoryLayout.size(ofValue: addr.sun_path)
+        guard path.utf8.count < pathCapacity else {
             throw SocketClientError("socket path too long (\(path.utf8.count) bytes): \(path)")
         }
+        #if canImport(Darwin)
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        #else
+        let fd = socket(AF_UNIX, Int32(SOCK_STREAM.rawValue), 0)
+        #endif
         guard fd >= 0 else { throw SocketClientError("socket() failed: \(String(cString: strerror(errno)))") }
 
-        var addr = sockaddr_un()
         addr.sun_family = sa_family_t(AF_UNIX)
         let pathBytes = path.utf8CString
         withUnsafeMutablePointer(to: &addr.sun_path) { dst in
@@ -59,7 +68,7 @@ struct SocketClient {
 
         let result = withUnsafePointer(to: &addr) { ptr in
             ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
-                Darwin.connect(fd, sa, socklen_t(MemoryLayout<sockaddr_un>.size))
+                systemConnect(fd, sa, socklen_t(MemoryLayout<sockaddr_un>.size))
             }
         }
         guard result == 0 else {
@@ -187,4 +196,12 @@ struct SocketClient {
         }
         return lines.joined(separator: "\n")
     }
+}
+
+private func systemConnect(_ fd: Int32, _ addr: UnsafePointer<sockaddr>, _ len: socklen_t) -> Int32 {
+    #if canImport(Darwin)
+    return Darwin.connect(fd, addr, len)
+    #else
+    return Glibc.connect(fd, addr, len)
+    #endif
 }

--- a/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
@@ -1,5 +1,9 @@
 import ArgumentParser
+#if canImport(Darwin)
 import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
 import Foundation
 import Testing
 import agtermCore
@@ -59,6 +63,31 @@ struct SocketClientTests {
         #expect(throws: SocketClientError.self) { try client.send(ControlRequest(cmd: .tree)) }
     }
 
+    @Test func socketPathLimitMatchesPlatformCapacity() {
+        let addr = sockaddr_un()
+        let capacity = MemoryLayout.size(ofValue: addr.sun_path)
+        let fittingPath = "/" + String(repeating: "x", count: capacity - 2)
+        let oversizedPath = "/" + String(repeating: "x", count: capacity - 1)
+
+        do {
+            _ = try SocketClient(path: fittingPath).send(ControlRequest(cmd: .tree))
+            Issue.record("expected connect to a missing socket to fail")
+        } catch let error as SocketClientError {
+            #expect(!error.description.hasPrefix("socket path too long"))
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+
+        do {
+            _ = try SocketClient(path: oversizedPath).send(ControlRequest(cmd: .tree))
+            Issue.record("expected an oversized socket path to fail")
+        } catch let error as SocketClientError {
+            #expect(error.description.hasPrefix("socket path too long"))
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
     /// A create command's `run()` returns without throwing on `{"ok":true}` and prints the new id.
     @Test func runEchoesNewIdForCreateCommand() throws {
         let server = StubServer(response: ControlResponse(ok: true, result: ControlResult(id: "9f3c")))
@@ -86,10 +115,10 @@ struct SocketClientTests {
         let pipe = Pipe()
         let saved = dup(STDOUT_FILENO)
         defer { close(saved) }
-        fflush(stdout)
+        fflush(nil)
         dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
         try body()
-        fflush(stdout)
+        fflush(nil)
         dup2(saved, STDOUT_FILENO)
         try pipe.fileHandleForWriting.close()
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
@@ -300,7 +329,7 @@ private final class StubServer: @unchecked Sendable {
     }
 
     func start() throws {
-        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        let fd = systemSocket()
         guard fd >= 0 else { throw SocketClientError("stub socket() failed") }
         unlink(path)
 
@@ -330,7 +359,7 @@ private final class StubServer: @unchecked Sendable {
     }
 
     private func accept(_ fd: Int32) {
-        let conn = Darwin.accept(fd, nil, nil)
+        let conn = systemAccept(fd)
         lock.lock(); let done = stopped; lock.unlock()
         // stop() woke this accept only to join it — don't serve a request on a stopping server.
         if done { if conn >= 0 { close(conn) }; return }
@@ -377,7 +406,7 @@ private final class StubServer: @unchecked Sendable {
 /// both stub servers so `stop()` can JOIN the accept loop before the listen fd is closed, which is what
 /// keeps a lingering loop from serving the next server's client on a reused fd number.
 private func wakeAccept(_ path: String) {
-    let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+    let fd = systemSocket()
     guard fd >= 0 else { return }
     defer { close(fd) }
     var addr = sockaddr_un()
@@ -390,7 +419,7 @@ private func wakeAccept(_ path: String) {
     }
     _ = withUnsafePointer(to: &addr) { ptr in
         ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
-            Darwin.connect(fd, sa, socklen_t(MemoryLayout<sockaddr_un>.size))
+            systemConnect(fd, sa, socklen_t(MemoryLayout<sockaddr_un>.size))
         }
     }
 }
@@ -413,7 +442,7 @@ private final class ScriptedStubServer: @unchecked Sendable {
     }
 
     func start() throws {
-        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        let fd = systemSocket()
         guard fd >= 0 else { throw SocketClientError("scripted socket() failed") }
         unlink(path)
 
@@ -444,7 +473,7 @@ private final class ScriptedStubServer: @unchecked Sendable {
 
     private func acceptLoop(_ fd: Int32) {
         while true {
-            let conn = Darwin.accept(fd, nil, nil)
+            let conn = systemAccept(fd)
             lock.lock(); let done = stopped; lock.unlock()
             // stop() flips `stopped` then self-connects to wake this accept; observing it here is what
             // lets the loop exit (and be joined) before the fd is closed, so it can never run accept on a
@@ -487,6 +516,30 @@ private final class ScriptedStubServer: @unchecked Sendable {
         close(listenFD); listenFD = -1
         unlink(path)
     }
+}
+
+private func systemSocket() -> Int32 {
+    #if canImport(Darwin)
+    return socket(AF_UNIX, SOCK_STREAM, 0)
+    #else
+    return socket(AF_UNIX, Int32(SOCK_STREAM.rawValue), 0)
+    #endif
+}
+
+private func systemAccept(_ fd: Int32) -> Int32 {
+    #if canImport(Darwin)
+    return Darwin.accept(fd, nil, nil)
+    #else
+    return Glibc.accept(fd, nil, nil)
+    #endif
+}
+
+private func systemConnect(_ fd: Int32, _ addr: UnsafePointer<sockaddr>, _ len: socklen_t) -> Int32 {
+    #if canImport(Darwin)
+    return Darwin.connect(fd, addr, len)
+    #else
+    return Glibc.connect(fd, addr, len)
+    #endif
 }
 
 /// Scripts the `--block` round trips: `session.overlay.open` returns a fixed id; `session.overlay.result`


### PR DESCRIPTION
## Summary

- Make the shared `agtermctlKit` Unix socket client compile on Linux by selecting Darwin or Glibc APIs at build time.
- Update socket-client tests to use the same platform abstraction.
- Relax shared config-path tests so they use an installed POSIX-like shell instead of assuming `/bin/zsh` exists.

## Why

The shared core package is host-free, but a few CLI support and test files still assumed Darwin APIs or a macOS shell layout.

This keeps the shared package buildable and testable on Linux while preserving the Darwin path.

## Validation

- `cd agtermCore && swift test`
- `swiftlint lint --config .swiftlint.yml agtermCore/Sources/agtermctlKit/SocketClient.swift agtermCore/Tests/agtermCoreTests/ConfigPathsTests.swift agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift`
- `git diff --check v0.8.2`
