### PR TITLE
feat: highlight the active workspace and session in the sidebar

### DIFF
--- a/agterm/Views/SidebarRowViews.swift
+++ b/agterm/Views/SidebarRowViews.swift
@@ -27,6 +27,26 @@ final class SidebarCellView: NSTableCellView {
     private static let addButtonWidth: CGFloat = 16
     private var hoverTrackingArea: NSTrackingArea?
 
+    /// True for a row whose name dims to the same tint as the leading icon so the active row reads
+    /// at full strength: a workspace cell whose workspace is NOT the active one (the active session's
+    /// owner), or any session cell (a non-selected session dims; the selected one is exempted by
+    /// `setColors`' selected check). Set by the cell builder; the coordinator refreshes workspace
+    /// cells when the active workspace changes.
+    var isSecondary = false
+
+    /// Whether the pointer is inside the cell (the same tracking area that reveals the workspace
+    /// "+"). While hovered, a secondary row's name shows the full default color — an instant swap,
+    /// no animation. Reset via `resetHover` when a reused cell is reconfigured.
+    private var isHovered = false
+
+    /// The selection state last applied by `setColors`, so the hover re-tint can re-run it without
+    /// re-deriving the row's selection.
+    private var lastSelected = false
+
+    /// Clears transient hover state on cell reuse (the old row's `mouseExited` may never fire for
+    /// the recycled cell).
+    func resetHover() { isHovered = false }
+
     /// Reveals or collapses the inline "+": the Finder/Xcode hover convention, so an idle row shows
     /// no button and the roll-up badge keeps its slot. Driven by `mouseEntered`/`mouseExited` and
     /// reset hidden when a reused cell is reconfigured in the row provider. No-op for session cells.
@@ -36,11 +56,11 @@ final class SidebarCellView: NSTableCellView {
         addButtonWidthConstraint.constant = visible ? Self.addButtonWidth : 0
     }
 
-    // hover tracking for the "+" reveal, workspace cells only (session cells have no button to show)
+    // hover tracking for the workspace "+" reveal and the secondary-row un-dim (every cell: session
+    // cells have no button, but their name un-dims under the pointer like a workspace's)
     override func updateTrackingAreas() {
         super.updateTrackingAreas()
         if let hoverTrackingArea { removeTrackingArea(hoverTrackingArea); self.hoverTrackingArea = nil }
-        guard addButton != nil else { return }
         let area = NSTrackingArea(
             rect: bounds,
             options: [.mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect],
@@ -52,6 +72,8 @@ final class SidebarCellView: NSTableCellView {
 
     override func mouseEntered(with event: NSEvent) {
         super.mouseEntered(with: event)
+        isHovered = true
+        if isSecondary { setColors(selected: lastSelected) }
         // the workspace-row "+" is a toggleable Interface element; gate it here so a hover only reveals
         // it when the element is shown. this is hover-time only: a live Settings flip takes effect on the
         // next hover, and a "+" already on screen when the element is hidden lingers until the next mouse
@@ -63,6 +85,8 @@ final class SidebarCellView: NSTableCellView {
 
     override func mouseExited(with event: NSEvent) {
         super.mouseExited(with: event)
+        isHovered = false
+        if isSecondary { setColors(selected: lastSelected) }
         setAddButtonVisible(false)
     }
 
@@ -73,12 +97,16 @@ final class SidebarCellView: NSTableCellView {
     /// table is first responder): the hosting `SidebarRowView` re-asserts it from its live `isSelected`
     /// on attach and on every selection flip, and the coordinator re-runs it on theme changes.
     func setColors(selected: Bool) {
+        lastSelected = selected
         let app = GhosttyApp.shared
         let color = selected
             ? (app.terminalSelectionForegroundColor ?? .white)
             : (app.terminalForegroundColor ?? .labelColor)
-        textField?.textColor = color
         let iconAlpha: CGFloat = selected ? 0.85 : 0.6
+        // a secondary row's name shares the icon's dimmed tint so the active workspace/session stands
+        // out; hovering the row restores the full color (see mouseEntered/mouseExited — instant swap).
+        let dimName = isSecondary && !isHovered && !selected
+        textField?.textColor = dimName ? color.withAlphaComponent(iconAlpha) : color
         imageView?.contentTintColor = color.withAlphaComponent(iconAlpha)
         addButton?.contentTintColor = color.withAlphaComponent(iconAlpha)
     }

--- a/agterm/Views/WorkspaceSidebar+RowRendering.swift
+++ b/agterm/Views/WorkspaceSidebar+RowRendering.swift
@@ -45,9 +45,9 @@ extension WorkspaceSidebar.Coordinator {
         switch node.kind {
         case .workspace:
             let workspace = store.workspaces.first(where: { $0.id == node.id })
-            // dim every workspace name except the active session's owner (see activeWorkspaceID);
+            // dim every workspace name except the active session's owner (see AppStore.activeWorkspaceID);
             // the coordinator re-tints these when the active workspace changes.
-            cell.isSecondary = node.id != activeWorkspaceID
+            cell.isSecondary = node.id != store.activeWorkspaceID
             field.stringValue = workspace?.name ?? ""
             field.font = .systemFont(ofSize: GhosttyApp.shared.sidebarFontSize, weight: .medium)
             field.setAccessibilityIdentifier("workspace-row")

--- a/agterm/Views/WorkspaceSidebar+RowRendering.swift
+++ b/agterm/Views/WorkspaceSidebar+RowRendering.swift
@@ -41,9 +41,13 @@ extension WorkspaceSidebar.Coordinator {
         applyBadge(toCell: cell, count: 0)
         cell.statusIcon.apply(AgentIndicator())
         cell.setAddButtonVisible(false)
+        cell.resetHover()
         switch node.kind {
         case .workspace:
             let workspace = store.workspaces.first(where: { $0.id == node.id })
+            // dim every workspace name except the active session's owner (see activeWorkspaceID);
+            // the coordinator re-tints these when the active workspace changes.
+            cell.isSecondary = node.id != activeWorkspaceID
             field.stringValue = workspace?.name ?? ""
             field.font = .systemFont(ofSize: GhosttyApp.shared.sidebarFontSize, weight: .medium)
             field.setAccessibilityIdentifier("workspace-row")
@@ -55,6 +59,9 @@ extension WorkspaceSidebar.Coordinator {
             cell.imageView?.image = workspaceIcon
             cell.imageView?.setAccessibilityIdentifier("workspace-icon")
         case .session:
+            // every session row dims when not selected (setColors exempts the selected row itself),
+            // so only the active session reads at full strength — matching the workspace treatment.
+            cell.isSecondary = true
             field.stringValue = rowLabel(forSession: node.id)
             field.font = .systemFont(ofSize: GhosttyApp.shared.sidebarFontSize)
             field.setAccessibilityIdentifier("session-row")

--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -401,19 +401,12 @@ struct WorkspaceSidebar: NSViewRepresentable {
             reloadChangedContentRows()
         }
 
-        /// The ACTIVE workspace for the sidebar highlight: strictly the active session's owner (nil with
-        /// no selection). Deliberately NOT `currentWorkspaceID`, whose last-workspace fallback is a
-        /// new-session placement anchor — highlighting that would light up an arbitrary workspace.
-        var activeWorkspaceID: UUID? {
-            store.selectedSessionID.flatMap { store.workspace(forSession: $0)?.id }
-        }
-
         /// Re-tints the visible workspace rows when the active workspace changed: the previously active
         /// row dims to secondary, the newly active one returns to full strength. Needed because a click's
         /// `selectSession` lands AFTER the selection delegate already repainted (same-row selection never
         /// re-fires it), so the build-time flag alone would go stale.
         private func refreshActiveWorkspaceHighlight() {
-            let activeID = activeWorkspaceID
+            let activeID = store.activeWorkspaceID
             guard activeID != lastActiveWorkspaceID else { return }
             lastActiveWorkspaceID = activeID
             guard let outline = outlineView else { return }

--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -204,6 +204,10 @@ struct WorkspaceSidebar: NSViewRepresentable {
         /// the scroll view above the document, hidden otherwise.
         private weak var emptyStateLabel: NSTextField?
 
+        /// Last-seen ACTIVE workspace id (the active session's owner), so `refreshActiveWorkspaceHighlight`
+        /// re-tints the workspace rows only when it actually moved.
+        private var lastActiveWorkspaceID: UUID?
+
         init(store: AppStore, actions: AppActions) {
             self.store = store
             self.actions = actions
@@ -381,6 +385,9 @@ struct WorkspaceSidebar: NSViewRepresentable {
         /// changes never rebuild — that full `reloadData` + re-expand re-lays-out every row and jitters
         /// their labels. A reload during an in-progress rename is skipped so a tick can't drop the edit.
         func reconcile() {
+            // the active-workspace tint rides every reconcile (selection changes re-invoke updateNSView),
+            // catching the same-row case where the selection delegate never re-fires.
+            defer { refreshActiveWorkspaceHighlight() }
             // a mode flip swaps the whole data source (tree ↔ flat flagged list), so rebuild regardless of
             // the shape diff; otherwise compare the mode-appropriate shape.
             let shape = currentShape()
@@ -392,6 +399,31 @@ struct WorkspaceSidebar: NSViewRepresentable {
                 return
             }
             reloadChangedContentRows()
+        }
+
+        /// The ACTIVE workspace for the sidebar highlight: strictly the active session's owner (nil with
+        /// no selection). Deliberately NOT `currentWorkspaceID`, whose last-workspace fallback is a
+        /// new-session placement anchor — highlighting that would light up an arbitrary workspace.
+        var activeWorkspaceID: UUID? {
+            store.selectedSessionID.flatMap { store.workspace(forSession: $0)?.id }
+        }
+
+        /// Re-tints the visible workspace rows when the active workspace changed: the previously active
+        /// row dims to secondary, the newly active one returns to full strength. Needed because a click's
+        /// `selectSession` lands AFTER the selection delegate already repainted (same-row selection never
+        /// re-fires it), so the build-time flag alone would go stale.
+        private func refreshActiveWorkspaceHighlight() {
+            let activeID = activeWorkspaceID
+            guard activeID != lastActiveWorkspaceID else { return }
+            lastActiveWorkspaceID = activeID
+            guard let outline = outlineView else { return }
+            for row in 0 ..< outline.numberOfRows {
+                guard let node = outline.item(atRow: row) as? SidebarNode, node.kind == .workspace,
+                      let cell = outline.view(atColumn: 0, row: row, makeIfNecessary: false) as? SidebarCellView
+                else { continue }
+                cell.isSecondary = node.id != activeID
+                cell.setColors(selected: outline.selectedRowIndexes.contains(row))
+            }
         }
 
         /// The structural shape for the current mode: the workspace tree (workspace id + ordered session

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -171,6 +171,14 @@ public final class AppStore {
         return workspaces.last?.id
     }
 
+    /// The workspace to HIGHLIGHT in the sidebar: strictly the active session's owner, nil with no
+    /// selection. Deliberately NOT `currentWorkspaceID` — its last-workspace fallback is a
+    /// new-session placement anchor, and highlighting it would light up an arbitrary workspace row.
+    public var activeWorkspaceID: UUID? {
+        guard let selectedSessionID else { return nil }
+        return workspace(forSession: selectedSessionID)?.id
+    }
+
     /// The auto-generated name for the next new workspace (`workspace 1`, `workspace 2`, …).
     public var defaultWorkspaceName: String {
         "workspace \(workspaces.count + 1)"

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -45,6 +45,29 @@ struct AppStoreTests {
         #expect(store.currentWorkspaceID == personal.id)
     }
 
+    @Test func activeWorkspaceFollowsSelectionWithNoFallback() {
+        let store = makeStore()
+        #expect(store.activeWorkspaceID == nil)
+        let work = store.addWorkspace(name: "work")
+        let personal = store.addWorkspace(name: "personal")
+        // unlike currentWorkspaceID, no selection means NO workspace is active — the sidebar
+        // highlight must not fall back to the last workspace.
+        store.selectSession(nil)
+        #expect(store.activeWorkspaceID == nil)
+        // a selected session pins its owning workspace, even with a later workspace present.
+        let session = try! #require(store.addSession(toWorkspace: work.id, cwd: "/a"))
+        store.selectSession(session.id)
+        #expect(store.activeWorkspaceID == work.id)
+        // selection moving to another workspace moves the highlight with it.
+        let other = try! #require(store.addSession(toWorkspace: personal.id, cwd: "/b"))
+        store.selectSession(other.id)
+        #expect(store.activeWorkspaceID == personal.id)
+        // deselecting clears the highlight entirely (currentWorkspaceID would report personal here).
+        store.selectSession(nil)
+        #expect(store.activeWorkspaceID == nil)
+        #expect(store.currentWorkspaceID == personal.id)
+    }
+
     @Test func addWorkspaceAppends() {
         let store = makeStore()
         let work = store.addWorkspace(name: "work")


### PR DESCRIPTION
## Why

The active session is already highlighted in the sidebar — its row carries the selection pill — but the workspace itself is not: every workspace name renders at the same full-strength theme foreground, so nothing tells you which workspace you're working in at a glance. This is especially needed when all workspaces are collapsed: the selection pill lives on the session row, which is hidden inside its collapsed parent — so there is simply no way to see which workspace is active.

The second important reason is that using the same color palette across all workspaces makes them feel less visually distinct, which can be conceptually confusing and makes it harder to differentiate between them at a glance. Dimming everything but the active context gives the sidebar a visual hierarchy: the active workspace and session at full strength, everything else receding.

## What

- **Non-active rows dim to a secondary color** — the exact tint the leading row icon already uses (theme foreground at 0.6 alpha), so no new color is introduced and it tracks the terminal theme. A workspace row dims unless it owns the active session; a session row dims unless it is the selected one (which also keeps its selection pill, as before).
- **Hovering a dimmed row instantly restores the full color** (no fade/animation), so a dimmed name is still comfortably readable under the pointer. This rides the tracking area that already reveals the workspace-row "+", now installed on session cells too.
- **The highlight anchors on `AppStore.activeWorkspaceID`**, a new host-free derivation: strictly the selected session's owning workspace, nil with no selection. Deliberately *not* `currentWorkspaceID` — its last-workspace fallback is a new-session placement anchor, and highlighting it would light up an arbitrary workspace when nothing is selected.
- The coordinator re-tints workspace rows from `reconcile()` when the active workspace moves, covering the same-row selection case where the selection delegate never re-fires.

## Testing

- New unit test `activeWorkspaceFollowsSelectionWithNoFallback` pins the no-fallback distinction vs `currentWorkspaceID`; full `agtermCore` suite green (1594 tests, 66 suites).
- `make build` and `make lint --strict` clean.
- Verified manually in an isolated dev instance: dimming follows selection across workspaces; hover un-dims with no animation.

Control-API note: pure visual chrome with nothing to drive — exempt from the control-coverage convention.