### PR TITLE
feat: add cursor-drained event subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,11 +179,11 @@ The theme picker (View ▸ Select Theme…, or the action palette) previews each
 
 ## Scripting agterm
 
-`agterm` can be driven from a script over a local unix-domain socket through a companion CLI, `agtermctl`. This is for personal scripting — fire-and-forget commands that manage workspaces and sessions, inject text, and invoke control actions. There is no terminal-output streaming and no event subscription.
+`agterm` can be driven from a script over a local unix-domain socket through a companion CLI, `agtermctl`. This is for personal scripting: commands manage workspaces and sessions, inject text, invoke control actions, and subscribe to control events. Terminal output is not streamed; use `session text` when a script needs to read a terminal buffer.
 
 To open a terminal at a directory without the CLI, `open -a agterm <path>` — or right-click a folder in Finder and choose **Open With ▸ agterm**. agterm adds a session in that directory to the last-active window. This works when agterm is already running (its usual state); if it isn't, launch agterm first, then run the command. The socket equivalent, and the way to place the session precisely, is `agtermctl session new --cwd <path>`.
 
-The sections below cover the common cases. All 64 commands, with every argument, return value, and error, are documented in the **[Command reference](https://agterm.com/commands)**.
+The sections below cover the common cases. All 65 commands, with every argument, return value, and error, are documented in the **[Command reference](https://agterm.com/commands)**.
 
 The app bundles `agtermctl` inside `agterm.app`. The easiest way to put it on your PATH is **Help ▸ Install Command Line Tool…**, which symlinks the bundled binary into `/usr/local/bin` (the first entry in macOS's default PATH). When that directory is user-writable it installs silently; otherwise it asks once for an administrator password.
 
@@ -197,6 +197,22 @@ cd agtermCore && swift build -c release
 ```
 
 Each command targets a session or workspace by its UUID, a unique prefix of that UUID (git-style), or the keyword `active` (the selected session / current workspace). `--target` defaults to `active`, so the current one rarely needs to be named. Mutating commands normally print the affected id; batch `session close` and `session move` accept repeated `--target` options and print the number of sessions actually changed. `tree` prints the workspace and session tree. Add `--json` for the raw response, or `--socket PATH` to override the socket path. The exit code is zero on success, non-zero on error.
+
+### Control events
+
+`agtermctl events` continuously prints app control events. It subscribes from the current tail, so events that happened before the command started are not replayed. Human output is concise; `--json` writes one bare JSON event per line and flushes it promptly for pipelines:
+
+```sh
+agtermctl events
+agtermctl events --json --kind status --kind notify
+agtermctl events --json --kind session.created,session.closed --limit 250
+```
+
+The event kinds are `status`, `notify`, `session.created`, `session.closed`, and `tree.changed`. Every event has an app-wide `seq`, a Unix `ts`, its `kind`, applicable `window`/`workspace`/`session` ids, and a kind-specific `payload`. Status payloads carry the session name, normalized status including explicit `idle` clears, a `blink` boolean, and optional pane and color fields. Notification payloads carry the effective title and body. Session lifecycle payloads carry the session name. `tree.changed` is a 100 ms coalesced signal that a window's workspace/session names, membership, or ordering changed; read `tree --json` for the new snapshot.
+
+The app retains the latest 4,096 events for its current process run. A raw `events.read` request with no cursor returns an empty batch whose `run` and `next` fields anchor a subscribe-from-now cursor. Resume with the pair using `agtermctl events --run RUN --after NEXT`; both options are required together. `--kind` may be repeated or comma-separated, `--limit` defaults to 100 and accepts 1 through 1,000, and filtered reads still advance the global cursor past nonmatching events. The streaming CLI polls immediately while draining events and waits 250 ms only after an empty page.
+
+The `--json` stream contains bare event objects, not the batch envelope, so a client that needs restart-safe resume must save `run` and `next` from raw `events.read` responses. A changed app run, expired cursor, or cursor ahead of the current sequence is a hard error with the current anchor in the raw response. `agtermctl events` exits non-zero for these cursor errors, server errors, or a missing app/socket; it never silently starts over. Stop a healthy stream with the usual SIGINT or SIGTERM behavior.
 
 `--workspace`/`--target` take an id, a unique id prefix, or `active` — never a name. (`session new` also accepts `--workspace-name <name>` to target a workspace by its sidebar label, plus `--create-workspace` to make it when none matches — the two are mutually exclusive with `--workspace`.) To create a workspace and then open a session in it, capture the printed id:
 

--- a/agterm/Control/ControlServer+AppCommands.swift
+++ b/agterm/Control/ControlServer+AppCommands.swift
@@ -13,6 +13,10 @@ extension ControlServer {
         }
     }
 
+    func readEvents(_ options: ControlEventReadOptions) -> ControlResponse {
+        library.readEvents(options)
+    }
+
     // MARK: - Sidebar
 
     /// Show / hide / toggle the frontmost window's sidebar (the custom split owns visibility, so there's

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -363,7 +363,7 @@ final class ControlServer {
             return response
         }
         switch request.cmd {
-        case .tree, .sessionNew, .sessionDuplicate, .sessionSelect, .sessionGo, .sessionClose, .sessionRename,
+        case .tree, .eventsRead, .sessionNew, .sessionDuplicate, .sessionSelect, .sessionGo, .sessionClose, .sessionRename,
                 .sessionReveal, .sessionMove,
                 .workspaceNew, .workspaceSelect, .workspaceRename, .workspaceDelete, .workspaceMove, .workspaceFocus,
                 .workspaceCollapse, .workspaceExpand,

--- a/agterm/Notifications/NotificationManager.swift
+++ b/agterm/Notifications/NotificationManager.swift
@@ -71,6 +71,9 @@ final class NotificationManager: NSObject, @preconcurrency UNUserNotificationCen
         // strict first-responder check: suppress only when you are actually typing in this pane.
         let firingIsFocused = surface === (NSApp.keyWindow?.firstResponder as? GhosttySurfaceView)
         guard TerminalNotification.shouldDeliver(firingIsFocused: firingIsFocused, appActive: NSApp.isActive) else { return }
+        guard let effectiveTitle = library?.store(forSession: session.id)?.recordNotificationEvent(
+            forSession: session.id, title: title, body: body
+        ) else { return }
 
         // the badge always tracks the unseen notification; the macOS banner is gated by the toggle.
         session.unseenCount += 1
@@ -78,7 +81,7 @@ final class NotificationManager: NSObject, @preconcurrency UNUserNotificationCen
         guard bannersEnabled else { return }
 
         let content = UNMutableNotificationContent()
-        content.title = title.isEmpty ? session.displayName : title
+        content.title = effectiveTitle
         content.body = body
         content.sound = notificationSound
         // the request identifier is the identity (`<windowID>:<sessionID>:<pane>`): it both coalesces
@@ -97,11 +100,14 @@ final class NotificationManager: NSObject, @preconcurrency UNUserNotificationCen
     @discardableResult
     func send(toSession session: Session, title: String, body: String) -> Bool {
         guard let windowID = library?.windowID(forSession: session.id) else { return false }
+        guard let effectiveTitle = library?.store(forSession: session.id)?.recordNotificationEvent(
+            forSession: session.id, title: title, body: body
+        ) else { return false }
         session.unseenCount += 1
         bounceDock()
         guard bannersEnabled else { return true }
         let content = UNMutableNotificationContent()
-        content.title = title.isEmpty ? session.displayName : title
+        content.title = effectiveTitle
         content.body = body
         content.sound = notificationSound
         let identity = TerminalNotification.identity(windowID: windowID, sessionID: session.id, pane: .main)

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -10,14 +10,15 @@ description: >
   select, close, resize, move); change font size; or reload and edit the keymap and the agterm-scoped
   ghostty config. Also covers the
   window/workspace/session addressing model and the AGTERM_* environment a spawned shell sees, plus
-  diagnosing problems (keymap editor, custom actions, logs) and filing a bug as a GitHub issue or a
+  subscribe to status, notification, session lifecycle, and tree-change events; diagnose problems
+  (keymap editor, custom actions, logs); and file a bug as a GitHub issue or a
   feature request / question as a GitHub Discussion.
 when_to_use: >
   Trigger on: agterm, agtermctl, agterm control socket, session.new, session.close, session.type,
   session.split, session.scratch, session.focus, session.resize, surface.zoom, dashboard, session.go, session.copy, session.paste, session.selectall, session.text, session.search, session.status,
   session.flag, session.seen, session.reveal, session.duplicate, session.background, session.overlay, workspace.new, workspace.select, workspace.move, workspace.focus, window.new, window.list,
   window.select, window.resize, window.move, window.zoom, window.fullscreen, quick terminal, sidebar, sidebar.mode, sidebar.expand, sidebar.collapse, flagged, notify, font.inc, keymap.reload, config.reload,
-  theme.set, theme.list, select theme, edit keymap, show an image, display an image inline, show-image,
+  theme.set, theme.list, events, events.read, event subscription, select theme, edit keymap, show an image, display an image inline, show-image,
   AGTERM_SESSION_ID, AGTERM_SOCKET, and asks to drive or script agterm. Also: troubleshoot agterm,
   keymap editor won't open, custom action / custom command not working, agterm logs, file an agterm
   bug, report an agterm issue, open an agterm discussion / feature request.
@@ -30,8 +31,9 @@ allowed-tools: Bash(agtermctl *)
 
 agterm is a native macOS terminal. It exposes a programmatic control channel over a local unix
 socket, driven by the companion CLI `agtermctl`. Use it to build and steer terminal layouts, run
-programs in overlays, type into sessions, and notify the user in the exact session you are working
-in. Fire-and-forget commands only: there is no terminal-output streaming and no event subscription.
+programs in overlays, type into sessions, notify the user in the exact session you are working in,
+and subscribe to control events. Events cover status, notifications, session lifecycle, and
+structural tree changes. They do not stream terminal output; use `session text` to read a buffer.
 
 ## Am I inside agterm?
 
@@ -71,9 +73,10 @@ is not on PATH, the user can install it, or you invoke it by absolute path.
 - Add `--json` to any command to get the raw JSON response (machine-readable). Without it, ordinary
   mutations print `ok`, batch close/move prints the affected session count, and `tree`/`list` print a
   human listing.
-- One request per invocation. Mutating commands return the affected/new id; batch session mutations return
-  the number actually changed. Create commands (`session new`, `session duplicate`, `workspace new`, `window new`)
-  print the new id.
+- Commands other than `events` make one request per invocation. `events` polls with a fresh connection
+  for each request. Mutating commands return the affected/new id; batch session mutations return the
+  number actually changed. Create commands (`session new`, `session duplicate`, `workspace new`,
+  `window new`) print the new id.
 
 ## The model
 
@@ -138,7 +141,7 @@ prompt concatenates with yours, and the program starts on the merged line. (`--n
 focus, but the newline and shared-buffer hazards of `type`-as-launcher remain — `--command` is still the
 rule.) After `--command`, confirm in `tree --json` that the new node's `foreground` shows your program running, not a bare shell prompt.
 
-## Command summary (64 commands)
+## Command summary (65 commands)
 
 Run `agtermctl <area> <cmd> --help` for exact flags. Full detail in **reference.md**; recipes in
 **examples.md**.
@@ -173,6 +176,13 @@ the open dashboard shows, in grid order — `<session-id>:left` for a primary pa
 a split pane, so a split session appears as both), `dashboardHighlighted` (the highlighted cell's pane ref —
 the one Enter jumps into, focusing that exact pane), `dashboardFontSize` (the absolute font size in points
 applied to the cells, omitted when untouched), and `dashboardFontMode` (`auto`|`fixed`|`untouched`).
+
+**events**: continuously print control events, subscribing from the current tail when no cursor is
+given. Use `--json` for one bare event object per line; filter with repeatable or comma-separated
+`--kind status|notify|session.created|session.closed|tree.changed`; resume with paired
+`--run RUN --after SEQ`; and set page size with `--limit 1...1000`. The app retains 4,096 events for
+one process run. Cursor run changes, expiry, and ahead-of-tail errors are fatal and are never silently
+rebaselined. There is no terminal-output event stream.
 
 **workspace** — `new [name] [--collapsed]` (`--collapsed` creates it closed in the sidebar so you can fill
 it with `session new --no-select` without it opening) · `rename <name>` · `delete` · `select` ·

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -449,6 +449,53 @@ agtermctl notify "build finished" --title "CI"                 # active session
 agtermctl notify "tests failed" --target "$sid"               # a specific session
 ```
 
+## Wait for a session status
+
+Subscribe before starting the work, then select the first matching status event. The initial read
+subscribes from now, so an old completed state is not mistaken for a new completion.
+
+```bash
+export target="$AGTERM_SESSION_ID"
+agtermctl events --json --kind status |
+  jq --unbuffered -e 'select(.session == env.target and .payload.status == "completed")' |
+  head -n 1
+```
+
+The pipeline ends after the match. A transport or cursor failure makes `agtermctl events` exit
+non-zero; preserve pipeline status in automation that must distinguish a match from a failed stream.
+
+## Relay accepted notifications
+
+The notification event exists even when desktop banners are disabled. Forward each accepted event as
+NDJSON to another process without parsing human output:
+
+```bash
+agtermctl events --json --kind notify |
+  jq --unbuffered -c '{at: .ts, window, workspace, session, title: .payload.title, body: .payload.body}' |
+  ./notification-relay
+```
+
+Foreground OSC notifications suppressed by agterm do not appear in this stream.
+
+## Clean up after sessions close
+
+Lifecycle events follow visible tree membership. A soft close emits `session.closed` immediately, and
+an undo later emits `session.created` for the same id. Delay irreversible cleanup if undo matters.
+
+```bash
+agtermctl events --json --kind session.closed |
+  jq --unbuffered -r '.session' |
+  while IFS= read -r sid; do
+    ./release-session-resources "$sid"
+  done
+```
+
+For resumable consumers, save the `run` and `next` fields from raw `events.read` batch responses and
+restart with `agtermctl events --run "$run" --after "$next" --json`. The streaming JSON lines are bare
+events and do not include the run id. If the command reports `event run changed`, `event cursor
+expired`, or `event cursor is ahead of the current sequence`, stop loudly. Rebootstrap only after the
+caller accepts that events may have been lost; never replace the cursor automatically.
+
 ## Agent status glyph
 
 ```bash

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -19,6 +19,55 @@ Full detail for every `agtermctl` command. See `SKILL.md` for the model and addr
   `ok` is false.
 - **Options go after the subcommand**: `agtermctl session type "ls" --target active`, never before it.
 
+## events
+
+`agtermctl events [--json] [--kind KIND ...] [--run UUID --after SEQ] [--limit N]` continuously
+prints control events. Each poll is one ordinary socket connection and one `events.read` response.
+The CLI immediately reads again after a non-empty page and waits 250 ms only after an empty page.
+
+With no cursor, the first read subscribes from now: it returns an empty batch anchored at the current
+tail, and the CLI prints only later events. The app keeps a non-destructive ring of the latest 4,096
+events for its current process run. Independent readers do not consume one another's events.
+
+The five event kinds and payloads are:
+
+- `status`: `name`, normalized `status` (`idle`|`active`|`blocked`|`completed`), a `blink` boolean,
+  and optional `pane` and `color`. Reasserting the same normalized status emits nothing; clearing emits
+  `idle`.
+- `notify`: `name`, effective `title`, and `body`. It is emitted after target and foreground-focus
+  suppression checks, including when desktop banners are disabled.
+- `session.created` / `session.closed`: session `name`, emitted when the session enters or leaves a
+  visible window tree. Undo emits a new `session.created`; grace-period finalization does not emit a
+  second close.
+- `tree.changed`: an empty payload and the affected window id. Name, membership, and ordering changes
+  are coalesced for 100 ms per window. Read `tree --json` for the current snapshot.
+
+Every event has `seq` (app-wide sequence), `ts` (Unix timestamp), `kind`, optional
+`window`/`workspace`/`session` ids, and `payload`. Human mode prints one compact line. `--json` emits
+one bare `ControlEvent` JSON object per line and flushes promptly.
+
+`--kind` may be repeated or comma-separated. Unknown kinds are errors. Filtering advances the global
+cursor across nonmatching events, so changing a filter does not replay skipped history. `--limit`
+defaults to 100 and accepts 1 through 1,000.
+
+The raw `events.read` response stores the batch under `result.events`:
+
+```json
+{"ok":true,"result":{"events":{"run":"01234567-89AB-CDEF-0123-456789ABCDEF","next":42,"items":[]}}}
+```
+
+A no-cursor response supplies the `run` and `next` anchor. Resume with both values:
+`agtermctl events --run RUN --after NEXT`. The options must appear together. The streaming `--json`
+format contains bare events rather than this batch envelope, so a restart-safe client must retain the
+cursor from raw `events.read` responses.
+
+Cursor failures return `ok: false`, one of `event run changed`, `event cursor expired`, or
+`event cursor is ahead of the current sequence`, plus the current empty anchor under
+`result.events`. Treat them as data-loss boundaries. Do not silently use the supplied anchor unless
+the caller explicitly accepts dropping the missing interval. `agtermctl events` exits non-zero on a
+cursor, transport, or server error and does not retry forever while the app is absent. SIGINT and
+SIGTERM use normal process behavior.
+
 ## Addressing
 
 - `--target` defaults to `active` (the selected session / current workspace). Accepts a full UUID

--- a/agtermCore/Sources/agtermCore/AppStore+Events.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Events.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+// MARK: - Control events
+
+extension AppStore {
+    /// Emits one window-scoped draft through the app-wide ring seam. The library-owned closure adds the
+    /// window id; callers supply model identities and already-normalized kind-specific payloads.
+    func emitControlEvent(_ kind: ControlEventKind, workspace: UUID? = nil, session: UUID? = nil,
+                          payload: ControlEventPayload = ControlEventPayload()) {
+        controlEventSink?(ControlEventDraft(
+            kind: kind,
+            workspace: workspace?.uuidString,
+            session: session?.uuidString,
+            payload: payload
+        ))
+    }
+
+    func scheduleTreeChanged() {
+        emitControlEvent(.treeChanged)
+    }
+
+    func emitSessionCreated(_ session: Session, workspace: UUID) {
+        emitControlEvent(.sessionCreated, workspace: workspace, session: session.id,
+                         payload: ControlEventPayload(name: session.displayName))
+        scheduleTreeChanged()
+    }
+
+    func emitSessionClosed(_ session: Session, workspace: UUID) {
+        emitControlEvent(.sessionClosed, workspace: workspace, session: session.id,
+                         payload: ControlEventPayload(name: session.displayName))
+        scheduleTreeChanged()
+    }
+
+    /// Records an accepted terminal/control notification in the app event ring and returns its effective
+    /// title. An unresolved session returns nil and emits nothing. Delivery gating belongs to the caller.
+    @discardableResult
+    public func recordNotificationEvent(forSession id: UUID, title: String, body: String) -> String? {
+        guard let session = session(withID: id), let workspace = workspace(forSession: id) else { return nil }
+        let effectiveTitle = title.isEmpty ? session.displayName : title
+        emitControlEvent(
+            .notify,
+            workspace: workspace.id,
+            session: id,
+            payload: ControlEventPayload(name: session.displayName, title: effectiveTitle, body: body)
+        )
+        return effectiveTitle
+    }
+}

--- a/agtermCore/Sources/agtermCore/AppStore+Naming.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Naming.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+// MARK: - Naming
+
+extension AppStore {
+    /// Sets a session's custom name, with a blank value restoring its automatic display name.
+    public func renameSession(_ sessionID: UUID, to name: String) {
+        guard let session = session(withID: sessionID) else { return }
+        let renamed = name.trimmedOrNil
+        guard session.customName != renamed else { return }
+        session.customName = renamed
+        scheduleTreeChanged()
+        save()
+    }
+
+    /// Renames a workspace. Blank and same-value names are structural no-ops.
+    public func renameWorkspace(_ workspaceID: UUID, to name: String) {
+        guard let trimmed = name.trimmedOrNil,
+              let index = workspaces.firstIndex(where: { $0.id == workspaceID }),
+              workspaces[index].name != trimmed else { return }
+        workspaces[index].name = trimmed
+        scheduleTreeChanged()
+        save()
+    }
+}

--- a/agtermCore/Sources/agtermCore/AppStore+PendingClose.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+PendingClose.swift
@@ -56,6 +56,7 @@ extension AppStore {
         let workspace = workspaces[location.workspaceIndex]
         let wasActive = selectedSessionID == sessionID
         let session = workspaces[location.workspaceIndex].sessions.remove(at: location.sessionIndex)
+        emitSessionClosed(session, workspace: workspace.id)
         // undo reinserts THIS object, so an override payload armed at bootstrap and never consumed would
         // survive the round trip and fire when the restored session's surface is built. Drop it here; the
         // persisted pin is untouched and still fires on the next launch.
@@ -129,6 +130,7 @@ extension AppStore {
             recordRecentClosedSession(close.session, workspaceID: close.workspaceID, workspaceName: close.workspaceName,
                                       workspaceIndex: close.workspaceIndex, sessionIndex: close.sessionIndex,
                                       id: close.recentID)
+            emitSessionClosed(close.session, workspace: close.workspaceID)
         }
         if removingActive {
             let activeClose = previousSelection.flatMap { id in closes.first { $0.session.id == id } }
@@ -163,7 +165,10 @@ extension AppStore {
     @discardableResult
     public func softRemoveWorkspace(_ workspaceID: UUID, grace: TimeInterval = AppStore.pendingCloseGraceInterval) -> Bool {
         guard canRemoveWorkspace, let index = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return false }
-        let workspace = foldingPendingCloses(of: workspaces.remove(at: index))
+        let visibleWorkspace = workspaces.remove(at: index)
+        for session in visibleWorkspace.sessions { emitSessionClosed(session, workspace: visibleWorkspace.id) }
+        if visibleWorkspace.sessions.isEmpty { scheduleTreeChanged() }
+        let workspace = foldingPendingCloses(of: visibleWorkspace)
         for session in workspace.sessions { session.clearPendingRestoreOverrides() } // same undo hazard
         let removingActive = selectedSessionID.map { id in workspace.sessions.contains { $0.id == id } } ?? false
         let restoringSelection = removingActive ? selectedSessionID : nil
@@ -329,6 +334,7 @@ extension AppStore {
         }
         let insertAt = max(0, min(close.sessionIndex, workspaces[workspaceIndex].sessions.count))
         workspaces[workspaceIndex].sessions.insert(close.session, at: insertAt)
+        emitSessionCreated(close.session, workspace: close.workspaceID)
     }
 
     private func restorePendingSessions(_ close: PendingSessionsClose, selecting requestedSessionID: UUID?) {
@@ -361,10 +367,14 @@ extension AppStore {
         // session held by this record cannot already be live elsewhere.
         if let existing = workspaces.firstIndex(where: { $0.id == close.workspace.id }) {
             let live = Set(workspaces.flatMap(\.sessions).map(\.id))
-            workspaces[existing].sessions.append(contentsOf: close.workspace.sessions.filter { !live.contains($0.id) })
+            let restored = close.workspace.sessions.filter { !live.contains($0.id) }
+            workspaces[existing].sessions.append(contentsOf: restored)
+            for session in restored { emitSessionCreated(session, workspace: workspaces[existing].id) }
         } else {
             let insertAt = max(0, min(close.workspaceIndex, workspaces.count))
             workspaces.insert(close.workspace, at: insertAt)
+            for session in close.workspace.sessions { emitSessionCreated(session, workspace: close.workspace.id) }
+            if close.workspace.sessions.isEmpty { scheduleTreeChanged() }
         }
         guard let target = close.selectedSessionID ?? close.workspace.sessions.first?.id else { return }
         selectedSessionID = target

--- a/agtermCore/Sources/agtermCore/AppStore+RecentClosed.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+RecentClosed.swift
@@ -18,6 +18,7 @@ extension AppStore {
             let session = session(from: recent.snapshot)
             let insertAt = max(0, min(recent.sessionIndex, workspaces[index].sessions.count))
             workspaces[index].sessions.insert(session, at: insertAt)
+            emitSessionCreated(session, workspace: workspaces[index].id)
             selectedSessionID = session.id
             replaceSidebarSelection(with: selectedSessionID)
             autoUnfocusIfOutsideFocus(selectedSessionID)
@@ -35,6 +36,8 @@ extension AppStore {
             // Persistent Open Recent appends like most editors' recent-project flow:
             // reopening brings the workspace back without reshuffling current workspaces.
             workspaces.append(workspace)
+            for session in workspace.sessions { emitSessionCreated(session, workspace: workspace.id) }
+            if workspace.sessions.isEmpty { scheduleTreeChanged() }
             selectedSessionID = recent.selectedSessionID.flatMap { sessionID in
                 workspace.sessions.contains { $0.id == sessionID } ? sessionID : nil
             } ?? workspace.sessions.first?.id
@@ -75,6 +78,7 @@ extension AppStore {
             let taken = Set(workspaces.flatMap(\.sessions).map(\.id)).union(pendingHeldSessionIDs())
             let missing = recent.snapshot.sessions.filter { !taken.contains($0.id) }.map { session(from: $0) }
             workspaces[index].sessions.append(contentsOf: missing)
+            for session in missing { emitSessionCreated(session, workspace: workspaces[index].id) }
             let target = recent.selectedSessionID.flatMap { id in
                 workspaces[index].sessions.contains { $0.id == id } ? id : nil
             } ?? workspaces[index].sessions.first?.id

--- a/agtermCore/Sources/agtermCore/AppStore+Status.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Status.swift
@@ -15,6 +15,7 @@ extension AppStore {
     /// triggers a `save()`.
     public func setAgentIndicator(_ indicator: AgentIndicator, forSession id: UUID) {
         guard let session = session(withID: id) else { return }
+        let previous = session.agentIndicator
         let wasBlocked = session.agentIndicator.status == .blocked
         var indicator = indicator
         // normalize a `.right` tag to `.left` when the session has NO split. A promoted survivor's
@@ -38,6 +39,19 @@ extension AppStore {
         // this session, so it can pull the user here once more; a re-asserted blocked-over-blocked is not a
         // new episode and stays muted (see Session.autoFollowConsumed).
         if !wasBlocked, indicator.status == .blocked { session.autoFollowConsumed = false }
+        guard previous != indicator else { return }
+        emitControlEvent(
+            .status,
+            workspace: workspace(forSession: id)?.id,
+            session: id,
+            payload: ControlEventPayload(
+                name: session.displayName,
+                status: indicator.status.rawValue,
+                pane: indicator.statusPane?.rawValue,
+                blink: indicator.blink,
+                color: indicator.color
+            )
+        )
     }
 
     /// The window-wide non-idle sessions, the single source of truth for the titlebar attention icon

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -98,7 +98,7 @@ public final class AppStore {
     @ObservationIgnored private let persistence: PersistenceStore
     @ObservationIgnored let recentClosedStore: RecentClosedStore?
     @ObservationIgnored var recentClosedDidChange: (() -> Void)?
-
+    @ObservationIgnored let controlEventSink: ((ControlEventDraft) -> Void)?
     /// Coalesces the high-frequency selection/font saves: a click-storm or a font ramp schedules one
     /// write ~0.3 s after the burst settles instead of hitting disk per event. `save()` cancels any
     /// pending scheduled save, so the quit-flush (`saveAllOpen()` → `save()`) still captures the latest.
@@ -147,12 +147,14 @@ public final class AppStore {
     public init(workspaces: [Workspace] = [], selectedSessionID: UUID? = nil,
                 persistence: PersistenceStore = PersistenceStore(),
                 recentClosedStore: RecentClosedStore? = nil,
-                recentClosedDidChange: (() -> Void)? = nil) {
+                recentClosedDidChange: (() -> Void)? = nil,
+                controlEventSink: ((ControlEventDraft) -> Void)? = nil) {
         self.workspaces = workspaces
         self.selectedSessionID = selectedSessionID
         self.persistence = persistence
         self.recentClosedStore = recentClosedStore
         self.recentClosedDidChange = recentClosedDidChange
+        self.controlEventSink = controlEventSink
     }
 
     /// The currently selected session, derived from `selectedSessionID`.
@@ -256,6 +258,7 @@ public final class AppStore {
         let workspace = Workspace(name: name, isExpanded: !collapsed)
         workspaces.append(workspace)
         if clearFocus { focusedWorkspaceID = nil }
+        scheduleTreeChanged()
         save()
         return workspace
     }
@@ -300,6 +303,7 @@ public final class AppStore {
             autoUnfocusIfOutsideFocus(session.id) // a control-driven add into another workspace must reveal it
             recordRecency()
         }
+        emitSessionCreated(session, workspace: workspaceID)
         save()
         return session
     }
@@ -347,7 +351,7 @@ public final class AppStore {
     /// flash). No-op for nil / an unknown id / a non-autoReset indicator.
     private func clearAutoResetIndicator(_ id: UUID?) {
         guard let id, let session = session(withID: id), session.agentIndicator.autoReset else { return }
-        session.agentIndicator = AgentIndicator()
+        setAgentIndicator(AgentIndicator(), forSession: id)
     }
 
     /// Clears a session's unseen-notification badge — it's been looked at. No-op for an unknown id.
@@ -366,22 +370,6 @@ public final class AppStore {
         sessionRecency.remove(id)
     }
 
-    /// Sets a session's custom name. An empty (or whitespace-only) name clears
-    /// `customName` to nil, reverting the row to the auto basename.
-    public func renameSession(_ sessionID: UUID, to name: String) {
-        guard let session = session(withID: sessionID) else { return }
-        session.customName = name.trimmedOrNil
-        save()
-    }
-
-    /// Renames a workspace. An empty (or whitespace-only) name is ignored —
-    /// workspaces have no auto fallback, so a blank name is rejected.
-    public func renameWorkspace(_ workspaceID: UUID, to name: String) {
-        guard let trimmed = name.trimmedOrNil, let index = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return }
-        workspaces[index].name = trimmed
-        save()
-    }
-
     /// Removes a session, tears down its surface, and — if it was the active
     /// session — reselects the most-recently-active surviving session in scope
     /// (see `closeReselectionTarget(after:)`), falling back to the positional neighbor.
@@ -390,6 +378,7 @@ public final class AppStore {
         let wasActive = selectedSessionID == sessionID
         let workspace = workspaces[location.workspaceIndex]
         let removed = workspaces[location.workspaceIndex].sessions.remove(at: location.sessionIndex)
+        emitSessionClosed(removed, workspace: workspace.id)
         recordRecentClosedSession(removed, workspaceID: workspace.id, workspaceName: workspace.name,
                                   workspaceIndex: location.workspaceIndex, sessionIndex: location.sessionIndex)
         removed.surface?.teardown()
@@ -424,6 +413,8 @@ public final class AppStore {
         let workspace = workspaces[index]
         let removingActive = selectedSessionID.map { id in workspace.sessions.contains { $0.id == id } } ?? false
         recordRecentClosedWorkspace(workspace, selectedSessionID: removingActive ? selectedSessionID : nil)
+        for session in workspace.sessions { emitSessionClosed(session, workspace: workspace.id) }
+        if workspace.sessions.isEmpty { scheduleTreeChanged() }
         for session in workspace.sessions {
             session.surface?.teardown()
             session.splitSurface?.teardown()
@@ -460,12 +451,14 @@ public final class AppStore {
     public func moveSession(_ sessionID: UUID, toWorkspace targetID: UUID, at index: Int? = nil) {
         guard let source = location(ofSession: sessionID) else { return }
         guard let targetIndex = workspaces.firstIndex(where: { $0.id == targetID }) else { return }
+        let before = workspaces.map { $0.sessions.map(\.id) }
 
         let session = workspaces[source.workspaceIndex].sessions.remove(at: source.sessionIndex)
         let destination = max(0, min(index ?? workspaces[targetIndex].sessions.count, workspaces[targetIndex].sessions.count))
         workspaces[targetIndex].sessions.insert(session, at: destination)
         if sessionID == selectedSessionID { autoUnfocusIfOutsideFocus(sessionID) }
         pruneSidebarSelection()
+        if before != workspaces.map({ $0.sessions.map(\.id) }) { scheduleTreeChanged() }
         save()
     }
 
@@ -477,6 +470,7 @@ public final class AppStore {
     @discardableResult
     public func moveSessions(_ sessionIDs: [UUID], toWorkspace targetID: UUID, at index: Int? = nil) -> Int {
         guard workspaces.contains(where: { $0.id == targetID }) else { return 0 }
+        let before = workspaces.map { $0.sessions.map(\.id) }
         var movingIDs = orderedSessionIDs(matching: Set(sessionIDs))
         // A one-element batch is wire-equivalent to `moveSession`: even within the destination
         // workspace it moves to the end. Multi-selection context moves leave existing members in place.
@@ -499,6 +493,7 @@ public final class AppStore {
         workspaces[targetIndex].sessions.insert(contentsOf: moving, at: destination)
         if let selectedSessionID, movingIDs.contains(selectedSessionID) { autoUnfocusIfOutsideFocus(selectedSessionID) }
         pruneSidebarSelection()
+        if before != workspaces.map({ $0.sessions.map(\.id) }) { scheduleTreeChanged() }
         save()
         return moving.count
     }
@@ -518,9 +513,11 @@ public final class AppStore {
     /// the move's removal (clamped to bounds). No-op on an unknown id.
     public func moveWorkspace(_ id: UUID, at index: Int) {
         guard let current = workspaces.firstIndex(where: { $0.id == id }) else { return }
+        let before = workspaces.map(\.id)
         let workspace = workspaces.remove(at: current)
         let dest = max(0, min(index, workspaces.count))
         workspaces.insert(workspace, at: dest)
+        if before != workspaces.map(\.id) { scheduleTreeChanged() }
         save()
     }
 

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -6,6 +6,7 @@ import Foundation
 @MainActor
 public protocol ControlActions {
     func controlTree(window: String?) -> ControlResponse
+    func readEvents(_ options: ControlEventReadOptions) -> ControlResponse
     func createSession(_ options: ControlSessionCreateOptions) -> ControlResponse
     func duplicateSession(_ target: String?, window: String?) -> ControlResponse
     func selectSession(_ target: String?, window: String?) -> ControlResponse
@@ -144,6 +145,8 @@ public struct ControlDispatcher {
         switch request.cmd {
         case .tree:
             return actions.controlTree(window: request.args?.window)
+        case .eventsRead:
+            return dispatchEventsRead(request)
         case .sessionNew, .sessionDuplicate, .sessionSelect, .sessionGo, .sessionClose, .sessionRename,
                 .sessionReveal, .sessionMove, .sessionFlag, .sessionSeen, .sessionStatus, .sessionRestore:
             return dispatchSessionCommand(request)
@@ -170,6 +173,43 @@ public struct ControlDispatcher {
             // UI-test-only seam handled app-side in `ControlServer` (needs AppKit + `ContentView.isUITestLaunch`).
             return nil
         }
+    }
+
+    private func dispatchEventsRead(_ request: ControlRequest) -> ControlResponse {
+        let args = request.args
+        let cursor: ControlEventCursor?
+        switch (args?.run, args?.after) {
+        case (nil, nil):
+            cursor = nil
+        case (.some, nil), (nil, .some):
+            return ControlResponse(ok: false, error: ControlEventRequestError.cursorPair)
+        case let (.some(runText), .some(afterText)):
+            guard let run = UUID(uuidString: runText) else {
+                return ControlResponse(ok: false, error: ControlEventRequestError.invalidRun)
+            }
+            guard let after = UInt64(afterText) else {
+                return ControlResponse(ok: false, error: ControlEventRequestError.invalidCursor)
+            }
+            cursor = ControlEventCursor(run: run, after: after)
+        }
+
+        let limit = args?.limit ?? 100
+        guard (1...1_000).contains(limit) else {
+            return ControlResponse(ok: false, error: ControlEventRequestError.invalidLimit)
+        }
+
+        var parsedKinds = Set<ControlEventKind>()
+        for field in args?.kinds ?? [] {
+            for component in field.split(separator: ",", omittingEmptySubsequences: false) {
+                let rawKind = component.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard let kind = ControlEventKind(rawValue: rawKind) else {
+                    return ControlResponse(ok: false, error: ControlEventRequestError.invalidKind(rawKind))
+                }
+                parsedKinds.insert(kind)
+            }
+        }
+        let kinds: Set<ControlEventKind>? = parsedKinds.isEmpty ? nil : parsedKinds
+        return actions.readEvents(ControlEventReadOptions(cursor: cursor, kinds: kinds, limit: limit))
     }
 
     private func dispatchSessionCommand(_ request: ControlRequest) -> ControlResponse {

--- a/agtermCore/Sources/agtermCore/ControlEvents.swift
+++ b/agtermCore/Sources/agtermCore/ControlEvents.swift
@@ -1,0 +1,185 @@
+import Foundation
+
+/// Event kinds retained by the app-run control event ring.
+public enum ControlEventKind: String, Codable, CaseIterable, Sendable, Equatable {
+    case status
+    case notify
+    case sessionCreated = "session.created"
+    case sessionClosed = "session.closed"
+    case treeChanged = "tree.changed"
+}
+
+/// Kind-specific event data. Optional fields keep the encoded payload compact while preserving one
+/// stable object shape for shell/JSON consumers.
+public struct ControlEventPayload: Codable, Sendable, Equatable {
+    public var name: String?
+    public var status: String?
+    public var pane: String?
+    public var blink: Bool?
+    public var color: String?
+    public var title: String?
+    public var body: String?
+
+    public init(name: String? = nil, status: String? = nil, pane: String? = nil,
+                blink: Bool? = nil, color: String? = nil, title: String? = nil, body: String? = nil) {
+        self.name = name
+        self.status = status
+        self.pane = pane
+        self.blink = blink
+        self.color = color
+        self.title = title
+        self.body = body
+    }
+}
+
+/// An event before the ring assigns its app-run sequence and timestamp.
+public struct ControlEventDraft: Sendable, Equatable {
+    public let kind: ControlEventKind
+    public let window: String?
+    public let workspace: String?
+    public let session: String?
+    public let payload: ControlEventPayload
+
+    public init(kind: ControlEventKind, window: String? = nil, workspace: String? = nil,
+                session: String? = nil, payload: ControlEventPayload = ControlEventPayload()) {
+        self.kind = kind
+        self.window = window
+        self.workspace = workspace
+        self.session = session
+        self.payload = payload
+    }
+}
+
+/// One immutable entry in the event ring.
+public struct ControlEvent: Codable, Sendable, Equatable {
+    public let seq: UInt64
+    public let ts: TimeInterval
+    public let kind: ControlEventKind
+    public let window: String?
+    public let workspace: String?
+    public let session: String?
+    public let payload: ControlEventPayload
+
+    public init(seq: UInt64, ts: TimeInterval, kind: ControlEventKind,
+                window: String? = nil, workspace: String? = nil, session: String? = nil,
+                payload: ControlEventPayload = ControlEventPayload()) {
+        self.seq = seq
+        self.ts = ts
+        self.kind = kind
+        self.window = window
+        self.workspace = workspace
+        self.session = session
+        self.payload = payload
+    }
+
+    public init(seq: UInt64, ts: TimeInterval, draft: ControlEventDraft) {
+        self.init(seq: seq, ts: ts, kind: draft.kind, window: draft.window,
+                  workspace: draft.workspace, session: draft.session, payload: draft.payload)
+    }
+}
+
+/// An independent consumer's position within one app run.
+public struct ControlEventCursor: Sendable, Equatable {
+    public let run: UUID
+    public let after: UInt64
+
+    public init(run: UUID, after: UInt64) {
+        self.run = run
+        self.after = after
+    }
+}
+
+/// A page returned by a ring read. `next` is the global sequence through which the ring scanned,
+/// including filtered-out entries.
+public struct ControlEventBatch: Codable, Sendable, Equatable {
+    public let run: UUID
+    public let next: UInt64
+    public let items: [ControlEvent]
+
+    public init(run: UUID, next: UInt64, items: [ControlEvent]) {
+        self.run = run
+        self.next = next
+        self.items = items
+    }
+}
+
+/// Cursor failures that require the caller to choose whether to rebaseline.
+public enum ControlEventReadError: String, Sendable, Equatable {
+    case runChanged = "event run changed"
+    case cursorExpired = "event cursor expired"
+    case cursorAhead = "event cursor is ahead of the current sequence"
+}
+
+/// Stable dispatcher validation errors shared with CLI and socket tests.
+public enum ControlEventRequestError {
+    public static let cursorPair = "events.read requires --run and --after together"
+    public static let invalidCursor = "invalid event cursor"
+    public static let invalidRun = "invalid event run id"
+    public static let invalidLimit = "event limit must be between 1 and 1000"
+
+    public static func invalidKind(_ kind: String) -> String {
+        "invalid event kind: \(kind)"
+    }
+}
+
+/// A successful page or a loud cursor failure carrying the ring's current anchor.
+public enum ControlEventReadResult: Sendable, Equatable {
+    case batch(ControlEventBatch)
+    case failure(ControlEventReadError, anchor: ControlEventBatch)
+}
+
+/// Bounded, non-destructive event history for one app process. Main-actor isolation matches the model
+/// mutation and control-dispatch seams, so the ring needs no lock or subscriber lifecycle.
+@MainActor
+public final class ControlEventRing {
+    public static let defaultCapacity = 4_096
+
+    private let capacity: Int
+    private let runID: UUID
+    private let now: () -> Date
+    private var entries: [ControlEvent] = []
+    private var currentSequence: UInt64 = 0
+
+    public init(capacity: Int = ControlEventRing.defaultCapacity,
+                runID: UUID = UUID(), now: @escaping () -> Date = Date.init) {
+        precondition(capacity > 0, "event ring capacity must be positive")
+        self.capacity = capacity
+        self.runID = runID
+        self.now = now
+    }
+
+    /// Append one event, assigning the next sequence and current Unix timestamp.
+    @discardableResult
+    public func append(_ draft: ControlEventDraft) -> ControlEvent {
+        currentSequence += 1
+        let event = ControlEvent(seq: currentSequence, ts: now().timeIntervalSince1970, draft: draft)
+        entries.append(event)
+        if entries.count > capacity {
+            entries.removeFirst(entries.count - capacity)
+        }
+        return event
+    }
+
+    /// Read retained entries after `cursor`, optionally filtering by kind. A nil cursor is the
+    /// subscribe-from-now bootstrap: it anchors at the tail and intentionally returns no history.
+    public func read(cursor: ControlEventCursor?, kinds: Set<ControlEventKind>? = nil,
+                     limit: Int = 100) -> ControlEventReadResult {
+        let anchor = ControlEventBatch(run: runID, next: currentSequence, items: [])
+        guard let cursor else { return .batch(anchor) }
+        guard cursor.run == runID else { return .failure(.runChanged, anchor: anchor) }
+        guard cursor.after <= currentSequence else { return .failure(.cursorAhead, anchor: anchor) }
+        if let oldest = entries.first?.seq, cursor.after < oldest - 1 {
+            return .failure(.cursorExpired, anchor: anchor)
+        }
+
+        var items: [ControlEvent] = []
+        for event in entries where event.seq > cursor.after {
+            guard kinds == nil || kinds!.contains(event.kind) else { continue }
+            items.append(event)
+            if items.count == limit {
+                return .batch(ControlEventBatch(run: runID, next: event.seq, items: items))
+            }
+        }
+        return .batch(ControlEventBatch(run: runID, next: currentSequence, items: items))
+    }
+}

--- a/agtermCore/Sources/agtermCore/ControlModes.swift
+++ b/agtermCore/Sources/agtermCore/ControlModes.swift
@@ -1,5 +1,18 @@
 import Foundation
 
+/// Host-facing `events.read` options after dispatcher validation and normalization.
+public struct ControlEventReadOptions: Equatable, Sendable {
+    public let cursor: ControlEventCursor?
+    public let kinds: Set<ControlEventKind>?
+    public let limit: Int
+
+    public init(cursor: ControlEventCursor?, kinds: Set<ControlEventKind>?, limit: Int) {
+        self.cursor = cursor
+        self.kinds = kinds
+        self.limit = limit
+    }
+}
+
 /// Parsed binary control mode with the shared default/toggle semantics used by mode-bearing commands.
 public enum ControlToggleMode: Equatable, Sendable {
     case on

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -5,6 +5,7 @@ import Foundation
 /// turns into an "unknown command" error rather than a crash.
 public enum Command: String, Codable, Sendable {
     case tree
+    case eventsRead = "events.read"
     case workspaceNew = "workspace.new"
     case workspaceRename = "workspace.rename"
     case workspaceDelete = "workspace.delete"
@@ -173,6 +174,13 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     public var after: String?
     /// Anchor session to place a session right BEFORE, the mirror of `after` (mutually exclusive with it).
     public var before: String?
+    /// App-run UUID paired with `after` for `events.read`. Both fields are omitted for a bootstrap read.
+    public var run: String?
+    /// Raw event-kind filters for `events.read`. Validation deliberately happens in the dispatcher so
+    /// unknown future kinds produce a normal control error rather than making the request undecodable.
+    public var kinds: [String]?
+    /// Maximum matching events returned by `events.read`; omitted uses the dispatcher default.
+    public var limit: Int?
     /// The desktop-notification title for `notify` (optional; defaults to the target session's name).
     public var title: String?
     /// The desktop-notification body for `notify` (required).
@@ -246,7 +254,8 @@ public struct ControlArgs: Codable, Sendable, Equatable {
                 command: String? = nil, wait: Bool? = nil, sizePercent: Int? = nil, full: Bool? = nil,
                 follow: Bool? = nil, window: String? = nil,
                 pane: String? = nil, paneID: String? = nil, to: String? = nil,
-                after: String? = nil, before: String? = nil,
+                after: String? = nil, before: String? = nil, run: String? = nil,
+                kinds: [String]? = nil, limit: Int? = nil,
                 title: String? = nil, body: String? = nil,
                 width: Int? = nil, height: Int? = nil, x: Int? = nil, y: Int? = nil, display: Int? = nil,
                 status: String? = nil, blink: Bool? = nil, autoReset: Bool? = nil, sound: String? = nil,
@@ -277,6 +286,9 @@ public struct ControlArgs: Codable, Sendable, Equatable {
         self.to = to
         self.after = after
         self.before = before
+        self.run = run
+        self.kinds = kinds
+        self.limit = limit
         self.title = title
         self.body = body
         self.width = width
@@ -675,12 +687,15 @@ public struct ControlResult: Codable, Sendable, Equatable {
     public var sync: Bool?
     public var light: String?
     public var dark: String?
+    /// A page from the app-run event ring, present for `events.read` success and cursor errors.
+    public var events: ControlEventBatch?
 
     public init(id: String? = nil, tree: ControlTree? = nil, text: String? = nil,
                 windows: [ControlWindowNode]? = nil, exitCode: Int? = nil, count: Int? = nil,
                 affected: Int? = nil,
                 theme: String? = nil, themes: [String]? = nil, ratio: Double? = nil,
-                sync: Bool? = nil, light: String? = nil, dark: String? = nil) {
+                sync: Bool? = nil, light: String? = nil, dark: String? = nil,
+                events: ControlEventBatch? = nil) {
         self.id = id
         self.tree = tree
         self.text = text
@@ -694,6 +709,7 @@ public struct ControlResult: Codable, Sendable, Equatable {
         self.sync = sync
         self.light = light
         self.dark = dark
+        self.events = events
     }
 }
 

--- a/agtermCore/Sources/agtermCore/WindowLibrary.swift
+++ b/agtermCore/Sources/agtermCore/WindowLibrary.swift
@@ -93,6 +93,10 @@ public final class WindowLibrary {
     /// the `windows/` subdirectory.
     @ObservationIgnored private let directory: URL
     @ObservationIgnored private let recentClosedStore: RecentClosedStore
+    /// One bounded run-identified ring shared by every window store for this library/app lifetime.
+    @ObservationIgnored private let controlEventRing: ControlEventRing
+    @ObservationIgnored private var treeEventDebouncers: [UUID: Debouncer]
+    @ObservationIgnored private var isBootstrapping = true
 
     /// Set once the launch reopen-all has run, so the scene `.task` (which fires per window) drives
     /// it exactly once. `@ObservationIgnored`: a launch-flow latch, not view state.
@@ -123,14 +127,18 @@ public final class WindowLibrary {
 
     /// Creates the library rooted at `directory`, running migration/recovery so the resulting
     /// window set is always valid and non-empty.
-    public init(directory: URL = PersistenceStore.defaultDirectory) {
+    public init(directory: URL = PersistenceStore.defaultDirectory,
+                controlEventRing: ControlEventRing? = nil) {
         self.directory = directory
         self.recentClosedStore = RecentClosedStore(directory: directory)
+        self.controlEventRing = controlEventRing ?? ControlEventRing()
+        self.treeEventDebouncers = [:]
         self.stores = [:]
         self.windows = []
         self.recentClosedItems = recentClosedStore.load()
         self.frontmostWindowID = nil
         bootstrap()
+        isBootstrapping = false
     }
 
     // MARK: - Lookup
@@ -184,6 +192,22 @@ public final class WindowLibrary {
                                      geometry: geometry($0.id),
                                      fullscreen: live?.fullscreen, zoomed: live?.zoomed)
         }
+    }
+
+    /// Reads the app-wide ring and maps both pages and cursor failures onto the stable control response.
+    public func readEvents(_ options: ControlEventReadOptions) -> ControlResponse {
+        switch controlEventRing.read(cursor: options.cursor, kinds: options.kinds, limit: options.limit) {
+        case .batch(let batch):
+            return ControlResponse(ok: true, result: ControlResult(events: batch))
+        case .failure(let error, let anchor):
+            return ControlResponse(ok: false, result: ControlResult(events: anchor), error: error.rawValue)
+        }
+    }
+
+    /// Test/quit seam: synchronously fires every pending per-window structural invalidation,
+    /// including one queued for a window that has just been removed from the catalog.
+    func flushTreeEvents() {
+        for debouncer in treeEventDebouncers.values { debouncer.flush() }
     }
 
     /// Resolve a control window target against the library's ordered window set. All known windows are
@@ -329,7 +353,7 @@ public final class WindowLibrary {
     @discardableResult
     public func newWindow(name: String? = nil) -> WindowInfo {
         let info = WindowInfo(name: name?.trimmedOrNil ?? defaultWindowName)
-        let store = makeStore(persistence: persistenceStore(for: info.id))
+        let store = makeStore(for: info.id, persistence: persistenceStore(for: info.id))
         let workspace = store.addWorkspace(name: "workspace 1")
         store.addSession(toWorkspace: workspace.id, cwd: FileManager.default.homeDirectoryForCurrentUser.path)
         windows.append(info)
@@ -356,9 +380,15 @@ public final class WindowLibrary {
         guard windows.contains(where: { $0.id == id }) else { return nil }
         if let existing = stores[id] { return existing }
         let persistence = persistenceStore(for: id)
-        let store = makeStore(persistence: persistence)
+        let store = makeStore(for: id, persistence: persistence)
         store.restore(from: persistence.load(), launchRestore: launchRestore)
         stores[id] = store
+        if !launchRestore {
+            for workspace in store.workspaces {
+                for session in workspace.sessions { store.emitSessionCreated(session, workspace: workspace.id) }
+            }
+            store.scheduleTreeChanged()
+        }
         saveIndex()
         return store
     }
@@ -395,7 +425,11 @@ public final class WindowLibrary {
         // cancel any queued claim for this id so a window still attaching can't re-open it after a
         // close that raced its registration (window.new immediately followed by window.close).
         pendingClaim.removeAll { $0 == id }
-        guard stores[id] != nil else { return }
+        guard let store = stores[id] else { return }
+        for workspace in store.workspaces {
+            for session in workspace.sessions { store.emitSessionClosed(session, workspace: workspace.id) }
+        }
+        store.scheduleTreeChanged()
         stores[id] = nil
         if frontmostWindowID == id { frontmostWindowID = activeWindowID }
         saveIndex()
@@ -405,7 +439,9 @@ public final class WindowLibrary {
     /// An empty/whitespace-only name is ignored. Persists the index.
     public func renameWindow(_ id: UUID, to name: String) {
         guard let trimmed = name.trimmedOrNil, let index = windows.firstIndex(where: { $0.id == id }) else { return }
+        guard windows[index].name != trimmed else { return }
         windows[index].name = trimmed
+        scheduleTreeChanged(for: id)
         saveIndex()
     }
 
@@ -418,6 +454,12 @@ public final class WindowLibrary {
     /// `frontmostWindowID` if it pointed at the removed window.
     public func removeWindow(_ id: UUID) {
         guard canRemoveWindow, let index = windows.firstIndex(where: { $0.id == id }) else { return }
+        if let store = stores[id] {
+            for workspace in store.workspaces {
+                for session in workspace.sessions { store.emitSessionClosed(session, workspace: workspace.id) }
+            }
+        }
+        scheduleTreeChanged(for: id)
         // cancel the store's pending debounced save BEFORE deleting the file — a save scheduled by a
         // just-before-delete selectSession/setFontSize captures the store weakly and fires ~0.3 s out;
         // since the delete-path willClose teardown skips its own save() (the window is no longer open),
@@ -587,7 +629,7 @@ public final class WindowLibrary {
         guard !snapshot.workspaces.isEmpty else { return false }
         // first window, so `defaultWindowName` yields "window 1" (windows is empty at this point).
         let info = WindowInfo(name: defaultWindowName)
-        let store = makeStore(persistence: persistenceStore(for: info.id))
+        let store = makeStore(for: info.id, persistence: persistenceStore(for: info.id))
         store.restore(from: snapshot, launchRestore: true)
         store.save()
         windows = [info]
@@ -609,9 +651,34 @@ public final class WindowLibrary {
         PersistenceStore(directory: windowsDirectory, fileName: "\(id.uuidString).json")
     }
 
-    private func makeStore(persistence: PersistenceStore) -> AppStore {
-        AppStore(persistence: persistence, recentClosedStore: recentClosedStore) { [weak self] in
-            self?.refreshRecentClosedItems()
+    private func makeStore(for windowID: UUID, persistence: PersistenceStore) -> AppStore {
+        AppStore(
+            persistence: persistence,
+            recentClosedStore: recentClosedStore,
+            recentClosedDidChange: { [weak self] in self?.refreshRecentClosedItems() },
+            controlEventSink: { [weak self] draft in
+                guard let self else { return }
+                guard !self.isBootstrapping else { return }
+                if draft.kind == .treeChanged {
+                    self.scheduleTreeChanged(for: windowID)
+                    return
+                }
+                self.controlEventRing.append(ControlEventDraft(
+                    kind: draft.kind,
+                    window: windowID.uuidString,
+                    workspace: draft.workspace,
+                    session: draft.session,
+                    payload: draft.payload
+                ))
+            }
+        )
+    }
+
+    private func scheduleTreeChanged(for windowID: UUID) {
+        let debouncer = treeEventDebouncers[windowID] ?? Debouncer()
+        treeEventDebouncers[windowID] = debouncer
+        debouncer.schedule(after: 0.1) { [weak self] in
+            self?.controlEventRing.append(ControlEventDraft(kind: .treeChanged, window: windowID.uuidString))
         }
     }
 

--- a/agtermCore/Sources/agtermctlKit/Commands.swift
+++ b/agtermCore/Sources/agtermctlKit/Commands.swift
@@ -90,7 +90,7 @@ public struct Agtermctl: ParsableCommand {
     public static let configuration = CommandConfiguration(
         commandName: "agtermctl",
         abstract: "Drive agterm over its control socket.",
-        subcommands: [Tree.self, Workspace.self, Session.self, Surface.self, Dashboard.self, Window.self, Quick.self,
+        subcommands: [Tree.self, Events.self, Workspace.self, Session.self, Surface.self, Dashboard.self, Window.self, Quick.self,
                       Sidebar.self, Notify.self, Font.self, Keymap.self, Config.self, Theme.self, Restore.self]
     )
 

--- a/agtermCore/Sources/agtermctlKit/EventCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/EventCommands.swift
@@ -1,0 +1,141 @@
+import ArgumentParser
+import Foundation
+import agtermCore
+
+struct EventStreamError: Error, CustomStringConvertible {
+    let description: String
+    init(_ description: String) { self.description = description }
+}
+
+struct EventStreamDependencies {
+    let send: (ControlRequest) throws -> ControlResponse
+    let sleep: (TimeInterval) -> Void
+    let writeLine: (String) throws -> Void
+
+    static func live(socketPath: String) -> EventStreamDependencies {
+        EventStreamDependencies(
+            send: { request in try SocketClient(path: socketPath).send(request) },
+            sleep: Thread.sleep(forTimeInterval:),
+            writeLine: { line in
+                FileHandle.standardOutput.write(Data((line + "\n").utf8))
+            }
+        )
+    }
+}
+
+struct EventStreamState {
+    private(set) var cursor: ControlEventCursor?
+    let kinds: Set<ControlEventKind>?
+    let limit: Int?
+
+    init(cursor: ControlEventCursor? = nil, kinds: Set<ControlEventKind>?, limit: Int?) {
+        self.cursor = cursor
+        self.kinds = kinds
+        self.limit = limit
+    }
+
+    func makeRequest() -> ControlRequest {
+        let rawKinds = kinds.map { selected in
+            ControlEventKind.allCases.filter(selected.contains).map(\.rawValue)
+        }
+        let args = ControlArgs(after: cursor.map { String($0.after) }, run: cursor?.run.uuidString,
+                               kinds: rawKinds, limit: limit)
+        if cursor == nil, rawKinds == nil, limit == nil { return ControlRequest(cmd: .eventsRead) }
+        return ControlRequest(cmd: .eventsRead, args: args)
+    }
+
+    mutating func consume(_ response: ControlResponse) throws -> [ControlEvent] {
+        guard response.ok else { throw EventStreamError(response.error ?? "events.read failed") }
+        guard let batch = response.result?.events else { throw EventStreamError("events.read response missing events") }
+        cursor = ControlEventCursor(run: batch.run, after: batch.next)
+        return batch.items
+    }
+}
+
+enum EventFormatter {
+    static func json(_ event: ControlEvent) throws -> String {
+        String(decoding: try JSONEncoder().encode(event), as: UTF8.self)
+    }
+
+    static func human(_ event: ControlEvent, timeZone: TimeZone = .current) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = timeZone
+        formatter.dateFormat = "HH:mm:ss"
+        let time = formatter.string(from: Date(timeIntervalSince1970: event.ts))
+        let name = event.payload.name ?? event.window ?? "-"
+        switch event.kind {
+        case .status:
+            var parts = [time, event.kind.rawValue, name, event.payload.status ?? "idle"]
+            if let pane = event.payload.pane { parts.append("pane=\(pane)") }
+            if event.payload.blink == true { parts.append("blink") }
+            if let color = event.payload.color { parts.append("color=\(color)") }
+            return parts.joined(separator: " ")
+        case .notify:
+            return "\(time) \(event.kind.rawValue) \(name) \(event.payload.title ?? name): \(event.payload.body ?? "")"
+        case .sessionCreated, .sessionClosed, .treeChanged:
+            return "\(time) \(event.kind.rawValue) \(name)"
+        }
+    }
+}
+
+struct Events: ParsableCommand {
+    static let configuration = CommandConfiguration(abstract: "Continuously print control events.")
+
+    @OptionGroup var options: BasicOptions
+    @Option(name: .customLong("kind"), help: "Event kind; repeat or comma-separate values.")
+    var kindFields: [String] = []
+    @Option(name: .customLong("run"), help: "App-run UUID paired with --after.") var runID: String?
+    @Option(name: .long, help: "Sequence cursor paired with --run.") var after: String?
+    @Option(name: .long, help: "Events per read (1...1000).") var limit: Int?
+
+    private var rawKinds: [String] {
+        kindFields.flatMap { field in
+            field.split(separator: ",", omittingEmptySubsequences: false)
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+        }
+    }
+
+    private var normalizedKinds: [ControlEventKind] { rawKinds.compactMap(ControlEventKind.init(rawValue:)) }
+
+    mutating func validate() throws {
+        guard (runID == nil) == (after == nil) else {
+            throw ValidationError(ControlEventRequestError.cursorPair)
+        }
+        if let runID, UUID(uuidString: runID) == nil { throw ValidationError(ControlEventRequestError.invalidRun) }
+        if let after, UInt64(after) == nil { throw ValidationError(ControlEventRequestError.invalidCursor) }
+        if let limit, !(1...1_000).contains(limit) { throw ValidationError(ControlEventRequestError.invalidLimit) }
+        for raw in rawKinds {
+            guard ControlEventKind(rawValue: raw) != nil else {
+                throw ValidationError(ControlEventRequestError.invalidKind(raw))
+            }
+        }
+    }
+
+    func makeInitialRequest() throws -> ControlRequest {
+        makeState().makeRequest()
+    }
+
+    func run() throws {
+        var state = makeState()
+        let dependencies = EventStreamDependencies.live(socketPath: options.socketPath())
+        while true { try poll(state: &state, dependencies: dependencies) }
+    }
+
+    func poll(state: inout EventStreamState, dependencies: EventStreamDependencies) throws {
+        let events = try state.consume(dependencies.send(state.makeRequest()))
+        for event in events {
+            let line = try options.json ? EventFormatter.json(event) : EventFormatter.human(event)
+            try dependencies.writeLine(line)
+        }
+        if events.isEmpty { dependencies.sleep(0.25) }
+    }
+
+    func makeState() -> EventStreamState {
+        let cursor = runID.flatMap(UUID.init(uuidString:)).flatMap { run in
+            after.flatMap(UInt64.init).map { ControlEventCursor(run: run, after: $0) }
+        }
+        let kinds = normalizedKinds.isEmpty ? nil : Set(normalizedKinds)
+        return EventStreamState(cursor: cursor, kinds: kinds, limit: limit)
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/AppStoreEventTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreEventTests.swift
@@ -1,0 +1,366 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+@MainActor
+final class AppStoreEventTests {
+    private let directory: URL
+    private let run = UUID(uuidString: "CBB5E3D0-7A9B-4C96-9EA2-18B14380DDB1")!
+
+    init() throws {
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agterm-events-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    @Test func everyWindowStoreFeedsOneAppRunRingWithStampedIdentity() throws {
+        let ring = ControlEventRing(runID: run, now: { Date(timeIntervalSince1970: 50) })
+        let library = WindowLibrary(directory: directory, controlEventRing: ring)
+        let anchor = try eventBatch(library.readEvents(ControlEventReadOptions(cursor: nil, kinds: nil, limit: 100)))
+        let firstWindow = try #require(library.windows.first)
+        let firstStore = try #require(library.store(for: firstWindow.id))
+        let firstWorkspace = try #require(firstStore.workspaces.first)
+        let firstSession = try #require(firstWorkspace.sessions.first)
+
+        firstStore.emitControlEvent(.status, workspace: firstWorkspace.id, session: firstSession.id,
+                                    payload: ControlEventPayload(name: firstSession.displayName, status: "active"))
+
+        let secondWindow = library.newWindow(name: "second")
+        let secondStore = try #require(library.store(for: secondWindow.id))
+        let secondWorkspace = try #require(secondStore.workspaces.first)
+        let secondSession = try #require(secondWorkspace.sessions.first)
+        secondStore.emitControlEvent(.notify, workspace: secondWorkspace.id, session: secondSession.id,
+                                     payload: ControlEventPayload(name: secondSession.displayName,
+                                                                  title: "done", body: "ok"))
+
+        let batch = try eventBatch(library.readEvents(ControlEventReadOptions(
+            cursor: ControlEventCursor(run: anchor.run, after: anchor.next), kinds: [.status, .notify], limit: 100
+        )))
+
+        #expect(batch.run == run)
+        #expect(batch.items.map(\.window) == [firstWindow.id.uuidString, secondWindow.id.uuidString])
+        #expect(batch.items.map(\.workspace) == [firstWorkspace.id.uuidString, secondWorkspace.id.uuidString])
+        #expect(batch.items.map(\.session) == [firstSession.id.uuidString, secondSession.id.uuidString])
+    }
+
+    @Test func runtimeCloseAndReopenKeepsCursorContinuity() throws {
+        let library = WindowLibrary(directory: directory, controlEventRing: ControlEventRing(runID: run))
+        let firstWindow = try #require(library.windows.first)
+        let firstStore = try #require(library.store(for: firstWindow.id))
+        let firstWorkspace = try #require(firstStore.workspaces.first)
+        let firstSession = try #require(firstWorkspace.sessions.first)
+        let anchor = try eventBatch(library.readEvents(ControlEventReadOptions(cursor: nil, kinds: nil, limit: 100)))
+
+        firstStore.emitControlEvent(.status, workspace: firstWorkspace.id, session: firstSession.id)
+        firstStore.save()
+        _ = library.newWindow(name: "keep-open")
+        library.closeWindow(firstWindow.id)
+        let reopened = try #require(library.loadStore(for: firstWindow.id))
+        let reopenedWorkspace = try #require(reopened.workspaces.first)
+        let reopenedSession = try #require(reopenedWorkspace.sessions.first)
+        reopened.emitControlEvent(.sessionCreated, workspace: reopenedWorkspace.id, session: reopenedSession.id)
+
+        let batch = try eventBatch(library.readEvents(ControlEventReadOptions(
+            cursor: ControlEventCursor(run: anchor.run, after: anchor.next), kinds: nil, limit: 100
+        )))
+
+        #expect(batch.run == anchor.run)
+        #expect(batch.items.map(\.seq) == [1, 2, 3, 4, 5])
+        #expect(batch.items.map(\.kind) == [
+            .status, .sessionCreated, .sessionClosed, .sessionCreated, .sessionCreated,
+        ])
+    }
+
+    @Test func cursorFailureResponseCarriesCurrentAnchor() throws {
+        let library = WindowLibrary(directory: directory, controlEventRing: ControlEventRing(runID: run))
+        let response = library.readEvents(ControlEventReadOptions(
+            cursor: ControlEventCursor(run: UUID(), after: 0), kinds: nil, limit: 100
+        ))
+
+        #expect(response.ok == false)
+        #expect(response.error == ControlEventReadError.runChanged.rawValue)
+        let anchor = try #require(response.result?.events)
+        #expect(anchor.run == run)
+        #expect(anchor.items.isEmpty)
+    }
+
+    @Test func normalizedStatusChangesEmitCompletePayloadsAndIdleEdge() throws {
+        let library = WindowLibrary(directory: directory, controlEventRing: ControlEventRing(runID: run))
+        let store = try #require(library.activeStore)
+        let workspace = try #require(store.workspaces.first)
+        let session = try #require(workspace.sessions.first)
+        let anchor = try eventBatch(library.readEvents(ControlEventReadOptions(cursor: nil, kinds: nil, limit: 100)))
+
+        store.setAgentIndicator(AgentIndicator(status: .active, statusPane: .right), forSession: session.id)
+        store.setAgentIndicator(AgentIndicator(status: .blocked, blink: true, color: "#aabbcc",
+                                               statusPane: .scratch), forSession: session.id)
+        store.setAgentIndicator(AgentIndicator(status: .completed), forSession: session.id)
+        store.setAgentIndicator(AgentIndicator(), forSession: session.id)
+
+        let batch = try eventBatch(library.readEvents(ControlEventReadOptions(
+            cursor: ControlEventCursor(run: anchor.run, after: anchor.next), kinds: [.status], limit: 100
+        )))
+        #expect(batch.items.map { $0.payload.status } == ["active", "blocked", "completed", "idle"])
+        #expect(batch.items[0].payload.pane == "left")
+        #expect(batch.items[1].payload.pane == "scratch")
+        #expect(batch.items[1].payload.blink == true)
+        #expect(batch.items[1].payload.color == "#aabbcc")
+        #expect(batch.items.allSatisfy { $0.payload.name == session.displayName })
+    }
+
+    @Test func sameNormalizedStatusAndUnknownSessionDoNotEmit() throws {
+        let library = WindowLibrary(directory: directory, controlEventRing: ControlEventRing(runID: run))
+        let store = try #require(library.activeStore)
+        let session = try #require(store.activeSession)
+        let anchor = try eventBatch(library.readEvents(ControlEventReadOptions(cursor: nil, kinds: nil, limit: 100)))
+        let indicator = AgentIndicator(status: .blocked, blink: true, statusPane: .right)
+
+        store.setAgentIndicator(indicator, forSession: session.id)
+        store.setAgentIndicator(indicator, forSession: session.id)
+        store.setAgentIndicator(indicator, forSession: UUID())
+
+        let batch = try eventBatch(library.readEvents(ControlEventReadOptions(
+            cursor: ControlEventCursor(run: anchor.run, after: anchor.next), kinds: [.status], limit: 100
+        )))
+        #expect(batch.items.count == 1)
+        #expect(session.statusChangedAt != nil)
+    }
+
+    @Test func autoResetVisitRoutesThroughStatusSetterAndEmitsIdle() throws {
+        let library = WindowLibrary(directory: directory, controlEventRing: ControlEventRing(runID: run))
+        let store = try #require(library.activeStore)
+        let session = try #require(store.activeSession)
+        let anchor = try eventBatch(library.readEvents(ControlEventReadOptions(cursor: nil, kinds: nil, limit: 100)))
+
+        store.setAgentIndicator(AgentIndicator(status: .completed, autoReset: true), forSession: session.id)
+        store.selectSession(session.id)
+
+        let batch = try eventBatch(library.readEvents(ControlEventReadOptions(
+            cursor: ControlEventCursor(run: anchor.run, after: anchor.next), kinds: [.status], limit: 100
+        )))
+        #expect(batch.items.map { $0.payload.status } == ["completed", "idle"])
+    }
+
+    @Test func notificationRecordingRequiresSessionResolutionAndUsesEffectiveTitle() throws {
+        let library = WindowLibrary(directory: directory, controlEventRing: ControlEventRing(runID: run))
+        let store = try #require(library.activeStore)
+        let session = try #require(store.activeSession)
+        let anchor = try eventBatch(library.readEvents(ControlEventReadOptions(cursor: nil, kinds: nil, limit: 100)))
+
+        #expect(store.recordNotificationEvent(forSession: UUID(), title: "missing", body: "no") == nil)
+        let effectiveTitle = store.recordNotificationEvent(forSession: session.id, title: "", body: "tests passed")
+
+        #expect(effectiveTitle == session.displayName)
+        let batch = try eventBatch(library.readEvents(ControlEventReadOptions(
+            cursor: ControlEventCursor(run: anchor.run, after: anchor.next), kinds: [.notify], limit: 100
+        )))
+        #expect(batch.items.count == 1)
+        #expect(batch.items[0].payload.name == session.displayName)
+        #expect(batch.items[0].payload.title == session.displayName)
+        #expect(batch.items[0].payload.body == "tests passed")
+    }
+
+    @Test func addSoftCloseUndoAndGraceFinalizationEmitVisibleMembershipEdgesOnly() throws {
+        let library = WindowLibrary(directory: directory, controlEventRing: ControlEventRing(runID: run))
+        let store = try #require(library.activeStore)
+        let workspace = try #require(store.workspaces.first)
+        let anchor = try eventBatch(library.readEvents(ControlEventReadOptions(cursor: nil, kinds: nil, limit: 100)))
+        let session = try #require(store.addSession(toWorkspace: workspace.id, cwd: "/tmp", name: "api"))
+
+        #expect(store.softCloseSession(session.id, grace: 60))
+        #expect(store.undoPendingClose())
+        #expect(store.softCloseSession(session.id, grace: 60))
+        store.finalizeAllPendingCloses()
+
+        let batch = try eventBatch(library.readEvents(ControlEventReadOptions(
+            cursor: ControlEventCursor(run: anchor.run, after: anchor.next),
+            kinds: [.sessionCreated, .sessionClosed], limit: 100
+        )))
+        #expect(batch.items.map(\.kind) == [.sessionCreated, .sessionClosed, .sessionCreated, .sessionClosed])
+        #expect(batch.items.allSatisfy { $0.session == session.id.uuidString && $0.payload.name == "api" })
+    }
+
+    @Test func duplicateSessionEmitsOneCreatedEdge() throws {
+        let library = WindowLibrary(directory: directory, controlEventRing: ControlEventRing(runID: run))
+        let store = try #require(library.activeStore)
+        let source = try #require(store.activeSession)
+        let workspace = try #require(store.workspace(forSession: source.id))
+        let anchor = try eventBatch(library.readEvents(ControlEventReadOptions(cursor: nil, kinds: nil, limit: 100)))
+
+        let duplicate = try #require(store.duplicateSession(source.id))
+
+        let batch = try eventBatch(library.readEvents(ControlEventReadOptions(
+            cursor: ControlEventCursor(run: anchor.run, after: anchor.next), kinds: [.sessionCreated], limit: 100
+        )))
+        #expect(batch.items.map(\.session) == [duplicate.id.uuidString])
+        #expect(batch.items.map(\.workspace) == [workspace.id.uuidString])
+    }
+
+    @Test func foldingPendingWorkspaceCloseDoesNotRepeatAlreadyHiddenSessionEdges() throws {
+        let library = WindowLibrary(directory: directory, controlEventRing: ControlEventRing(runID: run))
+        let store = try #require(library.activeStore)
+        let doomed = store.addWorkspace(name: "doomed")
+        _ = store.addWorkspace(name: "keep")
+        let first = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/one", name: "one"))
+        let second = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/two", name: "two"))
+        let anchor = try eventBatch(library.readEvents(ControlEventReadOptions(cursor: nil, kinds: nil, limit: 100)))
+
+        #expect(store.softCloseSession(first.id, grace: 60))
+        let sessionClose = try #require(store.pendingCloseSummary?.id)
+        #expect(store.softRemoveWorkspace(doomed.id, grace: 60))
+        #expect(store.undoPendingClose(sessionClose))
+        #expect(store.softRemoveWorkspace(doomed.id, grace: 60))
+
+        let batch = try eventBatch(library.readEvents(ControlEventReadOptions(
+            cursor: ControlEventCursor(run: anchor.run, after: anchor.next),
+            kinds: [.sessionCreated, .sessionClosed], limit: 100
+        )))
+        #expect(batch.items.map(\.kind) == [.sessionClosed, .sessionClosed, .sessionCreated, .sessionClosed])
+        #expect(batch.items.map(\.session) == [
+            first.id.uuidString, second.id.uuidString, first.id.uuidString, first.id.uuidString,
+        ])
+    }
+
+    @Test func workspaceRemovalEmitsClosedSessionsInTreeOrder() throws {
+        let library = WindowLibrary(directory: directory, controlEventRing: ControlEventRing(runID: run))
+        let store = try #require(library.activeStore)
+        let workspace = store.addWorkspace(name: "batch")
+        let first = try #require(store.addSession(toWorkspace: workspace.id, cwd: "/one", name: "one"))
+        let second = try #require(store.addSession(toWorkspace: workspace.id, cwd: "/two", name: "two"))
+        let anchor = try eventBatch(library.readEvents(ControlEventReadOptions(cursor: nil, kinds: nil, limit: 100)))
+
+        store.removeWorkspace(workspace.id)
+
+        let batch = try eventBatch(library.readEvents(ControlEventReadOptions(
+            cursor: ControlEventCursor(run: anchor.run, after: anchor.next), kinds: [.sessionClosed], limit: 100
+        )))
+        #expect(batch.items.map(\.session) == [first.id.uuidString, second.id.uuidString])
+        #expect(batch.items.map { $0.payload.name } == ["one", "two"])
+    }
+
+    @Test func runtimeWindowCloseAndReopenEmitBalancedSessionEdges() throws {
+        let library = WindowLibrary(directory: directory, controlEventRing: ControlEventRing(runID: run))
+        let window = library.newWindow(name: "runtime")
+        let store = try #require(library.store(for: window.id))
+        store.save()
+        let session = try #require(store.activeSession)
+        let anchor = try eventBatch(library.readEvents(ControlEventReadOptions(cursor: nil, kinds: nil, limit: 100)))
+
+        library.closeWindow(window.id)
+        _ = try #require(library.loadStore(for: window.id))
+
+        let batch = try eventBatch(library.readEvents(ControlEventReadOptions(
+            cursor: ControlEventCursor(run: anchor.run, after: anchor.next),
+            kinds: [.sessionCreated, .sessionClosed], limit: 100
+        )))
+        #expect(batch.items.map(\.kind) == [.sessionClosed, .sessionCreated])
+        #expect(batch.items.map(\.session) == [session.id.uuidString, session.id.uuidString])
+    }
+
+    @Test func deletingClosedWindowStillEmitsStructuralInvalidation() throws {
+        let library = WindowLibrary(directory: directory, controlEventRing: ControlEventRing(runID: run))
+        let window = library.newWindow(name: "closed")
+        let store = try #require(library.store(for: window.id))
+        store.save()
+        library.flushTreeEvents()
+        library.closeWindow(window.id)
+        library.flushTreeEvents()
+        let anchor = try eventBatch(library.readEvents(ControlEventReadOptions(cursor: nil, kinds: nil, limit: 100)))
+
+        library.removeWindow(window.id)
+        library.flushTreeEvents()
+
+        let batch = try eventBatch(library.readEvents(ControlEventReadOptions(
+            cursor: ControlEventCursor(run: anchor.run, after: anchor.next), kinds: [.treeChanged], limit: 100
+        )))
+        #expect(batch.items.map(\.window) == [window.id.uuidString])
+    }
+
+    @Test func deletingOpenWindowEmitsClosedEdgeAndStructuralInvalidation() throws {
+        let library = WindowLibrary(directory: directory, controlEventRing: ControlEventRing(runID: run))
+        let window = library.newWindow(name: "open")
+        let store = try #require(library.store(for: window.id))
+        let session = try #require(store.activeSession)
+        library.flushTreeEvents()
+        let anchor = try eventBatch(library.readEvents(ControlEventReadOptions(cursor: nil, kinds: nil, limit: 100)))
+
+        library.removeWindow(window.id)
+        library.flushTreeEvents()
+
+        let batch = try eventBatch(library.readEvents(ControlEventReadOptions(
+            cursor: ControlEventCursor(run: anchor.run, after: anchor.next), kinds: nil, limit: 100
+        )))
+        #expect(batch.items.map(\.kind) == [.sessionClosed, .treeChanged])
+        #expect(batch.items[0].session == session.id.uuidString)
+        #expect(batch.items.allSatisfy { $0.window == window.id.uuidString })
+    }
+
+    @Test func treeChangesCoalescePerWindowAndStayIndependent() throws {
+        let library = WindowLibrary(directory: directory, controlEventRing: ControlEventRing(runID: run))
+        let firstWindow = try #require(library.windows.first)
+        let firstStore = try #require(library.store(for: firstWindow.id))
+        let secondWindow = library.newWindow(name: "second")
+        let secondStore = try #require(library.store(for: secondWindow.id))
+        library.flushTreeEvents()
+        let anchor = try eventBatch(library.readEvents(ControlEventReadOptions(cursor: nil, kinds: nil, limit: 100)))
+
+        let workspace = firstStore.addWorkspace(name: "one")
+        firstStore.renameWorkspace(workspace.id, to: "renamed")
+        _ = secondStore.addSession(toWorkspace: secondStore.workspaces[0].id, cwd: "/tmp")
+
+        let beforeFlush = try eventBatch(library.readEvents(ControlEventReadOptions(
+            cursor: ControlEventCursor(run: anchor.run, after: anchor.next), kinds: [.treeChanged], limit: 100
+        )))
+        #expect(beforeFlush.items.isEmpty)
+        library.flushTreeEvents()
+        let batch = try eventBatch(library.readEvents(ControlEventReadOptions(
+            cursor: ControlEventCursor(run: anchor.run, after: anchor.next), kinds: [.treeChanged], limit: 100
+        )))
+        #expect(Set(batch.items.compactMap(\.window)) == Set([firstWindow.id.uuidString, secondWindow.id.uuidString]))
+        #expect(batch.items.count == 2)
+    }
+
+    @Test func statusAndSelectionDoNotScheduleStructuralInvalidation() throws {
+        let library = WindowLibrary(directory: directory, controlEventRing: ControlEventRing(runID: run))
+        let store = try #require(library.activeStore)
+        let session = try #require(store.activeSession)
+        library.flushTreeEvents()
+        let anchor = try eventBatch(library.readEvents(ControlEventReadOptions(cursor: nil, kinds: nil, limit: 100)))
+
+        store.setAgentIndicator(AgentIndicator(status: .active), forSession: session.id)
+        store.selectSession(session.id)
+        library.flushTreeEvents()
+
+        let batch = try eventBatch(library.readEvents(ControlEventReadOptions(
+            cursor: ControlEventCursor(run: anchor.run, after: anchor.next), kinds: [.treeChanged], limit: 100
+        )))
+        #expect(batch.items.isEmpty)
+    }
+
+    @Test func openRecentRecreationEmitsCreatedAfterHardClose() throws {
+        let library = WindowLibrary(directory: directory, controlEventRing: ControlEventRing(runID: run))
+        let store = try #require(library.activeStore)
+        let workspace = try #require(store.workspaces.first)
+        let session = try #require(store.addSession(toWorkspace: workspace.id, cwd: "/tmp", name: "recent"))
+        let anchor = try eventBatch(library.readEvents(ControlEventReadOptions(cursor: nil, kinds: nil, limit: 100)))
+
+        store.closeSession(session.id)
+        let recent = try #require(library.recentClosedItems.first { $0.session?.snapshot.id == session.id })
+        #expect(library.reopenRecentClosed(recent.id, into: store))
+
+        let batch = try eventBatch(library.readEvents(ControlEventReadOptions(
+            cursor: ControlEventCursor(run: anchor.run, after: anchor.next),
+            kinds: [.sessionCreated, .sessionClosed], limit: 100
+        )))
+        #expect(batch.items.map(\.kind) == [.sessionClosed, .sessionCreated])
+    }
+
+    private func eventBatch(_ response: ControlResponse) throws -> ControlEventBatch {
+        #expect(response.ok)
+        return try #require(response.result?.events)
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/ControlEventDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlEventDispatcherTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+@MainActor
+struct ControlEventDispatcherTests {
+    private let run = UUID(uuidString: "CBB5E3D0-7A9B-4C96-9EA2-18B14380DDB1")!
+
+    @Test func bootstrapRoutesWithDefaultsAndReturnsActionResponse() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        let batch = ControlEventBatch(run: run, next: 12, items: [])
+        actions.nextEventsReadResponse = ControlResponse(ok: true, result: ControlResult(events: batch))
+
+        let response = await dispatcher.dispatch(ControlRequest(cmd: .eventsRead))
+
+        #expect(response == actions.nextEventsReadResponse)
+        #expect(actions.calls == [.eventsRead(ControlEventReadOptions(cursor: nil, kinds: nil, limit: 100))])
+    }
+
+    @Test func parsesCursorKindsAndMaximumLimit() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        _ = await dispatcher.dispatch(ControlRequest(
+            cmd: .eventsRead,
+            args: ControlArgs(after: "42", run: run.uuidString,
+                              kinds: ["status, notify", "tree.changed", "status"], limit: 1_000)
+        ))
+
+        let expected = ControlEventReadOptions(
+            cursor: ControlEventCursor(run: run, after: 42),
+            kinds: [.status, .notify, .treeChanged],
+            limit: 1_000
+        )
+        #expect(actions.calls == [.eventsRead(expected)])
+    }
+
+    @Test func cursorFieldsMustBePaired() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let runOnly = await dispatcher.dispatch(ControlRequest(
+            cmd: .eventsRead, args: ControlArgs(run: run.uuidString)
+        ))
+        let afterOnly = await dispatcher.dispatch(ControlRequest(
+            cmd: .eventsRead, args: ControlArgs(after: "1")
+        ))
+
+        #expect(runOnly == ControlResponse(ok: false, error: "events.read requires --run and --after together"))
+        #expect(afterOnly == ControlResponse(ok: false, error: "events.read requires --run and --after together"))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test func rejectsInvalidRunAndDecimalCursor() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let badRun = await dispatcher.dispatch(ControlRequest(
+            cmd: .eventsRead, args: ControlArgs(after: "1", run: "not-a-uuid")
+        ))
+        let badCursor = await dispatcher.dispatch(ControlRequest(
+            cmd: .eventsRead, args: ControlArgs(after: "-1", run: run.uuidString)
+        ))
+
+        #expect(badRun == ControlResponse(ok: false, error: "invalid event run id"))
+        #expect(badCursor == ControlResponse(ok: false, error: "invalid event cursor"))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test func rejectsUnknownKindAfterRawRequestDecoding() async throws {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        let json = """
+        {"cmd":"events.read","args":{"kinds":["status","future.kind"]}}
+        """
+        let request = try JSONDecoder().decode(ControlRequest.self, from: Data(json.utf8))
+
+        let response = await dispatcher.dispatch(request)
+
+        #expect(response == ControlResponse(ok: false, error: "invalid event kind: future.kind"))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test func rejectsEmptyKindComponents() async {
+        for kinds in [[""], [","], ["status,"]] {
+            let actions = MockControlActions()
+            let response = await ControlDispatcher(actions: actions).dispatch(ControlRequest(
+                cmd: .eventsRead, args: ControlArgs(kinds: kinds)
+            ))
+
+            #expect(response == ControlResponse(ok: false, error: "invalid event kind: "))
+            #expect(actions.calls.isEmpty)
+        }
+    }
+
+    @Test func rejectsLimitsOutsideInclusiveBounds() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let zero = await dispatcher.dispatch(ControlRequest(cmd: .eventsRead, args: ControlArgs(limit: 0)))
+        let tooLarge = await dispatcher.dispatch(ControlRequest(cmd: .eventsRead, args: ControlArgs(limit: 1_001)))
+
+        #expect(zero == ControlResponse(ok: false, error: "event limit must be between 1 and 1000"))
+        #expect(tooLarge == ControlResponse(ok: false, error: "event limit must be between 1 and 1000"))
+        #expect(actions.calls.isEmpty)
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/ControlEventProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlEventProtocolTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+struct ControlEventProtocolTests {
+    private let run = UUID(uuidString: "CBB5E3D0-7A9B-4C96-9EA2-18B14380DDB1")!
+
+    @Test func everyEventKindAndPayloadRoundTrips() throws {
+        let events = [
+            ControlEvent(seq: 1, ts: 1.25, kind: .status, window: "win", workspace: "work", session: "sess",
+                         payload: ControlEventPayload(name: "api", status: "blocked", pane: "right",
+                                                      blink: true, color: "#aabbcc")),
+            ControlEvent(seq: 2, ts: 2.5, kind: .notify, window: "win", workspace: "work", session: "sess",
+                         payload: ControlEventPayload(name: "api", title: "Done", body: "tests passed")),
+            ControlEvent(seq: 3, ts: 3.5, kind: .sessionCreated, window: "win", workspace: "work",
+                         session: "created", payload: ControlEventPayload(name: "new")),
+            ControlEvent(seq: 4, ts: 4.5, kind: .sessionClosed, window: "win", workspace: "work",
+                         session: "closed", payload: ControlEventPayload(name: "old")),
+            ControlEvent(seq: 5, ts: 5.5, kind: .treeChanged, window: "win"),
+        ]
+
+        let data = try JSONEncoder().encode(events)
+        let decoded = try JSONDecoder().decode([ControlEvent].self, from: data)
+
+        #expect(decoded == events)
+        let json = String(decoding: data, as: UTF8.self)
+        for kind in ControlEventKind.allCases {
+            #expect(json.contains("\"kind\":\"" + kind.rawValue + "\""))
+        }
+    }
+
+    @Test func everyEventKindMatchesGoldenWireShape() throws {
+        let events = [
+            ControlEvent(seq: 1, ts: 1.25, kind: .status, window: "win", workspace: "work", session: "sess",
+                         payload: ControlEventPayload(name: "api", status: "blocked", pane: "right",
+                                                      blink: true, color: "#aabbcc")),
+            ControlEvent(seq: 2, ts: 2.5, kind: .notify, window: "win", workspace: "work", session: "sess",
+                         payload: ControlEventPayload(name: "api", title: "Done", body: "tests passed")),
+            ControlEvent(seq: 3, ts: 3.5, kind: .sessionCreated, window: "win", workspace: "work",
+                         session: "created", payload: ControlEventPayload(name: "new")),
+            ControlEvent(seq: 4, ts: 4.5, kind: .sessionClosed, window: "win", workspace: "work",
+                         session: "closed", payload: ControlEventPayload(name: "old")),
+            ControlEvent(seq: 5, ts: 5.5, kind: .treeChanged, window: "win"),
+        ]
+        let expected = [
+            ##"{"kind":"status","payload":{"blink":true,"color":"#aabbcc","name":"api","pane":"right","status":"blocked"},"seq":1,"session":"sess","ts":1.25,"window":"win","workspace":"work"}"##,
+            ##"{"kind":"notify","payload":{"body":"tests passed","name":"api","title":"Done"},"seq":2,"session":"sess","ts":2.5,"window":"win","workspace":"work"}"##,
+            ##"{"kind":"session.created","payload":{"name":"new"},"seq":3,"session":"created","ts":3.5,"window":"win","workspace":"work"}"##,
+            ##"{"kind":"session.closed","payload":{"name":"old"},"seq":4,"session":"closed","ts":4.5,"window":"win","workspace":"work"}"##,
+            ##"{"kind":"tree.changed","payload":{},"seq":5,"ts":5.5,"window":"win"}"##,
+        ]
+
+        #expect(try events.map(canonicalJSON) == expected)
+    }
+
+    @Test func optionalEventAndPayloadFieldsAreOmitted() throws {
+        let event = ControlEvent(seq: 1, ts: 10, kind: .treeChanged, window: "win")
+        let data = try JSONEncoder().encode(event)
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let payload = try #require(object["payload"] as? [String: Any])
+
+        #expect(object["workspace"] == nil)
+        #expect(object["session"] == nil)
+        #expect(payload.isEmpty)
+    }
+
+    @Test func bootstrapAndPopulatedBatchesRoundTripInResults() throws {
+        let bootstrap = ControlEventBatch(run: run, next: 41, items: [])
+        let event = ControlEvent(seq: 42, ts: 42.25, kind: .status, window: "win", workspace: "work",
+                                 session: "sess", payload: ControlEventPayload(name: "api", status: "active"))
+        let populated = ControlEventBatch(run: run, next: 42, items: [event])
+
+        for batch in [bootstrap, populated] {
+            let response = ControlResponse(ok: true, result: ControlResult(events: batch))
+            let data = try JSONEncoder().encode(response)
+            #expect(try JSONDecoder().decode(ControlResponse.self, from: data) == response)
+        }
+    }
+
+    @Test func errorResponseCanCarryCurrentEventAnchor() throws {
+        let anchor = ControlEventBatch(run: run, next: 99, items: [])
+        let response = ControlResponse(ok: false, result: ControlResult(events: anchor),
+                                       error: ControlEventReadError.cursorExpired.rawValue)
+
+        let data = try JSONEncoder().encode(response)
+        let decoded = try JSONDecoder().decode(ControlResponse.self, from: data)
+
+        #expect(decoded == response)
+        #expect(decoded.result?.events == anchor)
+        #expect(try canonicalJSON(response) ==
+            #"{"error":"event cursor expired","ok":false,"result":{"events":{"items":[],"next":99,"run":"CBB5E3D0-7A9B-4C96-9EA2-18B14380DDB1"}}}"#)
+    }
+
+    @Test func eventReadRequestKeepsKindsAsRawStringsOnTheWire() throws {
+        let request = ControlRequest(cmd: .eventsRead,
+                                     args: ControlArgs(after: "7", run: run.uuidString,
+                                                       kinds: ["status", "future.kind"], limit: 250))
+
+        let data = try JSONEncoder().encode(request)
+        let decoded = try JSONDecoder().decode(ControlRequest.self, from: data)
+
+        #expect(decoded == request)
+        #expect(decoded.args?.kinds == ["status", "future.kind"])
+    }
+
+    private func canonicalJSON<T: Encodable>(_ value: T) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return String(decoding: try encoder.encode(value), as: UTF8.self)
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/ControlEventRingTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlEventRingTests.swift
@@ -1,0 +1,153 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+@MainActor
+struct ControlEventRingTests {
+    private let runID = UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!
+    private let fixedDate = Date(timeIntervalSince1970: 1_783_969_641.38)
+
+    private func ring(capacity: Int = 4_096) -> ControlEventRing {
+        ControlEventRing(capacity: capacity, runID: runID, now: { fixedDate })
+    }
+
+    private func draft(_ kind: ControlEventKind, name: String = "api-fix") -> ControlEventDraft {
+        ControlEventDraft(
+            kind: kind,
+            window: "window",
+            workspace: "workspace",
+            session: "session",
+            payload: ControlEventPayload(name: name)
+        )
+    }
+
+    @Test func appendAssignsMonotonicSequenceAndTimestamp() {
+        let subject = ring()
+
+        let first = subject.append(draft(.status))
+        let second = subject.append(draft(.notify))
+
+        #expect(first.seq == 1)
+        #expect(second.seq == 2)
+        #expect(first.ts == fixedDate.timeIntervalSince1970)
+        #expect(first.kind == .status)
+        #expect(first.window == "window")
+        #expect(first.payload.name == "api-fix")
+    }
+
+    @Test func bootstrapAnchorsAtTailWithoutReplayingHistory() {
+        let subject = ring()
+        subject.append(draft(.status))
+        subject.append(draft(.notify))
+
+        let result = subject.read(cursor: nil)
+
+        #expect(result == .batch(ControlEventBatch(run: runID, next: 2, items: [])))
+    }
+
+    @Test func capacityEvictsOldestAndKeepsExactBoundaryReadable() {
+        let subject = ring(capacity: 2)
+        subject.append(draft(.status, name: "one"))
+        subject.append(draft(.notify, name: "two"))
+        subject.append(draft(.sessionCreated, name: "three"))
+
+        let boundary = subject.read(cursor: ControlEventCursor(run: runID, after: 1))
+        let expired = subject.read(cursor: ControlEventCursor(run: runID, after: 0))
+
+        #expect(boundary == .batch(ControlEventBatch(run: runID, next: 3, items: [
+            ControlEvent(seq: 2, ts: fixedDate.timeIntervalSince1970, draft: draft(.notify, name: "two")),
+            ControlEvent(seq: 3, ts: fixedDate.timeIntervalSince1970, draft: draft(.sessionCreated, name: "three")),
+        ])))
+        #expect(expired == .failure(.cursorExpired, anchor: ControlEventBatch(run: runID, next: 3, items: [])))
+    }
+
+    @Test func readsAreNonDestructiveAndIndependent() {
+        let subject = ring()
+        subject.append(draft(.status))
+
+        let cursor = ControlEventCursor(run: runID, after: 0)
+        let first = subject.read(cursor: cursor)
+        let second = subject.read(cursor: cursor)
+
+        #expect(first == second)
+        #expect(first.batch?.items.map(\.seq) == [1])
+    }
+
+    @Test func filterAdvancesAcrossNonmatchingEvents() {
+        let subject = ring()
+        subject.append(draft(.notify))
+        subject.append(draft(.status))
+        subject.append(draft(.sessionClosed))
+
+        let result = subject.read(
+            cursor: ControlEventCursor(run: runID, after: 0),
+            kinds: [.status]
+        )
+
+        #expect(result.batch?.items.map(\.kind) == [.status])
+        #expect(result.batch?.next == 3)
+    }
+
+    @Test func emptyFilteredBatchAdvancesToTail() {
+        let subject = ring()
+        subject.append(draft(.notify))
+        subject.append(draft(.sessionClosed))
+
+        let result = subject.read(
+            cursor: ControlEventCursor(run: runID, after: 0),
+            kinds: [.status]
+        )
+
+        #expect(result == .batch(ControlEventBatch(run: runID, next: 2, items: [])))
+    }
+
+    @Test func limitStopsAtLastReturnedMatchWithoutDroppingLaterMatches() {
+        let subject = ring()
+        subject.append(draft(.notify, name: "skip"))
+        subject.append(draft(.status, name: "first"))
+        subject.append(draft(.notify, name: "skip-two"))
+        subject.append(draft(.status, name: "second"))
+
+        let first = subject.read(
+            cursor: ControlEventCursor(run: runID, after: 0),
+            kinds: [.status],
+            limit: 1
+        )
+        let second = subject.read(
+            cursor: ControlEventCursor(run: runID, after: first.batch!.next),
+            kinds: [.status],
+            limit: 1
+        )
+
+        #expect(first.batch?.next == 2)
+        #expect(first.batch?.items.map(\.payload.name) == ["first"])
+        #expect(second.batch?.next == 4)
+        #expect(second.batch?.items.map(\.payload.name) == ["second"])
+    }
+
+    @Test func runMismatchReturnsCurrentAnchor() {
+        let subject = ring()
+        subject.append(draft(.status))
+        let otherRun = UUID(uuidString: "11111111-2222-3333-4444-555555555555")!
+
+        let result = subject.read(cursor: ControlEventCursor(run: otherRun, after: 0))
+
+        #expect(result == .failure(.runChanged, anchor: ControlEventBatch(run: runID, next: 1, items: [])))
+    }
+
+    @Test func cursorAheadReturnsCurrentAnchor() {
+        let subject = ring()
+        subject.append(draft(.status))
+
+        let result = subject.read(cursor: ControlEventCursor(run: runID, after: 2))
+
+        #expect(result == .failure(.cursorAhead, anchor: ControlEventBatch(run: runID, next: 1, items: [])))
+    }
+}
+
+private extension ControlEventReadResult {
+    var batch: ControlEventBatch? {
+        guard case .batch(let batch) = self else { return nil }
+        return batch
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
+++ b/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
@@ -10,6 +10,7 @@ import Testing
 final class MockControlActions: ControlActions {
     enum Call: Equatable {
         case tree(window: String?)
+        case eventsRead(ControlEventReadOptions)
         case sessionNew(ControlSessionCreateOptions)
         case sessionDuplicate(target: String?, window: String?)
         case sessionSelect(target: String?, window: String?)
@@ -76,6 +77,7 @@ final class MockControlActions: ControlActions {
 
     var calls: [Call] = []
     var nextTreeResponse = ControlResponse(ok: false, error: "tree not stubbed")
+    var nextEventsReadResponse = ControlResponse(ok: false, error: "events.read not stubbed")
     var nextSessionNewResponse = ControlResponse(ok: true)
     var nextSessionDuplicateResponse = ControlResponse(ok: true)
     var nextSidebarVisibilityResponse = ControlResponse(ok: true)
@@ -120,6 +122,11 @@ final class MockControlActions: ControlActions {
     func controlTree(window: String?) -> ControlResponse {
         calls.append(.tree(window: window))
         return nextTreeResponse
+    }
+
+    func readEvents(_ options: ControlEventReadOptions) -> ControlResponse {
+        calls.append(.eventsRead(options))
+        return nextEventsReadResponse
     }
 
     func createSession(_ options: ControlSessionCreateOptions) -> ControlResponse {

--- a/agtermCore/Tests/agtermCoreTests/SkillInstallTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SkillInstallTests.swift
@@ -1,7 +1,26 @@
+import Foundation
 import Testing
 @testable import agtermCore
 
 struct SkillInstallTests {
+    @Test func bundledSkillDocumentsEventSubscriptionCommand() throws {
+        let repository = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let skillDirectory = repository.appendingPathComponent("agterm/Resources/agent-skill")
+        let skill = try String(contentsOf: skillDirectory.appendingPathComponent("SKILL.md"), encoding: .utf8)
+        let reference = try String(contentsOf: skillDirectory.appendingPathComponent("reference.md"), encoding: .utf8)
+        let examples = try String(contentsOf: skillDirectory.appendingPathComponent("examples.md"), encoding: .utf8)
+
+        #expect(skill.contains("Command summary (65 commands)"))
+        #expect(skill.contains("**events**"))
+        #expect(reference.contains("## events"))
+        #expect(reference.contains("event cursor expired"))
+        #expect(examples.contains("agtermctl events --json"))
+    }
+
     @Test func skillDirectoryComposesUnderAgentBase() {
         #expect(SkillInstall.skillDirectory(home: "/Users/x", base: ".claude") == "/Users/x/.claude/skills/agterm")
         #expect(SkillInstall.skillDirectory(home: "/Users/x", base: ".codex") == "/Users/x/.codex/skills/agterm")

--- a/agtermCore/Tests/agtermctlKitTests/EventCommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/EventCommandsTests.swift
@@ -1,0 +1,166 @@
+import ArgumentParser
+import Foundation
+import Testing
+import agtermCore
+@testable import agtermctlKit
+
+struct EventCommandsTests {
+    private let run = UUID(uuidString: "CBB5E3D0-7A9B-4C96-9EA2-18B14380DDB1")!
+
+    @Test func parserBuildsBootstrapAndCursoredRequests() throws {
+        let plain = try Events.parse([])
+        #expect(try plain.makeInitialRequest() == ControlRequest(cmd: .eventsRead))
+
+        let resumed = try Events.parse([
+            "--json", "--kind", "status,notify", "--kind", "tree.changed",
+            "--run", run.uuidString, "--after", "42", "--limit", "1000",
+        ])
+        #expect(resumed.options.json)
+        #expect(try resumed.makeInitialRequest() == ControlRequest(
+            cmd: .eventsRead,
+            args: ControlArgs(after: "42", run: run.uuidString,
+                              kinds: ["status", "notify", "tree.changed"], limit: 1_000)
+        ))
+    }
+
+    @Test func parserRejectsInvalidPairsKindsAndLimits() {
+        for argv in [
+            ["--run", run.uuidString], ["--after", "1"], ["--run", "bad", "--after", "1"],
+            ["--run", run.uuidString, "--after", "-1"], ["--kind", "future"],
+            ["--kind", ""], ["--kind", ","], ["--kind", "status,"],
+            ["--limit", "0"], ["--limit", "1001"],
+        ] {
+            #expect(throws: (any Error).self) { try Events.parse(argv) }
+        }
+    }
+
+    @Test func streamStateBootstrapsAndAdvancesCursor() throws {
+        var state = EventStreamState(kinds: [.status], limit: 2)
+        #expect(state.makeRequest() == ControlRequest(cmd: .eventsRead,
+                                                     args: ControlArgs(kinds: ["status"], limit: 2)))
+
+        let empty = ControlEventBatch(run: run, next: 5, items: [])
+        let emptyEvents = try state.consume(ControlResponse(ok: true, result: ControlResult(events: empty)))
+        #expect(emptyEvents.isEmpty)
+        #expect(state.makeRequest().args?.after == "5")
+        #expect(state.makeRequest().args?.run == run.uuidString)
+
+        let event = ControlEvent(seq: 6, ts: 10, kind: .status,
+                                 payload: ControlEventPayload(name: "api", status: "active"))
+        let page = ControlEventBatch(run: run, next: 6, items: [event])
+        let pageEvents = try state.consume(ControlResponse(ok: true, result: ControlResult(events: page)))
+        #expect(pageEvents == [event])
+        #expect(state.makeRequest().args?.after == "6")
+    }
+
+    @Test func runPollsEmptyPagesWritesNDJSONImmediatelyAndResumesFromCursor() throws {
+        let event = ControlEvent(seq: 6, ts: 10, kind: .status,
+                                 payload: ControlEventPayload(name: "api", status: "active"))
+        var responses = [
+            ControlResponse(ok: true, result: ControlResult(events: ControlEventBatch(run: run, next: 5, items: []))),
+            ControlResponse(ok: true, result: ControlResult(events: ControlEventBatch(run: run, next: 6, items: [event]))),
+        ]
+        var requests: [ControlRequest] = []
+        var sleeps: [TimeInterval] = []
+        var lines: [String] = []
+        let dependencies = EventStreamDependencies(
+            send: { request in
+                requests.append(request)
+                return responses.removeFirst()
+            },
+            sleep: { sleeps.append($0) },
+            writeLine: { lines.append($0) }
+        )
+        let command = try Events.parse(["--json"])
+        var state = command.makeState()
+
+        try command.poll(state: &state, dependencies: dependencies)
+        try command.poll(state: &state, dependencies: dependencies)
+
+        #expect(requests.count == 2)
+        #expect(requests[0] == ControlRequest(cmd: .eventsRead))
+        #expect(requests[1].args?.run == run.uuidString)
+        #expect(requests[1].args?.after == "5")
+        #expect(sleeps == [0.25])
+        #expect(lines.count == 1)
+        #expect(!lines[0].contains("\n"))
+        #expect(try JSONDecoder().decode(ControlEvent.self, from: Data(lines[0].utf8)) == event)
+    }
+
+    @Test func runStopsImmediatelyOnTransportServerAndOutputFailures() throws {
+        let command = try Events.parse([])
+        var transportState = command.makeState()
+        var transportSends = 0
+        #expect(throws: EventStreamError.self) {
+            try command.poll(state: &transportState, dependencies: EventStreamDependencies(
+                send: { _ in
+                    transportSends += 1
+                    throw EventStreamError("transport failed")
+                }, sleep: { _ in }, writeLine: { _ in }
+            ))
+        }
+        #expect(transportSends == 1)
+
+        var serverState = command.makeState()
+        var serverSends = 0
+        #expect(throws: EventStreamError.self) {
+            try command.poll(state: &serverState, dependencies: EventStreamDependencies(
+                send: { _ in
+                    serverSends += 1
+                    return ControlResponse(ok: false, error: ControlEventReadError.cursorExpired.rawValue)
+                }, sleep: { _ in }, writeLine: { _ in }
+            ))
+        }
+        #expect(serverSends == 1)
+
+        var outputState = command.makeState()
+        var outputSends = 0
+        #expect(throws: EventStreamError.self) {
+            try command.poll(state: &outputState, dependencies: EventStreamDependencies(
+                send: { _ in
+                    outputSends += 1
+                    let event = ControlEvent(seq: 1, ts: 0, kind: .treeChanged)
+                    return ControlResponse(ok: true, result: ControlResult(
+                        events: ControlEventBatch(run: run, next: 1, items: [event])
+                    ))
+                }, sleep: { _ in }, writeLine: { _ in throw EventStreamError("output failed") }
+            ))
+        }
+        #expect(outputSends == 1)
+    }
+
+    @Test func streamStatePreservesSuppliedCursorAndRejectsServerFailures() throws {
+        var state = EventStreamState(cursor: ControlEventCursor(run: run, after: 9), kinds: nil, limit: nil)
+        #expect(state.makeRequest().args?.after == "9")
+        #expect(throws: EventStreamError.self) {
+            try state.consume(ControlResponse(ok: false, error: ControlEventReadError.cursorExpired.rawValue))
+        }
+        #expect(throws: EventStreamError.self) {
+            try state.consume(ControlResponse(ok: true))
+        }
+    }
+
+    @Test func formattersCoverEveryKindAndNDJSONIsOneBareEvent() throws {
+        let events = [
+            ControlEvent(seq: 1, ts: 0, kind: .status,
+                         payload: ControlEventPayload(name: "api", status: "blocked", pane: "right", blink: true)),
+            ControlEvent(seq: 2, ts: 0, kind: .notify,
+                         payload: ControlEventPayload(name: "api", title: "Done", body: "ok")),
+            ControlEvent(seq: 3, ts: 0, kind: .sessionCreated, payload: ControlEventPayload(name: "new")),
+            ControlEvent(seq: 4, ts: 0, kind: .sessionClosed, payload: ControlEventPayload(name: "old")),
+            ControlEvent(seq: 5, ts: 0, kind: .treeChanged, window: "win"),
+        ]
+        let human = events.map { EventFormatter.human($0, timeZone: TimeZone(secondsFromGMT: 0)!) }
+        #expect(human[0] == "00:00:00 status api blocked pane=right blink")
+        #expect(human[1] == "00:00:00 notify api Done: ok")
+        #expect(human[2] == "00:00:00 session.created new")
+        #expect(human[3] == "00:00:00 session.closed old")
+        #expect(human[4] == "00:00:00 tree.changed win")
+
+        for event in events {
+            let line = try EventFormatter.json(event)
+            #expect(!line.contains("\n"))
+            #expect(try JSONDecoder().decode(ControlEvent.self, from: Data(line.utf8)) == event)
+        }
+    }
+}

--- a/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
@@ -14,6 +14,24 @@ import agtermCore
 // test's output lands in the other's pipe). serial execution keeps the redirect exclusive.
 @Suite(.serialized)
 struct SocketClientTests {
+    @Test func consecutiveEventReadsUseIndependentOneShotConnections() throws {
+        let run = UUID(uuidString: "CBB5E3D0-7A9B-4C96-9EA2-18B14380DDB1")!
+        let script = EventReadScript(run: run)
+        let server = ScriptedStubServer(responder: script.respond)
+        try server.start()
+        defer { server.stop() }
+        let client = SocketClient(path: server.path)
+
+        let first = try client.send(ControlRequest(cmd: .eventsRead))
+        let anchor = try #require(first.result?.events)
+        let second = try client.send(ControlRequest(
+            cmd: .eventsRead, args: ControlArgs(after: String(anchor.next), run: anchor.run.uuidString)
+        ))
+
+        #expect(second.result?.events?.next == 8)
+        #expect(script.requests().map { $0.args?.after } == [nil, "7"])
+    }
+
     @Test func roundTripOkResponse() throws {
         let canned = ControlResponse(ok: true, result: ControlResult(id: "9f3c"))
         let server = StubServer(response: canned)
@@ -327,6 +345,25 @@ struct SocketClientTests {
         #expect(lines.contains("* Builtin Light"))
         #expect(lines.contains("  Nord"))
         #expect(lines.contains("  default ghostty")) // unmarked while syncing
+    }
+}
+
+private final class EventReadScript: @unchecked Sendable {
+    private let lock = NSLock()
+    private var seen: [ControlRequest] = []
+    private let run: UUID
+
+    init(run: UUID) { self.run = run }
+
+    func respond(_ request: ControlRequest) -> ControlResponse {
+        lock.lock(); seen.append(request); let count = seen.count; lock.unlock()
+        let next: UInt64 = count == 1 ? 7 : 8
+        return ControlResponse(ok: true, result: ControlResult(events: ControlEventBatch(run: run, next: next, items: [])))
+    }
+
+    func requests() -> [ControlRequest] {
+        lock.lock(); defer { lock.unlock() }
+        return seen
     }
 }
 

--- a/agtermUITests/EventSubscriptionUITests.swift
+++ b/agtermUITests/EventSubscriptionUITests.swift
@@ -1,0 +1,141 @@
+import XCTest
+
+@MainActor
+final class EventSubscriptionUITests: ControlAPITestCase {
+    func testEventSubscriptionEndToEnd() throws {
+        let seededID = try activeSessionID()
+        let anchor = try eventAnchor()
+
+        try assertOK(##"{"cmd":"session.status","target":"\##(seededID)","args":{"status":"blocked","pane":"left","blink":true,"color":"#aabbcc"}}"##)
+        try assertOK(##"{"cmd":"session.status","target":"\##(seededID)","args":{"status":"blocked","pane":"left","blink":true,"color":"#aabbcc"}}"##)
+        try assertOK(#"{"cmd":"session.status","target":"\#(seededID)","args":{"status":"idle"}}"#)
+
+        let statusRead = try readEvents(anchor: anchor, kinds: ["status"])
+        try statusRead.items.forEach(assertCommonEnvelope)
+        XCTAssertEqual(statusRead.items.compactMap { ($0["payload"] as? [String: Any])?["status"] as? String },
+                       ["blocked", "idle"], "same-value status reassertion must not duplicate")
+        let blockedPayload = try XCTUnwrap(statusRead.items.first?["payload"] as? [String: Any])
+        XCTAssertFalse((blockedPayload["name"] as? String ?? "").isEmpty)
+        XCTAssertEqual(blockedPayload["pane"] as? String, "left")
+        XCTAssertEqual(blockedPayload["blink"] as? Bool, true)
+        XCTAssertEqual(blockedPayload["color"] as? String, "#aabbcc")
+        let idlePayload = try XCTUnwrap(statusRead.items.last?["payload"] as? [String: Any])
+        XCTAssertNil(idlePayload["pane"])
+        XCTAssertEqual(idlePayload["blink"] as? Bool, false)
+        XCTAssertNil(idlePayload["color"])
+
+        let second = try sendCommand(#"{"cmd":"session.new","args":{"name":"second"}}"#)
+        let secondID = try XCTUnwrap((second["result"] as? [String: Any])?["id"] as? String)
+        try assertOK(#"{"cmd":"session.status","target":"\#(seededID)","args":{"status":"completed","autoReset":true}}"#)
+        app.staticTexts.matching(identifier: "session-row").element(boundBy: 0).click()
+        let visitRead = try pollEvents(anchor: statusRead.anchor, kinds: ["status"], minimum: 2)
+        XCTAssertEqual(visitRead.items.compactMap { ($0["payload"] as? [String: Any])?["status"] as? String }.suffix(2),
+                       ["completed", "idle"])
+
+        try assertOK(#"{"cmd":"notify","target":"\#(seededID)","args":{"title":"Done","body":"tests passed"}}"#)
+        let notifyRead = try pollEvents(anchor: visitRead.anchor, kinds: ["notify"], minimum: 1)
+        let notify = try XCTUnwrap(notifyRead.items.last)
+        try assertCommonEnvelope(notify)
+        let payload = try XCTUnwrap(notify["payload"] as? [String: Any])
+        XCTAssertFalse((payload["name"] as? String ?? "").isEmpty)
+        XCTAssertEqual(payload["title"] as? String, "Done")
+        XCTAssertEqual(payload["body"] as? String, "tests passed")
+
+        let lifecycleAnchor = notifyRead.anchor
+        let created = try sendCommand(#"{"cmd":"session.new","args":{"name":"ephemeral"}}"#)
+        let createdID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String)
+        app.menuBars.menuBarItems["File"].click()
+        let close = app.menuItems["Close Session"]
+        XCTAssertTrue(close.waitForExistence(timeout: 2))
+        XCTAssertTrue(close.isEnabled)
+        close.click()
+        app.menuBars.menuBarItems["File"].click()
+        let reopen = app.menuItems["Reopen Closed Item"]
+        XCTAssertTrue(reopen.waitForExistence(timeout: 2))
+        XCTAssertTrue(reopen.isEnabled)
+        reopen.click()
+        let lifecycle = try pollEvents(anchor: lifecycleAnchor,
+                                       kinds: ["session.created", "session.closed"], minimum: 3)
+        try lifecycle.items.forEach(assertCommonEnvelope)
+        let edges = lifecycle.items.filter { ($0["session"] as? String) == createdID }.compactMap { $0["kind"] as? String }
+        XCTAssertEqual(edges, ["session.created", "session.closed", "session.created"])
+        for event in lifecycle.items where (event["session"] as? String) == createdID {
+            let lifecyclePayload = try XCTUnwrap(event["payload"] as? [String: Any])
+            XCTAssertEqual(lifecyclePayload["name"] as? String, "ephemeral")
+        }
+
+        let treeAnchor = lifecycle.anchor
+        try assertOK(#"{"cmd":"session.rename","target":"\#(createdID)","args":{"name":"burst one"}}"#)
+        try assertOK(#"{"cmd":"session.rename","target":"\#(createdID)","args":{"name":"burst two"}}"#)
+        let treeRead = try pollEvents(anchor: treeAnchor, kinds: ["tree.changed"], minimum: 1)
+        XCTAssertEqual(treeRead.items.count, 1)
+        let treeEvent = try XCTUnwrap(treeRead.items.first)
+        try assertCommonEnvelope(treeEvent)
+        XCTAssertEqual((treeEvent["payload"] as? [String: Any])?.count, 0)
+        XCTAssertNil(treeEvent["workspace"])
+        XCTAssertNil(treeEvent["session"])
+        RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+        let noDuplicateTree = try readEvents(anchor: treeRead.anchor, kinds: ["tree.changed"])
+        XCTAssertTrue(noDuplicateTree.items.isEmpty)
+
+        let independent = try readEvents(anchor: anchor, kinds: nil)
+        XCTAssertTrue(independent.items.contains { ($0["kind"] as? String) == "notify" })
+        XCTAssertTrue(independent.items.contains { ($0["session"] as? String) == secondID })
+        XCTAssertGreaterThanOrEqual(statusRead.anchor.after, anchor.after)
+    }
+
+    private typealias Anchor = (run: String, after: UInt64)
+    private typealias EventRead = (anchor: Anchor, items: [[String: Any]])
+
+    private func eventAnchor() throws -> Anchor {
+        try readEvents(anchor: nil, kinds: nil).anchor
+    }
+
+    private func readEvents(anchor: Anchor?, kinds: [String]?) throws -> EventRead {
+        var args: [String: Any] = [:]
+        if let anchor { args["run"] = anchor.run; args["after"] = String(anchor.after) }
+        if let kinds { args["kinds"] = kinds }
+        var request: [String: Any] = ["cmd": "events.read"]
+        if !args.isEmpty { request["args"] = args }
+        let data = try JSONSerialization.data(withJSONObject: request)
+        let response = try sendCommand(String(decoding: data, as: UTF8.self))
+        XCTAssertEqual(response["ok"] as? Bool, true, "events.read should succeed: \(response)")
+        let batch = try XCTUnwrap((response["result"] as? [String: Any])?["events"] as? [String: Any])
+        return (
+            (try XCTUnwrap(batch["run"] as? String), UInt64(try XCTUnwrap(batch["next"] as? NSNumber).uint64Value)),
+            batch["items"] as? [[String: Any]] ?? []
+        )
+    }
+
+    private func pollEvents(anchor: Anchor, kinds: [String], minimum: Int) throws -> EventRead {
+        let deadline = Date().addingTimeInterval(5)
+        var current = anchor
+        var items: [[String: Any]] = []
+        repeat {
+            let page = try readEvents(anchor: current, kinds: kinds)
+            current = page.anchor
+            items.append(contentsOf: page.items)
+            if items.count >= minimum { return (current, items) }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        } while Date() < deadline
+        XCTFail("timed out waiting for \(minimum) events; got \(items)")
+        return (current, items)
+    }
+
+    private func assertOK(_ request: String) throws {
+        let response = try sendCommand(request)
+        XCTAssertEqual(response["ok"] as? Bool, true, "request should succeed: \(response)")
+    }
+
+    private func assertCommonEnvelope(_ event: [String: Any]) throws {
+        XCTAssertGreaterThan(try XCTUnwrap(event["seq"] as? NSNumber).uint64Value, 0)
+        XCTAssertGreaterThan(try XCTUnwrap(event["ts"] as? NSNumber).doubleValue, 0)
+        XCTAssertFalse((event["kind"] as? String ?? "").isEmpty)
+        XCTAssertFalse((event["window"] as? String ?? "").isEmpty)
+        _ = try XCTUnwrap(event["payload"] as? [String: Any])
+        if (event["kind"] as? String) != "tree.changed" {
+            XCTAssertFalse((event["workspace"] as? String ?? "").isEmpty)
+            XCTAssertFalse((event["session"] as? String ?? "").isEmpty)
+        }
+    }
+}

--- a/docs/plans/completed/20260722-cursor-drained-event-subscription.md
+++ b/docs/plans/completed/20260722-cursor-drained-event-subscription.md
@@ -1,0 +1,326 @@
+# Cursor-Drained Event Subscription
+
+## Overview
+
+Implement the full v1 event surface accepted in [GitHub Discussion #211](https://github.com/umputun/agterm/discussions/211), using the maintainer-selected design: a bounded in-memory event ring drained by ordinary one-request/one-response control calls. `agtermctl events` presents a continuous human or NDJSON stream by short-polling `events.read`; the app never hands off a file descriptor, keeps no subscriber registry, and preserves the control server's serial read/dispatch/write/close lifecycle and existing deadlines.
+
+The v1 kinds are:
+
+- `status`
+- `notify`
+- `session.created`
+- `session.closed`
+- `tree.changed` (per-window structural invalidation, coalesced over 100 ms)
+
+This closes gaps that `tree --json` sampling cannot: short-lived status transitions, auto-reset clears, notification title/body, and balanced session lifetime edges. It also gives clients an explicit cursor and app-run identity so they detect retention loss or an app restart instead of silently skipping events.
+
+Explicitly out of scope:
+
+- persistent streaming connections, an event socket, a subscriber broker, or file-descriptor handoff
+- disk persistence or replay across app runs
+- long-polling, server-side waits, acknowledgements, delivery guarantees, or backpressure queues per client
+- terminal output/scrollback streaming
+- outbound user-script hooks; a later hook can consume this ring without changing the event contract
+- `--since` by timestamp or unbounded history
+
+## Context (from discovery)
+
+Files/components involved:
+
+- `agtermCore/Sources/agtermCore/ControlProtocol.swift` and `ControlDispatcher.swift` define the shared wire catalog, request arguments, responses, and host action seam.
+- `agterm/Control/ControlServer.swift` is deliberately serial and one-shot, with per-read/write and overall deadlines; `events.read` must use this path unchanged.
+- `agtermCore/Sources/agtermCore/AppStore*.swift` owns status normalization and every workspace/session entry and exit path, including grace closes, undo, and Open Recent.
+- `agtermCore/Sources/agtermCore/WindowLibrary.swift` owns app-run window/store lifecycle and is the natural owner of the app-wide ring.
+- `agterm/Notifications/NotificationManager.swift` is the shared delivery chokepoint for OSC and control notifications and retains the title/body long enough to emit them.
+- `agtermCore/Sources/agtermctlKit` owns the one-shot socket client and CLI; the existing overlay `--block` loop is the nearest polling precedent.
+- README scripting docs and the bundled agent skill currently promise “no event subscription” and must be updated together.
+
+Relevant invariants:
+
+- Status emission belongs after `setAgentIndicator` normalization. Equality compares the normalized `AgentIndicator`, not `statusChangedAt`, so a same-value non-idle reassertion may restamp attention ordering without emitting another event.
+- `clearAutoResetIndicator` currently assigns `AgentIndicator()` directly. It must route through the same status mutation/emission helper so a visit-clear produces the closing `idle` edge.
+- Soft close emits `session.closed` when the row leaves the visible tree, not when its grace timer later tears down the surface. Undo emits `session.created` when the same object re-enters.
+- Initial app restoration establishes state without replaying every restored session as newly created. Closing and reopening a window during the same app run does emit balanced close/create edges.
+- The main checkout is clean on `master`; implementation is non-trivial and must happen in an isolated worktree after refreshing `origin/master`.
+
+## Development Approach
+
+- **Testing approach: TDD.** Write the failing tests for each task before production code, then make only that task green.
+- Complete each task fully before starting the next; every code task includes success, error, and edge-path tests.
+- After each task, run `cd agtermCore && swift test`; app-target tasks also require `make build`; run `make lint` before moving on.
+- Keep `agtermCore` host-free and Swift 6 strict-concurrency clean. Event storage and model emission are main-actor isolated; the socket accept loop continues to cross to the main actor exactly once per request.
+- Keep source files under 1,000 lines and test files under 2,000. Add focused event files/tests instead of growing `AppStore.swift`, `ControlProtocolTests.swift`, or `ControlDispatcherTests.swift` past their limits.
+- Preserve backward compatibility: all new request/result fields are optional, existing command wire forms and response rendering remain unchanged, and unknown event kinds receive a normal control error rather than failing JSON decoding.
+- Update this plan when implementation discovers a scope or contract change; mark task checkboxes immediately.
+
+Worktree preparation before Task 1:
+
+1. Fetch `origin master` from the main checkout.
+2. Create an isolated worktree from the refreshed remote tip using the project's supported worktree workflow.
+3. Symlink `GhosttyKit.xcframework` and the `ghostty`/`terminfo` resources from the main checkout before building; never rebuild or mutate the main checkout's artifacts.
+
+## Testing Strategy
+
+- **Host-free unit tests:** ring ordering/retention, cursor semantics, Codable wire shape, dispatcher validation/routing, AppStore status and lifecycle emission, WindowLibrary open/close balance, CLI parsing/state advancement, NDJSON and human formatting.
+- **Socket tests:** prove every poll is a fresh connection and a single response, verify consecutive cursored reads, and verify transport/server errors terminate the CLI rather than spin.
+- **XCUITest:** use an isolated app/socket to exercise real control commands and GUI-native edges: status set/clear, auto-reset visit-clear, notify payload, session create/soft-close/undo, and debounced structural changes. Do not touch the deployed daily-driver app.
+- **Final gates:** `cd agtermCore && swift test`, `make build`, and `make lint`. Run the focused event XCUITest target in an isolated state directory; do not run unrelated UI suites that synthesize input across the live screen.
+
+Do not weaken or delete a failing test to make a task green.
+
+## Solution Overview
+
+### Ring and cursor semantics
+
+Add a host-free, `@MainActor` `ControlEventRing` owned by `WindowLibrary` for the lifetime of one app process:
+
+- `run` is a UUID generated once when the ring is initialized.
+- `seq` is a monotonically increasing `UInt64`, beginning at 1; it is never reused during that run.
+- capacity defaults to 4,096 events and is injectable for tests. Appending beyond capacity drops the oldest entries only.
+- timestamps are Unix seconds as `Double`, with an injectable clock for deterministic tests.
+- reads are non-destructive; independent consumers use their own `(run, after)` cursor.
+
+`events.read` accepts these command-specific fields in `ControlArgs`:
+
+- existing `after: String?`, interpreted here as an unsigned decimal sequence (it remains a session-id anchor for `session.new`/`session.move`)
+- new `run: String?`
+- new `kinds: [String]?`
+- new `limit: Int?` (default 100, valid range 1...1,000)
+
+`run` and `after` are either both omitted or both supplied:
+
+- both omitted: bootstrap/subscription read; return no historical events and anchor at the current tail
+- both supplied: return matching retained events strictly after `after`
+- run mismatch, cursor older than retained history, or cursor ahead of the current tail: `ok:false` with a stable error string and the current anchor in `result.events`, so a caller can deliberately rebaseline
+
+Filtering never creates a hidden gap. The returned `next` cursor advances across every scanned global event, including non-matching kinds. When `limit` matching events are reached, scanning stops at that event; otherwise `next` advances to the current tail. An empty filtered batch can therefore advance safely without rescanning irrelevant entries.
+
+### Public wire contract
+
+Add `Command.eventsRead = "events.read"`, `ControlEventKind`, `ControlEvent`, `ControlEventPayload`, and `ControlEventBatch`; add `events: ControlEventBatch?` to `ControlResult`.
+
+Successful response:
+
+```json
+{
+  "ok": true,
+  "result": {
+    "events": {
+      "run": "CBB5E3D0-7A9B-4C96-9EA2-18B14380DDB1",
+      "next": 42,
+      "items": [
+        {
+          "seq": 42,
+          "ts": 1783969641.38,
+          "kind": "status",
+          "window": "0F96…",
+          "workspace": "D545…",
+          "session": "9E55…",
+          "payload": {"name": "api-fix", "status": "blocked", "blink": true}
+        }
+      ]
+    }
+  }
+}
+```
+
+Event fields:
+
+- common: `seq`, `ts`, `kind`, and optional `window`, `workspace`, `session`
+- `status`: `name`, `status` (`idle|active|completed|blocked`), optional `pane`, `blink`, `color`; the idle closing edge is explicit
+- `notify`: `name`, effective `title` (session name fallback already applied), and `body`
+- `session.created` / `session.closed`: `name`, with window/workspace/session identity in common fields
+- `tree.changed`: empty payload and the affected window id; consumers re-read `tree --window <id>` for detail
+
+Error strings are constants shared by server and CLI tests:
+
+- `events.read requires --run and --after together`
+- `invalid event cursor`
+- `invalid event run id`
+- `invalid event kind: <kind>`
+- `event limit must be between 1 and 1000`
+- `event run changed`
+- `event cursor expired`
+- `event cursor is ahead of the current sequence`
+
+### Emission semantics
+
+`WindowLibrary` owns the ring and passes a window-scoped event sink into each `AppStore`. Event helper methods live in a focused `AppStore+Events.swift` extension rather than expanding the near-limit main file.
+
+- **Status:** capture the previous normalized indicator, perform current normalization/mutation, and append only when normalized value changed. Route auto-reset, pane teardown/promotion clears, GUI Clear Status, hooks, and `session.status` through this one helper.
+- **Notify:** append only after the notification resolves to an open session/window and passes OSC focus suppression. Emit whether or not banners are enabled, because the unseen badge/event still exists. A failed target/window resolution emits nothing.
+- **Session lifecycle:** append at visible-tree membership changes. Ordinary add/duplicate, Open Recent, undo, and runtime window reopen emit `created`; hard/soft session close, workspace removal, open-window deletion, and runtime window close emit `closed`. Grace finalization emits nothing. Batch/workspace paths emit one event per session in stable tree order.
+- **Tree invalidation:** schedule one `tree.changed` per affected window after 100 ms for membership, name, and order mutations (window/workspace/session create, close/delete, reopen/undo, rename, move, and reorder). Status, notification, selection, pane visibility, cwd/title, and other non-structural projection changes do not schedule it; their dedicated event or existing polling/read command remains authoritative.
+
+### CLI behavior
+
+Add top-level `agtermctl events` with `--json`, repeatable or comma-separated `--kind`, optional paired `--run`/`--after`, and `--limit`:
+
+- no cursor: make one bootstrap read, then poll from its returned anchor; pre-subscription history is not printed
+- cursor supplied: drain retained catch-up first, then continue from returned `next`
+- poll every 250 ms only after an empty batch; immediately request the next batch after a non-empty or limit-filled batch
+- each poll uses the existing `SocketClient.send`, hence a new connection and one response
+- `--json` writes one bare `ControlEvent` JSON object per line and flushes promptly for pipes; human mode prints `HH:mm:ss kind name detail`
+- terminate non-zero on transport errors, server errors, run changes, or cursor expiry; never silently rebaseline and never retry forever while the app is absent
+- normal SIGINT/SIGTERM process behavior stops the loop; no custom signal subsystem is added
+
+## Progress Tracking
+
+- Mark completed items with `[x]` immediately.
+- Add newly discovered tasks with a `+` prefix.
+- Mark blockers with `WARNING:` and record the evidence.
+- Keep this plan synchronized with any accepted wire-contract change.
+
+## Implementation Steps
+
+### Task 1: Add the bounded event ring and cursor rules with tests first
+
+**Files:**
+
+- Create: `agtermCore/Sources/agtermCore/ControlEvents.swift`
+- Create: `agtermCore/Tests/agtermCoreTests/ControlEventRingTests.swift`
+
+- [x] Write failing tests for sequence/timestamp assignment, 4,096-default and injected small-capacity eviction, independent non-destructive reads, and deterministic injected run/clock values.
+- [x] Write failing tests for bootstrap-from-tail, exclusive cursors, filtered cursor advancement, limit pagination without loss, empty filtered batches, and stable global ordering.
+- [x] Write failing tests for run mismatch, expired/ahead cursors, and exact-boundary retention (`after == oldest - 1` remains valid).
+- [x] Implement the typed event model, ring append/read result, capacity enforcement, and stable error constants on the main actor.
+- [x] Run `cd agtermCore && swift test`; all tests must pass before Task 2.
+
+### Task 2: Add `events.read` to the one-shot control protocol and dispatcher
+
+**Files:**
+
+- Modify: `agtermCore/Sources/agtermCore/ControlProtocol.swift`
+- Modify: `agtermCore/Sources/agtermCore/ControlDispatcher.swift`
+- Modify: `agtermCore/Sources/agtermCore/ControlModes.swift`
+- Modify: `agtermCore/Tests/agtermCoreTests/MockControlActions.swift`
+- Create: `agtermCore/Tests/agtermCoreTests/ControlEventProtocolTests.swift`
+- Create: `agtermCore/Tests/agtermCoreTests/ControlEventDispatcherTests.swift`
+
+- [x] Write failing Codable tests for every event kind/payload, omitted optional fields, bootstrap batch, populated batch, and error response carrying the current anchor.
+- [x] Write failing dispatcher tests for paired cursor validation, decimal/UUID parsing, comma/repeat-normalized kind lists, default/max limit, every invalid-input error, and action routing.
+- [x] Add the exhaustive `Command` cases, optional request/result fields, typed read options, `ControlActions` requirement, mock call, and dispatcher arm as one compile-safe change.
+- [x] Keep raw unknown kinds decodable as strings until dispatcher validation, producing the pinned control error rather than `invalid request`.
+- [x] Run `cd agtermCore && swift test`; all tests must pass before Task 3.
+
+### Task 3: Wire the app-run ring into `WindowLibrary` and the control server
+
+**Files:**
+
+- Modify: `agtermCore/Sources/agtermCore/WindowLibrary.swift`
+- Modify: `agtermCore/Sources/agtermCore/AppStore.swift`
+- Create: `agtermCore/Sources/agtermCore/AppStore+Events.swift`
+- Create: `agtermCore/Sources/agtermCore/AppStore+Naming.swift`
+- Modify: `agterm/Control/ControlServer.swift`
+- Modify: `agtermCore/Tests/agtermCoreTests/WindowLibraryTests.swift`
+- Create: `agtermCore/Tests/agtermCoreTests/AppStoreEventTests.swift`
+
+- [x] Write failing tests proving one ring/run is shared by every open window, each store sink stamps the correct window/workspace/session ids, and runtime close/reopen can retain cursor continuity.
+- [x] Make `WindowLibrary` own the ring, inject a window-scoped sink into every store creation/load path, and expose only the read/append operations needed by app seams.
+- [x] Route `.eventsRead` through `ControlDispatcher` into the same main-actor ring while leaving `handleConnection`, socket deadlines, and fast-path cache behavior unchanged.
+- [x] Verify an `events.read` call still performs exactly one request, one response, and close; add no listener queue, subscriber state, or wait in the server.
+- [x] Run `cd agtermCore && swift test`, `make build`, and `make lint`; all must pass before Task 4.
+
+### Task 4: Emit normalized status and notification edges
+
+**Files:**
+
+- Modify: `agtermCore/Sources/agtermCore/AppStore+Status.swift`
+- Modify: `agtermCore/Sources/agtermCore/AppStore.swift`
+- Modify: `agtermCore/Sources/agtermCore/AppStore+Panes.swift`
+- Modify: `agterm/Notifications/NotificationManager.swift`
+- Modify: `agtermCore/Tests/agtermCoreTests/AppStoreEventTests.swift`
+
+- [x] Write failing tests for active/blocked/completed/idle payloads, pane normalization, blink/color fields, same-value reassertion suppression despite timestamp restamping, unknown sessions, and auto-reset visit/leave clears.
+- [x] Refactor all status clear paths, especially `clearAutoResetIndicator`, through the normalized `setAgentIndicator` emission point without changing current attention/auto-follow behavior.
+- [x] Emit notification events from both OSC and `notify` paths after successful target/focus gating, using the effective title and emitting even when banners are disabled.
+- [x] Add tests or a pure notification-recording seam for accepted/suppressed/invalid notification paths; ensure no event appears when delivery is rejected before the unseen badge increments.
+- [x] Run `cd agtermCore && swift test`, `make build`, and `make lint`; all must pass before Task 5.
+
+### Task 5: Emit balanced session lifecycle and debounced structural invalidations
+
+**Files:**
+
+- Modify: `agtermCore/Sources/agtermCore/AppStore.swift`
+- Modify: `agtermCore/Sources/agtermCore/AppStore+PendingClose.swift`
+- Modify: `agtermCore/Sources/agtermCore/AppStore+RecentClosed.swift`
+- Modify: `agtermCore/Sources/agtermCore/WindowLibrary.swift`
+- Modify: `agtermCore/Sources/agtermCore/AppStore+Events.swift`
+- Modify: `agtermCore/Tests/agtermCoreTests/AppStoreEventTests.swift`
+- Create: `agtermCore/Tests/agtermCoreTests/WindowEventLifecycleTests.swift`
+
+- [x] Write failing tests for add/duplicate, hard close, soft close at removal time, no duplicate on grace finalization, grouped/workspace close ordering, undo, Open Recent, runtime window close/reopen, and open/closed window deletion.
+- [x] Implement exactly one `session.created`/`session.closed` per visible-tree membership edge, preserving session identity on undo and suppressing launch-bootstrap creation noise.
+- [x] Write failing debounce tests for create/close, rename, move/reorder, cross-workspace batches, and two independent windows; use an injectable/flushable debounce seam rather than wall-clock sleeps.
+- [x] Schedule one `tree.changed` per affected window per 100 ms burst, with no structural event for status-only, notification-only, selection-only, or same-value/no-op mutations.
+- [x] Run `cd agtermCore && swift test`, `make build`, and `make lint`; all must pass before Task 6.
+
+### Task 6: Add the continuous `agtermctl events` consumer
+
+**Files:**
+
+- Create: `agtermCore/Sources/agtermctlKit/EventCommands.swift`
+- Modify: `agtermCore/Sources/agtermctlKit/Commands.swift`
+- Modify: `agtermCore/Sources/agtermctlKit/SocketClient.swift`
+- Create: `agtermCore/Tests/agtermctlKitTests/EventCommandsTests.swift`
+- Modify: `agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift`
+
+- [x] Write failing parser tests for default invocation, JSON mode, repeated/comma-separated kinds, paired run/after, limit bounds, and invalid combinations.
+- [x] Extract a testable stream state machine that builds each `events.read` request, consumes batches, advances cursors, and decides whether to poll immediately or sleep; test empty, filtered, paginated, and error transitions.
+- [x] Implement the 250 ms loop using a fresh `SocketClient.send` per poll, with immediate follow-up after non-empty batches and non-zero termination on any transport/server/cursor error.
+- [x] Write failing then passing formatter tests for every human event kind and stable one-object-per-line NDJSON output; flush each event promptly for `jq --unbuffered`/shell pipelines.
+- [x] Run `cd agtermCore && swift test` and `make lint`; all must pass before Task 7.
+
+### Task 7: Verify the real app and GUI-native closing edges
+
+**Files:**
+
+- Create: `agtermUITests/EventSubscriptionUITests.swift`
+- Modify only if reusable harness extraction is necessary: `agtermUITests/ControlAPITestCase.swift`
+
+- [x] Write an isolated-socket XCUITest that anchors a cursor, sets and clears status through the control API, and verifies ordered blocked/idle events with no duplicate for a same-value reassertion.
+- [x] Verify `completed --auto-reset` followed by a real session visit emits the idle closing edge.
+- [x] Verify `notify` preserves effective title/body, plus create → soft-close → undo produces created/closed/created and one coalesced structural invalidation per burst.
+- [x] Verify filtered reads advance past nonmatching events and a later unfiltered consumer with its own cursor remains independent.
+- [x] Run the focused XCUITest against a separate Debug app with isolated state/socket, then run `make build` and `make lint`; do not touch the deployed app.
+
+### Task 8: Document the event API and remove the old non-goal
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `agterm/Resources/agent-skill/SKILL.md`
+- Modify: `agterm/Resources/agent-skill/reference.md`
+- Modify: `agterm/Resources/agent-skill/examples.md`
+- Modify: `agtermCore/Tests/agtermCoreTests/SkillInstallTests.swift`
+
+- [x] Replace “no event subscription” with the bounded cursor-ring contract while retaining the explicit “no terminal-output streaming” boundary.
+- [x] Document event kinds/payloads, subscribe-from-now behavior, resumable run/after cursors, retention/run errors, filtering, limits, 250 ms latency, and process exit behavior.
+- [x] Add status-wait, notification relay, and session cleanup examples using `agtermctl events --json`; warn that missed/changed cursors fail loudly and require deliberate rebootstrap.
+- [x] Update bundled-skill catalog/reference expectations and command lists so installed docs match the CLI exactly.
+- [x] Run `cd agtermCore && swift test`, `make build`, and `make lint`; all must pass before Task 9.
+
+### Task 9: Final acceptance and plan completion
+
+- [x] Confirm all five kinds and every documented payload field match the encoded NDJSON observed in the focused e2e test.
+- [x] Confirm the control accept loop and four existing timeout/deadline protections are unchanged and no persistent client state exists server-side.
+- [x] Run the full host-free suite: `cd agtermCore && swift test`.
+- [x] Run the app build: `make build`.
+- [x] Run strict lint: `make lint`.
+- [x] Confirm source/test file-size limits and a clean implementation worktree except for intended changes.
+- [x] Move this plan to `docs/plans/completed/` only after every acceptance item is green.
+
+## Post-Completion
+
+- Manually run `agtermctl events --json | jq --unbuffered .` against an isolated Debug instance and confirm Ctrl-C exits cleanly and events arrive within the expected 250–350 ms polling/debounce envelope.
+- Ask the Stream Deck consumer from Discussion #211/#267 to test cursor resumption, status flashes, notification payloads, and session add/remove with the documented v1 wire shape.
+- Treat outbound exec hooks, disk journaling, longer replay, and additional event kinds as separate follow-up proposals backed by concrete consumers.
+
+## Assumptions and Defaults
+
+- Full v1 means exactly the five accepted kinds above; no wildcard/custom kinds.
+- Ring capacity is 4,096, batch default is 100, batch maximum is 1,000, CLI poll interval is 250 ms, and `tree.changed` debounce is 100 ms per window.
+- `agtermctl events` starts at the current tail unless both `--run` and `--after` are supplied; it never dumps arbitrary pre-start history.
+- Cursor/run discontinuity is a hard, visible failure. Automatic rebasing would hide lost transitions and is intentionally forbidden.
+- Structural `tree.changed` covers membership/name/order only. Status and notifications have dedicated kinds; other live tree projections remain query-on-demand in v1.
+- No GUI control or Settings toggle is added; this is a control-native capability.


### PR DESCRIPTION
implements the event subscription accepted in Discussion #211 with a bounded in-memory ring and ordinary one-shot `events.read` cursor reads. `agtermctl events` short-polls the API and prints human or NDJSON output without changing the control server's connection lifecycle.

v1 emits `status`, `notify`, `session.created`, `session.closed`, and `tree.changed`. The structural event is a per-window coalesced invalidation; consumers re-read `tree --json` for detail. Cursors are scoped to an app run and fail explicitly on restart, expiry, or invalid positions.

a minimal client that jumps to a session when it reports `blocked`:

```sh
agtermctl events --json --kind status |
  jq -r --unbuffered 'select(.payload.status == "blocked") | .session' |
  while IFS= read -r session; do
    agtermctl session select --target "$session"
  done
```

tested with:

- `cd agtermCore && swift test` (1,727 tests)
- focused `EventSubscriptionUITests`
- `make build`
- `make lint`

discussion: https://github.com/umputun/agterm/discussions/211
