### PR TITLE
docs: note setuid foreground processes are omitted from tree

### DIFF
--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -126,7 +126,8 @@ Run `agtermctl <area> <cmd> --help` for exact flags. Full detail in **reference.
 
 **tree** — print the workspace/session tree (`--json` for structured). Each session node carries
 `foreground`/`splitForeground` (the live argv of each pane's foreground process, omitted when the pane
-is at its shell prompt) — i.e. what each pane is currently running — `status` (the agent-status set
+is at its shell prompt, or running a setuid/setgid program like `top` or `sudo` whose argv macOS won't
+expose) — i.e. what each pane is currently running — `status` (the agent-status set
 via `session status`: `active`|`completed`|`blocked`, omitted when idle), `statusPane` (which pane set
 that status: `left` (main) | `right` (split) | `scratch`, from `session status --pane`, omitted when
 unset or idle), `statusBlink`/`statusColor` (the status glyph's `--blink` flag and `--color` `#rrggbb`

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -9,7 +9,7 @@ Worked `agtermctl` examples. See `reference.md` for exact flags and return shape
 agtermctl tree --json        # workspaces -> sessions, active/split/overlay/scratch/flagged flags, surface ids
 agtermctl window list --json # windows, with open/active flags
 
-# what is each pane RUNNING right now (foreground argv; absent when at the shell prompt)
+# what is each pane RUNNING right now (foreground argv; absent at the shell prompt or for a setuid program like top/sudo)
 agtermctl tree --json | jq -r '.result.tree.workspaces[].sessions[] | "\(.name): \(.foreground // "shell")"'
 ```
 

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -59,7 +59,8 @@ as `status`, so it is never reported without a `status`), `statusBlink` (`true` 
 set to blink — the `--blink` value; omitted when idle or not blinking) and `statusColor` (the `#rrggbb`
 glyph-tint override — the `--color` value; omitted when idle or using the default color),
 `foreground`/`splitForeground` (the live argv of each pane's foreground
-process — what it is running — omitted when the pane sits at its shell prompt), `background` (the
+process — what it is running — omitted when the pane sits at its shell prompt, and also for a
+setuid/setgid foreground process like `top` or `sudo`, whose argv macOS refuses to expose), `background` (the
 background spec set via `session background` — a `{kind, text?, imagePath?, colorHex?, opacity?, fit?,
 position?, repeats?}` object; `kind` is `image`/`text`/`color` — omitted when none is set), `unseen`
 (the unseen-notification badge count — raised by `notify`/OSC 9/777, cleared by `session seen` — omitted

--- a/site/commands.html
+++ b/site/commands.html
@@ -398,7 +398,7 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">statusColor</span>,
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">foreground</span> /
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">splitForeground</span> (each pane's live foreground
-                argv, omitted at the shell prompt),
+                argv, omitted at the shell prompt or for a setuid program like top/sudo),
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">background</span>, and
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">unseen</span>.
               </p>


### PR DESCRIPTION
documents that a setuid/setgid foreground process (`top`, `sudo`) reads as omitted on the `tree` `foreground`/`splitForeground` fields, since macOS blocks `sysctl(KERN_PROCARGS2)` for a privileged binary owned by a non-root caller. The docs previously noted only the shell-prompt omission.

updates the agent-skill (`SKILL.md`, `reference.md`, `examples.md`) and `site/commands.html`.

Related to #218.
