### PR TITLE
Preserve split-pane focus on re-show, add sidebar-visibility read-back to the control API

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -746,6 +746,18 @@ paths:
   is each pane running".
   It ALSO surfaces `background` on each node — the `BackgroundWatermark` spec set via `session.background`
   (omitted when none), the read side of set/clear so a script can query the current watermark.
+  `tree` ALSO carries, at the TOP level (alongside `idleMs`/`autoFollowMs`), `sidebarVisible` — the read
+  side of the write-only `sidebar` command (per-window sidebar visibility), populated LIVE from the
+  projected window's store in `AppStore.controlTree`.
+  The SAME field also rides each `ControlWindowNode` on `window.list` (read from `stores[id]?.sidebarVisible`,
+  omitted for a closed window), so a script can enumerate every window's sidebar state.
+  BUT `window.list` is served from the background-thread `cachedWindowNodes` cache
+  (refreshed after every dispatched command + on frontmost change), and a GUI-only ⌃⌘S toggle is neither —
+  so `AppStore.setSidebarVisible` posts `.agtermSidebarVisibilityChanged` (agtermCore) and `ControlServer`
+  observes it to `refreshWindowCache`, keeping the cached `sidebarVisible` honest.
+  A script that reads-then-acts (e.g. the tmux-style zoom that must restore the sidebar only if it was
+  visible) should still prefer `tree`'s LIVE `sidebarVisible` over the cached `window.list` one — the tree
+  is built on the main actor per request, so it can never lag.
   `restore.clear` clears every open session's saved CAPTURED foreground command (`Session.foregroundCommand`/`splitForegroundCommand`)
   and persists via `library.saveAllOpen()`, so the next restart restores plain shells for those panes instead
   of re-running the captured commands (also closing the force-quit re-fire: the restored command is consumed

--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -96,8 +96,11 @@ paths:
   `effectiveCwd` stays the PRIMARY pane's (non-focus-aware) for seeding new panes + the `AGTERM_SESSION_PWD`
   token; `Session.activeSurface` is the focused pane's surface (the focus helpers + the collapsed detail
   pane target it).
-  **Opening a split moves focus to the new (right) pane** (`AppStore.toggleSplit` sets `splitFocused = true`
-  on open; hiding leaves it set so the focused pane is the one shown maximized).
+  **Opening a NEW split moves focus to the new (right) pane** (`AppStore.toggleSplit` sets `splitFocused = true`
+  only when the split is genuinely new — `hasSplit` was false; hiding leaves it set so the focused pane
+  is the one shown maximized, and RE-showing a hidden split PRESERVES that pane rather than jerking focus
+  back to the right — so a hide/show round-trip, e.g. the tmux-style zoom script that drives `session split off`
+  then `on`, keeps whichever pane you had focused).
   **Hiding the split (the toolbar toggle) keeps BOTH shells alive** and shows the focused pane maximized
   — `detailPane`'s collapsed branch renders `\.splitSurface` when `splitFocused`,
   else `\.surface` — so reopening restores the two panes in place; nothing is destroyed (`closeSplit`

--- a/.claude/rules/windows.md
+++ b/.claude/rules/windows.md
@@ -177,9 +177,17 @@ never two bundles in one window.
   `testHeaderButtonsStillReceiveClicksOverControlArea` / `testDragHeaderMovesWindow` in `ControlWindowUITests`.
 - **`window.*` control additions (eight commands, plus `window.zoom`).**
   `window.new` (returns the new id + opens its window), `window.list` (returns `windows` with each window's
-  `open`/`active` flag), `window.select` (raise-or-open), `window.close` (`WindowRegistry.close` → standard
-  teardown), `window.rename`, `window.delete` (`canRemoveWindow` keep-at-least-one → error,
+  `open`/`active` flag, plus `autoFollowMs` and `sidebarVisible` read from the open window's store — both
+  omitted for a closed window), `window.select` (raise-or-open), `window.close` (`WindowRegistry.close` →
+  standard teardown), `window.rename`, `window.delete` (`canRemoveWindow` keep-at-least-one → error,
   not a GUI confirm).
+  `window.list` is answered from the background-thread `cachedWindowNodes` cache (see the fast-path note
+  above), refreshed after every dispatched command + on `.agtermWindowFrontmostChanged`.
+  `sidebarVisible` is the first frequently-GUI-mutated field on that node, so a GUI-only ⌃⌘S sidebar
+  toggle (no control command, no frontmost change) would otherwise leave it stale — `AppStore.setSidebarVisible`
+  posts `.agtermSidebarVisibilityChanged` and `ControlServer` observes it to `refreshWindowCache`.
+  The live, never-cached copy of `sidebarVisible` is on `tree`'s top level (main-actor per request);
+  prefer it for read-then-act scripts.
   `window.resize` (`args.width`/`height` → the window's frame size in points) and `window.move` (`args.x`/`y`
   → the top-left relative to display `args.display`, default the window's current display;
   y from the display top, so multiple displays are addressed by index) drive the app-side `WindowRegistry.resize`/`move`

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -485,10 +485,11 @@ final class AppActions {
 
     // MARK: - Split
 
-    /// Toggle the active session's split. Opening shows both panes and moves focus to the new (right)
-    /// pane; closing HIDES the split (both shells stay alive, nothing is destroyed) and shows the
-    /// focused pane maximized, so reopening restores the two panes in their original positions. Either
-    /// way focus follows `splitFocused`, which `AppStore.toggleSplit` sets to the new pane on open.
+    /// Toggle the active session's split. Opening a NEW split shows both panes and moves focus to the
+    /// new (right) pane; closing HIDES the split (both shells stay alive, nothing is destroyed) and shows
+    /// the focused pane maximized, so reopening restores the two panes in their original positions with
+    /// the SAME pane focused. Either way focus follows `splitFocused`, which `AppStore.toggleSplit` sets
+    /// to the new pane only when the split is genuinely new (a re-show preserves the prior focused pane).
     func toggleSplit() {
         guard let store, let session = store.activeSession else { return }
         store.toggleSplit(session.id)

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -119,6 +119,11 @@ final class ControlServer {
         NotificationCenter.default.addObserver(forName: .agtermWindowFrontmostChanged, object: nil, queue: .main) { [weak self] _ in
             MainActor.assumeIsolated { self?.refreshWindowCache() }
         }
+        // a GUI-only sidebar toggle (⌃⌘S / toolbar / menu / palette) mutates sidebarVisible without a
+        // control command, so refresh the cache on it too — otherwise window.list's sidebarVisible lags.
+        NotificationCenter.default.addObserver(forName: .agtermSidebarVisibilityChanged, object: nil, queue: .main) { [weak self] _ in
+            MainActor.assumeIsolated { self?.refreshWindowCache() }
+        }
     }
 
     /// The socket path the app and the CLI rendezvous on. `AGTERM_CONTROL_SOCKET` is an explicit override

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -121,7 +121,10 @@ final class ControlServer {
         }
         // a GUI-only sidebar toggle (⌃⌘S / toolbar / menu / palette) mutates sidebarVisible without a
         // control command, so refresh the cache on it too — otherwise window.list's sidebarVisible lags.
-        NotificationCenter.default.addObserver(forName: .agtermSidebarVisibilityChanged, object: nil, queue: .main) { [weak self] _ in
+        // queue nil (NOT .main) delivers synchronously on the posting thread: setSidebarVisible is
+        // @MainActor, so the refresh runs on the main actor BEFORE the toggle returns. An async .main hop
+        // would leave a window where a background window.list fast-path read still sees the stale cache.
+        NotificationCenter.default.addObserver(forName: .agtermSidebarVisibilityChanged, object: nil, queue: nil) { [weak self] _ in
             MainActor.assumeIsolated { self?.refreshWindowCache() }
         }
     }

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -72,11 +72,12 @@ of the tree).
 Inspect the live tree any time with `agtermctl tree --json` (workspaces → sessions, each with
 `id`, `name`, `cwd`, `title`, `active`, `split`, `overlay`, `scratch`, `status`, `background`). `title` is the raw OSC
 terminal title (e.g. a remote host over SSH), omitted when none was reported — read it when a
-session's local `cwd` is stale because it's connected to a remote. The tree object also carries two
-read-only top-level fields: `idleMs` (ms since the last user input in the window) and `autoFollowMs`
-(the Auto-follow timeout in ms, omitted when Disabled). List windows with
-`agtermctl window list --json`; each window also reports `autoFollowMs` (but not the live `idleMs`,
-which is `tree`-only).
+session's local `cwd` is stale because it's connected to a remote. The tree object also carries three
+read-only top-level fields: `idleMs` (ms since the last user input in the window), `autoFollowMs`
+(the Auto-follow timeout in ms, omitted when Disabled), and `sidebarVisible` (whether the window's
+sidebar is currently shown — the read side of the write-only `sidebar` command). List windows with
+`agtermctl window list --json`; each window also reports `autoFollowMs` and `sidebarVisible` (the
+latter omitted for a closed window), but not the live `idleMs`, which is `tree`-only.
 
 ## Addressing
 

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -50,11 +50,13 @@ position?, repeats?}` object; `kind` is `image`/`text`/`color` — omitted when 
 (the unseen-notification badge count — raised by `notify`/OSC 9/777, cleared by `session seen` — omitted
 when zero). Workspace nodes carry `id`, `name`, `active`, `sessions`.
 
-The tree object itself carries two top-level read-only fields: `idleMs` (milliseconds since the last
-user input in the window, omitted before any activity) and `autoFollowMs` (the window's Auto-follow
-timeout in milliseconds, omitted when the setting is Disabled). `idleMs` is live and grows while the
-window is idle, so it is on `tree` only, never `window.list`. Both are read-only projections of GUI
-state; there is no control command to set them.
+The tree object itself carries three top-level read-only fields: `idleMs` (milliseconds since the last
+user input in the window, omitted before any activity), `autoFollowMs` (the window's Auto-follow
+timeout in milliseconds, omitted when the setting is Disabled), and `sidebarVisible` (whether the
+window's sidebar is currently shown — the read side of the write-only `sidebar` command, so a script
+can restore it, e.g. a tmux-style zoom that hides the sidebar and must re-show it only when it was
+visible before). `idleMs` is live and grows while the window is idle, so it is on `tree` only, never
+`window.list`; `sidebarVisible` is on both. All three are read-only projections of GUI state.
 
 ## workspace
 
@@ -266,11 +268,12 @@ shell (no controlling terminal — `/dev/tty` errors). See examples.md for usage
 ## window
 
 - `window new [name]` — create and open a window; returns its id.
-- `window list` — `result.windows`, each with `id`, `name`, `open`, `active`, and `autoFollowMs` (the
-  window's Auto-follow timeout in milliseconds, omitted when the setting is Disabled). The `autoFollowMs`
-  here is served from a cache and reflects the value as of the last refresh, so a just-changed setting may
-  lag until the next command. Unlike `tree`, `window.list` does NOT carry `idleMs` — the live idle metric
-  would freeze in that cache.
+- `window list` — `result.windows`, each with `id`, `name`, `open`, `active`, `autoFollowMs` (the
+  window's Auto-follow timeout in milliseconds, omitted when the setting is Disabled), and
+  `sidebarVisible` (whether that window's sidebar is shown, read from the open window's store — omitted
+  for a closed window with no live store). The `autoFollowMs` here is served from a cache and reflects the
+  value as of the last refresh, so a just-changed setting may lag until the next command. Unlike `tree`,
+  `window.list` does NOT carry `idleMs` — the live idle metric would freeze in that cache.
 - `window select <id>` — raise it if open, else open it.
 - `window close <id>` — close the on-screen window (the bundle is kept; reopen with select).
 - `window rename <id> <name>`.

--- a/agtermCore/Sources/agtermCore/AppStore+AutoFollow.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+AutoFollow.swift
@@ -9,6 +9,13 @@ extension Notification.Name {
     /// responder into the newly selected session (selection alone does not move it, since the eager deck
     /// keeps the prior surface as first responder).
     public static let agtermAutoFollowed = Notification.Name("agterm.autoFollowed")
+
+    /// Posted by `AppStore.setSidebarVisible` whenever a window's sidebar visibility actually changes.
+    /// `window.list` is served from a background-thread cache refreshed after every control command and on
+    /// frontmost changes, but a GUI-only sidebar toggle (⌃⌘S / toolbar / menu / palette) is neither — so
+    /// the app-target `ControlServer` observes this to refresh the cache, keeping `window.list`'s
+    /// `sidebarVisible` honest (the live `tree` reads it directly and needs no refresh).
+    public static let agtermSidebarVisibilityChanged = Notification.Name("agterm.sidebarVisibilityChanged")
 }
 
 // MARK: - Auto-follow attention

--- a/agtermCore/Sources/agtermCore/AppStore+Panes.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Panes.swift
@@ -9,12 +9,15 @@ extension AppStore {
     public func toggleSplit(_ sessionID: UUID) {
         guard let session = session(withID: sessionID) else { return }
         session.isSplit.toggle()
-        // opening marks the session as having a split and moves focus to the new (right) pane; hiding
-        // (toggling off) leaves `hasSplit` and `splitFocused` set so the split indicators persist and
-        // the focused pane is the one shown maximized. Only `closeSplit` clears them.
+        // opening a NEW split marks the session as having one and moves focus to the new (right) pane;
+        // RE-showing a hidden split preserves whichever pane was focused before it was hidden (so a
+        // hide/show round-trip, e.g. the tmux-style zoom script, doesn't jerk focus to the right pane).
+        // hiding (toggling off) leaves `hasSplit` and `splitFocused` set so the split indicators persist
+        // and the focused pane is the one shown maximized. Only `closeSplit` clears them.
         if session.isSplit {
+            let isNewSplit = !session.hasSplit
             session.hasSplit = true
-            session.splitFocused = true
+            if isNewSplit { session.splitFocused = true }
         }
         save()
     }

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -183,7 +183,8 @@ public final class AppStore {
             return ControlWorkspaceNode(id: workspace.id.uuidString, name: workspace.name,
                                         active: workspace.id == activeWorkspaceID, sessions: sessions)
         }
-        return ControlTree(workspaces: nodes, idleMs: idleMs(), autoFollowMs: autoFollowMs)
+        return ControlTree(workspaces: nodes, idleMs: idleMs(), autoFollowMs: autoFollowMs,
+                           sidebarVisible: sidebarVisible)
     }
 
     /// Creates a workspace and appends it. Clears any active focus so the new (empty)
@@ -516,6 +517,9 @@ public final class AppStore {
         guard sidebarVisible != visible else { return }
         sidebarVisible = visible
         save()
+        // refresh the app-target ControlServer's window.list cache: a GUI-only toggle isn't a control
+        // command, so without this the cached sidebarVisible would lag until the next command.
+        NotificationCenter.default.post(name: .agtermSidebarVisibilityChanged, object: nil)
     }
 
     /// Flips this window's sidebar visibility and persists the new state.

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -319,11 +319,18 @@ public struct ControlTree: Codable, Sendable, Equatable {
     /// The window's auto-follow-blocked timeout in milliseconds, or nil when the feature is disabled
     /// (omitted from the JSON). The read side of the GUI-only Auto-follow setting.
     public let autoFollowMs: Int?
+    /// Whether the projected window's sidebar is currently visible, or nil when unknown (omitted from the
+    /// JSON). LIVE like `idleMs` — built fresh from the window's store per request — so a script can read
+    /// the current state (the read side of the write-only `sidebar` command; e.g. a tmux-style zoom that
+    /// must restore the sidebar only when it was visible before zooming). Also on `window.list` per window.
+    public let sidebarVisible: Bool?
 
-    public init(workspaces: [ControlWorkspaceNode], idleMs: Int? = nil, autoFollowMs: Int? = nil) {
+    public init(workspaces: [ControlWorkspaceNode], idleMs: Int? = nil, autoFollowMs: Int? = nil,
+                sidebarVisible: Bool? = nil) {
         self.workspaces = workspaces
         self.idleMs = idleMs
         self.autoFollowMs = autoFollowMs
+        self.sidebarVisible = sidebarVisible
     }
 }
 
@@ -339,13 +346,19 @@ public struct ControlWindowNode: Codable, Sendable, Equatable {
     /// just-changed setting may lag until the next command. Acceptable because the config rarely changes;
     /// the live `idleMs` is deliberately kept off `window.list` (tree-only) for exactly this reason.
     public let autoFollowMs: Int?
+    /// Whether this window's sidebar is currently visible, or nil for a CLOSED window with no live store
+    /// (omitted from the JSON) — read from the open window's store, mirroring `autoFollowMs`. The read side
+    /// of the write-only `sidebar` command, per window.
+    public let sidebarVisible: Bool?
 
-    public init(id: String, name: String, open: Bool, active: Bool, autoFollowMs: Int? = nil) {
+    public init(id: String, name: String, open: Bool, active: Bool, autoFollowMs: Int? = nil,
+                sidebarVisible: Bool? = nil) {
         self.id = id
         self.name = name
         self.open = open
         self.active = active
         self.autoFollowMs = autoFollowMs
+        self.sidebarVisible = sidebarVisible
     }
 }
 

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -319,10 +319,12 @@ public struct ControlTree: Codable, Sendable, Equatable {
     /// The window's auto-follow-blocked timeout in milliseconds, or nil when the feature is disabled
     /// (omitted from the JSON). The read side of the GUI-only Auto-follow setting.
     public let autoFollowMs: Int?
-    /// Whether the projected window's sidebar is currently visible, or nil when unknown (omitted from the
-    /// JSON). LIVE like `idleMs` — built fresh from the window's store per request — so a script can read
-    /// the current state (the read side of the write-only `sidebar` command; e.g. a tmux-style zoom that
-    /// must restore the sidebar only when it was visible before zooming). Also on `window.list` per window.
+    /// Whether the projected window's sidebar is currently visible. LIVE — built fresh from the window's
+    /// store per request — so a script can read the current state (the read side of the write-only
+    /// `sidebar` command; e.g. a tmux-style zoom that must restore the sidebar only when it was visible
+    /// before zooming). Always present on a `tree` response (the producer passes a non-optional `Bool`),
+    /// so unlike `idleMs`/`autoFollowMs` it never omits; the per-window `window.list` copy is nil/omitted
+    /// only for a closed window.
     public let sidebarVisible: Bool?
 
     public init(workspaces: [ControlWorkspaceNode], idleMs: Int? = nil, autoFollowMs: Int? = nil,

--- a/agtermCore/Sources/agtermCore/WindowLibrary.swift
+++ b/agtermCore/Sources/agtermCore/WindowLibrary.swift
@@ -162,10 +162,11 @@ public final class WindowLibrary {
     public func controlWindowNodes() -> [ControlWindowNode] {
         let active = activeWindowID
         return windows.map {
-            // reach each open store for its auto-follow timeout (config, rarely changes — safe on the cached
-            // fast path); a closed window has no store and reports nil.
+            // reach each open store for its auto-follow timeout + sidebar visibility (per-window state); a
+            // closed window has no store and reports nil for both.
             ControlWindowNode(id: $0.id.uuidString, name: $0.name, open: isOpen($0.id), active: $0.id == active,
-                              autoFollowMs: stores[$0.id]?.autoFollowMs)
+                              autoFollowMs: stores[$0.id]?.autoFollowMs,
+                              sidebarVisible: stores[$0.id]?.sidebarVisible)
         }
     }
 

--- a/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
@@ -24,6 +24,21 @@ struct AppStorePaneTests {
         #expect(session.splitFocused == true)
     }
 
+    @Test func toggleSplitReshowPreservesFocusedPane() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        store.toggleSplit(session.id)           // open a NEW split -> focuses the new (right) pane
+        #expect(session.splitFocused == true)
+        session.splitFocused = false            // focus the left pane
+        store.toggleSplit(session.id)           // hide (zoom): left pane stays the maximized one
+        #expect(session.isSplit == false)
+        #expect(session.splitFocused == false)
+        store.toggleSplit(session.id)           // re-show (un-zoom): must keep the left pane focused
+        #expect(session.isSplit == true)
+        #expect(session.splitFocused == false)  // regression guard: no jerk back to the right pane
+    }
+
     @Test func closeSplitHidesAndTearsDownSurface() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -791,6 +791,34 @@ struct AppStoreTests {
         ])
     }
 
+    @Test func controlTreeReportsSidebarVisibility() {
+        let store = makeStore()
+        #expect(store.controlTree().sidebarVisible == true) // default: sidebar shown
+        store.setSidebarVisible(false)
+        #expect(store.controlTree().sidebarVisible == false)
+        store.setSidebarVisible(true)
+        #expect(store.controlTree().sidebarVisible == true)
+    }
+
+    @Test func setSidebarVisiblePostsChangeNotificationOnlyOnChange() {
+        // the app-target ControlServer observes this to refresh window.list's cached sidebarVisible; the
+        // post must fire only on an actual change (queue nil so the synchronous post delivers inline).
+        final class Counter: @unchecked Sendable { var n = 0 }
+        let store = makeStore() // default sidebarVisible == true
+        let counter = Counter()
+        let token = NotificationCenter.default.addObserver(forName: .agtermSidebarVisibilityChanged, object: nil,
+                                                           queue: nil) { _ in counter.n += 1 }
+        defer { NotificationCenter.default.removeObserver(token) }
+        store.setSidebarVisible(true)   // unchanged from default -> no post
+        #expect(counter.n == 0)
+        store.setSidebarVisible(false)  // change -> post
+        #expect(counter.n == 1)
+        store.setSidebarVisible(false)  // unchanged -> no post
+        #expect(counter.n == 1)
+        store.setSidebarVisible(true)   // change -> post
+        #expect(counter.n == 2)
+    }
+
     @Test func controlTreeReportsUnseenCountWhenPositive() throws {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -432,45 +432,52 @@ struct ControlProtocolTests {
         #expect(decoded.unseen == nil)
     }
 
-    @Test func treeRoundTripsWithIdleAndAutoFollowMs() throws {
-        // the tree carries the live idle metric + the auto-follow config, both in ms.
+    @Test func treeRoundTripsWithLiveWindowFields() throws {
+        // the tree carries the live idle metric + the auto-follow config (both ms) + sidebar visibility.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false)
         let tree = ControlTree(workspaces: [ControlWorkspaceNode(id: "w1", name: "work", active: true,
                                                                  sessions: [session])],
-                               idleMs: 4200, autoFollowMs: 30_000)
+                               idleMs: 4200, autoFollowMs: 30_000, sidebarVisible: false)
         let response = ControlResponse(ok: true, result: ControlResult(tree: tree))
         let decoded = try roundTrip(response)
         #expect(decoded == response)
         #expect(decoded.result?.tree?.idleMs == 4200)
         #expect(decoded.result?.tree?.autoFollowMs == 30_000)
+        #expect(decoded.result?.tree?.sidebarVisible == false)
     }
 
-    @Test func treeOmitsIdleAndAutoFollowMsWhenNil() throws {
-        // no activity yet + auto-follow disabled — both keys must be omitted, not emitted as null.
+    @Test func treeOmitsLiveWindowFieldsWhenNil() throws {
+        // no activity yet + auto-follow disabled + unknown sidebar — every key must be omitted, not null.
         let tree = ControlTree(workspaces: [])
         let json = String(data: try JSONEncoder().encode(tree), encoding: .utf8) ?? ""
         #expect(!json.contains("idleMs"), "a nil idleMs must be omitted from the JSON; got \(json)")
         #expect(!json.contains("autoFollowMs"), "a nil autoFollowMs must be omitted from the JSON; got \(json)")
+        #expect(!json.contains("sidebarVisible"), "a nil sidebarVisible must be omitted from the JSON; got \(json)")
         let decoded = try JSONDecoder().decode(ControlTree.self, from: Data(json.utf8))
         #expect(decoded.idleMs == nil)
         #expect(decoded.autoFollowMs == nil)
+        #expect(decoded.sidebarVisible == nil)
     }
 
-    @Test func windowNodeRoundTripsWithAutoFollowMs() throws {
-        let node = ControlWindowNode(id: "w1", name: "work", open: true, active: true, autoFollowMs: 5000)
+    @Test func windowNodeRoundTripsWithPerWindowFields() throws {
+        let node = ControlWindowNode(id: "w1", name: "work", open: true, active: true, autoFollowMs: 5000,
+                                     sidebarVisible: true)
         let response = ControlResponse(ok: true, result: ControlResult(windows: [node]))
         let decoded = try roundTrip(response)
         #expect(decoded == response)
         #expect(decoded.result?.windows?.first?.autoFollowMs == 5000)
+        #expect(decoded.result?.windows?.first?.sidebarVisible == true)
     }
 
-    @Test func windowNodeOmitsAutoFollowMsWhenNil() throws {
-        // auto-follow disabled (or a closed window with no store) — the key must be omitted, not null.
+    @Test func windowNodeOmitsPerWindowFieldsWhenNil() throws {
+        // auto-follow disabled + a closed window with no store — both keys must be omitted, not null.
         let node = ControlWindowNode(id: "w1", name: "work", open: true, active: false)
         let json = String(data: try JSONEncoder().encode(node), encoding: .utf8) ?? ""
         #expect(!json.contains("autoFollowMs"), "a nil autoFollowMs must be omitted from the JSON; got \(json)")
+        #expect(!json.contains("sidebarVisible"), "a nil sidebarVisible must be omitted from the JSON; got \(json)")
         let decoded = try JSONDecoder().decode(ControlWindowNode.self, from: Data(json.utf8))
         #expect(decoded.autoFollowMs == nil)
+        #expect(decoded.sidebarVisible == nil)
     }
 
     @Test func backgroundWatermarkFitPositionSerializeAsRawStrings() throws {

--- a/agtermCore/Tests/agtermCoreTests/WindowLibraryTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/WindowLibraryTests.swift
@@ -122,13 +122,16 @@ final class WindowLibraryTests {
         let first = library.windows[0]
         let second = library.newWindow(name: "work")
 
-        // the second window has auto-follow enabled (30s); the first leaves it off (nil autoFollowMs).
+        // the second window has auto-follow enabled (30s) and its sidebar hidden; the first leaves
+        // auto-follow off (nil autoFollowMs) with the sidebar visible (the default).
         library.store(for: second.id)?.autoFollowTimeout = 30
+        library.store(for: second.id)?.setSidebarVisible(false)
 
         #expect(library.controlWindowNodes() == [
-            ControlWindowNode(id: first.id.uuidString, name: first.name, open: true, active: false),
+            ControlWindowNode(id: first.id.uuidString, name: first.name, open: true, active: false,
+                              sidebarVisible: true),
             ControlWindowNode(id: second.id.uuidString, name: "work", open: true, active: true,
-                              autoFollowMs: 30_000),
+                              autoFollowMs: 30_000, sidebarVisible: false),
         ])
     }
 
@@ -140,8 +143,10 @@ final class WindowLibraryTests {
         library.closeWindow(second.id)
         library.frontmostWindowID = second.id
 
+        // the open window reports its live sidebar visibility; the closed one has no store, so nil (omitted).
         #expect(library.controlWindowNodes() == [
-            ControlWindowNode(id: first.id.uuidString, name: first.name, open: true, active: true),
+            ControlWindowNode(id: first.id.uuidString, name: first.name, open: true, active: true,
+                              sidebarVisible: true),
             ControlWindowNode(id: second.id.uuidString, name: "work", open: false, active: false),
         ])
     }


### PR DESCRIPTION
Two related fixes that came out of a tmux-style zoom (hide the sidebar and collapse the split on zoom, restore both on un-zoom).

**Split-pane focus on re-show.** `AppStore.toggleSplit` forced `splitFocused = true` on every show, so re-showing a hidden split (the zoom's `session split off` then `on`, or a plain ⌘D hide/show) moved focus to the right pane. Now the right pane is focused only when the split is genuinely new (`hasSplit` was false); a re-show keeps whichever pane was focused before hiding. A fresh split still focuses the new pane.

**Sidebar visibility over the control API.** The `sidebar` command was write-only, so a script had no way to tell whether the sidebar was showing before a zoom, and un-zoom always restored it. Adds a `sidebarVisible` read-back on two surfaces:

- `tree` top-level: live, built on the main actor per request. Prefer this for read-then-act.
- each `window.list` node: read from the open window's store, omitted for a closed one.

`window.list` is served from a background cache, so a GUI-only ⌃⌘S toggle would leave it stale. `AppStore.setSidebarVisible` now posts `.agtermSidebarVisibilityChanged` and `ControlServer` observes it to refresh the cache. The observer is synchronous (the post is always main-actor), so the cached field is fresh before the toggle returns.

Docs updated on the keep-in-sync surfaces: the bundled agent-skill (`SKILL.md`, `reference.md`) and `.claude/rules` (`control-api.md`, `menu-actions.md`, `windows.md`).

The third commit fixes a race a review caught: the cache-refresh observer was async `.main`, which left a window where a background `window.list` read saw the stale cache after a GUI toggle.

`swift test` (1201), `make build`, and `make lint` all pass.
