### PR TITLE
fix: render session watermark on scratch terminal

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -362,8 +362,10 @@ paths:
   (still false for a FLOATING overlay, preserving the NSSplitView-overrun invariant).
   GUI half: ⌘J (`BuiltinAction.toggleScratch`), title-bar `scratch-toggle` button,
   View ▸ Show/Hide Scratch, the ⌃⇧P palette "Toggle Scratch" — all through `AppActions.toggleScratch()`.
-  The scratch surface is NOT wired to the session (no `view.session`, like the overlay) so its PWD/title
-  never clobber the sidebar name; `autoFocus` grabs first responder on show,
+  The scratch surface is NOT operationally wired to the session (no `view.session`, like the overlay) so
+  its PWD/title never clobber the sidebar name; a separate weak `watermarkSession` link carries only the
+  owning session's visual config, so its background watermark/color renders on the scratch too. `autoFocus`
+  grabs first responder on show,
   the detail pane's `.onChange(of: scratchActive)` reclaims it on hide.
   Four-point keep-in-sync audit: (1) `case sessionScratch = "session.scratch"` + the new `ControlSessionNode.scratch`
   flag in `ControlProtocol.swift` (reuses `ControlArgs.mode`), (2) the `.sessionScratch` dispatch arm
@@ -1450,7 +1452,7 @@ paths:
   opacity/color/fit/position validated against the shared host-free `WatermarkConfig`,
   used by BOTH the CLI `validate()` and the server.
   The `BackgroundWatermark` spec (host-free, `Codable`) is persisted in `SessionSnapshot` (survives restart)
-  via `AppStore.setBackgroundWatermark`, then applied to the session main + split surfaces as a PER-SURFACE
+  via `AppStore.setBackgroundWatermark`, then applied to the session main + split + scratch surfaces as a PER-SURFACE
   ghostty config overlay: `GhosttyApp.configWithOverlay` builds the same base files + an overlay file
   (`WatermarkConfig.overlayText`: for image/text the `background-image*` lines + `background-opacity = 1`
   so the image shows even under window translucency, which pins the global `background-opacity` to 0;

--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -272,8 +272,8 @@ paths:
   the window backing, the pane shows the theme background, and a later `printf` OSC 11 re-renders (the latch
   was released).
   `session.background color X` instead bumps the opacity back to `windowOpacity`, so the still-live OSC
-  override RESURFACES and masks X; and because `session.background` is session-scoped, both split panes are
-  affected even though the OSC tint was per-pane.
+  override RESURFACES and masks X; and because `session.background` is session-scoped, every realized
+  session surface (main, split, and scratch) is affected even though the OSC tint was per-pane.
   Only BACKGROUND is wired — OSC 10/12 (fg/cursor) render regardless of translucency.
   A per-prompt OSC re-emit is deduped in the `COLOR_CHANGE` caller (skip when the hex is unchanged) so a
   shell re-asserting OSC 11 every prompt does not rebuild the surface config each time.

--- a/agterm/Control/ControlServer+SurfaceIO.swift
+++ b/agterm/Control/ControlServer+SurfaceIO.swift
@@ -136,10 +136,10 @@ extension ControlServer {
         }
     }
 
-    /// Apply a session's current watermark spec to its realized main + split surfaces. A never-realized
+    /// Apply a session's current watermark spec to its realized main + split + scratch surfaces. A never-realized
     /// surface (nil) is skipped — it applies the spec itself on creation (`GhosttySurfaceView.createSurface`).
     private func applyWatermark(to session: Session) {
-        for surface in [session.surface, session.splitSurface] {
+        for surface in [session.surface, session.splitSurface, session.scratchSurface] {
             (surface as? GhosttySurfaceView)?.applyWatermarkFromSession()
         }
     }

--- a/agterm/Ghostty/GhosttySurfaceView+Config.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Config.swift
@@ -17,12 +17,13 @@ extension GhosttySurfaceView {
 
     /// Builds this session's background-watermark config overlay (base files + `background-image*` lines +
     /// the dashboard font override else the session's current font zoom, via `WatermarkConfig`/`WatermarkRenderer`)
-    /// and pushes it to the surface, retaining the config for teardown. A no-op when the surface has no owning session (the
-    /// overlay/scratch/quick-terminal surfaces never carry one). A nil watermark with no font override
+    /// and pushes it to the surface, retaining the config for teardown. Scratch surfaces inherit their
+    /// owner's visual config through `watermarkSession` while remaining operationally sessionless; overlay
+    /// and quick-terminal surfaces carry neither link. A nil watermark with no font override
     /// yields the plain base config, which CLEARS a previously-applied image. The `.text` PNG is (re)rendered
     /// here so it always matches the current string/color. Main-actor; reads the session imperatively.
     func applyWatermarkFromSession() {
-        guard let surface, let session else { return }
+        guard let surface, let session = session ?? watermarkSession else { return }
         // this installs a watermark/plain config with NO OSC-11 overlay, so release the OSC latch: it is the
         // dedupe key in the COLOR_CHANGE handler, and a stale value makes a subsequent identical OSC 11 (a
         // re-`printf` right after `session background clear/set`) get skipped and never render. the reload /
@@ -57,7 +58,10 @@ extension GhosttySurfaceView {
         // a transient OSC-11 background wins over the persisted watermark and must survive a config reload
         // that broadcast the shared config to this surface (which wiped it).
         if let hex = oscBackgroundColorHex { applyOSCBackground(hex); return }
-        guard session?.backgroundWatermark != nil || session?.fontSize != nil || dashboardFontOverride != nil else { return }
+        let configSession = session ?? watermarkSession
+        guard configSession?.backgroundWatermark != nil || configSession?.fontSize != nil || dashboardFontOverride != nil else {
+            return
+        }
         applyWatermarkFromSession()
     }
 
@@ -70,7 +74,7 @@ extension GhosttySurfaceView {
         // an OSC-11 background bakes the window opacity like a `.color` watermark, so a live opacity change
         // must re-emit it to keep the tint tracking the slider.
         if let hex = oscBackgroundColorHex { applyOSCBackground(hex); return }
-        guard session?.backgroundWatermark?.kind == .color else { return }
+        guard (session ?? watermarkSession)?.backgroundWatermark?.kind == .color else { return }
         applyWatermarkFromSession()
     }
 

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -52,6 +52,12 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     /// factory after construction.
     weak var session: Session?
 
+    /// The session whose per-session visual config this surface inherits when it deliberately has no
+    /// `session`. Scratch surfaces use this separate weak link so they can render the owning session's
+    /// watermark without letting their OSC title/PWD reports mutate the session model. Nil for overlays
+    /// and quick terminals; main/split surfaces use `session` directly.
+    weak var watermarkSession: Session?
+
     /// Whether this surface is the session's split (right) pane rather than the primary. Set by the
     /// split factory; routes `applyPwd`/`applyTitle` to `session.splitCwd`/`splitTitle` so the split
     /// pane's reports don't clobber the primary's, and clears back to false when the pane is promoted
@@ -598,11 +604,14 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
 
         // a session carrying a background watermark (set earlier on a never-shown session, or restored from
         // a snapshot) applies it now that the surface exists — covering deferred-size creation, the eager
-        // deck, and relaunch. No-op for the sessionless overlay/scratch/quick surfaces. ALSO re-applies a
+        // deck, and relaunch. Scratch inherits through `watermarkSession`; overlay/quick surfaces remain
+        // sessionless and skip it. ALSO re-applies a
         // standalone `dashboardFontOverride` (a dashboard member whose surface realizes AFTER the dashboard
         // set the transient font): `applyWatermarkFromSession` honors `dashboardFontOverride ?? session.fontSize`,
         // so without this the late-realized cell renders at the default font. Mirrors `reapplySessionConfigIfNeeded`.
-        if session?.backgroundWatermark != nil || dashboardFontOverride != nil { applyWatermarkFromSession() }
+        if (session ?? watermarkSession)?.backgroundWatermark != nil || dashboardFontOverride != nil {
+            applyWatermarkFromSession()
+        }
         // an overlay surface with its own background color (session.overlay.open --background-color) applies
         // it here too — the overlay is sessionless, so the watermark path above skips it.
         if overlayBackgroundColorHex != nil { applyOverlayBackgroundColor() }

--- a/agterm/SettingsModel.swift
+++ b/agterm/SettingsModel.swift
@@ -764,9 +764,9 @@ final class SettingsModel {
         return true
     }
 
-    /// All live ghostty surfaces across every open window: each session's primary + split surface in
-    /// every open window's store, plus every open window's quick terminal. A config reload therefore
-    /// broadcasts to all windows, not just the frontmost one.
+    /// All live ghostty surfaces across every open window: each session's primary + split + scratch
+    /// surfaces in every open window's store, plus every open window's quick terminal. A config reload
+    /// therefore broadcasts to all windows, not just the frontmost one.
     private func liveSurfaces() -> [GhosttySurfaceView] {
         var views = library.openIDs()
             .compactMap { library.store(for: $0) }

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -452,8 +452,9 @@ struct agtermApp: App {
     }
 
     /// Scratch-terminal surface factory: a third per-session shell, full-overlay rendered. Like the
-    /// overlay it is NOT wired to the session (no `view.session`/`isSplitPane`), so its PWD/title never
-    /// clobber the session's sidebar name; unlike the overlay it is kept alive when hidden. Runs a plain
+    /// overlay it is NOT operationally wired to the session (no `view.session`/`isSplitPane`), so its
+    /// PWD/title never clobber the session's sidebar name. It does retain a weak visual-config link so the
+    /// session watermark renders on it; unlike the overlay it is kept alive when hidden. Runs a plain
     /// login shell, or `session.scratchCommand` when set (`session.scratch --command`) — RUN-ONCE: the
     /// command is consumed here so a respawn after it exits is a plain shell. `autoFocus` grabs first
     /// responder on show (winning the SwiftUI/AppKit responder race); on the shell's `exit`, `closeScratch`
@@ -472,6 +473,7 @@ struct agtermApp: App {
                                       fontSize: session.fontSize.map(Float.init),
                                       command: command,
                                       autoFocus: !suppressAutoFocus, env: env)
+        view.watermarkSession = session
         let sessionID = session.id
         view.onExit = { store.closeScratch(sessionID) }
         Self.wireStatusClear(view, store: store, sessionID: sessionID, fixedPane: .scratch)


### PR DESCRIPTION
## Summary

- let scratch surfaces inherit the owning session's visual config without wiring their OSC title or PWD into the session model
- apply live watermark set and clear operations to realized scratch surfaces and reassert them across config and opacity reloads
- update the control and libghostty lifecycle notes

## Verification

- swift test: 1,727 tests passed
- swiftlint lint --strict --quiet
- Debug xcodebuild succeeded
- demonstrated in an isolated dev instance with the watermark visible on the scratch terminal

Closes #274