### PR TITLE
fix: identify spawned shells as agterm

### DIFF
--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -23,6 +23,10 @@ struct agtermApp: App {
     /// The plain `WindowGroup`'s scene id, used by `openWindow(id:)` to spawn additional windows.
     private static let windowGroupID = "terminal"
 
+    /// The version paired with agterm's `TERM_PROGRAM` identity in every spawned terminal.
+    private static let terminalProgramVersion =
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+
     init() {
         let library = agtermApp.restoredLibrary()
         _library = State(initialValue: library)
@@ -466,8 +470,9 @@ struct agtermApp: App {
         return view
     }
 
-    /// The `AGTERM_*` environment a tree surface (main / split / overlay / scratch) exposes to its spawned
-    /// shell. The window id comes from the open store that owns the session (split/overlay/scratch inherit it
+    /// The environment a tree surface (main / split / overlay / scratch) exposes to its spawned shell: the
+    /// `AGTERM_*` session facts plus agterm's app identity (`TERM_PROGRAM`/`TERM_PROGRAM_VERSION`). The window
+    /// id comes from the open store that owns the session (split/overlay/scratch inherit it
     /// via the same session); the workspace from the session's owning workspace; `AGTERM_SOCKET` is the path
     /// `ControlServer` will bind (resolved at init, so a launch-window shell that materializes before
     /// `start()` binds still sees it), honoring a test's `AGTERM_CONTROL_SOCKET` override. `pane` injects the
@@ -485,13 +490,15 @@ struct agtermApp: App {
         }
         return SurfaceEnvironment.session(sessionID: session.id, windowID: windowID,
                                           workspaceID: workspaceID, socketPath: controlServer.resolvedSocketPath,
+                                          programVersion: Self.terminalProgramVersion,
                                           pane: pane)
     }
 
-    /// The `AGTERM_*` environment a window's quick terminal exposes — scratch, not in the tree, so it
-    /// carries only `AGTERM_ENABLED`, `AGTERM_WINDOW_ID`, and `AGTERM_SOCKET` (no workspace/session ids).
+    /// The environment a window's quick terminal exposes — scratch, not in the tree, so its `AGTERM_*`
+    /// values carry only enabled, window, and socket facts (no workspace/session ids), plus app identity.
     @MainActor
     func quickTerminalEnv(for windowID: WindowInfo.ID) -> [String: String] {
-        SurfaceEnvironment.quickTerminal(windowID: windowID, socketPath: controlServer.resolvedSocketPath)
+        SurfaceEnvironment.quickTerminal(windowID: windowID, socketPath: controlServer.resolvedSocketPath,
+                                         programVersion: Self.terminalProgramVersion)
     }
 }

--- a/agtermCore/Sources/agtermCore/SurfaceEnvironment.swift
+++ b/agtermCore/Sources/agtermCore/SurfaceEnvironment.swift
@@ -1,18 +1,19 @@
 import Foundation
 
-/// Pure builders for the `AGTERM_*` environment values injected into spawned shells.
+/// Pure builders for the agterm identity and `AGTERM_*` values injected into spawned shells.
 /// The platform surface owns shell creation; this keeps the variable set testable.
 public enum SurfaceEnvironment {
     /// Environment for a session-owned surface: main pane, split pane, overlay, or scratch.
     /// `pane`, when non-nil, adds `AGTERM_PANE` so the hook wrapper can forward `--pane` and a status
     /// set from a background pane records which surface blocked; overlay surfaces pass nil (nil→main).
     public static func session(sessionID: UUID, windowID: UUID?, workspaceID: UUID?,
-                               socketPath: String, pane: StatusPane? = nil) -> [String: String] {
-        var env = [
+                               socketPath: String, programVersion: String,
+                               pane: StatusPane? = nil) -> [String: String] {
+        var env = terminalIdentity(programVersion: programVersion).merging([
             "AGTERM_ENABLED": "1",
             "AGTERM_SESSION_ID": sessionID.uuidString,
             "AGTERM_SOCKET": socketPath,
-        ]
+        ]) { _, agtermValue in agtermValue }
         if let windowID {
             env["AGTERM_WINDOW_ID"] = windowID.uuidString
         }
@@ -26,11 +27,21 @@ public enum SurfaceEnvironment {
     }
 
     /// Environment for a window's quick terminal, which is not part of the session tree.
-    public static func quickTerminal(windowID: UUID, socketPath: String) -> [String: String] {
-        [
+    public static func quickTerminal(windowID: UUID, socketPath: String,
+                                     programVersion: String) -> [String: String] {
+        terminalIdentity(programVersion: programVersion).merging([
             "AGTERM_ENABLED": "1",
             "AGTERM_WINDOW_ID": windowID.uuidString,
             "AGTERM_SOCKET": socketPath,
+        ]) { _, agtermValue in agtermValue }
+    }
+
+    private static func terminalIdentity(programVersion: String) -> [String: String] {
+        // Embedded libghostty defaults these to Ghostty, then reapplies the surface env as overrides.
+        // Identify the actual host so Ghostty-aware shell tools do not invoke a standalone Ghostty.app.
+        [
+            "TERM_PROGRAM": "agterm",
+            "TERM_PROGRAM_VERSION": programVersion,
         ]
     }
 }

--- a/agtermCore/Tests/agtermCoreTests/SurfaceEnvironmentTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SurfaceEnvironmentTests.swift
@@ -3,6 +3,29 @@ import Testing
 @testable import agtermCore
 
 struct SurfaceEnvironmentTests {
+    @Test func terminalIdentityBelongsToAgterm() {
+        let sessionID = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+        let windowID = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+
+        let sessionEnv = SurfaceEnvironment.session(
+            sessionID: sessionID,
+            windowID: windowID,
+            workspaceID: nil,
+            socketPath: "/tmp/agterm.sock",
+            programVersion: "0.12.0"
+        )
+        let quickEnv = SurfaceEnvironment.quickTerminal(
+            windowID: windowID,
+            socketPath: "/tmp/agterm.sock",
+            programVersion: "0.12.0"
+        )
+
+        for env in [sessionEnv, quickEnv] {
+            #expect(env["TERM_PROGRAM"] == "agterm")
+            #expect(env["TERM_PROGRAM_VERSION"] == "0.12.0")
+        }
+    }
+
     @Test func sessionEnvironmentCarriesAllKnownIdentifiers() {
         let sessionID = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
         let windowID = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
@@ -12,7 +35,8 @@ struct SurfaceEnvironmentTests {
             sessionID: sessionID,
             windowID: windowID,
             workspaceID: workspaceID,
-            socketPath: "/tmp/agterm.sock"
+            socketPath: "/tmp/agterm.sock",
+            programVersion: "0.12.0"
         )
 
         #expect(env == [
@@ -21,6 +45,8 @@ struct SurfaceEnvironmentTests {
             "AGTERM_WINDOW_ID": "22222222-2222-2222-2222-222222222222",
             "AGTERM_WORKSPACE_ID": "33333333-3333-3333-3333-333333333333",
             "AGTERM_SOCKET": "/tmp/agterm.sock",
+            "TERM_PROGRAM": "agterm",
+            "TERM_PROGRAM_VERSION": "0.12.0",
         ])
     }
 
@@ -31,13 +57,16 @@ struct SurfaceEnvironmentTests {
             sessionID: sessionID,
             windowID: nil,
             workspaceID: nil,
-            socketPath: "/tmp/agterm.sock"
+            socketPath: "/tmp/agterm.sock",
+            programVersion: "0.12.0"
         )
 
         #expect(env == [
             "AGTERM_ENABLED": "1",
             "AGTERM_SESSION_ID": "11111111-1111-1111-1111-111111111111",
             "AGTERM_SOCKET": "/tmp/agterm.sock",
+            "TERM_PROGRAM": "agterm",
+            "TERM_PROGRAM_VERSION": "0.12.0",
         ])
     }
 
@@ -54,6 +83,7 @@ struct SurfaceEnvironmentTests {
             windowID: nil,
             workspaceID: nil,
             socketPath: "/tmp/agterm.sock",
+            programVersion: "0.12.0",
             pane: pane
         )
 
@@ -74,6 +104,7 @@ struct SurfaceEnvironmentTests {
             windowID: windowID,
             workspaceID: workspaceID,
             socketPath: "/tmp/agterm.sock",
+            programVersion: "0.12.0",
             pane: nil
         )
 
@@ -85,18 +116,26 @@ struct SurfaceEnvironmentTests {
             "AGTERM_WINDOW_ID": "22222222-2222-2222-2222-222222222222",
             "AGTERM_WORKSPACE_ID": "33333333-3333-3333-3333-333333333333",
             "AGTERM_SOCKET": "/tmp/agterm.sock",
+            "TERM_PROGRAM": "agterm",
+            "TERM_PROGRAM_VERSION": "0.12.0",
         ])
     }
 
-    @Test func quickTerminalEnvironmentCarriesOnlyWindowAndSocketFacts() {
+    @Test func quickTerminalEnvironmentOmitsSessionAndWorkspaceIdentifiers() {
         let windowID = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
 
-        let env = SurfaceEnvironment.quickTerminal(windowID: windowID, socketPath: "/tmp/agterm.sock")
+        let env = SurfaceEnvironment.quickTerminal(
+            windowID: windowID,
+            socketPath: "/tmp/agterm.sock",
+            programVersion: "0.12.0"
+        )
 
         #expect(env == [
             "AGTERM_ENABLED": "1",
             "AGTERM_WINDOW_ID": "22222222-2222-2222-2222-222222222222",
             "AGTERM_SOCKET": "/tmp/agterm.sock",
+            "TERM_PROGRAM": "agterm",
+            "TERM_PROGRAM_VERSION": "0.12.0",
         ])
         #expect(env["AGTERM_SESSION_ID"] == nil)
         #expect(env["AGTERM_WORKSPACE_ID"] == nil)
@@ -109,7 +148,8 @@ struct SurfaceEnvironmentTests {
             sessionID: sessionID,
             windowID: nil,
             workspaceID: nil,
-            socketPath: ""
+            socketPath: "",
+            programVersion: "0.12.0"
         )
 
         #expect(env["AGTERM_SOCKET"] == "")


### PR DESCRIPTION
fixes agterm shells inheriting Ghostty's terminal identity from embedded libghostty.

agterm now overrides `TERM_PROGRAM` and `TERM_PROGRAM_VERSION` for every surface. Ghostty's functional environment remains unchanged.

verified with:

- `swift test` (1,502 tests)
- `make lint`
- `make build`
- isolated runtime probe confirming `TERM_PROGRAM=agterm`
- OSC 7 probe confirming `cd /tmp` updates the session cwd

fixes #201
