### PR TITLE
Resize an open overlay in place via session.overlay.resize

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -102,7 +102,7 @@ paths:
   The skill is a REFERENCE/knowledge skill (both user-invocable via `/agterm` and model-triggered,
   `allowed-tools: Bash(agtermctl *)`; the agent-neutral `description` carries the trigger nouns since
   Codex may ignore the extra `when_to_use` field — unknown frontmatter is harmless),
-  authored at `agterm/Resources/agent-skill/` (`SKILL.md` overview + model + addressing + 52-command
+  authored at `agterm/Resources/agent-skill/` (`SKILL.md` overview + model + addressing + 53-command
   summary + the image-display helper + a troubleshooting/reporting pointer;
   `reference.md` full per-command detail + keymap format; `examples.md` agtermctl recipes;
   `troubleshooting.md` diagnosing the common problems (keymap editor, custom actions,
@@ -172,10 +172,10 @@ paths:
   exact `uuidString` (case-insensitive), or a git-style unique prefix.
   Zero prefix hits → `notFound` error, ≥2 → `ambiguous` error listing the candidates.
   `--target` defaults to `active`, so scripts rarely type an id and never for "the current one".
-- **Command catalog (52 commands):**
+- **Command catalog (53 commands):**
   - `tree`
   - `workspace.new`/`workspace.rename`/`workspace.delete`/`workspace.select`/`workspace.move`/`workspace.focus`
-  - `session.new`/`session.close`/`session.select`/`session.rename`/`session.move`/`session.type`/`session.split`/`session.scratch`/`session.focus`/`session.resize`/`session.go`/`session.copy`/`session.text`/`session.search`/`session.status`/`session.flag`/`session.seen`/`session.background`/`session.overlay.open`/`session.overlay.close`/`session.overlay.result`
+  - `session.new`/`session.close`/`session.select`/`session.rename`/`session.move`/`session.type`/`session.split`/`session.scratch`/`session.focus`/`session.resize`/`session.go`/`session.copy`/`session.text`/`session.search`/`session.status`/`session.flag`/`session.seen`/`session.background`/`session.overlay.open`/`session.overlay.close`/`session.overlay.resize`/`session.overlay.result`
   - `quick`
   - `sidebar`/`sidebar.mode`/`sidebar.expand`/`sidebar.collapse`
   - `notify`
@@ -516,6 +516,27 @@ paths:
   at parse via `validate()`); the program's OUTPUT is its own concern — a TUI like revdiff renders in
   the overlay and writes results to its own `--output` file, which the caller reads (the control channel
   does NOT capture stdout).
+  `session.overlay.resize` (target = session) resizes an ALREADY-OPEN overlay IN PLACE between full and
+  floating — the way to change size without closing and re-running the program.
+  Exactly one of `sizePercent` (1...100 → floating) or `full: true` (→ the full-pane overlay) must be set;
+  both, neither, or a percent outside 1...100 is a dispatcher error (mirrored by the CLI `validate()`), and
+  `no overlay` when none is open.
+  It is a NEW `Command` case (unlike the `--follow` arg, which rode the existing `overlay.open`) because it
+  needs its own arg validation, and `full` is a NEW `ControlArgs` field added to distinguish "switch to
+  full" (nil `overlaySizePercent`) from "unset" on the wire.
+  The arm mutates the non-persisted `Session.overlaySizePercent` via `AppStore.resizeOverlay` (clamping
+  1...100, guarding `overlayActive`), and the detail pane re-flows the SAME surface host: the unified
+  `WindowContentView.overlayPanel` now renders BOTH variants (full = translucent, no chrome, panes hidden by
+  `hideForOverlay`; floating = opaque framed panel over visible panes), so a full<->% switch never re-parents
+  the overlay NSView (which would blank its Metal drawable) nor changes the ZStack shape — the old
+  `if fullOverlay` z2 sibling is gone, and the always-present `overlayPanel` at z3 is the single host.
+  Four-point keep-in-sync audit for `session.overlay.resize`: (1) `case sessionOverlayResize = "session.overlay.resize"`
+  + `ControlArgs.full` in `ControlProtocol.swift`, (2) the `.sessionOverlayResize` dispatcher arm (exactly-one
+  + range validation) → the app-side `resizeSessionOverlay` (→ `AppStore.resizeOverlay`) behind `ControlActions`,
+  (3) the `session overlay resize --size-percent|--full` subcommand (`Resize`, `validate()`-guarded) in
+  `agtermctlKit`, (4) round-trip in `ControlProtocolTests` + dispatcher routing/validation in `ControlDispatcherTests`
+  + `AppStorePaneTests` (resize clamp/switch/no-overlay) + CLI mapping in `CommandsTests` + the e2e
+  `testOverlayResizeSwitchesFloatingAndFull` in `ControlOverlaySplitUITests`.
   Mode-bearing commands (`session.split`/`quick`) compute the delta against current state so `on`/`off`/`show`/`hide`
   are idempotent, and an unknown mode is an error.
   `session.status` flags a per-session agent status on the sidebar row — `args.status` is `idle`|`active`|`completed`|`blocked`
@@ -828,5 +849,5 @@ paths:
   (image/text/color set/clear + tree read-back).
   **Agent-skill mirror (HARD keep-in-sync, 4th surface):** all commands are documented in the bundled
   `agterm/Resources/agent-skill/` (SKILL.md summary, reference.md detail,
-  examples.md recipes) and the command count there is bumped to 52 to match.
+  examples.md recipes) and the command count there is bumped to 53 to match.
 

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -236,9 +236,9 @@ paths:
   never a teardown), recreated fresh after its shell's own `exit`.
   NOT persisted (absent from `SessionSnapshot`, like the overlay) — `Session.scratchActive`/`scratchSurface`,
   `AppStore.toggleScratch`/`closeScratch` (the latter only on `exit` + session/workspace/window teardown).
-  Full-overlay rendering only (never floating) so it's a structural clone of the proven `if fullOverlay`
-  ZStack sibling at `.zIndex(1)`, BELOW the ephemeral overlay (`.zIndex(2)` — a normal overlay launched
-  over the scratch sits on top); the panes' opacity/hit-testing gate is `hideForOverlay = fullOverlay || scratchActive`
+  Full-overlay rendering only (never floating): a conditional `sessionDetail` ZStack sibling at `.zIndex(1)`
+  (the structural pattern the now-removed `if fullOverlay` sibling used), BELOW the ephemeral `overlayPanel`
+  (`.zIndex(3)` — a normal overlay launched over the scratch sits on top); the panes' opacity/hit-testing gate is `hideForOverlay = fullOverlay || scratchActive`
   (still false for a FLOATING overlay, preserving the NSSplitView-overrun invariant).
   GUI half: ⌘J (`BuiltinAction.toggleScratch`), title-bar `scratch-toggle` button,
   View ▸ Show/Hide Scratch, the ⌃⇧P palette "Toggle Scratch" — all through `AppActions.toggleScratch()`.
@@ -437,39 +437,46 @@ paths:
   `onExit → closeOverlay`.
   Both variants render IN the per-session eager deck, so the overlay program runs regardless of which
   session is active — the only visible difference is geometry.
-  The FULL overlay is an in-deck ZStack sibling in `WindowContentView.sessionDetail` (`.zIndex(2)` above the
-  pane(s), gated on `fullOverlay`): it draws translucent + blurred (NO opaque backing) with the pane(s)
-  behind hidden at `.opacity(0)` + `.allowsHitTesting(false)` (kept MOUNTED,
-  shells alive like the deck's inactive sessions), so its transparency reveals the window backing (desktop,
-  tint + blur), not the session.
-  The FLOATING overlay (`overlaySizePercent` set) is `floatingOverlayPanel(session:isActive:)`, an
-  ALWAYS-PRESENT ZStack sibling in `sessionDetail` (`.zIndex(3)`).
-  It is a CONSTANT-SHAPE sibling: the panel content (opaque `terminalColor` backing + hairline frame +
-  shadow, quick-terminal styling; the overlay surface; the click-catcher) is gated INSIDE it, so the ZStack
-  child COUNT stays constant across open/close — the same SHAPE as no-overlay, which is what keeps the
-  AppKit `NSSplitView` from re-hosting and overrunning UP into the transparent titlebar.
+  The overlay is ONE always-present, CONSTANT-SHAPE ZStack sibling in `WindowContentView.sessionDetail`,
+  `overlayPanel(session:isActive:)` at `.zIndex(3)`, hosting BOTH variants from a single surface host (the
+  pre-unify split — a `fullOverlay`-gated `.zIndex(2)` sibling PLUS a separate `floatingOverlayPanel` at
+  `.zIndex(3)` — is GONE; `session.overlay.resize` below is why one host matters).
+  The panel content (the overlay surface; the opaque `terminalColor` backing + hairline frame + shadow; the
+  click-catcher) is gated INSIDE the always-present `GeometryReader` on `session.overlayActive`, so the
+  ZStack child COUNT stays constant across open/close/resize — the same SHAPE as no-overlay, which is what
+  keeps the AppKit `NSSplitView` from re-hosting and overrunning UP into the transparent titlebar.
   (The panel used to mount OUTSIDE `sessionDetail` as a `detailPane` `.overlay` for exactly this reason;
-  the always-present constant-shape sibling holds the same invariant IN-deck, which is what lets the
-  floating surface mount per-session and run in the background like the full overlay.)
-  Hit-testing stays gated on `.allowsHitTesting(!fullOverlay)` and must NOT flip when a floating overlay
-  opens: changing the panes' OWN `allowsHitTesting` on overlay-open (e.g. to `!session.overlayActive`)
-  ALSO triggers the NSSplitView titlebar-overrun — the SAME class of perturbation as changing the ZStack's
-  shape, even though it looks like a pure interaction change (Codex insisted hit-testing was layout-inert;
-  a review-loop regression proved otherwise).
-  So the floating panes stay hit-testable, and the overlay's focus is protected by a transparent
-  `Color.clear.contentShape(Rectangle())` catcher INSIDE `floatingOverlayPanel` that absorbs clicks AROUND
-  the panel so they can't reach the panes and steal the overlay program's first responder.
+  the always-present constant-shape sibling holds the same invariant IN-deck.)
+  FULL (`overlaySizePercent` nil): fraction 1.0, drawn translucent + blurred with NO opaque backing and NO
+  chrome (`Color.clear` backing, 0 corner radius, 0 shadow), and the pane(s) behind hidden at `.opacity(0)`
+  + `.allowsHitTesting(false)` via `hideForOverlay` (= `fullOverlay || scratchActive`; kept MOUNTED, shells
+  alive like the deck's inactive sessions), so its transparency reveals the window backing (desktop, tint +
+  blur), not the session.
+  FLOATING (`overlaySizePercent` set): fraction = `percent/100`, drawn as an opaque `terminalColor`-backed,
+  hairline-framed, shadowed panel centered in the detail area with the pane(s) VISIBLE around it.
+  The modifier CHAIN is IDENTICAL across both variants — only the parameter VALUES flip (backing color,
+  corner radius, shadow radius, frame fraction) — so `session.overlay.resize` switching full<->% is a
+  value-update, never a child add/remove or a re-parent of the overlay surface NSView (a re-parent would
+  blank its Metal drawable).
+  Hit-testing on the PANES stays gated on `.allowsHitTesting(!hideForOverlay)` and must NOT flip when a
+  FLOATING overlay opens: changing the panes' OWN `allowsHitTesting` on overlay-open (e.g. to
+  `!session.overlayActive`) ALSO triggers the NSSplitView titlebar-overrun — the SAME class of perturbation
+  as changing the ZStack's shape, even though it looks like a pure interaction change (Codex insisted
+  hit-testing was layout-inert; a review-loop regression proved otherwise).
+  So a floating overlay leaves the panes hit-testable, and the overlay's focus is protected by a transparent
+  `Color.clear.contentShape(Rectangle())` catcher INSIDE `overlayPanel` that absorbs clicks AROUND the panel
+  so they can't reach the panes and steal the overlay program's first responder.
   (Generalize the rule: ANYTHING in `sessionDetail`'s HSplitView-hosting subtree that CHANGES SHAPE when
   `overlayActive` flips — adding/removing a sibling, a flattened ZStack, or a toggled pane modifier —
-  overruns the split into the titlebar; keep the subtree's shape identical across open/close and gate the
-  panel content INSIDE the constant-shape sibling.)
+  overruns the split into the titlebar; keep the subtree's shape identical across open/close/resize and gate
+  the panel content INSIDE the constant-shape sibling.)
   This constant-shape invariant is load-bearing: a CONDITIONAL sibling inside `sessionDetail`'s ZStack (the
   HSplitView-hosting subtree) made SwiftUI re-host it and the `NSSplitView` overrun UP into the
   transparent titlebar, painting the split over the header (Codex-confirmed;
   the quick terminal renders at this level for the same reason and never hit it).
-  `floatingOverlayPanel`'s `GeometryReader` reports the detail area EXACTLY — no manual sidebar/titlebar
-  insets (computing those at the window level mis-centered the panel one line low) — so it sizes the opaque
-  framed panel to `sizePercent`% and centers it in the detail area, the pane(s) visible around it.
+  `overlayPanel`'s `GeometryReader` reports the detail area EXACTLY — no manual sidebar/titlebar insets
+  (computing those at the window level mis-centered the panel one line low) — so it sizes the floating panel
+  to `sizePercent`% and centers it in the detail area, the pane(s) visible around it.
   `isActive` gates the overlay surface's focus, so a background floating overlay RUNS but does not steal
   focus (mirrors the full overlay).
   Because both kinds mount in the eager deck, `ControlServer` does NOT select on open by default; it SELECTS

--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -125,15 +125,15 @@ paths:
   `sessionDetail` subtree, so toggling it can't perturb the split at all.
   The bar reads `store.activeSession?.searchActive` and shows only when set.
   Because it is a `detailPane` `.overlay` it composites ABOVE the whole detail deck without any layout change
-  — the in-deck scratch (zIndex 1 inside `sessionDetail`), the FULL overlay (zIndex 2), and the floating
-  overlay panel (zIndex 3) — so search-over-scratch shows the bar on top of the scratch with no HSplitView
+  — the in-deck scratch (zIndex 1 inside `sessionDetail`) and the overlay panel (zIndex 3, hosting BOTH the
+  full and floating overlay) — so search-over-scratch shows the bar on top of the scratch with no HSplitView
   perturbation.
-  The FLOATING overlay takes the opposite route: it IS a `sessionDetail` ZStack sibling (`floatingOverlayPanel`
-  at `.zIndex(3)`), but an ALWAYS-PRESENT, constant-shape one — its panel content (surface + frame +
-  click-catcher) is gated INSIDE the sibling, so the ZStack child count never changes when a floating overlay
-  opens/closes and the `NSSplitView` is never re-hosted, even though the pane(s) stay VISIBLE behind the opaque
-  panel.
-  (`floatingOverlayPanel` is per-session in the eager deck, so its program runs regardless of which session is
+  The overlay takes the opposite route: it IS a `sessionDetail` ZStack sibling (`overlayPanel` at
+  `.zIndex(3)`), but an ALWAYS-PRESENT, constant-shape one — its panel content (surface + frame +
+  click-catcher) is gated INSIDE the sibling, so the ZStack child count never changes when an overlay
+  opens/closes/resizes and the `NSSplitView` is never re-hosted, even when a floating overlay leaves the
+  pane(s) VISIBLE behind its opaque panel.
+  (`overlayPanel` is per-session in the eager deck, so its program runs regardless of which session is
   active — see the surface-lifecycle note.)
 - **Window overlays sit BELOW the custom titlebar, NOT as a body-level `.overlay` (transparent-titlebar-scrim
   rule).** The quick terminal, command palettes, and Ctrl-Tab switcher render via `windowOverlayLayer`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,23 @@ surface ownership, and the C-boundary concurrency contract before changing the b
   Do NOT take a screenshot (`screencapture`) or capture an image via XCUITest (`XCUIScreen.screenshot`/`XCTAttachment`)
   — the user wants to interact with the running app themselves.
   The XCUITest runner is sandboxed and can't write `/tmp` anyway.
+- **Dev instance that must run the user's REAL custom commands / keymap = COPY the config into the
+  isolated state dir; don't rely on `AGTERM_STATE_DIR` alone.**
+  An isolated `AGTERM_STATE_DIR` ALSO redirects the config dir to `<stateDir>/config` (`ConfigPaths`
+  precedence: explicit `AppSettings.configDirectory` → `<stateDir>/config` when the state dir is set →
+  `~/.config/agterm`), so an isolated dev instance does NOT read `~/.config/agterm/keymap.conf` and loses
+  every custom command.
+  Keep them with `cp ~/.config/agterm/{keymap,ghostty,restore-denylist}.conf <stateDir>/config/` before
+  launch — there is NO env var that overrides the config dir independently of the state dir.
+  Two more gotchas: (1) do NOT set an `AGTERM_CONTROL_SOCKET` whose path differs from `<stateDir>/agterm.sock`
+  — a custom command's spawned `agtermctl` derives its socket from the inherited `AGTERM_STATE_DIR`
+  (`<stateDir>/agterm.sock`), so a server bound elsewhere is unreachable; set ONLY `AGTERM_STATE_DIR` (a
+  SHORT `/tmp` path) and let the app + CLI derive the same socket.
+  (2) to make custom commands use the freshly-BUILT `agtermctl` (not the deployed one on PATH), launch with
+  `--env PATH="<devApp>/Contents/MacOS:/opt/homebrew/bin:/usr/bin:/bin:…"` — `CustomCommandRunner` runs
+  `/bin/sh -c` over `ProcessInfo.processInfo.environment`, so the prepended PATH reaches the command; a
+  session shell's login rc re-prioritizes PATH back to the deployed `agtermctl`, so a MANUAL `agtermctl` in
+  a dev session needs the full dev-binary path while keybinding commands resolve the dev binary automatically.
 - **After launching a dev instance for the user to test, default to HANDS-OFF.**
   For the user's MANUAL test (the common case — "run it for me to test",
   "I'll test manually"), do NOT touch the running instance after launch:

--- a/README.md
+++ b/README.md
@@ -239,10 +239,12 @@ agtermctl session overlay open "revdiff HEAD~3" --size-percent 80 --background-c
 agtermctl session overlay open "revdiff HEAD~3" --target 9f3c --follow  # switch the user to session 9f3c as the overlay opens
 agtermctl session overlay open "make test" --wait              # keep the overlay open after exit (press a key to close)
 agtermctl session overlay open "make test" --block             # block until it exits; exit with its status
+agtermctl session overlay resize --size-percent 60 --target 9f3c  # resize an open overlay to a floating 60% panel
+agtermctl session overlay resize --full --target 9f3c          # switch it back to the full-pane overlay
 agtermctl session overlay close --target 9f3c                  # close it from a script
 ```
 
-By default an overlay opens on its `--target` without switching the active session — full and floating both run their program in the background and appear when the user visits that session; pass `--follow` to select the target as the overlay opens (a no-op if it is already active). By default it closes the instant the program exits; `--wait` keeps it on a "press any key to close" prompt so you can read the program's final output. A `*` `(overlay)` tag in `agtermctl tree` marks a session whose overlay is open.
+By default an overlay opens on its `--target` without switching the active session — full and floating both run their program in the background and appear when the user visits that session; pass `--follow` to select the target as the overlay opens (a no-op if it is already active). `session overlay resize` changes an already-open overlay in place — `--size-percent N` (1–100) makes it a floating panel, `--full` switches it back to full size — and the program keeps running across the change. By default it closes the instant the program exits; `--wait` keeps it on a "press any key to close" prompt so you can read the program's final output. A `*` `(overlay)` tag in `agtermctl tree` marks a session whose overlay is open.
 
 `--block` runs the program in the overlay (rendering normally) and blocks until it exits, then exits with the program's status — useful in a script that needs the outcome of an interactive run. The program's output stays its own concern: a TUI writes its result to its own file (for example `revdiff --output=…`) which the script reads, while `--block` reports only the exit status (the overlay never captures stdout). `--block` can't be combined with `--wait`; `session overlay result` reports the last overlay's exit status on demand for a manual open → poll flow.
 

--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -73,6 +73,15 @@ extension ControlServer: ControlActions {
         }
     }
 
+    func resizeSessionOverlay(_ target: String?, window: String?, sizePercent: Int?) -> ControlResponse {
+        resolver.resolveSession(target, window: window) { store, id in
+            guard store.resizeOverlay(id, sizePercent: sizePercent) else {
+                return ControlResponse(ok: false, error: "no overlay")
+            }
+            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
+        }
+    }
+
     func sessionOverlayResult(_ target: String?, window: String?) -> ControlResponse {
         resolver.resolveSession(target, window: window) { store, id in
             guard let session = store.session(withID: id) else {

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -354,8 +354,8 @@ final class ControlServer {
                 .sessionFocus, .sessionResize, .sessionStatus, .sessionFlag, .sessionSeen, .notify,
                 .fontInc, .fontDec, .fontReset, .keymapReload, .configReload, .themeSet, .themeList,
                 .sidebar, .sidebarMode, .sidebarExpand, .sidebarCollapse, .sessionType, .sessionCopy,
-                .sessionSearch, .sessionOverlayOpen, .sessionOverlayClose, .sessionOverlayResult,
-                .sessionBackground, .sessionText, .quick, .windowNew, .windowList, .windowSelect,
+                .sessionSearch, .sessionOverlayOpen, .sessionOverlayClose, .sessionOverlayResize,
+                .sessionOverlayResult, .sessionBackground, .sessionText, .quick, .windowNew, .windowList, .windowSelect,
                 .windowClose, .windowRename, .windowDelete, .windowResize, .windowMove, .windowZoom,
                 .windowFullscreen, .restoreClear:
             return ControlResponse(ok: false, error: "control dispatcher did not handle \(request.cmd.rawValue)")

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -98,7 +98,7 @@ you work. For any session-scoped command meant to act on *this* session — `ove
 `type`, `text`, `background`, `status`, `copy`, … — pass `--target "$AGTERM_SESSION_ID"`. Omit it and
 you open overlays / type into whatever the user has selected, not your own session.
 
-## Command summary (52 commands)
+## Command summary (53 commands)
 
 Run `agtermctl <area> <cmd> --help` for exact flags. Full detail in **reference.md**; recipes in
 **examples.md**.
@@ -165,8 +165,11 @@ seen` — omitted when zero).
   renders the pane opaque, overriding window translucency, so it shows; a `color` takes no opacity and
   honors the Settings window translucency instead.)
 - `overlay open <command> [--cwd DIR] [--wait] [--block] [--size-percent N] [--background-color #rrggbb] [--follow]` ·
+  `overlay resize (--size-percent N | --full)` ·
   `overlay close` ·
   `overlay result` — run a program on top of a session; `--block` waits and exits with its status.
+  `overlay resize` changes an ALREADY-OPEN overlay: `--size-percent N` (1-100) makes it a floating panel,
+  `--full` switches it back to the full-pane overlay; the program keeps running (no re-spawn).
   Target with `--target "$AGTERM_SESSION_ID"` for YOUR session (default `active` is the user's selection).
   **By default `overlay open` does NOT switch the user** — full and floating (`--size-percent`) both open
   on `--target` and run their program in the background; the panel appears when the user visits that

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -138,6 +138,9 @@ agtermctl session overlay open "zsh -lc 'htop'" --target "$AGTERM_SESSION_ID" --
 agtermctl session overlay open "revdiff HEAD~3" --target "$AGTERM_SESSION_ID" --size-percent 80 --background-color "#2a1a3a"
 # switch the user to the target as it opens:
 agtermctl session overlay open "revdiff HEAD~3" --target "$AGTERM_SESSION_ID" --size-percent 80 --follow
+# resize the open overlay in place (the program keeps running): shrink to a floating panel, then back to full
+agtermctl session overlay resize --size-percent 60 --target "$AGTERM_SESSION_ID"
+agtermctl session overlay resize --full --target "$AGTERM_SESSION_ID"
 # ... later
 agtermctl session overlay close
 ```

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -251,6 +251,12 @@ visible before). `idleMs` is live and grows while the window is idle, so it is o
   own output file, not the control channel. Returns the overlay's session id. `--target` defaults to
   `active`, so an automated caller should pass `--target "$AGTERM_SESSION_ID"` — otherwise a (usually
   blocking, full-pane) overlay lands on whatever session is currently active, not the calling one.
+- `session overlay resize (--size-percent N | --full) [--target] [--window W]` — resize an ALREADY-OPEN
+  overlay in place. Exactly one of `--size-percent N` (1–100, makes it a floating framed panel) or
+  `--full` (switches it back to the full-pane overlay that hides the session) is required; passing both
+  or neither, or a percent outside 1–100, is an error. The overlay program keeps running across the
+  resize — it is a layout re-flow, never a re-spawn. Errors `no overlay` when none is open. Returns the
+  session id.
 - `session overlay close [--target] [--window W]` — close (destroy) the overlay.
 - `session overlay result [--target] [--window W]` — returns `result.exitCode` once the overlay has
   closed. Errors `still running` while up, `no result` if none ran.

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -222,8 +222,8 @@ struct WindowContentView: View {
                 .frame(height: 1)
             detailPane
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                // the floating overlay renders in-deck inside `sessionDetail` (`floatingOverlayPanel`), not at
-                // this `detailPane` level.
+                // the overlay renders in-deck inside `sessionDetail` (`overlayPanel`), not at this
+                // `detailPane` level.
                 // the search bar, anchored at the `detailPane` level (never inside `sessionDetail`'s
                 // HSplitView ZStack) so toggling it can't overrun the NSSplitView up into the titlebar.
                 // Sits at the top-right of the detail area, like a standard find bar.
@@ -308,21 +308,21 @@ struct WindowContentView: View {
             // gate hit-testing on `hideForOverlay` (full overlay OR scratch), NOT `session.overlayActive`:
             // this modifier must NOT change when a floating overlay opens, or the AppKit NSSplitView
             // re-lays-out and overruns up into the titlebar (same class of perturbation as adding a sibling).
-            // a floating overlay therefore leaves the panes hit-testable here; `floatingOverlayPanel`'s
-            // transparent catcher absorbs clicks around the panel so they can't reach the panes.
+            // a floating overlay therefore leaves the panes hit-testable here; `overlayPanel`'s transparent
+            // catcher absorbs clicks around the panel so they can't reach the panes.
             .allowsHitTesting(!hideForOverlay)
-            // the scratch terminal renders here, in-deck, above the (hidden) pane(s) — like the FULL overlay,
-            // a full-coverage sibling is safe (the panes go opacity 0, the split's frame is hidden). It sits
-            // BELOW the ephemeral overlay (zIndex 1 vs 2) AND goes hidden while a full overlay is up, exactly
-            // like the pane(s): under window translucency every surface's background renders fully transparent,
-            // so a scratch left visible below would show through the overlay (reading as "the overlay opened
-            // under the scratch"). The FLOATING overlay is the `floatingOverlayPanel` sibling below (zIndex 3):
-            // it is ALWAYS present with a constant shape (its panel content is gated internally), so adding it
-            // never re-hosts the NSSplitView even though the panes stay VISIBLE — and its opaque panel needs no
-            // hiding of the scratch behind it.
+            // the scratch terminal renders here, in-deck, above the (hidden) pane(s) — a full-coverage sibling
+            // is safe (the panes go opacity 0, the split's frame is hidden). It sits BELOW the ephemeral overlay
+            // (zIndex 1 vs `overlayPanel`'s 3) AND goes hidden while a full overlay is up, exactly like the
+            // pane(s): under window translucency every surface's background renders fully transparent, so a
+            // scratch left visible below would show through the overlay (reading as "the overlay opened under
+            // the scratch"). BOTH overlay variants are the `overlayPanel` sibling below (zIndex 3): it is ALWAYS
+            // present with a constant shape (its content is gated internally), so opening/resizing an overlay
+            // never re-hosts the NSSplitView — and the floating panel's opaque backing needs no hiding of the
+            // scratch behind it.
             if session.scratchActive {
-                // gate focus on every surface that covers the scratch — a full overlay (renders above it,
-                // zIndex 2) AND the window-level quick terminal — so the deck's focusIfNeeded can't grab the
+                // gate focus on every surface that covers the scratch — a full overlay (renders above it, in
+                // `overlayPanel` at zIndex 3) AND the window-level quick terminal — so the deck's focusIfNeeded can't grab the
                 // scratch behind them. When the cover goes away, isActive flips true and the deck re-grabs it.
                 // (matches the autoFocus suppression in makeScratchSurface.) `deckVisible` mirrors the panes'
                 // rule so only an on-screen scratch is a file-drop target.
@@ -334,18 +334,14 @@ struct WindowContentView: View {
                     .id("\(session.id.uuidString)-scratch")
                     .zIndex(1)
             }
-            if fullOverlay {
-                TerminalView(session: session, surfaceKeyPath: \.overlaySurface,
-                             makeSurface: makeOverlaySurface, isActive: isActive, deckVisible: isActive)
-                    .id("\(session.id.uuidString)-overlay")
-                    .zIndex(2)
-            }
-            // the FLOATING overlay renders IN-DECK (per session) so its surface mounts + program runs even
-            // when the session isn't active. ALWAYS PRESENT (constant ZStack shape) — the panel content is
-            // gated INSIDE `floatingOverlayPanel`, the sibling itself never appears/disappears, so opening a
-            // floating overlay never re-hosts the NSSplitView (the titlebar-overrun trigger). Unlike the full
-            // overlay, it leaves the pane(s) visible behind its opaque framed panel.
-            floatingOverlayPanel(session: session, isActive: isActive)
+            // the overlay — FULL or FLOATING — renders IN-DECK (per session) so its surface mounts + program
+            // runs even when the session isn't active. ONE ALWAYS-PRESENT host (constant ZStack shape): the
+            // content is gated INSIDE `overlayPanel`, the sibling itself never appears/disappears, so opening,
+            // closing, OR resizing an overlay never re-hosts the NSSplitView (the titlebar-overrun trigger)
+            // and never re-parents the surface (which would blank its Metal drawable). Full fills the area
+            // translucent with the pane(s) hidden by `hideForOverlay`; floating draws an opaque framed panel
+            // over the still-visible pane(s). Switching full<->% (session.overlay.resize) only re-flows the frame.
+            overlayPanel(session: session, isActive: isActive)
                 .zIndex(3)
         }
         // when the overlay closes, the underlying pane must reclaim first responder. the pane re-activating
@@ -383,40 +379,48 @@ struct WindowContentView: View {
         }
     }
 
-    /// The FLOATING overlay, rendered IN-DECK inside each session's `sessionDetail` ZStack as an
-    /// ALWAYS-PRESENT sibling — the panel content is gated INSIDE the GeometryReader, so the ZStack's child
-    /// count never changes when the overlay opens (constant shape = no NSSplitView re-host = no titlebar
-    /// overrun). Because it is per-session in the eager deck, the surface mounts and its program runs even
-    /// when the session isn't active. The panel is an opaque, framed terminal sized to `overlaySizePercent`%
-    /// of the detail area and centered, with the session's pane(s) visible around it.
-    @ViewBuilder private func floatingOverlayPanel(session: Session, isActive: Bool) -> some View {
+    /// The overlay — FULL or FLOATING — rendered IN-DECK inside each session's `sessionDetail` ZStack as ONE
+    /// ALWAYS-PRESENT sibling. The content is gated INSIDE the GeometryReader, so the ZStack's child count
+    /// never changes when an overlay opens/closes (constant shape = no NSSplitView re-host = no titlebar
+    /// overrun), and BOTH variants share this single surface host, so `session.overlay.resize` switching
+    /// full<->% only re-flows the frame — it never re-parents the NSView (which would blank its Metal drawable).
+    /// A nil `overlaySizePercent` fills the detail area translucent (no opaque backing/frame) with the pane(s)
+    /// hidden by `hideForOverlay`; a percent draws an opaque, framed panel at that size, centered, with the
+    /// pane(s) visible around it. Per-session in the eager deck, so the surface mounts + program runs even when
+    /// the session isn't active.
+    @ViewBuilder private func overlayPanel(session: Session, isActive: Bool) -> some View {
         GeometryReader { geo in
             ZStack {
-                if session.floatingOverlayActive, let percent = session.overlaySizePercent {
-                    let fraction = CGFloat(percent) / 100
-                    // transparent click-catcher over the whole detail area: absorbs clicks AROUND the panel so
-                    // they can't reach the still-hit-testable panes behind and steal the overlay's first responder.
+                if session.overlayActive {
+                    let floating = session.overlaySizePercent != nil
+                    let fraction = session.overlaySizePercent.map { CGFloat($0) / 100 } ?? 1
+                    // transparent click-catcher over the whole detail area: absorbs clicks AROUND a floating
+                    // panel so they can't reach the still-hit-testable panes and steal the overlay's first
+                    // responder (the full variant hides the panes, so it's covered either way).
                     Color.clear.contentShape(Rectangle())
                     TerminalView(session: session, surfaceKeyPath: \.overlaySurface,
                                  makeSurface: makeOverlaySurface, isActive: isActive, deckVisible: isActive)
                         .frame(width: geo.size.width * fraction, height: geo.size.height * fraction)
-                        // solid backing + hairline frame + shadow so the floating panel reads as a distinct
-                        // opaque window over the still-visible session (libghostty draws only the terminal).
-                        .background(terminalColor)
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        // floating = opaque backing + hairline frame + shadow so it reads as a distinct window
+                        // over the still-visible session; full = translucent, no chrome (libghostty draws only
+                        // the terminal, so the window backing shows through). The modifier CHAIN stays constant
+                        // across both variants — only the parameters go inert for full — so a full<->% resize
+                        // keeps the same view tree and never re-hosts the surface NSView.
+                        .background(floating ? terminalColor : Color.clear)
+                        .clipShape(RoundedRectangle(cornerRadius: floating ? 12 : 0))
                         .overlay(
-                            RoundedRectangle(cornerRadius: 12)
-                                .strokeBorder(Color.white.opacity(0.18), lineWidth: 1)
+                            RoundedRectangle(cornerRadius: floating ? 12 : 0)
+                                .strokeBorder(floating ? Color.white.opacity(0.18) : Color.clear, lineWidth: 1)
                         )
-                        .shadow(radius: 24)
+                        .shadow(radius: floating ? 24 : 0)
                         .id("\(session.id.uuidString)-overlay")
                 }
             }
             .frame(width: geo.size.width, height: geo.size.height)
         }
-        // when not floating the panel is an empty full-frame GeometryReader — make it inert so it never
+        // when no overlay is up the panel is an empty full-frame GeometryReader — make it inert so it never
         // intercepts clicks meant for the pane(s).
-        .allowsHitTesting(session.floatingOverlayActive)
+        .allowsHitTesting(session.overlayActive)
     }
 
     /// The terminal search bar, attached as a top-aligned `.overlay` on `detailPane` — NOT inside any

--- a/agtermCore/Sources/agtermCore/AppStore+Panes.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Panes.swift
@@ -136,6 +136,17 @@ extension AppStore {
         return true
     }
 
+    /// Resizes an already-open overlay in place. `sizePercent` (clamped to 1...100) switches it to a
+    /// *floating* opaque framed panel at that percent of the pane with the session visible behind it;
+    /// nil switches it to the full-pane overlay that hides the session and draws translucent. The overlay
+    /// surface stays mounted (the detail pane hosts both variants in one place), so this only re-flows the
+    /// layout — the program keeps running, never re-spawns. No-op (returns false) with no overlay open.
+    @discardableResult public func resizeOverlay(_ sessionID: UUID, sizePercent: Int?) -> Bool {
+        guard let session = session(withID: sessionID), session.overlayActive else { return false }
+        session.overlaySizePercent = sizePercent.map { min(100, max(1, $0)) }
+        return true
+    }
+
     /// Records the overlay program's exit status (parsed app-side from the wrapper's temp file on the
     /// surface's teardown) so `session.overlay.result` can report it after the overlay closes. No-op
     /// for an unknown session.

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -43,6 +43,7 @@ public protocol ControlActions {
     func openSessionOverlay(_ target: String?, window: String?,
                             options: ControlSessionOverlayOpenOptions) -> ControlResponse
     func closeSessionOverlay(_ target: String?, window: String?) -> ControlResponse
+    func resizeSessionOverlay(_ target: String?, window: String?, sizePercent: Int?) -> ControlResponse
     func sessionOverlayResult(_ target: String?, window: String?) -> ControlResponse
     func setSessionBackground(_ target: String?, window: String?,
                               options: ControlSessionBackgroundOptions) -> ControlResponse
@@ -130,7 +131,7 @@ public struct ControlDispatcher {
             return dispatchSessionCommand(request)
         case .sessionSplit, .sessionScratch, .sessionFocus, .sessionResize, .sessionType,
                 .sessionCopy, .sessionSearch, .sessionOverlayOpen, .sessionOverlayClose,
-                .sessionOverlayResult, .sessionBackground, .sessionText:
+                .sessionOverlayResize, .sessionOverlayResult, .sessionBackground, .sessionText:
             return await dispatchSessionSurfaceCommand(request)
         case .workspaceNew, .workspaceSelect, .workspaceRename, .workspaceDelete,
                 .workspaceMove, .workspaceFocus:
@@ -326,6 +327,20 @@ public struct ControlDispatcher {
                                               ))
         case .sessionOverlayClose:
             return actions.closeSessionOverlay(request.target, window: request.args?.window)
+        case .sessionOverlayResize:
+            let wantsFull = request.args?.full == true
+            let percent = request.args?.sizePercent
+            if wantsFull, percent != nil {
+                return ControlResponse(ok: false, error: "session.overlay.resize: --full is mutually exclusive with --size-percent")
+            }
+            if !wantsFull, percent == nil {
+                return ControlResponse(ok: false, error: "session.overlay.resize requires --size-percent or --full")
+            }
+            if let percent, !(1...100).contains(percent) {
+                return ControlResponse(ok: false, error: "session.overlay.resize: --size-percent must be 1...100")
+            }
+            return actions.resizeSessionOverlay(request.target, window: request.args?.window,
+                                                sizePercent: wantsFull ? nil : percent)
         case .sessionOverlayResult:
             return actions.sessionOverlayResult(request.target, window: request.args?.window)
         case .sessionBackground:

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -31,6 +31,7 @@ public enum Command: String, Codable, Sendable {
     case sessionSearch = "session.search"
     case sessionOverlayOpen = "session.overlay.open"
     case sessionOverlayClose = "session.overlay.close"
+    case sessionOverlayResize = "session.overlay.resize"
     case sessionOverlayResult = "session.overlay.result"
     case quick
     case sidebar
@@ -141,8 +142,12 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     /// "press any key to close" prompt) instead of closing immediately.
     public var wait: Bool?
     /// For `session.overlay.open`, the percent of the pane (1...100) a *floating* overlay panel
-    /// occupies in both dimensions; omitted gives the default full-pane overlay.
+    /// occupies in both dimensions; omitted gives the default full-pane overlay. Also carries the new
+    /// size for `session.overlay.resize` (mutually exclusive with `full`).
     public var sizePercent: Int?
+    /// For `session.overlay.resize`, requests the full-pane (translucent, session-hidden) overlay —
+    /// the way to switch a floating overlay back to full. Mutually exclusive with `sizePercent`.
+    public var full: Bool?
     /// For `session.overlay.open`, whether to select/switch to the target after opening; omitted/false
     /// opens in the background without changing the active session (the default for both full and
     /// floating overlays).
@@ -173,8 +178,8 @@ public struct ControlArgs: Codable, Sendable, Equatable {
 
     public init(name: String? = nil, cwd: String? = nil, workspace: String? = nil, workspaceName: String? = nil,
                 createWorkspace: Bool? = nil, text: String? = nil, select: Bool? = nil, mode: String? = nil,
-                command: String? = nil, wait: Bool? = nil, sizePercent: Int? = nil, follow: Bool? = nil,
-                window: String? = nil,
+                command: String? = nil, wait: Bool? = nil, sizePercent: Int? = nil, full: Bool? = nil,
+                follow: Bool? = nil, window: String? = nil,
                 pane: String? = nil, to: String? = nil, after: String? = nil, before: String? = nil,
                 title: String? = nil, body: String? = nil,
                 width: Int? = nil, height: Int? = nil, x: Int? = nil, y: Int? = nil, display: Int? = nil,
@@ -193,6 +198,7 @@ public struct ControlArgs: Codable, Sendable, Equatable {
         self.command = command
         self.wait = wait
         self.sizePercent = sizePercent
+        self.full = full
         self.follow = follow
         self.window = window
         self.pane = pane

--- a/agtermCore/Sources/agtermctlKit/SessionCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/SessionCommands.swift
@@ -474,8 +474,8 @@ struct Session: ParsableCommand {
 
     struct Overlay: ParsableCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Open or close an ephemeral overlay terminal on a session.",
-            subcommands: [Open.self, Close.self, Result.self]
+            abstract: "Open, resize, or close an ephemeral overlay terminal on a session.",
+            subcommands: [Open.self, Close.self, Resize.self, Result.self]
         )
 
         struct Open: RequestCommand {
@@ -548,6 +548,29 @@ struct Session: ParsableCommand {
 
             func makeRequest() throws -> ControlRequest {
                 ControlRequest(cmd: .sessionOverlayClose, target: target.target, args: options.withWindow())
+            }
+        }
+
+        struct Resize: RequestCommand {
+            static let configuration = CommandConfiguration(abstract: "Resize an open overlay: floating at a percent, or back to full-pane.")
+            @Option(name: .long, help: "Resize to a floating, framed panel at PERCENT (1-100) of the pane.") var sizePercent: Int?
+            @Flag(name: .long, help: "Resize to full-pane (translucent, hides the session).") var full = false
+            @OptionGroup var target: TargetOptions
+            @OptionGroup var options: ClientOptions
+
+            // require exactly one of --size-percent / --full at parse time (before any connection), so it is a
+            // clean usage error and unit-testable without a socket; the dispatcher re-checks the same rules.
+            func validate() throws {
+                if full && sizePercent != nil { throw ValidationError("--full cannot be combined with --size-percent") }
+                if !full && sizePercent == nil { throw ValidationError("provide --size-percent PERCENT or --full") }
+                if let sizePercent, !(1...100).contains(sizePercent) {
+                    throw ValidationError("--size-percent must be between 1 and 100")
+                }
+            }
+
+            func makeRequest() throws -> ControlRequest {
+                ControlRequest(cmd: .sessionOverlayResize, target: target.target,
+                               args: options.withWindow(ControlArgs(sizePercent: sizePercent, full: full ? true : nil)))
             }
         }
 

--- a/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
@@ -293,6 +293,32 @@ struct AppStorePaneTests {
         #expect(session.overlaySizePercent == 1)
     }
 
+    @Test func resizeOverlaySwitchesFullAndFloatingAndClamps() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        // no overlay open → no-op, leaves size untouched.
+        #expect(store.resizeOverlay(session.id, sizePercent: 50) == false)
+        #expect(session.overlaySizePercent == nil)
+        // open full, then resize it to a floating percent (nil → 60).
+        store.openOverlay(session.id, command: "htop")
+        #expect(session.overlaySizePercent == nil)
+        #expect(store.resizeOverlay(session.id, sizePercent: 60) == true)
+        #expect(session.overlaySizePercent == 60)
+        #expect(session.floatingOverlayActive)
+        // resize back to full (nil).
+        #expect(store.resizeOverlay(session.id, sizePercent: nil) == true)
+        #expect(session.overlaySizePercent == nil)
+        #expect(session.fullOverlayActive)
+        // out-of-range percents clamp to 1...100.
+        store.resizeOverlay(session.id, sizePercent: 250)
+        #expect(session.overlaySizePercent == 100)
+        store.resizeOverlay(session.id, sizePercent: 0)
+        #expect(session.overlaySizePercent == 1)
+        // the overlay program keeps running across every resize (no re-spawn).
+        #expect(session.overlayActive)
+    }
+
     @Test func closeOverlayTearsDownAndClears() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -878,6 +878,51 @@ struct ControlDispatcherTests {
         #expect(actions.calls == [.overlayResult(target: "session", window: nil)])
     }
 
+    @Test func sessionOverlayResizeRoutesSizePercentAndWindow() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextOverlayResizeResponse = ControlResponse(ok: true, result: ControlResult(id: "session"))
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionOverlayResize, target: "session",
+            args: ControlArgs(sizePercent: 60, window: "win")
+        ))
+
+        #expect(response == ControlResponse(ok: true, result: ControlResult(id: "session")))
+        #expect(actions.calls == [.overlayResize(target: "session", window: "win", sizePercent: 60)])
+    }
+
+    @Test func sessionOverlayResizeFullRoutesNilSizePercent() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionOverlayResize, target: "session", args: ControlArgs(full: true)
+        ))
+
+        #expect(response?.ok == true)
+        #expect(actions.calls == [.overlayResize(target: "session", window: nil, sizePercent: nil)])
+    }
+
+    @Test func sessionOverlayResizeRejectsMissingConflictingAndOutOfRange() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let missing = await dispatcher.dispatch(ControlRequest(cmd: .sessionOverlayResize, target: "session"))
+        let both = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionOverlayResize, target: "session", args: ControlArgs(sizePercent: 50, full: true)))
+        let tooBig = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionOverlayResize, target: "session", args: ControlArgs(sizePercent: 101)))
+        let tooSmall = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionOverlayResize, target: "session", args: ControlArgs(sizePercent: 0)))
+
+        #expect(missing == ControlResponse(ok: false, error: "session.overlay.resize requires --size-percent or --full"))
+        #expect(both == ControlResponse(ok: false, error: "session.overlay.resize: --full is mutually exclusive with --size-percent"))
+        #expect(tooBig == ControlResponse(ok: false, error: "session.overlay.resize: --size-percent must be 1...100"))
+        #expect(tooSmall == ControlResponse(ok: false, error: "session.overlay.resize: --size-percent must be 1...100"))
+        #expect(actions.calls.isEmpty)
+    }
+
     @Test func sessionBackgroundRoutesParsedTextImageColorAndClearForms() async {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)
@@ -1251,6 +1296,7 @@ private final class MockControlActions: ControlActions {
         case sessionSearch(target: String?, window: String?, text: String?, to: String?)
         case overlayOpen(target: String?, window: String?, ControlSessionOverlayOpenOptions)
         case overlayClose(target: String?, window: String?)
+        case overlayResize(target: String?, window: String?, sizePercent: Int?)
         case overlayResult(target: String?, window: String?)
         case sessionBackground(target: String?, window: String?, ControlSessionBackgroundOptions)
         case sessionText(target: String?, window: String?, ControlSessionTextOptions)
@@ -1286,6 +1332,7 @@ private final class MockControlActions: ControlActions {
     var nextSessionSearchResponse = ControlResponse(ok: true)
     var nextOverlayOpenResponse = ControlResponse(ok: true)
     var nextOverlayCloseResponse = ControlResponse(ok: true)
+    var nextOverlayResizeResponse = ControlResponse(ok: true)
     var nextOverlayResultResponse = ControlResponse(ok: true)
     var nextSessionBackgroundResponse = ControlResponse(ok: true)
     var nextSessionTextResponse = ControlResponse(ok: true)
@@ -1485,6 +1532,11 @@ private final class MockControlActions: ControlActions {
     func closeSessionOverlay(_ target: String?, window: String?) -> ControlResponse {
         calls.append(.overlayClose(target: target, window: window))
         return nextOverlayCloseResponse
+    }
+
+    func resizeSessionOverlay(_ target: String?, window: String?, sizePercent: Int?) -> ControlResponse {
+        calls.append(.overlayResize(target: target, window: window, sizePercent: sizePercent))
+        return nextOverlayResizeResponse
     }
 
     func sessionOverlayResult(_ target: String?, window: String?) -> ControlResponse {

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -46,11 +46,23 @@ struct ControlProtocolTests {
             ControlRequest(cmd: .sessionOverlayOpen, target: "9f3c", args: ControlArgs(command: "htop", sizePercent: 70)),
             ControlRequest(cmd: .sessionOverlayOpen, target: "9f3c", args: ControlArgs(command: "revdiff", color: "#2a1a3a")),
             ControlRequest(cmd: .sessionOverlayClose, target: "9f3c"),
+            ControlRequest(cmd: .sessionOverlayResize, target: "9f3c", args: ControlArgs(sizePercent: 60)),
+            ControlRequest(cmd: .sessionOverlayResize, target: "9f3c", args: ControlArgs(full: true)),
             ControlRequest(cmd: .sessionOverlayResult, target: "9f3c"),
         ]
         for request in cases {
             #expect(try roundTrip(request) == request)
         }
+    }
+
+    @Test func sessionOverlayResizeOmitsFullWhenNil() throws {
+        let request = ControlRequest(cmd: .sessionOverlayResize, target: "9f3c", args: ControlArgs(sizePercent: 60))
+        let decoded = try roundTrip(request)
+        #expect(decoded == request)
+        #expect(decoded.args?.full == nil)
+        // omit-when-nil WIRE contract for the new `full` field: a percent resize must not emit `full` at all.
+        let json = String(data: try JSONEncoder().encode(request), encoding: .utf8) ?? ""
+        #expect(!json.contains("full"), "a nil full must be omitted from the JSON; got \(json)")
     }
 
     @Test func sessionOverlayOpenRoundTripsWithFollow() throws {

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -587,6 +587,26 @@ struct CommandsTests {
             == ControlRequest(cmd: .sessionOverlayResult, target: "9f3c"))
     }
 
+    @Test func sessionOverlayResizeWithSizePercent() throws {
+        let expected = ControlRequest(cmd: .sessionOverlayResize, target: "9f3c", args: ControlArgs(sizePercent: 40))
+        #expect(try request(["session", "overlay", "resize", "--size-percent", "40", "--target", "9f3c"]) == expected)
+    }
+
+    @Test func sessionOverlayResizeFull() throws {
+        let expected = ControlRequest(cmd: .sessionOverlayResize, target: "active", args: ControlArgs(full: true))
+        #expect(try request(["session", "overlay", "resize", "--full"]) == expected)
+    }
+
+    @Test func sessionOverlayResizeRejectsBadArgs() {
+        // validate() enforces exactly-one-of --size-percent/--full and the 1...100 range at parse time.
+        #expect(throws: (any Error).self) { try Agtermctl.parseAsRoot(["session", "overlay", "resize"]) }
+        #expect(throws: (any Error).self) {
+            try Agtermctl.parseAsRoot(["session", "overlay", "resize", "--full", "--size-percent", "50"])
+        }
+        #expect(throws: (any Error).self) { try Agtermctl.parseAsRoot(["session", "overlay", "resize", "--size-percent", "150"]) }
+        #expect(throws: (any Error).self) { try Agtermctl.parseAsRoot(["session", "overlay", "resize", "--size-percent", "0"]) }
+    }
+
     @Test func sessionOverlayBlockRejectsWait() {
         // validate() enforces the mutually-exclusive flags at parse time (before any connection).
         #expect(throws: (any Error).self) {

--- a/agtermUITests/ControlOverlaySplitUITests.swift
+++ b/agtermUITests/ControlOverlaySplitUITests.swift
@@ -36,6 +36,46 @@ final class ControlOverlaySplitUITests: ControlAPITestCase {
         XCTAssertEqual(closeAgain["error"] as? String, "no overlay", "\(closeAgain)")
     }
 
+    // session.overlay.resize switches an open overlay between floating and full in place. Overlay geometry
+    // is a Metal surface (not in the AX tree), so this asserts the COMMAND PATH: resize succeeds while the
+    // overlay is up (a percent AND --full) and the overlay stays up across it, errors with no overlay, and
+    // the dispatcher rejects missing/conflicting/out-of-range size args server-side (a raw client can't
+    // bypass the CLI validate()). The visual re-flow is verified manually.
+    func testOverlayResizeSwitchesFloatingAndFull() throws {
+        let created = try sendCommand(#"{"cmd":"session.new"}"#)
+        let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
+        let id = try XCTUnwrap(result["id"] as? String, "session.new should return the new id")
+
+        // resizing with no overlay open errors.
+        let noOverlay = try sendCommand(#"{"cmd":"session.overlay.resize","target":"\#(id)","args":{"sizePercent":60}}"#)
+        XCTAssertEqual(noOverlay["ok"] as? Bool, false, "resize with no overlay should fail: \(noOverlay)")
+        XCTAssertEqual(noOverlay["error"] as? String, "no overlay", "\(noOverlay)")
+
+        // open a full overlay (cat is long-lived), then resize it to floating and back to full.
+        let open = try sendCommand(#"{"cmd":"session.overlay.open","target":"\#(id)","args":{"command":"cat"}}"#)
+        XCTAssertEqual(open["ok"] as? Bool, true, "overlay open should succeed: \(open)")
+        XCTAssertTrue(pollSessionOverlay(id: id, expected: true, timeout: 10), "the overlay should be up")
+
+        let toFloating = try sendCommand(#"{"cmd":"session.overlay.resize","target":"\#(id)","args":{"sizePercent":60}}"#)
+        XCTAssertEqual(toFloating["ok"] as? Bool, true, "resize to floating should succeed: \(toFloating)")
+        // the overlay stays up across the resize (in-place re-flow, never a re-spawn).
+        XCTAssertTrue(pollSessionOverlay(id: id, expected: true, timeout: 5), "the overlay stays up after resize")
+
+        let toFull = try sendCommand(#"{"cmd":"session.overlay.resize","target":"\#(id)","args":{"full":true}}"#)
+        XCTAssertEqual(toFull["ok"] as? Bool, true, "resize back to full should succeed: \(toFull)")
+
+        // the dispatcher rejects the bad arg combos server-side.
+        let neither = try sendCommand(#"{"cmd":"session.overlay.resize","target":"\#(id)"}"#)
+        XCTAssertEqual(neither["ok"] as? Bool, false, "resize with neither arg should fail: \(neither)")
+        let both = try sendCommand(#"{"cmd":"session.overlay.resize","target":"\#(id)","args":{"sizePercent":50,"full":true}}"#)
+        XCTAssertEqual(both["ok"] as? Bool, false, "resize with both args should fail: \(both)")
+        let oob = try sendCommand(#"{"cmd":"session.overlay.resize","target":"\#(id)","args":{"sizePercent":150}}"#)
+        XCTAssertEqual(oob["ok"] as? Bool, false, "resize with out-of-range percent should fail: \(oob)")
+
+        let close = try sendCommand(#"{"cmd":"session.overlay.close","target":"\#(id)"}"#)
+        XCTAssertEqual(close["ok"] as? Bool, true, "overlay close should succeed: \(close)")
+    }
+
     // session.overlay.open --background-color: a valid #rrggbb opens the overlay (the colored surface is
     // a Metal layer, not in the AX tree, so the color is verified manually — this asserts the arm accepts
     // and applies it via the lifecycle), and a malformed color is rejected before the overlay opens.

--- a/agtermUITests/ControlOverlaySplitUITests.swift
+++ b/agtermUITests/ControlOverlaySplitUITests.swift
@@ -39,8 +39,9 @@ final class ControlOverlaySplitUITests: ControlAPITestCase {
     // session.overlay.resize switches an open overlay between floating and full in place. Overlay geometry
     // is a Metal surface (not in the AX tree), so this asserts the COMMAND PATH: resize succeeds while the
     // overlay is up (a percent AND --full) and the overlay stays up across it, errors with no overlay, and
-    // the dispatcher rejects missing/conflicting/out-of-range size args server-side (a raw client can't
-    // bypass the CLI validate()). The visual re-flow is verified manually.
+    // the dispatcher rejects missing/conflicting/out-of-range size args server-side; a raw JSON client (like
+    // this test) skips the CLI's validate() entirely, so the dispatcher is the real enforcement boundary.
+    // The visual re-flow is verified manually.
     func testOverlayResizeSwitchesFloatingAndFull() throws {
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
         let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")

--- a/site/docs.html
+++ b/site/docs.html
@@ -1160,7 +1160,10 @@
               --target 9f3c --follow<br /><br /><span style="color: #6b727a"
                 ># keep it open after exit, or block until it exits and inherit its status</span
               ><br />agtermctl session overlay open <span style="color: #f2b45c">"make test"</span> --wait<br />agtermctl session
-              overlay open <span style="color: #f2b45c">"make test"</span> --block<br />agtermctl session overlay close --target
+              overlay open <span style="color: #f2b45c">"make test"</span> --block<br /><br /><span style="color: #6b727a"
+                ># resize an open overlay in place — floating percent, or back to full (the program keeps running)</span
+              ><br />agtermctl session overlay resize --size-percent 60 --target 9f3c<br />agtermctl session overlay resize --full
+              --target 9f3c<br /><br />agtermctl session overlay close --target
               9f3c<br />agtermctl session overlay result
               <span style="color: #6b727a">&nbsp;&nbsp;# last overlay's exit status</span>
             </div>
@@ -1174,7 +1177,12 @@
               >
               floating alike);
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--follow</span> switches the user to
-              the target. A
+              the target.
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">session overlay resize</span> changes an
+              open overlay in place —
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--size-percent</span> makes it floating,
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--full</span> switches it back — without
+              restarting the program. A
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">(overlay)</span> tag in
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl tree</span> marks a session
               whose overlay is open.


### PR DESCRIPTION
Adds `session.overlay.resize` to resize an already-open overlay in place without restarting its program: `--size-percent N` (1-100) for a floating panel, or `--full` for the full-pane overlay. Exactly one of the two is required.

**Rendering unify.** Full and floating overlays now render from one always-present host (`WindowContentView.overlayPanel`) instead of a `fullOverlay`-gated zIndex-2 sibling plus a separate floating panel. The SwiftUI modifier chain stays constant across both variants (only the backing color, corner radius, shadow, and frame fraction flip), so switching full<->% is a value-update: it never re-parents the overlay's NSView (which would blank its Metal drawable) and never changes the ZStack shape (which would overrun the NSSplitView into the titlebar). Full stays translucent with the panes hidden; floating draws an opaque framed panel over the visible panes.

**Coverage.** The command is wired across every keep-in-sync surface: a `Command` case + `full` arg in `ControlProtocol`, dispatcher validation + `ControlActions.resizeSessionOverlay`, `AppStore.resizeOverlay` (clamps 1-100, guards `overlayActive`), the `ControlServer` arm, and the `agtermctl session overlay resize` subcommand. Tests cover the protocol round-trip, dispatcher routing/validation, the AppStore clamp/switch, CLI mapping, and an e2e (`testOverlayResizeSwitchesFloatingAndFull`). Docs updated across README, the bundled agent-skill (SKILL/reference/examples), the `control-api` rule, and the site.

Verified locally: `swift test` (1213 pass), `make lint` clean, `make build`, the overlay e2e class green, plus a hands-on full<->% resize check.
