### PR TITLE
fix: keep workspace and session ids unique across close, undo and reopen

### DIFF
--- a/agtermCore/Sources/agtermCore/AppStore+PendingClose.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+PendingClose.swift
@@ -77,7 +77,7 @@ extension AppStore {
     @discardableResult
     public func softRemoveWorkspace(_ workspaceID: UUID, grace: TimeInterval = AppStore.pendingCloseGraceInterval) -> Bool {
         guard canRemoveWorkspace, let index = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return false }
-        let workspace = workspaces.remove(at: index)
+        let workspace = foldingPendingCloses(of: workspaces.remove(at: index))
         let removingActive = selectedSessionID.map { id in workspace.sessions.contains { $0.id == id } } ?? false
         let restoringSelection = removingActive ? selectedSessionID : nil
         if focusedWorkspaceID == workspaceID { focusedWorkspaceID = nil }
@@ -173,13 +173,64 @@ extension AppStore {
         }
     }
 
+    /// Absorb any pending close of the same workspace into the copy being closed now, dropping the
+    /// superseded record. Undoing a session close rebuilds a missing workspace as a shell, so closing that
+    /// shell while the earlier record still waits out its grace would leave two pending records sharing a
+    /// workspace id. Both key one Open Recent entry by that id (`RecentClosedStore.record` dedupes on it),
+    /// so the newer snapshot would evict the older one and its sessions would survive nowhere once both
+    /// records finalize. The copy closed now is the newer state, so its name, expansion and session order
+    /// lead; the superseded record's sessions follow.
+    private func foldingPendingCloses(of workspace: Workspace) -> Workspace {
+        var folded = workspace
+        for closeID in pendingCloseOrder {
+            guard case .workspace(let close)? = pendingCloseRecords[closeID], close.workspace.id == workspace.id else { continue }
+            pendingCloseRecords.removeValue(forKey: closeID)
+            pendingCloseTasks.removeValue(forKey: closeID)?.cancel()
+            let present = Set(folded.sessions.map(\.id))
+            folded.sessions.append(contentsOf: close.workspace.sessions.filter { !present.contains($0.id) })
+        }
+        pendingCloseOrder.removeAll { pendingCloseRecords[$0] == nil }
+        return folded
+    }
+
+    /// Session ids a pending close still holds. They are absent from the tree, but their live objects are
+    /// intact and an undo reinserts them, so a restore that rebuilt one from a snapshot would put two
+    /// objects under a single id. Callers union this with the tree's ids to decide what is already taken.
+    func pendingHeldSessionIDs() -> Set<UUID> {
+        var held: Set<UUID> = []
+        for record in pendingCloseRecords.values {
+            switch record {
+            case .session(let close):
+                held.insert(close.session.id)
+            case .workspace(let close):
+                held.formUnion(close.workspace.sessions.map(\.id))
+            }
+        }
+        return held
+    }
+
+    /// A workspace to stand in for one a restore needs but the tree no longer holds. Prefer the newest
+    /// description of it: a pending close of that same workspace carries its live name and expansion state,
+    /// and once those finalize an Open Recent snapshot still does. `name` is the caller's older copy, used
+    /// only when neither describes the workspace.
+    func rebuiltWorkspaceShell(id: UUID, name: String) -> Workspace {
+        for closeID in pendingCloseOrder.reversed() {
+            guard case .workspace(let close)? = pendingCloseRecords[closeID], close.workspace.id == id else { continue }
+            return Workspace(id: id, name: close.workspace.name, isExpanded: close.workspace.isExpanded)
+        }
+        if let snapshot = recentClosedStore?.load().compactMap(\.workspace).first(where: { $0.snapshot.id == id })?.snapshot {
+            return Workspace(id: id, name: snapshot.name, isExpanded: !(snapshot.collapsed ?? false))
+        }
+        return Workspace(id: id, name: name)
+    }
+
     private func restorePendingSession(_ close: PendingSessionClose) {
         let workspaceIndex: Int
         if let existing = workspaces.firstIndex(where: { $0.id == close.workspaceID }) {
             workspaceIndex = existing
         } else {
             let insertAt = max(0, min(close.workspaceIndex, workspaces.count))
-            workspaces.insert(Workspace(id: close.workspaceID, name: close.workspaceName), at: insertAt)
+            workspaces.insert(rebuiltWorkspaceShell(id: close.workspaceID, name: close.workspaceName), at: insertAt)
             workspaceIndex = insertAt
         }
         let insertAt = max(0, min(close.sessionIndex, workspaces[workspaceIndex].sessions.count))
@@ -190,13 +241,24 @@ extension AppStore {
     }
 
     private func restorePendingWorkspace(_ close: PendingWorkspaceClose) {
-        let insertAt = max(0, min(close.workspaceIndex, workspaces.count))
-        workspaces.insert(close.workspace, at: insertAt)
-        if let target = close.selectedSessionID ?? close.workspace.sessions.first?.id {
-            selectedSessionID = target
-            autoUnfocusIfOutsideFocus(selectedSessionID)
-            recordRecency()
+        // an undone session close, or an Open Recent restore, rebuilds a missing workspace by id as a
+        // shell holding just that session. merge into the shell instead of inserting a second workspace
+        // sharing its id: every id-keyed lookup resolves the first match, so a duplicate would strand the
+        // other copy's sessions. the shell was seeded from this record, and anything the user changed on
+        // it since is newer, so its name and expansion state stand. the shell also keeps its slot, so
+        // `workspaceIndex` and this record's session order are not honored. the filter is defensive: a
+        // session held by this record cannot already be live elsewhere.
+        if let existing = workspaces.firstIndex(where: { $0.id == close.workspace.id }) {
+            let live = Set(workspaces.flatMap(\.sessions).map(\.id))
+            workspaces[existing].sessions.append(contentsOf: close.workspace.sessions.filter { !live.contains($0.id) })
+        } else {
+            let insertAt = max(0, min(close.workspaceIndex, workspaces.count))
+            workspaces.insert(close.workspace, at: insertAt)
         }
+        guard let target = close.selectedSessionID ?? close.workspace.sessions.first?.id else { return }
+        selectedSessionID = target
+        autoUnfocusIfOutsideFocus(selectedSessionID)
+        recordRecency()
     }
 
     private func hardFinalizePendingSession(_ session: Session) {

--- a/agtermCore/Sources/agtermCore/AppStore+RecentClosed.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+RecentClosed.swift
@@ -12,7 +12,7 @@ extension AppStore {
                 index = existing
             } else {
                 let insertAt = max(0, min(recent.workspaceIndex, workspaces.count))
-                workspaces.insert(Workspace(id: recent.workspaceID, name: recent.workspaceName), at: insertAt)
+                workspaces.insert(rebuiltWorkspaceShell(id: recent.workspaceID, name: recent.workspaceName), at: insertAt)
                 index = insertAt
             }
             let session = session(from: recent.snapshot)
@@ -26,7 +26,11 @@ extension AppStore {
         case .workspace:
             guard let recent = item.workspace else { return false }
             if restoreOrSelectExistingRecentWorkspace(recent) { return true }
-            let workspace = workspace(from: recent.snapshot)
+            var workspace = workspace(from: recent.snapshot)
+            // a session of this snapshot may have been moved into another workspace that is itself pending
+            // a close. its original object is alive in that record, so rebuild everything except it.
+            let taken = Set(workspaces.flatMap(\.sessions).map(\.id)).union(pendingHeldSessionIDs())
+            workspace.sessions.removeAll { taken.contains($0.id) }
             // Persistent Open Recent appends like most editors' recent-project flow:
             // reopening brings the workspace back without reshuffling current workspaces.
             workspaces.append(workspace)
@@ -51,14 +55,29 @@ extension AppStore {
 
     private func restoreOrSelectExistingRecentWorkspace(_ recent: RecentClosedWorkspace) -> Bool {
         let sessionIDs = Set(recent.snapshot.sessions.map(\.id))
-        if let pendingID = pendingCloseID(forWorkspaceID: recent.snapshot.id, sessionIDs: sessionIDs) {
-            return undoPendingClose(pendingID)
+        // pending closes may hold this workspace, or any number of its sessions closed one at a time. undo
+        // every match, not only the newest: an undo returns live sessions to the tree, and the merge below
+        // skips rebuilding only what it can see there. a session left pending would be rebuilt from the
+        // snapshot beside its live original, two objects under one id, and the original's surfaces torn
+        // down once its grace expired. each undo drops its own record, so the loop drains them. falling
+        // through matters too: returning an undo's result would report success while the caller deletes
+        // the recent entry holding the sessions that undo did not restore.
+        while let pendingID = pendingCloseID(forWorkspaceID: recent.snapshot.id, sessionIDs: sessionIDs) {
+            undoPendingClose(pendingID)
         }
-        if let existingWorkspace = workspaces.first(where: { $0.id == recent.snapshot.id }) {
+        if let index = workspaces.firstIndex(where: { $0.id == recent.snapshot.id }) {
+            // reopening a session first rebuilds this workspace as a shell holding only that session, so
+            // selecting without merging would drop the snapshot's other sessions while the caller deletes
+            // the recent entry on success — their only copy. rebuild the ones that exist nowhere: not in
+            // the tree, and not held by a pending close whose undo would reinsert the original.
+            let taken = Set(workspaces.flatMap(\.sessions).map(\.id)).union(pendingHeldSessionIDs())
+            let missing = recent.snapshot.sessions.filter { !taken.contains($0.id) }.map(session(from:))
+            workspaces[index].sessions.append(contentsOf: missing)
             let target = recent.selectedSessionID.flatMap { id in
-                existingWorkspace.sessions.contains { $0.id == id } ? id : nil
-            } ?? existingWorkspace.sessions.first?.id
+                workspaces[index].sessions.contains { $0.id == id } ? id : nil
+            } ?? workspaces[index].sessions.first?.id
             if let target { selectSession(target) }
+            save()
             return true
         }
         if let existingSession = workspaces.flatMap(\.sessions).first(where: { sessionIDs.contains($0.id) }) {
@@ -83,15 +102,17 @@ extension AppStore {
         return nil
     }
 
+    /// A pending close this workspace's restore should consume. Only records of the workspace itself: a
+    /// foreign workspace that merely holds one of the snapshot's sessions (moved there before it closed)
+    /// is a close the user meant, and undoing it would resurrect a workspace they deliberately dismissed.
+    /// The merge treats such a session as occupied instead, so it is never rebuilt beside the original.
     private func pendingCloseID(forWorkspaceID workspaceID: UUID, sessionIDs: Set<UUID>) -> UUID? {
         for id in pendingCloseOrder.reversed() {
             guard let record = pendingCloseRecords[id] else { continue }
             switch record {
-            case .workspace(let close)
-                where close.workspace.id == workspaceID
-                    || close.workspace.sessions.contains(where: { sessionIDs.contains($0.id) }):
+            case .workspace(let close) where close.workspace.id == workspaceID:
                 return id
-            case .session(let close) where sessionIDs.contains(close.session.id):
+            case .session(let close) where close.workspaceID == workspaceID && sessionIDs.contains(close.session.id):
                 return id
             default:
                 continue

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -729,11 +729,21 @@ public final class AppStore {
     /// skips `save()` for that reason). If the persisted `selectedSessionID` points
     /// at a session that no longer exists, it is cleared to keep selection valid.
     public func restore(from snapshot: Snapshot) {
-        workspaces = snapshot.workspaces.map { workspaceSnapshot in
-            let sessions = workspaceSnapshot.sessions.map(session(from:))
+        // fold workspaces sharing an id into the first occurrence, and keep only the first snapshot of any
+        // repeated session id, wherever it sits: a file written by a build that could duplicate either
+        // stays unreachable past the first match otherwise, and re-saves the corruption.
+        var seenSessionIDs: Set<UUID> = []
+        workspaces = snapshot.workspaces.reduce(into: [Workspace]()) { restored, workspaceSnapshot in
+            let sessions = workspaceSnapshot.sessions
+                .filter { seenSessionIDs.insert($0.id).inserted }
+                .map(session(from:))
+            if let existing = restored.firstIndex(where: { $0.id == workspaceSnapshot.id }) {
+                restored[existing].sessions.append(contentsOf: sessions)
+                return
+            }
             // absent/nil collapsed → expanded (back-compat with snapshots written before the field existed).
-            return Workspace(id: workspaceSnapshot.id, name: workspaceSnapshot.name, sessions: sessions,
-                             isExpanded: !(workspaceSnapshot.collapsed ?? false))
+            restored.append(Workspace(id: workspaceSnapshot.id, name: workspaceSnapshot.name, sessions: sessions,
+                                      isExpanded: !(workspaceSnapshot.collapsed ?? false)))
         }
         // clamp on restore (not just nil-default) so a corrupt or hand-edited snapshot can't drive an
         // out-of-range frame width; the drag path clamps to the same bounds.

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTestFixtures.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTestFixtures.swift
@@ -9,6 +9,15 @@ import Foundation
     return AppStore(persistence: PersistenceStore(directory: dir))
 }
 
+/// The same throwaway store, plus the Open Recent store it records closes into and the persistence it
+/// writes through, for the paths that read back what a close or a restore persisted.
+@MainActor func makeStoreWithRecentClosed() -> (AppStore, RecentClosedStore, PersistenceStore) {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent("agterm-tests-\(UUID().uuidString)")
+    let recentClosed = RecentClosedStore(directory: dir)
+    let persistence = PersistenceStore(directory: dir)
+    return (AppStore(persistence: persistence, recentClosedStore: recentClosed), recentClosed, persistence)
+}
+
 final class SpySurface: TerminalSurface {
     var teardownCount = 0
     func teardown() { teardownCount += 1 }

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -889,6 +889,67 @@ struct AppStoreTests {
         #expect(store.workspaces.flatMap(\.sessions).contains { $0 === moved })
     }
 
+    @Test func restoreDropsASessionRepeatedInsideOneWorkspace() {
+        let store = makeStore()
+        let repeated = UUID()
+        store.restore(from: Snapshot(workspaces: [
+            WorkspaceSnapshot(id: UUID(), name: "one", sessions: [
+                SessionSnapshot(id: repeated, customName: "a", cwd: "/a"),
+                SessionSnapshot(id: repeated, customName: "a-again", cwd: "/b"),
+            ]),
+        ]))
+
+        #expect(store.workspaces.flatMap(\.sessions).count { $0.id == repeated } == 1)
+        #expect(store.workspaces[0].sessions[0].customName == "a")
+    }
+
+    @Test func restoreDropsASessionRepeatedAcrossWorkspacesWithDifferentIDs() {
+        let store = makeStore()
+        let repeated = UUID()
+        store.restore(from: Snapshot(workspaces: [
+            WorkspaceSnapshot(id: UUID(), name: "one", sessions: [SessionSnapshot(id: repeated, customName: "a", cwd: "/a")]),
+            WorkspaceSnapshot(id: UUID(), name: "two", sessions: [SessionSnapshot(id: repeated, customName: "a-again", cwd: "/b")]),
+        ]))
+
+        #expect(store.workspaces.count == 2)
+        #expect(store.workspaces.flatMap(\.sessions).count { $0.id == repeated } == 1)
+        #expect(store.workspaces[1].sessions.isEmpty)
+    }
+
+    @Test func restoreFoldsWorkspacesSharingAnIDIntoOne() throws {
+        let store = makeStore()
+        let shared = UUID()
+        let firstID = UUID()
+        let secondID = UUID()
+        let snapshot = Snapshot(workspaces: [
+            WorkspaceSnapshot(id: shared, name: "one", sessions: [SessionSnapshot(id: firstID, customName: "a", cwd: "/a")]),
+            WorkspaceSnapshot(id: shared, name: "dupe", sessions: [SessionSnapshot(id: secondID, customName: "b", cwd: "/b")]),
+        ])
+
+        store.restore(from: snapshot)
+
+        #expect(store.workspaces.count == 1)
+        #expect(store.workspaces[0].name == "one")
+        #expect(store.workspaces[0].sessions.map(\.id) == [firstID, secondID])
+        #expect(store.session(withID: secondID) != nil)
+    }
+
+    @Test func restoreDropsASessionRepeatedAcrossWorkspacesSharingAnID() throws {
+        let store = makeStore()
+        let shared = UUID()
+        let repeated = UUID()
+        let snapshot = Snapshot(workspaces: [
+            WorkspaceSnapshot(id: shared, name: "one", sessions: [SessionSnapshot(id: repeated, customName: "a", cwd: "/a")]),
+            WorkspaceSnapshot(id: shared, name: "dupe", sessions: [SessionSnapshot(id: repeated, customName: "a-again", cwd: "/b")]),
+        ])
+
+        store.restore(from: snapshot)
+
+        #expect(store.workspaces.count == 1)
+        #expect(store.workspaces[0].sessions.map(\.id) == [repeated])
+        #expect(store.workspaces[0].sessions[0].customName == "a")
+    }
+
     @Test func finalizedSoftRemoveWorkspaceTearsDownSessions() throws {
         let store = makeStore()
         _ = store.addWorkspace(name: "keep")

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -511,6 +511,384 @@ struct AppStoreTests {
         #expect(surface.teardownCount == 0)
     }
 
+    @Test func undoingPendingSessionCloseThenWorkspaceCloseKeepsOneWorkspace() throws {
+        let store = makeStore()
+        let doomed = store.addWorkspace(name: "doomed")
+        _ = store.addWorkspace(name: "keep")
+        let first = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/a"))
+        let second = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/b"))
+        let firstSurface = SpySurface()
+        let secondSurface = SpySurface()
+        first.surface = firstSurface
+        second.surface = secondSurface
+
+        #expect(store.softCloseSession(first.id, grace: 60))
+        let sessionClose = try #require(store.pendingCloseSummary?.id)
+        #expect(store.softRemoveWorkspace(doomed.id, grace: 60))
+        let workspaceClose = try #require(store.pendingCloseSummary?.id)
+
+        // undoing the session first recreates the workspace shell; the workspace undo must merge into it
+        #expect(store.undoPendingClose(sessionClose))
+        #expect(store.undoPendingClose(workspaceClose))
+
+        #expect(store.workspaces.count(where: { $0.id == doomed.id }) == 1)
+        let restored = try #require(store.workspaces.first { $0.id == doomed.id })
+        #expect(restored.sessions.map(\.id) == [first.id, second.id])
+        #expect(restored.sessions[0] === first)
+        #expect(restored.sessions[1] === second)
+        #expect(store.selectedSessionID == second.id)
+        #expect(firstSurface.teardownCount == 0)
+        #expect(secondSurface.teardownCount == 0)
+    }
+
+    @Test func undoingWorkspaceCloseThenSessionCloseKeepsOneWorkspace() throws {
+        let store = makeStore()
+        let doomed = store.addWorkspace(name: "doomed")
+        _ = store.addWorkspace(name: "keep")
+        let first = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/a"))
+        let second = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/b"))
+
+        #expect(store.softCloseSession(first.id, grace: 60))
+        let sessionClose = try #require(store.pendingCloseSummary?.id)
+        #expect(store.softRemoveWorkspace(doomed.id, grace: 60))
+        let workspaceClose = try #require(store.pendingCloseSummary?.id)
+
+        // the reverse order takes the insert branch, then restorePendingSession finds the workspace
+        #expect(store.undoPendingClose(workspaceClose))
+        #expect(store.undoPendingClose(sessionClose))
+
+        #expect(store.workspaces.count(where: { $0.id == doomed.id }) == 1)
+        let restored = try #require(store.workspaces.first { $0.id == doomed.id })
+        #expect(restored.sessions.map(\.id) == [first.id, second.id])
+    }
+
+    @Test func rebuiltShellSeedsNameAndExpansionFromPendingWorkspaceClose() throws {
+        let store = makeStore()
+        let doomed = store.addWorkspace(name: "old")
+        _ = store.addWorkspace(name: "keep")
+        let first = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/a"))
+        _ = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/b"))
+
+        #expect(store.softCloseSession(first.id, grace: 60))
+        let sessionClose = try #require(store.pendingCloseSummary?.id)
+        // rename and collapse after the session close, so the session record's captured name is stale
+        store.renameWorkspace(doomed.id, to: "renamed")
+        store.setWorkspaceExpanded(doomed.id, expanded: false)
+        #expect(store.softRemoveWorkspace(doomed.id, grace: 60))
+        let workspaceClose = try #require(store.pendingCloseSummary?.id)
+
+        #expect(store.undoPendingClose(sessionClose))
+        // the shell is seeded from the still-pending workspace record, not the stale session record
+        let shell = try #require(store.workspaces.first { $0.id == doomed.id })
+        #expect(shell.name == "renamed")
+        #expect(shell.isExpanded == false)
+
+        #expect(store.undoPendingClose(workspaceClose))
+        let restored = try #require(store.workspaces.first { $0.id == doomed.id })
+        #expect(restored.name == "renamed")
+        #expect(restored.isExpanded == false)
+    }
+
+    @Test func workspaceUndoKeepsEditsMadeToTheRebuiltShell() throws {
+        let store = makeStore()
+        let doomed = store.addWorkspace(name: "old")
+        _ = store.addWorkspace(name: "keep")
+        let first = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/a"))
+        _ = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/b"))
+
+        #expect(store.softCloseSession(first.id, grace: 60))
+        let sessionClose = try #require(store.pendingCloseSummary?.id)
+        #expect(store.softRemoveWorkspace(doomed.id, grace: 60))
+        let workspaceClose = try #require(store.pendingCloseSummary?.id)
+
+        #expect(store.undoPendingClose(sessionClose))
+        // edits to the rebuilt shell are newer than the pending record and must survive the merge
+        store.renameWorkspace(doomed.id, to: "new")
+        store.setWorkspaceExpanded(doomed.id, expanded: false)
+        #expect(store.undoPendingClose(workspaceClose))
+
+        let restored = try #require(store.workspaces.first { $0.id == doomed.id })
+        #expect(restored.name == "new")
+        #expect(restored.isExpanded == false)
+    }
+
+    @Test func restoringRecentSessionThenUndoingWorkspaceCloseKeepsOneWorkspace() throws {
+        let store = makeStore()
+        let doomed = store.addWorkspace(name: "doomed")
+        _ = store.addWorkspace(name: "keep")
+        let first = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/a"))
+        let second = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/b"))
+
+        #expect(store.softCloseSession(first.id, grace: 60))
+        let sessionClose = try #require(store.pendingCloseSummary?.id)
+        store.finalizePendingClose(sessionClose)
+        #expect(store.softRemoveWorkspace(doomed.id, grace: 60))
+        let workspaceClose = try #require(store.pendingCloseSummary?.id)
+
+        // a finalized session reopens from Open Recent, which rebuilds the workspace shell on its own
+        let recent = RecentClosedItem(
+            kind: .session, title: "a", subtitle: "doomed",
+            session: RecentClosedSession(workspaceID: doomed.id, workspaceName: "doomed",
+                                         workspaceIndex: 0, sessionIndex: 0,
+                                         snapshot: store.sessionSnapshot(first))
+        )
+        #expect(store.restoreRecentClosed(recent))
+        #expect(store.undoPendingClose(workspaceClose))
+
+        #expect(store.workspaces.count(where: { $0.id == doomed.id }) == 1)
+        let restored = try #require(store.workspaces.first { $0.id == doomed.id })
+        #expect(Set(restored.sessions.map(\.id)) == Set([first.id, second.id]))
+        #expect(restored.sessions.count == 2)
+        #expect(store.selectedSessionID == second.id)
+        // the reopened session is rebuilt from its snapshot, so it is a fresh object; the merged-in
+        // one is the live object the pending record held
+        #expect(restored.sessions.contains { $0 === second })
+        #expect(restored.sessions.allSatisfy { $0 !== first })
+    }
+
+    @Test func undoingWorkspaceCloseMergesDisjointSessionsIntoRebuiltShell() throws {
+        let store = makeStore()
+        let doomed = store.addWorkspace(name: "doomed")
+        _ = store.addWorkspace(name: "keep")
+        let first = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/a"))
+        let second = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/b"))
+
+        // close the second session, so the workspace snapshot carries only the first
+        #expect(store.softCloseSession(second.id, grace: 60))
+        let sessionClose = try #require(store.pendingCloseSummary?.id)
+        #expect(store.softRemoveWorkspace(doomed.id, grace: 60))
+        let workspaceClose = try #require(store.pendingCloseSummary?.id)
+
+        #expect(store.undoPendingClose(sessionClose))
+        #expect(store.undoPendingClose(workspaceClose))
+
+        #expect(store.workspaces.count(where: { $0.id == doomed.id }) == 1)
+        let restored = try #require(store.workspaces.first { $0.id == doomed.id })
+        // the shell keeps its slot, so the merged order trails the shell's session
+        #expect(restored.sessions.map(\.id) == [second.id, first.id])
+        #expect(restored.sessions.contains { $0 === first })
+        #expect(restored.sessions.contains { $0 === second })
+    }
+
+    @Test func reopeningRecentWorkspaceMergesMissingSessionsIntoRebuiltShell() throws {
+        let (store, _, persistence) = makeStoreWithRecentClosed()
+        let doomed = store.addWorkspace(name: "doomed")
+        _ = store.addWorkspace(name: "keep")
+        let first = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/a"))
+        let second = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/b"))
+        let firstSnapshot = store.sessionSnapshot(first)
+        // snapshot the workspace while it still holds both, so it overlaps the shell the session restore
+        // rebuilds. a disjoint snapshot would merge cleanly even without the live-session filter.
+        let workspaceSnapshot = store.workspaceSnapshot(try #require(store.workspaces.first { $0.id == doomed.id }))
+
+        // both closes finalize, so only the recent snapshots remain
+        #expect(store.softCloseSession(first.id, grace: 60))
+        store.finalizePendingClose(try #require(store.pendingCloseSummary?.id))
+        #expect(store.softRemoveWorkspace(doomed.id, grace: 60))
+        store.finalizePendingClose(try #require(store.pendingCloseSummary?.id))
+
+        // reopening the session rebuilds the workspace as a shell holding only that session
+        let recentSession = RecentClosedItem(
+            kind: .session, title: "a", subtitle: "doomed",
+            session: RecentClosedSession(workspaceID: doomed.id, workspaceName: "doomed",
+                                         workspaceIndex: 0, sessionIndex: 0, snapshot: firstSnapshot)
+        )
+        #expect(store.restoreRecentClosed(recentSession))
+
+        // reopening the workspace must bring back the session the shell doesn't hold
+        let recentWorkspace = RecentClosedItem(
+            kind: .workspace, title: "doomed", subtitle: "2 sessions",
+            workspace: RecentClosedWorkspace(snapshot: workspaceSnapshot, selectedSessionID: second.id)
+        )
+        #expect(store.restoreRecentClosed(recentWorkspace))
+
+        let restored = try #require(store.workspaces.first { $0.id == doomed.id })
+        // count, not just the id set: the shell already holds `first`, and a merge that skips the
+        // live-session filter appends a second copy of it under the same id
+        #expect(restored.sessions.count == 2)
+        #expect(Set(restored.sessions.map(\.id)) == Set([first.id, second.id]))
+        #expect(store.session(withID: second.id) != nil)
+        #expect(store.selectedSessionID == second.id)
+        // the merge persists immediately, ahead of the debounced selection save
+        #expect(persistence.load().workspaces.first { $0.id == doomed.id }?.sessions.count == 2)
+    }
+
+    @Test func reopeningRecentWorkspaceRestoresSessionsHeldByAPendingSessionClose() throws {
+        let store = makeStore()
+        let doomed = store.addWorkspace(name: "doomed")
+        _ = store.addWorkspace(name: "keep")
+        let first = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/a"))
+        let second = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/b"))
+        let firstSnapshot = store.sessionSnapshot(first)
+        let workspaceSnapshot = store.workspaceSnapshot(try #require(store.workspaces.first { $0.id == doomed.id }))
+
+        #expect(store.softRemoveWorkspace(doomed.id, grace: 60))
+        store.finalizePendingClose(try #require(store.pendingCloseSummary?.id))
+
+        // reopen `first` alone, rebuilding the workspace as a shell, then soft-close it again so a
+        // pending session close holds it while the workspace's recent entry still lists both sessions
+        let recentSession = RecentClosedItem(
+            kind: .session, title: "a", subtitle: "doomed",
+            session: RecentClosedSession(workspaceID: doomed.id, workspaceName: "doomed",
+                                         workspaceIndex: 0, sessionIndex: 0, snapshot: firstSnapshot)
+        )
+        #expect(store.restoreRecentClosed(recentSession))
+        let rebuiltFirst = try #require(store.workspaces.first { $0.id == doomed.id }?.sessions.first)
+        #expect(store.softCloseSession(rebuiltFirst.id, grace: 60))
+
+        // the pending session close matches the workspace's recent entry, but undoing it restores only
+        // `first`. the workspace restore must still rebuild `second`, which nothing else holds.
+        let recentWorkspace = RecentClosedItem(
+            kind: .workspace, title: "doomed", subtitle: "2 sessions",
+            workspace: RecentClosedWorkspace(snapshot: workspaceSnapshot, selectedSessionID: second.id)
+        )
+        #expect(store.restoreRecentClosed(recentWorkspace))
+
+        let restored = try #require(store.workspaces.first { $0.id == doomed.id })
+        #expect(restored.sessions.count == 2)
+        #expect(Set(restored.sessions.map(\.id)) == Set([first.id, second.id]))
+        #expect(store.session(withID: second.id) != nil)
+    }
+
+    @Test func reopeningRecentWorkspaceDrainsEveryPendingSessionClose() throws {
+        let store = makeStore()
+        let doomed = store.addWorkspace(name: "doomed")
+        _ = store.addWorkspace(name: "keep")
+        let first = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/a"))
+        let second = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/b"))
+        let firstSurface = SpySurface()
+        first.surface = firstSurface
+        let workspaceSnapshot = store.workspaceSnapshot(try #require(store.workspaces.first { $0.id == doomed.id }))
+
+        // both sessions are held by their own pending close, so neither is live when the workspace's
+        // recent entry is reopened
+        #expect(store.softCloseSession(first.id, grace: 60))
+        let firstClose = try #require(store.pendingCloseSummary?.id)
+        #expect(store.softCloseSession(second.id, grace: 60))
+
+        let recentWorkspace = RecentClosedItem(
+            kind: .workspace, title: "doomed", subtitle: "2 sessions",
+            workspace: RecentClosedWorkspace(snapshot: workspaceSnapshot, selectedSessionID: first.id)
+        )
+        #expect(store.restoreRecentClosed(recentWorkspace))
+
+        let restored = try #require(store.workspaces.first { $0.id == doomed.id })
+        // the live originals come back, not snapshot rebuilds sharing their ids
+        #expect(restored.sessions.count == 2)
+        #expect(restored.sessions.contains { $0 === first })
+        #expect(restored.sessions.contains { $0 === second })
+        // no pending record still holds a session the tree now shows: undoing one would duplicate its id,
+        // finalizing one would tear down the surfaces of a session the user can see
+        #expect(store.pendingCloseRecords.isEmpty)
+        #expect(store.undoPendingClose(firstClose) == false)
+        #expect(store.workspaces.flatMap(\.sessions).count { $0.id == first.id } == 1)
+        #expect(firstSurface.teardownCount == 0)
+    }
+
+    @Test func closingARebuiltShellFoldsIntoTheStillPendingWorkspaceClose() throws {
+        let (store, recentClosed, _) = makeStoreWithRecentClosed()
+        let doomed = store.addWorkspace(name: "doomed")
+        _ = store.addWorkspace(name: "keep")
+        let first = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/a"))
+        let second = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/b"))
+
+        // close `first`, then the workspace holding `second`, then undo `first` so it lands in a rebuilt
+        // shell. closing that shell must not leave a second pending record sharing the workspace id:
+        // both would key one Open Recent entry, and the newer snapshot evicts the older one's sessions.
+        #expect(store.softCloseSession(first.id, grace: 60))
+        let sessionClose = try #require(store.pendingCloseSummary?.id)
+        #expect(store.softRemoveWorkspace(doomed.id, grace: 60))
+        let firstWorkspaceClose = try #require(store.pendingCloseSummary?.id)
+        #expect(store.undoPendingClose(sessionClose))
+        #expect(store.softRemoveWorkspace(doomed.id, grace: 60))
+        let foldedClose = try #require(store.pendingCloseSummary?.id)
+
+        #expect(foldedClose != firstWorkspaceClose)
+        #expect(store.pendingCloseRecords.count == 1)
+        // the superseded record is gone with its timer, so finalizing it cannot tear down the folded one
+        store.finalizePendingClose(firstWorkspaceClose)
+        #expect(store.pendingCloseRecords.count == 1)
+
+        #expect(store.undoPendingClose(foldedClose))
+        let restored = try #require(store.workspaces.first { $0.id == doomed.id })
+        #expect(restored.sessions.map(\.id) == [first.id, second.id])
+        #expect(recentClosed.load().isEmpty)
+    }
+
+    @Test func finalizedShellSeedsNameAndExpansionFromTheRecentWorkspaceSnapshot() throws {
+        let (store, recentClosed, _) = makeStoreWithRecentClosed()
+        _ = store.addWorkspace(name: "keep")
+        let workspaceID = UUID()
+        let sessionSnapshot = SessionSnapshot(id: UUID(), customName: "a", cwd: "/a")
+        // nothing pending describes the workspace, so its newest surviving description is the Open Recent
+        // snapshot, taken after the rename and collapse. the session entry's `workspaceName` predates both.
+        recentClosed.record(RecentClosedItem(
+            kind: .workspace, title: "renamed", subtitle: "1 session",
+            workspace: RecentClosedWorkspace(
+                snapshot: WorkspaceSnapshot(id: workspaceID, name: "renamed", sessions: [sessionSnapshot], collapsed: true),
+                selectedSessionID: nil)
+        ))
+
+        let recentSession = RecentClosedItem(
+            kind: .session, title: "a", subtitle: "old",
+            session: RecentClosedSession(workspaceID: workspaceID, workspaceName: "old",
+                                         workspaceIndex: 0, sessionIndex: 0, snapshot: sessionSnapshot)
+        )
+        #expect(store.restoreRecentClosed(recentSession))
+
+        let shell = try #require(store.workspaces.first { $0.id == workspaceID })
+        #expect(shell.name == "renamed")
+        #expect(!shell.isExpanded)
+    }
+
+    @Test func reopeningRecentWorkspaceLeavesAForeignPendingWorkspaceCloseAlone() throws {
+        let store = makeStore()
+        let wsW = store.addWorkspace(name: "W")
+        let wsV = store.addWorkspace(name: "V")
+        let moved = try #require(store.addSession(toWorkspace: wsW.id, cwd: "/moved"))
+        let staleSnapshot = store.workspaceSnapshot(try #require(store.workspaces.first { $0.id == wsW.id }))
+
+        // the session moves to V, then the user closes V deliberately. W's recent entry still lists it.
+        store.moveSession(moved.id, toWorkspace: wsV.id)
+        #expect(store.softRemoveWorkspace(wsV.id, grace: 60))
+
+        let recentW = RecentClosedItem(kind: .workspace, title: "W", subtitle: "1 session",
+                                       workspace: RecentClosedWorkspace(snapshot: staleSnapshot, selectedSessionID: moved.id))
+        _ = store.restoreRecentClosed(recentW)
+
+        // reopening W must not resurrect V, and must not rebuild `moved` beside the original V still holds
+        #expect(store.workspaces.contains { $0.id == wsV.id } == false)
+        #expect(store.pendingCloseRecords.count == 1)
+        #expect(store.workspaces.flatMap(\.sessions).count { $0.id == moved.id } == 0)
+    }
+
+    @Test func reopeningRecentWorkspaceNeverRebuildsASessionAForeignPendingCloseHolds() throws {
+        let store = makeStore()
+        let wsW = store.addWorkspace(name: "W")
+        let wsV = store.addWorkspace(name: "V")
+        _ = store.addWorkspace(name: "keep")
+        _ = store.addSession(toWorkspace: wsV.id, cwd: "/anchor")
+        let moved = try #require(store.addSession(toWorkspace: wsW.id, cwd: "/moved"))
+        let staleSnapshot = store.workspaceSnapshot(try #require(store.workspaces.first { $0.id == wsW.id }))
+
+        store.moveSession(moved.id, toWorkspace: wsV.id)
+        // W is gone for good, so reopening it rebuilds the workspace wholesale
+        #expect(store.softRemoveWorkspace(wsW.id, grace: 60))
+        store.finalizePendingClose(try #require(store.pendingCloseSummary?.id))
+        #expect(store.softRemoveWorkspace(wsV.id, grace: 60))
+        let vClose = try #require(store.pendingCloseSummary?.id)
+
+        let recentW = RecentClosedItem(kind: .workspace, title: "W", subtitle: "1 session",
+                                       workspace: RecentClosedWorkspace(snapshot: staleSnapshot, selectedSessionID: moved.id))
+        _ = store.restoreRecentClosed(recentW)
+        #expect(store.pendingCloseRecords[vClose] != nil)
+
+        // undoing V returns the original `moved`; the rebuilt W must not have made a second one
+        #expect(store.undoPendingClose(vClose))
+        #expect(store.workspaces.flatMap(\.sessions).count { $0.id == moved.id } == 1)
+        #expect(store.workspaces.flatMap(\.sessions).contains { $0 === moved })
+    }
+
     @Test func finalizedSoftRemoveWorkspaceTearsDownSessions() throws {
         let store = makeStore()
         _ = store.addWorkspace(name: "keep")


### PR DESCRIPTION
a session cannot exist without a parent workspace, so restoring one rebuilds a missing workspace by id as an empty shell. `restorePendingWorkspace` then inserted its own copy unconditionally, and the tree ended up with two workspaces under one UUID. Every id-keyed lookup resolves the first match, so the other copy's sessions were unreachable.

found while reviewing #179, but it predates it: reproduced on `master` against the single-session close path, untouched by that PR.

fixing the merge exposed four more paths through the same shell, each one able to lose a session for good.

**what goes wrong**

`restoreOrSelectExistingRecentWorkspace` returned the result of `undoPendingClose` whenever a pending close matched. That guard also matches a pending *session* record, so it restored one session, reported success, and `WindowLibrary` deleted the Open Recent entry holding the rest. Close `W[a,b]`, let it finalize, reopen `a`, close `a` again, reopen `W` inside the grace: `b` was gone.

it also undid only the newest match. With two sessions of one workspace each held by their own pending close, the second was still pending and so invisible to the merge's live-session check, which rebuilt it from the snapshot beside its live original. Two `Session` objects under one id, and `hardFinalizePendingSession` tearing down surfaces the sidebar still showed.

widening that to a drain then reached too far. The matcher also accepts a foreign workspace close that merely holds one of the snapshot's sessions, so reopening `W` resurrected a workspace the user had deliberately closed. Those sessions are now treated as occupied instead, which is what keeps the duplicate from coming back.

`softRemoveWorkspace` could leave two pending records sharing a workspace id (close a session, close the workspace, undo the session to rebuild the shell, close the shell). `RecentClosedStore.record` dedupes Open Recent entries by workspace snapshot id, so the newer snapshot evicted the older one, and once both records finalized the first record's sessions existed in neither the tree nor Open Recent.

`rebuiltWorkspaceShell` read the unordered `pendingCloseRecords` dictionary, and once every record finalized it fell back to a stale workspace name with default expansion.

separately, `restore(from:)` deduped session ids only while folding workspaces that shared a workspace id. A snapshot repeating a session id inside one workspace, or across two workspaces with distinct ids, rebuilt both copies and saved them back.

**tests**

every new test is mutation-verified: deleting the production line it claims to guard turns it red. That caught one of my own, whose fixture was disjoint, so the live-session filter never fired and the assertion passed with the filter deleted.

`swift test` 1329/1329, `make lint` clean, Debug and Release both build.

**not addressed here**

reopening a workspace whose snapshot session is alive in some *other* workspace still selects it and returns true without restoring the rest, and the caller drops the recent entry. Correct behavior is genuinely ambiguous, so I left it.

`focusedWorkspaceID` is cleared by `softRemoveWorkspace` and never restored on undo. Pre-existing and unrelated to the id invariant.

a rebuilt shell inherits `isExpanded`, so reopening a session into a collapsed workspace hides the row. That behavior predates this branch and changing it is a UI call, not a correctness one.
