### PR TITLE
feat: report the scratch pane in $AGT_PANE for custom commands

### DIFF
--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -54,11 +54,16 @@ paths:
   in a text field) and rebuilds its matcher on `.agtermKeymapChanged`.
   The runner also exposes a public `run(_:)` for the palette items, which resolve context from the active
   session (no first responder to key off).
-  `CommandContext.pane` (the `{AGT_PANE}`/`$AGT_PANE` token, `left`|`right`)
+  `CommandContext.pane` (the `{AGT_PANE}`/`$AGT_PANE` token, `left`|`right`|`scratch`)
   carries the fired-from pane: the keybind path derives it from the focused SURFACE's identity
-  (`splitSurface === focusedSurface`), the palette path from `session.splitFocused` —
+  (`splitSurface === focusedSurface` → `right`; the sessionless-surface branch `runFromSessionlessSurface`
+  identifies the active session's `scratchSurface` → `scratch`), the palette path from `session.splitFocused` —
   so a script can feed it back as `agtermctl session type --pane "$AGT_PANE"` to type into the very
   pane the shortcut was pressed in.
+  The scratch is the ONLY sessionless surface that reports a pane (the read leg of the `$AGT_PANE` →
+  `session type --pane scratch` round-trip, which `--pane` already accepted); the quick terminal and
+  overlays are NOT panes, so a chord fired from them takes the active-session palette path (their state
+  is queryable via `tree`'s `quickVisible`/`overlay`).
   It reflects the pane's physical surface slot: `left` for any single-pane session, including a promoted
   split survivor.
   When the primary pane's shell exits, `closePrimaryPane` MOVES the surviving split pane from

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ The shell line of a `command` may use these `{AGT_X}` tokens, expanded at fire t
 {AGT_PANE}         {AGT_SELECTION}      {AGT_SOCKET}
 ```
 
-The context is resolved from the focused pane's session, so a custom command runs in that session's working directory and can read its current selection. `{AGT_PANE}` is the pane the shortcut fired from — `left` (main) or `right` (split) — so a script can route a follow-up `agtermctl session type --pane "$AGT_PANE"` back into the very pane it was invoked in. A custom command runs as a detached `/bin/sh -c`; a non-zero exit (or a spawn failure) posts a notification banner.
+The context is resolved from the focused pane's session, so a custom command runs in that session's working directory and can read its current selection. `{AGT_PANE}` is the pane the shortcut fired from — `left` (main), `right` (split), or `scratch` (the session's scratch terminal) — so a script can route a follow-up `agtermctl session type --pane "$AGT_PANE"` back into the very pane it was invoked in. A custom command runs as a detached `/bin/sh -c`; a non-zero exit (or a spawn failure) posts a notification banner.
 
 Because it runs detached with no controlling terminal, a custom command suits fire-and-forget launches — GUI apps (`open -a …`), scripts, one-off shell lines — not interactive or full-screen programs: a TUI like `lazygit` run bare has no TTY to draw into and exits immediately. The `Lazygit` example above launches it the right way, in an overlay terminal that *does* have a TTY (`agtermctl session overlay open`, passing `{AGT_SOCKET}` so the CLI reaches this very app; add `--size-percent 80` for a floating panel instead of full-size). A per-session scratch terminal (`agtermctl session scratch on --command lazygit`) works too.
 

--- a/agterm/Commands/CustomCommandRunner.swift
+++ b/agterm/Commands/CustomCommandRunner.swift
@@ -197,17 +197,15 @@ final class CustomCommandRunner {
     }
 
     /// Run a command fired by KEYBIND: resolve context from the surface that actually had focus at
-    /// key-down time, so a chord fired from a split/overlay (or during a window-switch race) runs
+    /// key-down time, so a chord fired from a split/scratch (or during a window-switch race) runs
     /// against THAT surface's session/cwd/window and reads the selection from THAT exact surface. The
     /// owning session/store come from the focused surface's `session` resolved through the host-free
-    /// `WindowLibrary` (no AppKit lives in core). Falls back to the active session (the palette path)
-    /// when the surface has no tree session (the quick terminal or a non-session overlay), or no-ops
-    /// when there is genuinely no session.
+    /// `WindowLibrary` (no AppKit lives in core). A sessionless focused surface (quick terminal /
+    /// overlay / scratch) routes through `runFromSessionlessSurface`, which reports `.scratch` for the
+    /// active session's scratch and otherwise takes the palette path.
     func runFromKeybind(_ command: CustomCommand, focusedSurface: GhosttySurfaceView) {
         guard let session = focusedSurface.session, let store = library.store(forSession: session.id) else {
-            // the focused surface isn't a tree pane (quick terminal / scratch overlay) — fall back to
-            // the active session, the same context the palette path uses.
-            run(command)
+            runFromSessionlessSurface(command, focusedSurface: focusedSurface)
             return
         }
         // the fired-from pane is the surface's identity, not the session's focus flag — a chord fired
@@ -217,9 +215,24 @@ final class CustomCommandRunner {
         spawn(command, context: context)
     }
 
+    /// The keybind fallback for a sessionless focused surface (no `view.session`: the quick terminal,
+    /// an overlay, or the scratch). The scratch belongs to the ACTIVE session, so a chord fired from it
+    /// runs against that session with `pane = .scratch` and reads the scratch's own selection — the read
+    /// leg of the `$AGT_PANE` → `session type --pane scratch` round-trip. The quick terminal and overlays
+    /// are not panes (their state is queryable via `tree`), so they take the plain palette path.
+    private func runFromSessionlessSurface(_ command: CustomCommand, focusedSurface: GhosttySurfaceView) {
+        if let store = library.activeStore, let session = store.activeSession,
+           (session.scratchSurface as? GhosttySurfaceView) === focusedSurface {
+            let context = self.context(for: session, in: store, selectionSurface: focusedSurface, pane: .scratch)
+            spawn(command, context: context)
+            return
+        }
+        run(command)
+    }
+
     /// Resolve every `{AGT_X}` token for the given session: ids + cwd from the model, the names from
     /// the owning workspace/window, the selection from `selectionSurface` (the exact focused surface),
-    /// the fired-from pane (`left`|`right`) from the caller, and the socket from the control server.
+    /// the fired-from pane (`left`|`right`|`scratch`) from the caller, and the socket from the control server.
     private func context(for session: Session, in store: AppStore, selectionSurface: GhosttySurfaceView?,
                          pane: CommandContext.Pane) -> CommandContext {
         let workspace = store.workspace(forSession: session.id)

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -543,8 +543,9 @@ so `{AGT_SESSION_NAME}` and `{AGT_SESSION_PWD}` are as untrusted as `{AGT_SELECT
 - `{AGT_SESSION_NAME}` / `$AGT_SESSION_NAME` — the session's display name (the focused pane's terminal title, remote-settable via OSC).
 - `{AGT_SESSION_PWD}` / `$AGT_SESSION_PWD` — the focused pane's working directory.
 - `{AGT_SELECTION}` / `$AGT_SELECTION` — the current selection.
-- `{AGT_PANE}` / `$AGT_PANE` — the pane the command fired from: `left` (main) or `right` (split). Feed
-  it back as `session type --pane "$AGT_PANE"` to type into the very pane the shortcut was pressed in.
+- `{AGT_PANE}` / `$AGT_PANE` — the pane the command fired from: `left` (main), `right` (split), or
+  `scratch` (the session's scratch terminal). Feed it back as `session type --pane "$AGT_PANE"` to type
+  into the very pane the shortcut was pressed in.
 - Plus the other `$AGT_*` context vars the runner exports.
 
 Built-in action names for `map` include: `new_window`, `new_workspace`, `new_session`,

--- a/agtermCore/Sources/agtermCore/CustomCommand.swift
+++ b/agtermCore/Sources/agtermCore/CustomCommand.swift
@@ -34,6 +34,7 @@ public struct CommandContext: Equatable, Sendable {
     public enum Pane: String, Equatable, Sendable {
         case left
         case right
+        case scratch
     }
 
     public var sessionID: String
@@ -43,13 +44,13 @@ public struct CommandContext: Equatable, Sendable {
     public var workspaceName: String
     public var windowID: String
     public var windowName: String
-    /// The pane that had focus at fire time — `.left` (main) or `.right` (split). `.left` for any
-    /// single-pane session, including a promoted split survivor: when the primary pane exits,
-    /// `closePrimaryPane` moves the surviving split pane into the main slot, so it reports `.left` and
-    /// `session.type --pane left` reaches it. Typed (not a raw `String`) so `rawValue` can only be
-    /// `left`/`right`; it is consumed as the `$AGT_PANE` env var a script feeds back through
-    /// `session type --pane` (re-validated CLI- AND server-side — the enum pins the token this emits,
-    /// not the shell round-trip).
+    /// The pane that had focus at fire time — `.left` (main), `.right` (split), or `.scratch` (the
+    /// session's scratch terminal). `.left` for any single-pane session, including a promoted split
+    /// survivor: when the primary pane exits, `closePrimaryPane` moves the surviving split pane into the
+    /// main slot, so it reports `.left` and `session.type --pane left` reaches it. Typed (not a raw
+    /// `String`) so `rawValue` can only be `left`/`right`/`scratch`; it is consumed as the `$AGT_PANE`
+    /// env var a script feeds back through `session type --pane` (re-validated CLI- AND server-side —
+    /// the enum pins the token this emits, not the shell round-trip).
     public var pane: Pane
     public var selection: String
     public var socket: String

--- a/agtermCore/Tests/agtermCoreTests/CustomCommandTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/CustomCommandTests.swift
@@ -70,11 +70,20 @@ struct CustomCommandTests {
     @Test func paneDefaultsToLeft() {
         // an unspecified pane is the main pane — always a valid `session.type --pane` argument, so a
         // split-less session's context still round-trips into a pane-addressed control call. The typed
-        // `Pane` enum guarantees the value is left/right by construction; its rawValue feeds the token.
+        // `Pane` enum guarantees the value is left/right/scratch by construction; its rawValue feeds the token.
         #expect(CommandContext().pane == .left)
         #expect(CommandContext().environment()["AGT_PANE"] == "left")
         #expect(CommandContext().expand("{AGT_PANE}") == "left")
         #expect(CommandContext(pane: .right).expand("{AGT_PANE}") == "right")
+    }
+
+    @Test func paneScratchExpandsToScratch() {
+        // the scratch is a pane too — a chord fired from the session's scratch terminal reports
+        // `scratch`, which round-trips straight back through `session type --pane scratch`.
+        let ctx = CommandContext(pane: .scratch)
+        #expect(ctx.pane == .scratch)
+        #expect(ctx.environment()["AGT_PANE"] == "scratch")
+        #expect(ctx.expand("{AGT_PANE}") == "scratch")
     }
 
     @Test func environmentKeySetMatchesTheTokensExpandSubstitutes() {

--- a/agtermUITests/CustomCommandPaneTokenUITests.swift
+++ b/agtermUITests/CustomCommandPaneTokenUITests.swift
@@ -2,11 +2,12 @@ import Foundation
 import XCTest
 
 // Verifies the `CustomCommandRunner` pane derivation that populates `{AGT_PANE}`/`$AGT_PANE`: a custom
-// command reports the pane it fired FROM — "left" (main) or "right" (split). This is the only test that
-// pins that logic. The keybind path derives the pane from the focused SURFACE's identity (NOT the
-// session's `splitFocused` flag), and the palette path from the flag. The probe command writes
-// `$AGT_PANE` to a marker file, which the test reads back. A `ControlAPITestCase` subclass so it can
-// split/focus panes over the control socket while firing real keystrokes for the keybind path.
+// command reports the pane it fired FROM — "left" (main), "right" (split), or "scratch" (the session's
+// scratch terminal). This is the only test that pins that logic. The keybind path derives the pane from
+// the focused SURFACE's identity (NOT the session's `splitFocused` flag), and the palette path from the
+// flag. The probe command writes `$AGT_PANE` to a marker file, which the test reads back. A
+// `ControlAPITestCase` subclass so it can split/focus/scratch panes over the control socket while firing
+// real keystrokes for the keybind path.
 @MainActor
 final class CustomCommandPaneTokenUITests: ControlAPITestCase {
     // keybind path: fire the SAME chord from the main pane (no split) and then from the split's focused
@@ -42,6 +43,29 @@ final class CustomCommandPaneTokenUITests: ControlAPITestCase {
         app.activate()
         XCTAssertEqual(firePaneProbe(marker) { self.app.typeKey("e", modifierFlags: [.command, .shift]) }, "right",
                        "a chord fired from the split's right pane should report $AGT_PANE=right")
+    }
+
+    // keybind path, SCRATCH: open the session's scratch terminal over the socket (it auto-focuses on
+    // show), then fire the SAME chord from it → "scratch". This is the app-side proof of
+    // `runFromSessionlessSurface`'s scratch branch: the scratch surface has no `view.session`, so the
+    // runner identifies it as the ACTIVE session's `scratchSurface` and reports `.scratch`, the read leg
+    // of the `$AGT_PANE` → `session type --pane scratch` round-trip. The host-free tests can't reach the
+    // runner. The quick terminal and overlays deliberately have no pane value (their state is on `tree`).
+    func testAgtPaneKeybindReportsScratch() throws {
+        let marker = markerDir.appendingPathComponent("agt-pane-scratch")
+        try relaunch(withKeymap: "command \"Pane Probe\" cmd+shift+e printf %s \"$AGT_PANE\" > \"\(marker.path)\"\n")
+
+        focusMainTerminal()
+        let scratch = try sendCommand(#"{"cmd":"session.scratch","target":"active","args":{"mode":"on"}}"#)
+        XCTAssertEqual(scratch["ok"] as? Bool, true, "scratch on should succeed: \(scratch)")
+        // wait for the scratch surface to realize (shell spawned, readable) so the focus it grabs is real.
+        XCTAssertTrue(pollScratchRealized(timeout: 10), "the control-opened scratch should realize its surface")
+        app.activate()
+
+        // the scratch auto-focuses on show, but that focus is async — retry the chord until it reports the
+        // scratch (a chord landing before the scratch grabs first responder reports the main pane).
+        XCTAssertEqual(fireUntil("scratch", marker: marker) { self.app.typeKey("e", modifierFlags: [.command, .shift]) },
+                       "scratch", "a chord fired from the scratch terminal should report $AGT_PANE=scratch")
     }
 
     // palette path: the runner's `run(_:)` (no fired-from surface to key off) derives the pane from the
@@ -163,5 +187,34 @@ final class CustomCommandPaneTokenUITests: ControlAPITestCase {
         field.click()
         field.typeText(name)
         app.typeKey(.return, modifierFlags: [])
+    }
+
+    /// Poll `session.text --pane scratch` until it returns ok, proving the scratch surface has realized
+    /// (shell spawned, surface mounted) so the first responder it grabs on show is real.
+    private func pollScratchRealized(timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let response = try? sendCommand(#"{"cmd":"session.text","target":"active","args":{"pane":"scratch"}}"#),
+               response["ok"] as? Bool == true { return true }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        }
+        return false
+    }
+
+    /// Fire `press` repeatedly, clearing the marker each attempt, until it reads `expected` — tolerating
+    /// intermediate values while an async focus change settles. Returns the last value seen, or nil on
+    /// timeout, so a failed assertion shows what it actually reported.
+    private func fireUntil(_ expected: String, marker: URL, attempts: Int = 12, perAttempt: TimeInterval = 2,
+                           press: () -> Void) -> String? {
+        var last: String?
+        for _ in 0..<attempts {
+            try? FileManager.default.removeItem(at: marker)
+            press()
+            if let value = pollMarker(marker, timeout: perAttempt) {
+                last = value
+                if value == expected { return value }
+            }
+        }
+        return last
     }
 }


### PR DESCRIPTION
A custom-command keybind fired while a session's scratch terminal holds first responder now reports `$AGT_PANE=scratch`, instead of falling through to the active-session fallback and reporting `left`.

This aligns `$AGT_PANE` with the `left|right|scratch` vocabulary the rest of the `--pane` surfaces (`session type`/`text`/`status`/`font`) already share, and completes the `$AGT_PANE` -> `session type --pane "$AGT_PANE"` round-trip, which previously typed a scratch-fired command back into the *main* pane.

`CustomCommandRunner` gains `runFromSessionlessSurface`: a focused surface with no `view.session` that is the active session's `scratchSurface` (by object identity) reports `.scratch` and reads that surface's own selection. The quick terminal and overlays are not panes and keep the active-session fallback; their state is already queryable via `tree`.

Covered by a host-free `CommandContext.Pane.scratch` expansion test and an end-to-end `CustomCommandPaneTokenUITests` case that opens the scratch over the control socket, fires the chord, and asserts `$AGT_PANE=scratch`.

Related to #176
