### PR TITLE
fix(keymap): keep cmd+w with Close Session across a keymap reload

### DIFF
--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -43,8 +43,25 @@ paths:
   ride AppKit menu-key-equivalents: each built-in `Button` in `agtermApp`'s `.commands` reads `settingsModel.keymap.equivalent(for: .action)`
   via the `shortcut(for:)` helper (`Chord` → SwiftUI `KeyboardShortcut?`,
   applied only when non-nil so a keyless action stays keyless until mapped).
-  Because `keymap` is `@Observable` and `.commands` reads it, the menu shortcuts re-render on reload
-  — no notification needed for the menu.
+  **`keymap` being `@Observable` does NOT make the menu track it live — do not assume a reload reaches the
+  key equivalents.**
+  SwiftUI defers its menu rebuild to the next app ACTIVATION, so after a `keymap reload` the live
+  `NSMenuItem` key equivalents keep the OLD chords until the app is deactivated and reactivated.
+  The rebuild is also where SwiftUI's conflict resolution runs, and it resolves a collision by unbinding
+  **agterm's** item, never the stock one.
+  So once the stock File ▸ Close (`performClose:`) holds ⌘W, giving `close_session` the chord back leaves
+  agterm's item with NO chord and ⌘W closing the whole window.
+  `AppDelegate.applyCloseSessionChord` asserts that split from AppKit: clear the stock item's ⌘W while the
+  keymap gives the chord to `close_session`, restore it while it does not.
+  Re-run it at launch, on `.agtermKeymapChanged`, on `didBecomeActive` (async, so it lands after SwiftUI's
+  rebuild), and on menu tracking — SwiftUI re-applies its resolution on every rebuild, so a one-shot does
+  not stick (the `removeNativeFullScreenMenuItem` pattern).
+  ⌘W is the only chord asserted this way because it is the only built-in chord with a stock competitor;
+  every other rebind takes effect on the next activation.
+  **A change affecting menu shortcuts needs a RELOAD-path test — seeding `keymap.conf` before launch does
+  not exercise reload.**
+  Cover both in `agtermTests/CloseSessionChordTests.swift` and
+  `KeymapUITests.testCloseSessionReclaimsCommandWAfterReload`.
   Custom commands ride an app-wide `NSEvent` local `.keyDown` monitor in `CustomCommandRunner` (the same
   monitor pattern as the Ctrl-Tab switcher and Ctrl-1/2): it maps `NSEvent` → `Chord`,
   feeds a `KeybindMatcher` (firing simple chords + leader sequences like `ctrl+a>g`,

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ workspaces.json
 windows/
 *.sock
 
+# revmux review scaffolding: caller-written task context plus its run archive, local to a review
+.revmux/
+
 # track the path-scoped Claude rules (the global ~/.gitignore_global ignores .claude/)
 !.claude/
 .claude/*

--- a/agterm/AppDelegate.swift
+++ b/agterm/AppDelegate.swift
@@ -78,11 +78,89 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         AppDelegate.removeNativeFullScreenMenuItem()
         NotificationCenter.default.addObserver(self, selector: #selector(menuBeganTracking),
                                                name: NSMenu.didBeginTrackingNotification, object: nil)
+        // SwiftUI defers its menu rebuild to the next app ACTIVATION, and that rebuild is what lets the
+        // stock File ▸ Close claim ⌘W. Reconcile after it (async, so we run once SwiftUI has rebuilt) and
+        // on every keymap change, so a `keymap reload` takes effect on the chord immediately.
+        NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActive),
+                                               name: NSApplication.didBecomeActiveNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keymapChanged),
+                                               name: .agtermKeymapChanged, object: nil)
+        reconcileCloseSessionChord()
+    }
+
+    @objc private func appDidBecomeActive(_: Notification) {
+        DispatchQueue.main.async { [weak self] in
+            MainActor.assumeIsolated { self?.reconcileCloseSessionChord() }
+        }
+    }
+
+    @objc private func keymapChanged(_: Notification) {
+        MainActor.assumeIsolated { reconcileCloseSessionChord() }
     }
 
     @objc private func menuBeganTracking(_: Notification) {
-        MainActor.assumeIsolated { AppDelegate.removeNativeFullScreenMenuItem() }
+        MainActor.assumeIsolated {
+            AppDelegate.removeNativeFullScreenMenuItem()
+            reconcileCloseSessionChord()
+        }
     }
+
+    /// Keep ⌘W with agterm's File ▸ Close Session whenever the keymap says it owns that chord.
+    ///
+    /// SwiftUI hands the stock File ▸ Close (`performClose:`) a ⌘W key equivalent the moment agterm's own
+    /// item vacates the chord — a `map cmd+<other> close_session` plus `keymap reload` is enough. Putting
+    /// `close_session` back on ⌘W does NOT reclaim it: SwiftUI resolves the collision by dropping the
+    /// shortcut from its OWN item, leaving Close Session unbound and ⌘W closing the whole window until the
+    /// app is relaunched (issue #296). So agterm asserts the split itself rather than leaving it to
+    /// SwiftUI's one-time conflict resolution. Reconciled from the AppKit side, like
+    /// `removeNativeFullScreenMenuItem`, because there is no SwiftUI API for either half.
+    private func reconcileCloseSessionChord() {
+        guard let keymap = settingsModel?.keymap else { return }
+        AppDelegate.applyCloseSessionChord(keymap, in: NSApp.mainMenu)
+    }
+
+    /// Split ⌘W between agterm's Close Session item and the stock `performClose:` one, following `keymap`.
+    /// Operates on whichever submenu holds `performClose:`; a menu without both items is left alone.
+    ///
+    /// The stock item may hold ⌘W only while NO built-in resolves to it. Deciding that from `close_session`
+    /// alone is not enough: `parseKeymap` rejects a chord only when two DISTINCT actions resolve to it, so
+    /// `map cmd+e close_session` plus `map cmd+w new_session` is a clean keymap in which another action
+    /// legitimately owns ⌘W, and arming the stock item there would advertise the chord twice and let
+    /// SwiftUI's next rebuild unbind agterm's own item — the very failure this reconcile exists to prevent.
+    ///
+    /// agterm's item is a SwiftUI closure button with no distinguishing selector, so it can only be matched
+    /// by title — scoping that match to the submenu that owns `performClose:` keeps it narrow.
+    static func applyCloseSessionChord(_ keymap: Keymap, in mainMenu: NSMenu?) {
+        let closeSessionOwns = keymap.equivalent(for: .closeSession) == commandW
+        let anyBuiltinOwns = BuiltinAction.allCases.contains { keymap.equivalent(for: $0) == commandW }
+        let closeSelector = #selector(NSWindow.performClose(_:))
+        for topItem in mainMenu?.items ?? [] {
+            guard let submenu = topItem.submenu,
+                  let stockClose = submenu.items.first(where: { $0.action == closeSelector }),
+                  let ours = submenu.items.first(where: { $0.title == closeSessionItemTitle })
+            else { continue }
+            // our item carries ⌘W exactly while close_session owns it. Clearing a stale one matters because
+            // SwiftUI defers its rebuild to the next activation, so straight after a reload that rebound
+            // close_session away our item still advertises the chord the stock item is about to take.
+            if closeSessionOwns {
+                ours.keyEquivalent = "w"
+                ours.keyEquivalentModifierMask = .command
+            } else if hasCommandW(ours) {
+                ours.keyEquivalent = ""
+                ours.keyEquivalentModifierMask = []
+            }
+            stockClose.keyEquivalent = anyBuiltinOwns ? "" : "w"
+            stockClose.keyEquivalentModifierMask = anyBuiltinOwns ? [] : .command
+        }
+    }
+
+    private static func hasCommandW(_ item: NSMenuItem) -> Bool {
+        item.keyEquivalent == "w" && item.keyEquivalentModifierMask == .command
+    }
+
+    /// The File-menu title of agterm's own close-the-session item, matched by `applyCloseSessionChord`.
+    static let closeSessionItemTitle = "Close Session"
+    private static let commandW = Chord(mods: [.command], key: "w")
 
     /// Remove AppKit's auto-injected fullscreen menu item — the one whose action is `toggleFullScreen:`.
     /// agterm's own item uses a SwiftUI closure action (a different selector), so only the native item

--- a/agterm/agtermApp+Menus.swift
+++ b/agterm/agtermApp+Menus.swift
@@ -6,7 +6,9 @@ extension agtermApp {
     /// The active SwiftUI shortcut for a built-in action, driven by the keymap: the user override when
     /// one is `map`ped, else the action's shipped default. `nil` only for a keyless action, which stays
     /// keyless until the user maps a chord.
-    /// Because `keymap` is `@Observable`, reading it here re-renders the menu shortcut on a reload.
+    /// `keymap` is `@Observable`, but SwiftUI does not rebuild the menu when it changes — it defers to the
+    /// next app activation, so a reload leaves the live key equivalents stale until then.
+    /// ⌘W is asserted from AppKit instead, by `AppDelegate.applyCloseSessionChord`.
     private func shortcut(for action: BuiltinAction) -> KeyboardShortcut? {
         settingsModel.keymap.equivalent(for: action).map(Self.toShortcut)
     }

--- a/agtermTests/CloseSessionChordTests.swift
+++ b/agtermTests/CloseSessionChordTests.swift
@@ -1,0 +1,152 @@
+import AppKit
+import XCTest
+@testable import agterm
+import agtermCore
+
+/// Coverage for `AppDelegate.applyCloseSessionChord`, which decides whether ⌘W belongs to agterm's
+/// File ▸ Close Session or to the stock `performClose:` item.
+///
+/// SwiftUI hands the stock item a ⌘W key equivalent as soon as agterm's own item vacates the chord, and
+/// putting `close_session` back on ⌘W does not reclaim it — SwiftUI drops the shortcut from its OWN item
+/// instead, leaving Close Session unbound and ⌘W closing the whole window until relaunch. These tests
+/// drive the real `NSMenu` shapes the reconcile has to handle.
+@MainActor
+final class CloseSessionChordTests: XCTestCase {
+    private let commandW = Chord(mods: [.command], key: "w")
+
+    private func keymap(_ overrides: [BuiltinAction: Chord] = [:]) -> Keymap {
+        Keymap(builtinOverrides: overrides, commands: [])
+    }
+
+    // A File menu shaped like the real one: agterm's Close Session (a SwiftUI closure button, so no
+    // distinguishing selector) above the stock Close carrying `performClose:`.
+    private func makeFileMenu(oursKey: String = "", stockKey: String = "") -> (menu: NSMenu, ours: NSMenuItem, stock: NSMenuItem) {
+        let ours = NSMenuItem(title: AppDelegate.closeSessionItemTitle, action: nil, keyEquivalent: oursKey)
+        if !oursKey.isEmpty { ours.keyEquivalentModifierMask = .command }
+        let stock = NSMenuItem(title: "Close", action: #selector(NSWindow.performClose(_:)), keyEquivalent: stockKey)
+        if !stockKey.isEmpty { stock.keyEquivalentModifierMask = .command }
+        let submenu = NSMenu(title: "File")
+        submenu.addItem(ours)
+        submenu.addItem(stock)
+        let fileItem = NSMenuItem(title: "File", action: nil, keyEquivalent: "")
+        fileItem.submenu = submenu
+        let main = NSMenu()
+        main.addItem(fileItem)
+        return (main, ours, stock)
+    }
+
+    private func assertOwnsCommandW(_ item: NSMenuItem, _ message: String, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(item.keyEquivalent, "w", message, file: file, line: line)
+        XCTAssertEqual(item.keyEquivalentModifierMask, .command, message, file: file, line: line)
+    }
+
+    /// A menu item has no shortcut when its key equivalent is empty; the modifier mask alone is inert and
+    /// AppKit defaults it to `.command` even for an item created with no key, so asserting on it would
+    /// fail for items this reconcile never touches.
+    private func assertNoChord(_ item: NSMenuItem, _ message: String, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(item.keyEquivalent, "", message, file: file, line: line)
+    }
+
+    func testDefaultKeymapGivesCommandWToCloseSessionAlone() {
+        let menu = makeFileMenu(oursKey: "w")
+        AppDelegate.applyCloseSessionChord(keymap(), in: menu.menu)
+
+        assertOwnsCommandW(menu.ours, "Close Session should own ⌘W at its shipped default")
+        assertNoChord(menu.stock, "the stock Close must not compete for ⌘W")
+    }
+
+    // the reported state: SwiftUI resolved the collision by unbinding its own item, so Close Session
+    // carries NOTHING while the stock Close holds ⌘W. Reconcile has to undo exactly that.
+    func testRecoversFromSwiftUIUnbindingOurItem() {
+        let menu = makeFileMenu(oursKey: "", stockKey: "w")
+        AppDelegate.applyCloseSessionChord(keymap(), in: menu.menu)
+
+        assertOwnsCommandW(menu.ours, "Close Session should get ⌘W back")
+        assertNoChord(menu.stock, "the stock Close should have released ⌘W")
+    }
+
+    func testRebindingCloseSessionAwayHandsCommandWToTheStockClose() {
+        let menu = makeFileMenu(oursKey: "e")
+        AppDelegate.applyCloseSessionChord(keymap([.closeSession: Chord(mods: [.command], key: "e")]), in: menu.menu)
+
+        assertOwnsCommandW(menu.stock, "nothing of agterm's wants ⌘W, so the stock Close keeps it")
+    }
+
+    // a previous reconcile cleared the stock Close while close_session held ⌘W; rebinding away must hand
+    // the chord back rather than leaving ⌘W dead.
+    func testRebindingAwayRestoresAClearedStockChord() {
+        let menu = makeFileMenu(oursKey: "e", stockKey: "")
+        AppDelegate.applyCloseSessionChord(keymap([.closeSession: Chord(mods: [.command], key: "e")]), in: menu.menu)
+
+        assertOwnsCommandW(menu.stock, "a cleared stock chord must be restored once agterm stops wanting it")
+    }
+
+    // SwiftUI defers its rebuild to the next activation, so straight after a reload that rebound
+    // close_session away our item still advertises ⌘W. Arming the stock item without clearing that stale
+    // one would leave the File menu showing ⌘W twice, one of them on the close-the-whole-window item.
+    func testStaleOurChordIsClearedWhenTheStockCloseTakesCommandW() {
+        let menu = makeFileMenu(oursKey: "w", stockKey: "")
+        AppDelegate.applyCloseSessionChord(keymap([.closeSession: Chord(mods: [.command], key: "e")]), in: menu.menu)
+
+        assertNoChord(menu.ours, "our stale ⌘W must be released when the stock Close takes the chord")
+        assertOwnsCommandW(menu.stock, "the stock Close should hold ⌘W")
+    }
+
+    // `parseKeymap` rejects a chord only when two DISTINCT actions resolve to it, so moving close_session
+    // off ⌘W frees the chord for any other built-in. Deciding stock ownership from close_session alone
+    // would arm the stock item against a live built-in binding and re-create the reported failure.
+    func testAnotherBuiltinOwningCommandWKeepsTheStockCloseBare() {
+        let menu = makeFileMenu(oursKey: "e", stockKey: "w")
+        let overrides: [BuiltinAction: Chord] = [
+            .closeSession: Chord(mods: [.command], key: "e"),
+            .newSession: commandW,
+        ]
+        AppDelegate.applyCloseSessionChord(keymap(overrides), in: menu.menu)
+
+        assertNoChord(menu.stock, "new_session owns ⌘W, so the stock Close must not advertise it too")
+        XCTAssertEqual(menu.ours.keyEquivalent, "e", "our item's own chord must be left alone")
+    }
+
+    func testUnboundCloseSessionLeavesTheStockCloseItsChord() {
+        // close_session is keyless only if mapped to nothing; model that as another action taking its
+        // default chord so `equivalent(for:)` no longer returns ⌘W for it.
+        let menu = makeFileMenu()
+        AppDelegate.applyCloseSessionChord(keymap([.closeSession: Chord(mods: [.command], key: "e")]), in: menu.menu)
+
+        assertOwnsCommandW(menu.stock, "the stock Close keeps ⌘W when no built-in claims it")
+        assertNoChord(menu.ours, "an item whose action does not own ⌘W must not be given the chord")
+    }
+
+    // repeated flips are the reported workflow (rebind away, rebind back, both via `keymap reload`), so
+    // the reconcile has to be stable across them rather than correct only on the first transition.
+    func testRepeatedFlipsKeepOwnershipConsistent() {
+        let menu = makeFileMenu(oursKey: "w")
+        let away = keymap([.closeSession: Chord(mods: [.command], key: "e")])
+        for _ in 0..<3 {
+            AppDelegate.applyCloseSessionChord(away, in: menu.menu)
+            assertOwnsCommandW(menu.stock, "rebound away: the stock Close holds ⌘W")
+            assertNoChord(menu.ours, "rebound away: our item must not still advertise ⌘W")
+
+            AppDelegate.applyCloseSessionChord(keymap(), in: menu.menu)
+            assertOwnsCommandW(menu.ours, "rebound back: Close Session holds ⌘W")
+            assertNoChord(menu.stock, "rebound back: the stock Close must release ⌘W")
+        }
+    }
+
+    // a menu missing either half (no `performClose:`, or no Close Session) must be left untouched rather
+    // than half-reconciled — the Edit/View menus go through the same walk.
+    func testMenuWithoutBothItemsIsLeftAlone() {
+        let lone = NSMenuItem(title: "Something Else", action: nil, keyEquivalent: "w")
+        lone.keyEquivalentModifierMask = .command
+        let submenu = NSMenu(title: "View")
+        submenu.addItem(lone)
+        let top = NSMenuItem(title: "View", action: nil, keyEquivalent: "")
+        top.submenu = submenu
+        let main = NSMenu()
+        main.addItem(top)
+
+        AppDelegate.applyCloseSessionChord(keymap(), in: main)
+
+        assertOwnsCommandW(lone, "an unrelated menu must not be rewritten")
+    }
+}

--- a/agtermUITests/KeymapUITests.swift
+++ b/agtermUITests/KeymapUITests.swift
@@ -313,8 +313,42 @@ final class KeymapUITests: XCTestCase {
         return target
     }
 
-    /// Writes `keymap.conf` under the isolated state dir's `config` directory, before launch, so
-    /// `SettingsModel.loadKeymap` reads it at init (and `ensureStarterKeymap` leaves it untouched).
+    // issue #296: moving close_session OFF ⌘W lets SwiftUI's stock File ▸ Close claim the chord, and
+    // putting close_session BACK on ⌘W does not reclaim it — SwiftUI unbinds its own item instead, so ⌘W
+    // closed the whole window until the app was relaunched. Drive the reported sequence through RELOAD
+    // (never a relaunch): start with the override, remove it, reload, then press ⌘W and assert a session
+    // closed and the window survived. The existing keymap coverage only ever seeds the file at LAUNCH, so
+    // the reload path this regressed on had no test at all.
+    func testCloseSessionReclaimsCommandWAfterReload() throws {
+        seedKeymap("map cmd+e close_session\n")
+        app.launchForUITest()
+        XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session should exist")
+        XCTAssertTrue(poll { self.sessionRowCount() == 1 }, "should start with the one seeded session")
+
+        // a second session, so closing one leaves the window populated (an emptied window legitimately
+        // closes on ⌘W, which would make the assertion below ambiguous).
+        app.typeKey("n", modifierFlags: .command)
+        XCTAssertTrue(poll { self.sessionRowCount() == 2 }, "⌘N should add a second session")
+
+        // remove the override so close_session falls back to its shipped ⌘W, then reload — no relaunch.
+        seedKeymap("")
+        reloadKeymapFromMenu()
+
+        app.typeKey("w", modifierFlags: .command)
+        XCTAssertTrue(poll({ self.sessionRowCount() == 1 }, timeout: 10),
+                      "⌘W should close a session once the override is gone; the stock File ▸ Close must not keep the chord")
+        // the window-close confirmation is the pre-fix symptom — it must not have appeared.
+        XCTAssertFalse(app.sheets.firstMatch.exists, "⌘W must not raise the close-window confirmation")
+        XCTAssertEqual(app.state, .runningForeground, "the window must survive")
+    }
+
+    private func reloadKeymapFromMenu() {
+        app.menuBars.menuBarItems["File"].click()
+        let item = app.menuItems["Reload Keymap"]
+        XCTAssertTrue(item.waitForExistence(timeout: 5), "File menu should offer Reload Keymap")
+        item.click()
+    }
+
     private func seedKeymap(_ contents: String) {
         let configDir = stateDir.appendingPathComponent("config", isDirectory: true)
         try? FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)


### PR DESCRIPTION
⌘W closed the whole window instead of the active session, and only a relaunch cleared it.

**What happens.** agterm's File ▸ Close Session takes its chord from the keymap, so by default it carries ⌘W, and SwiftUI leaves the stock File ▸ Close bare. Two things then go wrong at runtime. SwiftUI does not rebuild the menu when the observable keymap changes, it defers to the next app activation, so after `keymap reload` the live key equivalents still hold the old chords. And that deferred rebuild is where SwiftUI's conflict resolution runs, which resolves a collision by unbinding agterm's own item, never the stock one.

So once `close_session` has been mapped away from ⌘W and the stock Close has taken the chord, mapping it back leaves Close Session with no chord at all while ⌘W still dispatches to `performClose:`. Sticky for the life of the process, which is why the reporter's restart looked like a fix.

**The fix.** `AppDelegate.applyCloseSessionChord` asserts the one contested chord from AppKit rather than trying to make SwiftUI rebuild. The stock item may hold ⌘W only while no built-in resolves to it: `parseKeymap` rejects a chord only when two distinct actions claim it, so moving `close_session` away frees ⌘W for any other action, and deciding ownership from `close_session` alone would arm the stock item against a live binding. A stale ⌘W on agterm's item is released when the stock item takes the chord, so the File menu never advertises it twice during the deferred-rebuild window.

Re-run at launch, on keymap change, on activation, and on menu tracking, since SwiftUI re-applies its resolution on every rebuild. Same shape as the existing `removeNativeFullScreenMenuItem`, which fights the same class of AppKit re-injection.

**Reproduced before fixing, on an isolated instance.** Rebind `close_session` off ⌘W, reload, remove the override, reload, then press ⌘W without relaunching: window-close prompt with live sessions. Relaunch with the same config and ⌘W closes a session. The mechanism was read off the live menu by dumping `NSApp.mainMenu` at reload time, after a render pass, on menu tracking and on activation, not inferred.

All four transitions verified by hand afterwards: ⌘W → ⌘E, ⌘E → ⌘W implicitly, ⌘E → ⌘W explicitly, and repeated flips in one run.

**Tests.** `agtermTests/CloseSessionChordTests.swift` covers both branches, the recovery from SwiftUI unbinding our item, another built-in owning ⌘W, the stale-chord release, and repeated flips. `KeymapUITests.testCloseSessionReclaimsCommandWAfterReload` drives the reported sequence end to end through reload, and was confirmed to fail with the fix disabled. The existing keymap coverage only ever seeded `keymap.conf` before launch, so the reload path had no test at all, which is where this lived.

`.claude/rules/keymap.md` claimed the menu re-renders on reload because `keymap` is `@Observable`. It does not, and that claim is corrected.

Second commit is unrelated, a `.gitignore` line for revmux review scaffolding.

Fix #296
