### PR TITLE
feat: expose an open overlay's size on the tree read side

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -59,6 +59,20 @@ paths:
   NOT add fresh validation/response logic inline in the `ControlServer` switch.
   (This is the control-channel case of the root `CLAUDE.md` "hoist host-free logic down into `agtermCore`"
   module-boundary rule.)
+- **The four-point audit is the WRITE path; a state-mutating command also owes a READ-BACK field.**
+  Whenever a command SETS or MUTATES per-session state, surface that state on `ControlSessionNode` (or
+  the tree top-level) so a script can query the value it just wrote: record-then-restore, read-modify-write,
+  and idempotency all depend on reading back what a `set`/`resize`/`toggle` changed.
+  The read field is populated in `AppStore.controlTree` and, like the other optionals, omitted from the
+  JSON when nil.
+  Existing pairs to mirror: `session.background`/`background`, `notify`+`session.seen`/`unseen`,
+  `session.status`/`status`+`statusPane`, `session.flag`/`flagged`, `sidebar`/`sidebarVisible` (top-level),
+  `session.overlay.resize`/`overlaySizePercent`.
+  This is a SEPARATE obligation from the four-point audit (Command + arg + CLI + tests) and easy to forget:
+  `session.overlay.resize` shipped write-only and `overlaySizePercent` was added only later, when a
+  tmux-zoom script needed to restore an overlay's exact size.
+  When adding a state-mutating command, add its read-back field in the SAME change and cover it with a
+  `treeSessionNodeRoundTrips…`/`…OmitsWhenNil` round-trip test plus a `controlTree` populate test.
 - **Bundling + install.**
   The `agterm` target's `Bundle agtermctl CLI` postBuildScript (`project.yml`) runs `swift build -c release --product agtermctl`,
   copies it to `agterm.app/Contents/MacOS/agtermctl`, ad-hoc signs the helper,

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -544,6 +544,10 @@ paths:
   `agtermctlKit`, (4) round-trip in `ControlProtocolTests` + dispatcher routing/validation in `ControlDispatcherTests`
   + `AppStorePaneTests` (resize clamp/switch/no-overlay) + CLI mapping in `CommandsTests` + the e2e
   `testOverlayResizeSwitchesFloatingAndFull` in `ControlOverlaySplitUITests`.
+  The READ side is `ControlSessionNode.overlaySizePercent` on each `tree` node (see the `tree` read-side
+  fields below) — populated in `AppStore.controlTree`, round-tripped by `treeSessionNodeRoundTripsWithOverlaySizePercent`/`…OmitsOverlaySizePercentWhenNil`
+  and `AppStorePaneTests.controlTreeReportsOverlaySizePercent`, and mirrored in the agent-skill `reference.md`
+  tree schema — so a script can record an overlay's size before zooming to `--full` and restore it exactly.
   Mode-bearing commands (`session.split`/`quick`) compute the delta against current state so `on`/`off`/`show`/`hide`
   are idempotent, and an unknown mode is an error.
   `session.status` flags a per-session agent status on the sidebar row — `args.status` is `idle`|`active`|`completed`|`blocked`
@@ -774,6 +778,12 @@ paths:
   is each pane running".
   It ALSO surfaces `background` on each node — the `BackgroundWatermark` spec set via `session.background`
   (omitted when none), the read side of set/clear so a script can query the current watermark.
+  It ALSO surfaces `overlaySizePercent` on each node — an OPEN overlay's size (`session.overlayActive ? session.overlaySizePercent : nil`
+  in the tree builder): nil/omitted = the full-pane overlay OR no overlay (so gate on `overlay` first),
+  else the floating panel's percent (1...100).
+  It is the READ side of `session.overlay.resize` (which had only the write side), so a tmux-style zoom
+  script can record the current size before switching to `--full` and restore the EXACT original on un-zoom
+  (not a guessed default).
   `tree` ALSO carries, at the TOP level (alongside `idleMs`/`autoFollowMs`), `sidebarVisible` — the read
   side of the write-only `sidebar` command (per-window sidebar visibility), populated LIVE from the
   projected window's store in `AppStore.controlTree`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,6 +292,19 @@ always in context:
   (The Working-norms bullet above generalizes this to control-native features with no GUI surface.) Genuinely
   meaningless exposure (pure visual chrome with nothing to drive — quit-confirm,
   CLI/skill installers, click-routing `reveal`) is the only exemption, and must be called out as such.
+- **A command that WRITES or sets session state owes a matching READ-BACK on the `tree` node.**
+  The four-point audit above covers only the WRITE path.
+  A command that mutates or sets per-session state must ALSO surface that state on `ControlSessionNode`
+  (or the tree top-level), so a script can query what it just changed: record-then-restore,
+  read-modify-write, and idempotency checks all need the read leg.
+  Every state-mutating command pairs with a read field:
+  `session.background`/`background`, `notify`+`session.seen`/`unseen`,
+  `session.status`/`status`+`statusPane`, `session.flag`/`flagged`, `sidebar`/`sidebarVisible`,
+  `session.overlay.resize`/`overlaySizePercent`.
+  When adding a state-mutating command, ask "how does a script read back what I just set?" and add that
+  field in the SAME change.
+  `session.overlay.resize` shipped write-only and the `overlaySizePercent` read-back was missed until a
+  tmux-zoom script needed record-then-restore, so it went in as a separate follow-up.
 - **The bundled agent skill is the fourth keep-in-sync surface.**
   Whenever you change the Control API (commands/args/returns), the keymap format,
   or the window/workspace/session/pane model, update `agterm/Resources/agent-skill/` (SKILL.md + reference.md

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -120,8 +120,10 @@ via `session status`: `active`|`completed`|`blocked`, omitted when idle), `statu
 that status: `left` (main) | `right` (split) | `scratch`, from `session status --pane`, omitted when
 unset or idle), `background` (the background
 spec — image/text watermark or solid color — set via `session background`, omitted when none — the read side of set/clear),
-and `unseen` (the unseen-notification badge count — raised by `notify`/OSC 9/777, cleared by `session
-seen` — omitted when zero).
+`unseen` (the unseen-notification badge count — raised by `notify`/OSC 9/777, cleared by `session
+seen` — omitted when zero), and `overlaySizePercent` (an open overlay's floating-panel percent 1–100,
+omitted for a full-pane overlay or no overlay so gate on `overlay` first; the read side of `overlay
+resize` for a record-then-restore zoom).
 
 **workspace** — `new [name]` · `rename <name>` · `delete` · `select` · `move --to up|down|top|bottom` ·
 `focus [on|off|toggle]` (collapse the sidebar tree to a single workspace).

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -39,7 +39,10 @@ Full detail for every `agtermctl` command. See `SKILL.md` for the model and addr
 `agtermctl tree [--json] [--window W]` — the workspace/session tree. Each session node:
 `id`, `name`, `cwd`, `title` (the raw OSC terminal title — e.g. a remote host over SSH — omitted
 when none reported; distinct from `name`, the derived sidebar label), `active` (selected),
-`split` (split shown), `overlay` (overlay shown), `scratch` (scratch shown), `flagged` (in the
+`split` (split shown), `overlay` (overlay shown), `overlaySizePercent` (an open overlay's size — the
+floating panel's percent of the pane, 1–100; omitted = a full-pane overlay or no overlay, so gate on
+`overlay` first; the read side of `session overlay resize`, e.g. record it before switching to `--full`
+to restore the exact size), `scratch` (scratch shown), `flagged` (in the
 flagged working-set), `status` (the agent-status — `active`|`completed`|`blocked` — omitted when
 idle), `statusPane` (which pane set that status — `left` (main) | `right` (split) | `scratch` — the
 `--pane` value from `session status`, omitted when unset or idle; gated on the same non-idle condition

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -173,6 +173,7 @@ public final class AppStore {
                                           cwd: session.effectiveCwd, title: session.oscTitle,
                                           active: session.id == activeID,
                                           split: session.isSplit, overlay: session.overlayActive,
+                                          overlaySizePercent: session.overlayActive ? session.overlaySizePercent : nil,
                                           scratch: session.scratchActive, flagged: session.flagged,
                                           foreground: foreground(session),
                                           splitForeground: splitForeground(session), status: status,

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -256,6 +256,10 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
     public let active: Bool
     public let split: Bool
     public let overlay: Bool
+    /// For an OPEN overlay (`overlay == true`), its size: nil/omitted = the FULL-pane overlay, else the
+    /// floating panel's percent of the pane (1...100). Absent when no overlay is open. The read side of
+    /// `session.overlay.resize` — record the current size before resizing so a script can restore it exactly.
+    public let overlaySizePercent: Int?
     public let scratch: Bool
     public let flagged: Bool
     /// The LIVE foreground process command (full argv) in the main pane, or nil when the pane is at its
@@ -279,7 +283,7 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
     public let unseen: Int?
 
     public init(id: String, name: String, cwd: String, title: String? = nil, active: Bool, split: Bool,
-                overlay: Bool = false, scratch: Bool = false, flagged: Bool = false,
+                overlay: Bool = false, overlaySizePercent: Int? = nil, scratch: Bool = false, flagged: Bool = false,
                 foreground: [String]? = nil, splitForeground: [String]? = nil, status: String? = nil,
                 statusPane: String? = nil, background: BackgroundWatermark? = nil, unseen: Int? = nil) {
         self.id = id
@@ -289,6 +293,7 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
         self.active = active
         self.split = split
         self.overlay = overlay
+        self.overlaySizePercent = overlaySizePercent
         self.scratch = scratch
         self.flagged = flagged
         self.foreground = foreground

--- a/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
@@ -319,6 +319,26 @@ struct AppStorePaneTests {
         #expect(session.overlayActive)
     }
 
+    @Test func controlTreeReportsOverlaySizePercent() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        // no overlay: the field is omitted (nil).
+        var node = try #require(store.controlTree().workspaces[0].sessions.first)
+        #expect(node.overlay == false)
+        #expect(node.overlaySizePercent == nil)
+        // floating overlay: the percent rides the node so a script can record it before zooming.
+        store.openOverlay(session.id, command: "htop", sizePercent: 95)
+        node = try #require(store.controlTree().workspaces[0].sessions.first)
+        #expect(node.overlay == true)
+        #expect(node.overlaySizePercent == 95)
+        // full-pane overlay: open but no size (nil = full).
+        store.resizeOverlay(session.id, sizePercent: nil)
+        node = try #require(store.controlTree().workspaces[0].sessions.first)
+        #expect(node.overlay == true)
+        #expect(node.overlaySizePercent == nil)
+    }
+
     @Test func closeOverlayTearsDownAndClears() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -444,6 +444,28 @@ struct ControlProtocolTests {
         #expect(decoded.unseen == nil)
     }
 
+    @Test func treeSessionNodeRoundTripsWithOverlaySizePercent() throws {
+        // the read side of session.overlay.resize: a floating overlay's percent rides the tree node so a
+        // script can record it before resizing to full and restore the exact size afterwards.
+        let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false,
+                                         overlay: true, overlaySizePercent: 95)
+        let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(
+            workspaces: [ControlWorkspaceNode(id: "w1", name: "work", active: true, sessions: [session])])))
+        let decoded = try roundTrip(response)
+        #expect(decoded == response)
+        #expect(decoded.result?.tree?.workspaces.first?.sessions.first?.overlaySizePercent == 95)
+    }
+
+    @Test func treeSessionNodeOmitsOverlaySizePercentWhenNil() throws {
+        // no overlay, or a FULL-pane overlay — the key must be omitted, not emitted as null (so a script
+        // reads absent as "full or no overlay", gating on the `overlay` bool first).
+        let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false, overlay: true)
+        let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
+        #expect(!json.contains("overlaySizePercent"), "a nil overlay size must be omitted from the JSON; got \(json)")
+        let decoded = try JSONDecoder().decode(ControlSessionNode.self, from: Data(json.utf8))
+        #expect(decoded.overlaySizePercent == nil)
+    }
+
     @Test func treeRoundTripsWithLiveWindowFields() throws {
         // the tree carries the live idle metric + the auto-follow config (both ms) + sidebar visibility.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false)


### PR DESCRIPTION
The `session.overlay.resize` control command could switch an open overlay between full-pane and floating, but nothing reported an overlay's current size. A tmux-style zoom script (leader-v, which hides the sidebar and collapses the split) had no way to zoom a floating overlay and restore its exact original size after switching to `--full`, it could only guess a fixed percent.

This adds the read side: `overlaySizePercent` on each `tree` session node, populated in `AppStore.controlTree` as `session.overlayActive ? session.overlaySizePercent : nil`. A script gates on `overlay` (is one open?) then reads `overlaySizePercent`: absent for a full-pane overlay or no overlay, else the floating panel's percent (1-100). Record it, resize `--full`, restore the exact size on un-zoom.

No new command, so the count stays 53. Keep-in-sync surfaces updated: the agent-skill `reference.md` and `SKILL.md` tree schema, and `.claude/rules/control-api.md`.

*Tests*: host-free round-trip (present and omitted-when-nil) in `ControlProtocolTests`, plus a `controlTree` populate test in `AppStorePaneTests` covering no-overlay, floating, and full. `swift test` green, `swiftlint --strict` clean.
