### PR TITLE
feat: add session.seen to clear a session's unseen-notification badge headlessly

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -102,7 +102,7 @@ paths:
   The skill is a REFERENCE/knowledge skill (both user-invocable via `/agterm` and model-triggered,
   `allowed-tools: Bash(agtermctl *)`; the agent-neutral `description` carries the trigger nouns since
   Codex may ignore the extra `when_to_use` field — unknown frontmatter is harmless),
-  authored at `agterm/Resources/agent-skill/` (`SKILL.md` overview + model + addressing + 50-command
+  authored at `agterm/Resources/agent-skill/` (`SKILL.md` overview + model + addressing + 51-command
   summary + the image-display helper + a troubleshooting/reporting pointer;
   `reference.md` full per-command detail + keymap format; `examples.md` agtermctl recipes;
   `troubleshooting.md` diagnosing the common problems (keymap editor, custom actions,
@@ -172,10 +172,10 @@ paths:
   exact `uuidString` (case-insensitive), or a git-style unique prefix.
   Zero prefix hits → `notFound` error, ≥2 → `ambiguous` error listing the candidates.
   `--target` defaults to `active`, so scripts rarely type an id and never for "the current one".
-- **Command catalog (50 commands):**
+- **Command catalog (51 commands):**
   - `tree`
   - `workspace.new`/`workspace.rename`/`workspace.delete`/`workspace.select`/`workspace.move`/`workspace.focus`
-  - `session.new`/`session.close`/`session.select`/`session.rename`/`session.move`/`session.type`/`session.split`/`session.scratch`/`session.focus`/`session.resize`/`session.go`/`session.copy`/`session.text`/`session.search`/`session.status`/`session.flag`/`session.background`/`session.overlay.open`/`session.overlay.close`/`session.overlay.result`
+  - `session.new`/`session.close`/`session.select`/`session.rename`/`session.move`/`session.type`/`session.split`/`session.scratch`/`session.focus`/`session.resize`/`session.go`/`session.copy`/`session.text`/`session.search`/`session.status`/`session.flag`/`session.seen`/`session.background`/`session.overlay.open`/`session.overlay.close`/`session.overlay.result`
   - `quick`
   - `sidebar`/`sidebar.mode`/`sidebar.expand`/`sidebar.collapse`
   - `notify`
@@ -669,6 +669,26 @@ paths:
   arm (`setSessionFlag`) in `ControlServer`, (3) the `session flag on|off|toggle|clear` subcommand (`FlagCommand`)
   in `agtermctlKit`, (4) round-trip in `ControlProtocolTests` + the e2e `testSessionFlagAndSidebarModeFlagged`
   in `ControlSidebarStatusUITests`.
+  `session.seen` (target = session) clears a session's unseen-notification badge WITHOUT changing the
+  selection, focus, or agent status — the focus-free counterpart to `notify`, which raises the badge over
+  the socket while the only clear paths (`AppStore.selectSession`, a pane's `onFocusChange(true)`) are
+  both focus-coupled.
+  It drives the already-public `AppStore.clearUnseen(_:)` (the same primitive `selectSession` calls),
+  so it is idempotent (a no-op when already zero; the count is ephemeral, absent from `SessionSnapshot`,
+  so it triggers no save) and returns the session id; NO args beyond target/window (leaner than `session.flag`
+  — no mode).
+  It is control-NATIVE (no GUI/menu equivalent — visiting the session is the GUI's only "mark seen", and
+  it is inseparable from selecting) — the same footing as `notify`/`session.type`/`session.copy`.
+  The read side is the new `unseen` field on `ControlSessionNode` (the `session.unseenCount`, populated
+  in the `tree` builder, omitted when zero), so a script can query the count and clear it symmetrically.
+  Four-point keep-in-sync audit for `session.seen`: (1) `case sessionSeen = "session.seen"` +
+  `unseen: Int?` on `ControlSessionNode` in `ControlProtocol.swift` (no new `ControlArgs` field),
+  (2) the `.sessionSeen` dispatch arm (`markSessionSeen`) in `ControlDispatcher`/`ControlServer` + the
+  `unseen` population in `AppStore.controlTree`, (3) the `session seen` subcommand (`Seen`) in `agtermctlKit`,
+  (4) round-trip (`sessionSeenRoundTrips` + `treeSessionNodeRoundTripsWithUnseen`/`…OmitsUnseenWhenNil`)
+  in `ControlProtocolTests` + dispatcher routing in `ControlDispatcherTests` + `AppStoreTests`
+  (`controlTreeReportsUnseenCountWhenPositive`/`…OmitsUnseenCountWhenZero`) + CLI mapping in `CommandsTests`
+  + the e2e `testSessionSeenClearsBadgeWithoutFocus` in `ControlSidebarStatusUITests`.
   `sidebar.mode` (frontmost window) flips the sidebar VIEW between the workspace tree and the flat flagged
   working-set list — `args.mode` is `tree`|`flagged`|`toggle` (delta-computed against `AppStore.sidebarMode`
   so it's idempotent, unknown mode = error), drives `setSidebarViewMode` → `AppStore.setSidebarMode`.
@@ -796,5 +816,5 @@ paths:
   (image/text/color set/clear + tree read-back).
   **Agent-skill mirror (HARD keep-in-sync, 4th surface):** all commands are documented in the bundled
   `agterm/Resources/agent-skill/` (SKILL.md summary, reference.md detail,
-  examples.md recipes) and the command count there is bumped to 50 to match.
+  examples.md recipes) and the command count there is bumped to 51 to match.
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ agterm arranges terminals into a small hierarchy. These are the only terms you n
 
 **Flagging and focus.** Two ways to cut down a busy sidebar. Flag a few sessions from different workspaces to get a flat working-set view of just those; a flag is durable and survives a move. Focus a single workspace to hide the others, with a one-click way back. The two are independent.
 
-**Notifications.** A program in any session can raise a desktop notification (via OSC 9 / 777, or the control API). It shows as a banner and a count badge on the session's row; clicking the banner jumps to the exact pane that raised it. For a coding agent that just needs to say it is waiting on you, [Agent status](#agent-status) is usually the better fit.
+**Notifications.** A program in any session can raise a desktop notification (via OSC 9 / 777, or the control API). It shows as a banner and a count badge on the session's row; clicking the banner jumps to the exact pane that raised it. The badge clears when you visit the session, or headlessly with `agtermctl session seen` — so an orchestrator driving a session over the socket can acknowledge its notifications without pulling focus to it (`agtermctl tree --json` reports each session's `unseen` count). For a coding agent that just needs to say it is waiting on you, [Agent status](#agent-status) is usually the better fit.
 
 **Agent status.** A coding agent in a session can report its state (active, blocked, completed) onto that session's row, so a screen of concurrent agents shows which one needs you. See [Agent status](#agent-status) for wiring it up.
 
@@ -200,6 +200,7 @@ agtermctl session split toggle                   # split the active session
 agtermctl session resize --split-ratio 0.7       # set the split divider (left-pane fraction); or --grow-left/--grow-right D
 agtermctl session scratch toggle                 # show/hide the active session's scratch terminal (on|off|toggle)
 agtermctl session flag on                        # flag the active session for the flagged working-set view (on|off|toggle|clear)
+agtermctl session seen --target 9f3c             # clear a session's unseen-notification badge without visiting it (focus-free)
 agtermctl sidebar mode flagged                   # show only the flagged sessions as a flat list (tree|flagged|toggle)
 agtermctl workspace focus on                     # collapse the sidebar tree to the active workspace (on|off|toggle)
 agtermctl session search "error"                 # open the search bar and highlight matches; prints the "N of M" counter

--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -437,6 +437,17 @@ extension ControlServer: ControlActions {
         }
     }
 
+    /// Clears a session's unseen-notification badge without changing the selection, focus, or agent
+    /// status — the focus-free counterpart to `notify`, which raises the badge over the socket but
+    /// which nothing could lower without visiting the session. Idempotent (a no-op when already zero,
+    /// since `clearUnseen` just assigns 0; the count is ephemeral so it triggers no save).
+    func markSessionSeen(_ target: String?, window: String?) -> ControlResponse {
+        resolver.resolveSession(target, window: window) { store, id in
+            store.clearUnseen(id)
+            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
+        }
+    }
+
     /// Mode-bearing `session.move`: `to` reorders the session within its own workspace
     /// (`up`|`down`|`top`|`bottom`), `workspace` relocates it to another workspace (appending), `place`
     /// relocates + positions relative to an anchor session (the anchor carries its own workspace). Exactly

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -343,7 +343,7 @@ final class ControlServer {
         case .tree, .sessionNew, .sessionSelect, .sessionGo, .sessionClose, .sessionRename,
                 .workspaceNew, .workspaceSelect, .workspaceRename, .workspaceDelete,
                 .sessionMove, .workspaceMove, .workspaceFocus, .sessionSplit, .sessionScratch,
-                .sessionFocus, .sessionResize, .sessionStatus, .sessionFlag, .notify,
+                .sessionFocus, .sessionResize, .sessionStatus, .sessionFlag, .sessionSeen, .notify,
                 .fontInc, .fontDec, .fontReset, .keymapReload, .configReload, .themeSet, .themeList,
                 .sidebar, .sidebarMode, .sidebarExpand, .sidebarCollapse, .sessionType, .sessionCopy,
                 .sessionSearch, .sessionOverlayOpen, .sessionOverlayClose, .sessionOverlayResult,

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -15,7 +15,7 @@ description: >
 when_to_use: >
   Trigger on: agterm, agtermctl, agterm control socket, session.new, session.close, session.type,
   session.split, session.scratch, session.focus, session.resize, session.go, session.copy, session.text, session.search, session.status,
-  session.flag, session.background, session.overlay, workspace.new, workspace.select, workspace.move, workspace.focus, window.new, window.list,
+  session.flag, session.seen, session.background, session.overlay, workspace.new, workspace.select, workspace.move, workspace.focus, window.new, window.list,
   window.select, window.resize, window.move, window.zoom, quick terminal, sidebar, sidebar.mode, sidebar.expand, sidebar.collapse, flagged, notify, font.inc, keymap.reload, config.reload,
   theme.set, theme.list, select theme, edit keymap, show an image, display an image inline, show-image,
   AGTERM_SESSION_ID, AGTERM_SOCKET, and asks to drive or script agterm. Also: troubleshoot agterm,
@@ -97,7 +97,7 @@ you work. For any session-scoped command meant to act on *this* session — `ove
 `type`, `text`, `background`, `status`, `copy`, … — pass `--target "$AGTERM_SESSION_ID"`. Omit it and
 you open overlays / type into whatever the user has selected, not your own session.
 
-## Command summary (50 commands)
+## Command summary (51 commands)
 
 Run `agtermctl <area> <cmd> --help` for exact flags. Full detail in **reference.md**; recipes in
 **examples.md**.
@@ -107,8 +107,10 @@ Run `agtermctl <area> <cmd> --help` for exact flags. Full detail in **reference.
 is at its shell prompt) — i.e. what each pane is currently running — `status` (the agent-status set
 via `session status`: `active`|`completed`|`blocked`, omitted when idle), `statusPane` (which pane set
 that status: `left` (main) | `right` (split) | `scratch`, from `session status --pane`, omitted when
-unset or idle), and `background` (the background
-spec — image/text watermark or solid color — set via `session background`, omitted when none — the read side of set/clear).
+unset or idle), `background` (the background
+spec — image/text watermark or solid color — set via `session background`, omitted when none — the read side of set/clear),
+and `unseen` (the unseen-notification badge count — raised by `notify`/OSC 9/777, cleared by `session
+seen` — omitted when zero).
 
 **workspace** — `new [name]` · `rename <name>` · `delete` · `select` · `move --to up|down|top|bottom` ·
 `focus [on|off|toggle]` (collapse the sidebar tree to a single workspace).
@@ -150,6 +152,10 @@ spec — image/text watermark or solid color — set via `session background`, o
   a fraction. Prints the applied (clamped) fraction.
 - `status <idle|active|completed|blocked> [--blink] [--auto-reset] [--sound NAME] [--color #rrggbb] [--pane left|right|scratch]` — set the sidebar agent glyph (`--sound default` or a system sound name plays a one-shot sound; `--color` tints the glyph for this call only, reverting on the next status set without it; `--pane` records which pane set it — `left`=main, `right`=split, `scratch` — so foreground typing in another pane won't clear it and any user-initiated GUI selection (auto-follow, attention-nav ⌃⌥↑/↓, plain session nav, the command palettes, a sidebar row click) reveals the blocking pane, read back as the tree `statusPane` field; the socket `session go next-attention` only steps the selection, it does not itself reveal the pane).
 - `flag [on|off|toggle|clear]` — flag a session for the flagged working-set view (`clear` unflags all).
+- `seen [--target] [--window W]` — clear the session's unseen-notification badge WITHOUT changing the
+  selection or focus (the focus-free counterpart to `notify`, which raises the badge). Idempotent — a
+  no-op when already zero. Read the current count from the tree node's `unseen` field. Use it so an
+  orchestrator can acknowledge a driven session's notifications without pulling focus to it.
 - `background image <path> [--opacity F] [--fit contain|cover|stretch|none] [--position P] [--repeat]` ·
   `background text <text> [--color #rrggbb] [--opacity F] [--fit ...] [--position ...]` ·
   `background color <#rrggbb>` · `background clear` — composite an image (PNG/JPEG) or rasterized text

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -225,6 +225,19 @@ agtermctl sidebar mode tree                               # back to the full tre
 agtermctl session flag clear                              # unflag everything in the window
 ```
 
+## Acknowledge a driven session's notifications without stealing focus
+
+An orchestrator relaying a session's output elsewhere (Telegram, another agent) fires `notify` to signal
+"your turn", which raises the session's red unseen badge. Nothing normally clears that badge except
+visiting the session — which pulls the selection to it. `session seen` clears it in place, so the badge
+stays a real attention signal on the sessions a human tends while the driven ones stay clean.
+
+```bash
+agtermctl notify --target "$SID" --body "your turn"      # raises the unseen badge
+agtermctl tree --json | jq '.result.tree.workspaces[].sessions[] | {id, unseen}'  # read the counts
+agtermctl session seen --target "$SID"                   # clear it, selection/focus unchanged
+```
+
 ## Focus a single workspace
 
 Collapse the sidebar tree to one workspace's sessions (hiding the others), with the full tree one

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -233,7 +233,7 @@ visiting the session — which pulls the selection to it. `session seen` clears 
 stays a real attention signal on the sessions a human tends while the driven ones stay clean.
 
 ```bash
-agtermctl notify --target "$SID" --body "your turn"      # raises the unseen badge
+agtermctl notify "your turn" --target "$SID"             # raises the unseen badge (body is positional)
 agtermctl tree --json | jq '.result.tree.workspaces[].sessions[] | {id, unseen}'  # read the counts
 agtermctl session seen --target "$SID"                   # clear it, selection/focus unchanged
 ```

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -46,8 +46,9 @@ idle), `statusPane` (which pane set that status — `left` (main) | `right` (spl
 as `status`, so it is never reported without a `status`), `foreground`/`splitForeground` (the live argv of each pane's foreground
 process — what it is running — omitted when the pane sits at its shell prompt), and `background` (the
 background spec set via `session background` — a `{kind, text?, imagePath?, colorHex?, opacity?, fit?,
-position?, repeats?}` object; `kind` is `image`/`text`/`color` — omitted when none is set). Workspace nodes carry
-`id`, `name`, `active`, `sessions`.
+position?, repeats?}` object; `kind` is `image`/`text`/`color` — omitted when none is set), and `unseen`
+(the unseen-notification badge count — raised by `notify`/OSC 9/777, cleared by `session seen` — omitted
+when zero). Workspace nodes carry `id`, `name`, `active`, `sessions`.
 
 The tree object itself carries two top-level read-only fields: `idleMs` (milliseconds since the last
 user input in the window, omitted before any activity) and `autoFollowMs` (the window's Auto-follow
@@ -201,6 +202,12 @@ state; there is no control command to set them.
   `active`) and are idempotent; `clear` ignores the target and unflags every session in the window.
   Pair with `sidebar mode flagged` to see just the flagged sessions as a flat `session : workspace`
   list. Unknown mode errors. The tree's `flagged` flag tracks membership.
+- `session seen [--target] [--window W]` — clear the session's unseen-notification badge without changing
+  the selection, focus, or agent status. It is the focus-free counterpart to `notify`: `notify` (and a
+  terminal's own OSC 9/777) raise the red badge, and until now the only way to clear it was visiting the
+  session. Idempotent — a no-op when the badge is already zero. Read the current count from the tree node's
+  `unseen` field. This lets an orchestrator acknowledge a driven session's notifications over the socket
+  while keeping the badge a real attention signal on the sessions a human tends.
 - `session background image <path> [--opacity F] [--fit contain|cover|stretch|none] [--position P] [--repeat] [--target] [--window W]`
   — composite the image at `path` (PNG or JPEG only) behind the terminal as a watermark. libghostty
   auto-fits it to the surface and re-fits on every window resize. `--opacity` is 0.0–1.0 (default 1.0);

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -177,7 +177,8 @@ public final class AppStore {
                                           foreground: foreground(session),
                                           splitForeground: splitForeground(session), status: status,
                                           statusPane: statusPane,
-                                          background: session.backgroundWatermark)
+                                          background: session.backgroundWatermark,
+                                          unseen: session.unseenCount > 0 ? session.unseenCount : nil)
             }
             return ControlWorkspaceNode(id: workspace.id.uuidString, name: workspace.name,
                                         active: workspace.id == activeWorkspaceID, sessions: sessions)

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -19,6 +19,7 @@ public protocol ControlActions {
     func moveWorkspace(_ target: String?, window: String?, direction: ReorderDirection) -> ControlResponse
     func focusWorkspace(_ target: String?, window: String?, mode: String?) -> ControlResponse
     func setSessionFlag(_ target: String?, window: String?, mode: String?) -> ControlResponse
+    func markSessionSeen(_ target: String?, window: String?) -> ControlResponse
     func setSessionStatus(_ target: String?, window: String?, update: ControlSessionStatusUpdate) -> ControlResponse
     func splitSession(_ target: String?, window: String?, mode: String?) -> ControlResponse
     func scratchSession(_ target: String?, window: String?, mode: String?, command: String?) -> ControlResponse
@@ -124,7 +125,7 @@ public struct ControlDispatcher {
         case .tree:
             return actions.controlTree(window: request.args?.window)
         case .sessionNew, .sessionSelect, .sessionGo, .sessionClose, .sessionRename,
-                .sessionMove, .sessionFlag, .sessionStatus:
+                .sessionMove, .sessionFlag, .sessionSeen, .sessionStatus:
             return dispatchSessionCommand(request)
         case .sessionSplit, .sessionScratch, .sessionFocus, .sessionResize, .sessionType,
                 .sessionCopy, .sessionSearch, .sessionOverlayOpen, .sessionOverlayClose,
@@ -218,6 +219,8 @@ public struct ControlDispatcher {
             return actions.moveSession(request.target, window: args?.window, move: .workspace(workspace))
         case .sessionFlag:
             return actions.setSessionFlag(request.target, window: request.args?.window, mode: request.args?.mode)
+        case .sessionSeen:
+            return actions.markSessionSeen(request.target, window: request.args?.window)
         case .sessionStatus:
             guard let status = AgentStatus(rawValue: request.args?.status ?? "") else {
                 return ControlResponse(ok: false, error: "invalid status")

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -20,6 +20,7 @@ public enum Command: String, Codable, Sendable {
     case sessionType = "session.type"
     case sessionStatus = "session.status"
     case sessionFlag = "session.flag"
+    case sessionSeen = "session.seen"
     case sessionBackground = "session.background"
     case sessionSplit = "session.split"
     case sessionScratch = "session.scratch"
@@ -265,11 +266,15 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
     /// The session's background watermark spec, or nil when none is set (omitted from the JSON). The read
     /// side of `session.background` — set/clear/query symmetry, so a script can inspect the current watermark.
     public let background: BackgroundWatermark?
+    /// The session's unseen-notification badge count, or nil when zero (omitted from the JSON). The read
+    /// side of the notification badge: `notify` (and terminal OSC 9/777) raise it, `session.seen` clears it.
+    /// Ephemeral like `status` — never persisted, so it resets to nil on restart.
+    public let unseen: Int?
 
     public init(id: String, name: String, cwd: String, title: String? = nil, active: Bool, split: Bool,
                 overlay: Bool = false, scratch: Bool = false, flagged: Bool = false,
                 foreground: [String]? = nil, splitForeground: [String]? = nil, status: String? = nil,
-                statusPane: String? = nil, background: BackgroundWatermark? = nil) {
+                statusPane: String? = nil, background: BackgroundWatermark? = nil, unseen: Int? = nil) {
         self.id = id
         self.name = name
         self.cwd = cwd
@@ -284,6 +289,7 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
         self.status = status
         self.statusPane = statusPane
         self.background = background
+        self.unseen = unseen
     }
 }
 

--- a/agtermCore/Sources/agtermctlKit/SessionCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/SessionCommands.swift
@@ -20,7 +20,7 @@ struct Session: ParsableCommand {
         abstract: "Session commands.",
         subcommands: [New.self, Close.self, Select.self, Go.self, Rename.self, Move.self, TypeText.self,
                       Split.self, Scratch.self, Focus.self, Resize.self, Copy.self, Text.self, Status.self, FlagCommand.self,
-                      Search.self, Background.self, Overlay.self]
+                      Seen.self, Search.self, Background.self, Overlay.self]
     )
 
     struct New: RequestCommand {
@@ -331,6 +331,16 @@ struct Session: ParsableCommand {
 
         func makeRequest() throws -> ControlRequest {
             ControlRequest(cmd: .sessionFlag, target: target.target, args: options.withWindow(ControlArgs(mode: mode)))
+        }
+    }
+
+    struct Seen: RequestCommand {
+        static let configuration = CommandConfiguration(abstract: "Clear a session's unseen-notification badge without changing the selection or focus (idempotent).")
+        @OptionGroup var target: TargetOptions
+        @OptionGroup var options: ClientOptions
+
+        func makeRequest() throws -> ControlRequest {
+            ControlRequest(cmd: .sessionSeen, target: target.target, args: options.withWindow())
         }
     }
 

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -165,6 +165,20 @@ struct AppStoreTests {
         store.clearUnseen(UUID()) // unknown id is a no-op, no crash
     }
 
+    @Test func clearUnseenDoesNotChangeSelection() {
+        // the focus-free invariant behind session.seen: clearing a NON-selected session's badge must
+        // leave the selection put (markSessionSeen calls clearUnseen and nothing else).
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let a = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        let b = store.addSession(toWorkspace: ws.id, cwd: "/b")!
+        a.unseenCount = 3
+        store.selectSession(b.id)
+        store.clearUnseen(a.id)
+        #expect(store.selectedSessionID == b.id) // focus-free: selecting is untouched
+        #expect(a.unseenCount == 0)              // the target's badge is cleared
+    }
+
     @Test func setAgentIndicatorSetsFieldOnRightSession() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -777,6 +777,28 @@ struct AppStoreTests {
         ])
     }
 
+    @Test func controlTreeReportsUnseenCountWhenPositive() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = try #require(store.addSession(toWorkspace: ws.id, cwd: "/repo"))
+        session.unseenCount = 4
+
+        let node = try #require(store.controlTree().workspaces[0].sessions.first)
+
+        #expect(node.unseen == 4)
+    }
+
+    @Test func controlTreeOmitsUnseenCountWhenZero() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = try #require(store.addSession(toWorkspace: ws.id, cwd: "/repo"))
+        session.unseenCount = 0
+
+        let node = try #require(store.controlTree().workspaces[0].sessions.first)
+
+        #expect(node.unseen == nil) // zero reads as "no badge", omitted from the wire
+    }
+
     @Test func controlTreeReportsStatusPaneForNonIdleSession() throws {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -439,6 +439,25 @@ struct ControlDispatcherTests {
         ])
     }
 
+    @Test func sessionSeenRoutesTargetAndWindow() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let seen = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionSeen,
+            target: "session",
+            args: ControlArgs(window: "win")
+        ))
+        let active = await dispatcher.dispatch(ControlRequest(cmd: .sessionSeen))
+
+        #expect(seen == ControlResponse(ok: true))
+        #expect(active == ControlResponse(ok: true))
+        #expect(actions.calls == [
+            .markSessionSeen(target: "session", window: "win"),
+            .markSessionSeen(target: nil, window: nil)
+        ])
+    }
+
     @Test func sessionStatusRoutesParsedStatusAndRejectsInvalidStatus() async {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)
@@ -1206,6 +1225,7 @@ private final class MockControlActions: ControlActions {
         case workspaceMove(target: String?, window: String?, ReorderDirection)
         case workspaceFocus(target: String?, window: String?, String?)
         case sessionFlag(target: String?, window: String?, String?)
+        case markSessionSeen(target: String?, window: String?)
         case sessionStatus(target: String?, window: String?, ControlSessionStatusUpdate)
         case sessionSplit(target: String?, window: String?, String?)
         case sessionScratch(target: String?, window: String?, String?, command: String?)
@@ -1342,6 +1362,11 @@ private final class MockControlActions: ControlActions {
 
     func setSessionFlag(_ target: String?, window: String?, mode: String?) -> ControlResponse {
         calls.append(.sessionFlag(target: target, window: window, mode))
+        return ControlResponse(ok: true)
+    }
+
+    func markSessionSeen(_ target: String?, window: String?) -> ControlResponse {
+        calls.append(.markSessionSeen(target: target, window: window))
         return ControlResponse(ok: true)
     }
 

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -118,6 +118,13 @@ struct ControlProtocolTests {
         #expect(decoded.args?.pane == "right")
     }
 
+    @Test func sessionSeenRoundTrips() throws {
+        let request = ControlRequest(cmd: .sessionSeen, target: "9f3c", args: ControlArgs(window: "win"))
+        let decoded = try roundTrip(request)
+        #expect(decoded == request)
+        #expect(decoded.cmd == .sessionSeen)
+    }
+
     @Test func sessionStatusRoundTripsWithStateAndBlink() throws {
         let request = ControlRequest(cmd: .sessionStatus, target: "9f3c",
                                      args: ControlArgs(status: "active", blink: true, autoReset: true))
@@ -403,6 +410,26 @@ struct ControlProtocolTests {
         #expect(!json.contains("background"), "a nil background must be omitted from the JSON; got \(json)")
         let decoded = try JSONDecoder().decode(ControlSessionNode.self, from: Data(json.utf8))
         #expect(decoded.background == nil)
+    }
+
+    @Test func treeSessionNodeRoundTripsWithUnseen() throws {
+        // the read side of the notification badge: the unseen count rides the tree node so a script can
+        // query it (and pair it with session.seen to clear).
+        let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: false, split: false, unseen: 3)
+        let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(
+            workspaces: [ControlWorkspaceNode(id: "w1", name: "work", active: true, sessions: [session])])))
+        let decoded = try roundTrip(response)
+        #expect(decoded == response)
+        #expect(decoded.result?.tree?.workspaces.first?.sessions.first?.unseen == 3)
+    }
+
+    @Test func treeSessionNodeOmitsUnseenWhenNil() throws {
+        // a session with no pending notifications — the key must be omitted, not emitted as null or 0.
+        let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false)
+        let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
+        #expect(!json.contains("unseen"), "a nil unseen count must be omitted from the JSON; got \(json)")
+        let decoded = try JSONDecoder().decode(ControlSessionNode.self, from: Data(json.utf8))
+        #expect(decoded.unseen == nil)
     }
 
     @Test func treeRoundTripsWithIdleAndAutoFollowMs() throws {

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -133,6 +133,15 @@ struct CommandsTests {
         #expect(try request(["session", "select"]) == ControlRequest(cmd: .sessionSelect, target: "active"))
     }
 
+    @Test func sessionSeenDefaultsActive() throws {
+        #expect(try request(["session", "seen"]) == ControlRequest(cmd: .sessionSeen, target: "active"))
+    }
+
+    @Test func sessionSeenTargetAndWindow() throws {
+        let expected = ControlRequest(cmd: .sessionSeen, target: "x", args: ControlArgs(window: "win"))
+        #expect(try request(["session", "seen", "--target", "x", "--window", "win"]) == expected)
+    }
+
     @Test func sessionRename() throws {
         let expected = ControlRequest(cmd: .sessionRename, target: "active", args: ControlArgs(name: "build"))
         #expect(try request(["session", "rename", "build"]) == expected)

--- a/agtermUITests/ControlSidebarStatusUITests.swift
+++ b/agtermUITests/ControlSidebarStatusUITests.swift
@@ -426,6 +426,76 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
                       "re-enabling the badge setting should show the count pill again")
     }
 
+    // session.seen clears a session's unseen badge WITHOUT changing the selection/focus — the focus-free
+    // counterpart to notify. Fire notify on a non-selected session so the badge + tree `unseen` read-back
+    // show, then session.seen clears both while the selection stays on the other session.
+    func testSessionSeenClearsBadgeWithoutFocus() throws {
+        let tree = try sendCommand(#"{"cmd":"tree"}"#)
+        let treeResult = try XCTUnwrap(tree["result"] as? [String: Any], "tree should carry a result")
+        let root = try XCTUnwrap(treeResult["tree"] as? [String: Any], "result should carry a tree")
+        let workspaces = try XCTUnwrap(root["workspaces"] as? [[String: Any]], "tree should list workspaces")
+        let sessions = try XCTUnwrap(workspaces.first?["sessions"] as? [[String: Any]], "workspace should list sessions")
+        let seeded = try XCTUnwrap(sessions.first?["id"] as? String, "should have a seeded session id")
+
+        // a second session takes focus, leaving the seeded one non-selected so its badge persists.
+        let created = try sendCommand(#"{"cmd":"session.new"}"#)
+        XCTAssertEqual(created["ok"] as? Bool, true)
+        let newSession = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "session.new returns the new id")
+        XCTAssertTrue(pollSessionCount(2, timeout: 10), "the new session should land")
+
+        // notify (no focus-suppression) bumps the non-selected session's unseen count → the badge shows.
+        let notified = try sendCommand(#"{"cmd":"notify","target":"\#(seeded)","args":{"body":"hi"}}"#)
+        XCTAssertEqual(notified["ok"] as? Bool, true, "notify should succeed: \(notified)")
+        XCTAssertTrue(app.staticTexts["notify-badge"].waitForExistence(timeout: 12),
+                      "the count badge should appear on the non-selected session's row")
+
+        // the tree read-back surfaces the unseen count and the new session is the active one.
+        XCTAssertEqual(unseenCount(forSession: seeded), 1, "tree should report the seeded session's unseen count")
+        XCTAssertEqual(activeNodeID(), newSession, "the new session should be the active selection")
+
+        // session.seen clears the badge; it targets the NON-selected session and returns its id.
+        let seen = try sendCommand(#"{"cmd":"session.seen","target":"\#(seeded)"}"#)
+        XCTAssertEqual(seen["ok"] as? Bool, true, "session.seen should succeed: \(seen)")
+        XCTAssertEqual((seen["result"] as? [String: Any])?["id"] as? String, seeded, "session.seen echoes the target id")
+        XCTAssertTrue(app.staticTexts["notify-badge"].waitForNonExistence(timeout: 12),
+                      "session.seen should clear the count pill")
+
+        // the clear is focus-free: the selection is unchanged and the tree no longer reports unseen.
+        XCTAssertEqual(activeNodeID(), newSession, "session.seen must NOT change the active selection")
+        XCTAssertNil(unseenCount(forSession: seeded), "the seeded session's unseen count should be cleared (omitted)")
+
+        // idempotent: a second seen on an already-clear session is still ok.
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.seen","target":"\#(seeded)"}"#)["ok"] as? Bool, true,
+                       "session.seen is idempotent when the badge is already zero")
+    }
+
+    // the unseen badge count reported for a session in the current tree, or nil when omitted (zero).
+    private func unseenCount(forSession id: String) -> Int? {
+        guard let result = (try? sendCommand(#"{"cmd":"tree"}"#))?["result"] as? [String: Any],
+              let root = result["tree"] as? [String: Any],
+              let workspaces = root["workspaces"] as? [[String: Any]] else { return nil }
+        for workspace in workspaces {
+            for session in (workspace["sessions"] as? [[String: Any]] ?? []) where session["id"] as? String == id {
+                return session["unseen"] as? Int
+            }
+        }
+        return nil
+    }
+
+    // the id of the active (selected) session in the current tree, or nil when none is selected.
+    // (distinct from ControlAPITestCase.activeSessionID(), which returns the first session unconditionally.)
+    private func activeNodeID() -> String? {
+        guard let result = (try? sendCommand(#"{"cmd":"tree"}"#))?["result"] as? [String: Any],
+              let root = result["tree"] as? [String: Any],
+              let workspaces = root["workspaces"] as? [[String: Any]] else { return nil }
+        for workspace in workspaces {
+            for session in (workspace["sessions"] as? [[String: Any]] ?? []) where session["active"] as? Bool == true {
+                return session["id"] as? String
+            }
+        }
+        return nil
+    }
+
     // notify posts a banner for the active session; a missing body errors.
     func testNotifySend() throws {
         let ok = try sendCommand(#"{"cmd":"notify","target":"active","args":{"body":"hello","title":"Test"}}"#)

--- a/agtermUITests/ControlSidebarStatusUITests.swift
+++ b/agtermUITests/ControlSidebarStatusUITests.swift
@@ -464,9 +464,17 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         XCTAssertEqual(activeNodeID(), newSession, "session.seen must NOT change the active selection")
         XCTAssertNil(unseenCount(forSession: seeded), "the seeded session's unseen count should be cleared (omitted)")
 
-        // idempotent: a second seen on an already-clear session is still ok.
-        XCTAssertEqual(try sendCommand(#"{"cmd":"session.seen","target":"\#(seeded)"}"#)["ok"] as? Bool, true,
-                       "session.seen is idempotent when the badge is already zero")
+        // idempotent: a second seen on an already-clear session is ok AND a genuine no-op (end-state holds).
+        let again = try sendCommand(#"{"cmd":"session.seen","target":"\#(seeded)"}"#)
+        XCTAssertEqual(again["ok"] as? Bool, true, "session.seen is idempotent when the badge is already zero")
+        XCTAssertNil(unseenCount(forSession: seeded), "a repeat seen keeps the badge cleared")
+        XCTAssertEqual(activeNodeID(), newSession, "a repeat seen must not change the active selection")
+
+        // an unknown target errors through the shared resolver, like the other session.* commands.
+        let bad = try sendCommand(#"{"cmd":"session.seen","target":"deadbeef"}"#)
+        XCTAssertEqual(bad["ok"] as? Bool, false, "session.seen with an unknown target should fail")
+        XCTAssertTrue((bad["error"] as? String ?? "").hasPrefix("no such session"),
+                      "should report no such session, got: \(bad)")
     }
 
     // the unseen badge count reported for a session in the current tree, or nil when omitted (zero).

--- a/site/docs.html
+++ b/site/docs.html
@@ -851,7 +851,8 @@
               as a macOS banner and an unseen-count badge on the sidebar row (rolled up onto a collapsed workspace); clicking the
               banner brings agterm forward and focuses the exact pane that raised it, and focusing a session clears its badge — or
               clear it headlessly with <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl session seen</span>
-              so an orchestrator driving a session over the socket can acknowledge it without pulling focus.
+              so an orchestrator driving a session over the socket can acknowledge it without pulling focus
+              (<span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl tree --json</span> reports each session's <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">unseen</span> count).
               Banners and count badges toggle independently in General settings. For a coding agent that just needs to say it is
               waiting, <a href="#status" style="color: #6d82f3">agent status</a> is usually the better fit.
             </p>

--- a/site/docs.html
+++ b/site/docs.html
@@ -849,7 +849,9 @@
               A program in any session can raise a desktop notification (via OSC 9 / 777, or
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl notify</span>). It surfaces
               as a macOS banner and an unseen-count badge on the sidebar row (rolled up onto a collapsed workspace); clicking the
-              banner brings agterm forward and focuses the exact pane that raised it, and focusing a session clears its badge.
+              banner brings agterm forward and focuses the exact pane that raised it, and focusing a session clears its badge — or
+              clear it headlessly with <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl session seen</span>
+              so an orchestrator driving a session over the socket can acknowledge it without pulling focus.
               Banners and count badges toggle independently in General settings. For a coding agent that just needs to say it is
               waiting, <a href="#status" style="color: #6d82f3">agent status</a> is usually the better fit.
             </p>
@@ -1083,7 +1085,8 @@
               agtermctl session split toggle<br />agtermctl session resize --split-ratio 0.7
               <span style="color: #6b727a">&nbsp;# or --grow-left/--grow-right D</span><br />agtermctl session scratch toggle
               <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;&nbsp;# on|off|toggle</span><br />agtermctl session flag on
-              <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;# on|off|toggle|clear</span><br />agtermctl
+              <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;# on|off|toggle|clear</span><br />agtermctl session seen --target 9f3c
+              <span style="color: #6b727a">&nbsp;# clear the unseen badge, focus-free</span><br />agtermctl
               sidebar mode flagged <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;# tree|flagged|toggle</span><br />agtermctl quick
               toggle<br />agtermctl font inc <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;# active surface font size</span
               ><br /><br /><span style="color: #6b727a"># open the search bar, print the "N of M" counter</span><br />agtermctl


### PR DESCRIPTION
`session.seen` clears a session's unseen-notification badge without changing the selection, focus, or agent status. It is the focus-free counterpart to `notify`: `notify` (and a terminal's own OSC 9/777) raise the red badge, but the only way to clear it was visiting the session, which pulls focus. An orchestrator driving a session over the control socket can now acknowledge its notifications without stealing focus, so the badge stays a real attention signal on the sessions a human tends.

Also adds an `unseen` read-back field on each `tree` session node, so a script can read the count and clear it symmetrically (omitted when zero).

Reuses the existing public `AppStore.clearUnseen`. The command follows the `session.flag` pattern across the keep-in-sync surfaces: `ControlProtocol`/`ControlDispatcher`/`ControlServer`, the `agtermctl session seen` CLI, tests (protocol round-trip, dispatcher routing, tree read-back, CLI mapping, e2e), the bundled agent-skill, `.claude/rules/control-api.md`, README, and the site docs.

Fix #148
