### PR TITLE
feat: session.new --no-select for background session creation

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -455,12 +455,26 @@ paths:
   The fix is an absolute path or a LOGIN-shell wrapper (`zsh -lc '…'`); a plain `sh -c` gets shell
   operators but NOT the login PATH, so the overlay's built-in `sh -c` wrapper does not by itself solve it
   (the bundled agent-skill documents this caveat on the three `--command`/overlay entries).
+  `args.noSelect` (the CLI's `--no-select`) creates the session in the BACKGROUND — `makeSessionResponse`
+  passes `select: !noSelect` to `AppStore.addSession` (which gates `selectedSessionID`/`autoUnfocusIfOutsideFocus`/`recordRecency`
+  on `select`) AND suppresses the `focusActiveSession()` call, so the current selection and focus are left
+  untouched.
+  It is the inverse of the overlay's `--follow` (overlay opens in the background by default and opts INTO
+  selecting; `session.new` selects by default and opts OUT), and like `--follow` it rides the existing
+  command as a new optional ARG — NO new `Command` case.
+  It is state-mutating-with-read-back EXEMPT: `--no-select` is a creation-time behavior, not queryable
+  per-session state, and the read-back is the EXISTING `tree` `active` flag (the new node is not `active`),
+  so no new `ControlSessionNode` field is owed.
+  Do NOT overload the existing `ControlArgs.select` (that is `session.type --select`, opposite polarity) —
+  `noSelect` is its own opt-in-true bool, mirroring `createWorkspace`/`follow`.
   Keep-in-sync: the `.sessionNew` case carries `ControlArgs.command` plus `ControlArgs.name` (custom
-  name) and `ControlArgs.workspaceName` + `ControlArgs.createWorkspace` (name-addressing + ensure);
+  name) and `ControlArgs.workspaceName` + `ControlArgs.createWorkspace` (name-addressing + ensure) +
+  `ControlArgs.noSelect` (threaded into `ControlSessionCreateOptions.noSelect`);
   the arm pre-validates the mutual-exclusion / create-needs-name rules and shares `makeSessionResponse`
-  across the id- and name-addressed paths; the `session new` CLI carries `--command`/`--name`/`--workspace-name`/`--create-workspace`
-  (the last two also `validate()`-guarded); and round-trip + e2e (`testSessionNewWithCommandRunsAsProcess`,
-  `testSessionNewWithName`, `testSessionNewWorkspaceNameCreatesThenReuses`) cover them.
+  across the id- and name-addressed paths; the `session new` CLI carries `--command`/`--name`/`--workspace-name`/`--create-workspace`/`--no-select`
+  (the two workspace flags also `validate()`-guarded); and round-trip + e2e (`testSessionNewWithCommandRunsAsProcess`,
+  `testSessionNewWithName`, `testSessionNewWorkspaceNameCreatesThenReuses`, `testSessionNewNoSelectKeepsActiveSelection`)
+  cover them.
   `session.duplicate` (target = session) creates a fresh session in the SAME workspace as the target,
   inserted directly AFTER it, rooted at the target's focused-pane cwd (`Session.focusedCwd` — the live
   OSC 7 directory the sidebar row shows and `session.reveal` opens), then selects + focuses it and returns

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -459,6 +459,11 @@ paths:
   passes `select: !noSelect` to `AppStore.addSession` (which gates `selectedSessionID`/`autoUnfocusIfOutsideFocus`/`recordRecency`
   on `select`) AND suppresses the `focusActiveSession()` call, so the current selection and focus are left
   untouched.
+  It ALSO threads through the workspace-focus filter: the `--create-workspace` path calls
+  `store.ensureWorkspace(named:, clearFocus: !options.noSelect)`, and `AppStore.addWorkspace`/`ensureWorkspace`
+  gained a `clearFocus: Bool = true` parameter gating the `focusedWorkspaceID = nil` auto-reveal — so a
+  `--no-select --create-workspace` create does NOT drop a focused workspace (all GUI/other `addWorkspace`
+  callers keep the default `clearFocus: true`, unchanged).
   It is the inverse of the overlay's `--follow` (overlay opens in the background by default and opts INTO
   selecting; `session.new` selects by default and opts OUT), and like `--follow` it rides the existing
   command as a new optional ARG — NO new `Command` case.

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ agtermctl session new --command "sh -c 'clear; ssh user@host'"  # --command is a
 agtermctl session new --name "myhost" --command "ssh user@host"  # pre-name the session (sidebar label set at creation)
 agtermctl session new --workspace-name servers --create-workspace --name "myhost"  # open in the "servers" workspace, creating it if absent (idempotent)
 agtermctl session new --after active             # create right after the current session (--before to precede it); the anchor's workspace is used
+agtermctl session new --cwd ~/src/agterm --no-select  # create in the background without switching to it (the current session stays active)
 agtermctl session duplicate --target 9f3c        # a second plain shell in that session's workspace and cwd, right after it (only the directory carries over)
 agtermctl session type --target 9f3c $'make test\n'      # inject text into a session by id prefix
 echo 'make test' | agtermctl session type --target active --stdin

--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -120,8 +120,10 @@ extension ControlServer: ControlActions {
                 guard !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                     return ControlResponse(ok: false, error: "workspace name must not be blank")
                 }
+                // a --no-select create must not clear the workspace-focus filter (addWorkspace's auto-reveal),
+                // so the background create leaves the current view untouched like the rest of --no-select.
                 let workspace = options.createWorkspace == true
-                    ? store.ensureWorkspace(named: name)
+                    ? store.ensureWorkspace(named: name, clearFocus: !options.noSelect)
                     : store.workspace(named: name)
                 guard let workspace else {
                     return ControlResponse(ok: false, error: "no workspace named \"\(name)\" (pass --create-workspace to add it)")

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -561,15 +561,18 @@ final class ControlServer {
     /// optional command/name), focuses it when it lands in the frontmost window (so a keymap `session new`
     /// opens focused like the GUI New Session; a background `--window` target keeps focus), and returns the
     /// new id. Shared by the id- and name-addressed paths of the `.sessionNew` arm. `at` is the anchor-relative
-    /// insertion slot for `--after`/`--before` (clamped in `AppStore`); nil appends.
+    /// insertion slot for `--after`/`--before` (clamped in `AppStore`); nil appends. With `options.noSelect`
+    /// the session is created in the background — `addSession` skips selecting it and the focus call is
+    /// suppressed, leaving the current selection and focus untouched.
     func makeSessionResponse(in store: AppStore, workspaceID: UUID,
                              options: ControlSessionCreateOptions, at index: Int? = nil) -> ControlResponse {
         let cwd = options.cwd ?? FileManager.default.homeDirectoryForCurrentUser.path
         guard let session = store.addSession(toWorkspace: workspaceID, cwd: cwd,
-                                             command: options.command, name: options.name, at: index) else {
+                                             command: options.command, name: options.name, at: index,
+                                             select: !options.noSelect) else {
             return ControlResponse(ok: false, error: "could not create session")
         }
-        if store === library.activeStore { actions.focusActiveSession() }
+        if !options.noSelect, store === library.activeStore { actions.focusActiveSession() }
         return ControlResponse(ok: true, result: ControlResult(id: session.id.uuidString))
     }
 

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -157,7 +157,7 @@ applied to the cells, omitted when untouched), and `dashboardFontMode` (`auto`|`
 focused from the tree workspace node's `focused` flag).
 
 **session**
-- `new [--cwd DIR] [--workspace W] [--workspace-name NAME] [--create-workspace] [--command CMD] [--name NAME] [--after SID | --before SID]` —
+- `new [--cwd DIR] [--workspace W] [--workspace-name NAME] [--create-workspace] [--command CMD] [--name NAME] [--after SID | --before SID] [--no-select]` —
   create (and focus) a session. Target the workspace by id/prefix (`--workspace`) OR by name
   (`--workspace-name`, mutually exclusive); add `--create-workspace` to reuse-or-create the named
   workspace when absent. `--command` runs that program as the session process instead of a login shell
@@ -166,7 +166,9 @@ focused from the tree workspace node's `focused` flag).
   `--name` seeds the sidebar label (default: the auto basename). `--after`/`--before` place it directly
   after/before an anchor session (id/prefix/`active`) instead of appending — the anchor carries its own
   workspace, so it's mutually exclusive with `--workspace`/`--workspace-name`. `new --after active` =
-  create right after the current session.
+  create right after the current session. `--no-select` creates the session in the BACKGROUND — it is
+  added to the sidebar but NOT selected or focused, leaving the current selection untouched (the new node
+  is not `active` in `tree`); omit it for the default select-and-focus behavior.
 - `duplicate [--target]` — create a fresh session (a plain login shell) in the target's workspace, right
   after it, rooted at the target's focused-pane cwd; selects + focuses it and returns the new id. ONLY the
   directory carries over — no custom name, command, split, scratch, status, flag, font size, or background.

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -59,6 +59,14 @@ duplicate "servers" workspace on repeated calls):
 agtermctl session new --workspace-name servers --create-workspace --name "myhost" --command "ssh user@host"
 ```
 
+Create a session in the background — do NOT switch to it. The current selection and keyboard focus stay
+put; the new session appears in the sidebar but is not `active` in `tree` (the read-back). It is the
+inverse of the overlay's `--follow`:
+
+```bash
+agtermctl session new --cwd "$HOME/project" --no-select
+```
+
 ## Duplicate a session (a second shell in the same directory)
 
 `session duplicate` creates a fresh session — a plain login shell — in the SAME workspace as the target,

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -148,7 +148,9 @@ All ten are read-only projections of GUI state.
   right after the current session in one round-trip. `--no-select` creates the session in the BACKGROUND:
   it is added to the sidebar but NOT selected or focused, so the current selection and focus are left
   untouched (the new node is not `active` in `tree` — that flag is the read-back); omit it for the default
-  select-and-focus behavior. Every other addressing/placement option composes with it.
+  select-and-focus behavior. Every other addressing/placement option composes with it, and a background
+  `--create-workspace` create does not clear a focused-workspace filter either (it leaves the sidebar view
+  put instead of revealing the new workspace).
 - `session duplicate [--target] [--window W]` — create a fresh session in the SAME workspace as the
   target, inserted directly AFTER it, rooted at the target's focused-pane working directory (the live
   OSC 7 cwd the sidebar row shows and `session reveal` opens); selects + focuses the new session and

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -123,7 +123,7 @@ All ten are read-only projections of GUI state.
 
 ## session
 
-- `session new [--cwd DIR] [--workspace W] [--workspace-name NAME] [--create-workspace] [--command CMD] [--name NAME] [--after SID | --before SID] [--window W]`
+- `session new [--cwd DIR] [--workspace W] [--workspace-name NAME] [--create-workspace] [--command CMD] [--name NAME] [--after SID | --before SID] [--no-select] [--window W]`
   — create a session and focus it; returns the new id. `--cwd` sets the start directory (default
   `$HOME`). The destination workspace is addressed one of two mutually-exclusive ways: `--workspace`
   (id / unique prefix / `active`, the default) or `--workspace-name` (the sidebar label) — the latter
@@ -145,7 +145,10 @@ All ten are read-only projections of GUI state.
   across all workspaces), so it names the destination workspace itself — `--after`/`--before` are
   therefore mutually exclusive with each other and with `--workspace`/`--workspace-name` (the anchor
   already picks the workspace). `agtermctl session new --after active` is the headline case: create
-  right after the current session in one round-trip.
+  right after the current session in one round-trip. `--no-select` creates the session in the BACKGROUND:
+  it is added to the sidebar but NOT selected or focused, so the current selection and focus are left
+  untouched (the new node is not `active` in `tree` — that flag is the read-back); omit it for the default
+  select-and-focus behavior. Every other addressing/placement option composes with it.
 - `session duplicate [--target] [--window W]` — create a fresh session in the SAME workspace as the
   target, inserted directly AFTER it, rooted at the target's focused-pane working directory (the live
   OSC 7 cwd the sidebar row shows and `session reveal` opens); selects + focuses the new session and

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -238,15 +238,15 @@ public final class AppStore {
                            dashboardFontMode: dashboardFontMode())
     }
 
-    /// Creates a workspace and appends it. Clears any active focus so the new (empty)
-    /// workspace is immediately visible — without this `visibleWorkspaces` would still
-    /// return only the focused one and the new workspace would be silently hidden until
-    /// the user manually unfocuses (the same auto-reveal contract as `addSession`).
+    /// Creates a workspace and appends it. When `clearFocus` (the default) it clears any active focus so
+    /// the new (empty) workspace is immediately visible — else `visibleWorkspaces` returns only the
+    /// focused one and the new workspace is silently hidden (the auto-reveal contract, like `addSession`).
+    /// Pass `clearFocus: false` to keep the current focus — a background `session.new --no-select` create.
     @discardableResult
-    public func addWorkspace(name: String) -> Workspace {
+    public func addWorkspace(name: String, clearFocus: Bool = true) -> Workspace {
         let workspace = Workspace(name: name)
         workspaces.append(workspace)
-        focusedWorkspaceID = nil
+        if clearFocus { focusedWorkspaceID = nil }
         save()
         return workspace
     }
@@ -259,12 +259,12 @@ public final class AppStore {
         return workspaces.first { $0.name == needle }
     }
 
-    /// The workspace named `name`, created if none exists (idempotent reuse-or-create). Returns nil only
-    /// when `name` is blank. Backs `session.new --workspace-name … --create-workspace`.
+    /// The workspace named `name`, created if none exists (idempotent); `clearFocus` (default true) is
+    /// forwarded to `addWorkspace` on the create path. Nil only when blank. Backs `--workspace-name --create-workspace`.
     @discardableResult
-    public func ensureWorkspace(named name: String) -> Workspace? {
+    public func ensureWorkspace(named name: String, clearFocus: Bool = true) -> Workspace? {
         guard let needle = name.trimmedOrNil else { return nil }
-        return workspace(named: needle) ?? addWorkspace(name: needle)
+        return workspace(named: needle) ?? addWorkspace(name: needle, clearFocus: clearFocus)
     }
 
     /// Creates a session in the given workspace and, when `select` is true (the default), selects it;

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -274,7 +274,7 @@ public final class AppStore {
     /// workspace matches.
     @discardableResult
     public func addSession(toWorkspace workspaceID: UUID, cwd: String, command: String? = nil,
-                           name: String? = nil, at index: Int? = nil) -> Session? {
+                           name: String? = nil, at index: Int? = nil, select: Bool = true) -> Session? {
         guard let wsIndex = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return nil }
         let session = Session(initialCwd: cwd, customName: name?.trimmedOrNil)
         session.initialCommand = command
@@ -284,9 +284,12 @@ public final class AppStore {
         } else {
             workspaces[wsIndex].sessions.append(session)
         }
-        selectedSessionID = session.id
-        autoUnfocusIfOutsideFocus(session.id) // a control-driven add into another workspace must reveal it
-        recordRecency()
+        // a background add (`session.new --no-select`) leaves selection/focus/recency untouched.
+        if select {
+            selectedSessionID = session.id
+            autoUnfocusIfOutsideFocus(session.id) // a control-driven add into another workspace must reveal it
+            recordRecency()
+        }
         save()
         return session
     }

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -267,11 +267,11 @@ public final class AppStore {
         return workspace(named: needle) ?? addWorkspace(name: needle)
     }
 
-    /// Creates a session in the given workspace and selects it. An optional `name` seeds the session's
-    /// `customName` (trimmed; blank clears it to the auto basename, matching `renameSession`). With `at`
-    /// nil the session is appended (the default); with `at` set it is inserted at the clamped index
-    /// (`0...count`), backing the control `session.new --after`/`--before` placement. Returns nil if no
-    /// workspace matches.
+    /// Creates a session in the given workspace and, when `select` is true (the default), selects it;
+    /// `select: false` appends it in the background, leaving selection/focus/recency untouched (backs
+    /// `session.new --no-select`). An optional `name` seeds `customName` (trimmed; blank = the auto
+    /// basename, matching `renameSession`). `at` nil appends (default); `at` set inserts at the clamped
+    /// index (`0...count`), backing `session.new --after`/`--before`. Returns nil if no workspace matches.
     @discardableResult
     public func addSession(toWorkspace workspaceID: UUID, cwd: String, command: String? = nil,
                            name: String? = nil, at index: Int? = nil, select: Bool = true) -> Session? {

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -191,7 +191,8 @@ public struct ControlDispatcher {
                 command: args?.command,
                 name: args?.name,
                 after: args?.after,
-                before: args?.before
+                before: args?.before,
+                noSelect: args?.noSelect == true
             ))
         case .sessionDuplicate:
             // no options: the source session names its own workspace AND its cwd, so a duplicate is fully

--- a/agtermCore/Sources/agtermCore/ControlModes.swift
+++ b/agtermCore/Sources/agtermCore/ControlModes.swift
@@ -95,10 +95,13 @@ public struct ControlSessionCreateOptions: Equatable, Sendable {
     public let after: String?
     /// Anchor session to place the new session right BEFORE, the mirror of `after`.
     public let before: String?
+    /// Create the session in the background: skip selecting and focusing it, leaving the current selection
+    /// untouched (the CLI's `--no-select`). Defaults to false — the normal select-and-focus behavior.
+    public let noSelect: Bool
 
     public init(window: String?, cwd: String?, workspace: String?, workspaceName: String?,
                 createWorkspace: Bool?, command: String?, name: String?,
-                after: String? = nil, before: String? = nil) {
+                after: String? = nil, before: String? = nil, noSelect: Bool = false) {
         self.window = window
         self.cwd = cwd
         self.workspace = workspace
@@ -108,6 +111,7 @@ public struct ControlSessionCreateOptions: Equatable, Sendable {
         self.name = name
         self.after = after
         self.before = before
+        self.noSelect = noSelect
     }
 }
 

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -95,6 +95,11 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     /// For `session.new` with `workspaceName`: create the named workspace when none exists (idempotent
     /// reuse-or-create). An error without `workspaceName` — there is nothing to create by id.
     public var createWorkspace: Bool?
+    /// For `session.new`: create the session in the background without selecting or focusing it, leaving
+    /// the current selection untouched (the CLI's `--no-select`). Omitted/`false` keeps the default
+    /// select-and-focus behavior. The read-back is the existing `tree` `active` flag — the new node is not
+    /// `active`.
+    public var noSelect: Bool?
     /// Text to inject for `session.type` / `quick.type`; the search needle for `session.search`.
     public var text: String?
     /// Whether `session.type` may select a never-shown session to realize its surface.
@@ -222,7 +227,7 @@ public struct ControlArgs: Codable, Sendable, Equatable {
 
     public init(name: String? = nil, cwd: String? = nil, targets: [String]? = nil,
                 workspace: String? = nil, workspaceName: String? = nil,
-                createWorkspace: Bool? = nil, text: String? = nil, select: Bool? = nil, mode: String? = nil,
+                createWorkspace: Bool? = nil, noSelect: Bool? = nil, text: String? = nil, select: Bool? = nil, mode: String? = nil,
                 command: String? = nil, wait: Bool? = nil, sizePercent: Int? = nil, full: Bool? = nil,
                 follow: Bool? = nil, window: String? = nil,
                 pane: String? = nil, paneID: String? = nil, to: String? = nil,
@@ -241,6 +246,7 @@ public struct ControlArgs: Codable, Sendable, Equatable {
         self.workspace = workspace
         self.workspaceName = workspaceName
         self.createWorkspace = createWorkspace
+        self.noSelect = noSelect
         self.text = text
         self.select = select
         self.mode = mode

--- a/agtermCore/Sources/agtermctlKit/SessionCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/SessionCommands.swift
@@ -34,6 +34,7 @@ struct Session: ParsableCommand {
         @Option(name: .long, help: "Initial session name (defaults to the auto basename).") var name: String?
         @Option(name: .long, help: "Place the new session right AFTER this anchor session (id/prefix/active); the anchor carries its own workspace, replacing --workspace.") var after: String?
         @Option(name: .long, help: "Place the new session right BEFORE this anchor session (id/prefix/active); mirror of --after.") var before: String?
+        @Flag(name: .long, help: "Create the session in the background without selecting or focusing it (leaves the current selection untouched).") var noSelect = false
         @OptionGroup var options: ClientOptions
         var echoesResultID: Bool { true }
 
@@ -56,8 +57,8 @@ struct Session: ParsableCommand {
         func makeRequest() throws -> ControlRequest {
             ControlRequest(cmd: .sessionNew, args: options.withWindow(
                 ControlArgs(name: name, cwd: cwd, workspace: workspace, workspaceName: workspaceName,
-                            createWorkspace: createWorkspace ? true : nil, command: command,
-                            after: after, before: before)))
+                            createWorkspace: createWorkspace ? true : nil, noSelect: noSelect ? true : nil,
+                            command: command, after: after, before: before)))
         }
     }
 

--- a/agtermCore/Tests/agtermCoreTests/AppStoreOrganizationTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreOrganizationTests.swift
@@ -200,6 +200,26 @@ struct AppStoreOrganizationTests {
         #expect(store.focusedWorkspaceID == nil)
     }
 
+    @Test func ensureWorkspaceClearFocusFalsePreservesFocusOnCreate() {
+        let store = makeStore()
+        let ws1 = store.addWorkspace(name: "one")
+        store.setFocusedWorkspace(ws1.id)
+        #expect(store.focusedWorkspaceID == ws1.id)
+        // a normal create clears focus so the new workspace is revealed (addWorkspace auto-reveal contract).
+        _ = store.addWorkspace(name: "two")
+        #expect(store.focusedWorkspaceID == nil)
+        // re-focus, then a background create (clearFocus: false, backing session.new --no-select
+        // --create-workspace) leaves the focus filter untouched.
+        store.setFocusedWorkspace(ws1.id)
+        let created = store.ensureWorkspace(named: "bg", clearFocus: false)
+        #expect(created != nil)
+        #expect(store.focusedWorkspaceID == ws1.id)
+        // reusing an existing workspace never touches focus regardless of clearFocus.
+        let reused = store.ensureWorkspace(named: "bg", clearFocus: true)
+        #expect(reused?.id == created?.id)
+        #expect(store.focusedWorkspaceID == ws1.id)
+    }
+
     @Test func removeFocusedWorkspaceClearsFocus() {
         let store = makeStore()
         let work = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -64,6 +64,20 @@ struct AppStoreTests {
         #expect(store.activeSession?.id == unwrapped.id)
     }
 
+    @Test func addSessionWithoutSelectLeavesSelectionUntouched() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let first = try! #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        #expect(store.selectedSessionID == first.id)
+        // a background add (control `session.new --no-select`) appends the session but keeps the current
+        // selection and recency, so `active` still points at the first session.
+        let background = try! #require(store.addSession(toWorkspace: ws.id, cwd: "/b", select: false))
+        #expect(store.workspaces[0].sessions.map(\.id) == [first.id, background.id])
+        #expect(store.selectedSessionID == first.id)
+        #expect(store.activeSession?.id == first.id)
+        #expect(store.sessionRecency.items == [first.id]) // the background add was not recorded
+    }
+
     @Test func addSessionCarriesInitialCommand() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -110,6 +110,21 @@ struct ControlDispatcherTests {
         #expect(actions.calls == [.sessionNew(options)])
     }
 
+    @Test func sessionNewRoutesNoSelect() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextSessionNewResponse = ControlResponse(ok: true, result: ControlResult(id: "bg-session"))
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionNew, args: ControlArgs(noSelect: true)
+        ))
+
+        let options = ControlSessionCreateOptions(window: nil, cwd: nil, workspace: nil, workspaceName: nil,
+                                                  createWorkspace: nil, command: nil, name: nil, noSelect: true)
+        #expect(response == ControlResponse(ok: true, result: ControlResult(id: "bg-session")))
+        #expect(actions.calls == [.sessionNew(options)])
+    }
+
     @Test func sessionNewRejectsAmbiguousWorkspaceArguments() async {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -37,6 +37,7 @@ struct ControlProtocolTests {
             ControlRequest(cmd: .sessionNew, args: ControlArgs(cwd: "/tmp", command: "ssh host -p 22")),
             ControlRequest(cmd: .sessionNew, args: ControlArgs(name: "myhost", command: "ssh host")),
             ControlRequest(cmd: .sessionNew, args: ControlArgs(workspaceName: "servers", createWorkspace: true)),
+            ControlRequest(cmd: .sessionNew, args: ControlArgs(noSelect: true)),
             ControlRequest(cmd: .sessionDuplicate, target: "9f3c"),
             ControlRequest(cmd: .sessionDuplicate, target: "active", args: ControlArgs(window: "win")),
             ControlRequest(cmd: .sessionClose, target: "9f3c"),

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -88,6 +88,12 @@ struct CommandsTests {
         #expect(try request(["session", "new", "--workspace-name", "servers", "--create-workspace"]) == expected)
     }
 
+    @Test func sessionNewWithNoSelect() throws {
+        // --no-select sets noSelect=true on the wire (omitted when the flag is absent).
+        let expected = ControlRequest(cmd: .sessionNew, args: ControlArgs(noSelect: true))
+        #expect(try request(["session", "new", "--no-select"]) == expected)
+    }
+
     @Test func sessionNewRejectsWorkspaceAndWorkspaceName() {
         // both addressing modes set — validate() rejects it before any request is built.
         #expect(validationMessage(["session", "new", "--workspace", "active", "--workspace-name", "servers"])

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -517,6 +517,31 @@ final class ControlAPIUITests: ControlAPITestCase {
                       "a blank name should report must-not-be-blank, not suggest --create-workspace: \(blank)")
     }
 
+    // session.new --no-select creates the session in the background: it is added (a second row appears and
+    // the returned id resolves in the tree) but the ORIGINAL session stays active, so the read-back `active`
+    // flag confirms the selection was not pulled to the new one.
+    func testSessionNewNoSelectKeepsActiveSelection() throws {
+        let original = try activeSessionID()
+
+        let created = try sendCommand(#"{"cmd":"session.new","args":{"noSelect":true}}"#)
+        XCTAssertEqual(created["ok"] as? Bool, true, "session.new --no-select should succeed: \(created)")
+        let newID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "session.new should return an id")
+        XCTAssertNotEqual(newID.lowercased(), original.lowercased(), "the background session should be a new session")
+
+        // poll until the new session appears, then assert the ORIGINAL is still active and the new one is not.
+        var confirmed = false
+        for _ in 0..<20 {
+            let tree = try sendCommand(#"{"cmd":"tree"}"#)
+            if let newNode = sessionNode(tree, id: newID), let oldNode = sessionNode(tree, id: original),
+               oldNode["active"] as? Bool == true, newNode["active"] as? Bool == false {
+                confirmed = true
+                break
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+        }
+        XCTAssertTrue(confirmed, "the new session should exist while the original stays active (not the new one)")
+    }
+
     // workspace.new returns an id and the workspace appears; workspace.rename is reflected in json.
     func testWorkspaceNewAndRename() throws {
         let created = try sendCommand(#"{"cmd":"workspace.new","args":{"name":"control ws"}}"#)

--- a/agtermUITests/ControlSidebarStatusUITests.swift
+++ b/agtermUITests/ControlSidebarStatusUITests.swift
@@ -168,6 +168,29 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         XCTAssertTrue((bad["error"] as? String ?? "").contains("invalid focus mode"), "should report invalid mode: \(bad)")
     }
 
+    // --no-select --create-workspace preserves the workspace-focus filter. A plain --create-workspace clears
+    // focusedWorkspaceID (addWorkspace's auto-reveal); --no-select threads clearFocus:false so a background
+    // create leaves the focused workspace (and the current session selection) untouched.
+    func testSessionNewNoSelectCreateWorkspacePreservesFocus() throws {
+        XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 10), "seeded session row")
+
+        let tree = try sendCommand(#"{"cmd":"tree"}"#)
+        let workspaces = try XCTUnwrap(((tree["result"] as? [String: Any])?["tree"] as? [String: Any])?["workspaces"] as? [[String: Any]],
+                                       "tree should carry workspaces")
+        let firstWsID = try XCTUnwrap(workspaces.first?["id"] as? String, "seeded workspace id")
+
+        // focus the seeded workspace.
+        XCTAssertEqual(try sendCommand(#"{"cmd":"workspace.focus","target":"\#(firstWsID)","args":{"mode":"on"}}"#)["ok"] as? Bool,
+                       true, "workspace.focus on should succeed")
+        XCTAssertTrue(workspaceFocused(firstWsID, timeout: 5), "the seeded workspace should be focused")
+
+        // background-create a session in a brand-new workspace: the focus filter must survive.
+        let created = try sendCommand(#"{"cmd":"session.new","args":{"workspaceName":"bg","createWorkspace":true,"noSelect":true}}"#)
+        XCTAssertEqual(created["ok"] as? Bool, true, "background create-workspace should succeed: \(created)")
+        XCTAssertTrue(workspaceFocused(firstWsID, timeout: 5),
+                      "--no-select --create-workspace must preserve the focused workspace (not clear it via auto-reveal)")
+    }
+
     // sidebar.collapse collapses every workspace except the active session's — the others' session rows
     // leave the AX tree while the active workspace's stay; sidebar.expand re-expands every workspace and
     // restores them.
@@ -632,6 +655,20 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
             }
         }
         return nil
+    }
+
+    // whether the workspace with `id` reports focused:true in the current tree (omitted/nil = not focused).
+    private func workspaceFocused(_ id: String, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if let result = (try? sendCommand(#"{"cmd":"tree"}"#))?["result"] as? [String: Any],
+               let root = result["tree"] as? [String: Any],
+               let workspaces = root["workspaces"] as? [[String: Any]],
+               let ws = workspaces.first(where: { ($0["id"] as? String)?.lowercased() == id.lowercased() }),
+               ws["focused"] as? Bool == true { return true }
+            usleep(200_000)
+        } while Date() < deadline
+        return false
     }
 
     // notify posts a banner for the active session; a missing body errors.

--- a/site/commands.html
+++ b/site/commands.html
@@ -574,7 +574,7 @@
             <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
                 agtermctl session new [--cwd DIR] [--workspace W | --workspace-name NAME [--create-workspace]] [--command CMD]
-                [--name NAME] [--after SID | --before SID] [--window W]
+                [--name NAME] [--after SID | --before SID] [--no-select] [--window W]
               </div>
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">session.new</div>
               <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
@@ -613,6 +613,13 @@
                 fails with exit 127. Use an absolute path, or wrap it:
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #f2b45c; white-space: nowrap">--command "zsh -lc 'htop'"</span>. The
                 command is persisted and re-runs on restore when <em>Restore running commands on restart</em> is enabled.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--no-select</span> creates the session in the
+                background: it is added to the sidebar but not selected or focused, leaving the current selection untouched (the
+                new node is not <span style="font-family: &quot;JetBrains Mono&quot;, monospace">active</span> in
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">tree</span> — that flag is the read-back). Omit it
+                for the default select-and-focus behavior.
               </p>
             </div>
 

--- a/site/docs.html
+++ b/site/docs.html
@@ -1205,6 +1205,8 @@
               <span style="color: #f2b45c">"$ws"</span> <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;&nbsp;# relocate to a workspace</span
               ><br />agtermctl session new --after active
               <span style="color: #6b727a">&nbsp;&nbsp;# create right after the current session (--before to precede)</span
+              ><br />agtermctl session new --cwd ~/src/agterm --no-select
+              <span style="color: #6b727a">&nbsp;&nbsp;# create in the background without switching to it</span
               ><br />agtermctl session duplicate --target <span style="color: #f2b45c">9f3c</span>
               <span style="color: #6b727a">&nbsp;&nbsp;# a fresh shell in that session's workspace and cwd, right after it</span><br />agtermctl session move --after
               <span style="color: #f2b45c">9f3c</span> <span style="color: #6b727a">&nbsp;&nbsp;# place after an anchor (its workspace is used; relocates cross-workspace)</span


### PR DESCRIPTION
Adds an opt-in `--no-select` flag to `session.new` (agtermctl + the control protocol) that creates a session in the background without selecting or focusing it, so the current selection and focus stay put. It is the inverse of the overlay's `--follow`: overlay opens in the background and opts into focusing, while `session.new` selects by default and opts out. The default (select + focus) is unchanged.

**Implementation.** A new opt-in `ControlArgs.noSelect` / `ControlSessionCreateOptions.noSelect`, kept separate from the existing `select` arg (which is `session.type --select`). `AppStore.addSession` gained a `select: Bool = true` parameter that gates `selectedSessionID` / `autoUnfocusIfOutsideFocus` / `recordRecency`, and `makeSessionResponse` passes `select: !noSelect` and skips the focus call. No new `Command` case, so the catalog stays at 61. The read-back is the existing `tree` `active` flag: a background session is not `active`.

**Workspace focus.** The `--create-workspace` case also keeps the workspace-focus filter. A background create threads `clearFocus: !noSelect` through `ensureWorkspace` / `addWorkspace` (a defaulted parameter, so the GUI and every other caller keep the auto-reveal), so `--no-select --create-workspace` no longer drops a focused workspace.

Tests: protocol round-trip, dispatcher, CLI parse, and AppStore unit tests, plus e2e for the background create and the workspace-focus preservation. Docs updated across the agent skill, `site/commands.html`, `site/docs.html`, README, and the control-api rule.
