### PR TITLE
fix: let agtermctl font target a split or scratch pane

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -410,8 +410,8 @@ paths:
   `session.selectall` selects the target's ENTIRE terminal buffer (main surface) — the analogue of ⌘A /
   Edit ▸ Select All.
   Both run a libghostty binding action on the resolved surface — `paste_from_clipboard` /
-  `select_all` — through the SAME `ControlServer+SurfaceIO.surfaceBindingAction` helper the `font.*` arms
-  use (resolve session → guard the surface is realized, `session not realized` otherwise → `performBindingAction`
+  `select_all` — through the shared `ControlServer+SurfaceIO.surfaceBindingAction` helper
+  (resolve session → guard the surface is realized, `session not realized` otherwise → `performBindingAction`
   → return the id), so paste takes the normal libghostty paste path (bracketed paste, PASTE requests are
   ungated so no OSC-52 prompt) and select_all covers the whole grid.
   They are the control half of the GUI Edit menu: agterm keeps the STANDARD SwiftUI Edit menu and
@@ -469,7 +469,9 @@ paths:
   since libghostty's built-in `super+a` is character-matched too (found in review — the fallback set must cover
   every shortcut the Edit menu owns, not just copy/paste).
   **The session-scoped surface arms resolve `Session.addressableSurface`, not `Session.surface`.**
-  `session.copy`/`session.paste`/`session.selectall`/`font.*` act on "the session" rather than a named `--pane`,
+  `session.copy`/`session.paste`/`session.selectall` act on "the session" rather than a named `--pane`
+  (and so does `font.*`'s omitted/`left` default — its `right`/`scratch` panes resolve `splitSurface`/`scratchSurface`
+  instead, via its own pane switch rather than `surfaceBindingAction`),
   and `addressableSurface` is `surface ?? splitSurface`: identical to `surface` for every ordinary or split
   session, but falling back to a PROMOTED SPLIT SURVIVOR whose primary shell exited (`closePrimaryPane` nils
   `surface` and keeps the live shell in `splitSurface`, asserted by `AppStorePaneTests`).

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -70,6 +70,9 @@ paths:
   `session.flag`/`flagged`, `session.focus`/`splitFocused`, `session.resize`/`splitRatio`,
   `session.overlay.resize`/`overlaySizePercent`, `sidebar`/`sidebarVisible` (top-level),
   `sidebar.mode`/`sidebarMode`, `workspace.focus`/`focused` (workspace node), `quick`/`quickVisible` (top-level),
+  `font.*`/`fontSize`+`splitFontSize`+`scratchFontSize` (the per-pane LIVE font size — the split/scratch
+  panes' fonts are otherwise unobservable, being live-only; supplied to `controlTree` by app-side closures
+  reading `GhosttySurfaceView.currentFontSize()`, since the host-free tree can't read a surface),
   `window.move`+`window.resize`/`geometry`, `window.fullscreen`+`window.zoom`/`fullscreen`+`zoomed`
   (the last three on `window.list`).
   This is a SEPARATE obligation from the four-point audit (Command + arg + CLI + tests) and easy to forget:

--- a/README.md
+++ b/README.md
@@ -220,11 +220,12 @@ agtermctl session search "error"                 # open the search bar and highl
 agtermctl session search --next                  # step to the next match (--prev steps back, --close hides the bar)
 agtermctl quick toggle                           # toggle the quick terminal (show|hide|toggle)
 agtermctl quick type 'ls -la'$'\n'               # type into the frontmost window's quick terminal (or --stdin); quick text reads it back
-agtermctl font inc                               # increase the active surface's font size
+agtermctl font inc                               # increase the session's (main pane's) font size
+agtermctl font dec --pane right                   # shrink just the split pane's font (--pane left|right|scratch)
 agtermctl theme set --light "Builtin Light" --dark Dracula  # set the light/dark theme slots (--dark none turns following off)
 ```
 
-`session type` types the text as real keystrokes, and every newline is a real Return press — so a trailing newline submits the command, and a multi-line payload runs line by line (a multi-line shell construct like a `for` loop is entered across the shell's continuation prompts and runs as one command). Note the `$'…\n'` quoting: a literal `\n` inside plain single quotes reaches the CLI as two characters, not a newline; use `$'…\n'` or pipe a real newline via `--stdin`. Typing goes to the session's left (main) pane by default; `--pane right` types into the split pane instead (an error when the session has no split), and `--pane scratch` reaches the session's scratch terminal even while it is hidden. `session text` takes the same `--pane`, so an agent can read a hidden scratch's output (e.g. a deploy you ran there) without leaving it open.
+`session type` types the text as real keystrokes, and every newline is a real Return press — so a trailing newline submits the command, and a multi-line payload runs line by line (a multi-line shell construct like a `for` loop is entered across the shell's continuation prompts and runs as one command). Note the `$'…\n'` quoting: a literal `\n` inside plain single quotes reaches the CLI as two characters, not a newline; use `$'…\n'` or pipe a real newline via `--stdin`. Typing goes to the session's left (main) pane by default; `--pane right` types into the split pane instead (an error when the session has no split), and `--pane scratch` reaches the session's scratch terminal even while it is hidden. `session text` takes the same `--pane`, so an agent can read a hidden scratch's output (e.g. a deploy you ran there) without leaving it open. `font inc|dec|reset` also takes `--pane left|right|scratch`, so you can resize just the split pane's font (an error when there is no split); only the main pane's size is remembered across a restart.
 
 `session copy` returns the target session's selected text in the response (it does not touch the system clipboard), so a script can move a selection from one session to another:
 

--- a/agterm/Control/ControlServer+SurfaceIO.swift
+++ b/agterm/Control/ControlServer+SurfaceIO.swift
@@ -6,11 +6,11 @@ import agtermCore
 /// surface-touching half of the dispatch. Split out of `ControlServer.swift` for the swiftlint size limit.
 extension ControlServer {
     /// Resolve the target session and run a libghostty binding action on its addressable surface (targets a
-    /// specific surface, unlike the menu path which only hits the focused one). Shared by the font arms
-    /// and the clipboard/selection arms (`session.paste`/`session.selectall`). `addressableSurface` is the
-    /// main pane, falling back to a promoted split survivor whose primary shell exited (which nils
-    /// `surface`) — otherwise a session the user is actively typing in would report "session not realized".
-    /// A never-shown session has no surface at all → error.
+    /// specific surface, unlike the menu path which only hits the focused one). Shared by the clipboard /
+    /// selection arms (`session.paste`/`session.selectall`). `addressableSurface` is the main pane, falling
+    /// back to a promoted split survivor whose primary shell exited (which nils `surface`) — otherwise a
+    /// session the user is actively typing in would report "session not realized". A never-shown session has
+    /// no surface at all → error.
     private func surfaceBindingAction(_ target: String?, window: String?, action: String) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
             guard let surface = store.session(withID: id)?.addressableSurface as? GhosttySurfaceView else {
@@ -21,10 +21,45 @@ extension ControlServer {
         }
     }
 
-    /// Run a font binding action (`font.inc`/`font.dec`/`font.reset`) on the target session's surface. A
-    /// menu-driven font change rides the same CELL_SIZE → persist path as the keybind.
-    func font(_ target: String?, window: String?, action: String) -> ControlResponse {
-        surfaceBindingAction(target, window: window, action: action)
+    /// Run a font binding action (`font.inc`/`font.dec`/`font.reset`) on a pane of the target session. A
+    /// menu-driven font change rides the same CELL_SIZE → persist path as the keybind. `pane` picks the
+    /// surface like `session.type`/`session.text` (`left`|`right`|`scratch`, no `other`): omitted/`left` is
+    /// the main pane (`addressableSurface`, so a promoted split survivor whose primary shell exited is still
+    /// reached — preserving the pre-pane behavior); `right` is the split pane (`session has no split pane`
+    /// without one); `scratch` is the session's scratch terminal (`session has no scratch terminal` when none
+    /// has been opened), whose surface is kept alive so its font is settable even while hidden. An unknown
+    /// value is an `invalid pane` error — validated here (mirroring the CLI `validate()`) so a raw socket
+    /// client can't bypass it. Only the main pane's size persists: the split/scratch surfaces' `onFontSizeChange`
+    /// is deliberately unwired, so their cmd +/- changes aren't saved (matching a GUI font change on them).
+    func font(_ target: String?, window: String?, pane: String?, action: String) -> ControlResponse {
+        return resolver.resolveSession(target, window: window) { store, id in
+            // resolveSession already resolved `id` from this store, so `session(withID:)` is non-nil.
+            guard let session = store.session(withID: id) else {
+                return ControlResponse(ok: false, error: "session not realized")
+            }
+            let chosen: (any TerminalSurface)?
+            switch pane {
+            case nil, "left":
+                chosen = session.addressableSurface
+            case "right":
+                guard let split = session.splitSurface else {
+                    return ControlResponse(ok: false, error: "session has no split pane")
+                }
+                chosen = split
+            case "scratch":
+                guard let scratch = session.scratchSurface else {
+                    return ControlResponse(ok: false, error: "session has no scratch terminal")
+                }
+                chosen = scratch
+            case .some(let value):
+                return ControlResponse(ok: false, error: "invalid pane: \(value)")
+            }
+            guard let surface = chosen as? GhosttySurfaceView else {
+                return ControlResponse(ok: false, error: "session not realized")
+            }
+            surface.performBindingAction(action)
+            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
+        }
     }
 
     /// Paste the system clipboard into the target session's surface (`session.paste`, the control analogue

--- a/agterm/Control/ControlServer+SurfaceIO.swift
+++ b/agterm/Control/ControlServer+SurfaceIO.swift
@@ -29,8 +29,11 @@ extension ControlServer {
     /// without one); `scratch` is the session's scratch terminal (`session has no scratch terminal` when none
     /// has been opened), whose surface is kept alive so its font is settable even while hidden. An unknown
     /// value is an `invalid pane` error — validated here (mirroring the CLI `validate()`) so a raw socket
-    /// client can't bypass it. Only the main pane's size persists: the split/scratch surfaces' `onFontSizeChange`
-    /// is deliberately unwired, so their cmd +/- changes aren't saved (matching a GUI font change on them).
+    /// client can't bypass it. A resolved pane whose libghostty surface isn't realized yet returns `session
+    /// not realized` (the `performBindingAction` Bool), so a split/scratch font request in the layout beat
+    /// after the pane is shown never silently no-ops. Only the main pane's size persists: the split/scratch
+    /// surfaces' `onFontSizeChange` is deliberately unwired, so their cmd +/- changes aren't saved (matching
+    /// a GUI font change on them).
     func font(_ target: String?, window: String?, pane: String?, action: String) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
             // resolveSession already resolved `id` from this store, so `session(withID:)` is non-nil.
@@ -57,7 +60,12 @@ extension ControlServer {
             guard let surface = chosen as? GhosttySurfaceView else {
                 return ControlResponse(ok: false, error: "session not realized")
             }
-            surface.performBindingAction(action)
+            // a false return = the view exists but its libghostty surface isn't realized yet (a split or
+            // scratch pane in the layout beat right after it's shown); report that instead of a false ok,
+            // matching session.type's inject() Bool contract so the action is never silently dropped.
+            guard surface.performBindingAction(action) else {
+                return ControlResponse(ok: false, error: "session not realized")
+            }
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
         }
     }

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -447,6 +447,9 @@ final class ControlServer {
                     ForegroundProcess.command(for: $0, shellBasename: shellBasename)
                 }
             },
+            fontSize: { ($0.surface as? GhosttySurfaceView)?.currentFontSize() },
+            splitFontSize: { ($0.splitSurface as? GhosttySurfaceView)?.currentFontSize() },
+            scratchFontSize: { ($0.scratchSurface as? GhosttySurfaceView)?.currentFontSize() },
             quickVisible: { windowID.flatMap { QuickTerminalRegistry.shared.controller(for: $0)?.isVisible } ?? false }
         )
     }

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -447,7 +447,7 @@ final class ControlServer {
                     ForegroundProcess.command(for: $0, shellBasename: shellBasename)
                 }
             },
-            fontSize: { ($0.surface as? GhosttySurfaceView)?.currentFontSize() },
+            fontSize: { ($0.addressableSurface as? GhosttySurfaceView)?.currentFontSize() },
             splitFontSize: { ($0.splitSurface as? GhosttySurfaceView)?.currentFontSize() },
             scratchFontSize: { ($0.scratchSurface as? GhosttySurfaceView)?.currentFontSize() },
             quickVisible: { windowID.flatMap { QuickTerminalRegistry.shared.controller(for: $0)?.isVisible } ?? false }

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -611,13 +611,21 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         ownedConfigs = [config]
     }
 
+    /// The surface's live font size in points (post cmd +/-), read from `inherited_config`; nil when the
+    /// libghostty surface isn't realized yet or hasn't resolved a size. The read side of `font.*` — the
+    /// control `tree` reads it per pane so a script can query what a font change set (the split/scratch
+    /// panes' sizes are otherwise unobservable, being live-only).
+    func currentFontSize() -> Double? {
+        guard let surface else { return nil }
+        let size = Double(ghostty_surface_inherited_config(surface, GHOSTTY_SURFACE_CONTEXT_WINDOW).font_size)
+        return size > 0 ? size : nil
+    }
+
     func reportFontSize() {
         // Already on the main actor (the CELL_SIZE callback hops via DispatchQueue.main.async).
-        // inherited_config carries the surface's live font size (post cmd +/-); a zero means
-        // libghostty hasn't resolved one yet, so skip it. The store no-ops a same-value write.
-        guard let surface else { return }
-        let size = Double(ghostty_surface_inherited_config(surface, GHOSTTY_SURFACE_CONTEXT_WINDOW).font_size)
-        guard size > 0 else { return }
+        // currentFontSize reads the surface's live font size; nil means libghostty hasn't resolved one
+        // yet, so skip it. The store no-ops a same-value write.
+        guard let size = currentFontSize() else { return }
         onFontSizeChange?(size)
     }
 

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -501,10 +501,15 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
 
     /// Triggers a libghostty keybind action on this surface (e.g. `increase_font_size:1`,
     /// `decrease_font_size:1`, `reset_font_size`), so a menu item can drive the same behavior
-    /// as the built-in keybind. A font change rides the usual CELL_SIZE → persist path.
-    func performBindingAction(_ action: String) {
-        guard let surface else { return }
+    /// as the built-in keybind. A font change rides the usual CELL_SIZE → persist path. Returns
+    /// whether the action ran: `false` when the libghostty surface isn't realized yet (the view
+    /// exists but its inner `surface` is nil), so a control caller can report `session not realized`
+    /// instead of a false ok. `@discardableResult` keeps the GUI/menu callers unchanged.
+    @discardableResult
+    func performBindingAction(_ action: String) -> Bool {
+        guard let surface else { return false }
         _ = ghostty_surface_binding_action(surface, action, UInt(action.utf8.count))
+        return true
     }
 
     /// The direction `navigateSearch` steps the selection. The pure enum (with its libghostty mapping)

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -227,7 +227,7 @@ Visibility/mode act on the frontmost window; `expand`/`collapse` default to the 
 
 **notify** — `notify <body> [--title T]` — post a desktop notification attributed to a session. To signal that you need the user, prefer `session status` (`blocked`/`completed`), a persistent typed attention state rather than a one-shot banner; keep `notify` for a one-off nudge.
 
-**font** — `font inc|dec|reset [--pane left|right|scratch]` — change a session pane's font size (omitted/`left` = main pane, `right` = the split pane, `scratch` = the scratch terminal).
+**font** — `font inc|dec|reset [--pane left|right|scratch]` — change a session pane's font size (omitted/`left` = main pane, `right` = the split pane, `scratch` = the scratch terminal). Read the resulting size back from `tree` (`fontSize`/`splitFontSize`/`scratchFontSize` per pane).
 
 **keymap** — `keymap reload` — re-read `keymap.conf` (prints the parse-diagnostic count).
 

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -227,7 +227,7 @@ Visibility/mode act on the frontmost window; `expand`/`collapse` default to the 
 
 **notify** — `notify <body> [--title T]` — post a desktop notification attributed to a session. To signal that you need the user, prefer `session status` (`blocked`/`completed`), a persistent typed attention state rather than a one-shot banner; keep `notify` for a one-off nudge.
 
-**font** — `font inc|dec|reset` — font size on the focused surface.
+**font** — `font inc|dec|reset [--pane left|right|scratch]` — change a session pane's font size (omitted/`left` = main pane, `right` = the split pane, `scratch` = the scratch terminal).
 
 **keymap** — `keymap reload` — re-read `keymap.conf` (prints the parse-diagnostic count).
 

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -400,8 +400,12 @@ attention list, the title-bar bell, and attention navigation (`session go --to n
 
 ## font
 
-`agtermctl font inc|dec|reset [--target] [--window W]` — increase / decrease / reset the font size on
-the focused surface.
+`agtermctl font inc|dec|reset [--pane left|right|scratch] [--target] [--window W]` — increase / decrease /
+reset the font size of a session pane. `--pane` picks which surface's font to change, like `session type`
+and `session text`: omitted or `left` is the main pane, `right` the split pane (errors with `session has
+no split pane` when the session has no split), `scratch` the session's scratch terminal (settable even
+while hidden). No `other` value. Only the MAIN pane's size is persisted across relaunch; a split/scratch
+pane's font change is live-only, matching a GUI cmd +/- on those panes.
 
 ## keymap
 

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -57,11 +57,14 @@ as `status`, so it is never reported without a `status`), `statusBlink` (`true` 
 set to blink — the `--blink` value; omitted when idle or not blinking) and `statusColor` (the `#rrggbb`
 glyph-tint override — the `--color` value; omitted when idle or using the default color),
 `foreground`/`splitForeground` (the live argv of each pane's foreground
-process — what it is running — omitted when the pane sits at its shell prompt), and `background` (the
+process — what it is running — omitted when the pane sits at its shell prompt), `background` (the
 background spec set via `session background` — a `{kind, text?, imagePath?, colorHex?, opacity?, fit?,
-position?, repeats?}` object; `kind` is `image`/`text`/`color` — omitted when none is set), and `unseen`
+position?, repeats?}` object; `kind` is `image`/`text`/`color` — omitted when none is set), `unseen`
 (the unseen-notification badge count — raised by `notify`/OSC 9/777, cleared by `session seen` — omitted
-when zero). Workspace nodes carry `id`, `name`, `active`, `sessions`, and `focused` (whether the sidebar
+when zero), and `fontSize`/`splitFontSize`/`scratchFontSize` (the LIVE font size in points of each pane —
+the read side of `font --pane`; each omitted when that pane's surface isn't realized. Only `fontSize` (the
+main pane) survives a relaunch; the split/scratch sizes are live-only, so read them back here rather than
+from the snapshot). Workspace nodes carry `id`, `name`, `active`, `sessions`, and `focused` (whether the sidebar
 tree is collapsed to this workspace — the read side of `workspace focus`, distinct from `active` the
 SELECTED workspace; omitted unless this is the focused one, and absent entirely when nothing is focused).
 
@@ -405,7 +408,9 @@ reset the font size of a session pane. `--pane` picks which surface's font to ch
 and `session text`: omitted or `left` is the main pane, `right` the split pane (errors with `session has
 no split pane` when the session has no split), `scratch` the session's scratch terminal (settable even
 while hidden). No `other` value. Only the MAIN pane's size is persisted across relaunch; a split/scratch
-pane's font change is live-only, matching a GUI cmd +/- on those panes.
+pane's font change is live-only, matching a GUI cmd +/- on those panes. Read the resulting size back from
+`tree` — `fontSize` (main), `splitFontSize`, `scratchFontSize`, each in points and omitted when that pane
+isn't realized.
 
 ## keymap
 

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -62,9 +62,10 @@ background spec set via `session background` — a `{kind, text?, imagePath?, co
 position?, repeats?}` object; `kind` is `image`/`text`/`color` — omitted when none is set), `unseen`
 (the unseen-notification badge count — raised by `notify`/OSC 9/777, cleared by `session seen` — omitted
 when zero), and `fontSize`/`splitFontSize`/`scratchFontSize` (the LIVE font size in points of each pane —
-the read side of `font --pane`; each omitted when that pane's surface isn't realized. Only `fontSize` (the
-main pane) survives a relaunch; the split/scratch sizes are live-only, so read them back here rather than
-from the snapshot). Workspace nodes carry `id`, `name`, `active`, `sessions`, and `focused` (whether the sidebar
+the read side of `font --pane`; each omitted when that pane isn't realized. `fontSize` tracks the
+default/left target (the main pane, or the promoted split survivor once the primary exits — the same pane
+`font --pane left` writes); only the main pane's size survives a relaunch, so the split/scratch sizes and a
+promoted survivor are live-only — read them back here rather than from the snapshot). Workspace nodes carry `id`, `name`, `active`, `sessions`, and `focused` (whether the sidebar
 tree is collapsed to this workspace — the read side of `workspace focus`, distinct from `active` the
 SELECTED workspace; omitted unless this is the focused one, and absent entirely when nothing is focused).
 

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -176,6 +176,9 @@ public final class AppStore {
     /// command lookup is supplied by the host because live process inspection is platform-specific.
     public func controlTree(foreground: (Session) -> [String]? = { _ in nil },
                             splitForeground: (Session) -> [String]? = { _ in nil },
+                            fontSize: (Session) -> Double? = { _ in nil },
+                            splitFontSize: (Session) -> Double? = { _ in nil },
+                            scratchFontSize: (Session) -> Double? = { _ in nil },
                             quickVisible: () -> Bool? = { nil }) -> ControlTree {
         let activeID = selectedSessionID
         let activeWorkspaceID = activeID.flatMap { workspace(forSession: $0)?.id }
@@ -199,7 +202,10 @@ public final class AppStore {
                                           statusBlink: idle ? nil : (session.agentIndicator.blink ? true : nil),
                                           statusColor: idle ? nil : session.agentIndicator.color,
                                           background: session.backgroundWatermark,
-                                          unseen: session.unseenCount > 0 ? session.unseenCount : nil)
+                                          unseen: session.unseenCount > 0 ? session.unseenCount : nil,
+                                          fontSize: fontSize(session),
+                                          splitFontSize: splitFontSize(session),
+                                          scratchFontSize: scratchFontSize(session))
             }
             return ControlWorkspaceNode(id: workspace.id.uuidString, name: workspace.name,
                                         active: workspace.id == activeWorkspaceID,

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -25,7 +25,7 @@ public protocol ControlActions {
     func scratchSession(_ target: String?, window: String?, mode: String?, command: String?) -> ControlResponse
     func focusSessionPane(_ target: String?, window: String?, pane: String?) -> ControlResponse
     func resizeSplit(_ target: String?, window: String?, resize: ControlSplitResize) -> ControlResponse
-    func font(_ target: String?, window: String?, action: String) -> ControlResponse
+    func font(_ target: String?, window: String?, pane: String?, action: String) -> ControlResponse
     func reloadKeymap() -> ControlResponse
     func reloadGhosttyConfig() -> ControlResponse
     func sendNotification(_ target: String?, window: String?, title: String?, body: String) -> ControlResponse
@@ -369,11 +369,14 @@ public struct ControlDispatcher {
     private func dispatchAppCommand(_ request: ControlRequest) -> ControlResponse {
         switch request.cmd {
         case .fontInc:
-            return actions.font(request.target, window: request.args?.window, action: "increase_font_size:1")
+            return actions.font(request.target, window: request.args?.window,
+                                pane: request.args?.pane, action: "increase_font_size:1")
         case .fontDec:
-            return actions.font(request.target, window: request.args?.window, action: "decrease_font_size:1")
+            return actions.font(request.target, window: request.args?.window,
+                                pane: request.args?.pane, action: "decrease_font_size:1")
         case .fontReset:
-            return actions.font(request.target, window: request.args?.window, action: "reset_font_size")
+            return actions.font(request.target, window: request.args?.window,
+                                pane: request.args?.pane, action: "reset_font_size")
         case .quick:
             return actions.setQuickTerminal(mode: request.args?.mode)
         case .keymapReload:

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -317,13 +317,25 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
     /// side of the notification badge: `notify` (and terminal OSC 9/777) raise it, `session.seen` clears it.
     /// Ephemeral like `status` — never persisted, so it resets to nil on restart.
     public let unseen: Int?
+    /// The MAIN pane's live font size in points, or nil when its surface isn't realized (omitted from the
+    /// JSON). The read side of `font --pane left` (and the default). Reflects the live cmd +/- value; only
+    /// the main pane's size is persisted across relaunch.
+    public let fontSize: Double?
+    /// The split (right) pane's live font size in points, or nil when the session has no realized split pane
+    /// (omitted). The read side of `font --pane right` — the split's font is otherwise unobservable, being
+    /// live-only (not persisted), so record it here before changing it.
+    public let splitFontSize: Double?
+    /// The scratch terminal's live font size in points, or nil when no scratch surface is realized (omitted).
+    /// The read side of `font --pane scratch` (also live-only).
+    public let scratchFontSize: Double?
 
     public init(id: String, name: String, cwd: String, title: String? = nil, active: Bool, split: Bool,
                 splitRatio: Double? = nil, splitFocused: Bool? = nil,
                 overlay: Bool = false, overlaySizePercent: Int? = nil, scratch: Bool = false, flagged: Bool = false,
                 foreground: [String]? = nil, splitForeground: [String]? = nil, status: String? = nil,
                 statusPane: String? = nil, statusBlink: Bool? = nil, statusColor: String? = nil,
-                background: BackgroundWatermark? = nil, unseen: Int? = nil) {
+                background: BackgroundWatermark? = nil, unseen: Int? = nil,
+                fontSize: Double? = nil, splitFontSize: Double? = nil, scratchFontSize: Double? = nil) {
         self.id = id
         self.name = name
         self.cwd = cwd
@@ -344,6 +356,9 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
         self.statusColor = statusColor
         self.background = background
         self.unseen = unseen
+        self.fontSize = fontSize
+        self.splitFontSize = splitFontSize
+        self.scratchFontSize = scratchFontSize
     }
 }
 

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -317,9 +317,10 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
     /// side of the notification badge: `notify` (and terminal OSC 9/777) raise it, `session.seen` clears it.
     /// Ephemeral like `status` — never persisted, so it resets to nil on restart.
     public let unseen: Int?
-    /// The MAIN pane's live font size in points, or nil when its surface isn't realized (omitted from the
-    /// JSON). The read side of `font --pane left` (and the default). Reflects the live cmd +/- value; only
-    /// the main pane's size is persisted across relaunch.
+    /// The default/left pane's live font size in points, resolved via `addressableSurface`: the main pane,
+    /// or the promoted split survivor once the primary has exited (the same pane `font --pane left`, and the
+    /// default, writes). Nil when that pane isn't realized (omitted from the JSON). Reflects the live cmd
+    /// +/- value; the main pane's size is persisted across relaunch, but a promoted survivor's is live-only.
     public let fontSize: Double?
     /// The split (right) pane's live font size in points, or nil when the session has no realized split pane
     /// (omitted). The read side of `font --pane right` — the split's font is otherwise unobservable, being

--- a/agtermCore/Sources/agtermctlKit/MiscCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/MiscCommands.swift
@@ -248,13 +248,21 @@ struct Font: ParsableCommand {
         subcommands: [Inc.self, Dec.self, Reset.self]
     )
 
+    /// Help text for the shared `--pane` option on the font subcommands. Reuses the `left|right|scratch`
+    /// vocabulary of `session type`/`session text`; omitted defaults to the main pane.
+    static let paneHelp = "Which pane's font to change: left (main), right (split), or scratch (the "
+        + "session's scratch terminal, even when hidden). Defaults to the left pane."
+
     struct Inc: RequestCommand {
         static let configuration = CommandConfiguration(abstract: "Increase font size.")
         @OptionGroup var target: TargetOptions
         @OptionGroup var options: ClientOptions
+        @Option(name: .long, help: ArgumentHelp(Font.paneHelp)) var pane: String?
+
+        func validate() throws { try validatePaneArgument(pane) }
 
         func makeRequest() throws -> ControlRequest {
-            ControlRequest(cmd: .fontInc, target: target.target, args: options.withWindow())
+            ControlRequest(cmd: .fontInc, target: target.target, args: options.withWindow(pane.map { ControlArgs(pane: $0) }))
         }
     }
 
@@ -262,9 +270,12 @@ struct Font: ParsableCommand {
         static let configuration = CommandConfiguration(abstract: "Decrease font size.")
         @OptionGroup var target: TargetOptions
         @OptionGroup var options: ClientOptions
+        @Option(name: .long, help: ArgumentHelp(Font.paneHelp)) var pane: String?
+
+        func validate() throws { try validatePaneArgument(pane) }
 
         func makeRequest() throws -> ControlRequest {
-            ControlRequest(cmd: .fontDec, target: target.target, args: options.withWindow())
+            ControlRequest(cmd: .fontDec, target: target.target, args: options.withWindow(pane.map { ControlArgs(pane: $0) }))
         }
     }
 
@@ -272,9 +283,12 @@ struct Font: ParsableCommand {
         static let configuration = CommandConfiguration(abstract: "Reset font size.")
         @OptionGroup var target: TargetOptions
         @OptionGroup var options: ClientOptions
+        @Option(name: .long, help: ArgumentHelp(Font.paneHelp)) var pane: String?
+
+        func validate() throws { try validatePaneArgument(pane) }
 
         func makeRequest() throws -> ControlRequest {
-            ControlRequest(cmd: .fontReset, target: target.target, args: options.withWindow())
+            ControlRequest(cmd: .fontReset, target: target.target, args: options.withWindow(pane.map { ControlArgs(pane: $0) }))
         }
     }
 }

--- a/agtermCore/Sources/agtermctlKit/SessionCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/SessionCommands.swift
@@ -2,11 +2,11 @@ import ArgumentParser
 import Foundation
 import agtermCore
 
-/// Shared `--pane` validation for the session commands that accept `left|right|scratch` (type, text, status).
-/// Rejects any other value with a clean usage error before the socket round-trip, matching the server-side
-/// switch (so the CLI and server can't drift, and a raw socket client still hits the same check server-side).
-/// These three commands intentionally reuse `StatusPane`'s `left|right|scratch` value set as the shared
-/// pane-addressing vocabulary — the enum is named for agent status but its cases are the pane names.
+/// Shared `--pane` validation for the commands that accept `left|right|scratch` (session type, text, status,
+/// and font). Rejects any other value with a clean usage error before the socket round-trip, matching the
+/// server-side switch (so the CLI and server can't drift, and a raw socket client still hits the same check
+/// server-side). These commands intentionally reuse `StatusPane`'s `left|right|scratch` value set as the
+/// shared pane-addressing vocabulary — the enum is named for agent status but its cases are the pane names.
 func validatePaneArgument(_ pane: String?) throws {
     if let pane, StatusPane(rawValue: pane) == nil {
         throw ValidationError("--pane must be left, right, or scratch")

--- a/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
@@ -407,6 +407,29 @@ struct AppStorePaneTests {
         #expect(node.scratchFontSize == 11)
     }
 
+    @Test func controlTreeFontSizeReadsPromotedSurvivorViaAddressableSurface() throws {
+        // regression: after the primary pane exits, the fontSize read-back must resolve through
+        // addressableSurface (the promoted split survivor) — the same surface the font default/left
+        // WRITE path targets — not bare `surface`, which is nil in that state. A closure over `surface`
+        // would report nothing for a session the user is actively typing in.
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        session.surface = SpySurface()
+        session.splitSurface = SpySurface()
+        session.isSplit = true
+        session.hasSplit = true
+        store.closePrimaryPane(session.id)                 // primary exits -> surface nil, survivor promoted
+        #expect(session.surface == nil)
+        #expect(session.addressableSurface != nil)
+        // the app wires fontSize off addressableSurface: it reports the survivor's size here...
+        let viaAddressable = store.controlTree(fontSize: { $0.addressableSurface != nil ? 13 : nil })
+        #expect(viaAddressable.workspaces[0].sessions.first?.fontSize == 13)
+        // ...whereas the old wiring over the (now nil) `surface` would report nothing.
+        let viaSurface = store.controlTree(fontSize: { $0.surface != nil ? 13 : nil })
+        #expect(viaSurface.workspaces[0].sessions.first?.fontSize == nil)
+    }
+
     @Test func controlTreeReportsSplitFocused() throws {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
@@ -390,6 +390,23 @@ struct AppStorePaneTests {
         #expect(node.splitRatio == 0.3)
     }
 
+    @Test func controlTreeThreadsFontSizesFromClosures() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        _ = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        // default closures: the font-size fields are omitted (nil), like foreground.
+        var node = try #require(store.controlTree().workspaces[0].sessions.first)
+        #expect(node.fontSize == nil)
+        #expect(node.splitFontSize == nil)
+        #expect(node.scratchFontSize == nil)
+        // the host supplies live per-pane sizes via closures (the app reads them off the surfaces).
+        node = try #require(store.controlTree(fontSize: { _ in 13 }, splitFontSize: { _ in 9.5 },
+                                              scratchFontSize: { _ in 11 }).workspaces[0].sessions.first)
+        #expect(node.fontSize == 13)
+        #expect(node.splitFontSize == 9.5)
+        #expect(node.scratchFontSize == 11)
+    }
+
     @Test func controlTreeReportsSplitFocused() throws {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -642,10 +642,13 @@ struct ControlDispatcherTests {
                                                      args: ControlArgs(pane: "right")))
         _ = await dispatcher.dispatch(ControlRequest(cmd: .fontInc, target: "session",
                                                      args: ControlArgs(window: "win", pane: "scratch")))
+        _ = await dispatcher.dispatch(ControlRequest(cmd: .fontReset, target: "session",
+                                                     args: ControlArgs(pane: "left")))
 
         #expect(actions.calls == [
             .font(target: "session", window: nil, pane: "right", "decrease_font_size:1"),
-            .font(target: "session", window: "win", pane: "scratch", "increase_font_size:1")
+            .font(target: "session", window: "win", pane: "scratch", "increase_font_size:1"),
+            .font(target: "session", window: nil, pane: "left", "reset_font_size")
         ])
     }
 

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -627,9 +627,25 @@ struct ControlDispatcherTests {
         #expect(dec == ControlResponse(ok: true, result: ControlResult(id: "session")))
         #expect(reset == ControlResponse(ok: true, result: ControlResult(id: "session")))
         #expect(actions.calls == [
-            .font(target: "session", window: "win", "increase_font_size:1"),
-            .font(target: "session", window: nil, "decrease_font_size:1"),
-            .font(target: "session", window: nil, "reset_font_size")
+            .font(target: "session", window: "win", pane: nil, "increase_font_size:1"),
+            .font(target: "session", window: nil, pane: nil, "decrease_font_size:1"),
+            .font(target: "session", window: nil, pane: nil, "reset_font_size")
+        ])
+    }
+
+    @Test func fontCommandsThreadPane() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextFontResponse = ControlResponse(ok: true, result: ControlResult(id: "session"))
+
+        _ = await dispatcher.dispatch(ControlRequest(cmd: .fontDec, target: "session",
+                                                     args: ControlArgs(pane: "right")))
+        _ = await dispatcher.dispatch(ControlRequest(cmd: .fontInc, target: "session",
+                                                     args: ControlArgs(window: "win", pane: "scratch")))
+
+        #expect(actions.calls == [
+            .font(target: "session", window: nil, pane: "right", "decrease_font_size:1"),
+            .font(target: "session", window: "win", pane: "scratch", "increase_font_size:1")
         ])
     }
 
@@ -1374,7 +1390,7 @@ private final class MockControlActions: ControlActions {
         case sessionScratch(target: String?, window: String?, String?, command: String?)
         case sessionFocus(target: String?, window: String?, String?)
         case sessionResize(target: String?, window: String?, ControlSplitResize)
-        case font(target: String?, window: String?, String)
+        case font(target: String?, window: String?, pane: String?, String)
         case keymapReload
         case configReload
         case notify(target: String?, window: String?, title: String?, body: String)
@@ -1552,8 +1568,8 @@ private final class MockControlActions: ControlActions {
         return ControlResponse(ok: true)
     }
 
-    func font(_ target: String?, window: String?, action: String) -> ControlResponse {
-        calls.append(.font(target: target, window: window, action))
+    func font(_ target: String?, window: String?, pane: String?, action: String) -> ControlResponse {
+        calls.append(.font(target: target, window: window, pane: pane, action))
         return nextFontResponse
     }
 

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -375,6 +375,26 @@ struct ControlProtocolTests {
         #expect(!json.contains("foreground"), "a nil foreground must be omitted from the JSON; got \(json)")
     }
 
+    @Test func treeSessionNodeRoundTripsWithFontSizes() throws {
+        let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: true,
+                                         fontSize: 13, splitFontSize: 9.5, scratchFontSize: 11)
+        let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(
+            workspaces: [ControlWorkspaceNode(id: "w1", name: "work", active: true, sessions: [session])])))
+        let decoded = try roundTrip(response)
+        #expect(decoded == response)
+        let node = decoded.result?.tree?.workspaces.first?.sessions.first
+        #expect(node?.fontSize == 13)
+        #expect(node?.splitFontSize == 9.5)
+        #expect(node?.scratchFontSize == 11)
+    }
+
+    @Test func treeSessionNodeOmitsFontSizesWhenNil() throws {
+        // an unrealized pane has no live font size — the keys must be omitted, not emitted as null.
+        let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false)
+        let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
+        #expect(!json.contains("fontSize"), "nil font sizes must be omitted from the JSON; got \(json)")
+    }
+
     @Test func treeSessionNodeRoundTripsWithStatus() throws {
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false, status: "blocked")
         let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -392,7 +392,10 @@ struct ControlProtocolTests {
         // an unrealized pane has no live font size — the keys must be omitted, not emitted as null.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false)
         let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
-        #expect(!json.contains("fontSize"), "nil font sizes must be omitted from the JSON; got \(json)")
+        // contains is case-sensitive: "fontSize" catches only the main key, "FontSize" catches the
+        // suffixed splitFontSize/scratchFontSize keys — assert both so all three omissions are covered.
+        #expect(!json.contains("fontSize"), "the main fontSize key must be omitted when nil; got \(json)")
+        #expect(!json.contains("FontSize"), "splitFontSize/scratchFontSize must be omitted when nil; got \(json)")
     }
 
     @Test func treeSessionNodeRoundTripsWithStatus() throws {

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -742,6 +742,25 @@ struct CommandsTests {
         #expect(try request(["font", "reset"]) == ControlRequest(cmd: .fontReset, target: "active"))
     }
 
+    @Test func fontIncWithPane() throws {
+        #expect(try request(["font", "inc", "--pane", "right", "--target", "s1"])
+            == ControlRequest(cmd: .fontInc, target: "s1", args: ControlArgs(pane: "right")))
+    }
+
+    @Test func fontDecWithPaneScratch() throws {
+        #expect(try request(["font", "dec", "--pane", "scratch"])
+            == ControlRequest(cmd: .fontDec, target: "active", args: ControlArgs(pane: "scratch")))
+    }
+
+    @Test func fontResetWithPaneAndWindow() throws {
+        #expect(try request(["font", "reset", "--pane", "left", "--window", "w1"])
+            == ControlRequest(cmd: .fontReset, target: "active", args: ControlArgs(window: "w1", pane: "left")))
+    }
+
+    @Test func fontRejectsInvalidPane() throws {
+        #expect(validationMessage(["font", "inc", "--pane", "other"]) == "--pane must be left, right, or scratch")
+    }
+
     @Test func keymapReload() throws {
         #expect(try request(["keymap", "reload"]) == ControlRequest(cmd: .keymapReload))
     }

--- a/agtermUITests/FontPaneUITests.swift
+++ b/agtermUITests/FontPaneUITests.swift
@@ -66,6 +66,20 @@ final class FontPaneUITests: ControlAPITestCase {
         XCTAssertEqual(response["error"] as? String, "session has no split pane", "should report no split pane: \(response)")
     }
 
+    // font --pane scratch on a session with no scratch terminal opened errors. The scratch is lazily
+    // spawned on first show, so a fresh session's scratchSurface is nil — deterministic, mirroring
+    // testFontPaneRightWithoutSplitErrors. This is the only e2e over the font scratch arm (the success
+    // path shares fontUntilOk's realized-surface proof with the split case).
+    func testFontPaneScratchWithoutScratchErrors() throws {
+        let created = try sendCommand(#"{"cmd":"session.new"}"#)
+        let newID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "session.new should return the new id")
+
+        let response = try sendCommand(fontRequest(cmd: "font.dec", target: newID, pane: "scratch"))
+        XCTAssertEqual(response["ok"] as? Bool, false, "font --pane scratch with no scratch should fail: \(response)")
+        XCTAssertEqual(response["error"] as? String, "session has no scratch terminal",
+                       "should report no scratch terminal: \(response)")
+    }
+
     // pane validation is enforced SERVER-SIDE, not only in the CLI `validate()`: a raw socket client bypasses
     // the CLI, so an unknown pane value must error here too (sendCommand is that raw client).
     func testFontRejectsInvalidPaneServerSide() throws {

--- a/agtermUITests/FontPaneUITests.swift
+++ b/agtermUITests/FontPaneUITests.swift
@@ -10,10 +10,11 @@ import XCTest
 // subclass like `SessionTypePaneUITests`, reusing the shared harness.
 @MainActor
 final class FontPaneUITests: ControlAPITestCase {
-    // font dec --pane right decrements the split surface, NOT the main/left one (the reported bug). The main
-    // pane's persisted size is the only readable font oracle, so the proof is: --pane right returns ok
-    // (the split surface exists and got the action) while the main pane's size stays put, and the default
-    // font dec then DOES shrink the main pane — so the two panes are addressed independently.
+    // font dec --pane right decrements the split surface, NOT the main/left one (the reported bug). Two
+    // oracles: the split pane's live font (read back via tree's splitFontSize) must DROP, proving the
+    // action landed on the split; and the main pane's persisted size must stay put, proving it didn't leak
+    // to the main. The default font dec then DOES shrink the main pane — so the panes are addressed
+    // independently.
     func testFontPaneRightTargetsSplitNotMain() throws {
         let split = try sendCommand(#"{"cmd":"session.split","target":"active","args":{"mode":"on"}}"#)
         XCTAssertEqual(split["ok"] as? Bool, true, "split on should succeed: \(split)")
@@ -24,6 +25,9 @@ final class FontPaneUITests: ControlAPITestCase {
         // settled — its point size doesn't change with pane width, so this stays constant hereafter.
         let baseline = try XCTUnwrap(pollFirstSessionFontSize(timeout: 10),
                                      "the main pane should report a persisted font size on launch")
+        // the split pane's live font baseline, read back from the tree once the split surface realizes.
+        let splitBaseline = try XCTUnwrap(pollSplitFontSize(target: id, timeout: 10),
+                                          "the split pane should report a live font size once realized")
 
         // ride out split-surface realization: a freshly shown split may not be realized for the first
         // request, which returns "session not realized" (continueAfterFailure = false forbids asserting in
@@ -35,6 +39,12 @@ final class FontPaneUITests: ControlAPITestCase {
             let response = try sendCommand(fontRequest(cmd: "font.dec", target: id, pane: "right"))
             XCTAssertEqual(response["ok"] as? Bool, true, "font dec --pane right should stay ok: \(response)")
         }
+
+        // POSITIVE proof the action landed on the split: its live font (tree read-back) dropped below its
+        // baseline. This is what the main-pane-only oracle couldn't show.
+        let splitAfter = try XCTUnwrap(pollSplitFontSize(target: id, below: splitBaseline - 0.5, timeout: 8),
+                                       "font --pane right should shrink the split pane's live font size")
+        XCTAssertLessThan(splitAfter, splitBaseline)
 
         // the main pane's persisted size must be untouched by the split-pane changes — the bug was that
         // font always hit the main/left surface. Wait past the debounced save, then assert no drift (a
@@ -117,6 +127,34 @@ final class FontPaneUITests: ControlAPITestCase {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             if let size = firstSessionFontSize(), size < threshold { return size }
+            usleep(200_000)
+        }
+        return nil
+    }
+
+    /// Reads session `id`'s `splitFontSize` from the current control tree, or nil when absent (the split
+    /// surface isn't realized) — the read-back for `font --pane right`.
+    private func splitFontSize(target id: String) throws -> Double? {
+        let tree = try sendCommand(#"{"cmd":"tree"}"#)
+        guard let result = tree["result"] as? [String: Any],
+              let t = result["tree"] as? [String: Any],
+              let workspaces = t["workspaces"] as? [[String: Any]] else { return nil }
+        for ws in workspaces {
+            for session in (ws["sessions"] as? [[String: Any]] ?? [])
+            where (session["id"] as? String)?.lowercased() == id.lowercased() {
+                return session["splitFontSize"] as? Double
+            }
+        }
+        return nil
+    }
+
+    /// Polls the tree until session `id`'s `splitFontSize` is present (and below `threshold` when given),
+    /// returning it, or nil on timeout.
+    private func pollSplitFontSize(target id: String, below threshold: Double? = nil,
+                                   timeout: TimeInterval) throws -> Double? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let size = try splitFontSize(target: id), threshold.map({ size < $0 }) ?? true { return size }
             usleep(200_000)
         }
         return nil

--- a/agtermUITests/FontPaneUITests.swift
+++ b/agtermUITests/FontPaneUITests.swift
@@ -1,0 +1,110 @@
+import Foundation
+import XCTest
+
+// font --pane e2e: the font commands can target a specific pane (`left`|`right`|`scratch`), mirroring
+// `session type`/`session text`. The split pane's font is NOT persisted (its surface's onFontSizeChange is
+// unwired by design), so the persisted MAIN-pane size is the oracle: `font dec --pane right` must return ok
+// (proving it reached the realized split surface) while leaving the main pane's persisted size untouched,
+// and the default (no --pane) must still shrink the main pane. The error cases (no split, invalid pane) go
+// straight over the socket so the SERVER, not just the CLI `validate()`, enforces them. A `ControlAPITestCase`
+// subclass like `SessionTypePaneUITests`, reusing the shared harness.
+@MainActor
+final class FontPaneUITests: ControlAPITestCase {
+    // font dec --pane right decrements the split surface, NOT the main/left one (the reported bug). The main
+    // pane's persisted size is the only readable font oracle, so the proof is: --pane right returns ok
+    // (the split surface exists and got the action) while the main pane's size stays put, and the default
+    // font dec then DOES shrink the main pane — so the two panes are addressed independently.
+    func testFontPaneRightTargetsSplitNotMain() throws {
+        let split = try sendCommand(#"{"cmd":"session.split","target":"active","args":{"mode":"on"}}"#)
+        XCTAssertEqual(split["ok"] as? Bool, true, "split on should succeed: \(split)")
+        XCTAssertTrue(pollActiveSessionSplit(true, timeout: 10), "the active session should report split:true")
+        let id = try activeSessionID()
+
+        // baseline captured AFTER the split is shown, so any post-split reflow of the main pane already
+        // settled — its point size doesn't change with pane width, so this stays constant hereafter.
+        let baseline = try XCTUnwrap(pollFirstSessionFontSize(timeout: 10),
+                                     "the main pane should report a persisted font size on launch")
+
+        // ride out split-surface realization: a freshly shown split may not be realized for the first
+        // request, which returns "session not realized" (continueAfterFailure = false forbids asserting in
+        // the retry loop, so fontUntilOk swallows the transient failures and returns the settled response).
+        let firstRight = try fontUntilOk(cmd: "font.dec", target: id, pane: "right")
+        XCTAssertEqual(firstRight["ok"] as? Bool, true,
+                       "font dec --pane right should reach the realized split surface: \(firstRight)")
+        for _ in 0..<3 {
+            let response = try sendCommand(fontRequest(cmd: "font.dec", target: id, pane: "right"))
+            XCTAssertEqual(response["ok"] as? Bool, true, "font dec --pane right should stay ok: \(response)")
+        }
+
+        // the main pane's persisted size must be untouched by the split-pane changes — the bug was that
+        // font always hit the main/left surface. Wait past the debounced save, then assert no drift (a
+        // buggy 4-point drop would fail; the split's font simply isn't persisted, so it can't move).
+        RunLoop.current.run(until: Date().addingTimeInterval(1.5))
+        let afterRight = try XCTUnwrap(firstSessionFontSize(), "the main pane size should still be readable")
+        XCTAssertEqual(afterRight, baseline, accuracy: 0.5,
+                       "font --pane right must not change the main pane's persisted size")
+
+        // the default (no --pane) still targets the main pane, so its persisted size drops below baseline.
+        for _ in 0..<4 {
+            let response = try sendCommand(fontRequest(cmd: "font.dec", target: id, pane: nil))
+            XCTAssertEqual(response["ok"] as? Bool, true, "default font dec should hit the main pane: \(response)")
+            RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+        }
+        let decreased = try XCTUnwrap(pollFirstSessionFontSize(below: baseline - 0.5, timeout: 8),
+                                      "the default (no --pane) font dec should shrink the main pane's persisted size")
+        XCTAssertLessThan(decreased, baseline)
+    }
+
+    // font --pane right on a non-split session errors. Sent straight over the socket (bypassing the CLI), so
+    // the SERVER itself rejects it — mirroring session.type/session.text.
+    func testFontPaneRightWithoutSplitErrors() throws {
+        let created = try sendCommand(#"{"cmd":"session.new"}"#)
+        let newID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "session.new should return the new id")
+
+        let response = try sendCommand(fontRequest(cmd: "font.dec", target: newID, pane: "right"))
+        XCTAssertEqual(response["ok"] as? Bool, false, "font --pane right with no split should fail: \(response)")
+        XCTAssertEqual(response["error"] as? String, "session has no split pane", "should report no split pane: \(response)")
+    }
+
+    // pane validation is enforced SERVER-SIDE, not only in the CLI `validate()`: a raw socket client bypasses
+    // the CLI, so an unknown pane value must error here too (sendCommand is that raw client).
+    func testFontRejectsInvalidPaneServerSide() throws {
+        let response = try sendCommand(#"{"cmd":"font.dec","target":"active","args":{"pane":"middle"}}"#)
+        XCTAssertEqual(response["ok"] as? Bool, false, "font pane:middle should fail server-side: \(response)")
+        XCTAssertEqual(response["error"] as? String, "invalid pane: middle", "should report the invalid pane: \(response)")
+    }
+
+    // MARK: - helpers
+
+    /// Build a `font.*` request line, adding `args.pane` only when a pane is given (a bare font request
+    /// carries no args, matching the CLI's compact form).
+    private func fontRequest(cmd: String, target: String, pane: String?) -> String {
+        var obj: [String: Any] = ["cmd": cmd, "target": target]
+        if let pane { obj["args"] = ["pane": pane] }
+        let data = try! JSONSerialization.data(withJSONObject: obj)
+        return String(data: data, encoding: .utf8)!
+    }
+
+    /// Send a font request, retrying while the split surface finishes realizing ("session not realized"),
+    /// and return the settled response (ok, or the last failure if it never realized).
+    private func fontUntilOk(cmd: String, target: String, pane: String?) throws -> [String: Any] {
+        var last: [String: Any] = [:]
+        for _ in 0..<20 {
+            last = try sendCommand(fontRequest(cmd: cmd, target: target, pane: pane))
+            if last["ok"] as? Bool == true { return last }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+        }
+        return last
+    }
+
+    /// Polls the snapshot until the first session's persisted `fontSize` drops below `threshold`, returning
+    /// it, or nil on timeout.
+    private func pollFirstSessionFontSize(below threshold: Double, timeout: TimeInterval) -> Double? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let size = firstSessionFontSize(), size < threshold { return size }
+            usleep(200_000)
+        }
+        return nil
+    }
+}

--- a/agtermUITests/FontPaneUITests.swift
+++ b/agtermUITests/FontPaneUITests.swift
@@ -98,6 +98,46 @@ final class FontPaneUITests: ControlAPITestCase {
         XCTAssertEqual(response["error"] as? String, "invalid pane: middle", "should report the invalid pane: \(response)")
     }
 
+    // the DEFAULT (and `--pane left`) font target follows a promoted split survivor. When the primary
+    // pane's shell exits while a split is shown, closePrimaryPane tears the primary surface down (surface
+    // == nil) and promotes the split shell to a single session. The default font WRITE resolves
+    // addressableSurface (= surface ?? splitSurface), so it hits the survivor — and the tree's fontSize
+    // read-back must resolve the SAME addressableSurface. This is the app-level guard for the read-side
+    // wiring: a regression to reading bare `surface` would OMIT fontSize here, because the primary surface
+    // is gone (the host-free AppStorePaneTests can't exercise ControlServer.buildTree's closure).
+    func testFontDefaultTargetsPromotedSplitSurvivor() throws {
+        let id = try activeSessionID()
+
+        let split = try sendCommand(#"{"cmd":"session.split","target":"\#(id)","args":{"mode":"on"}}"#)
+        XCTAssertEqual(split["ok"] as? Bool, true, "split on should succeed: \(split)")
+        XCTAssertTrue(pollActiveSessionSplit(true, timeout: 10), "the active session should report split:true")
+        // let the split (right) surface realize so the survivor has a live font before the primary exits.
+        _ = try XCTUnwrap(pollSplitFontSize(target: id, timeout: 10),
+                          "the split pane should report a live font size once realized")
+
+        // exit the primary -> onExit fires closePrimaryPane, promoting the split survivor to a single session.
+        XCTAssertTrue(try promoteSurvivorByExitingPrimary(target: id, timeout: 25),
+                      "exiting the primary should promote the split survivor (session survives, split -> false)")
+
+        // fontSize MUST read the promoted survivor via addressableSurface: the primary surface is torn down,
+        // so a read off bare `surface` would omit this field. Its presence proves the addressableSurface wiring.
+        let baseline = try XCTUnwrap(pollMainFontSize(target: id, timeout: 8),
+                                     "fontSize must read the promoted survivor via addressableSurface (surface is nil)")
+
+        // the DEFAULT font dec (no --pane) targets addressableSurface = the survivor.
+        for _ in 0..<4 {
+            let response = try sendCommand(fontRequest(cmd: "font.dec", target: id, pane: nil))
+            XCTAssertEqual(response["ok"] as? Bool, true, "default font dec should reach the promoted survivor: \(response)")
+            RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+        }
+
+        // the survivor's live font dropped, read back through fontSize — the default write and its read-back
+        // both track the promoted survivor.
+        let dropped = try XCTUnwrap(pollMainFontSize(target: id, below: baseline - 0.5, timeout: 8),
+                                    "the default font dec must shrink the promoted survivor's fontSize read-back")
+        XCTAssertLessThan(dropped, baseline)
+    }
+
     // MARK: - helpers
 
     /// Build a `font.*` request line, adding `args.pane` only when a pane is given (a bare font request
@@ -132,9 +172,9 @@ final class FontPaneUITests: ControlAPITestCase {
         return nil
     }
 
-    /// Reads session `id`'s `splitFontSize` from the current control tree, or nil when absent (the split
-    /// surface isn't realized) — the read-back for `font --pane right`.
-    private func splitFontSize(target id: String) throws -> Double? {
+    /// Reads session `id`'s node from the current control tree (searching every workspace), or nil when the
+    /// session is absent.
+    private func treeSessionNode(target id: String) throws -> [String: Any]? {
         let tree = try sendCommand(#"{"cmd":"tree"}"#)
         guard let result = tree["result"] as? [String: Any],
               let t = result["tree"] as? [String: Any],
@@ -142,10 +182,60 @@ final class FontPaneUITests: ControlAPITestCase {
         for ws in workspaces {
             for session in (ws["sessions"] as? [[String: Any]] ?? [])
             where (session["id"] as? String)?.lowercased() == id.lowercased() {
-                return session["splitFontSize"] as? Double
+                return session
             }
         }
         return nil
+    }
+
+    /// Reads session `id`'s `splitFontSize` from the control tree, or nil when absent (the split surface
+    /// isn't realized) — the read-back for `font --pane right`.
+    private func splitFontSize(target id: String) throws -> Double? {
+        try treeSessionNode(target: id)?["splitFontSize"] as? Double
+    }
+
+    /// Reads session `id`'s main/default `fontSize` from the control tree — the live font of
+    /// `addressableSurface` (the main pane, or the promoted split survivor) — or nil when that pane isn't
+    /// realized. The read-back for `font --pane left` / the default.
+    private func mainFontSize(target id: String) throws -> Double? {
+        try treeSessionNode(target: id)?["fontSize"] as? Double
+    }
+
+    /// Polls the tree until session `id`'s `fontSize` is present (and below `threshold` when given),
+    /// returning it, or nil on timeout.
+    private func pollMainFontSize(target id: String, below threshold: Double? = nil,
+                                  timeout: TimeInterval) throws -> Double? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let size = try mainFontSize(target: id), threshold.map({ size < $0 }) ?? true { return size }
+            usleep(200_000)
+        }
+        return nil
+    }
+
+    /// True once session `id` has collapsed to a single (non-split) pane (`split == false` while the session
+    /// still exists) — the promoted-survivor state after the primary pane's shell exits. The caller must
+    /// confirm the split was shown first, so a plain non-split session isn't mistaken for a promotion.
+    private func isPromotedSurvivor(target id: String) throws -> Bool {
+        guard let node = try treeSessionNode(target: id) else { return false }
+        return (node["split"] as? Bool) == false
+    }
+
+    /// Exits the PRIMARY (left) shell to promote the split survivor, waiting until the session collapses to
+    /// a single pane. Re-injects `exit` only while NOT yet promoted (a dropped first keystroke leaves the
+    /// primary alive, safe to retype), so a late retry can't also exit the survivor and close the session.
+    private func promoteSurvivorByExitingPrimary(target id: String, timeout: TimeInterval) throws -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if try isPromotedSurvivor(target: id) { return true }
+            let typed = try sendCommand(typeRequest(text: "exit\n", target: id, select: false, pane: "left"))
+            XCTAssertEqual(typed["ok"] as? Bool, true, "typing exit into the left pane should succeed: \(typed)")
+            for _ in 0..<20 {
+                if try isPromotedSurvivor(target: id) { return true }
+                RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+            }
+        }
+        return false
     }
 
     /// Polls the tree until session `id`'s `splitFontSize` is present (and below `threshold` when given),

--- a/site/docs.html
+++ b/site/docs.html
@@ -1139,7 +1139,7 @@
               <span style="color: #6b727a">&nbsp;# clear the unseen badge, focus-free</span><br />agtermctl
               sidebar mode flagged <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;# tree|flagged|toggle</span><br />agtermctl quick
               toggle <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;# show|hide|toggle</span><br />agtermctl quick type <span style="color: #f2b45c">'ls -la'</span>
-              <span style="color: #6b727a">&nbsp;# or --stdin; quick text reads it back</span><br />agtermctl font inc <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;# active surface font size</span
+              <span style="color: #6b727a">&nbsp;# or --stdin; quick text reads it back</span><br />agtermctl font inc <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;# main pane font size</span><br />agtermctl font dec --pane right <span style="color: #6b727a">&nbsp;# just the split pane (left|right|scratch)</span
               ><br /><br /><span style="color: #6b727a"># open the search bar, print the "N of M" counter</span><br />agtermctl
               session search <span style="color: #f2b45c">"error"</span><br />agtermctl session search --next
               <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;&nbsp;# --prev | --close</span>


### PR DESCRIPTION
`agtermctl font inc|dec|reset` only accepted `--target`/`--window` and always resized the session's main/left surface, so a split pane's font was unreachable from the CLI even though the two panes hold independent sizes (#186).

**Pane targeting**

Adds a `--pane left|right|scratch` option, mirroring the existing `session type`/`session text` pane addressing:

- omitted or `left` targets the main pane (unchanged behavior, via `addressableSurface`, which also reaches a promoted split survivor once the primary pane's shell exits)
- `right` targets the split pane (`session has no split pane` when there is none)
- `scratch` targets the session's scratch terminal, settable even while hidden (`session has no scratch terminal` when none is open)

Pane resolution and validation run server-side in the `ControlServer` font arm, so a raw socket client can't bypass them; the CLI validates via the shared `validatePaneArgument`. `performBindingAction` now returns a discardable `Bool`, so the font arm reports `session not realized` when a pane's surface isn't libghostty-realized yet instead of a silent false ok, matching `session.type`'s `inject()`.

**Read-back**

`agtermctl tree` now exposes each pane's live font size so a script can confirm a change: `fontSize` (the default/left pane, resolved via `addressableSurface`, so the main pane or the promoted split survivor), `splitFontSize` (the split pane), and `scratchFontSize` (the scratch terminal). Each is omitted when its pane isn't realized. Only the main pane's size persists across relaunch; the split/scratch surfaces' `onFontSizeChange` is deliberately unwired, matching a GUI cmd +/- on those panes, so read the live values back from the tree rather than the snapshot.

**Tests + docs**

Threaded through `ControlDispatcher` and the `agtermctl` CLI. Adds dispatcher and CLI unit tests, `AppStore`/protocol round-trip tests for the three tree fields (including a promoted-survivor case), and a `FontPaneUITests` e2e: `--pane right` shrinks the split's live font (read back via `splitFontSize`) while leaving the main pane's persisted size untouched, the default `font dec` follows a promoted split survivor (read back via `fontSize`), and the no-split / no-scratch / invalid-pane errors are enforced server-side. The bundled agent skill, README, site docs, and the `control-api` rule note are kept in sync.

Fix #186
