### PR TITLE
fix: apply libghostty mouse cursor shapes via cursorUpdate

### DIFF
--- a/agterm/Ghostty/GhosttyCallbacks.swift
+++ b/agterm/Ghostty/GhosttyCallbacks.swift
@@ -128,7 +128,7 @@ final class GhosttyCallbacks: @unchecked Sendable {
         case GHOSTTY_ACTION_MOUSE_SHAPE:
             // libghostty requests a mouse cursor shape for this surface — the pointing hand over a detected
             // link / OSC-8 hyperlink, the I-beam over the grid, resize/crosshair in the matching modes.
-            // recover the surface and apply the mapped NSCursor via its cursor rects.
+            // recover the surface and apply the mapped NSCursor.
             guard let view = surfaceView(from: target) else { return true }
             let shape = action.action.mouse_shape
             DispatchQueue.main.async { view.applyMouseShape(shape) }

--- a/agterm/Ghostty/GhosttySurfaceView+Input.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Input.swift
@@ -207,13 +207,23 @@ extension GhosttySurfaceView {
     override func rightMouseDragged(with event: NSEvent) { mouseMoved(with: event) }
     override func otherMouseDragged(with event: NSEvent) { mouseMoved(with: event) }
 
-    override func mouseMoved(with event: NSEvent) { reportMousePos(from: event) }
+    /// Re-assert the libghostty-requested cursor on every move. `cursorUpdate` only fires on tracking-area
+    /// entry (not per intra-area move), and SwiftUI — which owns the cursor for the hosted view — can reset
+    /// it on any move, so without this the pointing hand would revert to the arrow while moving along a link.
+    /// This fires only while the pointer is inside the view, so it can't leak the cursor outside the surface.
+    override func mouseMoved(with event: NSEvent) {
+        reportMousePos(from: event)
+        Self.nsCursor(for: mouseShape).set()
+    }
 
     /// The pointer entered the surface: restore libghostty's mouse position from the current point, undoing
     /// `mouseExited`'s `-1, -1` reset so hovered-link and cursor-shape state are correct on re-entry.
     /// (`scrollWheel` also syncs `mouse_pos` when stale, so the first post-re-entry scroll no longer depends
     /// on this — but the restore still matters for hover/link state before any move.)
-    override func mouseEntered(with event: NSEvent) { reportMousePos(from: event) }
+    override func mouseEntered(with event: NSEvent) {
+        pointerInside = true
+        reportMousePos(from: event)
+    }
 
     /// The pointer left the surface. Report negative coordinates so libghostty clears any hovered-link
     /// state — it drops `over_link`, reverts the mouse shape, and re-renders without the underline (see its
@@ -222,6 +232,7 @@ extension GhosttySurfaceView {
     /// (a button is down) so a selection/drag that crosses the edge isn't reported at `-1, -1`.
     override func mouseExited(with event: NSEvent) {
         guard let surface, NSEvent.pressedMouseButtons == 0 else { return }
+        pointerInside = false
         ghostty_surface_mouse_pos(surface, -1, -1, mods(event))
         lastReportedMousePoint = NSPoint(x: -1, y: -1)
     }
@@ -409,17 +420,25 @@ extension GhosttySurfaceView: @preconcurrency NSTextInputClient {
 
     /// Applies the cursor shape libghostty requested (`GHOSTTY_ACTION_MOUSE_SHAPE`) — the pointing hand
     /// over a link, the I-beam over the grid, resize/crosshair/grab in the matching modes. No-ops when
-    /// unchanged; otherwise invalidates the cursor rects so AppKit re-queries `resetCursorRects` and
-    /// re-applies the cursor under the current pointer position (libghostty sends this as the mouse moves).
+    /// unchanged; otherwise sets the cursor at once — but only while the pointer is inside, so a revert
+    /// delivered after the pointer already left (the I-beam libghostty emits once `mouseExited` reports
+    /// `-1, -1`) can't paint the terminal cursor onto the sidebar. Setting it here is what makes a stationary
+    /// shape change (⌘ pressed over a link without moving) take effect immediately; `mouseMoved` re-asserts it
+    /// as the pointer moves and `cursorUpdate` on entry.
     func applyMouseShape(_ shape: ghostty_action_mouse_shape_e) {
         guard shape != mouseShape else { return }
         mouseShape = shape
-        window?.invalidateCursorRects(for: self)
+        if pointerInside { Self.nsCursor(for: shape).set() }
     }
 
-    /// AppKit cursor-rectangle hook: paint the whole surface with the libghostty-requested cursor.
-    override func resetCursorRects() {
-        addCursorRect(bounds, cursor: Self.nsCursor(for: mouseShape))
+    /// AppKit cursor hook (the `.cursorUpdate` tracking-area callback, NOT cursor rectangles): paint the whole
+    /// surface with the libghostty-requested cursor. The surface is hosted inside SwiftUI (`TerminalView`),
+    /// which owns the cursor and resets it as the mouse moves, so `addCursorRect`/`resetCursorRects` never take
+    /// hold here (the link still underlines because libghostty draws that, but the pointing hand is dropped).
+    /// Setting the cursor from `cursorUpdate` re-asserts it on AppKit's cursor pass — the same reason upstream
+    /// Ghostty.app drives the cursor through SwiftUI rather than cursor rectangles.
+    override func cursorUpdate(with event: NSEvent) {
+        Self.nsCursor(for: mouseShape).set()
     }
 
     /// Maps a libghostty mouse-shape to the closest AppKit `NSCursor`. Shapes without a system cursor

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -282,10 +282,14 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
 
     /// The mouse-cursor shape libghostty last requested for this surface (`GHOSTTY_ACTION_MOUSE_SHAPE`):
     /// the I-beam over the grid, the pointing hand over a detected link / OSC-8 hyperlink, resize/crosshair
-    /// in the matching modes. `resetCursorRects` maps it to an `NSCursor`. Defaults to the terminal I-beam
+    /// in the matching modes. `cursorUpdate` maps it to an `NSCursor`. Defaults to the terminal I-beam
     /// so the resting cursor is right before the first event. Not `private` so the `+Input` extension (which
-    /// owns the cursor-rect override and `applyMouseShape`) can read it.
+    /// owns the `cursorUpdate` override and `applyMouseShape`) can read it.
     var mouseShape: ghostty_action_mouse_shape_e = GHOSTTY_MOUSE_SHAPE_TEXT
+
+    /// Whether the pointer is inside this surface (from `mouseEntered`/`mouseExited`), gating the immediate
+    /// `.set()` in `applyMouseShape` so a revert delivered after the pointer left can't leak onto the sidebar.
+    var pointerInside = false
 
     /// The last pointer position pushed to libghostty via `ghostty_surface_mouse_pos` (view-flipped
     /// coordinates), or nil before the first report. `scrollWheel` syncs the position only when the current
@@ -982,7 +986,7 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         if let existing = currentTrackingArea { removeTrackingArea(existing) }
         let area = NSTrackingArea(
             rect: bounds,
-            options: [.mouseMoved, .mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect],
+            options: [.mouseMoved, .mouseEnteredAndExited, .cursorUpdate, .activeInKeyWindow, .inVisibleRect],
             owner: self
         )
         addTrackingArea(area)


### PR DESCRIPTION
the libghostty-requested mouse cursor shape (the pointing hand over a link, plus resize/crosshair/i-beam) was applied via cursor rectangles, but `GhosttySurfaceView` is hosted inside SwiftUI (`TerminalView`), which owns the cursor and resets it on every mouse move - so the cursor rects never took hold. Holding ⌘ over a link still underlined it (libghostty draws that itself) but the pointing hand never appeared.

apply the shape from a `.cursorUpdate` tracking-area callback plus an immediate `NSCursor.set()` on shape change instead. This is how upstream Ghostty.app drives the cursor - through SwiftUI, not `addCursorRect`. The immediate set is gated on the pointer being inside the surface so a revert delivered after the pointer left can't paint the terminal cursor onto the sidebar, and `mouseMoved` re-asserts the shape per move since `cursorUpdate` fires only on tracking-area entry.

verified by eye in a dev build: ⌘-hover over a URL now shows the pointing hand and it holds while moving along the link; releasing ⌘ or leaving the link reverts to the i-beam. No unit test - the cursor shape isn't accessibility-observable (same as the existing cursor-focus / solid-hollow cases), so it's verified by eye.
