### PR TITLE
fix: keep keyboard focus on the overlay/scratch, not the pane behind it

### DIFF
--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -653,12 +653,16 @@ struct WorkspaceSidebar: NSViewRepresentable {
         /// attached to the window yet (a just-selected session's view is still
         /// materializing), so retry on the run loop until it is, with a bounded cap.
         /// Skipped while a rename field is the first responder or an edit is in progress.
+        ///
+        /// Restores to `topmostSurface`, never the main pane: an overlay or scratch covers the pane(s),
+        /// so focusing the pane would hand keystrokes to a surface the user cannot see and leave the
+        /// overlay program silently starved of input.
         func focusActiveTerminal(attempt: Int = 0) {
             // never steal focus from an in-progress rename.
             if renameController.isEditing { return }
             let window = outlineView?.window
             if let window, window.firstResponder is NSText { return }
-            if let window, let surface = store.activeSession?.surface as? GhosttySurfaceView, surface.window === window {
+            if let window, let surface = store.activeSession?.topmostSurface as? GhosttySurfaceView, surface.window === window {
                 window.makeFirstResponder(surface)
                 return
             }

--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -654,9 +654,10 @@ struct WorkspaceSidebar: NSViewRepresentable {
         /// materializing), so retry on the run loop until it is, with a bounded cap.
         /// Skipped while a rename field is the first responder or an edit is in progress.
         ///
-        /// Restores to `topmostSurface`, never the main pane: an overlay or scratch covers the pane(s),
-        /// so focusing the pane would hand keystrokes to a surface the user cannot see and leave the
-        /// overlay program silently starved of input.
+        /// Targets `topmostSurface` (overlay, else scratch, else the active pane) rather than the main
+        /// `surface`: while a cover is up it owns the keyboard, so focusing a pane instead would starve the
+        /// overlay/scratch program of input — and a full overlay or scratch also hides the pane, so the
+        /// keystrokes would land on a surface the user cannot see.
         func focusActiveTerminal(attempt: Int = 0) {
             // never steal focus from an in-progress rename.
             if renameController.isEditing { return }

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -216,7 +216,9 @@ struct agtermApp: App {
             store.closePrimaryPane(sessionID)
             // focus the surviving (now maximized) pane; if the whole (single) session closed instead,
             // focus the session it reselected to. the collapse/switch re-hosts the target, so use the retry.
-            let target = store.session(withID: sessionID)?.activeSurface ?? store.activeSession?.activeSurface
+            // resolve through `topmostSurface`, so a pane exiting under an overlay or scratch hands focus to
+            // the cover on top rather than to the pane it hides.
+            let target = store.session(withID: sessionID)?.topmostSurface ?? store.activeSession?.topmostSurface
             (target as? GhosttySurfaceView)?.focusAfterReparent()
         }
         view.onFocusChange = { focused in
@@ -334,7 +336,9 @@ struct agtermApp: App {
             store.closeSplitPane(sessionID)
             // focus the surviving (now maximized) pane; if the whole session closed (primary already
             // exited), focus the session it reselected to. the collapse/switch re-hosts it, so retry.
-            let target = store.session(withID: sessionID)?.activeSurface ?? store.activeSession?.activeSurface
+            // resolve through `topmostSurface`, so a pane exiting under an overlay or scratch hands focus to
+            // the cover on top rather than to the pane it hides.
+            let target = store.session(withID: sessionID)?.topmostSurface ?? store.activeSession?.topmostSurface
             (target as? GhosttySurfaceView)?.focusAfterReparent()
         }
         view.onFocusChange = { focused in

--- a/agtermCore/Sources/agtermCore/Session.swift
+++ b/agtermCore/Sources/agtermCore/Session.swift
@@ -308,10 +308,11 @@ public final class Session: Identifiable {
     /// pointed at the same surface.
     public var addressableSurface: (any TerminalSurface)? { surface ?? splitSurface }
 
-    /// The surface currently on top and owning keyboard focus: a full overlay, else the scratch, else
-    /// the active pane. Both the overlay and the scratch are full-coverage layers (panes hidden beneath
-    /// them), and the overlay renders above the scratch — so every focus path routes through this to keep
-    /// first responder on the visible top surface and never on a covered pane/scratch.
+    /// The surface currently on top and owning keyboard focus: an active overlay (full OR floating), else
+    /// the scratch, else the active pane. The overlay renders above the scratch, and a full overlay or the
+    /// scratch hides the pane(s) beneath it — so the session-focus helpers route through this to keep first
+    /// responder on the top surface and never on a covered pane/scratch. (`TerminalView.focusIfNeeded` is
+    /// the exception: it targets its own deck slot, which a cover already gates off via `isActive`.)
     public var topmostSurface: (any TerminalSurface)? {
         if overlayActive { return overlaySurface }
         if scratchActive { return scratchSurface }

--- a/agtermUITests/ControlOverlaySplitUITests.swift
+++ b/agtermUITests/ControlOverlaySplitUITests.swift
@@ -266,6 +266,47 @@ final class ControlOverlaySplitUITests: ControlAPITestCase {
         assertSidebarClickKeepsFocusOnCover(pre: pre, post: post, cover: "scratch")
     }
 
+    // a pane's shell exiting collapses the split and re-hosts the survivor, so its `onExit` re-grabs first
+    // responder. while a cover is up that grab must land on the cover, not on the surviving pane underneath
+    // it — otherwise finishing a command in a background pane silently steals the keyboard from the overlay.
+    func testPaneExitUnderOverlayKeepsFocusOnOverlay() throws {
+        let id = try activeSessionID()
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.split","target":"\#(id)","args":{"mode":"on"}}"#)["ok"] as? Bool,
+                       true, "opening the split should succeed")
+        XCTAssertTrue(pollActiveSessionSplit(true, timeout: 10), "the split should be up")
+
+        let pre = markerDir.appendingPathComponent("paneexit-pre")
+        let post = markerDir.appendingPathComponent("paneexit-post")
+        let ovlCmd = "sh -c 'IFS= read -r a; printf %s \"$a\" > \(pre.path); " +
+            "IFS= read -r b; printf %s \"$b\" > \(post.path); cat'"
+        let ovlJSON = try! JSONSerialization.data(withJSONObject:
+            ["cmd": "session.overlay.open", "target": id, "args": ["command": ovlCmd, "sizePercent": 50]])
+        XCTAssertEqual(try sendCommand(String(data: ovlJSON, encoding: .utf8)!)["ok"] as? Bool, true,
+                       "floating overlay open should succeed")
+        XCTAssertTrue(pollSessionOverlay(id: id, expected: true, timeout: 10), "the overlay should be up")
+        usleep(800_000) // let the overlay attach, grab focus, and its shell reach the first `read`
+
+        // prove the overlay owns the keyboard before the exit, so a later steal is attributable to onExit.
+        app.typeText("PRECLICK")
+        app.typeKey(.return, modifierFlags: [])
+        XCTAssertEqual(pollMarker(pre, timeout: 12), "PRECLICK", "the overlay must hold keyboard focus before the exit")
+
+        // exit the MAIN pane's shell by injecting into its surface directly (injection is focus-independent,
+        // so this drives closePrimaryPane -> onExit without touching first responder).
+        let typeJSON = try! JSONSerialization.data(withJSONObject:
+            ["cmd": "session.type", "target": id, "args": ["text": "exit\n", "pane": "left"]])
+        XCTAssertEqual(try sendCommand(String(data: typeJSON, encoding: .utf8)!)["ok"] as? Bool, true,
+                       "typing exit into the main pane should succeed")
+        // the split pane is promoted to the sole pane, so the session stops reporting a split.
+        XCTAssertTrue(pollActiveSessionSplit(false, timeout: 12), "the main pane's exit should collapse the split")
+        usleep(500_000) // onExit's focusAfterReparent retries; no observable signal to poll on
+
+        app.typeText("OVLCLICK")
+        app.typeKey(.return, modifierFlags: [])
+        XCTAssertEqual(pollMarker(post, timeout: 12), "OVLCLICK",
+                       "a pane exit under an overlay must leave focus on the overlay, not the surviving pane")
+    }
+
     /// Shared body of the two sidebar-click focus tests: prove the cover holds focus, click the covered
     /// session's own sidebar row (selection is a no-op, but the sidebar's focus-restore runs), then prove
     /// the keyboard still reaches the cover rather than the pane it sits on.

--- a/agtermUITests/ControlOverlaySplitUITests.swift
+++ b/agtermUITests/ControlOverlaySplitUITests.swift
@@ -221,6 +221,40 @@ final class ControlOverlaySplitUITests: ControlAPITestCase {
         XCTAssertEqual(afterValue, sessionTtyValue, "focus should return to the SAME session terminal, not be lost")
     }
 
+    // an overlay is modal within its session: a sidebar click restores keyboard focus to the terminal
+    // (so the sidebar never keeps it), but it must restore focus to the overlay ON TOP, not to the pane
+    // BEHIND it. clicking the overlaid session's own row otherwise hands first responder to the covered
+    // pane and the overlay program silently stops receiving input.
+    func testSidebarClickKeepsFocusOnOverlayNotPaneBehind() throws {
+        let tree = try sendCommand(#"{"cmd":"tree"}"#)
+        let treeResult = try XCTUnwrap(tree["result"] as? [String: Any], "tree should carry a result")
+        let root = try XCTUnwrap(treeResult["tree"] as? [String: Any], "result should carry a tree")
+        let workspaces = try XCTUnwrap(root["workspaces"] as? [[String: Any]], "tree should list workspaces")
+        let sessions = try XCTUnwrap(workspaces.first?["sessions"] as? [[String: Any]], "workspace should list sessions")
+        let id = try XCTUnwrap(sessions.first?["id"] as? String, "should have a seeded session id")
+
+        // the overlay shell captures one keyboard line then stays alive (cat), so the marker records who
+        // held first responder when the line was typed.
+        let ovlMarker = markerDir.appendingPathComponent("floating-overlay-keys")
+        let ovlCmd = "sh -c 'IFS= read -r x; printf %s \"$x\" > \(ovlMarker.path); cat'"
+        let ovlJSON = try! JSONSerialization.data(withJSONObject:
+            ["cmd": "session.overlay.open", "target": id, "args": ["command": ovlCmd, "sizePercent": 50]])
+        let open = try sendCommand(String(data: ovlJSON, encoding: .utf8)!)
+        XCTAssertEqual(open["ok"] as? Bool, true, "floating overlay open should succeed: \(open)")
+        XCTAssertTrue(pollSessionOverlay(id: id, expected: true, timeout: 10), "the floating overlay should be up")
+        usleep(800_000) // let the overlay surface attach, grab focus, and the shell reach `read`
+
+        // click the overlaid session's own sidebar row: selection is a no-op, but the sidebar's
+        // focus-restore runs and must land on the overlay, not the pane it covers.
+        app.staticTexts["session-row"].firstMatch.click()
+        usleep(500_000)
+
+        app.typeText("OVLCLICK")
+        app.typeKey(.return, modifierFlags: [])
+        XCTAssertEqual(pollMarker(ovlMarker, timeout: 12), "OVLCLICK",
+                       "a sidebar click must restore focus to the overlay, not the pane behind it")
+    }
+
     // a FULL overlay opened in a BACKGROUND (non-selected) session must NOT steal keyboard first responder.
     // the overlay's auto-focus is gated on its deck slot being active (deckActive), so typing reaches the
     // still-visible active session, not the hidden overlay. guards the focus-steal bug where a revdiff overlay

--- a/agtermUITests/ControlOverlaySplitUITests.swift
+++ b/agtermUITests/ControlOverlaySplitUITests.swift
@@ -221,38 +221,69 @@ final class ControlOverlaySplitUITests: ControlAPITestCase {
         XCTAssertEqual(afterValue, sessionTtyValue, "focus should return to the SAME session terminal, not be lost")
     }
 
-    // an overlay is modal within its session: a sidebar click restores keyboard focus to the terminal
-    // (so the sidebar never keeps it), but it must restore focus to the overlay ON TOP, not to the pane
-    // BEHIND it. clicking the overlaid session's own row otherwise hands first responder to the covered
-    // pane and the overlay program silently stops receiving input.
+    // a cover (overlay or scratch) is modal within its session: a sidebar click restores keyboard focus to
+    // the terminal (so the sidebar never keeps it), but it must restore focus to the cover ON TOP, not to
+    // the pane BEHIND it. clicking the covered session's own row otherwise hands first responder to the
+    // pane and the cover's program silently stops receiving input.
+    //
+    // each test captures TWO keyboard lines: the first, typed BEFORE the click, proves the cover already
+    // holds first responder (so the cover's own bounded auto-focus retry — 40 x 0.05s — has finished and
+    // cannot re-grab focus later and mask a steal). the second, typed after the click, is the assertion.
+    // without the pre-click line the test can pass on a buggy build: the click steals focus to the pane,
+    // then an auto-focus retry still in flight takes it back before the line is typed.
     func testSidebarClickKeepsFocusOnOverlayNotPaneBehind() throws {
-        let tree = try sendCommand(#"{"cmd":"tree"}"#)
-        let treeResult = try XCTUnwrap(tree["result"] as? [String: Any], "tree should carry a result")
-        let root = try XCTUnwrap(treeResult["tree"] as? [String: Any], "result should carry a tree")
-        let workspaces = try XCTUnwrap(root["workspaces"] as? [[String: Any]], "tree should list workspaces")
-        let sessions = try XCTUnwrap(workspaces.first?["sessions"] as? [[String: Any]], "workspace should list sessions")
-        let id = try XCTUnwrap(sessions.first?["id"] as? String, "should have a seeded session id")
-
-        // the overlay shell captures one keyboard line then stays alive (cat), so the marker records who
-        // held first responder when the line was typed.
-        let ovlMarker = markerDir.appendingPathComponent("floating-overlay-keys")
-        let ovlCmd = "sh -c 'IFS= read -r x; printf %s \"$x\" > \(ovlMarker.path); cat'"
+        let id = try activeSessionID()
+        let pre = markerDir.appendingPathComponent("overlay-pre-click")
+        let post = markerDir.appendingPathComponent("overlay-post-click")
+        // two blocking reads then `cat` to hold the shell; retyping is NOT idempotent (each `read`
+        // consumes exactly one line), so the markers are polled rather than re-typed.
+        let ovlCmd = "sh -c 'IFS= read -r a; printf %s \"$a\" > \(pre.path); " +
+            "IFS= read -r b; printf %s \"$b\" > \(post.path); cat'"
         let ovlJSON = try! JSONSerialization.data(withJSONObject:
             ["cmd": "session.overlay.open", "target": id, "args": ["command": ovlCmd, "sizePercent": 50]])
         let open = try sendCommand(String(data: ovlJSON, encoding: .utf8)!)
         XCTAssertEqual(open["ok"] as? Bool, true, "floating overlay open should succeed: \(open)")
         XCTAssertTrue(pollSessionOverlay(id: id, expected: true, timeout: 10), "the floating overlay should be up")
-        usleep(800_000) // let the overlay surface attach, grab focus, and the shell reach `read`
+        usleep(800_000) // let the overlay surface attach, grab focus, and the shell reach the first `read`
 
-        // click the overlaid session's own sidebar row: selection is a no-op, but the sidebar's
-        // focus-restore runs and must land on the overlay, not the pane it covers.
-        app.staticTexts["session-row"].firstMatch.click()
-        usleep(500_000)
+        assertSidebarClickKeepsFocusOnCover(pre: pre, post: post, cover: "overlay")
+    }
+
+    // the scratch terminal is the other `topmostSurface` branch (scratchActive -> scratchSurface) and is
+    // full-coverage, so a sidebar click landing on the pane would type into a shell that is not even visible.
+    func testSidebarClickKeepsFocusOnScratchNotPaneBehind() throws {
+        let pre = markerDir.appendingPathComponent("scratch-pre-click")
+        let post = markerDir.appendingPathComponent("scratch-post-click")
+        let cmd = "sh -c 'IFS= read -r a; printf %s \"$a\" > \(pre.path); " +
+            "IFS= read -r b; printf %s \"$b\" > \(post.path); cat'"
+        let json = try! JSONSerialization.data(withJSONObject:
+            ["cmd": "session.scratch", "target": "active", "args": ["mode": "on", "command": cmd]])
+        let show = try sendCommand(String(data: json, encoding: .utf8)!)
+        XCTAssertEqual(show["ok"] as? Bool, true, "showing the scratch should succeed: \(show)")
+        XCTAssertTrue(pollActiveSessionScratch(true, timeout: 10), "the scratch should be up")
+        usleep(800_000) // let the scratch surface attach, grab focus, and the shell reach the first `read`
+
+        assertSidebarClickKeepsFocusOnCover(pre: pre, post: post, cover: "scratch")
+    }
+
+    /// Shared body of the two sidebar-click focus tests: prove the cover holds focus, click the covered
+    /// session's own sidebar row (selection is a no-op, but the sidebar's focus-restore runs), then prove
+    /// the keyboard still reaches the cover rather than the pane it sits on.
+    private func assertSidebarClickKeepsFocusOnCover(pre: URL, post: URL, cover: String) {
+        app.typeText("PRECLICK")
+        app.typeKey(.return, modifierFlags: [])
+        XCTAssertEqual(pollMarker(pre, timeout: 12), "PRECLICK",
+                       "the \(cover) must hold keyboard focus before the click (else this test can't assert a steal)")
+
+        let row = app.staticTexts["session-row"].firstMatch
+        XCTAssertTrue(row.isHittable, "the covered session's sidebar row should be clickable")
+        row.click()
+        usleep(500_000) // the sidebar's focus-restore runs off the click; no observable signal to poll on
 
         app.typeText("OVLCLICK")
         app.typeKey(.return, modifierFlags: [])
-        XCTAssertEqual(pollMarker(ovlMarker, timeout: 12), "OVLCLICK",
-                       "a sidebar click must restore focus to the overlay, not the pane behind it")
+        XCTAssertEqual(pollMarker(post, timeout: 12), "OVLCLICK",
+                       "a sidebar click must restore focus to the \(cover), not the pane behind it")
     }
 
     // a FULL overlay opened in a BACKGROUND (non-selected) session must NOT steal keyboard first responder.


### PR DESCRIPTION
An overlay (full or `%`-sized floating) and the scratch terminal are modal within their session — they own the keyboard while up. Two focus-restore paths ignored that and handed first responder to the pane underneath, so the cover stayed on screen while keystrokes went to a shell the user often could not even see.

**The sidebar click.** `WorkspaceSidebar.Coordinator.focusActiveTerminal()` restored focus to `activeSession.surface` — always the main pane. It runs on every sidebar click (`SidebarOutlineView.mouseDown`), on rename-end, and once at launch. Clicking any sidebar row while a cover was up sent typing to the pane behind it.

**The pane exit.** The `onExit` handlers in `agtermApp.swift` resolved `activeSurface`, so a pane's shell exiting under a cover re-grabbed focus onto the surviving pane. Found by the review pass on the first fix.

Both now resolve `Session.topmostSurface` (overlay, else scratch, else the active pane), the accessor every other focus path already used. As a consequence a sidebar click on a split session focuses the *focused* pane rather than always the main one, which is the intended behavior.

Also corrects two doc comments that misdescribed the floating overlay as hiding the pane, and `topmostSurface`'s claim that every focus path routes through it.

*Tests:* three XCUITests, each verified to fail before the fix and pass after — sidebar click under a floating overlay, under the scratch, and a main-pane exit under a floating overlay. Each types a marker line **before** the triggering action to prove the cover really held the keyboard, so the overlay's own 2s auto-focus retry cannot mask a steal.