### PR TITLE
fix: skip codepoint read for non-key NSEvents in flagsChanged

### DIFF
--- a/agterm/Ghostty/GhosttySurfaceView+Input.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Input.swift
@@ -354,7 +354,11 @@ extension GhosttySurfaceView {
     }
 
     private func unshiftedCodepoint(from event: NSEvent) -> UInt32 {
-        guard let chars = event.characters(byApplyingModifiers: []),
+        // characters(byApplyingModifiers:) is valid only for key up/down events; on a FlagsChanged
+        // (bare modifier) event it raises an AppKit assertion. A modifier press carries no codepoint,
+        // so report 0 for any non-key event.
+        guard event.type == .keyDown || event.type == .keyUp,
+              let chars = event.characters(byApplyingModifiers: []),
               let scalar = chars.unicodeScalars.first
         else { return 0 }
         return scalar.value


### PR DESCRIPTION
On every ⌘/⇧/⌥ press, agterm logged an AppKit assertion:

```
*** Assertion failure in <private>, NSEvent.m:2800
[AppKit] Invalid message sent to event "NSEvent: type=FlagsChanged … keyCode=55"
  agterm  GhosttySurfaceView.flagsChanged(with: NSEvent)
```

**Root cause.** `flagsChanged(with:)` builds a key event via `buildKeyEvent`, which calls `unshiftedCodepoint(from:)` → `event.characters(byApplyingModifiers: [])`. That `NSEvent` method is valid only for key up/down events. On a FlagsChanged (bare modifier) event it raises `NSInternalInconsistencyException`; AppKit's event loop catches and logs it, so the app keeps running but reports the assertion on every modifier press.

**Impact.** More than log noise: the thrown exception aborts `flagsChanged` before it reaches `ghostty_surface_key`, so a bare modifier press or release never reaches libghostty. The fix restores that delivery.

**Fix.** A modifier press carries no codepoint, so `unshiftedCodepoint` now guards on `event.type == .keyDown || .keyUp` and returns 0 for anything else. The invalid call can no longer run on the FlagsChanged path, while the codepoint for real key events is unchanged. `flagsChanged`'s only other call, `isFlagPress`, reads just `keyCode`/`modifierFlags` (both valid for FlagsChanged); the remaining `characters*`/`isARepeat` reads in `+Input.swift` are on the key up/down paths.

**Verification.** Reproduced deterministically: constructing a FlagsChanged `NSEvent` and calling `characters(byApplyingModifiers:)` throws `NSInternalInconsistencyException` with the reported message, and the guard skips that call so it cannot fire. Build, `swift test`, and `swiftlint --strict` pass.

*No automated test.* The failure is a thrown ObjC exception that AppKit catches and logs, not a value change and not a crash, so there is nothing a unit test can assert on without new app-target test infrastructure (the repo has only UI and agtermCore test targets), and a `.flagsChanged` `NSEvent` cannot be synthesized in `swift test`. This matches the project's existing approach of hand-verifying `flagsChanged`/input plumbing.

*Related to #260*, the FlagsChanged assertion reported there.
