### PR TITLE
feat(keymap): allow arrow keys in chords

### DIFF
--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -130,19 +130,19 @@ paths:
   own dispatch — documented, not validated.
 - **`BuiltinAction.defaultChord` is the single source of truth for the built-in shortcuts (keep-in-sync
   surface).** Task 9 collapsed the old `BuiltinAction` ↔ menu keep-in-sync convention:
-  30 of the 36 built-in menu items now read `equivalent(for:)` (override else `defaultChord`) with NO
-  hardcoded `.keyboardShortcut` literal, so adding/changing a default chord happens in `defaultChord`
-  alone (`toggle_search` ⌘F, `toggle_sidebar` ⌃⌘S, `toggle_fullscreen` ⌃⌘F, `custom_command_palette` ⌃⇧O,
-  and `show_attention` ⌃⇧I are among these — expressible, so pure-`defaultChord`-driven,
-  not arrow exceptions).
-  The EXCEPTION is the six arrow-bound actions (`focus_left_pane` ⌘⌥←, `focus_right_pane` ⌘⌥→,
-  `previous_session` ⌥⌘↑, `next_session` ⌥⌘↓, `previous_attention_session` ⌃⌥↑,
-  `next_attention_session` ⌃⌥↓): `parseKeybind` accepts only single-char keys or `tab`/`space`/`return`/`delete`
-  — arrows are not expressible as a parsed `Chord`, so `defaultChord` returns nil for them and the menu
-  keeps its hardcoded arrow `.keyboardShortcut` as the FALLBACK when `equivalent(for:)` is nil (a user
-  can still `map` these to a parseable chord, which then wins).
-  So the six arrow actions are NOT pure-`defaultChord`-driven by design;
-  the other 29 are.
+  EVERY built-in menu item reads `equivalent(for:)` (override else `defaultChord`) with NO hardcoded
+  `.keyboardShortcut` literal, so adding/changing a default chord happens in `defaultChord` alone.
+  There is NO exception any more: the six formerly arrow-bound actions (`focus_left_pane` ⌘⌥←,
+  `focus_right_pane` ⌘⌥→, `previous_session` ⌥⌘↑, `next_session` ⌥⌘↓, `previous_attention_session` ⌃⌥↑,
+  `next_attention_session` ⌃⌥↓) return their real chords from `defaultChord` now that `parseKeybind`
+  accepts the four arrows, so EVERY keyed built-in is pure-`defaultChord`-driven and the menu holds no
+  hardcoded `.keyboardShortcut` at all.
+  The old props are gone — `agtermApp.arrowShortcut(for:)`, `BuiltinAction.arrowGlyphFallback`, and
+  `glyphHint`'s `?? arrowGlyphFallback` were deleted, and the starter file's six `(no default)` lines
+  became real chords.
+  This also CLOSED a hole: `firstBuiltinCollision` and `validateCommands` resolve through `defaultChord`,
+  so while the six were nil their live ⌥⌘↑/↓/←/→ were invisible to the conflict checker — a `map cmd+opt+up new_session`
+  would have double-bound the chord silently.
 - **Shifted symbols bind as `shift+<base>` — the runner normalizes to the UNSHIFTED base key.**
   `charactersIgnoringModifiers` KEEPS shift (shift+/ → "?", shift+= → "+"), and the old
   `.lowercased()` only undid that for letters (shift+u → "u"), so punctuation landed on the shifted glyph
@@ -155,10 +155,30 @@ paths:
   This is verified END-TO-END by `KeymapUITests.testCustomCommandShiftedSymbolFires` (a real synthesized
   Shift+/ keypress fires a `shift+/`-bound command) — the host-free tests structurally can't reach
   `chord(from:)`, which is exactly why the earlier parser-only version shipped a runtime that never fired.
+- **Arrows are bindable; a BARE arrow is not (`map` only).**
+  `bindableNamedKeys` carries `left`/`right`/`up`/`down` alongside `tab`/`space`/`return`/`delete`, and
+  `bindableArrowKeys` names the four separately for the one rule that treats them specially.
+  `parseMapLine` REJECTS a modifier-less arrow (`map left previous_session` → `chord '<x>' needs a modifier; map skipped`)
+  because a built-in becomes an always-on menu key-equivalent with NO text-field pass-through — unlike
+  the custom-command monitor, which returns false for an `NSText` responder — so a bare arrow would
+  swallow the key in the terminal, both palettes, the dashboard grid's key-catcher, and every text field
+  at once.
+  `parseCommandLine` already required a modifier on every custom chord, so the two verbs now agree for
+  arrows; a bare NON-arrow key stays legal for `map` (pre-existing, `map a new_session`).
+  The grammar itself accepts a bare arrow — the modifier rule is a `map` rule, not a parse rule, so a
+  leader tail like `ctrl+a>left` still works.
+- **The keyCode→name half of `NSEvent`→`Chord` is ONE host-free function.**
+  `namedKey(forKeyCode:)` (`Keybind.swift`) is the single source of truth, used by BOTH app-side monitors
+  — `CustomCommandRunner.chord(from:)` and `UndoCloseShortcut.chord(from:)`, which each carried their own
+  copy of the table before.
+  This matters because a name the GRAMMAR accepts but the keyCode map can't produce parses fine and then
+  never fires: an arrow would fall through to the character branch, whose `characters(byApplyingModifiers: [])`
+  yields the private-use `NSUpArrowFunctionKey` glyph — a VALID `Chord` no keymap line can spell.
+  That is exactly the shifted-symbol failure mode that shipped once (see the shift-symbol note above),
+  which is why `KeybindTests` pins `namedKey(forKeyCode:)`'s range to equal `bindableNamedKeys` exactly,
+  and why the runner path has its own e2e (`KeymapUITests.testCustomCommandArrowChordFires`).
 - **v1 scope cut (confirmed).**
   Built-in rebinds are single-chord only (leaders only for custom commands).
-  The arrows aren't expressible as a parsed `Chord` (the six arrow actions keep their defaults unless
-  mapped to a parseable chord).
   The literal `+`/`>` still can't be a bare key TOKEN (they are the chord-joiner / leader separator), but
   those keys ARE bindable as `shift+=`/`shift+.` (see the shift-symbol note above).
   `increase_font_size`'s default ⌘+ still renders `(not expressible)` in the STARTER file: its stored

--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -132,6 +132,9 @@ paths:
   surface).** Task 9 collapsed the old `BuiltinAction` ↔ menu keep-in-sync convention:
   EVERY built-in menu item reads `equivalent(for:)` (override else `defaultChord`) with NO hardcoded
   `.keyboardShortcut` literal, so adding/changing a default chord happens in `defaultChord` alone.
+  ONE keyed built-in carries no menu shortcut at all: `undo_close` (File ▸ Reopen Closed Item) is
+  delivered by the `UndoCloseShortcut` NSEvent monitor instead, so native text undo keeps working in the
+  rename/palette/Settings fields — it resolves the SAME `equivalent(for:)`, just not as a key-equivalent.
   There is NO exception any more: the six formerly arrow-bound actions (`focus_left_pane` ⌘⌥←,
   `focus_right_pane` ⌘⌥→, `previous_session` ⌥⌘↑, `next_session` ⌥⌘↓, `previous_attention_session` ⌃⌥↑,
   `next_attention_session` ⌃⌥↓) return their real chords from `defaultChord` now that `parseKeybind`
@@ -158,7 +161,7 @@ paths:
 - **Arrows are bindable; a BARE arrow is not (`map` only).**
   `bindableNamedKeys` carries `left`/`right`/`up`/`down` alongside `tab`/`space`/`return`/`delete`, and
   `bindableArrowKeys` names the four separately for the one rule that treats them specially.
-  `parseMapLine` REJECTS a modifier-less arrow (`map left previous_session` → `chord '<x>' needs a modifier; map skipped`)
+  `parseMapLine` REJECTS a modifier-less arrow (`map left previous_session` → `bare arrow chord '<x>' needs a modifier; map skipped`)
   because a built-in becomes an always-on menu key-equivalent with NO text-field pass-through — unlike
   the custom-command monitor, which returns false for an `NSText` responder — so a bare arrow would
   swallow the key in the terminal, both palettes, the dashboard grid's key-catcher, and every text field

--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -63,8 +63,8 @@ paths:
   or quick terminal), else the active session's surface.
   A menu-driven font change still rides the CELL_SIZE → persist path, like the keybind.
 - **In-terminal search (⌘F).**
-  `BuiltinAction.toggleSearch` (`defaultChord` = ⌘F, expressible/rebindable — NOT one of the arrow-bound
-  exceptions) drives `AppActions.toggleSearch()` → `focusedSurface().startSearch()` (the `start_search`
+  `BuiltinAction.toggleSearch` (`defaultChord` = ⌘F, rebindable like every other built-in)
+  drives `AppActions.toggleSearch()` → `focusedSurface().startSearch()` (the `start_search`
   binding action).
   It is a real View ▸ Find… menu item (reading `equivalent(for: .toggleSearch)`,
   no hardcoded shortcut) plus a ⌃⇧P palette "Find…" entry. libghostty replies with a `START_SEARCH` action;
@@ -273,13 +273,13 @@ paths:
   the target so an off-screen row is revealed.
   Distinct from the ⌃Tab MRU switcher (recency order) and the ⌃P fuzzy palette (search) — this is predictable
   spatial stepping in the sidebar's visual order.
-  **Attention navigation** (⌃⌥↑/⌃⌥↓ — the SAME arrow-fallback as the session nav,
-  since arrows aren't keymap-expressible) is the variant that steps through ONLY the sessions needing
+  **Attention navigation** (⌃⌥↑/⌃⌥↓, a plain `defaultChord` like the session nav — arrows are part of the
+  keymap grammar, so both are rebindable) is the variant that steps through ONLY the sessions needing
   attention (`AgentStatus.needsAttention` = `blocked`/`completed`), WRAPPING around and skipping idle/active.
   It reuses `AppStore.navigateSession` (the `.nextAttention`/`.previousAttention` cases — host-free,
   unit-tested) and is driven by Navigate ▸ Previous/Next Attention Session,
-  the action palette, and `session.go next-attention|prev-attention`; the two new `BuiltinAction`s (`previous_attention_session`/`next_attention_session`)
-  join the arrow-bound set (nil `defaultChord`, hardcoded ⌃⌥↑/↓ via `arrowShortcut`).
+  the action palette, and `session.go next-attention|prev-attention`; the two `BuiltinAction`s (`previous_attention_session`/`next_attention_session`)
+  carry ⌃⌥↑/↓ as their `defaultChord`.
   EVERY user-initiated GUI selection now REVEALS the blocked PANE, not just the session: the shared
   `AppActions.revealActiveBlockedPane()` (formerly private, now called on all selection paths) reads the
   landed session's `agentIndicator.statusPane` and focuses that pane — for `right`, the split surface via
@@ -317,7 +317,7 @@ paths:
   opens the session switcher, ⌃⇧P the action palette (the session/action shortcut split is deliberate).
 - **Built-in shortcut hints are one resolver, shared by the palette AND the toolbar/sidebar tooltips.**
   `AppActions.shortcutGlyph(for:)` (formerly `paletteHint`) → the host-free `Keymap.glyphHint(for:)`
-  (`equivalent(for:)?.glyphString ?? BuiltinAction.arrowGlyphFallback`, nil = no shortcut) renders an
+  (`equivalent(for:)?.glyphString`, nil = no shortcut) renders an
   action's CURRENT chord as macOS glyphs (`⌃⌘S`), tracking a `keymap.conf` rebind live.
   `paletteActions()` reads it for the right-aligned palette hint; `WindowContentView.helpHint(_:_:)`
   appends `" (<glyph>)"` to the `.help(…)` tooltip of the 8 `BuiltinAction`-backed toolbar/sidebar buttons
@@ -337,8 +337,8 @@ paths:
   Empty-query order is the `attentionSessions` order (the palette re-sorts by fuzzy score only once the
   user types); `.attention` needs no theme-preview wiring (`syncThemeSession` guards on `.themes`).
   Opened three keyboard/menu ways: `BuiltinAction.showAttention` (rawValue `show_attention`,
-  `defaultChord` ⌃⇧I — a distinct chord swallowed before the terminal like ⌃⇧P/⌃⇧O,
-  expressible/pure-`defaultChord`, NOT an arrow exception) → `AppActions.toggleAttentionPalette()` →
+  `defaultChord` ⌃⇧I — a distinct chord swallowed before the terminal like ⌃⇧P/⌃⇧O)
+  → `AppActions.toggleAttentionPalette()` →
   `palette.toggle(.attention)`, the **Navigate ▸ "Go to Attention…"** menu item (reading `equivalent(for: .showAttention)`),
   and a **"Show Attention"** entry in `paletteActions()` (the ⌃⇧P launcher).
   The title-bar bell is NOT a fourth palette opener: clicking it opens a MOUSE-form popover of the attention

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ command "Lazygit"      ctrl+a>g     agtermctl session overlay open lazygit --soc
 command "Deploy"                    ./deploy.sh
 ```
 
-A chord is modifier words joined by `+` and a base key, e.g. `cmd+shift+e` or `ctrl+\``. The modifiers are `ctrl`, `cmd`, `opt`, and `shift`. The base key is a single character or one of `tab`, `space`, `return`, `delete`, `left`, `right`, `up`, `down`. A key you type with Shift is written as `shift+<base key>` (the base key, not the shifted symbol): `shift+/` for `?`, `shift+5` for `%`, `shift+=` for `+`, `shift+.` for `>`. A custom command's chord may also be a leader sequence — chords separated by `>`, e.g. `ctrl+a>g` (press `ctrl+a`, then `g`). A `command` with no chord is palette-only. A custom command's chord must include a modifier: a bare key like `a` is rejected with a diagnostic and the line is treated as palette-only, so a binding can't silently shadow a plain terminal key (and a palette-only shell line that happens to start with a single-character token isn't swallowed as a binding).
+A chord is modifier words joined by `+` and a base key, e.g. `cmd+shift+e` or `ctrl+\``. The modifiers are `ctrl`, `cmd`, `opt`, and `shift`. The base key is a single character or one of `tab`, `space`, `return`, `delete`, `left`, `right`, `up`, `down`. A key you type with Shift is written as `shift+<base key>` (the base key, not the shifted symbol): `shift+/` for `?`, `shift+5` for `%`, `shift+=` for `+`, `shift+.` for `>`. A custom command's chord may also be a leader sequence — chords separated by `>`, e.g. `ctrl+a>g` (press `ctrl+a`, then `g`). A `command` with no chord is palette-only. A custom command's chord must include a modifier: a bare key like `a` is rejected with a diagnostic and the line is treated as palette-only, so a binding can't silently shadow a plain terminal key. The same diagnostic appears when the shell line simply starts with a bare key name — a single character, or one of the named keys like `up` or `tab` — and the line is kept as palette-only with its shell command intact.
 
 The bindable built-in action names are:
 
@@ -399,7 +399,7 @@ v1 limitations:
 - A `map` line may not bind a bare, modifier-less arrow (`map left previous_session`): a built-in rides an always-on menu key-equivalent, so a bare arrow would swallow the key in the terminal, the palettes, the dashboard grid, and every text field. Any modifier makes it bindable — `map cmd+shift+left previous_session` is fine. Custom commands already require a modifier on every chord.
 - The literal `+` and `>` can't be a bare key token (they are the chord-joiner and leader separators), but those keys are still bindable as `shift+=` and `shift+.`. Only `increase_font_size`'s default ⌘+ shows as a glyph rather than editable text, because its stored form doesn't round-trip through the file.
 - The Ctrl-Tab MRU session switcher and Ctrl-1/Ctrl-2 pane focus are not rebindable yet; they keep their current keys.
-- The action palette shows chords as live kitty syntax (e.g. `cmd+shift+e`) for both custom commands and built-in shortcuts; only `increase_font_size`'s ⌘+, which can't be expressed in the file, falls back to a glyph.
+- The action palette shows built-in shortcuts as macOS glyphs (⌘⇧E) and custom commands as raw kitty syntax (`cmd+shift+e`).
 
 ## Ghostty config
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ command "Lazygit"      ctrl+a>g     agtermctl session overlay open lazygit --soc
 command "Deploy"                    ./deploy.sh
 ```
 
-A chord is modifier words joined by `+` and a base key, e.g. `cmd+shift+e` or `ctrl+\``. The modifiers are `ctrl`, `cmd`, `opt`, and `shift`. The base key is a single character or one of `tab`, `space`, `return`, `delete`. A key you type with Shift is written as `shift+<base key>` (the base key, not the shifted symbol): `shift+/` for `?`, `shift+5` for `%`, `shift+=` for `+`, `shift+.` for `>`. A custom command's chord may also be a leader sequence — chords separated by `>`, e.g. `ctrl+a>g` (press `ctrl+a`, then `g`). A `command` with no chord is palette-only. A custom command's chord must include a modifier: a bare key like `a` is rejected with a diagnostic and the line is treated as palette-only, so a binding can't silently shadow a plain terminal key (and a palette-only shell line that happens to start with a single-character token isn't swallowed as a binding).
+A chord is modifier words joined by `+` and a base key, e.g. `cmd+shift+e` or `ctrl+\``. The modifiers are `ctrl`, `cmd`, `opt`, and `shift`. The base key is a single character or one of `tab`, `space`, `return`, `delete`, `left`, `right`, `up`, `down`. A key you type with Shift is written as `shift+<base key>` (the base key, not the shifted symbol): `shift+/` for `?`, `shift+5` for `%`, `shift+=` for `+`, `shift+.` for `>`. A custom command's chord may also be a leader sequence — chords separated by `>`, e.g. `ctrl+a>g` (press `ctrl+a`, then `g`). A `command` with no chord is palette-only. A custom command's chord must include a modifier: a bare key like `a` is rejected with a diagnostic and the line is treated as palette-only, so a binding can't silently shadow a plain terminal key (and a palette-only shell line that happens to start with a single-character token isn't swallowed as a binding).
 
 The bindable built-in action names are:
 
@@ -396,9 +396,10 @@ After editing the file, apply it with **File ▸ Reload Keymap**, the action pal
 v1 limitations:
 
 - Built-in rebinds are single-chord only; leader sequences (`ctrl+a>g`) work only for custom commands.
-- The arrow keys can't be written as a chord, so the arrow-bound actions (`focus_left_pane`, `focus_right_pane`, `previous_session`, `next_session`, `previous_attention_session`, `next_attention_session`) keep their default shortcuts unless you `map` them to a parseable chord. The literal `+` and `>` can't be a bare key token (they are the chord-joiner and leader separators), but those keys are still bindable as `shift+=` and `shift+.`. Only `increase_font_size`'s default ⌘+ shows as a glyph rather than editable text, because its stored form doesn't round-trip through the file.
+- A `map` line may not bind a bare, modifier-less arrow (`map left previous_session`): a built-in rides an always-on menu key-equivalent, so a bare arrow would swallow the key in the terminal, the palettes, the dashboard grid, and every text field. Any modifier makes it bindable — `map cmd+shift+left previous_session` is fine. Custom commands already require a modifier on every chord.
+- The literal `+` and `>` can't be a bare key token (they are the chord-joiner and leader separators), but those keys are still bindable as `shift+=` and `shift+.`. Only `increase_font_size`'s default ⌘+ shows as a glyph rather than editable text, because its stored form doesn't round-trip through the file.
 - The Ctrl-Tab MRU session switcher and Ctrl-1/Ctrl-2 pane focus are not rebindable yet; they keep their current keys.
-- The action palette shows chords as live kitty syntax (e.g. `cmd+shift+e`) for both custom commands and built-in shortcuts; only chords that can't be expressed in the file fall back to a glyph (the arrow-bound actions and `increase_font_size`'s ⌘+).
+- The action palette shows chords as live kitty syntax (e.g. `cmd+shift+e`) for both custom commands and built-in shortcuts; only `increase_font_size`'s ⌘+, which can't be expressed in the file, falls back to a glyph.
 
 ## Ghostty config
 

--- a/agterm/AppActions+Palette.swift
+++ b/agterm/AppActions+Palette.swift
@@ -11,11 +11,10 @@ extension AppActions {
     /// The macOS glyph string for a rebindable built-in's CURRENT shortcut (`⌘N`, `⌃⌘S`) — tracking
     /// rebinds, reading like the menu equivalent — or `nil` when the action has no shortcut. The SINGLE
     /// resolver behind both the action-palette hints and the toolbar/sidebar tooltips, so the two
-    /// surfaces can't drift. `glyphHint` resolves the live keymap (override else shipped default, with
-    /// the arrow-bound actions falling back to their hardcoded arrow glyph since arrows can't round-trip
-    /// through `parseKeybind`); before `settingsModel` is wired, fall back to the arrow glyph alone.
+    /// surfaces can't drift. `glyphHint` resolves the live keymap (override else shipped default);
+    /// before `settingsModel` is wired, the shipped default alone.
     func shortcutGlyph(for action: BuiltinAction) -> String? {
-        guard let keymap = settingsModel?.keymap else { return action.arrowGlyphFallback }
+        guard let keymap = settingsModel?.keymap else { return action.defaultChord?.glyphString }
         return keymap.glyphHint(for: action)
     }
 

--- a/agterm/Commands/CustomCommandRunner.swift
+++ b/agterm/Commands/CustomCommandRunner.swift
@@ -78,7 +78,7 @@ final class CustomCommandRunner {
     }
 
     /// The Esc virtual keycode the matcher treats specially (the leader abort); Return is a bindable
-    /// base key handled via `namedKeys`, not here.
+    /// base key handled via `namedKey(forKeyCode:)`, not here.
     private static let escapeKeyCode: UInt16 = 53
 
     /// Feed one key event to the matcher. Returns whether the event was consumed (so the caller drops
@@ -161,7 +161,7 @@ final class CustomCommandRunner {
         if flags.contains(.option) { mods.insert(.option) }
         if flags.contains(.shift) { mods.insert(.shift) }
 
-        if let named = Self.namedKeys[event.keyCode] {
+        if let named = namedKey(forKeyCode: event.keyCode) {
             return Chord(mods: mods, key: named)
         }
         // Derive the UNSHIFTED base key so every key normalizes the same way. `charactersIgnoringModifiers`
@@ -176,9 +176,6 @@ final class CustomCommandRunner {
         guard !key.isEmpty, key != " " else { return nil }
         return Chord(mods: mods, key: key)
     }
-
-    /// The special keys `parseKeybind` names, by macOS virtual keycode.
-    private static let namedKeys: [UInt16: String] = [48: "tab", 49: "space", 36: "return", 51: "delete"]
 
     private func startLeaderTimer() {
         cancelLeaderTimer()

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -676,11 +676,13 @@ Key Mapping). Two verbs, line-based; blank lines and `#` comments ignored:
   sequence (chords joined by `>`, e.g. `ctrl+a>g`). No chord → palette-only.
 
 A **chord** is modifier words joined by `+` then a base key: modifiers `ctrl`, `cmd`, `opt`, `shift`;
-base key is a single character or `tab`/`space`/`return`/`delete`. A key typed with Shift is written
-`shift+<base>` (`shift+/` = `?`, `shift+=` = `+`, `shift+5` = `%`) — the base key, not the shifted glyph.
-Arrows aren't expressible, and `+`/`>` can't be a bare key token (they are the separators), though those
-keys are bindable via `shift+=`/`shift+.`. Some chords are reserved (the Ctrl-Tab switcher, Ctrl-1/2 pane
-focus) and cannot be bound.
+base key is a single character or `tab`/`space`/`return`/`delete`/`left`/`right`/`up`/`down`. A key typed
+with Shift is written `shift+<base>` (`shift+/` = `?`, `shift+=` = `+`, `shift+5` = `%`) — the base key,
+not the shifted glyph. `+`/`>` can't be a bare key token (they are the separators), though those keys are
+bindable via `shift+=`/`shift+.`. A `map` line may not bind a bare, modifier-less arrow (`map left …`) —
+a built-in rides an always-on menu key-equivalent, so a bare arrow would swallow the key everywhere;
+any modifier makes it bindable. Some chords are reserved (the Ctrl-Tab switcher, Ctrl-1/2 pane focus)
+and cannot be bound.
 
 Custom-command tokens (expanded into the `/bin/sh -c` line, raw — prefer the quoted `$AGT_*` env form
 for untrusted content). A remote host can set the session title (OSC) and working directory (OSC 7),

--- a/agterm/Views/Palette.swift
+++ b/agterm/Views/Palette.swift
@@ -11,8 +11,7 @@ struct PaletteItem: Identifiable {
     /// The action's keyboard shortcut hint shown right-aligned, nil for items with no shortcut.
     /// Rebindable built-ins read the live keymap (`AppActions.shortcutGlyph`) so it tracks rebinds and
     /// render as macOS menu glyphs (e.g. `⌘⇧E`); custom commands show their raw kitty shortcut string
-    /// (e.g. `cmd+shift+e`). The six arrow-bound actions, not expressible as a `Chord`, keep their
-    /// hardcoded glyph fallback.
+    /// (e.g. `cmd+shift+e`).
     let shortcut: String?
     /// A small trailing badge label (e.g. `custom` for user-defined keymap commands), nil for none.
     let badge: String?

--- a/agterm/Views/UndoCloseShortcut.swift
+++ b/agterm/Views/UndoCloseShortcut.swift
@@ -38,16 +38,8 @@ final class UndoCloseShortcut {
         if flags.contains(.option) { mods.insert(.option) }
         if flags.contains(.shift) { mods.insert(.shift) }
 
-        let key: String?
-        switch event.keyCode {
-        case 36: key = "return"
-        case 48: key = "tab"
-        case 49: key = "space"
-        case 51: key = "delete"
-        default:
-            key = event.charactersIgnoringModifiers?.lowercased()
-        }
-        guard let key, key.count == 1 || ["return", "tab", "space", "delete"].contains(key) else { return nil }
+        let key = namedKey(forKeyCode: event.keyCode) ?? event.charactersIgnoringModifiers?.lowercased()
+        guard let key, key.count == 1 || bindableNamedKeys.contains(key) else { return nil }
         return Chord(mods: mods, key: key)
     }
 }

--- a/agterm/agtermApp+Menus.swift
+++ b/agterm/agtermApp+Menus.swift
@@ -4,35 +4,17 @@ import SwiftUI
 
 extension agtermApp {
     /// The active SwiftUI shortcut for a built-in action, driven by the keymap: the user override when
-    /// one is `map`ped, else the action's shipped default. `nil` when neither exists (a keyless action,
-    /// or one of the four arrow-bound actions whose default can't round-trip through the keymap grammar)
-    /// — the menu drops the shortcut for those (the arrow actions supply their own hardcoded fallback).
+    /// one is `map`ped, else the action's shipped default. `nil` only for a keyless action, which stays
+    /// keyless until the user maps a chord.
     /// Because `keymap` is `@Observable`, reading it here re-renders the menu shortcut on a reload.
     private func shortcut(for action: BuiltinAction) -> KeyboardShortcut? {
         settingsModel.keymap.equivalent(for: action).map(Self.toShortcut)
     }
 
-    /// The shortcut for one of the six arrow-bound actions: the user override when `map`ped, else the
-    /// hardcoded arrow default. Those defaults can't round-trip through the keymap grammar (`parseKeybind`
-    /// has no arrow keys), so `defaultChord` is nil and the fallback lives here in one place — keyed by
-    /// action so every arrow call site reads uniformly and the fallback set has a single home.
-    private func arrowShortcut(for action: BuiltinAction) -> KeyboardShortcut {
-        if let override = shortcut(for: action) { return override }
-        switch action {
-        case .focusLeftPane: return KeyboardShortcut(.leftArrow, modifiers: [.command, .option])
-        case .focusRightPane: return KeyboardShortcut(.rightArrow, modifiers: [.command, .option])
-        case .previousSession: return KeyboardShortcut(.upArrow, modifiers: [.command, .option])
-        case .nextSession: return KeyboardShortcut(.downArrow, modifiers: [.command, .option])
-        case .previousAttentionSession: return KeyboardShortcut(.upArrow, modifiers: [.control, .option])
-        case .nextAttentionSession: return KeyboardShortcut(.downArrow, modifiers: [.control, .option])
-        default: return KeyboardShortcut(.upArrow, modifiers: [.command, .option])
-        }
-    }
-
     /// Map a host-free `Chord` to a SwiftUI `KeyboardShortcut`. The base key is a single printable
     /// character (`Character`) or one of the named keys the grammar allows (`tab`/`space`/`return`/
-    /// `delete`); the modifiers map one-for-one. This is the menu-side mirror of the runner's
-    /// `NSEvent`→`Chord` mapping.
+    /// `delete` and the four arrows); the modifiers map one-for-one. This is the menu-side mirror of the
+    /// runner's `NSEvent`→`Chord` mapping.
     private static func toShortcut(_ chord: Chord) -> KeyboardShortcut {
         let key: KeyEquivalent
         switch chord.key {
@@ -40,6 +22,10 @@ extension agtermApp {
         case "space": key = .space
         case "return": key = .return
         case "delete": key = .delete
+        case "left": key = .leftArrow
+        case "right": key = .rightArrow
+        case "up": key = .upArrow
+        case "down": key = .downArrow
         default: key = KeyEquivalent(Character(chord.key))
         }
         var modifiers: EventModifiers = []
@@ -326,18 +312,17 @@ extension agtermApp {
                 // First/Last get no key (menu + palette + control only). Real menu items so AppKit menu
                 // dispatch swallows the shortcut before libghostty — never leaked to the shell.
                 Button { actions.selectPreviousSession() } label: { Label("Previous Session", systemImage: "chevron.up") }
-                    .keyboardShortcut(arrowShortcut(for: .previousSession))
+                    .keyboardShortcut(shortcut(for: .previousSession))
                     .disabled(library.activeStore?.activeSession == nil || modalActive)
                 Button { actions.selectNextSession() } label: { Label("Next Session", systemImage: "chevron.down") }
-                    .keyboardShortcut(arrowShortcut(for: .nextSession))
+                    .keyboardShortcut(shortcut(for: .nextSession))
                     .disabled(library.activeStore?.activeSession == nil || modalActive)
-                // step only through sessions needing attention (blocked/completed glyphs), wrapping. ⌃⌥↑/↓
-                // are arrow-bound like the session nav above, so they ride arrowShortcut's hardcoded fallback.
+                // step only through sessions needing attention (blocked/completed glyphs), wrapping.
                 Button { actions.selectPreviousAttentionSession() } label: { Label("Previous Attention Session", systemImage: "chevron.up.circle") }
-                    .keyboardShortcut(arrowShortcut(for: .previousAttentionSession))
+                    .keyboardShortcut(shortcut(for: .previousAttentionSession))
                     .disabled(library.activeStore?.activeSession == nil || modalActive)
                 Button { actions.selectNextAttentionSession() } label: { Label("Next Attention Session", systemImage: "chevron.down.circle") }
-                    .keyboardShortcut(arrowShortcut(for: .nextAttentionSession))
+                    .keyboardShortcut(shortcut(for: .nextAttentionSession))
                     .disabled(library.activeStore?.activeSession == nil || modalActive)
                 Button { actions.selectFirstSession() } label: { Label("First Session", systemImage: "arrow.up.to.line") }
                     .keyboardShortcut(shortcut(for: .firstSession))
@@ -346,19 +331,15 @@ extension agtermApp {
                     .keyboardShortcut(shortcut(for: .lastSession))
                     .disabled(library.activeStore?.activeSession == nil || modalActive)
                 Divider()
-                // arrow-bound actions: their default ⌘⌥←/→ can't round-trip through the keymap grammar
-                // (parseKeybind has no arrow keys), so defaultChord is nil and the hardcoded arrow is the
-                // FALLBACK — a user override (a parseable chord) wins. arrowShortcut(for:) owns the four
-                // fallbacks in one place.
                 Button { actions.focusPane(.main) } label: {
                     Label("Focus Left Pane", systemImage: "rectangle.lefthalf.filled")
                 }
-                .keyboardShortcut(arrowShortcut(for: .focusLeftPane))
+                .keyboardShortcut(shortcut(for: .focusLeftPane))
                 .disabled(library.activeStore?.activeSession?.hasSplit != true || modalActive)
                 Button { actions.focusPane(.split) } label: {
                     Label("Focus Right Pane", systemImage: "rectangle.righthalf.filled")
                 }
-                .keyboardShortcut(arrowShortcut(for: .focusRightPane))
+                .keyboardShortcut(shortcut(for: .focusRightPane))
                 .disabled(library.activeStore?.activeSession?.hasSplit != true || modalActive)
             }
             CommandGroup(replacing: .help) {

--- a/agtermCore/Sources/agtermCore/BuiltinAction.swift
+++ b/agtermCore/Sources/agtermCore/BuiltinAction.swift
@@ -27,15 +27,11 @@ public enum BuiltinAction: String, CaseIterable, Sendable {
 
     /// The shipped default chord for this action, or `nil` when it has no default key today.
     ///
-    /// `nil` covers two groups: the keyless actions (`rename_*`/`delete_*`/`duplicate_session`/`clear_status`/
-    /// `first_session`/`last_session`/`select_theme`/`toggle_flagged_view`/`focus_workspace`),
-    /// which gain a key only when the user `map`s one; AND the six
-    /// arrow-bound actions (`focus_left_pane` ⌘⌥←, `focus_right_pane` ⌘⌥→, `previous_session` ⌥⌘↑,
-    /// `next_session` ⌥⌘↓, `previous_attention_session` ⌃⌥↑, `next_attention_session` ⌃⌥↓). Arrows are
-    /// NOT expressible as a parsed `Chord` (`parseKeybind` only accepts single-char keys or
-    /// `tab`/`space`/`return`/`delete`), so they cannot round-trip through the keymap grammar and are not
-    /// returned here. The menu keeps its hardcoded arrow shortcut as the
-    /// fallback when `equivalent(for:)` is nil; the user can still re-`map` these to a parseable chord.
+    /// `nil` covers only the keyless actions (`rename_*`/`delete_*`/`duplicate_session`/`clear_status`/
+    /// `first_session`/`last_session`/`select_theme`/`toggle_flagged_view`/`focus_workspace`), which gain
+    /// a key only when the user `map`s one. Every action that ships with a key returns it here, including
+    /// the six arrow-bound ones — the arrows are part of the chord grammar, so their defaults round-trip
+    /// through `keymap.conf` like any other and the menu needs no hardcoded fallback.
     public var defaultChord: Chord? {
         switch self {
         case .newWindow: return Chord(mods: [.command, .option], key: "n")
@@ -61,30 +57,15 @@ public enum BuiltinAction: String, CaseIterable, Sendable {
         case .customCommandPalette: return Chord(mods: [.control, .shift], key: "o")
         case .showAttention: return Chord(mods: [.control, .shift], key: "i")
         case .dashboard: return Chord(mods: [.command, .shift], key: "d")
+        case .focusLeftPane: return Chord(mods: [.command, .option], key: "left")
+        case .focusRightPane: return Chord(mods: [.command, .option], key: "right")
+        case .previousSession: return Chord(mods: [.command, .option], key: "up")
+        case .nextSession: return Chord(mods: [.command, .option], key: "down")
+        case .previousAttentionSession: return Chord(mods: [.control, .option], key: "up")
+        case .nextAttentionSession: return Chord(mods: [.control, .option], key: "down")
         case .renameWindow, .deleteWindow, .renameWorkspace, .deleteWorkspace, .renameSession, .duplicateSession,
              .clearStatus, .firstSession, .lastSession, .selectTheme, .toggleFlaggedView, .focusWorkspace:
             return nil
-        case .focusLeftPane, .focusRightPane, .previousSession, .nextSession,
-             .previousAttentionSession, .nextAttentionSession:
-            // arrow-bound: not expressible as a parsed Chord; the menu keeps its hardcoded arrow key.
-            return nil
-        }
-    }
-
-    /// The hardcoded macOS menu glyph for the six arrow-bound actions, whose default shortcut can't
-    /// round-trip through `Chord`/`keymap.conf` (so `defaultChord` is nil). `nil` for every other
-    /// action — a keyless action stays keyless until the user maps a chord. This is the display
-    /// counterpart of the menu's hardcoded arrow `.keyboardShortcut`, used by `Keymap.glyphHint(for:)`
-    /// to render an action's current shortcut in the action palette and the toolbar tooltips.
-    public var arrowGlyphFallback: String? {
-        switch self {
-        case .focusLeftPane: return "⌥⌘←"
-        case .focusRightPane: return "⌥⌘→"
-        case .previousSession: return "⌥⌘↑"
-        case .nextSession: return "⌥⌘↓"
-        case .previousAttentionSession: return "⌃⌥↑"
-        case .nextAttentionSession: return "⌃⌥↓"
-        default: return nil
         }
     }
 }

--- a/agtermCore/Sources/agtermCore/Keybind.swift
+++ b/agtermCore/Sources/agtermCore/Keybind.swift
@@ -21,16 +21,23 @@ public struct Modifier: OptionSet, Hashable, Sendable {
 /// abort and is intentionally NOT bindable.
 ///
 /// The four arrows are here because the six arrow-bound built-ins ship their defaults on them, so the
-/// grammar must be able to spell what `BuiltinAction.defaultChord` returns. Adding a name here is only
-/// safe once every `NSEvent`→`Chord` site can produce it — `CustomCommandRunner` and
-/// `UndoCloseShortcut` both resolve named keys through `namedKey(forKeyCode:)`.
+/// grammar must be able to spell what `BuiltinAction.defaultChord` returns.
+///
+/// Adding a name here means updating four sites, two inbound and two outbound:
+/// - `CustomCommandRunner` and `UndoCloseShortcut` resolve `NSEvent` → name via `namedKey(forKeyCode:)`,
+///   so a name with no keycode parses in the file yet never fires;
+/// - `Chord.glyphString` renders the name in palette hints and tooltips — it degrades to the raw name,
+///   so a miss here is cosmetic;
+/// - `agtermApp.toShortcut` maps the name to a SwiftUI `KeyEquivalent`, and its `default` arm is
+///   `KeyEquivalent(Character(chord.key))`, which TRAPS on a multi-character string. That one is a
+///   crash on the first menu render, not a degradation, so it is the site to update first.
 public let bindableNamedKeys: Set<String> = Set(["tab", "space", "return", "delete"]).union(bindableArrowKeys)
 
 /// The four arrow keys, a subset of `bindableNamedKeys`. Named separately because they carry one extra
 /// rule: a built-in `map` may not bind a modifier-less arrow (`parseMapLine`), since an always-on menu
 /// key-equivalent on a bare arrow swallows the key in the terminal, the palettes, the dashboard grid,
 /// and every text field at once.
-public let bindableArrowKeys: Set<String> = ["left", "right", "up", "down"]
+let bindableArrowKeys: Set<String> = ["left", "right", "up", "down"]
 
 /// The named key for a macOS virtual key code, or `nil` for a key that carries a normal character
 /// (which the caller derives from the event itself). The single source of truth for the keyCode→name
@@ -124,8 +131,8 @@ public typealias Keybind = [Chord]
 /// The grammar is chords separated by `>`, each chord a `+`-joined list of modifier words and a
 /// final base key, case-insensitive. Examples: `cmd+shift+e`, `ctrl+a>b`, `ctrl + a > b`. The base
 /// key is a single printable character or one of `bindableNamedKeys` (`tab`/`space`/`return`/
-/// `delete`) — the keys the app-side runner can actually produce; any other multi-char word (e.g.
-/// `esc`, `f1`) is rejected. Returns `nil` for an empty input, an empty chord (e.g. a trailing `>`
+/// `delete`/`left`/`right`/`up`/`down`) — the keys the app-side runner can actually produce; any other
+/// multi-char word (e.g. `esc`, `f1`) is rejected. Returns `nil` for an empty input, an empty chord (e.g. a trailing `>`
 /// or `+`), a chord with no base key, more than one base key in a chord, an unrecognized modifier
 /// word, or an unproducible named key.
 public func parseKeybind(_ s: String) -> Keybind? {

--- a/agtermCore/Sources/agtermCore/Keybind.swift
+++ b/agtermCore/Sources/agtermCore/Keybind.swift
@@ -19,7 +19,36 @@ public struct Modifier: OptionSet, Hashable, Sendable {
 /// keys the app-side runner can produce from an `NSEvent`, so `parseKeybind` rejects any other name
 /// (a key the UI would accept but the runner could never fire). `esc` is reserved as the leader
 /// abort and is intentionally NOT bindable.
-public let bindableNamedKeys: Set<String> = ["tab", "space", "return", "delete"]
+///
+/// The four arrows are here because the six arrow-bound built-ins ship their defaults on them, so the
+/// grammar must be able to spell what `BuiltinAction.defaultChord` returns. Adding a name here is only
+/// safe once every `NSEvent`→`Chord` site can produce it — `CustomCommandRunner` and
+/// `UndoCloseShortcut` both resolve named keys through `namedKey(forKeyCode:)`.
+public let bindableNamedKeys: Set<String> = Set(["tab", "space", "return", "delete"]).union(bindableArrowKeys)
+
+/// The four arrow keys, a subset of `bindableNamedKeys`. Named separately because they carry one extra
+/// rule: a built-in `map` may not bind a modifier-less arrow (`parseMapLine`), since an always-on menu
+/// key-equivalent on a bare arrow swallows the key in the terminal, the palettes, the dashboard grid,
+/// and every text field at once.
+public let bindableArrowKeys: Set<String> = ["left", "right", "up", "down"]
+
+/// The named key for a macOS virtual key code, or `nil` for a key that carries a normal character
+/// (which the caller derives from the event itself). The single source of truth for the keyCode→name
+/// half of the `NSEvent`→`Chord` mapping, shared by every app-side monitor so a name added to
+/// `bindableNamedKeys` can't parse in the file yet fail to fire at runtime.
+public func namedKey(forKeyCode keyCode: UInt16) -> String? {
+    switch keyCode {
+    case 36: return "return"
+    case 48: return "tab"
+    case 49: return "space"
+    case 51: return "delete"
+    case 123: return "left"
+    case 124: return "right"
+    case 125: return "down"
+    case 126: return "up"
+    default: return nil
+    }
+}
 
 /// Whether a chord is owned by the app's always-on `NSEvent` monitors (NOT a menu key-equivalent), so a
 /// keybind that starts with it would dead-race the monitor and must be rejected. This MIRRORS the
@@ -75,6 +104,10 @@ public struct Chord: Equatable, Hashable, Sendable {
         case "space": s += "␣"
         case "return": s += "↩"
         case "delete": s += "⌫"
+        case "left": s += "←"
+        case "right": s += "→"
+        case "up": s += "↑"
+        case "down": s += "↓"
         default: s += key.count == 1 ? key.uppercased() : key
         }
         return s

--- a/agtermCore/Sources/agtermCore/Keymap.swift
+++ b/agtermCore/Sources/agtermCore/Keymap.swift
@@ -373,7 +373,7 @@ private func parseMapLine(_ rest: String, line: Int, overrides: inout [ParsedOve
     // `parseCommandLine` requires a modifier for the same reason.
     guard !(bindableArrowKeys.contains(chord.key) && chord.mods.isEmpty) else {
         diagnostics.append(KeymapDiagnostic(line: line,
-                                            message: "chord '\(chordText)' needs a modifier; map skipped"))
+                                            message: "bare arrow chord '\(chordText)' needs a modifier; map skipped"))
         return
     }
     guard let action = BuiltinAction(rawValue: actionName) else {

--- a/agtermCore/Sources/agtermCore/Keymap.swift
+++ b/agtermCore/Sources/agtermCore/Keymap.swift
@@ -16,19 +16,18 @@ public struct Keymap: Equatable, Sendable {
     }
 
     /// The active chord for a built-in action: the user override when one is present, else the
-    /// action's shipped `defaultChord` (which is `nil` for the keyless and arrow-bound actions).
+    /// action's shipped `defaultChord` (which is `nil` only for the keyless actions).
     public func equivalent(for action: BuiltinAction) -> Chord? {
         builtinOverrides[action] ?? action.defaultChord
     }
 
     /// The action's current shortcut as a macOS menu glyph string (e.g. `⌘N`, `⌃⌘S`), or `nil` when
     /// the action has no shortcut at all. Resolves the effective chord (`equivalent(for:)` — user
-    /// override else shipped default) and renders it via `Chord.glyphString`; for the arrow-bound
-    /// actions, which have no expressible default, it falls back to the hardcoded `arrowGlyphFallback`.
-    /// `nil` means "not configured" — the caller shows no shortcut. Drives both the action-palette
-    /// hints and the toolbar tooltips so the two surfaces can't drift.
+    /// override else shipped default) and renders it via `Chord.glyphString`. `nil` means "not
+    /// configured" — the caller shows no shortcut. Drives both the action-palette hints and the toolbar
+    /// tooltips so the two surfaces can't drift.
     public func glyphHint(for action: BuiltinAction) -> String? {
-        equivalent(for: action)?.glyphString ?? action.arrowGlyphFallback
+        equivalent(for: action)?.glyphString
     }
 }
 
@@ -171,8 +170,9 @@ private struct ParsedOverride {
 /// default, which may collide afresh with another action; the loop re-checks until no collision remains.
 /// Loser rule per collision: an override colliding with another action's UNMOVED default loses (keep the
 /// default owner); two colliding OVERRIDES → the later-in-file one loses. Each dropped override is
-/// diagnosed. The 12 shipped defaults are distinct, so every collision involves at least one override
-/// and each iteration removes ≥1 override → the loop terminates. Re-mapping the SAME action is last-wins
+/// diagnosed. The shipped defaults are all distinct (pinned by `BuiltinActionTests`), so every collision
+/// involves at least one override and each iteration removes ≥1 override → the loop terminates.
+/// Re-mapping the SAME action is last-wins
 /// (it can't collide with itself).
 private func resolveBuiltinOverrides(_ overrides: [ParsedOverride],
                                      diagnostics: inout [KeymapDiagnostic]) -> [BuiltinAction: Chord] {
@@ -254,9 +254,9 @@ private func firstBuiltinCollision(candidates: [BuiltinAction: Chord],
 /// command may freely reuse a default chord the user moved a built-in off of.
 private func validateCommands(_ commands: [CustomCommand], against keymap: Keymap,
                               diagnostics: inout [KeymapDiagnostic]) -> [CustomCommand] {
-    // active built-in chords: the override when present, else the shipped default. The keyless and
-    // arrow-bound actions contribute a chord only when the user mapped one (defaultChord == nil), so
-    // an unmapped arrow default never collides with a (parseable) custom chord.
+    // active built-in chords: the override when present, else the shipped default. The keyless actions
+    // contribute a chord only when the user mapped one (defaultChord == nil); every shipped default,
+    // arrows included, is in the set, so a custom command can't shadow one.
     let builtinChords = Set(BuiltinAction.allCases.compactMap { keymap.equivalent(for: $0) })
 
     var result = commands
@@ -365,6 +365,15 @@ private func parseMapLine(_ rest: String, line: Int, overrides: inout [ParsedOve
     // without dead-racing the monitor, so reject it for built-ins exactly as for custom commands.
     guard !isReservedMonitorChord(chord) else {
         diagnostics.append(KeymapDiagnostic(line: line, message: "chord '\(chordText)' is a reserved shortcut; map skipped"))
+        return
+    }
+    // a modifier-less arrow would install an always-on menu key-equivalent that swallows the key
+    // everywhere at once — the terminal, the palettes, the dashboard grid, and every text field — and
+    // the menu path (unlike the custom-command monitor) has no text-field pass-through to soften it.
+    // `parseCommandLine` requires a modifier for the same reason.
+    guard !(bindableArrowKeys.contains(chord.key) && chord.mods.isEmpty) else {
+        diagnostics.append(KeymapDiagnostic(line: line,
+                                            message: "chord '\(chordText)' needs a modifier; map skipped"))
         return
     }
     guard let action = BuiltinAction(rawValue: actionName) else {

--- a/agtermCore/Tests/agtermCoreTests/BuiltinActionTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/BuiltinActionTests.swift
@@ -38,22 +38,38 @@ struct BuiltinActionTests {
         #expect(BuiltinAction(rawValue: "New_Window") == nil)
     }
 
-    @Test func arrowGlyphFallbackCoversTheSixArrowActions() {
-        // the six arrow-bound actions can't round-trip through Chord, so their menu glyph is hardcoded.
-        #expect(BuiltinAction.focusLeftPane.arrowGlyphFallback == "⌥⌘←")
-        #expect(BuiltinAction.focusRightPane.arrowGlyphFallback == "⌥⌘→")
-        #expect(BuiltinAction.previousSession.arrowGlyphFallback == "⌥⌘↑")
-        #expect(BuiltinAction.nextSession.arrowGlyphFallback == "⌥⌘↓")
-        #expect(BuiltinAction.previousAttentionSession.arrowGlyphFallback == "⌃⌥↑")
-        #expect(BuiltinAction.nextAttentionSession.arrowGlyphFallback == "⌃⌥↓")
+    @Test func arrowBoundActionsShipRealDefaultsThatRoundTrip() {
+        // the six arrow-bound actions are ordinary defaultChord-driven actions: the menu holds no
+        // hardcoded fallback, so their shipped chords must be spellable in keymap.conf.
+        let expected: [BuiltinAction: (syntax: String, glyph: String)] = [
+            .focusLeftPane: ("cmd+opt+left", "⌥⌘←"), .focusRightPane: ("cmd+opt+right", "⌥⌘→"),
+            .previousSession: ("cmd+opt+up", "⌥⌘↑"), .nextSession: ("cmd+opt+down", "⌥⌘↓"),
+            .previousAttentionSession: ("ctrl+opt+up", "⌃⌥↑"), .nextAttentionSession: ("ctrl+opt+down", "⌃⌥↓"),
+        ]
+        for (action, want) in expected {
+            let chord = action.defaultChord
+            #expect(chord?.displayString == want.syntax, "default chord mismatch for \(action.rawValue)")
+            #expect(chord.map { parseKeybind(want.syntax) == [$0] } == true)
+            #expect(chord?.glyphString == want.glyph)
+        }
     }
 
-    @Test func nonArrowActionsHaveNoArrowGlyphFallback() {
-        // an action with an expressible default resolves through the keymap, not the fallback.
-        #expect(BuiltinAction.toggleSidebar.arrowGlyphFallback == nil)
-        #expect(BuiltinAction.newSession.arrowGlyphFallback == nil)
-        // a keyless, non-arrow action has nothing.
-        #expect(BuiltinAction.firstSession.arrowGlyphFallback == nil)
+    @Test func everyShippedDefaultRoundTripsExceptTheDocumentedPlusKey() {
+        // a default that can't round-trip renders as "(not expressible)" in the starter file and can't be
+        // re-typed by the user. increase_font_size's ⌘+ is the ONE documented exception (`+` is the chord
+        // joiner); anything else appearing here is a bug in the new default, not a new exception.
+        let notExpressible = BuiltinAction.allCases.filter { action in
+            guard let chord = action.defaultChord else { return false }
+            return parseKeybind(chord.displayString) != [chord]
+        }
+        #expect(notExpressible == [.increaseFontSize])
+    }
+
+    @Test func shippedDefaultsAreAllDistinct() {
+        // resolveBuiltinOverrides' termination argument depends on this: every collision must involve at
+        // least one user override, so no two shipped defaults may claim the same chord.
+        let defaults = BuiltinAction.allCases.compactMap(\.defaultChord)
+        #expect(Set(defaults).count == defaults.count)
     }
 
     @Test func defaultChordMatchesShippedTable() {
@@ -85,12 +101,12 @@ struct BuiltinActionTests {
             .toggleFlaggedView: nil, // keyless — gains a key only when the user maps one
             .toggleFlag: Chord(mods: [.command, .shift], key: "f"),
             .focusWorkspace: nil,   // keyless — gains a key only when the user maps one
-            .focusLeftPane: nil,    // ⌘⌥← — arrow, not expressible as a parsed Chord
-            .focusRightPane: nil,   // ⌘⌥→ — arrow
-            .previousSession: nil,  // ⌥⌘↑ — arrow
-            .nextSession: nil,      // ⌥⌘↓ — arrow
-            .previousAttentionSession: nil, // ⌃⌥↑ — arrow
-            .nextAttentionSession: nil,     // ⌃⌥↓ — arrow
+            .focusLeftPane: Chord(mods: [.command, .option], key: "left"),
+            .focusRightPane: Chord(mods: [.command, .option], key: "right"),
+            .previousSession: Chord(mods: [.command, .option], key: "up"),
+            .nextSession: Chord(mods: [.command, .option], key: "down"),
+            .previousAttentionSession: Chord(mods: [.control, .option], key: "up"),
+            .nextAttentionSession: Chord(mods: [.control, .option], key: "down"),
             .firstSession: nil,
             .lastSession: nil,
             .quickTerminal: Chord(mods: [.control], key: "`"),
@@ -150,12 +166,11 @@ struct BuiltinActionTests {
         let keyless: Set<BuiltinAction> = [
             .renameWindow, .deleteWindow, .renameWorkspace, .deleteWorkspace, .renameSession, .duplicateSession,
             .clearStatus, .firstSession, .lastSession, .selectTheme, .toggleFlaggedView, .focusWorkspace,
-            // arrow-bound actions are also nil here (arrows can't round-trip through parseKeybind).
-            .focusLeftPane, .focusRightPane, .previousSession, .nextSession,
-            .previousAttentionSession, .nextAttentionSession,
         ]
         for action in keyless {
             #expect(action.defaultChord == nil, "expected nil default for \(action.rawValue)")
         }
+        // nothing else is keyless — every remaining action ships a chord.
+        #expect(BuiltinAction.allCases.filter { $0.defaultChord == nil } == BuiltinAction.allCases.filter { keyless.contains($0) })
     }
 }

--- a/agtermCore/Tests/agtermCoreTests/ConfigPathsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ConfigPathsTests.swift
@@ -51,6 +51,18 @@ struct ConfigPathsTests {
         #expect(starter.contains("(not expressible)"))
         #expect(starter.contains("#   rename_session"))
         #expect(starter.contains("(no default)"))
+        // the six arrow-bound actions print their real chords — they used to claim "(no default)".
+        #expect(starter.contains("cmd+opt+left"))
+        #expect(starter.contains("cmd+opt+right"))
+        #expect(starter.contains("cmd+opt+up"))
+        #expect(starter.contains("cmd+opt+down"))
+        #expect(starter.contains("ctrl+opt+up"))
+        #expect(starter.contains("ctrl+opt+down"))
+        for action in [BuiltinAction.focusLeftPane, .focusRightPane, .previousSession, .nextSession,
+                       .previousAttentionSession, .nextAttentionSession] {
+            let line = starter.split(separator: "\n").first { $0.contains("#   \(action.rawValue) ") }
+            #expect(line?.contains("(no default)") == false, "\(action.rawValue) should print a real chord")
+        }
         for token in CommandContext.tokenNames {
             #expect(starter.contains("#   {\(token)}"))
         }

--- a/agtermCore/Tests/agtermCoreTests/KeybindTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/KeybindTests.swift
@@ -52,6 +52,50 @@ struct KeybindTests {
         #expect(parseKeybind("ctrl+space") == [Chord(mods: .control, key: "space")])
     }
 
+    @Test func parseArrowKeys() {
+        // the exact lines from the report that motivated arrow support (#278).
+        #expect(parseKeybind("cmd+shift+left") == [Chord(mods: [.command, .shift], key: "left")])
+        #expect(parseKeybind("cmd+shift+right") == [Chord(mods: [.command, .shift], key: "right")])
+        #expect(parseKeybind("cmd+opt+up") == [Chord(mods: [.command, .option], key: "up")])
+        #expect(parseKeybind("ctrl+opt+down") == [Chord(mods: [.control, .option], key: "down")])
+    }
+
+    @Test func parseArrowKeysIsCaseInsensitiveAndWorksBareAndInLeaders() {
+        #expect(parseKeybind("CMD+SHIFT+LEFT") == [Chord(mods: [.command, .shift], key: "left")])
+        // a bare arrow parses; the modifier requirement is a `map`/`command` rule, not a grammar one.
+        #expect(parseKeybind("up") == [Chord(mods: [], key: "up")])
+        #expect(parseKeybind("ctrl+a>left") == [Chord(mods: .control, key: "a"), Chord(mods: [], key: "left")])
+    }
+
+    @Test func parseStillRejectsNamedKeysTheRunnerCannotProduce() {
+        // guards against over-widening the named-key set: only the documented names are bindable, and
+        // `esc` stays reserved as the leader abort.
+        #expect(parseKeybind("cmd+esc") == nil)
+        #expect(parseKeybind("cmd+f1") == nil)
+        #expect(parseKeybind("cmd+home") == nil)
+        #expect(parseKeybind("cmd+end") == nil)
+        #expect(parseKeybind("cmd+pageup") == nil)
+        #expect(parseKeybind("cmd+arrowleft") == nil)
+    }
+
+    @Test func namedKeyForKeyCodeCoversExactlyTheBindableNamedKeys() {
+        // the keyCode→name map is what the app-side monitors use; a name the grammar accepts but the map
+        // can't produce would parse in the file and never fire (the shifted-symbol failure mode).
+        let produced = Set((0...127).compactMap { namedKey(forKeyCode: UInt16($0)) })
+        #expect(produced == bindableNamedKeys)
+        #expect(namedKey(forKeyCode: 123) == "left")
+        #expect(namedKey(forKeyCode: 124) == "right")
+        #expect(namedKey(forKeyCode: 125) == "down")
+        #expect(namedKey(forKeyCode: 126) == "up")
+        // a key that carries a normal character resolves from the event, not here.
+        #expect(namedKey(forKeyCode: 0) == nil)
+    }
+
+    @Test func bindableArrowKeysIsASubsetOfBindableNamedKeys() {
+        #expect(bindableArrowKeys.isSubset(of: bindableNamedKeys))
+        #expect(bindableArrowKeys == ["left", "right", "up", "down"])
+    }
+
     @Test func parseRejectsEmptyString() {
         #expect(parseKeybind("") == nil)
     }
@@ -190,5 +234,17 @@ struct KeybindTests {
         #expect(Chord(mods: [.command], key: "+").glyphString == "⌘+")
         #expect(Chord(mods: [.control], key: "tab").glyphString == "⌃⇥")
         #expect(Chord(mods: [.command], key: "return").glyphString == "⌘↩")
+        #expect(Chord(mods: [.command, .option], key: "left").glyphString == "⌥⌘←")
+        #expect(Chord(mods: [.command, .option], key: "right").glyphString == "⌥⌘→")
+        #expect(Chord(mods: [.command, .option], key: "up").glyphString == "⌥⌘↑")
+        #expect(Chord(mods: [.control, .option], key: "down").glyphString == "⌃⌥↓")
+    }
+
+    @Test func arrowChordsRoundTripThroughDisplayString() {
+        for key in bindableArrowKeys {
+            let chord = Chord(mods: [.command, .shift], key: key)
+            #expect(chord.displayString == "cmd+shift+\(key)")
+            #expect(parseKeybind(chord.displayString) == [chord])
+        }
     }
 }

--- a/agtermCore/Tests/agtermCoreTests/KeymapTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/KeymapTests.swift
@@ -28,8 +28,8 @@ struct KeymapTests {
     @Test func keylessActionWithoutOverrideReturnsNil() {
         let keymap = Keymap(builtinOverrides: [:], commands: [])
         #expect(keymap.equivalent(for: .firstSession) == nil)
-        // an arrow-bound action is also nil with no override.
-        #expect(keymap.equivalent(for: .focusLeftPane) == nil)
+        // an arrow-bound action resolves to its shipped default, like any other keyed action.
+        #expect(keymap.equivalent(for: .focusLeftPane) == Chord(mods: [.command, .option], key: "left"))
     }
 
     @Test func parseMapHappyPath() {
@@ -231,6 +231,57 @@ struct KeymapTests {
         #expect(keymap.builtinOverrides.isEmpty)
         #expect(diagnostics.count == 1)
         #expect(diagnostics[0].message.contains("invalid chord"))
+    }
+
+    @Test func parseArrowChordMapLines() {
+        // the exact lines from #278: arrows are part of the chord grammar, so these parse cleanly.
+        let text = """
+        map cmd+shift+left previous_session
+        map cmd+shift+right next_session
+        """
+        let (keymap, diagnostics) = parseKeymap(text)
+        #expect(diagnostics.isEmpty)
+        #expect(keymap.equivalent(for: .previousSession) == Chord(mods: [.command, .shift], key: "left"))
+        #expect(keymap.equivalent(for: .nextSession) == Chord(mods: [.command, .shift], key: "right"))
+    }
+
+    @Test func parseBareArrowMapIsRejected() {
+        // a modifier-less arrow would install an always-on menu key-equivalent swallowing the key in the
+        // terminal, the palettes, the dashboard grid, and every text field.
+        let (keymap, diagnostics) = parseKeymap("map left previous_session")
+        #expect(keymap.builtinOverrides.isEmpty)
+        // the action keeps its shipped default.
+        #expect(keymap.equivalent(for: .previousSession) == Chord(mods: [.command, .option], key: "up"))
+        #expect(diagnostics.count == 1)
+        #expect(diagnostics[0].message.contains("needs a modifier"))
+    }
+
+    @Test func parseModifiedArrowMapIsAcceptedForEveryArrow() {
+        // only the BARE form is rejected — any modifier makes an arrow bindable.
+        for key in ["left", "right", "up", "down"] {
+            let (keymap, diagnostics) = parseKeymap("map cmd+shift+\(key) new_session")
+            #expect(diagnostics.isEmpty, "unexpected diagnostics for cmd+shift+\(key)")
+            #expect(keymap.equivalent(for: .newSession) == Chord(mods: [.command, .shift], key: key))
+        }
+    }
+
+    @Test func mapOntoAnArrowActionsUnmovedDefaultIsRejected() {
+        // the six arrow defaults are now visible to the conflict checker: cmd+opt+up is previous_session's
+        // UNMOVED default, so claiming it for another action must be diagnosed, not silently double-bound.
+        let (keymap, diagnostics) = parseKeymap("map cmd+opt+up new_session")
+        #expect(keymap.builtinOverrides.isEmpty)
+        #expect(keymap.equivalent(for: .newSession) == Chord(mods: [.command], key: "n"))
+        #expect(keymap.equivalent(for: .previousSession) == Chord(mods: [.command, .option], key: "up"))
+        #expect(diagnostics.count == 1)
+        #expect(diagnostics[0].message.contains("conflicts with built-in 'previous_session'"))
+    }
+
+    @Test func customCommandOnAnArrowDefaultIsDropped() {
+        // cross-section validation sees the arrow defaults too, so a custom command can't shadow one.
+        let (keymap, diagnostics) = parseKeymap(#"command "Nav" cmd+opt+down echo hi"#)
+        #expect(keymap.commands.count == 1)
+        #expect(keymap.commands[0].shortcut.isEmpty)
+        #expect(diagnostics.count == 1)
     }
 
     @Test func parseDuplicateBuiltinChordDiagnostic() {

--- a/agtermCore/Tests/agtermCoreTests/KeymapTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/KeymapTests.swift
@@ -53,15 +53,15 @@ struct KeymapTests {
         #expect(keymap.glyphHint(for: .toggleSidebar) == "⌘K")
     }
 
-    @Test func glyphHintFallsBackToArrowGlyphForArrowActions() {
-        // arrow-bound actions have no expressible default chord, so the hint comes from the fallback.
+    @Test func glyphHintRendersArrowDefaultsAsGlyphs() {
+        // the arrow-bound actions resolve through defaultChord like any other keyed action.
         let keymap = Keymap(builtinOverrides: [:], commands: [])
         #expect(keymap.glyphHint(for: .previousSession) == "⌥⌘↑")
         #expect(keymap.glyphHint(for: .focusLeftPane) == "⌥⌘←")
     }
 
-    @Test func glyphHintOverrideWinsOverArrowFallback() {
-        // a user-mapped parseable chord beats the hardcoded arrow glyph.
+    @Test func glyphHintOverrideWinsOverArrowDefault() {
+        // a user-mapped chord beats the shipped arrow default.
         let keymap = Keymap(builtinOverrides: [.previousSession: Chord(mods: [.command], key: "p")], commands: [])
         #expect(keymap.glyphHint(for: .previousSession) == "⌘P")
     }
@@ -280,8 +280,19 @@ struct KeymapTests {
         // cross-section validation sees the arrow defaults too, so a custom command can't shadow one.
         let (keymap, diagnostics) = parseKeymap(#"command "Nav" cmd+opt+down echo hi"#)
         #expect(keymap.commands.count == 1)
+        // the keybind is dropped but the palette entry survives.
+        #expect(keymap.commands[0].name == "Nav")
         #expect(keymap.commands[0].shortcut.isEmpty)
         #expect(diagnostics.count == 1)
+        #expect(diagnostics[0].message.contains("built-in"))
+    }
+
+    @Test func parseBareNonArrowMapIsStillAccepted() {
+        // the modifier requirement is arrow-ONLY — a bare non-arrow map predates the rule and stays
+        // legal. Pins the guard's scope so widening it to every chord can't slip through unnoticed.
+        let (keymap, diagnostics) = parseKeymap("map a new_session")
+        #expect(diagnostics.isEmpty)
+        #expect(keymap.equivalent(for: .newSession) == Chord(mods: [], key: "a"))
     }
 
     @Test func parseDuplicateBuiltinChordDiagnostic() {

--- a/agtermUITests/KeymapArrowRebindUITests.swift
+++ b/agtermUITests/KeymapArrowRebindUITests.swift
@@ -1,11 +1,10 @@
 import XCTest
 
-/// Reproduction for issue #219: `map <chord> <action>` reportedly does nothing when the target action
-/// ships without a default chord. The four actions the report tested — `previous_session`,
-/// `next_session`, `previous_attention_session`, `next_attention_session` — are all in the six-member
-/// arrow-bound group (`defaultChord == nil`, a hardcoded arrow key-equivalent as the menu fallback via
-/// `agtermApp.arrowShortcut(for:)`). Uses the control socket to read the selected session by id, which is
-/// why it subclasses `ControlAPITestCase` (the `KeymapUITests` base can't reach the socket).
+/// Rebinding the six arrow-bound built-ins (`previous_session`, `next_session`, `focus_left_pane`,
+/// `focus_right_pane`, and the two attention-nav actions) — the group issue #219 reported as dead. They
+/// are ordinary `defaultChord`-driven actions now, rebindable to any chord including another arrow
+/// (issue #278). Uses the control socket to read the selected session by id, which is why it subclasses
+/// `ControlAPITestCase` (the `KeymapUITests` base can't reach the socket).
 @MainActor
 final class KeymapArrowRebindUITests: ControlAPITestCase {
     // map `next_session` (one of the four reported arrow-bound actions) to a parseable chord and prove the
@@ -34,6 +33,25 @@ final class KeymapArrowRebindUITests: ControlAPITestCase {
         _ = try sendCommand(#"{"cmd":"session.go","args":{"to":"next"}}"#)
         XCTAssertTrue(pollSelectedSession(sessionB, timeout: 10),
                       "session.go next over the socket should select B (proves navigation is alive)")
+    }
+
+    // the #278 case: rebind a built-in to an ARROW chord and prove the arrow key actually fires it. This
+    // covers the menu half of arrow support (Chord "left" -> KeyEquivalent.leftArrow in `toShortcut`);
+    // the runner half is covered by `KeymapUITests.testCustomCommandArrowChordFires`.
+    func testMapToAnArrowChordFires() throws {
+        try relaunch(withKeymap: "map cmd+shift+left next_session\n")
+        let sessionA = try activeSessionID()
+
+        let created = try sendCommand(#"{"cmd":"session.new"}"#)
+        let sessionB = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "new session id")
+        XCTAssertTrue(pollSessionRowCount(2, timeout: 10), "should have two sessions")
+
+        _ = try sendCommand(#"{"cmd":"session.select","target":"\#(sessionA)"}"#)
+        XCTAssertTrue(pollSelectedSession(sessionA, timeout: 10), "A should be selected before the chord")
+
+        app.typeKey(.leftArrow, modifierFlags: [.command, .shift])
+        XCTAssertTrue(pollSelectedSession(sessionB, timeout: 10),
+                      "the mapped arrow chord ⌘⇧← should fire next_session and select B (issue #278)")
     }
 
     // the same rebind but applied via a LIVE `keymap.reload` (the exact path issue #219 used —

--- a/agtermUITests/KeymapArrowRebindUITests.swift
+++ b/agtermUITests/KeymapArrowRebindUITests.swift
@@ -54,9 +54,32 @@ final class KeymapArrowRebindUITests: ControlAPITestCase {
                       "the mapped arrow chord ⌘⇧← should fire next_session and select B (issue #278)")
     }
 
+    // `UndoCloseShortcut` is the OTHER app-side NSEvent→Chord site, and the only KEYBOARD path to
+    // undo_close — File ▸ Reopen Closed Item ships no key equivalent, so native text undo keeps working
+    // in the rename/palette/Settings fields. Its arrow support arrived with the shared
+    // `namedKey(forKeyCode:)`, so an arrow chord bound there must actually fire.
+    // Two constraints shape this test: a SINGLE-target control close takes the hard path and never arms
+    // the grace window, so it closes TWO sessions in one command; and the grace is 3 s
+    // (`AppStore.pendingCloseGraceInterval`), so nothing may poll or wait between the close and the chord.
+    func testMapToAnArrowChordFiresUndoClose() throws {
+        try relaunch(withKeymap: "map cmd+shift+up undo_close\n")
+
+        let first = try sendCommand(#"{"cmd":"session.new"}"#)
+        let idA = try XCTUnwrap((first["result"] as? [String: Any])?["id"] as? String, "session A id")
+        let second = try sendCommand(#"{"cmd":"session.new"}"#)
+        let idB = try XCTUnwrap((second["result"] as? [String: Any])?["id"] as? String, "session B id")
+        XCTAssertTrue(pollSessionRowCount(3, timeout: 10), "should have three sessions before the close")
+
+        _ = try sendCommand(#"{"cmd":"session.close","args":{"targets":["\#(idA)","\#(idB)"]}}"#)
+        app.typeKey(.upArrow, modifierFlags: [.command, .shift])
+
+        XCTAssertTrue(pollSessionRowCount(3, timeout: 10),
+                      "the mapped arrow chord ⌘⇧↑ should fire undo_close and restore the closed group")
+    }
+
     // the same rebind but applied via a LIVE `keymap.reload` (the exact path issue #219 used —
-    // `agtermctl keymap reload` while running), not seeded at launch. The menu items start with the
-    // hardcoded arrow key-equivalents, and reload must RE-REGISTER the mapped chord onto them.
+    // `agtermctl keymap reload` while running), not seeded at launch. The menu items start with their
+    // shipped arrow defaults, and reload must RE-REGISTER the mapped chord onto them.
     func testMapArrowNavActionFiresAfterLiveReload() throws {
         let sessionA = try activeSessionID()
         let created = try sendCommand(#"{"cmd":"session.new"}"#)

--- a/agtermUITests/KeymapUITests.swift
+++ b/agtermUITests/KeymapUITests.swift
@@ -189,6 +189,21 @@ final class KeymapUITests: XCTestCase {
                       "a custom command bound to shift+/ should fire when Shift+/ (the ? key) is pressed")
     }
 
+    // a custom command bound to an ARROW chord fires. This is the path the host-free tests structurally
+    // cannot reach: the parser accepting `cmd+shift+left` means nothing unless the runner's NSEvent→Chord
+    // mapping produces key "left" for keyCode 123. Without the keyCode entry the event falls through to
+    // the character branch, which yields the private-use arrow character — a valid Chord no keymap line
+    // can spell, so the binding registers and silently never fires (the shifted-symbol failure mode).
+    func testCustomCommandArrowChordFires() throws {
+        let marker = markerDir.appendingPathComponent("arrow")
+        seedKeymap("command \"Touch Arrow\" cmd+shift+left touch '\(marker.path)'\n")
+        app.launchForUITest()
+        focusTerminal()
+
+        XCTAssertTrue(chordFiresMarker(marker) { app.typeKey(.leftArrow, modifierFlags: [.command, .shift]) },
+                      "a custom command bound to cmd+shift+left should fire when ⌘⇧← is pressed (issue #278)")
+    }
+
     // a custom command bound to a LEADER sequence fires: bind `ctrl+a>g` to `touch <file>`, focus the
     // terminal, press ctrl+a then g (two key events), assert the file appears. ctrl+a normally moves to
     // the line start in the shell, but the runner arms on it and consumes the sequence.

--- a/site/docs.html
+++ b/site/docs.html
@@ -1509,6 +1509,12 @@
               >/<span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">return</span>/<span
                 style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
                 >delete</span
+              >/<span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">left</span>/<span
+                style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
+                >right</span
+              >/<span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">up</span>/<span
+                style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
+                >down</span
               >). A Shift-typed symbol is written
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">shift+&lt;base&gt;</span>
               (e.g. <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">shift+/</span> for
@@ -1641,8 +1647,10 @@
                 <span
                   style="position: absolute; left: 0; top: 1px; color: #6d82f3; font-family: &quot;JetBrains Mono&quot;, monospace"
                   >›</span
-                >The arrow keys can't be written as a chord, so the arrow-bound actions keep their defaults unless
-                mapped to a parseable chord. The literal
+                >A <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">map</span> line can't bind a
+                bare, modifier-less arrow — a built-in rides an always-on menu key equivalent, so a bare arrow would
+                swallow the key in the terminal, the palettes, the dashboard grid, and every text field; any modifier
+                makes it bindable. The literal
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">+</span> and
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">&gt;</span> can't be a bare
                 key token (they are the separators), but those keys are bindable as


### PR DESCRIPTION
`parseKeybind` accepted only single-character keys plus tab/space/return/delete, so `map cmd+shift+left previous_session` failed with `invalid chord 'cmd+shift+left'` and no other spelling worked.

**What changed**

The four arrow names join the chord grammar, which lets the six actions that already ship on arrows (`focus_left_pane`, `focus_right_pane`, `previous_session`, `next_session`, and the two attention-nav ones) return their real chords from `BuiltinAction.defaultChord`. That removes the special case they needed: `arrowShortcut(for:)`, `arrowGlyphFallback`, and the `glyphHint` fallback are gone, so every keyed built-in resolves through one path. The generated starter `keymap.conf` also stops claiming `(no default)` for those six, which it did while their real chords lived only as hardcoded menu literals.

It closes a latent hole as well. The conflict checker resolves through `defaultChord`, so while the six returned nil their live chords were invisible to it, and `map cmd+opt+up new_session` would have silently double-bound the chord with no diagnostic.

A bare, modifier-less arrow is refused for `map`. A built-in becomes an always-on menu key equivalent with no text-field pass-through, so a bare arrow would swallow the key in the terminal, both palettes, the dashboard grid and every text field at once. Any modifier makes it bindable, and a bare non-arrow key stays legal as before.

The keyCode-to-name half of the `NSEvent` mapping moves into one host-free `namedKey(forKeyCode:)`. `CustomCommandRunner` and `UndoCloseShortcut` each carried their own copy, and a name the grammar accepts but a monitor cannot produce parses fine yet never fires; that exact failure shipped once already, for shifted symbols.

One behavior note worth knowing: widening the named-key set means a palette-only line whose shell command starts with a bare `up`/`down`/`left`/`right` now emits the same "must include a modifier" diagnostic that `tab`/`space`/`return`/`delete` already did. The shell line is kept intact, so only the diagnostic is new. README covers it.

**Verified**

1750 host-free tests and swiftlint strict, plus 6 end-to-end tests covering both delivery paths, the menu key equivalent and the NSEvent monitor. Also exercised by hand in an isolated build: the exact config from the issue, custom commands on arrow chords, a leader sequence ending in an arrow, and the shipped ⌃⌥↑/↓ defaults still firing after the move off hardcoded literals.

Fix #278
