### PR TITLE
fix: address round-6 review findings on the Dock menu

### DIFF
--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -10,13 +10,29 @@ paths:
   The `test` job runs `swift test --enable-code-coverage` in `agtermCore`, exports lcov, and uploads it as an artifact.
   The `coverage` job is the only `ubuntu-latest` job and downloads that artifact for a best-effort Coveralls upload.
   The `lint` job installs SwiftLint and runs `swiftlint lint --strict` without building.
-  The `build` job restores the libghostty/resource cache, installs xcodegen, runs the Release `scripts/build.sh`, and then runs the application-hosted `agtermTests` suite through `scripts/test-app.sh`.
+  The `build` job restores the libghostty/resource cache, installs xcodegen,
+  runs the Release `scripts/build.sh`,
+  and then runs the application-hosted `agtermTests` suite through `scripts/test-app.sh`.
+  The cache is an `actions/cache` keyed on `hashFiles('scripts/setup.sh')`,
+  so editing `setup.sh` invalidates it and pays the libghostty rebuild.
+  That job compiles the app TWICE by design, and the duplication is not removable.
+  `build.sh` is `-configuration Release`, which is what exercises the whole-module optimizer
+  (the SIL deserializer crash the module-boundary rule in `CLAUDE.md` describes only reproduces there).
+  `test-app.sh` builds Debug because `DockMenuTests` is `@testable import agterm`
+  and `ENABLE_TESTABILITY` is Debug-only,
+  so hosting the tests on the Release product would mean enabling testability in the shipped, notarized build.
+  Expect that job to run roughly twice as long as a plain build,
+  and do not "fix" it by unifying the configurations.
   All macOS jobs run on `macos-26`, and workflow concurrency cancels an older run for the same ref.
   There is NO `release.yml` — releases are cut locally; see `.claude/rules/release.md`.
 - **The Coveralls upload runs on Linux ON PURPOSE.**
   `coverallsapp/github-action@v2` installs its reporter from a brew tap on macOS, which is blocked by Homebrew's tap-trust gate, but downloads a prebuilt binary on Linux.
   The macOS `test` job therefore hands the lcov artifact to the Linux `coverage` job.
-  The `test` job rewrites `llvm-cov`'s absolute `SF:` paths to repo-relative paths so the reporter resolves them against its own checkout.
+  The `test` job rewrites `llvm-cov`'s absolute `SF:` paths to repo-relative paths,
+  stripping the `$GITHUB_WORKSPACE/` prefix,
+  so the reporter resolves them against its own checkout.
+  Get that rewrite wrong and the reporter matches nothing and prints `🚨 Nothing to report` while still exiting green.
+  That string is the symptom to look for; it is the only thing distinguishing this failure from a successful upload.
   The lcov upload, artifact download, and Coveralls submission are all `continue-on-error`.
   Core tests still gate the `test` job, and hosted AppKit tests independently gate the `build` job.
   A masked coverage failure can therefore show green, so verify the actual Coveralls build/API after changing this path.

--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -24,6 +24,12 @@ paths:
   Trivial one-liners (quick-terminal toggle) call the controller/store directly;
   `AppActions` owns the ones with real logic — new-session placement, the directory picker,
   split + focus, and font.
+  `toggleQuickTerminal` gates on the full `uiActionsEnabled` (terminal zoom AND the dashboard grid),
+  not zoom alone.
+  The View ▸ Quick Terminal item already carried `.disabled(modalActive)`,
+  and `WindowContentView+Dashboard` force-hides a shown quick terminal when the grid opens.
+  So the wider gate changes only the one remaining path, a rebound keymap chord,
+  and makes it agree with the menu instead of opening over the grid.
 - **Application Dock menu (`AppDelegate.applicationDockMenu`).**
   AppKit asks for a fresh menu when the Dock icon is right-clicked.
   The menu exposes New Session, Quick Terminal, Dashboard, the captured window's MRU sessions, and that window's attention ordering.
@@ -304,7 +310,15 @@ paths:
   carry ⌃⌥↑/↓ as their `defaultChord`.
   EVERY user-initiated GUI selection of a status that NEEDS ATTENTION reveals the tagged PANE, not just the session.
   The shared `AppActions.revealActiveBlockedPane(captured:)` focuses the pane recorded in the pre-reset indicator returned by `AppStore.selectSession` or `navigateSession`.
-  When GUI navigation has no target, its action falls back to the active session's live indicator so a sole selected attention session still reveals its tagged pane and an empty filtered list preserves ordinary focus behavior.
+  ATTENTION nav falls back to the active session's live indicator when `navigateSession` returns no target.
+  `attentionTarget` excludes the CURRENT session,
+  so when the sole session needing attention is the one already selected it returns nil and nothing is selected.
+  That fallback is the only reason ⌃⌥↑/↓ still reveals its tagged pane there.
+  PLAIN session nav has NO such fallback and reveals only when the selection actually MOVED.
+  A plain step resolving to the session already selected just re-focuses:
+  `next`/`previous` wrap inside a one-element filtered set, and `first`/`last` repeat while already at that end.
+  `selectSession` does not short-circuit a same-target select, so it still returns an indicator there,
+  and revealing on it would clear `splitFocused` and pull the user off the split pane he is typing in.
   For `right`, it focuses the split surface via `focusSplitPane(_:wantSplit: true)`, gated on `splitSurface != nil`, and `onFocusChange` reasserts `splitFocused` to win the shown-split re-render race.
   A promoted split survivor is not covered by that branch because promotion moves it into `surface` with `splitSurface == nil` and retags a `.right` block to `.left`.
   For `left` or nil, it explicitly clears `splitFocused` and calls `focusSplitPane(_:wantSplit: false)` to target the primary pane.

--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -27,11 +27,15 @@ paths:
   `toggleQuickTerminal` gates on the full `uiActionsEnabled` (terminal zoom AND the dashboard grid),
   not zoom alone.
   This is defence in depth, not a gap being closed: all three callers of the method were already gated.
-  The View ▸ Quick Terminal item carries `.disabled(modalActive)`, which also covers a `keymap.conf` rebind of the built-in, because that rebind IS the item's key equivalent;
+  The View ▸ Quick Terminal item carries `.disabled(modalActive)`,
+  which also covers a `keymap.conf` rebind of the built-in, because that rebind IS the item's key equivalent;
   the palette caller is gated by `runPaletteCommand`'s own `uiActionsEnabled` check;
   and the Dock item rechecks `uiActionsEnabled(for:)` at invocation.
   The control `quick` command never reaches this method at all, driving `QuickTerminalRegistry` directly.
-  The title-bar quick-terminal button is not a caller either — it toggles the controller directly, and is unreachable while a modal is up because `WindowContentView+Dashboard` swaps the whole titlebar.
+  The title-bar quick-terminal button is not a caller either — it toggles the controller directly,
+  and is unreachable while a modal is up because `WindowContentView+Dashboard` swaps the whole titlebar.
+  `WindowContentView+Dashboard` also force-hides a SHOWN quick terminal when the grid opens,
+  so the gate only ever blocks opening one over the grid, never strands one behind it.
 - **Application Dock menu (`AppDelegate.applicationDockMenu`).**
   AppKit asks for a fresh menu when the Dock icon is right-clicked.
   The menu exposes New Session, Quick Terminal, Dashboard, the captured window's MRU sessions, and that window's attention ordering.
@@ -297,12 +301,15 @@ paths:
   no-ops on an empty tree, and routes through `selectSession` (recency + badge + persist + workspace-derivation).
   It is shared by the menu, the action palette, and the control channel (`session.go`) so the three can't
   drift.
-  The four GUI actions (`AppActions.select{Next,Previous,First,Last}Session`) are one-liners over the private `AppActions.navigatePlain(_:)`.
+  The four GUI actions (`AppActions.select{Next,Previous,First,Last}Session`)
+  are one-liners over the private `AppActions.navigatePlain(_:)`.
   A step that MOVES the selection routes through `revealActiveBlockedPane(captured:)`,
-  which reveals the tagged pane when the moved-to session needs attention and otherwise falls through to `focusActiveSession()`,
+  which reveals the tagged pane when the moved-to session needs attention,
+  and otherwise falls through to `focusActiveSession()`,
   so first responder follows into the moved-to terminal either way (the sidebar never steals focus).
   A step that resolves to the session ALREADY selected skips the reveal and calls `focusActiveSession()` directly.
-  Both paths are still subject to the shared modal focus guards (zoom, dashboard, rename, palette, quick terminal), which suppress the responder move in either branch.
+  Both paths are still subject to the shared modal focus guards (zoom, dashboard, rename, palette, quick terminal),
+  which suppress the responder move in either branch.
   `WorkspaceSidebar.syncSelection()` expands the owning workspace if collapsed and `scrollRowToVisible`s
   the target so an off-screen row is revealed.
   Distinct from the ⌃Tab MRU switcher (recency order) and the ⌃P fuzzy palette (search) — this is predictable

--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -26,10 +26,12 @@ paths:
   split + focus, and font.
   `toggleQuickTerminal` gates on the full `uiActionsEnabled` (terminal zoom AND the dashboard grid),
   not zoom alone.
-  The View ▸ Quick Terminal item already carried `.disabled(modalActive)`,
-  and `WindowContentView+Dashboard` force-hides a shown quick terminal when the grid opens.
-  So the wider gate changes only the one remaining path, a rebound keymap chord,
-  and makes it agree with the menu instead of opening over the grid.
+  This is defence in depth, not a gap being closed: all three callers of the method were already gated.
+  The View ▸ Quick Terminal item carries `.disabled(modalActive)`, which also covers a `keymap.conf` rebind of the built-in, because that rebind IS the item's key equivalent;
+  the palette caller is gated by `runPaletteCommand`'s own `uiActionsEnabled` check;
+  and the Dock item rechecks `uiActionsEnabled(for:)` at invocation.
+  The control `quick` command never reaches this method at all, driving `QuickTerminalRegistry` directly.
+  The title-bar quick-terminal button is not a caller either — it toggles the controller directly, and is unreachable while a modal is up because `WindowContentView+Dashboard` swaps the whole titlebar.
 - **Application Dock menu (`AppDelegate.applicationDockMenu`).**
   AppKit asks for a fresh menu when the Dock icon is right-clicked.
   The menu exposes New Session, Quick Terminal, Dashboard, the captured window's MRU sessions, and that window's attention ordering.
@@ -295,8 +297,12 @@ paths:
   no-ops on an empty tree, and routes through `selectSession` (recency + badge + persist + workspace-derivation).
   It is shared by the menu, the action palette, and the control channel (`session.go`) so the three can't
   drift.
-  Each GUI action (`AppActions.select{Next,Previous,First,Last}Session`) calls `focusActiveSession()`
-  after the move so first responder follows into the moved-to terminal (the sidebar never steals focus);
+  The four GUI actions (`AppActions.select{Next,Previous,First,Last}Session`) are one-liners over the private `AppActions.navigatePlain(_:)`.
+  A step that MOVES the selection routes through `revealActiveBlockedPane(captured:)`,
+  which reveals the tagged pane when the moved-to session needs attention and otherwise falls through to `focusActiveSession()`,
+  so first responder follows into the moved-to terminal either way (the sidebar never steals focus).
+  A step that resolves to the session ALREADY selected skips the reveal and calls `focusActiveSession()` directly.
+  Both paths are still subject to the shared modal focus guards (zoom, dashboard, rename, palette, quick terminal), which suppress the responder move in either branch.
   `WorkspaceSidebar.syncSelection()` expands the owning workspace if collapsed and `scrollRowToVisible`s
   the target so an off-screen row is revealed.
   Distinct from the ⌃Tab MRU switcher (recency order) and the ⌃P fuzzy palette (search) — this is predictable

--- a/.claude/rules/sidebar.md
+++ b/.claude/rules/sidebar.md
@@ -82,13 +82,15 @@ paths:
   Covered by `SidebarUITests.testClickWorkspaceRowTogglesExpansion`.
 - **A session ROW click reveals a blocked session's pane-tagged pane.**
   `Coordinator.outlineViewSelectionDidChange` selects the clicked session (`selectSession`) then — async,
-  after the selection + the sidebar's own focus-restore settle — calls `AppActions.revealActiveBlockedPane()`,
+  after the selection + the sidebar's own focus-restore settle — calls `AppActions.revealActiveBlockedPane(captured:)`
+  with the pre-reset indicator `selectSession` returned,
   so clicking a session whose agent blocked in its split (right) or scratch pane lands you on THAT pane,
   not the plain focused pane.
   It is a no-op (plain `focusActiveSession`) for an IDLE or ACTIVE session, so ordinary clicks and
   informational working-state tags are unaffected — the reveal never dismisses a merely-shown scratch
   (a blocked/completed nil-tagged status is treated as `left`/main).
-  This matches attention-nav, plain session nav, the command palettes, and idle auto-follow,
+  This matches attention-nav, plain session nav, the command palettes, a Dock-menu session row, the title-bar
+  bell popover, and idle auto-follow,
   which all route through the same helper (see the Menu/actions + Notifications rules).
   Covered by `PaneAwareStatusUITests.testSidebarClickRevealsBlockedSplitPane`.
 - Accessibility identifiers `session-row`, `workspace-row`, `edit-field`,

--- a/agterm/AppActions+Focus.swift
+++ b/agterm/AppActions+Focus.swift
@@ -159,8 +159,16 @@ extension AppActions {
         // `.left`/nil reveal routes here (a plain `session status blocked` with no `--pane` lands in that
         // branch), so a sidebar row click followed within the ~360ms retry window by ⌘R or a palette open
         // would otherwise pull first responder off the field and type the name into the terminal.
-        if renamePending { return }
-        if palette?.mode != nil { return }
+        // SCOPED to the session's own window like the two gates above, and for the same cross-window reason:
+        // both flags are app-GLOBAL (one `renamePending`, one `PaletteController` shared by every window),
+        // so unscoped they would let a palette open in the frontmost window silently skip the responder move
+        // for a `session.focus` aimed at a background one — leaving that window's `splitFocused` and its real
+        // first responder disagreeing, with the control command still reporting ok. The rename/palette race
+        // this guards is always in the frontmost window, so scoping costs the protection nothing.
+        if library.windowID(forSession: session.id) == library.activeWindowID {
+            if renamePending { return }
+            if palette?.mode != nil { return }
+        }
         // the quick terminal is a window-level cover above the session; while it's up it owns focus, so
         // don't move first responder to a pane behind it (its own hide restores the session). The caller
         // has already set `splitFocused`, so the right pane shows once the quick terminal is dismissed.

--- a/agterm/AppActions+Focus.swift
+++ b/agterm/AppActions+Focus.swift
@@ -163,8 +163,12 @@ extension AppActions {
         // both flags are app-GLOBAL (one `renamePending`, one `PaletteController` shared by every window),
         // so unscoped they would let a palette open in the frontmost window silently skip the responder move
         // for a `session.focus` aimed at a background one — leaving that window's `splitFocused` and its real
-        // first responder disagreeing, with the control command still reporting ok. The rename/palette race
-        // this guards is always in the frontmost window, so scoping costs the protection nothing.
+        // first responder disagreeing, with the control command still reporting ok. Scoping costs the
+        // protection nothing because only the KEY window receives keystrokes, so the race actually guarded
+        // here — a retry stealing the field the user is typing into — is frontmost-only by construction.
+        // (A BACKGROUND window can still hold an inline editor, since the rename notifications fan out to
+        // every window's sidebar coordinator; nobody is typing into that one, and the fan-out itself is a
+        // separate, older defect.)
         if library.windowID(forSession: session.id) == library.activeWindowID {
             if renamePending { return }
             if palette?.mode != nil { return }

--- a/agterm/AppActions+Focus.swift
+++ b/agterm/AppActions+Focus.swift
@@ -43,7 +43,8 @@ extension AppActions {
     /// Reveal and focus the active session's blocked pane, reading its agent-status pane tag so navigation
     /// lands on the pane actually waiting for input rather than the session's plain focused pane. Called on
     /// every user-initiated selection — the auto-follow jump, attention navigation (⌃⌥↑/↓), plain session
-    /// nav (⌥⌘↑/↓/first/last), the ⌃P / attention command palette, and a sidebar row click — so however you
+    /// nav (⌥⌘↑/↓/first/last), the ⌃P / attention command palette, a sidebar row click, a title-bar bell
+    /// popover row, and a Dock-menu session row — so however you
     /// reach a blocked session you land on its waiting pane; it is a no-op (plain `focusActiveSession`) for an
     /// idle or active session, so ordinary selections and a working agent's informational pane tag do not
     /// change the user's pane selection. `.right` — only WHEN the split surface exists
@@ -153,6 +154,13 @@ extension AppActions {
         // reason: while it's up its key-catcher owns first responder, and a NON-member deck surface behind it
         // is not view-only, so grabbing first responder here would leak keystrokes into a hidden terminal.
         if dashboardActive(for: session) { return }
+        // the inline rename field and an open palette own the keyboard, exactly as in `focusActiveSession`,
+        // which re-checks both on every one of its retries. this loop needs them for the same reason: the
+        // `.left`/nil reveal routes here (a plain `session status blocked` with no `--pane` lands in that
+        // branch), so a sidebar row click followed within the ~360ms retry window by ⌘R or a palette open
+        // would otherwise pull first responder off the field and type the name into the terminal.
+        if renamePending { return }
+        if palette?.mode != nil { return }
         // the quick terminal is a window-level cover above the session; while it's up it owns focus, so
         // don't move first responder to a pane behind it (its own hide restores the session). The caller
         // has already set `splitFocused`, so the right pane shows once the quick terminal is dismissed.

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -45,8 +45,10 @@ final class AppActions {
     /// While terminal zoom OR the dashboard grid is active, the UI is modal: keyboard/menu/palette actions
     /// must not mutate the deck behind it. The zoom/dashboard toggles, socket commands, and macOS window
     /// controls remain separate paths (they never gate on this), so the user is never trapped and can always
-    /// dismiss the modal. `frontmostDashboard?.isOpen` mirrors `terminalZoomActive`, resolved on the frontmost
-    /// window like the zoom target.
+    /// dismiss the modal. This is the frontmost-window shorthand for the per-window check below, resolved on
+    /// `library.activeWindowID` like the zoom target. With NO window open that id is nil and the gate DENIES
+    /// (the per-window check's `guard let windowID else { return false }`), so a deck action can't run against
+    /// no window while the app is tearing down.
     var uiActionsEnabled: Bool { uiActionsEnabled(for: library.activeWindowID) }
 
     /// The modal gate for a specific window. Session-addressed entry points use this instead of the
@@ -420,32 +422,27 @@ final class AppActions {
     /// then moves first responder into the moved-to session's focused pane. Each also notes the manual
     /// navigation as user activity so it buys the full idle grace before auto-follow can pull the
     /// selection back (the control `session.go` drives `navigateSession` directly, so it stays silent).
-    /// If a filtered list has no navigation target, the GUI action keeps the current session's live
-    /// indicator so the same reveal/focus behavior still runs for that selection no-op.
-    func selectNextSession() {
+    /// A step that resolves to the session ALREADY selected reveals nothing and just re-focuses: `next`/`previous`
+    /// wrap inside the filtered set, so a one-element set re-selects the current session, and `first`/`last`
+    /// do the same while you are already at that end. `selectSession` does not short-circuit a same-target
+    /// select, so it still returns an indicator there — revealing on it would clear `splitFocused` and yank
+    /// first responder onto the primary pane on a keystroke that moved nothing, off the split the user is
+    /// typing in. Attention nav deliberately DOES reveal on its no-op; see it below for why.
+    private func navigatePlain(_ direction: SessionNavigation) {
         guard uiActionsEnabled else { return }
         store?.noteUserActivity()
-        let indicator = store?.navigateSession(.next) ?? store?.activeSession?.agentIndicator
+        let before = store?.selectedSessionID
+        // no live-indicator fallback here (unlike attention nav): a plain direction returns nil only when
+        // `navigableSessions` is EMPTY, and then nothing was selected, which the moved-check below catches.
+        let indicator = store?.navigateSession(direction)
+        guard store?.selectedSessionID != before else { focusActiveSession(); return }
         revealActiveBlockedPane(captured: indicator)
     }
-    func selectPreviousSession() {
-        guard uiActionsEnabled else { return }
-        store?.noteUserActivity()
-        let indicator = store?.navigateSession(.previous) ?? store?.activeSession?.agentIndicator
-        revealActiveBlockedPane(captured: indicator)
-    }
-    func selectFirstSession() {
-        guard uiActionsEnabled else { return }
-        store?.noteUserActivity()
-        let indicator = store?.navigateSession(.first) ?? store?.activeSession?.agentIndicator
-        revealActiveBlockedPane(captured: indicator)
-    }
-    func selectLastSession() {
-        guard uiActionsEnabled else { return }
-        store?.noteUserActivity()
-        let indicator = store?.navigateSession(.last) ?? store?.activeSession?.agentIndicator
-        revealActiveBlockedPane(captured: indicator)
-    }
+
+    func selectNextSession() { navigatePlain(.next) }
+    func selectPreviousSession() { navigatePlain(.previous) }
+    func selectFirstSession() { navigatePlain(.first) }
+    func selectLastSession() { navigatePlain(.last) }
 
     /// Step to the next/previous session needing attention (status `blocked` or `completed`), wrapping
     /// around and skipping idle/active sessions. Shares `navigateSession` with the GUI, palette, and the
@@ -453,6 +450,12 @@ final class AppActions {
     /// session nav (a manual step to an attention session buys the idle grace too), then reveals and focuses
     /// the moved-to session's blocked pane (`revealActiveBlockedPane`) so nav lands on the split/scratch pane
     /// that set the status, not just the session's plain focused pane.
+    /// Unlike the plain nav above, this DOES reveal on a selection no-op, and the `?? activeSession?.agentIndicator`
+    /// fallback is the only thing that makes it: `attentionTarget` EXCLUDES the current session, so when the
+    /// sole session needing attention is the one already selected it returns nil and `navigateSession` selects
+    /// nothing. Without the fallback the reveal degrades to plain `focusActiveSession` and ⌃⌥↑/↓ stops taking
+    /// you to that session's tagged split/scratch pane — the case an agent hits constantly, since a pane-scoped
+    /// block is not cleared by typing in the OTHER pane. Do not drop it as redundant.
     func selectNextAttentionSession() {
         guard uiActionsEnabled else { return }
         store?.noteUserActivity()
@@ -780,7 +783,10 @@ final class AppActions {
 
     // MARK: - Quick terminal (frontmost window)
 
-    /// Toggle the frontmost window's quick terminal (each window owns its own controller).
+    /// Toggle the frontmost window's quick terminal (each window owns its own controller). Gated on the full
+    /// `uiActionsEnabled` (zoom AND dashboard), not zoom alone: the View ▸ Quick Terminal item already carries
+    /// `.disabled(modalActive)` and the dashboard force-hides a shown quick terminal, so this makes the one
+    /// remaining path — a rebound keymap chord — agree with the menu instead of opening over the grid.
     func toggleQuickTerminal() {
         guard uiActionsEnabled else { return }
         frontmostQuickTerminal?.toggle()

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -784,9 +784,10 @@ final class AppActions {
     // MARK: - Quick terminal (frontmost window)
 
     /// Toggle the frontmost window's quick terminal (each window owns its own controller). Gated on the full
-    /// `uiActionsEnabled` (zoom AND dashboard), not zoom alone: the View ▸ Quick Terminal item already carries
-    /// `.disabled(modalActive)` and the dashboard force-hides a shown quick terminal, so this makes the one
-    /// remaining path — a rebound keymap chord — agree with the menu instead of opening over the grid.
+    /// `uiActionsEnabled` (zoom AND dashboard), not zoom alone — defence in depth rather than a gap being
+    /// closed, since all three callers already gate: the View ▸ Quick Terminal item's `.disabled(modalActive)`
+    /// (which covers a `keymap.conf` rebind too, because that rebind is the item's own key equivalent), the
+    /// palette's `runPaletteCommand` check, and the Dock item's invocation-time `uiActionsEnabled(for:)`.
     func toggleQuickTerminal() {
         guard uiActionsEnabled else { return }
         frontmostQuickTerminal?.toggle()

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -710,20 +710,27 @@ final class AppActions {
     /// Start an inline rename of the active session. The sidebar owns the edit field, so this posts
     /// a notification it observes; `renamePending` keeps the palette-close focus restore off the
     /// field while the edit starts.
+    /// The post carries the frontmost STORE as its object, and `WorkspaceSidebar.Coordinator` registers
+    /// with `object: store`, so only that window's sidebar starts an edit — the same per-window scoping
+    /// `expandAllWorkspaces(in:)` uses. Posting with a nil object instead reached EVERY open window's
+    /// coordinator, and their `selectedSessionID` guard does not scope anything (every window has a
+    /// selection), so each one opened an editor nobody was typing into and each leaked one unbalanced
+    /// `suppressAutoFollow`.
     func renameActiveSession() {
         guard uiActionsEnabled else { return }
-        guard store?.activeSession != nil else { return }
+        guard let store, store.activeSession != nil else { return }
         renamePending = true
-        NotificationCenter.default.post(name: .agtermBeginRenameSession, object: nil)
+        NotificationCenter.default.post(name: .agtermBeginRenameSession, object: store)
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { [weak self] in self?.renamePending = false }
     }
 
     /// Start an inline rename of the active session's workspace (the same one new sessions land in).
+    /// Store-scoped like `renameActiveSession` above, for the same reason.
     func renameActiveWorkspace() {
         guard uiActionsEnabled else { return }
-        guard store?.currentWorkspaceID != nil else { return }
+        guard let store, store.currentWorkspaceID != nil else { return }
         renamePending = true
-        NotificationCenter.default.post(name: .agtermBeginRenameWorkspace, object: nil)
+        NotificationCenter.default.post(name: .agtermBeginRenameWorkspace, object: store)
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { [weak self] in self?.renamePending = false }
     }
 

--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -221,15 +221,18 @@ struct WorkspaceSidebar: NSViewRepresentable {
             renameController.onRenameEnded = { [weak self] in self?.focusActiveTerminal() }
             // the menu/palette can't reach the inline editor directly, so they post a
             // notification and this coordinator starts the edit on the selected row.
+            // Scoped by `object: store` like expand/collapse below: the selected-session guard in the
+            // handlers is NOT a per-window scope (every open window has a selected session), so an
+            // object: nil pairing started an inline edit in EVERY window — each leaving an editor the
+            // user never opened, plus an unbalanced `suppressAutoFollow` that wedged that window's idle
+            // auto-follow off for good.
             NotificationCenter.default.addObserver(self, selector: #selector(beginRenameSessionNotified),
-                                                   name: .agtermBeginRenameSession, object: nil)
+                                                   name: .agtermBeginRenameSession, object: store)
             NotificationCenter.default.addObserver(self, selector: #selector(beginRenameWorkspaceNotified),
-                                                   name: .agtermBeginRenameWorkspace, object: nil)
+                                                   name: .agtermBeginRenameWorkspace, object: store)
             // expand/collapse target ONLY the frontmost window's sidebar: AppActions posts these with the
             // frontmost store as the object, and registering with `object: store` lets NotificationCenter
             // deliver only to the Coordinator whose store matches — so other windows' sidebars stay put.
-            // (The rename observers above are object: nil and self-scope via the selected-session guard;
-            // expand/collapse have no such natural per-window guard, so they scope by the store object.)
             NotificationCenter.default.addObserver(self, selector: #selector(expandWorkspacesNotified),
                                                    name: .agtermExpandWorkspaces, object: store)
             NotificationCenter.default.addObserver(self, selector: #selector(collapseWorkspacesNotified),

--- a/agtermTests/DockMenuTests.swift
+++ b/agtermTests/DockMenuTests.swift
@@ -62,7 +62,12 @@ final class DockMenuTests: XCTestCase {
         try await super.tearDown()
     }
 
-    func testHostProcessStartsWithIsolatedStateSocketAndShellFreeScene() throws {
+    // Covers the two legs that keep a hosted run off the user's real environment: the state dir and the
+    // control-socket path Xcode expands into the launch environment. It deliberately does NOT claim to
+    // cover the shell-free scene — nothing here observes the `isHostedUnitTest` branch being CONSUMED, and
+    // the only obvious probe (`AppDelegate.controlServer == nil`) rides the scene's async `.task`, so it
+    // would pass even with the branch deleted. Renaming rather than adding a assertion that cannot fail.
+    func testHostProcessStartsWithIsolatedStateAndSocket() throws {
         let environment = ProcessInfo.processInfo.environment
         let statePath = try XCTUnwrap(environment["AGTERM_STATE_DIR"])
         let socketPath = try XCTUnwrap(environment["AGTERM_CONTROL_SOCKET"])
@@ -124,6 +129,13 @@ final class DockMenuTests: XCTestCase {
         XCTAssertFalse(try item("Quick Terminal", in: menu).isEnabled)
         XCTAssertTrue(try item("Dashboard", in: menu).isEnabled,
                       "an open dashboard remains enabled so the Dock action can close it")
+
+        // and the enabled item must actually CLOSE it. This is the `dashboardWasOpen == true` half of the
+        // staleness guard (`dashboard.isOpen == dashboardWasOpen`), which nothing else invokes: every other
+        // dashboard case builds the menu while it is closed. Tightening that guard to `!dashboard.isOpen`
+        // would make the item inert here with the rest of the suite still green.
+        try invokeWithNilSender(try item("Dashboard", in: menu))
+        XCTAssertFalse(dashboard.isOpen, "a Dashboard item built while the dashboard was open should close it")
     }
 
     func testRecentSessionsUseMRUOrderExcludeCurrentAndShareSwitcherCap() throws {

--- a/agtermTests/InlineRenameScopeTests.swift
+++ b/agtermTests/InlineRenameScopeTests.swift
@@ -1,0 +1,92 @@
+import AppKit
+import XCTest
+@testable import agterm
+import agtermCore
+
+/// Hosted coverage for the per-window scoping of the inline-rename notifications. The sidebar owns the
+/// edit field, so `AppActions.renameActive{Session,Workspace}` reach it by notification; the object those
+/// posts carry is what decides WHICH window's sidebar starts an edit. `WorkspaceSidebar.Coordinator`
+/// registers with `object: store`, so a post carrying a different store (or nil) must not reach it.
+///
+/// This asserts the post's object rather than driving a real sidebar: the Coordinator needs a live
+/// `NSOutlineView` and a row to edit, while the defect being pinned is entirely in the addressing.
+@MainActor
+final class InlineRenameScopeTests: XCTestCase {
+    private var stateDir: URL!
+    private var library: WindowLibrary!
+    private var actions: AppActions!
+    private var tokens: [NSObjectProtocol] = []
+
+    override func setUp() async throws {
+        try await super.setUp()
+        await MainActor.run {
+            stateDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("agterm-rename-scope-tests-\(UUID().uuidString)", isDirectory: true)
+            library = WindowLibrary(directory: stateDir)
+            actions = AppActions(library: library)
+        }
+    }
+
+    override func tearDown() async throws {
+        await MainActor.run {
+            tokens.forEach { NotificationCenter.default.removeObserver($0) }
+            tokens.removeAll()
+            actions = nil
+            library = nil
+            try? FileManager.default.removeItem(at: stateDir)
+            stateDir = nil
+        }
+        try await super.tearDown()
+    }
+
+    // A rename started from the menu / palette / keymap must open an editor in the FRONTMOST window only.
+    // Posting with a nil object reached every open window's coordinator — their `selectedSessionID` guard
+    // is not a scope, since every window has a selection — so each one opened an editor the user never
+    // asked for and leaked an unbalanced `suppressAutoFollow`, wedging that window's idle auto-follow off.
+    func testRenameSessionPostsScopedToTheFrontmostStore() throws {
+        let (frontStore, otherStore) = try twoWindows()
+        let front = observe(.agtermBeginRenameSession, object: frontStore)
+        let other = observe(.agtermBeginRenameSession, object: otherStore)
+
+        actions.renameActiveSession()
+
+        XCTAssertEqual(front.count, 1, "the frontmost window's sidebar should be asked to start the edit")
+        XCTAssertEqual(other.count, 0, "a background window's sidebar must not start an edit it never asked for")
+    }
+
+    func testRenameWorkspacePostsScopedToTheFrontmostStore() throws {
+        let (frontStore, otherStore) = try twoWindows()
+        let front = observe(.agtermBeginRenameWorkspace, object: frontStore)
+        let other = observe(.agtermBeginRenameWorkspace, object: otherStore)
+
+        actions.renameActiveWorkspace()
+
+        XCTAssertEqual(front.count, 1, "the frontmost window's sidebar should be asked to start the edit")
+        XCTAssertEqual(other.count, 0, "a background window's sidebar must not start an edit it never asked for")
+    }
+
+    /// Opens a second window and leaves the FIRST one frontmost, returning (frontmost store, other store).
+    private func twoWindows() throws -> (AppStore, AppStore) {
+        let frontID = try XCTUnwrap(library.activeWindowID)
+        let frontStore = try XCTUnwrap(library.activeStore)
+        let otherID = library.newWindow(name: "window B").id
+        let otherStore = try XCTUnwrap(library.loadStore(for: otherID))
+        library.frontmostWindowID = frontID
+        XCTAssertFalse(frontStore === otherStore, "the two windows must own distinct stores")
+        return (frontStore, otherStore)
+    }
+
+    /// Counts deliveries of `name` filtered to `object`, mirroring how the sidebar coordinator registers.
+    private func observe(_ name: Notification.Name, object: AnyObject) -> Counter {
+        let counter = Counter()
+        let token = NotificationCenter.default.addObserver(
+            forName: name, object: object, queue: nil
+        ) { _ in counter.count += 1 }
+        tokens.append(token)
+        return counter
+    }
+
+    private final class Counter {
+        var count = 0
+    }
+}

--- a/agtermTests/SessionNavRevealTests.swift
+++ b/agtermTests/SessionNavRevealTests.swift
@@ -1,0 +1,78 @@
+import AppKit
+import XCTest
+@testable import agterm
+import agtermCore
+
+/// Hosted coverage for the plain-session-nav pane reveal (`AppActions.navigatePlain(_:)`). This lives in
+/// the app-hosted target rather than `agtermUITests` on purpose: it reaches `AppActions` directly through
+/// `@testable import agterm`, needs no terminal surface to observe the outcome (the reveal's `.left`/nil
+/// arm writes the MODEL flag `splitFocused` before it ever touches first responder), and — unlike the
+/// XCUITest suite, which CI does not run — it runs on every push via `scripts/test-app.sh`.
+@MainActor
+final class SessionNavRevealTests: XCTestCase {
+    private var stateDir: URL!
+    private var library: WindowLibrary!
+    private var actions: AppActions!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        await MainActor.run {
+            stateDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("agterm-session-nav-tests-\(UUID().uuidString)", isDirectory: true)
+            library = WindowLibrary(directory: stateDir)
+            actions = AppActions(library: library)
+        }
+    }
+
+    override func tearDown() async throws {
+        await MainActor.run {
+            actions = nil
+            library = nil
+            try? FileManager.default.removeItem(at: stateDir)
+            stateDir = nil
+        }
+        try await super.tearDown()
+    }
+
+    // A plain nav step that resolves to the session ALREADY selected must not run the pane reveal. `next`
+    // wraps within the filtered set, so a one-element set re-selects the current session, and
+    // `selectSession` does not short-circuit a same-target select — it still returns an indicator. Revealing
+    // on that indicator would clear `splitFocused` and pull the user onto the primary pane on a keystroke
+    // that moved nothing. An UNTAGGED `blocked` is the shape a plain `agtermctl session status blocked`
+    // sends and routes to the `.left`/nil arm, which is the arm that does the clearing.
+    func testPlainNavThatMovesNothingKeepsSplitFocus() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let session = try XCTUnwrap(store.activeSession)
+        XCTAssertEqual(store.navigableSessions.count, 1, "the wrap-onto-self case needs a one-element set")
+
+        session.agentIndicator = AgentIndicator(status: .blocked)
+        session.splitFocused = true
+
+        actions.selectNextSession()
+
+        XCTAssertEqual(store.selectedSessionID, session.id, "wrapping in a one-element set re-selects it")
+        XCTAssertTrue(session.splitFocused,
+                      "a nav step that moved nothing must leave the user on the split pane he was typing in")
+    }
+
+    // The other direction, so the test above cannot pass by the reveal being dead everywhere: a step that
+    // DOES move still reveals the moved-to session's tagged pane. Same untagged `blocked` shape, so the
+    // same `.left`/nil arm runs — here it should clear `splitFocused`, targeting the primary pane.
+    func testPlainNavThatMovesRunsTheReveal() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let first = try XCTUnwrap(store.activeSession)
+        let workspaceID = try XCTUnwrap(store.currentWorkspaceID)
+        let second = try XCTUnwrap(store.addSession(toWorkspace: workspaceID, cwd: NSHomeDirectory()))
+
+        second.agentIndicator = AgentIndicator(status: .blocked)
+        second.splitFocused = true
+        store.selectSession(first.id)
+        XCTAssertEqual(store.navigableSessions.count, 2)
+
+        actions.selectNextSession()
+
+        XCTAssertEqual(store.selectedSessionID, second.id, "the step should move to the second session")
+        XCTAssertFalse(second.splitFocused,
+                       "a step that moved should reveal the untagged block's primary pane")
+    }
+}

--- a/agtermUITests/PaneAwareStatusUITests.swift
+++ b/agtermUITests/PaneAwareStatusUITests.swift
@@ -103,6 +103,48 @@ final class PaneAwareStatusUITests: ControlAPITestCase {
                       "previous-attention should reveal the selected session's tagged right pane")
     }
 
+    // The INVERSE of the test above, and the reason plain nav and attention nav must not share a fallback:
+    // a PLAIN ⌥⌘↓ that resolves to the session already selected must leave the user's pane alone. In a
+    // one-element filtered set (flagged mode, a single flag) `next` wraps back onto the current session, so
+    // `navigateSession` re-selects it and — since `selectSession` does not short-circuit a same-target select
+    // — still hands back an indicator. Revealing on that would clear `splitFocused` and drop the user onto
+    // the primary pane on a keystroke that moved nothing.
+    func testPlainNavNoOpKeepsTheFocusedSplitPane() throws {
+        let sessionA = try activeSessionID()
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.split","target":"\#(sessionA)","args":{"mode":"on"}}"#)["ok"] as? Bool,
+                       true, "split on should succeed")
+        XCTAssertTrue(pollActiveSessionSplit(true, timeout: 10), "the session should report split:true")
+
+        let leftTag = "PNOL-\(UUID().uuidString.prefix(8))"
+        let rightTag = "PNOR-\(UUID().uuidString.prefix(8))"
+        try seedPaneMarker(target: sessionA, pane: "left", tag: leftTag)
+        try seedPaneMarker(target: sessionA, pane: "right", tag: rightTag)
+
+        // the user is working in the split (right) pane while the agent blocks in the MAIN pane. An UNTAGGED
+        // block is treated as `left`, which is what a plain `agtermctl session status blocked` sends, and a
+        // left-scoped block is not cleared by typing in the right pane, so the state persists into the nav.
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.focus","target":"\#(sessionA)","args":{"pane":"right"}}"#)["ok"] as? Bool,
+                       true, "focusing the right pane should succeed")
+        XCTAssertTrue(try pollOnScreen(target: sessionA, contains: "\(rightTag)-42"),
+                      "the split pane should be the on-screen surface before nav")
+        try blockPane("blocked", pane: nil, target: sessionA)
+
+        // narrow the navigable set to this one session so ⌥⌘↓ wraps onto it instead of moving elsewhere.
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.flag","target":"\#(sessionA)","args":{"mode":"on"}}"#)["ok"] as? Bool,
+                       true, "flagging the session should succeed")
+        XCTAssertEqual(try sendCommand(#"{"cmd":"sidebar.mode","args":{"mode":"flagged"}}"#)["ok"] as? Bool,
+                       true, "switching to flagged mode should succeed")
+
+        app.typeKey(.downArrow, modifierFlags: [.command, .option])
+
+        XCTAssertTrue(try pollActiveNode(equals: sessionA, timeout: 12),
+                      "the wrapping step should keep the same session selected")
+        XCTAssertFalse(try pollOnScreen(target: sessionA, contains: "\(leftTag)-42", timeout: 3),
+                       "a plain nav that moved nothing must not pull the on-screen surface onto the primary pane")
+        XCTAssertTrue(try pollOnScreen(target: sessionA, contains: "\(rightTag)-42"),
+                      "the split pane the user was working in should still be the on-screen surface")
+    }
+
     // a `right`-tagged block on a HIDDEN split: nav reveals it by swapping which pane shows MAXIMIZED (the
     // split stays hidden — split:false — but the right pane is now the on-screen one), not by re-showing the
     // two panes side-by-side.


### PR DESCRIPTION
Follow-up to the round-6 review on #284, plus one pre-existing bug that review turned up.

**The nav regression #284 introduced.** The `.left`/nil arm of `revealActiveBlockedPane(captured:)` became an unconditional `splitFocused = false` + `focusSplitPane(wantSplit: false)`, where master ended that arm in `focusActiveSession()`. `selectSession` does not short-circuit a same-target select, so a plain nav step that resolved to the session already selected still got an indicator back and fired the reveal, pulling you off the split pane you were typing in. Reachable two ways: `next`/`previous` wrapping in a one-element filtered set, and `first`/`last` while already at that end, which needs no filter at all.

The four plain-nav actions now share a private `navigatePlain(_:)` that records `selectedSessionID` before navigating and reveals only when it changed. The `?? activeSession?.agentIndicator` fallback is gone from that path: a plain direction returns nil from `navigateSession` only when `navigableSessions` is empty, and then nothing was selected, so the moved-check already covers it. Attention nav keeps its fallback, since `attentionTarget` excludes the current session and that is exactly the case it exists for.

**`focusSplitPane` guard gaps.** It checks zoom, dashboard and the quick terminal, but not `renamePending` or an open palette, which `focusActiveSession` re-checks on every one of its 12 retries. Since the `.left`/nil reveal routes through it, a row click followed within the ~360ms retry window by ⌘R or a palette open could pull first responder off the field. Both guards added, scoped to the session's own window like the two above them, because both flags are app-global while this path is deliberately cross-window.

**Inline rename fanned out to every window.** Separate from #284, and older. `renameActiveSession`/`renameActiveWorkspace` posted with `object: nil` and every window's sidebar coordinator observed with `object: nil`, so one rename started an inline edit in every open window. The handlers' `selectedSessionID` guard scopes nothing, since every window has a selection. Each stray edit also leaked one `suppressAutoFollow` (a counter only that field's own `controlTextDidEndEditing` decrements), so two renames wedged idle auto-follow off for good in the other windows, and switching to one put first responder on a rename field you never opened. Now scoped by `object: store`, matching how expand/collapse already work three lines below. The comment claiming the rename observers self-scope was the inverse of the behavior.

**Corrections to things the earlier rounds got wrong.** `menu-actions.md` claimed every GUI action calls `focusActiveSession()` after the move, contradicting the paragraph added below it. The "one remaining path, a rebound keymap chord" line named a route that does not exist: a rebound built-in chord is the menu item's key equivalent, already `.disabled(modalActive)`. `sidebar.md` still named the deleted `revealActiveBlockedPane()` signature and omitted the Dock from its caller list. `ci.md` lost the `🚨 Nothing to report` Coveralls symptom and the cache key in its rewrite, and never recorded that the build job compiles the app twice by design.

**Tests.** Four new hosted cases in `agtermTests`, which CI actually runs. The XCUITest suite does not run in CI, and the one XCUITest guarding the nav fix narrowed nothing anyway, since the harness seeds a single session. `SessionNavRevealTests` covers both nav directions, `InlineRenameScopeTests` covers the rename scoping, and the Dock-menu suite gains the built-open dashboard close toggle. Every new assertion was checked against reverted code to confirm it fails without the fix.

Related to #284
