### PR TITLE
feat: hold a command session open after its command exits

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ ws=$(agtermctl workspace new work)               # create a workspace, capture i
 agtermctl session new --workspace "$ws" --cwd ~/src/agterm  # open a session in it, print its id
 agtermctl session new --command "ssh user@host"  # run a command as the session's process (like kitty launch; no typed command, closes on exit)
 agtermctl session new --command "sh -c 'clear; ssh user@host'"  # --command is argv-style (no shell); wrap in sh -c for ;, $VAR, redirects
+agtermctl session new --command "zsh -lc 'make test'" --wait  # hold the session open after the command exits (press any key to close) so its final output stays readable; --wait needs --command
 agtermctl session new --name "myhost" --command "ssh user@host"  # pre-name the session (sidebar label set at creation)
 agtermctl session new --workspace-name servers --create-workspace --name "myhost"  # open in the "servers" workspace, creating it if absent (idempotent)
 agtermctl session new --after active             # create right after the current session (--before to precede it); the anchor's workspace is used

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -568,8 +568,8 @@ final class ControlServer {
                              options: ControlSessionCreateOptions, at index: Int? = nil) -> ControlResponse {
         let cwd = options.cwd ?? FileManager.default.homeDirectoryForCurrentUser.path
         guard let session = store.addSession(toWorkspace: workspaceID, cwd: cwd,
-                                             command: options.command, name: options.name, at: index,
-                                             select: !options.noSelect) else {
+                                             command: options.command, name: options.name,
+                                             wait: options.wait ?? false, at: index, select: !options.noSelect) else {
             return ControlResponse(ok: false, error: "could not create session")
         }
         if !options.noSelect, store === library.activeStore { actions.focusActiveSession() }

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -135,7 +135,9 @@ unset or idle), `statusBlink`/`statusColor` (the status glyph's `--blink` flag a
 override from `session status`, omitted when idle / not blinking / default color), `background` (the background
 spec — image/text watermark or solid color — set via `session background`, omitted when none — the read side of set/clear),
 `unseen` (the unseen-notification badge count — raised by `notify`/OSC 9/777, cleared by `session
-seen` — omitted when zero), `overlaySizePercent` (an open overlay's floating-panel percent 1–100,
+seen` — omitted when zero), `commandWait` (whether a `--command` session was created with `--wait` to
+hold open after the command exits — the read side of `session new --wait`, omitted for a plain or
+non-holding session), `overlaySizePercent` (an open overlay's floating-panel percent 1–100,
 omitted for a full-pane overlay or no overlay so gate on `overlay` first; the read side of `overlay
 resize` for a record-then-restore zoom), `splitRatio` (the left-pane divider fraction 0.05–0.95 of a
 session that has a split — shown or hidden; omitted when there's no split or the ratio was never set (at
@@ -157,12 +159,15 @@ applied to the cells, omitted when untouched), and `dashboardFontMode` (`auto`|`
 focused from the tree workspace node's `focused` flag).
 
 **session**
-- `new [--cwd DIR] [--workspace W] [--workspace-name NAME] [--create-workspace] [--command CMD] [--name NAME] [--after SID | --before SID] [--no-select]` —
+- `new [--cwd DIR] [--workspace W] [--workspace-name NAME] [--create-workspace] [--command CMD] [--wait] [--name NAME] [--after SID | --before SID] [--no-select]` —
   create (and focus) a session. Target the workspace by id/prefix (`--workspace`) OR by name
   (`--workspace-name`, mutually exclusive); add `--create-workspace` to reuse-or-create the named
   workspace when absent. `--command` runs that program as the session process instead of a login shell
   (argv-only, and with the app's GUI `PATH` — a Homebrew/non-default binary needs an absolute path or a
   `zsh -lc '…'` wrapper, else exit 127; same caveat for `scratch --command` and `overlay open` below);
+  `--wait` (with `--command`, else an error) HOLDS the session open after the command exits, showing the
+  press-any-key prompt with the final output intact instead of closing (persists across restart, unlike an
+  overlay's live-only wait; read back on `tree`'s `commandWait`);
   `--name` seeds the sidebar label (default: the auto basename). `--after`/`--before` place it directly
   after/before an anchor session (id/prefix/`active`) instead of appending — the anchor carries its own
   workspace, so it's mutually exclusive with `--workspace`/`--workspace-name`. `new --after active` =

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -44,6 +44,7 @@ Run a command AS the session's process (closes when it exits, no echoed command 
 ```bash
 agtermctl session new --command "ssh host -p 22"     # a default-PATH binary: argv-split (quotes respected), no shell, no echo
 agtermctl session new --command "zsh -lc 'htop'"     # Homebrew/non-default binary: --command has the app's GUI PATH, so wrap in a login shell (or use an absolute path); bare "htop" exits 127
+agtermctl session new --command "zsh -lc 'make test'" --wait   # HOLD the row open after the command exits (press any key to close) so its final output stays readable; --wait needs --command
 ```
 
 Create a session pre-named (label set at creation, no follow-up rename):

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -47,7 +47,10 @@ default 0.5) — the read side
 of `session resize`, record it to restore the exact divider position),
 `splitFocused` (which pane holds focus in a session that HAS a split — `true` = the split/right pane,
 `false` = the main/left pane; omitted when there's no split; the read side of `session focus`, record it
-to restore focus via `session focus --pane left|right`), `overlay` (overlay shown),
+to restore focus via `session focus --pane left|right`),
+`commandWait` (whether a `--command` session was created with `--wait` to hold open after the command
+exits — the read side of `session new --wait`; omitted for a plain or non-holding session),
+`overlay` (overlay shown),
 `overlaySizePercent` (an open overlay's size — the
 floating panel's percent of the pane, 1–100; omitted = a full-pane overlay or no overlay, so gate on
 `overlay` first; the read side of `session overlay resize`, e.g. record it before switching to `--full`
@@ -123,7 +126,7 @@ All ten are read-only projections of GUI state.
 
 ## session
 
-- `session new [--cwd DIR] [--workspace W] [--workspace-name NAME] [--create-workspace] [--command CMD] [--name NAME] [--after SID | --before SID] [--no-select] [--window W]`
+- `session new [--cwd DIR] [--workspace W] [--workspace-name NAME] [--create-workspace] [--command CMD] [--wait] [--name NAME] [--after SID | --before SID] [--no-select] [--window W]`
   — create a session and focus it; returns the new id. `--cwd` sets the start directory (default
   `$HOME`). The destination workspace is addressed one of two mutually-exclusive ways: `--workspace`
   (id / unique prefix / `active`, the default) or `--workspace-name` (the sidebar label) — the latter
@@ -135,6 +138,11 @@ All ten are read-only projections of GUI state.
   default — no `/opt/homebrew/bin`), so a bare Homebrew or other non-default binary fails with exit 127.
   Wrap in a login shell for both — `--command "zsh -lc 'htop'"` — or give an absolute path
   (`/opt/homebrew/bin/htop`).
+  `--wait` (only with `--command`, else an error) HOLDS the session open after the command exits —
+  showing libghostty's press-any-key prompt with the final output intact instead of closing immediately —
+  so you can read a build/test/deploy's final output or an early failure that would otherwise flash and
+  vanish. It persists across restart (unlike an overlay's live-only `--wait`), so a restored command
+  session that re-runs its command holds again; read it back on `tree`'s `commandWait`.
   The command is persisted (`SessionSnapshot.initialCommand`) and re-runs on restore when **Restore
   running commands on restart** is on (default off → a restored session is a plain shell); a live
   captured foreground takes precedence over it. `--name`

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -216,8 +216,8 @@ struct agtermApp: App {
                                               hadForeground: hadForeground, foregroundInput: restoreInput,
                                               initialCommand: session.initialCommand)
         let view = GhosttySurfaceView(workingDirectory: session.initialCwd, fontSize: session.fontSize.map(Float.init),
-                                      command: plan.command,
-                                      initialInput: plan.initialInput, env: env)
+                                      command: plan.command, initialInput: plan.initialInput,
+                                      waitAfterCommand: session.commandWait, env: env)
         view.session = session
         let sessionID = session.id
         view.onExit = { [weak view] in

--- a/agtermCore/Sources/agtermCore/AppStore+Panes.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Panes.swift
@@ -96,8 +96,10 @@ extension AppStore {
         session.splitFocused = false
         session.splitRatio = nil // promoted to a single pane; a later split should open even, not stale
         // the command pane is gone — the promoted survivor is a plain shell, so drop the creation command
-        // or a restart would resurrect the exited command instead of restoring the promoted shell.
+        // (and its held-open flag) together or a restart would resurrect the exited command instead of the
+        // promoted shell, and a snapshot would persist commandWait with no initialCommand.
         session.initialCommand = nil
+        session.commandWait = false
         // migrate the split pane's live/persisted metadata up to the session (main) fields, then clear the
         // now-meaningless split fields so nothing still describes a pane that no longer exists.
         // cwd prefers the split's live PWD, then its restore-seed (`initialSplitCwd`, set for a restored

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -212,6 +212,7 @@ public final class AppStore {
                                           overlay: session.overlayActive,
                                           overlaySizePercent: session.overlayActive ? session.overlaySizePercent : nil,
                                           scratch: session.scratchActive, flagged: session.flagged,
+                                          commandWait: (session.initialCommand != nil && session.commandWait) ? true : nil,
                                           foreground: foreground(session),
                                           splitForeground: splitForeground(session), status: status,
                                           statusPane: statusPane,
@@ -274,10 +275,11 @@ public final class AppStore {
     /// index (`0...count`), backing `session.new --after`/`--before`. Returns nil if no workspace matches.
     @discardableResult
     public func addSession(toWorkspace workspaceID: UUID, cwd: String, command: String? = nil,
-                           name: String? = nil, at index: Int? = nil, select: Bool = true) -> Session? {
+                           name: String? = nil, wait: Bool = false, at index: Int? = nil, select: Bool = true) -> Session? {
         guard let wsIndex = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return nil }
         let session = Session(initialCwd: cwd, customName: name?.trimmedOrNil)
         session.initialCommand = command
+        session.commandWait = wait
         if let index {
             let destination = max(0, min(index, workspaces[wsIndex].sessions.count))
             workspaces[wsIndex].sessions.insert(session, at: destination)
@@ -919,7 +921,7 @@ public final class AppStore {
                         flagged: session.flagged,
                         foregroundCommand: session.foregroundCommand,
                         splitForegroundCommand: session.splitForegroundCommand,
-                        initialCommand: session.initialCommand,
+                        initialCommand: session.initialCommand, commandWait: session.commandWait ? true : nil,
                         backgroundWatermark: session.backgroundWatermark)
     }
 
@@ -939,6 +941,7 @@ public final class AppStore {
         session.foregroundCommand = snapshot.foregroundCommand
         session.splitForegroundCommand = snapshot.splitForegroundCommand
         session.initialCommand = snapshot.initialCommand
+        session.commandWait = snapshot.commandWait ?? false
         session.wasRestored = true
         session.backgroundWatermark = snapshot.backgroundWatermark
         return session

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -182,6 +182,10 @@ public struct ControlDispatcher {
             if args?.createWorkspace == true, args?.workspaceName == nil {
                 return ControlResponse(ok: false, error: "--create-workspace requires --workspace-name")
             }
+            // --wait holds the surface after the command exits, so it is meaningless without a command.
+            if args?.wait == true, args?.command == nil {
+                return ControlResponse(ok: false, error: "--wait requires --command")
+            }
             return actions.createSession(ControlSessionCreateOptions(
                 window: args?.window,
                 cwd: args?.cwd,
@@ -189,6 +193,7 @@ public struct ControlDispatcher {
                 workspaceName: args?.workspaceName,
                 createWorkspace: args?.createWorkspace,
                 command: args?.command,
+                wait: args?.wait,
                 name: args?.name,
                 after: args?.after,
                 before: args?.before,

--- a/agtermCore/Sources/agtermCore/ControlModes.swift
+++ b/agtermCore/Sources/agtermCore/ControlModes.swift
@@ -89,6 +89,10 @@ public struct ControlSessionCreateOptions: Equatable, Sendable {
     public let workspaceName: String?
     public let createWorkspace: Bool?
     public let command: String?
+    /// Whether a `--command` session HOLDS its surface after the command exits (`--wait`) instead of
+    /// closing immediately. Meaningful only with `command`; the dispatcher rejects `--wait` without a
+    /// `--command`.
+    public let wait: Bool?
     public let name: String?
     /// Anchor session to place the new session right AFTER (id / prefix / `active`); the anchor carries
     /// its own workspace, so this bypasses `workspace`/`workspaceName`. Mutually exclusive with `before`.
@@ -100,7 +104,7 @@ public struct ControlSessionCreateOptions: Equatable, Sendable {
     public let noSelect: Bool
 
     public init(window: String?, cwd: String?, workspace: String?, workspaceName: String?,
-                createWorkspace: Bool?, command: String?, name: String?,
+                createWorkspace: Bool?, command: String?, wait: Bool? = nil, name: String?,
                 after: String? = nil, before: String? = nil, noSelect: Bool = false) {
         self.window = window
         self.cwd = cwd
@@ -108,6 +112,7 @@ public struct ControlSessionCreateOptions: Equatable, Sendable {
         self.workspaceName = workspaceName
         self.createWorkspace = createWorkspace
         self.command = command
+        self.wait = wait
         self.name = name
         self.after = after
         self.before = before

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -167,8 +167,9 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     public var body: String?
     /// The program the overlay terminal runs for `session.overlay.open` (e.g. `revdiff`).
     public var command: String?
-    /// Whether `session.overlay.open` keeps the overlay open after its command exits (showing the
-    /// "press any key to close" prompt) instead of closing immediately.
+    /// Whether a command surface keeps its "press any key to close" prompt after the command exits instead
+    /// of closing immediately: `session.overlay.open --wait` (the overlay) and `session.new --command …
+    /// --wait` (the primary session surface, held via `Session.commandWait`).
     public var wait: Bool?
     /// For `session.overlay.open`, the percent of the pane (1...100) a *floating* overlay panel
     /// occupies in both dimensions; omitted gives the default full-pane overlay. Also carries the new
@@ -355,6 +356,11 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
     public let overlaySizePercent: Int?
     public let scratch: Bool
     public let flagged: Bool
+    /// For a `--command` session, whether it was created to HOLD its surface after the command exits
+    /// (`session.new --command … --wait`) rather than closing immediately; nil/omitted for a plain session
+    /// or a non-holding command session. The read side of `session.new --wait`, so a script can record and
+    /// restore the flag (it persists across restart, unlike an overlay's live-only wait).
+    public let commandWait: Bool?
     /// The LIVE foreground process command (full argv) in the main pane, or nil when the pane is at its
     /// shell prompt (omitted from the JSON). The same capture the restore-running-command feature uses,
     /// surfaced for introspection ("what is each pane running").
@@ -401,6 +407,7 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
     public init(id: String, name: String, cwd: String, title: String? = nil, active: Bool, split: Bool,
                 splitRatio: Double? = nil, splitFocused: Bool? = nil,
                 overlay: Bool = false, overlaySizePercent: Int? = nil, scratch: Bool = false, flagged: Bool = false,
+                commandWait: Bool? = nil,
                 foreground: [String]? = nil, splitForeground: [String]? = nil, status: String? = nil,
                 statusPane: String? = nil, statusBlink: Bool? = nil, statusColor: String? = nil,
                 background: BackgroundWatermark? = nil, unseen: Int? = nil,
@@ -418,6 +425,7 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
         self.overlaySizePercent = overlaySizePercent
         self.scratch = scratch
         self.flagged = flagged
+        self.commandWait = commandWait
         self.foreground = foreground
         self.splitForeground = splitForeground
         self.status = status

--- a/agtermCore/Sources/agtermCore/Session.swift
+++ b/agtermCore/Sources/agtermCore/Session.swift
@@ -123,6 +123,15 @@ public final class Session: Identifiable {
     /// is gated by `restoreRunningCommand` (via `wasRestored`); a fresh session always runs it.
     @ObservationIgnored public var initialCommand: String?
 
+    /// Whether a `--command` session HOLDS its surface after the command exits (showing libghostty's
+    /// "press any key to close" prompt with the final output intact) instead of closing immediately, set
+    /// at creation via `session.new --command … --wait`. The same libghostty `wait_after_command` the
+    /// overlay's `overlayWait` uses, applied to the PRIMARY surface (`makeSurface` reads it). Meaningful
+    /// only with `initialCommand`; a plain shell has nothing to hold. `@ObservationIgnored`. Persisted via
+    /// `SessionSnapshot.commandWait` so a restored command session that re-runs its command holds again,
+    /// keeping the held/closed behavior consistent across restart.
+    @ObservationIgnored public var commandWait: Bool = false
+
     /// True when this session was rebuilt by `AppStore.restore(from:)` rather than freshly created. The
     /// surface factory reads it to gate the `initialCommand` re-run: a FRESH command session always runs
     /// its command, but a RESTORED one re-runs only when `restoreRunningCommand` is on (else a plain

--- a/agtermCore/Sources/agtermCore/Snapshot.swift
+++ b/agtermCore/Sources/agtermCore/Snapshot.swift
@@ -128,6 +128,11 @@ public struct SessionSnapshot: Codable, Equatable, Sendable {
     /// (e.g. an `ssh …` shortcut) re-runs its command on restore instead of coming back a plain shell. A
     /// live `foregroundCommand` takes precedence at restore. Optional for forward-compat like the fields above.
     public var initialCommand: String?
+    /// Whether a `--command` session holds its surface after the command exits (`session.new --command …
+    /// --wait`), so a restored command session that re-runs its command holds again instead of vanishing —
+    /// keeping the held/closed behavior consistent across restart. nil (missing key) decodes as false.
+    /// Optional for forward-compat like the fields above.
+    public var commandWait: Bool?
     /// The session's background watermark (image or rasterized text), or nil for none. Optional so a
     /// snapshot already on disk before this field was added still decodes (as nil → no watermark) instead
     /// of failing the load and wiping the saved tree, like the fields above. A `.text` watermark
@@ -137,7 +142,8 @@ public struct SessionSnapshot: Codable, Equatable, Sendable {
     public init(id: UUID, customName: String?, cwd: String, isSplit: Bool? = nil, fontSize: Double? = nil,
                 splitCwd: String? = nil, splitRatio: Double? = nil, flagged: Bool? = nil,
                 foregroundCommand: [String]? = nil, splitForegroundCommand: [String]? = nil,
-                initialCommand: String? = nil, backgroundWatermark: BackgroundWatermark? = nil) {
+                initialCommand: String? = nil, commandWait: Bool? = nil,
+                backgroundWatermark: BackgroundWatermark? = nil) {
         self.id = id
         self.customName = customName
         self.cwd = cwd
@@ -149,12 +155,13 @@ public struct SessionSnapshot: Codable, Equatable, Sendable {
         self.foregroundCommand = foregroundCommand
         self.splitForegroundCommand = splitForegroundCommand
         self.initialCommand = initialCommand
+        self.commandWait = commandWait
         self.backgroundWatermark = backgroundWatermark
     }
 
     enum CodingKeys: String, CodingKey {
         case id, customName, cwd, isSplit, fontSize, splitCwd, splitRatio, flagged
-        case foregroundCommand, splitForegroundCommand, initialCommand, backgroundWatermark
+        case foregroundCommand, splitForegroundCommand, initialCommand, commandWait, backgroundWatermark
     }
 
     /// Custom decode so `backgroundWatermark` is LOSSY: a present-but-invalid spec (an unknown
@@ -176,6 +183,7 @@ public struct SessionSnapshot: Codable, Equatable, Sendable {
         foregroundCommand = try c.decodeIfPresent([String].self, forKey: .foregroundCommand)
         splitForegroundCommand = try c.decodeIfPresent([String].self, forKey: .splitForegroundCommand)
         initialCommand = try c.decodeIfPresent(String.self, forKey: .initialCommand)
+        commandWait = try c.decodeIfPresent(Bool.self, forKey: .commandWait)
         backgroundWatermark = (try? c.decodeIfPresent(BackgroundWatermark.self, forKey: .backgroundWatermark)) ?? nil
     }
 }

--- a/agtermCore/Sources/agtermctlKit/SessionCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/SessionCommands.swift
@@ -31,6 +31,7 @@ struct Session: ParsableCommand {
         @Option(name: .long, help: "Target workspace by name; errors if not found unless --create-workspace. Mutually exclusive with --workspace.") var workspaceName: String?
         @Flag(name: .long, help: "With --workspace-name, create the workspace when it does not exist (reuse it otherwise).") var createWorkspace = false
         @Option(name: .long, help: "Run this command as the session's process instead of the login shell (no echoed command line; the session closes when it exits).") var command: String?
+        @Flag(name: .long, help: "With --command, hold the session open after the command exits (press any key to close) instead of closing immediately.") var wait = false
         @Option(name: .long, help: "Initial session name (defaults to the auto basename).") var name: String?
         @Option(name: .long, help: "Place the new session right AFTER this anchor session (id/prefix/active); the anchor carries its own workspace, replacing --workspace.") var after: String?
         @Option(name: .long, help: "Place the new session right BEFORE this anchor session (id/prefix/active); mirror of --after.") var before: String?
@@ -52,13 +53,16 @@ struct Session: ParsableCommand {
             if createWorkspace, workspaceName == nil {
                 throw ValidationError("--create-workspace requires --workspace-name")
             }
+            if wait, command == nil {
+                throw ValidationError("--wait requires --command")
+            }
         }
 
         func makeRequest() throws -> ControlRequest {
             ControlRequest(cmd: .sessionNew, args: options.withWindow(
                 ControlArgs(name: name, cwd: cwd, workspace: workspace, workspaceName: workspaceName,
                             createWorkspace: createWorkspace ? true : nil, noSelect: noSelect ? true : nil,
-                            command: command, after: after, before: before)))
+                            command: command, wait: wait ? true : nil, after: after, before: before)))
         }
     }
 

--- a/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
@@ -470,8 +470,10 @@ struct AppStorePaneTests {
         let plain = store.addSession(toWorkspace: ws.id, cwd: "/b", command: "make test")!
         node = try #require(store.controlTree().workspaces[0].sessions.first { $0.id == plain.id.uuidString })
         #expect(node.commandWait == nil)
-        // a plain session (no command) omits it even if the flag were somehow set — gated on initialCommand.
+        // a plain session (no command) omits it even when the flag IS set — gated on initialCommand, so a
+        // mutant that drops the `initialCommand != nil` term would report true here and fail.
         let shell = store.addSession(toWorkspace: ws.id, cwd: "/c")!
+        shell.commandWait = true
         node = try #require(store.controlTree().workspaces[0].sessions.first { $0.id == shell.id.uuidString })
         #expect(node.commandWait == nil)
     }

--- a/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
@@ -459,6 +459,23 @@ struct AppStorePaneTests {
         #expect(session.overlayActive)
     }
 
+    @Test func controlTreeReportsCommandWait() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        // a held --command session reports the flag so a script can record and restore it.
+        store.addSession(toWorkspace: ws.id, cwd: "/a", command: "make test", wait: true)
+        var node = try #require(store.controlTree().workspaces[0].sessions.first)
+        #expect(node.commandWait == true)
+        // a non-holding command session omits it (nil).
+        let plain = store.addSession(toWorkspace: ws.id, cwd: "/b", command: "make test")!
+        node = try #require(store.controlTree().workspaces[0].sessions.first { $0.id == plain.id.uuidString })
+        #expect(node.commandWait == nil)
+        // a plain session (no command) omits it even if the flag were somehow set — gated on initialCommand.
+        let shell = store.addSession(toWorkspace: ws.id, cwd: "/c")!
+        node = try #require(store.controlTree().workspaces[0].sessions.first { $0.id == shell.id.uuidString })
+        #expect(node.commandWait == nil)
+    }
+
     @Test func controlTreeReportsOverlaySizePercent() throws {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -88,6 +88,16 @@ struct AppStoreTests {
         #expect(plain.initialCommand == nil)
     }
 
+    @Test func addSessionCarriesCommandWait() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let held = try! #require(store.addSession(toWorkspace: ws.id, cwd: "/tmp", command: "make test", wait: true))
+        #expect(held.commandWait == true)
+        // default is false — a command session closes when its command exits.
+        let plain = try! #require(store.addSession(toWorkspace: ws.id, cwd: "/tmp", command: "make test"))
+        #expect(plain.commandWait == false)
+    }
+
     @Test func addSessionSeedsCustomName() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
@@ -1133,137 +1143,6 @@ struct AppStoreTests {
         #expect(store.canRemoveWorkspace == false)
         store.removeWorkspace(only.id)
         #expect(store.workspaces.map(\.id) == [only.id])
-    }
-
-    @Test func splitCwdRoundTripsThroughSnapshot() {
-        let store = makeStore()
-        let ws = store.addWorkspace(name: "work")
-        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
-        session.isSplit = true
-        session.currentCwd = "/a/primary"
-        session.splitCwd = "/var/log"
-        let snap = store.snapshot()
-        let snapped = snap.workspaces[0].sessions[0]
-        #expect(snapped.cwd == "/a/primary")
-        #expect(snapped.splitCwd == "/var/log")
-        // restore into a fresh store: each pane keeps its own seed.
-        let restored = makeStore()
-        restored.restore(from: snap)
-        let r = restored.workspaces[0].sessions[0]
-        #expect(r.initialCwd == "/a/primary")
-        #expect(r.initialSplitCwd == "/var/log")
-        #expect(r.isSplit == true)
-    }
-
-    @Test func foregroundCommandRoundTripsThroughSnapshot() {
-        let store = makeStore()
-        let ws = store.addWorkspace(name: "work")
-        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
-        session.foregroundCommand = ["ssh", "gate", "-p", "22"]
-        session.splitForegroundCommand = ["tail", "-f", "/var/log/x"]
-        let snap = store.snapshot()
-        let snapped = snap.workspaces[0].sessions[0]
-        #expect(snapped.foregroundCommand == ["ssh", "gate", "-p", "22"])
-        #expect(snapped.splitForegroundCommand == ["tail", "-f", "/var/log/x"])
-        let restored = makeStore()
-        restored.restore(from: snap)
-        let r = restored.workspaces[0].sessions[0]
-        #expect(r.foregroundCommand == ["ssh", "gate", "-p", "22"])
-        #expect(r.splitForegroundCommand == ["tail", "-f", "/var/log/x"])
-    }
-
-    @Test func legacySnapshotWithoutForegroundCommandDecodesNil() throws {
-        // a snapshot written before this field existed must still decode (nil = plain shell on restore).
-        let json = #"{"id":"00000000-0000-0000-0000-000000000001","cwd":"/tmp"}"#
-        let snap = try JSONDecoder().decode(SessionSnapshot.self, from: Data(json.utf8))
-        #expect(snap.foregroundCommand == nil)
-        #expect(snap.splitForegroundCommand == nil)
-        #expect(snap.initialCommand == nil)
-        #expect(snap.cwd == "/tmp")
-    }
-
-    @Test func initialCommandRoundTripsThroughSnapshot() {
-        // a command session (e.g. `--command ssh …`) persists its creation command so it re-runs on
-        // restore instead of coming back a plain shell.
-        let store = makeStore()
-        let ws = store.addWorkspace(name: "work")
-        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
-        session.initialCommand = "ssh user@host -t 'ssh inner'"
-        #expect(session.wasRestored == false) // a fresh session is not marked restored
-        let snap = store.snapshot()
-        #expect(snap.workspaces[0].sessions[0].initialCommand == "ssh user@host -t 'ssh inner'")
-        let restored = makeStore()
-        restored.restore(from: snap)
-        let r = restored.workspaces[0].sessions[0]
-        #expect(r.initialCommand == "ssh user@host -t 'ssh inner'")
-        #expect(r.wasRestored == true) // restore marks the session, so the surface factory can gate its re-run
-    }
-
-    @Test func sidebarWidthAndVisibilityRoundTripThroughSnapshot() {
-        let store = makeStore()
-        _ = store.addWorkspace(name: "work")
-        store.sidebarWidth = 312
-        store.sidebarVisible = false
-        let snap = store.snapshot()
-        #expect(snap.sidebarWidth == 312)
-        #expect(snap.sidebarVisible == false)
-        let restored = makeStore()
-        restored.restore(from: snap)
-        #expect(restored.sidebarWidth == 312)
-        #expect(restored.sidebarVisible == false)
-    }
-
-    @Test func sidebarDefaultsWhenSnapshotOmitsThem() {
-        // a snapshot written before these fields existed decodes them as nil; restore falls back to defaults.
-        let store = makeStore()
-        store.sidebarWidth = 400
-        store.sidebarVisible = false
-        store.restore(from: Snapshot(workspaces: []))
-        #expect(store.sidebarWidth == 220)
-        #expect(store.sidebarVisible == true)
-    }
-
-    @Test func restoreClampsOutOfRangeSidebarWidth() {
-        // a corrupt or hand-edited snapshot must not drive an out-of-range frame width; restore clamps it.
-        let store = makeStore()
-        store.restore(from: Snapshot(workspaces: [], sidebarWidth: 2000))
-        #expect(store.sidebarWidth == AppStore.sidebarWidthMax)
-        store.restore(from: Snapshot(workspaces: [], sidebarWidth: 10))
-        #expect(store.sidebarWidth == AppStore.sidebarWidthMin)
-    }
-
-    @Test func restoreClampsOutOfRangeSplitRatio() {
-        // a corrupt snapshot ratio must not feed an out-of-range fraction into NSSplitView.setPosition.
-        let store = makeStore()
-        let ws = store.addWorkspace(name: "work")
-        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
-        session.isSplit = true
-        session.splitRatio = 5.0
-        let restored = makeStore()
-        restored.restore(from: store.snapshot())
-        #expect(restored.workspaces[0].sessions[0].splitRatio == AppStore.splitRatioMax)
-    }
-
-    @Test func splitRatioRoundTripsThroughSnapshot() {
-        let store = makeStore()
-        let ws = store.addWorkspace(name: "work")
-        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
-        session.isSplit = true
-        session.splitRatio = 0.63
-        #expect(store.snapshot().workspaces[0].sessions[0].splitRatio == 0.63)
-        let restored = makeStore()
-        restored.restore(from: store.snapshot())
-        #expect(restored.workspaces[0].sessions[0].splitRatio == 0.63)
-    }
-
-    @Test func sessionSnapshotDecodesWithoutSplitRatio() throws {
-        // a SessionSnapshot persisted before splitRatio existed (the key absent) must decode to nil, not
-        // fail the load — the forward-compat contract the optional field documents.
-        let json = "{\"id\":\"\(UUID().uuidString)\",\"cwd\":\"/a\"}"
-        let snap = try JSONDecoder().decode(SessionSnapshot.self, from: Data(json.utf8))
-        #expect(snap.splitRatio == nil)
-        #expect(snap.isSplit == nil)
-        #expect(snap.fontSize == nil)
     }
 
     @Test func selectionUpdatesRecencyMostRecentFirst() {

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -138,6 +138,35 @@ struct ControlDispatcherTests {
         #expect(actions.calls.isEmpty)
     }
 
+    @Test func sessionNewThreadsWaitWithCommand() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextSessionNewResponse = ControlResponse(ok: true, result: ControlResult(id: "held"))
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionNew,
+            args: ControlArgs(command: "make test", wait: true)
+        ))
+
+        let options = ControlSessionCreateOptions(window: nil, cwd: nil, workspace: nil, workspaceName: nil,
+                                                  createWorkspace: nil, command: "make test", wait: true, name: nil)
+        #expect(response == ControlResponse(ok: true, result: ControlResult(id: "held")))
+        #expect(actions.calls == [.sessionNew(options)])
+    }
+
+    @Test func sessionNewRejectsWaitWithoutCommand() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionNew,
+            args: ControlArgs(wait: true)
+        ))
+
+        #expect(response == ControlResponse(ok: false, error: "--wait requires --command"))
+        #expect(actions.calls.isEmpty)
+    }
+
     @Test func sessionNewRejectsCreateWorkspaceWithoutName() async {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -539,6 +539,27 @@ struct ControlProtocolTests {
         #expect(decoded.unseen == nil)
     }
 
+    @Test func treeSessionNodeRoundTripsWithCommandWait() throws {
+        // the read side of session.new --wait: a held command session carries the flag so a script can
+        // record it and restore the session with --wait (it persists across restart, unlike overlay wait).
+        let session = ControlSessionNode(id: "s1", name: "build", cwd: "/tmp", active: false, split: false,
+                                         commandWait: true)
+        let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(
+            workspaces: [ControlWorkspaceNode(id: "w1", name: "work", active: true, sessions: [session])])))
+        let decoded = try roundTrip(response)
+        #expect(decoded == response)
+        #expect(decoded.result?.tree?.workspaces.first?.sessions.first?.commandWait == true)
+    }
+
+    @Test func treeSessionNodeOmitsCommandWaitWhenNil() throws {
+        // a plain session or a non-holding command session — the key must be omitted, not emitted as null.
+        let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false)
+        let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
+        #expect(!json.contains("commandWait"), "a nil commandWait must be omitted from the JSON; got \(json)")
+        let decoded = try JSONDecoder().decode(ControlSessionNode.self, from: Data(json.utf8))
+        #expect(decoded.commandWait == nil)
+    }
+
     @Test func treeSessionNodeRoundTripsWithOverlaySizePercent() throws {
         // the read side of session.overlay.resize: a floating overlay's percent rides the tree node so a
         // script can record it before resizing to full and restore the exact size afterwards.

--- a/agtermCore/Tests/agtermCoreTests/SnapshotRoundTripTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SnapshotRoundTripTests.swift
@@ -1,0 +1,161 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+// SessionSnapshot / Snapshot serialization + restore round-trips, forward-compat legacy decodes, and
+// restore-time clamping. Split out of AppStoreTests to keep both files within the line budget.
+@MainActor
+struct SnapshotRoundTripTests {
+    @Test func splitCwdRoundTripsThroughSnapshot() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        session.isSplit = true
+        session.currentCwd = "/a/primary"
+        session.splitCwd = "/var/log"
+        let snap = store.snapshot()
+        let snapped = snap.workspaces[0].sessions[0]
+        #expect(snapped.cwd == "/a/primary")
+        #expect(snapped.splitCwd == "/var/log")
+        // restore into a fresh store: each pane keeps its own seed.
+        let restored = makeStore()
+        restored.restore(from: snap)
+        let r = restored.workspaces[0].sessions[0]
+        #expect(r.initialCwd == "/a/primary")
+        #expect(r.initialSplitCwd == "/var/log")
+        #expect(r.isSplit == true)
+    }
+
+    @Test func foregroundCommandRoundTripsThroughSnapshot() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        session.foregroundCommand = ["ssh", "gate", "-p", "22"]
+        session.splitForegroundCommand = ["tail", "-f", "/var/log/x"]
+        let snap = store.snapshot()
+        let snapped = snap.workspaces[0].sessions[0]
+        #expect(snapped.foregroundCommand == ["ssh", "gate", "-p", "22"])
+        #expect(snapped.splitForegroundCommand == ["tail", "-f", "/var/log/x"])
+        let restored = makeStore()
+        restored.restore(from: snap)
+        let r = restored.workspaces[0].sessions[0]
+        #expect(r.foregroundCommand == ["ssh", "gate", "-p", "22"])
+        #expect(r.splitForegroundCommand == ["tail", "-f", "/var/log/x"])
+    }
+
+    @Test func legacySnapshotWithoutForegroundCommandDecodesNil() throws {
+        // a snapshot written before this field existed must still decode (nil = plain shell on restore).
+        let json = #"{"id":"00000000-0000-0000-0000-000000000001","cwd":"/tmp"}"#
+        let snap = try JSONDecoder().decode(SessionSnapshot.self, from: Data(json.utf8))
+        #expect(snap.foregroundCommand == nil)
+        #expect(snap.splitForegroundCommand == nil)
+        #expect(snap.initialCommand == nil)
+        #expect(snap.cwd == "/tmp")
+    }
+
+    @Test func initialCommandRoundTripsThroughSnapshot() {
+        // a command session (e.g. `--command ssh …`) persists its creation command so it re-runs on
+        // restore instead of coming back a plain shell.
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        session.initialCommand = "ssh user@host -t 'ssh inner'"
+        #expect(session.wasRestored == false) // a fresh session is not marked restored
+        let snap = store.snapshot()
+        #expect(snap.workspaces[0].sessions[0].initialCommand == "ssh user@host -t 'ssh inner'")
+        let restored = makeStore()
+        restored.restore(from: snap)
+        let r = restored.workspaces[0].sessions[0]
+        #expect(r.initialCommand == "ssh user@host -t 'ssh inner'")
+        #expect(r.wasRestored == true) // restore marks the session, so the surface factory can gate its re-run
+    }
+
+    @Test func commandWaitRoundTripsThroughSnapshot() {
+        // a held --command session persists the flag so a restored session that re-runs its command holds
+        // again, keeping the held/closed behavior consistent across restart (issue #254).
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a", command: "make test", wait: true)!
+        #expect(session.commandWait == true)
+        let snap = store.snapshot()
+        #expect(snap.workspaces[0].sessions[0].commandWait == true)
+        let restored = makeStore()
+        restored.restore(from: snap)
+        #expect(restored.workspaces[0].sessions[0].commandWait == true)
+    }
+
+    @Test func legacySnapshotWithoutCommandWaitDecodesNil() throws {
+        // a snapshot written before --wait existed has no commandWait key; it must decode as nil (not fail
+        // the whole load), like every other post-v1 optional field; restore maps nil to false.
+        let json = #"{"id":"\#(UUID().uuidString)","customName":null,"cwd":"/a","initialCommand":"make test"}"#
+        let snap = try JSONDecoder().decode(SessionSnapshot.self, from: Data(json.utf8))
+        #expect(snap.commandWait == nil)
+    }
+
+    @Test func sidebarWidthAndVisibilityRoundTripThroughSnapshot() {
+        let store = makeStore()
+        _ = store.addWorkspace(name: "work")
+        store.sidebarWidth = 312
+        store.sidebarVisible = false
+        let snap = store.snapshot()
+        #expect(snap.sidebarWidth == 312)
+        #expect(snap.sidebarVisible == false)
+        let restored = makeStore()
+        restored.restore(from: snap)
+        #expect(restored.sidebarWidth == 312)
+        #expect(restored.sidebarVisible == false)
+    }
+
+    @Test func sidebarDefaultsWhenSnapshotOmitsThem() {
+        // a snapshot written before these fields existed decodes them as nil; restore falls back to defaults.
+        let store = makeStore()
+        store.sidebarWidth = 400
+        store.sidebarVisible = false
+        store.restore(from: Snapshot(workspaces: []))
+        #expect(store.sidebarWidth == 220)
+        #expect(store.sidebarVisible == true)
+    }
+
+    @Test func restoreClampsOutOfRangeSidebarWidth() {
+        // a corrupt or hand-edited snapshot must not drive an out-of-range frame width; restore clamps it.
+        let store = makeStore()
+        store.restore(from: Snapshot(workspaces: [], sidebarWidth: 2000))
+        #expect(store.sidebarWidth == AppStore.sidebarWidthMax)
+        store.restore(from: Snapshot(workspaces: [], sidebarWidth: 10))
+        #expect(store.sidebarWidth == AppStore.sidebarWidthMin)
+    }
+
+    @Test func restoreClampsOutOfRangeSplitRatio() {
+        // a corrupt snapshot ratio must not feed an out-of-range fraction into NSSplitView.setPosition.
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        session.isSplit = true
+        session.splitRatio = 5.0
+        let restored = makeStore()
+        restored.restore(from: store.snapshot())
+        #expect(restored.workspaces[0].sessions[0].splitRatio == AppStore.splitRatioMax)
+    }
+
+    @Test func splitRatioRoundTripsThroughSnapshot() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        session.isSplit = true
+        session.splitRatio = 0.63
+        #expect(store.snapshot().workspaces[0].sessions[0].splitRatio == 0.63)
+        let restored = makeStore()
+        restored.restore(from: store.snapshot())
+        #expect(restored.workspaces[0].sessions[0].splitRatio == 0.63)
+    }
+
+    @Test func sessionSnapshotDecodesWithoutSplitRatio() throws {
+        // a SessionSnapshot persisted before splitRatio existed (the key absent) must decode to nil, not
+        // fail the load — the forward-compat contract the optional field documents.
+        let json = "{\"id\":\"\(UUID().uuidString)\",\"cwd\":\"/a\"}"
+        let snap = try JSONDecoder().decode(SessionSnapshot.self, from: Data(json.utf8))
+        #expect(snap.splitRatio == nil)
+        #expect(snap.isSplit == nil)
+        #expect(snap.fontSize == nil)
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/SnapshotRoundTripTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SnapshotRoundTripTests.swift
@@ -84,6 +84,21 @@ struct SnapshotRoundTripTests {
         #expect(restored.workspaces[0].sessions[0].commandWait == true)
     }
 
+    @Test func commandWaitFalseRoundTripsAsNilAndRestoresFalse() {
+        // a command session created WITHOUT --wait writes commandWait as nil (false is omitted), and restore
+        // maps that nil back to false via session(from:)'s `?? false` — not true. Exercises both the write
+        // gate and the nil->false restore mapping (a `?? true` mutant would restore true and fail here).
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a", command: "make test")!
+        #expect(session.commandWait == false)
+        let snap = store.snapshot()
+        #expect(snap.workspaces[0].sessions[0].commandWait == nil)
+        let restored = makeStore()
+        restored.restore(from: snap)
+        #expect(restored.workspaces[0].sessions[0].commandWait == false)
+    }
+
     @Test func legacySnapshotWithoutCommandWaitDecodesNil() throws {
         // a snapshot written before --wait existed has no commandWait key; it must decode as nil (not fail
         // the whole load), like every other post-v1 optional field; restore maps nil to false.

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -94,6 +94,17 @@ struct CommandsTests {
         #expect(try request(["session", "new", "--no-select"]) == expected)
     }
 
+    @Test func sessionNewWithCommandWait() throws {
+        // --wait rides with --command to hold the session open after the command exits (omitted otherwise).
+        let expected = ControlRequest(cmd: .sessionNew, args: ControlArgs(command: "make test", wait: true))
+        #expect(try request(["session", "new", "--command", "make test", "--wait"]) == expected)
+    }
+
+    @Test func sessionNewRejectsWaitWithoutCommand() {
+        // --wait holds a command surface, so it is meaningless without --command — validate() rejects it.
+        #expect(validationMessage(["session", "new", "--wait"]) == "--wait requires --command")
+    }
+
     @Test func sessionNewRejectsWorkspaceAndWorkspaceName() {
         // both addressing modes set — validate() rejects it before any request is built.
         #expect(validationMessage(["session", "new", "--workspace", "active", "--workspace-name", "servers"])

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -395,6 +395,30 @@ final class ControlAPIUITests: ControlAPITestCase {
         try? FileManager.default.removeItem(atPath: marker)
     }
 
+    // session.new --command --wait HOLDS the session open after the command exits (issue #254): the command
+    // `true` exits immediately, so WITHOUT --wait the session would vanish; WITH it the session stays on the
+    // press-any-key prompt and the tree reports commandWait=true (the read-back).
+    func testSessionNewCommandWaitHoldsSessionAfterExit() throws {
+        let created = try sendCommand(#"{"cmd":"session.new","args":{"command":"true","wait":true}}"#)
+        XCTAssertEqual(created["ok"] as? Bool, true, "session.new --command --wait should succeed: \(created)")
+        let newID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "session.new should return an id")
+
+        // let the command run and exit; the surface holds on the prompt rather than closing the session.
+        RunLoop.current.run(until: Date().addingTimeInterval(2))
+
+        let tree = try sendCommand(#"{"cmd":"tree"}"#)
+        let node = try XCTUnwrap(sessionNode(tree, id: newID), "the held session must still exist after its command exited")
+        XCTAssertEqual(node["commandWait"] as? Bool, true, "the tree should report commandWait=true for a held session")
+    }
+
+    // --wait holds a command surface, so it is meaningless without a command; the dispatcher rejects it
+    // SERVER-SIDE (a raw socket client can't bypass the CLI validate()).
+    func testSessionNewWaitWithoutCommandRejectedServerSide() throws {
+        let resp = try sendCommand(#"{"cmd":"session.new","args":{"wait":true}}"#)
+        XCTAssertEqual(resp["ok"] as? Bool, false, "--wait without --command must be rejected: \(resp)")
+        XCTAssertEqual(resp["error"] as? String, "--wait requires --command")
+    }
+
     // a control session.new (frontmost window) FOCUSES the new session, so real keystrokes reach it: the
     // command is `head -n1 > marker` (captures one typed line), and we type via the keyboard — the text
     // only lands if the new session grabbed first responder. Guards the gate-command focus fix.

--- a/site/commands.html
+++ b/site/commands.html
@@ -433,7 +433,10 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">foreground</span> /
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">splitForeground</span> (each pane's live foreground
                 argv, omitted at the shell prompt or for a setuid program like top/sudo),
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">background</span>, and
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">background</span>,
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">commandWait</span> (a held
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--command</span> session created with
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">session new --wait</span>; omitted otherwise), and
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">unseen</span>.
               </p>
               <p style="font-size: 14px; line-height: 1.65; color: #949ba4; margin: 8px 0 0">

--- a/site/commands.html
+++ b/site/commands.html
@@ -573,7 +573,7 @@
 
             <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
-                agtermctl session new [--cwd DIR] [--workspace W | --workspace-name NAME [--create-workspace]] [--command CMD]
+                agtermctl session new [--cwd DIR] [--workspace W | --workspace-name NAME [--create-workspace]] [--command CMD] [--wait]
                 [--name NAME] [--after SID | --before SID] [--no-select] [--window W]
               </div>
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">session.new</div>
@@ -620,6 +620,15 @@
                 new node is not <span style="font-family: &quot;JetBrains Mono&quot;, monospace">active</span> in
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">tree</span> — that flag is the read-back). Omit it
                 for the default select-and-focus behavior.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--wait</span> (only with
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--command</span>, else an error) <strong style="color: #bfbab0">holds</strong>
+                the session open after the command exits — the press-any-key prompt with the final output intact instead of
+                closing — so a build, test, or deploy's last output (or an early failure) stays readable. It persists across
+                restart, so a restored command session that re-runs its command holds again. Read it back on
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">tree</span>'s
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">commandWait</span>.
               </p>
             </div>
 

--- a/site/docs.html
+++ b/site/docs.html
@@ -1195,7 +1195,9 @@
               ><br /><span style="color: #6d82f3">ws</span>=$(agtermctl workspace new work)<br />agtermctl session new --workspace
               <span style="color: #f2b45c">"$ws"</span> --cwd ~/src/agterm<br /><br /><span style="color: #6b727a"
                 ># run a command as the session's process (argv-style; wrap in sh -c for shell syntax)</span
-              ><br />agtermctl session new --command <span style="color: #f2b45c">"ssh user@host"</span><br />agtermctl session new
+              ><br />agtermctl session new --command <span style="color: #f2b45c">"ssh user@host"</span><br />agtermctl session new --command
+              <span style="color: #f2b45c">"zsh -lc 'make test'"</span> --wait
+              <span style="color: #6b727a">&nbsp;&nbsp;# hold open after the command exits (press any key to close); needs --command</span><br />agtermctl session new
               --name <span style="color: #f2b45c">myhost</span> --workspace-name
               <span style="color: #f2b45c">servers</span> --create-workspace<br /><br /><span style="color: #6b727a"
                 ># step / reorder / relocate</span


### PR DESCRIPTION
Adds `agtermctl session new --command CMD --wait`, which holds the session open on libghostty's press-any-key prompt after the command exits (final output intact) instead of closing immediately. It is the session-surface counterpart of the existing `overlay open --wait`, opt-in and default unchanged.

Requested in #254: a `session new --command` session vanishes the moment its command exits, so a build/test/deploy's final output (or an early failure) is gone before you can read it, and a scripted monitoring layout silently shrinks as commands finish.

**How it works.** Reuses the same libghostty `wait_after_command` the overlay already uses, wired into the primary surface via `Session.commandWait` (a sibling of `Session.overlayWait`). The flag persists in `SessionSnapshot.commandWait`, so a restored command session that re-runs its command holds again rather than diverging across restart, and it reads back on the `tree` node's `commandWait`. `--wait` without `--command` is rejected both server-side (dispatcher) and CLI-side (`validate()`).

No new control command: it is a flag on the existing `session.new` (like `--follow`), so the command catalog stays at 61. Keep-in-sync surfaces updated: the bundled agent skill, `site/commands.html`, `site/docs.html`, and README.

Fix #254
