### PR TITLE
fix: stop split-focus flicker from overlapping focus retry loops

### DIFF
--- a/agterm/AppActions+Focus.swift
+++ b/agterm/AppActions+Focus.swift
@@ -1,0 +1,45 @@
+import agtermCore
+import AppKit
+import SwiftUI
+
+extension AppActions {
+    /// Move first responder to the split (right) pane on open, or the primary on close.
+    /// Re-asserts over a short window because the split surface materializes a beat after the
+    /// toggle and the HSplitView collapse churns the primary view. While a full-coverage surface
+    /// (scratch or overlay) is up, the requested pane is hidden beneath it, so keep first responder on
+    /// the visible `topmostSurface` instead — the caller has already set `splitFocused`, so the correct
+    /// pane shows once the cover is dismissed.
+    func focusSplitPane(_ session: Session, wantSplit: Bool, attempt: Int = 0, generation: Int? = nil) {
+        // each fresh call SUPERSEDES any in-flight retry loop. without this, two calls with opposite
+        // targets (focus-left then focus-right) each run their own 12x30ms `makeFirstResponder` loop
+        // concurrently and ping-pong first responder between the panes for ~400ms - both surfaces redraw
+        // on every flip, which is the split-focus flicker. the surviving (newest) loop still re-asserts
+        // through the split-materialize / reparent churn (a lone loop's re-asserts are no-ops once its
+        // target is first responder), so the retry keeps its original purpose.
+        let gen: Int
+        if let generation {
+            guard generation == focusGeneration else { return } // superseded by a newer focus op
+            gen = generation
+        } else {
+            focusGeneration += 1
+            gen = focusGeneration
+        }
+        // gate on the SESSION's window, not the frontmost one: this path is cross-window (the control
+        // channel focuses sessions in background windows), where the frontmost window's zoom is irrelevant.
+        if terminalZoomActive(for: session) { return }
+        // the quick terminal is a window-level cover above the session; while it's up it owns focus, so
+        // don't move first responder to a pane behind it (its own hide restores the session). The caller
+        // has already set `splitFocused`, so the right pane shows once the quick terminal is dismissed.
+        if frontmostQuickTerminal?.isVisible == true { return }
+        let target: (any TerminalSurface)? = (session.overlayActive || session.scratchActive)
+            ? session.topmostSurface
+            : (wantSplit ? session.splitSurface : session.surface)
+        if let view = target as? GhosttySurfaceView, let window = view.window {
+            window.makeFirstResponder(view)
+        }
+        guard attempt < 12 else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.03) { [weak self] in
+            self?.focusSplitPane(session, wantSplit: wantSplit, attempt: attempt + 1, generation: gen)
+        }
+    }
+}

--- a/agterm/AppActions+Focus.swift
+++ b/agterm/AppActions+Focus.swift
@@ -10,19 +10,21 @@ extension AppActions {
     /// the visible `topmostSurface` instead — the caller has already set `splitFocused`, so the correct
     /// pane shows once the cover is dismissed.
     func focusSplitPane(_ session: Session, wantSplit: Bool, attempt: Int = 0, generation: Int? = nil) {
-        // each fresh call SUPERSEDES any in-flight retry loop. without this, two calls with opposite
-        // targets (focus-left then focus-right) each run their own 12x30ms `makeFirstResponder` loop
-        // concurrently and ping-pong first responder between the panes for ~400ms - both surfaces redraw
-        // on every flip, which is the split-focus flicker. the surviving (newest) loop still re-asserts
-        // through the split-materialize / reparent churn (a lone loop's re-asserts are no-ops once its
-        // target is first responder), so the retry keeps its original purpose.
+        // each fresh call SUPERSEDES any in-flight retry loop FOR THE SAME SESSION. without this, two
+        // calls with opposite targets (focus-left then focus-right) each run their own 12x30ms
+        // `makeFirstResponder` loop concurrently and ping-pong first responder between the panes for
+        // ~400ms - both surfaces redraw on every flip, the split-focus flicker. the counter is keyed by
+        // session so a focus op on one session/window never cancels ANOTHER session's still-materializing
+        // retry (independent first-responder chains). the surviving loop still re-asserts through the
+        // split-materialize / reparent churn (a lone loop's re-asserts are no-ops once its target is first
+        // responder), so the retry keeps its original purpose.
         let gen: Int
         if let generation {
-            guard generation == focusGeneration else { return } // superseded by a newer focus op
+            guard generation == focusGeneration[session.id] else { return } // superseded by a newer op on this session
             gen = generation
         } else {
-            focusGeneration += 1
-            gen = focusGeneration
+            gen = (focusGeneration[session.id] ?? 0) + 1
+            focusGeneration[session.id] = gen
         }
         // gate on the SESSION's window, not the frontmost one: this path is cross-window (the control
         // channel focuses sessions in background windows), where the frontmost window's zoom is irrelevant.

--- a/agterm/AppActions+Focus.swift
+++ b/agterm/AppActions+Focus.swift
@@ -10,21 +10,23 @@ extension AppActions {
     /// the visible `topmostSurface` instead — the caller has already set `splitFocused`, so the correct
     /// pane shows once the cover is dismissed.
     func focusSplitPane(_ session: Session, wantSplit: Bool, attempt: Int = 0, generation: Int? = nil) {
-        // each fresh call SUPERSEDES any in-flight retry loop FOR THE SAME SESSION. without this, two
-        // calls with opposite targets (focus-left then focus-right) each run their own 12x30ms
+        // each fresh call SUPERSEDES any in-flight retry loop in the SAME WINDOW. without this, two calls
+        // with opposite targets (focus-left then focus-right) each run their own 12x30ms
         // `makeFirstResponder` loop concurrently and ping-pong first responder between the panes for
-        // ~400ms - both surfaces redraw on every flip, the split-focus flicker. the counter is keyed by
-        // session so a focus op on one session/window never cancels ANOTHER session's still-materializing
-        // retry (independent first-responder chains). the surviving loop still re-asserts through the
+        // ~400ms - both surfaces redraw on every flip, the split-focus flicker. the counter is keyed by the
+        // owning WINDOW: one NSWindow has one first responder, so a newer focus op anywhere in it supersedes
+        // an older loop there (last-focus-wins), while different windows stay independent (never cancel each
+        // other's still-materializing retries). the surviving loop still re-asserts through the
         // split-materialize / reparent churn (a lone loop's re-asserts are no-ops once its target is first
         // responder), so the retry keeps its original purpose.
         let gen: Int
+        let scope = library.windowID(forSession: session.id) ?? session.id // fall back to session id when windowless
         if let generation {
-            guard generation == focusGeneration[session.id] else { return } // superseded by a newer op on this session
+            guard generation == focusGeneration[scope] else { return } // superseded by a newer op in this window
             gen = generation
         } else {
-            gen = (focusGeneration[session.id] ?? 0) + 1
-            focusGeneration[session.id] = gen
+            gen = (focusGeneration[scope] ?? 0) + 1
+            focusGeneration[scope] = gen
         }
         // gate on the SESSION's window, not the frontmost one: this path is cross-window (the control
         // channel focuses sessions in background windows), where the frontmost window's zoom is irrelevant.

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -22,7 +22,7 @@ final class AppActions {
 
     /// The frontmost window's quick-terminal controller (each window owns its own), resolved through
     /// the same frontmost-window accessor as `store`. Nil when no window is open.
-    private var frontmostQuickTerminal: QuickTerminalController? {
+    var frontmostQuickTerminal: QuickTerminalController? {
         QuickTerminalRegistry.shared.controller(for: library.activeWindowID)
     }
 
@@ -40,7 +40,7 @@ final class AppActions {
     /// session-addressed focus paths: control commands resolve sessions across ALL windows, so gating
     /// them on the FRONTMOST window's zoom would silently drop the focus step for an un-zoomed
     /// background window (and miss a zoomed non-frontmost one).
-    private func terminalZoomActive(for session: Session) -> Bool {
+    func terminalZoomActive(for session: Session) -> Bool {
         guard let windowID = library.windowID(forSession: session.id) else { return false }
         return TerminalZoomRegistry.shared.controller(for: windowID)?.target != nil
     }
@@ -906,31 +906,10 @@ final class AppActions {
         }
     }
 
-    /// Move first responder to the split (right) pane on open, or the primary on close.
-    /// Re-asserts over a short window because the split surface materializes a beat after the
-    /// toggle and the HSplitView collapse churns the primary view. While a full-coverage surface
-    /// (scratch or overlay) is up, the requested pane is hidden beneath it, so keep first responder on
-    /// the visible `topmostSurface` instead — the caller has already set `splitFocused`, so the correct
-    /// pane shows once the cover is dismissed.
-    func focusSplitPane(_ session: Session, wantSplit: Bool, attempt: Int = 0) {
-        // gate on the SESSION's window, not the frontmost one: this path is cross-window (the control
-        // channel focuses sessions in background windows), where the frontmost window's zoom is irrelevant.
-        if terminalZoomActive(for: session) { return }
-        // the quick terminal is a window-level cover above the session; while it's up it owns focus, so
-        // don't move first responder to a pane behind it (its own hide restores the session). The caller
-        // has already set `splitFocused`, so the right pane shows once the quick terminal is dismissed.
-        if frontmostQuickTerminal?.isVisible == true { return }
-        let target: (any TerminalSurface)? = (session.overlayActive || session.scratchActive)
-            ? session.topmostSurface
-            : (wantSplit ? session.splitSurface : session.surface)
-        if let view = target as? GhosttySurfaceView, let window = view.window {
-            window.makeFirstResponder(view)
-        }
-        guard attempt < 12 else { return }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.03) { [weak self] in
-            self?.focusSplitPane(session, wantSplit: wantSplit, attempt: attempt + 1)
-        }
-    }
+    /// Bumped by each fresh `focusSplitPane` call (in AppActions+Focus) so an older retry loop cancels
+    /// itself when a newer focus op supersedes it - prevents two opposite-target loops from ping-ponging
+    /// first responder.
+    var focusGeneration = 0
 
     /// Bring a session/pane to the foreground from a notification click: surface the owning window
     /// (reopening it when the banner was clicked after the window closed), select the session (which

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -906,10 +906,12 @@ final class AppActions {
         }
     }
 
-    /// Bumped by each fresh `focusSplitPane` call (in AppActions+Focus) so an older retry loop cancels
-    /// itself when a newer focus op supersedes it - prevents two opposite-target loops from ping-ponging
-    /// first responder.
-    var focusGeneration = 0
+    /// Per-session generation counters (keyed by session id; bumped in AppActions+Focus). A fresh
+    /// `focusSplitPane` call bumps its session's counter so an older in-flight retry loop for the SAME
+    /// session cancels itself when superseded, stopping the opposite-target ping-pong flicker. Keyed by
+    /// session so a focus op on one session/window never cancels another session's still-materializing
+    /// focus retry (they target independent first-responder chains).
+    var focusGeneration: [UUID: Int] = [:]
 
     /// Bring a session/pane to the foreground from a notification click: surface the owning window
     /// (reopening it when the banner was clicked after the window closed), select the session (which

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -906,11 +906,11 @@ final class AppActions {
         }
     }
 
-    /// Per-session generation counters (keyed by session id; bumped in AppActions+Focus). A fresh
-    /// `focusSplitPane` call bumps its session's counter so an older in-flight retry loop for the SAME
-    /// session cancels itself when superseded, stopping the opposite-target ping-pong flicker. Keyed by
-    /// session so a focus op on one session/window never cancels another session's still-materializing
-    /// focus retry (they target independent first-responder chains).
+    /// Per-window generation counters (keyed by the owning window id; bumped in AppActions+Focus). A fresh
+    /// `focusSplitPane` call bumps its window's counter so an older in-flight retry loop in the SAME window
+    /// cancels itself when superseded, stopping the opposite-target ping-pong flicker and giving
+    /// last-focus-wins within a window. Keyed by window (one NSWindow = one first responder) so a focus op
+    /// in one window never cancels another window's still-materializing focus retry.
     var focusGeneration: [UUID: Int] = [:]
 
     /// Bring a session/pane to the foreground from a notification click: surface the owning window


### PR DESCRIPTION
split panes flickered on a rapid focus change - the tmux-style zoom keybind (`session split on` + `session focus right`, or focus-left then focus-right) fires two focus ops back-to-back, and `focusSplitPane` spawned an uncancelled 12x30ms `makeFirstResponder` retry loop per call. Two loops with opposite targets ran at once and ping-ponged first responder between the panes for ~400ms, so `splitFocused` flipped ~13 times and both surfaces redrew on each flip. Intermittent, pre-existing (I see it back to 0.11.0), and never on a plain `cmd+d` (single call).

**fix**: a per-window generation counter. A fresh `focusSplitPane` call bumps its window's counter, and an in-flight loop bows out on its next tick once its generation is stale. Keyed by the owning window because one NSWindow has one first responder - so a focus op in one window never cancels another window's still-materializing retry, and same-window ops get last-focus-wins. The surviving loop still re-asserts through the split-materialize / reparent churn, so the retry keeps its purpose.

**refactor**: `focusSplitPane` moves to a new `AppActions+Focus.swift` to keep `AppActions.swift` under the 1000-line cap. `focusGeneration` stays in the main class (extensions can't hold stored properties); `frontmostQuickTerminal` and `terminalZoomActive(for:)` widened to internal for the extension.

verified by hand with the real repro - instrumented the churn (13 flips collapsed to a single settle) and confirmed visually. No unit test: the method is AppKit-entangled (`makeFirstResponder`, ~360ms timing), so it can't be host-free tested and a UI test of the flip would be flaky. Extracting the generation gate into a host-free helper is a possible follow-up.
