### PR TITLE
docs(cookbook): add the status-announcer recipe

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -13,6 +13,7 @@ Recipes come from other people as well as the maintainer. Every one is reviewed 
 | [window-per-project](window-per-project/) | park every other window in the Dock and raise one | 0.17.1, jq |
 | [fzf-path-picker](fzf-path-picker/) | pick a path with fzf and type it into the shell | 0.8.0, fzf, fd, zsh |
 | [overlay-and-split](overlay-and-split/) | keymap lines: a stateful split toggle and TUI overlays | 0.10.0, jq |
+| [status-announcer](status-announcer/) | demo: speak agent status changes from a dedicated session | 0.16.0, jq |
 | [claude-session-resume](claude-session-resume/) | each tab reopens its own Claude Code conversation after a restart | 0.3.1, zsh, Claude Code |
 | [codex-session-resume](codex-session-resume/) | each tab reopens its own codex conversation after a restart | 0.3.1, zsh, Codex CLI |
 

--- a/cookbook/status-announcer/README.md
+++ b/cookbook/status-announcer/README.md
@@ -1,0 +1,98 @@
+# Status announcer
+
+Speak agent status changes out loud from a dedicated session, as a worked example of wiring the event stream to something.
+
+## What it does
+
+This one is a demonstration rather than a tool. Talking terminals get old within the hour, and nothing here is meant to survive on your machine past the afternoon you try it. What it is good for is showing the shape of a non-trivial event-driven flow end to end, because every piece of it is a piece you would need for something you did want to keep: subscribing to the stream, filtering it, resolving the ids an event carries into names, and running the whole thing somewhere that survives you switching sessions.
+
+"Toggle Status Announcer" in the command palette creates a session named `status-announcer` running an event loop, and closes it when one is already running. While it runs, every session that goes `blocked`, `completed` or `idle` is announced through `say`, naming the workspace and the session: "umputun dev, api fix blocked".
+
+Starting it does not pull you into it. The session is created in the background, so your selection and focus stay where they were. It also keeps a log of what it heard, one line per event, which is what you look at when you want to know whether it is working:
+
+```
+status announcer: listening for blocked completed idle
+run the toggle again to stop
+
+13:57:52  umputun.dev / api-fix  blocked
+13:57:56  far.side / remote-agent  completed
+```
+
+The log keeps the real names; only the spoken copy is flattened for pronunciation.
+
+`active` is not announced. The agent-status hooks re-assert it on every tool call, so a loop that spoke it would never stop talking.
+
+If you want the shape without the voice, replace `say` with a `curl` to ntfy or Telegram, an append to a journal file, or a Stream Deck key. The rest of the script stays as it is.
+
+## Requirements
+
+- agterm 0.16.0 or later. Event subscription through `agtermctl events` shipped in that release.
+- `jq`
+- `say` and `/bin/zsh`, both of which come with macOS
+
+## Setup
+
+Copy the script somewhere on your `PATH` and make it executable:
+
+```sh
+mkdir -p ~/bin
+cp agt-announce.sh ~/bin/
+chmod +x ~/bin/agt-announce.sh
+```
+
+Add one entry to `~/.config/agterm/keymap.conf`:
+
+```
+command "Toggle Status Announcer"  /bin/zsh -lc '~/bin/agt-announce.sh'
+```
+
+No chord, so the entry is palette-only, which suits something you turn on once and forget. Add one if you want it on a key: the token after the quoted name is a chord when it carries a modifier.
+
+The login shell in that line is load-bearing. A custom command runs under the app's `PATH` rather than yours, which is the launchd default: `/usr/local/bin` plus the system directories, with no `/opt/homebrew/bin`. `agtermctl` resolves there because **Help ▸ Install Command Line Tool…** symlinks it into `/usr/local/bin`, but a Homebrew `jq` does not, and a custom command's output goes nowhere, so it would fail with nothing on screen to say why. `/bin/zsh -lc` sources your profile and puts your own `PATH` back.
+
+Apply the file with File ▸ Reload Keymap or `agtermctl keymap reload`.
+
+Two variables at the top of the script are worth knowing about. `ANNOUNCER_NAME` is the session name the toggle matches on, and `SPOKEN` is the space-separated list of statuses to announce.
+
+## Usage
+
+Press ⌃⇧P, type "announcer", hit Enter. ⌃⇧O opens a palette holding the custom commands alone, which is the shorter route. Run it again to close the session and stop.
+
+To hear it do something without waiting for an agent:
+
+```sh
+agtermctl session status blocked --target <some-session-id>
+agtermctl session status idle --target <some-session-id>
+```
+
+The script also runs from a shell, `agt-announce.sh` to toggle, which is where error text goes when something is wrong.
+
+## How it works
+
+`agtermctl events --json --kind status` prints one JSON object per status change and keeps printing. Each carries the session id, the window id, the workspace id, and a payload holding the session name and the new status. One `jq` filters the whole stream in a single pass: it drops the announcer's own session by comparing against `$AGTERM_SESSION_ID`, drops statuses outside `SPOKEN`, and emits the four fields it kept as a tab-separated line for a plain `read` loop.
+
+`--unbuffered` on that `jq` is what makes announcements arrive per event. Without it jq buffers, and the voice waits for a block to fill.
+
+The workspace name is the interesting part, because the event does not carry it. It carries the workspace id, so the loop reads `agtermctl tree --json --window <window>` and matches the id against `.result.tree.workspaces[]`. The `--window` matters: a bare `tree` projects the frontmost window, so an agent blocking in a background window would resolve to no workspace at all, and that only shows up once you have a second window open. Looking it up per event rather than caching a map and invalidating it on `tree.changed` costs nothing here, since these events fire only on real transitions.
+
+The toggle searches every open window for the announcer, walking `agtermctl window list --json` and reading each window's tree, rather than looking only at the frontmost one. A frontmost-only search would fail to find an announcer started from another window and start a second one talking over the first.
+
+It creates the session with `--no-select`, which leaves your selection and focus untouched. Without it, turning the announcer on drops you into a session you have no reason to be looking at.
+
+There are two login-shell wrappers, in two different places, for one reason. The keymap line wraps the toggle because a custom command runs under the app's `PATH`. The toggle wraps the loop, in the `--command` it hands to `session.new`, because that command is exec'd by the app under the same `PATH` and does not inherit anything from the toggle that asked for it.
+
+`say` pronounces punctuation, so the phrase goes through `tr '._-' '   '` first. Otherwise a workspace named `umputun.dev` is announced as "umputun dot dev".
+
+## Limits
+
+**Toggling off closes the announcer session and kills the shell running in it.** The toggle matches by name, so if you already have a session called `status-announcer`, that is the one it closes. Change `ANNOUNCER_NAME` at the top of the script if the name is taken.
+
+It is a demonstration, and the voice wears out its welcome quickly. Nothing here is worth keeping on for a working day.
+
+The announcer session closes itself if the event stream ends, taking its log with it. `agtermctl events` exits non-zero on a cursor, transport, or server error, and a session created with `--command` closes when its command exits, so the session simply disappears. The script prints no parting message, because a session created that way is torn down before anything written on the way out could be read. Expected when agterm quits, confusing when a transient error takes it out while agterm keeps running: the announcer is gone and nothing said so. Toggle it back on.
+
+Bursts are announced late, not dropped. `say` blocks until it finishes talking, so three sessions blocking at once are spoken one after another while the events queue behind them.
+
+A session set to `completed --auto-reset` is announced twice: once when it completes, and again as `idle` when you visit it and the status clears. That falls out of announcing `idle` at all. Drop `idle` from `SPOKEN` if it bothers you.
+
+Starting the announcer does not replay what it missed. The stream subscribes from the moment it starts, so anything that happened while it was off is gone.

--- a/cookbook/status-announcer/agt-announce.sh
+++ b/cookbook/status-announcer/agt-announce.sh
@@ -1,0 +1,115 @@
+#!/bin/sh
+# agt-announce.sh - speak agent status changes out loud, from a dedicated session.
+#
+# No argument toggles the announcer: it closes the session when one is already
+# running, and creates it running the event loop when none is. "loop" is the
+# loop itself, which is what that session runs. You call the first form; the
+# second one calls itself.
+set -e
+
+AGTERMCTL=${AGTERMCTL:-agtermctl}
+
+# The dedicated session's name. Toggling off closes whatever session carries it,
+# so pick something you would not name a session of your own.
+ANNOUNCER_NAME=${ANNOUNCER_NAME:-status-announcer}
+
+# Which statuses to speak, space separated. "active" is deliberately absent: the
+# agent-status hooks re-assert it on every tool call, so speaking it never stops.
+SPOKEN=${SPOKEN:-"blocked completed idle"}
+
+TAB=$(printf '\t')
+
+# This script's absolute path. The toggle passes it to session.new as the new
+# session's command, so the path has to survive leaving this process.
+self_path() {
+	dir=$(dirname "$0")
+	cd "$dir" 2>/dev/null || exit 1
+	printf '%s/%s' "$(pwd)" "$(basename "$0")"
+}
+
+# The announcer's session id, searched across every open window, empty when it is
+# not running. Scanning all windows rather than the frontmost one keeps the toggle
+# honest: found from anywhere, so a second announcer is never started by accident.
+find_announcer() {
+	"$AGTERMCTL" window list --json |
+		jq -r '.result.windows[] | select(.open) | .id' |
+		while read -r window; do
+			"$AGTERMCTL" tree --json --window "$window" |
+				jq -r --arg name "$ANNOUNCER_NAME" \
+					'.result.tree.workspaces[].sessions[]
+						| select(.name == $name) | .id'
+		done | head -n 1
+}
+
+# A workspace's name from the ids the event carried. Empty when the window has
+# closed since, which the caller speaks around rather than failing on.
+workspace_name() {
+	[ -n "$1" ] && [ -n "$2" ] || return 0
+	"$AGTERMCTL" tree --json --window "$1" 2>/dev/null |
+		jq -r --arg id "$2" '.result.tree.workspaces[]
+			| select(.id == $id) | .name' |
+		head -n 1
+}
+
+# Print the change, then speak it. Printing first means the session shows an event
+# as it arrives, rather than after say has finished talking about the one before.
+# The line keeps the real names; only the spoken copy is flattened.
+announce() {
+	ws=$1
+	sess=$2
+	st=$3
+	if [ -n "$ws" ]; then
+		printf '%s  %s / %s  %s\n' "$(date +%H:%M:%S)" "$ws" "$sess" "$st"
+		phrase="$ws, $sess $st"
+	else
+		printf '%s  %s  %s\n' "$(date +%H:%M:%S)" "$sess" "$st"
+		phrase="$sess $st"
+	fi
+	# say pronounces punctuation, so "umputun.dev" comes out as "umputun dot dev".
+	# Flattening the separators is the difference between a name and a spelling.
+	say "$(printf '%s' "$phrase" | tr '._-' '   ')"
+}
+
+# Read the status stream and speak each transition. jq filters the whole stream in
+# one pass; --unbuffered is what makes it arrive per event rather than per block.
+loop() {
+	printf 'status announcer: listening for %s\n' "$SPOKEN"
+	printf 'run the toggle again to stop\n\n'
+	"$AGTERMCTL" events --json --kind status |
+		jq -r --unbuffered --arg self "${AGTERM_SESSION_ID:-}" --arg spoken "$SPOKEN" '
+			($spoken | split(" ")) as $want
+			| select(.session != $self)
+			| select(.payload.status as $status | $want | index($status))
+			| [.payload.status, .payload.name, .window, .workspace] | @tsv' |
+		while IFS="$TAB" read -r status name window workspace; do
+			announce "$(workspace_name "$window" "$workspace")" "$name" "$status"
+		done
+	# nothing is printed past here on purpose: the session was created with
+	# --command, so it closes the moment this function returns, and a parting
+	# message would be torn down before it could be read.
+}
+
+toggle() {
+	running=$(find_announcer)
+	if [ -n "$running" ]; then
+		"$AGTERMCTL" session close --target "$running"
+		return
+	fi
+	# session.new execs its command directly under the app's launchd PATH, which
+	# has no /opt/homebrew/bin, so jq would exit 127 and the session would vanish
+	# the moment it opened. The login shell is what puts your own PATH back.
+	# --no-select leaves your selection and focus where they are. The announcer is a
+	# background thing; being yanked into it every time you start it is a nuisance.
+	script=$(self_path)
+	"$AGTERMCTL" session new --name "$ANNOUNCER_NAME" --no-select \
+		--command "/bin/zsh -lc \"'$script' loop\""
+}
+
+case ${1:-toggle} in
+toggle) toggle ;;
+loop) loop ;;
+*)
+	echo "usage: ${0##*/} [toggle|loop]" >&2
+	exit 2
+	;;
+esac


### PR DESCRIPTION
adds a cookbook recipe wiring the control event stream to `say`, growing the minimal client from discussion #211 into something complete enough to copy.

it is a demonstration rather than a tool, and the README says so in the summary line, in the opening paragraph and again in *Limits*. Talking terminals get old within the hour. What it is good for is showing the shape of an event-driven flow end to end, since every piece of it is a piece a real consumer would need.

**what it does.** a palette-only `command` toggles a session named `status-announcer` running the loop, and closes it when one is already up. Every session going `blocked`, `completed` or `idle` is announced with its workspace and session name, and logged to that session one line per event. `active` is filtered out, since the agent-status hooks re-assert it on every tool call.

**the parts worth reading.** the workspace name is not in the event payload, only its id, so the loop resolves it with `tree --json --window <window>`; the `--window` is what stops a background window's workspace resolving to nothing. The toggle searches every open window rather than the frontmost one, so it cannot start a second announcer talking over the first. There are two login-shell wrappers in two different places, because a custom command and the command `session.new` execs both run under the app's launchd `PATH`, where a Homebrew `jq` is out of reach.

**checked on an isolated dev instance** before opening this: toggle on and off across two windows, `--no-select` leaving the selection where it was, `active` filtered out, punctuation flattened for speech but not for the log, and a session in a background window resolving its workspace correctly. The script is shellcheck clean, and the cookbook layout, index and heading checks pass locally.

*Requirements say 0.16.0 or later, the release `agtermctl events` shipped in. Every other flag it uses predates that.*
