### PR TITLE
feat(sidebar): add agent status tooltips

### DIFF
--- a/agterm/Views/SidebarRowViews.swift
+++ b/agterm/Views/SidebarRowViews.swift
@@ -169,8 +169,9 @@ final class StatusIconView: NSImageView {
     required init?(coder _: NSCoder) { fatalError("init(coder:) is not supported") }
 
     /// apply renders the indicator's tinted glyph (hiding the view and stopping any blink on `.idle`),
-    /// updates the accessibility value to the state name, and starts/stops the blink animation.
+    /// updates the tooltip and accessibility value to the state name, and starts/stops the blink animation.
     func apply(_ indicator: AgentIndicator) {
+        toolTip = indicator.status.tooltipText
         guard indicator.status != .idle else {
             isHidden = true
             image = nil

--- a/agtermCore/Sources/agtermCore/AgentStatus.swift
+++ b/agtermCore/Sources/agtermCore/AgentStatus.swift
@@ -59,6 +59,11 @@ public enum AgentStatus: String, Codable, Sendable, CaseIterable {
         case .idle: return ""
         }
     }
+
+    /// Tooltip for a visible status glyph. Idle renders no glyph and therefore has no tooltip.
+    public var tooltipText: String? {
+        self == .idle ? nil : "Agent status: \(rawValue.capitalized)"
+    }
 }
 
 /// StatusPane records which pane of a session set the current agent status, using the same

--- a/agtermCore/Tests/agtermCoreTests/AgentStatusTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AgentStatusTests.swift
@@ -160,4 +160,11 @@ struct AgentStatusTests {
         // idle never renders a glyph
         #expect(AgentStatus.idle.symbolName == "")
     }
+
+    @Test func tooltipTextNamesVisibleStatusesAndOmitsIdle() {
+        #expect(AgentStatus.active.tooltipText == "Agent status: Active")
+        #expect(AgentStatus.blocked.tooltipText == "Agent status: Blocked")
+        #expect(AgentStatus.completed.tooltipText == "Agent status: Completed")
+        #expect(AgentStatus.idle.tooltipText == nil)
+    }
 }


### PR DESCRIPTION
add hover help to the sidebar agent-status glyphs. Active, blocked, and completed show their status name; idle has no tooltip.

the tooltip is cleared when a reused row becomes idle.

tested with:

- `make test` (1,733 tests)
- `make lint`
- `make build`
- `git diff --check`
