### PR TITLE
docs(agent-skill): correct the foreground check wording (follow-up to #257)

### DIFF
--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -136,7 +136,7 @@ or a concurrent agent writes to that same buffer. An untargeted `session type` f
 whatever is `active`, and `session new` focuses — so a just-created session is briefly `active`, a stray
 prompt concatenates with yours, and the program starts on the merged line. (`--no-select` skips the
 focus, but the newline and shared-buffer hazards of `type`-as-launcher remain — `--command` is still the
-rule.) After `--command`, confirm in `tree --json` that the new node's `foreground` is your argv.
+rule.) After `--command`, confirm in `tree --json` that the new node's `foreground` shows your program running, not a bare shell prompt.
 
 ## Command summary (61 commands)
 


### PR DESCRIPTION
Follow-up to #257, addressing the review nit.

For the wrapped example — `--command "zsh -lc 'claude …'"` — `tree`'s `foreground` reports the **running** process (`claude …` once it's up), not the literal `zsh -lc '…'` argv passed in. It equals the argv only for a bare `--command "ssh host"` with no wrapper.

Rewords the check from *"foreground is your argv"* to *"foreground shows your program running, not a bare shell prompt"*, which is accurate for both the wrapped and bare cases.

Docs only. Thanks for the catch.
