### PR TITLE
feat: per-workspace root directory

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -237,9 +237,9 @@ paths:
   rules, then remaining targets resolve inside that same store so one command never mutates multiple windows.
   The top-level `target` also carries the first explicit batch target so a new CLI talking to a still-running
   pre-batch server degrades to a named session instead of accidentally acting on `active`.
-- **Command catalog (61 commands):**
+- **Command catalog (62 commands):**
   - `tree`
-  - `workspace.new`/`workspace.rename`/`workspace.delete`/`workspace.select`/`workspace.move`/`workspace.focus`
+  - `workspace.new`/`workspace.rename`/`workspace.delete`/`workspace.select`/`workspace.move`/`workspace.focus`/`workspace.root`
   - `session.new`/`session.duplicate`/`session.close`/`session.select`/`session.rename`/`session.reveal`/`session.move`/`session.type`/`session.split`/`session.scratch`/`session.focus`/`session.resize`/`session.go`/`session.copy`/`session.paste`/`session.selectall`/`session.text`/`session.search`/`session.status`/`session.flag`/`session.seen`/`session.background`/`session.overlay.open`/`session.overlay.close`/`session.overlay.resize`/`session.overlay.result`
   - `surface.zoom`
   - `dashboard`

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -117,7 +117,7 @@ final class AppActions {
     func newSession() {
         guard uiActionsEnabled else { return }
         guard let store, let workspaceID = store.currentWorkspaceID,
-              let session = store.addSession(toWorkspace: workspaceID, cwd: resolvedNewSessionCwd())
+              let session = store.addSession(toWorkspace: workspaceID, cwd: resolvedNewSessionCwd(inWorkspace: workspaceID))
         else { return }
         // creating + selecting a session is a user-initiated selection: note activity so it buys the full
         // idle grace before auto-follow can pull the selection away from the just-made session.
@@ -132,10 +132,22 @@ final class AppActions {
     /// the setting. Falls back to home when `settingsModel` isn't wired yet (before the scene `.task`) or
     /// the setting resolves there. Read as the `addSession` argument, so it captures the active session's
     /// cwd BEFORE the new session exists.
-    func resolvedNewSessionCwd() -> String {
+    func resolvedNewSessionCwd(inWorkspace workspaceID: UUID? = nil) -> String {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
+        // A workspace root (if set AND it still exists on disk) hard-overrides the global new-session
+        // policy; a missing/deleted root falls through to the setting.
+        let root = existingDirectory(workspaceID.flatMap { id in store?.workspaces.first { $0.id == id }?.root })
         return settingsModel?.settings.resolveNewSessionCwd(
-            currentSessionCwd: store?.activeSession?.focusedCwd, home: home) ?? home
+            workspaceRoot: root, currentSessionCwd: store?.activeSession?.focusedCwd, home: home) ?? (root ?? home)
+    }
+
+    /// Returns the path only if it names an existing directory, else nil — so a stale/deleted workspace
+    /// root silently falls back to the global new-session policy at spawn time.
+    private func existingDirectory(_ path: String?) -> String? {
+        guard let path, !path.isEmpty else { return nil }
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: path, isDirectory: &isDir), isDir.boolValue else { return nil }
+        return path
     }
 
     func openDirectory() {

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -366,6 +366,7 @@ final class ControlServer {
         case .tree, .sessionNew, .sessionDuplicate, .sessionSelect, .sessionGo, .sessionClose, .sessionRename,
                 .sessionReveal, .sessionMove,
                 .workspaceNew, .workspaceSelect, .workspaceRename, .workspaceDelete, .workspaceMove, .workspaceFocus,
+                .workspaceRoot,
                 .sessionSplit, .sessionScratch, .sessionFocus, .sessionResize, .surfaceZoom,
                 .sessionStatus, .sessionFlag, .sessionSeen, .notify,
                 .fontInc, .fontDec, .fontReset, .keymapReload, .configReload, .themeSet, .themeList,
@@ -566,7 +567,8 @@ final class ControlServer {
     /// suppressed, leaving the current selection and focus untouched.
     func makeSessionResponse(in store: AppStore, workspaceID: UUID,
                              options: ControlSessionCreateOptions, at index: Int? = nil) -> ControlResponse {
-        let cwd = options.cwd ?? FileManager.default.homeDirectoryForCurrentUser.path
+        let root = existingDirectory(store.workspaces.first { $0.id == workspaceID }?.root)
+        let cwd = options.cwd ?? root ?? FileManager.default.homeDirectoryForCurrentUser.path
         guard let session = store.addSession(toWorkspace: workspaceID, cwd: cwd,
                                              command: options.command, name: options.name,
                                              wait: options.wait ?? false, at: index, select: !options.noSelect) else {
@@ -576,11 +578,27 @@ final class ControlServer {
         return ControlResponse(ok: true, result: ControlResult(id: session.id.uuidString))
     }
 
+    func setWorkspaceRoot(_ target: String?, window: String?, path: String?) -> ControlResponse {
+        resolver.resolveWorkspace(target, window: window) { store, id in
+            store.setWorkspaceRoot(id, path: path) // verbatim path; empty → nil; delta-guarded + save
+            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
+        }
+    }
+
     /// `value` trimmed of surrounding whitespace, or nil if absent or blank after trimming.
     func trimmed(_ value: String?) -> String? {
         guard let value else { return nil }
         let result = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return result.isEmpty ? nil : result
+    }
+
+    /// The path back only if it names an existing directory, else nil — a stale/deleted workspace root
+    /// silently falls back to $HOME (mirroring the GUI's spawn-time check).
+    private func existingDirectory(_ path: String?) -> String? {
+        guard let path, !path.isEmpty else { return nil }
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: path, isDirectory: &isDir), isDir.boolValue else { return nil }
+        return path
     }
 
     private func log(_ message: @autoclosure () -> String) {

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -15,7 +15,7 @@ description: >
 when_to_use: >
   Trigger on: agterm, agtermctl, agterm control socket, session.new, session.close, session.type,
   session.split, session.scratch, session.focus, session.resize, surface.zoom, dashboard, session.go, session.copy, session.paste, session.selectall, session.text, session.search, session.status,
-  session.flag, session.seen, session.reveal, session.duplicate, session.background, session.overlay, workspace.new, workspace.select, workspace.move, workspace.focus, window.new, window.list,
+  session.flag, session.seen, session.reveal, session.duplicate, session.background, session.overlay, workspace.new, workspace.select, workspace.move, workspace.focus, workspace.root, window.new, window.list,
   window.select, window.resize, window.move, window.zoom, window.fullscreen, quick terminal, sidebar, sidebar.mode, sidebar.expand, sidebar.collapse, flagged, notify, font.inc, keymap.reload, config.reload,
   theme.set, theme.list, select theme, edit keymap, show an image, display an image inline, show-image,
   AGTERM_SESSION_ID, AGTERM_SOCKET, and asks to drive or script agterm. Also: troubleshoot agterm,
@@ -138,7 +138,7 @@ prompt concatenates with yours, and the program starts on the merged line. (`--n
 focus, but the newline and shared-buffer hazards of `type`-as-launcher remain — `--command` is still the
 rule.) After `--command`, confirm in `tree --json` that the new node's `foreground` shows your program running, not a bare shell prompt.
 
-## Command summary (61 commands)
+## Command summary (62 commands)
 
 Run `agtermctl <area> <cmd> --help` for exact flags. Full detail in **reference.md**; recipes in
 **examples.md**.
@@ -174,7 +174,9 @@ applied to the cells, omitted when untouched), and `dashboardFontMode` (`auto`|`
 
 **workspace** — `new [name]` · `rename <name>` · `delete` · `select` · `move --to up|down|top|bottom` ·
 `focus [on|off|toggle]` (collapse the sidebar tree to a single workspace; read back which workspace is
-focused from the tree workspace node's `focused` flag).
+focused from the tree workspace node's `focused` flag) · `root <dir|--clear>` (the workspace's start
+directory — new sessions open there, overriding the global new-session-directory setting; read back from
+the tree workspace node's `root` field).
 
 **session**
 - `new [--cwd DIR] [--workspace W] [--workspace-name NAME] [--create-workspace] [--command CMD] [--wait] [--name NAME] [--after SID | --before SID] [--no-select]` —

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -302,6 +302,8 @@ navigation is scoped to that workspace's sessions; unfocusing restores stepping 
 agtermctl workspace focus on --target "$AGTERM_WORKSPACE_ID"  # zoom to this workspace
 agtermctl workspace focus toggle --target a1b2                # flip focus on another workspace
 agtermctl workspace focus off                                 # restore the full tree
+agtermctl workspace root ~/src/myproject --target "$AGTERM_WORKSPACE_ID"  # new sessions here open in ~/src/myproject
+agtermctl workspace root --clear --target "$AGTERM_WORKSPACE_ID"          # back to the global setting
 ```
 
 ## Expand or collapse the sidebar tree

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -112,6 +112,11 @@ All ten are read-only projections of GUI state.
 - `workspace rename <name> [--target] [--window W]`.
 - `workspace delete [--target] [--window W]` — keep-at-least-one; deleting the last workspace errors.
 - `workspace select [--target] [--window W]`.
+- `workspace root <dir|--clear> [--target] [--window W]` — set the workspace's root directory, or
+  `--clear`/`clear` to unset. When set, every new session created in that workspace opens in the root,
+  a hard override of the global new-session-directory setting; when unset, new sessions follow that
+  setting. A relative/`~` path is absolutized against the CLI's cwd. The read side is the `root` field on
+  each `tree` workspace node (omitted when unset). A non-existent root falls back at spawn time.
 - `workspace move --to up|down|top|bottom [--target] [--window W]` — reorder among siblings. Missing
   or invalid `--to` errors. Note: `--target active` resolves to the current workspace, which with no
   selected session falls back to the last workspace; address a specific workspace by id to step the

--- a/agterm/Views/WorkspaceSidebar+ContextMenu.swift
+++ b/agterm/Views/WorkspaceSidebar+ContextMenu.swift
@@ -143,6 +143,16 @@ extension WorkspaceSidebar.Coordinator {
             focus.target = self
             focus.representedObject = node
             menu.addItem(focus)
+            let setRoot = NSMenuItem(title: "Set Root Directory…", action: #selector(menuSetWorkspaceRoot(_:)), keyEquivalent: "")
+            setRoot.target = self
+            setRoot.representedObject = node
+            menu.addItem(setRoot)
+            if store.workspaces.first(where: { $0.id == node.id })?.root != nil {
+                let clearRoot = NSMenuItem(title: "Clear Root Directory", action: #selector(menuClearWorkspaceRoot(_:)), keyEquivalent: "")
+                clearRoot.target = self
+                clearRoot.representedObject = node
+                menu.addItem(clearRoot)
+            }
             menu.addItem(.separator())
             let delete = NSMenuItem(title: "Delete Workspace", action: #selector(menuDeleteWorkspace(_:)), keyEquivalent: "")
             delete.target = self
@@ -210,7 +220,7 @@ extension WorkspaceSidebar.Coordinator {
         guard let node = sender.representedObject as? SidebarNode else { return }
         // resolve the cwd via the same new-session-directory setting as AppActions.newSession(), so the
         // workspace-row New Session honors it too (home / current session's cwd / a fixed custom dir).
-        addSession(toWorkspace: node.id, cwd: actions.resolvedNewSessionCwd())
+        addSession(toWorkspace: node.id, cwd: actions.resolvedNewSessionCwd(inWorkspace: node.id))
     }
 
     /// Inline "+" button on a workspace row — same action as the right-click "New Session" menu item.
@@ -223,7 +233,7 @@ extension WorkspaceSidebar.Coordinator {
         guard let outline = outlineView else { return }
         let row = outline.row(for: sender)
         guard row >= 0, let node = outline.item(atRow: row) as? SidebarNode, node.kind == .workspace else { return }
-        addSession(toWorkspace: node.id, cwd: actions.resolvedNewSessionCwd())
+        addSession(toWorkspace: node.id, cwd: actions.resolvedNewSessionCwd(inWorkspace: node.id))
     }
 
     @objc private func menuDeleteWorkspace(_ sender: NSMenuItem) {
@@ -234,6 +244,27 @@ extension WorkspaceSidebar.Coordinator {
     @objc private func menuFocusWorkspace(_ sender: NSMenuItem) {
         guard let node = sender.representedObject as? SidebarNode else { return }
         actions.focusWorkspace(node.id)
+    }
+
+    /// "Set Root Directory…": pick a folder that becomes the workspace's root (new sessions open there).
+    @objc private func menuSetWorkspaceRoot(_ sender: NSMenuItem) {
+        guard let node = sender.representedObject as? SidebarNode else { return }
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.directoryURL = DirectoryPanelDefaults.url(paths: store.workspaces.first(where: { $0.id == node.id })?.root
+            ?? store.activeSession?.focusedCwd)
+        panel.prompt = "Set Root"
+        panel.message = "Choose a root directory for this workspace"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        store.setWorkspaceRoot(node.id, path: url.path)
+    }
+
+    /// "Clear Root Directory": unset the workspace's root so new sessions follow the global setting again.
+    @objc private func menuClearWorkspaceRoot(_ sender: NSMenuItem) {
+        guard let node = sender.representedObject as? SidebarNode else { return }
+        store.setWorkspaceRoot(node.id, path: nil)
     }
 
     /// "Open Directory…": pick a folder and add a session rooted there.

--- a/agtermCore/Sources/agtermCore/AppSettings.swift
+++ b/agtermCore/Sources/agtermCore/AppSettings.swift
@@ -394,7 +394,9 @@ public struct AppSettings: Codable, Equatable, Sendable {
     /// nil/blank `currentSessionCwd`, or a nil/blank custom path all fall back to `home`: `home` → home;
     /// `currentSession` → `currentSessionCwd` (else home); `custom` → `newSessionCustomDirectory` (else
     /// home). Host-free so `AppActions.newSession()` and the tests share one resolution.
-    public func resolveNewSessionCwd(currentSessionCwd: String?, home: String) -> String {
+    public func resolveNewSessionCwd(workspaceRoot: String?, currentSessionCwd: String?, home: String) -> String {
+        // A workspace root (when set) is a HARD override of the global new-session-directory policy.
+        if let root = workspaceRoot, !root.isEmpty { return root }
         switch NewSessionDirectory(rawValue: newSessionDirectory ?? "") ?? .home {
         case .home:
             return home

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -228,6 +228,7 @@ public final class AppStore {
             return ControlWorkspaceNode(id: workspace.id.uuidString, name: workspace.name,
                                         active: workspace.id == activeWorkspaceID,
                                         focused: workspace.id == focusedWorkspaceID ? true : nil,
+                                        root: workspace.root,
                                         sessions: sessions)
         }
         return ControlTree(workspaces: nodes, idleMs: idleMs(), autoFollowMs: autoFollowMs,
@@ -371,6 +372,16 @@ public final class AppStore {
     public func renameWorkspace(_ workspaceID: UUID, to name: String) {
         guard let trimmed = name.trimmedOrNil, let index = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return }
         workspaces[index].name = trimmed
+        save()
+    }
+
+    /// Sets or clears a workspace's root directory (new sessions open there). Stored verbatim; an empty
+    /// path normalizes to nil (cleared). Delta-guarded so a no-op set doesn't rewrite the snapshot.
+    public func setWorkspaceRoot(_ workspaceID: UUID, path: String?) {
+        guard let index = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return }
+        let normalized = path?.trimmedOrNil
+        guard workspaces[index].root != normalized else { return }
+        workspaces[index].root = normalized
         save()
     }
 
@@ -927,7 +938,7 @@ public final class AppStore {
 
     func workspaceSnapshot(_ workspace: Workspace) -> WorkspaceSnapshot {
         WorkspaceSnapshot(id: workspace.id, name: workspace.name, sessions: workspace.sessions.map(sessionSnapshot),
-                          collapsed: workspace.isExpanded ? nil : true)
+                          collapsed: workspace.isExpanded ? nil : true, root: workspace.root)
     }
 
     func session(from snapshot: SessionSnapshot) -> Session {
@@ -949,7 +960,7 @@ public final class AppStore {
 
     func workspace(from snapshot: WorkspaceSnapshot) -> Workspace {
         Workspace(id: snapshot.id, name: snapshot.name, sessions: snapshot.sessions.map(session(from:)),
-                  isExpanded: !(snapshot.collapsed ?? false))
+                  isExpanded: !(snapshot.collapsed ?? false), root: snapshot.root)
     }
 
 }

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -22,6 +22,7 @@ public protocol ControlActions {
     func moveSessions(_ targets: [String], window: String?, move: ControlSessionMove) -> ControlResponse
     func moveWorkspace(_ target: String?, window: String?, direction: ReorderDirection) -> ControlResponse
     func focusWorkspace(_ target: String?, window: String?, mode: String?) -> ControlResponse
+    func setWorkspaceRoot(_ target: String?, window: String?, path: String?) -> ControlResponse
     func setSessionFlag(_ target: String?, window: String?, mode: String?) -> ControlResponse
     func markSessionSeen(_ target: String?, window: String?) -> ControlResponse
     func setSessionStatus(_ target: String?, window: String?, update: ControlSessionStatusUpdate) -> ControlResponse
@@ -146,7 +147,7 @@ public struct ControlDispatcher {
                 .sessionText:
             return await dispatchSessionSurfaceCommand(request)
         case .workspaceNew, .workspaceSelect, .workspaceRename, .workspaceDelete,
-                .workspaceMove, .workspaceFocus:
+                .workspaceMove, .workspaceFocus, .workspaceRoot:
             return dispatchWorkspaceCommand(request)
         case .quick, .fontInc, .fontDec, .fontReset, .keymapReload,
                 .configReload, .notify, .themeSet, .themeList, .sidebar, .sidebarMode, .sidebarExpand,
@@ -327,6 +328,11 @@ public struct ControlDispatcher {
             return actions.moveWorkspace(request.target, window: request.args?.window, direction: direction)
         case .workspaceFocus:
             return actions.focusWorkspace(request.target, window: request.args?.window, mode: request.args?.mode)
+        case .workspaceRoot:
+            // `clear`, an empty path, or a missing path unsets the root; anything else sets it verbatim.
+            let trimmed = request.args?.path?.trimmedOrNil
+            let path = trimmed == "clear" ? nil : trimmed
+            return actions.setWorkspaceRoot(request.target, window: request.args?.window, path: path)
         default:
             preconditionFailure("unexpected workspace command: \(request.cmd.rawValue)")
         }

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -19,6 +19,7 @@ public enum Command: String, Codable, Sendable {
     case sessionMove = "session.move"
     case workspaceMove = "workspace.move"
     case workspaceFocus = "workspace.focus"
+    case workspaceRoot = "workspace.root"
     case sessionType = "session.type"
     case sessionStatus = "session.status"
     case sessionFlag = "session.flag"
@@ -451,13 +452,18 @@ public struct ControlWorkspaceNode: Codable, Sendable, Equatable {
     /// SELECTED workspace): focus collapses the sidebar to a single workspace. The read side of the
     /// write-only `workspace.focus` — so a script can record which workspace is focused and restore it.
     public let focused: Bool?
+    /// The workspace's root directory (new sessions open there), omitted from the JSON when nil. The read
+    /// side of the write-only `workspace.root` — so a script can record a workspace's root and restore it.
+    public let root: String?
     public let sessions: [ControlSessionNode]
 
-    public init(id: String, name: String, active: Bool, focused: Bool? = nil, sessions: [ControlSessionNode]) {
+    public init(id: String, name: String, active: Bool, focused: Bool? = nil, root: String? = nil,
+                sessions: [ControlSessionNode]) {
         self.id = id
         self.name = name
         self.active = active
         self.focused = focused
+        self.root = root
         self.sessions = sessions
     }
 }

--- a/agtermCore/Sources/agtermCore/Snapshot.swift
+++ b/agtermCore/Sources/agtermCore/Snapshot.swift
@@ -79,12 +79,18 @@ public struct WorkspaceSnapshot: Codable, Equatable, Sendable {
     /// `SessionSnapshot`. Only a collapsed workspace writes it (`true`); an expanded one omits it, so an
     /// all-expanded tree serializes byte-identically to a legacy snapshot.
     public var collapsed: Bool?
+    /// The workspace's root directory (new sessions open there), or nil for none. Optional so a snapshot
+    /// already on disk before this field was added still decodes (missing → nil → no root) instead of
+    /// failing the load and wiping the saved tree, like `collapsed`.
+    public var root: String?
 
-    public init(id: UUID, name: String, sessions: [SessionSnapshot], collapsed: Bool? = nil) {
+    public init(id: UUID, name: String, sessions: [SessionSnapshot], collapsed: Bool? = nil,
+                root: String? = nil) {
         self.id = id
         self.name = name
         self.sessions = sessions
         self.collapsed = collapsed
+        self.root = root
     }
 }
 

--- a/agtermCore/Sources/agtermCore/Workspace.swift
+++ b/agtermCore/Sources/agtermCore/Workspace.swift
@@ -10,19 +10,25 @@ public struct Workspace: Identifiable {
     /// Whether the sidebar row is expanded (its session rows shown). Defaults true so a freshly created
     /// workspace opens; persisted per workspace so the collapse state survives a relaunch.
     public var isExpanded: Bool
+    /// The workspace's root directory: when set, every new session created in this workspace opens there
+    /// (a hard override of the global `AppSettings.newSessionDirectory`). nil (the default) falls through to
+    /// the global new-session-directory policy. Persisted per workspace.
+    public var root: String?
 
-    public init(name: String, sessions: [Session] = [], isExpanded: Bool = true) {
+    public init(name: String, sessions: [Session] = [], isExpanded: Bool = true, root: String? = nil) {
         id = UUID()
         self.name = name
         self.sessions = sessions
         self.isExpanded = isExpanded
+        self.root = root
     }
 
-    public init(id: UUID, name: String, sessions: [Session] = [], isExpanded: Bool = true) {
+    public init(id: UUID, name: String, sessions: [Session] = [], isExpanded: Bool = true, root: String? = nil) {
         self.id = id
         self.name = name
         self.sessions = sessions
         self.isExpanded = isExpanded
+        self.root = root
     }
 
     /// Total unseen-notification count across this workspace's sessions, for the badge on a

--- a/agtermCore/Sources/agtermctlKit/WorkspaceCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/WorkspaceCommands.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import Foundation
 import agtermCore
 
 // MARK: - workspace
@@ -6,7 +7,7 @@ import agtermCore
 struct Workspace: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Workspace commands.",
-        subcommands: [New.self, Rename.self, Delete.self, Select.self, Move.self, Focus.self]
+        subcommands: [New.self, Rename.self, Delete.self, Select.self, Move.self, Focus.self, Root.self]
     )
 
     struct New: RequestCommand {
@@ -76,6 +77,34 @@ struct Workspace: ParsableCommand {
 
         func makeRequest() throws -> ControlRequest {
             ControlRequest(cmd: .workspaceFocus, target: target.target, args: options.withWindow(ControlArgs(mode: mode)))
+        }
+    }
+
+    struct Root: RequestCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Set a workspace's root directory (new sessions open there), or clear it.")
+        @Argument(help: "A directory path, or `clear` to unset the root.") var dir: String?
+        @Flag(help: "Clear the workspace's root directory.") var clear = false
+        @OptionGroup var target: TargetOptions
+        @OptionGroup var options: ClientOptions
+
+        func validate() throws {
+            let hasDir = !(dir?.trimmingCharacters(in: .whitespaces).isEmpty ?? true)
+            guard clear || hasDir else {
+                throw ValidationError("provide a directory path, or --clear")
+            }
+        }
+
+        func makeRequest() throws -> ControlRequest {
+            var path: String?
+            if !clear, let raw = dir, raw != "clear" {
+                // absolutize a relative/~ path — the app resolves it in ITS own cwd, not the CLI's.
+                let expanded = (raw as NSString).expandingTildeInPath
+                let base = expanded.hasPrefix("/") ? expanded
+                    : FileManager.default.currentDirectoryPath + "/" + expanded
+                path = URL(fileURLWithPath: base).standardizedFileURL.path
+            }
+            return ControlRequest(cmd: .workspaceRoot, target: target.target, args: options.withWindow(ControlArgs(path: path)))
         }
     }
 }

--- a/agtermCore/Tests/agtermCoreTests/AppSettingsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppSettingsTests.swift
@@ -441,28 +441,43 @@ struct AppSettingsTests {
 
     @Test func resolveNewSessionCwdHomeIsDefault() {
         // nil mode (default) and an explicit "home" both resolve to home, ignoring the session cwd.
-        #expect(AppSettings().resolveNewSessionCwd(currentSessionCwd: "/proj", home: "/home") == "/home")
-        #expect(AppSettings(newSessionDirectory: "home").resolveNewSessionCwd(currentSessionCwd: "/proj", home: "/home") == "/home")
+        #expect(AppSettings().resolveNewSessionCwd(workspaceRoot: nil, currentSessionCwd: "/proj", home: "/home") == "/home")
+        #expect(AppSettings(newSessionDirectory: "home").resolveNewSessionCwd(workspaceRoot: nil, currentSessionCwd: "/proj", home: "/home") == "/home")
         // an unknown future mode falls back to home rather than crashing.
-        #expect(AppSettings(newSessionDirectory: "future").resolveNewSessionCwd(currentSessionCwd: "/proj", home: "/home") == "/home")
+        #expect(AppSettings(newSessionDirectory: "future").resolveNewSessionCwd(workspaceRoot: nil, currentSessionCwd: "/proj", home: "/home") == "/home")
     }
 
     @Test func resolveNewSessionCwdCurrentSessionInheritsOrFallsBack() {
         let settings = AppSettings(newSessionDirectory: "currentSession")
-        #expect(settings.resolveNewSessionCwd(currentSessionCwd: "/proj", home: "/home") == "/proj")
+        #expect(settings.resolveNewSessionCwd(workspaceRoot: nil, currentSessionCwd: "/proj", home: "/home") == "/proj")
         // no active session (nil cwd) or a blank cwd falls back to home.
-        #expect(settings.resolveNewSessionCwd(currentSessionCwd: nil, home: "/home") == "/home")
-        #expect(settings.resolveNewSessionCwd(currentSessionCwd: "", home: "/home") == "/home")
+        #expect(settings.resolveNewSessionCwd(workspaceRoot: nil, currentSessionCwd: nil, home: "/home") == "/home")
+        #expect(settings.resolveNewSessionCwd(workspaceRoot: nil, currentSessionCwd: "", home: "/home") == "/home")
     }
 
     @Test func resolveNewSessionCwdCustomUsesPathElseHome() {
         #expect(AppSettings(newSessionDirectory: "custom", newSessionCustomDirectory: "/fixed")
-            .resolveNewSessionCwd(currentSessionCwd: "/proj", home: "/home") == "/fixed")
+            .resolveNewSessionCwd(workspaceRoot: nil, currentSessionCwd: "/proj", home: "/home") == "/fixed")
         // custom mode with an unset or blank path falls back to home.
         #expect(AppSettings(newSessionDirectory: "custom")
-            .resolveNewSessionCwd(currentSessionCwd: "/proj", home: "/home") == "/home")
+            .resolveNewSessionCwd(workspaceRoot: nil, currentSessionCwd: "/proj", home: "/home") == "/home")
         #expect(AppSettings(newSessionDirectory: "custom", newSessionCustomDirectory: "")
-            .resolveNewSessionCwd(currentSessionCwd: "/proj", home: "/home") == "/home")
+            .resolveNewSessionCwd(workspaceRoot: nil, currentSessionCwd: "/proj", home: "/home") == "/home")
+    }
+
+    @Test func resolveNewSessionCwdWorkspaceRootOverridesEveryMode() {
+        // a non-empty workspace root wins over EVERY newSessionDirectory mode (home/currentSession/custom).
+        for mode in [nil, "home", "currentSession", "custom"] {
+            let settings = AppSettings(newSessionDirectory: mode, newSessionCustomDirectory: "/fixed")
+            #expect(settings.resolveNewSessionCwd(workspaceRoot: "/proj/root", currentSessionCwd: "/cur", home: "/home") == "/proj/root")
+        }
+    }
+
+    @Test func resolveNewSessionCwdBlankWorkspaceRootFallsThroughToTheMode() {
+        // a nil or empty workspace root falls through to the global new-session-directory policy.
+        let settings = AppSettings(newSessionDirectory: "currentSession")
+        #expect(settings.resolveNewSessionCwd(workspaceRoot: nil, currentSessionCwd: "/cur", home: "/home") == "/cur")
+        #expect(settings.resolveNewSessionCwd(workspaceRoot: "", currentSessionCwd: "/cur", home: "/home") == "/cur")
     }
 
     @Test func autoFollowAttentionUnknownDecodesToOff() {

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -1447,6 +1447,19 @@ struct AppStoreTests {
         #expect(store.controlTree().workspaces.allSatisfy { $0.focused == nil })
     }
 
+    @Test func setWorkspaceRootPersistsAndReportsOnTree() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "proj")
+        func root() -> String? { store.controlTree().workspaces.first { $0.id == ws.id.uuidString }?.root }
+        #expect(root() == nil)
+        store.setWorkspaceRoot(ws.id, path: "/proj/root")
+        #expect(root() == "/proj/root")
+        store.setWorkspaceRoot(ws.id, path: nil) // clear
+        #expect(root() == nil)
+        store.setWorkspaceRoot(ws.id, path: "   ") // blank normalizes to nil
+        #expect(root() == nil)
+    }
+
     @Test func controlTreeReportsSidebarMode() {
         let store = makeStore()
         #expect(store.controlTree().sidebarMode == "tree") // default: the workspace tree

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -419,6 +419,27 @@ struct ControlDispatcherTests {
         ])
     }
 
+    @Test func workspaceRootRoutesPathAndClearThroughActions() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let set = await dispatcher.dispatch(ControlRequest(
+            cmd: .workspaceRoot, target: "workspace", args: ControlArgs(window: "win", path: "/proj/root")))
+        let clearExplicit = await dispatcher.dispatch(ControlRequest(
+            cmd: .workspaceRoot, target: "workspace", args: ControlArgs(path: "clear")))
+        let clearMissing = await dispatcher.dispatch(ControlRequest(cmd: .workspaceRoot, target: "workspace"))
+
+        #expect(set == ControlResponse(ok: true))
+        #expect(clearExplicit == ControlResponse(ok: true))
+        #expect(clearMissing == ControlResponse(ok: true))
+        // a path passes through verbatim; `clear` and a missing path both normalize to nil (unset).
+        #expect(actions.calls == [
+            .setWorkspaceRoot(target: "workspace", window: "win", "/proj/root"),
+            .setWorkspaceRoot(target: "workspace", window: nil, nil),
+            .setWorkspaceRoot(target: "workspace", window: nil, nil)
+        ])
+    }
+
     @Test func workspaceRenameRejectsMissingOrBlankNameWithoutCallingActions() async {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -25,10 +25,21 @@ struct ControlProtocolTests {
             ControlRequest(cmd: .workspaceRename, target: "active", args: ControlArgs(name: "renamed")),
             ControlRequest(cmd: .workspaceDelete, target: "9f3c"),
             ControlRequest(cmd: .workspaceSelect, target: "9f3c"),
+            ControlRequest(cmd: .workspaceRoot, target: "9f3c", args: ControlArgs(path: "/proj/root")),
         ]
         for request in cases {
             #expect(try roundTrip(request) == request)
         }
+    }
+
+    @Test func workspaceNodeRootRoundTripsAndOmitsWhenNil() throws {
+        let withRoot = ControlWorkspaceNode(id: "w1", name: "work", active: true, root: "/proj", sessions: [])
+        let data = try JSONEncoder().encode(withRoot)
+        #expect(try JSONDecoder().decode(ControlWorkspaceNode.self, from: data) == withRoot)
+        #expect(String(decoding: data, as: UTF8.self).contains("\"root\""))
+        // no root → the key is omitted from the JSON (synthesized encodeIfPresent for the optional).
+        let noRoot = ControlWorkspaceNode(id: "w1", name: "work", active: true, sessions: [])
+        #expect(!String(decoding: try JSONEncoder().encode(noRoot), as: UTF8.self).contains("\"root\""))
     }
 
     @Test func sessionCommandsRoundTrip() throws {

--- a/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
+++ b/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
@@ -26,6 +26,7 @@ final class MockControlActions: ControlActions {
         case sessionMoveBatch(targets: [String], window: String?, ControlSessionMove)
         case workspaceMove(target: String?, window: String?, ReorderDirection)
         case workspaceFocus(target: String?, window: String?, String?)
+        case setWorkspaceRoot(target: String?, window: String?, String?)
         case sessionFlag(target: String?, window: String?, String?)
         case markSessionSeen(target: String?, window: String?)
         case sessionStatus(target: String?, window: String?, ControlSessionStatusUpdate)
@@ -196,6 +197,11 @@ final class MockControlActions: ControlActions {
 
     func focusWorkspace(_ target: String?, window: String?, mode: String?) -> ControlResponse {
         calls.append(.workspaceFocus(target: target, window: window, mode))
+        return ControlResponse(ok: true)
+    }
+
+    func setWorkspaceRoot(_ target: String?, window: String?, path: String?) -> ControlResponse {
+        calls.append(.setWorkspaceRoot(target: target, window: window, path))
         return ControlResponse(ok: true)
     }
 

--- a/agtermCore/Tests/agtermCoreTests/WorkspaceTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/WorkspaceTests.swift
@@ -17,4 +17,23 @@ struct WorkspaceTests {
         let workspace = Workspace(name: "empty", sessions: [Session(initialCwd: "/a")])
         #expect(workspace.unseenCount == 0)
     }
+
+    @Test func rootDefaultsNilAndIsSettable() {
+        // the per-workspace start directory: absent by default, holds a path once set.
+        var workspace = Workspace(name: "proj", sessions: [])
+        #expect(workspace.root == nil)
+        workspace.root = "/Users/me/proj"
+        #expect(workspace.root == "/Users/me/proj")
+    }
+
+    @Test func snapshotRootRoundTripsAndLegacyDecodesWithoutRoot() throws {
+        let snap = WorkspaceSnapshot(id: UUID(), name: "work", sessions: [], root: "/proj")
+        let data = try JSONEncoder().encode(snap)
+        #expect(try JSONDecoder().decode(WorkspaceSnapshot.self, from: data) == snap)
+        // a legacy snapshot with NO root key still decodes (root → nil) — Optional, no version bump.
+        let legacy = Data(#"{"id":"11111111-1111-1111-1111-111111111111","name":"work","sessions":[]}"#.utf8)
+        let decoded = try JSONDecoder().decode(WorkspaceSnapshot.self, from: legacy)
+        #expect(decoded.root == nil)
+        #expect(decoded.name == "work")
+    }
 }


### PR DESCRIPTION
Give a workspace an optional root directory. When set, every new session created in that workspace opens there — a hard override of the global `newSessionDirectory` setting; unset falls through to that setting, and a non-existent root falls back at spawn time. A workspace usually maps to a project, so "new session here" lands in the project directory without a global setting change (today it opens `$HOME` once the workspace has no session to inherit a cwd from).

**Model.** `Workspace.root` and `WorkspaceSnapshot.root` are Optional with no snapshot version bump — a legacy `workspaces.json` decodes with `root == nil`.

**Resolution.** `AppSettings.resolveNewSessionCwd(workspaceRoot:…)` applies the override; both new-session entry points honor it — `AppActions.resolvedNewSessionCwd(inWorkspace:)` (with an on-disk existence check so a stale/deleted root falls through instead of failing the spawn) and the control `makeSessionResponse`.

**Control + UI.** A `workspace.root` command — `ControlActions.setWorkspaceRoot`, `AppStore.setWorkspaceRoot`, the `ControlWorkspaceNode.root` read-back on `tree`, and `agtermctl workspace root <dir|--clear>` — plus workspace-row **Set Root Directory…** / **Clear Root Directory** context items in the sidebar.

**Tests.** `agtermCore` stays green (+7): resolve precedence, `Workspace.root`, snapshot codable + legacy decode, command round-trip, `ControlWorkspaceNode` omit-when-nil, dispatcher routing, and the `controlTree` read-back. The app target and `agtermctl` build, `make lint` is clean, and the bundled agent skill (`SKILL.md`/`reference.md`/`examples.md`) plus the `control-api` rule are updated (command count 61 → 62).

Developed downstream in [rook](https://github.com/jokius/rook) and ported back here (names/paths translated to `agterm`) as a goodwill contribution — no pressure to take it. One thing left for you: the website (`site/commands.html`, `site/docs.html`) still reads "61 commands" and has no `workspace.root` entry — I didn't want to guess at your hand-authored per-command HTML.
