### PR TITLE
fix: mouse scroll and split-pane selection after reactivating a window

### DIFF
--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -240,10 +240,14 @@ paths:
   Separately, `mouse_scroll` reports at libghostty's LAST-KNOWN cell, and a no-mouse-move reactivation
   (cmd-tab/keyboard, or scrolling to reactivate with the pointer already inside) fires no `mouseDown`/`mouseEntered`,
   so the position is stale or `-1,-1` (from `mouseExited`).
-  `scrollWheel` therefore pushes `ghostty_surface_mouse_pos` from its own event before `mouse_scroll`, so
-  the first scroll inside a mouse-reporting TUI (Claude Code, vim, less) lands at the real cell instead of
-  doing nothing until you nudge the mouse — the companion to the `mouseEntered` restore (which only covers
-  cross-the-boundary re-entry).
+  `scrollWheel` therefore pushes `ghostty_surface_mouse_pos` from its own event before `mouse_scroll`, but
+  ONLY when the point is stale — it differs from `lastReportedMousePoint`, which every mouse handler updates
+  through the shared `reportMousePos` helper.
+  So the first scroll after a no-move reactivation lands at the real cell instead of doing nothing until you
+  nudge the mouse, while a normal already-synced scroll does NOT re-push the same cell on every packet —
+  which in an any-motion + sgr-pixel mouse-reporting TUI would otherwise emit a synthetic motion report per
+  packet.
+  It is the companion to the `mouseEntered` restore (which only covers cross-the-boundary re-entry).
   Like the cursor-focus case, this input plumbing is not accessibility-observable and is verified by hand,
   not a UI test.
 - **OSC 52 clipboard access is gated in OUR callbacks, not by a ghostty-internal dialog.**

--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -228,6 +228,24 @@ paths:
   Cursor solid/hollow is not accessibility-observable, so it is NOT unit/UI-testable — verified by instrumenting
   `set_focus` and reading `log show` across split-open + multi-window key switches (exactly one focused
   surface app-wide in every case).
+- **A background window's LEFT reactivation click reaches the surface (`acceptsFirstMouse`), and `scrollWheel` self-syncs the mouse cell.**
+  `GhosttySurfaceView.acceptsFirstMouse(for:)` returns true ONLY for `.leftMouseDown`, so the click that
+  raises an inactive window also runs `mouseDown` — selecting the clicked split pane (`makeFirstResponder`
+  → `onFocusChange` → `splitFocused`), the counterpart to the first-responder path above, instead of AppKit
+  swallowing the click just to raise the window.
+  It is gated to the LEFT button on purpose: a first-mouse right/middle click would otherwise reach
+  `rightMouseDown`/`otherMouseDown`, which forward to libghostty, and with the default
+  `right-click-action = paste` (`AppSettings.rightClickPaste`, nil = paste) that would paste the clipboard
+  into a window you only meant to raise.
+  Separately, `mouse_scroll` reports at libghostty's LAST-KNOWN cell, and a no-mouse-move reactivation
+  (cmd-tab/keyboard, or scrolling to reactivate with the pointer already inside) fires no `mouseDown`/`mouseEntered`,
+  so the position is stale or `-1,-1` (from `mouseExited`).
+  `scrollWheel` therefore pushes `ghostty_surface_mouse_pos` from its own event before `mouse_scroll`, so
+  the first scroll inside a mouse-reporting TUI (Claude Code, vim, less) lands at the real cell instead of
+  doing nothing until you nudge the mouse — the companion to the `mouseEntered` restore (which only covers
+  cross-the-boundary re-entry).
+  Like the cursor-focus case, this input plumbing is not accessibility-observable and is verified by hand,
+  not a UI test.
 - **OSC 52 clipboard access is gated in OUR callbacks, not by a ghostty-internal dialog.**
   A program reading (`\e]52;c;?\a`) or writing (`\e]52;c;<base64>\a`) the system clipboard reaches agterm
   through `read_clipboard_cb`/`confirm_read_clipboard_cb` and `write_clipboard_cb` (`GhosttyCallbacks`).

--- a/agterm/Ghostty/GhosttySurfaceView+Input.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Input.swift
@@ -195,10 +195,10 @@ extension GhosttySurfaceView {
         ghostty_surface_mouse_pos(surface, pt.x, pt.y, mods(event))
     }
 
-    /// The pointer entered the surface: restore libghostty's mouse position from the current point. Paired
-    /// with `mouseExited`'s `-1, -1` reset — without it, `scrollWheel` (which never sets `mouse_pos`) would
-    /// report a scroll at the stale `-1, -1` if you scroll right after re-entering, before any move, inside
-    /// a mouse-reporting TUI (vim/less/htop).
+    /// The pointer entered the surface: restore libghostty's mouse position from the current point, undoing
+    /// `mouseExited`'s `-1, -1` reset so hovered-link and cursor-shape state are correct on re-entry.
+    /// (`scrollWheel` now also syncs `mouse_pos` from its own event, so the first post-re-entry scroll no
+    /// longer depends on this — but the restore still matters for hover/link state before any move.)
     override func mouseEntered(with event: NSEvent) {
         guard let surface else { return }
         let pt = mousePoint(from: event)
@@ -218,12 +218,13 @@ extension GhosttySurfaceView {
     override func scrollWheel(with event: NSEvent) {
         guard let surface else { return }
         // sync libghostty's mouse position from THIS event before scrolling: mouse_scroll reports the
-        // scroll at the last-known cell, and re-activating the window by clicking (acceptsFirstMouse is
-        // off, so the click is swallowed — no mouseDown) or via cmd-tab delivers no mouseDown/mouseEntered,
-        // leaving the position stale or -1,-1 (from mouseExited). without this the first scroll inside a
+        // scroll at the last-known cell. reactivating the window with no mouse move — cmd-tab/keyboard, or
+        // scrolling to reactivate while the pointer is already inside — delivers no mouseDown/mouseEntered,
+        // so the position stays stale or -1,-1 (from mouseExited). without this the first scroll inside a
         // mouse-reporting TUI (Claude Code, vim, less) reports at the stale cell and does nothing until you
-        // nudge the mouse. companion to the mouseEntered restore, which only covers the cross-the-boundary
-        // re-entry path, not reactivation while the pointer is already inside.
+        // nudge the mouse. (a LEFT click reactivation is already covered by mouseDown via acceptsFirstMouse;
+        // this handles the no-click paths.) companion to the mouseEntered restore, which only covers the
+        // cross-the-boundary re-entry path.
         let pt = mousePoint(from: event)
         ghostty_surface_mouse_pos(surface, pt.x, pt.y, mods(event))
         var scrollMods: ghostty_input_scroll_mods_t = 0

--- a/agterm/Ghostty/GhosttySurfaceView+Input.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Input.swift
@@ -217,6 +217,15 @@ extension GhosttySurfaceView {
 
     override func scrollWheel(with event: NSEvent) {
         guard let surface else { return }
+        // sync libghostty's mouse position from THIS event before scrolling: mouse_scroll reports the
+        // scroll at the last-known cell, and re-activating the window by clicking (acceptsFirstMouse is
+        // off, so the click is swallowed — no mouseDown) or via cmd-tab delivers no mouseDown/mouseEntered,
+        // leaving the position stale or -1,-1 (from mouseExited). without this the first scroll inside a
+        // mouse-reporting TUI (Claude Code, vim, less) reports at the stale cell and does nothing until you
+        // nudge the mouse. companion to the mouseEntered restore, which only covers the cross-the-boundary
+        // re-entry path, not reactivation while the pointer is already inside.
+        let pt = mousePoint(from: event)
+        ghostty_surface_mouse_pos(surface, pt.x, pt.y, mods(event))
         var scrollMods: ghostty_input_scroll_mods_t = 0
         if event.hasPreciseScrollingDeltas { scrollMods |= 1 }
         ghostty_surface_mouse_scroll(surface, event.scrollingDeltaX, event.scrollingDeltaY, scrollMods)

--- a/agterm/Ghostty/GhosttySurfaceView+Input.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Input.swift
@@ -135,19 +135,28 @@ extension GhosttySurfaceView {
         return NSPoint(x: local.x, y: bounds.height - local.y)
     }
 
+    /// Push the pointer position from `event` to libghostty and remember it in `lastReportedMousePoint`.
+    /// Every handler that reports a position routes through here so `scrollWheel` can tell when the position
+    /// is already current and skip a redundant `mouse_pos` (which a mouse-reporting TUI would otherwise turn
+    /// into a per-packet synthetic motion report).
+    private func reportMousePos(from event: NSEvent) {
+        guard let surface else { return }
+        let pt = mousePoint(from: event)
+        ghostty_surface_mouse_pos(surface, pt.x, pt.y, mods(event))
+        lastReportedMousePoint = pt
+    }
+
     override func mouseDown(with event: NSEvent) {
         guard let surface else { return }
         window?.makeFirstResponder(self)
         updateGhosttyFocus()
-        let pt = mousePoint(from: event)
-        ghostty_surface_mouse_pos(surface, pt.x, pt.y, mods(event))
+        reportMousePos(from: event)
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, mods(event))
     }
 
     override func mouseUp(with event: NSEvent) {
         guard let surface else { return }
-        let pt = mousePoint(from: event)
-        ghostty_surface_mouse_pos(surface, pt.x, pt.y, mods(event))
+        reportMousePos(from: event)
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, mods(event))
     }
 
@@ -157,15 +166,13 @@ extension GhosttySurfaceView {
     // terminal context menu, so the return value is discarded like the left handler.
     override func rightMouseDown(with event: NSEvent) {
         guard let surface else { return }
-        let pt = mousePoint(from: event)
-        ghostty_surface_mouse_pos(surface, pt.x, pt.y, mods(event))
+        reportMousePos(from: event)
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_RIGHT, mods(event))
     }
 
     override func rightMouseUp(with event: NSEvent) {
         guard let surface else { return }
-        let pt = mousePoint(from: event)
-        ghostty_surface_mouse_pos(surface, pt.x, pt.y, mods(event))
+        reportMousePos(from: event)
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_RIGHT, mods(event))
     }
 
@@ -173,15 +180,13 @@ extension GhosttySurfaceView {
     // (back/forward, etc.) falls through to the responder chain via super.
     override func otherMouseDown(with event: NSEvent) {
         guard event.buttonNumber == 2, let surface else { super.otherMouseDown(with: event); return }
-        let pt = mousePoint(from: event)
-        ghostty_surface_mouse_pos(surface, pt.x, pt.y, mods(event))
+        reportMousePos(from: event)
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_MIDDLE, mods(event))
     }
 
     override func otherMouseUp(with event: NSEvent) {
         guard event.buttonNumber == 2, let surface else { super.otherMouseUp(with: event); return }
-        let pt = mousePoint(from: event)
-        ghostty_surface_mouse_pos(surface, pt.x, pt.y, mods(event))
+        reportMousePos(from: event)
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_MIDDLE, mods(event))
     }
 
@@ -189,21 +194,13 @@ extension GhosttySurfaceView {
     override func rightMouseDragged(with event: NSEvent) { mouseMoved(with: event) }
     override func otherMouseDragged(with event: NSEvent) { mouseMoved(with: event) }
 
-    override func mouseMoved(with event: NSEvent) {
-        guard let surface else { return }
-        let pt = mousePoint(from: event)
-        ghostty_surface_mouse_pos(surface, pt.x, pt.y, mods(event))
-    }
+    override func mouseMoved(with event: NSEvent) { reportMousePos(from: event) }
 
     /// The pointer entered the surface: restore libghostty's mouse position from the current point, undoing
     /// `mouseExited`'s `-1, -1` reset so hovered-link and cursor-shape state are correct on re-entry.
-    /// (`scrollWheel` now also syncs `mouse_pos` from its own event, so the first post-re-entry scroll no
-    /// longer depends on this — but the restore still matters for hover/link state before any move.)
-    override func mouseEntered(with event: NSEvent) {
-        guard let surface else { return }
-        let pt = mousePoint(from: event)
-        ghostty_surface_mouse_pos(surface, pt.x, pt.y, mods(event))
-    }
+    /// (`scrollWheel` also syncs `mouse_pos` when stale, so the first post-re-entry scroll no longer depends
+    /// on this — but the restore still matters for hover/link state before any move.)
+    override func mouseEntered(with event: NSEvent) { reportMousePos(from: event) }
 
     /// The pointer left the surface. Report negative coordinates so libghostty clears any hovered-link
     /// state — it drops `over_link`, reverts the mouse shape, and re-renders without the underline (see its
@@ -213,20 +210,25 @@ extension GhosttySurfaceView {
     override func mouseExited(with event: NSEvent) {
         guard let surface, NSEvent.pressedMouseButtons == 0 else { return }
         ghostty_surface_mouse_pos(surface, -1, -1, mods(event))
+        lastReportedMousePoint = NSPoint(x: -1, y: -1)
     }
 
     override func scrollWheel(with event: NSEvent) {
         guard let surface else { return }
-        // sync libghostty's mouse position from THIS event before scrolling: mouse_scroll reports the
-        // scroll at the last-known cell. reactivating the window with no mouse move — cmd-tab/keyboard, or
-        // scrolling to reactivate while the pointer is already inside — delivers no mouseDown/mouseEntered,
-        // so the position stays stale or -1,-1 (from mouseExited). without this the first scroll inside a
-        // mouse-reporting TUI (Claude Code, vim, less) reports at the stale cell and does nothing until you
-        // nudge the mouse. (a LEFT click reactivation is already covered by mouseDown via acceptsFirstMouse;
-        // this handles the no-click paths.) companion to the mouseEntered restore, which only covers the
-        // cross-the-boundary re-entry path.
+        // sync libghostty's mouse position before scrolling, but ONLY when it's stale: mouse_scroll reports
+        // at the last-known cell, and reactivating the window with no mouse move — cmd-tab/keyboard, or
+        // scrolling to reactivate with the pointer already inside — delivers no mouseDown/mouseEntered, so
+        // the position stays stale or -1,-1 (from mouseExited) and the first scroll inside a mouse-reporting
+        // TUI (Claude Code, vim, less) reports at the wrong cell until you nudge the mouse. gating on
+        // lastReportedMousePoint means an already-synced (normal) scroll doesn't re-push the same cell every
+        // packet — which in an any-motion + sgr-pixel TUI would emit a synthetic motion report per packet.
+        // (a LEFT click reactivation is already covered by mouseDown via acceptsFirstMouse; this handles the
+        // no-click paths.)
         let pt = mousePoint(from: event)
-        ghostty_surface_mouse_pos(surface, pt.x, pt.y, mods(event))
+        if pt != lastReportedMousePoint {
+            ghostty_surface_mouse_pos(surface, pt.x, pt.y, mods(event))
+            lastReportedMousePoint = pt
+        }
         var scrollMods: ghostty_input_scroll_mods_t = 0
         if event.hasPreciseScrollingDeltas { scrollMods |= 1 }
         ghostty_surface_mouse_scroll(surface, event.scrollingDeltaX, event.scrollingDeltaY, scrollMods)

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -867,14 +867,17 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
 
     override var acceptsFirstResponder: Bool { true }
 
-    /// Deliver the click that reactivates a background/inactive window straight to the surface (a "first
-    /// mouse") instead of AppKit swallowing it just to raise the window. Without this, clicking a specific
-    /// pane of a two-pane split from another window raises the window but never runs `mouseDown`, so the
-    /// clicked pane doesn't become first responder and `splitFocused` stays on the previously-focused pane
-    /// ("the mouse works but the pane isn't selected"). Returning true makes the reactivation click behave
-    /// like any normal in-window click — it selects the pane AND is reported to the program — matching
-    /// Terminal.app/iTerm2/Ghostty.
-    override func acceptsFirstMouse(for _: NSEvent?) -> Bool { true }
+    /// Deliver the LEFT click that reactivates a background/inactive window straight to the surface (a
+    /// "first mouse") instead of AppKit swallowing it just to raise the window. Without this, clicking a
+    /// specific pane of a two-pane split from another window raises the window but never runs `mouseDown`,
+    /// so the clicked pane doesn't become first responder and `splitFocused` stays on the previously-focused
+    /// pane ("the mouse works but the pane isn't selected"). The left click then behaves like any normal
+    /// in-window click — it selects the pane AND is reported to the program — matching Terminal.app/iTerm2/Ghostty.
+    /// Gated to `.leftMouseDown` on purpose: a first-mouse right/middle click would otherwise reach
+    /// `rightMouseDown`/`otherMouseDown`, which forward to libghostty, and with the default
+    /// `right-click-action = paste` that would paste the clipboard into a window you only meant to raise —
+    /// so right/middle first clicks just raise the window.
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { event?.type == .leftMouseDown }
 
     override func becomeFirstResponder() -> Bool {
         let result = super.becomeFirstResponder()

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -227,6 +227,13 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     /// owns the cursor-rect override and `applyMouseShape`) can read it.
     var mouseShape: ghostty_action_mouse_shape_e = GHOSTTY_MOUSE_SHAPE_TEXT
 
+    /// The last pointer position pushed to libghostty via `ghostty_surface_mouse_pos` (view-flipped
+    /// coordinates), or nil before the first report. `scrollWheel` syncs the position only when the current
+    /// point differs from this, so a normal already-synced scroll doesn't re-push the same cell on every
+    /// packet — which in an any-motion + sgr-pixel mouse-reporting TUI would emit a synthetic motion report
+    /// per packet. Not `private` so the `+Input` extension (which owns the mouse handlers) can read/write it.
+    var lastReportedMousePoint: NSPoint?
+
     init(workingDirectory: String, fontSize: Float? = nil, command: String? = nil, initialInput: String? = nil,
          waitAfterCommand: Bool = false, autoFocus: Bool = false, env: [String: String] = [:]) {
         self.workingDirectory = workingDirectory

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -867,6 +867,15 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
 
     override var acceptsFirstResponder: Bool { true }
 
+    /// Deliver the click that reactivates a background/inactive window straight to the surface (a "first
+    /// mouse") instead of AppKit swallowing it just to raise the window. Without this, clicking a specific
+    /// pane of a two-pane split from another window raises the window but never runs `mouseDown`, so the
+    /// clicked pane doesn't become first responder and `splitFocused` stays on the previously-focused pane
+    /// ("the mouse works but the pane isn't selected"). Returning true makes the reactivation click behave
+    /// like any normal in-window click — it selects the pane AND is reported to the program — matching
+    /// Terminal.app/iTerm2/Ghostty.
+    override func acceptsFirstMouse(for _: NSEvent?) -> Bool { true }
+
     override func becomeFirstResponder() -> Bool {
         let result = super.becomeFirstResponder()
         if result, let surface {


### PR DESCRIPTION
Two related fixes for the moment you click back into agterm from another window.

Scroll: the first mouse-wheel scroll did nothing inside a mouse-reporting TUI (Claude Code, vim, less) until you nudged the mouse. `scrollWheel` never told libghostty the pointer position, so `mouse_scroll` reported at a stale (or `-1,-1`) cell. It now syncs the position from the scroll event first, but only when the cell is actually stale, tracked by a `lastReportedMousePoint` cache that every mouse handler updates through a shared `reportMousePos` helper. A normal already-synced scroll doesn't re-push the position, so it can't spam motion reports at a TUI in any-motion + sgr-pixel mode.

Split panes: clicking a specific pane from another window raised the window but left focus on the previously-focused pane ("the mouse works but the pane isn't selected"). `acceptsFirstMouse` was off, so the reactivating click was swallowed and `mouseDown` never ran. It now returns true for a LEFT click, so the click reaches `mouseDown` and selects the pane, like any normal in-window click. It stays gated to the left button on purpose: a first-mouse right/middle click would forward to libghostty, and with the default `right-click-action = paste` that would paste the clipboard into a window you only meant to raise.

No automated test: mouse-reporting scroll and first-mouse focus aren't accessibility-observable, and any XCUITest scroll fires a preceding mouseMoved that masks the exact staleness this fixes. Verified by hand in a dev instance and documented in `.claude/rules/libghostty.md`.
