### PR TITLE
fix: make site navigation responsive on mobile

### DIFF
--- a/site/commands.html
+++ b/site/commands.html
@@ -133,7 +133,14 @@
           <details class="site-nav-mobile">
             <summary>menu</summary>
             <nav aria-label="Mobile navigation" onclick="this.parentElement.open=false">
-              <label for="doc-drawer">contents</label>
+              <button
+                type="button"
+                class="doc-drawer-trigger"
+                aria-controls="doc-navigation"
+                onclick="document.getElementById('doc-drawer').checked=true; document.querySelector('#doc-navigation a').focus()"
+              >
+                contents
+              </button>
               <a href="/">← home</a>
               <a href="/docs">docs</a>
               <a href="https://github.com/umputun/agterm">GitHub ↗</a>
@@ -143,7 +150,12 @@
       </div>
 
       <input class="doc-drawer-toggle" type="checkbox" id="doc-drawer" />
-      <label class="doc-drawer-overlay" for="doc-drawer" aria-label="Close documentation navigation"></label>
+      <button
+        type="button"
+        class="doc-drawer-overlay"
+        aria-label="Close documentation navigation"
+        onclick="document.getElementById('doc-drawer').checked=false; document.querySelector('.site-nav-mobile summary').focus()"
+      ></button>
 
       <!-- ===== LAYOUT ===== -->
       <div
@@ -152,6 +164,7 @@
       >
         <!-- SIDEBAR -->
         <aside
+          id="doc-navigation"
           class="doc-scroll"
           style="
             position: sticky;
@@ -165,7 +178,7 @@
         >
           <nav
             aria-label="Command reference sections"
-            onclick="document.getElementById('doc-drawer').checked=false"
+            onclick="document.getElementById('doc-drawer').checked=false; document.querySelector('.site-nav-mobile summary').focus()"
             style="display: flex; flex-direction: column; gap: 4px; font-size: 13.5px"
           >
             <a href="#overview" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">Overview</a>

--- a/site/commands.html
+++ b/site/commands.html
@@ -64,6 +64,7 @@
         "
       >
         <div
+          class="site-nav-bar"
           style="
             max-width: 1240px;
             margin: 0 auto;
@@ -104,6 +105,7 @@
             >
           </a>
           <div
+            class="site-nav-desktop"
             style="
               display: flex;
               align-items: center;
@@ -128,11 +130,26 @@
               >GitHub ↗</a
             >
           </div>
+          <details class="site-nav-mobile">
+            <summary>menu</summary>
+            <nav aria-label="Mobile navigation" onclick="this.parentElement.open=false">
+              <label for="doc-drawer">contents</label>
+              <a href="/">← home</a>
+              <a href="/docs">docs</a>
+              <a href="https://github.com/umputun/agterm">GitHub ↗</a>
+            </nav>
+          </details>
         </div>
       </div>
 
+      <input class="doc-drawer-toggle" type="checkbox" id="doc-drawer" />
+      <label class="doc-drawer-overlay" for="doc-drawer" aria-label="Close documentation navigation"></label>
+
       <!-- ===== LAYOUT ===== -->
-      <div style="max-width: 1240px; margin: 0 auto; display: grid; grid-template-columns: 236px 1fr; gap: 48px; padding: 0 28px">
+      <div
+        class="doc-layout"
+        style="max-width: 1240px; margin: 0 auto; display: grid; grid-template-columns: 236px 1fr; gap: 48px; padding: 0 28px"
+      >
         <!-- SIDEBAR -->
         <aside
           class="doc-scroll"
@@ -146,7 +163,11 @@
             font-family: &quot;JetBrains Mono&quot;, monospace;
           "
         >
-          <nav style="display: flex; flex-direction: column; gap: 4px; font-size: 13.5px">
+          <nav
+            aria-label="Command reference sections"
+            onclick="document.getElementById('doc-drawer').checked=false"
+            style="display: flex; flex-direction: column; gap: 4px; font-size: 13.5px"
+          >
             <a href="#overview" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">Overview</a>
             <a href="#addressing" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">Addressing</a>
             <div style="height: 16px"></div>
@@ -174,7 +195,7 @@
         </aside>
 
         <!-- CONTENT -->
-        <main style="min-width: 0; padding: 48px 0 120px; max-width: 760px">
+        <main class="doc-content" style="min-width: 0; padding: 48px 0 120px; max-width: 760px">
           <div
             style="
               font-family: &quot;JetBrains Mono&quot;, monospace;

--- a/site/docs.html
+++ b/site/docs.html
@@ -64,6 +64,7 @@
         "
       >
         <div
+          class="site-nav-bar"
           style="
             max-width: 1240px;
             margin: 0 auto;
@@ -104,6 +105,7 @@
             >
           </a>
           <div
+            class="site-nav-desktop"
             style="
               display: flex;
               align-items: center;
@@ -128,11 +130,26 @@
               >GitHub ↗</a
             >
           </div>
+          <details class="site-nav-mobile">
+            <summary>menu</summary>
+            <nav aria-label="Mobile navigation" onclick="this.parentElement.open=false">
+              <label for="doc-drawer">contents</label>
+              <a href="/">← home</a>
+              <a href="/commands">commands</a>
+              <a href="https://github.com/umputun/agterm">GitHub ↗</a>
+            </nav>
+          </details>
         </div>
       </div>
 
+      <input class="doc-drawer-toggle" type="checkbox" id="doc-drawer" />
+      <label class="doc-drawer-overlay" for="doc-drawer" aria-label="Close documentation navigation"></label>
+
       <!-- ===== LAYOUT ===== -->
-      <div style="max-width: 1240px; margin: 0 auto; display: grid; grid-template-columns: 236px 1fr; gap: 48px; padding: 0 28px">
+      <div
+        class="doc-layout"
+        style="max-width: 1240px; margin: 0 auto; display: grid; grid-template-columns: 236px 1fr; gap: 48px; padding: 0 28px"
+      >
         <!-- SIDEBAR -->
         <aside
           class="doc-scroll"
@@ -146,7 +163,11 @@
             font-family: &quot;JetBrains Mono&quot;, monospace;
           "
         >
-          <nav style="display: flex; flex-direction: column; gap: 4px; font-size: 13.5px">
+          <nav
+            aria-label="Documentation sections"
+            onclick="document.getElementById('doc-drawer').checked=false"
+            style="display: flex; flex-direction: column; gap: 4px; font-size: 13.5px"
+          >
             <a href="#overview" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">Overview</a>
             <a href="#install" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">Install</a>
             <div style="height: 16px"></div>
@@ -177,7 +198,7 @@
         </aside>
 
         <!-- CONTENT -->
-        <main style="min-width: 0; padding: 48px 0 120px; max-width: 760px">
+        <main class="doc-content" style="min-width: 0; padding: 48px 0 120px; max-width: 760px">
           <!-- title -->
           <div
             style="

--- a/site/docs.html
+++ b/site/docs.html
@@ -133,7 +133,14 @@
           <details class="site-nav-mobile">
             <summary>menu</summary>
             <nav aria-label="Mobile navigation" onclick="this.parentElement.open=false">
-              <label for="doc-drawer">contents</label>
+              <button
+                type="button"
+                class="doc-drawer-trigger"
+                aria-controls="doc-navigation"
+                onclick="document.getElementById('doc-drawer').checked=true; document.querySelector('#doc-navigation a').focus()"
+              >
+                contents
+              </button>
               <a href="/">← home</a>
               <a href="/commands">commands</a>
               <a href="https://github.com/umputun/agterm">GitHub ↗</a>
@@ -143,7 +150,12 @@
       </div>
 
       <input class="doc-drawer-toggle" type="checkbox" id="doc-drawer" />
-      <label class="doc-drawer-overlay" for="doc-drawer" aria-label="Close documentation navigation"></label>
+      <button
+        type="button"
+        class="doc-drawer-overlay"
+        aria-label="Close documentation navigation"
+        onclick="document.getElementById('doc-drawer').checked=false; document.querySelector('.site-nav-mobile summary').focus()"
+      ></button>
 
       <!-- ===== LAYOUT ===== -->
       <div
@@ -152,6 +164,7 @@
       >
         <!-- SIDEBAR -->
         <aside
+          id="doc-navigation"
           class="doc-scroll"
           style="
             position: sticky;
@@ -165,7 +178,7 @@
         >
           <nav
             aria-label="Documentation sections"
-            onclick="document.getElementById('doc-drawer').checked=false"
+            onclick="document.getElementById('doc-drawer').checked=false; document.querySelector('.site-nav-mobile summary').focus()"
             style="display: flex; flex-direction: column; gap: 4px; font-size: 13.5px"
           >
             <a href="#overview" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">Overview</a>

--- a/site/index.html
+++ b/site/index.html
@@ -123,7 +123,7 @@
         font-family: &quot;IBM Plex Sans&quot;, system-ui, sans-serif;
         -webkit-font-smoothing: antialiased;
         min-height: 100vh;
-        overflow-x: hidden;
+        overflow-x: clip;
       "
     >
       <!-- ===== NAV ===== -->
@@ -138,6 +138,7 @@
         "
       >
         <div
+          class="site-nav-bar"
           style="
             max-width: 1140px;
             margin: 0 auto;
@@ -167,6 +168,7 @@
             >
           </a>
           <div
+            class="site-nav-desktop"
             style="
               display: flex;
               align-items: center;
@@ -195,6 +197,17 @@
               >GitHub ↗</a
             >
           </div>
+          <details class="site-nav-mobile">
+            <summary>menu</summary>
+            <nav aria-label="Mobile navigation" onclick="this.parentElement.open=false">
+              <a href="#features">features</a>
+              <a href="#scripting">scripting</a>
+              <a href="#install">install</a>
+              <a href="/docs">docs</a>
+              <a href="/commands">commands</a>
+              <a href="https://github.com/umputun/agterm">GitHub ↗</a>
+            </nav>
+          </details>
         </div>
       </div>
 

--- a/site/style.css
+++ b/site/style.css
@@ -50,6 +50,120 @@ html {
 a {
   text-decoration: none;
 }
+.site-nav-mobile {
+  display: none;
+  position: relative;
+  font-family: "JetBrains Mono", monospace;
+}
+.site-nav-mobile summary {
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0 10px;
+  display: grid;
+  place-items: center;
+  color: #c9cdd2;
+  cursor: pointer;
+  list-style: none;
+  border-radius: 7px;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.16);
+}
+.site-nav-mobile summary::-webkit-details-marker {
+  display: none;
+}
+.site-nav-mobile[open] summary {
+  color: #6d82f3;
+}
+.site-nav-mobile nav {
+  position: absolute;
+  top: 52px;
+  right: 0;
+  width: min(280px, calc(100vw - 32px));
+  padding: 8px;
+  display: grid;
+  background: #22272b;
+  border-radius: 10px;
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.12),
+    0 16px 40px rgba(0, 0, 0, 0.35);
+}
+.site-nav-mobile nav a,
+.site-nav-mobile nav label {
+  min-height: 44px;
+  padding: 0 12px;
+  display: flex;
+  align-items: center;
+  color: #b7bdc5;
+  cursor: pointer;
+  border-radius: 6px;
+}
+.site-nav-mobile nav a:hover,
+.site-nav-mobile nav a:focus-visible,
+.site-nav-mobile nav label:hover {
+  color: #e6e1d7;
+  background: rgba(255, 255, 255, 0.06);
+}
+.doc-drawer-toggle,
+.doc-drawer-overlay {
+  display: none;
+}
+@media (max-width: 720px) {
+  .site-nav-bar {
+    padding: 0 16px !important;
+  }
+  .site-nav-desktop {
+    display: none !important;
+  }
+  .site-nav-mobile {
+    display: block;
+  }
+  .doc-layout {
+    grid-template-columns: minmax(0, 1fr) !important;
+    gap: 0 !important;
+    padding: 0 18px !important;
+  }
+  .doc-layout > .doc-scroll {
+    position: fixed !important;
+    top: 64px !important;
+    bottom: auto;
+    left: 0;
+    z-index: 49;
+    width: min(320px, calc(100vw - 48px));
+    height: calc(100vh - 64px) !important;
+    height: calc(100dvh - 64px) !important;
+    padding: 20px 12px 40px !important;
+    background: #191d20;
+    box-shadow: 18px 0 48px rgba(0, 0, 0, 0.38);
+    transform: translateX(-110%);
+    visibility: hidden;
+    pointer-events: none;
+    transition: transform 160ms cubic-bezier(0.2, 0, 0, 1);
+  }
+  .doc-drawer-toggle:checked ~ .doc-layout > .doc-scroll {
+    transform: translateX(0);
+    visibility: visible;
+    pointer-events: auto;
+  }
+  .doc-drawer-toggle:checked + .doc-drawer-overlay {
+    position: fixed;
+    inset: 64px 0 0;
+    z-index: 48;
+    display: block;
+    background: rgba(0, 0, 0, 0.48);
+  }
+  .doc-content {
+    max-width: none !important;
+    padding: 32px 0 96px !important;
+  }
+  .doc-content p > span[style*="white-space: nowrap"] {
+    white-space: normal !important;
+    overflow-wrap: anywhere;
+  }
+  .doc-content div[style*="flex-wrap: wrap"] > span[style*="white-space: nowrap"] {
+    max-width: 100%;
+    white-space: normal !important;
+    overflow-wrap: anywhere;
+  }
+}
 .cap-grid {
   grid-template-columns: repeat(4, 1fr);
 }

--- a/site/style.css
+++ b/site/style.css
@@ -21,6 +21,7 @@ body {
   margin: 0;
   padding: 0;
   background: #191d20;
+  overflow-x: clip;
 }
 ::selection {
   background: rgba(109, 130, 243, 0.28);
@@ -87,18 +88,24 @@ a {
     0 16px 40px rgba(0, 0, 0, 0.35);
 }
 .site-nav-mobile nav a,
-.site-nav-mobile nav label {
+.site-nav-mobile nav button {
   min-height: 44px;
   padding: 0 12px;
   display: flex;
   align-items: center;
+  width: 100%;
   color: #b7bdc5;
   cursor: pointer;
+  font: inherit;
+  text-align: left;
+  background: none;
+  border: 0;
   border-radius: 6px;
 }
 .site-nav-mobile nav a:hover,
 .site-nav-mobile nav a:focus-visible,
-.site-nav-mobile nav label:hover {
+.site-nav-mobile nav button:hover,
+.site-nav-mobile nav button:focus-visible {
   color: #e6e1d7;
   background: rgba(255, 255, 255, 0.06);
 }
@@ -148,17 +155,20 @@ a {
     inset: 64px 0 0;
     z-index: 48;
     display: block;
+    padding: 0;
     background: rgba(0, 0, 0, 0.48);
+    cursor: pointer;
+    border: 0;
   }
   .doc-content {
     max-width: none !important;
     padding: 32px 0 96px !important;
   }
-  .doc-content p > span[style*="white-space: nowrap"] {
+  .doc-content p > span[style*="white-space"][style*="nowrap"] {
     white-space: normal !important;
     overflow-wrap: anywhere;
   }
-  .doc-content div[style*="flex-wrap: wrap"] > span[style*="white-space: nowrap"] {
+  .doc-content div[style*="flex-wrap: wrap"] > span[style*="white-space"][style*="nowrap"] {
     max-width: 100%;
     white-space: normal !important;
     overflow-wrap: anywhere;


### PR DESCRIPTION
## Problem

The site header only exposed its desktop navigation, so links overflowed the viewport on phones. The documentation pages also kept their fixed-width sidebar and two-column layout, squeezing the article into an unreadable strip.

## Fix

- Add a compact mobile menu while keeping the existing desktop navigation unchanged.
- Keep the header pinned at the top while scrolling on mobile.
- Turn the documentation sidebar into an off-canvas contents drawer with an overlay and automatic close after section navigation.
- Switch documentation content to a single-column mobile layout and size the drawer to the dynamic viewport height.
- Allow long inline command tokens and error labels to wrap on narrow screens instead of causing horizontal overflow.

The implementation stays within the existing static site: no dependencies or script bundle were added.

## Validation

- Manually tested `/`, `/docs`, and `/commands` in a real browser at 320px, 390px, 720px, 721px, and 1280px widths.
- Verified mobile menu open/close behavior, sticky header behavior, drawer scrolling, overlay close, and section-link navigation.
- Verified zero horizontal overflow on `/commands` at 320px and 390px.
- Verified the desktop navigation and sticky documentation sidebar remain unchanged above the mobile breakpoint.
- Verified no browser console errors.
- `git diff --check`

## Screenshots

**Commands - Before / After**

<img width="1592" height="1400" alt="comparison-commands-mobile" src="https://github.com/user-attachments/assets/7821cb9b-db1e-455c-a2c8-76a246180506" />

**Docs - Before / After**


<img width="1592" height="1400" alt="comparison-docs-mobile" src="https://github.com/user-attachments/assets/eaed4f5e-3f6c-4ff8-8976-545b1d10ef76" />

**Landing Page - Before / After**


<img width="1592" height="1400" alt="comparison-home-mobile" src="https://github.com/user-attachments/assets/530c0165-51df-40a6-9304-02fc3b5882d3" />
