### PR TITLE
Bind shifted-symbol keys in keymaps via shift+<base>

### DIFF
--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -114,13 +114,27 @@ paths:
   can still `map` these to a parseable chord, which then wins).
   So the six arrow actions are NOT pure-`defaultChord`-driven by design;
   the other 29 are.
+- **Shifted symbols bind as `shift+<base>` — the runner normalizes to the UNSHIFTED base key.**
+  `charactersIgnoringModifiers` KEEPS shift (shift+/ → "?", shift+= → "+"), and the old
+  `.lowercased()` only undid that for letters (shift+u → "u"), so punctuation landed on the shifted glyph
+  and never matched a `shift+/`-style binding.
+  `CustomCommandRunner.chord(from:)` now derives the base key via `characters(byApplyingModifiers: [])`
+  (the same call `GhosttySurfaceView` uses for unmodified key input), so the runtime chord for shift+/ is
+  `(shift, "/")` and matches the parser's `shift+/`.
+  So every shifted symbol is written `shift+<base>` (`shift+/` = `?`, `shift+=` = `+`, `shift+5` = `%`,
+  `shift+.` = `>`).
+  This is verified END-TO-END by `KeymapUITests.testCustomCommandShiftedSymbolFires` (a real synthesized
+  Shift+/ keypress fires a `shift+/`-bound command) — the host-free tests structurally can't reach
+  `chord(from:)`, which is exactly why the earlier parser-only version shipped a runtime that never fired.
 - **v1 scope cut (confirmed).**
-  Built-in rebinds are single-chord only (leaders only for custom commands);
-  keys that clash with the grammar separators aren't expressible in the file — the arrows (the four arrow
-  actions above keep their defaults unless mapped to a parseable chord),
-  `+` (the chord-joiner, so `increase_font_size`'s default ⌘+ can't be written — `chordSyntax` renders
-  it as `(not expressible)` in the starter and verifies the round-trip),
-  and `>` (the leader separator).
+  Built-in rebinds are single-chord only (leaders only for custom commands).
+  The arrows aren't expressible as a parsed `Chord` (the six arrow actions keep their defaults unless
+  mapped to a parseable chord).
+  The literal `+`/`>` still can't be a bare key TOKEN (they are the chord-joiner / leader separator), but
+  those keys ARE bindable as `shift+=`/`shift+.` (see the shift-symbol note above).
+  `increase_font_size`'s default ⌘+ still renders `(not expressible)` in the STARTER file: its stored
+  `Chord(key:"+")` can't round-trip through `displayString` (which emits the `+` glyph, `chordSyntax`
+  verifies the round-trip) — a display-side detail, separate from key MATCHING.
   The Ctrl-Tab MRU switcher and Ctrl-1/Ctrl-2 pane focus are NOT rebindable (they are monitor-driven,
   not menu items — folding them in would reintroduce a monitor-vs-monitor precedence question;
   a custom command bound to one is dropped via `reservedMonitorChords`).

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ command "Lazygit"      ctrl+a>g     agtermctl session overlay open lazygit --soc
 command "Deploy"                    ./deploy.sh
 ```
 
-A chord is modifier words joined by `+` and a base key, e.g. `cmd+shift+e` or `ctrl+\``. The modifiers are `ctrl`, `cmd`, `opt`, and `shift`. The base key is a single character or one of `tab`, `space`, `return`, `delete`. A custom command's chord may also be a leader sequence — chords separated by `>`, e.g. `ctrl+a>g` (press `ctrl+a`, then `g`). A `command` with no chord is palette-only. A custom command's chord must include a modifier: a bare key like `a` is rejected with a diagnostic and the line is treated as palette-only, so a binding can't silently shadow a plain terminal key (and a palette-only shell line that happens to start with a single-character token isn't swallowed as a binding).
+A chord is modifier words joined by `+` and a base key, e.g. `cmd+shift+e` or `ctrl+\``. The modifiers are `ctrl`, `cmd`, `opt`, and `shift`. The base key is a single character or one of `tab`, `space`, `return`, `delete`. A key you type with Shift is written as `shift+<base key>` (the base key, not the shifted symbol): `shift+/` for `?`, `shift+5` for `%`, `shift+=` for `+`, `shift+.` for `>`. A custom command's chord may also be a leader sequence — chords separated by `>`, e.g. `ctrl+a>g` (press `ctrl+a`, then `g`). A `command` with no chord is palette-only. A custom command's chord must include a modifier: a bare key like `a` is rejected with a diagnostic and the line is treated as palette-only, so a binding can't silently shadow a plain terminal key (and a palette-only shell line that happens to start with a single-character token isn't swallowed as a binding).
 
 The bindable built-in action names are:
 
@@ -340,7 +340,7 @@ After editing the file, apply it with **File ▸ Reload Keymap**, the action pal
 v1 limitations:
 
 - Built-in rebinds are single-chord only; leader sequences (`ctrl+a>g`) work only for custom commands.
-- A few keys are not expressible in the file because they clash with the grammar's separators: the arrow keys, `+` (the chord-joiner, so `increase_font_size`'s default ⌘+ can't be written), and `>` (the leader separator). The arrow-bound actions (`focus_left_pane`, `focus_right_pane`, `previous_session`, `next_session`, `previous_attention_session`, `next_attention_session`) and `increase_font_size` keep their default shortcuts unless you `map` them to a parseable chord.
+- The arrow keys can't be written as a chord, so the arrow-bound actions (`focus_left_pane`, `focus_right_pane`, `previous_session`, `next_session`, `previous_attention_session`, `next_attention_session`) keep their default shortcuts unless you `map` them to a parseable chord. The literal `+` and `>` can't be a bare key token (they are the chord-joiner and leader separators), but those keys are still bindable as `shift+=` and `shift+.`. Only `increase_font_size`'s default ⌘+ shows as a glyph rather than editable text, because its stored form doesn't round-trip through the file.
 - The Ctrl-Tab MRU session switcher and Ctrl-1/Ctrl-2 pane focus are not rebindable yet; they keep their current keys.
 - The action palette shows chords as live kitty syntax (e.g. `cmd+shift+e`) for both custom commands and built-in shortcuts; only chords that can't be expressed in the file fall back to a glyph (the arrow-bound actions and `increase_font_size`'s ⌘+).
 

--- a/agterm/Commands/CustomCommandRunner.swift
+++ b/agterm/Commands/CustomCommandRunner.swift
@@ -141,9 +141,14 @@ final class CustomCommandRunner {
         if let named = Self.namedKeys[event.keyCode] {
             return Chord(mods: mods, key: named)
         }
-        // charactersIgnoringModifiers yields the base letter regardless of shift, matching the parser's
-        // lowercased single-char keys (e.g. shift+u → "u").
-        guard let chars = event.charactersIgnoringModifiers, let first = chars.first else { return nil }
+        // Derive the UNSHIFTED base key so every key normalizes the same way. `charactersIgnoringModifiers`
+        // KEEPS shift (shift+/ → "?", shift+= → "+"), and `.lowercased()` only undoes that for letters, so
+        // punctuation would otherwise land on the shifted glyph and never match a `shift+/`-style binding.
+        // `characters(byApplyingModifiers: [])` applies NO modifiers, giving the base char for any key
+        // (shift+/ → "/", shift+5 → "5", shift+u → "u"), matching how the keymap spells chords as
+        // `shift+<base>` (same call `GhosttySurfaceView` uses for unmodified key input).
+        guard let chars = event.characters(byApplyingModifiers: []) ?? event.charactersIgnoringModifiers,
+              let first = chars.first else { return nil }
         let key = String(first).lowercased()
         guard !key.isEmpty, key != " " else { return nil }
         return Chord(mods: mods, key: key)

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -367,9 +367,11 @@ Key Mapping). Two verbs, line-based; blank lines and `#` comments ignored:
   sequence (chords joined by `>`, e.g. `ctrl+a>g`). No chord → palette-only.
 
 A **chord** is modifier words joined by `+` then a base key: modifiers `ctrl`, `cmd`, `opt`, `shift`;
-base key is a single character or `tab`/`space`/`return`/`delete`. Arrows, `+`, and `>` are not
-expressible as a parsed chord. Some chords are reserved (the Ctrl-Tab switcher, Ctrl-1/2 pane focus)
-and cannot be bound.
+base key is a single character or `tab`/`space`/`return`/`delete`. A key typed with Shift is written
+`shift+<base>` (`shift+/` = `?`, `shift+=` = `+`, `shift+5` = `%`) — the base key, not the shifted glyph.
+Arrows aren't expressible, and `+`/`>` can't be a bare key token (they are the separators), though those
+keys are bindable via `shift+=`/`shift+.`. Some chords are reserved (the Ctrl-Tab switcher, Ctrl-1/2 pane
+focus) and cannot be bound.
 
 Custom-command tokens (expanded into the `/bin/sh -c` line, raw — prefer the quoted `$AGT_*` env form
 for untrusted content). A remote host can set the session title (OSC) and working directory (OSC 7),

--- a/agtermCore/Sources/agtermCore/ConfigPaths.swift
+++ b/agtermCore/Sources/agtermCore/ConfigPaths.swift
@@ -47,7 +47,8 @@ public enum ConfigPaths {
         #   map <chord> <action>
         #       Rebind a built-in action to a single chord (no leader sequences for built-ins).
         #       Chords use kitty syntax: mods joined by `+`, e.g. `cmd+shift+d`, `ctrl+\\``.
-        #       Mods: ctrl, cmd, opt, shift. Example:
+        #       Mods: ctrl, cmd, opt, shift. A Shift-typed symbol is shift+<base key>
+        #       (shift+/ for ?, shift+= for +, shift+5 for %). Example:
         #
         #           map cmd+shift+d  toggle_split
         #

--- a/agtermUITests/KeymapUITests.swift
+++ b/agtermUITests/KeymapUITests.swift
@@ -127,6 +127,21 @@ final class KeymapUITests: XCTestCase {
                       "the custom single chord ⌘⇧E should run its command and touch the marker file")
     }
 
+    // a custom command bound to a SHIFTED-SYMBOL key fires: bind `shift+/` (the `?` key) to `touch
+    // <file>`, focus the terminal, press Shift+/ (which types `?`), assert the file appears. Regression
+    // guard for the base-key derivation in `CustomCommandRunner.chord(from:)`: the runner must normalize
+    // a shifted symbol to its BASE key (shift+/ → key "/", matching the `shift+/` binding), not to the
+    // shifted glyph "?" — a parser↔runtime mismatch the host-free tests structurally can't reach.
+    func testCustomCommandShiftedSymbolFires() throws {
+        let marker = markerDir.appendingPathComponent("shifted")
+        seedKeymap("command \"Touch Q\" shift+/ touch '\(marker.path)'\n")
+        app.launchForUITest()
+        focusTerminal()
+
+        XCTAssertTrue(chordFiresMarker(marker) { app.typeKey("/", modifierFlags: .shift) },
+                      "a custom command bound to shift+/ should fire when Shift+/ (the ? key) is pressed")
+    }
+
     // a custom command bound to a LEADER sequence fires: bind `ctrl+a>g` to `touch <file>`, focus the
     // terminal, press ctrl+a then g (two key events), assert the file appears. ctrl+a normally moves to
     // the line start in the shell, but the runner arms on it and consumes the sequence.

--- a/site/docs.html
+++ b/site/docs.html
@@ -1340,7 +1340,13 @@
               >/<span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">return</span>/<span
                 style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
                 >delete</span
-              >). Custom commands may also use a leader sequence
+              >). A Shift-typed symbol is written
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">shift+&lt;base&gt;</span>
+              (e.g. <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">shift+/</span> for
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">?</span>,
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">shift+=</span> for
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">+</span>) — the base key, not the
+              shifted symbol. Custom commands may also use a leader sequence
               (<span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">ctrl+a&gt;g</span>), and their chord
               must include a modifier — a bare key can't shadow a plain terminal key.
             </p>
@@ -1466,13 +1472,15 @@
                 <span
                   style="position: absolute; left: 0; top: 1px; color: #6d82f3; font-family: &quot;JetBrains Mono&quot;, monospace"
                   >›</span
-                >A few keys can't be expressed because they clash with the grammar's separators: the arrow keys,
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">+</span> (the chord-joiner), and
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">&gt;</span> (the leader separator).
-                The arrow-bound actions and <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
-                  >increase_font_size</span
-                >
-                keep their defaults unless mapped to a parseable chord.
+                >The arrow keys can't be written as a chord, so the arrow-bound actions keep their defaults unless
+                mapped to a parseable chord. The literal
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">+</span> and
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">&gt;</span> can't be a bare
+                key token (they are the separators), but those keys are bindable as
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">shift+=</span> and
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">shift+.</span>; only
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">increase_font_size</span>'s
+                default ⌘+ shows as a glyph because its stored form doesn't round-trip through the file.
               </li>
               <li style="font-size: 14.5px; line-height: 1.6; color: #949ba4; padding-left: 22px; position: relative">
                 <span


### PR DESCRIPTION
Custom-command keymap chords couldn't fire on shifted-symbol keys like `?`, `%`, `+`, or `>`. `CustomCommandRunner.chord(from:)` derived the base key from `charactersIgnoringModifiers`, which keeps Shift, so pressing `shift+/` produced key `?` while `.lowercased()` only normalized letters. The runtime chord never matched the parser's `shift+/` (key `/`), so the binding silently never fired.

The fix derives the base key with `characters(byApplyingModifiers: [])`, which applies no modifiers and returns the unshifted base char for any key: `shift+/` gives `/`, `shift+5` gives `5`, `shift+u` gives `u`. That's the same call `GhosttySurfaceView` already uses for unmodified key input. The parser is unchanged, so every key now normalizes uniformly and `shift+<base>` binds the physical key you'd expect (`shift+/` = `?`, `shift+=` = `+`, `shift+.` = `>`).

Existing binds are unaffected: the old and new derivations differ only when Shift is physically held, which was already the broken case (letters were already normalized by `.lowercased()`).

Docs updated across the keymap surfaces (README, the agent-skill reference, the site docs, the starter `keymap.conf`, and the keymap rule) to state the `shift+<base>` rule and correct the old "`+`/`>` not expressible" note.

Added `KeymapUITests.testCustomCommandShiftedSymbolFires`, a real-keypress end-to-end test that binds `shift+/` and confirms it fires. The host-free tests can't reach `chord(from:)` since it takes an `NSEvent`, which is why the parser-only view of this looked fine while the runtime never matched.

*Behavior note:* the shifted-glyph spelling like `shift+?` no longer matches; `shift+<base>` (`shift+/`) is the form now. That spelling only ever worked via the bug this fixes and was never documented.
