### PR TITLE
fix: clamp restored window frames to visible screens

### DIFF
--- a/agterm/Views/WindowAccessor.swift
+++ b/agterm/Views/WindowAccessor.swift
@@ -231,7 +231,50 @@ struct WindowAccessor: NSViewRepresentable {
             guard let saved = UserDefaults.standard.string(forKey: Self.frameKey(windowID)) else { return }
             let frame = NSRectFromString(saved)
             guard frame.width > 0, frame.height > 0 else { return }
-            window.setFrame(frame, display: true)
+            window.setFrame(Self.constrainedRestoredFrame(frame, for: window), display: true)
+        }
+
+        /// Normalize a persisted frame before restore. A saved `NSRect` may come from a display that is
+        /// no longer attached; applying it directly can put the relaunched window entirely off-screen.
+        /// Keep the saved size/position when possible, but clamp it to a visible strip on a current screen.
+        private static func constrainedRestoredFrame(_ frame: NSRect, for window: NSWindow) -> NSRect {
+            guard let screen = bestScreen(for: frame, fallback: window.screen ?? NSScreen.main) else { return frame }
+            let maxSize = screen.visibleFrame.size
+            let size = WindowGeometry.clampSize(
+                WindowGeometry.Size(width: Double(frame.width), height: Double(frame.height)),
+                min: WindowGeometry.Size(width: Double(window.minSize.width), height: Double(window.minSize.height)),
+                max: WindowGeometry.Size(width: Double(maxSize.width), height: Double(maxSize.height))
+            )
+            let origin = WindowGeometry.clampOrigin(
+                WindowGeometry.Point(x: Double(frame.origin.x), y: Double(frame.origin.y)),
+                windowSize: size,
+                displayFrame: WindowGeometry.Rect(
+                    origin: WindowGeometry.Point(x: Double(screen.visibleFrame.origin.x),
+                                                 y: Double(screen.visibleFrame.origin.y)),
+                    size: WindowGeometry.Size(width: Double(screen.visibleFrame.width),
+                                              height: Double(screen.visibleFrame.height))
+                )
+            )
+            return NSRect(x: CGFloat(origin.x), y: CGFloat(origin.y),
+                          width: CGFloat(size.width), height: CGFloat(size.height))
+        }
+
+        /// Select the current screen that most likely owns the saved frame. If the frame intersects no
+        /// attached screen, treat it as stale external-display geometry and restore on the fallback screen.
+        private static func bestScreen(for frame: NSRect, fallback: NSScreen?) -> NSScreen? {
+            let screens = NSScreen.screens
+            guard !screens.isEmpty else { return fallback }
+            let best = screens.max { intersectionArea($0.frame, frame) < intersectionArea($1.frame, frame) }
+            guard let best, intersectionArea(best.frame, frame) > 0 else { return fallback ?? screens.first }
+            return best
+        }
+
+        /// Score how much of a saved frame still overlaps a candidate screen; used only to choose the
+        /// restore target, not to decide the final clamped origin.
+        private static func intersectionArea(_ lhs: NSRect, _ rhs: NSRect) -> CGFloat {
+            let intersection = lhs.intersection(rhs)
+            guard !intersection.isNull else { return 0 }
+            return max(0, intersection.width) * max(0, intersection.height)
         }
 
         /// Installs (or re-asserts) the confirm-before-close proxy as the window's delegate, chaining to

--- a/agterm/Views/WindowAccessor.swift
+++ b/agterm/Views/WindowAccessor.swift
@@ -236,7 +236,7 @@ struct WindowAccessor: NSViewRepresentable {
 
         /// Normalize a persisted frame before restore. A saved `NSRect` may come from a display that is
         /// no longer attached; applying it directly can put the relaunched window entirely off-screen.
-        /// Keep the saved size/position when possible, but clamp it to a visible strip on a current screen.
+        /// Keep the saved size/position when possible, but fully contain it on a current screen.
         private static func constrainedRestoredFrame(_ frame: NSRect, for window: NSWindow) -> NSRect {
             let screens = NSScreen.screens
             guard !screens.isEmpty, let fallback = window.screen ?? NSScreen.main ?? screens.first else { return frame }

--- a/agterm/Views/WindowAccessor.swift
+++ b/agterm/Views/WindowAccessor.swift
@@ -238,43 +238,16 @@ struct WindowAccessor: NSViewRepresentable {
         /// no longer attached; applying it directly can put the relaunched window entirely off-screen.
         /// Keep the saved size/position when possible, but clamp it to a visible strip on a current screen.
         private static func constrainedRestoredFrame(_ frame: NSRect, for window: NSWindow) -> NSRect {
-            guard let screen = bestScreen(for: frame, fallback: window.screen ?? NSScreen.main) else { return frame }
-            let maxSize = screen.visibleFrame.size
-            let size = WindowGeometry.clampSize(
-                WindowGeometry.Size(width: Double(frame.width), height: Double(frame.height)),
-                min: WindowGeometry.Size(width: Double(window.minSize.width), height: Double(window.minSize.height)),
-                max: WindowGeometry.Size(width: Double(maxSize.width), height: Double(maxSize.height))
-            )
-            let origin = WindowGeometry.clampOrigin(
-                WindowGeometry.Point(x: Double(frame.origin.x), y: Double(frame.origin.y)),
-                windowSize: size,
-                displayFrame: WindowGeometry.Rect(
-                    origin: WindowGeometry.Point(x: Double(screen.visibleFrame.origin.x),
-                                                 y: Double(screen.visibleFrame.origin.y)),
-                    size: WindowGeometry.Size(width: Double(screen.visibleFrame.width),
-                                              height: Double(screen.visibleFrame.height))
-                )
-            )
-            return NSRect(x: CGFloat(origin.x), y: CGFloat(origin.y),
-                          width: CGFloat(size.width), height: CGFloat(size.height))
-        }
-
-        /// Select the current screen that most likely owns the saved frame. If the frame intersects no
-        /// attached screen, treat it as stale external-display geometry and restore on the fallback screen.
-        private static func bestScreen(for frame: NSRect, fallback: NSScreen?) -> NSScreen? {
             let screens = NSScreen.screens
-            guard !screens.isEmpty else { return fallback }
-            let best = screens.max { intersectionArea($0.frame, frame) < intersectionArea($1.frame, frame) }
-            guard let best, intersectionArea(best.frame, frame) > 0 else { return fallback ?? screens.first }
-            return best
-        }
-
-        /// Score how much of a saved frame still overlaps a candidate screen; used only to choose the
-        /// restore target, not to decide the final clamped origin.
-        private static func intersectionArea(_ lhs: NSRect, _ rhs: NSRect) -> CGFloat {
-            let intersection = lhs.intersection(rhs)
-            guard !intersection.isNull else { return 0 }
-            return max(0, intersection.width) * max(0, intersection.height)
+            guard !screens.isEmpty, let fallback = window.screen ?? NSScreen.main ?? screens.first else { return frame }
+            let displayFrames = screens.map { WindowGeometry.Rect($0.frame) }
+            let fallbackIndex = screens.firstIndex(of: fallback) ?? 0
+            let displayIndex = WindowGeometry.bestDisplayIndex(for: WindowGeometry.Rect(frame), among: displayFrames) ?? fallbackIndex
+            let displayFrame = WindowGeometry.Rect(screens[displayIndex].visibleFrame)
+            let constrained = WindowGeometry.constrain(frame: WindowGeometry.Rect(frame),
+                                                       min: WindowGeometry.Size(window.minSize),
+                                                       displayFrame: displayFrame)
+            return constrained.nsRect
         }
 
         /// Installs (or re-asserts) the confirm-before-close proxy as the window's delegate, chaining to
@@ -329,6 +302,24 @@ struct WindowAccessor: NSViewRepresentable {
                                                 blurRadius: GhosttyApp.shared.windowBlurRadius,
                                                 toolbarMode: GhosttyApp.shared.toolbarMode))
         }
+    }
+}
+
+// CoreGraphics <-> host-free WindowGeometry conversions for restore-frame clamping. The arithmetic lives
+// in agtermCore so display-selection and off-screen restore edge cases stay unit-testable.
+private extension WindowGeometry.Size {
+    init(_ cg: CGSize) { self.init(width: Double(cg.width), height: Double(cg.height)) }
+}
+
+private extension WindowGeometry.Rect {
+    init(_ cg: CGRect) {
+        self.init(origin: WindowGeometry.Point(x: Double(cg.origin.x), y: Double(cg.origin.y)),
+                  size: WindowGeometry.Size(cg.size))
+    }
+
+    var nsRect: NSRect {
+        NSRect(x: CGFloat(origin.x), y: CGFloat(origin.y),
+               width: CGFloat(size.width), height: CGFloat(size.height))
     }
 }
 

--- a/agtermCore/Sources/agtermCore/WindowGeometry.swift
+++ b/agtermCore/Sources/agtermCore/WindowGeometry.swift
@@ -88,11 +88,17 @@ public enum WindowGeometry {
         return bestArea > 0 ? bestIndex : nil
     }
 
-    /// Constrains a saved window frame to a target display: shrink oversized frames to the display bounds,
-    /// grow undersized frames to the window minimum, then clamp the origin so a visible strip remains.
+    /// Constrains a saved window frame to a target display for automatic restore: shrink oversized frames
+    /// to the display bounds, grow undersized frames to the window minimum, then fully contain the frame so
+    /// a stale above-display coordinate can't restore with only the bottom strip visible and titlebar hidden.
     public static func constrain(frame: Rect, min minSize: Size, displayFrame: Rect) -> Rect {
         let size = clampSize(frame.size, min: minSize, max: displayFrame.size)
-        let origin = clampOrigin(frame.origin, windowSize: size, displayFrame: displayFrame)
+        let displayMinX = displayFrame.origin.x
+        let displayMaxX = displayFrame.origin.x + displayFrame.size.width
+        let displayMinY = displayFrame.origin.y
+        let displayMaxY = displayFrame.origin.y + displayFrame.size.height
+        let origin = Point(x: clamp(frame.origin.x, displayMinX, displayMaxX - size.width),
+                           y: clamp(frame.origin.y, displayMinY, displayMaxY - size.height))
         return Rect(origin: origin, size: size)
     }
 

--- a/agtermCore/Sources/agtermCore/WindowGeometry.swift
+++ b/agtermCore/Sources/agtermCore/WindowGeometry.swift
@@ -72,8 +72,40 @@ public enum WindowGeometry {
         return Point(x: clamp(requested.x, minX, maxX), y: clamp(requested.y, minY, maxY))
     }
 
+    /// Returns the display frame with the largest overlap with `frame`, or nil when `frame` overlaps no
+    /// current display. The app restore path uses nil as the disconnected-display signal and falls back to
+    /// the window/main screen instead of trusting stale coordinates.
+    public static func bestDisplayIndex(for frame: Rect, among displayFrames: [Rect]) -> Int? {
+        var bestIndex: Int?
+        var bestArea = 0.0
+        for (index, displayFrame) in displayFrames.enumerated() {
+            let area = intersectionArea(frame, displayFrame)
+            if area > bestArea {
+                bestArea = area
+                bestIndex = index
+            }
+        }
+        return bestArea > 0 ? bestIndex : nil
+    }
+
+    /// Constrains a saved window frame to a target display: shrink oversized frames to the display bounds,
+    /// grow undersized frames to the window minimum, then clamp the origin so a visible strip remains.
+    public static func constrain(frame: Rect, min minSize: Size, displayFrame: Rect) -> Rect {
+        let size = clampSize(frame.size, min: minSize, max: displayFrame.size)
+        let origin = clampOrigin(frame.origin, windowSize: size, displayFrame: displayFrame)
+        return Rect(origin: origin, size: size)
+    }
+
     /// Clamps `value` into `[lo, hi]`. If `lo > hi` (a degenerate range) the upper bound wins.
     private static func clamp(_ value: Double, _ lo: Double, _ hi: Double) -> Double {
         Swift.min(Swift.max(value, lo), hi)
+    }
+
+    private static func intersectionArea(_ lhs: Rect, _ rhs: Rect) -> Double {
+        let minX = Swift.max(lhs.origin.x, rhs.origin.x)
+        let maxX = Swift.min(lhs.origin.x + lhs.size.width, rhs.origin.x + rhs.size.width)
+        let minY = Swift.max(lhs.origin.y, rhs.origin.y)
+        let maxY = Swift.min(lhs.origin.y + lhs.size.height, rhs.origin.y + rhs.size.height)
+        return Swift.max(0, maxX - minX) * Swift.max(0, maxY - minY)
     }
 }

--- a/agtermCore/Tests/agtermCoreTests/WindowGeometryTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/WindowGeometryTests.swift
@@ -113,16 +113,36 @@ struct WindowGeometryTests {
                                               min: WindowGeometry.Size(width: 640, height: 400),
                                               displayFrame: display())
 
-        expectSize(result.size, 1920, 1080)
+        expectRect(result, 0, 0, 1920, 1080)
     }
 
-    @Test func constrainKeepsOffScreenOriginAtLeastPartiallyVisible() {
+    @Test func constrainFullyContainsOffScreenRightFrame() {
         let frame = WindowGeometry.Rect(origin: WindowGeometry.Point(x: 5000, y: 100),
                                         size: WindowGeometry.Size(width: 800, height: 600))
         let result = WindowGeometry.constrain(frame: frame,
                                               min: WindowGeometry.Size(width: 640, height: 400),
                                               displayFrame: display())
 
-        expectRect(result, 1920 - WindowGeometry.visibleMargin, 100, 800, 600)
+        expectRect(result, 1920 - 800, 100, 800, 600)
+    }
+
+    @Test func constrainFullyContainsFrameAboveDisplaySoTitlebarIsReachable() {
+        let frame = WindowGeometry.Rect(origin: WindowGeometry.Point(x: 100, y: 5000),
+                                        size: WindowGeometry.Size(width: 800, height: 600))
+        let result = WindowGeometry.constrain(frame: frame,
+                                              min: WindowGeometry.Size(width: 640, height: 400),
+                                              displayFrame: display())
+
+        expectRect(result, 100, 1080 - 600, 800, 600)
+    }
+
+    @Test func constrainClampsOriginAgainstShrunkOversizedFrame() {
+        let frame = WindowGeometry.Rect(origin: WindowGeometry.Point(x: 5000, y: 100),
+                                        size: WindowGeometry.Size(width: 5000, height: 4000))
+        let result = WindowGeometry.constrain(frame: frame,
+                                              min: WindowGeometry.Size(width: 640, height: 400),
+                                              displayFrame: display())
+
+        expectRect(result, 0, 0, 1920, 1080)
     }
 }

--- a/agtermCore/Tests/agtermCoreTests/WindowGeometryTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/WindowGeometryTests.swift
@@ -13,6 +13,11 @@ struct WindowGeometryTests {
         #expect(point.y == y)
     }
 
+    private func expectRect(_ rect: WindowGeometry.Rect, _ x: Double, _ y: Double, _ width: Double, _ height: Double) {
+        expectPoint(rect.origin, x, y)
+        expectSize(rect.size, width, height)
+    }
+
     private func display() -> WindowGeometry.Rect {
         WindowGeometry.Rect(origin: WindowGeometry.Point(x: 0, y: 0),
                             size: WindowGeometry.Size(width: 1920, height: 1080))
@@ -79,5 +84,45 @@ struct WindowGeometryTests {
                                                 displayFrame: display())
         // maxY = 1080 - margin; x stays in range and is unchanged.
         expectPoint(result, 100, 1080 - WindowGeometry.visibleMargin)
+    }
+
+    @Test func bestDisplayIndexChoosesLargestOverlapAcrossDisplays() {
+        let displays = [
+            WindowGeometry.Rect(origin: WindowGeometry.Point(x: 0, y: 0),
+                                size: WindowGeometry.Size(width: 1920, height: 1080)),
+            WindowGeometry.Rect(origin: WindowGeometry.Point(x: 1920, y: 0),
+                                size: WindowGeometry.Size(width: 1920, height: 1080))
+        ]
+        let frame = WindowGeometry.Rect(origin: WindowGeometry.Point(x: 1800, y: 100),
+                                        size: WindowGeometry.Size(width: 400, height: 500))
+
+        #expect(WindowGeometry.bestDisplayIndex(for: frame, among: displays) == 1)
+    }
+
+    @Test func bestDisplayIndexReturnsNilWhenFrameOverlapsNoDisplay() {
+        let frame = WindowGeometry.Rect(origin: WindowGeometry.Point(x: 5000, y: 100),
+                                        size: WindowGeometry.Size(width: 800, height: 600))
+
+        #expect(WindowGeometry.bestDisplayIndex(for: frame, among: [display()]) == nil)
+    }
+
+    @Test func constrainShrinksOversizedFrameToDisplay() {
+        let frame = WindowGeometry.Rect(origin: WindowGeometry.Point(x: 100, y: 100),
+                                        size: WindowGeometry.Size(width: 5000, height: 4000))
+        let result = WindowGeometry.constrain(frame: frame,
+                                              min: WindowGeometry.Size(width: 640, height: 400),
+                                              displayFrame: display())
+
+        expectSize(result.size, 1920, 1080)
+    }
+
+    @Test func constrainKeepsOffScreenOriginAtLeastPartiallyVisible() {
+        let frame = WindowGeometry.Rect(origin: WindowGeometry.Point(x: 5000, y: 100),
+                                        size: WindowGeometry.Size(width: 800, height: 600))
+        let result = WindowGeometry.constrain(frame: frame,
+                                              min: WindowGeometry.Size(width: 640, height: 400),
+                                              displayFrame: display())
+
+        expectRect(result, 1920 - WindowGeometry.visibleMargin, 100, 800, 600)
     }
 }


### PR DESCRIPTION
## Summary
- Clamp saved window frames before applying them during relaunch.
- Move the pure restore-geometry decisions into `WindowGeometry` so they are host-free and unit-tested.
- Keep `WindowAccessor` responsible only for converting `NSWindow`/`NSScreen` values into core geometry types.

## Bug
`agterm` saves each window frame and reapplies it on launch. If the last saved frame was on an external display that is no longer connected, the app restored that exact frame with only a width/height check. The window could reopen entirely off-screen, leaving the user with an apparently missing window.

## Fix
The restore path now normalizes the saved frame first. Core geometry code picks the current display with the largest overlap, reports no-overlap as a disconnected-display case, clamps oversized frames to the display, and fully contains the restored frame on the chosen display. The full-containment step avoids the vertical edge case where a frame saved on a monitor above the current display would restore with only its bottom strip visible and the titlebar still off-screen.

## Validation
- `swift test --package-path agtermCore --filter WindowGeometryTests`
- `./scripts/test.sh`
- `make build`
- `swiftlint lint --strict --quiet agterm/Views/WindowAccessor.swift agtermCore/Sources/agtermCore/WindowGeometry.swift agtermCore/Tests/agtermCoreTests/WindowGeometryTests.swift`