### PR TITLE
feat: add inline '+' button on workspace rows to create new sessions

### DIFF
--- a/agterm/Views/SidebarRowViews.swift
+++ b/agterm/Views/SidebarRowViews.swift
@@ -19,6 +19,47 @@ final class SidebarCellView: NSTableCellView {
     /// against toggling expansion when the click lands on this button.
     var addButton: NSButton?
 
+    /// Width of `addButton`, toggled between 0 (hidden) and the glyph width by `setAddButtonVisible`
+    /// — the same collapse-the-slot convention as `StatusIconView.widthConstraint`, so an idle row's
+    /// name reclaims the space. Set by the cell builder alongside `addButton`.
+    var addButtonWidthConstraint: NSLayoutConstraint?
+
+    private static let addButtonWidth: CGFloat = 16
+    private var hoverTrackingArea: NSTrackingArea?
+
+    /// Reveals or collapses the inline "+": the Finder/Xcode hover convention, so an idle row shows
+    /// no button and the roll-up badge keeps its slot. Driven by `mouseEntered`/`mouseExited` and
+    /// reset hidden when a reused cell is reconfigured in the row provider. No-op for session cells.
+    func setAddButtonVisible(_ visible: Bool) {
+        guard let addButton, let addButtonWidthConstraint else { return }
+        addButton.isHidden = !visible
+        addButtonWidthConstraint.constant = visible ? Self.addButtonWidth : 0
+    }
+
+    // hover tracking for the "+" reveal, workspace cells only (session cells have no button to show)
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let hoverTrackingArea { removeTrackingArea(hoverTrackingArea); self.hoverTrackingArea = nil }
+        guard addButton != nil else { return }
+        let area = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect],
+            owner: self
+        )
+        addTrackingArea(area)
+        hoverTrackingArea = area
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        super.mouseEntered(with: event)
+        setAddButtonVisible(true)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        super.mouseExited(with: event)
+        setAddButtonVisible(false)
+    }
+
     /// Color the row text/icon from the terminal theme: a selected row pairs with the selection
     /// foreground (over the selection-background pill the row draws), or white over the soft wash when
     /// the theme exposes no selection color; an unselected row uses the theme foreground, icons dimmed.

--- a/agterm/Views/SidebarRowViews.swift
+++ b/agterm/Views/SidebarRowViews.swift
@@ -14,6 +14,11 @@ final class SidebarCellView: NSTableCellView {
     /// Hidden on `.idle` (workspace rows always idle for now).
     let statusIcon = StatusIconView()
 
+    /// Inline "+" button between the name and the status icon, present only on workspace cells.
+    /// Nil for session cells. Set by the cell builder and used by `handleSingleClick` to guard
+    /// against toggling expansion when the click lands on this button.
+    var addButton: NSButton?
+
     /// Color the row text/icon from the terminal theme: a selected row pairs with the selection
     /// foreground (over the selection-background pill the row draws), or white over the soft wash when
     /// the theme exposes no selection color; an unselected row uses the theme foreground, icons dimmed.
@@ -26,7 +31,9 @@ final class SidebarCellView: NSTableCellView {
             ? (app.terminalSelectionForegroundColor ?? .white)
             : (app.terminalForegroundColor ?? .labelColor)
         textField?.textColor = color
-        imageView?.contentTintColor = color.withAlphaComponent(selected ? 0.85 : 0.6)
+        let iconAlpha: CGFloat = selected ? 0.85 : 0.6
+        imageView?.contentTintColor = color.withAlphaComponent(iconAlpha)
+        addButton?.contentTintColor = color.withAlphaComponent(iconAlpha)
     }
 }
 

--- a/agterm/Views/WorkspaceSidebar+ContextMenu.swift
+++ b/agterm/Views/WorkspaceSidebar+ContextMenu.swift
@@ -16,10 +16,14 @@ extension WorkspaceSidebar.Coordinator {
     @objc func handleSingleClick(_ sender: NSOutlineView) {
         let row = sender.clickedRow
         guard row >= 0, let node = sender.item(atRow: row) as? SidebarNode, node.kind == .workspace else { return }
-        // clicking the disclosure triangle already toggles natively — ignore that region so we don't double-toggle.
         if let event = NSApp.currentEvent {
             let point = sender.convert(event.locationInWindow, from: nil)
+            // clicking the disclosure triangle already toggles natively — ignore that region so we don't double-toggle.
             if point.x < sender.frameOfOutlineCell(atRow: row).maxX { return }
+            // clicking the inline "+" button is handled by the button itself — don't schedule the toggle.
+            if let cell = sender.view(atColumn: 0, row: row, makeIfNecessary: false) as? SidebarCellView,
+               let btn = cell.addButton,
+               btn.convert(btn.bounds, to: sender).contains(point) { return }
         }
         pendingRowToggle?.cancel()
         let toggle = DispatchWorkItem { [weak self, weak node] in
@@ -190,6 +194,19 @@ extension WorkspaceSidebar.Coordinator {
         guard let node = sender.representedObject as? SidebarNode else { return }
         // resolve the cwd via the same new-session-directory setting as AppActions.newSession(), so the
         // workspace-row New Session honors it too (home / current session's cwd / a fixed custom dir).
+        addSession(toWorkspace: node.id, cwd: actions.resolvedNewSessionCwd())
+    }
+
+    /// Inline "+" button on a workspace row — same action as the right-click "New Session" menu item.
+    /// The button carries no workspace id; we derive it from the outline row at click time so reused
+    /// cells always target the correct workspace.
+    @objc func addSessionButtonClicked(_ sender: NSButton) {
+        // cancel any pending single-click workspace toggle so clicking "+" doesn't also flip expansion.
+        pendingRowToggle?.cancel()
+        pendingRowToggle = nil
+        guard let outline = outlineView else { return }
+        let row = outline.row(for: sender)
+        guard row >= 0, let node = outline.item(atRow: row) as? SidebarNode, node.kind == .workspace else { return }
         addSession(toWorkspace: node.id, cwd: actions.resolvedNewSessionCwd())
     }
 

--- a/agterm/Views/WorkspaceSidebar+RowRendering.swift
+++ b/agterm/Views/WorkspaceSidebar+RowRendering.swift
@@ -37,9 +37,10 @@ extension WorkspaceSidebar.Coordinator {
         field.isEditable = false
         field.isBordered = false
         field.drawsBackground = false
-        // a recycled cell may carry the prior row's badge/status; reset before use
+        // a recycled cell may carry the prior row's badge/status/hover state; reset before use
         applyBadge(toCell: cell, count: 0)
         cell.statusIcon.apply(AgentIndicator())
+        cell.setAddButtonVisible(false)
         switch node.kind {
         case .workspace:
             let workspace = store.workspaces.first(where: { $0.id == node.id })
@@ -107,8 +108,10 @@ extension WorkspaceSidebar.Coordinator {
     /// the icon and badge stay whole.
     ///
     /// Workspace cells additionally get an inline "+" button (`cell.addButton`) between the name
-    /// and the status icon — clicking it adds a new session to that workspace via
-    /// `addSessionButtonClicked`, the same path as the right-click "New Session" menu item.
+    /// and the status icon, revealed only while the pointer hovers the row (the Finder/Xcode
+    /// convention; see `SidebarCellView.setAddButtonVisible`) — clicking it adds a new session to
+    /// that workspace via `addSessionButtonClicked`, the same path as the right-click "New Session"
+    /// menu item.
     private func makeCell(identifier: NSUserInterfaceItemIdentifier) -> SidebarCellView {
         let cell = SidebarCellView()
         cell.identifier = identifier
@@ -169,11 +172,17 @@ extension WorkspaceSidebar.Coordinator {
             let addBtn = makeAddSessionButton()
             cell.addSubview(addBtn)
             cell.addButton = addBtn
+            // hover-revealed: starts hidden at zero width (setAddButtonVisible toggles the width
+            // constraint, like StatusIconView), so an idle row's name gets the same -6 trailing
+            // margin a session row has and the roll-up badge keeps its slot uncontested.
+            let width = addBtn.widthAnchor.constraint(equalToConstant: 0)
+            cell.addButtonWidthConstraint = width
+            addBtn.isHidden = true
             constraints += [
-                field.trailingAnchor.constraint(equalTo: addBtn.leadingAnchor, constant: -4),
-                addBtn.trailingAnchor.constraint(equalTo: statusIcon.leadingAnchor, constant: -4),
+                field.trailingAnchor.constraint(equalTo: addBtn.leadingAnchor, constant: -6),
+                addBtn.trailingAnchor.constraint(equalTo: statusIcon.leadingAnchor),
                 addBtn.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
-                addBtn.widthAnchor.constraint(equalToConstant: 16),
+                width,
                 addBtn.heightAnchor.constraint(equalToConstant: 16),
             ]
         } else {

--- a/agterm/Views/WorkspaceSidebar+RowRendering.swift
+++ b/agterm/Views/WorkspaceSidebar+RowRendering.swift
@@ -105,9 +105,14 @@ extension WorkspaceSidebar.Coordinator {
     /// `beginEditing`), and a trailing notification badge. The name hugs and resists compression
     /// weakly while the icon and badge hug and resist strongly, so the name truncates first and
     /// the icon and badge stay whole.
+    ///
+    /// Workspace cells additionally get an inline "+" button (`cell.addButton`) between the name
+    /// and the status icon — clicking it adds a new session to that workspace via
+    /// `addSessionButtonClicked`, the same path as the right-click "New Session" menu item.
     private func makeCell(identifier: NSUserInterfaceItemIdentifier) -> SidebarCellView {
         let cell = SidebarCellView()
         cell.identifier = identifier
+        let isWorkspace = identifier.rawValue == "workspace-cell"
 
         let icon = NSImageView()
         icon.translatesAutoresizingMaskIntoConstraints = false
@@ -142,16 +147,15 @@ extension WorkspaceSidebar.Coordinator {
         badge.setContentCompressionResistancePriority(.required, for: .horizontal)
         cell.addSubview(badge)
 
-        NSLayoutConstraint.activate([
+        var constraints: [NSLayoutConstraint] = [
             icon.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 2),
             icon.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
             icon.widthAnchor.constraint(equalToConstant: 16),
             icon.heightAnchor.constraint(equalToConstant: 16),
             field.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 6),
             field.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
-            // chain: name (flex) | status icon | badge (trailing). the status icon and badge hug
-            // their content, so the name truncates first and both stay whole.
-            field.trailingAnchor.constraint(equalTo: statusIcon.leadingAnchor, constant: -6),
+            // chain: name (flex) | [+ button for workspace] | status icon | badge (trailing).
+            // the status icon and badge hug their content, so the name truncates first and both stay whole.
             statusIcon.trailingAnchor.constraint(equalTo: badge.leadingAnchor),
             statusIcon.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
             // width is owned by StatusIconView (0 when idle, glyph-width otherwise) so an idle row
@@ -159,8 +163,44 @@ extension WorkspaceSidebar.Coordinator {
             statusIcon.heightAnchor.constraint(equalToConstant: 16),
             badge.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -2),
             badge.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
-        ])
+        ]
+
+        if isWorkspace {
+            let addBtn = makeAddSessionButton()
+            cell.addSubview(addBtn)
+            cell.addButton = addBtn
+            constraints += [
+                field.trailingAnchor.constraint(equalTo: addBtn.leadingAnchor, constant: -4),
+                addBtn.trailingAnchor.constraint(equalTo: statusIcon.leadingAnchor, constant: -4),
+                addBtn.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+                addBtn.widthAnchor.constraint(equalToConstant: 16),
+                addBtn.heightAnchor.constraint(equalToConstant: 16),
+            ]
+        } else {
+            constraints.append(field.trailingAnchor.constraint(equalTo: statusIcon.leadingAnchor, constant: -6))
+        }
+
+        NSLayoutConstraint.activate(constraints)
         return cell
+    }
+
+    private func makeAddSessionButton() -> NSButton {
+        let btn = NSButton()
+        btn.translatesAutoresizingMaskIntoConstraints = false
+        btn.isBordered = false
+        let config = NSImage.SymbolConfiguration(pointSize: 11, weight: .regular)
+        btn.image = NSImage(systemSymbolName: "plus", accessibilityDescription: "New Session")?
+            .withSymbolConfiguration(config)
+        btn.image?.isTemplate = true
+        btn.imageScaling = .scaleProportionallyUpOrDown
+        btn.contentTintColor = .secondaryLabelColor
+        btn.setContentHuggingPriority(.required, for: .horizontal)
+        btn.setContentCompressionResistancePriority(.required, for: .horizontal)
+        btn.setAccessibilityIdentifier("workspace-add-session")
+        btn.setAccessibilityLabel("New Session")
+        btn.target = self
+        btn.action = #selector(addSessionButtonClicked(_:))
+        return btn
     }
 
     /// The row's label: the session `displayName` in tree mode, or `session : workspace` (the session

--- a/agtermUITests/SidebarUITests.swift
+++ b/agtermUITests/SidebarUITests.swift
@@ -384,11 +384,21 @@ final class SidebarUITests: XCTestCase {
     }
 
     /// The inline "+" button on a workspace row adds a session to that workspace —
-    /// the same action as right-click "New Session" on the row.
+    /// the same action as right-click "New Session" on the row. The button is hover-revealed
+    /// (hidden at zero width on an idle row), so the row must be hovered before it is hittable.
     func testInlineAddSessionButtonCreatesSession() throws {
         XCTAssertTrue(sessionRow().waitForExistence(timeout: 20), "seeded session should exist")
+        let ws = app.staticTexts["workspace 1"]
+        XCTAssertTrue(ws.waitForExistence(timeout: 5), "seeded workspace should exist")
         let addBtn = app.descendants(matching: .any).matching(identifier: "workspace-add-session").firstMatch
-        XCTAssertTrue(addBtn.waitForExistence(timeout: 5), "workspace row should show an inline '+' button")
+        // hover the row to reveal the button; retry — the first synthesized move can land before
+        // the window is key, and .activeInKeyWindow tracking swallows it.
+        let deadline = Date().addingTimeInterval(8)
+        while !addBtn.isHittable, Date() < deadline {
+            ws.hover()
+            usleep(200_000)
+        }
+        XCTAssertTrue(addBtn.isHittable, "hovering the workspace row should reveal the inline '+' button")
         addBtn.click()
         XCTAssertTrue(pollSessionCount(workspace: "workspace 1", expected: 2, timeout: 5),
                       "workspace 1 should have 2 sessions after clicking the inline '+' button")

--- a/agtermUITests/SidebarUITests.swift
+++ b/agtermUITests/SidebarUITests.swift
@@ -383,6 +383,17 @@ final class SidebarUITests: XCTestCase {
                       "workspace 1 should have 2 sessions after add-session -> New Session")
     }
 
+    /// The inline "+" button on a workspace row adds a session to that workspace —
+    /// the same action as right-click "New Session" on the row.
+    func testInlineAddSessionButtonCreatesSession() throws {
+        XCTAssertTrue(sessionRow().waitForExistence(timeout: 20), "seeded session should exist")
+        let addBtn = app.descendants(matching: .any).matching(identifier: "workspace-add-session").firstMatch
+        XCTAssertTrue(addBtn.waitForExistence(timeout: 5), "workspace row should show an inline '+' button")
+        addBtn.click()
+        XCTAssertTrue(pollSessionCount(workspace: "workspace 1", expected: 2, timeout: 5),
+                      "workspace 1 should have 2 sessions after clicking the inline '+' button")
+    }
+
     // Verifies the "Open Directory…" wiring: the menu item presents the native
     // folder picker. (The picker is system UI; choosing a directory and the
     // resulting addSession(cwd:) are covered at the model level by AppStoreTests.)


### PR DESCRIPTION
## Summary

Currently there is no single-click way to start a new session in a workspace — the only options are the bottom-bar menu (two clicks: open menu → New Session) or the right-click context menu (two clicks: right-click row → New Session). This adds a `+` button directly on each workspace row so a new session is one click away.

- Adds a small `+` button to the trailing edge of each workspace row in the sidebar, between the workspace name and the status/badge area
- Clicking it creates a new session in that workspace — identical to right-click → New Session, using the same `addSession(toWorkspace:cwd:)` path including the new-session-directory setting
- Guards `handleSingleClick` so clicking `+` never also triggers the expand/collapse toggle; `addSessionButtonClicked` additionally cancels any pending deferred toggle
- Button tint tracks the row's theme color (selected vs unselected) via `setColors`

## Test plan

- [x] Build succeeds (`make build`)
- [x] SwiftLint clean (`make lint`)
- [x] `SidebarUITests/testInlineAddSessionButtonCreatesSession` passes — clicks the inline button, verifies workspace gains a second session
- [ ] Manual: click `+` on a workspace row → new session appears and is selected
- [ ] Manual: button tint matches row text color on selection and theme changes

<img width="1012" height="712" alt="Screenshot 2026-07-17 at 13 22 58" src="https://github.com/user-attachments/assets/5b67d741-ed1e-4240-b472-e5b63285d681" />
