### PR TITLE
fix: honor the OSC 111 background reset

### DIFF
--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -237,10 +237,14 @@ paths:
   a NotificationCenter event from it; it does not paint the surface).
   Under translucency the surface renders `background-opacity = 0`, so an OSC 11 background is invisible —
   the terminal is transparent and the AppKit window backing (theme) shows through.
-  `GhosttyCallbacks` handles `COLOR_CHANGE` for the BACKGROUND kind and calls `GhosttySurfaceView.applyOSCBackground(_:)`,
-  which gives THIS surface its own `.color` config overlay (`WatermarkConfig.overlayText` — the SAME
-  per-surface path as `session background color`), baking the window opacity into `background-opacity`, so
-  the pane renders its tint translucently, per-pane, without touching the window backing or any other surface.
+  `GhosttyCallbacks` handles `COLOR_CHANGE` for the BACKGROUND kind and hands the color to
+  `GhosttySurfaceView.handleOSCBackgroundChange(_:)`, which routes it through the host-free
+  `OSCBackgroundPolicy` and then calls `applyOSCBackground(_:)` / `releaseOSCBackground()`.
+  The apply gives THIS surface its own config overlay carrying ONLY `background-opacity = windowOpacity`
+  (`WatermarkConfig.oscBackgroundOverlayText`), so the pane renders its tint translucently, per-pane,
+  without touching the window backing or any other surface.
+  **That overlay must never carry a `background` key** — see the OSC 111 paragraph below;
+  restating the OSC color there is what broke the reset in #309.
   Held on `GhosttySurfaceView.oscBackgroundColorHex` and re-asserted across a config reload and a live
   opacity change (`reapplySessionConfigIfNeeded`/`reapplyColorBackgroundIfNeeded`), and preserved across a
   dashboard open/close (the `dashboardFontOverride` didSet re-emits it).
@@ -254,14 +258,21 @@ paths:
   There is NO embedding C API to clear the `override`: config updates touch only `default`, the `reset`
   binding action's `fullReset` (RIS) does NOT touch colors, `csi`/`esc`/`text` write to the child pty and
   not the VT parser, and `COLOR_CHANGE` is outbound-only.
-  Even OSC 111 does not null the override: in this pin `DynamicRGB.reset()` COPIES the current `default`
-  into `override`, so the override only changes when the program emits a color-reset sequence or the surface
-  is recreated (a fresh shell).
+  OSC 111 does not NULL the override either: in this pin `DynamicRGB.reset()` COPIES the current `default`
+  into `override`, so a reset renders whatever the config's `background` currently is.
+  **That is exactly why the OSC overlay must not restate the color.**
+  `ghostty_surface_update_config` reaches `Termio.changeConfig`, which re-seeds
+  `terminal.colors.background.default` from the config's `background` key on EVERY per-surface update
+  (`Termio.zig`) — so an overlay carrying `background = <the OSC color>` overwrites the default layer with
+  the program's own color, and the program's OSC 111 then "resets" to it.
+  That was #309: the pane stayed recolored after a TUI exited, and an OSC 11 QUERY still reported the
+  program's color, because `get()` = `override orelse default` and BOTH layers held it.
+  Lifting only `background-opacity` leaves `default` at the theme color, so the reset genuinely reverts.
   The explicit spec is therefore the DEFAULT layer, visible only when no OSC override is live; `tree`'s
   `background` reports the stored spec, which can differ from what a live OSC program is painting.
   `oscBackgroundColorHex` mirrors the OSC color currently applied to THIS surface's overlay (nil when a
-  watermark/plain config is applied instead): it is BOTH the dedupe key in the `COLOR_CHANGE` caller and the
-  re-assert source across reload / opacity / dashboard.
+  watermark/plain config is applied instead): it is BOTH the dedupe key (read by `OSCBackgroundPolicy`) and
+  the re-assert source across reload / opacity / dashboard.
   `applyWatermarkFromSession` (every `session.background` set/clear) RELEASES the latch, because it installs
   a config with no OSC overlay; without this, a re-`printf` of the SAME OSC 11 color right after `session
   background clear/set` matches the stale latch, is deduped away, and never renders.
@@ -275,11 +286,18 @@ paths:
   override RESURFACES and masks X; and because `session.background` is session-scoped, every realized
   session surface (main, split, and scratch) is affected even though the OSC tint was per-pane.
   Only BACKGROUND is wired — OSC 10/12 (fg/cursor) render regardless of translucency.
-  A per-prompt OSC re-emit is deduped in the `COLOR_CHANGE` caller (skip when the hex is unchanged) so a
-  shell re-asserting OSC 11 every prompt does not rebuild the surface config each time.
-  Reset (OSC 111) arrives as a `COLOR_CHANGE` to the theme color, so the pane reverts to the theme
-  background (intended — the callback cannot distinguish a reset from a deliberate set-to-theme-color); a
-  pane/tab close clears the latch outright.
+  **`OSCBackgroundPolicy` (agtermCore, unit-tested) owns the set-vs-reset routing and the dedupe**, because
+  libghostty reports both through the SAME action with no flag telling them apart — a reset simply carries
+  the terminal's default background.
+  So the surface's own BASELINE color identifies a reset: the session's `.color` watermark, a sessionless
+  overlay's `--background-color`, else the theme background (`baselineBackgroundHex()`) — whichever ghostty
+  last seeded `default` from.
+  A reported color equal to it means reset → `releaseOSCBackground()` drops the overlay and restores the
+  surface's own config; an unchanged color means a per-prompt re-emit → ignored, so a shell re-asserting
+  OSC 11 every prompt does not rebuild the surface config each time; anything else applies.
+  A program that deliberately sets OSC 11 to the exact baseline color is indistinguishable from one
+  resetting to it, which is harmless — both render that color.
+  A pane/tab close clears the latch outright.
   Diagnosed with codex; verified BY EYE (background color is not accessibility-observable, like the
   cursor solid/hollow case), only visible under translucency (at 100% opacity ghostty renders the OSC bg
   itself).

--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -289,9 +289,16 @@ paths:
   **`OSCBackgroundPolicy` (agtermCore, unit-tested) owns the set-vs-reset routing and the dedupe**, because
   libghostty reports both through the SAME action with no flag telling them apart — a reset simply carries
   the terminal's default background.
-  So the surface's own BASELINE color identifies a reset: the session's `.color` watermark, a sessionless
-  overlay's `--background-color`, else the theme background (`baselineBackgroundHex()`) — whichever ghostty
-  last seeded `default` from.
+  So the BASELINE color identifies a reset — whichever color ghostty last seeded `default` from for this
+  surface (`OSCBackgroundPolicy.baseline`, fed by `baselineBackgroundHex()`).
+  With no OSC overlay installed that is the surface's OWN color: the session's `.color` watermark, a
+  sessionless overlay's `--background-color`, else the theme.
+  **While an OSC overlay IS installed it is always the THEME**, because that overlay emits no `background`
+  key, so the config in force is the base one and `default` holds the theme rather than the surface's color.
+  Getting this wrong routes a reset on a `.color` session (or a colored overlay) to `.apply` instead of
+  `.reset`: pixels are unaffected (the un-clearable `override` masks `default` either way), but the overlay
+  is never released and the latch stays pinned for a program that already exited, so every reload / opacity
+  tick / dashboard toggle re-installs it.
   A reported color equal to it means reset → `releaseOSCBackground()` drops the overlay and restores the
   surface's own config; an unchanged color means a per-prompt re-emit → ignored, so a shell re-asserting
   OSC 11 every prompt does not rebuild the surface config each time; anything else applies.

--- a/agterm/Ghostty/GhosttyCallbacks.swift
+++ b/agterm/Ghostty/GhosttyCallbacks.swift
@@ -144,20 +144,18 @@ final class GhosttyCallbacks: @unchecked Sendable {
             DispatchQueue.main.async { view.openLink(link) }
             return true
         case GHOSTTY_ACTION_COLOR_CHANGE:
-            // a program set a dynamic terminal color via OSC 10/11/12 (fg/bg/cursor). libghostty already
-            // applied it to its own render state, but under window translucency every surface renders
-            // background-opacity 0 (the AppKit window backing supplies the tint), so an OSC 11 BACKGROUND
-            // stays invisible until we give THIS surface its own `.color` overlay — a per-pane tint. Only
-            // background needs acting on; foreground/cursor render regardless of translucency. Copy the
-            // color out synchronously (the struct is only valid for this call), then hop to the apply.
+            // a program set or RESET a dynamic terminal color via OSC 10/11/12 (fg/bg/cursor) or their
+            // 110/111/112 resets. libghostty already applied it to its own render state, but under window
+            // translucency every surface renders background-opacity 0 (the AppKit window backing supplies
+            // the tint), so an OSC 11 BACKGROUND stays invisible until we lift THIS surface's opacity — a
+            // per-pane tint. Only background needs acting on; foreground/cursor render regardless of
+            // translucency. Copy the color out synchronously (the struct is only valid for this call), then
+            // hop to the main actor, where the set-vs-reset routing and the per-prompt dedupe are decided.
             guard let view = surfaceView(from: target) else { return true }
             let change = action.action.color_change
             guard change.kind == GHOSTTY_ACTION_COLOR_KIND_BACKGROUND else { return true }
             let hex = String(format: "#%02x%02x%02x", Int(change.r), Int(change.g), Int(change.b))
-            // dedupe the per-prompt OSC re-emit storm: a shell that re-asserts OSC 11 on every prompt would
-            // otherwise drive a full per-surface config rebuild each time. skip when unchanged — the reload
-            // and opacity re-assert callers still force a re-apply by calling applyOSCBackground directly.
-            DispatchQueue.main.async { guard view.oscBackgroundColorHex != hex else { return }; view.applyOSCBackground(hex) }
+            DispatchQueue.main.async { view.handleOSCBackgroundChange(hex) }
             return true
         default:
             return false

--- a/agterm/Ghostty/GhosttySurfaceView+Config.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Config.swift
@@ -99,23 +99,52 @@ extension GhosttySurfaceView {
         ownedConfigs = [config]
     }
 
+    /// Route a dynamic background color libghostty reported for THIS surface (`GHOSTTY_ACTION_COLOR_CHANGE`,
+    /// kind background). The action carries no set-vs-reset flag — OSC 111 simply reports the terminal's
+    /// default background — so the surface's own baseline color is what identifies a reset: the session's
+    /// `.color` watermark, a sessionless overlay's `--background-color`, else the theme background. That is
+    /// exactly what ghostty seeded the terminal's `default` color layer from, so a reported color equal to
+    /// it means the program reset. `OSCBackgroundPolicy` owns the decision (and the per-prompt dedupe).
+    func handleOSCBackgroundChange(_ hex: String) {
+        switch OSCBackgroundPolicy.decide(incoming: hex, themeBackground: baselineBackgroundHex(),
+                                          current: oscBackgroundColorHex) {
+        case .apply(let color): applyOSCBackground(color)
+        case .reset: releaseOSCBackground()
+        case .ignore: break
+        }
+    }
+
+    /// The background color this surface renders with no OSC override live — what ghostty seeded the
+    /// terminal's `default` color layer from when it last took this surface's config.
+    private func baselineBackgroundHex() -> String? {
+        if let watermark = (session ?? watermarkSession)?.backgroundWatermark, watermark.kind == .color,
+           let hex = watermark.colorHex {
+            return hex
+        }
+        return overlayBackgroundColorHex ?? GhosttyApp.shared.terminalBackgroundColor?.agtermHexString
+    }
+
     /// Apply the dynamic background color a program set on THIS surface via OSC 11. libghostty already
-    /// stored the color in its terminal state, but under window translucency the surface renders
-    /// `background-opacity = 0` (the AppKit window backing supplies the tint), so the OSC color is
-    /// invisible. This gives the surface its OWN `.color` overlay — the SAME per-surface path as
-    /// `session background color`, baking the current window opacity into `background-opacity` — so the
-    /// pane renders its tint (translucent, honoring the opacity slider), per-pane, without touching the
-    /// window backing, the chrome, or any other surface. Reads the current font (dashboard override /
-    /// session zoom / live zoom / initial) so the config re-apply can't reset the pane's font — including a
-    /// sessionless scratch/overlay whose live cmd-+/- zoom would otherwise reset. A malformed hex is rejected.
-    /// Retains the per-surface config in `ownedConfigs`, freed on teardown.
+    /// stored the color in the terminal's dynamic `override` layer and the renderer draws
+    /// `override orelse default`, so the color itself needs no restating — but under window translucency
+    /// the surface renders `background-opacity = 0` (the AppKit window backing supplies the tint), which
+    /// makes the OSC color invisible. This gives the surface its OWN overlay lifting the opacity back to
+    /// the window's, so the pane renders its tint (translucent, honoring the opacity slider), per-pane,
+    /// without touching the window backing, the chrome, or any other surface.
+    ///
+    /// The overlay deliberately carries no `background` key: that would re-seed the terminal's `default`
+    /// color layer with the OSC color, and since OSC 111 resets the override TO that default, the program's
+    /// reset would restore its own color and strand the pane recolored (issue #309).
+    ///
+    /// Reads the current font (dashboard override / session zoom / live zoom / initial) so the config
+    /// re-apply can't reset the pane's font — including a sessionless scratch/overlay whose live cmd-+/-
+    /// zoom would otherwise reset. A malformed hex is rejected. Retains the per-surface config in
+    /// `ownedConfigs`, freed on teardown.
     func applyOSCBackground(_ hex: String) {
         guard let surface, WatermarkConfig.isValidColorHex(hex) else { return }
         oscBackgroundColorHex = hex
-        let overlay = WatermarkConfig.overlayText(watermark: BackgroundWatermark(kind: .color, colorHex: hex),
-                                                  resolvedImagePath: nil,
-                                                  fontSize: dashboardFontOverride ?? session?.fontSize ?? currentFontSize() ?? initialFontSize.map(Double.init),
-                                                  windowOpacity: GhosttyApp.shared.windowOpacity)
+        let overlay = WatermarkConfig.oscBackgroundOverlayText(fontSize: currentEffectiveFontSize(),
+                                                               windowOpacity: GhosttyApp.shared.windowOpacity)
         guard let config = GhosttyApp.shared.configWithOverlay(overlay) else {
             NSLog("osc background: per-surface config build failed")
             return
@@ -123,5 +152,32 @@ extension GhosttySurfaceView {
         ghostty_surface_update_config(surface, config)
         ownedConfigs.forEach { ghostty_config_free($0) }
         ownedConfigs = [config]
+    }
+
+    /// Drop this surface's OSC-11 overlay after a program reset the dynamic background, falling back to
+    /// the surface's own baseline config: the session's watermark/zoom, a sessionless overlay's
+    /// `--background-color`, else the plain config with the live font zoom preserved. libghostty has
+    /// already restored its own `override` to the default color, so this only takes the opacity lift away.
+    func releaseOSCBackground() {
+        oscBackgroundColorHex = nil
+        if session != nil || watermarkSession != nil { applyWatermarkFromSession(); return }
+        if overlayBackgroundColorHex != nil { applyOverlayBackgroundColor(); return }
+        guard let surface else { return }
+        let overlay = WatermarkConfig.overlayText(watermark: nil, resolvedImagePath: nil,
+                                                  fontSize: currentEffectiveFontSize())
+        guard let config = GhosttyApp.shared.configWithOverlay(overlay) else {
+            NSLog("osc background: per-surface config rebuild failed on reset")
+            return
+        }
+        ghostty_surface_update_config(surface, config)
+        ownedConfigs.forEach { ghostty_config_free($0) }
+        ownedConfigs = [config]
+    }
+
+    /// The font size a per-surface config re-apply must restate so it doesn't reset the pane's zoom:
+    /// the dashboard's transient override, else the session's zoom, else a sessionless surface's live
+    /// cmd-+/- size, else its creation size.
+    private func currentEffectiveFontSize() -> Double? {
+        dashboardFontOverride ?? session?.fontSize ?? currentFontSize() ?? initialFontSize.map(Double.init)
     }
 }

--- a/agterm/Ghostty/GhosttySurfaceView+Config.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Config.swift
@@ -16,12 +16,18 @@ extension GhosttySurfaceView {
     }
 
     /// Builds this session's background-watermark config overlay (base files + `background-image*` lines +
-    /// the dashboard font override else the session's current font zoom, via `WatermarkConfig`/`WatermarkRenderer`)
+    /// the font from `currentEffectiveFontSize()`, via `WatermarkConfig`/`WatermarkRenderer`)
     /// and pushes it to the surface, retaining the config for teardown. Scratch surfaces inherit their
     /// owner's visual config through `watermarkSession` while remaining operationally sessionless; overlay
     /// and quick-terminal surfaces carry neither link. A nil watermark with no font override
     /// yields the plain base config, which CLEARS a previously-applied image. The `.text` PNG is (re)rendered
     /// here so it always matches the current string/color. Main-actor; reads the session imperatively.
+    ///
+    /// The font deliberately falls through to the LIVE size, not just `session.fontSize`: a split or
+    /// scratch pane has its `onFontSizeChange` unwired (see `ControlServer+SurfaceIO.font`), so its
+    /// cmd-+/- zoom is never persisted and is readable only from the surface. Composing from
+    /// `session.fontSize` alone snapped those panes back to the session's size (or the config default) on
+    /// every re-apply — a `session.background` set/clear, and now also an OSC reset.
     func applyWatermarkFromSession() {
         guard let surface, let session = session ?? watermarkSession else { return }
         // this installs a watermark/plain config with NO OSC-11 overlay, so release the OSC latch: it is the
@@ -32,7 +38,7 @@ extension GhosttySurfaceView {
         oscBackgroundColorHex = nil
         let resolvedImagePath = WatermarkRenderer.materialize(session.backgroundWatermark, sessionID: session.id)
         let overlay = WatermarkConfig.overlayText(watermark: session.backgroundWatermark,
-                                                  resolvedImagePath: resolvedImagePath, fontSize: dashboardFontOverride ?? session.fontSize,
+                                                  resolvedImagePath: resolvedImagePath, fontSize: currentEffectiveFontSize(),
                                                   windowOpacity: GhosttyApp.shared.windowOpacity)
         guard let config = GhosttyApp.shared.configWithOverlay(overlay) else {
             NSLog("watermark: per-surface config build failed for session %@", session.id.uuidString)

--- a/agterm/Ghostty/GhosttySurfaceView+Config.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Config.swift
@@ -80,15 +80,19 @@ extension GhosttySurfaceView {
 
     /// Applies a solid background color to a sessionless OVERLAY surface (`session.overlay.open
     /// --background-color`). Mirrors `applyWatermarkFromSession`'s `.color` path but reads the overlay's
-    /// own `overlayBackgroundColorHex` + `initialFontSize` instead of a session — the overlay carries no
-    /// `session`, so that path skips it. Bakes the window translucency into `background-opacity` at open
+    /// own `overlayBackgroundColorHex` instead of a session — the overlay carries no `session`, so that
+    /// path skips it. Bakes the window translucency into `background-opacity` at open
     /// time (the ephemeral overlay gets no live updates, so it does not re-track a later opacity change —
     /// unlike a session `.color`). A no-op — or a malformed hex, rejected by the leading `isValidColorHex`
     /// guard — leaves the plain base config. Retains the per-surface config in `ownedConfigs`, freed on teardown.
+    ///
+    /// The font comes from `currentEffectiveFontSize()`, NOT the creation size: this also runs on the OSC
+    /// reset path, where the overlay may have been zoomed with cmd-+/- since it opened, and restating the
+    /// creation size there would snap the pane back.
     func applyOverlayBackgroundColor() {
         guard let surface, let hex = overlayBackgroundColorHex, WatermarkConfig.isValidColorHex(hex) else { return }
         let overlay = WatermarkConfig.overlayText(watermark: BackgroundWatermark(kind: .color, colorHex: hex),
-                                                  resolvedImagePath: nil, fontSize: initialFontSize.map(Double.init),
+                                                  resolvedImagePath: nil, fontSize: currentEffectiveFontSize(),
                                                   windowOpacity: GhosttyApp.shared.windowOpacity)
         guard let config = GhosttyApp.shared.configWithOverlay(overlay) else {
             NSLog("overlay background: per-surface config build failed")
@@ -114,14 +118,24 @@ extension GhosttySurfaceView {
         }
     }
 
-    /// The background color this surface renders with no OSC override live — what ghostty seeded the
-    /// terminal's `default` color layer from when it last took this surface's config.
+    /// What ghostty seeded the terminal's `default` color layer from when it last took this surface's
+    /// config — the color a reported change must equal to count as a reset. `OSCBackgroundPolicy.baseline`
+    /// owns the rule, including why an installed OSC overlay makes the answer the theme rather than this
+    /// surface's own color; here we only gather the two inputs.
     private func baselineBackgroundHex() -> String? {
+        OSCBackgroundPolicy.baseline(oscOverlayActive: oscBackgroundColorHex != nil,
+                                     surfaceBackground: surfaceOwnBackgroundHex(),
+                                     themeBackground: GhosttyApp.shared.terminalBackgroundColor?.agtermHexString)
+    }
+
+    /// The background color this surface's OWN config carries: a `.color` session watermark, else a
+    /// sessionless overlay's `--background-color`. Nil when the surface runs the plain base config.
+    private func surfaceOwnBackgroundHex() -> String? {
         if let watermark = (session ?? watermarkSession)?.backgroundWatermark, watermark.kind == .color,
            let hex = watermark.colorHex {
             return hex
         }
-        return overlayBackgroundColorHex ?? GhosttyApp.shared.terminalBackgroundColor?.agtermHexString
+        return overlayBackgroundColorHex
     }
 
     /// Apply the dynamic background color a program set on THIS surface via OSC 11. libghostty already

--- a/agtermCore/Sources/agtermCore/OSCBackgroundPolicy.swift
+++ b/agtermCore/Sources/agtermCore/OSCBackgroundPolicy.swift
@@ -40,6 +40,21 @@ public enum OSCBackgroundPolicy {
         return .apply(incoming)
     }
 
+    /// The color a reported change must equal to count as a reset: whatever ghostty last seeded the
+    /// terminal's `default` layer from for this surface.
+    ///
+    /// `surfaceBackground` is the color the surface's OWN config carries (a `.color` session watermark, a
+    /// sessionless overlay's `--background-color`), and `themeBackground` the base config's. The catch is
+    /// `oscOverlayActive`: the OSC overlay emits no `background` key, so while it is installed the config
+    /// in force is the base one and `default` holds the THEME, not the surface's color. Reporting the
+    /// surface color then makes a reset look like a set — the overlay is never released and the latch
+    /// stays pinned for a program that has already exited.
+    public static func baseline(oscOverlayActive: Bool, surfaceBackground: String?,
+                                themeBackground: String?) -> String? {
+        guard !oscOverlayActive else { return themeBackground }
+        return surfaceBackground ?? themeBackground
+    }
+
     /// A hex color reduced to its six lowercase digits, so `#1D1F21`, `1d1f21` and `#1d1f21` compare equal.
     private static func normalized(_ hex: String) -> String {
         let trimmed = hex.trimmingCharacters(in: .whitespaces)

--- a/agtermCore/Sources/agtermCore/OSCBackgroundPolicy.swift
+++ b/agtermCore/Sources/agtermCore/OSCBackgroundPolicy.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Decides what a surface does with a dynamic background color reported by libghostty
+/// (`GHOSTTY_ACTION_COLOR_CHANGE`, kind background). Host-free so the routing is unit-tested; the app
+/// target owns only the config push.
+///
+/// libghostty reports a SET (OSC 11) and a RESET (OSC 111) through the same action, with no flag telling
+/// them apart — a reset simply carries the terminal's default background, which is the theme color. So
+/// the theme background is what identifies a reset, and a program that deliberately sets OSC 11 to the
+/// exact theme color is indistinguishable from one resetting to it. That ambiguity is harmless: both
+/// render the theme background.
+public enum OSCBackgroundPolicy {
+    /// What the surface should do with the reported color.
+    public enum Decision: Equatable {
+        /// Render this color as the surface's dynamic background.
+        case apply(String)
+        /// The program reset to the theme default — drop the OSC overlay and fall back to the session's
+        /// own config (watermark or plain).
+        case reset
+        /// Nothing to do: a per-prompt re-emit of the color already applied, a reset with no overlay
+        /// live, or a malformed color.
+        case ignore
+    }
+
+    /// Route a reported `incoming` color, given the theme's background (nil before the first config
+    /// resolve) and the color currently applied to this surface (`current`, nil for none).
+    ///
+    /// Comparison is case- and `#`-insensitive: the callback formats `#rrggbb` lowercase while the theme
+    /// color arrives from `NSColor.agtermHexString` as `#RRGGBB`, so a literal compare would miss every
+    /// reset.
+    public static func decide(incoming: String, themeBackground: String?, current: String?) -> Decision {
+        guard WatermarkConfig.isValidColorHex(incoming) else { return .ignore }
+        let color = normalized(incoming)
+        if let themeBackground, normalized(themeBackground) == color {
+            return current == nil ? .ignore : .reset
+        }
+        // dedupe the per-prompt re-emit storm: a shell re-asserting OSC 11 on every prompt would
+        // otherwise drive a full per-surface config rebuild each time.
+        if let current, normalized(current) == color { return .ignore }
+        return .apply(incoming)
+    }
+
+    /// A hex color reduced to its six lowercase digits, so `#1D1F21`, `1d1f21` and `#1d1f21` compare equal.
+    private static func normalized(_ hex: String) -> String {
+        let trimmed = hex.trimmingCharacters(in: .whitespaces)
+        return (trimmed.hasPrefix("#") ? String(trimmed.dropFirst()) : trimmed).lowercased()
+    }
+}

--- a/agtermCore/Sources/agtermCore/WatermarkConfig.swift
+++ b/agtermCore/Sources/agtermCore/WatermarkConfig.swift
@@ -96,6 +96,25 @@ public enum WatermarkConfig {
         return lines.isEmpty ? "" : lines.joined(separator: "\n") + "\n"
     }
 
+    /// The per-surface ghostty config overlay that makes a program's LIVE OSC 11 background visible: a
+    /// `background-opacity = <windowOpacity>` line plus the usual `font-size` zoom preservation.
+    ///
+    /// It deliberately carries NO `background` key, which is what separates it from the `.color` overlay
+    /// above. libghostty holds the OSC color in the terminal's dynamic `override` layer and the renderer
+    /// already draws `override orelse default`, so the color needs no restating — only the opacity, which
+    /// the base config pins to 0 under window translucency (leaving the OSC tint invisible).
+    ///
+    /// Writing the color into `background` instead would reach ghostty's `Termio.changeConfig`, which
+    /// seeds the terminal's `default` color layer from the config on every surface update. Since OSC 111
+    /// resets the override TO that default, restating the OSC color here makes the reset a no-op and
+    /// strands the pane on the program's color after it exits.
+    public static func oscBackgroundOverlayText(fontSize: Double?, windowOpacity: Double) -> String {
+        let opacity = windowOpacity.isFinite ? min(max(windowOpacity, 0), 1) : 1
+        var lines = ["background-opacity = \(formatted(opacity))"]
+        if let fontSize { lines.append("font-size = \(formatted(fontSize))") }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
     /// Format a `Double` for a ghostty config value: an integral value without a trailing `.0`
     /// (`14.0` → `14`), else the minimal decimal (`0.15` → `0.15`). Locale-independent (always `.`):
     /// `String(format:)` uses the C locale. Uses fixed-point, NOT `String(Double)`, because the latter

--- a/agtermCore/Tests/agtermCoreTests/OSCBackgroundPolicyTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/OSCBackgroundPolicyTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+struct OSCBackgroundPolicyTests {
+    @Test func firstColorApplies() {
+        let decision = OSCBackgroundPolicy.decide(incoming: "#123456", themeBackground: "#1d1f21", current: nil)
+        #expect(decision == .apply("#123456"))
+    }
+
+    @Test func differentColorReplacesTheLiveOne() {
+        let decision = OSCBackgroundPolicy.decide(incoming: "#abcdef", themeBackground: "#1d1f21", current: "#123456")
+        #expect(decision == .apply("#abcdef"))
+    }
+
+    @Test func repeatedSameColorIsDeduped() {
+        // a shell re-asserting OSC 11 on every prompt must not drive a surface config rebuild each time.
+        let decision = OSCBackgroundPolicy.decide(incoming: "#123456", themeBackground: "#1d1f21", current: "#123456")
+        #expect(decision == .ignore)
+    }
+
+    @Test func resetToThemeBackgroundReleasesTheOverlay() {
+        // issue #309: OSC 111 arrives as a color change back to the theme background. It must release the
+        // overlay rather than be deduped or re-applied, or the pane stays recolored after a TUI exits.
+        let decision = OSCBackgroundPolicy.decide(incoming: "#1d1f21", themeBackground: "#1d1f21", current: "#123456")
+        #expect(decision == .reset)
+    }
+
+    @Test func resetWithNoOverlayLiveIsIgnored() {
+        let decision = OSCBackgroundPolicy.decide(incoming: "#1d1f21", themeBackground: "#1d1f21", current: nil)
+        #expect(decision == .ignore)
+    }
+
+    @Test func hexComparisonIgnoresCaseAndLeadingHash() {
+        // the callback formats `#rrggbb` lowercase; the theme color arrives from `NSColor.agtermHexString`
+        // as `#RRGGBB`. A case-sensitive compare would miss every reset.
+        #expect(OSCBackgroundPolicy.decide(incoming: "#1d1f21", themeBackground: "#1D1F21", current: "#123456") == .reset)
+        #expect(OSCBackgroundPolicy.decide(incoming: "#1d1f21", themeBackground: "1D1F21", current: "#123456") == .reset)
+        #expect(OSCBackgroundPolicy.decide(incoming: "#ABCDEF", themeBackground: "#1d1f21", current: "#abcdef") == .ignore)
+    }
+
+    @Test func unknownThemeBackgroundStillDedupesAndApplies() {
+        // before the first config resolve the theme color is nil: no reset can be recognized, but the
+        // set/dedupe path must keep working.
+        #expect(OSCBackgroundPolicy.decide(incoming: "#123456", themeBackground: nil, current: nil) == .apply("#123456"))
+        #expect(OSCBackgroundPolicy.decide(incoming: "#123456", themeBackground: nil, current: "#123456") == .ignore)
+    }
+
+    @Test(arguments: ["", "#12345", "#12345g", "nonsense", "＃ＦＦ００００"])
+    func malformedIncomingColorIsIgnored(_ hex: String) {
+        #expect(OSCBackgroundPolicy.decide(incoming: hex, themeBackground: "#1d1f21", current: nil) == .ignore)
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/OSCBackgroundPolicyTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/OSCBackgroundPolicyTests.swift
@@ -50,4 +50,36 @@ struct OSCBackgroundPolicyTests {
     func malformedIncomingColorIsIgnored(_ hex: String) {
         #expect(OSCBackgroundPolicy.decide(incoming: hex, themeBackground: "#1d1f21", current: nil) == .ignore)
     }
+
+    @Test func baselineIsTheSurfaceColorWithNoOSCOverlayInstalled() {
+        let hex = OSCBackgroundPolicy.baseline(oscOverlayActive: false, surfaceBackground: "#aa0000",
+                                               themeBackground: "#1d1f21")
+        #expect(hex == "#aa0000")
+    }
+
+    @Test func baselineIsTheThemeWhileAnOSCOverlayIsInstalled() {
+        // the OSC overlay emits no `background` key, so the config in force is the base one and ghostty
+        // seeded the terminal's default layer from the THEME, not from the surface's own color. Reporting
+        // the surface color here makes a reset look like a set and strands the latch.
+        let hex = OSCBackgroundPolicy.baseline(oscOverlayActive: true, surfaceBackground: "#aa0000",
+                                               themeBackground: "#1d1f21")
+        #expect(hex == "#1d1f21")
+    }
+
+    @Test func baselineFallsBackToTheThemeWithNoSurfaceColor() {
+        #expect(OSCBackgroundPolicy.baseline(oscOverlayActive: false, surfaceBackground: nil,
+                                             themeBackground: "#1d1f21") == "#1d1f21")
+        #expect(OSCBackgroundPolicy.baseline(oscOverlayActive: false, surfaceBackground: nil,
+                                             themeBackground: nil) == nil)
+    }
+
+    @Test func resetOnAColoredSurfaceRoutesToResetNotApply() {
+        // the regression this pairs with: a `.color` session runs OSC 11, then the program resets. The
+        // reset reports the THEME (the OSC overlay dropped the watermark's background key), so a baseline
+        // still claiming the watermark color would return .apply and never release the overlay.
+        let baseline = OSCBackgroundPolicy.baseline(oscOverlayActive: true, surfaceBackground: "#aa0000",
+                                                    themeBackground: "#1d1f21")
+        #expect(OSCBackgroundPolicy.decide(incoming: "#1d1f21", themeBackground: baseline,
+                                           current: "#123456") == .reset)
+    }
 }

--- a/agtermCore/Tests/agtermCoreTests/WatermarkConfigTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/WatermarkConfigTests.swift
@@ -213,4 +213,26 @@ struct WatermarkConfigTests {
         #expect(!WatermarkConfig.isValidText(""))
         #expect(!WatermarkConfig.isValidText(String(repeating: "a", count: WatermarkConfig.maxTextLength + 1)))
     }
+
+    @Test func oscOverlayNeverWritesTheBackgroundKey() {
+        let text = WatermarkConfig.oscBackgroundOverlayText(fontSize: nil, windowOpacity: 0.8)
+        #expect(text == "background-opacity = 0.8\n")
+        // the crux of issue #309: a `background = <hex>` line here reaches ghostty's `Termio.changeConfig`,
+        // which seeds the terminal's DEFAULT color layer from it. OSC 111 resets the override TO that
+        // default, so writing the OSC color here makes the reset restore the OSC color, not the theme.
+        #expect(!text.contains("background ="))
+    }
+
+    @Test func oscOverlayPreservesFontZoom() {
+        let text = WatermarkConfig.oscBackgroundOverlayText(fontSize: 16, windowOpacity: 1)
+        #expect(text.contains("background-opacity = 1\n"))
+        #expect(text.contains("font-size = 16\n"))
+        #expect(!text.contains("background ="))
+    }
+
+    @Test(arguments: [(2.0, "1"), (-1.0, "0"), (Double.nan, "1")])
+    func oscOverlayClampsOpacity(_ opacity: Double, _ expected: String) {
+        let text = WatermarkConfig.oscBackgroundOverlayText(fontSize: nil, windowOpacity: opacity)
+        #expect(text == "background-opacity = \(expected)\n")
+    }
 }


### PR DESCRIPTION
agterm honored `OSC 11` (set background) but not `OSC 111` (reset), so a TUI that colors the background and restores it on exit left the pane stuck on its color. Reported with Docker Sandboxes `sbx`, a Bubble Tea v2 app whose renderer emits `ansi.ResetBackgroundColor` on close.

**Root cause**

Self-inflicted, not a libghostty limitation. The OSC 11 handler pushed a per-surface config carrying `background = <the OSC color>`. That reaches ghostty's `Termio.changeConfig`, which re-seeds `terminal.colors.background.default` from the config on every surface update. `DynamicRGB.reset()` is `override = default`, so OSC 111 restored the program's own color. The follow-up `COLOR_CHANGE` then carried the same hex and was dropped by the dedupe guard, and an OSC 11 query still reported the program's color, because `get()` is `override orelse default` and both layers held it.

**Fix**

The renderer takes the background color from terminal state and the alpha from `background-opacity`, two independent sources. So the overlay only has to lift the opacity that window translucency pins to 0, and never restates the color. `default` stays at the theme and the reset reverts.

libghostty signals set and reset through the same action with no distinguishing flag, so the new host-free `OSCBackgroundPolicy` identifies a reset by the reported color equalling the surface's baseline, and owns the per-prompt dedupe that used to sit inline in the callback. While an OSC overlay is installed that baseline is the theme, since the overlay emits no `background` key.

Two adjacent font bugs surfaced while wiring the reset path and are fixed here. A `--background-color` overlay and a split or scratch pane each lost their live cmd-+/- zoom on a config re-apply, because those panes have `onFontSizeChange` unwired on purpose and their zoom is readable only from the surface. Both paths now compose from the same `currentEffectiveFontSize()` chain. The split/scratch case predates this branch and also fired on `session.background` set/clear.

**Verified**

A/B against a pre-fix build of the same worktree, same harness: the background query after `OSC 111` reported `rgb:1212/3434/5656`, the program's color, before the change and the theme color after. Checked at full opacity and under translucency.

`swift test` 1929, `make test-app` 46, `make lint --strict` clean. 12 new host-free tests cover the overlay emitter and the set/reset/dedupe routing.

*Note on scope: an explicit `session.background` still cannot override a live OSC 11, since the program's `override` layer masks the config `default` and the pinned libghostty exposes no API to clear it. That limitation is unchanged and documented.*

Fix #309
