### PR TITLE
feat: build universal binaries (Apple Silicon + Intel)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,11 +214,14 @@ The app must build, `swift test` must stay green, and `make lint` must pass afte
 ## GhosttyKit.xcframework
 
 - Source: **built from upstream `ghostty-org/ghostty` source** by `scripts/setup.sh`,
-  pinned to the `GHOSTTY_REV` SHA (`zig build -Demit-xcframework=true -Dxcframework-target=native …`
+  pinned to the `GHOSTTY_REV` SHA (`zig build -Demit-xcframework=true -Dxcframework-target=universal …`
   with zig 0.15.2).
   Self-owned: the only inputs are upstream ghostty at a pinned commit and the zig/Metal toolchains —
   no third-party fork, no daily-build release that can be pruned.
   Bump `GHOSTTY_REV` deliberately when adopting a newer libghostty.
+  The `universal` target emits a fat `macos-arm64_x86_64` slice (plus iOS slices agterm never links),
+  so the app builds universal (`ARCHS: $(ARCHS_STANDARD)`) and Release/dist run on Apple Silicon and Intel;
+  zig cross-compiles the non-native slice from either arch of build machine.
 - **The pin is a pre-regression commit on purpose.**
   A libghostty `main` renderer regression introduced after `4dcb09ada` (2026-04-30) blanks the scrollback
   on a font-size *increase* (decrease is fine); it is NOT an agterm bug and no app-side change fixes

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ A file open in the quick terminal, the window's shared scratch overlay:
 
 ## Install
 
-Pre-built releases are for **Apple Silicon (arm64) Macs running macOS 14 or later**.
+Pre-built releases are **universal binaries (Apple Silicon + Intel) for macOS 14 or later**.
 
 Releases are signed with a Developer ID certificate and notarized by Apple, so macOS Gatekeeper opens them with no extra steps.
 
@@ -107,7 +107,7 @@ The app's **Help** menu has three one-time installers. None are needed to use ag
 
 Requirements:
 
-- macOS 14 or later.
+- macOS 14 or later, Apple Silicon or Intel (the build produces a universal binary).
 - Xcode 26 with `xcodegen` on `PATH`, plus its Metal Toolchain (auto-downloaded on first setup).
 - Homebrew, for the `zig@0.15` formula `scripts/setup.sh` builds libghostty with.
 

--- a/project.yml
+++ b/project.yml
@@ -16,7 +16,10 @@ settings:
     SWIFT_VERSION: "6.0"
     SDKROOT: macosx
     MACOSX_DEPLOYMENT_TARGET: "14.0"
-    ARCHS: arm64
+    # Universal app (arm64 + x86_64), matching the universal GhosttyKit.xcframework
+    # scripts/setup.sh builds. Debug stays fast: ONLY_ACTIVE_ARCH=YES builds just the
+    # machine's own arch; Release/dist emit both slices.
+    ARCHS: "$(ARCHS_STANDARD)"
     ONLY_ACTIVE_ARCH: NO
     SWIFT_STRICT_CONCURRENCY: complete
     DEAD_CODE_STRIPPING: YES
@@ -127,8 +130,19 @@ targets:
           # otherwise trip the re-seal below.
           rm -rf "$CODESIGNING_FOLDER_PATH/Contents/Resources/AppIcon.icon"
           core="$SRCROOT/agtermCore"
-          swift build --package-path "$core" -c release --product agtermctl
-          src="$(swift build --package-path "$core" -c release --product agtermctl --show-bin-path)/agtermctl"
+          # build agtermctl for the same arch set as the app: both slices when the app is
+          # universal (Release), just the native arch for ONLY_ACTIVE_ARCH (Debug) builds.
+          # --arch flags must match between the build and --show-bin-path calls — SwiftPM
+          # puts --arch builds under .build/apple/Products, not .build/release.
+          if [[ "$ONLY_ACTIVE_ARCH" == "YES" ]]; then
+            cli_archs="$NATIVE_ARCH_ACTUAL"
+          else
+            cli_archs="$ARCHS"
+          fi
+          arch_flags=""
+          for a in $cli_archs; do arch_flags="$arch_flags --arch $a"; done
+          swift build --package-path "$core" -c release $arch_flags --product agtermctl
+          src="$(swift build --package-path "$core" -c release $arch_flags --product agtermctl --show-bin-path)/agtermctl"
           dest="$CODESIGNING_FOLDER_PATH/Contents/MacOS/agtermctl"
           mkdir -p "$(dirname "$dest")"
           cp -f "$src" "$dest"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -67,7 +67,7 @@ notarize() {
 }
 
 # build the GitHub release body: the matching CHANGELOG.md section followed by a
-# short install note (signed + notarized; Apple Silicon only, macOS 14+).
+# short install note (signed + notarized; universal arm64 + x86_64, macOS 14+).
 release_notes() {
   local section
   section="$(awk -v ver="v$VERSION" '
@@ -85,7 +85,7 @@ release_notes() {
   cat <<EOF
 ---
 
-Signed with a Developer ID certificate and notarized by Apple, so macOS Gatekeeper opens it with no extra steps. Apple Silicon (arm64) only, macOS 14 or later.
+Signed with a Developer ID certificate and notarized by Apple, so macOS Gatekeeper opens it with no extra steps. Universal binary (Apple Silicon + Intel), macOS 14 or later.
 
 - **Homebrew:** \`brew install --cask umputun/apps/agterm\`
 - **Direct download:** open the \`.dmg\` and drag \`agterm.app\` into \`/Applications\`.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,6 +4,8 @@
 # We build from source rather than downloading a prebuilt artifact so the toolchain is fully
 # self-owned: the only inputs are upstream ghostty-org/ghostty at a pinned SHA, zig 0.15.2, and
 # Xcode's Metal Toolchain. No third-party fork, no daily-build release that can be pruned.
+# The xcframework is built universal (arm64 + x86_64) so Release/dist builds produce a universal
+# app; zig cross-compiles the non-native slice, so this works from either arch of build machine.
 #
 # The pin is DELIBERATELY a pre-regression commit: a libghostty renderer regression introduced on
 # main after this SHA blanks the terminal scrollback on a font-size increase.
@@ -65,8 +67,8 @@ git -C "$BUILD_DIR" remote add origin "$GHOSTTY_REPO"
 git -C "$BUILD_DIR" fetch -q --depth 1 origin "$GHOSTTY_REV"
 git -C "$BUILD_DIR" -c advice.detachedHead=false checkout -q FETCH_HEAD
 
-echo "building GhosttyKit.xcframework with zig 0.15.2 (a few minutes)..."
-( cd "$BUILD_DIR" && "$ZIG" build -Doptimize=ReleaseFast -Demit-xcframework=true -Dxcframework-target=native -Demit-macos-app=false )
+echo "building GhosttyKit.xcframework with zig 0.15.2 (universal, both arches — several minutes)..."
+( cd "$BUILD_DIR" && "$ZIG" build -Doptimize=ReleaseFast -Demit-xcframework=true -Dxcframework-target=universal -Demit-macos-app=false )
 
 if $need_xc; then
   echo "staging GhosttyKit.xcframework..."

--- a/site/docs.html
+++ b/site/docs.html
@@ -335,7 +335,7 @@
               or the direct download below; building from source is optional.
             </div>
             <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 20px">
-              Releases are signed and notarized for Apple Silicon (arm64) Macs running macOS 14 or later, so they open without any
+              Releases are universal binaries (Apple Silicon + Intel), signed and notarized, for macOS 14 or later, so they open without any
               Gatekeeper workaround.
             </p>
             <h3
@@ -469,7 +469,7 @@
               Build from source
             </h3>
             <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 0 0 14px">
-              Requires macOS 14+, Xcode 26 with
+              Requires macOS 14+ (Apple Silicon or Intel), Xcode 26 with
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">xcodegen</span> on PATH (plus its
               Metal Toolchain), and Homebrew.
             </p>

--- a/site/index.html
+++ b/site/index.html
@@ -83,7 +83,7 @@
             "name": "Is agterm free?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Yes. agterm is free and installs on Apple Silicon macOS 14 or later with: brew install --cask umputun/apps/agterm."
+              "text": "Yes. agterm is free and installs on Apple Silicon or Intel Macs, macOS 14 or later, with: brew install --cask umputun/apps/agterm."
             }
           },
           {
@@ -107,7 +107,7 @@
             "name": "Does agterm require macOS?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Yes. agterm is a native macOS app for Apple Silicon, macOS 14 or later, signed and notarized."
+              "text": "Yes. agterm is a native macOS app for Apple Silicon and Intel (universal binary), macOS 14 or later, signed and notarized."
             }
           }
         ]
@@ -278,7 +278,7 @@
           >
         </div>
         <p style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 12.5px; color: #6b727a; margin: 0 0 44px">
-          Apple Silicon · macOS 14+ · signed &amp; notarized · embeds Ghostty's engine
+          Apple Silicon &amp; Intel · macOS 14+ · signed &amp; notarized · embeds Ghostty's engine
         </p>
 
         <!-- product shot -->
@@ -1407,7 +1407,7 @@ agtermctl session status completed --auto-reset \
           </div>
         </div>
         <p style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 12.5px; color: #6b727a; margin: 28px 0 0">
-          Signed and notarized for Apple Silicon (arm64) Macs on macOS 14+ — opens without any Gatekeeper workaround.
+          Signed and notarized universal binary (Apple Silicon + Intel) for macOS 14+ — opens without any Gatekeeper workaround.
         </p>
       </div>
 


### PR DESCRIPTION
Addresses #190 — makes both source builds and (from the next release) the shipped DMG work on Intel Macs by going universal.

## What changed

- `scripts/setup.sh` builds libghostty with `-Dxcframework-target=universal`, so the xcframework carries a fat `macos-arm64_x86_64` slice. Zig cross-compiles the non-native slice, so this works from either arch of build machine.
- `project.yml` sets `ARCHS: $(ARCHS_STANDARD)`. Debug keeps `ONLY_ACTIVE_ARCH=YES`, so dev builds stay single-arch and fast; Release/dist emit both slices. This is also what un-breaks source builds on Intel — the previous `ARCHS: arm64` pin produced binaries that can't run there.
- The `Bundle agtermctl CLI` post-build script passes matching `--arch` flags to SwiftPM (both slices when the app is universal, native-only in Debug), so a universal app doesn't ship a single-arch CLI.
- Docs synced per the keep-in-sync conventions: README (install + build-from-source), `site/index.html` + `site/docs.html` claims, the release-notes template in `release.sh`, and the CLAUDE.md quote of the zig command.

## Verified (on an Intel Mac, Xcode 26.3, macOS 15.7)

- Debug builds single-arch x86_64; app launches and works (rendering, control socket, `agtermctl tree`).
- Release build produces fat `agterm` and `agtermctl` (`lipo -info`: `x86_64 arm64`), so the release WMO path is exercised on both slices.
- `swift test` (1366 tests) and `make lint --strict` clean.

## Maintainer notes / trade-offs

- The universal zig build roughly doubles the one-time libghostty build (and the CI `build` job's setup step). Upstream's `universal` target also emits iOS slices agterm never links; the xcframework grows to ~540 MB on disk (gitignored).
- README/site now claim universal releases, which becomes true when the next release is cut — probably best merged alongside one. `release.sh` itself needed no arch changes, only its notes text; signing/notarizing the universal DMG is untested here since that flow is maintainer-only.
- The Homebrew cask in `umputun/homebrew-apps` will need its `depends_on arch` arm64 restriction dropped at the same release (that's the actual failure in #190).