### PR TITLE
docs(agent-skill): add "Launching a program in a session" recipe

### DIFF
--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -120,6 +120,24 @@ you work. For any session-scoped command meant to act on *this* session — `ove
 `type`, `text`, `background`, `status`, `copy`, … — pass `--target "$AGTERM_SESSION_ID"`. Omit it and
 you open overlays / type into whatever the user has selected, not your own session.
 
+## Launching a program in a session
+
+**Bind it at creation.** `session new --command` (and `scratch --command`) makes the program the session
+process, so no shell line is involved:
+
+```bash
+agtermctl session new --cwd ~/proj --name worker \
+  --command "zsh -lc 'claude \"\$(cat ~/brief.md)\"'"   # GUI PATH: wrap a non-default binary
+```
+
+`session type` drives an ALREADY-RUNNING program — it is not a launcher. Its keystrokes land in a line
+buffer you do not own: a newline submits (a multi-line brief becomes N premature Enters), and the user
+or a concurrent agent writes to that same buffer. An untargeted `session type` from another agent hits
+whatever is `active`, and `session new` focuses — so a just-created session is briefly `active`, a stray
+prompt concatenates with yours, and the program starts on the merged line. (`--no-select` skips the
+focus, but the newline and shared-buffer hazards of `type`-as-launcher remain — `--command` is still the
+rule.) After `--command`, confirm in `tree --json` that the new node's `foreground` is your argv.
+
 ## Command summary (61 commands)
 
 Run `agtermctl <area> <cmd> --help` for exact flags. Full detail in **reference.md**; recipes in


### PR DESCRIPTION
## Problem

When an agent (Claude Code / Codex driving agterm via the bundled agent skill) launches a program in a fresh session — e.g. starts a sub-agent with a multi-line brief — SKILL.md's structure leads it to `session new` (plain shell) + `session type`, instead of `session new --command`. That path is fragile:

- `session new` selects+focuses the new session, so it's briefly `active`. An untargeted `session type` from a concurrent agent lands on `active` and concatenates onto the launch line — the program starts on a merged command. (Hit in practice: a sub-agent started with a foreign prompt glued to its own.)
- A multi-line payload typed via `session type` submits early at each embedded newline.

`--command` avoids both, but it was one clause inside the dense `session new` description while `session type` is a prominent standalone bullet — so agents defaulted to `type`.

## Evidence

Isolated eval, 6 fresh agents, each given **only** SKILL.md (as the Skill tool loads it), task *"launch an agent with a multi-line brief in a new session"*:

- **4/6** chose `session new` + `session type` (fragile path)
- **2/6** chose `session new --command`
- 1 of the 4 explicitly **rejected** `--command` citing the GUI-PATH exit-127 caveat — not realizing `zsh -lc '…'` resolves it
- **0/6** verified `foreground` via `tree --json` afterwards

`--no-select` narrows one vector but agents still default to `type`. With the added section, a local rerun gives 4/4 taking `--command` and checking foreground.

## Change

One co-located section, *"Launching a program in a session"*, before the command summary: the positive recipe (`--command` + `zsh -lc` wrapper for a non-default binary), why `type` is not a launcher (shared line buffer, newline submits, `active` race), and a `tree --json` foreground check. A positive recipe rather than a prohibition, since agents route around tool-choice bans.

Docs only — no code change.
