### PR TITLE
fix(sidebar): re-tint row text from the row view's live selection state

### DIFF
--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -103,6 +103,20 @@ paths:
   The row draws the themed pill in `drawBackground(in:)` for every state,
   and the Coordinator's `refreshSelectionAppearance()` repaints the pills + re-tints the row text on
   selection change (AppKit won't redraw rows on its own with `.none`) and on `.agtermAppearanceChanged`.
+  **The row view is the single source of truth for the cell's selection tint.**
+  The pill reads `isSelected` live at draw time, but the text/icon color is applied imperatively
+  (`SidebarCellView.setColors`), so the two can desync when a re-tint event is missed —
+  the cell builder's `row(forItem:)` can return -1 mid-reload/expand-collapse animation
+  (the constant OSC-title `reloadItem` ticks make this window easy to hit),
+  and on the ~1/3 of themes using the inverted-selection idiom (`selection-background == foreground`,
+  e.g. `Ghostty Default Style Dark`) a stale tint renders the row text fully INVISIBLE
+  (white-on-white pill, plus the previously-selected row dark-on-dark).
+  `SidebarRowView` therefore re-asserts `setColors` from its own live `isSelected`:
+  its `didSet` re-tints the hosted cell on every selection flip,
+  and `didAddSubview` tints a cell the moment it attaches (superseding the builder's build-time guess).
+  Rename `restore` reads the same row-view `isSelected` instead of recomputing via `row(for:)`.
+  Text color is not accessibility-observable, so this is verified by eye — like the disclosure-triangle
+  and cursor solid/hollow cases.
   **`SidebarOutlineView.acceptsFirstResponder` is `false`** so a mouse click selects without stealing
   first responder from the terminal — that responder bounce (terminal → outline → terminal,
   via `mouseDown`'s `focusActiveTerminal`) otherwise makes AppKit re-set `SidebarRowView.isEmphasized`,

--- a/agterm/Views/SidebarRenameController.swift
+++ b/agterm/Views/SidebarRenameController.swift
@@ -128,10 +128,12 @@ final class SidebarRenameController: NSObject, NSTextFieldDelegate {
         field.setAccessibilityIdentifier(kind == .workspace ? "workspace-row" : "session-row")
         // beginEditing painted the field with the theme fg-on-bg for the edit box; restore the row's
         // selection-aware themed color so a commit that didn't change the name (no reload) doesn't
-        // leave the edit color stuck on the row.
-        if let outline = outlineView, let cell = field.superview as? SidebarCellView {
-            let row = outline.row(for: field)
-            cell.setColors(selected: row >= 0 && outline.selectedRowIndexes.contains(row))
+        // leave the edit color stuck on the row. read the hosting row view's live isSelected (the
+        // state the selection pill draws from) rather than recomputing via row(for:), which can miss
+        // if the row was reloaded during the edit — a stale tint here is invisible text on themes
+        // where foreground == selection-background.
+        if let cell = field.superview as? SidebarCellView {
+            cell.setColors(selected: (cell.superview as? NSTableRowView)?.isSelected ?? false)
         }
     }
 }

--- a/agterm/Views/SidebarRowViews.swift
+++ b/agterm/Views/SidebarRowViews.swift
@@ -17,8 +17,9 @@ final class SidebarCellView: NSTableCellView {
     /// Color the row text/icon from the terminal theme: a selected row pairs with the selection
     /// foreground (over the selection-background pill the row draws), or white over the soft wash when
     /// the theme exposes no selection color; an unselected row uses the theme foreground, icons dimmed.
-    /// Driven by the coordinator from the real selection state (not `backgroundStyle`, which AppKit only
-    /// flips while the table is first responder).
+    /// Driven from the real selection state (not `backgroundStyle`, which AppKit only flips while the
+    /// table is first responder): the hosting `SidebarRowView` re-asserts it from its live `isSelected`
+    /// on attach and on every selection flip, and the coordinator re-runs it on theme changes.
     func setColors(selected: Bool) {
         let app = GhosttyApp.shared
         let color = selected
@@ -163,6 +164,13 @@ final class StatusIconView: NSImageView {
 /// whenever the sidebar isn't first responder (the normal case, since focus lives in the terminal),
 /// which would override a custom `drawSelection`. `isEmphasized` is overridden so the row redraws when
 /// the window's key state changes (the brightness dims for a background window).
+///
+/// The row view is the single source of truth for the cell's selection tint: `isSelected` (the same
+/// live state the pill draws from) re-tints the hosted `SidebarCellView` whenever AppKit updates it,
+/// and `didAddSubview` tints a cell the moment it attaches. Without this, the pill (drawn live) and
+/// the text color (applied imperatively at cell build) can desync — and on the many themes where
+/// `foreground == selection-background` (the inverted-selection idiom), a stale tint renders the row
+/// text fully invisible.
 final class SidebarRowView: NSTableRowView {
     /// White-wash fallback opacity (themes with no selection color): brighter for the key window,
     /// dimmer for a background one.
@@ -174,6 +182,28 @@ final class SidebarRowView: NSTableRowView {
         // isEmphasized is derived from the window's key state; the setter only triggers a redraw.
         // swiftlint:disable:next unused_setter_value
         set { needsDisplay = true }
+    }
+
+    override var isSelected: Bool {
+        didSet {
+            guard isSelected != oldValue else { return }
+            // the pill follows isSelected at draw time; re-tint the cell from the same state so the
+            // text/icon can never keep the other state's color (white-on-white on inverted-selection
+            // themes). AppKit won't redraw on its own with selectionHighlightStyle == .none.
+            needsDisplay = true
+            retintCellViews()
+        }
+    }
+
+    override func didAddSubview(_ subview: NSView) {
+        super.didAddSubview(subview)
+        // a cell materialized into an already-selected row (reload/expand row-map flux can make the
+        // cell builder's own selection lookup miss) picks up the row's live state on attach.
+        (subview as? SidebarCellView)?.setColors(selected: isSelected)
+    }
+
+    private func retintCellViews() {
+        for case let cell as SidebarCellView in subviews { cell.setColors(selected: isSelected) }
     }
 
     override func drawBackground(in dirtyRect: NSRect) {

--- a/agterm/Views/WorkspaceSidebar+RowRendering.swift
+++ b/agterm/Views/WorkspaceSidebar+RowRendering.swift
@@ -72,7 +72,10 @@ extension WorkspaceSidebar.Coordinator {
             cell.imageView?.setAccessibilityIdentifier("session-icon")
         }
         // text/icon colors track the terminal theme; a selected row uses the selection foreground.
-        // refreshSelectionAppearance re-runs this for all rows on selection and theme changes.
+        // this build-time tint is a first guess — row(forItem:) can miss (-1) while the row map is in
+        // flux during a reload or expand/collapse animation. SidebarRowView.didAddSubview re-asserts
+        // the tint from the row's live isSelected when the cell attaches, and its isSelected didSet
+        // keeps it in step afterwards; refreshSelectionAppearance re-runs it on theme changes.
         let selected = outlineView.selectedRowIndexes.contains(outlineView.row(forItem: item))
         cell.setColors(selected: selected)
         return cell


### PR DESCRIPTION
## Bug

Sidebar row text can render invisible — same foreground color as the pill/background behind it. Shows up as an unreadable selected row (white text on the white selection pill) or a blank-looking unselected row.

Reported with `Ghostty Default Style Dark` (video below), but it's not specific to that theme.

## Root cause

The sidebar draws its own selection, split across two mechanisms that can disagree:

- The **selection pill** (`SidebarRowView.drawBackground`) reads `NSTableRowView.isSelected` live, every redraw.
- The **row text/icon color** (`SidebarCellView.setColors`) is applied imperatively, only at three moments: cell build, `refreshSelectionAppearance()` on selection-did-change, and `.agtermAppearanceChanged`.

When a re-tint is missed, the pill keeps tracking reality while the text keeps the *other* state's color. On the ~1/3 of bundled themes using the inverted-selection idiom (`selection-background == foreground`, e.g. the default-style dark themes, Black Metal family, Ayu), that stale color is exactly invisible: white text on a white pill, or the previously-selected row left dark-on-dark.

Two ways to miss the re-tint:

1. The cell builder computes `selected` from `selectedRowIndexes.contains(row(forItem:))`. During a `reloadData` or an expand/collapse animation `row(forItem:)` transiently returns `-1`, so the selected row's cell gets built with unselected (white) colors and nothing heals it until the next selection change. Sessions driven by an agent tick their OSC title constantly (spinner glyphs), so `reconcile` fires `reloadItem` on those rows continuously — plenty of chances to land mid-animation.
2. Inline rename paints the edit field white, and `restore` re-applies the row color via `row(for: field)`. If that lookup misses (row reloaded/scrolled during the edit), white sticks.

Measured across the 487 bundled themes: 153 (31%) render the stale state below 1.5:1 contrast in at least one direction, 94 in both.

## Fix

Make the row view the single source of truth for the cell's selection tint — the same `isSelected` the pill already draws from:

- `SidebarRowView.isSelected.didSet` re-tints the hosted cell on every selection flip.
- `SidebarRowView.didAddSubview` tints a cell the moment it attaches, so a cell materialized into an already-selected row picks up the correct color regardless of what the builder's `row(forItem:)` returned.
- Rename `restore` reads the row view's live `isSelected` instead of recomputing via `row(for:)`.

The build-time tint and `refreshSelectionAppearance` (theme changes) stay as-is; this just closes the desync windows.

## Testing

Build + `swift test` (1109 tests) + `make lint --strict` all green.

Text color isn't accessibility-observable, so there's no UI-test assertion for it (same as the disclosure-triangle and cursor solid/hollow cases) — verified by eye on two side-by-side dev instances (pre-fix vs post-fix) under `Ghostty Default Style Dark`, stressing per-row reloads against sidebar collapse/expand. Pre-fix flickers/sticks invisible; post-fix stays readable.

Repro on the running app: select a session, keep a title ticker running in it (`while true; printf '\e]2;tick %s\a' $RANDOM; sleep 0.2; end`), then repeatedly collapse/expand its workspace in the sidebar. Old build: the selected row's label blinks out. New build: stays readable.

## Bug video

https://github.com/user-attachments/assets/281c7afa-6456-4032-99bd-0f9f726a9392

