### PR TITLE
feat: add per-workspace collapse/expand control commands

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -70,7 +70,8 @@ paths:
   `session.flag`/`flagged`, `session.focus`/`splitFocused`, `session.resize`/`splitRatio`,
   `session.restore`/`restoreCommand`+`splitRestoreCommand`,
   `session.overlay.resize`/`overlaySizePercent`, `sidebar`/`sidebarVisible` (top-level),
-  `sidebar.mode`/`sidebarMode`, `workspace.focus`/`focused` (workspace node), `quick`/`quickVisible` (top-level),
+  `sidebar.mode`/`sidebarMode`, `workspace.focus`/`focused` (workspace node),
+  `workspace.collapse`+`workspace.expand`/`collapsed` (workspace node), `quick`/`quickVisible` (top-level),
   `font.*`/`fontSize`+`splitFontSize`+`scratchFontSize` (the per-pane LIVE font size — the split/scratch
   panes' fonts are otherwise unobservable, being live-only; supplied to `controlTree` by app-side closures
   reading `GhosttySurfaceView.currentFontSize()`, since the host-free tree can't read a surface),
@@ -160,7 +161,7 @@ paths:
   The skill is a REFERENCE/knowledge skill (both user-invocable via `/agterm` and model-triggered,
   `allowed-tools: Bash(agtermctl *)`; the agent-neutral `description` carries the trigger nouns since
   Codex may ignore the extra `when_to_use` field — unknown frontmatter is harmless),
-  authored at `agterm/Resources/agent-skill/` (`SKILL.md` overview + model + addressing + 62-command
+  authored at `agterm/Resources/agent-skill/` (`SKILL.md` overview + model + addressing + 64-command
   summary + the image-display helper + a troubleshooting/reporting pointer;
   `reference.md` full per-command detail + keymap format; `examples.md` agtermctl recipes;
   `troubleshooting.md` diagnosing the common problems (keymap editor, custom actions,
@@ -238,9 +239,9 @@ paths:
   rules, then remaining targets resolve inside that same store so one command never mutates multiple windows.
   The top-level `target` also carries the first explicit batch target so a new CLI talking to a still-running
   pre-batch server degrades to a named session instead of accidentally acting on `active`.
-- **Command catalog (62 commands):**
+- **Command catalog (64 commands):**
   - `tree`
-  - `workspace.new`/`workspace.rename`/`workspace.delete`/`workspace.select`/`workspace.move`/`workspace.focus`
+  - `workspace.new`/`workspace.rename`/`workspace.delete`/`workspace.select`/`workspace.move`/`workspace.focus`/`workspace.collapse`/`workspace.expand`
   - `session.new`/`session.duplicate`/`session.close`/`session.select`/`session.rename`/`session.reveal`/`session.move`/`session.type`/`session.split`/`session.scratch`/`session.focus`/`session.resize`/`session.go`/`session.copy`/`session.paste`/`session.selectall`/`session.text`/`session.search`/`session.status`/`session.flag`/`session.seen`/`session.restore`/`session.background`/`session.overlay.open`/`session.overlay.close`/`session.overlay.resize`/`session.overlay.result`
   - `surface.zoom`
   - `dashboard`
@@ -266,7 +267,7 @@ paths:
   Setting echoes the resulting effective side in `result.text`; the BARE form (no name) reads the side
   the last config feed applied (`SettingsModel.lastAppliedIsDark`), which the test polls to prove the
   flip actually drove the reload.
-  `AppearanceFlipUITests` is its only consumer; the public command count stays 62.
+  `AppearanceFlipUITests` is its only consumer; the public command count stays 64.
 
   `workspace.delete` honors keep-at-least-one and returns an error instead of the GUI confirm alert (nothing
   blocks on a modal).
@@ -1209,6 +1210,43 @@ paths:
   (3) the `workspace focus on|off|toggle` subcommand (`Focus`) in `agtermctlKit`,
   (4) round-trip in `ControlProtocolTests` + the e2e `testWorkspaceFocusHidesOtherWorkspaces` in `ControlSidebarStatusUITests`
   plus the `FocusWorkspaceUITests` XCUITest.
+  `workspace.collapse`/`workspace.expand` (target = workspace) collapse/expand ONE workspace's subtree in
+  the sidebar tree — the per-workspace analogue of the all-workspace `sidebar.expand`/`sidebar.collapse`
+  (scope by prefix: `sidebar.*` acts on every workspace, `workspace.*` on the addressed one).
+  They resolve the workspace via `resolveWorkspace` (honoring the global `--window` selector), drive
+  `setWorkspaceExpansion` → `AppActions.setWorkspaceExpanded(_:expanded:in:)`, and return the workspace id.
+  Unlike the GUI (a row click drives `expandItem`/`collapseItem` directly, keep-in-sync EXEMPT), there is
+  no GUI caller — the row click is the only GUI path — so this is a control-only pair.
+  The app-side arm posts `.agtermSetWorkspaceExpanded` carrying the target `AppStore` as the object + the
+  workspace id/desired-state in `userInfo`; `WorkspaceSidebar.Coordinator.setWorkspaceExpandedNotified`
+  ALWAYS writes the persisted `AppStore.setWorkspaceExpanded` (delta-guarded, the source of truth) + keeps
+  the tracked `expandedWorkspaceIDs` in step, THEN drives the live outline row with `suppressExpansionPersist`
+  when it is on screen (tree mode, row resolved) — so the intent survives a collapsed/focused-away/flagged
+  row and a transient focus force-reveal, and a redundant callback re-persist is avoided.
+  Idempotent.
+  Its READ side is `ControlWorkspaceNode.collapsed` (`workspace.isExpanded ? nil : true` in the tree
+  builder, mirroring the persisted `WorkspaceSnapshot.collapsed`): `true` when collapsed, omitted when
+  expanded, so a script can record a workspace's open/closed state, restore it, or toggle by reading it first.
+  `workspace.new` gains a `--collapsed` flag (`ControlArgs.collapsed`, threaded into `AppStore.addWorkspace(name:collapsed:)`
+  → `Workspace(isExpanded: !collapsed)`): a runtime-added workspace with `isExpanded == false` renders
+  collapsed (the reconcile's `formUnion(filter(\.isExpanded))` excludes it), so it can be built and filled
+  with `session.new --no-select` without opening.
+  Four-point keep-in-sync audit: (1) `case workspaceCollapse = "workspace.collapse"` + `case workspaceExpand = "workspace.expand"`
+  + `ControlArgs.collapsed` + `ControlWorkspaceNode.collapsed` in `ControlProtocol.swift`,
+  (2) the `.workspaceCollapse`/`.workspaceExpand` dispatch arms → `ControlActions.setWorkspaceExpansion`
+  (+ `createWorkspace(…collapsed:)`) in `ControlServer+WorkspaceCommands.swift`, the app-side
+  `AppActions.setWorkspaceExpanded(_:expanded:in:)` + `WorkspaceSidebar.Coordinator.setWorkspaceExpandedNotified`
+  (+ the `.agtermSetWorkspaceExpanded` name + the two userInfo keys) + the `collapsed` population in
+  `AppStore.controlTree`, (3) the `workspace collapse`/`workspace expand` subcommands + `workspace new --collapsed`
+  in `agtermctlKit`, (4) round-trip + omit-when-nil + raw-string decode in `ControlProtocolTests`,
+  dispatcher routing in `ControlDispatcherTests`, CLI mapping in `CommandsTests`,
+  `AppStoreTests.controlTreeReportsCollapsedWorkspace` + `AppStoreOrganizationTests.newWorkspaceCollapsedStartsCollapsed`,
+  and the e2e `testWorkspaceCollapseAndExpand` + `testWorkspaceNewCollapsedStaysClosedWhenFilled` in
+  `ControlSidebarStatusUITests`.
+  The workspace-command adapter arms (create/select/rename/delete/move/focus + this pair + the all-workspace
+  `expandWorkspaces`/`collapseWorkspaces` helpers) live in `ControlServer+WorkspaceCommands.swift`, split
+  out of `ControlServer+SessionActions.swift` (the `+WindowCommands.swift` family-split precedent) to keep
+  that file under the 1000-line limit; they still satisfy the `ControlActions` conformance declared there.
   `tree` now also surfaces, on each `ControlSessionNode`, `foreground`/`splitForeground` — the LIVE foreground-process
   argv of the main + split panes (nil/omitted at the shell prompt), the SAME `ForegroundProcess.command(for:shellBasename:)`
   capture the restore-running-command feature uses (`ghostty_surface_foreground_pid` → `sysctl(KERN_PROCARGS2)`
@@ -1445,12 +1483,12 @@ paths:
   (image/text/color set/clear + tree read-back).
   **Agent-skill mirror (HARD keep-in-sync, 4th surface):** all commands are documented in the bundled
   `agterm/Resources/agent-skill/` (SKILL.md summary, reference.md detail,
-  examples.md recipes) and the command count there is bumped to 62 to match.
+  examples.md recipes) and the command count there is bumped to 64 to match.
   **Website mirror (HARD keep-in-sync):** the site's per-command reference `site/commands.html` documents
   EVERY `agtermctl` control command — one inline-styled card per command carrying its invocation, its
   arguments, and the `tree` read-back field, grouped into its command family's section.
   A new `Command` case REQUIRES a new `site/commands.html` entry (a changed command an updated one, a
   removed command a deleted one), in lockstep with the agent skill above and `README.md`/`site/docs.html`;
-  the page's "62 commands" copy must track the catalog count.
+  the page's "64 commands" copy must track the catalog count.
   It drifted once because the site keep-in-sync convention named only `docs.html`/`index.html`, so
   `dashboard` and `surface.zoom` shipped undocumented here.

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -1217,12 +1217,20 @@ paths:
   `setWorkspaceExpansion` → `AppActions.setWorkspaceExpanded(_:expanded:in:)`, and return the workspace id.
   Unlike the GUI (a row click drives `expandItem`/`collapseItem` directly, keep-in-sync EXEMPT), there is
   no GUI caller — the row click is the only GUI path — so this is a control-only pair.
-  The app-side arm posts `.agtermSetWorkspaceExpanded` carrying the target `AppStore` as the object + the
-  workspace id/desired-state in `userInfo`; `WorkspaceSidebar.Coordinator.setWorkspaceExpandedNotified`
-  ALWAYS writes the persisted `AppStore.setWorkspaceExpanded` (delta-guarded, the source of truth) + keeps
-  the tracked `expandedWorkspaceIDs` in step, THEN drives the live outline row with `suppressExpansionPersist`
-  when it is on screen (tree mode, row resolved) — so the intent survives a collapsed/focused-away/flagged
-  row and a transient focus force-reveal, and a redundant callback re-persist is avoided.
+  The app-side flow keeps the source-of-truth persist OUT of the view: `AppActions.setWorkspaceExpanded(_:expanded:in:)`
+  writes `AppStore.setWorkspaceExpanded` (delta-guarded) FIRST, THEN posts `.agtermSetWorkspaceExpanded`
+  carrying the target `AppStore` as the object + the workspace id/desired-state in `userInfo`.
+  The persist must NOT ride the notification alone: `WindowContentView` mounts `WorkspaceSidebar` only
+  while `sidebarVisible`, so with the sidebar HIDDEN the Coordinator is torn down (its `.agtermSetWorkspaceExpanded`
+  observer removed in `isolated deinit`) and a notification-only write would silently drop, leaving the
+  `collapsed` read-back stale while the command still returns `ok` — the record-then-restore/toggle
+  contract the feature exists for.
+  So `WorkspaceSidebar.Coordinator.setWorkspaceExpandedNotified` is VIEW-SYNC ONLY: it keeps the tracked
+  `expandedWorkspaceIDs` in step — so the intent survives a collapsed/focused-away/flagged row and a
+  transient focus force-reveal — and drives the live outline row with `suppressExpansionPersist` when it
+  is on screen (tree mode, row resolved).
+  This mirrors `workspace.focus` (persists `setFocusedWorkspace` in the arm) and `session.resize`
+  (persists `applySplitRatio` in the arm, posts only to move the live divider).
   Idempotent.
   Its READ side is `ControlWorkspaceNode.collapsed` (`workspace.isExpanded ? nil : true` in the tree
   builder, mirroring the persisted `WorkspaceSnapshot.collapsed`): `true` when collapsed, omitted when

--- a/.claude/rules/sidebar.md
+++ b/.claude/rules/sidebar.md
@@ -74,10 +74,11 @@ paths:
   This is pure click-routing over the existing per-workspace `expandItem`/`collapseItem` (an exempt case
   under the control keep-in-sync rule): the row click itself adds NO control command.
   The per-workspace collapse/expand IS driven over the socket by `workspace.collapse`/`workspace.expand`
-  (distinct from the ALL-workspaces `sidebar.expand`/`sidebar.collapse`), but by a SEPARATE path — the
-  control arm posts `.agtermSetWorkspaceExpanded` and the Coordinator's `setWorkspaceExpandedNotified`
-  syncs the persisted `isExpanded` + the live outline row — NOT by routing through this click handler (see
-  the Control API rule).
+  (distinct from the ALL-workspaces `sidebar.expand`/`sidebar.collapse`), but by a SEPARATE path that does
+  NOT route through this click handler: `AppActions.setWorkspaceExpanded` persists `isExpanded` on the
+  store DIRECTLY (source of truth, so it survives a hidden sidebar whose Coordinator is torn down), THEN
+  posts `.agtermSetWorkspaceExpanded` for the Coordinator's `setWorkspaceExpandedNotified` to sync only the
+  live outline row + tracked set (see the Control API rule).
   Covered by `SidebarUITests.testClickWorkspaceRowTogglesExpansion`.
 - **A session ROW click reveals a blocked session's pane-tagged pane.**
   `Coordinator.outlineViewSelectionDidChange` selects the clicked session (`selectSession`) then — async,

--- a/.claude/rules/sidebar.md
+++ b/.claude/rules/sidebar.md
@@ -72,8 +72,12 @@ paths:
   (instant-toggle was tried and rejected: AppKit commits the first click of a double before it knows a
   second is coming, so instant forces a visible toggle-then-revert flicker on rename).
   This is pure click-routing over the existing per-workspace `expandItem`/`collapseItem` (an exempt case
-  under the control keep-in-sync rule), so it adds NO control command — the ALL-workspaces
-  `sidebar.expand`/`sidebar.collapse` stay the control surface.
+  under the control keep-in-sync rule): the row click itself adds NO control command.
+  The per-workspace collapse/expand IS driven over the socket by `workspace.collapse`/`workspace.expand`
+  (distinct from the ALL-workspaces `sidebar.expand`/`sidebar.collapse`), but by a SEPARATE path — the
+  control arm posts `.agtermSetWorkspaceExpanded` and the Coordinator's `setWorkspaceExpandedNotified`
+  syncs the persisted `isExpanded` + the live outline row — NOT by routing through this click handler (see
+  the Control API rule).
   Covered by `SidebarUITests.testClickWorkspaceRowTogglesExpansion`.
 - **A session ROW click reveals a blocked session's pane-tagged pane.**
   `Coordinator.outlineViewSelectionDidChange` selects the clicked session (`selectSession`) then — async,

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ The theme picker (View ▸ Select Theme…, or the action palette) previews each
 
 To open a terminal at a directory without the CLI, `open -a agterm <path>` — or right-click a folder in Finder and choose **Open With ▸ agterm**. agterm adds a session in that directory to the last-active window. This works when agterm is already running (its usual state); if it isn't, launch agterm first, then run the command. The socket equivalent, and the way to place the session precisely, is `agtermctl session new --cwd <path>`.
 
-The sections below cover the common cases. All 62 commands, with every argument, return value, and error, are documented in the **[Command reference](https://agterm.com/commands)**.
+The sections below cover the common cases. All 64 commands, with every argument, return value, and error, are documented in the **[Command reference](https://agterm.com/commands)**.
 
 The app bundles `agtermctl` inside `agterm.app`. The easiest way to put it on your PATH is **Help ▸ Install Command Line Tool…**, which symlinks the bundled binary into `/usr/local/bin` (the first entry in macOS's default PATH). When that directory is user-writable it installs silently; otherwise it asks once for an administrator password.
 
@@ -230,6 +230,8 @@ agtermctl session move --after 9f3c              # place the active session righ
 agtermctl session move "$ws" --target 9f3c --target abcd  # move a batch as one ordered block; --after/--before also accept repeated --target
 agtermctl session close --target 9f3c --target abcd       # close a batch with one grace-period undo
 agtermctl workspace move --to top                # reorder a workspace among its siblings (up|down|top|bottom)
+agtermctl workspace new work --collapsed          # create a workspace closed in the sidebar (fill it with session new --no-select without it opening)
+agtermctl workspace collapse --target "$ws"       # collapse one workspace in the sidebar tree; workspace expand re-opens it (per-workspace, unlike sidebar expand/collapse)
 agtermctl session split toggle                   # split the active session
 agtermctl session resize --split-ratio 0.7       # set the split divider (left-pane fraction); or --grow-left/--grow-right D
 agtermctl session scratch toggle                 # show/hide the active session's scratch terminal (on|off|toggle)

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -567,6 +567,19 @@ final class AppActions {
         NotificationCenter.default.post(name: .agtermCollapseWorkspaces, object: store)
     }
 
+    /// Collapse or expand a SINGLE workspace in `store`'s window sidebar — the per-workspace control path
+    /// (`workspace.collapse`/`workspace.expand`), distinct from the all-workspace `expandAllWorkspaces`/`collapseOtherWorkspaces`
+    /// above. Posts a store-scoped notification carrying the workspace id + desired state; the matching
+    /// window's `WorkspaceSidebar.Coordinator` syncs both the persisted `Workspace.isExpanded` and the live
+    /// outline row (see its `setWorkspaceExpandedNotified`). There is no GUI caller — a row click drives the
+    /// outline directly — so this exists only for the control channel.
+    func setWorkspaceExpanded(_ id: UUID, expanded: Bool, in store: AppStore) {
+        NotificationCenter.default.post(
+            name: .agtermSetWorkspaceExpanded, object: store,
+            userInfo: [WorkspaceSidebar.Coordinator.workspaceIDUserInfoKey: id,
+                       WorkspaceSidebar.Coordinator.expandedUserInfoKey: expanded])
+    }
+
     // MARK: - Flagged working-set
 
     /// Toggle a session's flagged membership (the durable flagged working-set the flat sidebar view

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -569,11 +569,17 @@ final class AppActions {
 
     /// Collapse or expand a SINGLE workspace in `store`'s window sidebar — the per-workspace control path
     /// (`workspace.collapse`/`workspace.expand`), distinct from the all-workspace `expandAllWorkspaces`/`collapseOtherWorkspaces`
-    /// above. Posts a store-scoped notification carrying the workspace id + desired state; the matching
-    /// window's `WorkspaceSidebar.Coordinator` syncs both the persisted `Workspace.isExpanded` and the live
-    /// outline row (see its `setWorkspaceExpandedNotified`). There is no GUI caller — a row click drives the
-    /// outline directly — so this exists only for the control channel.
+    /// above. Persists `Workspace.isExpanded` DIRECTLY on the store (the source of truth for the `collapsed`
+    /// read-back, delta-guarded so it's idempotent), THEN posts a store-scoped notification so the matching
+    /// window's `WorkspaceSidebar.Coordinator` syncs the live outline row + its tracked expansion set (see
+    /// `setWorkspaceExpandedNotified`). The persist must NOT depend on the sidebar Coordinator: it is torn
+    /// down when the window's sidebar is hidden (`WindowContentView` mounts it only while `sidebarVisible`),
+    /// so a notification-only write would silently drop with the sidebar hidden and leave the read-back stale.
+    /// Mirrors `workspace.focus`/`session.resize`, which likewise persist in the arm and post only for the
+    /// live view. There is no GUI caller — a row click drives the outline directly — so this exists only for
+    /// the control channel.
     func setWorkspaceExpanded(_ id: UUID, expanded: Bool, in store: AppStore) {
+        store.setWorkspaceExpanded(id, expanded: expanded)
         NotificationCenter.default.post(
             name: .agtermSetWorkspaceExpanded, object: store,
             userInfo: [WorkspaceSidebar.Coordinator.workspaceIDUserInfoKey: id,

--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -216,45 +216,6 @@ extension ControlServer: ControlActions {
         }
     }
 
-    func createWorkspace(window: String?, name: String?) -> ControlResponse {
-        // placement target: the window's frontmost store (or `args.window`'s). name defaults to
-        // the auto-generated workspace name when none is given.
-        resolver.resolvePlacementStore(window) { store in
-            let name = trimmed(name) ?? store.defaultWorkspaceName
-            let workspace = store.addWorkspace(name: name)
-            return ControlResponse(ok: true, result: ControlResult(id: workspace.id.uuidString))
-        }
-    }
-
-    func selectWorkspace(_ target: String?, window: String?) -> ControlResponse {
-        // selecting a workspace selects its first session (workspace rows are not selectable on
-        // their own); an empty workspace just clears nothing and reports the workspace id.
-        resolver.resolveWorkspace(target, window: window) { store, id in
-            if let first = store.workspaces.first(where: { $0.id == id })?.sessions.first {
-                store.selectSession(first.id)
-            }
-            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
-        }
-    }
-
-    func renameWorkspace(_ target: String?, window: String?, name: String) -> ControlResponse {
-        resolver.resolveWorkspace(target, window: window) { store, id in
-            store.renameWorkspace(id, to: name)
-            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
-        }
-    }
-
-    func deleteWorkspace(_ target: String?, window: String?) -> ControlResponse {
-        // honors keep-at-least-one; returns an error rather than the GUI confirm alert.
-        resolver.resolveWorkspace(target, window: window) { store, id in
-            guard store.canRemoveWorkspace else {
-                return ControlResponse(ok: false, error: "cannot delete last workspace")
-            }
-            store.removeWorkspace(id)
-            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
-        }
-    }
-
     /// Resolve the target session and drive the split directly on its owning store (NOT the
     /// argument-less `AppActions.toggleSplit()`, which only acts on the active session). `mode` is
     /// `on|off|toggle`, computed against the session's current `isSplit` so `on`/`off` are
@@ -626,36 +587,6 @@ extension ControlServer: ControlActions {
                 guard response.ok else { return response }
             }
             return body(store, ids)
-        }
-    }
-
-    /// `workspace.move`: reorder a workspace among its siblings (`up`|`down`|`top`|`bottom`). `to` is
-    /// required; an invalid direction errors. Resolves the workspace target via `resolveWorkspace`
-    /// (honoring the global `--window` selector like other workspace commands).
-    func moveWorkspace(_ target: String?, window: String?, direction dir: ReorderDirection) -> ControlResponse {
-        return resolver.resolveWorkspace(target, window: window) { store, id in
-            store.reorderWorkspace(id, dir)
-            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
-        }
-    }
-
-    /// Focus (or unfocus) a workspace — collapse the sidebar tree to that workspace's subtree, or restore
-    /// the full tree. `mode` is `on|off|toggle`: `on` focuses the target, `off` unfocuses it only when it
-    /// is the currently focused one (a no-op otherwise), `toggle` flips. Delta-computed via
-    /// `AppStore.setFocusedWorkspace` so a no-op mode skips the write (idempotent). An unknown mode is an
-    /// error. The control half of the workspace row's Focus/Unfocus menu + the pill ✕.
-    func focusWorkspace(_ target: String?, window: String?, mode: String?) -> ControlResponse {
-        let mode = mode ?? "toggle"
-        return resolver.resolveWorkspace(target, window: window) { store, id in
-            let want: UUID?
-            switch mode {
-            case "on": want = id
-            case "off": want = store.focusedWorkspaceID == id ? nil : store.focusedWorkspaceID
-            case "toggle": want = store.focusedWorkspaceID == id ? nil : id
-            default: return ControlResponse(ok: false, error: "invalid focus mode: \(mode)")
-            }
-            store.setFocusedWorkspace(want) // no-op + no save when unchanged (idempotent)
-            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
         }
     }
 

--- a/agterm/Control/ControlServer+WorkspaceCommands.swift
+++ b/agterm/Control/ControlServer+WorkspaceCommands.swift
@@ -81,9 +81,10 @@ extension ControlServer {
     /// Collapse (`expanded: false`) or expand (`expanded: true`) a SINGLE workspace in a window's sidebar
     /// tree — the per-workspace analogue of the all-workspace `sidebar.expand`/`sidebar.collapse`. Resolves
     /// the target workspace via `resolveWorkspace` (honoring the global `--window` selector), then drives
-    /// `AppActions.setWorkspaceExpanded(_:expanded:in:)`, which posts a store-scoped notification so ONLY
-    /// that window's sidebar Coordinator syncs both the persisted `Workspace.isExpanded` and the live outline
-    /// row. Idempotent (the store mutator is delta-guarded). Returns the workspace id; the read-back is the
+    /// `AppActions.setWorkspaceExpanded(_:expanded:in:)`, which persists `Workspace.isExpanded` on the store
+    /// directly (the source of truth for the `collapsed` read-back, so it works even when the target
+    /// window's sidebar is hidden) and posts a store-scoped notification for the live outline sync.
+    /// Idempotent (the store mutator is delta-guarded). Returns the workspace id; the read-back is the
     /// `tree` workspace node's `collapsed` field.
     func setWorkspaceExpansion(_ target: String?, window: String?, expanded: Bool) -> ControlResponse {
         resolver.resolveWorkspace(target, window: window) { store, id in

--- a/agterm/Control/ControlServer+WorkspaceCommands.swift
+++ b/agterm/Control/ControlServer+WorkspaceCommands.swift
@@ -1,0 +1,94 @@
+import Foundation
+import agtermCore
+
+/// `ControlServer` workspace-command adapter arms (create/select/rename/delete/move/focus and the
+/// per-workspace collapse/expand). Split out of `ControlServer+SessionActions.swift` to keep that file
+/// under the swiftlint size limit; these satisfy the `ControlActions` requirements whose conformance is
+/// declared there. Each does only target resolution + the AppKit/store side effect — all validation/response
+/// shaping lives host-free in `ControlDispatcher`. (The all-workspace `sidebar.expand`/`sidebar.collapse`
+/// arms live in `ControlServer+AppCommands.swift`.)
+extension ControlServer {
+    func createWorkspace(window: String?, name: String?, collapsed: Bool) -> ControlResponse {
+        // placement target: the window's frontmost store (or `args.window`'s). name defaults to
+        // the auto-generated workspace name when none is given. `collapsed` seeds the workspace closed
+        // so a script can fill it with `session.new --no-select` without it opening.
+        resolver.resolvePlacementStore(window) { store in
+            let name = trimmed(name) ?? store.defaultWorkspaceName
+            let workspace = store.addWorkspace(name: name, collapsed: collapsed)
+            return ControlResponse(ok: true, result: ControlResult(id: workspace.id.uuidString))
+        }
+    }
+
+    func selectWorkspace(_ target: String?, window: String?) -> ControlResponse {
+        // selecting a workspace selects its first session (workspace rows are not selectable on
+        // their own); an empty workspace just clears nothing and reports the workspace id.
+        resolver.resolveWorkspace(target, window: window) { store, id in
+            if let first = store.workspaces.first(where: { $0.id == id })?.sessions.first {
+                store.selectSession(first.id)
+            }
+            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
+        }
+    }
+
+    func renameWorkspace(_ target: String?, window: String?, name: String) -> ControlResponse {
+        resolver.resolveWorkspace(target, window: window) { store, id in
+            store.renameWorkspace(id, to: name)
+            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
+        }
+    }
+
+    func deleteWorkspace(_ target: String?, window: String?) -> ControlResponse {
+        // honors keep-at-least-one; returns an error rather than the GUI confirm alert.
+        resolver.resolveWorkspace(target, window: window) { store, id in
+            guard store.canRemoveWorkspace else {
+                return ControlResponse(ok: false, error: "cannot delete last workspace")
+            }
+            store.removeWorkspace(id)
+            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
+        }
+    }
+
+    /// `workspace.move`: reorder a workspace among its siblings (`up`|`down`|`top`|`bottom`). `to` is
+    /// required; an invalid direction errors. Resolves the workspace target via `resolveWorkspace`
+    /// (honoring the global `--window` selector like other workspace commands).
+    func moveWorkspace(_ target: String?, window: String?, direction dir: ReorderDirection) -> ControlResponse {
+        return resolver.resolveWorkspace(target, window: window) { store, id in
+            store.reorderWorkspace(id, dir)
+            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
+        }
+    }
+
+    /// Focus (or unfocus) a workspace — collapse the sidebar tree to that workspace's subtree, or restore
+    /// the full tree. `mode` is `on|off|toggle`: `on` focuses the target, `off` unfocuses it only when it
+    /// is the currently focused one (a no-op otherwise), `toggle` flips. Delta-computed via
+    /// `AppStore.setFocusedWorkspace` so a no-op mode skips the write (idempotent). An unknown mode is an
+    /// error. The control half of the workspace row's Focus/Unfocus menu + the pill ✕.
+    func focusWorkspace(_ target: String?, window: String?, mode: String?) -> ControlResponse {
+        let mode = mode ?? "toggle"
+        return resolver.resolveWorkspace(target, window: window) { store, id in
+            let want: UUID?
+            switch mode {
+            case "on": want = id
+            case "off": want = store.focusedWorkspaceID == id ? nil : store.focusedWorkspaceID
+            case "toggle": want = store.focusedWorkspaceID == id ? nil : id
+            default: return ControlResponse(ok: false, error: "invalid focus mode: \(mode)")
+            }
+            store.setFocusedWorkspace(want) // no-op + no save when unchanged (idempotent)
+            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
+        }
+    }
+
+    /// Collapse (`expanded: false`) or expand (`expanded: true`) a SINGLE workspace in a window's sidebar
+    /// tree — the per-workspace analogue of the all-workspace `sidebar.expand`/`sidebar.collapse`. Resolves
+    /// the target workspace via `resolveWorkspace` (honoring the global `--window` selector), then drives
+    /// `AppActions.setWorkspaceExpanded(_:expanded:in:)`, which posts a store-scoped notification so ONLY
+    /// that window's sidebar Coordinator syncs both the persisted `Workspace.isExpanded` and the live outline
+    /// row. Idempotent (the store mutator is delta-guarded). Returns the workspace id; the read-back is the
+    /// `tree` workspace node's `collapsed` field.
+    func setWorkspaceExpansion(_ target: String?, window: String?, expanded: Bool) -> ControlResponse {
+        resolver.resolveWorkspace(target, window: window) { store, id in
+            actions.setWorkspaceExpanded(id, expanded: expanded, in: store)
+            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
+        }
+    }
+}

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -366,6 +366,7 @@ final class ControlServer {
         case .tree, .sessionNew, .sessionDuplicate, .sessionSelect, .sessionGo, .sessionClose, .sessionRename,
                 .sessionReveal, .sessionMove,
                 .workspaceNew, .workspaceSelect, .workspaceRename, .workspaceDelete, .workspaceMove, .workspaceFocus,
+                .workspaceCollapse, .workspaceExpand,
                 .sessionSplit, .sessionScratch, .sessionFocus, .sessionResize, .surfaceZoom,
                 .sessionStatus, .sessionFlag, .sessionSeen, .sessionRestore, .notify,
                 .fontInc, .fontDec, .fontReset, .keymapReload, .configReload, .themeSet, .themeList,

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -138,7 +138,7 @@ prompt concatenates with yours, and the program starts on the merged line. (`--n
 focus, but the newline and shared-buffer hazards of `type`-as-launcher remain — `--command` is still the
 rule.) After `--command`, confirm in `tree --json` that the new node's `foreground` shows your program running, not a bare shell prompt.
 
-## Command summary (62 commands)
+## Command summary (64 commands)
 
 Run `agtermctl <area> <cmd> --help` for exact flags. Full detail in **reference.md**; recipes in
 **examples.md**.
@@ -174,9 +174,15 @@ a split pane, so a split session appears as both), `dashboardHighlighted` (the h
 the one Enter jumps into, focusing that exact pane), `dashboardFontSize` (the absolute font size in points
 applied to the cells, omitted when untouched), and `dashboardFontMode` (`auto`|`fixed`|`untouched`).
 
-**workspace** — `new [name]` · `rename <name>` · `delete` · `select` · `move --to up|down|top|bottom` ·
+**workspace** — `new [name] [--collapsed]` (`--collapsed` creates it closed in the sidebar so you can fill
+it with `session new --no-select` without it opening) · `rename <name>` · `delete` · `select` ·
+`move --to up|down|top|bottom` ·
 `focus [on|off|toggle]` (collapse the sidebar tree to a single workspace; read back which workspace is
-focused from the tree workspace node's `focused` flag).
+focused from the tree workspace node's `focused` flag) ·
+`collapse [--target W] [--window W]` · `expand [--target W] [--window W]` (collapse/expand ONE workspace
+in the sidebar tree — the per-workspace pair, distinct from the all-workspace `sidebar expand`/`collapse`;
+read the open/closed state back from the tree workspace node's `collapsed` flag, `true` when collapsed and
+omitted when expanded).
 
 **session**
 - `new [--cwd DIR] [--workspace W] [--workspace-name NAME] [--create-workspace] [--command CMD] [--wait] [--name NAME] [--after SID | --before SID] [--no-select]` —

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -360,6 +360,27 @@ agtermctl sidebar collapse                               # collapse all but the 
 agtermctl sidebar collapse --window "$AGTERM_WINDOW_ID"  # collapse a specific window's sidebar
 ```
 
+## Build a collapsed workspace and fill it quietly
+
+Collapse or expand ONE workspace by id (the per-workspace pair, unlike `sidebar expand`/`collapse` which
+act on all of them). Create a workspace already collapsed with `workspace new --collapsed`, then add
+sessions with `session new --no-select` so it never opens or steals the current selection — the recipe
+for staging a batch of sessions out of the way. Read the open/closed state back from the tree workspace
+node's `collapsed` flag (`true` when collapsed, omitted when expanded).
+
+```bash
+ws=$(agtermctl workspace new "batch" --collapsed --json | jq -r '.result.id')
+for dir in ~/a ~/b ~/c; do
+  agtermctl session new --cwd "$dir" --workspace "$ws" --no-select   # added, but the workspace stays shut
+done
+agtermctl workspace expand --target "$ws"    # open it when you want to see the staged sessions
+agtermctl workspace collapse --target "$ws"  # fold it away again
+
+# toggle: read the flag first, then flip
+collapsed=$(agtermctl tree --json | jq -r --arg w "$ws" '.result.tree.workspaces[] | select(.id==$w) | .collapsed // false')
+[ "$collapsed" = true ] && agtermctl workspace expand --target "$ws" || agtermctl workspace collapse --target "$ws"
+```
+
 ## Copy a selection and reuse it
 
 `session copy` returns the selection as text (it does not use the system clipboard). Pipe it onward.

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -82,9 +82,12 @@ so a script can zoom them without changing split/scratch visibility first. Cavea
 derive from the session's own flags, not from zoom — and `visible` reads false for a pane behind a
 FLOATING overlay even though it is visually on screen; address by `id`/`kind`, and read the zoom state
 from the top-level `zoomedSurface`. Workspace nodes carry
-`id`, `name`, `active`, `sessions`, and `focused` (whether the sidebar
+`id`, `name`, `active`, `sessions`, `focused` (whether the sidebar
 tree is collapsed to this workspace — the read side of `workspace focus`, distinct from `active` the
-SELECTED workspace; omitted unless this is the focused one, and absent entirely when nothing is focused).
+SELECTED workspace; omitted unless this is the focused one, and absent entirely when nothing is focused),
+and `collapsed` (whether this workspace is COLLAPSED in the sidebar tree — the read side of
+`workspace collapse`/`workspace expand` and `workspace new --collapsed`; `true` when collapsed, omitted
+when expanded, so an all-expanded tree carries no `collapsed` keys).
 
 The tree object itself carries ten top-level read-only fields: `idleMs` (milliseconds since the last
 user input in the window, omitted before any activity), `autoFollowMs` (the window's Auto-follow
@@ -111,8 +114,10 @@ All ten are read-only projections of GUI state.
 
 ## workspace
 
-- `workspace new [name] [--window W]` — create a workspace; returns its id. Name defaults to an
-  auto-generated one.
+- `workspace new [name] [--collapsed] [--window W]` — create a workspace; returns its id. Name defaults
+  to an auto-generated one. `--collapsed` creates it CLOSED in the sidebar tree so a script can build a
+  workspace and fill it with `session new --no-select` without it ever opening (a fresh workspace is
+  expanded by default). Read the state back from the tree workspace node's `collapsed` flag.
 - `workspace rename <name> [--target] [--window W]`.
 - `workspace delete [--target] [--window W]` — keep-at-least-one; deleting the last workspace errors.
 - `workspace select [--target] [--window W]`.
@@ -127,6 +132,15 @@ All ten are read-only projections of GUI state.
   While a workspace is focused, `session go` navigation is scoped to that workspace's sessions (and to
   the flagged set in flagged mode); an explicit `session select` of a session outside the focused
   workspace still auto-unfocuses to reveal it. An unknown mode errors.
+- `workspace collapse [--target] [--window W]` — collapse ONE workspace's subtree in the sidebar tree
+  (hide its sessions); returns the workspace id. The per-workspace counterpart of `sidebar collapse`
+  (which collapses ALL but the active workspace) — this targets exactly the addressed workspace and does
+  not depend on which one is active. Idempotent. Persisted. Read back from the tree workspace node's
+  `collapsed` flag.
+- `workspace expand [--target] [--window W]` — expand ONE workspace's subtree (show its sessions);
+  returns the workspace id. The inverse of `workspace collapse`, and the per-workspace counterpart of
+  `sidebar expand`. Idempotent. To TOGGLE a workspace, read its `collapsed` flag off `tree` first, then
+  call `expand` or `collapse`.
 
 ## session
 

--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -345,16 +345,17 @@ struct WorkspaceSidebar: NSViewRepresentable {
             collapseOthers()
         }
 
-        /// Collapse or expand a SINGLE workspace (the `workspace.collapse`/`workspace.expand` control path).
-        /// Always writes the persisted `Workspace.isExpanded` (delta-guarded, idempotent) as the source of
-        /// truth and keeps the tracked `expandedWorkspaceIDs` in step — so the intent survives a collapsed
-        /// (flagged-mode / focused-away) row and a transient focus force-reveal. Then drives the LIVE outline
-        /// row when it is on screen (tree mode, row resolved), suppressing the expand/collapse callback's
-        /// re-persist since the store already holds the truth.
+        /// Sync the sidebar to a SINGLE workspace's collapse/expand (the `workspace.collapse`/`workspace.expand`
+        /// control path). The persisted `Workspace.isExpanded` is ALREADY written by
+        /// `AppActions.setWorkspaceExpanded` before this notification is posted (that write is the source of
+        /// truth and does not depend on this Coordinator being alive), so this handler only keeps the tracked
+        /// `expandedWorkspaceIDs` in step — so the intent survives a collapsed (flagged-mode / focused-away)
+        /// row and a transient focus force-reveal — and drives the LIVE outline row when it is on screen
+        /// (tree mode, row resolved), suppressing the expand/collapse callback's re-persist since the store
+        /// already holds the truth.
         @objc private func setWorkspaceExpandedNotified(_ notification: Notification) {
             guard let id = notification.userInfo?[Self.workspaceIDUserInfoKey] as? UUID,
                   let expanded = notification.userInfo?[Self.expandedUserInfoKey] as? Bool else { return }
-            store.setWorkspaceExpanded(id, expanded: expanded)
             if expanded { expandedWorkspaceIDs.insert(id) } else { expandedWorkspaceIDs.remove(id) }
             guard store.sidebarMode == .tree, let outline = outlineView,
                   let node = nodeCache[id], outline.row(forItem: node) >= 0 else { return }

--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -190,6 +190,12 @@ struct WorkspaceSidebar: NSViewRepresentable {
         /// notifications (the documented value is the literal string `"NSObject"`).
         private static let outlineItemUserInfoKey = "NSObject"
 
+        /// `userInfo` keys for the `.agtermSetWorkspaceExpanded` per-workspace poke (the `workspace.collapse`/`workspace.expand`
+        /// control path): the target workspace `UUID` and the desired `Bool` expansion state. Read by
+        /// `setWorkspaceExpandedNotified`, written by `AppActions.setWorkspaceExpanded(_:expanded:in:)`.
+        static let workspaceIDUserInfoKey = "agterm.workspaceID"
+        static let expandedUserInfoKey = "agterm.expanded"
+
         /// Last-seen visible content (label, split icon, badge) per session and workspace id, so a
         /// reconcile reloads only the rows whose content changed. An absent key ≠ any real content.
         private var lastRowContent: [UUID: RowContent] = [:]
@@ -228,6 +234,9 @@ struct WorkspaceSidebar: NSViewRepresentable {
                                                    name: .agtermExpandWorkspaces, object: store)
             NotificationCenter.default.addObserver(self, selector: #selector(collapseWorkspacesNotified),
                                                    name: .agtermCollapseWorkspaces, object: store)
+            // the per-workspace collapse/expand poke (workspace.collapse/expand) is store-scoped the same way.
+            NotificationCenter.default.addObserver(self, selector: #selector(setWorkspaceExpandedNotified(_:)),
+                                                   name: .agtermSetWorkspaceExpanded, object: store)
             // a theme change (new terminal foreground) re-tints the visible rows in place.
             NotificationCenter.default.addObserver(self, selector: #selector(appearanceChanged),
                                                    name: .agtermAppearanceChanged, object: nil)
@@ -334,6 +343,24 @@ struct WorkspaceSidebar: NSViewRepresentable {
         /// on tree mode itself, so flagged mode is a clean no-op.
         @objc private func collapseWorkspacesNotified() {
             collapseOthers()
+        }
+
+        /// Collapse or expand a SINGLE workspace (the `workspace.collapse`/`workspace.expand` control path).
+        /// Always writes the persisted `Workspace.isExpanded` (delta-guarded, idempotent) as the source of
+        /// truth and keeps the tracked `expandedWorkspaceIDs` in step — so the intent survives a collapsed
+        /// (flagged-mode / focused-away) row and a transient focus force-reveal. Then drives the LIVE outline
+        /// row when it is on screen (tree mode, row resolved), suppressing the expand/collapse callback's
+        /// re-persist since the store already holds the truth.
+        @objc private func setWorkspaceExpandedNotified(_ notification: Notification) {
+            guard let id = notification.userInfo?[Self.workspaceIDUserInfoKey] as? UUID,
+                  let expanded = notification.userInfo?[Self.expandedUserInfoKey] as? Bool else { return }
+            store.setWorkspaceExpanded(id, expanded: expanded)
+            if expanded { expandedWorkspaceIDs.insert(id) } else { expandedWorkspaceIDs.remove(id) }
+            guard store.sidebarMode == .tree, let outline = outlineView,
+                  let node = nodeCache[id], outline.row(forItem: node) >= 0 else { return }
+            suppressExpansionPersist = true
+            if expanded { outline.expandItem(node) } else { outline.collapseItem(node) }
+            suppressExpansionPersist = false
         }
 
         // MARK: - Model rebuild
@@ -833,6 +860,10 @@ extension Notification.Name {
     /// `WorkspaceSidebar.Coordinator` observes them scoped to that one window's sidebar.
     static let agtermExpandWorkspaces = Notification.Name("agterm.expandWorkspaces")
     static let agtermCollapseWorkspaces = Notification.Name("agterm.collapseWorkspaces")
+    /// Posted by the `workspace.collapse`/`workspace.expand` control arm to collapse or expand a SINGLE
+    /// workspace, with the target window's `AppStore` as the object and the workspace id + desired state in
+    /// `userInfo`. Object-scoped like the all-workspace pokes, so only the matching window's sidebar reacts.
+    static let agtermSetWorkspaceExpanded = Notification.Name("agterm.setWorkspaceExpanded")
     /// Posted by the `session.resize` control arm after it stores a new split-divider fraction, with the
     /// target `Session` as the object so the matching `SplitProbeView` (in `ContentView`) moves the live
     /// divider to `Session.splitRatio`. Object-scoped like the expand/collapse pokes, so only the one

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -232,6 +232,7 @@ public final class AppStore {
             return ControlWorkspaceNode(id: workspace.id.uuidString, name: workspace.name,
                                         active: workspace.id == activeWorkspaceID,
                                         focused: workspace.id == focusedWorkspaceID ? true : nil,
+                                        collapsed: workspace.isExpanded ? nil : true,
                                         sessions: sessions)
         }
         return ControlTree(workspaces: nodes, idleMs: idleMs(), autoFollowMs: autoFollowMs,
@@ -247,9 +248,12 @@ public final class AppStore {
     /// the new (empty) workspace is immediately visible — else `visibleWorkspaces` returns only the
     /// focused one and the new workspace is silently hidden (the auto-reveal contract, like `addSession`).
     /// Pass `clearFocus: false` to keep the current focus — a background `session.new --no-select` create.
+    /// Pass `collapsed: true` to create it already collapsed in the sidebar (backs `workspace.new --collapsed`):
+    /// a runtime add defaults `isExpanded == true` and renders open, so a collapsed workspace can be built
+    /// and filled with `addSession(select: false)` without opening.
     @discardableResult
-    public func addWorkspace(name: String, clearFocus: Bool = true) -> Workspace {
-        let workspace = Workspace(name: name)
+    public func addWorkspace(name: String, collapsed: Bool = false, clearFocus: Bool = true) -> Workspace {
+        let workspace = Workspace(name: name, isExpanded: !collapsed)
         workspaces.append(workspace)
         if clearFocus { focusedWorkspaceID = nil }
         save()

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -14,7 +14,7 @@ public protocol ControlActions {
     func closeSessions(_ targets: [String], window: String?) -> ControlResponse
     func renameSession(_ target: String?, window: String?, name: String) -> ControlResponse
     func revealSession(_ target: String?, window: String?) -> ControlResponse
-    func createWorkspace(window: String?, name: String?) -> ControlResponse
+    func createWorkspace(window: String?, name: String?, collapsed: Bool) -> ControlResponse
     func selectWorkspace(_ target: String?, window: String?) -> ControlResponse
     func renameWorkspace(_ target: String?, window: String?, name: String) -> ControlResponse
     func deleteWorkspace(_ target: String?, window: String?) -> ControlResponse
@@ -22,6 +22,7 @@ public protocol ControlActions {
     func moveSessions(_ targets: [String], window: String?, move: ControlSessionMove) -> ControlResponse
     func moveWorkspace(_ target: String?, window: String?, direction: ReorderDirection) -> ControlResponse
     func focusWorkspace(_ target: String?, window: String?, mode: String?) -> ControlResponse
+    func setWorkspaceExpansion(_ target: String?, window: String?, expanded: Bool) -> ControlResponse
     func setSessionFlag(_ target: String?, window: String?, mode: String?) -> ControlResponse
     func markSessionSeen(_ target: String?, window: String?) -> ControlResponse
     func setSessionStatus(_ target: String?, window: String?, update: ControlSessionStatusUpdate) -> ControlResponse
@@ -152,7 +153,7 @@ public struct ControlDispatcher {
                 .sessionText:
             return await dispatchSessionSurfaceCommand(request)
         case .workspaceNew, .workspaceSelect, .workspaceRename, .workspaceDelete,
-                .workspaceMove, .workspaceFocus:
+                .workspaceMove, .workspaceFocus, .workspaceCollapse, .workspaceExpand:
             return dispatchWorkspaceCommand(request)
         case .quick, .fontInc, .fontDec, .fontReset, .keymapReload,
                 .configReload, .notify, .themeSet, .themeList, .sidebar, .sidebarMode, .sidebarExpand,
@@ -371,7 +372,8 @@ public struct ControlDispatcher {
     private func dispatchWorkspaceCommand(_ request: ControlRequest) -> ControlResponse {
         switch request.cmd {
         case .workspaceNew:
-            return actions.createWorkspace(window: request.args?.window, name: request.args?.name)
+            return actions.createWorkspace(window: request.args?.window, name: request.args?.name,
+                                           collapsed: request.args?.collapsed ?? false)
         case .workspaceSelect:
             return actions.selectWorkspace(request.target, window: request.args?.window)
         case .workspaceRename:
@@ -391,6 +393,10 @@ public struct ControlDispatcher {
             return actions.moveWorkspace(request.target, window: request.args?.window, direction: direction)
         case .workspaceFocus:
             return actions.focusWorkspace(request.target, window: request.args?.window, mode: request.args?.mode)
+        case .workspaceCollapse:
+            return actions.setWorkspaceExpansion(request.target, window: request.args?.window, expanded: false)
+        case .workspaceExpand:
+            return actions.setWorkspaceExpansion(request.target, window: request.args?.window, expanded: true)
         default:
             preconditionFailure("unexpected workspace command: \(request.cmd.rawValue)")
         }

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -19,6 +19,8 @@ public enum Command: String, Codable, Sendable {
     case sessionMove = "session.move"
     case workspaceMove = "workspace.move"
     case workspaceFocus = "workspace.focus"
+    case workspaceCollapse = "workspace.collapse"
+    case workspaceExpand = "workspace.expand"
     case sessionType = "session.type"
     case sessionStatus = "session.status"
     case sessionFlag = "session.flag"
@@ -96,6 +98,11 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     /// For `session.new` with `workspaceName`: create the named workspace when none exists (idempotent
     /// reuse-or-create). An error without `workspaceName` — there is nothing to create by id.
     public var createWorkspace: Bool?
+    /// For `workspace.new`: create the workspace already COLLAPSED in the sidebar (the CLI's `--collapsed`)
+    /// instead of the default expanded state, so a script can build a workspace and fill it with
+    /// `session.new --no-select` without it opening. Omitted/`false` = expanded. The read-back is the
+    /// `tree` workspace node's `collapsed` field.
+    public var collapsed: Bool?
     /// For `session.new`: create the session in the background without selecting or focusing it, leaving
     /// the current selection untouched (the CLI's `--no-select`). Omitted/`false` keeps the default
     /// select-and-focus behavior. The read-back is the existing `tree` `active` flag — the new node is not
@@ -234,7 +241,8 @@ public struct ControlArgs: Codable, Sendable, Equatable {
 
     public init(name: String? = nil, cwd: String? = nil, targets: [String]? = nil,
                 workspace: String? = nil, workspaceName: String? = nil,
-                createWorkspace: Bool? = nil, noSelect: Bool? = nil, text: String? = nil, select: Bool? = nil, mode: String? = nil,
+                createWorkspace: Bool? = nil, collapsed: Bool? = nil, noSelect: Bool? = nil,
+                text: String? = nil, select: Bool? = nil, mode: String? = nil,
                 command: String? = nil, wait: Bool? = nil, sizePercent: Int? = nil, full: Bool? = nil,
                 follow: Bool? = nil, window: String? = nil,
                 pane: String? = nil, paneID: String? = nil, to: String? = nil,
@@ -253,6 +261,7 @@ public struct ControlArgs: Codable, Sendable, Equatable {
         self.workspace = workspace
         self.workspaceName = workspaceName
         self.createWorkspace = createWorkspace
+        self.collapsed = collapsed
         self.noSelect = noSelect
         self.text = text
         self.select = select
@@ -469,13 +478,21 @@ public struct ControlWorkspaceNode: Codable, Sendable, Equatable {
     /// SELECTED workspace): focus collapses the sidebar to a single workspace. The read side of the
     /// write-only `workspace.focus` — so a script can record which workspace is focused and restore it.
     public let focused: Bool?
+    /// Whether this workspace is COLLAPSED in the sidebar tree (`true`), or nil when expanded — the
+    /// default — so an all-expanded tree omits the field (matching the persisted `WorkspaceSnapshot.collapsed`).
+    /// The read side of the write-only `workspace.collapse`/`workspace.expand` (and `workspace.new --collapsed`),
+    /// so a script can record a workspace's open/closed state and restore it, or toggle by reading it first.
+    /// Reports the persisted model state (`!isExpanded`), independent of a transient focus force-reveal.
+    public let collapsed: Bool?
     public let sessions: [ControlSessionNode]
 
-    public init(id: String, name: String, active: Bool, focused: Bool? = nil, sessions: [ControlSessionNode]) {
+    public init(id: String, name: String, active: Bool, focused: Bool? = nil,
+                collapsed: Bool? = nil, sessions: [ControlSessionNode]) {
         self.id = id
         self.name = name
         self.active = active
         self.focused = focused
+        self.collapsed = collapsed
         self.sessions = sessions
     }
 }

--- a/agtermCore/Sources/agtermctlKit/WorkspaceCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/WorkspaceCommands.swift
@@ -6,17 +6,19 @@ import agtermCore
 struct Workspace: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Workspace commands.",
-        subcommands: [New.self, Rename.self, Delete.self, Select.self, Move.self, Focus.self]
+        subcommands: [New.self, Rename.self, Delete.self, Select.self, Move.self, Focus.self,
+                      Collapse.self, Expand.self]
     )
 
     struct New: RequestCommand {
         static let configuration = CommandConfiguration(abstract: "Create a workspace.")
         @Argument(help: "Workspace name (defaults to the auto-generated name).") var name: String?
+        @Flag(name: .long, help: "Create the workspace collapsed in the sidebar.") var collapsed = false
         @OptionGroup var options: ClientOptions
         var echoesResultID: Bool { true }
 
         func makeRequest() throws -> ControlRequest {
-            ControlRequest(cmd: .workspaceNew, args: options.withWindow(ControlArgs(name: name)))
+            ControlRequest(cmd: .workspaceNew, args: options.withWindow(ControlArgs(name: name, collapsed: collapsed ? true : nil)))
         }
     }
 
@@ -76,6 +78,26 @@ struct Workspace: ParsableCommand {
 
         func makeRequest() throws -> ControlRequest {
             ControlRequest(cmd: .workspaceFocus, target: target.target, args: options.withWindow(ControlArgs(mode: mode)))
+        }
+    }
+
+    struct Collapse: RequestCommand {
+        static let configuration = CommandConfiguration(abstract: "Collapse a workspace in the sidebar tree.")
+        @OptionGroup var target: TargetOptions
+        @OptionGroup var options: ClientOptions
+
+        func makeRequest() throws -> ControlRequest {
+            ControlRequest(cmd: .workspaceCollapse, target: target.target, args: options.withWindow())
+        }
+    }
+
+    struct Expand: RequestCommand {
+        static let configuration = CommandConfiguration(abstract: "Expand a workspace in the sidebar tree.")
+        @OptionGroup var target: TargetOptions
+        @OptionGroup var options: ClientOptions
+
+        func makeRequest() throws -> ControlRequest {
+            ControlRequest(cmd: .workspaceExpand, target: target.target, args: options.withWindow())
         }
     }
 }

--- a/agtermCore/Tests/agtermCoreTests/AppStoreOrganizationTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreOrganizationTests.swift
@@ -246,6 +246,13 @@ struct AppStoreOrganizationTests {
         #expect(store.workspaces[0].isExpanded)
     }
 
+    @Test func newWorkspaceCollapsedStartsCollapsed() {
+        let store = makeStore()
+        let work = store.addWorkspace(name: "work", collapsed: true)
+        #expect(!work.isExpanded)
+        #expect(!store.workspaces[0].isExpanded)
+    }
+
     @Test func setWorkspacesExpandedTogglesAndPersists() {
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent("agterm-tests-\(UUID().uuidString)")
         let persistence = PersistenceStore(directory: dir)

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -1447,6 +1447,21 @@ struct AppStoreTests {
         #expect(store.controlTree().workspaces.allSatisfy { $0.focused == nil })
     }
 
+    @Test func controlTreeReportsCollapsedWorkspace() {
+        let store = makeStore()
+        let ws2 = store.addWorkspace(name: "second")
+        // all workspaces expanded by default: no node reports collapsed.
+        #expect(store.controlTree().workspaces.allSatisfy { $0.collapsed == nil })
+        // collapse the second workspace: ONLY its node reports collapsed == true.
+        store.setWorkspaceExpanded(ws2.id, expanded: false)
+        let nodes = store.controlTree().workspaces
+        #expect(nodes.first { $0.id == ws2.id.uuidString }?.collapsed == true)
+        #expect(nodes.filter { $0.collapsed == true }.count == 1)
+        // re-expanding it omits the field again.
+        store.setWorkspaceExpanded(ws2.id, expanded: true)
+        #expect(store.controlTree().workspaces.allSatisfy { $0.collapsed == nil })
+    }
+
     @Test func controlTreeReportsSidebarMode() {
         let store = makeStore()
         #expect(store.controlTree().sidebarMode == "tree") // default: the workspace tree

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -1462,6 +1462,23 @@ struct AppStoreTests {
         #expect(store.controlTree().workspaces.allSatisfy { $0.collapsed == nil })
     }
 
+    @Test func controlTreeCollapsedIsIdempotentAndFocusIndependent() {
+        let store = makeStore()
+        let ws2 = store.addWorkspace(name: "second")
+        // idempotent: collapsing twice leaves exactly one collapsed node reporting true (delta-guarded).
+        store.setWorkspaceExpanded(ws2.id, expanded: false)
+        store.setWorkspaceExpanded(ws2.id, expanded: false)
+        let afterTwice = store.controlTree().workspaces
+        #expect(afterTwice.filter { $0.collapsed == true }.count == 1)
+        #expect(afterTwice.first { $0.id == ws2.id.uuidString }?.collapsed == true)
+        // focus-independent: focusing the collapsed workspace force-reveals it in the sidebar but must NOT
+        // flip the persisted model, so the `collapsed` read-back still reports true.
+        store.setFocusedWorkspace(ws2.id)
+        let focused = store.controlTree().workspaces.first { $0.id == ws2.id.uuidString }
+        #expect(focused?.collapsed == true)
+        #expect(focused?.focused == true)
+    }
+
     @Test func controlTreeReportsSidebarMode() {
         let store = makeStore()
         #expect(store.controlTree().sidebarMode == "tree") // default: the workspace tree

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -412,7 +412,7 @@ struct ControlDispatcherTests {
         #expect(renamed == ControlResponse(ok: true))
         #expect(deleted == ControlResponse(ok: true))
         #expect(actions.calls == [
-            .workspaceNew(window: "win", "api"),
+            .workspaceNew(window: "win", "api", collapsed: false),
             .workspaceSelect(target: "workspace", window: "win"),
             .workspaceRename(target: "workspace", window: nil, "renamed"),
             .workspaceDelete(target: "workspace", window: nil)
@@ -564,6 +564,37 @@ struct ControlDispatcherTests {
 
         #expect(focused == ControlResponse(ok: true))
         #expect(actions.calls == [.workspaceFocus(target: "workspace", window: "win", "on")])
+    }
+
+    @Test func workspaceCollapseAndExpandRouteExpandedFlag() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let collapsed = await dispatcher.dispatch(ControlRequest(
+            cmd: .workspaceCollapse, target: "workspace", args: ControlArgs(window: "win")
+        ))
+        let expanded = await dispatcher.dispatch(ControlRequest(
+            cmd: .workspaceExpand, target: "active"
+        ))
+
+        #expect(collapsed == ControlResponse(ok: true))
+        #expect(expanded == ControlResponse(ok: true))
+        #expect(actions.calls == [
+            .workspaceExpansion(target: "workspace", window: "win", expanded: false),
+            .workspaceExpansion(target: "active", window: nil, expanded: true)
+        ])
+    }
+
+    @Test func workspaceNewRoutesCollapsedFlag() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let created = await dispatcher.dispatch(ControlRequest(
+            cmd: .workspaceNew, args: ControlArgs(name: "api", collapsed: true, window: "win")
+        ))
+
+        #expect(created == ControlResponse(ok: true))
+        #expect(actions.calls == [.workspaceNew(window: "win", "api", collapsed: true)])
     }
 
     @Test func sessionFlagRoutesModeForHostSideValidation() async {

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -835,6 +835,37 @@ struct ControlProtocolTests {
         #expect(decoded.focused == nil)
     }
 
+    @Test func workspaceNodeRoundTripsWithCollapsed() throws {
+        // the read side of workspace.collapse/expand: a collapsed workspace is flagged so a script can
+        // record its open/closed state and restore it, or toggle by reading it first.
+        let ws = ControlWorkspaceNode(id: "w1", name: "work", active: true, collapsed: true, sessions: [])
+        let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(workspaces: [ws])))
+        let decoded = try roundTrip(response)
+        #expect(decoded == response)
+        #expect(decoded.result?.tree?.workspaces.first?.collapsed == true)
+    }
+
+    @Test func workspaceNodeOmitsCollapsedWhenNil() throws {
+        // an expanded workspace (the default) omits the key rather than emitting null, so an all-expanded
+        // tree stays byte-compatible with a legacy response.
+        let ws = ControlWorkspaceNode(id: "w1", name: "work", active: true, sessions: [])
+        let json = String(data: try JSONEncoder().encode(ws), encoding: .utf8) ?? ""
+        #expect(!json.contains("collapsed"), "a nil collapsed must be omitted from the JSON; got \(json)")
+        let decoded = try JSONDecoder().decode(ControlWorkspaceNode.self, from: Data(json.utf8))
+        #expect(decoded.collapsed == nil)
+    }
+
+    @Test func workspaceCollapseExpandRawStringsMapToCommands() throws {
+        let collapse = try JSONDecoder().decode(ControlRequest.self,
+                                                from: Data(#"{"cmd":"workspace.collapse","target":"9f3c"}"#.utf8))
+        #expect(collapse.cmd == .workspaceCollapse)
+        #expect(collapse.target == "9f3c")
+        let expand = try JSONDecoder().decode(ControlRequest.self,
+                                              from: Data(#"{"cmd":"workspace.expand","target":"active"}"#.utf8))
+        #expect(expand.cmd == .workspaceExpand)
+        #expect(expand.target == "active")
+    }
+
     @Test func treeRoundTripsWithSidebarMode() throws {
         // the read side of sidebar.mode: the sidebar view mode (tree/flagged) rides the tree top level.
         let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(

--- a/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
+++ b/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
@@ -18,7 +18,7 @@ final class MockControlActions: ControlActions {
         case sessionCloseBatch(targets: [String], window: String?)
         case sessionRename(target: String?, window: String?, String)
         case sessionReveal(target: String?, window: String?)
-        case workspaceNew(window: String?, String?)
+        case workspaceNew(window: String?, String?, collapsed: Bool)
         case workspaceSelect(target: String?, window: String?)
         case workspaceRename(target: String?, window: String?, String)
         case workspaceDelete(target: String?, window: String?)
@@ -26,6 +26,7 @@ final class MockControlActions: ControlActions {
         case sessionMoveBatch(targets: [String], window: String?, ControlSessionMove)
         case workspaceMove(target: String?, window: String?, ReorderDirection)
         case workspaceFocus(target: String?, window: String?, String?)
+        case workspaceExpansion(target: String?, window: String?, expanded: Bool)
         case sessionFlag(target: String?, window: String?, String?)
         case markSessionSeen(target: String?, window: String?)
         case sessionStatus(target: String?, window: String?, ControlSessionStatusUpdate)
@@ -161,8 +162,8 @@ final class MockControlActions: ControlActions {
         return ControlResponse(ok: true)
     }
 
-    func createWorkspace(window: String?, name: String?) -> ControlResponse {
-        calls.append(.workspaceNew(window: window, name))
+    func createWorkspace(window: String?, name: String?, collapsed: Bool) -> ControlResponse {
+        calls.append(.workspaceNew(window: window, name, collapsed: collapsed))
         return ControlResponse(ok: true)
     }
 
@@ -198,6 +199,11 @@ final class MockControlActions: ControlActions {
 
     func focusWorkspace(_ target: String?, window: String?, mode: String?) -> ControlResponse {
         calls.append(.workspaceFocus(target: target, window: window, mode))
+        return ControlResponse(ok: true)
+    }
+
+    func setWorkspaceExpansion(_ target: String?, window: String?, expanded: Bool) -> ControlResponse {
+        calls.append(.workspaceExpansion(target: target, window: window, expanded: expanded))
         return ControlResponse(ok: true)
     }
 

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -36,6 +36,11 @@ struct CommandsTests {
         #expect(try request(["workspace", "new"]) == ControlRequest(cmd: .workspaceNew, args: ControlArgs(name: nil)))
     }
 
+    @Test func workspaceNewCollapsed() throws {
+        let expected = ControlRequest(cmd: .workspaceNew, args: ControlArgs(name: "Work", collapsed: true))
+        #expect(try request(["workspace", "new", "Work", "--collapsed"]) == expected)
+    }
+
     @Test func workspaceRename() throws {
         let expected = ControlRequest(cmd: .workspaceRename, target: "9f3c", args: ControlArgs(name: "Renamed"))
         #expect(try request(["workspace", "rename", "Renamed", "--target", "9f3c"]) == expected)
@@ -70,6 +75,14 @@ struct CommandsTests {
 
     @Test func workspaceFocusRejectsBadMode() {
         #expect(throws: (any Error).self) { try Agtermctl.parseAsRoot(["workspace", "focus", "sideways"]) }
+    }
+
+    @Test func workspaceCollapseDefaultsActive() throws {
+        #expect(try request(["workspace", "collapse"]) == ControlRequest(cmd: .workspaceCollapse, target: "active"))
+    }
+
+    @Test func workspaceExpandWithTarget() throws {
+        #expect(try request(["workspace", "expand", "--target", "9f3c"]) == ControlRequest(cmd: .workspaceExpand, target: "9f3c"))
     }
 
     @Test func sessionNewWithCwdAndWorkspace() throws {

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -85,6 +85,16 @@ struct CommandsTests {
         #expect(try request(["workspace", "expand", "--target", "9f3c"]) == ControlRequest(cmd: .workspaceExpand, target: "9f3c"))
     }
 
+    @Test func workspaceCollapseThreadsWindow() throws {
+        let expected = ControlRequest(cmd: .workspaceCollapse, target: "9f3c", args: ControlArgs(window: "win"))
+        #expect(try request(["workspace", "collapse", "--target", "9f3c", "--window", "win"]) == expected)
+    }
+
+    @Test func workspaceExpandThreadsWindow() throws {
+        let expected = ControlRequest(cmd: .workspaceExpand, target: "active", args: ControlArgs(window: "win"))
+        #expect(try request(["workspace", "expand", "--window", "win"]) == expected)
+    }
+
     @Test func sessionNewWithCwdAndWorkspace() throws {
         let expected = ControlRequest(cmd: .sessionNew, args: ControlArgs(cwd: "/tmp", workspace: "ws1"))
         #expect(try request(["session", "new", "--cwd", "/tmp", "--workspace", "ws1"]) == expected)

--- a/agtermUITests/ControlSidebarStatusUITests.swift
+++ b/agtermUITests/ControlSidebarStatusUITests.swift
@@ -769,11 +769,53 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         XCTAssertTrue(sessionRowValueExists(containing: "buried"), "the buried session should now be visible")
     }
 
+    func testWorkspaceCollapsePersistsWithSidebarHidden() throws {
+        XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 10), "seeded session row")
+        // add a second workspace to target.
+        let newWs = try sendCommand(#"{"cmd":"workspace.new","args":{"name":"target"}}"#)
+        let wsID = try XCTUnwrap((newWs["result"] as? [String: Any])?["id"] as? String, "workspace.new should return an id")
+
+        // HIDE the sidebar: WindowContentView mounts WorkspaceSidebar only while sidebarVisible, so hiding
+        // tears down its Coordinator and the .agtermSetWorkspaceExpanded observer. A notification-only
+        // persist would silently drop here — the store write must happen in the control arm regardless.
+        XCTAssertEqual(try sendCommand(#"{"cmd":"sidebar","args":{"mode":"hide"}}"#)["ok"] as? Bool, true,
+                       "sidebar hide should succeed")
+        XCTAssertTrue(pollTreeSidebarHidden(timeout: 10), "the sidebar should report hidden")
+
+        // collapse the target with the sidebar hidden: the read-back must reflect it IMMEDIATELY.
+        let collapse = try sendCommand(#"{"cmd":"workspace.collapse","target":"\#(wsID)"}"#)
+        XCTAssertEqual(collapse["ok"] as? Bool, true, "workspace.collapse should succeed: \(collapse)")
+        XCTAssertEqual(try treeWorkspaces().first { $0["id"] as? String == wsID }?["collapsed"] as? Bool, true,
+                       "collapse must persist with the sidebar hidden — collapsed reads back true immediately")
+
+        // expand it again while still hidden: the field clears.
+        XCTAssertEqual(try sendCommand(#"{"cmd":"workspace.expand","target":"\#(wsID)"}"#)["ok"] as? Bool, true,
+                       "workspace.expand should succeed")
+        XCTAssertNil(try treeWorkspaces().first { $0["id"] as? String == wsID }?["collapsed"],
+                     "expand must persist with the sidebar hidden — collapsed omitted")
+    }
+
     /// The tree's workspace nodes, for read-back assertions.
     private func treeWorkspaces() throws -> [[String: Any]] {
         let tree = try sendCommand(#"{"cmd":"tree"}"#)
         let result = try XCTUnwrap(tree["result"] as? [String: Any], "tree should carry a result")
         let t = try XCTUnwrap(result["tree"] as? [String: Any], "result should carry a tree")
         return try XCTUnwrap(t["workspaces"] as? [[String: Any]], "tree should carry workspaces")
+    }
+
+    /// Polls until the tree's top-level `sidebarVisible` reads false (draining the run loop so SwiftUI can
+    /// tear the sidebar down), proving the Coordinator observer is gone before the collapse.
+    private func pollTreeSidebarHidden(timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let tree = try? sendCommand(#"{"cmd":"tree"}"#),
+               let result = tree["result"] as? [String: Any],
+               let t = result["tree"] as? [String: Any],
+               (t["sidebarVisible"] as? Bool) == false {
+                return true
+            }
+            usleep(200_000)
+        }
+        return false
     }
 }

--- a/agtermUITests/ControlSidebarStatusUITests.swift
+++ b/agtermUITests/ControlSidebarStatusUITests.swift
@@ -699,4 +699,81 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         }
         XCTFail("the notification-badges toggle never became hittable")
     }
+
+    func testWorkspaceCollapseAndExpand() throws {
+        XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 10), "seeded session row")
+
+        // name the seeded session, then add a second workspace with its own named session.
+        let seededID = try activeSessionID()
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.rename","target":"\#(seededID)","args":{"name":"stay"}}"#)["ok"] as? Bool,
+                       true, "renaming the seeded session should succeed")
+        let newWs = try sendCommand(#"{"cmd":"workspace.new","args":{"name":"second"}}"#)
+        let secondWsID = try XCTUnwrap((newWs["result"] as? [String: Any])?["id"] as? String, "workspace.new should return an id")
+        let created = try sendCommand(#"{"cmd":"session.new","args":{"workspace":"\#(secondWsID)"}}"#)
+        let newSessID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "session.new should return an id")
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.rename","target":"\#(newSessID)","args":{"name":"hidden"}}"#)["ok"] as? Bool,
+                       true, "renaming the new session should succeed")
+        XCTAssertTrue(pollSessionRowCount(2, timeout: 10), "both session rows should be present expanded")
+
+        // collapse ONLY the second workspace: its "hidden" row leaves the AX tree, "stay" stays — unlike
+        // sidebar.collapse, this targets one workspace and does not depend on which one is active.
+        let collapse = try sendCommand(#"{"cmd":"workspace.collapse","target":"\#(secondWsID)"}"#)
+        XCTAssertEqual(collapse["ok"] as? Bool, true, "workspace.collapse should succeed: \(collapse)")
+        XCTAssertEqual((collapse["result"] as? [String: Any])?["id"] as? String, secondWsID, "should echo the workspace id")
+        XCTAssertTrue(pollSessionRowCount(1, timeout: 10), "collapse should hide the targeted workspace's rows")
+        XCTAssertTrue(sessionRowValueExists(containing: "stay"), "the untouched workspace's session should remain")
+        XCTAssertFalse(sessionRowValueExists(containing: "hidden"), "the collapsed workspace's session should be hidden")
+
+        // read-back: the collapsed workspace reports collapsed == true, the other omits the field.
+        let collapsedTree = try treeWorkspaces()
+        XCTAssertEqual(collapsedTree.first { $0["id"] as? String == secondWsID }?["collapsed"] as? Bool, true,
+                       "the collapsed workspace should read back collapsed == true")
+        XCTAssertNil(collapsedTree.first { $0["id"] as? String != secondWsID }?["collapsed"],
+                     "an expanded workspace should omit the collapsed field")
+
+        // expand it again: the "hidden" row returns and the field is omitted.
+        let expand = try sendCommand(#"{"cmd":"workspace.expand","target":"\#(secondWsID)"}"#)
+        XCTAssertEqual(expand["ok"] as? Bool, true, "workspace.expand should succeed: \(expand)")
+        XCTAssertTrue(pollSessionRowCount(2, timeout: 10), "expand should restore the workspace's rows")
+        XCTAssertTrue(sessionRowValueExists(containing: "hidden"), "the expanded workspace's session should return")
+        let expandedTree = try treeWorkspaces()
+        XCTAssertNil(expandedTree.first { $0["id"] as? String == secondWsID }?["collapsed"],
+                     "the re-expanded workspace should omit the collapsed field")
+    }
+
+    func testWorkspaceNewCollapsedStaysClosedWhenFilled() throws {
+        XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 10), "seeded session row")
+        let seededID = try activeSessionID()
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.rename","target":"\#(seededID)","args":{"name":"stay"}}"#)["ok"] as? Bool,
+                       true, "renaming the seeded session should succeed")
+
+        // create a COLLAPSED workspace, then fill it with a background (--no-select) session: it must NOT open.
+        let newWs = try sendCommand(#"{"cmd":"workspace.new","args":{"name":"quiet","collapsed":true}}"#)
+        let quietID = try XCTUnwrap((newWs["result"] as? [String: Any])?["id"] as? String, "workspace.new should return an id")
+        XCTAssertEqual(try treeWorkspaces().first { $0["id"] as? String == quietID }?["collapsed"] as? Bool, true,
+                       "a --collapsed workspace should read back collapsed == true")
+        let created = try sendCommand(#"{"cmd":"session.new","args":{"workspace":"\#(quietID)","noSelect":true}}"#)
+        let buriedID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "session.new should return an id")
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.rename","target":"\#(buriedID)","args":{"name":"buried"}}"#)["ok"] as? Bool,
+                       true, "renaming the buried session should succeed")
+
+        // the buried session stays hidden inside the collapsed workspace; the selection never left "stay".
+        XCTAssertTrue(pollSessionRowCount(1, timeout: 10), "the collapsed workspace's session should stay hidden")
+        XCTAssertFalse(sessionRowValueExists(containing: "buried"), "the buried session should not be visible")
+        XCTAssertEqual(try activeSessionID(), seededID, "the background add must not move the selection")
+
+        // expanding the workspace reveals the buried session.
+        XCTAssertEqual(try sendCommand(#"{"cmd":"workspace.expand","target":"\#(quietID)"}"#)["ok"] as? Bool, true,
+                       "workspace.expand should succeed")
+        XCTAssertTrue(pollSessionRowCount(2, timeout: 10), "expanding should reveal the buried session")
+        XCTAssertTrue(sessionRowValueExists(containing: "buried"), "the buried session should now be visible")
+    }
+
+    /// The tree's workspace nodes, for read-back assertions.
+    private func treeWorkspaces() throws -> [[String: Any]] {
+        let tree = try sendCommand(#"{"cmd":"tree"}"#)
+        let result = try XCTUnwrap(tree["result"] as? [String: Any], "tree should carry a result")
+        let t = try XCTUnwrap(result["tree"] as? [String: Any], "result should carry a tree")
+        return try XCTUnwrap(t["workspaces"] as? [[String: Any]], "tree should carry workspaces")
+    }
 }

--- a/site/commands.html
+++ b/site/commands.html
@@ -6,7 +6,7 @@
     <title>Command reference — agterm | agtermctl control API</title>
     <meta
       name="description"
-      content="Complete agtermctl reference: all 62 control commands for agterm — sessions, workspaces, windows, overlays, the quick terminal, sidebar, agent status, themes, and keymaps, with arguments and return values."
+      content="Complete agtermctl reference: all 64 control commands for agterm — sessions, workspaces, windows, overlays, the quick terminal, sidebar, agent status, themes, and keymaps, with arguments and return values."
     />
     <meta
       name="keywords"
@@ -18,7 +18,7 @@
     <meta property="og:title" content="Command reference — agterm" />
     <meta
       property="og:description"
-      content="All 62 agtermctl control commands with arguments, return values, and errors."
+      content="All 64 agtermctl control commands with arguments, return values, and errors."
     />
     <meta property="og:url" content="https://agterm.com/commands" />
     <meta property="og:image" content="https://agterm.com/assets/agterm-og.png" />
@@ -30,7 +30,7 @@
     <meta name="twitter:title" content="Command reference — agterm" />
     <meta
       name="twitter:description"
-      content="All 62 agtermctl control commands with arguments, return values, and errors."
+      content="All 64 agtermctl control commands with arguments, return values, and errors."
     />
     <meta name="twitter:image" content="https://agterm.com/assets/agterm-og.png" />
     <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
@@ -234,7 +234,7 @@
             Command reference
           </h1>
           <p style="font-size: 19px; line-height: 1.6; color: #bfbab0; margin: 0 0 8px">
-            All 62 commands of the agterm control API, with arguments and return values. Every one is reachable from the
+            All 64 commands of the agterm control API, with arguments and return values. Every one is reachable from the
             <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl</span> CLI and from the local
             control socket.
           </p>
@@ -447,10 +447,13 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">id</span>,
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">name</span>,
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">active</span>,
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">sessions</span>, and
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">sessions</span>,
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">focused</span> (the read side of
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">workspace focus</span>, distinct from
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">active</span>).
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">active</span>), and
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">collapsed</span> (the read side of
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">workspace collapse</span>/<span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">expand</span>;
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">true</span> when collapsed, omitted when expanded).
               </p>
               <p style="font-size: 14px; line-height: 1.65; color: #949ba4; margin: 8px 0 0">
                 <strong style="color: #bfbab0">Top level:</strong>
@@ -483,12 +486,15 @@
 
             <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
-                agtermctl workspace new [name] [--window W]
+                agtermctl workspace new [name] [--collapsed] [--window W]
               </div>
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">workspace.new</div>
               <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
                 Create a workspace. The name defaults to an auto-generated one.
-                <strong style="color: #bfbab0">Returns</strong>
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--collapsed</span> creates it closed in the
+                sidebar tree, so a script can fill it with
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">session new --no-select</span> without it
+                opening. <strong style="color: #bfbab0">Returns</strong>
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">result.id</span>.
               </p>
             </div>
@@ -557,6 +563,45 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">session select</span> of a session outside it
                 auto-unfocuses. Read back via the workspace node's
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">focused</span> field.
+              </p>
+            </div>
+
+            <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
+                agtermctl workspace collapse [--target T] [--window W]
+              </div>
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">workspace.collapse</div>
+              <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
+                Collapse a single workspace's subtree in the sidebar tree, hiding its sessions. The per-workspace
+                counterpart of <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">sidebar collapse</span>
+                (which collapses every workspace but the active one) — this targets exactly the addressed workspace. Idempotent
+                and persisted. <strong style="color: #bfbab0">Returns</strong>
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">result.id</span>.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                Read the open/closed state back via the workspace node's
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">collapsed</span> field
+                (<span style="font-family: &quot;JetBrains Mono&quot;, monospace">true</span> when collapsed, omitted when expanded).
+              </p>
+            </div>
+
+            <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
+                agtermctl workspace expand [--target T] [--window W]
+              </div>
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">workspace.expand</div>
+              <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
+                Expand a single workspace's subtree, showing its sessions — the inverse of
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">workspace collapse</span> and the
+                per-workspace counterpart of <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">sidebar expand</span>.
+                Idempotent and persisted. <strong style="color: #bfbab0">Returns</strong>
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">result.id</span>.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                To toggle a workspace, read its <span style="font-family: &quot;JetBrains Mono&quot;, monospace">collapsed</span> field
+                off <span style="font-family: &quot;JetBrains Mono&quot;, monospace">tree</span> first, then call
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">expand</span> or
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">collapse</span>.
               </p>
             </div>
           </section>

--- a/site/docs.html
+++ b/site/docs.html
@@ -1128,7 +1128,7 @@
               "
             >
               <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 0">
-                Looking for the full list? All 62 commands, with every argument, return value, and error, live on the
+                Looking for the full list? All 64 commands, with every argument, return value, and error, live on the
                 <a href="/commands" style="color: #6d82f3; font-weight: 500">Command reference →</a>
               </p>
             </div>
@@ -1217,7 +1217,10 @@
               ><br />agtermctl session close --target 9f3c --target abcd
               <span style="color: #6b727a">&nbsp;&nbsp;# one grace-period undo for the batch</span
               ><br />agtermctl workspace move --to top
-              <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;# reorder a workspace</span><br />agtermctl workspace focus on
+              <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;# reorder a workspace</span><br />agtermctl workspace new work --collapsed
+              <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;# create a workspace closed in the sidebar (fill with session new --no-select)</span
+              ><br />agtermctl workspace collapse --target <span style="color: #f2b45c">9f3c</span>
+              <span style="color: #6b727a">&nbsp;# collapse one workspace; workspace expand re-opens it</span><br />agtermctl workspace focus on
               <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;# collapse tree to active ws (on|off|toggle)</span>
               <br />agtermctl session reveal --target <span style="color: #f2b45c">9f3c</span>
               <span style="color: #6b727a">&nbsp;# reveal the focused pane's cwd in Finder</span>


### PR DESCRIPTION
adds per-workspace collapse/expand to the control API, the per-workspace counterpart to the existing all-workspace `sidebar.expand`/`sidebar.collapse`.

**what's new**

- `agtermctl workspace collapse [--target] [--window]` and `workspace expand [--target] [--window]` collapse or expand a single workspace's sidebar subtree by target (id / unique prefix / `active`), honoring the global `--window` selector. Scope by prefix: `sidebar.*` acts on every workspace, `workspace.*` on the addressed one.
- `agtermctl workspace new --collapsed` creates a workspace already closed in the sidebar, so a script can fill it with `session new --no-select` without it opening.
- read-back: a new `collapsed` field on each `tree` workspace node (`true` when collapsed, omitted when expanded), so a script can record and restore the state, or toggle by reading it first.

**how it works**

the control arm persists `Workspace.isExpanded` on the store directly (the source of truth for the read-back), then posts a store-scoped notification for the sidebar to sync its live outline row. The persist does NOT ride the notification alone on purpose: the sidebar Coordinator is torn down when a window's sidebar is hidden, so a notification-only write would silently drop and leave the read-back stale while the command still returned `ok`. This mirrors `workspace.focus` and `session.resize`, which also persist in the arm and post only for the live view.

**also**

- extracted the workspace-command arms into a new `ControlServer+WorkspaceCommands.swift` to keep `ControlServer+SessionActions.swift` under the 1000-line limit, matching the existing `+WindowCommands.swift` split.
- command count 62 -> 64 across the keep-in-sync surfaces (agent skill, `site/commands.html` + `docs.html`, `README.md`, rules). This is rebased on top of #271, so 64 counts its `session.restore`.

tests: host-free round-trip / dispatcher / CLI / `controlTree` coverage plus `addWorkspace(collapsed:)`, and e2e for collapse/expand, `--collapsed`, and the hidden-sidebar read-back case.
