### PR TITLE
fix: scope the terminal cursor to the on-screen deck pane

### DIFF
--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -403,6 +403,19 @@ paths:
   when its window becomes key — gated `deckVisible` + `isKeyWindow` + pointer-in-bounds, so it never paints
   the terminal cursor over the sidebar or a background window, and it wins uncontested since hidden panes are
   already muted.
+  `deckVisible` itself is computed in `WindowContentView.sessionDetail` (the pane's `visible`, plus the
+  scratch and overlay `deckVisible` expressions); each must exclude EVERY layer that covers the surface, or
+  the covered surface keeps `deckVisible = true` and competes anyway.
+  Full overlay / scratch drop it via `hideForOverlay`; the window-level quick terminal drops it via
+  `!quickTerminal.isVisible` on the pane, scratch, AND overlay expressions (it covers the deck WITHOUT
+  touching `deckInteractive`/`hideForOverlay`, so without that term the covered surfaces flicker against the
+  quick-terminal surface — issue #225's quick-terminal path).
+  A FLOATING overlay is the one residual: it leaves the pane VISIBLE in the margin around the panel (so the
+  pane legitimately keeps `deckVisible = true`), and no boolean gate can scope the cursor to the
+  panel-vs-margin split — over the panel's overlap the pane and the overlay surface can still show competing
+  shapes.
+  This is a known limitation of the boolean approach: narrow (needs a floating overlay AND the two surfaces
+  cached at different shapes) and far milder than the original many-surface flicker.
   The tracking + pointer methods live in `GhosttySurfaceView+Tracking.swift` (`currentTrackingArea` is
   `internal`, not `private`, so that extension can manage the stored area).
   Cursor shape is not accessibility-observable, so this is verified BY EYE (like the cursor solid/hollow

--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -383,6 +383,33 @@ paths:
   It is the companion to the `mouseEntered` restore (which only covers cross-the-boundary re-entry).
   Like the cursor-focus case, this input plumbing is not accessibility-observable and is verified by hand,
   not a UI test.
+- **Only the ON-SCREEN deck pane may set the process-global cursor (`deckVisible` gates every cursor write).**
+  Every session's surface is eagerly realized with a `.mouseMoved`/`.cursorUpdate` tracking area, and AppKit
+  tracking ignores SwiftUI `.opacity(0)`/sibling overlap the SAME way drag-destination resolution does — a
+  hidden surface's `visibleRect` is NOT clipped by the visible pane stacked over it.
+  So several stacked surfaces receive the SAME `mouseMoved` and each ran `NSCursor.set()`; a hidden session
+  cached at a different mouse shape (a mouse-reporting TUI, or an OSC 22 pointer shape) then flickered its
+  shape over the visible terminal on every move — issue #225's arrow↔I-beam flicker, seen in RESTORED
+  sessions precisely because restore mounts MANY surfaces at once (one session shows no competition).
+  The fix gates the cursor on `deckVisible` (the same on-screen-pane flag drag registration uses) in TWO
+  places: `setupTrackingArea` installs the tracking area only while `deckVisible` (a hidden surface gets no
+  `mouseMoved` at all — this also stops the `reportMousePos` fan-out to every hidden TUI), AND the three
+  cursor-set sites (`mouseMoved`, `applyMouseShape`, `cursorUpdate`) each `guard deckVisible`.
+  The tracking-area gate ALONE is NOT enough: AppKit still delivers a `cursorUpdate` to a HIDDEN surface on
+  window activation, so a background pane cached at a stale shape would paint it on the reactivating click
+  without the `.set()`-site guards.
+  Conversely AppKit does NOT re-issue a `cursorUpdate` to the VISIBLE pane on bare activation, so
+  `reassertCursorOnActivation` (called from the `didBecomeKey` observer) re-asserts the visible pane's cursor
+  when its window becomes key — gated `deckVisible` + `isKeyWindow` + pointer-in-bounds, so it never paints
+  the terminal cursor over the sidebar or a background window, and it wins uncontested since hidden panes are
+  already muted.
+  The tracking + pointer methods live in `GhosttySurfaceView+Tracking.swift` (`currentTrackingArea` is
+  `internal`, not `private`, so that extension can manage the stored area).
+  Cursor shape is not accessibility-observable, so this is verified BY EYE (like the cursor solid/hollow
+  case), reproduced deterministically with several stacked sessions given differing OSC 22 shapes
+  (`printf '\033]22;crosshair\007'`).
+  Do NOT "simplify" this to only the tracking-area gate (the refocus crosshair returns) or only the
+  `.set()`-site gates (hidden TUIs keep getting the `reportMousePos` fan-out).
 - **OSC 52 clipboard access is gated in OUR callbacks, not by a ghostty-internal dialog.**
   A program reading (`\e]52;c;?\a`) or writing (`\e]52;c;<base64>\a`) the system clipboard reaches agterm
   through `read_clipboard_cb`/`confirm_read_clipboard_cb` and `write_clipboard_cb` (`GhosttyCallbacks`).

--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -410,12 +410,18 @@ paths:
   `!quickTerminal.isVisible` on the pane, scratch, AND overlay expressions (it covers the deck WITHOUT
   touching `deckInteractive`/`hideForOverlay`, so without that term the covered surfaces flicker against the
   quick-terminal surface — issue #225's quick-terminal path).
-  A FLOATING overlay is the one residual: it leaves the pane VISIBLE in the margin around the panel (so the
-  pane legitimately keeps `deckVisible = true`), and no boolean gate can scope the cursor to the
-  panel-vs-margin split — over the panel's overlap the pane and the overlay surface can still show competing
-  shapes.
-  This is a known limitation of the boolean approach: narrow (needs a floating overlay AND the two surfaces
-  cached at different shapes) and far milder than the original many-surface flicker.
+  Two residual cases remain, both far milder than the original many-surface flicker and both predating this
+  change.
+  A FLOATING overlay leaves the pane VISIBLE in the margin around the panel (so the pane legitimately keeps
+  `deckVisible = true`), and no boolean gate can scope the cursor to the panel-vs-margin split — over the
+  panel's overlap the pane and the overlay surface can still show competing shapes.
+  The command palette and Ctrl-Tab switcher (window-level SwiftUI overlays NOT in the `deckVisible`
+  predicate) likewise leave the covered pane `deckVisible = true`, so over them the covered terminal surface
+  can still write its cached cursor (cosmetic, plus a rare drop-through) — but that is ONE terminal surface
+  under a SwiftUI overlay, not two terminals fighting, and these are transient keyboard-driven overlays the
+  pointer rarely rests on.
+  Both are left as known limitations of the boolean approach rather than chasing every window-level overlay
+  into the predicate (the quick terminal is gated because it is the persistent, mouse-used one).
   The tracking + pointer methods live in `GhosttySurfaceView+Tracking.swift` (`currentTrackingArea` is
   `internal`, not `private`, so that extension can manage the stored area).
   Cursor shape is not accessibility-observable, so this is verified BY EYE (like the cursor solid/hollow

--- a/agterm/Ghostty/GhosttySurfaceView+Input.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Input.swift
@@ -449,9 +449,10 @@ extension GhosttySurfaceView: @preconcurrency NSTextInputClient {
 
     /// Re-assert this pane's cursor when its window becomes key. AppKit does NOT re-issue a `cursorUpdate`
     /// to the visible pane on bare window activation, so a reactivating click otherwise leaves the OS default
-    /// (arrow) cursor until the next mouse move. Gated exactly like the `.set()` sites — `deckVisible` (only
-    /// the on-screen pane sets the cursor) and pointer-in-bounds (never paint the terminal cursor over the
-    /// sidebar/titlebar or a background window) — so with hidden surfaces already muted it wins uncontested.
+    /// (arrow) cursor until the next mouse move. Gated on `deckVisible` (only the on-screen pane sets the
+    /// cursor) + `isKeyWindow` + pointer-in-bounds (checked fresh from `mouseLocationOutsideOfEventStream`,
+    /// since `pointerInside` can be stale on a no-move activation) — so it never paints the terminal cursor
+    /// over the sidebar/titlebar or a background window, and with hidden surfaces already muted it wins uncontested.
     func reassertCursorOnActivation() {
         guard deckVisible, let window, window.isKeyWindow else { return }
         let pointInView = convert(window.mouseLocationOutsideOfEventStream, from: nil)

--- a/agterm/Ghostty/GhosttySurfaceView+Input.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Input.swift
@@ -210,9 +210,11 @@ extension GhosttySurfaceView {
     /// Re-assert the libghostty-requested cursor on every move. `cursorUpdate` only fires on tracking-area
     /// entry (not per intra-area move), and SwiftUI — which owns the cursor for the hosted view — can reset
     /// it on any move, so without this the pointing hand would revert to the arrow while moving along a link.
-    /// This fires only while the pointer is inside the view, so it can't leak the cursor outside the surface.
+    /// Gated on `deckVisible`: only the on-screen pane sets the process-global cursor, so a background deck
+    /// surface never paints its shape over the visible terminal (issue #225).
     override func mouseMoved(with event: NSEvent) {
         reportMousePos(from: event)
+        guard deckVisible else { return }
         Self.nsCursor(for: mouseShape).set()
     }
 
@@ -420,15 +422,16 @@ extension GhosttySurfaceView: @preconcurrency NSTextInputClient {
 
     /// Applies the cursor shape libghostty requested (`GHOSTTY_ACTION_MOUSE_SHAPE`) — the pointing hand
     /// over a link, the I-beam over the grid, resize/crosshair/grab in the matching modes. No-ops when
-    /// unchanged; otherwise sets the cursor at once — but only while the pointer is inside, so a revert
-    /// delivered after the pointer already left (the I-beam libghostty emits once `mouseExited` reports
-    /// `-1, -1`) can't paint the terminal cursor onto the sidebar. Setting it here is what makes a stationary
-    /// shape change (⌘ pressed over a link without moving) take effect immediately; `mouseMoved` re-asserts it
-    /// as the pointer moves and `cursorUpdate` on entry.
+    /// unchanged; otherwise sets the cursor at once — but only while this is the on-screen pane (`deckVisible`)
+    /// and the pointer is inside, so a background deck surface never paints its shape over the visible terminal
+    /// (issue #225), and a revert delivered after the pointer already left (the I-beam libghostty emits once
+    /// `mouseExited` reports `-1, -1`) can't paint the terminal cursor onto the sidebar. Setting it here is what
+    /// makes a stationary shape change (⌘ pressed over a link without moving) take effect immediately;
+    /// `mouseMoved` re-asserts it as the pointer moves and `cursorUpdate` on entry.
     func applyMouseShape(_ shape: ghostty_action_mouse_shape_e) {
         guard shape != mouseShape else { return }
         mouseShape = shape
-        if pointerInside { Self.nsCursor(for: shape).set() }
+        if deckVisible, pointerInside { Self.nsCursor(for: shape).set() }
     }
 
     /// AppKit cursor hook (the `.cursorUpdate` tracking-area callback, NOT cursor rectangles): paint the whole
@@ -436,8 +439,23 @@ extension GhosttySurfaceView: @preconcurrency NSTextInputClient {
     /// which owns the cursor and resets it as the mouse moves, so `addCursorRect`/`resetCursorRects` never take
     /// hold here (the link still underlines because libghostty draws that, but the pointing hand is dropped).
     /// Setting the cursor from `cursorUpdate` re-asserts it on AppKit's cursor pass — the same reason upstream
-    /// Ghostty.app drives the cursor through SwiftUI rather than cursor rectangles.
+    /// Ghostty.app drives the cursor through SwiftUI rather than cursor rectangles. Gated on `deckVisible`:
+    /// AppKit still delivers a `cursorUpdate` to a hidden deck surface on window activation, so a background
+    /// pane must not set the cursor here (issue #225 refocus).
     override func cursorUpdate(with event: NSEvent) {
+        guard deckVisible else { return }
+        Self.nsCursor(for: mouseShape).set()
+    }
+
+    /// Re-assert this pane's cursor when its window becomes key. AppKit does NOT re-issue a `cursorUpdate`
+    /// to the visible pane on bare window activation, so a reactivating click otherwise leaves the OS default
+    /// (arrow) cursor until the next mouse move. Gated exactly like the `.set()` sites — `deckVisible` (only
+    /// the on-screen pane sets the cursor) and pointer-in-bounds (never paint the terminal cursor over the
+    /// sidebar/titlebar or a background window) — so with hidden surfaces already muted it wins uncontested.
+    func reassertCursorOnActivation() {
+        guard deckVisible, let window, window.isKeyWindow else { return }
+        let pointInView = convert(window.mouseLocationOutsideOfEventStream, from: nil)
+        guard bounds.contains(pointInView) else { return }
         Self.nsCursor(for: mouseShape).set()
     }
 

--- a/agterm/Ghostty/GhosttySurfaceView+Tracking.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Tracking.swift
@@ -1,0 +1,42 @@
+import AppKit
+import GhosttyKit
+
+extension GhosttySurfaceView {
+    /// Only the on-screen deck pane tracks the pointer. Every session's surface is eagerly realized, and
+    /// AppKit tracking areas ignore SwiftUI's `.opacity(0)` and sibling overlap exactly like the
+    /// drag-destination resolution (`deckVisible`) — a hidden surface's `visibleRect` is NOT clipped by an
+    /// overlapping sibling, so with `.mouseMoved`/`.cursorUpdate` still armed it receives the SAME move as the
+    /// visible pane and races to set the one process-global `NSCursor`. A hidden session cached at a different
+    /// mouse shape (a mouse-reporting TUI, or an OSC 22 pointer shape) then flickers over the visible terminal
+    /// (issue #225). `setupTrackingArea` installs the area only while `deckVisible`, so a hidden surface's
+    /// `mouseMoved`/`cursorUpdate` never fire — which also silences `applyMouseShape`'s `.set()` (guarded on
+    /// `pointerInside`, only set from `mouseEntered`). On going off-screen, clear the hover/pointer state a
+    /// now-untracked surface would otherwise keep (like `mouseExited`).
+    func updatePointerTracking() {
+        setupTrackingArea()
+        guard !deckVisible else { return }
+        pointerInside = false
+        if let surface { ghostty_surface_mouse_pos(surface, -1, -1, GHOSTTY_MODS_NONE) }
+        lastReportedMousePoint = NSPoint(x: -1, y: -1)
+    }
+
+    func setupTrackingArea() {
+        if let existing = currentTrackingArea { removeTrackingArea(existing); currentTrackingArea = nil }
+        // only the on-screen pane owns the pointer (see `updatePointerTracking`): a hidden deck surface
+        // installs NO tracking area, so its `mouseMoved`/`cursorUpdate` never fire and it can't race to set
+        // the one process-global cursor — the multi-surface flicker of issue #225.
+        guard deckVisible else { return }
+        let area = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseMoved, .mouseEnteredAndExited, .cursorUpdate, .activeInKeyWindow, .inVisibleRect],
+            owner: self
+        )
+        addTrackingArea(area)
+        currentTrackingArea = area
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        setupTrackingArea()
+    }
+}

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -207,9 +207,13 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     /// panes do NOT reach AppKit's drag machinery (the NSView keeps `alphaValue == 1`, and AppKit's
     /// drag-destination resolution does NOT consult `hitTest`), so if every surface stayed a registered
     /// drag target a file drop would land on whichever is topmost in z-order — an INVISIBLE background
-    /// session — instead of the one under the cursor. `didSet` (un)registers the drag types to fix that.
+    /// session — instead of the one under the cursor. `didSet` (un)registers the drag types to fix that,
+    /// and (dis)installs the mouse-tracking area for the same reason (see `updatePointerTracking`).
     var deckVisible = true {
-        didSet { updateDropRegistration() }
+        didSet {
+            updateDropRegistration()
+            updatePointerTracking()
+        }
     }
 
     /// View-only mode: the surface is rendered but takes NO mouse or keyboard input (the dashboard grid
@@ -278,7 +282,7 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     var _selectedRange = NSRange(location: NSNotFound, length: 0)
     var keyTextAccumulator: [String] = []
     var currentKeyEvent: NSEvent?
-    private var currentTrackingArea: NSTrackingArea?
+    var currentTrackingArea: NSTrackingArea?
 
     /// The mouse-cursor shape libghostty last requested for this surface (`GHOSTTY_ACTION_MOUSE_SHAPE`):
     /// the I-beam over the grid, the pointing hand over a detected link / OSC-8 hyperlink, resize/crosshair
@@ -330,7 +334,10 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
                     // focus transition does. becomeFirstResponder can't cover this: AppKit's per-window
                     // first responder never resigned while agterm was backgrounded, so no focus transition
                     // fires on return, leaving the badge stuck until you switch sessions and back.
-                    if becameKey { self.clearUnseenOnRefocus() }
+                    if becameKey {
+                        self.reassertCursorOnActivation()
+                        self.clearUnseenOnRefocus()
+                    }
                 }
             }
             focusObservers.append(token)
@@ -978,23 +985,5 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
             if !suppressFocusChange { onFocusChange?(false) }
         }
         return result
-    }
-
-    // MARK: - Tracking area
-
-    private func setupTrackingArea() {
-        if let existing = currentTrackingArea { removeTrackingArea(existing) }
-        let area = NSTrackingArea(
-            rect: bounds,
-            options: [.mouseMoved, .mouseEnteredAndExited, .cursorUpdate, .activeInKeyWindow, .inVisibleRect],
-            owner: self
-        )
-        addTrackingArea(area)
-        currentTrackingArea = area
-    }
-
-    override func updateTrackingAreas() {
-        super.updateTrackingAreas()
-        setupTrackingArea()
     }
 }

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -211,6 +211,9 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     /// and (dis)installs the mouse-tracking area for the same reason (see `updatePointerTracking`).
     var deckVisible = true {
         didSet {
+            // `TerminalView` assigns this on every SwiftUI update pass, so skip the tracking-area teardown/
+            // rebuild + drag re-registration unless the visibility actually flipped.
+            guard deckVisible != oldValue else { return }
             updateDropRegistration()
             updatePointerTracking()
         }
@@ -282,6 +285,9 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     var _selectedRange = NSRange(location: NSNotFound, length: 0)
     var keyTextAccumulator: [String] = []
     var currentKeyEvent: NSEvent?
+
+    // the pointer's mouse-tracking area, managed by GhosttySurfaceView+Tracking.swift (a stored property
+    // can't live in an extension, so it stays here as internal rather than private).
     var currentTrackingArea: NSTrackingArea?
 
     /// The mouse-cursor shape libghostty last requested for this surface (`GHOSTTY_ACTION_MOUSE_SHAPE`):

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -375,10 +375,14 @@ struct WindowContentView: View {
         // this subtree's shape/hit-testing must not change when a floating overlay opens (NSSplitView overrun).
         let hideForOverlay = fullOverlay || session.scratchActive
         let overlaid = session.overlayActive || session.scratchActive
-        // on-screen = selected session, not hidden by a full overlay/scratch. Shared by BOTH split panes
-        // (unlike the focus-gated `isActive`), it gates each surface's drag-type (un)registration so a file
-        // drop lands on the visible pane, not an invisible background deck surface (matches the panes' hit-testing).
-        let visible = deckInteractive && isActive && !hideForOverlay
+        // on-screen = selected session, not hidden by a full overlay/scratch, and not covered by the
+        // window-level quick terminal. Shared by BOTH split panes (unlike the focus-gated `isActive`), it
+        // gates each surface's drag-type (un)registration AND its mouse-cursor tracking (the `deckVisible`
+        // note in libghostty.md) so neither a file drop nor a cursor write lands on an off-screen surface.
+        // `!quickTerminal.isVisible` mutes the covered pane while the quick terminal is up — otherwise the
+        // covered pane keeps deckVisible=true and races the quick-terminal surface for the cursor and fans
+        // mouse-motion into the covered TUI (issue #225 quick-terminal path).
+        let visible = deckInteractive && isActive && !hideForOverlay && !quickTerminal.isVisible
         ZStack {
             // the session's pane(s), kept MOUNTED while an overlay is up — shells stay alive, like the deck
             // does for inactive sessions. a FULL overlay hides them (opacity 0) so its translucency reveals the
@@ -470,7 +474,7 @@ struct WindowContentView: View {
                 // rule so only an on-screen scratch is a file-drop target.
                 TerminalView(session: session, surfaceKeyPath: \.scratchSurface, makeSurface: makeScratchSurface,
                              isActive: deckInteractive && isActive && !session.overlayActive && !quickTerminal.isVisible,
-                             deckVisible: deckInteractive && isActive && !fullOverlay)
+                             deckVisible: deckInteractive && isActive && !fullOverlay && !quickTerminal.isVisible)
                     .opacity(fullOverlay ? 0 : 1)
                     .allowsHitTesting(!fullOverlay)
                     .id("\(session.id.uuidString)-scratch")
@@ -530,7 +534,7 @@ struct WindowContentView: View {
                     // responder (the full variant hides the panes, so it's covered either way).
                     Color.clear.contentShape(Rectangle())
                     TerminalView(session: session, surfaceKeyPath: \.overlaySurface,
-                                 makeSurface: makeOverlaySurface, isActive: isActive, deckVisible: isActive)
+                                 makeSurface: makeOverlaySurface, isActive: isActive, deckVisible: isActive && !quickTerminal.isVisible)
                         .frame(width: geo.size.width * fraction, height: geo.size.height * fraction)
                         // floating = opaque backing + hairline frame + shadow so it reads as a distinct window
                         // over the still-visible session; full = translucent, no chrome (libghostty draws only


### PR DESCRIPTION
Fixes the mouse-cursor flicker reported in #225 (symptom 1): in restored sessions the cursor flickered between shapes (arrow / I-beam) over the visible terminal.

**Root cause.** The eager deck mounts every session's terminal surface at once, each with a `.mouseMoved`/`.cursorUpdate` tracking area. AppKit tracking ignores SwiftUI opacity and sibling overlap the same way drag-destination resolution does (the repo already documents this for file drops), so several stacked surfaces received the same `mouseMoved` and each called the process-global `NSCursor.set()`. A hidden session cached at a different mouse shape (a mouse-reporting TUI, or an OSC 22 pointer shape) then painted its shape over the visible terminal. That is why it hit restored sessions, which mount many surfaces at once, and not a single-session window.

**Fix.** Gate every cursor write on the existing `deckVisible` flag (the on-screen-pane flag drag registration already uses):

- `setupTrackingArea` installs the tracking area only while `deckVisible`, so a hidden surface gets no `mouseMoved` at all (this also drops the `reportMousePos` fan-out to hidden TUIs)
- `mouseMoved`, `applyMouseShape`, and `cursorUpdate` each `guard deckVisible`. The tracking gate alone is not enough because AppKit still delivers a `cursorUpdate` to a hidden surface on window activation
- `reassertCursorOnActivation` re-asserts the visible pane's cursor on `didBecomeKey` (AppKit does not re-issue `cursorUpdate` on bare activation), gated `deckVisible` + `isKeyWindow` + pointer-in-bounds
- the covered pane, scratch, and overlay are muted while the quick terminal covers the deck (`!quickTerminal.isVisible`)

The Cmd-hover pointing-hand cursor over links (#207) is preserved. Tracking and pointer methods moved to `GhosttySurfaceView+Tracking.swift` to keep the file under the size cap.

Verified by eye (cursor shape is not accessibility-observable): the flicker is gone across restored/stacked sessions and the quick terminal, refocus shows the right cursor at once, and Cmd-hover still shows the pointing hand. `swift test` and `make lint` pass.

*Only symptom 1 (cursor flicker) is addressed here. Symptom 2 (scroll freeze) is separate: the scroll path and the pinned libghostty are unchanged between the reporter's 0.12.1 and 0.14, so it needs its own isolation. This references #225 without closing it.*

Known limitations (documented in the code): a floating overlay's overlap region and the command-palette / Ctrl-Tab switcher overlays can still show a cosmetic cursor competition. Both are transient and pre-existing.

Related to #225
