### PR TITLE
fix: align sidebar rows with the terminal and thin the hidden drag strip

### DIFF
--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -92,10 +92,14 @@ paths:
   The triangle color is not accessibility-observable, so this is verified by eye, not a UI test — like
   the cursor solid/hollow case.
 - **Sidebar selection is drawn entirely by `SidebarRowView`, not AppKit.**
-  `outline.selectionHighlightStyle = .none` (set right after `style = .sourceList`,
+  `outline.selectionHighlightStyle = .none` (set right after `style = .plain`,
   which would otherwise reset it) so AppKit draws no selection of its own — otherwise it paints a gray
   *unemphasized* capsule whenever the sidebar isn't first responder (the normal case,
   since focus lives in the terminal), overriding any custom `drawSelection`.
+  The `.plain` style (chosen over `.sourceList` to drop the built-in ~10px top inset above the first row)
+  also reverts the outline's `backgroundColor` to an OPAQUE `controlBackgroundColor`, so
+  `outline.backgroundColor = .clear` is set alongside `scroll.drawsBackground = false` to keep the column
+  transparent over the terminal-colored/translucent window backing.
   The row draws the themed pill in `drawBackground(in:)` for every state,
   and the Coordinator's `refreshSelectionAppearance()` repaints the pills + re-tints the row text on
   selection change (AppKit won't redraw rows on its own with `.none`) and on `.agtermAppearanceChanged`.
@@ -107,7 +111,7 @@ paths:
   **Reconcile splits SHAPE from CONTENT** (`TreeShape` ids/order → full `rebuildAndReload`;
   `RowContent` name/icon/badge → per-row `reloadItem`) so a cwd-driven `displayName` change reloads only
   its row instead of a full `reloadData` + re-expand that re-lays-out and horizontally jitters every
-  source-list row.
+  sidebar row.
   **Inline rename** paints the edit field with the terminal theme's foreground-on-background (the row's
   selection-foreground would be dark-on-dark in the system edit box), and `restore` re-applies the row's
   selection-aware color when editing ends (a same-name commit doesn't reload the row).

--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -23,7 +23,8 @@ paths:
   stored raw as `String?` (like `newSessionDirectory`/`autoFollowAttention`) for tolerant forward-compat
   decode — an unknown future value degrades to the default instead of nuking the whole `settings.json`.
   nil = compact [the app default]; `.normal` adds the cwd subtitle line, `.hidden` drops the titlebar row
-  AND the traffic lights for a full-bleed terminal, leaving only an invisible ~6px top drag strip.
+  AND the traffic lights for a full-bleed terminal, leaving only an invisible ~3px top drag strip (thin so
+  it doesn't cover the terminal's first row, which is at window-padding-y = 6).
   Resolved via `effectiveToolbarMode` = `toolbarMode.flatMap(ToolbarMode.init(rawValue:)) ?? (compactToolbar == false ? .normal : .compact)`;
   `compactToolbar: Bool?` is RETAINED only as a legacy decode shim (the old two-state key: `false` = normal,
   nil/true = compact) so pre-existing `settings.json` still opens right — writing a mode nils it, so it

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -40,7 +40,7 @@ See `CLAUDE.md` for the socket lifecycle, addressing, command catalog, and the k
 
 ### Sidebar (NSOutlineView)
 
-`WorkspaceSidebar` is an `NSViewRepresentable` wrapping an `NSOutlineView` (source-list style). It replaces an earlier SwiftUI `List`, which could not do reliable cross-section drag-and-drop. A `@MainActor` `Coordinator` is the data source and delegate, backed by `AppStore`:
+`WorkspaceSidebar` is an `NSViewRepresentable` wrapping an `NSOutlineView` (`.plain` style, with a custom row height and a content inset matching the terminal's ghostty padding). It replaces an earlier SwiftUI `List`, which could not do reliable cross-section drag-and-drop. A `@MainActor` `Coordinator` is the data source and delegate, backed by `AppStore`:
 
 - **Stable item identity.** Outline items are reference-type `SidebarNode`s cached by id and reused across reloads, so `NSOutlineView` keeps expansion and selection state. `updateNSView` reads the observed store (tree + `selectedSessionID`), so model changes reload the outline.
 - **Selection.** Only session rows are selectable; selecting one routes through `AppStore.selectSession`, and `store.selectedSessionID` is reflected back into the outline (guarded against re-entry).

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -538,14 +538,15 @@ struct WindowContentView: View {
     }
 
     /// The window chrome above the terminal: the full custom titlebar row, or — in hidden mode — an
-    /// invisible ~6px top drag strip and nothing else (no row, and `WindowAppearance.sync` also drops the
+    /// invisible ~3px top drag strip and nothing else (no row, and `WindowAppearance.sync` also drops the
     /// traffic lights) so the terminal runs full-bleed while the window stays movable + double-click-zoomable.
     @ViewBuilder private var customTitlebar: some View {
         if toolbarMode == .hidden {
-            // the top ~6px loses click-through (the accepted cost) but keeps the standard title-bar
-            // gestures via the same `WindowControlArea` the full row uses.
+            // only the top ~3px loses click-through (the accepted cost) — kept thin so it doesn't cover the
+            // terminal's first row (window-padding-y = 6), which would otherwise swallow clicks meant to
+            // select it; it still keeps the standard title-bar gestures via the same `WindowControlArea`.
             Color.clear
-                .frame(height: 6)
+                .frame(height: 3)
                 .frame(maxWidth: .infinity)
                 // Color.clear is hit-testable in SwiftUI, so it would swallow the mouseDown before it
                 // reaches the WindowControlArea behind it — opt out (like the titlebarRow spacers) so the

--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -10,10 +10,10 @@ let sessionPasteboardType = NSPasteboard.PasteboardType("com.umputun.agterm.sess
 /// drags (within the outline) use this to identify the workspace being reordered.
 let workspacePasteboardType = NSPasteboard.PasteboardType("com.umputun.agterm.workspace")
 
-/// AppKit `NSOutlineView` sidebar (source-list style) hosted in SwiftUI via
-/// `NSViewRepresentable`. Replaces the SwiftUI `List` sidebar so cross-workspace
-/// drag-and-drop works natively: a session row can be dragged onto a different
-/// workspace and the model moves it (same `Session` instance preserved).
+/// AppKit `NSOutlineView` sidebar (`.plain` style + a custom row height and a left content inset that
+/// matches the terminal's ghostty padding) hosted in SwiftUI via `NSViewRepresentable`. Replaces the
+/// SwiftUI `List` sidebar so cross-workspace drag-and-drop works natively: a session row can be dragged
+/// onto a different workspace and the model moves it (same `Session` instance preserved).
 ///
 /// Two-level tree: workspaces (expandable parents, bold) → sessions (children).
 /// Only session rows are selectable detail targets. Inline rename via double-click
@@ -31,14 +31,18 @@ struct WorkspaceSidebar: NSViewRepresentable {
         outline.dataSource = context.coordinator
         outline.delegate = context.coordinator
         outline.headerView = nil
-        outline.rowSizeStyle = .default
+        // .plain style (not .sourceList) so there is no built-in ~10px top inset above the first row (the
+        // sidebar tree runs flush below the titlebar in every toolbar mode); a custom row height restores
+        // the roomy source-list-like row size that .plain's .default would otherwise shrink to ~17px.
+        outline.rowSizeStyle = .custom
+        outline.rowHeight = 28
         outline.floatsGroupRows = false
         outline.indentationPerLevel = 14
         outline.autosaveExpandedItems = false
         outline.target = context.coordinator
         outline.action = #selector(Coordinator.handleSingleClick(_:))
         outline.doubleAction = #selector(Coordinator.handleDoubleClick(_:))
-        if #available(macOS 11.0, *) { outline.style = .sourceList }
+        if #available(macOS 11.0, *) { outline.style = .plain }
         // disable AppKit's own selection drawing: it would paint a gray unemphasized capsule whenever
         // the sidebar isn't first responder (focus normally lives in the terminal). SidebarRowView
         // draws the themed selection pill itself in drawBackground for every state.
@@ -84,8 +88,8 @@ struct WorkspaceSidebar: NSViewRepresentable {
         scroll.drawsBackground = false
         scroll.borderType = .noBorder
         context.coordinator.installEmptyState(in: scroll)
-        // in hidden toolbar mode the sidebar must run flush to the window top like the terminal.
-        context.coordinator.applyToolbarModeContentInset(scroll)
+        // inset the tree to match the terminal's ghostty padding so they line up in every toolbar mode.
+        context.coordinator.applySidebarContentInset(scroll)
         return scroll
     }
 
@@ -222,15 +226,16 @@ struct WorkspaceSidebar: NSViewRepresentable {
             outlineView?.appearance = NSAppearance(named: GhosttyApp.shared.terminalThemeIsDark ? .darkAqua : .aqua)
         }
 
-        /// In the hidden toolbar mode the titlebar row collapses to zero and the terminal runs flush to
-        /// the window top; the sidebar's scroll view otherwise reserves the title-bar band as a top
-        /// content inset (the terminal, a plain surface, has none), leaving its first row stranded below
-        /// the terminal. Drop the automatic inset when hidden so the row aligns; normal/compact keep it.
-        func applyToolbarModeContentInset(_ scroll: NSScrollView?) {
+        /// Inset the sidebar tree to line up with the terminal's ghostty padding (agterm/Resources/ghostty-defaults.conf):
+        /// window-padding-x = 8 matches the terminal's left margin, plus a small 2px top nudge so the first
+        /// row's text sits on the terminal's first line. Most of the ~window-padding-y = 6 gap above the text
+        /// comes from the row centering its content (`centerYAnchor`) in a ~28px row; the 2px fine-tunes it (a
+        /// full 6px top inset would double it). The `.plain` outline style adds no insets of its own, so we own
+        /// them (auto-adjust off). Mode-independent — same offset in every toolbar mode.
+        func applySidebarContentInset(_ scroll: NSScrollView?) {
             guard let scroll else { return }
-            let hidden = GhosttyApp.shared.toolbarMode == .hidden
-            scroll.automaticallyAdjustsContentInsets = !hidden
-            if hidden { scroll.contentInsets = NSEdgeInsets() }
+            scroll.automaticallyAdjustsContentInsets = false
+            scroll.contentInsets = NSEdgeInsets(top: 2, left: 8, bottom: 0, right: 0)
         }
 
         @objc private func appearanceChanged() {
@@ -245,7 +250,7 @@ struct WorkspaceSidebar: NSViewRepresentable {
             updateEmptyState()
             // a settings change may have flipped the toolbar mode; realign the scroll view's top inset so
             // hidden mode runs flush (like toolbarMode's other chrome mirrors).
-            applyToolbarModeContentInset(outlineView?.enclosingScrollView)
+            applySidebarContentInset(outlineView?.enclosingScrollView)
         }
 
         /// Re-apply the status glyph on every visible session row so a global agent-status color change

--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -43,6 +43,11 @@ struct WorkspaceSidebar: NSViewRepresentable {
         outline.action = #selector(Coordinator.handleSingleClick(_:))
         outline.doubleAction = #selector(Coordinator.handleDoubleClick(_:))
         if #available(macOS 11.0, *) { outline.style = .plain }
+        // .plain reverts the outline's backgroundColor to an OPAQUE controlBackgroundColor (unlike
+        // .sourceList's translucent source-list material), which would paint over the sidebar tint wash and
+        // the terminal-colored/translucent window backing. Clear it so the transparent column shows through,
+        // matching scroll.drawsBackground = false below.
+        outline.backgroundColor = .clear
         // disable AppKit's own selection drawing: it would paint a gray unemphasized capsule whenever
         // the sidebar isn't first responder (focus normally lives in the terminal). SidebarRowView
         // draws the themed selection pill itself in drawBackground for every state.
@@ -226,8 +231,9 @@ struct WorkspaceSidebar: NSViewRepresentable {
             outlineView?.appearance = NSAppearance(named: GhosttyApp.shared.terminalThemeIsDark ? .darkAqua : .aqua)
         }
 
-        /// Inset the sidebar tree to line up with the terminal's ghostty padding (agterm/Resources/ghostty-defaults.conf):
-        /// window-padding-x = 8 matches the terminal's left margin, plus a small 2px top nudge so the first
+        /// Inset the sidebar tree to line up with the terminal's DEFAULT ghostty padding (agterm/Resources/ghostty-defaults.conf;
+        /// a user window-padding override in ghostty.conf is not tracked here): window-padding-x = 8 matches
+        /// the terminal's left margin, plus a small 2px top nudge so the first
         /// row's text sits on the terminal's first line. Most of the ~window-padding-y = 6 gap above the text
         /// comes from the row centering its content (`centerYAnchor`) in a ~28px row; the 2px fine-tunes it (a
         /// full 6px top inset would double it). The `.plain` outline style adds no insets of its own, so we own
@@ -248,8 +254,8 @@ struct WorkspaceSidebar: NSViewRepresentable {
             // color change — re-apply every visible glyph so a Settings color edit takes effect live.
             reapplyStatusGlyphs()
             updateEmptyState()
-            // a settings change may have flipped the toolbar mode; realign the scroll view's top inset so
-            // hidden mode runs flush (like toolbarMode's other chrome mirrors).
+            // re-apply the sidebar content inset in case a settings change requires recomputing it (the
+            // inset itself is mode-independent, so this is a cheap re-assert, not a per-mode recalculation).
             applySidebarContentInset(outlineView?.enclosingScrollView)
         }
 
@@ -295,7 +301,7 @@ struct WorkspaceSidebar: NSViewRepresentable {
         /// mean no add/remove/move/reorder, so a row's content change (name/icon/badge) is handled by a
         /// targeted per-row reload instead of a full rebuild. Row TEXT is deliberately NOT here: a
         /// cwd-driven `displayName` change must not trigger a full `reloadData` + re-expand (which
-        /// re-lays-out every source-list row and jitters their labels horizontally).
+        /// re-lays-out every sidebar row and jitters their labels horizontally).
         private struct TreeShape: Equatable {
             let workspaceID: UUID
             let sessionIDs: [UUID]

--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -10,8 +10,8 @@ let sessionPasteboardType = NSPasteboard.PasteboardType("com.umputun.agterm.sess
 /// drags (within the outline) use this to identify the workspace being reordered.
 let workspacePasteboardType = NSPasteboard.PasteboardType("com.umputun.agterm.workspace")
 
-/// AppKit `NSOutlineView` sidebar (`.plain` style + a custom row height and a left content inset that
-/// matches the terminal's ghostty padding) hosted in SwiftUI via `NSViewRepresentable`. Replaces the
+/// AppKit `NSOutlineView` sidebar (`.plain` style + a custom row height and top/left content insets that
+/// match the terminal's ghostty padding) hosted in SwiftUI via `NSViewRepresentable`. Replaces the
 /// SwiftUI `List` sidebar so cross-workspace drag-and-drop works natively: a session row can be dragged
 /// onto a different workspace and the model moves it (same `Session` instance preserved).
 ///


### PR DESCRIPTION
The workspace sidebar had a persistent gap above the first row in every toolbar mode - the first workspace sat lower than the terminal's first line. Root cause: the `NSOutlineView` `.sourceList` style adds a built-in ~10px top inset.

Switched the outline to `.plain` (no built-in inset), kept the rows roomy with an explicit `rowHeight = 28`, and set the scroll view's `contentInsets` to match the terminal's ghostty padding (`window-padding-x = 8` left + a 2px top nudge) so the first workspace lines up with the terminal's first line. The `.plain` style also reverts the outline's `backgroundColor` to an opaque `controlBackgroundColor`, so it's cleared to keep the column transparent over the terminal-colored/translucent backing. The content-inset helper is now mode-independent (renamed `applyToolbarModeContentInset` to `applySidebarContentInset`).

Also thins the hidden-mode top drag strip from 6px to 3px: at 6px it overlapped the terminal's first row (`window-padding-y = 6`) and swallowed clicks meant to select it, while keeping the window draggable.
