### PR TITLE
fix blank pane after hidden split promotion

### DIFF
--- a/agterm/Views/TerminalView.swift
+++ b/agterm/Views/TerminalView.swift
@@ -80,8 +80,8 @@ struct TerminalView: NSViewRepresentable {
     /// observable invalidations) don't steal focus.
     ///
     /// Focus is taken once, when this representable first attaches to a window
-    /// (each `TerminalView(session).id(session.id)` is a fresh representable, so
-    /// this fires when a session becomes active). On later updates focus is left
+    /// (each terminal host carries stable session + surface identity, so replacing
+    /// the hosted surface creates a fresh representable). On later updates focus is left
     /// alone unless the surface already holds it — and never grabbed while a text
     /// field editor is first responder, so editing a sidebar rename survives a
     /// re-render. Mouse clicks (`mouseDown`) cover focus for the rest.

--- a/agterm/Views/WindowContentView+Zoom.swift
+++ b/agterm/Views/WindowContentView+Zoom.swift
@@ -146,7 +146,7 @@ extension WindowContentView {
         case .primary:
             TerminalView(session: session, surfaceKeyPath: \.surface, makeSurface: makeSurface,
                          isActive: true, deckVisible: true, reportsFocusChange: false)
-                .id("\(session.id.uuidString)-zoom-primary")
+                .id("\(primarySurfaceID(session))-zoom")
         case .split:
             TerminalView(session: session, surfaceKeyPath: \.splitSurface, makeSurface: makeSplitSurface,
                          isActive: true, deckVisible: true, reportsFocusChange: false)

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -587,12 +587,12 @@ struct WindowContentView: View {
         }
     }
 
-    /// Keeps the primary host stable while its surface is unchanged, but remounts it when a split survivor
-    /// is promoted into `session.surface`. `TerminalView.updateNSView` cannot replace the AppKit view that
-    /// `makeNSView` returned, so session identity alone would keep hosting the torn-down prior primary.
-    private func primarySurfaceID(_ session: Session) -> String {
-        guard let surface = session.surface else { return "\(session.id.uuidString)-primary-none" }
-        return "\(session.id.uuidString)-primary-\(ObjectIdentifier(surface as AnyObject))"
+    /// Keeps a primary host stable through lazy surface creation and ordinary updates, but remounts it
+    /// when one live surface replaces another (split-survivor promotion). `TerminalView.updateNSView`
+    /// cannot replace the AppKit view that `makeNSView` returned, so session identity alone would keep
+    /// hosting the torn-down prior primary.
+    func primarySurfaceID(_ session: Session) -> String {
+        "\(session.id.uuidString)-primary-\(session.primarySurfaceHostRevision)"
     }
 
     /// Mutes the inactive split pane's TEXT so the active pane stands out, WITHOUT darkening the

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -407,7 +407,7 @@ struct WindowContentView: View {
                                              isActive: deckInteractive && isActive && !session.splitFocused && !overlaid,
                                              deckVisible: visible)
                                     .overlay { paneDim(session.splitFocused) }
-                                    .id(session.id)
+                                    .id(primarySurfaceID(session))
                             } else {
                                 Color.clear
                                     .id("\(session.id.uuidString)-primary-placeholder")
@@ -448,7 +448,7 @@ struct WindowContentView: View {
                     if deckHostsSurface(session: session, surface: .primary) {
                         TerminalView(session: session, surfaceKeyPath: \.surface, makeSurface: makeSurface,
                                      isActive: deckInteractive && isActive && !overlaid, deckVisible: visible)
-                            .id(session.id)
+                            .id(primarySurfaceID(session))
                     } else {
                         Color.clear
                             .id("\(session.id.uuidString)-primary-placeholder")
@@ -585,6 +585,14 @@ struct WindowContentView: View {
             .padding(.top, 8)
             .padding(.trailing, 8)
         }
+    }
+
+    /// Keeps the primary host stable while its surface is unchanged, but remounts it when a split survivor
+    /// is promoted into `session.surface`. `TerminalView.updateNSView` cannot replace the AppKit view that
+    /// `makeNSView` returned, so session identity alone would keep hosting the torn-down prior primary.
+    private func primarySurfaceID(_ session: Session) -> String {
+        guard let surface = session.surface else { return "\(session.id.uuidString)-primary-none" }
+        return "\(session.id.uuidString)-primary-\(ObjectIdentifier(surface as AnyObject))"
     }
 
     /// Mutes the inactive split pane's TEXT so the active pane stands out, WITHOUT darkening the

--- a/agtermCore/Sources/agtermCore/Session.swift
+++ b/agtermCore/Sources/agtermCore/Session.swift
@@ -64,9 +64,19 @@ public final class Session: Identifiable {
     /// so it survives a relaunch (and a workspace move — the flag travels with the session).
     public var flagged: Bool = false
 
+    /// Changes only when one live primary-slot surface is replaced by another. SwiftUI terminal hosts
+    /// include this stable revision in their identity: lazy nil → first-surface creation stays at zero,
+    /// while split-survivor promotion advances it so the host remounts the replacement AppKit view.
+    @ObservationIgnored public private(set) var primarySurfaceHostRevision = 0
+
     /// The app-side surface (a `GhosttySurfaceView`). Lazily created on first
     /// display and owned here so it survives sidebar/detail view churn.
-    @ObservationIgnored public var surface: (any TerminalSurface)?
+    @ObservationIgnored public var surface: (any TerminalSurface)? {
+        didSet {
+            guard let oldValue, let surface, oldValue !== surface else { return }
+            primarySurfaceHostRevision &+= 1
+        }
+    }
 
     /// Whether the session is shown as a one-level vertical split (two panes side by
     /// side). Observed, so the detail pane shows/hides the second pane when toggled.

--- a/agtermCore/Tests/agtermCoreTests/SessionTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SessionTests.swift
@@ -112,6 +112,20 @@ struct SessionTests {
         #expect(session.focusedCwd == "/Users/user")       // the main cwd, not an initialCwd fallback
     }
 
+    @Test func primarySurfaceHostRevisionChangesOnlyForLiveReplacement() {
+        let session = Session(initialCwd: "/Users/user")
+        let original = FakeSurface()
+        let replacement = FakeSurface()
+
+        #expect(session.primarySurfaceHostRevision == 0)
+        session.surface = original
+        #expect(session.primarySurfaceHostRevision == 0) // lazy creation must not force a second mount
+        session.surface = original
+        #expect(session.primarySurfaceHostRevision == 0) // assigning the same instance is still stable
+        session.surface = replacement
+        #expect(session.primarySurfaceHostRevision == 1) // promotion replaces the hosted AppKit view
+    }
+
     @Test func subtitleDetailUsesCwdForNamedSessionWithoutTitle() {
         // named local session: local auto-title is suppressed so oscTitle is nil; the second line is the cwd.
         let session = Session(initialCwd: "/Users/user/dev/foo", customName: "build")

--- a/agtermUITests/ControlSurfaceZoomUITests.swift
+++ b/agtermUITests/ControlSurfaceZoomUITests.swift
@@ -39,6 +39,64 @@ final class ControlSurfaceZoomUITests: ControlAPITestCase {
         XCTAssertTrue(pollSplitRatio(0.33, timeout: 10), "zoom round-trip must not change the split ratio")
     }
 
+    // A primary surface can exit while terminal zoom owns its host. When a live split exists, that exit
+    // promotes the split surface into the primary slot without changing the zoom target's semantic identity
+    // (`surface:<session>:left`). The zoom host must still replace its torn-down AppKit view and focus the
+    // promoted survivor; otherwise the zoom stays blank until the user exits it.
+    func testZoomedPrimaryExitRehostsAndFocusesPromotedSurvivor() throws {
+        let sessionID = try activeSessionID()
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.split","args":{"mode":"on"}}"#)["ok"] as? Bool, true,
+                       "split on should succeed")
+        XCTAssertTrue(try pollSplit(sessionID, timeout: 10), "the split should be live before zoom")
+
+        // Prove the future survivor's shell is ready before the one-shot primary exit.
+        let survivorReady = markerDir.appendingPathComponent("zoom-survivor-ready")
+        var survivorValue: String?
+        for _ in 0..<4 where survivorValue == nil {
+            let typed = try sendCommand(typeRequest(
+                text: "printf ZOOMSURVIVOR > '\(survivorReady.path)'\n",
+                target: sessionID, select: false, pane: "right"))
+            XCTAssertEqual(typed["ok"] as? Bool, true, "typing to the split survivor should succeed: \(typed)")
+            survivorValue = pollMarker(survivorReady, timeout: 3)
+        }
+        XCTAssertEqual(survivorValue, "ZOOMSURVIVOR", "the split survivor should be reading commands")
+
+        let leftSurface = try activeSurfaceID(kind: "left")
+        let zoom = try sendCommand(#"{"cmd":"surface.zoom","target":"\#(leftSurface)","args":{"mode":"show"}}"#)
+        XCTAssertEqual(zoom["ok"] as? Bool, true, "surface zoom show should succeed: \(zoom)")
+        XCTAssertTrue(app.buttons["terminal-zoom-exit"].waitForExistence(timeout: 10),
+                      "zoom should own the primary host before it exits")
+
+        // Confirm keyboard focus reached the zoomed primary before sending the non-repeatable `exit`.
+        let primaryReady = markerDir.appendingPathComponent("zoom-primary-ready")
+        var primaryValue: String?
+        for _ in 0..<4 where primaryValue == nil {
+            app.typeText("printf ZOOMPRIMARY > '\(primaryReady.path)'")
+            app.typeKey(.return, modifierFlags: [])
+            primaryValue = pollMarker(primaryReady, timeout: 3)
+        }
+        XCTAssertEqual(primaryValue, "ZOOMPRIMARY", "the zoomed primary should own keyboard focus")
+
+        app.typeText("exit")
+        app.typeKey(.return, modifierFlags: [])
+        XCTAssertTrue(poll(until: (try? sessionNodeIfPresent(id: sessionID)?["split"] as? Bool) == false, timeout: 15),
+                      "primary exit should promote the split survivor")
+        XCTAssertTrue(app.buttons["terminal-zoom-exit"].exists,
+                      "promotion should keep the semantic primary target zoomed")
+
+        // Type without clicking or leaving zoom. A stale representable still hosts the torn-down primary
+        // and can never write this marker; a remounted survivor receives focus and runs it.
+        let afterPromotion = markerDir.appendingPathComponent("zoom-after-promotion")
+        var promotedValue: String?
+        for _ in 0..<4 where promotedValue == nil {
+            app.typeText("printf ZOOMPROMOTED > '\(afterPromotion.path)'")
+            app.typeKey(.return, modifierFlags: [])
+            promotedValue = pollMarker(afterPromotion, timeout: 3)
+        }
+        XCTAssertEqual(promotedValue, "ZOOMPROMOTED",
+                       "the promoted survivor should be hosted and focused without leaving zoom")
+    }
+
     func testScratchOpenedWhileZoomedRealizesSurface() throws {
         let leftSurface = try activeSurfaceID(kind: "left")
         let zoom = try sendCommand(#"{"cmd":"surface.zoom","target":"\#(leftSurface)","args":{"mode":"show"}}"#)

--- a/agtermUITests/SplitUITests.swift
+++ b/agtermUITests/SplitUITests.swift
@@ -274,6 +274,42 @@ final class SplitUITests: XCTestCase {
         XCTAssertEqual(survivorTTY, rightTTY, "after exiting the primary, the surviving right pane is focused")
     }
 
+    // Regression for #303: when the split is hidden with the PRIMARY shown, exiting that primary promotes
+    // the live right pane into the primary slot without changing the surrounding SwiftUI branch. The
+    // terminal host must therefore remount for the promoted surface, or the visible pane remains the dead
+    // primary while the live survivor is stranded off-screen. Verify by typing WITHOUT focusing after exit.
+    func testExitPrimaryPaneWhileSplitHiddenHostsAndFocusesSurvivor() throws {
+        let row = app.staticTexts["session-row"]
+        XCTAssertTrue(row.waitForExistence(timeout: 20), "seeded session should exist")
+        row.click()
+        usleep(800_000)
+
+        let splitButton = app.buttons["split-toggle"]
+        XCTAssertTrue(splitButton.waitForExistence(timeout: 5), "split toolbar button should exist")
+
+        // Open the split and record the right pane's tty — this is the survivor that will be promoted.
+        splitButton.click()
+        usleep(800_000)
+        let rightTTY = ttyAfterCommand(named: "hidden-survivor")
+        XCTAssertNotNil(rightTTY, "right shell should write its tty")
+
+        // Show only the primary pane while keeping the right shell alive off-screen.
+        app.typeKey("1", modifierFlags: .control)
+        usleep(500_000)
+        splitButton.click()
+        XCTAssertTrue(waitSplitValue(splitButton, "left"), "the hidden split should show the primary pane")
+
+        // Exit the shown primary. The hidden right pane must promote into the visible host and take focus.
+        app.typeText("exit")
+        app.typeKey(.return, modifierFlags: [])
+        XCTAssertTrue(waitSplitValue(splitButton, "none"), "promotion should leave a regular non-split session")
+        XCTAssertTrue(row.waitForExistence(timeout: 5), "exiting the hidden primary must keep the session")
+
+        // Type WITHOUT focusing — this fails if SwiftUI kept hosting the torn-down primary surface.
+        XCTAssertEqual(ttyAfterCommand(named: "after-hidden-promotion"), rightTTY,
+                       "the promoted hidden survivor should be visible and focused")
+    }
+
     // promote → re-split → exit-main: the round-1 zombie scenario, driven through the REAL pane-exit
     // routing (typing `exit`, not calling closePrimaryPane directly like the host-free test). After the
     // primary exits, the right pane promotes into the sole/main slot; a fresh split then opens a new right


### PR DESCRIPTION
fixes the blank terminal left behind when the primary shell exits while a hidden split is still alive.

the regression came from [9edcfc2](https://github.com/umputun/agterm/commit/9edcfc25ac693221295617643ee7dd4d15172853) in [#121](https://github.com/umputun/agterm/pull/121): survivor promotion updated the model slot, but the SwiftUI host remained keyed only by session and pane role.

the split survivor is already promoted into `session.surface`, but SwiftUI kept hosting the torn-down primary `NSView` because the host identity did not change. Track live primary replacements with a stable revision and use it for the normal and terminal-zoom hosts. Lazy first creation keeps the same identity, so ordinary startup updates do not remount the Metal surface.

adds focused UI regressions for hidden-split and zoomed promotion, plus a model test for replacement-only identity changes.

Fixes #303
