### PR TITLE
feat: open a terminal at a folder with open -a agterm <path>

### DIFF
--- a/.claude/rules/windows.md
+++ b/.claude/rules/windows.md
@@ -256,4 +256,41 @@ never two bundles in one window.
   is matched across ALL open stores (`resolveTargetAcrossWindows`) and mapped back to its owning `AppStore`.
   See the Control API section for the catalog and the keep-in-sync four-point audit (all eight window
   commands satisfy it).
+- **`open -a agterm /path` (the OS "open terminal here" integration — Discussion #230) is WARM-ONLY on purpose.**
+  `AppDelegate.application(_:open:)` resolves each URL to a directory (host-free `OpenPathResolver`:
+  a folder → itself, a file → its parent, nil for a non-file / missing path), queues it in
+  `pendingOpenDirectories`, and `drainPendingOpenDirectories` grafts a session into the last-active window
+  via `AppActions.openSession(atDirectory:)` (which mirrors `newSession()` — note-activity + select +
+  focus — but seeds the cwd from the path and targets `library.activeStore`, the SAME window the control
+  channel's `session.new` defaults to).
+  The drain gates on `library.activeStore?.currentWorkspaceID != nil` and retries on a bounded 0.1 s
+  backoff (dropping the queue after 50 ticks so a stray folder can't wedge a timer); the scene `.task`
+  hands the delegate `actions` and calls the drain once, and `application(_:open:)` calls it inline for
+  the running instance.
+  `CFBundleDocumentTypes`/`LSItemContentTypes = public.folder` (role Viewer) in `Info.plist` is what puts
+  agterm in Finder's right-click **Open With ▸ agterm** for folders; it is NOT required for `open -a`
+  routing (odoc delivers the folder either way) — only for the Finder listing.
+  **The COLD case (agterm NOT running) is deliberately unsupported and flashes-then-quits, and this is a
+  hard SwiftUI-`WindowGroup` limitation, not a missing feature — do NOT re-attempt an in-process fix.**
+  On a cold `open -a agterm /path` (an `odoc` AppleEvent) SwiftUI auto-opens the `WindowGroup` window,
+  lets it FULLY initialize (it adopts a launch id, runs the scene `.task`, starts the control server,
+  runs `consumeReopen()` so `hasReopened` is already true), then RETRACTS the un-presented window
+  (SwiftUI's "don't keep an untitled window on a document launch" behavior) BEFORE delivering the open
+  event — and macOS then reaps the windowless odoc process (verified: `applicationShouldTerminateAfterLastWindowClosed`
+  returning `false` does NOT stop it, and no `applicationWillTerminate` fires).
+  This was proven NOT to be the deployed daily-driver twin (a fully-independent bundle id fails
+  identically) and is NOT fixable by the reference tricks: a forced `NSWorkspace.open` reopen never gets a
+  window-less moment and the claim queue strays the re-presented window (`adoptedLaunchID` is stuck +
+  `hasReopened` true); `applicationShouldOpenUntitledFile`/`applicationShouldHandleReopen` are never even
+  consulted on odoc; and `WindowGroup.defaultLaunchBehavior(.presented)` (the intended API) is macOS 15+
+  while the floor is macOS 14 and `SceneBuilder` rejects `if #available`.
+  The reference terminals confirm the shape: AppKit ones (Ghostty, iTerm, kitty, conterm) create
+  `NSWindow`s manually and never hit the retract; the SwiftUI-`WindowGroup` one that ships folder-open
+  (Muxy) routes it through its OWN CLI (socket when warm, argv/`oapp` when cold), never odoc.
+  The ONLY clean cold path is a relaunch (odoc → `oapp`), deliberately NOT taken (a double-launch flicker
+  for the rare not-running case; agterm is a daily driver, so warm covers ~all real use).
+  KEEP-IN-SYNC EXEMPT: `openSession(atDirectory:)` is the OS-`open` entry point onto a capability the
+  socket ALREADY exposes (`session.new --cwd <path>`, frontmost-defaulted), so it needs no new `Command`
+  case / `agtermctl` subcommand / `commands.html` entry — call it out as the exemption it is, like
+  `reveal`.
 

--- a/.claude/rules/windows.md
+++ b/.claude/rules/windows.md
@@ -267,6 +267,9 @@ never two bundles in one window.
   backoff (dropping the queue after 50 ticks so a stray folder can't wedge a timer); the scene `.task`
   hands the delegate `actions` and calls the drain once, and `application(_:open:)` calls it inline for
   the running instance.
+  After a session lands it `WindowRegistry.raise`s `library.activeWindowID` (deminiaturize + make-key) so
+  an "open here" into a MINIMIZED last-active window is actually visible — `NSApp.activate()` alone only
+  brings the app forward and would leave the window in the Dock; a no-op for an already-frontmost window.
   `CFBundleDocumentTypes`/`LSItemContentTypes = public.folder` (role Viewer) in `Info.plist` is what puts
   agterm in Finder's right-click **Open With ▸ agterm** for folders; it is NOT required for `open -a`
   routing (odoc delivers the folder either way) — only for the Finder listing.

--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ The theme picker (View ▸ Select Theme…, or the action palette) previews each
 
 `agterm` can be driven from a script over a local unix-domain socket through a companion CLI, `agtermctl`. This is for personal scripting — fire-and-forget commands that manage workspaces and sessions, inject text, and invoke control actions. There is no terminal-output streaming and no event subscription.
 
+To open a terminal at a directory without the CLI, `open -a agterm <path>` — or right-click a folder in Finder and choose **Open With ▸ agterm**. agterm adds a session in that directory to the last-active window. This works when agterm is already running (its usual state); if it isn't, launch agterm first, then run the command. The socket equivalent, and the way to place the session precisely, is `agtermctl session new --cwd <path>`.
+
 The sections below cover the common cases. All 61 commands, with every argument, return value, and error, are documented in the **[Command reference](https://agterm.com/commands)**.
 
 The app bundles `agtermctl` inside `agterm.app`. The easiest way to put it on your PATH is **Help ▸ Install Command Line Tool…**, which symlinks the bundled binary into `/usr/local/bin` (the first entry in macOS's default PATH). When that directory is user-writable it installs silently; otherwise it asks once for an administrator password.

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -158,6 +158,27 @@ final class AppActions {
         focusActiveSession()
     }
 
+    /// Opens a new session at `directory` in the last-active window — the target of `open -a agterm /path`
+    /// (the OS "open terminal here" integration). Mirrors `newSession()`
+    /// (note-activity + select + focus) but seeds the cwd from the passed directory instead of the
+    /// new-session-directory setting. Resolves `library.activeStore` (the frontmost/last-active window,
+    /// the same target the control channel's `session.new` defaults to), so it is NOT gated on
+    /// `uiActionsEnabled` — an external OS command, like a socket command, must land regardless of a
+    /// modal zoom/dashboard. Returns whether a session was created, so the delegate's cold-start drain
+    /// can retry until restore has settled the frontmost store.
+    @discardableResult
+    func openSession(atDirectory directory: String) -> Bool {
+        guard let store, let workspaceID = store.currentWorkspaceID,
+              let session = store.addSession(toWorkspace: workspaceID, cwd: directory)
+        else { return false }
+        // creating + selecting a session is a user-initiated selection: note activity so it buys the full
+        // idle grace before auto-follow can pull the selection away from the just-made session.
+        store.noteUserActivity()
+        store.selectSession(session.id)
+        focusActiveSession()
+        return true
+    }
+
     /// Duplicates a session — a fresh shell in the source's directory, placed right after it. Scoped to the
     /// caller's store (like the other sidebar row actions) so a background window's context menu acts on its
     /// own row, not the frontmost store's session. `AppStore.duplicateSession` carries the directory-only

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -164,9 +164,8 @@ final class AppActions {
     /// new-session-directory setting. Resolves `library.activeStore` (the frontmost/last-active window,
     /// the same target the control channel's `session.new` defaults to), so it is NOT gated on
     /// `uiActionsEnabled` — an external OS command, like a socket command, must land regardless of a
-    /// modal zoom/dashboard. Returns whether a session was created, so the delegate's cold-start drain
-    /// can retry until restore has settled the frontmost store.
-    @discardableResult
+    /// modal zoom/dashboard. Returns whether a session was created, so the delegate's drain can retry
+    /// until the frontmost store resolves.
     func openSession(atDirectory directory: String) -> Bool {
         guard let store, let workspaceID = store.currentWorkspaceID,
               let session = store.addSession(toWorkspace: workspaceID, cwd: directory)

--- a/agterm/AppDelegate.swift
+++ b/agterm/AppDelegate.swift
@@ -99,7 +99,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `OpenPathResolver`), which is queued and drained into a new session in the last-active window.
     /// This serves the WARM case — agterm already running (its daily-driver norm) — where the running
     /// instance has a window and grafts the session immediately.
-    func application(_ application: NSApplication, open urls: [URL]) {
+    func application(_: NSApplication, open urls: [URL]) {
         let directories = urls.compactMap { OpenPathResolver.directory(for: $0) }
         guard !directories.isEmpty else { return }
         pendingOpenDirectories.append(contentsOf: directories)
@@ -120,8 +120,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
         NSApp.activate()
+        let beforeCount = pendingOpenDirectories.count
         while let directory = pendingOpenDirectories.first, actions.openSession(atDirectory: directory) {
             pendingOpenDirectories.removeFirst()
+        }
+        // raise/deminiaturize the window the session landed in — `NSApp.activate()` only brings the app
+        // forward, so an "open terminal here" into a minimized last-active window would otherwise leave it
+        // in the Dock and show nothing. `WindowRegistry.raise` deminiaturizes + makes key; a no-op for an
+        // already-frontmost window. Only when a session actually landed.
+        if pendingOpenDirectories.count < beforeCount, let windowID = library?.activeWindowID {
+            WindowRegistry.shared.raise(windowID)
         }
         if !pendingOpenDirectories.isEmpty, retry < 50 {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
@@ -289,11 +297,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_: NSApplication) -> Bool {
-        // keep the app alive while an `open -a agterm /path` is still pending: on a COLD document launch
-        // SwiftUI discards the un-presented launch window, which trips last-window-closed before the drain's
-        // forced reopen can present a window and graft the session. Checked first (and independent of
-        // `library`, which the scene `.task` hasn't wired yet on that path). A plain launch never has a
-        // pending queue, and once the drain empties it normal quit semantics resume.
         // key termination off the model open-set, NOT AppKit's transient window count: closing one
         // window (or a re-render that briefly drops the surviving NSWindow) can leave a momentary
         // zero-window state while the library still has an open window, and quitting there would kill

--- a/agterm/AppDelegate.swift
+++ b/agterm/AppDelegate.swift
@@ -19,6 +19,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// debounced `settings.json` writes (opacity/blur, theme preview) on terminate.
     var settingsModel: SettingsModel?
 
+    /// The action hub, handed over once the scene appears so `application(_:open:)` can open a session at
+    /// a folder path passed by `open -a agterm /path`. Nil before the scene `.task` runs.
+    var actions: AppActions?
+
+    /// Directories requested via `open -a agterm /path` (the OS "open terminal here" integration) that
+    /// haven't become sessions yet — queued until the frontmost window's store resolves, so a `session
+    /// new`-style graft lands in the last-active window.
+    private var pendingOpenDirectories: [String] = []
+
     private var restoreObserver: NSObjectProtocol?
     private var scheduledReconciliationReasons: Set<String> = []
 
@@ -81,6 +90,42 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             guard let submenu = topItem.submenu else { continue }
             for item in submenu.items where item.action == selector {
                 submenu.removeItem(item)
+            }
+        }
+    }
+
+    /// `open -a agterm /path` (the OS "open terminal here" integration): macOS delivers the folder/file
+    /// URLs here. Each resolves to a directory (a folder → itself, a file → its parent, via the host-free
+    /// `OpenPathResolver`), which is queued and drained into a new session in the last-active window.
+    /// This serves the WARM case — agterm already running (its daily-driver norm) — where the running
+    /// instance has a window and grafts the session immediately.
+    func application(_ application: NSApplication, open urls: [URL]) {
+        let directories = urls.compactMap { OpenPathResolver.directory(for: $0) }
+        guard !directories.isEmpty else { return }
+        pendingOpenDirectories.append(contentsOf: directories)
+        drainPendingOpenDirectories()
+    }
+
+    /// Turn every queued `open -a` directory into a new session in the last-active window, one at a time,
+    /// dropping each entry only after its session lands (a transient failure keeps it queued). No-op when
+    /// the queue is empty. When the frontmost store isn't resolvable yet it retries on a 0.1 s backoff,
+    /// giving up after a bounded number of ticks so a folder can't wedge a stuck timer.
+    func drainPendingOpenDirectories(retry: Int = 0) {
+        guard !pendingOpenDirectories.isEmpty else { return }
+        guard let actions, library?.activeStore?.currentWorkspaceID != nil else {
+            guard retry < 50 else { pendingOpenDirectories.removeAll(); return }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+                self?.drainPendingOpenDirectories(retry: retry + 1)
+            }
+            return
+        }
+        NSApp.activate()
+        while let directory = pendingOpenDirectories.first, actions.openSession(atDirectory: directory) {
+            pendingOpenDirectories.removeFirst()
+        }
+        if !pendingOpenDirectories.isEmpty, retry < 50 {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+                self?.drainPendingOpenDirectories(retry: retry + 1)
             }
         }
     }
@@ -244,6 +289,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_: NSApplication) -> Bool {
+        // keep the app alive while an `open -a agterm /path` is still pending: on a COLD document launch
+        // SwiftUI discards the un-presented launch window, which trips last-window-closed before the drain's
+        // forced reopen can present a window and graft the session. Checked first (and independent of
+        // `library`, which the scene `.task` hasn't wired yet on that path). A plain launch never has a
+        // pending queue, and once the drain empties it normal quit semantics resume.
         // key termination off the model open-set, NOT AppKit's transient window count: closing one
         // window (or a re-render that briefly drops the surviving NSWindow) can leave a momentary
         // zero-window state while the library still has an open window, and quitting there would kill

--- a/agterm/Info.plist
+++ b/agterm/Info.plist
@@ -36,5 +36,18 @@
 	<string>© 2026 Umputun</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Command-line tools you run inside agterm (for example, voice dictation in Claude Code) request microphone access through agterm.</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Folder</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.folder</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -113,8 +113,8 @@ struct agtermApp: App {
                     // remove the monitor on terminate.
                     appDelegate.customCommandRunner = customCommandRunner
                     appDelegate.settingsModel = settingsModel
-                    // hand the delegate the action hub and drain any folders queued by a cold-launch
-                    // `open -a agterm /path` now that a window store can resolve.
+                    // hand the delegate the action hub and drain any folders an `open -a agterm /path`
+                    // queued before the window store resolved.
                     appDelegate.actions = actions
                     appDelegate.drainPendingOpenDirectories()
                     customCommandRunner.start()

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -113,6 +113,10 @@ struct agtermApp: App {
                     // remove the monitor on terminate.
                     appDelegate.customCommandRunner = customCommandRunner
                     appDelegate.settingsModel = settingsModel
+                    // hand the delegate the action hub and drain any folders queued by a cold-launch
+                    // `open -a agterm /path` now that a window store can resolve.
+                    appDelegate.actions = actions
+                    appDelegate.drainPendingOpenDirectories()
                     customCommandRunner.start()
                     // wire the keymap + runner into the action hub so the command palette can list the
                     // custom commands and run them (both are built after `actions`, so they're set here

--- a/agtermCore/Sources/agtermCore/OpenPathResolver.swift
+++ b/agtermCore/Sources/agtermCore/OpenPathResolver.swift
@@ -5,10 +5,10 @@ import Foundation
 /// else its parent directory when it is an existing file. Returns nil for a non-file URL or a path that
 /// does not exist, so the caller opens no stray session.
 public enum OpenPathResolver {
-    public static func directory(for url: URL, fileManager: FileManager = .default) -> String? {
+    public static func directory(for url: URL) -> String? {
         guard url.isFileURL else { return nil }
         var isDirectory: ObjCBool = false
-        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) else { return nil }
+        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) else { return nil }
         return isDirectory.boolValue ? url.path : url.deletingLastPathComponent().path
     }
 }

--- a/agtermCore/Sources/agtermCore/OpenPathResolver.swift
+++ b/agtermCore/Sources/agtermCore/OpenPathResolver.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Resolves a filesystem URL handed to the app by `open -a agterm <path>` (the OS "open terminal here"
+/// integration) to the directory a new session should start in: the path itself when it is a directory,
+/// else its parent directory when it is an existing file. Returns nil for a non-file URL or a path that
+/// does not exist, so the caller opens no stray session.
+public enum OpenPathResolver {
+    public static func directory(for url: URL, fileManager: FileManager = .default) -> String? {
+        guard url.isFileURL else { return nil }
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) else { return nil }
+        return isDirectory.boolValue ? url.path : url.deletingLastPathComponent().path
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/OpenPathResolverTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/OpenPathResolverTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+struct OpenPathResolverTests {
+    @Test func directoryReturnsItself() throws {
+        let dir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        #expect(OpenPathResolver.directory(for: dir) == dir.path)
+    }
+
+    @Test func fileReturnsParentDirectory() throws {
+        let dir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("note.txt")
+        try Data().write(to: file)
+        #expect(OpenPathResolver.directory(for: file) == dir.path)
+    }
+
+    @Test func nonexistentPathReturnsNil() throws {
+        let dir = try makeTempDirectory()
+        try FileManager.default.removeItem(at: dir)
+        #expect(OpenPathResolver.directory(for: dir) == nil)
+    }
+
+    @Test func nonFileURLReturnsNil() throws {
+        let url = try #require(URL(string: "https://example.com/tmp"))
+        #expect(OpenPathResolver.directory(for: url) == nil)
+    }
+
+    private func makeTempDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("open-path-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}

--- a/site/docs.html
+++ b/site/docs.html
@@ -1139,6 +1139,14 @@
               no output streaming and no event subscription.
             </p>
             <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 16px">
+              To open a terminal at a directory without the CLI,
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #e6e1d7">open -a agterm &lt;path&gt;</span> — or
+              right-click a folder in Finder and choose <strong style="color: #e6e1d7">Open With ▸ agterm</strong>. agterm adds a
+              session in that directory to the last-active window. This works when agterm is already running (its usual state); if it
+              isn't, launch agterm first, then run the command. The socket equivalent, and the way to place the session precisely, is
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl session new --cwd &lt;path&gt;</span>.
+            </p>
+            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 16px">
               Each command targets a session or workspace by its UUID, a unique prefix of that UUID (git-style), or the keyword
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">active</span> (the selected session /
               current workspace). <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--target</span>


### PR DESCRIPTION
`open -a agterm <path>`, or right-click a folder in Finder and choose **Open With ▸ agterm**, now adds a terminal session in that directory to the last-active window when agterm is already running. Addresses the "open terminal here" request in discussion #230.

`AppDelegate.application(_:open:)` receives the folder/file URLs, the host-free `OpenPathResolver` maps each to a directory (a folder to itself, a file to its parent), and the drain grafts a session into `library.activeStore` (the frontmost window, the same target `session.new` defaults to), then raises/deminiaturizes that window so the terminal is visible even if it was minimized. `CFBundleDocumentTypes` (`public.folder`) registers the Finder Open-With listing. Session creation reuses the existing `AppActions` seam, so it stays a thin OS-open adapter onto a capability the socket already exposes (`session.new --cwd`), and no new control command is owed.

*Warm-only by design.* This works when agterm is already running, which is its daily-driver norm. A cold `open -a agterm <path>` with agterm not running is deliberately unsupported: a plain SwiftUI `WindowGroup` retracts its window on a document launch and macOS reaps the process, a limitation the reference terminals sidestep via AppKit or their own CLI. The reasoning and the ruled-out approaches are recorded in `.claude/rules/windows.md` so it isn't re-chased.

Host-free path resolution is unit-tested; the AppKit open handler is manually verified per convention. Docs updated in README, the docs site, and the windows rule.
