### PR TITLE
feat: add read-back for the focused split pane, status blink/color, and quick-terminal visibility

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -66,8 +66,12 @@ paths:
   The read field is populated in `AppStore.controlTree` and, like the other optionals, omitted from the
   JSON when nil.
   Existing pairs to mirror: `session.background`/`background`, `notify`+`session.seen`/`unseen`,
-  `session.status`/`status`+`statusPane`, `session.flag`/`flagged`, `sidebar`/`sidebarVisible` (top-level),
-  `session.overlay.resize`/`overlaySizePercent`.
+  `session.status`/`status`+`statusPane` (+`statusBlink`/`statusColor` for `--blink`/`--color`),
+  `session.flag`/`flagged`, `session.focus`/`splitFocused`, `session.resize`/`splitRatio`,
+  `session.overlay.resize`/`overlaySizePercent`, `sidebar`/`sidebarVisible` (top-level),
+  `sidebar.mode`/`sidebarMode`, `workspace.focus`/`focused` (workspace node), `quick`/`quickVisible` (top-level),
+  `window.move`+`window.resize`/`geometry`, `window.fullscreen`+`window.zoom`/`fullscreen`+`zoomed`
+  (the last three on `window.list`).
   This is a SEPARATE obligation from the four-point audit (Command + arg + CLI + tests) and easy to forget:
   `session.overlay.resize` shipped write-only and `overlaySizePercent` was added only later, when a
   tmux-zoom script needed to restore an overlay's exact size.

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -269,6 +269,8 @@ paths:
   shown side-by-side or hidden — when hidden, focusing a pane swaps which one shows maximized),
   drives `AppActions.setSplitFocus(_:of:)`, and is the control half of the ⌘⌥←/→ keyboard nav + the "Focus
   Left/Right Pane" menu/palette items.
+  Its READ side is `ControlSessionNode.splitFocused` (`true`=split/right, `false`=main/left, nil=no split;
+  see the `tree` read-side fields below), so a script can record the focused pane and restore it.
   `session.resize` moves the split DIVIDER — it is control-NATIVE (the divider is otherwise mouse-drag
   only; NO GUI/menu/keymap action, so a key is bound by mapping a `command "agtermctl session resize …"`
   custom action).
@@ -811,6 +813,12 @@ paths:
   It is the READ side of `session.resize` (whose applied ratio was echoed ONLY on the resize call's own
   `ControlResult.ratio`), so a script can record the current ratio before maximizing a pane and restore the
   exact divider even if the USER dragged it.
+  It ALSO surfaces `splitFocused` on each node — which pane holds focus in a session that HAS a split
+  (`session.hasSplit ? session.splitFocused : nil` in the tree builder, so shown OR hidden splits report it):
+  `true` = the split (right) pane, `false` = the main (left) pane, nil/omitted when there is no split.
+  It is the READ side of `session.focus` (write-only), so a script can record which pane was focused and
+  restore it via `session.focus --pane left|right` (a `false` is emitted, distinct from the nil no-split
+  case — the left pane being focused is real state).
   `tree` ALSO carries, at the TOP level (alongside `idleMs`/`autoFollowMs`), `sidebarVisible` — the read
   side of the write-only `sidebar` command (per-window sidebar visibility), populated LIVE from the
   projected window's store in `AppStore.controlTree`.

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -631,6 +631,10 @@ paths:
   (see the Menu/actions rule).
   It reads back on each `tree` node as `ControlSessionNode.statusPane` (omitted when nil, gated on the SAME
   non-idle condition as `status` so an idle node reports neither).
+  The `--blink` flag and `--color` override read back the same way — `ControlSessionNode.statusBlink`
+  (`true` when blinking, omitted otherwise) and `statusColor` (the `#rrggbb`, omitted when using the default
+  color), both populated in the tree builder gated on the SAME non-idle condition — so a script can record
+  the FULL status (state + pane + blink + color) and restore it.
   Four-point keep-in-sync audit for `session.status --pane`: (1) the `StatusPane` enum + `AgentIndicator.statusPane`
   + `AgentIndicator.clearedBy(pane:isEscape:)` + `ControlSessionStatusUpdate.pane` + `ControlSessionNode.statusPane`
   + `SurfaceEnvironment.session(pane:)` (injects `AGTERM_PANE`) in `agtermCore`, plus the dispatcher `StatusPane`

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -566,6 +566,14 @@ paths:
   tree schema — so a script can record an overlay's size before zooming to `--full` and restore it exactly.
   Mode-bearing commands (`session.split`/`quick`) compute the delta against current state so `on`/`off`/`show`/`hide`
   are idempotent, and an unknown mode is an error.
+  `quick`'s visibility reads back on `ControlTree.quickVisible` at the tree TOP level — LIVE, resolved
+  app-side in `buildTree` from the projected window's `QuickTerminalController.isVisible` (the window id
+  found by store identity, `library.openIDs().first { library.store(for:) === store }`, since the quick
+  terminal is per-window); `tree`-only like `sidebarMode` (the GUI ⌃` toggle bypasses the command path, so
+  a cached `window.list` copy would go stale), so a script can make the `quick` toggle idempotent.
+  Threaded as a `quickVisible: () -> Bool?` closure on `AppStore.controlTree` (defaulting nil for host-free
+  tests), covered by `treeRoundTripsWithQuickVisible`/`treeOmitsQuickVisibleWhenNil` +
+  `AppStoreTests.controlTreeReportsQuickVisibleFromClosure`; the app-side `QuickTerminalRegistry` read is build-verified.
   `session.status` flags a per-session agent status on the sidebar row — `args.status` is `idle`|`active`|`completed`|`blocked`
   (`AgentStatus(rawValue:)` → an `invalid status` error on anything else),
   `args.blink` pulses the glyph, and `args.autoReset` (status-agnostic, caller-set,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,8 +299,11 @@ always in context:
   read-modify-write, and idempotency checks all need the read leg.
   Every state-mutating command pairs with a read field:
   `session.background`/`background`, `notify`+`session.seen`/`unseen`,
-  `session.status`/`status`+`statusPane`, `session.flag`/`flagged`, `sidebar`/`sidebarVisible`,
-  `session.overlay.resize`/`overlaySizePercent`.
+  `session.status`/`status`+`statusPane` (+`statusBlink`/`statusColor` for `--blink`/`--color`),
+  `session.flag`/`flagged`, `session.focus`/`splitFocused`, `session.resize`/`splitRatio`,
+  `session.overlay.resize`/`overlaySizePercent`, `sidebar`/`sidebarVisible`, `sidebar.mode`/`sidebarMode`,
+  `workspace.focus`/`focused`, `quick`/`quickVisible`,
+  `window.move`+`window.resize`/`geometry`, `window.fullscreen`+`window.zoom`/`fullscreen`+`zoomed`.
   When adding a state-mutating command, ask "how does a script read back what I just set?" and add that
   field in the SAME change.
   `session.overlay.resize` shipped write-only and the `overlaySizePercent` read-back was missed until a

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -396,7 +396,8 @@ final class ControlServer {
     func buildTree(in store: AppStore) -> ControlTree {
         let shellBasename = ProcessInfo.processInfo.environment["SHELL"].map(CommandRestore.basename)
         // the projected window owns its quick terminal; find its id by store identity to read the live
-        // QuickTerminalController.isVisible (nil controller = never opened = not visible).
+        // QuickTerminalController.isVisible (a nil controller — never opened, or the window is tearing
+        // down — reads as not visible).
         let windowID = library.openIDs().first { library.store(for: $0) === store }
         return store.controlTree(
             foreground: { session in

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -395,6 +395,9 @@ final class ControlServer {
     /// active workspace (the one owning the selected session).
     func buildTree(in store: AppStore) -> ControlTree {
         let shellBasename = ProcessInfo.processInfo.environment["SHELL"].map(CommandRestore.basename)
+        // the projected window owns its quick terminal; find its id by store identity to read the live
+        // QuickTerminalController.isVisible (nil controller = never opened = not visible).
+        let windowID = library.openIDs().first { library.store(for: $0) === store }
         return store.controlTree(
             foreground: { session in
                 (session.surface as? GhosttySurfaceView).flatMap {
@@ -405,7 +408,8 @@ final class ControlServer {
                 (session.splitSurface as? GhosttySurfaceView).flatMap {
                     ForegroundProcess.command(for: $0, shellBasename: shellBasename)
                 }
-            }
+            },
+            quickVisible: { windowID.flatMap { QuickTerminalRegistry.shared.controller(for: $0)?.isVisible } ?? false }
         )
     }
 

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -82,11 +82,12 @@ of the tree).
 Inspect the live tree any time with `agtermctl tree --json` (workspaces → sessions, each with
 `id`, `name`, `cwd`, `title`, `active`, `split`, `overlay`, `scratch`, `status`, `background`). `title` is the raw OSC
 terminal title (e.g. a remote host over SSH), omitted when none was reported — read it when a
-session's local `cwd` is stale because it's connected to a remote. The tree object also carries four
+session's local `cwd` is stale because it's connected to a remote. The tree object also carries five
 read-only top-level fields: `idleMs` (ms since the last user input in the window), `autoFollowMs`
 (the Auto-follow timeout in ms, omitted when Disabled), `sidebarVisible` (whether the window's
-sidebar is currently shown — the read side of the write-only `sidebar` command), and `sidebarMode`
-(`tree` or `flagged` — the read side of `sidebar mode`). List windows with
+sidebar is currently shown — the read side of the write-only `sidebar` command), `sidebarMode`
+(`tree` or `flagged` — the read side of `sidebar mode`), and `quickVisible` (whether the window's quick
+terminal is shown — the read side of the write-only `quick` command). List windows with
 `agtermctl window list --json`; each window also reports `autoFollowMs`, `sidebarVisible`, `geometry`
 (the live frame `{x, y, width, height, display}` in the units `window move`/`window resize` take — the
 read side, so record it then restore the exact frame), and `fullscreen`/`zoomed` (the read side of

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -127,10 +127,12 @@ spec — image/text watermark or solid color — set via `session background`, o
 `unseen` (the unseen-notification badge count — raised by `notify`/OSC 9/777, cleared by `session
 seen` — omitted when zero), `overlaySizePercent` (an open overlay's floating-panel percent 1–100,
 omitted for a full-pane overlay or no overlay so gate on `overlay` first; the read side of `overlay
-resize` for a record-then-restore zoom), and `splitRatio` (the left-pane divider fraction 0.05–0.95 of a
+resize` for a record-then-restore zoom), `splitRatio` (the left-pane divider fraction 0.05–0.95 of a
 session that has a split — shown or hidden; omitted when there's no split or the ratio was never set (at
 the default 0.5) —
-the read side of `session resize`, record it to restore the exact divider).
+the read side of `session resize`, record it to restore the exact divider), and `splitFocused`
+(which pane holds focus in a session that has a split — `true` = split/right, `false` = main/left; omitted
+when there's no split; the read side of `session focus`, record it to restore focus).
 
 **workspace** — `new [name]` · `rename <name>` · `delete` · `select` · `move --to up|down|top|bottom` ·
 `focus [on|off|toggle]` (collapse the sidebar tree to a single workspace; read back which workspace is

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -122,7 +122,8 @@ Run `agtermctl <area> <cmd> --help` for exact flags. Full detail in **reference.
 is at its shell prompt) — i.e. what each pane is currently running — `status` (the agent-status set
 via `session status`: `active`|`completed`|`blocked`, omitted when idle), `statusPane` (which pane set
 that status: `left` (main) | `right` (split) | `scratch`, from `session status --pane`, omitted when
-unset or idle), `background` (the background
+unset or idle), `statusBlink`/`statusColor` (the status glyph's `--blink` flag and `--color` `#rrggbb`
+override from `session status`, omitted when idle / not blinking / default color), `background` (the background
 spec — image/text watermark or solid color — set via `session background`, omitted when none — the read side of set/clear),
 `unseen` (the unseen-notification badge count — raised by `notify`/OSC 9/777, cleared by `session
 seen` — omitted when zero), `overlaySizePercent` (an open overlay's floating-panel percent 1–100,

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -42,7 +42,10 @@ when none reported; distinct from `name`, the derived sidebar label), `active` (
 `split` (split shown), `splitRatio` (the left-pane fraction 0.05–0.95 of a session that HAS a split —
 shown or hidden; omitted when there's no split or the ratio was never explicitly set (divider at the
 default 0.5) — the read side
-of `session resize`, record it to restore the exact divider position), `overlay` (overlay shown),
+of `session resize`, record it to restore the exact divider position),
+`splitFocused` (which pane holds focus in a session that HAS a split — `true` = the split/right pane,
+`false` = the main/left pane; omitted when there's no split; the read side of `session focus`, record it
+to restore focus via `session focus --pane left|right`), `overlay` (overlay shown),
 `overlaySizePercent` (an open overlay's size — the
 floating panel's percent of the pane, 1–100; omitted = a full-pane overlay or no overlay, so gate on
 `overlay` first; the read side of `session overlay resize`, e.g. record it before switching to `--full`

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -65,15 +65,17 @@ when zero). Workspace nodes carry `id`, `name`, `active`, `sessions`, and `focus
 tree is collapsed to this workspace — the read side of `workspace focus`, distinct from `active` the
 SELECTED workspace; omitted unless this is the focused one, and absent entirely when nothing is focused).
 
-The tree object itself carries four top-level read-only fields: `idleMs` (milliseconds since the last
+The tree object itself carries five top-level read-only fields: `idleMs` (milliseconds since the last
 user input in the window, omitted before any activity), `autoFollowMs` (the window's Auto-follow
 timeout in milliseconds, omitted when the setting is Disabled), `sidebarVisible` (whether the
 window's sidebar is currently shown — the read side of the write-only `sidebar` command, so a script
 can restore it, e.g. a tmux-style zoom that hides the sidebar and must re-show it only when it was
-visible before), and `sidebarMode` (`tree` or `flagged` — the sidebar view mode, the read side of
-`sidebar mode`). `idleMs` is live and grows while the window is idle, so it is on `tree` only, never
-`window.list`; `sidebarVisible` is on both; `sidebarMode` is `tree`-only (a GUI flagged-view toggle
-would leave a cached copy stale). All four are read-only projections of GUI state.
+visible before), `sidebarMode` (`tree` or `flagged` — the sidebar view mode, the read side of
+`sidebar mode`), and `quickVisible` (whether the window's quick terminal is currently shown — the read
+side of the write-only `quick` command, so a script can make the toggle idempotent). `idleMs` is live
+and grows while the window is idle, so it is on `tree` only, never `window.list`; `sidebarVisible` is on
+both; `sidebarMode` and `quickVisible` are `tree`-only (a GUI toggle would leave a cached copy stale).
+All five are read-only projections of GUI state.
 
 ## workspace
 

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -53,7 +53,10 @@ to restore the exact size), `scratch` (scratch shown), `flagged` (in the
 flagged working-set), `status` (the agent-status — `active`|`completed`|`blocked` — omitted when
 idle), `statusPane` (which pane set that status — `left` (main) | `right` (split) | `scratch` — the
 `--pane` value from `session status`, omitted when unset or idle; gated on the same non-idle condition
-as `status`, so it is never reported without a `status`), `foreground`/`splitForeground` (the live argv of each pane's foreground
+as `status`, so it is never reported without a `status`), `statusBlink` (`true` when the status glyph is
+set to blink — the `--blink` value; omitted when idle or not blinking) and `statusColor` (the `#rrggbb`
+glyph-tint override — the `--color` value; omitted when idle or using the default color),
+`foreground`/`splitForeground` (the live argv of each pane's foreground
 process — what it is running — omitted when the pane sits at its shell prompt), and `background` (the
 background spec set via `session background` — a `{kind, text?, imagePath?, colorHex?, opacity?, fit?,
 position?, repeats?}` object; `kind` is `image`/`text`/`color` — omitted when none is set), and `unseen`

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -161,7 +161,8 @@ public final class AppStore {
     /// Projects this store's workspace/session model into the control-channel `tree` payload. Foreground
     /// command lookup is supplied by the host because live process inspection is platform-specific.
     public func controlTree(foreground: (Session) -> [String]? = { _ in nil },
-                            splitForeground: (Session) -> [String]? = { _ in nil }) -> ControlTree {
+                            splitForeground: (Session) -> [String]? = { _ in nil },
+                            quickVisible: () -> Bool? = { nil }) -> ControlTree {
         let activeID = selectedSessionID
         let activeWorkspaceID = activeID.flatMap { workspace(forSession: $0)?.id }
         let nodes = workspaces.map { workspace in
@@ -192,7 +193,8 @@ public final class AppStore {
                                         sessions: sessions)
         }
         return ControlTree(workspaces: nodes, idleMs: idleMs(), autoFollowMs: autoFollowMs,
-                           sidebarVisible: sidebarVisible, sidebarMode: sidebarMode.rawValue)
+                           sidebarVisible: sidebarVisible, sidebarMode: sidebarMode.rawValue,
+                           quickVisible: quickVisible())
     }
 
     /// Creates a workspace and appends it. Clears any active focus so the new (empty)

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -181,6 +181,8 @@ public final class AppStore {
                                           foreground: foreground(session),
                                           splitForeground: splitForeground(session), status: status,
                                           statusPane: statusPane,
+                                          statusBlink: idle ? nil : (session.agentIndicator.blink ? true : nil),
+                                          statusColor: idle ? nil : session.agentIndicator.color,
                                           background: session.backgroundWatermark,
                                           unseen: session.unseenCount > 0 ? session.unseenCount : nil)
             }

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -174,6 +174,7 @@ public final class AppStore {
                                           active: session.id == activeID,
                                           split: session.isSplit,
                                           splitRatio: session.hasSplit ? session.splitRatio : nil,
+                                          splitFocused: session.hasSplit ? session.splitFocused : nil,
                                           overlay: session.overlayActive,
                                           overlaySizePercent: session.overlayActive ? session.overlaySizePercent : nil,
                                           scratch: session.scratchActive, flagged: session.flagged,

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -374,14 +374,21 @@ public struct ControlTree: Codable, Sendable, Equatable {
     /// mode and restore it. `tree`-only (not on `window.list`), since a GUI-only flagged-view toggle would
     /// leave a cached copy stale — read the live tree copy instead.
     public let sidebarMode: String?
+    /// Whether the projected window's quick terminal is currently visible. LIVE — resolved app-side per
+    /// request from the window's `QuickTerminalController` — so a script can make the `quick` toggle
+    /// idempotent (show only when hidden). The read side of the write-only `quick` command. `tree`-only
+    /// (not on `window.list`), since a GUI-only ⌃` toggle bypasses the command path and would leave a
+    /// cached copy stale — read the live tree copy instead. nil in a host-produced tree with no app closure.
+    public let quickVisible: Bool?
 
     public init(workspaces: [ControlWorkspaceNode], idleMs: Int? = nil, autoFollowMs: Int? = nil,
-                sidebarVisible: Bool? = nil, sidebarMode: String? = nil) {
+                sidebarVisible: Bool? = nil, sidebarMode: String? = nil, quickVisible: Bool? = nil) {
         self.workspaces = workspaces
         self.idleMs = idleMs
         self.autoFollowMs = autoFollowMs
         self.sidebarVisible = sidebarVisible
         self.sidebarMode = sidebarMode
+        self.quickVisible = quickVisible
     }
 }
 

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -285,6 +285,12 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
     /// Which pane set the session's agent status (`"left"|"right"|"scratch"`, `left`=main, `right`=split),
     /// or nil when idle or unspecified (omitted from the JSON). The read side of `session.status --pane`.
     public let statusPane: String?
+    /// Whether the session's agent status glyph is set to blink (pulse for attention), or nil when idle or
+    /// not blinking (omitted from the JSON). The read side of `session.status --blink`.
+    public let statusBlink: Bool?
+    /// The per-call `#rrggbb` glyph-tint override for the session's agent status, or nil when idle or using
+    /// the Settings-configured status color (omitted from the JSON). The read side of `session.status --color`.
+    public let statusColor: String?
     /// The session's background watermark spec, or nil when none is set (omitted from the JSON). The read
     /// side of `session.background` — set/clear/query symmetry, so a script can inspect the current watermark.
     public let background: BackgroundWatermark?
@@ -297,7 +303,8 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
                 splitRatio: Double? = nil, splitFocused: Bool? = nil,
                 overlay: Bool = false, overlaySizePercent: Int? = nil, scratch: Bool = false, flagged: Bool = false,
                 foreground: [String]? = nil, splitForeground: [String]? = nil, status: String? = nil,
-                statusPane: String? = nil, background: BackgroundWatermark? = nil, unseen: Int? = nil) {
+                statusPane: String? = nil, statusBlink: Bool? = nil, statusColor: String? = nil,
+                background: BackgroundWatermark? = nil, unseen: Int? = nil) {
         self.id = id
         self.name = name
         self.cwd = cwd
@@ -314,6 +321,8 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
         self.splitForeground = splitForeground
         self.status = status
         self.statusPane = statusPane
+        self.statusBlink = statusBlink
+        self.statusColor = statusColor
         self.background = background
         self.unseen = unseen
     }

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -261,6 +261,11 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
     /// — record it before maximizing a pane so a script can restore the exact divider position (the applied
     /// ratio is otherwise echoed only on the `session.resize` call itself).
     public let splitRatio: Double?
+    /// For a session that HAS a split pane (shown or hidden), which pane holds keyboard focus: `true` = the
+    /// split (right) pane, `false` = the main (left) pane; nil when the session has no split (omitted from
+    /// the JSON). The read side of `session.focus` — record which pane was focused so a script can restore
+    /// it via `session.focus --pane left|right`.
+    public let splitFocused: Bool?
     public let overlay: Bool
     /// For an OPEN overlay (`overlay == true`), its size: nil/omitted = the FULL-pane overlay, else the
     /// floating panel's percent of the pane (1...100). Absent when no overlay is open. The read side of
@@ -289,7 +294,7 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
     public let unseen: Int?
 
     public init(id: String, name: String, cwd: String, title: String? = nil, active: Bool, split: Bool,
-                splitRatio: Double? = nil,
+                splitRatio: Double? = nil, splitFocused: Bool? = nil,
                 overlay: Bool = false, overlaySizePercent: Int? = nil, scratch: Bool = false, flagged: Bool = false,
                 foreground: [String]? = nil, splitForeground: [String]? = nil, status: String? = nil,
                 statusPane: String? = nil, background: BackgroundWatermark? = nil, unseen: Int? = nil) {
@@ -300,6 +305,7 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
         self.active = active
         self.split = split
         self.splitRatio = splitRatio
+        self.splitFocused = splitFocused
         self.overlay = overlay
         self.overlaySizePercent = overlaySizePercent
         self.scratch = scratch

--- a/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
@@ -363,6 +363,28 @@ struct AppStorePaneTests {
         #expect(node.splitRatio == 0.3)
     }
 
+    @Test func controlTreeReportsSplitFocused() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        // no split: the field is omitted (nil).
+        var node = try #require(store.controlTree().workspaces[0].sessions.first)
+        #expect(node.splitFocused == nil)
+        // opening a split focuses the new (right) pane.
+        store.toggleSplit(session.id)
+        node = try #require(store.controlTree().workspaces[0].sessions.first)
+        #expect(node.splitFocused == true)
+        // focusing the main (left) pane surfaces false — distinct from nil (= no split).
+        session.splitFocused = false
+        node = try #require(store.controlTree().workspaces[0].sessions.first)
+        #expect(node.splitFocused == false)
+        // a hidden split keeps the focus readable (gated on hasSplit, not isSplit).
+        store.toggleSplit(session.id)
+        node = try #require(store.controlTree().workspaces[0].sessions.first)
+        #expect(node.split == false)
+        #expect(node.splitFocused == false)
+    }
+
     @Test func closeOverlayTearsDownAndClears() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
@@ -385,6 +385,28 @@ struct AppStorePaneTests {
         #expect(node.splitFocused == false)
     }
 
+    @Test func controlTreeReportsStatusModifiers() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        // idle: no status, so blink/color are omitted.
+        var node = try #require(store.controlTree().workspaces[0].sessions.first)
+        #expect(node.statusBlink == nil)
+        #expect(node.statusColor == nil)
+        // a blocked status with blink + a color override surfaces both modifiers.
+        store.setAgentIndicator(AgentIndicator(status: .blocked, blink: true, color: "#ff8800"), forSession: session.id)
+        node = try #require(store.controlTree().workspaces[0].sessions.first)
+        #expect(node.status == "blocked")
+        #expect(node.statusBlink == true)
+        #expect(node.statusColor == "#ff8800")
+        // a status without blink omits statusBlink (false -> nil); without a color override omits statusColor.
+        store.setAgentIndicator(AgentIndicator(status: .active), forSession: session.id)
+        node = try #require(store.controlTree().workspaces[0].sessions.first)
+        #expect(node.status == "active")
+        #expect(node.statusBlink == nil)
+        #expect(node.statusColor == nil)
+    }
+
     @Test func closeOverlayTearsDownAndClears() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -824,6 +824,15 @@ struct AppStoreTests {
         #expect(store.controlTree().sidebarMode == "tree")
     }
 
+    @Test func controlTreeReportsQuickVisibleFromClosure() {
+        let store = makeStore()
+        // no closure (host-free / default): omitted (nil).
+        #expect(store.controlTree().quickVisible == nil)
+        // the app supplies the live QuickTerminalController.isVisible via the closure.
+        #expect(store.controlTree(quickVisible: { true }).quickVisible == true)
+        #expect(store.controlTree(quickVisible: { false }).quickVisible == false)
+    }
+
     @Test func setSidebarVisiblePostsChangeNotificationOnlyOnChange() {
         // the app-target ControlServer observes this to refresh window.list's cached sidebarVisible; the
         // post must fire only on an actual change (queue nil so the synchronous post delivers inline).

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -650,6 +650,25 @@ struct ControlProtocolTests {
         #expect(decoded.result?.tree?.sidebarMode == "flagged")
     }
 
+    @Test func treeRoundTripsWithQuickVisible() throws {
+        // the read side of quick: the quick-terminal visibility rides the tree top level so a script can
+        // make the toggle idempotent.
+        let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(
+            workspaces: [], quickVisible: true)))
+        let decoded = try roundTrip(response)
+        #expect(decoded == response)
+        #expect(decoded.result?.tree?.quickVisible == true)
+    }
+
+    @Test func treeOmitsQuickVisibleWhenNil() throws {
+        // a host-produced tree with no app closure — the key must be omitted, not emitted as null.
+        let tree = ControlTree(workspaces: [])
+        let json = String(data: try JSONEncoder().encode(tree), encoding: .utf8) ?? ""
+        #expect(!json.contains("quickVisible"), "a nil quickVisible must be omitted from the JSON; got \(json)")
+        let decoded = try JSONDecoder().decode(ControlTree.self, from: Data(json.utf8))
+        #expect(decoded.quickVisible == nil)
+    }
+
     @Test func backgroundWatermarkFitPositionSerializeAsRawStrings() throws {
         // the Fit/Position enums must serialize to ghostty's exact key strings (identical to the former
         // String), so the wire + persisted JSON are unchanged by the enum migration.

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -486,6 +486,27 @@ struct ControlProtocolTests {
         #expect(decoded.splitRatio == nil)
     }
 
+    @Test func treeSessionNodeRoundTripsWithSplitFocused() throws {
+        // the read side of session.focus: which pane holds focus rides the tree node so a script can record
+        // it and restore focus afterwards. false = the main (left) pane, true = the split (right) pane.
+        let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: true, splitFocused: false)
+        let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(
+            workspaces: [ControlWorkspaceNode(id: "w1", name: "work", active: true, sessions: [session])])))
+        let decoded = try roundTrip(response)
+        #expect(decoded == response)
+        #expect(decoded.result?.tree?.workspaces.first?.sessions.first?.splitFocused == false)
+    }
+
+    @Test func treeSessionNodeOmitsSplitFocusedWhenNil() throws {
+        // no split — the key must be omitted, not emitted as null (a false value IS emitted, since it means
+        // the left pane is focused, distinct from "no split").
+        let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false)
+        let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
+        #expect(!json.contains("splitFocused"), "a nil split focus must be omitted from the JSON; got \(json)")
+        let decoded = try JSONDecoder().decode(ControlSessionNode.self, from: Data(json.utf8))
+        #expect(decoded.splitFocused == nil)
+    }
+
     @Test func treeRoundTripsWithLiveWindowFields() throws {
         // the tree carries the live idle metric + the auto-follow config (both ms) + sidebar visibility.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false)

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -399,6 +399,30 @@ struct ControlProtocolTests {
         #expect(decoded.statusPane == nil)
     }
 
+    @Test func treeSessionNodeRoundTripsWithStatusBlinkAndColor() throws {
+        // the read side of session.status --blink/--color: the status modifiers ride the tree node.
+        let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false,
+                                         status: "blocked", statusBlink: true, statusColor: "#ff8800")
+        let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(
+            workspaces: [ControlWorkspaceNode(id: "w1", name: "work", active: true, sessions: [session])])))
+        let decoded = try roundTrip(response)
+        #expect(decoded == response)
+        let node = decoded.result?.tree?.workspaces.first?.sessions.first
+        #expect(node?.statusBlink == true)
+        #expect(node?.statusColor == "#ff8800")
+    }
+
+    @Test func treeSessionNodeOmitsStatusBlinkAndColorWhenNil() throws {
+        // an idle / non-blinking / default-color status — both keys must be omitted, not emitted as null.
+        let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false, status: "blocked")
+        let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
+        #expect(!json.contains("statusBlink"), "a nil statusBlink must be omitted; got \(json)")
+        #expect(!json.contains("statusColor"), "a nil statusColor must be omitted; got \(json)")
+        let decoded = try JSONDecoder().decode(ControlSessionNode.self, from: Data(json.utf8))
+        #expect(decoded.statusBlink == nil)
+        #expect(decoded.statusColor == nil)
+    }
+
     @Test func treeSessionNodeRoundTripsWithBackground() throws {
         // the read side of session.background: the watermark spec rides the tree node so a script can query it.
         let watermark = BackgroundWatermark(kind: .text, text: "PROD", colorHex: "#ff0000",


### PR DESCRIPTION
Completes the control-surface read-back audit (after #167 and #168) by adding the LOW-tier read-backs for three write-only commands, so a script can record-then-restore the state each one sets:

- `session.focus` -> `splitFocused` (tree session node): which split pane holds keyboard focus (`true` = split/right, `false` = main/left, omitted when no split).
- `session.status --blink`/`--color` -> `statusBlink`/`statusColor` (tree session node): the status-glyph modifiers, gated on the same non-idle condition as `status`/`statusPane`.
- `quick` -> `quickVisible` (tree top-level): the projected window's quick-terminal visibility, so a script can make the toggle idempotent.

`splitFocused` and the status modifiers are pure host-free reads in `AppStore.controlTree`. `quickVisible` is resolved live app-side (from the projected window's `QuickTerminalController.isVisible`, the window id found by store identity) and kept `tree`-only, so it dodges the `window.list` cache-staleness the window fields in #168 needed. All are JSON-only fields, omitted when nil; no new command, so the count stays 53.

`fontSize` (`font.*`) was deliberately left out: `font.*` is relative (`inc`/`dec`/`reset`) with no absolute set, so a `fontSize` read-back can't drive a precise restore without also adding a `font.set` write command.

Ran the review-fix loop (codex + qa-expert + implementation-reviewer + documentation) before opening: clean, 0 critical/major. The final commit is that loop's cleanup pass (extends the read-back registry doc that had gone stale, rewords a comment).

Keep-in-sync surfaces updated: agent-skill `reference.md` + `SKILL.md`, `.claude/rules/control-api.md`, and the read-back registry in `CLAUDE.md`.

*Tests*: host-free round-trips (present + omitted-when-nil) and `controlTree` populate transitions for all three; the app-side `quickVisible` resolution is build-verified, consistent with the geometry/fullscreen reads. `swift test` green (1239), `swiftlint --strict` clean, Release build clean.
