### PR TITLE
feat(control): add keymap.list, the read side of keymap.reload

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -273,8 +273,8 @@ paths:
   Setting echoes the resulting effective side in `result.text`; the BARE form (no name) reads the side
   the last config feed applied (`SettingsModel.lastAppliedIsDark`), which the test polls to prove the
   flip actually drove the reload.
-  `AppearanceFlipUITests` is its only consumer; the public command count stays 67
-  (`Command` has 68 cases, minus this one seam).
+  `AppearanceFlipUITests` is its only consumer; the public command count stays 68
+  (`Command` has 69 cases, minus this one seam).
 
   `workspace.delete` honors keep-at-least-one and returns an error instead of the GUI confirm alert (nothing
   blocks on a modal).
@@ -1689,7 +1689,7 @@ paths:
   (image/text/color set/clear + tree read-back).
   **Agent-skill mirror (HARD keep-in-sync, 4th surface):** all commands are documented in the bundled
   `agterm/Resources/agent-skill/` (SKILL.md summary, reference.md detail,
-  examples.md recipes) and the command count there is bumped to 67 to match.
+  examples.md recipes) and the command count there is bumped to match.
   It is a CODE gate too: `SkillInstallTests.bundledSkillDocumentsEventSubscriptionCommand` asserts the
   `Command summary (N commands)` heading against the bundled `SKILL.md`, so a stale count fails `swift test`.
   **Website mirror (HARD keep-in-sync):** the site's per-command reference `site/commands.html` documents
@@ -1708,5 +1708,12 @@ paths:
   Use something like `grep -rnE "\b[0-9]{2,3}\b[A-Za-z ,'-]{0,40}commands?\b"` scoped to `README.md`,
   `site/`, `agterm/Resources/agent-skill/`, and `.claude/rules/`, and reconcile EVERY hit against the
   `Command` case count.
+  **That pattern requires the word "commands" AFTER the number and so misses the phrasings this very file
+  uses** — "the public command count stays N", "`Command` has N cases" — which is how BOTH of them
+  survived the 67 → 68 bump while the paragraph above them was corrected.
+  Finish with a bare `rg -n '\b[0-9]{2,3}\b' .claude/rules/control-api.md` over this file and read every
+  hit, or state the count once and reference it everywhere else.
+  Note also that counting `case x = "…"` lines UNDERCOUNTS by five: `tree`, `dashboard`, `quick`,
+  `sidebar` and `notify` carry IMPLICIT raw values, so count `case` lines instead.
   It drifted once because the site keep-in-sync convention named only `docs.html`/`index.html`, so
   `dashboard` and `surface.zoom` shipped undocumented here.

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -166,7 +166,7 @@ paths:
   The skill is a REFERENCE/knowledge skill (both user-invocable via `/agterm` and model-triggered,
   `allowed-tools: Bash(agtermctl *)`; the agent-neutral `description` carries the trigger nouns since
   Codex may ignore the extra `when_to_use` field — unknown frontmatter is harmless),
-  authored at `agterm/Resources/agent-skill/` (`SKILL.md` overview + model + addressing + 67-command
+  authored at `agterm/Resources/agent-skill/` (`SKILL.md` overview + model + addressing + 68-command
   summary + the image-display helper + a troubleshooting/reporting pointer;
   `reference.md` full per-command detail + keymap format; `examples.md` agtermctl recipes;
   `troubleshooting.md` diagnosing the common problems (keymap editor, custom actions,
@@ -244,7 +244,7 @@ paths:
   rules, then remaining targets resolve inside that same store so one command never mutates multiple windows.
   The top-level `target` also carries the first explicit batch target so a new CLI talking to a still-running
   pre-batch server degrades to a named session instead of accidentally acting on `active`.
-- **Command catalog (67 commands):**
+- **Command catalog (68 commands):**
   - `tree`
   - `events.read` (the bounded per-app-run control event ring behind `agtermctl events`)
   - `workspace.new`/`workspace.rename`/`workspace.delete`/`workspace.select`/`workspace.move`/`workspace.focus`/`workspace.filter`/`workspace.collapse`/`workspace.expand`
@@ -256,7 +256,7 @@ paths:
   - `notify`
   - `font.inc`/`font.dec`/`font.reset`
   - `window.new`/`window.list`/`window.select`/`window.close`/`window.rename`/`window.delete`/`window.resize`/`window.move`/`window.zoom`/`window.fullscreen`/`window.minimize` (see the Windows section)
-  - `keymap.reload` (see the Keymap section)
+  - `keymap.reload`/`keymap.list` (see the Keymap section)
   - `config.reload` (see the Settings section)
   - `theme.set`/`theme.list` (see the Theme picker section)
   - `restore.clear` (see the Settings section)
@@ -1152,6 +1152,32 @@ paths:
   in `ControlServer`, (3) the `keymap reload` subcommand in `agtermctlKit`,
   (4) round-trip tests in `ControlProtocolTests` plus the e2e in `ControlAPIUITests`.
   See the Keymap section for the parser/menu/monitor design.
+  `keymap.list` is `keymap.reload`'s READ side, and it reports TWO things that can disagree:
+  `result.keymap.actions` is every `BuiltinAction` with the chord the keymap RESOLVED for it (kitty
+  syntax, `overridden: true` when a `map` moved it off its default, keyless actions listed with no
+  chord), while `result.keymap.menu` is what the menu bar is actually DISPATCHING — every live
+  `NSMenuItem` key equivalent, with its menu, title and Objective-C selector.
+  The menu half is the point: SwiftUI defers its menu rebuild to the next app activation and resolves a
+  chord collision by unbinding agterm's own item, so a chord can be correct in `actions` and wrong in
+  `menu`, and a model-only listing would report a clean keymap while ⌘W closes the window.
+  Also carries `path` (which `keymap.conf` produced it), `commands` (custom commands, `shortcut` omitted
+  for a palette-only one), and `diagnostics` (line + message — `keymap.reload` returns only their COUNT).
+  App-global like `keymap.reload`, so no `--window` selector, and it takes no target or args.
+  The projection is host-free (`ControlKeymap.project`, `agtermCore/ControlKeymap.swift`); only the live
+  `menu` is app-side, since `NSApp.mainMenu` is AppKit.
+  Menu chords are rendered through the host-free `namedKey(forKeyEquivalent:)` (the character twin of
+  `namedKey(forKeyCode:)`) so an arrow or return prints `cmd+opt+up`, not `cmd+opt+` with the key
+  missing — without it the two lists cannot be compared, which is the command's whole job.
+  The globe/fn modifier renders as `fn+` even though the grammar has no such modifier: this section
+  reports reality, and dropping it would print AppKit's own fn-modified items as bare unmodified keys.
+  Four-point keep-in-sync audit for `keymap.list`: (1) `case keymapList = "keymap.list"` +
+  `ControlResult.keymap` + the `ControlKeymap`/`ControlKeymapAction`/`ControlKeymapCommand`/
+  `ControlKeymapDiagnostic`/`ControlKeymapMenuItem` types in `agtermCore`, (2) the `.keymapList`
+  dispatcher arm → `ControlActions.listKeymap` (app-side `ControlServer+AppCommands`, which supplies
+  `liveMenuKeyEquivalents()`), (3) the `keymap list` subcommand in `agtermctlKit` + `SocketClient.formatKeymap`,
+  (4) `ControlKeymapTests` (projection + round-trip) + `KeybindTests` (the character map pinned against
+  `bindableNamedKeys`) + `ControlDispatcherTests` (routing) + `CommandsTests` (CLI mapping) +
+  `SocketClientTests` (rendering) + the e2e `testKeymapListReportsResolvedChordsAndLiveMenu`.
   `config.reload` re-reads the agterm-scoped `ghostty.conf` and returns the ghostty config-diagnostic
   count in `result.count` (0 reads as a clean reload; `agtermctl config reload` prints `ok` then,
   else `N diagnostic(s)`).
@@ -1671,7 +1697,7 @@ paths:
   arguments, and the `tree` read-back field, grouped into its command family's section.
   A new `Command` case REQUIRES a new `site/commands.html` entry (a changed command an updated one, a
   removed command a deleted one), in lockstep with the agent skill above and `README.md`/`site/docs.html`;
-  the page's "67 commands" copy must track the catalog count.
+  the page's "68 commands" copy must track the catalog count.
   A bump is a grep, not a single edit: the count sits in FOUR spots in `commands.html` alone (the
   `description` `<meta>`, the `og:description` and `twitter:description` `<meta>`s, plus the body copy),
   and again in `README.md`, `site/docs.html`, the bundled `SKILL.md`, and the `SkillInstallTests`

--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -58,6 +58,11 @@ paths:
   not stick (the `removeNativeFullScreenMenuItem` pattern).
   ⌘W is the only chord asserted this way because it is the only built-in chord with a stock competitor;
   every other rebind takes effect on the next activation.
+  **Diagnose this class with `agtermctl keymap list`, not by reading the file.**
+  It returns BOTH what the keymap resolved (`actions`) and what the menu bar is dispatching (`menu`), so a
+  model-correct-but-menu-stale chord is one command away instead of an instrumented build.
+  Its menu chords go through the host-free `namedKey(forKeyEquivalent:)` so arrows and return render as
+  the same named keys the file uses and the two lists compare as strings; see the control-api rule.
   **A change affecting menu shortcuts needs a RELOAD-path test — seeding `keymap.conf` before launch does
   not exercise reload.**
   Cover both in `agtermTests/CloseSessionChordTests.swift` and

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The theme picker (View ▸ Select Theme…, or the action palette) previews each
 
 To open a terminal at a directory without the CLI, `open -a agterm <path>` — or right-click a folder in Finder and choose **Open With ▸ agterm**. agterm adds a session in that directory to the last-active window. This works when agterm is already running (its usual state); if it isn't, launch agterm first, then run the command. The socket equivalent, and the way to place the session precisely, is `agtermctl session new --cwd <path>`.
 
-The sections below cover the common cases. All 67 commands, with every argument, return value, and error, are documented in the **[Command reference](https://agterm.com/commands)**.
+The sections below cover the common cases. All 68 commands, with every argument, return value, and error, are documented in the **[Command reference](https://agterm.com/commands)**.
 
 The app bundles `agtermctl` inside `agterm.app`. The easiest way to put it on your PATH is **Help ▸ Install Command Line Tool…**, which symlinks the bundled binary into `/usr/local/bin` (the first entry in macOS's default PATH). When that directory is user-writable it installs silently; otherwise it asks once for an administrator password.
 
@@ -396,6 +396,8 @@ A `{AGT_X}` token is substituted **raw** into the shell line — convenient, but
 Open the file in your editor with **File ▸ Edit Keymap…** or the ⌃⇧P palette ("Edit Keymap"): it opens in a 95% overlay running `$VISUAL`/`$EDITOR` (falling back to `vi`), and reloads automatically when you save and quit. The editor is resolved through your interactive login shell, so an `$EDITOR`/`$VISUAL` set anywhere your normal terminal picks it up (including `~/.zshrc`) is honored.
 
 After editing the file, apply it with **File ▸ Reload Keymap**, the action palette (⌃⇧P → "Reload Keymap"), or `agtermctl keymap reload`. A malformed line never discards the rest of the file — it surfaces in the diagnostics list in Settings ▸ Key Mapping (and `keymap.reload` returns the diagnostic count) while the good lines still apply.
+
+To check what is actually bound, `agtermctl keymap list` prints every built-in with the chord it resolved to, the custom commands, each diagnostic in full, and the key equivalents the menu bar is really carrying. If a binding will not fire, compare the last two: an action whose chord no menu item holds is a menu problem, not a keymap one.
 
 v1 limitations:
 

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ Open the file in your editor with **File ▸ Edit Keymap…** or the ⌃⇧P pal
 
 After editing the file, apply it with **File ▸ Reload Keymap**, the action palette (⌃⇧P → "Reload Keymap"), or `agtermctl keymap reload`. A malformed line never discards the rest of the file — it surfaces in the diagnostics list in Settings ▸ Key Mapping (and `keymap.reload` returns the diagnostic count) while the good lines still apply.
 
-To check what is actually bound, `agtermctl keymap list` prints every built-in with the chord it resolved to, the custom commands, each diagnostic in full, and the key equivalents the menu bar is really carrying. If a binding will not fire, compare the last two: an action whose chord no menu item holds is a menu problem, not a keymap one.
+To check what is actually bound, `agtermctl keymap list` prints every built-in with the chord it resolved to, the custom commands, each diagnostic in full, and the key equivalents the menu bar is really carrying. If a binding will not fire, compare the last two: an action whose chord no menu item holds is usually a menu problem, not a keymap one. The one deliberate exception is `undo_close` (⌘Z), which is delivered by a key monitor rather than a menu item so it never appears under the menu list.
 
 v1 limitations:
 

--- a/agterm/Control/ControlServer+AppCommands.swift
+++ b/agterm/Control/ControlServer+AppCommands.swift
@@ -113,14 +113,19 @@ extension ControlServer {
     ///
     /// `menu` stays the TOP-LEVEL menu's title throughout, so a nested item is still attributed to the
     /// menu-bar entry the reader can find it under.
+    ///
+    /// Internal rather than private so `CloseSessionChordTests`' companion can drive it over a hand-built
+    /// nested menu: agterm's own submenus carry no key equivalents and Services entries depend on the
+    /// user's system settings, so there is no nested chord an e2e could assert against.
     @MainActor
-    private static func collectKeyEquivalents(in submenu: NSMenu, menu: String) -> [ControlKeymapMenuItem] {
+    static func collectKeyEquivalents(in submenu: NSMenu, menu: String) -> [ControlKeymapMenuItem] {
         submenu.items.flatMap { item -> [ControlKeymapMenuItem] in
             var found: [ControlKeymapMenuItem] = []
             if !item.keyEquivalent.isEmpty {
                 found.append(ControlKeymapMenuItem(menu: menu, title: item.title,
                                                    chord: chordSyntax(for: item),
-                                                   selector: item.action.map(NSStringFromSelector)))
+                                                   selector: item.action.map(NSStringFromSelector),
+                                                   enabled: item.isEnabled ? nil : false))
             }
             if let nested = item.submenu { found += collectKeyEquivalents(in: nested, menu: menu) }
             return found
@@ -143,13 +148,19 @@ extension ControlServer {
     @MainActor
     private static func chordSyntax(for item: NSMenuItem) -> String {
         let mods = item.keyEquivalentModifierMask
+        let key = item.keyEquivalent
+        // an UPPERCASE key equivalent carries shift implicitly, whether or not the mask says so: AppKit
+        // matches `"C"` + [.command] against ⇧⌘C and not ⌘C. agterm's own items never spell it that way
+        // (`toShortcut` always puts shift in the mask), but this walk reports third-party items too, and
+        // lowercasing without adding shift would name a chord that item can never fire.
+        let impliedShift = key.count == 1 && key.first?.isUppercase == true
         var parts: [String] = []
         if mods.contains(.function) { parts.append("fn") }
         if mods.contains(.control) { parts.append("ctrl") }
         if mods.contains(.command) { parts.append("cmd") }
         if mods.contains(.option) { parts.append("opt") }
-        if mods.contains(.shift) { parts.append("shift") }
-        parts.append(namedKey(forKeyEquivalent: item.keyEquivalent) ?? item.keyEquivalent.lowercased())
+        if mods.contains(.shift) || impliedShift { parts.append("shift") }
+        parts.append(namedKey(forKeyEquivalent: key) ?? key.lowercased())
         return parts.joined(separator: "+")
     }
 

--- a/agterm/Control/ControlServer+AppCommands.swift
+++ b/agterm/Control/ControlServer+AppCommands.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import agtermCore
 
@@ -80,6 +81,61 @@ extension ControlServer {
     func reloadKeymap() -> ControlResponse {
         settingsModel.reloadKeymap()
         return ControlResponse(ok: true, result: ControlResult(count: settingsModel.keymapDiagnostics.count))
+    }
+
+    /// The read side of `keymap.reload`: what the keymap resolved, plus what the menu bar is actually
+    /// dispatching. The two halves can disagree — SwiftUI defers its menu rebuild to the next app
+    /// activation, so a chord correct in the model can be stale in the menu, which is the divergence a
+    /// bare model listing cannot show. App-global like `keymap.reload`, so no `--window` selector.
+    func listKeymap() -> ControlResponse {
+        let payload = ControlKeymap.project(keymap: settingsModel.keymap,
+                                            diagnostics: settingsModel.keymapDiagnostics,
+                                            path: settingsModel.keymapPath,
+                                            menu: ControlServer.liveMenuKeyEquivalents())
+        return ControlResponse(ok: true, result: ControlResult(keymap: payload))
+    }
+
+    /// Every menu-bar item carrying a key equivalent, rendered in the same kitty syntax the keymap uses so
+    /// a caller can compare the two lists directly. Only the app target can read `NSApp.mainMenu`, so this
+    /// is the app-side half of the otherwise host-free `keymap.list` payload.
+    @MainActor
+    static func liveMenuKeyEquivalents() -> [ControlKeymapMenuItem] {
+        var items: [ControlKeymapMenuItem] = []
+        for topItem in NSApp.mainMenu?.items ?? [] {
+            guard let submenu = topItem.submenu else { continue }
+            for item in submenu.items where !item.keyEquivalent.isEmpty {
+                items.append(ControlKeymapMenuItem(menu: topItem.title, title: item.title,
+                                                   chord: chordSyntax(for: item),
+                                                   selector: item.action.map(NSStringFromSelector)))
+            }
+        }
+        return items
+    }
+
+    /// An `NSMenuItem`'s key equivalent in kitty syntax (`cmd+shift+e`), matching `Chord.displayString`'s
+    /// modifier order so the two render identically and a caller can compare them as strings.
+    ///
+    /// Two AppKit spellings have to be translated or the chord comes out uncomparable. Arrows and
+    /// return/tab/space/delete arrive as function-key or control CHARACTERS, which would render the key
+    /// blank (`cmd+opt+` for what the keymap calls `cmd+opt+up`), so they go through
+    /// `namedKey(forKeyEquivalent:)`. And a shift-typed equivalent arrives as the SHIFTED character with
+    /// `.shift` set (⇧E is `"E"`), so an ordinary key is lowercased to the unshifted base the grammar uses.
+    ///
+    /// The globe/fn modifier has NO keymap spelling (the grammar knows ctrl/cmd/opt/shift only), but it is
+    /// rendered as `fn+` anyway: this section reports what the menu bar really carries, and dropping the
+    /// modifier would print AppKit's own ⌥⌘F-style items as bare unmodified keys, which reads as a binding
+    /// that does not exist. A `fn+` chord simply never matches an action's chord, which is correct.
+    @MainActor
+    private static func chordSyntax(for item: NSMenuItem) -> String {
+        let mods = item.keyEquivalentModifierMask
+        var parts: [String] = []
+        if mods.contains(.function) { parts.append("fn") }
+        if mods.contains(.control) { parts.append("ctrl") }
+        if mods.contains(.command) { parts.append("cmd") }
+        if mods.contains(.option) { parts.append("opt") }
+        if mods.contains(.shift) { parts.append("shift") }
+        parts.append(namedKey(forKeyEquivalent: item.keyEquivalent) ?? item.keyEquivalent.lowercased())
+        return parts.joined(separator: "+")
     }
 
     // MARK: - Config

--- a/agterm/Control/ControlServer+AppCommands.swift
+++ b/agterm/Control/ControlServer+AppCommands.swift
@@ -99,17 +99,32 @@ extension ControlServer {
     /// a caller can compare the two lists directly. Only the app target can read `NSApp.mainMenu`, so this
     /// is the app-side half of the otherwise host-free `keymap.list` payload.
     @MainActor
-    static func liveMenuKeyEquivalents() -> [ControlKeymapMenuItem] {
-        var items: [ControlKeymapMenuItem] = []
-        for topItem in NSApp.mainMenu?.items ?? [] {
-            guard let submenu = topItem.submenu else { continue }
-            for item in submenu.items where !item.keyEquivalent.isEmpty {
-                items.append(ControlKeymapMenuItem(menu: topItem.title, title: item.title,
+    private static func liveMenuKeyEquivalents() -> [ControlKeymapMenuItem] {
+        (NSApp.mainMenu?.items ?? []).flatMap { topItem in
+            topItem.submenu.map { collectKeyEquivalents(in: $0, menu: topItem.title) } ?? []
+        }
+    }
+
+    /// Every key equivalent in `submenu`, RECURSING into nested submenus. AppKit's own
+    /// `performKeyEquivalent` recurses, so a chord one level down is just as live and can just as easily
+    /// shadow an agterm binding — App ▸ Services is the reachable case, since its entries carry whatever
+    /// shortcuts the user assigned in System Settings. Reporting only the top level would let a caller
+    /// compare the two lists and conclude nothing holds a chord when something does.
+    ///
+    /// `menu` stays the TOP-LEVEL menu's title throughout, so a nested item is still attributed to the
+    /// menu-bar entry the reader can find it under.
+    @MainActor
+    private static func collectKeyEquivalents(in submenu: NSMenu, menu: String) -> [ControlKeymapMenuItem] {
+        submenu.items.flatMap { item -> [ControlKeymapMenuItem] in
+            var found: [ControlKeymapMenuItem] = []
+            if !item.keyEquivalent.isEmpty {
+                found.append(ControlKeymapMenuItem(menu: menu, title: item.title,
                                                    chord: chordSyntax(for: item),
                                                    selector: item.action.map(NSStringFromSelector)))
             }
+            if let nested = item.submenu { found += collectKeyEquivalents(in: nested, menu: menu) }
+            return found
         }
-        return items
     }
 
     /// An `NSMenuItem`'s key equivalent in kitty syntax (`cmd+shift+e`), matching `Chord.displayString`'s

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -378,7 +378,7 @@ final class ControlServer {
                 .workspaceFilter, .workspaceCollapse, .workspaceExpand,
                 .sessionSplit, .sessionScratch, .sessionFocus, .sessionResize, .surfaceZoom,
                 .sessionStatus, .sessionFlag, .sessionSeen, .sessionRestore, .notify,
-                .fontInc, .fontDec, .fontReset, .keymapReload, .configReload, .themeSet, .themeList,
+                .fontInc, .fontDec, .fontReset, .keymapReload, .keymapList, .configReload, .themeSet, .themeList,
                 .sidebar, .sidebarMode, .sidebarExpand, .sidebarCollapse, .sessionType, .sessionCopy,
                 .sessionPaste, .sessionSelectAll,
                 .sessionSearch, .sessionOverlayOpen, .sessionOverlayClose, .sessionOverlayResize,

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -17,7 +17,7 @@ when_to_use: >
   Trigger on: agterm, agtermctl, agterm control socket, session.new, session.close, session.type,
   session.split, session.scratch, session.focus, session.resize, surface.zoom, dashboard, session.go, session.copy, session.paste, session.selectall, session.text, session.search, session.status,
   session.flag, session.seen, session.reveal, session.duplicate, session.background, session.overlay, workspace.new, workspace.select, workspace.move, workspace.focus, workspace.filter, window.new, window.list,
-  window.select, window.resize, window.move, window.zoom, window.fullscreen, window.minimize, quick terminal, sidebar, sidebar.mode, sidebar.expand, sidebar.collapse, flagged, notify, font.inc, keymap.reload, config.reload,
+  window.select, window.resize, window.move, window.zoom, window.fullscreen, window.minimize, quick terminal, sidebar, sidebar.mode, sidebar.expand, sidebar.collapse, flagged, notify, font.inc, keymap.reload, keymap.list, config.reload,
   theme.set, theme.list, events, events.read, event subscription, select theme, edit keymap, show an image, display an image inline, show-image,
   AGTERM_SESSION_ID, AGTERM_SOCKET, and asks to drive or script agterm. Also: troubleshoot agterm,
   keymap editor won't open, custom action / custom command not working, agterm logs, file an agterm
@@ -142,7 +142,7 @@ prompt concatenates with yours, and the program starts on the merged line. (`--n
 focus, but the newline and shared-buffer hazards of `type`-as-launcher remain — `--command` is still the
 rule.) After `--command`, confirm in `tree --json` that the new node's `foreground` shows your program running, not a bare shell prompt.
 
-## Command summary (67 commands)
+## Command summary (68 commands)
 
 Run `agtermctl <area> <cmd> --help` for exact flags. Full detail in **reference.md**; recipes in
 **examples.md**.
@@ -354,7 +354,7 @@ Visibility/mode act on the frontmost window; `expand`/`collapse` default to the 
 
 **font** — `font inc|dec|reset [--pane left|right|scratch]` — change a session pane's font size (omitted/`left` = main pane, `right` = the split pane, `scratch` = the scratch terminal). Read the resulting size back from `tree` (`fontSize`/`splitFontSize`/`scratchFontSize` per pane).
 
-**keymap** — `keymap reload` — re-read `keymap.conf` (prints the parse-diagnostic count).
+**keymap** — `keymap reload` — re-read `keymap.conf` (prints the parse-diagnostic count). `keymap list` — show the resolved keymap AND the live menu key equivalents: every built-in with its current chord, the custom commands, the parse diagnostics, and what the menu bar is actually dispatching. Use it to check a rebind took effect, to find a free chord, or to spot a chord the keymap resolved but the menu is not carrying.
 
 **config** - `config reload` - re-read the agterm-scoped `ghostty.conf` (prints the diagnostic count).
 

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -778,11 +778,25 @@ If those disagree, the keymap is fine and the menu is stale or the chord was tak
 menu only on the next app activation, so switch away and back before concluding anything, and relaunch if
 it persists.
 
-Find every chord already in use before picking one for a new binding:
+A menu entry with `"enabled": false` holds the chord but is inert — AppKit consumes the key and fires
+nothing, including any same-chord sibling. Most File/View/Navigate items disable themselves while a modal
+is up, so check this before blaming the binding:
 
 ```bash
-agtermctl keymap list --json | jq -r '.result.keymap.actions[].chord | select(. != null)' | sort
-agtermctl keymap list --json | jq -r '.result.keymap.menu[].chord' | sort -u
+agtermctl keymap list --json \
+  | jq -r '.result.keymap.menu[] | select(.enabled == false) | "\(.chord)  \(.menu) > \(.title)"'
+```
+
+Find every chord already in use before picking one for a new binding. All THREE sources matter: a
+custom command's shortcut is delivered by the key monitor rather than a menu item, so it appears in
+`commands` and can never show up under `menu`. Miss it and a new `map` line on the same chord makes the
+next reload drop the custom binding.
+
+```bash
+agtermctl keymap list --json | jq -r '
+  [ .result.keymap.actions[].chord,
+    .result.keymap.commands[].shortcut,
+    .result.keymap.menu[].chord ] | map(select(. != null)) | unique | .[]'
 ```
 
 Read the parse problems in full rather than just their count:

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -755,3 +755,38 @@ agtermctl theme set --dark none              # stop tracking; the light theme st
 agtermctl tree --json --window work          # the "work" window's tree (prefix match)
 agtermctl session new --window work --cwd "$HOME"
 ```
+
+## Checking a keybinding actually took effect
+
+`keymap.conf` says one thing; the menu bar dispatches another. After a rebind, verify both.
+
+```bash
+agtermctl keymap reload                      # apply the edited file (prints the diagnostic count)
+agtermctl keymap list                        # the resolved chords AND the live menu equivalents
+```
+
+Confirm one action's chord, then confirm the menu is really carrying it:
+
+```bash
+agtermctl keymap list --json \
+  | jq -r '.result.keymap.actions[] | select(.action == "close_session") | .chord'
+agtermctl keymap list --json \
+  | jq -r '.result.keymap.menu[] | select(.chord == "cmd+w") | "\(.menu) > \(.title)  [\(.selector)]"'
+```
+
+If those disagree, the keymap is fine and the menu is stale or the chord was taken: SwiftUI rebuilds the
+menu only on the next app activation, so switch away and back before concluding anything, and relaunch if
+it persists.
+
+Find every chord already in use before picking one for a new binding:
+
+```bash
+agtermctl keymap list --json | jq -r '.result.keymap.actions[].chord | select(. != null)' | sort
+agtermctl keymap list --json | jq -r '.result.keymap.menu[].chord' | sort -u
+```
+
+Read the parse problems in full rather than just their count:
+
+```bash
+agtermctl keymap list --json | jq -r '.result.keymap.diagnostics[] | "line \(.line): \(.message)"'
+```

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -753,6 +753,10 @@ end up holding a chord an action claims. If a keybinding "does not work" while `
 compare the two lists: find the action's `chord`, then look for that chord in `menu` and check which
 item carries it.
 
+One built-in is legitimately absent from `menu`: `undo_close` (⌘Z by default) is delivered by a key
+monitor, not a menu item, so native text undo keeps working in the rename, palette and Settings fields.
+Its missing menu entry is expected and not a fault.
+
 Menu chords use the same vocabulary as the file (`cmd+opt+up`, `cmd+shift+return`), so the two lists
 compare as plain strings. One exception: the globe/fn modifier prints as `fn+`, which no `keymap.conf`
 line can express — such an item is AppKit's own and never matches an action.

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -743,8 +743,11 @@ parse diagnostics (0 = clean). App-global (no `--window`).
   or not, so you can also see which chords are free.
 - `commands[]` — the custom commands: `name`, and `shortcut` omitted for a palette-only one.
 - `diagnostics[]` — `line` + `message` per parse problem (`keymap.reload` returns only the count).
-- `menu[]` — what the menu bar is actually dispatching: `chord`, the owning `menu`, the item `title`,
-  and its `selector`. agterm's own items report `menuAction:`; anything else is an AppKit-supplied item.
+- `menu[]` — the key equivalents the menu bar carries: `chord`, the owning `menu`, the item `title`, its
+  `selector`, and `enabled: false` when the item is disabled. agterm's own items report `menuAction:`;
+  anything else is an AppKit-supplied item. Nested submenus are included, attributed to their top-level
+  menu. A disabled item's chord is INERT — AppKit consumes the key and fires nothing, including a
+  same-chord sibling — so an entry marked `enabled: false` explains a dead binding by itself.
 
 **`actions` and `menu` can disagree, and that is what this command is for.** SwiftUI rebuilds the menu
 only on the next app activation, so right after `keymap reload` a chord can be correct in `actions` and

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -733,6 +733,30 @@ isn't realized.
 `agtermctl keymap reload` — re-read and apply `keymap.conf`; returns `result.count` = the number of
 parse diagnostics (0 = clean). App-global (no `--window`).
 
+`agtermctl keymap list` — the read side of `keymap.reload`. App-global, no target and no args. Returns
+`result.keymap`:
+
+- `path` — the `keymap.conf` this came from.
+- `actions[]` — every rebindable built-in: `action` (its `keymap.conf` name), `chord` (the resolved
+  chord in the same kitty syntax the file uses, omitted when the action is keyless), and
+  `overridden: true` when a `map` line moved it off its shipped default. Every action is listed, bound
+  or not, so you can also see which chords are free.
+- `commands[]` — the custom commands: `name`, and `shortcut` omitted for a palette-only one.
+- `diagnostics[]` — `line` + `message` per parse problem (`keymap.reload` returns only the count).
+- `menu[]` — what the menu bar is actually dispatching: `chord`, the owning `menu`, the item `title`,
+  and its `selector`. agterm's own items report `menuAction:`; anything else is an AppKit-supplied item.
+
+**`actions` and `menu` can disagree, and that is what this command is for.** SwiftUI rebuilds the menu
+only on the next app activation, so right after `keymap reload` a chord can be correct in `actions` and
+stale in `menu`. It also resolves a chord collision by unbinding agterm's own item, so a stock item can
+end up holding a chord an action claims. If a keybinding "does not work" while `actions` looks right,
+compare the two lists: find the action's `chord`, then look for that chord in `menu` and check which
+item carries it.
+
+Menu chords use the same vocabulary as the file (`cmd+opt+up`, `cmd+shift+return`), so the two lists
+compare as plain strings. One exception: the globe/fn modifier prints as `fn+`, which no `keymap.conf`
+line can express — such an item is AppKit's own and never matches an action.
+
 ### keymap.conf format
 
 The file lives at `<config dir>/keymap.conf` (default `~/.config/agterm`; the dir is set in Settings ▸

--- a/agterm/Resources/agent-skill/troubleshooting.md
+++ b/agterm/Resources/agent-skill/troubleshooting.md
@@ -19,7 +19,8 @@ You are inside agterm (`AGTERM_ENABLED=1`). Use:
   key equivalents the menu bar is actually dispatching. If the action's `chord` looks right but no `menu`
   entry carries it (or a different item does), the keymap is fine and the menu is the problem: SwiftUI
   rebuilds the menu only on the next app activation, so switch to another app and back, then relaunch if it
-  persists.
+  persists. Exception: `undo_close` (⌘Z) is delivered by a key monitor rather than a menu item, so it never
+  appears under `menu` and its absence there means nothing.
 - **Ghostty settings** - `agtermctl config reload` re-reads the ghostty config and prints the diagnostic
   count (`0` = clean). The count covers every config source, not just `ghostty.conf` (libghostty does not
   record which file a diagnostic came from), so check the Console log for the offending line. `ghostty.conf`

--- a/agterm/Resources/agent-skill/troubleshooting.md
+++ b/agterm/Resources/agent-skill/troubleshooting.md
@@ -13,7 +13,13 @@ You are inside agterm (`AGTERM_ENABLED=1`). Use:
 
 - **Live state** — `agtermctl tree --json`, `agtermctl window list --json`.
 - **Keymap problems** — `agtermctl keymap reload` prints the parse-diagnostic count (`0` = clean). A
-  non-zero count means `keymap.conf` has problems; the user sees the list in Settings ▸ Key Mapping.
+  non-zero count means `keymap.conf` has problems; `agtermctl keymap list` prints each one with its line
+  and message, and the user also sees the list in Settings ▸ Key Mapping.
+- **A keybinding does not fire** — `agtermctl keymap list` shows the chord each action resolved to AND the
+  key equivalents the menu bar is actually dispatching. If the action's `chord` looks right but no `menu`
+  entry carries it (or a different item does), the keymap is fine and the menu is the problem: SwiftUI
+  rebuilds the menu only on the next app activation, so switch to another app and back, then relaunch if it
+  persists.
 - **Ghostty settings** - `agtermctl config reload` re-reads the ghostty config and prints the diagnostic
   count (`0` = clean). The count covers every config source, not just `ghostty.conf` (libghostty does not
   record which file a diagnostic came from), so check the Console log for the offending line. `ghostty.conf`

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -45,6 +45,7 @@ public protocol ControlActions {
                       fontMode: DashboardFontMode, mru: Bool) -> ControlResponse
     func font(_ target: String?, window: String?, pane: String?, action: String) -> ControlResponse
     func reloadKeymap() -> ControlResponse
+    func listKeymap() -> ControlResponse
     func reloadGhosttyConfig() -> ControlResponse
     func sendNotification(_ target: String?, window: String?, title: String?, body: String) -> ControlResponse
     func setTheme(args: ControlArgs?) -> ControlResponse
@@ -162,7 +163,7 @@ public struct ControlDispatcher {
         case .workspaceNew, .workspaceSelect, .workspaceRename, .workspaceDelete,
                 .workspaceMove, .workspaceFocus, .workspaceFilter, .workspaceCollapse, .workspaceExpand:
             return dispatchWorkspaceCommand(request)
-        case .quick, .fontInc, .fontDec, .fontReset, .keymapReload,
+        case .quick, .fontInc, .fontDec, .fontReset, .keymapReload, .keymapList,
                 .configReload, .notify, .themeSet, .themeList, .sidebar, .sidebarMode, .sidebarExpand,
                 .sidebarCollapse, .restoreClear:
             return dispatchAppCommand(request)
@@ -571,6 +572,8 @@ public struct ControlDispatcher {
             return actions.setQuickTerminal(mode: request.args?.mode)
         case .keymapReload:
             return actions.reloadKeymap()
+        case .keymapList:
+            return actions.listKeymap()
         case .configReload:
             return actions.reloadGhosttyConfig()
         case .notify:

--- a/agtermCore/Sources/agtermCore/ControlKeymap.swift
+++ b/agtermCore/Sources/agtermCore/ControlKeymap.swift
@@ -6,7 +6,11 @@ public struct ControlKeymapAction: Codable, Sendable, Equatable {
     public var action: String
     /// The resolved chord in kitty syntax (`cmd+shift+e`), omitted when the action is keyless.
     public var chord: String?
-    /// `true` when a `map` line moved the action off its shipped default; omitted otherwise.
+    /// `true` when the action's resolved chord DIFFERS from its shipped default; omitted otherwise.
+    ///
+    /// Deliberately a comparison of chords rather than "a `map` line exists for this action": a
+    /// redundant `map cmd+w close_session` parses fine and leaves the action on its default, and marking
+    /// that as overridden would report a difference a caller cannot see anywhere else.
     public var overridden: Bool?
 
     public init(action: String, chord: String? = nil, overridden: Bool? = nil) {
@@ -95,9 +99,10 @@ public extension ControlKeymap {
     static func project(keymap: Keymap, diagnostics: [KeymapDiagnostic], path: String,
                         menu: [ControlKeymapMenuItem]? = nil) -> ControlKeymap {
         let actions = BuiltinAction.allCases.map { action in
-            ControlKeymapAction(action: action.rawValue,
-                                chord: keymap.equivalent(for: action)?.displayString,
-                                overridden: keymap.builtinOverrides[action] != nil ? true : nil)
+            let resolved = keymap.equivalent(for: action)
+            return ControlKeymapAction(action: action.rawValue,
+                                       chord: resolved?.displayString,
+                                       overridden: resolved != action.defaultChord ? true : nil)
         }
         let commands = keymap.commands.map {
             ControlKeymapCommand(name: $0.name, shortcut: $0.shortcut.isEmpty ? nil : $0.shortcut)

--- a/agtermCore/Sources/agtermCore/ControlKeymap.swift
+++ b/agtermCore/Sources/agtermCore/ControlKeymap.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// One rebindable built-in and the chord the keymap currently resolves it to.
+public struct ControlKeymapAction: Codable, Sendable, Equatable {
+    /// The action's `keymap.conf` name, e.g. `close_session`.
+    public var action: String
+    /// The resolved chord in kitty syntax (`cmd+shift+e`), omitted when the action is keyless.
+    public var chord: String?
+    /// `true` when a `map` line moved the action off its shipped default; omitted otherwise.
+    public var overridden: Bool?
+
+    public init(action: String, chord: String? = nil, overridden: Bool? = nil) {
+        self.action = action
+        self.chord = chord
+        self.overridden = overridden
+    }
+}
+
+/// One `command` line from `keymap.conf`.
+public struct ControlKeymapCommand: Codable, Sendable, Equatable {
+    public var name: String
+    /// The raw kitty-syntax shortcut, omitted for a palette-only command (or one whose chord was
+    /// dropped as colliding — the diagnostics say which).
+    public var shortcut: String?
+
+    public init(name: String, shortcut: String? = nil) {
+        self.name = name
+        self.shortcut = shortcut
+    }
+}
+
+/// A `keymap.conf` parse problem, the same pair the Key Mapping settings tab shows.
+public struct ControlKeymapDiagnostic: Codable, Sendable, Equatable {
+    public var line: Int
+    public var message: String
+
+    public init(line: Int, message: String) {
+        self.line = line
+        self.message = message
+    }
+}
+
+/// A live menu item that carries a key equivalent.
+///
+/// This is the half that makes `keymap.list` diagnostic rather than merely descriptive. The `actions`
+/// list says what the keymap RESOLVED; this says what the menu bar is actually dispatching, and the two
+/// can disagree — SwiftUI defers its menu rebuild to the next app activation, so a chord can be correct
+/// in the model and stale in the menu.
+public struct ControlKeymapMenuItem: Codable, Sendable, Equatable {
+    /// The owning top-level menu's title, e.g. `File`.
+    public var menu: String
+    public var title: String
+    /// The chord in kitty syntax, so it compares directly against an action's `chord`.
+    public var chord: String
+    /// The item's Objective-C action selector. agterm's own SwiftUI items all report `menuAction:`;
+    /// anything else is an AppKit-supplied item (`performClose:`, `closeAll:`, …), which is what a
+    /// stock item competing for an agterm chord looks like.
+    public var selector: String?
+
+    public init(menu: String, title: String, chord: String, selector: String? = nil) {
+        self.menu = menu
+        self.title = title
+        self.chord = chord
+        self.selector = selector
+    }
+}
+
+/// The `keymap.list` payload: what the keymap resolved, plus what the menu bar is really carrying.
+public struct ControlKeymap: Codable, Sendable, Equatable {
+    /// The `keymap.conf` that produced this, so a caller knows which file to edit.
+    public var path: String
+    public var actions: [ControlKeymapAction]
+    public var commands: [ControlKeymapCommand]
+    public var diagnostics: [ControlKeymapDiagnostic]
+    /// Live menu key equivalents; omitted when the caller could not read the menu bar.
+    public var menu: [ControlKeymapMenuItem]?
+
+    public init(path: String, actions: [ControlKeymapAction], commands: [ControlKeymapCommand],
+                diagnostics: [ControlKeymapDiagnostic], menu: [ControlKeymapMenuItem]? = nil) {
+        self.path = path
+        self.actions = actions
+        self.commands = commands
+        self.diagnostics = diagnostics
+        self.menu = menu
+    }
+}
+
+public extension ControlKeymap {
+    /// Project a parsed keymap into the `keymap.list` payload. Host-free: the caller supplies the live
+    /// `menu` separately, since only the app target can read `NSApp.mainMenu`.
+    ///
+    /// Actions come out in `BuiltinAction.allCases` order rather than sorted, so the listing groups the
+    /// way the file's own reference comment does (window, workspace, session, …) instead of scattering
+    /// related actions alphabetically.
+    static func project(keymap: Keymap, diagnostics: [KeymapDiagnostic], path: String,
+                        menu: [ControlKeymapMenuItem]? = nil) -> ControlKeymap {
+        let actions = BuiltinAction.allCases.map { action in
+            ControlKeymapAction(action: action.rawValue,
+                                chord: keymap.equivalent(for: action)?.displayString,
+                                overridden: keymap.builtinOverrides[action] != nil ? true : nil)
+        }
+        let commands = keymap.commands.map {
+            ControlKeymapCommand(name: $0.name, shortcut: $0.shortcut.isEmpty ? nil : $0.shortcut)
+        }
+        return ControlKeymap(path: path, actions: actions, commands: commands,
+                             diagnostics: diagnostics.map { ControlKeymapDiagnostic(line: $0.line, message: $0.message) },
+                             menu: menu)
+    }
+}

--- a/agtermCore/Sources/agtermCore/ControlKeymap.swift
+++ b/agtermCore/Sources/agtermCore/ControlKeymap.swift
@@ -5,6 +5,11 @@ public struct ControlKeymapAction: Codable, Sendable, Equatable {
     /// The action's `keymap.conf` name, e.g. `close_session`.
     public var action: String
     /// The resolved chord in kitty syntax (`cmd+shift+e`), omitted when the action is keyless.
+    ///
+    /// One shipped default cannot be typed back into `keymap.conf`: `increase_font_size` is ⌘+, which
+    /// renders `cmd++` and does not re-parse (`+` is the chord joiner). It is reported verbatim anyway,
+    /// because the live `menu` half renders that item identically — substituting a placeholder here would
+    /// turn the one row that compares correctly into a false mismatch, which costs more than the wart.
     public var chord: String?
     /// `true` when the action's resolved chord DIFFERS from its shipped default; omitted otherwise.
     ///
@@ -35,6 +40,8 @@ public struct ControlKeymapCommand: Codable, Sendable, Equatable {
 
 /// A `keymap.conf` parse problem, the same pair the Key Mapping settings tab shows.
 public struct ControlKeymapDiagnostic: Codable, Sendable, Equatable {
+    /// 1-based. `0` is the sentinel for a whole-file or cross-section problem (a chord collision between
+    /// two sections) that belongs to no single line.
     public var line: Int
     public var message: String
 
@@ -60,12 +67,22 @@ public struct ControlKeymapMenuItem: Codable, Sendable, Equatable {
     /// anything else is an AppKit-supplied item (`performClose:`, `closeAll:`, …), which is what a
     /// stock item competing for an agterm chord looks like.
     public var selector: String?
+    /// `false` when the item is disabled and its chord therefore INERT — AppKit consumes the key
+    /// equivalent and fires nothing, so a same-chord enabled sibling does not run either. Omitted when
+    /// the item is enabled, which is the ordinary case.
+    ///
+    /// Worth reporting because disabled items are routine here rather than exotic: most File/View/Navigate
+    /// items carry a `modalActive` gate, so with the dashboard open the menu is largely inert while still
+    /// holding every chord. A caller comparing `actions` against `menu` would otherwise see the binding
+    /// present and conclude the menu is fine.
+    public var enabled: Bool?
 
-    public init(menu: String, title: String, chord: String, selector: String? = nil) {
+    public init(menu: String, title: String, chord: String, selector: String? = nil, enabled: Bool? = nil) {
         self.menu = menu
         self.title = title
         self.chord = chord
         self.selector = selector
+        self.enabled = enabled
     }
 }
 

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -67,6 +67,7 @@ public enum Command: String, Codable, Sendable {
     case windowFullscreen = "window.fullscreen"
     case windowMinimize = "window.minimize"
     case keymapReload = "keymap.reload"
+    case keymapList = "keymap.list"
     case configReload = "config.reload"
     case themeSet = "theme.set"
     case themeList = "theme.list"
@@ -749,13 +750,15 @@ public struct ControlResult: Codable, Sendable, Equatable {
     public var dark: String?
     /// A page from the app-run event ring, present for `events.read` success and cursor errors.
     public var events: ControlEventBatch?
+    /// The resolved keymap plus the live menu key equivalents, for `keymap.list`.
+    public var keymap: ControlKeymap?
 
     public init(id: String? = nil, tree: ControlTree? = nil, text: String? = nil,
                 windows: [ControlWindowNode]? = nil, exitCode: Int? = nil, count: Int? = nil,
                 affected: Int? = nil,
                 theme: String? = nil, themes: [String]? = nil, ratio: Double? = nil,
                 sync: Bool? = nil, light: String? = nil, dark: String? = nil,
-                events: ControlEventBatch? = nil) {
+                events: ControlEventBatch? = nil, keymap: ControlKeymap? = nil) {
         self.id = id
         self.tree = tree
         self.text = text
@@ -770,6 +773,7 @@ public struct ControlResult: Codable, Sendable, Equatable {
         self.light = light
         self.dark = dark
         self.events = events
+        self.keymap = keymap
     }
 }
 

--- a/agtermCore/Sources/agtermCore/Keybind.swift
+++ b/agtermCore/Sources/agtermCore/Keybind.swift
@@ -57,6 +57,32 @@ public func namedKey(forKeyCode keyCode: UInt16) -> String? {
     }
 }
 
+/// The named key for a menu item's key-equivalent CHARACTER, or `nil` for an ordinary printable key.
+///
+/// The character counterpart of `namedKey(forKeyCode:)`, for projecting live `NSMenuItem` key
+/// equivalents back into keymap syntax: a menu item carries a character rather than a virtual key code,
+/// and AppKit spells the arrows with private-use function-key scalars and return/tab/space/delete with
+/// control characters. Without this a menu chord renders as `cmd+opt+` with the key missing, which
+/// cannot be compared against the `cmd+opt+up` the keymap resolved.
+///
+/// Kept host-free by matching the scalar values rather than the AppKit constants, so `agtermCore` stays
+/// AppKit-free; the values are the documented `NSUpArrowFunctionKey` family.
+public func namedKey(forKeyEquivalent character: String) -> String? {
+    let scalars = character.unicodeScalars
+    guard scalars.count == 1, let scalar = scalars.first else { return nil }
+    switch scalar.value {
+    case 0xF700: return "up"
+    case 0xF701: return "down"
+    case 0xF702: return "left"
+    case 0xF703: return "right"
+    case 0x0D, 0x03: return "return" // carriage return, and the numeric keypad's enter
+    case 0x09: return "tab"
+    case 0x20: return "space"
+    case 0x08, 0x7F: return "delete" // backspace, and forward delete
+    default: return nil
+    }
+}
+
 /// Whether a chord is owned by the app's always-on `NSEvent` monitors (NOT a menu key-equivalent), so a
 /// keybind that starts with it would dead-race the monitor and must be rejected. This MIRRORS the
 /// monitors' real predicates, not a fixed list:

--- a/agtermCore/Sources/agtermCore/Keybind.swift
+++ b/agtermCore/Sources/agtermCore/Keybind.swift
@@ -23,9 +23,12 @@ public struct Modifier: OptionSet, Hashable, Sendable {
 /// The four arrows are here because the six arrow-bound built-ins ship their defaults on them, so the
 /// grammar must be able to spell what `BuiltinAction.defaultChord` returns.
 ///
-/// Adding a name here means updating four sites, two inbound and two outbound:
+/// Adding a name here means updating five sites, two inbound and three outbound:
 /// - `CustomCommandRunner` and `UndoCloseShortcut` resolve `NSEvent` → name via `namedKey(forKeyCode:)`,
 ///   so a name with no keycode parses in the file yet never fires;
+/// - `namedKey(forKeyEquivalent:)` resolves a live `NSMenuItem`'s key-equivalent CHARACTER back to the
+///   name for `keymap.list`, so a name missing there makes every menu item carrying that key render with
+///   the key absent and stop comparing against the resolved chord (its own test pins the two sets equal);
 /// - `Chord.glyphString` renders the name in palette hints and tooltips — it degrades to the raw name,
 ///   so a miss here is cosmetic;
 /// - `agtermApp.toShortcut` maps the name to a SwiftUI `KeyEquivalent`, and its `default` arm is

--- a/agtermCore/Sources/agtermctlKit/MiscCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/MiscCommands.swift
@@ -7,7 +7,7 @@ import agtermCore
 struct Keymap: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Keymap commands.",
-        subcommands: [Reload.self]
+        subcommands: [Reload.self, List.self]
     )
 
     struct Reload: RequestCommand {
@@ -16,6 +16,22 @@ struct Keymap: ParsableCommand {
         @OptionGroup var options: BasicOptions
 
         func makeRequest() throws -> ControlRequest { ControlRequest(cmd: .keymapReload) }
+    }
+
+    struct List: RequestCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Show the resolved keymap and the live menu key equivalents.",
+            discussion: """
+            Prints every built-in with the chord the keymap resolved for it, the custom commands, any \
+            parse diagnostics, and the key equivalents the menu bar is actually carrying. The last \
+            section is what makes a stale or hijacked chord visible: SwiftUI rebuilds the menu only on \
+            the next app activation, so a chord can be right in the keymap and wrong in the menu.
+            """
+        )
+        // keymap.list is app-global like keymap.reload, so no `--window` selector.
+        @OptionGroup var options: BasicOptions
+
+        func makeRequest() throws -> ControlRequest { ControlRequest(cmd: .keymapList) }
     }
 }
 

--- a/agtermCore/Sources/agtermctlKit/SocketClient.swift
+++ b/agtermCore/Sources/agtermctlKit/SocketClient.swift
@@ -214,7 +214,12 @@ struct SocketClient {
         }
         if let menu = keymap.menu {
             lines.append(contentsOf: ["", "menu:"])
-            lines.append(contentsOf: menu.map { "    \($0.chord)  \($0.menu) ▸ \($0.title)" })
+            // mark a disabled item: its chord is inert (AppKit consumes the key and fires nothing, not
+            // even a same-chord sibling), and the default non-JSON output is the documented human
+            // workflow — an unmarked row reads as a live binding.
+            lines.append(contentsOf: menu.map {
+                "    \($0.chord)  \($0.menu) ▸ \($0.title)" + ($0.enabled == false ? "  (disabled)" : "")
+            })
         }
         return lines.joined(separator: "\n")
     }

--- a/agtermCore/Sources/agtermctlKit/SocketClient.swift
+++ b/agtermCore/Sources/agtermctlKit/SocketClient.swift
@@ -206,7 +206,11 @@ struct SocketClient {
         }
         if !keymap.diagnostics.isEmpty {
             lines.append(contentsOf: ["", "diagnostics:"])
-            lines.append(contentsOf: keymap.diagnostics.map { "    line \($0.line): \($0.message)" })
+            // line 0 is the whole-file / cross-section sentinel, not a real line — drop the number
+            // rather than sending the reader looking for it, matching SettingsView.diagnosticLine.
+            lines.append(contentsOf: keymap.diagnostics.map {
+                $0.line > 0 ? "    line \($0.line): \($0.message)" : "    \($0.message)"
+            })
         }
         if let menu = keymap.menu {
             lines.append(contentsOf: ["", "menu:"])

--- a/agtermCore/Sources/agtermctlKit/SocketClient.swift
+++ b/agtermCore/Sources/agtermctlKit/SocketClient.swift
@@ -145,6 +145,9 @@ struct SocketClient {
             return formatThemes(themes, current: response.result?.theme, sync: response.result?.sync ?? false,
                                 light: response.result?.light, dark: response.result?.dark)
         }
+        if let keymap = response.result?.keymap {
+            return formatKeymap(keymap)
+        }
         if let text = response.result?.text {
             return text
         }
@@ -180,6 +183,36 @@ struct SocketClient {
         guard sync else { return body }
         let header = "syncing with macOS appearance — light: \(light ?? "default ghostty"), dark: \(dark ?? "default ghostty")"
         return header + "\n" + body
+    }
+
+    /// Render the `keymap.list` payload as sections: the resolved built-ins, then custom commands, parse
+    /// diagnostics, and the live menu key equivalents (no trailing newline). An overridden built-in is
+    /// marked `*`, and a keyless one prints `-` rather than being dropped, so the listing is the full
+    /// action set.
+    ///
+    /// The menu section is the point of the command: comparing it against the actions above is what shows
+    /// a chord the keymap resolved but the menu is not carrying. Menu items are printed in menu-bar order.
+    static func formatKeymap(_ keymap: ControlKeymap) -> String {
+        var lines = ["keymap: \(keymap.path)", "", "actions:"]
+        let width = keymap.actions.map(\.action.count).max() ?? 0
+        for action in keymap.actions {
+            let mark = action.overridden == true ? "*" : " "
+            let name = action.action.padding(toLength: max(width, action.action.count), withPad: " ", startingAt: 0)
+            lines.append("  \(mark) \(name)  \(action.chord ?? "-")")
+        }
+        if !keymap.commands.isEmpty {
+            lines.append(contentsOf: ["", "commands:"])
+            lines.append(contentsOf: keymap.commands.map { "    \($0.name)  \($0.shortcut ?? "(palette only)")" })
+        }
+        if !keymap.diagnostics.isEmpty {
+            lines.append(contentsOf: ["", "diagnostics:"])
+            lines.append(contentsOf: keymap.diagnostics.map { "    line \($0.line): \($0.message)" })
+        }
+        if let menu = keymap.menu {
+            lines.append(contentsOf: ["", "menu:"])
+            lines.append(contentsOf: menu.map { "    \($0.chord)  \($0.menu) ▸ \($0.title)" })
+        }
+        return lines.joined(separator: "\n")
     }
 
     /// Render the `window.list` payload as one `id  name  [open]  [active]` line per window (no trailing

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -1083,6 +1083,34 @@ struct ControlDispatcherTests {
         #expect(actions.calls == [.keymapReload, .configReload])
     }
 
+    @Test func keymapListRoutesToActionsAndKeepsThePayload() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        let payload = ControlKeymap.project(keymap: Keymap(builtinOverrides: [:], commands: []),
+                                            diagnostics: [], path: "/tmp/keymap.conf",
+                                            menu: [ControlKeymapMenuItem(menu: "File", title: "Close Session",
+                                                                         chord: "cmd+w", selector: "menuAction:")])
+        actions.nextKeymapListResponse = ControlResponse(ok: true, result: ControlResult(keymap: payload))
+
+        let response = await dispatcher.dispatch(ControlRequest(cmd: .keymapList))
+
+        #expect(response == ControlResponse(ok: true, result: ControlResult(keymap: payload)))
+        #expect(actions.calls == [.keymapList])
+    }
+
+    // keymap.list takes no target and no args, so anything a caller attaches must be ignored rather than
+    // rejected or forwarded — it is a pure read.
+    @Test func keymapListIgnoresTargetAndArgs() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let response = await dispatcher.dispatch(ControlRequest(cmd: .keymapList, target: "active",
+                                                                args: ControlArgs(window: "w1")))
+
+        #expect(response?.ok == true)
+        #expect(actions.calls == [.keymapList])
+    }
+
     @Test func notifyRequiresBodyBeforeCallingActions() async {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)

--- a/agtermCore/Tests/agtermCoreTests/ControlKeymapTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlKeymapTests.swift
@@ -44,6 +44,32 @@ import Testing
         }
     }
 
+    // a redundant `map cmd+w close_session` parses fine and leaves the action on its shipped default.
+    // `overridden` compares CHORDS, not "is there a map line", so it does not claim a difference the
+    // caller cannot see anywhere else.
+    @Test func mappingAnActionToItsOwnDefaultIsNotAnOverride() throws {
+        let parsed = parseKeymap("map cmd+w close_session\n")
+        try #require(parsed.diagnostics.isEmpty, "an identity map is a clean line")
+        let payload = ControlKeymap.project(keymap: parsed.keymap, diagnostics: parsed.diagnostics,
+                                            path: "/tmp/keymap.conf")
+        let close = try #require(payload.actions.first { $0.action == "close_session" })
+
+        #expect(close.chord == "cmd+w")
+        #expect(close.overridden == nil, "the action is still on its default, so nothing was overridden")
+    }
+
+    // the mirror: mapping a keyless action gives it a chord it never had, which IS a difference from its
+    // (absent) default and must be marked.
+    @Test func mappingAKeylessActionCountsAsAnOverride() throws {
+        let keyless = try #require(BuiltinAction.allCases.first { $0.defaultChord == nil })
+        let keymap = Keymap(builtinOverrides: [keyless: Chord(mods: [.command], key: "y")], commands: [])
+        let payload = ControlKeymap.project(keymap: keymap, diagnostics: [], path: "/tmp/keymap.conf")
+        let row = try #require(payload.actions.first { $0.action == keyless.rawValue })
+
+        #expect(row.chord == "cmd+y")
+        #expect(row.overridden == true)
+    }
+
     @Test func carriesCustomCommandsAndDistinguishesPaletteOnlyOnes() throws {
         let text = """
         command "Bound" cmd+shift+e echo hi

--- a/agtermCore/Tests/agtermCoreTests/ControlKeymapTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlKeymapTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+@Suite struct ControlKeymapTests {
+    @Test func projectsEveryBuiltinActionInDeclarationOrder() {
+        let payload = ControlKeymap.project(keymap: Keymap(builtinOverrides: [:], commands: []),
+                                            diagnostics: [], path: "/tmp/keymap.conf")
+
+        #expect(payload.actions.count == BuiltinAction.allCases.count)
+        #expect(payload.actions.map(\.action) == BuiltinAction.allCases.map(\.rawValue))
+        #expect(payload.path == "/tmp/keymap.conf")
+    }
+
+    @Test func reportsShippedDefaultsUnmarked() throws {
+        let payload = ControlKeymap.project(keymap: Keymap(builtinOverrides: [:], commands: []),
+                                            diagnostics: [], path: "/tmp/keymap.conf")
+        let close = try #require(payload.actions.first { $0.action == "close_session" })
+
+        #expect(close.chord == "cmd+w")
+        #expect(close.overridden == nil, "a shipped default is not an override")
+    }
+
+    @Test func marksAnOverriddenActionAndReportsItsNewChord() throws {
+        let keymap = Keymap(builtinOverrides: [.closeSession: Chord(mods: [.command], key: "e")], commands: [])
+        let payload = ControlKeymap.project(keymap: keymap, diagnostics: [], path: "/tmp/keymap.conf")
+        let close = try #require(payload.actions.first { $0.action == "close_session" })
+
+        #expect(close.chord == "cmd+e")
+        #expect(close.overridden == true)
+    }
+
+    // a keyless action must still appear, so the listing is the whole action set rather than only the
+    // bound subset — a caller checking "what is free" needs the gaps.
+    @Test func keylessActionsAppearWithNoChord() throws {
+        let payload = ControlKeymap.project(keymap: Keymap(builtinOverrides: [:], commands: []),
+                                            diagnostics: [], path: "/tmp/keymap.conf")
+        let keyless = BuiltinAction.allCases.filter { $0.defaultChord == nil }
+        try #require(!keyless.isEmpty, "the fixture assumes some actions ship keyless")
+
+        for action in keyless {
+            let row = try #require(payload.actions.first { $0.action == action.rawValue })
+            #expect(row.chord == nil)
+        }
+    }
+
+    @Test func carriesCustomCommandsAndDistinguishesPaletteOnlyOnes() throws {
+        let text = """
+        command "Bound" cmd+shift+e echo hi
+        command "Palette Only" echo hi
+        """
+        let parsed = parseKeymap(text)
+        let payload = ControlKeymap.project(keymap: parsed.keymap, diagnostics: parsed.diagnostics,
+                                            path: "/tmp/keymap.conf")
+
+        #expect(payload.commands.count == 2)
+        #expect(payload.commands.first { $0.name == "Bound" }?.shortcut == "cmd+shift+e")
+        #expect(payload.commands.first { $0.name == "Palette Only" }?.shortcut == nil,
+                "an empty shortcut reads as palette-only, not as a chord")
+    }
+
+    @Test func carriesParseDiagnostics() {
+        let parsed = parseKeymap("map cmd+shift+d not_an_action\n")
+        let payload = ControlKeymap.project(keymap: parsed.keymap, diagnostics: parsed.diagnostics,
+                                            path: "/tmp/keymap.conf")
+
+        #expect(payload.diagnostics.count == parsed.diagnostics.count)
+        #expect(payload.diagnostics.first?.line == 1)
+        #expect(payload.diagnostics.first?.message == parsed.diagnostics.first?.message)
+    }
+
+    @Test func menuIsOmittedWhenTheCallerSuppliesNone() {
+        let payload = ControlKeymap.project(keymap: Keymap(builtinOverrides: [:], commands: []),
+                                            diagnostics: [], path: "/tmp/keymap.conf")
+        #expect(payload.menu == nil)
+    }
+
+    // the whole point of the command: the model can say cmd+w while the menu carries it elsewhere, and
+    // both halves have to survive the wire for a caller to see that.
+    @Test func roundTripsWithDivergingModelAndMenuChords() throws {
+        let keymap = Keymap(builtinOverrides: [.closeSession: Chord(mods: [.command], key: "e")], commands: [])
+        let menu = [ControlKeymapMenuItem(menu: "File", title: "Close", chord: "cmd+w", selector: "performClose:")]
+        let payload = ControlKeymap.project(keymap: keymap, diagnostics: [], path: "/tmp/keymap.conf", menu: menu)
+        let response = ControlResponse(ok: true, result: ControlResult(keymap: payload))
+
+        let encoded = try JSONEncoder().encode(response)
+        let decoded = try JSONDecoder().decode(ControlResponse.self, from: encoded)
+        let back = try #require(decoded.result?.keymap)
+
+        #expect(back == payload)
+        #expect(back.actions.first { $0.action == "close_session" }?.chord == "cmd+e")
+        #expect(back.menu?.first?.chord == "cmd+w")
+        #expect(back.menu?.first?.selector == "performClose:")
+    }
+
+    @Test func keymapListRequestRoundTrips() throws {
+        let request = ControlRequest(cmd: .keymapList)
+        let encoded = try JSONEncoder().encode(request)
+        let decoded = try JSONDecoder().decode(ControlRequest.self, from: encoded)
+        #expect(decoded.cmd == .keymapList)
+    }
+
+    @Test func keymapListRawStringMapsToCommand() throws {
+        let decoded = try JSONDecoder().decode(ControlRequest.self, from: Data(#"{"cmd":"keymap.list"}"#.utf8))
+        #expect(decoded.cmd == .keymapList)
+    }
+
+    @Test func resultOmitsKeymapWhenNil() throws {
+        let encoded = try JSONEncoder().encode(ControlResponse(ok: true, result: ControlResult()))
+        let json = String(decoding: encoded, as: UTF8.self)
+        #expect(!json.contains("keymap"))
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/KeybindTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/KeybindTests.swift
@@ -3,6 +3,26 @@ import Testing
 @testable import agtermCore
 
 struct KeybindTests {
+    // the character counterpart of namedKey(forKeyCode:) must cover the SAME vocabulary, or a menu key
+    // equivalent renders with its key missing and stops comparing against the chord the keymap resolved.
+    @Test func namedKeyForKeyEquivalentCoversEveryBindableNamedKey() {
+        let characters: [String: String] = [
+            "\u{F700}": "up", "\u{F701}": "down", "\u{F702}": "left", "\u{F703}": "right",
+            "\r": "return", "\t": "tab", " ": "space", "\u{7F}": "delete",
+        ]
+        for (character, expected) in characters {
+            #expect(namedKey(forKeyEquivalent: character) == expected)
+        }
+        #expect(Set(characters.values) == bindableNamedKeys,
+                "the character map and the file grammar must name the same keys")
+    }
+
+    @Test func namedKeyForKeyEquivalentIgnoresOrdinaryAndEmptyKeys() {
+        #expect(namedKey(forKeyEquivalent: "w") == nil)
+        #expect(namedKey(forKeyEquivalent: "") == nil)
+        #expect(namedKey(forKeyEquivalent: "ab") == nil, "only a single scalar can be a named key")
+    }
+
     @Test func parseSimpleChord() {
         let kb = parseKeybind("cmd+shift+e")
         #expect(kb == [Chord(mods: [.command, .shift], key: "e")])

--- a/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
+++ b/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
@@ -41,6 +41,7 @@ final class MockControlActions: ControlActions {
         case dashboard(targets: [String], window: String?, close: Bool, fontMode: DashboardFontMode, mru: Bool)
         case font(target: String?, window: String?, pane: String?, String)
         case keymapReload
+        case keymapList
         case configReload
         case notify(target: String?, window: String?, title: String?, body: String)
         case themeSet(String?)
@@ -102,6 +103,7 @@ final class MockControlActions: ControlActions {
     var nextCollapseResponse = ControlResponse(ok: true)
     var nextFontResponse = ControlResponse(ok: true)
     var nextNotifyResponse = ControlResponse(ok: true)
+    var nextKeymapListResponse = ControlResponse(ok: true)
     var nextKeymapResponse = ControlResponse(ok: true)
     var nextConfigResponse = ControlResponse(ok: true)
     var nextThemeSetResponse = ControlResponse(ok: true)
@@ -310,6 +312,11 @@ final class MockControlActions: ControlActions {
     func reloadKeymap() -> ControlResponse {
         calls.append(.keymapReload)
         return nextKeymapResponse
+    }
+
+    func listKeymap() -> ControlResponse {
+        calls.append(.keymapList)
+        return nextKeymapListResponse
     }
 
     func reloadGhosttyConfig() -> ControlResponse {

--- a/agtermCore/Tests/agtermCoreTests/SkillInstallTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SkillInstallTests.swift
@@ -14,7 +14,10 @@ struct SkillInstallTests {
         let reference = try String(contentsOf: skillDirectory.appendingPathComponent("reference.md"), encoding: .utf8)
         let examples = try String(contentsOf: skillDirectory.appendingPathComponent("examples.md"), encoding: .utf8)
 
-        #expect(skill.contains("Command summary (67 commands)"))
+        #expect(skill.contains("Command summary (68 commands)"))
+        #expect(skill.contains("`keymap list`"))
+        #expect(reference.contains("`agtermctl keymap list`"))
+        #expect(examples.contains("agtermctl keymap list"))
         #expect(skill.contains("**events**"))
         #expect(reference.contains("## events"))
         #expect(reference.contains("event cursor expired"))

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -1086,6 +1086,15 @@ struct CommandsTests {
         #expect(throws: (any Error).self) { try Agtermctl.parseAsRoot(["keymap", "reload", "--window", "w1"]) }
     }
 
+    @Test func keymapList() throws {
+        #expect(try request(["keymap", "list"]) == ControlRequest(cmd: .keymapList))
+    }
+
+    @Test func keymapListRejectsWindowSelector() {
+        // keymap.list is app-global like keymap.reload, so --window is meaningless.
+        #expect(throws: (any Error).self) { try Agtermctl.parseAsRoot(["keymap", "list", "--window", "w1"]) }
+    }
+
     @Test func configReload() throws {
         #expect(try request(["config", "reload"]) == ControlRequest(cmd: .configReload))
     }

--- a/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
@@ -107,6 +107,45 @@ struct SocketClientTests {
     }
 
     /// A create command's `run()` returns without throwing on `{"ok":true}` and prints the new id.
+    @Test func formatsKeymapWithEveryActionAndTheLiveMenu() {
+        let keymap = Keymap(builtinOverrides: [.closeSession: Chord(mods: [.command], key: "e")], commands: [])
+        let payload = ControlKeymap.project(
+            keymap: keymap, diagnostics: [KeymapDiagnostic(line: 3, message: "unknown action")],
+            path: "/tmp/keymap.conf",
+            menu: [ControlKeymapMenuItem(menu: "File", title: "Close", chord: "cmd+w", selector: "performClose:")]
+        )
+
+        let out = SocketClient.formatKeymap(payload)
+
+        #expect(out.contains("keymap: /tmp/keymap.conf"))
+        #expect(out.contains("* close_session"), "an overridden action is marked")
+        #expect(out.contains("cmd+e"))
+        #expect(out.contains("line 3: unknown action"))
+        #expect(out.contains("cmd+w  File ▸ Close"), "the live menu chord is listed for comparison")
+        // every action appears, keyless ones included, so the listing is the whole set
+        for action in BuiltinAction.allCases { #expect(out.contains(action.rawValue)) }
+    }
+
+    @Test func formatsKeymapWithoutOptionalSectionsWhenEmpty() {
+        let payload = ControlKeymap.project(keymap: Keymap(builtinOverrides: [:], commands: []),
+                                            diagnostics: [], path: "/tmp/keymap.conf")
+
+        let out = SocketClient.formatKeymap(payload)
+
+        #expect(!out.contains("commands:"))
+        #expect(!out.contains("diagnostics:"))
+        #expect(!out.contains("menu:"), "menu is omitted, not printed empty, when the caller supplied none")
+        #expect(out.contains("close_session"))
+    }
+
+    @Test func formatResponsePicksTheKeymapRenderer() {
+        let payload = ControlKeymap.project(keymap: Keymap(builtinOverrides: [:], commands: []),
+                                            diagnostics: [], path: "/tmp/keymap.conf")
+        let out = SocketClient.formatResponse(ControlResponse(ok: true, result: ControlResult(keymap: payload)),
+                                              json: false)
+        #expect(out.hasPrefix("keymap: /tmp/keymap.conf"))
+    }
+
     @Test func runEchoesNewIdForCreateCommand() throws {
         let server = StubServer(response: ControlResponse(ok: true, result: ControlResult(id: "9f3c")))
         try server.start()

--- a/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
@@ -126,6 +126,23 @@ struct SocketClientTests {
         for action in BuiltinAction.allCases { #expect(out.contains(action.rawValue)) }
     }
 
+    // line 0 is the whole-file / cross-section sentinel, not a real line. The GUI already drops the
+    // number for it (SettingsView.diagnosticLine), so the CLI must not send a reader hunting for line 0.
+    @Test func formatsKeymapDroppingTheLineNumberForWholeFileDiagnostics() {
+        let payload = ControlKeymap.project(
+            keymap: Keymap(builtinOverrides: [:], commands: []),
+            diagnostics: [KeymapDiagnostic(line: 0, message: "conflicts with a built-in; keybind dropped"),
+                          KeymapDiagnostic(line: 7, message: "unknown action")],
+            path: "/tmp/keymap.conf"
+        )
+
+        let out = SocketClient.formatKeymap(payload)
+
+        #expect(out.contains("    conflicts with a built-in; keybind dropped"))
+        #expect(!out.contains("line 0"), "the sentinel must not be printed as a line number")
+        #expect(out.contains("line 7: unknown action"), "a real line number is still shown")
+    }
+
     @Test func formatsKeymapWithoutOptionalSectionsWhenEmpty() {
         let payload = ControlKeymap.project(keymap: Keymap(builtinOverrides: [:], commands: []),
                                             diagnostics: [], path: "/tmp/keymap.conf")

--- a/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
@@ -143,6 +143,24 @@ struct SocketClientTests {
         #expect(out.contains("line 7: unknown action"), "a real line number is still shown")
     }
 
+    // a disabled item's chord is inert, and the default (non-JSON) output is the documented human
+    // workflow — leaving the flag out of the rendering drops the one fact that explains a dead binding.
+    @Test func formatsKeymapMarkingDisabledMenuItems() {
+        let payload = ControlKeymap.project(
+            keymap: Keymap(builtinOverrides: [:], commands: []), diagnostics: [], path: "/tmp/keymap.conf",
+            menu: [ControlKeymapMenuItem(menu: "Navigate", title: "Focus Left Pane", chord: "cmd+opt+left",
+                                         selector: "menuAction:", enabled: false),
+                   ControlKeymapMenuItem(menu: "File", title: "New Session", chord: "cmd+n",
+                                         selector: "menuAction:")]
+        )
+
+        let out = SocketClient.formatKeymap(payload)
+
+        #expect(out.contains("cmd+opt+left  Navigate ▸ Focus Left Pane  (disabled)"))
+        #expect(out.contains("cmd+n  File ▸ New Session\n") || out.hasSuffix("cmd+n  File ▸ New Session"),
+                "an enabled row carries no marker")
+    }
+
     @Test func formatsKeymapWithoutOptionalSectionsWhenEmpty() {
         let payload = ControlKeymap.project(keymap: Keymap(builtinOverrides: [:], commands: []),
                                             diagnostics: [], path: "/tmp/keymap.conf")

--- a/agtermTests/LiveMenuKeyEquivalentsTests.swift
+++ b/agtermTests/LiveMenuKeyEquivalentsTests.swift
@@ -1,0 +1,112 @@
+import AppKit
+import XCTest
+@testable import agterm
+import agtermCore
+
+/// Coverage for the live-menu half of `keymap.list` — `ControlServer.collectKeyEquivalents`.
+///
+/// This half cannot be exercised end to end: agterm's own nested submenus (File ▸ Open Window, File ▸
+/// Open Recent) carry no key equivalents, and App ▸ Services entries carry only the shortcuts a user
+/// assigned in System Settings, so no nested chord exists for an XCUITest to assert against. These tests
+/// build the menu shapes instead.
+@MainActor
+final class LiveMenuKeyEquivalentsTests: XCTestCase {
+    private func item(_ title: String, key: String, mods: NSEvent.ModifierFlags = .command,
+                      action: Selector? = nil, enabled: Bool = true) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: key)
+        item.keyEquivalentModifierMask = mods
+        // an item with no action is auto-disabled by AppKit unless autoenabling is off, so drive the
+        // enabled state explicitly through the same flag the real menu ends up carrying.
+        item.isEnabled = enabled
+        return item
+    }
+
+    private func menu(_ title: String, _ items: [NSMenuItem]) -> NSMenu {
+        let menu = NSMenu(title: title)
+        menu.autoenablesItems = false
+        items.forEach(menu.addItem)
+        return menu
+    }
+
+    // the reason the recursion exists: AppKit's performKeyEquivalent recurses, so a chord one level down
+    // is live and can shadow an agterm binding. Reporting only the top level would let a caller compare
+    // the two lists and conclude nothing holds a chord when something does.
+    func testCollectsKeyEquivalentsFromNestedSubmenus() {
+        let nested = menu("Services", [item("Nested Service", key: "j", mods: [.command, .shift])])
+        let parent = item("Services", key: "", action: nil)
+        parent.submenu = nested
+        let file = menu("File", [item("New Session", key: "n"), parent])
+
+        let found = ControlServer.collectKeyEquivalents(in: file, menu: "File")
+
+        XCTAssertEqual(found.map(\.chord), ["cmd+n", "cmd+shift+j"],
+                       "a nested item's chord must be collected, not dropped at the first level")
+        XCTAssertEqual(found.map(\.menu), ["File", "File"],
+                       "a nested item stays attributed to the top-level menu the reader can find it under")
+    }
+
+    func testRecursesMoreThanOneLevelDeep() {
+        let deepest = menu("Deeper", [item("Buried", key: "b")])
+        let midItem = item("Deeper", key: "", action: nil)
+        midItem.submenu = deepest
+        let mid = menu("Nested", [midItem])
+        let nestedItem = item("Nested", key: "", action: nil)
+        nestedItem.submenu = mid
+        let top = menu("File", [nestedItem])
+
+        let found = ControlServer.collectKeyEquivalents(in: top, menu: "File")
+
+        XCTAssertEqual(found.map(\.chord), ["cmd+b"], "the walk must not stop at a fixed depth")
+    }
+
+    func testItemsWithoutKeyEquivalentsAreSkipped() {
+        let file = menu("File", [item("No Chord", key: ""), item("Has Chord", key: "n")])
+
+        let found = ControlServer.collectKeyEquivalents(in: file, menu: "File")
+
+        XCTAssertEqual(found.map(\.title), ["Has Chord"])
+    }
+
+    // a disabled item's chord is INERT — AppKit consumes the key equivalent and fires nothing, so a
+    // caller comparing the two lists must be able to tell it apart from a live binding.
+    func testDisabledItemsAreMarkedAndEnabledOnesAreNot() throws {
+        let file = menu("File", [item("Live", key: "n"), item("Inert", key: "d", enabled: false)])
+
+        let found = ControlServer.collectKeyEquivalents(in: file, menu: "File")
+
+        XCTAssertNil(try XCTUnwrap(found.first { $0.title == "Live" }).enabled,
+                     "an enabled item omits the flag rather than reporting true")
+        XCTAssertEqual(try XCTUnwrap(found.first { $0.title == "Inert" }).enabled, false)
+    }
+
+    // AppKit matches an uppercase key equivalent against the SHIFTED chord even with shift absent from
+    // the mask, so lowercasing without adding shift would name a chord the item can never fire.
+    func testUppercaseKeyEquivalentReportsImpliedShift() throws {
+        let file = menu("Edit", [item("Paste and Match Style", key: "V", mods: [.command, .option])])
+
+        let found = try XCTUnwrap(ControlServer.collectKeyEquivalents(in: file, menu: "Edit").first)
+
+        XCTAssertEqual(found.chord, "cmd+opt+shift+v")
+    }
+
+    // arrows and return arrive as function-key / control characters; rendering them raw would leave the
+    // key missing and stop the chord comparing against the action list.
+    func testNamedKeysRenderInKeymapVocabulary() {
+        let file = menu("Navigate", [
+            item("Previous Session", key: "\u{F700}", mods: [.command, .option]),
+            item("Zoom", key: "\r", mods: [.command, .shift]),
+        ])
+
+        let found = ControlServer.collectKeyEquivalents(in: file, menu: "Navigate")
+
+        XCTAssertEqual(found.map(\.chord), ["cmd+opt+up", "cmd+shift+return"])
+    }
+
+    func testSelectorIsReportedSoStockItemsAreDistinguishable() throws {
+        let file = menu("File", [item("Close", key: "w", action: #selector(NSWindow.performClose(_:)))])
+
+        let found = try XCTUnwrap(ControlServer.collectKeyEquivalents(in: file, menu: "File").first)
+
+        XCTAssertEqual(found.selector, "performClose:", "a stock item is identified by its selector")
+    }
+}

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -1655,6 +1655,17 @@ final class ControlAPIUITests: ControlAPITestCase {
         // the seeded override moved Close Session to ⌘E, and the stock File ▸ Close then holds ⌘W — the
         // exact pairing that made #296 diagnosable at a glance.
         XCTAssertTrue(chords.contains("cmd+e"), "the rebound Close Session chord should show in the menu: \(chords)")
+        // a shift-bound built-in has to render `cmd+shift+n`, NOT the uppercase-character spelling
+        // `cmd+n` AppKit also accepts — that would collide on the page with New Window's real ⌘N and
+        // report a binding that does not exist. Only a live menu can settle which spelling SwiftUI used.
+        XCTAssertTrue(chords.contains("cmd+shift+n"),
+                      "a shift-bound built-in should carry shift in the mask, not fold into an uppercase key: \(chords)")
+        XCTAssertEqual(chords.filter { $0 == "cmd+n" }.count, 1,
+                       "only New Session holds ⌘N; a folded shift chord would duplicate it: \(chords)")
+        // the walk recurses, so a nested submenu's equivalents are included rather than silently dropped.
+        // App ▸ Services is the reachable case (its entries carry user-assigned system shortcuts).
+        let menus = Set(menu.compactMap { $0["menu"] as? String })
+        XCTAssertTrue(menus.contains("File"), "top-level menus should be attributed by their menu-bar title: \(menus)")
         XCTAssertNotNil(keymap["path"] as? String, "the payload should name the keymap file")
     }
 

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -1620,6 +1620,44 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertGreaterThanOrEqual(count, 1, "a broken keymap line should yield at least one diagnostic: \(response)")
     }
 
+    // keymap.list is the read side of keymap.reload: what the keymap resolved, plus what the menu bar is
+    // actually dispatching. Seed an override and a custom command, then assert both halves came back and
+    // that the override moved the chord.
+    func testKeymapListReportsResolvedChordsAndLiveMenu() throws {
+        try relaunch(withKeymap: "map cmd+e close_session\ncommand \"Bound\" cmd+shift+e echo hi\n")
+        let response = try sendCommand(#"{"cmd":"keymap.list"}"#)
+        XCTAssertEqual(response["ok"] as? Bool, true, "keymap.list should succeed: \(response)")
+        let result = try XCTUnwrap(response["result"] as? [String: Any], "keymap.list should carry a result")
+        let keymap = try XCTUnwrap(result["keymap"] as? [String: Any], "keymap.list should carry a keymap payload")
+
+        let actions = try XCTUnwrap(keymap["actions"] as? [[String: Any]], "the payload should list actions")
+        XCTAssertGreaterThan(actions.count, 40, "every built-in should be listed, not just the bound ones")
+        let close = try XCTUnwrap(actions.first { $0["action"] as? String == "close_session" },
+                                  "close_session should be listed: \(actions)")
+        XCTAssertEqual(close["chord"] as? String, "cmd+e", "the override should be reflected: \(close)")
+        XCTAssertEqual(close["overridden"] as? Bool, true, "an overridden action should be marked: \(close)")
+
+        let commands = try XCTUnwrap(keymap["commands"] as? [[String: Any]], "the payload should list custom commands")
+        XCTAssertEqual(commands.first?["name"] as? String, "Bound")
+        XCTAssertEqual(commands.first?["shortcut"] as? String, "cmd+shift+e")
+
+        // the live half: the menu bar carries real key equivalents, rendered in keymap syntax so the two
+        // lists compare directly. This is what a model-only listing cannot show.
+        let menu = try XCTUnwrap(keymap["menu"] as? [[String: Any]], "the payload should carry the live menu")
+        XCTAssertFalse(menu.isEmpty, "the menu bar should report key equivalents: \(menu)")
+        let chords = menu.compactMap { $0["chord"] as? String }
+        XCTAssertTrue(chords.contains("cmd+n"), "a stable built-in chord should appear in the menu: \(chords)")
+        // arrows and return arrive from AppKit as function-key/control CHARACTERS. They have to be
+        // rendered as the keymap's named keys or the chord comes back with the key missing (`cmd+opt+`)
+        // and cannot be compared against the action list above, which is the whole point of this section.
+        XCTAssertTrue(chords.contains("cmd+opt+up"), "an arrow chord should render its named key: \(chords)")
+        XCTAssertTrue(chords.contains("cmd+shift+return"), "a return chord should render its named key: \(chords)")
+        // the seeded override moved Close Session to ⌘E, and the stock File ▸ Close then holds ⌘W — the
+        // exact pairing that made #296 diagnosable at a glance.
+        XCTAssertTrue(chords.contains("cmd+e"), "the rebound Close Session chord should show in the menu: \(chords)")
+        XCTAssertNotNil(keymap["path"] as? String, "the payload should name the keymap file")
+    }
+
     // MARK: - Config
 
     // config.reload re-reads the agterm-scoped ghostty.conf and returns the config-diagnostic count.

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -1662,8 +1662,9 @@ final class ControlAPIUITests: ControlAPITestCase {
                       "a shift-bound built-in should carry shift in the mask, not fold into an uppercase key: \(chords)")
         XCTAssertEqual(chords.filter { $0 == "cmd+n" }.count, 1,
                        "only New Session holds ⌘N; a folded shift chord would duplicate it: \(chords)")
-        // the walk recurses, so a nested submenu's equivalents are included rather than silently dropped.
-        // App ▸ Services is the reachable case (its entries carry user-assigned system shortcuts).
+        // items are attributed to their top-level menu. The nested-submenu recursion cannot be asserted
+        // here — agterm's own submenus carry no key equivalents and Services entries depend on the user's
+        // system settings — so it is covered in agtermTests/LiveMenuKeyEquivalentsTests instead.
         let menus = Set(menu.compactMap { $0["menu"] as? String })
         XCTAssertTrue(menus.contains("File"), "top-level menus should be attributed by their menu-bar title: \(menus)")
         XCTAssertNotNil(keymap["path"] as? String, "the payload should name the keymap file")

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -37,6 +37,13 @@ After editing `keymap.conf`, nothing changes until you reload it.
 - **Settings ▸ Key Mapping** shows a read-only list of parse problems (a malformed line, a dropped binding, a conflict). This is the first place to look when a binding does not behave.
 - **File ▸ Reload Keymap** re-reads the file. A reload that found problems posts a banner with the count.
 - **`agtermctl keymap reload`** does the same from the command line and prints the diagnostic count (`0` means a clean reload).
+- **`agtermctl keymap list`** shows what is actually bound: every built-in with the chord it resolved to, the custom commands, each diagnostic in full rather than just a count, and the key equivalents the menu bar is really carrying.
+
+## A keybinding does not fire
+
+Run `agtermctl keymap list` and compare its two lists. If the action's chord is what you expect but no menu entry carries it (or a different item does), the keymap is fine and the menu is stale: agterm rebuilds the menu when the app next becomes active, so switch to another app and back, and relaunch if it persists.
+
+One built-in is legitimately missing from the menu list: `undo_close` (⌘Z) is delivered by a key monitor rather than a menu item, so that native text undo keeps working in the rename, palette and Settings fields. Its absence there is expected.
 
 ## The keymap editor will not open
 

--- a/site/commands.html
+++ b/site/commands.html
@@ -6,7 +6,7 @@
     <title>Command reference — agterm | agtermctl control API</title>
     <meta
       name="description"
-      content="Complete agtermctl reference: all 67 control commands for agterm — sessions, workspaces, windows, overlays, the quick terminal, sidebar, agent status, themes, and keymaps, with arguments and return values."
+      content="Complete agtermctl reference: all 68 control commands for agterm — sessions, workspaces, windows, overlays, the quick terminal, sidebar, agent status, themes, and keymaps, with arguments and return values."
     />
     <meta
       name="keywords"
@@ -18,7 +18,7 @@
     <meta property="og:title" content="Command reference — agterm" />
     <meta
       property="og:description"
-      content="All 67 agtermctl control commands with arguments, return values, and errors."
+      content="All 68 agtermctl control commands with arguments, return values, and errors."
     />
     <meta property="og:url" content="https://agterm.com/commands" />
     <meta property="og:image" content="https://agterm.com/assets/agterm-og.png" />
@@ -30,7 +30,7 @@
     <meta name="twitter:title" content="Command reference — agterm" />
     <meta
       name="twitter:description"
-      content="All 67 agtermctl control commands with arguments, return values, and errors."
+      content="All 68 agtermctl control commands with arguments, return values, and errors."
     />
     <meta name="twitter:image" content="https://agterm.com/assets/agterm-og.png" />
     <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
@@ -235,7 +235,7 @@
             Command reference
           </h1>
           <p style="font-size: 19px; line-height: 1.6; color: #bfbab0; margin: 0 0 8px">
-            All 67 commands of the agterm control API, with arguments and return values. Every one is reachable from the
+            All 68 commands of the agterm control API, with arguments and return values. Every one is reachable from the
             <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl</span> CLI and from the local
             control socket.
           </p>
@@ -1983,6 +1983,26 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">result.count</span> — the number of parse diagnostics
                 (0 is a clean reload). App-global; the same path as File ▸ Reload Keymap. See
                 <a href="/docs#keymap" style="color: #6d82f3">Customizing keys</a> for the file format.
+              </p>
+            </div>
+
+            <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
+                agtermctl keymap list
+              </div>
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">keymap.list</div>
+              <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
+                Show the resolved keymap and the live menu key equivalents.
+                <strong style="color: #bfbab0">Returns</strong>
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">result.keymap</span> with
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">path</span>,
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">actions</span> (every built-in with the chord it
+                resolved to, marked when a <span style="font-family: &quot;JetBrains Mono&quot;, monospace">map</span> line moved it
+                off its default), <span style="font-family: &quot;JetBrains Mono&quot;, monospace">commands</span>,
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">diagnostics</span> (line and message, not just the
+                count), and <span style="font-family: &quot;JetBrains Mono&quot;, monospace">menu</span> — the key equivalents the menu
+                bar is actually dispatching. The last two lists can disagree, which is how you tell a keymap problem from a menu
+                one when a binding will not fire. App-global; takes no target or arguments.
               </p>
             </div>
           </section>

--- a/site/commands.html
+++ b/site/commands.html
@@ -2001,8 +2001,10 @@
                 off its default), <span style="font-family: &quot;JetBrains Mono&quot;, monospace">commands</span>,
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">diagnostics</span> (line and message, not just the
                 count), and <span style="font-family: &quot;JetBrains Mono&quot;, monospace">menu</span> — the key equivalents the menu
-                bar is actually dispatching. The last two lists can disagree, which is how you tell a keymap problem from a menu
-                one when a binding will not fire. App-global; takes no target or arguments.
+                bar carries, nested submenus included, each with its selector and marked
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">enabled: false</span> when the item is disabled and its
+                chord therefore inert. The action and menu lists can disagree, which is how you tell a keymap problem from a menu one
+                when a binding will not fire. App-global; takes no target or arguments.
               </p>
             </div>
           </section>

--- a/site/docs.html
+++ b/site/docs.html
@@ -1647,8 +1647,10 @@
               To check what is actually bound,
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl keymap list</span> prints every
               built-in with the chord it resolved to, the custom commands, each diagnostic in full, and the key equivalents the menu
-              bar is really carrying. If a binding will not fire, compare the last two: an action whose chord no menu item holds is a
-              menu problem, not a keymap one.
+              bar is really carrying. If a binding will not fire, compare the last two: an action whose chord no menu item holds is
+              usually a menu problem, not a keymap one. The one deliberate exception is
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">undo_close</span> (⌘Z), delivered by a
+              key monitor rather than a menu item, so it never appears in the menu list.
             </p>
             <h3
               style="

--- a/site/docs.html
+++ b/site/docs.html
@@ -1115,7 +1115,7 @@
               "
             >
               <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 0">
-                Looking for the full list? All 67 commands, with every argument, return value, and error, live on the
+                Looking for the full list? All 68 commands, with every argument, return value, and error, live on the
                 <a href="/commands" style="color: #6d82f3; font-weight: 500">Command reference →</a>
               </p>
             </div>
@@ -1642,6 +1642,13 @@
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl keymap reload</span>. A
               malformed line never discards the rest — it surfaces in the diagnostics list in Settings ▸ Key Mapping while the good
               lines still apply.
+            </p>
+            <p style="font-size: 15.5px; line-height: 1.75; color: #cbc6bc; margin: 0 0 18px">
+              To check what is actually bound,
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl keymap list</span> prints every
+              built-in with the chord it resolved to, the custom commands, each diagnostic in full, and the key equivalents the menu
+              bar is really carrying. If a binding will not fire, compare the last two: an action whose chord no menu item holds is a
+              menu problem, not a keymap one.
             </p>
             <h3
               style="


### PR DESCRIPTION
`keymap.reload` was write-only. Nothing could ask the app what a keybinding had resolved to, which is why diagnosing #296 took eight rounds of pressing keys by hand and reporting what happened.

A plain listing would not have helped there. The keymap resolved `close_session` to ⌘W correctly the whole time; what was wrong was the live `NSMenuItem`. So `keymap.list` returns both halves, and they can disagree:

- `actions`: every built-in with the chord it resolved to, `overridden` when that differs from the shipped default, keyless actions listed too so you can see which chords are free
- `menu`: the key equivalents the menu bar carries, nested submenus included, each with its selector and marked `enabled: false` when the item is disabled and its chord therefore inert

Plus `path`, `commands`, and `diagnostics` with line and message rather than just a count.

Both lists render in the same kitty syntax, so equal bindings produce equal strings and you can compare them directly. That needed `namedKey(forKeyEquivalent:)`, the character twin of the existing `namedKey(forKeyCode:)`: AppKit hands over arrows and return as function-key and control characters, which would print `cmd+opt+` with the key missing against the `cmd+opt+up` the keymap resolved. Its range is pinned against `bindableNamedKeys` so the two cannot drift, and the globe/fn modifier prints as `fn+` rather than being dropped and reading as a bare key.

The projection is host-free in `ControlKeymap`; only the live menu read is app-side.

**Reviewed in three rounds, which found real defects.** Deciding `overridden` from "is there a map line" marked an action that had not moved, since a redundant `map cmd+w close_session` parses clean and leaves the default in place. The menu walk did not recurse, so a nested Services shortcut could hold a chord while the listing said nothing did. The examples recipe for surveying chords in use queried two of the three sources and would have picked one that made the next reload drop the user's own custom binding. And the `enabled` flag reached the payload and every doc surface but not the CLI formatter, so the default output that troubleshooting tells you to run showed inert rows as if they were live.

Two findings were resolved in the code's favour rather than changed. Shift-bound chords render correctly, verified against a live menu and now pinned by the e2e. And `increase_font_size` reports `cmd++`, which cannot be typed back into the file, but substituting a placeholder would turn the one row that compares correctly into a false mismatch, so it is documented instead.

Catalog count 67 to 68, mirrored in the agent skill, `site/commands.html`, `site/docs.html`, README, and both troubleshooting guides. Note for the next bump: five `Command` cases carry implicit raw values, so counting `case x = "..."` lines undercounts by five, and the grep this file recommends misses the phrasings the rule file itself uses. Both are written down now.
