### PR TITLE
feat: reopen recently closed items

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ The bindable built-in action names are:
 new_window         rename_window      delete_window
 new_workspace      rename_workspace   delete_workspace
 new_session        open_directory     rename_session
-close_session      clear_status
+close_session      reopen_recent      undo_close         clear_status
 increase_font_size decrease_font_size reset_font_size
 toggle_split       toggle_scratch     toggle_search
 toggle_sidebar     toggle_flag        toggle_flagged_view

--- a/agterm/AppActions+Palette.swift
+++ b/agterm/AppActions+Palette.swift
@@ -28,7 +28,9 @@ extension AppActions {
             sidebarShowsFlaggedOnly: activeStore?.sidebarMode == .flagged,
             activeSessionFlagged: activeStore?.activeSession?.flagged == true,
             hasFocusedWorkspace: activeStore?.focusedWorkspaceID != nil,
-            activeSessionHasSplit: activeStore?.activeSession?.hasSplit == true
+            activeSessionHasSplit: activeStore?.activeSession?.hasSplit == true,
+            hasPendingClose: activeStore?.pendingCloseSummary != nil,
+            hasRecentClosed: !library.recentClosedItems.isEmpty
         )
     }
 
@@ -47,6 +49,8 @@ extension AppActions {
         case .renameSession: renameActiveSession()
         case .renameWorkspace: renameActiveWorkspace()
         case .closeSession: closeActiveSession()
+        case .reopenRecent: openLatestRecentClosed()
+        case .undoClose: undoClose()
         case .clearStatus: clearActiveSessionStatus()
         case .previousSession: selectPreviousSession()
         case .nextSession: selectNextSession()

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -1,5 +1,6 @@
 import agtermCore
 import AppKit
+import SwiftUI
 
 /// The user-facing actions shared by the toolbar / bottom-bar buttons (`ContentView`) and the
 /// menu bar (`agtermApp`'s `.commands`), so the two never drift. `@MainActor`; holds the store, and
@@ -146,7 +147,7 @@ final class AppActions {
         // ⌘W was handled either way — on cancel we return true so the File menu doesn't fall back to
         // closing the whole window.
         guard confirmCloseSession(session) else { return true }
-        store.closeSession(session.id)
+        closeSessionAfterConfirmation(session.id, in: store)
         focusActiveSession()
         return true
     }
@@ -160,7 +161,31 @@ final class AppActions {
     func closeSession(_ id: UUID, in store: AppStore) {
         guard let session = store.session(withID: id) else { return }
         guard confirmCloseSession(session) else { return }
-        store.closeSession(id)
+        closeSessionAfterConfirmation(id, in: store)
+    }
+
+    /// Undo the latest grace-period session/workspace close in the frontmost window.
+    func undoClose() {
+        guard let store else { return }
+        let restored = withAnimation(.easeInOut(duration: 0.16)) {
+            store.undoPendingClose()
+        }
+        guard restored else { return }
+        focusActiveSession()
+    }
+
+    func openRecentClosed(_ id: RecentClosedItem.ID) {
+        guard library.reopenRecentClosed(id) else { return }
+        focusActiveSession()
+    }
+
+    func openLatestRecentClosed() {
+        guard library.reopenLatestRecentClosed() else { return }
+        focusActiveSession()
+    }
+
+    func clearRecentClosedItems() {
+        library.clearRecentClosedItems()
     }
 
     /// A native warning confirm before closing `session`, gated by `AppSettings.confirmCloseSession`.
@@ -171,10 +196,26 @@ final class AppActions {
         let alert = NSAlert()
         alert.alertStyle = .warning
         alert.messageText = "Close “\(session.displayName)”?"
-        alert.informativeText = "The session and everything running in it will be closed."
+        alert.informativeText = closeGraceUndoEnabled
+            ? "The session will close after a short undo window."
+            : "The session will close immediately and can be reopened from File > Open Recent."
         alert.addButton(withTitle: "Close")
         alert.addButton(withTitle: "Cancel")
         return alert.runModal() == .alertFirstButtonReturn
+    }
+
+    private var closeGraceUndoEnabled: Bool {
+        settingsModel?.settings.closeGraceUndoEnabled ?? true
+    }
+
+    private func closeSessionAfterConfirmation(_ id: UUID, in store: AppStore) {
+        if closeGraceUndoEnabled {
+            withAnimation(.easeInOut(duration: 0.16)) {
+                _ = store.softCloseSession(id)
+            }
+        } else {
+            store.closeSession(id)
+        }
     }
 
     /// Clear the active session's agent-status indicator back to idle (the same effect as `agtermctl
@@ -278,7 +319,13 @@ final class AppActions {
         guard let store, store.canRemoveWorkspace,
               let workspace = store.workspaces.first(where: { $0.id == workspaceID }) else { return }
         if !workspace.sessions.isEmpty, !confirmDeleteWorkspace(workspace) { return }
-        store.removeWorkspace(workspaceID)
+        if closeGraceUndoEnabled {
+            withAnimation(.easeInOut(duration: 0.16)) {
+                _ = store.softRemoveWorkspace(workspaceID)
+            }
+        } else {
+            store.removeWorkspace(workspaceID)
+        }
     }
 
     /// Delete the current workspace (the one new sessions land in) — used by the menu bar and the
@@ -299,9 +346,12 @@ final class AppActions {
         let alert = NSAlert()
         alert.alertStyle = .warning
         alert.messageText = "Delete “\(name)”?"
+        let suffix = closeGraceUndoEnabled
+            ? "after a short undo window."
+            : "immediately. You can reopen it from File > Open Recent."
         alert.informativeText = sessionCount == 1
-            ? "This closes its session and ends the running shell."
-            : "This closes \(sessionCount) sessions and ends their running shells."
+            ? "This closes its session \(suffix)"
+            : "This closes \(sessionCount) sessions \(suffix)"
         alert.addButton(withTitle: "Delete")
         alert.addButton(withTitle: "Cancel")
         return alert.runModal() == .alertFirstButtonReturn

--- a/agterm/AppDelegate.swift
+++ b/agterm/AppDelegate.swift
@@ -214,6 +214,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if settingsModel?.settings.restoreRunningCommand == true, let library {
             captureForegroundCommands(library: library)
         }
+        library?.finalizeAllPendingCloses()
         // flush every open window's store (per-window cwd changes since the last structural mutation
         // aren't auto-persisted) and the index. replaces the single-store save.
         library?.saveAllOpen()

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -418,7 +418,7 @@ so `{AGT_SESSION_NAME}` and `{AGT_SESSION_PWD}` are as untrusted as `{AGT_SELECT
 - Plus the other `$AGT_*` context vars the runner exports.
 
 Built-in action names for `map` include: `new_window`, `new_workspace`, `new_session`,
-`open_directory`, `rename_session`, `close_session`, `clear_status`, `increase_font_size`,
+`open_directory`, `rename_session`, `close_session`, `reopen_recent`, `undo_close`, `clear_status`, `increase_font_size`,
 `decrease_font_size`, `reset_font_size`, `toggle_split`, `toggle_scratch`, `toggle_sidebar`, `quick_terminal`,
 `session_palette`, `command_palette`, `custom_command_palette`, and the navigation actions (`previous_session`, `next_session`,
 `first_session`, `last_session`, `previous_attention_session`, `next_attention_session`,

--- a/agterm/SettingsModel.swift
+++ b/agterm/SettingsModel.swift
@@ -250,6 +250,8 @@ final class SettingsModel {
     /// Persist whether closing a session from the GUI first asks for confirmation (nil = off). Not a ghostty
     /// key and nothing renders it continuously — `AppActions` reads it on demand at close time — so it just saves.
     func setConfirmCloseSession(_ value: Bool?) { settings.confirmCloseSession = value; try? settingsStore.save(settings) }
+    /// Persist whether GUI closes use the short undo grace period. nil = on; false = close immediately.
+    func setCloseGraceUndoEnabled(_ value: Bool?) { settings.closeGraceUndoEnabled = value; try? settingsStore.save(settings) }
     /// Persist the user-idle auto-follow timeout (nil = off) and fan it out to every open window's store.
     /// Not a ghostty key — a per-window `AppStore` behavior — so it just saves, then pushes the resolved
     /// timeout into the live stores (a newly opened window seeds itself via `applyAutoFollow(to:)`).

--- a/agterm/Views/SettingsView.swift
+++ b/agterm/Views/SettingsView.swift
@@ -114,6 +114,8 @@ private struct GeneralSettingsView: View {
                     .accessibilityIdentifier("settings-restore-running-command")
                 Toggle("Confirm before closing a session", isOn: confirmCloseSession)
                     .accessibilityIdentifier("settings-confirm-close-session")
+                Toggle("Allow undo after closing sessions and workspaces", isOn: closeGraceUndoEnabled)
+                    .accessibilityIdentifier("settings-close-grace-undo")
             }
 
             Section("Ghostty Config") {
@@ -138,6 +140,12 @@ private struct GeneralSettingsView: View {
     private var confirmCloseSession: Binding<Bool> {
         Binding(get: { model.settings.confirmCloseSession ?? false },
                 set: { model.setConfirmCloseSession($0 ? true : nil) })
+    }
+
+    /// nil (the default) reads as ON; turning it off stores false and makes GUI closes immediate.
+    private var closeGraceUndoEnabled: Binding<Bool> {
+        Binding(get: { model.settings.closeGraceUndoEnabled ?? true },
+                set: { model.setCloseGraceUndoEnabled($0 ? nil : false) })
     }
 
     /// 1:1 with the toggle; nil (the default) reads as OFF, so on → true / off → nil keeps settings.json

--- a/agterm/Views/UndoCloseShortcut.swift
+++ b/agterm/Views/UndoCloseShortcut.swift
@@ -1,0 +1,53 @@
+import agtermCore
+import AppKit
+
+/// Local monitor for the undo-close chord. It deliberately avoids a menu `keyboardShortcut` so native
+/// text undo keeps working in rename fields, palettes, and settings controls.
+@MainActor
+final class UndoCloseShortcut {
+    private let actions: AppActions
+    private var monitor: Any?
+
+    init(actions: AppActions) {
+        self.actions = actions
+    }
+
+    func start() {
+        guard monitor == nil else { return }
+        monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self else { return event }
+            return self.handleKeyDown(event) ? nil : event
+        }
+    }
+
+    private func handleKeyDown(_ event: NSEvent) -> Bool {
+        guard actions.store?.pendingCloseSummary != nil else { return false }
+        guard NSApp.keyWindow?.firstResponder is NSText == false else { return false }
+        guard let chord = chord(from: event) else { return false }
+        let expected = actions.settingsModel?.keymap.equivalent(for: .undoClose) ?? BuiltinAction.undoClose.defaultChord
+        guard chord == expected else { return false }
+        actions.undoClose()
+        return true
+    }
+
+    private func chord(from event: NSEvent) -> Chord? {
+        var mods: Modifier = []
+        let flags = event.modifierFlags
+        if flags.contains(.control) { mods.insert(.control) }
+        if flags.contains(.command) { mods.insert(.command) }
+        if flags.contains(.option) { mods.insert(.option) }
+        if flags.contains(.shift) { mods.insert(.shift) }
+
+        let key: String?
+        switch event.keyCode {
+        case 36: key = "return"
+        case 48: key = "tab"
+        case 49: key = "space"
+        case 51: key = "delete"
+        default:
+            key = event.charactersIgnoringModifiers?.lowercased()
+        }
+        guard let key, key.count == 1 || ["return", "tab", "space", "delete"].contains(key) else { return nil }
+        return Chord(mods: mods, key: key)
+    }
+}

--- a/agterm/Views/WindowAccessor.swift
+++ b/agterm/Views/WindowAccessor.swift
@@ -151,6 +151,7 @@ struct WindowAccessor: NSViewRepresentable {
                         UserDefaults.standard.set(NSStringFromRect(window.frame), forKey: TitleProbeView.frameKey(windowID))
                     }
                     WindowRegistry.shared.unregister(windowID)
+                    store.finalizeAllPendingCloses()
                     // flush cwd drift since the last structural mutation before dropping the store —
                     // AppStore doesn't save on a live `cd`, so a closed-then-reopened window would
                     // otherwise load a stale snapshot. Skip it when the window is no longer open in the

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -165,6 +165,8 @@ struct WindowContentView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         }
         .safeAreaInset(edge: .bottom) { bottomBar }
+        .overlay(alignment: .bottom) { pendingCloseToast.padding(.horizontal, 8).padding(.bottom, 34) }
+        .animation(.easeInOut(duration: 0.16), value: store.pendingCloseSummary?.id)
         // the lighter/darker sidebar tint: a wash behind the transparent outline + bottom bar, so the
         // whole column reads as one surface a touch darker/lighter than the terminal. Behind the column
         // content (so it never tints row text) and over the window background (so it composes with
@@ -846,6 +848,48 @@ struct WindowContentView: View {
         .foregroundStyle(chromeText)
         // no explicit background: the sidebar is transparent (the window's terminal color shows
         // through), so a `.bar` material here would paint a mismatched darker strip.
+    }
+
+    @ViewBuilder private var pendingCloseToast: some View {
+        if let summary = store.pendingCloseSummary {
+            HStack(spacing: 8) {
+                Image(systemName: summary.kind == .workspace ? "rectangle.stack" : "terminal")
+                    .imageScale(.small)
+                Text("Closed \(summary.title)")
+                    .font(.caption)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer(minLength: 4)
+                Button {
+                    let restored = withAnimation(.easeInOut(duration: 0.16)) {
+                        store.undoPendingClose(summary.id)
+                    }
+                    if restored {
+                        actions.focusActiveSession()
+                    }
+                } label: {
+                    Text("Reopen")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 3)
+                        .background(Color.white.opacity(0.16), in: RoundedRectangle(cornerRadius: 5))
+                }
+                .buttonStyle(.borderless)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .foregroundStyle(.white)
+            .background(Color.black.opacity(0.86), in: RoundedRectangle(cornerRadius: 8))
+            .overlay {
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color.white.opacity(0.16), lineWidth: 1)
+            }
+            .shadow(color: .black.opacity(0.18), radius: 10, y: 4)
+            .frame(maxWidth: 300)
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+            .accessibilityIdentifier("pending-close-toast")
+        }
     }
 
 }

--- a/agterm/agtermApp+Menus.swift
+++ b/agterm/agtermApp+Menus.swift
@@ -50,6 +50,11 @@ extension agtermApp {
         return KeyboardShortcut(key, modifiers: modifiers)
     }
 
+    private func recentTitle(_ item: RecentClosedItem) -> String {
+        guard let subtitle = item.subtitle, !subtitle.isEmpty else { return item.title }
+        return "\(item.title) - \(subtitle)"
+    }
+
     @CommandsBuilder
     var appCommands: some Commands {
             // App menu: replace the default "About Agterm" with one that opens the standard
@@ -103,6 +108,34 @@ extension agtermApp {
                     .keyboardShortcut(shortcut(for: .newSession))
                 Button("Open Directory…") { actions.openDirectory() }
                     .keyboardShortcut(shortcut(for: .openDirectory))
+                Menu("Open Recent") {
+                    let recentSessions = library.recentClosedItems.filter { $0.kind == .session }
+                    let recentWorkspaces = library.recentClosedItems.filter { $0.kind == .workspace }
+                    if recentSessions.isEmpty && recentWorkspaces.isEmpty {
+                        Text("No Recent Items")
+                    } else {
+                        if !recentSessions.isEmpty {
+                            Section("Sessions") {
+                                ForEach(recentSessions) { item in
+                                    Button(recentTitle(item)) { actions.openRecentClosed(item.id) }
+                                }
+                            }
+                        }
+                        if !recentWorkspaces.isEmpty {
+                            Section("Workspaces") {
+                                ForEach(recentWorkspaces) { item in
+                                    Button(recentTitle(item)) { actions.openRecentClosed(item.id) }
+                                }
+                            }
+                        }
+                        Divider()
+                        Button("Clear Menu") { actions.clearRecentClosedItems() }
+                    }
+                }
+                .disabled(library.recentClosedItems.isEmpty)
+                Button("Reopen Last Closed Item") { actions.openLatestRecentClosed() }
+                    .keyboardShortcut(shortcut(for: .reopenRecent))
+                    .disabled(library.recentClosedItems.isEmpty)
                 Button("Rename Session") { actions.renameActiveSession() }
                     .keyboardShortcut(shortcut(for: .renameSession))
                     .disabled(library.activeStore?.activeSession == nil)
@@ -112,6 +145,8 @@ extension agtermApp {
                     if !actions.closeActiveSession() { NSApp.keyWindow?.performClose(nil) }
                 }
                 .keyboardShortcut(shortcut(for: .closeSession))
+                Button("Reopen Closed Item") { actions.undoClose() }
+                    .disabled(library.activeStore?.pendingCloseSummary == nil)
                 Button("Clear Status") { actions.clearActiveSessionStatus() }
                     .keyboardShortcut(shortcut(for: .clearStatus))
                     .disabled(library.activeStore?.activeSession == nil)

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -14,6 +14,7 @@ struct agtermApp: App {
     @State var palette = PaletteController()
     @State private var sessionSwitcher: SessionSwitcher
     @State private var paneShortcuts: PaneShortcuts
+    @State private var undoCloseShortcut: UndoCloseShortcut
     @State var settingsModel: SettingsModel
     @State private var controlServer: ControlServer
     @State private var customCommandRunner: CustomCommandRunner
@@ -38,6 +39,7 @@ struct agtermApp: App {
         _controlServer = State(initialValue: controlServer)
         _sessionSwitcher = State(initialValue: SessionSwitcher(library: library))
         _paneShortcuts = State(initialValue: PaneShortcuts(library: library, actions: actions))
+        _undoCloseShortcut = State(initialValue: UndoCloseShortcut(actions: actions))
         // the custom-command runner needs the keymap (settings) and the bound socket path (control
         // server) for the `{AGT_SOCKET}` token; built last so both are available.
         _customCommandRunner = State(initialValue: CustomCommandRunner(
@@ -99,6 +101,9 @@ struct agtermApp: App {
                     sessionSwitcher.start()
                     // install the Ctrl-1/Ctrl-2 direct pane-focus key monitor (idempotent).
                     paneShortcuts.start()
+                    // install the undo-close shortcut (idempotent); it passes through text fields so
+                    // native edit undo still wins there.
+                    undoCloseShortcut.start()
                     // install the custom-command key monitor (idempotent); rebuilds its matcher from
                     // the keymap on `.agtermKeymapChanged`. Hand the delegate a reference so it can
                     // remove the monitor on terminate.

--- a/agtermCore/Sources/agtermCore/AppSettings.swift
+++ b/agtermCore/Sources/agtermCore/AppSettings.swift
@@ -171,6 +171,9 @@ public struct AppSettings: Codable, Equatable, Sendable {
     /// app-level behavior flag read on demand by `AppActions`, NOT a ghostty key — it never appears in
     /// `ghosttyConfigLines()`; the control channel's `session.close` closes without a prompt.
     public var confirmCloseSession: Bool?
+    /// Whether GUI closes keep a short undo grace period before final teardown. nil means the default
+    /// (on). When off, GUI closes are immediate but still enter File > Open Recent.
+    public var closeGraceUndoEnabled: Bool?
     /// The user-idle timeout that auto-follows the window's selection to the oldest blocked session, as an
     /// `AutoFollowAttention` raw value; nil means the default (`off` — disabled). An app-level per-window
     /// behavior value driving `AppStore`'s idle controller, NOT a ghostty key — it never appears in
@@ -192,7 +195,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
                 inheritGlobalGhosttyConfig: Bool? = nil, attentionButtonEnabled: Bool? = nil,
                 blockedStatusSoundName: String? = nil, rightClickPaste: Bool? = nil,
                 newSessionDirectory: String? = nil, newSessionCustomDirectory: String? = nil,
-                confirmCloseSession: Bool? = nil, autoFollowAttention: String? = nil,
+                confirmCloseSession: Bool? = nil, closeGraceUndoEnabled: Bool? = nil,
+                autoFollowAttention: String? = nil,
                 autoFollowStayOnActive: Bool? = nil) {
         self.fontFamily = fontFamily
         self.fontSize = fontSize
@@ -219,6 +223,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.newSessionDirectory = newSessionDirectory
         self.newSessionCustomDirectory = newSessionCustomDirectory
         self.confirmCloseSession = confirmCloseSession
+        self.closeGraceUndoEnabled = closeGraceUndoEnabled
         self.autoFollowAttention = autoFollowAttention
         self.autoFollowStayOnActive = autoFollowStayOnActive
     }

--- a/agtermCore/Sources/agtermCore/AppStore+PendingClose.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+PendingClose.swift
@@ -1,0 +1,217 @@
+import Foundation
+
+/// The kind of close currently available to undo.
+public enum PendingCloseKind: String, Sendable {
+    case session
+    case workspace
+}
+
+/// Observable domain summary for the latest undoable close. The app target decides how to present it.
+public struct PendingCloseSummary: Identifiable, Equatable, Sendable {
+    public let id: UUID
+    public let kind: PendingCloseKind
+    public let title: String
+
+    public init(id: UUID, kind: PendingCloseKind, title: String) {
+        self.id = id
+        self.kind = kind
+        self.title = title
+    }
+}
+
+enum PendingCloseRecord {
+    case session(PendingSessionClose)
+    case workspace(PendingWorkspaceClose)
+}
+
+struct PendingSessionClose {
+    let session: Session
+    let workspaceID: UUID
+    let workspaceName: String
+    let workspaceIndex: Int
+    let sessionIndex: Int
+}
+
+struct PendingWorkspaceClose {
+    let workspace: Workspace
+    let workspaceIndex: Int
+    let selectedSessionID: UUID?
+}
+
+extension AppStore {
+    public static let pendingCloseGraceInterval: TimeInterval = 3
+
+    /// Hide a session from the visible tree but keep its surfaces alive for a short undo window.
+    /// If the grace expires, `finalizePendingClose` performs the same teardown as `closeSession`.
+    @discardableResult
+    public func softCloseSession(_ sessionID: UUID, grace: TimeInterval = AppStore.pendingCloseGraceInterval) -> Bool {
+        guard let location = location(ofSession: sessionID) else { return false }
+        let workspace = workspaces[location.workspaceIndex]
+        let wasActive = selectedSessionID == sessionID
+        let session = workspaces[location.workspaceIndex].sessions.remove(at: location.sessionIndex)
+        let closeID = UUID()
+        pendingCloseRecords[closeID] = .session(PendingSessionClose(
+            session: session,
+            workspaceID: workspace.id,
+            workspaceName: workspace.name,
+            workspaceIndex: location.workspaceIndex,
+            sessionIndex: location.sessionIndex
+        ))
+        pendingCloseOrder.append(closeID)
+        recordRecentClosedSession(session, workspaceID: workspace.id, workspaceName: workspace.name,
+                                  workspaceIndex: location.workspaceIndex, sessionIndex: location.sessionIndex,
+                                  id: closeID)
+        if wasActive {
+            selectedSessionID = reselectionTarget(after: location)
+            autoUnfocusIfOutsideFocus(selectedSessionID)
+            recordRecency()
+        }
+        showPendingCloseSummary(id: closeID)
+        schedulePendingCloseFinalization(id: closeID, grace: grace)
+        cancelPendingSave()
+        return true
+    }
+
+    /// Hide a workspace from the visible tree but keep all of its sessions alive for a short undo window.
+    /// The last workspace cannot be soft-closed, matching `removeWorkspace`.
+    @discardableResult
+    public func softRemoveWorkspace(_ workspaceID: UUID, grace: TimeInterval = AppStore.pendingCloseGraceInterval) -> Bool {
+        guard canRemoveWorkspace, let index = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return false }
+        let workspace = workspaces.remove(at: index)
+        let removingActive = selectedSessionID.map { id in workspace.sessions.contains { $0.id == id } } ?? false
+        let restoringSelection = removingActive ? selectedSessionID : nil
+        if focusedWorkspaceID == workspaceID { focusedWorkspaceID = nil }
+        if removingActive {
+            let fallbackIndex = min(index, workspaces.count - 1)
+            selectedSessionID = workspaces[fallbackIndex].sessions.first?.id
+                ?? workspaces.first(where: { !$0.sessions.isEmpty })?.sessions.first?.id
+            autoUnfocusIfOutsideFocus(selectedSessionID)
+            recordRecency()
+        }
+
+        let closeID = UUID()
+        pendingCloseRecords[closeID] = .workspace(PendingWorkspaceClose(
+            workspace: workspace,
+            workspaceIndex: index,
+            selectedSessionID: restoringSelection
+        ))
+        pendingCloseOrder.append(closeID)
+        recordRecentClosedWorkspace(workspace, selectedSessionID: restoringSelection, id: closeID)
+        showPendingCloseSummary(id: closeID)
+        schedulePendingCloseFinalization(id: closeID, grace: grace)
+        cancelPendingSave()
+        return true
+    }
+
+    /// Undo the latest pending close, or a specific pending-close record when `id` is supplied.
+    @discardableResult
+    public func undoPendingClose(_ id: UUID? = nil) -> Bool {
+        let closeID = id ?? pendingCloseSummary?.id
+        guard let closeID, let record = pendingCloseRecords.removeValue(forKey: closeID) else { return false }
+        pendingCloseTasks.removeValue(forKey: closeID)?.cancel()
+        pendingCloseOrder.removeAll { $0 == closeID }
+        switch record {
+        case .session(let close):
+            restorePendingSession(close)
+        case .workspace(let close):
+            restorePendingWorkspace(close)
+        }
+        removeRecentClosedItem(closeID)
+        if pendingCloseSummary?.id == closeID { promotePendingCloseSummary() }
+        save()
+        return true
+    }
+
+    func finalizePendingClose(_ id: UUID) {
+        guard let record = pendingCloseRecords.removeValue(forKey: id) else { return }
+        pendingCloseTasks.removeValue(forKey: id)?.cancel()
+        pendingCloseOrder.removeAll { $0 == id }
+        switch record {
+        case .session(let close):
+            hardFinalizePendingSession(close.session)
+        case .workspace(let close):
+            hardFinalizePendingWorkspace(close.workspace)
+        }
+        if pendingCloseSummary?.id == id { promotePendingCloseSummary() }
+        save()
+    }
+
+    public func finalizeAllPendingCloses() {
+        for id in Array(pendingCloseRecords.keys) {
+            finalizePendingClose(id)
+        }
+    }
+
+    private func showPendingCloseSummary(id: UUID) {
+        guard let record = pendingCloseRecords[id] else { return }
+        pendingCloseSummary = summary(for: id, record: record)
+    }
+
+    private func promotePendingCloseSummary() {
+        guard let id = pendingCloseOrder.last, let record = pendingCloseRecords[id] else {
+            pendingCloseSummary = nil
+            return
+        }
+        pendingCloseSummary = summary(for: id, record: record)
+    }
+
+    private func summary(for id: UUID, record: PendingCloseRecord) -> PendingCloseSummary {
+        switch record {
+        case .session(let close):
+            return PendingCloseSummary(id: id, kind: .session, title: close.session.displayName)
+        case .workspace(let close):
+            return PendingCloseSummary(id: id, kind: .workspace, title: close.workspace.name)
+        }
+    }
+
+    private func schedulePendingCloseFinalization(id: UUID, grace: TimeInterval) {
+        pendingCloseTasks[id]?.cancel()
+        let delay = UInt64(max(0, grace) * 1_000_000_000)
+        pendingCloseTasks[id] = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: delay)
+            self?.finalizePendingClose(id)
+        }
+    }
+
+    private func restorePendingSession(_ close: PendingSessionClose) {
+        let workspaceIndex: Int
+        if let existing = workspaces.firstIndex(where: { $0.id == close.workspaceID }) {
+            workspaceIndex = existing
+        } else {
+            let insertAt = max(0, min(close.workspaceIndex, workspaces.count))
+            workspaces.insert(Workspace(id: close.workspaceID, name: close.workspaceName), at: insertAt)
+            workspaceIndex = insertAt
+        }
+        let insertAt = max(0, min(close.sessionIndex, workspaces[workspaceIndex].sessions.count))
+        workspaces[workspaceIndex].sessions.insert(close.session, at: insertAt)
+        selectedSessionID = close.session.id
+        autoUnfocusIfOutsideFocus(selectedSessionID)
+        recordRecency()
+    }
+
+    private func restorePendingWorkspace(_ close: PendingWorkspaceClose) {
+        let insertAt = max(0, min(close.workspaceIndex, workspaces.count))
+        workspaces.insert(close.workspace, at: insertAt)
+        if let target = close.selectedSessionID ?? close.workspace.sessions.first?.id {
+            selectedSessionID = target
+            autoUnfocusIfOutsideFocus(selectedSessionID)
+            recordRecency()
+        }
+    }
+
+    private func hardFinalizePendingSession(_ session: Session) {
+        session.surface?.teardown()
+        session.splitSurface?.teardown()
+        session.overlaySurface?.teardown()
+        session.scratchSurface?.teardown()
+        WatermarkStorage.removeRenderedText(sessionID: session.id)
+        removeFromRecency(session.id)
+    }
+
+    private func hardFinalizePendingWorkspace(_ workspace: Workspace) {
+        for session in workspace.sessions {
+            hardFinalizePendingSession(session)
+        }
+    }
+
+}

--- a/agtermCore/Sources/agtermCore/AppStore+RecentClosed.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+RecentClosed.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+extension AppStore {
+    @discardableResult
+    public func restoreRecentClosed(_ item: RecentClosedItem) -> Bool {
+        switch item.kind {
+        case .session:
+            guard let recent = item.session else { return false }
+            if restoreOrSelectExistingRecentSession(recent) { return true }
+            let index: Int
+            if let existing = workspaces.firstIndex(where: { $0.id == recent.workspaceID }) {
+                index = existing
+            } else {
+                let insertAt = max(0, min(recent.workspaceIndex, workspaces.count))
+                workspaces.insert(Workspace(id: recent.workspaceID, name: recent.workspaceName), at: insertAt)
+                index = insertAt
+            }
+            let session = session(from: recent.snapshot)
+            let insertAt = max(0, min(recent.sessionIndex, workspaces[index].sessions.count))
+            workspaces[index].sessions.insert(session, at: insertAt)
+            selectedSessionID = session.id
+            autoUnfocusIfOutsideFocus(selectedSessionID)
+            recordRecency()
+            save()
+            return true
+        case .workspace:
+            guard let recent = item.workspace else { return false }
+            if restoreOrSelectExistingRecentWorkspace(recent) { return true }
+            let workspace = workspace(from: recent.snapshot)
+            // Persistent Open Recent appends like most editors' recent-project flow:
+            // reopening brings the workspace back without reshuffling current workspaces.
+            workspaces.append(workspace)
+            selectedSessionID = recent.selectedSessionID.flatMap { sessionID in
+                workspace.sessions.contains { $0.id == sessionID } ? sessionID : nil
+            } ?? workspace.sessions.first?.id
+            autoUnfocusIfOutsideFocus(selectedSessionID)
+            recordRecency()
+            save()
+            return true
+        }
+    }
+
+    private func restoreOrSelectExistingRecentSession(_ recent: RecentClosedSession) -> Bool {
+        if let pendingID = pendingCloseID(containingSessionID: recent.snapshot.id) {
+            return undoPendingClose(pendingID)
+        }
+        guard session(withID: recent.snapshot.id) != nil else { return false }
+        selectSession(recent.snapshot.id)
+        return true
+    }
+
+    private func restoreOrSelectExistingRecentWorkspace(_ recent: RecentClosedWorkspace) -> Bool {
+        let sessionIDs = Set(recent.snapshot.sessions.map(\.id))
+        if let pendingID = pendingCloseID(forWorkspaceID: recent.snapshot.id, sessionIDs: sessionIDs) {
+            return undoPendingClose(pendingID)
+        }
+        if let existingWorkspace = workspaces.first(where: { $0.id == recent.snapshot.id }) {
+            let target = recent.selectedSessionID.flatMap { id in
+                existingWorkspace.sessions.contains { $0.id == id } ? id : nil
+            } ?? existingWorkspace.sessions.first?.id
+            if let target { selectSession(target) }
+            return true
+        }
+        if let existingSession = workspaces.flatMap(\.sessions).first(where: { sessionIDs.contains($0.id) }) {
+            selectSession(existingSession.id)
+            return true
+        }
+        return false
+    }
+
+    private func pendingCloseID(containingSessionID sessionID: UUID) -> UUID? {
+        for id in pendingCloseOrder.reversed() {
+            guard let record = pendingCloseRecords[id] else { continue }
+            switch record {
+            case .session(let close) where close.session.id == sessionID:
+                return id
+            case .workspace(let close) where close.workspace.sessions.contains(where: { $0.id == sessionID }):
+                return id
+            default:
+                continue
+            }
+        }
+        return nil
+    }
+
+    private func pendingCloseID(forWorkspaceID workspaceID: UUID, sessionIDs: Set<UUID>) -> UUID? {
+        for id in pendingCloseOrder.reversed() {
+            guard let record = pendingCloseRecords[id] else { continue }
+            switch record {
+            case .workspace(let close)
+                where close.workspace.id == workspaceID
+                    || close.workspace.sessions.contains(where: { sessionIDs.contains($0.id) }):
+                return id
+            case .session(let close) where sessionIDs.contains(close.session.id):
+                return id
+            default:
+                continue
+            }
+        }
+        return nil
+    }
+
+    @discardableResult
+    func recordRecentClosedSession(_ session: Session,
+                                   workspaceID: UUID,
+                                   workspaceName: String,
+                                   workspaceIndex: Int,
+                                   sessionIndex: Int,
+                                   id: UUID = UUID()) -> UUID? {
+        guard let recentClosedStore else { return nil }
+        recentClosedStore.record(RecentClosedItem(
+            id: id,
+            kind: .session,
+            title: session.displayName,
+            subtitle: workspaceName,
+            session: RecentClosedSession(workspaceID: workspaceID,
+                                         workspaceName: workspaceName,
+                                         workspaceIndex: workspaceIndex,
+                                         sessionIndex: sessionIndex,
+                                         snapshot: sessionSnapshot(session))
+        ))
+        recentClosedDidChange?()
+        return id
+    }
+
+    @discardableResult
+    func recordRecentClosedWorkspace(_ workspace: Workspace,
+                                     selectedSessionID: UUID?,
+                                     id: UUID = UUID()) -> UUID? {
+        guard let recentClosedStore else { return nil }
+        let sessionCount = workspace.sessions.count
+        recentClosedStore.record(RecentClosedItem(
+            id: id,
+            kind: .workspace,
+            title: workspace.name,
+            subtitle: "\(sessionCount) session\(sessionCount == 1 ? "" : "s")",
+            workspace: RecentClosedWorkspace(snapshot: workspaceSnapshot(workspace), selectedSessionID: selectedSessionID)
+        ))
+        recentClosedDidChange?()
+        return id
+    }
+
+    func removeRecentClosedItem(_ id: UUID) {
+        guard let recentClosedStore else { return }
+        recentClosedStore.remove(id)
+        recentClosedDidChange?()
+    }
+}

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -83,7 +83,17 @@ public final class AppStore {
     /// survives a relaunch.
     @ObservationIgnored public private(set) var sessionRecency = RecencyStack<UUID>()
 
+    /// The latest session/workspace close that can still be undone. The hidden sessions/workspaces live
+    /// in `pendingCloseRecords`; this observed summary is the host-free state the app target presents.
+    public var pendingCloseSummary: PendingCloseSummary?
+
+    @ObservationIgnored var pendingCloseRecords: [UUID: PendingCloseRecord] = [:]
+    @ObservationIgnored var pendingCloseOrder: [UUID] = []
+    @ObservationIgnored var pendingCloseTasks: [UUID: Task<Void, Never>] = [:]
+
     @ObservationIgnored private let persistence: PersistenceStore
+    @ObservationIgnored let recentClosedStore: RecentClosedStore?
+    @ObservationIgnored var recentClosedDidChange: (() -> Void)?
 
     /// Coalesces the high-frequency selection/font saves: a click-storm or a font ramp schedules one
     /// write ~0.3 s after the burst settles instead of hitting disk per event. `save()` cancels any
@@ -131,10 +141,14 @@ public final class AppStore {
     @ObservationIgnored var autoFollowSuppressionCount = 0
 
     public init(workspaces: [Workspace] = [], selectedSessionID: UUID? = nil,
-                persistence: PersistenceStore = PersistenceStore()) {
+                persistence: PersistenceStore = PersistenceStore(),
+                recentClosedStore: RecentClosedStore? = nil,
+                recentClosedDidChange: (() -> Void)? = nil) {
         self.workspaces = workspaces
         self.selectedSessionID = selectedSessionID
         self.persistence = persistence
+        self.recentClosedStore = recentClosedStore
+        self.recentClosedDidChange = recentClosedDidChange
     }
 
     /// The currently selected session, derived from `selectedSessionID`.
@@ -279,7 +293,7 @@ public final class AppStore {
     /// trip this — it stays the safety net only for the explicit cross-set cases. No-op when unfocused,
     /// when nothing is selected, or when the selection is inside the focused workspace. Persistence
     /// rides the caller's `selectSession` save.
-    private func autoUnfocusIfOutsideFocus(_ sessionID: UUID?) {
+    func autoUnfocusIfOutsideFocus(_ sessionID: UUID?) {
         guard let focusedWorkspaceID, let sessionID else { return }
         if workspace(forSession: sessionID)?.id != focusedWorkspaceID { self.focusedWorkspaceID = nil }
     }
@@ -309,8 +323,12 @@ public final class AppStore {
 
     /// Pushes the current selection to the front of the recency stack (the Ctrl-Tab order).
     /// No-op when nothing is selected.
-    private func recordRecency() {
+    func recordRecency() {
         if let selectedSessionID { sessionRecency.push(selectedSessionID) }
+    }
+
+    func removeFromRecency(_ id: UUID) {
+        sessionRecency.remove(id)
     }
 
     /// Sets a session's custom name. An empty (or whitespace-only) name clears
@@ -335,7 +353,10 @@ public final class AppStore {
     public func closeSession(_ sessionID: UUID) {
         guard let location = location(ofSession: sessionID) else { return }
         let wasActive = selectedSessionID == sessionID
+        let workspace = workspaces[location.workspaceIndex]
         let removed = workspaces[location.workspaceIndex].sessions.remove(at: location.sessionIndex)
+        recordRecentClosedSession(removed, workspaceID: workspace.id, workspaceName: workspace.name,
+                                  workspaceIndex: location.workspaceIndex, sessionIndex: location.sessionIndex)
         removed.surface?.teardown()
         removed.splitSurface?.teardown()
         removed.overlaySurface?.teardown()
@@ -362,8 +383,10 @@ public final class AppStore {
     /// no sessions remain.
     public func removeWorkspace(_ workspaceID: UUID) {
         guard canRemoveWorkspace, let index = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return }
-        let removingActive = selectedSessionID.map { id in workspaces[index].sessions.contains { $0.id == id } } ?? false
-        for session in workspaces[index].sessions {
+        let workspace = workspaces[index]
+        let removingActive = selectedSessionID.map { id in workspace.sessions.contains { $0.id == id } } ?? false
+        recordRecentClosedWorkspace(workspace, selectedSessionID: removingActive ? selectedSessionID : nil)
+        for session in workspace.sessions {
             session.surface?.teardown()
             session.splitSurface?.teardown()
             session.overlaySurface?.teardown()
@@ -686,16 +709,7 @@ public final class AppStore {
     /// `@MainActor`; the resulting value is `Sendable` and safe to hand to a writer.
     public func snapshot() -> Snapshot {
         let workspaceSnapshots = workspaces.map { workspace in
-            let sessions = workspace.sessions.map { session in
-                SessionSnapshot(id: session.id, customName: session.customName, cwd: session.currentCwd ?? session.initialCwd,
-                                isSplit: session.isSplit, fontSize: session.fontSize,
-                                splitCwd: session.splitCwd ?? session.initialSplitCwd, splitRatio: session.splitRatio,
-                                flagged: session.flagged,
-                                foregroundCommand: session.foregroundCommand,
-                                splitForegroundCommand: session.splitForegroundCommand,
-                                initialCommand: session.initialCommand,
-                                backgroundWatermark: session.backgroundWatermark)
-            }
+            let sessions = workspace.sessions.map(sessionSnapshot)
             // only a collapsed workspace writes the flag; an expanded one omits it (nil) so an all-expanded
             // tree serializes identically to a legacy snapshot.
             return WorkspaceSnapshot(id: workspace.id, name: workspace.name, sessions: sessions,
@@ -716,23 +730,7 @@ public final class AppStore {
     /// at a session that no longer exists, it is cleared to keep selection valid.
     public func restore(from snapshot: Snapshot) {
         workspaces = snapshot.workspaces.map { workspaceSnapshot in
-            let sessions = workspaceSnapshot.sessions.map { sessionSnapshot -> Session in
-                let session = Session(id: sessionSnapshot.id, initialCwd: sessionSnapshot.cwd, customName: sessionSnapshot.customName)
-                session.isSplit = sessionSnapshot.isSplit ?? false
-                session.hasSplit = session.isSplit
-                session.fontSize = sessionSnapshot.fontSize
-                session.initialSplitCwd = sessionSnapshot.splitCwd
-                // clamp on restore (like sidebarWidth) so a corrupt snapshot can't feed an out-of-range
-                // fraction into NSSplitView.setPosition; nil stays nil (the even default).
-                session.splitRatio = sessionSnapshot.splitRatio.map { min(AppStore.splitRatioMax, max(AppStore.splitRatioMin, $0)) }
-                session.flagged = sessionSnapshot.flagged ?? false
-                session.foregroundCommand = sessionSnapshot.foregroundCommand
-                session.splitForegroundCommand = sessionSnapshot.splitForegroundCommand
-                session.initialCommand = sessionSnapshot.initialCommand
-                session.wasRestored = true
-                session.backgroundWatermark = sessionSnapshot.backgroundWatermark
-                return session
-            }
+            let sessions = workspaceSnapshot.sessions.map(session(from:))
             // absent/nil collapsed → expanded (back-compat with snapshots written before the field existed).
             return Workspace(id: workspaceSnapshot.id, name: workspaceSnapshot.name, sessions: sessions,
                              isExpanded: !(workspaceSnapshot.collapsed ?? false))
@@ -810,7 +808,7 @@ public final class AppStore {
         return nil
     }
 
-    private func location(ofSession sessionID: UUID) -> (workspaceIndex: Int, sessionIndex: Int)? {
+    func location(ofSession sessionID: UUID) -> (workspaceIndex: Int, sessionIndex: Int)? {
         for (wi, workspace) in workspaces.enumerated() {
             if let si = workspace.sessions.firstIndex(where: { $0.id == sessionID }) { return (wi, si) }
         }
@@ -820,7 +818,7 @@ public final class AppStore {
     /// Picks the next selection after removing the session at `location`. Prefers
     /// the session that shifted into the removed slot, then the previous one in
     /// that workspace, then the first session of any remaining workspace.
-    private func reselectionTarget(after location: (workspaceIndex: Int, sessionIndex: Int)) -> UUID? {
+    func reselectionTarget(after location: (workspaceIndex: Int, sessionIndex: Int)) -> UUID? {
         let sessions = workspaces[location.workspaceIndex].sessions
         if location.sessionIndex < sessions.count { return sessions[location.sessionIndex].id }
         if location.sessionIndex > 0 { return sessions[location.sessionIndex - 1].id }
@@ -829,4 +827,42 @@ public final class AppStore {
         }
         return nil
     }
+
+    func sessionSnapshot(_ session: Session) -> SessionSnapshot {
+        SessionSnapshot(id: session.id, customName: session.customName, cwd: session.currentCwd ?? session.initialCwd,
+                        isSplit: session.isSplit, fontSize: session.fontSize,
+                        splitCwd: session.splitCwd ?? session.initialSplitCwd, splitRatio: session.splitRatio,
+                        flagged: session.flagged,
+                        foregroundCommand: session.foregroundCommand,
+                        splitForegroundCommand: session.splitForegroundCommand,
+                        initialCommand: session.initialCommand,
+                        backgroundWatermark: session.backgroundWatermark)
+    }
+
+    func workspaceSnapshot(_ workspace: Workspace) -> WorkspaceSnapshot {
+        WorkspaceSnapshot(id: workspace.id, name: workspace.name, sessions: workspace.sessions.map(sessionSnapshot),
+                          collapsed: workspace.isExpanded ? nil : true)
+    }
+
+    func session(from snapshot: SessionSnapshot) -> Session {
+        let session = Session(id: snapshot.id, initialCwd: snapshot.cwd, customName: snapshot.customName)
+        session.isSplit = snapshot.isSplit ?? false
+        session.hasSplit = session.isSplit
+        session.fontSize = snapshot.fontSize
+        session.initialSplitCwd = snapshot.splitCwd
+        session.splitRatio = snapshot.splitRatio.map { min(AppStore.splitRatioMax, max(AppStore.splitRatioMin, $0)) }
+        session.flagged = snapshot.flagged ?? false
+        session.foregroundCommand = snapshot.foregroundCommand
+        session.splitForegroundCommand = snapshot.splitForegroundCommand
+        session.initialCommand = snapshot.initialCommand
+        session.wasRestored = true
+        session.backgroundWatermark = snapshot.backgroundWatermark
+        return session
+    }
+
+    func workspace(from snapshot: WorkspaceSnapshot) -> Workspace {
+        Workspace(id: snapshot.id, name: snapshot.name, sessions: snapshot.sessions.map(session(from:)),
+                  isExpanded: !(snapshot.collapsed ?? false))
+    }
+
 }

--- a/agtermCore/Sources/agtermCore/BuiltinAction.swift
+++ b/agtermCore/Sources/agtermCore/BuiltinAction.swift
@@ -10,7 +10,7 @@ public enum BuiltinAction: String, CaseIterable, Sendable {
     case newWindow = "new_window", renameWindow = "rename_window", deleteWindow = "delete_window"
     case newWorkspace = "new_workspace", renameWorkspace = "rename_workspace", deleteWorkspace = "delete_workspace"
     case newSession = "new_session", openDirectory = "open_directory", renameSession = "rename_session"
-    case closeSession = "close_session", clearStatus = "clear_status"
+    case closeSession = "close_session", reopenRecent = "reopen_recent", undoClose = "undo_close", clearStatus = "clear_status"
     case increaseFontSize = "increase_font_size", decreaseFontSize = "decrease_font_size", resetFontSize = "reset_font_size"
     case toggleSplit = "toggle_split", toggleScratch = "toggle_scratch", toggleSearch = "toggle_search"
     case toggleSidebar = "toggle_sidebar", selectTheme = "select_theme", toggleFullscreen = "toggle_fullscreen"
@@ -40,6 +40,8 @@ public enum BuiltinAction: String, CaseIterable, Sendable {
         case .newSession: return Chord(mods: [.command], key: "n")
         case .openDirectory: return Chord(mods: [.command], key: "o")
         case .closeSession: return Chord(mods: [.command], key: "w")
+        case .reopenRecent: return Chord(mods: [.command, .shift], key: "t")
+        case .undoClose: return Chord(mods: [.command], key: "z")
         case .increaseFontSize: return Chord(mods: [.command], key: "+")
         case .decreaseFontSize: return Chord(mods: [.command], key: "-")
         case .resetFontSize: return Chord(mods: [.command], key: "0")

--- a/agtermCore/Sources/agtermCore/PaletteCatalog.swift
+++ b/agtermCore/Sources/agtermCore/PaletteCatalog.swift
@@ -9,6 +9,8 @@ public struct PaletteContext: Sendable, Equatable {
     public let activeSessionFlagged: Bool
     public let hasFocusedWorkspace: Bool
     public let activeSessionHasSplit: Bool
+    public let hasPendingClose: Bool
+    public let hasRecentClosed: Bool
 
     public init(canRemoveWorkspace: Bool = false,
                 hasFlaggedSessions: Bool = false,
@@ -16,7 +18,9 @@ public struct PaletteContext: Sendable, Equatable {
                 sidebarShowsFlaggedOnly: Bool = false,
                 activeSessionFlagged: Bool = false,
                 hasFocusedWorkspace: Bool = false,
-                activeSessionHasSplit: Bool = false) {
+                activeSessionHasSplit: Bool = false,
+                hasPendingClose: Bool = false,
+                hasRecentClosed: Bool = false) {
         self.canRemoveWorkspace = canRemoveWorkspace
         self.hasFlaggedSessions = hasFlaggedSessions
         self.sidebarShowsWorkspaceTree = sidebarShowsWorkspaceTree
@@ -24,13 +28,15 @@ public struct PaletteContext: Sendable, Equatable {
         self.activeSessionFlagged = activeSessionFlagged
         self.hasFocusedWorkspace = hasFocusedWorkspace
         self.activeSessionHasSplit = activeSessionHasSplit
+        self.hasPendingClose = hasPendingClose
+        self.hasRecentClosed = hasRecentClosed
     }
 }
 
 /// Static action-palette rows, in the same order the macOS palette presents them before dynamic rows.
 public enum PaletteCommand: String, CaseIterable, Sendable {
     case newSession, newWorkspace, openDirectory
-    case renameSession, renameWorkspace, closeSession, clearStatus
+    case renameSession, renameWorkspace, closeSession, reopenRecent, undoClose, clearStatus
     case previousSession, nextSession, previousAttentionSession, nextAttentionSession
     case firstSession, lastSession, showAttention
     case toggleSplit, toggleScratch, toggleSidebar, toggleFlag, focusWorkspace
@@ -54,6 +60,10 @@ public enum PaletteCommand: String, CaseIterable, Sendable {
             return context.sidebarShowsWorkspaceTree
         case .focusLeftPane, .focusRightPane:
             return context.activeSessionHasSplit
+        case .undoClose:
+            return context.hasPendingClose
+        case .reopenRecent:
+            return context.hasRecentClosed
         default:
             return true
         }
@@ -71,6 +81,8 @@ public enum PaletteCommand: String, CaseIterable, Sendable {
         case .renameSession: return "Rename Session"
         case .renameWorkspace: return "Rename Workspace"
         case .closeSession: return "Close Session"
+        case .reopenRecent: return "Reopen Last Closed Item"
+        case .undoClose: return "Reopen Closed Item"
         case .clearStatus: return "Clear Status"
         case .previousSession: return "Previous Session"
         case .nextSession: return "Next Session"
@@ -114,6 +126,8 @@ public enum PaletteCommand: String, CaseIterable, Sendable {
         case .renameSession: return .renameSession
         case .renameWorkspace: return .renameWorkspace
         case .closeSession: return .closeSession
+        case .reopenRecent: return .reopenRecent
+        case .undoClose: return .undoClose
         case .clearStatus: return .clearStatus
         case .previousSession: return .previousSession
         case .nextSession: return .nextSession

--- a/agtermCore/Sources/agtermCore/RecentClosed.swift
+++ b/agtermCore/Sources/agtermCore/RecentClosed.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+public enum RecentClosedKind: String, Codable, Sendable {
+    case session
+    case workspace
+}
+
+public struct RecentClosedItem: Codable, Identifiable, Equatable, Sendable {
+    public let id: UUID
+    public let kind: RecentClosedKind
+    public let title: String
+    public let subtitle: String?
+    public let closedAt: Date
+    public let session: RecentClosedSession?
+    public let workspace: RecentClosedWorkspace?
+
+    public init(id: UUID = UUID(), kind: RecentClosedKind, title: String, subtitle: String?,
+                closedAt: Date = Date(), session: RecentClosedSession? = nil,
+                workspace: RecentClosedWorkspace? = nil) {
+        self.id = id
+        self.kind = kind
+        self.title = title
+        self.subtitle = subtitle
+        self.closedAt = closedAt
+        self.session = session
+        self.workspace = workspace
+    }
+}
+
+public struct RecentClosedSession: Codable, Equatable, Sendable {
+    public let workspaceID: UUID
+    public let workspaceName: String
+    public let workspaceIndex: Int
+    public let sessionIndex: Int
+    public let snapshot: SessionSnapshot
+
+    public init(workspaceID: UUID, workspaceName: String, workspaceIndex: Int, sessionIndex: Int,
+                snapshot: SessionSnapshot) {
+        self.workspaceID = workspaceID
+        self.workspaceName = workspaceName
+        self.workspaceIndex = workspaceIndex
+        self.sessionIndex = sessionIndex
+        self.snapshot = snapshot
+    }
+}
+
+public struct RecentClosedWorkspace: Codable, Equatable, Sendable {
+    public let snapshot: WorkspaceSnapshot
+    public let selectedSessionID: UUID?
+
+    public init(snapshot: WorkspaceSnapshot, selectedSessionID: UUID?) {
+        self.snapshot = snapshot
+        self.selectedSessionID = selectedSessionID
+    }
+}
+
+public struct RecentClosedState: Codable, Equatable, Sendable {
+    public static let currentVersion = 1
+
+    public var version: Int
+    public var items: [RecentClosedItem]
+
+    public init(version: Int = RecentClosedState.currentVersion, items: [RecentClosedItem] = []) {
+        self.version = version
+        self.items = items
+    }
+}
+
+public struct RecentClosedStore: Sendable {
+    private let directory: URL
+    private let fileName: String
+    private let limit: Int
+
+    private var fileURL: URL { directory.appendingPathComponent(fileName) }
+
+    public init(directory: URL = PersistenceStore.defaultDirectory,
+                fileName: String = "recent-closed.json",
+                limit: Int = 20) {
+        self.directory = directory
+        self.fileName = fileName
+        self.limit = max(1, limit)
+    }
+
+    public func load() -> [RecentClosedItem] {
+        guard let data = try? Data(contentsOf: fileURL) else { return [] }
+        guard let state = try? JSONDecoder().decode(RecentClosedState.self, from: data) else { return [] }
+        guard state.version == RecentClosedState.currentVersion else { return [] }
+        return Array(state.items.prefix(limit))
+    }
+
+    public func record(_ item: RecentClosedItem) {
+        var items = load()
+        items.removeAll { existing in
+            if existing.id == item.id { return true }
+            switch (existing.kind, item.kind) {
+            case (.session, .session):
+                return existing.session?.snapshot.id == item.session?.snapshot.id
+            case (.workspace, .workspace):
+                return existing.workspace?.snapshot.id == item.workspace?.snapshot.id
+            default:
+                return false
+            }
+        }
+        items.insert(item, at: 0)
+        save(Array(items.prefix(limit)))
+    }
+
+    public func remove(_ id: UUID) {
+        save(load().filter { $0.id != id })
+    }
+
+    public func clear() {
+        save([])
+    }
+
+    private func save(_ items: [RecentClosedItem]) {
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            try encoder.encode(RecentClosedState(items: items)).write(to: fileURL, options: .atomic)
+        } catch {
+            NSLog("agterm: save recent closed failed: %@", String(describing: error))
+        }
+    }
+}

--- a/agtermCore/Sources/agtermCore/WindowLibrary.swift
+++ b/agtermCore/Sources/agtermCore/WindowLibrary.swift
@@ -78,6 +78,10 @@ public final class WindowLibrary {
     /// The ordered window metadata, for the menu/palette.
     public private(set) var windows: [WindowInfo]
 
+    /// App-wide recent closed sessions/workspaces, newest first. Reopening inserts the saved item into
+    /// the active window; this list is independent of window reopen semantics.
+    public private(set) var recentClosedItems: [RecentClosedItem]
+
     /// The id of the frontmost on-screen window, mirrored into the index on change.
     public var frontmostWindowID: UUID?
 
@@ -88,6 +92,7 @@ public final class WindowLibrary {
     /// The state directory (AGTERM_STATE_DIR-aware); the index lives here and per-window files in
     /// the `windows/` subdirectory.
     @ObservationIgnored private let directory: URL
+    @ObservationIgnored private let recentClosedStore: RecentClosedStore
 
     /// Set once the launch reopen-all has run, so the scene `.task` (which fires per window) drives
     /// it exactly once. `@ObservationIgnored`: a launch-flow latch, not view state.
@@ -120,8 +125,10 @@ public final class WindowLibrary {
     /// window set is always valid and non-empty.
     public init(directory: URL = PersistenceStore.defaultDirectory) {
         self.directory = directory
+        self.recentClosedStore = RecentClosedStore(directory: directory)
         self.stores = [:]
         self.windows = []
+        self.recentClosedItems = recentClosedStore.load()
         self.frontmostWindowID = nil
         bootstrap()
     }
@@ -309,7 +316,7 @@ public final class WindowLibrary {
     @discardableResult
     public func newWindow(name: String? = nil) -> WindowInfo {
         let info = WindowInfo(name: name?.trimmedOrNil ?? defaultWindowName)
-        let store = AppStore(persistence: persistenceStore(for: info.id))
+        let store = makeStore(persistence: persistenceStore(for: info.id))
         let workspace = store.addWorkspace(name: "workspace 1")
         store.addSession(toWorkspace: workspace.id, cwd: FileManager.default.homeDirectoryForCurrentUser.path)
         windows.append(info)
@@ -331,11 +338,35 @@ public final class WindowLibrary {
         guard windows.contains(where: { $0.id == id }) else { return nil }
         if let existing = stores[id] { return existing }
         let persistence = persistenceStore(for: id)
-        let store = AppStore(persistence: persistence)
+        let store = makeStore(persistence: persistence)
         store.restore(from: persistence.load())
         stores[id] = store
         saveIndex()
         return store
+    }
+
+    @discardableResult
+    public func reopenRecentClosed(_ itemID: UUID, into targetStore: AppStore? = nil) -> Bool {
+        refreshRecentClosedItems()
+        guard let item = recentClosedItems.first(where: { $0.id == itemID }),
+              let store = targetStore ?? activeStore,
+              store.restoreRecentClosed(item)
+        else { return false }
+        recentClosedStore.remove(itemID)
+        refreshRecentClosedItems()
+        return true
+    }
+
+    @discardableResult
+    public func reopenLatestRecentClosed(into targetStore: AppStore? = nil) -> Bool {
+        refreshRecentClosedItems()
+        guard let item = recentClosedItems.first else { return false }
+        return reopenRecentClosed(item.id, into: targetStore)
+    }
+
+    public func clearRecentClosedItems() {
+        recentClosedStore.clear()
+        refreshRecentClosedItems()
     }
 
     /// Closes a window: drops its store (marking it closed) and persists the index. The caller
@@ -436,6 +467,11 @@ public final class WindowLibrary {
         for store in stores.values { store.save() }
     }
 
+    /// Finalizes any grace-period session/workspace closes in open windows before a window/app teardown.
+    public func finalizeAllPendingCloses() {
+        for store in stores.values { store.finalizeAllPendingCloses() }
+    }
+
     /// Writes `windows.json`: the ordered window list (with each window's open flag) and the
     /// frontmost id. A write failure is logged and swallowed.
     public func saveIndex() {
@@ -533,7 +569,7 @@ public final class WindowLibrary {
         guard !snapshot.workspaces.isEmpty else { return false }
         // first window, so `defaultWindowName` yields "window 1" (windows is empty at this point).
         let info = WindowInfo(name: defaultWindowName)
-        let store = AppStore(persistence: persistenceStore(for: info.id))
+        let store = makeStore(persistence: persistenceStore(for: info.id))
         store.restore(from: snapshot)
         store.save()
         windows = [info]
@@ -553,6 +589,16 @@ public final class WindowLibrary {
     /// A `PersistenceStore` pointed at the window's `windows/<id>.json` file.
     private func persistenceStore(for id: UUID) -> PersistenceStore {
         PersistenceStore(directory: windowsDirectory, fileName: "\(id.uuidString).json")
+    }
+
+    private func makeStore(persistence: PersistenceStore) -> AppStore {
+        AppStore(persistence: persistence, recentClosedStore: recentClosedStore) { [weak self] in
+            self?.refreshRecentClosedItems()
+        }
+    }
+
+    private func refreshRecentClosedItems() {
+        recentClosedItems = recentClosedStore.load()
     }
 
     private func log(_ message: @autoclosure () -> String) {

--- a/agtermCore/Tests/agtermCoreTests/AppSettingsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppSettingsTests.swift
@@ -17,6 +17,14 @@ struct AppSettingsTests {
         #expect(decoded.fontSize == 16)
         #expect(decoded.fontFamily == nil)
         #expect(decoded.theme == nil)
+        #expect(decoded.closeGraceUndoEnabled == nil)
+    }
+
+    @Test func closeGraceUndoSettingRoundTripsAndDefaultsToNil() throws {
+        let disabled = AppSettings(closeGraceUndoEnabled: false)
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(disabled))
+        #expect(decoded.closeGraceUndoEnabled == false)
+        #expect(AppSettings().closeGraceUndoEnabled == nil)
     }
 
     @Test func emptySettingsEmitOnlyAlwaysOnDefaults() {

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -382,6 +382,143 @@ struct AppStoreTests {
         #expect(split.teardownCount == 1)
     }
 
+    @Test func softCloseSessionHidesWithoutTearingDownAndUndoRestoresSameSession() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let first = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a", name: "alpha"))
+        let second = try #require(store.addSession(toWorkspace: ws.id, cwd: "/b", name: "beta"))
+        let surface = SpySurface()
+        first.surface = surface
+        store.selectSession(first.id)
+
+        #expect(store.softCloseSession(first.id, grace: 60))
+
+        #expect(store.workspaces[0].sessions.map(\.id) == [second.id])
+        #expect(store.selectedSessionID == second.id)
+        #expect(surface.teardownCount == 0)
+        let summary = try #require(store.pendingCloseSummary)
+        #expect(summary.kind == .session)
+        #expect(summary.title == "alpha")
+
+        #expect(store.undoPendingClose(summary.id))
+
+        #expect(store.workspaces[0].sessions.map(\.id) == [first.id, second.id])
+        #expect(store.selectedSessionID == first.id)
+        #expect(store.workspaces[0].sessions[0] === first)
+        #expect(surface.teardownCount == 0)
+        #expect(store.pendingCloseSummary == nil)
+    }
+
+    @Test func finalizedSoftCloseSessionTearsDownAndCannotUndo() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        let surface = SpySurface()
+        session.surface = surface
+
+        #expect(store.softCloseSession(session.id, grace: 60))
+        let summary = try #require(store.pendingCloseSummary)
+        store.finalizePendingClose(summary.id)
+
+        #expect(surface.teardownCount == 1)
+        #expect(!store.undoPendingClose(summary.id))
+        #expect(store.pendingCloseSummary == nil)
+    }
+
+    @Test func undoingLatestPendingClosePromotesPreviousPendingClose() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let first = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a", name: "alpha"))
+        let second = try #require(store.addSession(toWorkspace: ws.id, cwd: "/b", name: "beta"))
+        let third = try #require(store.addSession(toWorkspace: ws.id, cwd: "/c", name: "gamma"))
+
+        #expect(store.softCloseSession(first.id, grace: 60))
+        #expect(store.pendingCloseSummary?.title == "alpha")
+        #expect(store.softCloseSession(second.id, grace: 60))
+        #expect(store.pendingCloseSummary?.title == "beta")
+
+        #expect(store.undoPendingClose())
+        #expect(store.workspaces[0].sessions.map(\.id) == [second.id, third.id])
+        #expect(store.pendingCloseSummary?.title == "alpha")
+
+        #expect(store.undoPendingClose())
+        #expect(store.workspaces[0].sessions.map(\.id) == [first.id, second.id, third.id])
+        #expect(store.pendingCloseSummary == nil)
+    }
+
+    @Test func undoBeforeScheduledFinalizeMakesTimerFireNoOp() async throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        let surface = SpySurface()
+        session.surface = surface
+
+        #expect(store.softCloseSession(session.id, grace: 0.01))
+        let summary = try #require(store.pendingCloseSummary)
+        #expect(store.undoPendingClose(summary.id))
+        try await Task.sleep(nanoseconds: 30_000_000)
+
+        #expect(store.session(withID: session.id) === session)
+        #expect(surface.teardownCount == 0)
+        #expect(store.pendingCloseSummary == nil)
+    }
+
+    @Test func scheduledFinalizeTearsDownAfterGrace() async throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        let surface = SpySurface()
+        session.surface = surface
+
+        #expect(store.softCloseSession(session.id, grace: 0.01))
+        try await Task.sleep(nanoseconds: 30_000_000)
+
+        #expect(store.session(withID: session.id) == nil)
+        #expect(surface.teardownCount == 1)
+        #expect(store.pendingCloseSummary == nil)
+    }
+
+    @Test func softRemoveWorkspaceHidesWithoutTearingDownAndUndoRestores() throws {
+        let store = makeStore()
+        let keep = store.addWorkspace(name: "keep")
+        let doomed = store.addWorkspace(name: "doomed")
+        let session = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/a"))
+        let surface = SpySurface()
+        session.surface = surface
+        _ = store.addSession(toWorkspace: keep.id, cwd: "/b")
+
+        #expect(store.softRemoveWorkspace(doomed.id, grace: 60))
+
+        #expect(store.workspaces.map(\.id) == [keep.id])
+        #expect(surface.teardownCount == 0)
+        let summary = try #require(store.pendingCloseSummary)
+        #expect(summary.kind == .workspace)
+        #expect(summary.title == "doomed")
+
+        #expect(store.undoPendingClose(summary.id))
+
+        #expect(store.workspaces.map(\.id) == [keep.id, doomed.id])
+        #expect(store.workspaces[1].sessions[0] === session)
+        #expect(store.selectedSessionID == session.id)
+        #expect(surface.teardownCount == 0)
+    }
+
+    @Test func finalizedSoftRemoveWorkspaceTearsDownSessions() throws {
+        let store = makeStore()
+        _ = store.addWorkspace(name: "keep")
+        let doomed = store.addWorkspace(name: "doomed")
+        let session = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/a"))
+        let surface = SpySurface()
+        session.surface = surface
+
+        #expect(store.softRemoveWorkspace(doomed.id, grace: 60))
+        let summary = try #require(store.pendingCloseSummary)
+        store.finalizePendingClose(summary.id)
+
+        #expect(surface.teardownCount == 1)
+        #expect(store.workspaces.map(\.name) == ["keep"])
+    }
+
     @Test func removeWorkspaceTearsDownSessionsAndPrunesRecency() {
         let store = makeStore()
         let keep = store.addWorkspace(name: "keep")

--- a/agtermCore/Tests/agtermCoreTests/BuiltinActionTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/BuiltinActionTests.swift
@@ -23,8 +23,10 @@ struct BuiltinActionTests {
         #expect(BuiltinAction.toggleFlag.rawValue == "toggle_flag")
         #expect(BuiltinAction.focusWorkspace.rawValue == "focus_workspace")
         #expect(BuiltinAction.showAttention.rawValue == "show_attention")
+        #expect(BuiltinAction.reopenRecent.rawValue == "reopen_recent")
+        #expect(BuiltinAction.undoClose.rawValue == "undo_close")
         #expect(BuiltinAction.toggleFullscreen.rawValue == "toggle_fullscreen")
-        #expect(BuiltinAction.allCases.count == 36)
+        #expect(BuiltinAction.allCases.count == 38)
     }
 
     @Test func rejectsUnknownName() {
@@ -63,6 +65,8 @@ struct BuiltinActionTests {
             .openDirectory: Chord(mods: [.command], key: "o"),
             .renameSession: nil,
             .closeSession: Chord(mods: [.command], key: "w"),
+            .reopenRecent: Chord(mods: [.command, .shift], key: "t"),
+            .undoClose: Chord(mods: [.command], key: "z"),
             .clearStatus: nil,
             .increaseFontSize: Chord(mods: [.command], key: "+"),
             .decreaseFontSize: Chord(mods: [.command], key: "-"),

--- a/agtermCore/Tests/agtermCoreTests/PaletteCatalogTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/PaletteCatalogTests.swift
@@ -10,6 +10,8 @@ struct PaletteCatalogTests {
             "Rename Session",
             "Rename Workspace",
             "Close Session",
+            "Reopen Last Closed Item",
+            "Reopen Closed Item",
             "Clear Status",
             "Previous Session",
             "Next Session",
@@ -46,7 +48,7 @@ struct PaletteCatalogTests {
     }
 
     @Test func catalogHasTheExpectedStaticCommandCount() {
-        #expect(PaletteCommand.allCases.count == 38)
+        #expect(PaletteCommand.allCases.count == 40)
     }
 
     @Test func idsRoundTripThroughRawValue() {
@@ -87,12 +89,18 @@ struct PaletteCatalogTests {
         #expect(PaletteCommand.clearFocus.isVisible(in: PaletteContext(hasFocusedWorkspace: true)))
         #expect(!PaletteCommand.focusLeftPane.isVisible(in: PaletteContext(activeSessionHasSplit: false)))
         #expect(PaletteCommand.focusRightPane.isVisible(in: PaletteContext(activeSessionHasSplit: true)))
+        #expect(!PaletteCommand.undoClose.isVisible(in: PaletteContext(hasPendingClose: false)))
+        #expect(PaletteCommand.undoClose.isVisible(in: PaletteContext(hasPendingClose: true)))
+        #expect(!PaletteCommand.reopenRecent.isVisible(in: PaletteContext(hasRecentClosed: false)))
+        #expect(PaletteCommand.reopenRecent.isVisible(in: PaletteContext(hasRecentClosed: true)))
     }
 
     @Test func builtinMappingsCoverRebindableCommands() {
         #expect(PaletteCommand.newSession.builtinAction == .newSession)
         #expect(PaletteCommand.find.builtinAction == .toggleSearch)
         #expect(PaletteCommand.resetFontSize.builtinAction == .resetFontSize)
+        #expect(PaletteCommand.reopenRecent.builtinAction == .reopenRecent)
+        #expect(PaletteCommand.undoClose.builtinAction == .undoClose)
         #expect(PaletteCommand.clearFlagged.builtinAction == nil)
         #expect(PaletteCommand.expandWorkspaces.builtinAction == nil)
     }

--- a/agtermCore/Tests/agtermCoreTests/RecentClosedTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/RecentClosedTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+final class RecentClosedTests {
+    private let directory: URL
+
+    init() throws {
+        directory = FileManager.default.temporaryDirectory.appendingPathComponent("agterm-recent-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    private var fileURL: URL { directory.appendingPathComponent("recent-closed.json") }
+
+    @Test func diskRoundTripPreservesNewestFirstItems() {
+        let store = RecentClosedStore(directory: directory)
+        let first = sessionItem(title: "first")
+        let second = workspaceItem(title: "workspace")
+
+        store.record(first)
+        store.record(second)
+
+        let loaded = RecentClosedStore(directory: directory).load()
+        #expect(loaded.map(\.id) == [second.id, first.id])
+        #expect(loaded[0].workspace?.snapshot.name == "workspace")
+        #expect(loaded[1].session?.snapshot.customName == "first")
+    }
+
+    @Test func recordDedupesSessionsAndWorkspacesBySnapshotID() {
+        let store = RecentClosedStore(directory: directory)
+        let sessionID = UUID()
+        let workspaceID = UUID()
+
+        store.record(sessionItem(id: UUID(), snapshotID: sessionID, title: "old session"))
+        store.record(sessionItem(id: UUID(), snapshotID: sessionID, title: "new session"))
+        store.record(workspaceItem(id: UUID(), snapshotID: workspaceID, title: "old workspace"))
+        store.record(workspaceItem(id: UUID(), snapshotID: workspaceID, title: "new workspace"))
+
+        let loaded = store.load()
+        #expect(loaded.map(\.title) == ["new workspace", "new session"])
+        #expect(loaded.compactMap { $0.session?.snapshot.id } == [sessionID])
+        #expect(loaded.compactMap { $0.workspace?.snapshot.id } == [workspaceID])
+    }
+
+    @Test func defaultLimitKeepsTwentyNewestItems() {
+        let store = RecentClosedStore(directory: directory)
+
+        for index in 0..<25 {
+            store.record(sessionItem(title: "session \(index)"))
+        }
+
+        let loaded = store.load()
+        #expect(loaded.count == 20)
+        #expect(loaded.first?.title == "session 24")
+        #expect(loaded.last?.title == "session 5")
+    }
+
+    @Test func versionMismatchLoadsAsEmpty() throws {
+        let item = sessionItem(title: "stale")
+        let data = try JSONEncoder().encode(RecentClosedState(version: RecentClosedState.currentVersion + 1,
+                                                              items: [item]))
+        try data.write(to: fileURL)
+
+        #expect(RecentClosedStore(directory: directory).load().isEmpty)
+    }
+
+    private func sessionItem(id: UUID = UUID(), snapshotID: UUID = UUID(), title: String) -> RecentClosedItem {
+        RecentClosedItem(
+            id: id,
+            kind: .session,
+            title: title,
+            subtitle: "work",
+            session: RecentClosedSession(
+                workspaceID: UUID(),
+                workspaceName: "work",
+                workspaceIndex: 0,
+                sessionIndex: 0,
+                snapshot: SessionSnapshot(id: snapshotID, customName: title, cwd: "/tmp")
+            )
+        )
+    }
+
+    private func workspaceItem(id: UUID = UUID(), snapshotID: UUID = UUID(), title: String) -> RecentClosedItem {
+        RecentClosedItem(
+            id: id,
+            kind: .workspace,
+            title: title,
+            subtitle: "1 session",
+            workspace: RecentClosedWorkspace(
+                snapshot: WorkspaceSnapshot(
+                    id: snapshotID,
+                    name: title,
+                    sessions: [SessionSnapshot(id: UUID(), customName: "api", cwd: "/tmp")]
+                ),
+                selectedSessionID: nil
+            )
+        )
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/WindowLibraryTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/WindowLibraryTests.swift
@@ -74,6 +74,143 @@ final class WindowLibraryTests {
         #expect(library.totalUnseenCount == 2)
     }
 
+    @Test func closingSessionRecordsAndReopensRecentItem() {
+        let library = WindowLibrary(directory: directory)
+        let store = try! #require(library.activeStore)
+        let originalWorkspace = store.addWorkspace(name: "project")
+        let first = try! #require(store.addSession(toWorkspace: originalWorkspace.id, cwd: "/first", name: "first"))
+        let session = try! #require(store.addSession(toWorkspace: originalWorkspace.id, cwd: "/project", name: "api"))
+        let last = try! #require(store.addSession(toWorkspace: originalWorkspace.id, cwd: "/last", name: "last"))
+        _ = store.addWorkspace(name: "other")
+
+        store.closeSession(session.id)
+
+        let recent = try! #require(library.recentClosedItems.first)
+        #expect(recent.kind == .session)
+        #expect(recent.title == "api")
+        #expect(recent.subtitle == originalWorkspace.name)
+        #expect(store.session(withID: session.id) == nil)
+
+        #expect(library.reopenRecentClosed(recent.id))
+        let restored = try! #require(store.session(withID: session.id))
+        #expect(restored.initialCwd == "/project")
+        #expect(restored.customName == "api")
+        let restoredWorkspace = try! #require(store.workspaces.first { $0.id == originalWorkspace.id })
+        #expect(restoredWorkspace.sessions.map(\.id) == [first.id, session.id, last.id])
+        #expect(store.selectedSessionID == session.id)
+        #expect(library.recentClosedItems.isEmpty)
+    }
+
+    @Test func reopeningRecentSessionRecreatesMissingOriginalWorkspace() {
+        let library = WindowLibrary(directory: directory)
+        let store = try! #require(library.activeStore)
+        let originalWorkspace = store.addWorkspace(name: "project")
+        let session = try! #require(store.addSession(toWorkspace: originalWorkspace.id, cwd: "/project", name: "api"))
+
+        store.closeSession(session.id)
+        let recent = try! #require(library.recentClosedItems.first)
+        store.removeWorkspace(originalWorkspace.id)
+
+        #expect(library.reopenRecentClosed(recent.id))
+        let restoredWorkspace = try! #require(store.workspaces.first { $0.id == originalWorkspace.id })
+        #expect(restoredWorkspace.name == "project")
+        #expect(restoredWorkspace.sessions.map(\.id) == [session.id])
+        #expect(store.selectedSessionID == session.id)
+    }
+
+    @Test func reopeningStaleRecentSessionSelectsExistingSessionInsteadOfDuplicatingID() {
+        let library = WindowLibrary(directory: directory)
+        let store = try! #require(library.activeStore)
+        let workspace = store.addWorkspace(name: "project")
+        let session = try! #require(store.addSession(toWorkspace: workspace.id, cwd: "/project", name: "api"))
+
+        store.closeSession(session.id)
+        let recent = try! #require(library.recentClosedItems.first)
+        #expect(store.restoreRecentClosed(recent))
+        #expect(store.restoreRecentClosed(recent))
+
+        let matching = store.workspaces.flatMap(\.sessions).filter { $0.id == session.id }
+        #expect(matching.count == 1)
+        #expect(store.selectedSessionID == session.id)
+    }
+
+    @Test func closingWorkspaceRecordsAndReopensRecentItem() {
+        let library = WindowLibrary(directory: directory)
+        let store = try! #require(library.activeStore)
+        let workspace = store.addWorkspace(name: "project")
+        let session = try! #require(store.addSession(toWorkspace: workspace.id, cwd: "/project", name: "api"))
+
+        store.removeWorkspace(workspace.id)
+
+        let recent = try! #require(library.recentClosedItems.first)
+        #expect(recent.kind == .workspace)
+        #expect(recent.title == "project")
+        #expect(recent.subtitle == "1 session")
+        #expect(store.workspaces.contains { $0.id == workspace.id } == false)
+
+        #expect(library.reopenRecentClosed(recent.id))
+        let restoredWorkspace = try! #require(store.workspaces.first { $0.id == workspace.id })
+        #expect(restoredWorkspace.name == "project")
+        #expect(restoredWorkspace.sessions.map(\.id) == [session.id])
+        #expect(store.selectedSessionID == session.id)
+        #expect(library.recentClosedItems.isEmpty)
+    }
+
+    @Test func reopeningStaleRecentWorkspaceSelectsExistingWorkspaceInsteadOfDuplicatingIDs() {
+        let library = WindowLibrary(directory: directory)
+        let store = try! #require(library.activeStore)
+        let workspace = store.addWorkspace(name: "project")
+        let session = try! #require(store.addSession(toWorkspace: workspace.id, cwd: "/project", name: "api"))
+
+        store.removeWorkspace(workspace.id)
+        let recent = try! #require(library.recentClosedItems.first)
+        #expect(store.restoreRecentClosed(recent))
+        #expect(store.restoreRecentClosed(recent))
+
+        let matchingWorkspaces = store.workspaces.filter { $0.id == workspace.id }
+        let matchingSessions = store.workspaces.flatMap(\.sessions).filter { $0.id == session.id }
+        #expect(matchingWorkspaces.count == 1)
+        #expect(matchingSessions.count == 1)
+        #expect(store.selectedSessionID == session.id)
+    }
+
+    @Test func reopeningRecentDuringGraceRestoresPendingSessionWithoutRebuildingSnapshot() {
+        let library = WindowLibrary(directory: directory)
+        let store = try! #require(library.activeStore)
+        let workspace = store.workspaces[0]
+        let session = try! #require(store.addSession(toWorkspace: workspace.id, cwd: "/grace", name: "grace"))
+        let surface = SpySurface()
+        session.surface = surface
+
+        #expect(store.softCloseSession(session.id, grace: 60))
+        let recent = try! #require(library.recentClosedItems.first)
+        #expect(library.reopenRecentClosed(recent.id))
+
+        let restored = try! #require(store.session(withID: session.id))
+        #expect(restored === session)
+        #expect(surface.teardownCount == 0)
+        #expect(library.recentClosedItems.isEmpty)
+    }
+
+    @Test func graceUndoRecordsRecentAndUndoRemovesIt() {
+        let library = WindowLibrary(directory: directory)
+        let store = try! #require(library.activeStore)
+        let workspace = store.workspaces[0]
+        let undone = try! #require(store.addSession(toWorkspace: workspace.id, cwd: "/undo", name: "undo"))
+        #expect(store.softCloseSession(undone.id, grace: 60))
+        #expect(library.recentClosedItems.map(\.title) == ["undo"])
+        #expect(store.undoPendingClose())
+        #expect(library.recentClosedItems.isEmpty)
+
+        let finalized = try! #require(store.addSession(toWorkspace: workspace.id, cwd: "/final", name: "final"))
+        #expect(store.softCloseSession(finalized.id, grace: 60))
+        store.finalizeAllPendingCloses()
+
+        let recent = try! #require(library.recentClosedItems.first)
+        #expect(recent.kind == .session)
+        #expect(recent.title == "final")
+    }
+
     @Test func defaultWindowNameCountsUp() {
         let library = WindowLibrary(directory: directory)
         #expect(library.defaultWindowName == "window 2")


### PR DESCRIPTION
## Summary

Adds reopen support for accidentally or recently closed sessions and workspaces.

- Grace-period undo for GUI session/workspace closes, including Cmd-Z support and a sidebar toast.
- Persistent File > Open Recent entries for closed sessions and workspaces.
- A settings toggle to disable the grace-period undo while keeping recent reopen behavior.

## Technical notes

- Core owns the host-free pending-close and recent-closed state; SwiftUI/AppKit only render menus, toast UI, and keyboard monitoring.
- Recent session/workspace restore reuses the existing snapshot model so restored state matches window restore fidelity.
- GUI grace-period closes keep surfaces alive until finalization; finalized closes record persistent recent items.

## Demo

https://github.com/user-attachments/assets/2734a157-9e28-44b3-8750-97f18072a8b7

p.s. decided for features like this it it easier to start with PR right away, then discuss, @umputun I hope you are Ok with this approach