### PR TITLE
fix: remove accidentally committed worktree symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
-# downloaded prebuilt libghostty (never committed — see scripts/setup.sh)
-GhosttyKit.xcframework/
-agterm/Resources/ghostty/
-agterm/Resources/terminfo/
+# libghostty built by scripts/setup.sh (never committed — no trailing slash, so the
+# worktree-convenience symlinks at these paths are ignored too, not just the real dirs)
+GhosttyKit.xcframework
+agterm/Resources/ghostty
+agterm/Resources/terminfo
 *.tar.gz
 
 # build artifacts

--- a/GhosttyKit.xcframework
+++ b/GhosttyKit.xcframework
@@ -1,1 +1,0 @@
-/Users/umputun/dev.umputun/agterm/GhosttyKit.xcframework

--- a/agterm/Resources/ghostty
+++ b/agterm/Resources/ghostty
@@ -1,1 +1,0 @@
-/Users/umputun/dev.umputun/agterm/agterm/Resources/ghostty

--- a/agterm/Resources/terminfo
+++ b/agterm/Resources/terminfo
@@ -1,1 +1,0 @@
-/Users/umputun/dev.umputun/agterm/agterm/Resources/terminfo


### PR DESCRIPTION
ca817a2 (#158) accidentally committed three worktree-convenience symlinks — `GhosttyKit.xcframework`, `agterm/Resources/ghostty`, and `agterm/Resources/terminfo` — as mode-120000 entries whose targets are absolute paths in the maintainer's home directory (`/Users/umputun/dev.umputun/agterm/...`).

## Effect on a fresh clone

The symlinks arrive dangling. `scripts/setup.sh` still works (its `-d` present-check fails on a dangling link, so it correctly rebuilds), but its staging `rm -rf`s the tracked symlinks and drops real directories in their place — leaving every clone with three permanent tracked deletions in `git status`.

## Root cause and fix

The `.gitignore` entries for these paths ended with a trailing slash, which matches only real directories — that's how symlinks at the same paths slipped past. This PR removes the committed symlinks and drops the trailing slashes so the paths are ignored in either form and this can't recur.

## Verified

Deleted all three paths from disk (fresh-clone state), re-ran `scripts/setup.sh` and a Debug build: setup regenerates and stages everything, the build succeeds, and `git status` stays clean throughout — the regenerated dirs are covered by the updated ignore entries. Existing checkouts are unaffected in practice: the build outputs at those paths are untracked/ignored either way, and `setup.sh` regenerates them on demand.