### PR TITLE
feat(control): add window.minimize and window.new --minimized

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -77,8 +77,8 @@ paths:
   `font.*`/`fontSize`+`splitFontSize`+`scratchFontSize` (the per-pane LIVE font size — the split/scratch
   panes' fonts are otherwise unobservable, being live-only; supplied to `controlTree` by app-side closures
   reading `GhosttySurfaceView.currentFontSize()`, since the host-free tree can't read a surface),
-  `window.move`+`window.resize`/`geometry`, `window.fullscreen`+`window.zoom`/`fullscreen`+`zoomed`
-  (the last three on `window.list`).
+  `window.move`+`window.resize`/`geometry`, `window.fullscreen`+`window.zoom`/`fullscreen`+`zoomed`,
+  `window.minimize`/`minimized` (the last four on `window.list`).
   This is a SEPARATE obligation from the four-point audit (Command + arg + CLI + tests) and easy to forget:
   `session.overlay.resize` shipped write-only and `overlaySizePercent` was added only later, when a
   tmux-zoom script needed to restore an overlay's exact size.
@@ -165,7 +165,7 @@ paths:
   The skill is a REFERENCE/knowledge skill (both user-invocable via `/agterm` and model-triggered,
   `allowed-tools: Bash(agtermctl *)`; the agent-neutral `description` carries the trigger nouns since
   Codex may ignore the extra `when_to_use` field — unknown frontmatter is harmless),
-  authored at `agterm/Resources/agent-skill/` (`SKILL.md` overview + model + addressing + 65-command
+  authored at `agterm/Resources/agent-skill/` (`SKILL.md` overview + model + addressing + 66-command
   summary + the image-display helper + a troubleshooting/reporting pointer;
   `reference.md` full per-command detail + keymap format; `examples.md` agtermctl recipes;
   `troubleshooting.md` diagnosing the common problems (keymap editor, custom actions,
@@ -243,7 +243,7 @@ paths:
   rules, then remaining targets resolve inside that same store so one command never mutates multiple windows.
   The top-level `target` also carries the first explicit batch target so a new CLI talking to a still-running
   pre-batch server degrades to a named session instead of accidentally acting on `active`.
-- **Command catalog (65 commands):**
+- **Command catalog (66 commands):**
   - `tree`
   - `events.read` (the bounded per-app-run control event ring behind `agtermctl events`)
   - `workspace.new`/`workspace.rename`/`workspace.delete`/`workspace.select`/`workspace.move`/`workspace.focus`/`workspace.collapse`/`workspace.expand`
@@ -254,7 +254,7 @@ paths:
   - `sidebar`/`sidebar.mode`/`sidebar.expand`/`sidebar.collapse`
   - `notify`
   - `font.inc`/`font.dec`/`font.reset`
-  - `window.new`/`window.list`/`window.select`/`window.close`/`window.rename`/`window.delete`/`window.resize`/`window.move`/`window.zoom`/`window.fullscreen` (see the Windows section)
+  - `window.new`/`window.list`/`window.select`/`window.close`/`window.rename`/`window.delete`/`window.resize`/`window.move`/`window.zoom`/`window.fullscreen`/`window.minimize` (see the Windows section)
   - `keymap.reload` (see the Keymap section)
   - `config.reload` (see the Settings section)
   - `theme.set`/`theme.list` (see the Theme picker section)
@@ -272,7 +272,7 @@ paths:
   Setting echoes the resulting effective side in `result.text`; the BARE form (no name) reads the side
   the last config feed applied (`SettingsModel.lastAppliedIsDark`), which the test polls to prove the
   flip actually drove the reload.
-  `AppearanceFlipUITests` is its only consumer; the public command count stays 65.
+  `AppearanceFlipUITests` is its only consumer; the public command count stays 66.
 
   `workspace.delete` honors keep-at-least-one and returns an error instead of the GUI confirm alert (nothing
   blocks on a modal).
@@ -1391,13 +1391,17 @@ paths:
   just rebuilds the same cheap agterm nodes.
   The host-free plumbing (the closure + node field) is unit-tested (`controlWindowNodesIncludeGeometryFromClosure`,
   the round-trips); the coordinate conversion + the NSWindow-notification cache refresh are app-side, build-verified.
-  Each `ControlWindowNode` ALSO carries `fullscreen`/`zoomed` — the read side of the write-only
-  `window.fullscreen`/`window.zoom` toggles (so a script can toggle idempotently), filled by a PARALLEL
+  Each `ControlWindowNode` ALSO carries `fullscreen`/`zoomed`/`minimized` — the read side of the write-only
+  `window.fullscreen`/`window.zoom`/`window.minimize` (so a script can act idempotently), filled by a PARALLEL
   app-side `flags:` closure on `controlWindowNodes` (kept separate from `geometry:` so each stays a clean
   addition) that `buildWindowList` reads from `WindowRegistry.windowFlags(for:)`
-  (`styleMask.contains(.fullScreen)` / `NSWindow.isZoomed`); both nil/omitted for a closed window, on the
-  cache like `geometry`. The closure plumbing is unit-tested (`controlWindowNodesIncludeFullscreenZoomFromClosure`
+  (`styleMask.contains(.fullScreen)` / `NSWindow.isZoomed` / `NSWindow.isMiniaturized`); all nil/omitted for a
+  closed window, on the cache like `geometry`. The closure plumbing is unit-tested (`controlWindowNodesIncludeFullscreenZoomFromClosure`
   + the round-trips); the NSWindow reads are app-side, build-verified.
+  `minimized` is LIVE-ONLY, never persisted: nothing in `WindowEntry`/`Snapshot`/the UserDefaults frame
+  records it, per-window AppKit restoration is opted out (`WindowAccessor` sets `isRestorable = false`), and
+  `bringForward` deminiaturizes on attach — so every window reopens un-minimized and a script that parks
+  windows must re-apply after a relaunch.
   `restore.clear` clears every open session's saved CAPTURED foreground command (`Session.foregroundCommand`/`splitForegroundCommand`)
   and persists via `library.saveAllOpen()`, so the next restart restores plain shells for those panes instead
   of re-running the captured commands (also closing the force-quit re-fire: the restored command is consumed
@@ -1568,12 +1572,12 @@ paths:
   (image/text/color set/clear + tree read-back).
   **Agent-skill mirror (HARD keep-in-sync, 4th surface):** all commands are documented in the bundled
   `agterm/Resources/agent-skill/` (SKILL.md summary, reference.md detail,
-  examples.md recipes) and the command count there is bumped to 65 to match.
+  examples.md recipes) and the command count there is bumped to 66 to match.
   **Website mirror (HARD keep-in-sync):** the site's per-command reference `site/commands.html` documents
   EVERY `agtermctl` control command — one inline-styled card per command carrying its invocation, its
   arguments, and the `tree` read-back field, grouped into its command family's section.
   A new `Command` case REQUIRES a new `site/commands.html` entry (a changed command an updated one, a
   removed command a deleted one), in lockstep with the agent skill above and `README.md`/`site/docs.html`;
-  the page's "65 commands" copy must track the catalog count.
+  the page's "66 commands" copy must track the catalog count.
   It drifted once because the site keep-in-sync convention named only `docs.html`/`index.html`, so
   `dashboard` and `surface.zoom` shipped undocumented here.

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -78,7 +78,7 @@ paths:
   panes' fonts are otherwise unobservable, being live-only; supplied to `controlTree` by app-side closures
   reading `GhosttySurfaceView.currentFontSize()`, since the host-free tree can't read a surface),
   `window.move`+`window.resize`/`geometry`, `window.fullscreen`+`window.zoom`/`fullscreen`+`zoomed`,
-  `window.minimize`/`minimized` (the last four on `window.list`).
+  `window.minimize`+`window.new --minimized`/`minimized` (the last four on `window.list`).
   This is a SEPARATE obligation from the four-point audit (Command + arg + CLI + tests) and easy to forget:
   `session.overlay.resize` shipped write-only and `overlaySizePercent` was added only later, when a
   tmux-zoom script needed to restore an overlay's exact size.

--- a/.claude/rules/notifications.md
+++ b/.claude/rules/notifications.md
@@ -57,6 +57,14 @@ paths:
   `didReceive` parses it, `NSApp.activate`s, and calls `AppActions.reveal(sessionID:pane:)`:
   `selectSession` (which clears the badge + derives the workspace) then `focusSplitPane` for the pane,
   stale-safe (unknown session → just activate; a `.split` no longer split → primary).
+  `revealSession` ALSO raises the owning window (`WindowRegistry.raise`, which deminiaturizes first).
+  `NSApp.activate` brings the APP forward, and `makeFirstResponder` moves focus WITHIN a window, but
+  neither orders a window front — so without the raise a banner for a session in a MINIMIZED or merely
+  backgrounded window changed the selection invisibly and the click looked dead.
+  The closed-window branch already raised via `openWindow`; the open-window branch now matches.
+  This path has no automated coverage — its only caller is the `UNUserNotificationCenter` delegate, which
+  XCUITest cannot drive — so verify it by hand; the raise MECHANISM is pinned by
+  `testWindowMinimizeAndRestore`, which asserts `window.select` un-minimizes.
   `reveal` is internal click-routing (not on toolbar/menu/palette) composing the already-controllable
   `session.select`, so it has NO control command (keep-in-sync exempt, by user decision).
 - **Badge.**

--- a/.claude/rules/windows.md
+++ b/.claude/rules/windows.md
@@ -226,7 +226,74 @@ never two bundles in one window.
   `windowCommandsRoundTrip` (`ControlProtocolTests`) +
   `windowCommandsRouteParsedInputsAndKeepActionResponses` (`ControlDispatcherTests`) + the CLI mapping in
   `CommandsTests` + the e2e `testWindowFullscreen` in `ControlWindowUITests`.
-- **`window.*` control additions (eight commands, plus `window.zoom`/`window.fullscreen`).**
+- **`window.minimize` (Dock-minimize toggle — control + ⌘M / yellow button / title-bar double-click GUI).**
+  `WindowRegistry.minimize(_:mode:)` drives the standard `NSWindow.miniaturize`/`deminiaturize`.
+  It is MODE-BEARING (`on`|`off`|`toggle`, default toggle via `ControlToggleMode.parse`), unlike the bare
+  `window.zoom`/`window.fullscreen` toggles, because the workflow it exists for — park every window except
+  the one you're on — needs a deterministic minimize without reading state first.
+  It is NOT control-native: ⌘M (AppKit's own Window menu, which agterm never replaces), the yellow
+  traffic-light button, and the Minimize title-bar double-click action all drive the same AppKit path.
+  That is exactly why the read-back needs the `NSWindow.didMiniaturize`/`didDeminiaturize` observers in
+  `ControlServer` — three GUI drivers mutate it with no control command.
+  It requires the window OPEN (closed → the `window not open` error) and REJECTS a window in native full
+  screen (`cannot minimize a full-screen window — window.fullscreen it first`): AppKit no-ops `miniaturize`
+  there, so applying it would report success having done nothing.
+  The arm is `async` and settle-POLLS `WindowRegistry.isMinimized(id) == desired` before replying, because
+  miniaturize/deminiaturize are ANIMATED — without the poll the `defer`-ed `refreshWindowCache()` captures
+  the pre-animation value and the next `window.list` reports the state the caller just changed away from.
+  Its READ side is `ControlWindowNode.minimized` on `window.list`, and a minimized window still reports its
+  `geometry` — the frame it comes back to — which needs `WindowRegistry.resolvedScreen(for:)`, since
+  `NSWindow.screen` is nil while miniaturized.
+  That resolver (`window.screen` → `WindowGeometry.bestDisplayIndex` largest-overlap → `NSScreen.main`) is
+  SHARED by `geometry`, `move`, and `resize` on purpose: a read resolved by overlap and a write resolved
+  against `NSScreen.main` would disagree on the display index, so a minimized window's frame would stop
+  round-tripping back through `window.move`.
+  `minimized` is LIVE-ONLY (never persisted — see the control-api rule), so a parking script re-applies
+  after a relaunch, and a Dock-icon click restores minimized windows through AppKit's default reopen
+  handling (agterm implements no `applicationShouldHandleReopen`).
+  Four-point keep-in-sync audit: (1) `case windowMinimize = "window.minimize"` + `minimized` on
+  `ControlWindowNode` in `ControlProtocol.swift` (reuses `ControlArgs.mode`),
+  (2) the `.windowMinimize` dispatcher arm (mode parse + error string) → `ControlActions.windowMinimize`
+  (app-side `ControlServer+WindowCommands`) → `WindowRegistry.minimize`, plus the two miniaturize
+  notifications in the `ControlServer` observer array,
+  (3) the `window minimize <id> [on|off|toggle]` subcommand in `agtermctlKit`,
+  (4) `.windowMinimize` in `windowCommandsRoundTrip` + `windowNodeRoundTripsWithMinimized`/`…OmitsMinimizedWhenNil`
+  (`ControlProtocolTests`) + `windowCommandsRouteParsedInputsAndKeepActionResponses` /
+  `…RejectInvalidInputsBeforeCallingActions` (`ControlDispatcherTests`) +
+  `controlWindowNodesIncludeFullscreenZoomFromClosure` (`WindowLibraryTests`) + the CLI mapping in
+  `CommandsTests` + the e2e `testWindowMinimizeAndRestore` in `ControlWindowUITests`.
+  **CLI positional note:** every `window` subcommand takes the id as its first positional, so `minimize`'s
+  mode is a SECOND optional positional and a bare `window minimize on` would bind the mode word to the id.
+  A window address is a hex UUID prefix or `active` and can never be a mode word, so `makeRequest` recovers
+  that case by targeting `active` — covered by `windowMinimizeBareModeTargetsActive`.
+  Do NOT "fix" it by copying `surface zoom`'s mode-first-plus-`--target` shape; that is a different family
+  convention.
+- **`window.new` replies only once its NSWindow has ATTACHED — the open-vs-attached distinction.**
+  A window is "open" the moment its `AppStore` loads (`WindowLibrary.isOpen` = `stores[id] != nil`), which
+  `newWindow()` does SYNCHRONOUSLY. The NSWindow lands much later: registration happens in
+  `TitleProbeView.viewDidMoveToWindow`, which needs `ContentView` to resolve its store (`Color.clear` until
+  then), `.onAppear` → `resolveStore`, and a SECOND render pass before the accessor attaches.
+  So `window.new` used to return with `open: true` and no NSWindow, and an immediate
+  `window.resize <new id>` — the shipped `examples.md` recipe — failed with `window not open`.
+  `windowNew` is therefore `async` and polls `WindowRegistry.isRegistered(id)`; `windowSelect` polls
+  `library.isOpen(id) && isRegistered(id)` (the CONJUNCTION — `isOpen` alone is what `tree --window` needs
+  and stays, but it flips a render pass before the NSWindow exists).
+  Never gate a readiness poll on `isOpen` alone for anything that touches the NSWindow.
+- **The `window.list` cache must refresh on ATTACH, not just on frontmost change.**
+  `window.list` is fast-path-served from `cachedWindowNodes` and never rebuilds its own cache, so the node
+  captured right after `window.new` (no geometry, no flags) stuck FOREVER for a polling script: `newWindow()`
+  pre-sets `frontmostWindowID`, so the new window's first `didBecomeKey` computes `changed == false` and
+  skips `.agtermWindowFrontmostChanged`, and a brand-new id has no saved frame, so `restoreSavedFrame`
+  early-returns and no `didMove`/`didResize` fires either.
+  `WindowRegistry.register`/`unregister` therefore post `.agtermWindowAttachmentChanged`
+  (`GhosttyApp.swift`, app-side — the poster is app-side), which `ControlServer` observes to
+  `refreshWindowCache`.
+  It also covers the paths the `window.new` poll cannot: GUI New Window (⌘⌥N), launch reopen-all, and a
+  red-button close (whose `willClose` unregisters with no command in play).
+  Use `queue: .main`, NOT the `queue: nil` the sidebar observer uses: `unregister` runs near the TOP of the
+  `willClose` block and `library.closeWindow` at the BOTTOM, so a synchronous refresh would capture
+  `open: true` + `geometry: nil` and never refresh again.
+- **`window.*` control additions (eight commands, plus `window.zoom`/`window.fullscreen`/`window.minimize`).**
   `window.new` (returns the new id + opens its window), `window.list` (returns `windows` with each window's
   `open`/`active` flag, plus `autoFollowMs` and `sidebarVisible` read from the open window's store, and
   `geometry` — the live NSWindow frame `{x, y, width, height, display}` in `window.move`/`window.resize`'s

--- a/.claude/rules/windows.md
+++ b/.claude/rules/windows.md
@@ -248,9 +248,22 @@ never two bundles in one window.
   SHARED by `geometry`, `move`, and `resize` on purpose: a read resolved by overlap and a write resolved
   against `NSScreen.main` would disagree on the display index, so a minimized window's frame would stop
   round-tripping back through `window.move`.
+  Parking the FRONTMOST window HANDS `frontmostWindowID` off to a still-visible open window
+  (`handOffFrontmost`).
+  `activeWindowID` only falls back when the frontmost window's STORE is gone, and a minimized window keeps
+  its store, so without the handoff `tree`, `session.new`, `quick`, the palette, and the menu bar all keep
+  routing into a window sitting in the Dock — exactly the state a park-all-but-one script produces.
+  AppKit keys another window on a minimize only while the APP is active, so a background script never gets
+  that handoff for free; when AppKit DID hand off, `reportFrontmost` already moved the id and the guard
+  skips.
+  With every open window minimized there is no candidate, so the pointer stays put rather than being
+  cleared.
   `minimized` is LIVE-ONLY (never persisted — see the control-api rule), so a parking script re-applies
-  after a relaunch, and a Dock-icon click restores minimized windows through AppKit's default reopen
-  handling (agterm implements no `applicationShouldHandleReopen`).
+  after a relaunch.
+  Both GUI directions keep the read-back honest, verified: a ⌘M/menu minimize
+  (`testMenuMinimizeReadsBackOverControl`) and a Dock-icon click restore (AppKit's default reopen handling
+  — agterm implements no `applicationShouldHandleReopen`) each flip the flag with no control command in
+  play.
   Four-point keep-in-sync audit: (1) `case windowMinimize = "window.minimize"` + `minimized` on
   `ControlWindowNode` in `ControlProtocol.swift` (reuses `ControlArgs.mode`),
   (2) the `.windowMinimize` dispatcher arm (mode parse + error string) → `ControlActions.windowMinimize`

--- a/.claude/rules/windows.md
+++ b/.claude/rules/windows.md
@@ -281,6 +281,20 @@ never two bundles in one window.
   that case by targeting `active` — covered by `windowMinimizeBareModeTargetsActive`.
   Do NOT "fix" it by copying `surface zoom`'s mode-first-plus-`--target` shape; that is a different family
   convention.
+- **`window.new --minimized` creates a window already parked.**
+  It rides the existing command as an ARG (`ControlArgs.minimized`), so there is no new `Command` case and
+  the catalog count is unchanged — the `session.new --no-select` precedent, and like it the read-back is
+  the EXISTING field (`window.list`'s `minimized`), so no new node field is owed.
+  Ordering inside the arm is load-bearing: `WindowAccessor` presents a new window BOTH synchronously in
+  `viewDidMoveToWindow` and again on the next main-queue turn, and that second present deminiaturizes — so
+  `park` waits one poll tick after registration before minimizing, else the park is silently undone.
+  It then hands frontmost off (the same `handOffFrontmost`), because `newWindow()` pre-sets
+  `frontmostWindowID` and a window in the Dock must not be where untargeted commands land.
+  It ALSO required fixing `bringForwardForUITests` (`WindowAccessor`): its guard returned WITHOUT latching
+  for an already-presented window, leaving all six ticks of the 0.95 s schedule armed to fight a later
+  deliberate minimize — the same oscillation hazard its own comment warns about.
+  It now latches as soon as the window is on screen.
+  Verified load-bearing: reverting that latch fails `testWindowNewMinimizedStaysParked`.
 - **`window.new` replies only once its NSWindow has ATTACHED — the open-vs-attached distinction.**
   A window is "open" the moment its `AppStore` loads (`WindowLibrary.isOpen` = `stores[id] != nil`), which
   `newWindow()` does SYNCHRONOUSLY. The NSWindow lands much later: registration happens in

--- a/.claude/rules/windows.md
+++ b/.claude/rules/windows.md
@@ -295,6 +295,24 @@ never two bundles in one window.
   deliberate minimize — the same oscillation hazard its own comment warns about.
   It now latches as soon as the window is on screen.
   Verified load-bearing: reverting that latch fails `testWindowNewMinimizedStaysParked`.
+- **A control command that changes which window is frontmost must SAY SO — `takeFrontmost`, not AppKit.**
+  `library.frontmostWindowID` is normally written by `WindowAccessor.reportFrontmost` on `didBecomeKey`,
+  and AppKit does not deliver that while the app is INACTIVE — which is exactly the state a driving script
+  is in.
+  So `window.select` used to `raise` the window, reply `ok`, and leave frontmost on the PREVIOUS window;
+  every untargeted command that followed (`session.new`, `tree`, the palette, the quick terminal) then
+  routed into the window the caller had just navigated away from.
+  Both `windowSelect` and `handOffFrontmost` now go through `takeFrontmost(_:)`, which records the id,
+  persists the index, and runs the auto-hidden-sidebar reconcile — the same three things `reportFrontmost`
+  does, minus the notification the dispatch path already covers.
+  **This path has NO XCUITest coverage, deliberately.** Reproducing it requires agterm to be inactive, and
+  every way to arrange that from XCUITest disturbs the user's session — activating another app jumps to
+  whatever Space that app's window is on.
+  A test written without deactivating the app passes with OR without the fix (verified: it did), so it
+  would guard nothing.
+  Verify by hand on an ISOLATED instance instead: open two windows, leave agterm in the background, run
+  `window select <the non-active one>`, then check `window list` reports it `active` and that an untargeted
+  `session new` lands in it.
 - **`window.new` replies only once its NSWindow has ATTACHED — the open-vs-attached distinction.**
   A window is "open" the moment its `AppStore` loads (`WindowLibrary.isOpen` = `stores[id] != nil`), which
   `newWindow()` does SYNCHRONOUSLY. The NSWindow lands much later: registration happens in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -361,7 +361,8 @@ always in context:
   `session.flag`/`flagged`, `session.focus`/`splitFocused`, `session.resize`/`splitRatio`,
   `session.overlay.resize`/`overlaySizePercent`, `sidebar`/`sidebarVisible`, `sidebar.mode`/`sidebarMode`,
   `workspace.focus`/`focused`, `quick`/`quickVisible`,
-  `window.move`+`window.resize`/`geometry`, `window.fullscreen`+`window.zoom`/`fullscreen`+`zoomed`.
+  `window.move`+`window.resize`/`geometry`, `window.fullscreen`+`window.zoom`/`fullscreen`+`zoomed`,
+  `window.minimize`/`minimized`.
   When adding a state-mutating command, ask "how does a script read back what I just set?" and add that
   field in the SAME change.
   `session.overlay.resize` shipped write-only and the `overlaySizePercent` read-back was missed until a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,22 @@ The app must build, `swift test` and `make test-app` must stay green, and `make 
   The XCUITests no longer collide either: the `.debug` bundle id means XCUITest's launch-time terminate
   hits only the `.debug` instance, not the deployed `com.umputun.agterm`,
   and they still use an isolated `AGTERM_STATE_DIR`/socket.
+- **NEVER run a MUTATING `agtermctl` command against the DEFAULT socket — that socket is the user's LIVE
+  daily driver.**
+  The kill/relaunch ban below is only part of the rule: a bare `agtermctl window move|resize|minimize|new`,
+  `session new|close|type`, `workspace …` reaches the DEPLOYED app, because `agtermctl` on PATH is the
+  deployed copy and its socket auto-resolves to `~/Library/Application Support/agterm/agterm.sock`.
+  This has already cost real damage: a review subagent "checked" the bundled `agent-skill/examples.md`
+  window-stacking recipe by RUNNING it and restacked all four of the user's live windows onto one frame.
+  Read-only probes (`tree`, `window list`) are tolerable; anything that WRITES must target an isolated
+  instance with an explicit `--socket <tmp>/agterm.sock`.
+  **Never "test" a bundled recipe or doc example by executing it** — read it statically, or run it against
+  an isolated instance.
+- **Every DISPATCHED SUBAGENT must carry that constraint VERBATIM in its prompt.**
+  A subagent inherits the same PATH and socket default, so it reaches the daily driver exactly as easily as
+  you do, and it never reads this file unless told to.
+  Any agent prompt that could plausibly lead to running the app or its CLI must state: never execute
+  `agterm`/`agtermctl` against the default socket, never launch or quit the app, static reading only.
 - **NEVER kill or relaunch the deployed `~/Applications/agterm.app` — it is the user's REAL,
   in-use daily terminal with LIVE sessions.** BANNED: `pkill agterm` / `pkill -x agterm`,
   `osascript -e 'tell application "agterm" to quit'`, and ANY quit-then-relaunch of the deployed app

--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ agtermctl session type --target "$id" --select $'echo hello\n'
 ```sh
 agtermctl window list                            # id  name  [open]  [active]
 w=$(agtermctl window new work)                   # create and open a window, capture its id
+agtermctl window new proj-b --minimized          # create one already parked in the Dock
 agtermctl window select "$w"                     # raise it (opening it first if it was closed)
 agtermctl window rename "$w" personal            # rename it
 agtermctl window close "$w"                      # close its on-screen window (the bundle is kept)

--- a/README.md
+++ b/README.md
@@ -318,9 +318,9 @@ w=$(agtermctl window new work)                   # create and open a window, cap
 agtermctl window new proj-b --minimized          # create one already parked in the Dock
 agtermctl window select "$w"                     # raise it (opening it first if it was closed)
 agtermctl window rename "$w" personal            # rename it
+agtermctl window minimize "$w" on                # park it in the Dock (off restores, toggle flips)
 agtermctl window close "$w"                      # close its on-screen window (the bundle is kept)
 agtermctl window delete "$w"                     # delete it (the last window can't be deleted)
-agtermctl window minimize "$w" on                # park it in the Dock (off restores, toggle flips)
 ```
 
 A global `--window <id>` option on the session, workspace, `tree`, and `font` commands targets a *specific* window's tree instead of the frontmost one (the window must be open). Without it, those commands act on the frontmost window:

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ agterm arranges terminals into a small hierarchy. These are the only terms you n
 
 **Workspace.** A workspace is a named group of sessions for one project or context, for example "work" or "personal". Sessions belong to a workspace and can move between workspaces while still running, keeping their shell and scrollback. There is always at least one workspace.
 
-**Window.** A window is a whole set of workspaces and sessions in its own on-screen macOS window, with its own sidebar. Each window has its own sessions, so "work" and "personal" can run as two separate windows at once, each with its own tree. You keep a library of windows and open one per on-screen window; the windows open at quit reopen on the next launch with their frames. Right-click agterm's Dock icon for New Session, Quick Terminal, Dashboard, recent sessions, and sessions needing attention. The Dock menu is scoped to the last-active window: its lists and actions stay tied to that window even if another window comes forward while the menu is open.
+**Window.** A window is a whole set of workspaces and sessions in its own on-screen macOS window, with its own sidebar. Each window has its own sessions, so "work" and "personal" can run as two separate windows at once, each with its own tree. You keep a library of windows and open one per on-screen window; the windows open at quit reopen on the next launch with their frames. Windows are also fully scriptable: `agtermctl window` can create, raise, move, resize, and minimize them, so a few lines of shell can give every window the same frame and park all but the one you are on, turning several windows into what feels like one that switches contents. Right-click agterm's Dock icon for New Session, Quick Terminal, Dashboard, recent sessions, and sessions needing attention. The Dock menu is scoped to the last-active window: its lists and actions stay tied to that window even if another window comes forward while the menu is open.
 
 **Flagging and focus.** Two ways to cut down a busy sidebar. Flag a few sessions from different workspaces to get a flat working-set view of just those; a flag is durable and survives a move. Focus a single workspace to hide the others, with a one-click way back. The two are independent.
 
@@ -183,7 +183,7 @@ The theme picker (View ▸ Select Theme…, or the action palette) previews each
 
 To open a terminal at a directory without the CLI, `open -a agterm <path>` — or right-click a folder in Finder and choose **Open With ▸ agterm**. agterm adds a session in that directory to the last-active window. This works when agterm is already running (its usual state); if it isn't, launch agterm first, then run the command. The socket equivalent, and the way to place the session precisely, is `agtermctl session new --cwd <path>`.
 
-The sections below cover the common cases. All 65 commands, with every argument, return value, and error, are documented in the **[Command reference](https://agterm.com/commands)**.
+The sections below cover the common cases. All 66 commands, with every argument, return value, and error, are documented in the **[Command reference](https://agterm.com/commands)**.
 
 The app bundles `agtermctl` inside `agterm.app`. The easiest way to put it on your PATH is **Help ▸ Install Command Line Tool…**, which symlinks the bundled binary into `/usr/local/bin` (the first entry in macOS's default PATH). When that directory is user-writable it installs silently; otherwise it asks once for an administrator password.
 
@@ -319,6 +319,7 @@ agtermctl window select "$w"                     # raise it (opening it first if
 agtermctl window rename "$w" personal            # rename it
 agtermctl window close "$w"                      # close its on-screen window (the bundle is kept)
 agtermctl window delete "$w"                     # delete it (the last window can't be deleted)
+agtermctl window minimize "$w" on                # park it in the Dock (off restores, toggle flips)
 ```
 
 A global `--window <id>` option on the session, workspace, `tree`, and `font` commands targets a *specific* window's tree instead of the frontmost one (the window must be open). Without it, those commands act on the frontmost window:

--- a/agterm/AppActions+Focus.swift
+++ b/agterm/AppActions+Focus.swift
@@ -239,13 +239,18 @@ extension AppActions {
     /// Selects a session in its owning store and focuses the firing pane.
     private func revealSession(_ sessionID: UUID, pane: PaneRole, in store: AppStore) {
         guard let session = store.session(withID: sessionID) else { return }
+        let windowID = library.windowID(forSession: session.id)
         // a banner click is an explicit "take me there": if the owning window is zoomed, exit zoom
         // first so the reveal is visible — otherwise the selection change happens behind the opaque
         // zoom layer and the click looks dead (every other UI entry point is gated or exits zoom).
-        if let windowID = library.windowID(forSession: session.id),
-           let zoom = TerminalZoomRegistry.shared.controller(for: windowID), zoom.target != nil {
+        if let windowID, let zoom = TerminalZoomRegistry.shared.controller(for: windowID), zoom.target != nil {
             zoom.clear()
         }
+        // and raise the owning window, which `makeFirstResponder` alone does not do. `NSApp.activate` in
+        // the notification handler brings the APP forward, not a window minimized to the Dock or sitting
+        // behind another one — so without this the selection would change invisibly. The closed-window
+        // branch already raises via `openWindow`; this makes the open-window branch symmetric.
+        if let windowID { WindowRegistry.shared.raise(windowID) }
         // clicking a notification banner is a user-initiated selection: note activity on the SAME (owning)
         // store it selects into — reveal can cross windows — so it buys the full idle grace before
         // auto-follow can pull the selection away.

--- a/agterm/Control/ControlServer+WindowCommands.swift
+++ b/agterm/Control/ControlServer+WindowCommands.swift
@@ -37,16 +37,14 @@ extension ControlServer {
     /// unregistered and `minimize` answers `.notOpen`. LOG that rather than swallowing it: the window is
     /// then still on screen holding focus while the caller was told it was parked. Frontmost is handed off
     /// only when the park actually applied — an unparked window is visible, so nothing is owed.
-    @discardableResult
-    private func park(_ id: WindowInfo.ID) async -> Bool {
+    private func park(_ id: WindowInfo.ID) async {
         try? await Task.sleep(nanoseconds: 50_000_000)
         guard case .applied = WindowRegistry.shared.minimize(id, mode: .on) else {
             log("window.new --minimized: \(id) never attached in time, left presented")
-            return false
+            return
         }
         await pollUntil { WindowRegistry.shared.isMinimized(id) }
         handOffFrontmost(from: id)
-        return true
     }
 
     /// Project the window library into the `window.list` response: every window with its open flag and
@@ -69,12 +67,19 @@ extension ControlServer {
     /// store loaded — which is what `tree --window` needs, so it stays — but it flips a render pass before
     /// the NSWindow exists, so a frame command issued right after would still hit `window not open`. An
     /// already-open, already-attached window satisfies both on the first iteration.
+    ///
+    /// Selecting also takes frontmost EXPLICITLY. `raise` makes the window key, but `frontmostWindowID` is
+    /// only updated by `WindowAccessor.reportFrontmost` on `didBecomeKey`, which AppKit does not deliver
+    /// while the app is inactive — so a background `window select` used to reply ok while every untargeted
+    /// command kept routing into the previously-active window. Same asymmetry `handOffFrontmost` fixes on
+    /// the minimize path, and the same reconcile is owed.
     func windowSelect(_ target: String?) async -> ControlResponse {
         switch resolver.resolveWindowID(target) {
         case .failure(let response): return response
         case .success(let id):
             actions.openWindow?(id)
             await pollUntil { self.library.isOpen(id) && WindowRegistry.shared.isRegistered(id) }
+            takeFrontmost(id)
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
         }
     }
@@ -206,13 +211,21 @@ extension ControlServer {
         guard library.frontmostWindowID == id else { return }
         guard let next = library.openIDs().first(where: { $0 != id && !WindowRegistry.shared.isMinimized($0) })
         else { return }
-        library.frontmostWindowID = next
+        takeFrontmost(next)
+    }
+
+    /// Make `id` the logical frontmost window, the way `WindowAccessor.reportFrontmost` does on the GUI
+    /// path: record it, persist the index, and reconcile the auto-hidden sidebars.
+    ///
+    /// The control channel needs its own path because `reportFrontmost` fires on `didBecomeKey`, which
+    /// AppKit does not deliver while the app is inactive — exactly when a script is driving. Without the
+    /// reconcile the window that just became visible keeps its sidebar collapsed until the user next
+    /// activates agterm. Idempotent, and the reconcile resolves through `activeWindowID`, which returns
+    /// the id assigned just above.
+    private func takeFrontmost(_ id: WindowInfo.ID) {
+        guard library.frontmostWindowID != id else { return }
+        library.frontmostWindowID = id
         library.saveIndex()
-        // becoming frontmost also reconciles the auto-hidden sidebars, which `WindowAccessor.reportFrontmost`
-        // does on the GUI path. It is not reached here — AppKit only re-keys another window while the app is
-        // active — so without this the window that just became visible keeps its sidebar collapsed until the
-        // user next activates agterm. Idempotent, and resolves through `activeWindowID`, which returns the id
-        // just assigned above.
         if GhosttyApp.shared.autoHideSidebarInactiveWindows { library.applyInactiveWindowSidebarHiding() }
     }
 

--- a/agterm/Control/ControlServer+WindowCommands.swift
+++ b/agterm/Control/ControlServer+WindowCommands.swift
@@ -16,8 +16,8 @@ extension ControlServer {
     /// after SwiftUI resolves the store and runs a second render pass. Fire-and-forget like the other
     /// polls — a window that never renders times out and the command still replies ok.
     ///
-    /// `minimized` parks the new window in the Dock instead of presenting it, so a script can build a set
-    /// of project windows without each one flashing on screen and taking focus.
+    /// `minimized` creates the window and THEN parks it in the Dock, so a script can build a set of
+    /// project windows and be left on one it can still see.
     func windowNew(name: String?, minimized: Bool) async -> ControlResponse {
         let info = library.newWindow(name: trimmed(name))
         actions.openWindow?(info.id)
@@ -32,11 +32,21 @@ extension ControlServer {
     /// synchronously and again on the next main-queue turn, and that second present deminiaturizes — so
     /// minimizing the instant registration lands would simply be undone. One poll tick yields the main
     /// actor long enough for the queued present to drain first.
-    private func park(_ id: WindowInfo.ID) async {
+    ///
+    /// The attach poll above is bounded and fire-and-forget, so a window that never rendered reaches here
+    /// unregistered and `minimize` answers `.notOpen`. LOG that rather than swallowing it: the window is
+    /// then still on screen holding focus while the caller was told it was parked. Frontmost is handed off
+    /// only when the park actually applied — an unparked window is visible, so nothing is owed.
+    @discardableResult
+    private func park(_ id: WindowInfo.ID) async -> Bool {
         try? await Task.sleep(nanoseconds: 50_000_000)
-        guard case .applied = WindowRegistry.shared.minimize(id, mode: .on) else { return }
+        guard case .applied = WindowRegistry.shared.minimize(id, mode: .on) else {
+            log("window.new --minimized: \(id) never attached in time, left presented")
+            return false
+        }
         await pollUntil { WindowRegistry.shared.isMinimized(id) }
         handOffFrontmost(from: id)
+        return true
     }
 
     /// Project the window library into the `window.list` response: every window with its open flag and
@@ -198,6 +208,12 @@ extension ControlServer {
         else { return }
         library.frontmostWindowID = next
         library.saveIndex()
+        // becoming frontmost also reconciles the auto-hidden sidebars, which `WindowAccessor.reportFrontmost`
+        // does on the GUI path. It is not reached here — AppKit only re-keys another window while the app is
+        // active — so without this the window that just became visible keeps its sidebar collapsed until the
+        // user next activates agterm. Idempotent, and resolves through `activeWindowID`, which returns the id
+        // just assigned above.
+        if GhosttyApp.shared.autoHideSidebarInactiveWindows { library.applyInactiveWindowSidebarHiding() }
     }
 
     /// Resolve a window id and rename it (the name lives in the index). Requires a name. Returns the id.

--- a/agterm/Control/ControlServer+WindowCommands.swift
+++ b/agterm/Control/ControlServer+WindowCommands.swift
@@ -15,11 +15,28 @@ extension ControlServer {
     /// synchronously, so `isOpen` is already true and would prove nothing, while the NSWindow only attaches
     /// after SwiftUI resolves the store and runs a second render pass. Fire-and-forget like the other
     /// polls — a window that never renders times out and the command still replies ok.
-    func windowNew(name: String?) async -> ControlResponse {
+    ///
+    /// `minimized` parks the new window in the Dock instead of presenting it, so a script can build a set
+    /// of project windows without each one flashing on screen and taking focus.
+    func windowNew(name: String?, minimized: Bool) async -> ControlResponse {
         let info = library.newWindow(name: trimmed(name))
         actions.openWindow?(info.id)
         await pollUntil { WindowRegistry.shared.isRegistered(info.id) }
+        if minimized { await park(info.id) }
         return ControlResponse(ok: true, result: ControlResult(id: info.id.uuidString))
+    }
+
+    /// Park a freshly created window: minimize it, wait out the animation, and hand frontmost back.
+    ///
+    /// The wait before minimizing is load-bearing. `WindowAccessor` presents the window on attach BOTH
+    /// synchronously and again on the next main-queue turn, and that second present deminiaturizes — so
+    /// minimizing the instant registration lands would simply be undone. One poll tick yields the main
+    /// actor long enough for the queued present to drain first.
+    private func park(_ id: WindowInfo.ID) async {
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        guard case .applied = WindowRegistry.shared.minimize(id, mode: .on) else { return }
+        await pollUntil { WindowRegistry.shared.isMinimized(id) }
+        handOffFrontmost(from: id)
     }
 
     /// Project the window library into the `window.list` response: every window with its open flag and

--- a/agterm/Control/ControlServer+WindowCommands.swift
+++ b/agterm/Control/ControlServer+WindowCommands.swift
@@ -8,9 +8,17 @@ import agtermCore
 extension ControlServer {
     /// Create a new window (library) and open its on-screen window via the action hub's window opener
     /// (the same `enqueueClaim` + `openWindow(id:)` path the menu uses). Returns the new window id.
-    func windowNew(name: String?) -> ControlResponse {
+    ///
+    /// Bounded-polls for the NSWindow to ATTACH before replying, so `window.new` followed immediately by
+    /// `window.resize`/`move`/`zoom` works — those need a registered window and would otherwise fail. The
+    /// poll must gate on `WindowRegistry.isRegistered`, NOT `library.isOpen`: `newWindow()` loads the store
+    /// synchronously, so `isOpen` is already true and would prove nothing, while the NSWindow only attaches
+    /// after SwiftUI resolves the store and runs a second render pass. Fire-and-forget like the other
+    /// polls — a window that never renders times out and the command still replies ok.
+    func windowNew(name: String?) async -> ControlResponse {
         let info = library.newWindow(name: trimmed(name))
         actions.openWindow?(info.id)
+        await pollUntil { WindowRegistry.shared.isRegistered(info.id) }
         return ControlResponse(ok: true, result: ControlResult(id: info.id.uuidString))
     }
 
@@ -26,16 +34,20 @@ extension ControlServer {
     }
 
     /// Resolve a window id and surface it: raise an already-open window, or open a closed one (the
-    /// action hub's opener claims its id + spawns the window). A closed window's store loads only when
-    /// its SwiftUI window appears, so this bounded-polls for it to open before replying — a script can
-    /// then immediately target it (`tree --window <id>`) without racing the window appearing. Returns
-    /// the window id.
+    /// action hub's opener claims its id + spawns the window). This bounded-polls for the NSWindow to
+    /// ATTACH before replying — a script can then immediately target it (`tree --window <id>`, or a
+    /// frame command) without racing the window appearing. Returns the window id.
+    ///
+    /// The poll waits for BOTH the store and the NSWindow. `library.isOpen` alone only reports that the
+    /// store loaded — which is what `tree --window` needs, so it stays — but it flips a render pass before
+    /// the NSWindow exists, so a frame command issued right after would still hit `window not open`. An
+    /// already-open, already-attached window satisfies both on the first iteration.
     func windowSelect(_ target: String?) async -> ControlResponse {
         switch resolver.resolveWindowID(target) {
         case .failure(let response): return response
         case .success(let id):
             actions.openWindow?(id)
-            await pollUntil { self.library.isOpen(id) }
+            await pollUntil { self.library.isOpen(id) && WindowRegistry.shared.isRegistered(id) }
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
         }
     }
@@ -125,6 +137,31 @@ extension ControlServer {
                 return ControlResponse(ok: false, error: "window not open — window.select it first")
             }
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
+        }
+    }
+
+    /// Resolve a window id and minimize it to the Dock, or restore it, per the mode. The window must be
+    /// open; a closed window errors, as does one in native full screen (AppKit no-ops `miniaturize` there,
+    /// so reporting ok would be a lie). The control half of ⌘M / the yellow traffic-light button / the
+    /// Minimize title-bar double-click action.
+    ///
+    /// Miniaturize and deminiaturize are ANIMATED, so `isMiniaturized` lags the call — without the settle
+    /// poll the `defer`-ed window-cache refresh would capture the OLD value and the very next
+    /// `window.list` would report the state the caller just changed away from.
+    func windowMinimize(_ target: String?, mode: ControlToggleMode) async -> ControlResponse {
+        switch resolver.resolveWindowID(target) {
+        case .failure(let response): return response
+        case .success(let id):
+            switch WindowRegistry.shared.minimize(id, mode: mode) {
+            case .notOpen:
+                return ControlResponse(ok: false, error: "window not open — window.select it first")
+            case .fullScreen:
+                return ControlResponse(ok: false,
+                                       error: "cannot minimize a full-screen window — window.fullscreen it first")
+            case .applied(let desired):
+                await pollUntil { WindowRegistry.shared.isMinimized(id) == desired }
+                return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
+            }
         }
     }
 

--- a/agterm/Control/ControlServer+WindowCommands.swift
+++ b/agterm/Control/ControlServer+WindowCommands.swift
@@ -160,9 +160,27 @@ extension ControlServer {
                                        error: "cannot minimize a full-screen window — window.fullscreen it first")
             case .applied(let desired):
                 await pollUntil { WindowRegistry.shared.isMinimized(id) == desired }
+                if desired { handOffFrontmost(from: id) }
                 return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
             }
         }
+    }
+
+    /// After parking the FRONTMOST window, point `frontmostWindowID` at a window the user can still see.
+    ///
+    /// `activeWindowID` only falls back when the frontmost window's STORE is gone (i.e. closed), and a
+    /// minimized window keeps its store — so without this every untargeted command (`tree`, `session.new`,
+    /// `quick`, the palette, the menu bar) keeps routing into a window sitting in the Dock. AppKit keys
+    /// another window on a minimize only while the APP is active, so a script parking windows in the
+    /// background never gets that handoff; when AppKit DID hand off, `reportFrontmost` already moved the
+    /// id and the guard below skips. With every open window minimized there is nothing to hand to, so the
+    /// pointer stays put rather than being cleared.
+    private func handOffFrontmost(from id: WindowInfo.ID) {
+        guard library.frontmostWindowID == id else { return }
+        guard let next = library.openIDs().first(where: { $0 != id && !WindowRegistry.shared.isMinimized($0) })
+        else { return }
+        library.frontmostWindowID = next
+        library.saveIndex()
     }
 
     /// Resolve a window id and rename it (the name lives in the index). Requires a name. Returns the id.

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -137,10 +137,19 @@ final class ControlServer {
         // it fires for ANY window, but a non-agterm panel just rebuilds the same cheap agterm nodes, and a
         // drag's didMove/didResize storm just keeps the cache current.
         for name in [NSWindow.didMoveNotification, NSWindow.didResizeNotification,
-                     NSWindow.didEnterFullScreenNotification, NSWindow.didExitFullScreenNotification] {
+                     NSWindow.didEnterFullScreenNotification, NSWindow.didExitFullScreenNotification,
+                     NSWindow.didMiniaturizeNotification, NSWindow.didDeminiaturizeNotification] {
             NotificationCenter.default.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
                 MainActor.assumeIsolated { self?.refreshWindowCache() }
             }
+        }
+        // a window's NSWindow attaches a render pass or two AFTER its store loads, so the node cached right
+        // after window.new carries no geometry/flags — and nothing else refreshes it on that path (see the
+        // .agtermWindowAttachmentChanged doc comment). Refresh on attach/detach so the cache is honest for
+        // every opener, including GUI New Window and launch reopen-all, which run no control command at all.
+        NotificationCenter.default.addObserver(forName: .agtermWindowAttachmentChanged, object: nil,
+                                               queue: .main) { [weak self] _ in
+            MainActor.assumeIsolated { self?.refreshWindowCache() }
         }
     }
 
@@ -376,7 +385,7 @@ final class ControlServer {
                 .sessionOverlayResult, .sessionBackground, .sessionText, .quick, .quickType, .quickText,
                 .windowNew, .windowList, .windowSelect,
                 .windowClose, .windowRename, .windowDelete, .windowResize, .windowMove, .windowZoom,
-                .windowFullscreen, .restoreClear, .dashboard:
+                .windowFullscreen, .windowMinimize, .restoreClear, .dashboard:
             return ControlResponse(ok: false, error: "control dispatcher did not handle \(request.cmd.rawValue)")
         case .debugAppearance:
             return setDebugAppearance(args: request.args)

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -593,7 +593,9 @@ final class ControlServer {
         return result.isEmpty ? nil : result
     }
 
-    private func log(_ message: @autoclosure () -> String) {
+    /// Internal, not private: the command arms live in `ControlServer+*.swift` extensions, which cannot
+    /// reach a private member declared here.
+    func log(_ message: @autoclosure () -> String) {
         NSLog("agterm: %@", message())
     }
 }

--- a/agterm/Ghostty/GhosttyApp.swift
+++ b/agterm/Ghostty/GhosttyApp.swift
@@ -698,6 +698,14 @@ extension Notification.Name {
     /// would otherwise stay stale until the next dispatched command.
     static let agtermWindowFrontmostChanged = Notification.Name("agterm.windowFrontmostChanged")
 
+    /// Posted by `WindowRegistry` when a window's NSWindow attaches or detaches, so the control server can
+    /// refresh its cached `window.list`. A window is "open" (its store loaded) well before its NSWindow
+    /// exists, so `window.new` builds its cached node with no `geometry`/`fullscreen`/`zoomed`/`minimized`;
+    /// nothing else refreshes it afterwards on that path — `newWindow()` pre-sets `frontmostWindowID`, so
+    /// the first `didBecomeKey` is a no-change and skips `.agtermWindowFrontmostChanged`, and a brand-new
+    /// window has no saved frame to restore, so no `didMove`/`didResize` fires either.
+    static let agtermWindowAttachmentChanged = Notification.Name("agterm.windowAttachmentChanged")
+
     /// Posted after `keymap.conf` is (re)loaded and reparsed, so the custom-command runner rebuilds its
     /// matcher and the action palette re-reads the custom commands. The data-driven menu shortcuts
     /// re-render on their own because they read the `@Observable` keymap directly.

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -293,7 +293,7 @@ omitted when expanded).
   overlay is a real terminal (pty), which is also how you **display an image inline** — via the bundled
   `scripts/show-image.sh` (see below).
 
-**window** — `new [name]` · `list` · `select <id>` · `close <id>` · `rename <id> <name>` ·
+**window** — `new [name] [--minimized]` · `list` · `select <id>` · `close <id>` · `rename <id> <name>` ·
 `delete <id>` · `resize <id> --width W --height H` · `move <id> --x X --y Y [--display N]` ·
 `zoom <id>` (maximize-to-screen toggle, the double-click-header gesture; a plain green-button click does full screen) ·
 `fullscreen <id>` (toggle native macOS full screen, the green-button / ⌃⌘F action) ·

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -17,7 +17,7 @@ when_to_use: >
   Trigger on: agterm, agtermctl, agterm control socket, session.new, session.close, session.type,
   session.split, session.scratch, session.focus, session.resize, surface.zoom, dashboard, session.go, session.copy, session.paste, session.selectall, session.text, session.search, session.status,
   session.flag, session.seen, session.reveal, session.duplicate, session.background, session.overlay, workspace.new, workspace.select, workspace.move, workspace.focus, window.new, window.list,
-  window.select, window.resize, window.move, window.zoom, window.fullscreen, quick terminal, sidebar, sidebar.mode, sidebar.expand, sidebar.collapse, flagged, notify, font.inc, keymap.reload, config.reload,
+  window.select, window.resize, window.move, window.zoom, window.fullscreen, window.minimize, quick terminal, sidebar, sidebar.mode, sidebar.expand, sidebar.collapse, flagged, notify, font.inc, keymap.reload, config.reload,
   theme.set, theme.list, events, events.read, event subscription, select theme, edit keymap, show an image, display an image inline, show-image,
   AGTERM_SESSION_ID, AGTERM_SOCKET, and asks to drive or script agterm. Also: troubleshoot agterm,
   keymap editor won't open, custom action / custom command not working, agterm logs, file an agterm
@@ -100,9 +100,10 @@ sidebar is currently shown — the read side of the write-only `sidebar` command
 terminal is shown — the read side of the write-only `quick` command). List windows with
 `agtermctl window list --json`; each window also reports `autoFollowMs`, `sidebarVisible`, `geometry`
 (the live frame `{x, y, width, height, display}` in the units `window move`/`window resize` take — the
-read side, so record it then restore the exact frame), and `fullscreen`/`zoomed` (the read side of
-`window fullscreen`/`window zoom`, so a script can make those toggles idempotent) — all omitted for a
-closed window, but not the live `idleMs`, which is `tree`-only.
+read side, so record it then restore the exact frame), and `fullscreen`/`zoomed`/`minimized` (the read side
+of `window fullscreen`/`window zoom`/`window minimize`, so a script can act idempotently) — all omitted for
+a closed window, but not the live `idleMs`, which is `tree`-only. A MINIMIZED window still reports its
+`geometry` (the frame it comes back to), so a re-align script can include it.
 
 ## Addressing
 
@@ -141,7 +142,7 @@ prompt concatenates with yours, and the program starts on the merged line. (`--n
 focus, but the newline and shared-buffer hazards of `type`-as-launcher remain — `--command` is still the
 rule.) After `--command`, confirm in `tree --json` that the new node's `foreground` shows your program running, not a bare shell prompt.
 
-## Command summary (65 commands)
+## Command summary (66 commands)
 
 Run `agtermctl <area> <cmd> --help` for exact flags. Full detail in **reference.md**; recipes in
 **examples.md**.
@@ -295,7 +296,10 @@ omitted when expanded).
 **window** — `new [name]` · `list` · `select <id>` · `close <id>` · `rename <id> <name>` ·
 `delete <id>` · `resize <id> --width W --height H` · `move <id> --x X --y Y [--display N]` ·
 `zoom <id>` (maximize-to-screen toggle, the double-click-header gesture; a plain green-button click does full screen) ·
-`fullscreen <id>` (toggle native macOS full screen, the green-button / ⌃⌘F action).
+`fullscreen <id>` (toggle native macOS full screen, the green-button / ⌃⌘F action) ·
+`minimize <id> [on|off|toggle]` (minimize to the Dock or restore, the ⌘M / yellow-button action; default
+`toggle`, the id may be omitted so `window minimize on` targets the active window; errors on a full-screen
+window; read back as `minimized` on `window list`).
 
 **surface** — `zoom [show|hide|toggle] [--target surface:<session-id>:left|right|scratch|overlay|quick] [--window W]`
 — zoom a terminal surface to fill the window (sidebar hidden; a slim title-bar strip with an exit

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -617,7 +617,7 @@ process effect.
 agtermctl session go --to next            # step selection to the next session
 agtermctl session go --to next-attention  # jump to the next blocked/completed session
 w=$(agtermctl window new "scratch" --json | jq -r '.result.id')
-# or build one already parked, so it never flashes on screen or takes focus:
+# or park one in the Dock right after creating it (it appears briefly on its way there):
 # p=$(agtermctl window new "proj-b" --minimized --json | jq -r '.result.id')
 agtermctl window resize "$w" --width 1200 --height 800
 agtermctl window move "$w" --x 100 --y 100 --display 0
@@ -639,7 +639,8 @@ Switching then looks like switching a tab rather than managing five windows.
 # align every window to the active one's frame, so raising one covers the others exactly
 set -- $(agtermctl window list --json | jq -r '.result.windows[] | select(.active) | .geometry
   | "\(.x) \(.y) \(.width) \(.height) \(.display)"')
-agtermctl window list --json | jq -r '.result.windows[].id' | while read -r id; do
+# select(.open): a closed window has no NSWindow, so resize/move would error on it
+agtermctl window list --json | jq -r '.result.windows[] | select(.open) | .id' | while read -r id; do
   agtermctl window resize "$id" --width "$3" --height "$4"
   agtermctl window move "$id" --x "$1" --y "$2" --display "$5"
 done
@@ -650,16 +651,23 @@ for p in "Project A" "Project B" "Project C"; do
 done
 
 # show exactly one project: raise it, park the rest
+# show exactly one project: raise it, park the rest. `select` opens a closed window, so it needs no
+# filter; `park` does — minimize errors on a window that has no NSWindow.
 show() {
   agtermctl window list --json | jq -r --arg n "$1" '.result.windows[]
+    | select(.name == $n or .open)
     | "\(if .name == $n then "select" else "park" end) \(.id)"' |
   while read -r act id; do
-    [ "$act" = select ] && agtermctl window select "$id" || agtermctl window minimize "$id" on
+    if [ "$act" = select ]; then
+      agtermctl window select "$id"
+    else
+      agtermctl window minimize "$id" on
+    fi
   done
 }
 ```
 
-A minimized window still reports its `geometry`, so re-running the align step covers parked windows too.
+A minimized window still reports its `geometry`, so a script can record the frame it will come back to.
 The minimized state is live-only — re-run `show` after restarting agterm.
 
 ## Reload the keymap after editing it

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -621,8 +621,39 @@ agtermctl window resize "$w" --width 1200 --height 800
 agtermctl window move "$w" --x 100 --y 100 --display 0
 agtermctl window zoom "$w"                 # maximize-to-screen toggle (call again to restore)
 agtermctl window fullscreen "$w"           # native macOS full screen toggle (⌃⌘F / green button)
-agtermctl window select "$w"
+agtermctl window minimize "$w" on          # park it in the Dock (off restores, toggle flips)
+agtermctl window select "$w"               # raise it, un-minimizing if it was parked
 ```
+
+`window new` returns only once the window is really on screen, so the `window resize` above works on the
+first try — no polling needed between them.
+
+## Show one project at a time in a single spot
+
+One window per project, all on the SAME frame, with everything but the current one parked in the Dock.
+Switching then looks like switching a tab rather than managing five windows.
+
+```bash
+# align every window to the active one's frame, so raising one covers the others exactly
+set -- $(agtermctl window list --json | jq -r '.result.windows[] | select(.active) | .geometry
+  | "\(.x) \(.y) \(.width) \(.height) \(.display)"')
+agtermctl window list --json | jq -r '.result.windows[].id' | while read -r id; do
+  agtermctl window resize "$id" --width "$3" --height "$4"
+  agtermctl window move "$id" --x "$1" --y "$2" --display "$5"
+done
+
+# show exactly one project: raise it, park the rest
+show() {
+  agtermctl window list --json | jq -r --arg n "$1" '.result.windows[]
+    | "\(if .name == $n then "select" else "park" end) \(.id)"' |
+  while read -r act id; do
+    [ "$act" = select ] && agtermctl window select "$id" || agtermctl window minimize "$id" on
+  done
+}
+```
+
+A minimized window still reports its `geometry`, so re-running the align step covers parked windows too.
+The minimized state is live-only — re-run `show` after restarting agterm.
 
 ## Reload the keymap after editing it
 

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -617,6 +617,8 @@ process effect.
 agtermctl session go --to next            # step selection to the next session
 agtermctl session go --to next-attention  # jump to the next blocked/completed session
 w=$(agtermctl window new "scratch" --json | jq -r '.result.id')
+# or build one already parked, so it never flashes on screen or takes focus:
+# p=$(agtermctl window new "proj-b" --minimized --json | jq -r '.result.id')
 agtermctl window resize "$w" --width 1200 --height 800
 agtermctl window move "$w" --x 100 --y 100 --display 0
 agtermctl window zoom "$w"                 # maximize-to-screen toggle (call again to restore)
@@ -640,6 +642,11 @@ set -- $(agtermctl window list --json | jq -r '.result.windows[] | select(.activ
 agtermctl window list --json | jq -r '.result.windows[].id' | while read -r id; do
   agtermctl window resize "$id" --width "$3" --height "$4"
   agtermctl window move "$id" --x "$1" --y "$2" --display "$5"
+done
+
+# building the set from scratch: create every project window already parked, then show one
+for p in "Project A" "Project B" "Project C"; do
+  agtermctl window new "$p" --minimized >/dev/null
 done
 
 # show exactly one project: raise it, park the rest

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -667,8 +667,9 @@ show() {
 }
 ```
 
-A minimized window still reports its `geometry`, so a script can record the frame it will come back to.
-The minimized state is live-only — re-run `show` after restarting agterm.
+A minimized window still reports its `geometry`, and `window move`/`window resize` apply to it — a parked
+window comes back at whatever frame was written while it sat in the Dock, so re-running the align step
+covers parked windows too. The minimized state is live-only — re-run `show` after restarting agterm.
 
 ## Reload the keymap after editing it
 

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -491,9 +491,9 @@ shell (no controlling terminal — `/dev/tty` errors). See examples.md for usage
 
 - `window new [name] [--minimized]` — create and open a window; returns its id. It replies only once
   the on-screen window exists, so an immediate `window resize`/`move` on the returned id works.
-  `--minimized` creates it already parked in the Dock instead of presenting it, and leaves frontmost
-  on a window you can still see — for building a set of project windows without each one flashing up
-  and taking focus.
+  `--minimized` parks it in the Dock right after creating it, and leaves frontmost on a window you can
+  still see — for building a set of project windows and ending up on one you are looking at. The window
+  is presented briefly before it is parked, so expect it to appear and take focus on its way to the Dock.
 - `window list` — `result.windows`, each with `id`, `name`, `open`, `active`, `autoFollowMs` (the
   window's Auto-follow timeout in milliseconds, omitted when the setting is Disabled), and
   `sidebarVisible` (whether that window's sidebar is shown, read from the open window's store — omitted
@@ -534,7 +534,8 @@ shell (no controlling terminal — `/dev/tty` errors). See examples.md for usage
   address is always a hex UUID prefix or `active`, so `window minimize on` is understood as the active
   window. The window must be open, and a window in NATIVE FULL SCREEN is rejected
   (`cannot minimize a full-screen window — window.fullscreen it first`) because AppKit no-ops miniaturize
-  there. Restoring puts the window back on screen without raising it — use `window select` for that. This
+  there. Restoring puts the window back on screen without making it key — use `window select` to restore
+  and raise in one step. This
   is the control half of ⌘M, the yellow traffic-light button, and the Minimize title-bar double-click
   action. Read back as `minimized` on `window list`. The state is LIVE-ONLY: it is never persisted, so
   every window reopens un-minimized after a restart, and a Dock-icon click restores minimized windows.

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -489,7 +489,11 @@ shell (no controlling terminal — `/dev/tty` errors). See examples.md for usage
 
 ## window
 
-- `window new [name]` — create and open a window; returns its id.
+- `window new [name] [--minimized]` — create and open a window; returns its id. It replies only once
+  the on-screen window exists, so an immediate `window resize`/`move` on the returned id works.
+  `--minimized` creates it already parked in the Dock instead of presenting it, and leaves frontmost
+  on a window you can still see — for building a set of project windows without each one flashing up
+  and taking focus.
 - `window list` — `result.windows`, each with `id`, `name`, `open`, `active`, `autoFollowMs` (the
   window's Auto-follow timeout in milliseconds, omitted when the setting is Disabled), and
   `sidebarVisible` (whether that window's sidebar is shown, read from the open window's store — omitted

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -496,13 +496,15 @@ shell (no controlling terminal — `/dev/tty` errors). See examples.md for usage
   for a closed window with no live store), and `geometry` (the open window's live frame `{x, y, width,
   height, display}` in the SAME units `window move`/`window resize` take — `x`/`y` top-left relative to
   `display`, y down — omitted for a closed window; the read side of `window move`/`window resize`, so
-  record it, move/resize, then restore the exact frame), plus `fullscreen` and `zoomed` (whether the
-  window is in native full screen / zoomed-to-screen — the read side of `window fullscreen` / `window
-  zoom`, so a script can make those toggles idempotent; both omitted for a closed window). The
-  `geometry`/`fullscreen`/`zoomed` fields stay current — the cache is refreshed when a window
-  moves/resizes/zooms/enters or exits full screen, so a hand-drag or GUI toggle is reflected without needing
-  another command. (`autoFollowMs` still reflects the last cache refresh, since a settings change is rare;
-  and unlike `tree`, `window.list` does NOT carry `idleMs` — the live idle metric would freeze in the cache.)
+  record it, move/resize, then restore the exact frame), plus `fullscreen`, `zoomed` and `minimized`
+  (whether the window is in native full screen / zoomed-to-screen / minimized to the Dock — the read side
+  of `window fullscreen` / `window zoom` / `window minimize`, so a script can act idempotently; all omitted
+  for a closed window). A MINIMIZED window still reports its `geometry` — the frame it comes back to — so a
+  re-align script can include one. The `geometry`/`fullscreen`/`zoomed`/`minimized` fields stay current —
+  the cache is refreshed when a window moves/resizes/zooms/enters or exits full screen/minimizes or
+  restores, so a hand-drag or GUI toggle is reflected without needing another command. (`autoFollowMs`
+  still reflects the last cache refresh, since a settings change is rare; and unlike `tree`, `window.list`
+  does NOT carry `idleMs` — the live idle metric would freeze in the cache.)
 - `window select <id>` — raise it if open, else open it.
 - `window close <id>` — close the on-screen window (the bundle is kept; reopen with select).
 - `window rename <id> <name>`.
@@ -522,6 +524,16 @@ shell (no controlling terminal — `/dev/tty` errors). See examples.md for usage
   via `NSWindow.toggleFullScreen`. A second call exits. The window must be open. This is the control half
   of the View ▸ Toggle Full Screen menu item (⌃⌘F, rebindable as `toggle_fullscreen`) and the green
   traffic-light button — distinct from `zoom`, which only maximizes the frame in the same Space.
+- `window minimize <id> [on|off|toggle]` — minimize the window to the Dock, or restore it, via
+  `NSWindow.miniaturize`/`deminiaturize`. The mode resolves against the window's current state, so `on` and
+  `off` are idempotent and only `toggle` (the default) flips. Both positionals are optional and a window
+  address is always a hex UUID prefix or `active`, so `window minimize on` is understood as the active
+  window. The window must be open, and a window in NATIVE FULL SCREEN is rejected
+  (`cannot minimize a full-screen window — window.fullscreen it first`) because AppKit no-ops miniaturize
+  there. Restoring puts the window back on screen without raising it — use `window select` for that. This
+  is the control half of ⌘M, the yellow traffic-light button, and the Minimize title-bar double-click
+  action. Read back as `minimized` on `window list`. The state is LIVE-ONLY: it is never persisted, so
+  every window reopens un-minimized after a restart, and a Dock-icon click restores minimized windows.
 
 `window resize`/`move` are control-native (no GUI equivalent — the title bar already drags-to-resize).
 

--- a/agterm/Views/WindowAccessor.swift
+++ b/agterm/Views/WindowAccessor.swift
@@ -307,7 +307,14 @@ struct WindowAccessor: NSViewRepresentable {
             // present a window that isn't on screen yet (FB11763863: created minimized/background), then
             // latch off. Re-fronting on later ticks (or a momentary !isVisible during a re-render) would
             // fight a deliberate window.select and oscillate the key window, flapping the "active" flag.
-            guard !didPresentForUITests, window.isMiniaturized || !window.isVisible else { return }
+            guard !didPresentForUITests else { return }
+            // already on screen: it presented on its own, so latch NOW instead of leaving the remaining
+            // ticks armed. Staying armed is the same hazard the comment above warns about, one step later:
+            // a window parked by window.minimize within the schedule would be dragged back out of the Dock.
+            guard window.isMiniaturized || !window.isVisible else {
+                didPresentForUITests = true
+                return
+            }
             NSApp.unhide(nil)
             NSApp.activate()
             if window.isMiniaturized { window.deminiaturize(nil) }

--- a/agterm/WindowRegistry.swift
+++ b/agterm/WindowRegistry.swift
@@ -16,6 +16,7 @@ final class WindowRegistry {
 
     func register(_ id: WindowInfo.ID, window: NSWindow) {
         windows[id] = window
+        NotificationCenter.default.post(name: .agtermWindowAttachmentChanged, object: nil)
     }
 
     /// Whether an on-screen window is registered for `id` (i.e. its NSWindow has attached).
@@ -28,6 +29,7 @@ final class WindowRegistry {
 
     func unregister(_ id: WindowInfo.ID) {
         windows[id] = nil
+        NotificationCenter.default.post(name: .agtermWindowAttachmentChanged, object: nil)
     }
 
     func contains(_ window: NSWindow) -> Bool {
@@ -61,7 +63,7 @@ final class WindowRegistry {
     @discardableResult
     func resize(_ id: WindowInfo.ID, width: Int, height: Int) -> Bool {
         guard let window = windows[id] else { return false }
-        let maxSize = (window.screen ?? NSScreen.main)?.visibleFrame.size
+        let maxSize = resolvedScreen(for: window)?.visibleFrame.size
             ?? CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
         let size = WindowGeometry.clampSize(WindowGeometry.Size(CGSize(width: CGFloat(width), height: CGFloat(height))),
                                             min: WindowGeometry.Size(window.minSize),
@@ -87,7 +89,7 @@ final class WindowRegistry {
             guard display >= 0, display < screens.count else { return false }
             screen = screens[display]
         } else {
-            screen = window.screen ?? NSScreen.main
+            screen = resolvedScreen(for: window)
         }
         guard let screen else { return false }
         // (x, y) is the top-left relative to the screen's top-left (y down) → AppKit screen point (y up).
@@ -124,15 +126,61 @@ final class WindowRegistry {
         return true
     }
 
+    /// Whether the window for `id` is minimized to the Dock. False when none is registered. The settle-poll
+    /// predicate for `window.minimize`, which must wait out the animation before reporting.
+    func isMinimized(_ id: WindowInfo.ID) -> Bool { windows[id]?.isMiniaturized ?? false }
+
+    /// The outcome of a `minimize` request, so the caller can tell "not open" from "not minimizable".
+    enum MinimizeOutcome {
+        case applied(desired: Bool)
+        case notOpen
+        case fullScreen
+    }
+
+    /// Minimizes the on-screen window for `id` to the Dock, or restores it, driving the standard
+    /// `NSWindow.miniaturize`/`deminiaturize` — the same action as ⌘M, the yellow traffic-light button, and
+    /// the Minimize title-bar double-click action. The mode resolves against the window's CURRENT state, so
+    /// `on`/`off` are idempotent and only `toggle` flips. Restoring puts the window back on screen without
+    /// making it key; `window.select` (`raise`) is the raise-it-too path.
+    ///
+    /// A window in native full screen is rejected rather than silently ignored: AppKit no-ops
+    /// `miniaturize` there, so applying it would report success having done nothing.
+    func minimize(_ id: WindowInfo.ID, mode: ControlToggleMode) -> MinimizeOutcome {
+        guard let window = windows[id] else { return .notOpen }
+        let desired = mode.desiredValue(current: window.isMiniaturized)
+        guard window.isMiniaturized != desired else { return .applied(desired: desired) }
+        guard !window.styleMask.contains(.fullScreen) else { return .fullScreen }
+        if desired { window.miniaturize(nil) } else { window.deminiaturize(nil) }
+        return .applied(desired: desired)
+    }
+
+    /// The screen a window's frame belongs to. `NSWindow.screen` is nil whenever the window is off-screen —
+    /// notably while MINIMIZED to the Dock, and while the app is hidden — so fall back to the display its
+    /// frame overlaps most (`WindowGeometry.bestDisplayIndex`, the same resolution the frame-restore path
+    /// uses), then the main screen for a frame overlapping nothing (a disconnected display).
+    ///
+    /// Shared by `geometry`, `move`, and `resize` on purpose: a read resolved by overlap and a write
+    /// resolved against `NSScreen.main` would disagree on the display index, so a minimized window's
+    /// reported frame would stop round-tripping back through `window.move`.
+    private func resolvedScreen(for window: NSWindow) -> NSScreen? {
+        if let screen = window.screen { return screen }
+        let screens = NSScreen.screens
+        let frames = screens.map { WindowGeometry.Rect($0.frame) }
+        if let index = WindowGeometry.bestDisplayIndex(for: WindowGeometry.Rect(window.frame), among: frames) {
+            return screens[index]
+        }
+        return NSScreen.main ?? screens.first
+    }
+
     /// The window's current frame in the SAME coordinate system `move`/`resize` accept, so `window.list`'s
     /// read-back round-trips back through `window.move`/`window.resize`: `x`/`y` are the top-left relative to
     /// the window's display top-left (y down), `width`/`height` the frame size, `display` the screen index.
     /// This is the inverse of `move`'s forward math (`x = minX - screen.minX`, `y = screen.maxY - maxY`) to
     /// integer-point precision: the values round to `Int` since `window.move`/`window.resize` take `Int`, so a
     /// user-dragged fractional frame restores to the nearest point (which is all those commands accept).
-    /// Nil when no window is registered for `id` (closed) or it has no screen. The `window.list` frame source.
+    /// Nil when no window is registered for `id` (closed). The `window.list` frame source.
     func geometry(for id: WindowInfo.ID) -> ControlWindowFrame? {
-        guard let window = windows[id], let screen = window.screen else { return nil }
+        guard let window = windows[id], let screen = resolvedScreen(for: window) else { return nil }
         let frame = window.frame
         let x = Int((frame.minX - screen.frame.minX).rounded())
         let y = Int((screen.frame.maxY - frame.maxY).rounded())
@@ -142,12 +190,14 @@ final class WindowRegistry {
                                   display: display)
     }
 
-    /// Whether the window for `id` is in native full screen and/or zoomed (maximized-to-screen, NOT full
-    /// screen), or nil when no window is registered (closed). The read side of `window.fullscreen`/`window.zoom`
-    /// on `window.list`, so a script can make those toggles idempotent.
-    func windowFlags(for id: WindowInfo.ID) -> (fullscreen: Bool, zoomed: Bool)? {
+    /// Whether the window for `id` is in native full screen, zoomed (maximized-to-screen, NOT full screen),
+    /// and/or minimized to the Dock, or nil when no window is registered (closed). The read side of
+    /// `window.fullscreen`/`window.zoom`/`window.minimize` on `window.list`, so a script can make those
+    /// toggles idempotent.
+    func windowFlags(for id: WindowInfo.ID) -> (fullscreen: Bool, zoomed: Bool, minimized: Bool)? {
         guard let window = windows[id] else { return nil }
-        return (fullscreen: window.styleMask.contains(.fullScreen), zoomed: window.isZoomed)
+        return (fullscreen: window.styleMask.contains(.fullScreen), zoomed: window.isZoomed,
+                minimized: window.isMiniaturized)
     }
 }
 

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -67,7 +67,7 @@ public protocol ControlActions {
     func setSessionBackground(_ target: String?, window: String?,
                               options: ControlSessionBackgroundOptions) -> ControlResponse
     func readSessionText(_ target: String?, window: String?, options: ControlSessionTextOptions) -> ControlResponse
-    func windowNew(name: String?) -> ControlResponse
+    func windowNew(name: String?) async -> ControlResponse
     func windowList() -> ControlResponse
     func windowSelect(_ target: String?) async -> ControlResponse
     func windowClose(_ target: String?) async -> ControlResponse
@@ -77,6 +77,7 @@ public protocol ControlActions {
     func windowMove(_ target: String?, x: Int, y: Int, display: Int?) -> ControlResponse
     func windowZoom(_ target: String?) -> ControlResponse
     func windowFullscreen(_ target: String?) -> ControlResponse
+    func windowMinimize(_ target: String?, mode: ControlToggleMode) async -> ControlResponse
     func clearRestoreCommands() -> ControlResponse
 }
 
@@ -165,7 +166,7 @@ public struct ControlDispatcher {
         case .quickType, .quickText:
             return await dispatchQuickCommand(request)
         case .windowNew, .windowList, .windowSelect, .windowClose, .windowRename,
-                .windowDelete, .windowResize, .windowMove, .windowZoom, .windowFullscreen:
+                .windowDelete, .windowResize, .windowMove, .windowZoom, .windowFullscreen, .windowMinimize:
             return await dispatchWindowCommand(request)
         case .dashboard:
             return dispatchDashboard(request)
@@ -688,7 +689,7 @@ public struct ControlDispatcher {
     private func dispatchWindowCommand(_ request: ControlRequest) async -> ControlResponse {
         switch request.cmd {
         case .windowNew:
-            return actions.windowNew(name: request.args?.name)
+            return await actions.windowNew(name: request.args?.name)
         case .windowList:
             return actions.windowList()
         case .windowSelect:
@@ -717,6 +718,11 @@ public struct ControlDispatcher {
             return actions.windowZoom(request.target)
         case .windowFullscreen:
             return actions.windowFullscreen(request.target)
+        case .windowMinimize:
+            guard let mode = ControlToggleMode.parse(request.args?.mode) else {
+                return ControlResponse(ok: false, error: "invalid window minimize mode: \(request.args?.mode ?? "toggle")")
+            }
+            return await actions.windowMinimize(request.target, mode: mode)
         default:
             preconditionFailure("unexpected window command: \(request.cmd.rawValue)")
         }

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -67,7 +67,7 @@ public protocol ControlActions {
     func setSessionBackground(_ target: String?, window: String?,
                               options: ControlSessionBackgroundOptions) -> ControlResponse
     func readSessionText(_ target: String?, window: String?, options: ControlSessionTextOptions) -> ControlResponse
-    func windowNew(name: String?) async -> ControlResponse
+    func windowNew(name: String?, minimized: Bool) async -> ControlResponse
     func windowList() -> ControlResponse
     func windowSelect(_ target: String?) async -> ControlResponse
     func windowClose(_ target: String?) async -> ControlResponse
@@ -689,7 +689,7 @@ public struct ControlDispatcher {
     private func dispatchWindowCommand(_ request: ControlRequest) async -> ControlResponse {
         switch request.cmd {
         case .windowNew:
-            return await actions.windowNew(name: request.args?.name)
+            return await actions.windowNew(name: request.args?.name, minimized: request.args?.minimized ?? false)
         case .windowList:
             return actions.windowList()
         case .windowSelect:

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -64,6 +64,7 @@ public enum Command: String, Codable, Sendable {
     case windowMove = "window.move"
     case windowZoom = "window.zoom"
     case windowFullscreen = "window.fullscreen"
+    case windowMinimize = "window.minimize"
     case keymapReload = "keymap.reload"
     case configReload = "config.reload"
     case themeSet = "theme.set"
@@ -116,7 +117,8 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     /// Mode for `session.split` / `quick` / `surface.zoom` (`on|off|toggle`,
     /// `show|hide|toggle` for quick/surface zoom),
     /// `session.flag` (`on|off|toggle|clear`), `sidebar.mode` (`tree|flagged|toggle`),
-    /// `workspace.focus` (`on|off|toggle`), `session.background` (`image|text|color|clear`), and
+    /// `workspace.focus` (`on|off|toggle`), `window.minimize` (`on|off|toggle`),
+    /// `session.background` (`image|text|color|clear`), and
     /// `session.restore` (`set|none|clear` — pin `command`, pin nothing, or drop the pin).
     public var mode: String?
     /// The image file path for `session.background` mode `image` (PNG or JPEG).
@@ -652,10 +654,16 @@ public struct ControlWindowNode: Codable, Sendable, Equatable {
     /// Whether the window is zoomed (maximized-to-screen, NOT full screen), or nil for a CLOSED window
     /// (omitted from the JSON). The read side of the write-only `window.zoom` toggle. Read live app-side.
     public let zoomed: Bool?
+    /// Whether the window is minimized to the Dock, or nil for a CLOSED window (omitted from the JSON).
+    /// The read side of `window.minimize`, so a script can skip a redundant minimize or restore the set
+    /// of windows it put away. Read live app-side; like `geometry` it rides the cache, refreshed on the
+    /// NSWindow miniaturize/deminiaturize notifications so ⌘M or a Dock click is reflected too. A
+    /// minimized window still reports its `geometry` (the frame it will come back to).
+    public let minimized: Bool?
 
     public init(id: String, name: String, open: Bool, active: Bool, autoFollowMs: Int? = nil,
                 sidebarVisible: Bool? = nil, geometry: ControlWindowFrame? = nil,
-                fullscreen: Bool? = nil, zoomed: Bool? = nil) {
+                fullscreen: Bool? = nil, zoomed: Bool? = nil, minimized: Bool? = nil) {
         self.id = id
         self.name = name
         self.open = open
@@ -665,6 +673,7 @@ public struct ControlWindowNode: Codable, Sendable, Equatable {
         self.geometry = geometry
         self.fullscreen = fullscreen
         self.zoomed = zoomed
+        self.minimized = minimized
     }
 }
 

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -105,6 +105,12 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     /// `session.new --no-select` without it opening. Omitted/`false` = expanded. The read-back is the
     /// `tree` workspace node's `collapsed` field.
     public var collapsed: Bool?
+    /// For `window.new`: create the window already MINIMIZED to the Dock (the CLI's `--minimized`) instead
+    /// of presenting it, so a script can build a set of project windows without each one flashing on screen
+    /// and stealing focus. Omitted/`false` presents it as usual. The read-back is the `window.list` node's
+    /// `minimized` field; the new window also hands frontmost back to a still-visible window, so untargeted
+    /// commands do not route into the Dock.
+    public var minimized: Bool?
     /// For `session.new`: create the session in the background without selecting or focusing it, leaving
     /// the current selection untouched (the CLI's `--no-select`). Omitted/`false` keeps the default
     /// select-and-focus behavior. The read-back is the existing `tree` `active` flag — the new node is not
@@ -256,7 +262,8 @@ public struct ControlArgs: Codable, Sendable, Equatable {
 
     public init(name: String? = nil, cwd: String? = nil, targets: [String]? = nil,
                 workspace: String? = nil, workspaceName: String? = nil,
-                createWorkspace: Bool? = nil, collapsed: Bool? = nil, noSelect: Bool? = nil,
+                createWorkspace: Bool? = nil, collapsed: Bool? = nil, minimized: Bool? = nil,
+                noSelect: Bool? = nil,
                 text: String? = nil, select: Bool? = nil, mode: String? = nil,
                 command: String? = nil, wait: Bool? = nil, sizePercent: Int? = nil, full: Bool? = nil,
                 follow: Bool? = nil, window: String? = nil,
@@ -279,6 +286,7 @@ public struct ControlArgs: Codable, Sendable, Equatable {
         self.workspaceName = workspaceName
         self.createWorkspace = createWorkspace
         self.collapsed = collapsed
+        self.minimized = minimized
         self.noSelect = noSelect
         self.text = text
         self.select = select

--- a/agtermCore/Sources/agtermCore/WindowLibrary.swift
+++ b/agtermCore/Sources/agtermCore/WindowLibrary.swift
@@ -191,19 +191,20 @@ public final class WindowLibrary {
     /// handles live in `WindowRegistry`, not this host-free model), defaulting to nil so unit tests and any
     /// non-AppKit caller get a geometry-free list.
     public func controlWindowNodes(geometry: (WindowInfo.ID) -> ControlWindowFrame? = { _ in nil },
-                                   flags: (WindowInfo.ID) -> (fullscreen: Bool, zoomed: Bool)? = { _ in nil })
+                                   flags: (WindowInfo.ID) -> (fullscreen: Bool, zoomed: Bool, minimized: Bool)? = { _ in nil })
         -> [ControlWindowNode] {
         let active = activeWindowID
         return windows.map {
             // reach each open store for its auto-follow timeout + sidebar visibility (per-window state); a
-            // closed window has no store and reports nil for both. The frame + fullscreen/zoom flags come
-            // from the app-side closures (nil for a closed window with no NSWindow).
+            // closed window has no store and reports nil for both. The frame + fullscreen/zoom/minimized
+            // flags come from the app-side closures (nil for a closed window with no NSWindow).
             let live = flags($0.id)
             return ControlWindowNode(id: $0.id.uuidString, name: $0.name, open: isOpen($0.id), active: $0.id == active,
                                      autoFollowMs: stores[$0.id]?.autoFollowMs,
                                      sidebarVisible: stores[$0.id]?.sidebarVisible,
                                      geometry: geometry($0.id),
-                                     fullscreen: live?.fullscreen, zoomed: live?.zoomed)
+                                     fullscreen: live?.fullscreen, zoomed: live?.zoomed,
+                                     minimized: live?.minimized)
         }
     }
 

--- a/agtermCore/Sources/agtermctlKit/WindowCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/WindowCommands.swift
@@ -13,7 +13,8 @@ struct Window: ParsableCommand {
     struct New: RequestCommand {
         static let configuration = CommandConfiguration(abstract: "Create and open a window.")
         @Argument(help: "Window name (defaults to the auto-generated name).") var name: String?
-        @Flag(name: .long, help: "Create it minimized to the Dock instead of presenting it.") var minimized = false
+        @Flag(name: .long, help: "Park it in the Dock once created, leaving frontmost on a visible window.")
+        var minimized = false
         @OptionGroup var options: BasicOptions
         var echoesResultID: Bool { true }
 

--- a/agtermCore/Sources/agtermctlKit/WindowCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/WindowCommands.swift
@@ -13,11 +13,12 @@ struct Window: ParsableCommand {
     struct New: RequestCommand {
         static let configuration = CommandConfiguration(abstract: "Create and open a window.")
         @Argument(help: "Window name (defaults to the auto-generated name).") var name: String?
+        @Flag(name: .long, help: "Create it minimized to the Dock instead of presenting it.") var minimized = false
         @OptionGroup var options: BasicOptions
         var echoesResultID: Bool { true }
 
         func makeRequest() throws -> ControlRequest {
-            ControlRequest(cmd: .windowNew, args: ControlArgs(name: name))
+            ControlRequest(cmd: .windowNew, args: ControlArgs(name: name, minimized: minimized ? true : nil))
         }
     }
 

--- a/agtermCore/Sources/agtermctlKit/WindowCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/WindowCommands.swift
@@ -7,7 +7,7 @@ struct Window: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Window commands.",
         subcommands: [New.self, List.self, Select.self, Close.self, Rename.self, Delete.self, Resize.self, Move.self,
-                      Zoom.self, Fullscreen.self]
+                      Zoom.self, Fullscreen.self, Minimize.self]
     )
 
     struct New: RequestCommand {
@@ -102,5 +102,24 @@ struct Window: ParsableCommand {
         @OptionGroup var options: BasicOptions
 
         func makeRequest() throws -> ControlRequest { ControlRequest(cmd: .windowFullscreen, target: id) }
+    }
+
+    struct Minimize: RequestCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Minimize a window to the Dock, or restore it."
+        )
+        @Argument(help: "Window id, unique prefix, or 'active'.") var id: String = "active"
+        @Argument(help: "on, off, or toggle (default: toggle).") var mode: String?
+        @OptionGroup var options: BasicOptions
+
+        func makeRequest() throws -> ControlRequest {
+            // both positionals are optional, so a bare `window minimize on` binds the mode word to `id`.
+            // A window address is a UUID prefix (hex only) or `active`, so it can never be a mode word —
+            // recovering the intent here is unambiguous and keeps the id optional for the common case.
+            if mode == nil, ControlToggleMode.parse(id) != nil {
+                return ControlRequest(cmd: .windowMinimize, target: "active", args: ControlArgs(mode: id))
+            }
+            return ControlRequest(cmd: .windowMinimize, target: id, args: ControlArgs(mode: mode ?? "toggle"))
+        }
     }
 }

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -1814,18 +1814,24 @@ struct ControlDispatcherTests {
             cmd: .windowNew,
             args: ControlArgs(name: "Build")
         ))
+        let parked = await dispatcher.dispatch(ControlRequest(
+            cmd: .windowNew,
+            args: ControlArgs(name: "Parked", minimized: true)
+        ))
         let listed = await dispatcher.dispatch(ControlRequest(cmd: .windowList))
         let selected = await dispatcher.dispatch(ControlRequest(cmd: .windowSelect, target: "win-b"))
         let closed = await dispatcher.dispatch(ControlRequest(cmd: .windowClose, target: "win-b"))
         let deleted = await dispatcher.dispatch(ControlRequest(cmd: .windowDelete, target: "win-b"))
 
         #expect(created == ControlResponse(ok: true, result: ControlResult(id: "win-b")))
+        #expect(parked == ControlResponse(ok: true, result: ControlResult(id: "win-b")))
         #expect(listed == ControlResponse(ok: true, result: ControlResult(windows: windows)))
         #expect(selected == ControlResponse(ok: true, result: ControlResult(id: "win-b")))
         #expect(closed == ControlResponse(ok: true, result: ControlResult(id: "win-b")))
         #expect(deleted == ControlResponse(ok: false, error: "cannot delete last window"))
         #expect(actions.calls == [
-            .windowNew("Build"),
+            .windowNew("Build", minimized: false),
+            .windowNew("Parked", minimized: true),
             .windowList,
             .windowSelect(target: "win-b"),
             .windowClose(target: "win-b"),

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -1859,18 +1859,30 @@ struct ControlDispatcherTests {
         let zoomed = await dispatcher.dispatch(ControlRequest(cmd: .windowZoom, target: "9f3c"))
         actions.nextWindowFullscreenResponse = ControlResponse(ok: true, result: ControlResult(id: "win"))
         let fullscreen = await dispatcher.dispatch(ControlRequest(cmd: .windowFullscreen, target: "9f3c"))
+        actions.nextWindowMinimizeResponse = ControlResponse(ok: true, result: ControlResult(id: "win"))
+        let minimized = await dispatcher.dispatch(ControlRequest(
+            cmd: .windowMinimize,
+            target: "9f3c",
+            args: ControlArgs(mode: "on")
+        ))
+        // an omitted mode is the toggle default, matching the other mode-bearing commands
+        let toggled = await dispatcher.dispatch(ControlRequest(cmd: .windowMinimize, target: "9f3c"))
 
         #expect(renamed == ControlResponse(ok: true, result: ControlResult(id: "win")))
         #expect(resized == ControlResponse(ok: true, result: ControlResult(id: "win")))
         #expect(moved == ControlResponse(ok: true, result: ControlResult(id: "win")))
         #expect(zoomed == ControlResponse(ok: false, error: "window not open — window.select it first"))
         #expect(fullscreen == ControlResponse(ok: true, result: ControlResult(id: "win")))
+        #expect(minimized == ControlResponse(ok: true, result: ControlResult(id: "win")))
+        #expect(toggled == ControlResponse(ok: true, result: ControlResult(id: "win")))
         #expect(actions.calls == [
             .windowRename(target: "9f3c", "Renamed"),
             .windowResize(target: "9f3c", width: 1200, height: 800),
             .windowMove(target: "9f3c", x: 100, y: 50, display: 1),
             .windowZoom(target: "9f3c"),
-            .windowFullscreen(target: "9f3c")
+            .windowFullscreen(target: "9f3c"),
+            .windowMinimize(target: "9f3c", mode: .on),
+            .windowMinimize(target: "9f3c", mode: .toggle)
         ])
     }
 
@@ -1899,12 +1911,18 @@ struct ControlDispatcherTests {
             target: "win",
             args: ControlArgs(x: 100)
         ))
+        let badMinimizeMode = await dispatcher.dispatch(ControlRequest(
+            cmd: .windowMinimize,
+            target: "win",
+            args: ControlArgs(mode: "hide")
+        ))
 
         #expect(missingName == ControlResponse(ok: false, error: "window.rename requires a name"))
         #expect(blankName == ControlResponse(ok: false, error: "window.rename requires a name"))
         #expect(missingResize == ControlResponse(ok: false, error: "window.resize requires positive width and height"))
         #expect(badResize == ControlResponse(ok: false, error: "window.resize requires positive width and height"))
         #expect(missingMoveY == ControlResponse(ok: false, error: "window.move requires x and y"))
+        #expect(badMinimizeMode == ControlResponse(ok: false, error: "invalid window minimize mode: hide"))
         #expect(actions.calls.isEmpty)
     }
 

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -851,6 +851,28 @@ struct ControlProtocolTests {
         #expect(decoded.zoomed == nil)
     }
 
+    @Test func windowNodeRoundTripsWithMinimized() throws {
+        // the read side of window.minimize, so a script can skip a redundant minimize and restore the set of
+        // windows it put away. A minimized window still reports the frame it comes back to.
+        let frame = ControlWindowFrame(x: 100, y: 50, width: 900, height: 600, display: 0)
+        let node = ControlWindowNode(id: "w1", name: "work", open: true, active: false,
+                                     geometry: frame, minimized: true)
+        let response = ControlResponse(ok: true, result: ControlResult(windows: [node]))
+        let decoded = try roundTrip(response)
+        #expect(decoded == response)
+        #expect(decoded.result?.windows?.first?.minimized == true)
+        #expect(decoded.result?.windows?.first?.geometry == frame)
+    }
+
+    @Test func windowNodeOmitsMinimizedWhenNil() throws {
+        // a closed window with no live NSWindow — the key must be omitted, not emitted as null.
+        let node = ControlWindowNode(id: "w1", name: "work", open: false, active: false)
+        let json = String(data: try JSONEncoder().encode(node), encoding: .utf8) ?? ""
+        #expect(!json.contains("minimized"), "a nil minimized must be omitted from the JSON; got \(json)")
+        let decoded = try JSONDecoder().decode(ControlWindowNode.self, from: Data(json.utf8))
+        #expect(decoded.minimized == nil)
+    }
+
     @Test func workspaceNodeRoundTripsWithFocused() throws {
         // the read side of workspace.focus: the sidebar-focused workspace is flagged so a script can record
         // which one is focused and restore it (distinct from `active`, the selected workspace).
@@ -1193,6 +1215,8 @@ struct ControlProtocolTests {
             ControlRequest(cmd: .windowDelete, target: "9f3c"),
             ControlRequest(cmd: .windowZoom, target: "9f3c"),
             ControlRequest(cmd: .windowFullscreen, target: "9f3c"),
+            ControlRequest(cmd: .windowMinimize, target: "9f3c", args: ControlArgs(mode: "on")),
+            ControlRequest(cmd: .windowMinimize, target: "active"),
         ]
         for request in cases {
             #expect(try roundTrip(request) == request)

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -1208,6 +1208,7 @@ struct ControlProtocolTests {
     @Test func windowCommandsRoundTrip() throws {
         let cases: [ControlRequest] = [
             ControlRequest(cmd: .windowNew, args: ControlArgs(name: "work")),
+            ControlRequest(cmd: .windowNew, args: ControlArgs(name: "parked", minimized: true)),
             ControlRequest(cmd: .windowList),
             ControlRequest(cmd: .windowSelect, target: "9f3c"),
             ControlRequest(cmd: .windowClose, target: "9f3c"),

--- a/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
+++ b/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
@@ -72,6 +72,7 @@ final class MockControlActions: ControlActions {
         case windowMove(target: String?, x: Int, y: Int, display: Int?)
         case windowZoom(target: String?)
         case windowFullscreen(target: String?)
+        case windowMinimize(target: String?, mode: ControlToggleMode)
         case restoreClear
     }
 
@@ -116,6 +117,7 @@ final class MockControlActions: ControlActions {
     var nextWindowMoveResponse = ControlResponse(ok: true)
     var nextWindowZoomResponse = ControlResponse(ok: true)
     var nextWindowFullscreenResponse = ControlResponse(ok: true)
+    var nextWindowMinimizeResponse = ControlResponse(ok: true)
     var nextRestoreClearResponse = ControlResponse(ok: true)
     var nextSessionRestoreResponse = ControlResponse(ok: true)
 
@@ -393,7 +395,7 @@ final class MockControlActions: ControlActions {
         return nextSessionTextResponse
     }
 
-    func windowNew(name: String?) -> ControlResponse {
+    func windowNew(name: String?) async -> ControlResponse {
         calls.append(.windowNew(name))
         return nextWindowNewResponse
     }
@@ -441,6 +443,11 @@ final class MockControlActions: ControlActions {
     func windowFullscreen(_ target: String?) -> ControlResponse {
         calls.append(.windowFullscreen(target: target))
         return nextWindowFullscreenResponse
+    }
+
+    func windowMinimize(_ target: String?, mode: ControlToggleMode) async -> ControlResponse {
+        calls.append(.windowMinimize(target: target, mode: mode))
+        return nextWindowMinimizeResponse
     }
 
     func clearRestoreCommands() -> ControlResponse {

--- a/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
+++ b/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
@@ -62,7 +62,7 @@ final class MockControlActions: ControlActions {
         case overlayResult(target: String?, window: String?)
         case sessionBackground(target: String?, window: String?, ControlSessionBackgroundOptions)
         case sessionText(target: String?, window: String?, ControlSessionTextOptions)
-        case windowNew(String?)
+        case windowNew(String?, minimized: Bool)
         case windowList
         case windowSelect(target: String?)
         case windowClose(target: String?)
@@ -395,8 +395,8 @@ final class MockControlActions: ControlActions {
         return nextSessionTextResponse
     }
 
-    func windowNew(name: String?) async -> ControlResponse {
-        calls.append(.windowNew(name))
+    func windowNew(name: String?, minimized: Bool) async -> ControlResponse {
+        calls.append(.windowNew(name, minimized: minimized))
         return nextWindowNewResponse
     }
 

--- a/agtermCore/Tests/agtermCoreTests/SkillInstallTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SkillInstallTests.swift
@@ -14,11 +14,15 @@ struct SkillInstallTests {
         let reference = try String(contentsOf: skillDirectory.appendingPathComponent("reference.md"), encoding: .utf8)
         let examples = try String(contentsOf: skillDirectory.appendingPathComponent("examples.md"), encoding: .utf8)
 
-        #expect(skill.contains("Command summary (65 commands)"))
+        #expect(skill.contains("Command summary (66 commands)"))
         #expect(skill.contains("**events**"))
         #expect(reference.contains("## events"))
         #expect(reference.contains("event cursor expired"))
         #expect(examples.contains("agtermctl events --json"))
+        // the window-minimize mirror: summary line, per-command detail, and a recipe
+        #expect(skill.contains("minimize <id> [on|off|toggle]"))
+        #expect(reference.contains("`window minimize <id> [on|off|toggle]`"))
+        #expect(examples.contains("agtermctl window minimize"))
     }
 
     @Test func skillDirectoryComposesUnderAgentBase() {

--- a/agtermCore/Tests/agtermCoreTests/WindowLibraryTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/WindowLibraryTests.swift
@@ -371,15 +371,21 @@ final class WindowLibraryTests {
         let library = WindowLibrary(directory: directory)
         let first = library.windows[0]
         let second = library.newWindow(name: "work")
-        // the app-side flags closure supplies each window's live fullscreen/zoom state.
-        let nodes = library.controlWindowNodes(flags: { $0 == second.id ? (fullscreen: true, zoomed: false) : nil })
+        // the app-side flags closure supplies each window's live fullscreen/zoom/minimized state.
+        let nodes = library.controlWindowNodes(flags: {
+            $0 == second.id ? (fullscreen: true, zoomed: false, minimized: true) : nil
+        })
         #expect(nodes[0].id == first.id.uuidString)
         #expect(nodes[0].fullscreen == nil) // no flags supplied for the first window
         #expect(nodes[0].zoomed == nil)
+        #expect(nodes[0].minimized == nil)
         #expect(nodes[1].fullscreen == true) // the closure's flags ride the second node
         #expect(nodes[1].zoomed == false)
-        // the default (no closure) omits both — the host-free / non-AppKit path.
-        #expect(library.controlWindowNodes().allSatisfy { $0.fullscreen == nil && $0.zoomed == nil })
+        #expect(nodes[1].minimized == true)
+        // the default (no closure) omits all three — the host-free / non-AppKit path.
+        #expect(library.controlWindowNodes().allSatisfy {
+            $0.fullscreen == nil && $0.zoomed == nil && $0.minimized == nil
+        })
     }
 
     @Test func controlWindowNodesUseActiveWindowFallback() {

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -1157,6 +1157,30 @@ struct CommandsTests {
         #expect(try request(["window", "fullscreen"]) == ControlRequest(cmd: .windowFullscreen, target: "active"))
     }
 
+    @Test func windowMinimize() throws {
+        #expect(try request(["window", "minimize", "9f3c", "on"])
+            == ControlRequest(cmd: .windowMinimize, target: "9f3c", args: ControlArgs(mode: "on")))
+        #expect(try request(["window", "minimize", "9f3c", "off"])
+            == ControlRequest(cmd: .windowMinimize, target: "9f3c", args: ControlArgs(mode: "off")))
+    }
+
+    @Test func windowMinimizeDefaultsActiveAndToggle() throws {
+        #expect(try request(["window", "minimize"])
+            == ControlRequest(cmd: .windowMinimize, target: "active", args: ControlArgs(mode: "toggle")))
+    }
+
+    @Test func windowMinimizeBareModeTargetsActive() throws {
+        // both positionals are optional, so a bare mode word would otherwise bind to the id. A window
+        // address is a hex UUID prefix or `active`, never a mode word, so the recovery can't misfire.
+        #expect(try request(["window", "minimize", "on"])
+            == ControlRequest(cmd: .windowMinimize, target: "active", args: ControlArgs(mode: "on")))
+        #expect(try request(["window", "minimize", "toggle"])
+            == ControlRequest(cmd: .windowMinimize, target: "active", args: ControlArgs(mode: "toggle")))
+        // an id that merely looks like a mode word is still an id (hex `0ff`, not the word `off`)
+        #expect(try request(["window", "minimize", "0ff"])
+            == ControlRequest(cmd: .windowMinimize, target: "0ff", args: ControlArgs(mode: "toggle")))
+    }
+
     @Test func windowDeleteDefaultsActive() throws {
         #expect(try request(["window", "delete"]) == ControlRequest(cmd: .windowDelete, target: "active"))
     }

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -1100,6 +1100,14 @@ struct CommandsTests {
         #expect(try request(["window", "new"]) == ControlRequest(cmd: .windowNew, args: ControlArgs(name: nil)))
     }
 
+    @Test func windowNewMinimized() throws {
+        #expect(try request(["window", "new", "Work", "--minimized"])
+            == ControlRequest(cmd: .windowNew, args: ControlArgs(name: "Work", minimized: true)))
+        // omitted rather than false, so an un-flagged create stays byte-identical on the wire
+        #expect(try request(["window", "new", "Work"])
+            == ControlRequest(cmd: .windowNew, args: ControlArgs(name: "Work", minimized: nil)))
+    }
+
     @Test func windowList() throws {
         #expect(try request(["window", "list"]) == ControlRequest(cmd: .windowList))
     }

--- a/agtermUITests/ControlWindowUITests.swift
+++ b/agtermUITests/ControlWindowUITests.swift
@@ -163,6 +163,100 @@ final class ControlWindowUITests: ControlAPITestCase {
                        "window should restore toward \(normal) after exiting full screen, got \(window.frame.size)")
     }
 
+    // window.minimize puts the window in the Dock and brings it back, with `minimized` reading back on
+    // window.list. Everything is asserted through the control channel: a miniaturized window is off-screen,
+    // so any XCUIElement query against it hangs on event synthesis rather than failing. The restore rides
+    // `addTeardownBlock` (registered BEFORE the minimize) because `continueAfterFailure = false` unwinds
+    // through an ObjC exception that skips a Swift `defer`, which would leave the runner's screen with a
+    // Dock-parked window. It drives the LAUNCH window on purpose — a freshly created one is still inside
+    // `WindowAccessor`'s ~0.95s UI-test bring-forward schedule, which would deminiaturize it mid-test.
+    func testWindowMinimizeAndRestore() throws {
+        XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session")
+        let id = try XCTUnwrap(try windowList().first?["id"] as? String, "the seeded window should have an id")
+        let before = try XCTUnwrap(try windowList().first?["geometry"] as? [String: Any],
+                                   "an open window should report its geometry")
+
+        addTeardownBlock { _ = try? self.sendCommand(#"{"cmd":"window.minimize","args":{"mode":"off"}}"#) }
+
+        XCTAssertEqual(try sendCommand(#"{"cmd":"window.minimize","args":{"mode":"on"}}"#)["ok"] as? Bool, true)
+        XCTAssertTrue(pollWindowList(timeout: 10) { $0.first?["minimized"] as? Bool == true },
+                      "window.list should report minimized:true after window.minimize on")
+
+        // the payoff for a re-align script: a minimized window keeps reporting the frame it comes back to.
+        // NSWindow.screen is nil while miniaturized, so this fails without the overlap-based screen fallback.
+        let whileMinimized = try XCTUnwrap(try windowList().first?["geometry"] as? [String: Any],
+                                           "a minimized window must still report its geometry")
+        for key in ["x", "y", "width", "height", "display"] {
+            XCTAssertEqual(whileMinimized[key] as? Int, before[key] as? Int,
+                           "\(key) should survive minimizing: before=\(before) now=\(whileMinimized)")
+        }
+
+        // `on` again is a no-op, not a flip — the mode resolves against current state.
+        XCTAssertEqual(try sendCommand(#"{"cmd":"window.minimize","args":{"mode":"on"}}"#)["ok"] as? Bool, true)
+        XCTAssertEqual(try windowList().first?["minimized"] as? Bool, true, "a repeated `on` must stay minimized")
+
+        // window.select restores it too — `WindowRegistry.raise` deminiaturizes before making key, which is
+        // also what pulls a minimized window forward on a notification-banner reveal.
+        XCTAssertEqual(try sendCommand(#"{"cmd":"window.select","target":"\#(id)"}"#)["ok"] as? Bool, true)
+        XCTAssertTrue(pollWindowList(timeout: 10) { $0.first?["minimized"] as? Bool == false },
+                      "window.select should un-minimize the window it raises")
+
+        // and the explicit restore is idempotent from there.
+        XCTAssertEqual(try sendCommand(#"{"cmd":"window.minimize","target":"\#(id)","args":{"mode":"off"}}"#)["ok"] as? Bool,
+                       true)
+        XCTAssertEqual(try windowList().first?["minimized"] as? Bool, false)
+        // only now is the window back on screen, so element queries are safe again.
+        XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 10),
+                      "the restored window should be interactive again")
+    }
+
+    // AppKit's own Window ▸ Minimize (⌘M) mutates the state with no control command in play, so the
+    // read-back only stays honest because `ControlServer` observes NSWindow.didMiniaturize. This drives the
+    // menu item — the GUI half — and asserts the flag flips, which is the regression guard for those
+    // observers. The menu click happens while the window is still on screen, so no element query touches a
+    // miniaturized window; the teardown block restores it whatever happens.
+    func testMenuMinimizeReadsBackOverControl() throws {
+        XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session")
+        XCTAssertEqual(try windowList().first?["minimized"] as? Bool, false, "should start un-minimized")
+
+        addTeardownBlock { _ = try? self.sendCommand(#"{"cmd":"window.minimize","args":{"mode":"off"}}"#) }
+
+        app.menuBars.menuBarItems["Window"].click()
+        app.menuBars.menuItems["Minimize"].click()
+        XCTAssertTrue(pollWindowList(timeout: 10) { $0.first?["minimized"] as? Bool == true },
+                      "a ⌘M minimize must reach window.list's minimized flag")
+
+        XCTAssertEqual(try sendCommand(#"{"cmd":"window.minimize","args":{"mode":"off"}}"#)["ok"] as? Bool, true)
+        XCTAssertTrue(pollWindowList(timeout: 10) { $0.first?["minimized"] as? Bool == false },
+                      "window.minimize off should restore it")
+        XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 10),
+                      "the restored window should be interactive again")
+    }
+
+    // window.new must not reply until its NSWindow has attached: the store loads synchronously (so the
+    // library reports open:true at once) while the NSWindow lands two SwiftUI render passes later. Before
+    // the attach poll, an immediate window.resize on the returned id failed with "window not open", and the
+    // node cached right after window.new carried no geometry — with nothing on that path refreshing it
+    // afterwards, so window.list reported a geometry-less window indefinitely.
+    func testWindowNewIsUsableImmediately() throws {
+        XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session")
+        let created = try sendCommand(#"{"cmd":"window.new","args":{"name":"immediate"}}"#)
+        XCTAssertEqual(created["ok"] as? Bool, true, "window.new should succeed: \(created)")
+        let result = try XCTUnwrap(created["result"] as? [String: Any], "window.new should carry a result")
+        let newID = try XCTUnwrap(result["id"] as? String, "window.new should return the new id")
+
+        // no polling and no intervening command: window.list is fast-path-served from the cache, so a node
+        // built before the attach would still be missing geometry here.
+        let list = try windowList()
+        let made = try XCTUnwrap(list.first { ($0["id"] as? String)?.lowercased() == newID.lowercased() },
+                                 "the new window should be listed: \(list)")
+        XCTAssertNotNil(made["geometry"] as? [String: Any],
+                        "window.new should report the new window's geometry without another command: \(made)")
+
+        let resized = try sendCommand(#"{"cmd":"window.resize","target":"\#(newID)","args":{"width":900,"height":650}}"#)
+        XCTAssertEqual(resized["ok"] as? Bool, true, "resize right after window.new should succeed: \(resized)")
+    }
+
     // A point 14pt below the top edge, horizontally centred: clears the top resize strip, lands inside the
     // titlebar band (compact 30 / normal 48), and sits in the empty header (a Spacer) — clear of the traffic
     // lights on the left and the toolbar buttons on the right, so the click falls through the decorative

--- a/agtermUITests/ControlWindowUITests.swift
+++ b/agtermUITests/ControlWindowUITests.swift
@@ -210,6 +210,38 @@ final class ControlWindowUITests: ControlAPITestCase {
                       "the restored window should be interactive again")
     }
 
+    // Parking the FRONTMOST window must hand frontmost to a window that is still visible. `activeWindowID`
+    // only falls back when the frontmost window's store is gone, and a minimized window keeps its store, so
+    // without the handoff every untargeted command keeps routing into a window sitting in the Dock — the
+    // exact state a park-all-but-one script produces. AppKit only keys another window while the app is
+    // active, so this cannot be left to it.
+    func testMinimizingFrontmostHandsOffActive() throws {
+        XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session")
+        let launchID = try XCTUnwrap(try windowList().first?["id"] as? String, "the seeded window should have an id")
+
+        let created = try sendCommand(#"{"cmd":"window.new","args":{"name":"second"}}"#)
+        let newID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "window.new returns an id")
+        XCTAssertTrue(pollWindowList(timeout: 10) { list in
+            list.first { ($0["id"] as? String)?.lowercased() == newID.lowercased() }?["active"] as? Bool == true
+        }, "the new window should be frontmost before we park it")
+        // wait out WindowAccessor's UI-test bring-forward schedule (~0.95s from attach), which would
+        // deminiaturize the brand-new window out from under the assertion.
+        usleep(1_200_000)
+
+        addTeardownBlock { _ = try? self.sendCommand(#"{"cmd":"window.minimize","target":"\#(newID)","args":{"mode":"off"}}"#) }
+        XCTAssertEqual(try sendCommand(#"{"cmd":"window.minimize","target":"\#(newID)","args":{"mode":"on"}}"#)["ok"] as? Bool,
+                       true)
+
+        let handedOff = pollWindowList(timeout: 10) { list in
+            let parked = list.first { ($0["id"] as? String)?.lowercased() == newID.lowercased() }
+            let remaining = list.first { ($0["id"] as? String)?.lowercased() == launchID.lowercased() }
+            return parked?["minimized"] as? Bool == true && remaining?["active"] as? Bool == true
+        }
+        let finalList = (try? windowList()) ?? []
+        XCTAssertTrue(handedOff,
+                      "minimizing the frontmost window should make the still-visible one active: \(finalList)")
+    }
+
     // AppKit's own Window ▸ Minimize (⌘M) mutates the state with no control command in play, so the
     // read-back only stays honest because `ControlServer` observes NSWindow.didMiniaturize. This drives the
     // menu item — the GUI half — and asserts the flag flips, which is the regression guard for those

--- a/agtermUITests/ControlWindowUITests.swift
+++ b/agtermUITests/ControlWindowUITests.swift
@@ -168,8 +168,9 @@ final class ControlWindowUITests: ControlAPITestCase {
     // so any XCUIElement query against it hangs on event synthesis rather than failing. The restore rides
     // `addTeardownBlock` (registered BEFORE the minimize) because `continueAfterFailure = false` unwinds
     // through an ObjC exception that skips a Swift `defer`, which would leave the runner's screen with a
-    // Dock-parked window. It drives the LAUNCH window on purpose — a freshly created one is still inside
-    // `WindowAccessor`'s ~0.95s UI-test bring-forward schedule, which would deminiaturize it mid-test.
+    // Dock-parked window. A parked window stays parked because `bringForwardForUITests` latches on its
+    // first tick — the delay-0 block finds the window already on screen and disarms the rest of the
+    // schedule — so nothing deminiaturizes it out from under the assertions.
     func testWindowMinimizeAndRestore() throws {
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session")
         let id = try XCTUnwrap(try windowList().first?["id"] as? String, "the seeded window should have an id")
@@ -252,10 +253,9 @@ final class ControlWindowUITests: ControlAPITestCase {
         XCTAssertTrue(pollWindowList(timeout: 10) { list in
             list.first { ($0["id"] as? String)?.lowercased() == newID.lowercased() }?["active"] as? Bool == true
         }, "the new window should be frontmost before we park it")
-        // wait out WindowAccessor's UI-test bring-forward schedule (~0.95s from attach), which would
-        // deminiaturize the brand-new window out from under the assertion.
-        usleep(1_200_000)
-
+        // no wait is needed before parking: `bringForwardForUITests` latches on its delay-0 tick, which is
+        // enqueued inside the same `viewDidMoveToWindow` body that registers the window — so it has run
+        // long before `window.new` replies, and the later ticks are inert.
         addTeardownBlock { _ = try? self.sendCommand(#"{"cmd":"window.minimize","target":"\#(newID)","args":{"mode":"off"}}"#) }
         XCTAssertEqual(try sendCommand(#"{"cmd":"window.minimize","target":"\#(newID)","args":{"mode":"on"}}"#)["ok"] as? Bool,
                        true)

--- a/agtermUITests/ControlWindowUITests.swift
+++ b/agtermUITests/ControlWindowUITests.swift
@@ -210,6 +210,34 @@ final class ControlWindowUITests: ControlAPITestCase {
                       "the restored window should be interactive again")
     }
 
+    // window.new --minimized creates the window already parked, so a script can build a set of project
+    // windows without each one flashing on screen and taking focus. The window must come up minimized and
+    // must NOT be left as the frontmost one — a window in the Dock would otherwise swallow every untargeted
+    // command. This also guards the ordering inside the command: WindowAccessor presents a new window on
+    // the next main-queue turn as well as synchronously, so parking it too early is silently undone.
+    func testWindowNewMinimizedStaysParked() throws {
+        XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session")
+        let launchID = try XCTUnwrap(try windowList().first?["id"] as? String, "the seeded window should have an id")
+
+        let created = try sendCommand(#"{"cmd":"window.new","args":{"name":"parked","minimized":true}}"#)
+        XCTAssertEqual(created["ok"] as? Bool, true, "window.new --minimized should succeed: \(created)")
+        let newID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "window.new returns an id")
+        addTeardownBlock { _ = try? self.sendCommand(#"{"cmd":"window.minimize","target":"\#(newID)","args":{"mode":"off"}}"#) }
+
+        let list = try windowList()
+        let made = try XCTUnwrap(list.first { ($0["id"] as? String)?.lowercased() == newID.lowercased() },
+                                 "the new window should be listed: \(list)")
+        XCTAssertEqual(made["minimized"] as? Bool, true, "window.new --minimized should report minimized: \(made)")
+        XCTAssertEqual(made["active"] as? Bool, false, "a parked window must not be left frontmost: \(made)")
+        XCTAssertEqual(list.first { ($0["id"] as? String)?.lowercased() == launchID.lowercased() }?["active"] as? Bool,
+                       true, "the visible window should keep frontmost: \(list)")
+
+        // and it STAYS parked past WindowAccessor's deferred present and its UI-test schedule.
+        usleep(1_500_000)
+        XCTAssertEqual(try windowList().first { ($0["id"] as? String)?.lowercased() == newID.lowercased() }?["minimized"] as? Bool,
+                       true, "the parked window must not be dragged back out of the Dock")
+    }
+
     // Parking the FRONTMOST window must hand frontmost to a window that is still visible. `activeWindowID`
     // only falls back when the frontmost window's store is gone, and a minimized window keeps its store, so
     // without the handoff every untargeted command keeps routing into a window sitting in the Dock — the

--- a/site/commands.html
+++ b/site/commands.html
@@ -18,7 +18,7 @@
     <meta property="og:title" content="Command reference — agterm" />
     <meta
       property="og:description"
-      content="All 65 agtermctl control commands with arguments, return values, and errors."
+      content="All 66 agtermctl control commands with arguments, return values, and errors."
     />
     <meta property="og:url" content="https://agterm.com/commands" />
     <meta property="og:image" content="https://agterm.com/assets/agterm-og.png" />
@@ -30,7 +30,7 @@
     <meta name="twitter:title" content="Command reference — agterm" />
     <meta
       name="twitter:description"
-      content="All 65 agtermctl control commands with arguments, return values, and errors."
+      content="All 66 agtermctl control commands with arguments, return values, and errors."
     />
     <meta name="twitter:image" content="https://agterm.com/assets/agterm-og.png" />
     <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
@@ -235,7 +235,7 @@
             Command reference
           </h1>
           <p style="font-size: 19px; line-height: 1.6; color: #bfbab0; margin: 0 0 8px">
-            All 65 commands of the agterm control API, with arguments and return values. Every one is reachable from the
+            All 66 commands of the agterm control API, with arguments and return values. Every one is reachable from the
             <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl</span> CLI and from the local
             control socket.
           </p>
@@ -1384,12 +1384,14 @@
                 (<span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">{x, y, width, height, display}</span>, the read side
                 of <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">window move</span>/<span style="font-family: &quot;JetBrains Mono&quot;, monospace">resize</span>,
                 in the same units they take), plus
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">fullscreen</span> and
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">zoomed</span>. The last three are omitted for a closed
-                window.
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">fullscreen</span>,
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">zoomed</span> and
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">minimized</span>. The last four are omitted for a closed
+                window. A minimized window still reports its
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">geometry</span> — the frame it comes back to.
               </p>
               <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">geometry</span>/<span style="font-family: &quot;JetBrains Mono&quot;, monospace">fullscreen</span>/<span style="font-family: &quot;JetBrains Mono&quot;, monospace">zoomed</span>
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">geometry</span>/<span style="font-family: &quot;JetBrains Mono&quot;, monospace">fullscreen</span>/<span style="font-family: &quot;JetBrains Mono&quot;, monospace">zoomed</span>/<span style="font-family: &quot;JetBrains Mono&quot;, monospace">minimized</span>
                 stay current across hand-drags and GUI toggles. Unlike
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">tree</span>, this does not carry
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">idleMs</span> — a live metric would freeze in the
@@ -1482,6 +1484,27 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">zoom</span>. Read back via
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">window list</span>'s
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">fullscreen</span>.
+              </p>
+            </div>
+
+            <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
+                agtermctl window minimize &lt;id&gt; [on|off|toggle]
+              </div>
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">window.minimize</div>
+              <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
+                Minimize a window to the Dock, or restore it. The mode resolves against the window's current state, so
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">on</span>/<span style="font-family: &quot;JetBrains Mono&quot;, monospace">off</span>
+                are idempotent and only <span style="font-family: &quot;JetBrains Mono&quot;, monospace">toggle</span> (the default) flips. Both
+                positionals are optional, so <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">window minimize on</span>
+                targets the active window. The window must be open, and one in native full screen is rejected. The control half of ⌘M,
+                the yellow traffic-light button, and the Minimize title-bar double-click action. Read back via
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">window list</span>'s
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">minimized</span>.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                Give every window the same frame and park all but one, and switching windows looks like switching a tab. The minimized
+                state is live-only — it is never persisted, so windows reopen un-minimized after a restart.
               </p>
             </div>
           </section>

--- a/site/commands.html
+++ b/site/commands.html
@@ -1356,11 +1356,16 @@
 
             <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
-                agtermctl window new [name]
+                agtermctl window new [name] [--minimized]
               </div>
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">window.new</div>
               <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
-                Create and open a window.
+                Create and open a window. It replies only once the on-screen window exists, so an immediate
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">window resize</span>/<span style="font-family: &quot;JetBrains Mono&quot;, monospace">move</span>
+                on the returned id works.
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--minimized</span> creates it already parked in the Dock
+                instead of presenting it, leaving frontmost on a window you can still see — for building a set of project windows
+                without each one flashing up and taking focus.
                 <strong style="color: #bfbab0">Returns</strong>
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">result.id</span>.
               </p>

--- a/site/commands.html
+++ b/site/commands.html
@@ -1363,9 +1363,9 @@
                 Create and open a window. It replies only once the on-screen window exists, so an immediate
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">window resize</span>/<span style="font-family: &quot;JetBrains Mono&quot;, monospace">move</span>
                 on the returned id works.
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--minimized</span> creates it already parked in the Dock
-                instead of presenting it, leaving frontmost on a window you can still see — for building a set of project windows
-                without each one flashing up and taking focus.
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--minimized</span> parks it in the Dock right after
+                creating it, leaving frontmost on a window you can still see — for building a set of project windows and ending up
+                on one you are looking at. The window is presented briefly before it is parked.
                 <strong style="color: #bfbab0">Returns</strong>
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">result.id</span>.
               </p>

--- a/site/docs.html
+++ b/site/docs.html
@@ -951,7 +951,10 @@
               A window is a top-level bundle of workspaces and sessions in its own on-screen macOS window, with its own sidebar and
               its own sessions — so "work" and "personal" can run as two separate windows at once, each with its own tree. Keep a
               library of windows, open one per screen, and create, rename, or delete them from the File menu (New Window ⌥⌘N) or the
-              action palette. The set of windows open at quit reopens on the next launch, frames restored.
+              action palette. The set of windows open at quit reopens on the next launch, frames restored. Windows are also fully
+              scriptable — <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl window</span> can
+              create, raise, move, resize, and minimize them, so a few lines of shell can give every window the same frame and park
+              all but the one you are on, turning several windows into what feels like one that switches contents.
             </p>
           </section>
 
@@ -1108,7 +1111,7 @@
               "
             >
               <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 0">
-                Looking for the full list? All 65 commands, with every argument, return value, and error, live on the
+                Looking for the full list? All 66 commands, with every argument, return value, and error, live on the
                 <a href="/commands" style="color: #6d82f3; font-weight: 500">Command reference →</a>
               </p>
             </div>
@@ -1378,7 +1381,9 @@
               ><br />agtermctl window rename <span style="color: #f2b45c">"$w"</span> personal<br />agtermctl window close
               <span style="color: #f2b45c">"$w"</span> <span style="color: #6b727a">&nbsp;&nbsp;# close its window (bundle kept)</span
               ><br />agtermctl window delete <span style="color: #f2b45c">"$w"</span>
-              <span style="color: #6b727a">&nbsp;# delete (last window can't be deleted)</span><br /><br /><span
+              <span style="color: #6b727a">&nbsp;# delete (last window can't be deleted)</span
+              ><br />agtermctl window minimize <span style="color: #f2b45c">"$w"</span> on
+              <span style="color: #6b727a">&nbsp;# park it in the Dock (off restores)</span><br /><br /><span
                 style="color: #6b727a"
                 ># --window targets a specific window's tree on session/workspace/tree/font</span
               ><br />agtermctl tree --window <span style="color: #f2b45c">"$w"</span><br />agtermctl session new --window

--- a/site/docs.html
+++ b/site/docs.html
@@ -1376,14 +1376,17 @@
               "
             >
               agtermctl window list <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;&nbsp;# id  name  [open]  [active]</span
-              ><br /><span style="color: #6d82f3">w</span>=$(agtermctl window new work)<br />agtermctl window select
+              ><br /><span style="color: #6d82f3">w</span>=$(agtermctl window new work)<br />agtermctl window new proj-b
+              --minimized <span style="color: #6b727a">&nbsp;# create one, parked in the Dock</span
+              ><br />agtermctl window select
               <span style="color: #f2b45c">"$w"</span> <span style="color: #6b727a">&nbsp;# raise it (opening if closed)</span
-              ><br />agtermctl window rename <span style="color: #f2b45c">"$w"</span> personal<br />agtermctl window close
+              ><br />agtermctl window rename <span style="color: #f2b45c">"$w"</span> personal
+              <br />agtermctl window minimize <span style="color: #f2b45c">"$w"</span> on
+              <span style="color: #6b727a">&nbsp;# park it in the Dock (off restores)</span
+              ><br />agtermctl window close
               <span style="color: #f2b45c">"$w"</span> <span style="color: #6b727a">&nbsp;&nbsp;# close its window (bundle kept)</span
               ><br />agtermctl window delete <span style="color: #f2b45c">"$w"</span>
-              <span style="color: #6b727a">&nbsp;# delete (last window can't be deleted)</span
-              ><br />agtermctl window minimize <span style="color: #f2b45c">"$w"</span> on
-              <span style="color: #6b727a">&nbsp;# park it in the Dock (off restores)</span><br /><br /><span
+              <span style="color: #6b727a">&nbsp;# delete (last window can't be deleted)</span><br /><br /><span
                 style="color: #6b727a"
                 ># --window targets a specific window's tree on session/workspace/tree/font</span
               ><br />agtermctl tree --window <span style="color: #f2b45c">"$w"</span><br />agtermctl session new --window


### PR DESCRIPTION
Adds `window.minimize` so a script can park a window in the Dock, which is what the control API was missing for the one-window-per-project workflow from discussion #293. It could already raise a window (`window.select` deminiaturizes), but nothing could put one away, and `window.move` clamps the origin so off-screen parking is impossible either.

```
agtermctl window minimize <id> [on|off|toggle]    # default toggle
agtermctl window new <name> --minimized           # create it, then park it
agtermctl window list --json                      # reads back as `minimized`
```

Explicit modes rather than a bare toggle like `window zoom`, because parking every window but the current one has to be deterministic without reading state back first. It is the control half of ⌘M, the yellow button, and the Minimize title-bar double-click, so the NSWindow miniaturize notifications join the cache-refresh set to keep the read-back honest. A window in native full screen is rejected: AppKit no-ops miniaturize there, so replying ok would be a lie.

A minimized window still reports its `geometry`. `NSWindow.screen` is nil while miniaturized, so `geometry`/`move`/`resize` now share one `resolvedScreen` fallback (largest-overlap display, then main). Sharing it is what keeps a parked window's frame round-tripping back through `window.move` instead of the read and the write disagreeing on the display index.

**Four defects found while building and reviewing this**

`window.new` replied before its NSWindow attached, so an immediate `window.resize` on the returned id failed with `window not open` - the exact sequence shipped as a recipe in the bundled agent skill. It now polls `WindowRegistry.isRegistered`.

`window.list` is fast-path-served from a background cache that nothing refreshed once a window attached, so a new window reported no geometry indefinitely. `newWindow()` pre-sets `frontmostWindowID`, so the first `didBecomeKey` is a no-change and skips `.agtermWindowFrontmostChanged`, and a brand-new window has no saved frame so no `didMove` fires either. `register`/`unregister` now post `.agtermWindowAttachmentChanged`, which also covers GUI New Window, launch reopen-all, and a red-button close.

Minimizing the frontmost window left `frontmostWindowID` on it, so `tree`, `session.new`, `quick` and the palette all kept routing into a window sitting in the Dock.

`window.select` had the same hole from the other side: it raised the window and replied ok, but `frontmostWindowID` is only written by `reportFrontmost` on `didBecomeKey`, which AppKit does not deliver while the app is inactive, exactly the state a driving script is in. Both paths now go through `takeFrontmost()`.

**Coverage and its one gap**

1789 core tests and 20 window e2e tests, all green, plus `make lint --strict`. New e2e cover minimize/restore with geometry surviving, `window.new --minimized` staying parked, the frontmost handoff, a menu-driven ⌘M reading back over the socket, and `window.new` being immediately usable.

The `window.select` fix has no e2e. Reproducing it needs agterm inactive, and every way to arrange that from XCUITest disturbs the session by jumping Spaces; a test written without deactivating the app passes with or without the fix (verified, it did). Rather than ship a test that guards nothing, the gap and its manual reproduction are recorded in `.claude/rules/windows.md`. Both AppKit questions behind the docs were settled by hand on an isolated instance: `deminiaturize` alone does not make the window key, and `move`/`resize` do apply to a parked window.

Doc surfaces updated: README, `site/docs.html`, `site/commands.html`, the bundled agent skill, and the control-api/windows/notifications rules. Command count 65 to 66.

One deliberate non-change: `--minimized` presents the window briefly before parking it. Suppressing that would mean defeating `WindowGroup`'s own presentation plus the two `bringForward` calls whose deminiaturize-on-attach the restore path depends on, so the docs were corrected to describe present-then-park instead.
