### PR TITLE
fix: disable ghostty cursor-click-to-move at the shell prompt

### DIFF
--- a/agterm/Resources/ghostty-defaults.conf
+++ b/agterm/Resources/ghostty-defaults.conf
@@ -17,6 +17,14 @@ window-padding-y = 6
 cursor-style = block
 shell-integration-features = no-cursor,no-title
 
+# disable ghostty's click-to-move-cursor at the shell prompt. with shell integration
+# (OSC 133) a click in the prompt input emits arrow keys to move the shell cursor to the
+# clicked column, but a double-click to SELECT a word (e.g. a branch name shown in the
+# prompt) fires it too, jerking the cursor to the start of the line so a following paste
+# lands in the wrong place. this governs only the shell-prompt click; a TUI's own mouse
+# reporting (vim/htop/etc.) is a separate path and is unaffected.
+cursor-click-to-move = false
+
 # make ⌘C/⌘V/⌘A copy/paste/select-all work on non-Latin keyboard layouts. libghostty's
 # built-in binds are unicode triggers (`super+c`/`super+v`/`super+a`), matched against
 # the character the active layout produces — so on a Russian/Greek/etc. layout the


### PR DESCRIPTION
Double-clicking a word in the zsh prompt (e.g. a branch name shown by the prompt) moved the shell's input cursor to the start of the command line, so a following ⌘C / ⌘V pasted in the wrong position (#262).

**Cause.** ghostty's `cursor-click-to-move` (default on). With shell integration (OSC 133 prompt marks, which agterm enables in every session), a click in the prompt input emits arrow keys to move the shell cursor to the clicked column. In the pinned libghostty build a double-click to *select* a word triggers it too, and a click on prompt decoration left of the input clamps the move to the input start, so the cursor jumps to the beginning of the line. A current Ghostty.app does not reproduce this even with `cursor-click-to-move = true`, so it is specific to the pinned build (`GHOSTTY_REV` 4dcb09ada) rather than universal.

**Fix.** Set `cursor-click-to-move = false` in the bundled `ghostty-defaults.conf` (off by default; re-enable in `~/.config/agterm/ghostty.conf`). Worth revisiting when the ghostty pin is next bumped.

`maybePromptClick` in the pinned ghostty source only fires at a shell prompt with OSC 133 click support and no active selection, so this governs only the shell-prompt click. A TUI's own mouse reporting (vim/htop/revdiff) is a separate path and is unaffected, confirmed by testing revdiff with the setting off.

Fix #262
