### PR TITLE
feat: add quick type and quick text control commands

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -120,7 +120,7 @@ paths:
   The skill is a REFERENCE/knowledge skill (both user-invocable via `/agterm` and model-triggered,
   `allowed-tools: Bash(agtermctl *)`; the agent-neutral `description` carries the trigger nouns since
   Codex may ignore the extra `when_to_use` field — unknown frontmatter is harmless),
-  authored at `agterm/Resources/agent-skill/` (`SKILL.md` overview + model + addressing + 53-command
+  authored at `agterm/Resources/agent-skill/` (`SKILL.md` overview + model + addressing + 55-command
   summary + the image-display helper + a troubleshooting/reporting pointer;
   `reference.md` full per-command detail + keymap format; `examples.md` agtermctl recipes;
   `troubleshooting.md` diagnosing the common problems (keymap editor, custom actions,
@@ -190,11 +190,11 @@ paths:
   exact `uuidString` (case-insensitive), or a git-style unique prefix.
   Zero prefix hits → `notFound` error, ≥2 → `ambiguous` error listing the candidates.
   `--target` defaults to `active`, so scripts rarely type an id and never for "the current one".
-- **Command catalog (53 commands):**
+- **Command catalog (55 commands):**
   - `tree`
   - `workspace.new`/`workspace.rename`/`workspace.delete`/`workspace.select`/`workspace.move`/`workspace.focus`
   - `session.new`/`session.close`/`session.select`/`session.rename`/`session.move`/`session.type`/`session.split`/`session.scratch`/`session.focus`/`session.resize`/`session.go`/`session.copy`/`session.text`/`session.search`/`session.status`/`session.flag`/`session.seen`/`session.background`/`session.overlay.open`/`session.overlay.close`/`session.overlay.resize`/`session.overlay.result`
-  - `quick`
+  - `quick`/`quick.type`/`quick.text`
   - `sidebar`/`sidebar.mode`/`sidebar.expand`/`sidebar.collapse`
   - `notify`
   - `font.inc`/`font.dec`/`font.reset`
@@ -216,7 +216,7 @@ paths:
   Setting echoes the resulting effective side in `result.text`; the BARE form (no name) reads the side
   the last config feed applied (`SettingsModel.lastAppliedIsDark`), which the test polls to prove the
   flip actually drove the reload.
-  `AppearanceFlipUITests` is its only consumer; the public command count stays 53.
+  `AppearanceFlipUITests` is its only consumer; the public command count stays 55.
 
   `workspace.delete` honors keep-at-least-one and returns an error instead of the GUI confirm alert (nothing
   blocks on a modal).
@@ -592,6 +592,18 @@ paths:
   Threaded as a `quickVisible: () -> Bool?` closure on `AppStore.controlTree` (defaulting nil for host-free
   tests), covered by `treeRoundTripsWithQuickVisible`/`treeOmitsQuickVisibleWhenNil` +
   `AppStoreTests.controlTreeReportsQuickVisibleFromClosure`; the app-side `QuickTerminalRegistry` read is build-verified.
+  `quick.type`/`quick.text` are the input/read-back pair for the quick terminal, the twins of `session.type`/`session.text`
+  (the quick terminal is the one typing surface the socket couldn't reach before — issue #170).
+  Both are frontmost-window-only (no `--target`/`--window`/`--pane`; the quick terminal is a single per-window surface),
+  dispatcher-owned via `ControlActions.typeQuick(text:)` / `readQuickText(all:lines:)`, and inject/read through the
+  same `GhosttySurfaceView.inject(text:)` / `readScreenText(all:lines:)` primitives the session commands use.
+  Because the quick terminal keeps one long-lived surface there is no realize-and-select poll like `session.type`:
+  they type/read when a surface exists and return `quick terminal not open` when the overlay has never been shown
+  (mirroring `session has no scratch terminal`), `no open window` when there is no window at all.
+  `quick.text` is the read-back for `quick.type` (there is no NEW tree-node field — you read via the sibling `text`
+  command, exactly as `session.text` reads back `session.type`).
+  Covered by the `quickType*`/`quickText*` `ControlDispatcherTests` + the e2e `testQuickTypeAndReadText`
+  (type a marker, read it back off the quick surface).
   `session.status` flags a per-session agent status on the sidebar row — `args.status` is `idle`|`active`|`completed`|`blocked`
   (`AgentStatus(rawValue:)` → an `invalid status` error on anything else),
   `args.blink` pulses the glyph, and `args.autoReset` (status-agnostic, caller-set,
@@ -967,5 +979,5 @@ paths:
   (image/text/color set/clear + tree read-back).
   **Agent-skill mirror (HARD keep-in-sync, 4th surface):** all commands are documented in the bundled
   `agterm/Resources/agent-skill/` (SKILL.md summary, reference.md detail,
-  examples.md recipes) and the command count there is bumped to 53 to match.
+  examples.md recipes) and the command count there is bumped to 55 to match.
 

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -595,11 +595,16 @@ paths:
   `quick.type`/`quick.text` are the input/read-back pair for the quick terminal, the twins of `session.type`/`session.text`
   (the quick terminal is the one typing surface the socket couldn't reach before — issue #170).
   Both are frontmost-window-only (no `--target`/`--window`/`--pane`; the quick terminal is a single per-window surface),
-  dispatcher-owned via `ControlActions.typeQuick(text:)` / `readQuickText(all:lines:)`, and inject/read through the
-  same `GhosttySurfaceView.inject(text:)` / `readScreenText(all:lines:)` primitives the session commands use.
-  Because the quick terminal keeps one long-lived surface there is no realize-and-select poll like `session.type`:
-  they type/read when a surface exists and return `quick terminal not open` when the overlay has never been shown
-  (mirroring `session has no scratch terminal`), `no open window` when there is no window at all.
+  dispatcher-owned via `ControlActions.typeQuick(text:)` / `readQuickText(all:lines:)` (both `async`), and inject/read
+  through the same `GhosttySurfaceView.inject(text:)` / `readScreenText(all:lines:)` primitives the session commands use.
+  They are `async` because `quick show` flips `isVisible` before SwiftUI mounts + libghostty realizes the surface, so
+  a bounded main-actor poll (12×30 ms, the `session.type` realize-poll pattern) waits out the mount — `quick show; quick
+  type` back-to-back is reliable rather than racing.
+  Fast-fail when NOT racing: `quick terminal not open` when the overlay has never been shown (no surface AND not visible,
+  so the poll returns at once), `quick terminal not realized` / `failed to read surface buffer` if a shown surface never
+  comes up within the poll, `no open window` when there is no window.
+  A shown-then-hidden quick terminal keeps its surface alive, so it types/reads while hidden (like `session.type --pane
+  scratch`).
   `quick.text` is the read-back for `quick.type` (there is no NEW tree-node field — you read via the sibling `text`
   command, exactly as `session.text` reads back `session.type`).
   Covered by the `quickType*`/`quickText*` `ControlDispatcherTests` + the e2e `testQuickTypeAndReadText`

--- a/README.md
+++ b/README.md
@@ -214,7 +214,8 @@ agtermctl sidebar mode flagged                   # show only the flagged session
 agtermctl workspace focus on                     # collapse the sidebar tree to the active workspace (on|off|toggle)
 agtermctl session search "error"                 # open the search bar and highlight matches; prints the "N of M" counter
 agtermctl session search --next                  # step to the next match (--prev steps back, --close hides the bar)
-agtermctl quick toggle                           # toggle the quick terminal
+agtermctl quick toggle                           # toggle the quick terminal (show|hide|toggle)
+agtermctl quick type 'ls -la'$'\n'               # type into the frontmost window's quick terminal (or --stdin); quick text reads it back
 agtermctl font inc                               # increase the active surface's font size
 agtermctl theme set --light "Builtin Light" --dark Dracula  # set the light/dark theme slots (--dark none turns following off)
 ```

--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -594,40 +594,56 @@ extension ControlServer: ControlActions {
     }
 
     /// Inject `text` as literal keystrokes into the frontmost window's quick terminal, the quick-terminal
-    /// twin of `session.type` (input goes where the user is typing when the overlay is up). The quick
-    /// terminal keeps one long-lived surface, so there's no realize-and-select poll like `session.type`:
-    /// it types when a surface exists, and reports `quick terminal not open` when the overlay has never
-    /// been shown (mirroring `session has no scratch terminal`). No open window is an error.
-    func typeQuick(text: String) -> ControlResponse {
+    /// twin of `session.type` (input goes where the user is typing when the overlay is up). `quick show`
+    /// flips `isVisible` before SwiftUI mounts + libghostty realizes the surface, so `quick show; quick
+    /// type` would otherwise race the mount — this polls briefly (like `session.type`'s realize poll) so a
+    /// back-to-back script types reliably. Fails fast with `quick terminal not open` when the overlay has
+    /// never been shown (no surface AND not visible), `quick terminal not realized` if a shown surface
+    /// never comes up within the poll, `no open window` when there is no window.
+    func typeQuick(text: String) async -> ControlResponse {
         guard let controller = QuickTerminalRegistry.shared.controller(for: library.activeWindowID) else {
             return ControlResponse(ok: false, error: "no open window")
         }
-        guard let surface = controller.currentSurface() else {
-            return ControlResponse(ok: false, error: "quick terminal not open")
+        for _ in 0..<12 {
+            if let surface = controller.currentSurface() {
+                // a false inject means the view exists but its libghostty surface isn't realized yet — keep
+                // polling rather than reporting a silent-drop false ok. A shown-then-hidden surface stays
+                // alive and realized (types while hidden, like `--pane scratch`), so it lands here at once.
+                if surface.inject(text: text) {
+                    return ControlResponse(ok: true)
+                }
+            } else if !controller.isVisible {
+                // no surface and not showing → never shown; don't wait out the poll.
+                return ControlResponse(ok: false, error: "quick terminal not open")
+            }
+            try? await Task.sleep(nanoseconds: 30_000_000)
         }
-        // a false inject means the surface exists but its libghostty surface isn't realized yet (the ms
-        // after `quick show`, before layout) — report that rather than a silent-drop false ok.
-        guard surface.inject(text: text) else {
-            return ControlResponse(ok: false, error: "quick terminal not realized")
-        }
-        return ControlResponse(ok: true)
+        return ControlResponse(ok: false, error: "quick terminal not realized")
     }
 
     /// Read the frontmost window's quick-terminal screen as plain text, the quick-terminal twin of
     /// `session.text` — the read-back for `quick.type`. `all` reads the full screen + scrollback, `lines`
-    /// keeps only the last N; the quick terminal has a single surface, so there's no `--pane`. `quick
-    /// terminal not open` when the overlay has never been shown; no open window is an error.
-    func readQuickText(all: Bool, lines: Int?) -> ControlResponse {
+    /// keeps only the last N; the quick terminal has a single surface, so there's no `--pane`. Polls for
+    /// mount + realization like `typeQuick` so `quick show; quick text` doesn't race the mount; fails fast
+    /// with `quick terminal not open` when never shown, `failed to read surface buffer` if a shown surface
+    /// never realizes within the poll, `no open window` when there is no window.
+    func readQuickText(all: Bool, lines: Int?) async -> ControlResponse {
         guard let controller = QuickTerminalRegistry.shared.controller(for: library.activeWindowID) else {
             return ControlResponse(ok: false, error: "no open window")
         }
-        guard let surface = controller.currentSurface() else {
-            return ControlResponse(ok: false, error: "quick terminal not open")
+        for _ in 0..<12 {
+            if let surface = controller.currentSurface() {
+                // readScreenText returns nil only for an unrealized surface ("" for a realized blank
+                // screen), so a non-nil result means the surface is up — return it.
+                if let text = surface.readScreenText(all: all, lines: lines) {
+                    return ControlResponse(ok: true, result: ControlResult(text: text))
+                }
+            } else if !controller.isVisible {
+                return ControlResponse(ok: false, error: "quick terminal not open")
+            }
+            try? await Task.sleep(nanoseconds: 30_000_000)
         }
-        guard let text = surface.readScreenText(all: all, lines: lines) else {
-            return ControlResponse(ok: false, error: "failed to read surface buffer")
-        }
-        return ControlResponse(ok: true, result: ControlResult(text: text))
+        return ControlResponse(ok: false, error: "failed to read surface buffer")
     }
 
     /// Show / hide / toggle the frontmost window's sidebar (the custom split owns visibility, so there's

--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -593,6 +593,43 @@ extension ControlServer: ControlActions {
         return ControlResponse(ok: true)
     }
 
+    /// Inject `text` as literal keystrokes into the frontmost window's quick terminal, the quick-terminal
+    /// twin of `session.type` (input goes where the user is typing when the overlay is up). The quick
+    /// terminal keeps one long-lived surface, so there's no realize-and-select poll like `session.type`:
+    /// it types when a surface exists, and reports `quick terminal not open` when the overlay has never
+    /// been shown (mirroring `session has no scratch terminal`). No open window is an error.
+    func typeQuick(text: String) -> ControlResponse {
+        guard let controller = QuickTerminalRegistry.shared.controller(for: library.activeWindowID) else {
+            return ControlResponse(ok: false, error: "no open window")
+        }
+        guard let surface = controller.currentSurface() else {
+            return ControlResponse(ok: false, error: "quick terminal not open")
+        }
+        // a false inject means the surface exists but its libghostty surface isn't realized yet (the ms
+        // after `quick show`, before layout) — report that rather than a silent-drop false ok.
+        guard surface.inject(text: text) else {
+            return ControlResponse(ok: false, error: "quick terminal not realized")
+        }
+        return ControlResponse(ok: true)
+    }
+
+    /// Read the frontmost window's quick-terminal screen as plain text, the quick-terminal twin of
+    /// `session.text` — the read-back for `quick.type`. `all` reads the full screen + scrollback, `lines`
+    /// keeps only the last N; the quick terminal has a single surface, so there's no `--pane`. `quick
+    /// terminal not open` when the overlay has never been shown; no open window is an error.
+    func readQuickText(all: Bool, lines: Int?) -> ControlResponse {
+        guard let controller = QuickTerminalRegistry.shared.controller(for: library.activeWindowID) else {
+            return ControlResponse(ok: false, error: "no open window")
+        }
+        guard let surface = controller.currentSurface() else {
+            return ControlResponse(ok: false, error: "quick terminal not open")
+        }
+        guard let text = surface.readScreenText(all: all, lines: lines) else {
+            return ControlResponse(ok: false, error: "failed to read surface buffer")
+        }
+        return ControlResponse(ok: true, result: ControlResult(text: text))
+    }
+
     /// Show / hide / toggle the frontmost window's sidebar (the custom split owns visibility, so there's
     /// no system toggle). Flips only when the requested state differs; an unknown mode is an error, and no
     /// open window is an error rather than a silent no-op.

--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -604,7 +604,12 @@ extension ControlServer: ControlActions {
         guard let controller = QuickTerminalRegistry.shared.controller(for: library.activeWindowID) else {
             return ControlResponse(ok: false, error: "no open window")
         }
-        for _ in 0..<12 {
+        // probe first (fast path), then sleep-then-probe up to 12 more times — a probe follows every sleep
+        // so the full ~360ms window is used, matching `session.type`'s realize poll (no wasted trailing sleep).
+        for attempt in 0...12 {
+            if attempt > 0 {
+                try? await Task.sleep(nanoseconds: 30_000_000)
+            }
             if let surface = controller.currentSurface() {
                 // a false inject means the view exists but its libghostty surface isn't realized yet — keep
                 // polling rather than reporting a silent-drop false ok. A shown-then-hidden surface stays
@@ -616,7 +621,6 @@ extension ControlServer: ControlActions {
                 // no surface and not showing → never shown; don't wait out the poll.
                 return ControlResponse(ok: false, error: "quick terminal not open")
             }
-            try? await Task.sleep(nanoseconds: 30_000_000)
         }
         return ControlResponse(ok: false, error: "quick terminal not realized")
     }
@@ -631,7 +635,11 @@ extension ControlServer: ControlActions {
         guard let controller = QuickTerminalRegistry.shared.controller(for: library.activeWindowID) else {
             return ControlResponse(ok: false, error: "no open window")
         }
-        for _ in 0..<12 {
+        // probe first, then sleep-then-probe up to 12 more times (a probe follows every sleep), like `typeQuick`.
+        for attempt in 0...12 {
+            if attempt > 0 {
+                try? await Task.sleep(nanoseconds: 30_000_000)
+            }
             if let surface = controller.currentSurface() {
                 // readScreenText returns nil only for an unrealized surface ("" for a realized blank
                 // screen), so a non-nil result means the surface is up — return it.
@@ -641,7 +649,6 @@ extension ControlServer: ControlActions {
             } else if !controller.isVisible {
                 return ControlResponse(ok: false, error: "quick terminal not open")
             }
-            try? await Task.sleep(nanoseconds: 30_000_000)
         }
         return ControlResponse(ok: false, error: "failed to read surface buffer")
     }

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -370,7 +370,8 @@ final class ControlServer {
                 .fontInc, .fontDec, .fontReset, .keymapReload, .configReload, .themeSet, .themeList,
                 .sidebar, .sidebarMode, .sidebarExpand, .sidebarCollapse, .sessionType, .sessionCopy,
                 .sessionSearch, .sessionOverlayOpen, .sessionOverlayClose, .sessionOverlayResize,
-                .sessionOverlayResult, .sessionBackground, .sessionText, .quick, .windowNew, .windowList, .windowSelect,
+                .sessionOverlayResult, .sessionBackground, .sessionText, .quick, .quickType, .quickText,
+                .windowNew, .windowList, .windowSelect,
                 .windowClose, .windowRename, .windowDelete, .windowResize, .windowMove, .windowZoom,
                 .windowFullscreen, .restoreClear:
             return ControlResponse(ok: false, error: "control dispatcher did not handle \(request.cmd.rawValue)")

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -113,7 +113,7 @@ you work. For any session-scoped command meant to act on *this* session — `ove
 `type`, `text`, `background`, `status`, `copy`, … — pass `--target "$AGTERM_SESSION_ID"`. Omit it and
 you open overlays / type into whatever the user has selected, not your own session.
 
-## Command summary (53 commands)
+## Command summary (55 commands)
 
 Run `agtermctl <area> <cmd> --help` for exact flags. Full detail in **reference.md**; recipes in
 **examples.md**.
@@ -209,7 +209,10 @@ focused from the tree workspace node's `focused` flag).
 `zoom <id>` (maximize-to-screen toggle, the double-click-header gesture; a plain green-button click does full screen) ·
 `fullscreen <id>` (toggle native macOS full screen, the green-button / ⌃⌘F action).
 
-**quick** — `[show|hide|toggle]` — the window's quick terminal.
+**quick** — `[show|hide|toggle]` (visibility; read back from the tree's `quickVisible`) ·
+`type TEXT` (or `--stdin`) inject keystrokes into the frontmost window's quick terminal ·
+`text [--all] [--lines N]` read its screen back — the twins of `session type`/`session text`,
+frontmost-window-only (no `--target`/`--window`/`--pane`).
 
 **sidebar** — `[show|hide|toggle]` (visibility; read back from the tree's `sidebarVisible`) ·
 `mode [tree|flagged|toggle]` (flip between the workspace tree and the flat flagged working-set list; read

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -214,6 +214,20 @@ agtermctl session scratch toggle
 agtermctl session scratch on --command "zsh -lc 'lazygit'"   # run a program instead of a shell (run-once); login-shell wrap so Homebrew's PATH is found (bare "lazygit" exits 127)
 ```
 
+## Drive the quick terminal
+
+The quick terminal is the window's throwaway overlay (not in the session tree). Show it, type into it,
+and read it back — the twins of `session type`/`session text`, but always the frontmost window's quick
+terminal (no `--target`/`--pane`).
+
+```bash
+agtermctl quick show                                 # drop the overlay over whatever is active
+agtermctl quick type 'ls -la'$'\n'                   # inject keystrokes (\n runs it)
+echo "some payload" | agtermctl quick type --stdin   # pipe stdin in (e.g. a paste helper)
+agtermctl quick text --all                           # read its screen + scrollback back
+agtermctl tree | jq .quickVisible                    # is it open right now?
+```
+
 ## Flag a working set and view just the flagged sessions
 
 Flag a few sessions across workspaces, then flip the sidebar to the flat flagged list (each row labeled

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -332,7 +332,17 @@ shell (no controlling terminal — `/dev/tty` errors). See examples.md for usage
 
 `agtermctl quick [show|hide|toggle]` — the frontmost window's quick terminal (a single scratch
 terminal at 90% of the window, not in the tree; its shell stays alive across hides). Errors with
-`no open window` when none is open.
+`no open window` when none is open. Read its visibility back from the tree's top-level `quickVisible`.
+
+`agtermctl quick type TEXT` (or `--stdin`) — inject `TEXT` as literal keystrokes into the frontmost
+window's quick terminal, the quick-terminal twin of `session type`. There is no `--target`/`--window`
+(always the frontmost window's quick terminal) and no `--pane` (a single surface). Errors with
+`quick terminal not open` when the overlay has never been shown, `no open window` when none is open.
+
+`agtermctl quick text [--all] [--lines N]` — print the frontmost window's quick-terminal buffer as
+plain text (the read-back for `quick type`; does not touch the system clipboard). `--all` reads the
+full screen + scrollback, `--lines N` keeps only the last N (mutually exclusive). Same `quick terminal
+not open` / `no open window` errors as `quick type`.
 
 ## sidebar
 

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -336,13 +336,17 @@ terminal at 90% of the window, not in the tree; its shell stays alive across hid
 
 `agtermctl quick type TEXT` (or `--stdin`) — inject `TEXT` as literal keystrokes into the frontmost
 window's quick terminal, the quick-terminal twin of `session type`. There is no `--target`/`--window`
-(always the frontmost window's quick terminal) and no `--pane` (a single surface). Errors with
-`quick terminal not open` when the overlay has never been shown, `no open window` when none is open.
+(always the frontmost window's quick terminal) and no `--pane` (a single surface). It polls briefly for
+the surface to come up, so `quick show; quick type` back-to-back is reliable (the overlay mounts a beat
+after `quick show` flips visibility). Errors with `quick terminal not open` when the overlay has never
+been shown, `quick terminal not realized` if a shown surface never comes up in time, `no open window`
+when none is open. Typing into a shown-then-hidden quick terminal still works (its shell stays alive).
 
 `agtermctl quick text [--all] [--lines N]` — print the frontmost window's quick-terminal buffer as
 plain text (the read-back for `quick type`; does not touch the system clipboard). `--all` reads the
-full screen + scrollback, `--lines N` keeps only the last N (mutually exclusive). Same `quick terminal
-not open` / `no open window` errors as `quick type`.
+full screen + scrollback, `--lines N` keeps only the last N (mutually exclusive). Polls for the surface
+like `quick type`. Errors with `quick terminal not open` (never shown), `failed to read surface buffer`
+(shown surface never realized in time), `no open window`.
 
 ## sidebar
 
@@ -506,7 +510,8 @@ user-edited file read at launch — there is no control command for it.
 `invalid fit` / `invalid position` / `invalid opacity` / `invalid color` / `text too long` /
 `unsupported image (PNG or JPEG only)` / `no such image file` / `image path must not contain control characters` / `invalid background mode` (session background),
 `invalid sidebar mode` (sidebar), `invalid focus mode` (workspace focus),
-`no open window` (quick/sidebar), `window not open`
+`no open window` (quick/sidebar), `quick terminal not open` / `quick terminal not realized` (quick type) /
+`failed to read surface buffer` (quick text / session text), `window not open`
 (resize/move/`--window`), `unknown theme: <name>` (theme set), `unknown sound: <name>` (session status --sound),
 `invalid color (expected #rrggbb)` (session status --color),
 `--pane must be left, right, or scratch` (the `--pane` value check — the `agtermctl` CLI rejects a bad pane

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -36,8 +36,8 @@ public protocol ControlActions {
     func expandSidebar(window: String?) -> ControlResponse
     func collapseSidebar(window: String?) -> ControlResponse
     func setQuickTerminal(mode: String?) -> ControlResponse
-    func typeQuick(text: String) -> ControlResponse
-    func readQuickText(all: Bool, lines: Int?) -> ControlResponse
+    func typeQuick(text: String) async -> ControlResponse
+    func readQuickText(all: Bool, lines: Int?) async -> ControlResponse
     func typeSession(_ target: String?, window: String?, options: ControlSessionTypeOptions) async -> ControlResponse
     func copySessionSelection(_ target: String?, window: String?) -> ControlResponse
     func searchSession(_ target: String?, window: String?,
@@ -138,10 +138,12 @@ public struct ControlDispatcher {
         case .workspaceNew, .workspaceSelect, .workspaceRename, .workspaceDelete,
                 .workspaceMove, .workspaceFocus:
             return dispatchWorkspaceCommand(request)
-        case .quick, .quickType, .quickText, .fontInc, .fontDec, .fontReset, .keymapReload,
+        case .quick, .fontInc, .fontDec, .fontReset, .keymapReload,
                 .configReload, .notify, .themeSet, .themeList, .sidebar, .sidebarMode, .sidebarExpand,
                 .sidebarCollapse, .restoreClear:
             return dispatchAppCommand(request)
+        case .quickType, .quickText:
+            return await dispatchQuickCommand(request)
         case .windowNew, .windowList, .windowSelect, .windowClose, .windowRename,
                 .windowDelete, .windowResize, .windowMove, .windowZoom, .windowFullscreen:
             return await dispatchWindowCommand(request)
@@ -367,21 +369,6 @@ public struct ControlDispatcher {
             return actions.font(request.target, window: request.args?.window, action: "reset_font_size")
         case .quick:
             return actions.setQuickTerminal(mode: request.args?.mode)
-        case .quickType:
-            guard let text = request.args?.text else {
-                return ControlResponse(ok: false, error: "quick.type requires text")
-            }
-            return actions.typeQuick(text: text)
-        case .quickText:
-            let all = request.args?.all ?? false
-            let lines = request.args?.lines
-            if all, lines != nil {
-                return ControlResponse(ok: false, error: "use either --all or --lines, not both")
-            }
-            if let lines, lines <= 0 {
-                return ControlResponse(ok: false, error: "--lines must be greater than 0")
-            }
-            return actions.readQuickText(all: all, lines: lines)
         case .keymapReload:
             return actions.reloadKeymap()
         case .configReload:
@@ -414,6 +401,31 @@ public struct ControlDispatcher {
             return actions.clearRestoreCommands()
         default:
             preconditionFailure("unexpected app command: \(request.cmd.rawValue)")
+        }
+    }
+
+    /// The quick-terminal input/read commands, `async` because the app side polls briefly for the surface
+    /// to mount + realize after `quick show` (the twin of `session.type`/`session.text`, which are async
+    /// for the same realize-wait reason).
+    private func dispatchQuickCommand(_ request: ControlRequest) async -> ControlResponse {
+        switch request.cmd {
+        case .quickType:
+            guard let text = request.args?.text else {
+                return ControlResponse(ok: false, error: "quick.type requires text")
+            }
+            return await actions.typeQuick(text: text)
+        case .quickText:
+            let all = request.args?.all ?? false
+            let lines = request.args?.lines
+            if all, lines != nil {
+                return ControlResponse(ok: false, error: "use either --all or --lines, not both")
+            }
+            if let lines, lines <= 0 {
+                return ControlResponse(ok: false, error: "--lines must be greater than 0")
+            }
+            return await actions.readQuickText(all: all, lines: lines)
+        default:
+            preconditionFailure("unexpected quick command: \(request.cmd.rawValue)")
         }
     }
 

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -36,6 +36,8 @@ public protocol ControlActions {
     func expandSidebar(window: String?) -> ControlResponse
     func collapseSidebar(window: String?) -> ControlResponse
     func setQuickTerminal(mode: String?) -> ControlResponse
+    func typeQuick(text: String) -> ControlResponse
+    func readQuickText(all: Bool, lines: Int?) -> ControlResponse
     func typeSession(_ target: String?, window: String?, options: ControlSessionTypeOptions) async -> ControlResponse
     func copySessionSelection(_ target: String?, window: String?) -> ControlResponse
     func searchSession(_ target: String?, window: String?,
@@ -136,8 +138,8 @@ public struct ControlDispatcher {
         case .workspaceNew, .workspaceSelect, .workspaceRename, .workspaceDelete,
                 .workspaceMove, .workspaceFocus:
             return dispatchWorkspaceCommand(request)
-        case .quick, .fontInc, .fontDec, .fontReset, .keymapReload, .configReload, .notify,
-                .themeSet, .themeList, .sidebar, .sidebarMode, .sidebarExpand,
+        case .quick, .quickType, .quickText, .fontInc, .fontDec, .fontReset, .keymapReload,
+                .configReload, .notify, .themeSet, .themeList, .sidebar, .sidebarMode, .sidebarExpand,
                 .sidebarCollapse, .restoreClear:
             return dispatchAppCommand(request)
         case .windowNew, .windowList, .windowSelect, .windowClose, .windowRename,
@@ -365,6 +367,21 @@ public struct ControlDispatcher {
             return actions.font(request.target, window: request.args?.window, action: "reset_font_size")
         case .quick:
             return actions.setQuickTerminal(mode: request.args?.mode)
+        case .quickType:
+            guard let text = request.args?.text else {
+                return ControlResponse(ok: false, error: "quick.type requires text")
+            }
+            return actions.typeQuick(text: text)
+        case .quickText:
+            let all = request.args?.all ?? false
+            let lines = request.args?.lines
+            if all, lines != nil {
+                return ControlResponse(ok: false, error: "use either --all or --lines, not both")
+            }
+            if let lines, lines <= 0 {
+                return ControlResponse(ok: false, error: "--lines must be greater than 0")
+            }
+            return actions.readQuickText(all: all, lines: lines)
         case .keymapReload:
             return actions.reloadKeymap()
         case .configReload:

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -34,6 +34,8 @@ public enum Command: String, Codable, Sendable {
     case sessionOverlayResize = "session.overlay.resize"
     case sessionOverlayResult = "session.overlay.result"
     case quick
+    case quickType = "quick.type"
+    case quickText = "quick.text"
     case sidebar
     case sidebarMode = "sidebar.mode"
     case sidebarExpand = "sidebar.expand"
@@ -84,7 +86,7 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     /// For `session.new` with `workspaceName`: create the named workspace when none exists (idempotent
     /// reuse-or-create). An error without `workspaceName` — there is nothing to create by id.
     public var createWorkspace: Bool?
-    /// Text to inject for `session.type`; the search needle for `session.search`.
+    /// Text to inject for `session.type` / `quick.type`; the search needle for `session.search`.
     public var text: String?
     /// Whether `session.type` may select a never-shown session to realize its surface.
     public var select: Bool?
@@ -123,9 +125,9 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     /// pane, negative grows the right (the CLI's `--grow-left`/`--grow-right`). Applied to the session's
     /// current fraction (0.5 when never moved). Mutually exclusive with `ratio`.
     public var ratioDelta: Double?
-    /// For `session.text`: read the full screen + scrollback instead of just the visible screen.
+    /// For `session.text` / `quick.text`: read the full screen + scrollback instead of just the visible screen.
     public var all: Bool?
-    /// For `session.text`: keep only the last N lines of the full buffer.
+    /// For `session.text` / `quick.text`: keep only the last N lines of the full buffer.
     public var lines: Int?
     /// Direction for `session.go` (`next`|`prev`|`previous`|`first`|`last`), for the reorder form of
     /// `session.move` / `workspace.move` (`up`|`down`|`top`|`bottom`), and for `session.search`

--- a/agtermCore/Sources/agtermctlKit/MiscCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/MiscCommands.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import Foundation
 import agtermCore
 
 // MARK: - keymap
@@ -97,14 +98,71 @@ struct Theme: ParsableCommand {
 
 // MARK: - quick
 
-struct Quick: RequestCommand {
-    static let configuration = CommandConfiguration(abstract: "Quick terminal (show|hide|toggle).")
-    @Argument(help: "Mode: show, hide, or toggle (default).") var mode: String = "toggle"
-    // the quick terminal is always the frontmost window's, so this carries no `--window` selector.
-    @OptionGroup var options: BasicOptions
+struct Quick: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Quick terminal: visibility, type into it, read its text.",
+        subcommands: [Visibility.self, TypeText.self, Text.self],
+        defaultSubcommand: Visibility.self
+    )
 
-    func makeRequest() throws -> ControlRequest {
-        ControlRequest(cmd: .quick, args: ControlArgs(mode: mode))
+    /// `agtermctl quick [show|hide|toggle]` — the default, so the bare verb keeps working. Shows/hides the
+    /// frontmost window's quick terminal.
+    struct Visibility: RequestCommand {
+        static let configuration = CommandConfiguration(commandName: "visibility", abstract: "Quick terminal visibility (show|hide|toggle).")
+        @Argument(help: "Mode: show, hide, or toggle (default).") var mode: String = "toggle"
+        // the quick terminal is always the frontmost window's, so this carries no `--window` selector.
+        @OptionGroup var options: BasicOptions
+
+        func makeRequest() throws -> ControlRequest {
+            ControlRequest(cmd: .quick, args: ControlArgs(mode: mode))
+        }
+    }
+
+    /// `agtermctl quick type TEXT` — inject literal keystrokes into the frontmost window's quick terminal
+    /// (the quick-terminal twin of `session type`). No `--target`/`--window`: it's always the frontmost
+    /// window's quick terminal.
+    struct TypeText: RequestCommand {
+        static let configuration = CommandConfiguration(commandName: "type", abstract: "Inject text into the quick terminal.")
+        @Argument(help: "Text to inject (omit with --stdin).") var text: String?
+        @Flag(name: .long, help: "Read the text from stdin instead of an argument.") var stdin = false
+        @OptionGroup var options: BasicOptions
+
+        func makeRequest() throws -> ControlRequest {
+            let payload: String
+            if stdin {
+                // non-UTF8 stdin decodes to nil and injects nothing — terminal input is UTF-8 text.
+                let data = FileHandle.standardInput.readDataToEndOfFile()
+                payload = String(data: data, encoding: .utf8) ?? ""
+            } else if let text {
+                payload = text
+            } else {
+                throw ValidationError("provide TEXT or --stdin")
+            }
+            return ControlRequest(cmd: .quickType, args: ControlArgs(text: payload))
+        }
+    }
+
+    /// `agtermctl quick text` — print the frontmost window's quick-terminal buffer as plain text (the
+    /// read-back for `quick type`; does not touch the system clipboard). No `--pane`: the quick terminal
+    /// has a single surface.
+    struct Text: RequestCommand {
+        static let configuration = CommandConfiguration(commandName: "text", abstract: "Print the quick terminal's buffer as plain text.")
+        @Flag(name: .long, help: "Read the full screen + scrollback instead of just the visible screen.") var all = false
+        @Option(name: .long, help: "Keep only the last N lines of the full buffer.") var lines: Int?
+        @OptionGroup var options: BasicOptions
+
+        func validate() throws {
+            if all, lines != nil {
+                throw ValidationError("use either --all or --lines, not both")
+            }
+            if let lines, lines <= 0 {
+                throw ValidationError("--lines must be greater than 0")
+            }
+        }
+
+        func makeRequest() throws -> ControlRequest {
+            ControlRequest(cmd: .quickText, args: ControlArgs(all: all ? true : nil, lines: lines))
+        }
     }
 }
 

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -1099,6 +1099,62 @@ struct ControlDispatcherTests {
         #expect(actions.calls == [.quick("maybe")])
     }
 
+    @Test func quickTypeRoutesTextAndKeepsActionResponse() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextQuickTypeResponse = ControlResponse(ok: false, error: "quick terminal not open")
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .quickType,
+            args: ControlArgs(text: "hello")
+        ))
+
+        #expect(response == ControlResponse(ok: false, error: "quick terminal not open"))
+        #expect(actions.calls == [.quickType(text: "hello")])
+    }
+
+    @Test func quickTypeRequiresTextBeforeCallingActions() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let response = await dispatcher.dispatch(ControlRequest(cmd: .quickType))
+
+        #expect(response == ControlResponse(ok: false, error: "quick.type requires text"))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test func quickTextRoutesOptionsAndKeepsExactActionResponse() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextQuickTextResponse = ControlResponse(ok: true, result: ControlResult(text: "line\n"))
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .quickText,
+            args: ControlArgs(lines: 10)
+        ))
+
+        #expect(response == ControlResponse(ok: true, result: ControlResult(text: "line\n")))
+        #expect(actions.calls == [.quickText(all: false, lines: 10)])
+    }
+
+    @Test func quickTextRejectsInvalidLineOptionsBeforeCallingActions() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let both = await dispatcher.dispatch(ControlRequest(
+            cmd: .quickText,
+            args: ControlArgs(all: true, lines: 5)
+        ))
+        let zero = await dispatcher.dispatch(ControlRequest(
+            cmd: .quickText,
+            args: ControlArgs(lines: 0)
+        ))
+
+        #expect(both == ControlResponse(ok: false, error: "use either --all or --lines, not both"))
+        #expect(zero == ControlResponse(ok: false, error: "--lines must be greater than 0"))
+        #expect(actions.calls.isEmpty)
+    }
+
     @Test func sessionSearchRoutesRawInputsAndKeepsActionResponse() async {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)
@@ -1291,6 +1347,8 @@ private final class MockControlActions: ControlActions {
         case expand(window: String?)
         case collapse(window: String?)
         case quick(String?)
+        case quickType(text: String)
+        case quickText(all: Bool, lines: Int?)
         case sessionType(target: String?, window: String?, ControlSessionTypeOptions)
         case sessionCopy(target: String?, window: String?)
         case sessionSearch(target: String?, window: String?, text: String?, to: String?)
@@ -1327,6 +1385,8 @@ private final class MockControlActions: ControlActions {
     var nextThemeSetResponse = ControlResponse(ok: true)
     var nextThemeListResponse = ControlResponse(ok: true)
     var nextQuickResponse = ControlResponse(ok: true)
+    var nextQuickTypeResponse = ControlResponse(ok: true)
+    var nextQuickTextResponse = ControlResponse(ok: true)
     var nextSessionTypeResponse = ControlResponse(ok: true)
     var nextSessionCopyResponse = ControlResponse(ok: true)
     var nextSessionSearchResponse = ControlResponse(ok: true)
@@ -1504,6 +1564,16 @@ private final class MockControlActions: ControlActions {
     func setQuickTerminal(mode: String?) -> ControlResponse {
         calls.append(.quick(mode))
         return nextQuickResponse
+    }
+
+    func typeQuick(text: String) -> ControlResponse {
+        calls.append(.quickType(text: text))
+        return nextQuickTypeResponse
+    }
+
+    func readQuickText(all: Bool, lines: Int?) -> ControlResponse {
+        calls.append(.quickText(all: all, lines: lines))
+        return nextQuickTextResponse
     }
 
     func typeSession(_ target: String?, window: String?,

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -1137,6 +1137,20 @@ struct ControlDispatcherTests {
         #expect(actions.calls == [.quickText(all: false, lines: 10)])
     }
 
+    @Test func quickTextRoutesAllFlagOnTheSuccessPath() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextQuickTextResponse = ControlResponse(ok: true, result: ControlResult(text: "full\n"))
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .quickText,
+            args: ControlArgs(all: true)
+        ))
+
+        #expect(response == ControlResponse(ok: true, result: ControlResult(text: "full\n")))
+        #expect(actions.calls == [.quickText(all: true, lines: nil)])
+    }
+
     @Test func quickTextRejectsInvalidLineOptionsBeforeCallingActions() async {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)
@@ -1566,12 +1580,12 @@ private final class MockControlActions: ControlActions {
         return nextQuickResponse
     }
 
-    func typeQuick(text: String) -> ControlResponse {
+    func typeQuick(text: String) async -> ControlResponse {
         calls.append(.quickType(text: text))
         return nextQuickTypeResponse
     }
 
-    func readQuickText(all: Bool, lines: Int?) -> ControlResponse {
+    func readQuickText(all: Bool, lines: Int?) async -> ControlResponse {
         calls.append(.quickText(all: all, lines: lines))
         return nextQuickTextResponse
     }

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -232,6 +232,18 @@ struct ControlProtocolTests {
         }
     }
 
+    @Test func quickTypeAndTextCommandsRoundTrip() throws {
+        let cases: [ControlRequest] = [
+            ControlRequest(cmd: .quickType, args: ControlArgs(text: "hello\n")),
+            ControlRequest(cmd: .quickText),
+            ControlRequest(cmd: .quickText, args: ControlArgs(all: true)),
+            ControlRequest(cmd: .quickText, args: ControlArgs(lines: 50)),
+        ]
+        for request in cases {
+            #expect(try roundTrip(request) == request)
+        }
+    }
+
     @Test func sessionScratchRoundTripsWithCommand() throws {
         let request = ControlRequest(cmd: .sessionScratch, target: "active", args: ControlArgs(mode: "on", command: "htop"))
         let decoded = try roundTrip(request)

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -622,6 +622,37 @@ struct CommandsTests {
         #expect(try request(["quick", "show"]) == ControlRequest(cmd: .quick, args: ControlArgs(mode: "show")))
     }
 
+    @Test func quickTypeWithText() throws {
+        #expect(try request(["quick", "type", "ls\n"]) == ControlRequest(cmd: .quickType, args: ControlArgs(text: "ls\n")))
+    }
+
+    @Test func quickTypeStdinFlagParses() throws {
+        // the --stdin flag parses (we don't call makeRequest here — it would block reading stdin).
+        let command = try Quick.TypeText.parse(["--stdin"])
+        #expect(command.stdin)
+        #expect(command.text == nil)
+    }
+
+    @Test func quickTextDefaultsToVisibleScreen() throws {
+        #expect(try request(["quick", "text"]) == ControlRequest(cmd: .quickText, args: ControlArgs()))
+    }
+
+    @Test func quickTextWithAll() throws {
+        #expect(try request(["quick", "text", "--all"]) == ControlRequest(cmd: .quickText, args: ControlArgs(all: true)))
+    }
+
+    @Test func quickTextWithLines() throws {
+        #expect(try request(["quick", "text", "--lines", "50"]) == ControlRequest(cmd: .quickText, args: ControlArgs(lines: 50)))
+    }
+
+    @Test func quickTextRejectsAllWithLines() {
+        #expect(validationMessage(["quick", "text", "--all", "--lines", "10"]) == "use either --all or --lines, not both")
+    }
+
+    @Test func quickTextRejectsZeroLines() {
+        #expect(validationMessage(["quick", "text", "--lines", "0"]) == "--lines must be greater than 0")
+    }
+
     @Test func sidebarDefaultsToggle() throws {
         #expect(try request(["sidebar"]) == ControlRequest(cmd: .sidebar, args: ControlArgs(mode: "toggle")))
     }

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -633,6 +633,12 @@ struct CommandsTests {
         #expect(command.text == nil)
     }
 
+    @Test func quickTypeWithoutTextOrStdinThrows() {
+        // "provide TEXT or --stdin" is raised in makeRequest (not validate), so it's reached via request(),
+        // which calls makeRequest, rather than parseAsRoot alone.
+        #expect(throws: (any Error).self) { try request(["quick", "type"]) }
+    }
+
     @Test func quickTextDefaultsToVisibleScreen() throws {
         #expect(try request(["quick", "text"]) == ControlRequest(cmd: .quickText, args: ControlArgs()))
     }

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -707,25 +707,26 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertEqual(closed["ok"] as? Bool, false, "quick.type before show should fail: \(closed)")
         XCTAssertEqual(closed["error"] as? String, "quick terminal not open", "should report the closed overlay")
 
+        // show, then IMMEDIATELY type once — no waitForExistence, no retry. The server-side realize poll
+        // must ride out the SwiftUI mount so this first post-show type lands, which is what proves the
+        // show->type race is fixed (a regression that dropped the poll would return "not realized" here).
         let shown = try sendCommand(#"{"cmd":"quick","args":{"mode":"show"}}"#)
         XCTAssertEqual(shown["ok"] as? Bool, true, "quick show should succeed: \(shown)")
-        XCTAssertTrue(quick.waitForExistence(timeout: 10), "quick terminal should appear")
+        let typed = try sendCommand(#"{"cmd":"quick.type","args":{"text":"QUICKPROBE"}}"#)
+        XCTAssertEqual(typed["ok"] as? Bool, true, "a single quick.type right after quick show must land via the realize poll: \(typed)")
 
-        // retype-and-poll: inject a marker and read it back off the quick surface, riding out shell and
-        // libghostty realization readiness (the first injects may report "not realized").
+        // read the typed marker back off the quick surface, polling only for the shell echo to render (a
+        // no-newline marker, so it stays on the prompt line and never executes).
         var readBack: String?
-        outer: for _ in 0..<8 {
-            _ = try sendCommand(#"{"cmd":"quick.type","args":{"text":"QUICKPROBE"}}"#)
-            for _ in 0..<8 {
-                let response = try sendCommand(#"{"cmd":"quick.text","args":{"all":true}}"#)
-                if let text = (response["result"] as? [String: Any])?["text"] as? String, text.contains("QUICKPROBE") {
-                    readBack = text
-                    break outer
-                }
-                RunLoop.current.run(until: Date().addingTimeInterval(0.4))
+        for _ in 0..<20 {
+            let response = try sendCommand(#"{"cmd":"quick.text","args":{"all":true}}"#)
+            if let text = (response["result"] as? [String: Any])?["text"] as? String, text.contains("QUICKPROBE") {
+                readBack = text
+                break
             }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.4))
         }
-        XCTAssertNotNil(readBack, "quick.type should reach the surface and quick.text should read the marker back")
+        XCTAssertNotNil(readBack, "quick.text should read the typed marker back")
     }
 
     // session.select by a UNIQUE prefix of a session id resolves to that session: seed two sessions with

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -697,6 +697,37 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertFalse(quick.exists, "an invalid mode must leave the quick terminal hidden")
     }
 
+    // quick.type before the overlay has ever been shown errors (not a silent drop); once shown, a typed
+    // marker reads back off the quick terminal's own buffer via quick.text.
+    func testQuickTypeAndReadText() throws {
+        let quick = app.descendants(matching: .any).matching(identifier: "quick-terminal").firstMatch
+        XCTAssertFalse(quick.exists, "quick terminal should start hidden")
+
+        let closed = try sendCommand(#"{"cmd":"quick.type","args":{"text":"x"}}"#)
+        XCTAssertEqual(closed["ok"] as? Bool, false, "quick.type before show should fail: \(closed)")
+        XCTAssertEqual(closed["error"] as? String, "quick terminal not open", "should report the closed overlay")
+
+        let shown = try sendCommand(#"{"cmd":"quick","args":{"mode":"show"}}"#)
+        XCTAssertEqual(shown["ok"] as? Bool, true, "quick show should succeed: \(shown)")
+        XCTAssertTrue(quick.waitForExistence(timeout: 10), "quick terminal should appear")
+
+        // retype-and-poll: inject a marker and read it back off the quick surface, riding out shell and
+        // libghostty realization readiness (the first injects may report "not realized").
+        var readBack: String?
+        outer: for _ in 0..<8 {
+            _ = try sendCommand(#"{"cmd":"quick.type","args":{"text":"QUICKPROBE"}}"#)
+            for _ in 0..<8 {
+                let response = try sendCommand(#"{"cmd":"quick.text","args":{"all":true}}"#)
+                if let text = (response["result"] as? [String: Any])?["text"] as? String, text.contains("QUICKPROBE") {
+                    readBack = text
+                    break outer
+                }
+                RunLoop.current.run(until: Date().addingTimeInterval(0.4))
+            }
+        }
+        XCTAssertNotNil(readBack, "quick.type should reach the surface and quick.text should read the marker back")
+    }
+
     // session.select by a UNIQUE prefix of a session id resolves to that session: seed two sessions with
     // distinct id prefixes, select the second by a prefix unique to it, and assert the tree marks it active.
     func testSessionSelectByUniquePrefix() throws {

--- a/site/docs.html
+++ b/site/docs.html
@@ -1119,7 +1119,8 @@
               <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;# on|off|toggle|clear</span><br />agtermctl session seen --target 9f3c
               <span style="color: #6b727a">&nbsp;# clear the unseen badge, focus-free</span><br />agtermctl
               sidebar mode flagged <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;# tree|flagged|toggle</span><br />agtermctl quick
-              toggle<br />agtermctl font inc <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;# active surface font size</span
+              toggle <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;# show|hide|toggle</span><br />agtermctl quick type <span style="color: #f2b45c">'ls -la'</span>
+              <span style="color: #6b727a">&nbsp;# or --stdin; quick text reads it back</span><br />agtermctl font inc <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;# active surface font size</span
               ><br /><br /><span style="color: #6b727a"># open the search bar, print the "N of M" counter</span><br />agtermctl
               session search <span style="color: #f2b45c">"error"</span><br />agtermctl session search --next
               <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;&nbsp;# --prev | --close</span>


### PR DESCRIPTION
Adds `quick type` and `quick text` to the control API, the quick-terminal twins of `session type` / `session text`, so the quick terminal (previously drivable only as show/hide/toggle) can be typed into and read back over the socket. Follows up the accepted request in #170.

**What's new**
- `agtermctl quick type TEXT` (or `--stdin`) injects keystrokes into the frontmost window's quick terminal.
- `agtermctl quick text [--all] [--lines N]` reads its screen back (the read-back for `quick type`).

Both are frontmost-window-only (no `--target`/`--window`/`--pane`, since the quick terminal is a single per-window surface) and go through the same `GhosttySurfaceView.inject`/`readScreenText` primitives the session commands use. They're `async` with a bounded realize poll like `session type`, so `quick show; quick type` back-to-back rides out the SwiftUI mount instead of racing it.

Full keep-in-sync: `Command` cases + host-free dispatcher validation in `agtermCore` + `agtermctl` subcommands + dispatcher/CLI/protocol round-trip tests + an e2e (`testQuickTypeAndReadText`) that types a marker and reads it back. Docs updated across `control-api.md`, the bundled agent skill (count 53 to 55), README, and the site.

`AGT_FOCUS` (the other half of the #170 follow-up) is deferred to an Ideas discussion for scoping.

Related to #170
