### PR TITLE
fix: hide titlebar buttons while the dashboard is open

### DIFF
--- a/agterm/Views/WindowContentView+Dashboard.swift
+++ b/agterm/Views/WindowContentView+Dashboard.swift
@@ -49,6 +49,45 @@ extension WindowContentView {
         return chromeText
     }
 
+    /// The stripped chrome above the OPEN dashboard grid, the exact counterpart of `zoomTitlebar`: in
+    /// hidden-toolbar mode the same invisible ~3px drag strip, otherwise a bare bar carrying ONLY an exit
+    /// button — none of the sidebar/split/scratch/quick-terminal/attention controls the full `customTitlebar`
+    /// renders. Dropping them is the fix: while the view-only grid is up those buttons would steal the
+    /// key-catcher's first responder (stranding Esc) and drive actions that make no sense behind the modal.
+    /// Window drag / double-click / traffic lights stay via `WindowControlArea`; the exit button runs the
+    /// same close-and-refocus path as Esc.
+    @ViewBuilder var dashboardTitlebar: some View {
+        if toolbarMode == .hidden {
+            Color.clear
+                .frame(height: 3)
+                .frame(maxWidth: .infinity)
+                .allowsHitTesting(false)
+                .background { WindowControlArea() }
+        } else {
+            HStack(spacing: 0) {
+                Color.clear
+                    .frame(width: 78)
+                    .allowsHitTesting(false)
+                Spacer(minLength: 12)
+                Button {
+                    closeDashboardFromKeyboard()
+                } label: {
+                    Image(systemName: "xmark")
+                }
+                .help("Exit Dashboard")
+                .accessibilityLabel("Exit Dashboard")
+                .accessibilityIdentifier("dashboard-exit")
+                .padding(.trailing, 14)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(chromeText)
+            .imageScale(toolbarMode == .normal ? .large : .medium)
+            .frame(height: titlebarHeight)
+            .frame(maxWidth: .infinity)
+            .background { WindowControlArea() }
+        }
+    }
+
     /// The dashboard grid overlay, mounted in `windowOverlayLayer` while this window's `DashboardController`
     /// is open (inset by `titlebarHeight`, below `customTitlebar`, like the other window overlays). Closed
     /// over its `onSelect`/`onClose` closures + the control socket; view-only cells reparent each member's

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -90,8 +90,17 @@ struct WindowContentView: View {
                 windowOverlayLayer
                     .padding(.top, titlebarHeight)
                     .zIndex(1)
-                customTitlebar
-                    .zIndex(2)
+                if dashboard.isOpen {
+                    // the open dashboard is a view-only modal, like terminal zoom: swap the full titlebar for
+                    // a stripped bar (mirroring zoomTitlebar) so its interactive buttons can't steal the
+                    // key-catcher's first responder — which strands Esc — or drive actions that make no sense
+                    // behind the grid. The two modes are mutually exclusive, so only one titlebar is ever up.
+                    dashboardTitlebar
+                        .zIndex(2)
+                } else {
+                    customTitlebar
+                        .zIndex(2)
+                }
             }
         }
         // with the title bar hidden (.hiddenTitleBar), pull our header to the very top so the traffic

--- a/agtermUITests/DashboardUITests.swift
+++ b/agtermUITests/DashboardUITests.swift
@@ -193,6 +193,36 @@ final class DashboardUITests: ControlAPITestCase {
                        "Esc leaves the pre-open selection in place")
     }
 
+    // while the view-only dashboard is open the full titlebar is swapped for a stripped bar (mirroring
+    // terminal zoom): its interactive session controls are GONE, so a stray click on one can no longer steal
+    // the key-catcher's first responder (which stranded Esc) or drive an action behind the grid. Only an exit
+    // button remains, and clicking it closes the dashboard.
+    func testDashboardTitlebarStripsInteractiveButtonsAndExitCloses() throws {
+        let ids = try prepareSessions(extra: 1)
+
+        // baseline: the full titlebar's session controls exist before opening.
+        XCTAssertTrue(app.buttons["split-toggle"].waitForExistence(timeout: 15),
+                      "the split button renders in the normal titlebar")
+
+        try openDashboard(members: ids)
+
+        // opening swaps in the stripped titlebar: every interactive session control is gone...
+        for control in ["split-toggle", "sidebar-toggle-button", "scratch-toggle", "quick-terminal-toggle"] {
+            XCTAssertTrue(app.buttons[control].waitForNonExistence(timeout: 10),
+                          "\(control) must not render while the dashboard is open")
+        }
+        // ...and only the exit button remains (the counterpart of terminal-zoom-exit).
+        let exit = app.buttons["dashboard-exit"]
+        XCTAssertTrue(exit.waitForExistence(timeout: 10), "the stripped dashboard titlebar shows an exit button")
+
+        // the exit button closes the dashboard (same close-and-refocus path as Esc)...
+        exit.click()
+        XCTAssertTrue(dashboardOverlay.waitForNonExistence(timeout: 10), "the exit button closes the dashboard")
+        // ...and the full titlebar returns once it is closed.
+        XCTAssertTrue(app.buttons["split-toggle"].waitForExistence(timeout: 10),
+                      "the full titlebar returns once the dashboard closes")
+    }
+
     // the correctness crux: while the dashboard is open it is VIEW-ONLY — neither a typed keystroke nor a
     // mouse click reaches any terminal. Proven with a three-phase probe so the negative is not vacuous:
     //   1. before opening, GUI typing DOES reach the focused terminal (a marker file is written);


### PR DESCRIPTION
while the dashboard grid is open it is a view-only modal, but the full titlebar kept rendering its interactive buttons (sidebar, split, scratch, quick terminal, attention bell). Clicking one stole first responder from the dashboard's key-catcher, which stranded Esc so the grid could not be closed, and drove actions that make no sense behind the modal.

swap the full titlebar for a stripped `dashboardTitlebar` while open, the counterpart of `zoomTitlebar`: only an exit button over the window drag/double-click backing. Mirrors how terminal zoom already strips its chrome, so the key-catcher keeps first responder and Esc closes the grid again.

adds a `DashboardUITests` case asserting the session buttons are gone while open, the exit button closes it, and the full titlebar returns on close.
