### PR TITLE
fix: clear notification badge when refocusing the app on a visible session

### DIFF
--- a/.claude/rules/notifications.md
+++ b/.claude/rules/notifications.md
@@ -53,6 +53,14 @@ paths:
   and `reloadChangedBadgeRows`/`snapshotBadges` reload only the changed session + workspace rows.
   Cleared by `AppStore.selectSession` and by a pane's `onFocusChange(true)` (which also calls `clearDelivered`
   — focusing a pane means you've seen the session).
+  `onFocusChange(true)` fires on a first-responder TRANSITION, which does NOT happen when agterm merely
+  regains key focus (AppKit's per-window first responder never resigned while the app was backgrounded),
+  so refocusing the app onto the same on-screen session left the badge stuck (#155).
+  `GhosttySurfaceView.clearUnseenOnRefocus` closes that: the `didBecomeKey` observer (already re-pushing
+  the cursor's `liveFocus`) also re-runs the same `onFocusChange(true)` clear on the become-key edge, gated
+  on `liveFocus` (key window AND this pane is first responder) so it fires only for the ONE focused pane of
+  the now-key window — the inverse of the suppression condition below. A non-focused session's pill is
+  untouched (its `liveFocus` is false), so it stays until you select that session.
   **The count pill rendering is gated by the `notificationBadgeEnabled` Settings toggle** (see the Settings
   section): the Coordinator's `effectiveUnseen(_:)` returns 0 when the flag is off,
   applied to BOTH the session badge and the workspace roll-up (and to `RowContent.unseen` so a toggle

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -256,11 +256,33 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     private func observeKeyWindowChanges() {
         let center = NotificationCenter.default
         for name in [NSWindow.didBecomeKeyNotification, NSWindow.didResignKeyNotification] {
+            let becameKey = name == NSWindow.didBecomeKeyNotification
             let token = center.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
-                MainActor.assumeIsolated { self?.updateGhosttyFocus() }
+                MainActor.assumeIsolated {
+                    guard let self else { return }
+                    self.updateGhosttyFocus()
+                    // returning focus to agterm (cmd-tab or a reactivating click) while this pane is the
+                    // one on screen counts as "seeing" the session — clear its unseen badge, the same as a
+                    // focus transition does. becomeFirstResponder can't cover this: AppKit's per-window
+                    // first responder never resigned while agterm was backgrounded, so no focus transition
+                    // fires on return, leaving the badge stuck until you switch sessions and back.
+                    if becameKey { self.clearUnseenOnRefocus() }
+                }
             }
             focusObservers.append(token)
         }
+    }
+
+    /// Clear the "you've seen it" state (unseen badge + delivered banners) for this pane's session when
+    /// agterm regains key focus on it — the inverse of notification suppression (which drops a banner only
+    /// when the firing pane is the key window's first responder AND the app is active). `liveFocus` already
+    /// encodes both: a window is key only while the app is active, so it fires solely for the focused pane of
+    /// the now-key window, never a background one. Reuses `onFocusChange`, so it clears exactly for the
+    /// main/split panes that already clear on a focus transition (a scratch/overlay has no `onFocusChange`
+    /// and doesn't clear on focus either), and no-ops after teardown (the closure is nil'd).
+    private func clearUnseenOnRefocus() {
+        guard liveFocus else { return }
+        onFocusChange?(true)
     }
 
     /// The cursor-focus state to report to libghostty: solid only when this surface is the first responder

--- a/agtermUITests/ControlSidebarStatusUITests.swift
+++ b/agtermUITests/ControlSidebarStatusUITests.swift
@@ -509,7 +509,10 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
 
         // re-key the seeded session's window (the cmd-tab / reactivating-click equivalent). No session
         // switch happens, so a passing clear here can only come from the didBecomeKey → onFocusChange path.
+        // window.select can return before the window is actually key under XCUITest, so wait for it to report
+        // active before asserting the didBecomeKey-driven clear.
         XCTAssertEqual(try sendCommand(#"{"cmd":"window.select","target":"\#(firstWindow)"}"#)["ok"] as? Bool, true)
+        XCTAssertTrue(pollWindowActive(firstWindow, timeout: 12), "window 1 should become key again after window.select")
         XCTAssertTrue(app.staticTexts["notify-badge"].waitForNonExistence(timeout: 12),
                       "refocusing the window should clear the on-screen session's badge without a session switch")
     }
@@ -517,41 +520,55 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
     // the refocus clear is gated on liveFocus, so it clears ONLY the focused pane's session — never other
     // badged sessions in the same window. This is the inverse of testRefocusingWindowClearsOnScreenSessionBadge:
     // a regression that dropped the liveFocus guard (clearing every session's badge on didBecomeKey) would
-    // still pass the positive test but fail this one. Two sessions in one window (the second focused); after
-    // refocus only the focused session's badge clears while the non-focused one survives.
-    // A focused session in a KEY window can't hold an unseen badge (it's being seen), so the two badges are
-    // established at different times: the non-focused one while window 1 is key, the focused one only after
-    // window 1 loses key (so it isn't the key window's first responder — the same reason the positive test's
-    // badge survives until refocus).
+    // still pass the positive test but fail this one. The seeded session holds focus while a SECOND session
+    // carries the badge; refocus lands on the seeded (focused) session, so the second session's pill must
+    // survive. The badged session is deliberately the non-focused one so its badge is tree-verifiable both
+    // before and after the refocus (a focused session in a key window can't hold an unseen badge).
     func testRefocusingWindowKeepsNonFocusedSessionBadge() throws {
         let seeded = try activeSessionID()
         let firstWindow = try XCTUnwrap(
             ((try sendCommand(#"{"cmd":"window.list"}"#)["result"] as? [String: Any])?["windows"] as? [[String: Any]])?
                 .first?["id"] as? String, "should have the seeded window id")
 
-        // a second session in the SAME window takes focus; the seeded one becomes the non-focused survivor.
+        // add a second session, then re-select the seeded one so IT holds focus and the second is the
+        // non-focused session whose badge the refocus must leave alone.
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
-        let focused = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "session.new returns the new id")
+        let other = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "session.new returns the new id")
         XCTAssertTrue(pollSessionCount(2, timeout: 10), "the second session should land")
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.select","target":"\#(seeded)"}"#)["ok"] as? Bool, true)
 
-        // badge the NON-focused seeded session while window 1 is key — an unfocused session isn't "seen", so
-        // its badge persists (verified via the frontmost tree while window 1 is still frontmost).
-        XCTAssertEqual(try sendCommand(#"{"cmd":"notify","target":"\#(seeded)","args":{"body":"a"}}"#)["ok"] as? Bool, true)
-        XCTAssertTrue(pollUnseen(seeded, equals: 1, timeout: 12), "the non-focused session should carry a badge before the refocus")
+        // badge the NON-focused second session and confirm the badge landed — an unfocused session isn't
+        // "seen", so its badge persists and is readable via the frontmost tree while window 1 is frontmost.
+        XCTAssertEqual(try sendCommand(#"{"cmd":"notify","target":"\#(other)","args":{"body":"hi"}}"#)["ok"] as? Bool, true)
+        XCTAssertTrue(pollUnseen(other, equals: 1, timeout: 12), "the non-focused session should carry a badge before the refocus")
 
-        // a second window materializes and takes key, so window 1 is no longer key. Now badge the FOCUSED
-        // session too: with window 1 un-keyed its focused pane isn't the key window's first responder, so
-        // this badge also persists until the refocus.
+        // a second window materializes and takes key, so window 1 is no longer key.
         XCTAssertEqual(try sendCommand(#"{"cmd":"window.new"}"#)["ok"] as? Bool, true)
         let appeared = Date().addingTimeInterval(10)
         while Date() < appeared, app.windows.count < 2 { usleep(200_000) }
         XCTAssertGreaterThanOrEqual(app.windows.count, 2, "the second window should materialize and take key")
-        XCTAssertEqual(try sendCommand(#"{"cmd":"notify","target":"\#(focused)","args":{"body":"b"}}"#)["ok"] as? Bool, true)
 
-        // re-key window 1: the refocus clears ONLY the focused pane's session; the non-focused one survives.
+        // re-key window 1 (the cmd-tab refocus). Focus lands on the SEEDED session, never the badged one, so
+        // the non-focused session's pill must survive. Wait for the window to actually become key first.
         XCTAssertEqual(try sendCommand(#"{"cmd":"window.select","target":"\#(firstWindow)"}"#)["ok"] as? Bool, true)
-        XCTAssertTrue(pollUnseen(focused, equals: nil, timeout: 12), "the focused session's badge should clear on refocus")
-        XCTAssertEqual(unseenCount(forSession: seeded), 1, "a non-focused session's badge must survive the refocus")
+        XCTAssertTrue(pollWindowActive(firstWindow, timeout: 12), "window 1 should become key again after window.select")
+        XCTAssertEqual(unseenCount(forSession: other), 1, "a non-focused session's badge must survive the refocus")
+    }
+
+    // polls window.list until the window with `id` reports active (frontmost/key), or times out. Under
+    // XCUITest a window.select response can arrive before the window is actually key, so tests wait on this
+    // before asserting a didBecomeKey-driven effect. Returns true on match, false on timeout.
+    private func pollWindowActive(_ id: String, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let result = (try? sendCommand(#"{"cmd":"window.list"}"#))?["result"] as? [String: Any],
+               let windows = result["windows"] as? [[String: Any]],
+               windows.contains(where: { ($0["id"] as? String)?.lowercased() == id.lowercased() && $0["active"] as? Bool == true }) {
+                return true
+            }
+            usleep(200_000)
+        }
+        return false
     }
 
     // polls the frontmost window's tree until the given session's unseen count equals `expected` (nil = the

--- a/agtermUITests/ControlSidebarStatusUITests.swift
+++ b/agtermUITests/ControlSidebarStatusUITests.swift
@@ -477,6 +477,43 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
                       "should report no such session, got: \(bad)")
     }
 
+    // returning agterm to the foreground on a session that's on screen clears that session's badge — the
+    // same "you've seen it" clear a focus transition does. Reproduced across two windows because re-keying
+    // a window fires the SAME NSWindow.didBecomeKey path as app reactivation, without the flaky
+    // background-the-app dance: open a second window so the seeded session's window loses key, notify the
+    // seeded session so its badge shows, then re-select its window. window.select does NOT re-select the
+    // session, so only the didBecomeKey → onFocusChange clear can drop the badge — a genuine regression
+    // for #155 (the badge used to stay stuck until you switched sessions and back).
+    func testRefocusingWindowClearsOnScreenSessionBadge() throws {
+        let seeded = try activeSessionID()
+
+        // capture the seeded window's id before opening a second one — window.select needs it to re-key
+        // the ORIGINAL window (--target defaults to the active window, which becomes the new one).
+        let windows = try XCTUnwrap(
+            (try sendCommand(#"{"cmd":"window.list"}"#)["result"] as? [String: Any])?["windows"] as? [[String: Any]],
+            "window.list should carry windows")
+        let firstWindow = try XCTUnwrap(windows.first?["id"] as? String, "should have the seeded window id")
+
+        // a second window materializes and takes key, so the seeded session's window is no longer key (its
+        // focused pane keeps first responder per-window, but the window isn't key — the bug's precondition).
+        XCTAssertEqual(try sendCommand(#"{"cmd":"window.new"}"#)["ok"] as? Bool, true)
+        let appeared = Date().addingTimeInterval(10)
+        while Date() < appeared, app.windows.count < 2 { usleep(200_000) }
+        XCTAssertGreaterThanOrEqual(app.windows.count, 2, "the second window should materialize and take key")
+
+        // notify (no focus-suppression) bumps the seeded session's badge while its window is unkeyed.
+        let notified = try sendCommand(#"{"cmd":"notify","target":"\#(seeded)","args":{"body":"hi"}}"#)
+        XCTAssertEqual(notified["ok"] as? Bool, true, "notify should succeed: \(notified)")
+        XCTAssertTrue(app.staticTexts["notify-badge"].waitForExistence(timeout: 12),
+                      "the badge should appear on the seeded session's row")
+
+        // re-key the seeded session's window (the cmd-tab / reactivating-click equivalent). No session
+        // switch happens, so a passing clear here can only come from the didBecomeKey → onFocusChange path.
+        XCTAssertEqual(try sendCommand(#"{"cmd":"window.select","target":"\#(firstWindow)"}"#)["ok"] as? Bool, true)
+        XCTAssertTrue(app.staticTexts["notify-badge"].waitForNonExistence(timeout: 12),
+                      "refocusing the window should clear the on-screen session's badge without a session switch")
+    }
+
     // the unseen badge count reported for a session in the current tree, or nil when omitted (zero).
     private func unseenCount(forSession id: String) -> Int? {
         guard let result = (try? sendCommand(#"{"cmd":"tree"}"#))?["result"] as? [String: Any],

--- a/agtermUITests/ControlSidebarStatusUITests.swift
+++ b/agtermUITests/ControlSidebarStatusUITests.swift
@@ -514,6 +514,57 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
                       "refocusing the window should clear the on-screen session's badge without a session switch")
     }
 
+    // the refocus clear is gated on liveFocus, so it clears ONLY the focused pane's session — never other
+    // badged sessions in the same window. This is the inverse of testRefocusingWindowClearsOnScreenSessionBadge:
+    // a regression that dropped the liveFocus guard (clearing every session's badge on didBecomeKey) would
+    // still pass the positive test but fail this one. Two sessions in one window (the second focused); after
+    // refocus only the focused session's badge clears while the non-focused one survives.
+    // A focused session in a KEY window can't hold an unseen badge (it's being seen), so the two badges are
+    // established at different times: the non-focused one while window 1 is key, the focused one only after
+    // window 1 loses key (so it isn't the key window's first responder — the same reason the positive test's
+    // badge survives until refocus).
+    func testRefocusingWindowKeepsNonFocusedSessionBadge() throws {
+        let seeded = try activeSessionID()
+        let firstWindow = try XCTUnwrap(
+            ((try sendCommand(#"{"cmd":"window.list"}"#)["result"] as? [String: Any])?["windows"] as? [[String: Any]])?
+                .first?["id"] as? String, "should have the seeded window id")
+
+        // a second session in the SAME window takes focus; the seeded one becomes the non-focused survivor.
+        let created = try sendCommand(#"{"cmd":"session.new"}"#)
+        let focused = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "session.new returns the new id")
+        XCTAssertTrue(pollSessionCount(2, timeout: 10), "the second session should land")
+
+        // badge the NON-focused seeded session while window 1 is key — an unfocused session isn't "seen", so
+        // its badge persists (verified via the frontmost tree while window 1 is still frontmost).
+        XCTAssertEqual(try sendCommand(#"{"cmd":"notify","target":"\#(seeded)","args":{"body":"a"}}"#)["ok"] as? Bool, true)
+        XCTAssertTrue(pollUnseen(seeded, equals: 1, timeout: 12), "the non-focused session should carry a badge before the refocus")
+
+        // a second window materializes and takes key, so window 1 is no longer key. Now badge the FOCUSED
+        // session too: with window 1 un-keyed its focused pane isn't the key window's first responder, so
+        // this badge also persists until the refocus.
+        XCTAssertEqual(try sendCommand(#"{"cmd":"window.new"}"#)["ok"] as? Bool, true)
+        let appeared = Date().addingTimeInterval(10)
+        while Date() < appeared, app.windows.count < 2 { usleep(200_000) }
+        XCTAssertGreaterThanOrEqual(app.windows.count, 2, "the second window should materialize and take key")
+        XCTAssertEqual(try sendCommand(#"{"cmd":"notify","target":"\#(focused)","args":{"body":"b"}}"#)["ok"] as? Bool, true)
+
+        // re-key window 1: the refocus clears ONLY the focused pane's session; the non-focused one survives.
+        XCTAssertEqual(try sendCommand(#"{"cmd":"window.select","target":"\#(firstWindow)"}"#)["ok"] as? Bool, true)
+        XCTAssertTrue(pollUnseen(focused, equals: nil, timeout: 12), "the focused session's badge should clear on refocus")
+        XCTAssertEqual(unseenCount(forSession: seeded), 1, "a non-focused session's badge must survive the refocus")
+    }
+
+    // polls the frontmost window's tree until the given session's unseen count equals `expected` (nil = the
+    // badge is cleared / omitted), returning true on match or false on timeout.
+    private func pollUnseen(_ id: String, equals expected: Int?, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if unseenCount(forSession: id) == expected { return true }
+            usleep(200_000)
+        }
+        return unseenCount(forSession: id) == expected
+    }
+
     // the unseen badge count reported for a session in the current tree, or nil when omitted (zero).
     private func unseenCount(forSession id: String) -> Int? {
         guard let result = (try? sendCommand(#"{"cmd":"tree"}"#))?["result"] as? [String: Any],


### PR DESCRIPTION
the unseen-count badge only cleared on a first-responder transition (`onFocusChange(true)`) or a session select. AppKit's per-window first responder doesn't resign when the app is merely backgrounded, so returning focus to agterm without switching sessions left the badge stuck until you switched away and back.

extends the surface's existing `didBecomeKey` observer (already re-solidifying the cursor on refocus) to re-run the same "seen" clear on the become-key edge via `clearUnseenOnRefocus()`, gated on `liveFocus` so it fires only for the focused pane of the now-key window. It's the inverse of notification suppression: the badge clears under the same "you're now looking at it" condition that would have dropped the banner. A background session's pill is untouched.

two XCUITests, both driven over the control socket (re-keying a window fires the same `NSWindow.didBecomeKey` path as app reactivation, without the flaky background-the-app dance):

- `testRefocusingWindowClearsOnScreenSessionBadge` - the focused session's badge clears on refocus. Verified it fails without the fix.
- `testRefocusingWindowKeepsNonFocusedSessionBadge` - a non-focused session's badge survives refocus, guarding the `liveFocus` "only the focused pane clears" invariant. Verified it fails when the guard is removed while the positive test still passes.

Fix #155
