### PR TITLE
Fix invisible sidebar disclosure triangle under theme/system-appearance mismatch

### DIFF
--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -29,6 +29,18 @@ paths:
   text (a luminance-contrast black/white fallback when only the background is set).
   The borderless New-Session `Menu` glyph ignores `foregroundStyle` on its label,
   so it's tinted via `.tint(chromeText)`.
+- **The sidebar's disclosure triangle tracks the theme via `NSAppearance`, not a color we set.**
+  The expand/collapse triangle is drawn by `NSOutlineView` itself, colored from the view's `NSAppearance`
+  — which follows the macOS system light/dark setting, NOT the terminal theme.
+  So a light theme under macOS dark mode (or the mirror, a dark theme under macOS light mode) draws the
+  triangle in the wrong brightness and it vanishes against the themed sidebar background
+  (the row text/icons stay visible only because they're set explicitly to `terminalForegroundColor`).
+  `WorkspaceSidebar.Coordinator.applyThemeAppearance()` pins `outline.appearance` to `.darkAqua`/`.aqua`
+  from `GhosttyApp.terminalThemeIsDark` (the theme background's perceived luminance via the host-free
+  `agtermCore.ThemeBrightness.isDark`), called in `makeNSView` (launch) and `appearanceChanged` (live
+  theme switch).
+  The triangle color is not accessibility-observable, so this is verified by eye, not a UI test — like
+  the cursor solid/hollow case.
 - **Sidebar selection is drawn entirely by `SidebarRowView`, not AppKit.**
   `outline.selectionHighlightStyle = .none` (set right after `style = .sourceList`,
   which would otherwise reset it) so AppKit draws no selection of its own — otherwise it paints a gray

--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -36,9 +36,12 @@ paths:
   triangle in the wrong brightness and it vanishes against the themed sidebar background
   (the row text/icons stay visible only because they're set explicitly to `terminalForegroundColor`).
   `WorkspaceSidebar.Coordinator.applyThemeAppearance()` pins `outline.appearance` to `.darkAqua`/`.aqua`
-  from `GhosttyApp.terminalThemeIsDark` (the theme background's perceived luminance via the host-free
-  `agtermCore.ThemeBrightness.isDark`), called in `makeNSView` (launch) and `appearanceChanged` (live
-  theme switch).
+  from `GhosttyApp.terminalThemeIsDark`, called in `makeNSView` (launch) and `appearanceChanged` (live
+  theme switch — which the Sidebar-Tint slider also posts, so a tint change re-pins).
+  `terminalThemeIsDark` classifies the perceived luminance of the color the triangle actually sits on:
+  the theme background with the sidebar-tint wash applied (`ThemeBrightness.isDark(…, shiftAmount:)`,
+  host-free), NOT the raw background — so a strong tint that pushes a near-threshold theme across the
+  0.5 midpoint still picks the readable triangle.
   The triangle color is not accessibility-observable, so this is verified by eye, not a UI test — like
   the cursor solid/hollow case.
 - **Sidebar selection is drawn entirely by `SidebarRowView`, not AppKit.**

--- a/agterm/Ghostty/GhosttyApp.swift
+++ b/agterm/Ghostty/GhosttyApp.swift
@@ -30,14 +30,18 @@ final class GhosttyApp {
     /// text + icons, title bar text + buttons) uses it so non-terminal text tracks the theme instead
     /// of the system label color. Nil if the color couldn't be read.
     private(set) var terminalForegroundColor: NSColor?
-    /// Whether the active terminal theme reads as dark, by the background's perceived luminance. Pins
-    /// AppKit-drawn chrome (the sidebar disclosure triangle) to the theme instead of the macOS system
-    /// appearance, so a light theme under macOS dark mode still draws dark, visible chrome. Defaults to
-    /// dark when the background couldn't be read (the app's default chrome).
+    /// Whether the active terminal theme reads as dark, by the perceived luminance of the sidebar
+    /// background the disclosure triangle sits on — the theme background with the sidebar-tint wash
+    /// applied. Pins AppKit-drawn chrome (the sidebar disclosure triangle) to the theme instead of the
+    /// macOS system appearance, so a light theme under macOS dark mode still draws dark, visible chrome.
+    /// Classifying the washed color (not the raw background) keeps it correct when a strong sidebar tint
+    /// pushes a near-threshold theme across the midpoint. Defaults to dark when the background couldn't
+    /// be read (the app's default chrome).
     var terminalThemeIsDark: Bool {
         guard let bg = terminalBackgroundColor?.usingColorSpace(.sRGB) else { return true }
+        let shiftAmount = AppSettings.sidebarShiftAmount(strength: sidebarBackgroundShift)
         return ThemeBrightness.isDark(red: Double(bg.redComponent), green: Double(bg.greenComponent),
-                                      blue: Double(bg.blueComponent))
+                                      blue: Double(bg.blueComponent), shiftAmount: shiftAmount)
     }
     /// The terminal selection-background color (theme `selection-background`). The selected sidebar row
     /// draws its pill in this color so it matches the terminal's own selection. Nil if the theme

--- a/agterm/Ghostty/GhosttyApp.swift
+++ b/agterm/Ghostty/GhosttyApp.swift
@@ -30,6 +30,15 @@ final class GhosttyApp {
     /// text + icons, title bar text + buttons) uses it so non-terminal text tracks the theme instead
     /// of the system label color. Nil if the color couldn't be read.
     private(set) var terminalForegroundColor: NSColor?
+    /// Whether the active terminal theme reads as dark, by the background's perceived luminance. Pins
+    /// AppKit-drawn chrome (the sidebar disclosure triangle) to the theme instead of the macOS system
+    /// appearance, so a light theme under macOS dark mode still draws dark, visible chrome. Defaults to
+    /// dark when the background couldn't be read (the app's default chrome).
+    var terminalThemeIsDark: Bool {
+        guard let bg = terminalBackgroundColor?.usingColorSpace(.sRGB) else { return true }
+        return ThemeBrightness.isDark(red: Double(bg.redComponent), green: Double(bg.greenComponent),
+                                      blue: Double(bg.blueComponent))
+    }
     /// The terminal selection-background color (theme `selection-background`). The selected sidebar row
     /// draws its pill in this color so it matches the terminal's own selection. Nil if the theme
     /// doesn't set it (the row falls back to a soft white wash).

--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -58,6 +58,9 @@ struct WorkspaceSidebar: NSViewRepresentable {
 
         context.coordinator.outlineView = outline
         context.coordinator.renameController.outlineView = outline
+        // pin the outline appearance to the theme brightness up front so the disclosure triangle reads on
+        // launch (a light theme under macOS dark mode would otherwise draw an invisible light triangle).
+        context.coordinator.applyThemeAppearance()
         // seed the tracked expansion from the persisted per-workspace state BEFORE the reload, so
         // rebuildAndReload restores each workspace's saved open/collapsed state (a collapsed workspace
         // stays collapsed across relaunch) instead of force-expanding every row.
@@ -209,8 +212,17 @@ struct WorkspaceSidebar: NSViewRepresentable {
             outline.enumerateAvailableRowViews { rowView, _ in rowView.needsDisplay = true }
         }
 
+        /// Pin the outline's appearance to the terminal theme's brightness so AppKit-drawn chrome — the
+        /// disclosure triangle — tracks the theme, not the macOS system light/dark setting. Without this a
+        /// light theme under macOS dark mode draws a light-gray triangle that's invisible on the light
+        /// sidebar (the row text/icons stay visible only because they're set explicitly to the theme color).
+        func applyThemeAppearance() {
+            outlineView?.appearance = NSAppearance(named: GhosttyApp.shared.terminalThemeIsDark ? .darkAqua : .aqua)
+        }
+
         @objc private func appearanceChanged() {
             refreshSelectionAppearance()
+            applyThemeAppearance()
             // a settings change may have flipped the badge-visibility toggle; reconcile so the gated
             // unseen count (0 when off, the real count when on) reloads the affected badge rows.
             reconcile()

--- a/agtermCore/Sources/agtermCore/ThemeBrightness.swift
+++ b/agtermCore/Sources/agtermCore/ThemeBrightness.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Classifies a terminal theme's background as dark or light by perceived luminance.
+///
+/// Used to pin AppKit-drawn chrome (the sidebar's disclosure triangle) to the terminal theme's
+/// brightness instead of the macOS system light/dark setting: a light theme under macOS dark mode
+/// otherwise draws a light-gray triangle that vanishes on the light sidebar. Host-free so it is
+/// unit-tested; the app target reads the sRGB components off the theme's `NSColor` and calls in.
+public enum ThemeBrightness {
+    /// Whether an sRGB background (each component 0...1) reads as dark, by Rec. 601 perceived luminance
+    /// against a 0.5 midpoint. A nil/unknown background should default to dark at the call site.
+    public static func isDark(red: Double, green: Double, blue: Double) -> Bool {
+        let luminance = 0.299 * red + 0.587 * green + 0.114 * blue
+        return luminance < 0.5
+    }
+}

--- a/agtermCore/Sources/agtermCore/ThemeBrightness.swift
+++ b/agtermCore/Sources/agtermCore/ThemeBrightness.swift
@@ -13,4 +13,18 @@ public enum ThemeBrightness {
         let luminance = 0.299 * red + 0.587 * green + 0.114 * blue
         return luminance < 0.5
     }
+
+    /// Whether the sidebar reads as dark once the sidebar-tint wash is composited over the sRGB theme
+    /// background. `shiftAmount` is the signed wash from `AppSettings.sidebarShiftAmount`: negative
+    /// lightens (white wash toward 1), positive darkens (black wash toward 0), magnitude = wash opacity.
+    /// The disclosure triangle sits on this washed color, not the raw background, so this is what the
+    /// appearance pin classifies — a near-threshold theme plus a strong tint can cross the midpoint.
+    public static func isDark(red: Double, green: Double, blue: Double, shiftAmount: Double) -> Bool {
+        let opacity = min(1, abs(shiftAmount))
+        // compositing Color(white: w).opacity(o) over c gives c*(1-o) + w*o; lighten washes white (w=1),
+        // darken washes black (w=0), so the added term is `opacity` when lightening and 0 when darkening.
+        let added = shiftAmount < 0 ? opacity : 0
+        func wash(_ c: Double) -> Double { c * (1 - opacity) + added }
+        return isDark(red: wash(red), green: wash(green), blue: wash(blue))
+    }
 }

--- a/agtermCore/Tests/agtermCoreTests/ThemeBrightnessTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ThemeBrightnessTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+struct ThemeBrightnessTests {
+    @Test func pureBlackAndWhite() {
+        #expect(ThemeBrightness.isDark(red: 0, green: 0, blue: 0))
+        #expect(!ThemeBrightness.isDark(red: 1, green: 1, blue: 1))
+    }
+
+    @Test func realThemeBackgrounds() {
+        // gruvbox dark hard #1d2021, solarized dark #002b36 → dark
+        #expect(ThemeBrightness.isDark(red: 0.114, green: 0.125, blue: 0.129))
+        #expect(ThemeBrightness.isDark(red: 0.0, green: 0.169, blue: 0.212))
+        // github light ~#ffffff, solarized light #fdf6e3 → light
+        #expect(!ThemeBrightness.isDark(red: 0.992, green: 0.965, blue: 0.890))
+    }
+
+    @Test func greenDominatesTheLumaWeighting() {
+        // pure green is the brightest primary under Rec. 601 (0.587) → light
+        #expect(!ThemeBrightness.isDark(red: 0, green: 1, blue: 0))
+        // pure blue is the dimmest (0.114) → dark
+        #expect(ThemeBrightness.isDark(red: 0, green: 0, blue: 1))
+        // pure red sits below the 0.5 midpoint (0.299) → dark
+        #expect(ThemeBrightness.isDark(red: 1, green: 0, blue: 0))
+    }
+
+    @Test func grayScaleAroundTheMidpoint() {
+        // a mid gray's luminance equals its component, so it pins the 0.5 threshold: brighter than the
+        // midpoint reads light, dimmer reads dark. (exactly 0.5 is a float-rounding knife edge no real
+        // theme lands on, so it isn't asserted.)
+        #expect(!ThemeBrightness.isDark(red: 0.55, green: 0.55, blue: 0.55))
+        #expect(ThemeBrightness.isDark(red: 0.45, green: 0.45, blue: 0.45))
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/ThemeBrightnessTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ThemeBrightnessTests.swift
@@ -12,7 +12,7 @@ struct ThemeBrightnessTests {
         // gruvbox dark hard #1d2021, solarized dark #002b36 → dark
         #expect(ThemeBrightness.isDark(red: 0.114, green: 0.125, blue: 0.129))
         #expect(ThemeBrightness.isDark(red: 0.0, green: 0.169, blue: 0.212))
-        // github light ~#ffffff, solarized light #fdf6e3 → light
+        // solarized light #fdf6e3 → light
         #expect(!ThemeBrightness.isDark(red: 0.992, green: 0.965, blue: 0.890))
     }
 
@@ -31,5 +31,22 @@ struct ThemeBrightnessTests {
         // theme lands on, so it isn't asserted.)
         #expect(!ThemeBrightness.isDark(red: 0.55, green: 0.55, blue: 0.55))
         #expect(ThemeBrightness.isDark(red: 0.45, green: 0.45, blue: 0.45))
+    }
+
+    @Test func neutralShiftMatchesTheRawClassifier() {
+        // shiftAmount 0 (the neutral tint) applies no wash, so it agrees with the un-shifted classifier.
+        #expect(ThemeBrightness.isDark(red: 0.114, green: 0.125, blue: 0.129, shiftAmount: 0))
+        #expect(!ThemeBrightness.isDark(red: 0.992, green: 0.965, blue: 0.890, shiftAmount: 0))
+    }
+
+    @Test func strongTintCrossesTheMidpoint() {
+        // hot dog stand #ea3323 has raw luma ~0.41 → dark, but a full lightening wash (shiftAmount -0.30,
+        // the sidebar-tint slider at its lightest) raises the effective sidebar to ~0.59 → light.
+        let (r, g, b) = (0.918, 0.200, 0.137)
+        #expect(ThemeBrightness.isDark(red: r, green: g, blue: b))                       // raw background: dark
+        #expect(!ThemeBrightness.isDark(red: r, green: g, blue: b, shiftAmount: -0.30))  // washed sidebar: light
+        // mirror direction: a light gray (raw ~0.55 → light) with a full darkening wash (+0.30) → ~0.385 → dark.
+        #expect(!ThemeBrightness.isDark(red: 0.55, green: 0.55, blue: 0.55))
+        #expect(ThemeBrightness.isDark(red: 0.55, green: 0.55, blue: 0.55, shiftAmount: 0.30))
     }
 }


### PR DESCRIPTION
The sidebar's expand/collapse disclosure triangle was invisible when the terminal theme's brightness disagreed with the macOS system appearance. The reported case: a light theme under macOS Dark mode drew a light-gray triangle on the light sidebar. The mirror case, a dark theme under macOS Light mode, had the same problem.

**Cause.** The triangle is drawn by `NSOutlineView` itself, colored from the view's `NSAppearance`, which follows the macOS system light/dark setting, not the terminal theme. The row text and icons stayed visible only because those are set explicitly to the theme foreground.

**Fix.** Pin the outline view's appearance to the theme's brightness (`.darkAqua`/`.aqua`), derived from the perceived luminance of the color the triangle actually sits on: the theme background with the sidebar-tint wash applied. It is set on launch and re-applied on every live theme or sidebar-tint change (both post `.agtermAppearanceChanged`). The luminance classifier is host-free in `agtermCore` (`ThemeBrightness`) and unit-tested; the app target reads the sRGB components off the theme `NSColor`.

Fixes both directions of the mismatch. The triangle color is not accessibility-observable, so the appearance pin is verified by eye (like the cursor solid/hollow state), while the luminance math is covered by unit tests.

**Notes.**
- No control-API, agent-skill, or README changes: pure rendering chrome with nothing to drive (the keep-in-sync exemption).
- Reviewed with the multi-agent review loop. The second commit classifies the tint-washed sidebar color so a strong non-default sidebar tint on a near-threshold theme still picks the readable triangle.
