### PR TITLE
add native control picker to the control API

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -206,7 +206,7 @@ paths:
   The skill is a REFERENCE/knowledge skill (both user-invocable via `/agterm` and model-triggered,
   `allowed-tools: Bash(agtermctl *)`; the agent-neutral `description` carries the trigger nouns since
   Codex may ignore the extra `when_to_use` field — unknown frontmatter is harmless),
-  authored at `agterm/Resources/agent-skill/` (`SKILL.md` overview + model + addressing + 68-command
+  authored at `agterm/Resources/agent-skill/` (`SKILL.md` overview + model + addressing + 71-command
   summary + the image-display helper + a troubleshooting/reporting pointer;
   `reference.md` full per-command detail + keymap format; `examples.md` agtermctl recipes;
   `troubleshooting.md` diagnosing the common problems (keymap editor, custom actions,
@@ -284,13 +284,14 @@ paths:
   rules, then remaining targets resolve inside that same store so one command never mutates multiple windows.
   The top-level `target` also carries the first explicit batch target so a new CLI talking to a still-running
   pre-batch server degrades to a named session instead of accidentally acting on `active`.
-- **Command catalog (68 commands):**
+- **Command catalog (71 commands):**
   - `tree`
   - `events.read` (the bounded per-app-run control event ring behind `agtermctl events`)
   - `workspace.new`/`workspace.rename`/`workspace.delete`/`workspace.select`/`workspace.move`/`workspace.focus`/`workspace.filter`/`workspace.collapse`/`workspace.expand`
   - `session.new`/`session.duplicate`/`session.close`/`session.select`/`session.rename`/`session.reveal`/`session.move`/`session.type`/`session.split`/`session.scratch`/`session.focus`/`session.resize`/`session.go`/`session.copy`/`session.paste`/`session.selectall`/`session.text`/`session.search`/`session.status`/`session.flag`/`session.seen`/`session.restore`/`session.background`/`session.overlay.open`/`session.overlay.close`/`session.overlay.resize`/`session.overlay.result`
   - `surface.zoom`
   - `dashboard`
+  - `pick.open`/`pick.result`/`pick.cancel`
   - `quick`/`quick.type`/`quick.text`
   - `sidebar`/`sidebar.mode`/`sidebar.expand`/`sidebar.collapse`
   - `notify`
@@ -313,8 +314,8 @@ paths:
   Setting echoes the resulting effective side in `result.text`; the BARE form (no name) reads the side
   the last config feed applied (`SettingsModel.lastAppliedIsDark`), which the test polls to prove the
   flip actually drove the reload.
-  `AppearanceFlipUITests` is its only consumer; the public command count stays 68
-  (`Command` has 69 cases, minus this one seam).
+  `AppearanceFlipUITests` is its only consumer; the public command count stays 71
+  (`Command` has 72 cases, minus this one seam).
 
   `workspace.delete` honors keep-at-least-one and returns an error instead of the GUI confirm alert (nothing
   blocks on a modal).
@@ -982,6 +983,22 @@ paths:
   It is state-mutating-with-read-back EXEMPT: the resulting state IS `dashboardMembers`,
   so no new tree field is owed.
   See the `libghostty.md` dashboard note for the reparent/overlay/view-only + transient-font-override mechanics.
+  `pick.open` presents one caller-supplied, per-window native fuzzy picker and returns its globally unique id.
+  The wire request carries `ControlArgs.items` as 1 through 1,000 `{id,label,subtitle?}` records, optional `prompt`, `allowCustom`, `follow`, and the shared `window` selector.
+  Host-free validation in `ControlDispatcher.dispatchPickCommand` rejects an empty list, too many items, empty labels, duplicate ids, and control characters in labels or subtitles before it creates the `PendingPick`.
+  `ControlServer.openPick` resolves the target window's `PickController` through `PickRegistry`, rejects a second pending pick, and closes the built-in command palette only when the picker opens in the active window.
+  A background target stays background by default, while `follow` raises it and synchronizes `WindowLibrary.frontmostWindowID`.
+  `pick.result` requires the exact picker id and returns `pending`, `picked` with `id`/`label`/`index`, `custom` with `query`, or `cancelled`.
+  `pick.cancel` requires the exact picker id, cancels a pending picker, and succeeds without changing an already terminal result.
+  `ControlTree.pickPending` is the read-back, populated from the target window's controller and omitted when no picker is pending.
+  `WindowContentView` renders a pending pick through `CommandPalette(items:)`, and only one picker is mounted per window.
+  Selection, custom input, Esc, ⌘W, window close, and app termination all resolve the request, with every lifecycle exit mapping to `cancelled`.
+  `PickRegistry.unregister` retains the cancellation long enough for a blocking caller whose next poll follows window teardown, and the next successful open in that window clears the retained result.
+  The CLI group defaults to open, sniffs stdin as a JSON array when its first non-whitespace byte is `[`, and otherwise maps nonblank lines to items whose id equals the label.
+  Blocking `agtermctl pick` polls `pick.result` every 100 ms for the first second and every 500 ms afterward, prints the bare result JSON, and exits 0 for `picked`/`custom`, 2 for `cancelled`, or 1 for failures.
+  `--no-block` prints `{"id":"…"}`, while `pick result ID` and `pick cancel ID` expose the later one-shot operations with the same `--window` scope.
+  Keep-in-sync audit: `ControlProtocol.swift` owns the three cases, item/result types, args, and `pickPending`; `ControlDispatcher+Pick.swift` owns validation and routing; `ControlServer+Pick.swift`, `PickController`, `PickRegistry`, and `WindowContentView` own app state and presentation; `MiscCommands.swift` and `SocketClient.swift` own CLI input, polling, output, and exit codes.
+  Tests cover protocol round trips, dispatcher validation, controller state, hosted window/focus/lifetime paths, CLI parsing and backoff, palette rows, tree read-back, and focused `ControlPickUITests`.
   Mode-bearing commands (`session.split`/`quick`) compute the delta against current state so `on`/`off`/`show`/`hide`
   are idempotent, and an unknown mode is an error.
   `quick`'s visibility reads back on `ControlTree.quickVisible` at the tree TOP level — LIVE, resolved
@@ -1737,7 +1754,7 @@ paths:
   arguments, and the `tree` read-back field, grouped into its command family's section.
   A new `Command` case REQUIRES a new `site/commands.html` entry (a changed command an updated one, a
   removed command a deleted one), in lockstep with the agent skill above and `README.md`/`site/docs.html`;
-  the page's "68 commands" copy must track the catalog count.
+  the page's "71 commands" copy must track the catalog count.
   A bump is a grep, not a single edit: the count sits in FOUR spots in `commands.html` alone (the
   `description` `<meta>`, the `og:description` and `twitter:description` `<meta>`s, plus the body copy),
   and again in `README.md`, `site/docs.html`, the bundled `SKILL.md`, and the `SkillInstallTests`

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -994,7 +994,8 @@ paths:
   `WindowContentView` renders a pending pick through `CommandPalette(items:)`, and only one picker is mounted per window.
   Selection, custom input, Esc, ⌘W, and window close resolve the request, with lifecycle exits mapping to `cancelled`.
   App termination cancels picker state before socket shutdown, but a polling client can race process exit and receive a transport failure rather than the terminal result.
-  `PickRegistry.unregister` retains the cancellation long enough for a blocking caller whose next poll follows window teardown; the next successful open in that window clears the retained result, including after permanent window deletion.
+  `PickController` keeps terminal results keyed by pick id (the 8 most recent), so a later picker in that window never erases an answer whose blocking caller has not polled it yet — the poll interval is 500 ms, which is long enough for the next `pick.open` to land.
+  `PickRegistry.unregister` moves a closed window's results into a 32-entry app-wide retention, so a poll following window teardown — including permanent window deletion — still reads them; both stores evict oldest-first and nothing else frees them.
   The CLI group defaults to open, sniffs stdin as a JSON array when its first non-whitespace byte is `[`, and otherwise maps nonblank lines to items whose id equals the label.
   Blocking `agtermctl pick` polls `pick.result` every 100 ms for the first second and every 500 ms afterward, prints the bare result JSON, and exits 0 for `picked`/`custom`, 2 for `cancelled`, or 1 for failures.
   `--no-block` prints `{"id":"…"}`, while `pick result ID` and `pick cancel ID` expose the later one-shot operations with the same `--window` scope.

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -988,12 +988,13 @@ paths:
   Host-free validation in `ControlDispatcher.dispatchPickCommand` rejects an empty list, too many items, empty labels, duplicate ids, and control characters in labels or subtitles before it creates the `PendingPick`.
   `ControlServer.openPick` resolves the target window's `PickController` through `PickRegistry`, rejects a second pending pick, and closes the built-in command palette only when the picker opens in the active window.
   A background target stays background by default, while `follow` raises it and synchronizes `WindowLibrary.frontmostWindowID`.
-  `pick.result` requires the exact picker id and returns `pending`, `picked` with `id`/`label`/`index`, `custom` with `query`, or `cancelled`.
-  `pick.cancel` requires the exact picker id, cancels a pending picker, and succeeds without changing an already terminal result.
+  `pick.result` requires the exact globally unique picker id and returns `pending`, `picked` with `id`/`label`/`index`, `custom` with `query`, or `cancelled`; without `window`, id lookup stays pinned to the owning window across frontmost changes.
+  `pick.cancel` uses the same id routing, cancels a pending picker, and succeeds without changing an already terminal result. An explicit `window` must match the live or close-retained pick's owner.
   `ControlTree.pickPending` is the read-back, populated from the target window's controller and omitted when no picker is pending.
   `WindowContentView` renders a pending pick through `CommandPalette(items:)`, and only one picker is mounted per window.
-  Selection, custom input, Esc, ⌘W, window close, and app termination all resolve the request, with every lifecycle exit mapping to `cancelled`.
-  `PickRegistry.unregister` retains the cancellation long enough for a blocking caller whose next poll follows window teardown, and the next successful open in that window clears the retained result.
+  Selection, custom input, Esc, ⌘W, and window close resolve the request, with lifecycle exits mapping to `cancelled`.
+  App termination cancels picker state before socket shutdown, but a polling client can race process exit and receive a transport failure rather than the terminal result.
+  `PickRegistry.unregister` retains the cancellation long enough for a blocking caller whose next poll follows window teardown; the next successful open in that window clears the retained result, including after permanent window deletion.
   The CLI group defaults to open, sniffs stdin as a JSON array when its first non-whitespace byte is `[`, and otherwise maps nonblank lines to items whose id equals the label.
   Blocking `agtermctl pick` polls `pick.result` every 100 ms for the first second and every 500 ms afterward, prints the bare result JSON, and exits 0 for `picked`/`custom`, 2 for `cancelled`, or 1 for failures.
   `--no-block` prints `{"id":"…"}`, while `pick result ID` and `pick cancel ID` expose the later one-shot operations with the same `--window` scope.

--- a/.claude/rules/ui-tests.md
+++ b/.claude/rules/ui-tests.md
@@ -151,8 +151,12 @@ paths:
   subtitle child right below it IS.
   A row with no subtitle collapses to the full-width row element and clicks fine, which is what makes this
   look intermittent: the same helper works until an item carries a subtitle.
-  Resolve a row with the first HITTABLE match (`allElementsBoundByIndex.first { $0.isHittable }`), falling
-  back to `firstMatch` for the existence waits that run before anything exists — see `ControlPickUITests.paletteRow`.
+  CLICK a row through a helper that picks the first HITTABLE match
+  (`allElementsBoundByIndex.first { $0.isHittable } ?? matches.firstMatch`) and keep the plain lazy
+  `firstMatch` helper for the existence waits — see `ControlPickUITests.clickPaletteRow` vs `paletteRow`.
+  Keep the two SEPARATE: `allElementsBoundByIndex` resolves eagerly, and folding it into the helper the
+  `waitForExistence` calls use broke `testPickKeepsKeyboardAfterClosingBuiltInPalette`, whose row does not
+  exist yet when the helper is called.
   The symptom is a fast `Not hittable: StaticText …` failure, NOT the slow synthesize-event timeout that
   means occlusion; it reproduces with HazeOver quit and on a clean checkout.
 - **Driving a Picker in XCUITest depends on its style.**

--- a/.claude/rules/ui-tests.md
+++ b/.claude/rules/ui-tests.md
@@ -143,6 +143,18 @@ paths:
   just `xcodebuild test …` (builds then tests).
   Read the real reason from the xcresult (`xcrun xcresulttool get test-results tests --path <xcresult>`,
   find the `Failure Message` node) rather than trusting the "0 tests / crash" summary.
+- **A palette row answers to its identifier more than once, and the match you get first cannot be clicked.**
+  `PaletteRow` sets `palette-item-<id>` on the row, and SwiftUI propagates an identifier to every text
+  child that has none of its own, so a row WITH a subtitle exposes two matching elements.
+  `matching(identifier:).firstMatch` returns the title `StaticText`, which is never hittable — the row owns
+  the tap target, so the AX hit test at the title's center does not resolve to the title — while the
+  subtitle child right below it IS.
+  A row with no subtitle collapses to the full-width row element and clicks fine, which is what makes this
+  look intermittent: the same helper works until an item carries a subtitle.
+  Resolve a row with the first HITTABLE match (`allElementsBoundByIndex.first { $0.isHittable }`), falling
+  back to `firstMatch` for the existence waits that run before anything exists — see `ControlPickUITests.paletteRow`.
+  The symptom is a fast `Not hittable: StaticText …` failure, NOT the slow synthesize-event timeout that
+  means occlusion; it reproduces with HazeOver quit and on a clean checkout.
 - **Driving a Picker in XCUITest depends on its style.**
   A `.segmented` Picker exposes each option as a hittable descendant by label — match
   `picker.descendants(matching: .any).matching(label == "X").firstMatch` and `.click()` it directly.

--- a/.claude/rules/ui-tests.md
+++ b/.claude/rules/ui-tests.md
@@ -1,7 +1,45 @@
 ---
 paths:
   - "agtermUITests/**/*.swift"
+  - "agtermTests/**/*.swift"
 ---
+
+## Application-hosted tests (`agtermTests/`)
+
+These run INSIDE the real app, so a mistake here kills the process instead of failing an assertion.
+
+- **A window a test owns MUST set `isReleasedWhenClosed = false`.**
+  `NSWindow`'s designated initializer defaults it to true, so `close()` sends a release ARC never
+  balances while the suite still holds the window (a `registeredWindows` dictionary, `WindowRegistry`).
+  The over-release frees it under its surviving references and the next autorelease-pool pop on the main
+  queue dereferences freed memory.
+  The symptom is NOT a test failure: the host dies, xcodebuild says `Restarting after unexpected exit,
+  crash, or test timeout` with no assertion and no signal, and the suite restarts and finishes.
+  Freed memory is reused nondeterministically, so it passes locally and dies on the runner — and adding
+  unrelated tests to the same class can be what makes a latent one start firing.
+  `orderOut(nil)` does not trigger it; only `close()` does.
+- **Read a dead host, do not infer it.**
+  The streamed CI log names nothing useful.
+  `xcrun xcresulttool get test-results tests --path <xcresult>` gives the real message (e.g. "The test
+  runner exited with code 1 before finishing running tests").
+  The STACK comes from ghostty's crash handler: `~/.local/state/ghostty/crash/*.ghosttycrash` is a sentry
+  envelope whose attachment is a minidump — split the envelope (header line, then item-header/payload
+  pairs), write the `.dmp`, and read it with `lldb -b -o "bt all" -c <dmp>`.
+  CI discards both, so add a temporary `upload-artifact` step with `if: failure()` covering the crash
+  directory and `build/DerivedData/Logs/Test/*.xcresult`, then remove it once the cause is known.
+  Reaching for the artifact after the FIRST failed fix is cheaper than a second guess.
+- **Never stub out `GhosttyApp` to make a hosted test quieter.**
+  Ghostty's handler is the app's crash reporter; suppressing its init deletes the only record of why the
+  host died and converts an immediate death into a silent one.
+- **The hosted host is not the app you think.**
+  `AGTERM_HOSTED_TESTS=1` (set by the `agtermTests` scheme in `project.yml`) makes the scene render
+  `Color.clear`, which skips the `.task` that assigns `appDelegate.library` — so the delegate's `library`
+  is nil for the whole run, and code keying off it behaves differently than in the real app.
+  `NSApp.delegate as? AppDelegate` is also nil (SwiftUI wraps it in `@NSApplicationDelegateAdaptor`), so
+  reach the delegate another way rather than asserting on that cast.
+  Locally the placeholder window IS presented (`NSApp.windows.count == 1`, titled "Agterm"); launched by
+  another process on CI it is not — the same FB11763863 shape as the UI-test note below, and the reason
+  window-count assumptions differ between the two environments.
 
 ## UI tests
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,24 +124,6 @@ jobs:
         run: scripts/build.sh
       - name: Application-hosted unit tests
         run: scripts/test-app.sh
-      # the hosted host has died mid-suite on this runner while passing locally; the crash report and
-      # the result bundle are the only records of why, and both live in paths the job otherwise discards.
-      - name: Collect hosted-test crash evidence
-        if: failure()
-        run: |
-          mkdir -p /tmp/crash-evidence
-          cp -R ~/.local/state/ghostty/crash /tmp/crash-evidence/ghostty-crash 2>/dev/null || true
-          cp -R ~/Library/Logs/DiagnosticReports /tmp/crash-evidence/diagnostic-reports 2>/dev/null || true
-          cp -R build/DerivedData/Logs/Test/*.xcresult /tmp/crash-evidence/ 2>/dev/null || true
-          ls -laR /tmp/crash-evidence | head -50
-      - name: Upload hosted-test crash evidence
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: hosted-test-crash-evidence
-          path: /tmp/crash-evidence
-          retention-days: 5
-          if-no-files-found: warn
 
   cookbook:
     name: Cookbook checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,24 @@ jobs:
         run: scripts/build.sh
       - name: Application-hosted unit tests
         run: scripts/test-app.sh
+      # the hosted host has died mid-suite on this runner while passing locally; the crash report and
+      # the result bundle are the only records of why, and both live in paths the job otherwise discards.
+      - name: Collect hosted-test crash evidence
+        if: failure()
+        run: |
+          mkdir -p /tmp/crash-evidence
+          cp -R ~/.local/state/ghostty/crash /tmp/crash-evidence/ghostty-crash 2>/dev/null || true
+          cp -R ~/Library/Logs/DiagnosticReports /tmp/crash-evidence/diagnostic-reports 2>/dev/null || true
+          cp -R build/DerivedData/Logs/Test/*.xcresult /tmp/crash-evidence/ 2>/dev/null || true
+          ls -laR /tmp/crash-evidence | head -50
+      - name: Upload hosted-test crash evidence
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hosted-test-crash-evidence
+          path: /tmp/crash-evidence
+          retention-days: 5
+          if-no-files-found: warn
 
   cookbook:
     name: Cookbook checks

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ The theme picker (View ▸ Select Theme…, or the action palette) previews each
 
 To open a terminal at a directory without the CLI, `open -a agterm <path>` — or right-click a folder in Finder and choose **Open With ▸ agterm**. agterm adds a session in that directory to the last-active window. This works when agterm is already running (its usual state); if it isn't, launch agterm first, then run the command. The socket equivalent, and the way to place the session precisely, is `agtermctl session new --cwd <path>`.
 
-The sections below cover the common cases. All 68 commands, with every argument, return value, and error, are documented in the **[Command reference](https://agterm.com/commands)**.
+The sections below cover the common cases. All 71 commands, with every argument, return value, and error, are documented in the **[Command reference](https://agterm.com/commands)**.
 
 The app bundles `agtermctl` inside `agterm.app`. The easiest way to put it on your PATH is **Help ▸ Install Command Line Tool…**, which symlinks the bundled binary into `/usr/local/bin` (the first entry in macOS's default PATH). When that directory is user-writable it installs silently; otherwise it asks once for an administrator password.
 
@@ -198,6 +198,25 @@ cd agtermCore && swift build -c release
 ```
 
 Each command targets a session or workspace by its UUID, a unique prefix of that UUID (git-style), or the keyword `active` (the selected session / current workspace). `--target` defaults to `active`, so the current one rarely needs to be named. Mutating commands normally print the affected id; batch `session close` and `session move` accept repeated `--target` options and print the number of sessions actually changed. `tree` prints the workspace and session tree. Add `--json` for the raw response, or `--socket PATH` to override the socket path. The exit code is zero on success, non-zero on error.
+
+### Native picker
+
+`agtermctl pick` reads choices from stdin and opens agterm's native fuzzy picker.
+Input can be nonblank lines or a JSON array of objects with `id`, `label`, and an optional `subtitle`.
+The default call blocks and prints the selected item as JSON.
+Use `--allow-custom` to accept a query that does not match an item, `--window` to target another open window, and `--follow` to raise that window.
+
+```sh
+printf '%s\n' staging production | agtermctl pick --prompt "Deploy where?"
+
+pick_id=$(printf '%s\n' alpha beta | agtermctl pick --no-block | jq -r '.id')
+agtermctl pick result "$pick_id"      # bare JSON result; exit 1 while pending, 2 when cancelled
+agtermctl pick cancel "$pick_id"
+agtermctl tree --json | jq -r '.result.tree.pickPending // empty'
+```
+
+Only one picker can be pending per window.
+The top-level `pickPending` tree field carries its id and is omitted after it resolves.
 
 ### Control events
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Each command targets a session or workspace by its UUID, a unique prefix of that
 
 `agtermctl pick` reads choices from stdin and opens agterm's native fuzzy picker.
 Input can be nonblank lines or a JSON array of objects with `id`, `label`, and an optional `subtitle`.
-The default call blocks and prints the selected item as JSON.
+The default call blocks and prints terminal-result JSON: picked item, custom query, or cancellation.
 Use `--allow-custom` to accept a query that does not match an item, `--window` to target another open window, and `--follow` to raise that window.
 
 ```sh

--- a/agterm/AppActions+Focus.swift
+++ b/agterm/AppActions+Focus.swift
@@ -17,6 +17,12 @@ extension AppActions {
         DashboardControllerRegistry.shared.controller(for: library.activeWindowID)?.isOpen == true
     }
 
+    /// Whether the specified window has a native control picker pending. Kept as one window-scoped
+    /// predicate so both frontmost and session-addressed focus paths use the same modal invariant.
+    func pickActive(for windowID: WindowInfo.ID?) -> Bool {
+        PickRegistry.shared.controller(for: windowID)?.pending != nil
+    }
+
     /// Whether terminal zoom is active in the window OWNING this session. The right gate for the
     /// session-addressed focus paths: control commands resolve sessions across ALL windows, so gating
     /// them on the FRONTMOST window's zoom would silently drop the focus step for an un-zoomed
@@ -124,6 +130,7 @@ extension AppActions {
         // Theme…" launcher (which closes the action palette, then opens the .themes picker a tick later)
         // can't have its field focus stolen back by the close-restore's retry.
         if palette?.mode != nil { return }
+        if pickActive(for: library.activeWindowID) { return }
         if frontmostQuickTerminal?.isVisible == true { return }
         if let view = store?.activeSession?.topmostSurface as? GhosttySurfaceView, let window = view.window {
             window.makeFirstResponder(view)
@@ -166,6 +173,7 @@ extension AppActions {
         // reason: while it's up its key-catcher owns first responder, and a NON-member deck surface behind it
         // is not view-only, so grabbing first responder here would leak keystrokes into a hidden terminal.
         if dashboardActive(for: session) { return }
+        if pickActive(for: library.windowID(forSession: session.id)) { return }
         // the inline rename field and an open palette own the keyboard, exactly as in `focusActiveSession`,
         // which re-checks both on every one of its retries. this loop needs them for the same reason: the
         // `.left`/nil reveal routes here (a plain `session status blocked` with no `--pane` lands in that

--- a/agterm/AppActions+Palette.swift
+++ b/agterm/AppActions+Palette.swift
@@ -197,24 +197,24 @@ extension AppActions {
     /// icon — none of these route through the action palette's `runItem`, so a synchronous toggle is
     /// correct. The ⌃⇧P launcher uses `openAttentionPalette()` instead (it must reopen async).
     func toggleAttentionPalette() {
-        guard !terminalZoomActive else { return }
+        guard !terminalZoomActive, !pickActive(for: library.activeWindowID) else { return }
         palette?.toggle(.attention)
     }
 
     /// Menu/keymap palette launchers route through actions, not direct `palette.toggle`, so terminal zoom's
     /// modal UI guard is applied consistently to the keyboard shortcut and menu paths.
     func toggleSessionPalette() {
-        guard !terminalZoomActive else { return }
+        guard !terminalZoomActive, !pickActive(for: library.activeWindowID) else { return }
         palette?.toggle(.sessions)
     }
 
     func toggleActionPalette() {
-        guard !terminalZoomActive else { return }
+        guard !terminalZoomActive, !pickActive(for: library.activeWindowID) else { return }
         palette?.toggle(.actions)
     }
 
     func toggleCustomCommandPalette() {
-        guard !terminalZoomActive else { return }
+        guard !terminalZoomActive, !pickActive(for: library.activeWindowID) else { return }
         palette?.toggle(.customCommands)
     }
 
@@ -224,9 +224,10 @@ extension AppActions {
     /// `toggle` would be undone by that close. The async `open` lets `.attention` reopen a tick later as a
     /// fresh view that survives the close.
     func openAttentionPalette() {
-        guard !terminalZoomActive else { return }
+        guard !terminalZoomActive, !pickActive(for: library.activeWindowID) else { return }
         DispatchQueue.main.async { [weak self] in
-            guard let self, !self.terminalZoomActive else { return }
+            guard let self, !self.terminalZoomActive,
+                  !self.pickActive(for: self.library.activeWindowID) else { return }
             self.palette?.open(.attention)
         }
     }
@@ -239,9 +240,10 @@ extension AppActions {
     /// this returns, so reopening async lets `.themes` survive the close (the rename actions reopen the
     /// same way).
     func openThemePalette() {
-        guard !terminalZoomActive else { return }
+        guard !terminalZoomActive, !pickActive(for: library.activeWindowID) else { return }
         DispatchQueue.main.async { [weak self] in
-            guard let self, !self.terminalZoomActive else { return }
+            guard let self, !self.terminalZoomActive,
+                  !self.pickActive(for: self.library.activeWindowID) else { return }
             self.palette?.open(.themes)
         }
     }

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -97,6 +97,12 @@ final class AppActions {
     /// so an idle auto-follow in the key window moves first responder into the newly selected session.
     private var autoFollowObserver: NSObjectProtocol?
 
+    /// Cancels every window-scoped picker when AppKit begins termination. This observer runs on the
+    /// same synchronous notification as the delegate's quit flush, but never participates in
+    /// `applicationShouldTerminate`: a caller waiting on a pick gets `cancelled` without delaying either
+    /// the quit-confirmation prompt or termination itself.
+    private var terminationObserver: NSObjectProtocol?
+
     init(library: WindowLibrary) {
         self.library = library
         // bridge the host-free `AppStore.autoFollowFire` post to the app-target focus move: agtermCore can't
@@ -108,6 +114,11 @@ final class AppActions {
             let indicator = note.userInfo?[AppStore.autoFollowIndicatorKey] as? AgentIndicator
             MainActor.assumeIsolated { self?.autoFollowed(sessionID, indicator: indicator) }
         }
+        terminationObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.willTerminateNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.cancelAllPendingPicks() }
+        }
     }
 
     // isolated so it can read the `@MainActor` non-Sendable observer token; balances the block-based
@@ -115,6 +126,7 @@ final class AppActions {
     // unbalanced addObserver(forName:) is a latent leak either way.
     isolated deinit {
         if let autoFollowObserver { NotificationCenter.default.removeObserver(autoFollowObserver) }
+        if let terminationObserver { NotificationCenter.default.removeObserver(terminationObserver) }
     }
 
     // MARK: - Workspaces & sessions
@@ -249,6 +261,9 @@ final class AppActions {
     // dismissed, not only a full one.
     @discardableResult
     func closeActiveSession() -> Bool {
+        // A pick is an external caller waiting on an answer, so it is the first ⌘W layer even when a
+        // terminal is zoomed behind it. Resolve rather than merely hiding it so the caller can finish.
+        if cancelPendingPick(for: library.activeWindowID) { return true }
         // terminal zoom is the window-topmost cover of all: ⌘W dismisses it like the covers below
         // (stepwise — a zoomed quick terminal un-zooms first, the next ⌘W hides it) rather than
         // swallowing the keystroke, and still never mutates hidden session/window state behind it. the
@@ -266,6 +281,26 @@ final class AppActions {
         closeSessionAfterConfirmation(session.id, in: store)
         focusActiveSession()
         return true
+    }
+
+    /// Resolve the pending picker owned by `windowID` as cancelled. Used by ⌘W and app termination;
+    /// window teardown cancels through `PickRegistry.unregister` so it can retain the terminal result.
+    @discardableResult
+    func cancelPendingPick(for windowID: WindowInfo.ID?) -> Bool {
+        guard let controller = PickRegistry.shared.controller(for: windowID),
+              controller.pending != nil
+        else { return false }
+        controller.cancel()
+        return true
+    }
+
+    /// Resolve all open windows' pending pickers during the synchronous app-termination notification.
+    /// The window library deliberately retains its open ids through quit teardown, so every mounted
+    /// controller remains addressable here.
+    private func cancelAllPendingPicks() {
+        for windowID in library.openIDs() {
+            cancelPendingPick(for: windowID)
+        }
     }
 
     /// Close the session with `id` in `store` from a GUI surface (the sidebar row's Close), honoring the

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -42,10 +42,11 @@ final class AppActions {
         frontmostTerminalZoom?.target != nil
     }
 
-    /// While terminal zoom OR the dashboard grid is active, the UI is modal: keyboard/menu/palette actions
-    /// must not mutate the deck behind it. The zoom/dashboard toggles, socket commands, and macOS window
-    /// controls remain separate paths (they never gate on this), so the user is never trapped and can always
-    /// dismiss the modal. This is the frontmost-window shorthand for the per-window check below, resolved on
+    /// While terminal zoom, the dashboard grid, OR the topmost native picker is active, the UI is modal:
+    /// keyboard/menu/palette actions must not mutate the deck behind it. Dismissal paths remain independently
+    /// callable so the user is never trapped: the dashboard toggle stays available while its grid is the
+    /// topmost modal, while zoom/dashboard toggles are blocked behind a picker. This is the frontmost-window
+    /// shorthand below, resolved on
     /// `library.activeWindowID` like the zoom target. With NO window open that id is nil and the gate DENIES
     /// (the per-window check's `guard let windowID else { return false }`), so a deck action can't run against
     /// no window while the app is tearing down.
@@ -57,6 +58,7 @@ final class AppActions {
         guard let windowID else { return false }
         return TerminalZoomRegistry.shared.controller(for: windowID)?.target == nil
             && DashboardControllerRegistry.shared.controller(for: windowID)?.isOpen != true
+            && PickRegistry.shared.controller(for: windowID)?.pending == nil
     }
 
     /// Set briefly while a rename is being started, so the focus-restore that runs when a palette
@@ -297,7 +299,7 @@ final class AppActions {
     /// Resolve all open windows' pending pickers during the synchronous app-termination notification.
     /// The window library deliberately retains its open ids through quit teardown, so every mounted
     /// controller remains addressable here.
-    private func cancelAllPendingPicks() {
+    func cancelAllPendingPicks() {
         for windowID in library.openIDs() {
             cancelPendingPick(for: windowID)
         }
@@ -807,10 +809,11 @@ final class AppActions {
     // MARK: - Quick terminal (frontmost window)
 
     /// Toggle the frontmost window's quick terminal (each window owns its own controller). Gated on the full
-    /// `uiActionsEnabled` (zoom AND dashboard), not zoom alone — defence in depth rather than a gap being
-    /// closed, since all three callers already gate: the View ▸ Quick Terminal item's `.disabled(modalActive)`
-    /// (which covers a `keymap.conf` rebind too, because that rebind is the item's own key equivalent), the
-    /// palette's `runPaletteCommand` check, and the Dock item's invocation-time `uiActionsEnabled(for:)`.
+    /// `uiActionsEnabled` (zoom, dashboard, AND native picker), not zoom alone — defence in depth rather
+    /// than a gap being closed, since all three callers already gate: the View ▸ Quick Terminal item's
+    /// `.disabled(modalActive)` (which covers a `keymap.conf` rebind too, because that rebind is the item's
+    /// own key equivalent), the palette's `runPaletteCommand` check, and the Dock item's invocation-time
+    /// `uiActionsEnabled(for:)`.
     func toggleQuickTerminal() {
         guard uiActionsEnabled else { return }
         frontmostQuickTerminal?.toggle()
@@ -818,15 +821,19 @@ final class AppActions {
 
     /// Toggle the frontmost window's full-window terminal zoom. Core resolves which surface is active
     /// (quick, overlay, scratch, split, or primary); the owning window renders it above all chrome.
-    func toggleTerminalZoom() { frontmostTerminalZoom?.toggle() }
+    func toggleTerminalZoom() {
+        guard !pickActive(for: library.activeWindowID) else { return }
+        frontmostTerminalZoom?.toggle()
+    }
 
     /// Toggle the frontmost window's dashboard — the keyboard/menu/palette opener for the MRU dashboard grid
     /// (the ⌘⇧D / Navigate ▸ Dashboard equivalent of `agtermctl dashboard --mru --auto-size`). Inert while
-    /// terminal zoom is active (mirrors the GUI siblings + the `.disabled(zoomed)` menu item; the control
-    /// path keeps its own zoom-clear). Open → close it and refocus the active session; closed → open it over
-    /// the window's most-recently-used sessions, auto-sized. A no-op when the window has no recent sessions.
+    /// terminal zoom or the topmost native picker is active (mirrors the GUI siblings and menu disablement).
+    /// Dashboard state alone does not block the toggle, so an open grid remains its own close escape hatch.
+    /// Open → close it and refocus the active session; closed → open it over the window's most-recently-used
+    /// sessions, auto-sized. A no-op when the window has no recent sessions.
     func toggleDashboard() {
-        guard !terminalZoomActive else { return }
+        guard !terminalZoomActive, !pickActive(for: library.activeWindowID) else { return }
         guard let dashboard = frontmostDashboard else { return }
         if dashboard.isOpen {
             dashboard.close()
@@ -902,6 +909,7 @@ final class AppActions {
     /// target — `onSearchStart` opens the bar and pins the surface. Shared by the Find menu item, the
     /// palette, and ⌘F.
     func toggleSearch() {
+        guard !pickActive(for: library.activeWindowID) else { return }
         if store?.activeSession?.searchActive == true {
             (store?.activeSession?.searchSurface as? GhosttySurfaceView)?.endSearch()
             return

--- a/agterm/AppDelegate.swift
+++ b/agterm/AppDelegate.swift
@@ -335,6 +335,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_: Notification) {
+        // Resolve in-memory picker state before closing the socket. A client that is already polling may
+        // observe cancellation; process exit still means a later poll can race socket teardown.
+        actions?.cancelAllPendingPicks()
         controlServer?.stop()
         customCommandRunner?.stop()
         // clear the OS-level Dock badge — it outlives the process, and unseenCount is ephemeral, so a quit

--- a/agterm/AppDelegate.swift
+++ b/agterm/AppDelegate.swift
@@ -387,7 +387,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // window (or a re-render that briefly drops the surviving NSWindow) can leave a momentary
         // zero-window state while the library still has an open window, and quitting there would kill
         // the app (and the control server) mid-session. Quit only when no window is open in the model.
-        guard let library else { return true }
+        //
+        // With no library there is no open-set to consult, so "every window is closed" is not a
+        // conclusion this can draw — stay alive. The nil case is not reachable in a running app (the
+        // scene's `.task` wires the library before any window can close); it is the state the
+        // application-hosted test host runs in, where quitting would kill the test process itself.
+        guard let library else { return false }
         return library.openIDs().isEmpty
     }
 }

--- a/agterm/AppDelegate.swift
+++ b/agterm/AppDelegate.swift
@@ -387,12 +387,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // window (or a re-render that briefly drops the surviving NSWindow) can leave a momentary
         // zero-window state while the library still has an open window, and quitting there would kill
         // the app (and the control server) mid-session. Quit only when no window is open in the model.
-        //
-        // With no library there is no open-set to consult, so "every window is closed" is not a
-        // conclusion this can draw — stay alive. The nil case is not reachable in a running app (the
-        // scene's `.task` wires the library before any window can close); it is the state the
-        // application-hosted test host runs in, where quitting would kill the test process itself.
-        guard let library else { return false }
+        guard let library else { return true }
         return library.openIDs().isEmpty
     }
 }

--- a/agterm/Control/ControlServer+AppCommands.swift
+++ b/agterm/Control/ControlServer+AppCommands.swift
@@ -240,6 +240,10 @@ extension ControlServer {
             return ControlResponse(ok: false, error: "invalid quick mode: \(mode ?? "toggle")")
         }
         let want = parsedMode.desiredValue(current: controller.isVisible)
+        if want, !controller.isVisible,
+           PickRegistry.shared.controller(for: library.activeWindowID)?.pending != nil {
+            return ControlResponse(ok: false, error: "pick pending")
+        }
         if let zoom = TerminalZoomRegistry.shared.controller(for: library.activeWindowID), zoom.target != nil {
             // a script must always be able to DISMISS the quick terminal (hide was a guaranteed-ok
             // idempotent no-op pre-zoom, and cleanup code relies on that): hiding un-zooms a zoomed

--- a/agterm/Control/ControlServer+Pick.swift
+++ b/agterm/Control/ControlServer+Pick.swift
@@ -8,6 +8,7 @@ extension ControlServer {
             guard controller.open(pick) else {
                 return ControlResponse(ok: false, error: "pick already pending")
             }
+            PickRegistry.shared.clearRetainedResult(for: windowID)
 
             if follow {
                 WindowRegistry.shared.raise(windowID)
@@ -21,7 +22,10 @@ extension ControlServer {
     }
 
     func pickResult(_ target: String, window: String?) -> ControlResponse {
-        withPickController(window: window) { controller, _ in
+        if let result = PickRegistry.shared.retainedResult(for: target) {
+            return ControlResponse(ok: true, result: ControlResult(pick: result))
+        }
+        return withPickController(window: window) { controller, _ in
             guard let result = controller.result(for: target) else {
                 return ControlResponse(ok: false, error: "unknown pick: \(target)")
             }
@@ -30,7 +34,10 @@ extension ControlServer {
     }
 
     func cancelPick(_ target: String, window: String?) -> ControlResponse {
-        withPickController(window: window) { controller, _ in
+        if PickRegistry.shared.retainedResult(for: target) != nil {
+            return ControlResponse(ok: true)
+        }
+        return withPickController(window: window) { controller, _ in
             guard controller.result(for: target) != nil else {
                 return ControlResponse(ok: false, error: "unknown pick: \(target)")
             }

--- a/agterm/Control/ControlServer+Pick.swift
+++ b/agterm/Control/ControlServer+Pick.swift
@@ -22,8 +22,23 @@ extension ControlServer {
     }
 
     func pickResult(_ target: String, window: String?) -> ControlResponse {
-        if let result = PickRegistry.shared.retainedResult(for: target) {
-            return ControlResponse(ok: true, result: ControlResult(pick: result))
+        if window == nil {
+            if let live = PickRegistry.shared.livePick(for: target),
+               let result = live.controller.result(for: target) {
+                return ControlResponse(ok: true, result: ControlResult(pick: result))
+            }
+            if let retained = PickRegistry.shared.retainedResult(for: target) {
+                return ControlResponse(ok: true, result: ControlResult(pick: retained.result))
+            }
+            return ControlResponse(ok: false, error: "unknown pick: \(target)")
+        }
+        if let retained = PickRegistry.shared.retainedResult(for: target) {
+            return resolver.resolveWindowID(window) { windowID in
+                guard windowID == retained.windowID else {
+                    return ControlResponse(ok: false, error: "unknown pick: \(target)")
+                }
+                return ControlResponse(ok: true, result: ControlResult(pick: retained.result))
+            }
         }
         return withPickController(window: window) { controller, _ in
             guard let result = controller.result(for: target) else {
@@ -34,8 +49,22 @@ extension ControlServer {
     }
 
     func cancelPick(_ target: String, window: String?) -> ControlResponse {
-        if PickRegistry.shared.retainedResult(for: target) != nil {
-            return ControlResponse(ok: true)
+        if window == nil {
+            if let live = PickRegistry.shared.livePick(for: target) {
+                if live.controller.pending?.id == target { live.controller.cancel() }
+                return ControlResponse(ok: true)
+            }
+            if PickRegistry.shared.retainedResult(for: target) != nil {
+                return ControlResponse(ok: true)
+            }
+            return ControlResponse(ok: false, error: "unknown pick: \(target)")
+        }
+        if let retained = PickRegistry.shared.retainedResult(for: target) {
+            return resolver.resolveWindowID(window) { windowID in
+                windowID == retained.windowID
+                    ? ControlResponse(ok: true)
+                    : ControlResponse(ok: false, error: "unknown pick: \(target)")
+            }
         }
         return withPickController(window: window) { controller, _ in
             guard controller.result(for: target) != nil else {

--- a/agterm/Control/ControlServer+Pick.swift
+++ b/agterm/Control/ControlServer+Pick.swift
@@ -1,0 +1,73 @@
+import agtermCore
+
+/// App-side host for the per-window native picker. Argument validation and response routing stay in
+/// `ControlDispatcher`; this layer resolves the target window and drives its registered controller.
+extension ControlServer {
+    func openPick(_ pick: PendingPick, window: String?, follow: Bool) -> ControlResponse {
+        withPickController(window: window) { controller, windowID in
+            guard controller.open(pick) else {
+                return ControlResponse(ok: false, error: "pick already pending")
+            }
+
+            if follow {
+                WindowRegistry.shared.raise(windowID)
+                selectPickWindow(windowID)
+            }
+            if library.activeWindowID == windowID {
+                actions.palette?.close()
+            }
+            return ControlResponse(ok: true, result: ControlResult(id: pick.id))
+        }
+    }
+
+    func pickResult(_ target: String, window: String?) -> ControlResponse {
+        withPickController(window: window) { controller, _ in
+            guard let result = controller.result(for: target) else {
+                return ControlResponse(ok: false, error: "unknown pick: \(target)")
+            }
+            return ControlResponse(ok: true, result: ControlResult(pick: result))
+        }
+    }
+
+    func cancelPick(_ target: String, window: String?) -> ControlResponse {
+        withPickController(window: window) { controller, _ in
+            guard controller.result(for: target) != nil else {
+                return ControlResponse(ok: false, error: "unknown pick: \(target)")
+            }
+            if controller.pending?.id == target {
+                controller.cancel()
+            }
+            return ControlResponse(ok: true)
+        }
+    }
+
+    private func withPickController(
+        window: String?,
+        _ body: (PickController, WindowInfo.ID) -> ControlResponse
+    ) -> ControlResponse {
+        guard library.activeStore != nil else {
+            return ControlResponse(ok: false, error: "no open window")
+        }
+        return resolver.resolvePlacementStore(window) { store in
+            guard let windowID = library.windowID(for: store) else {
+                return ControlResponse(ok: false, error: "no open window")
+            }
+            guard let controller = PickRegistry.shared.controller(for: windowID) else {
+                return ControlResponse(ok: false, error: "no pick surface")
+            }
+            return body(controller, windowID)
+        }
+    }
+
+    /// Make a followed picker window the logical frontmost target as well as raising its live NSWindow.
+    /// AppKit does not publish `didBecomeKey` while the app is inactive, so control-driven presentation
+    /// must mirror the `window.select` bookkeeping synchronously.
+    private func selectPickWindow(_ windowID: WindowInfo.ID) {
+        guard library.frontmostWindowID != windowID else { return }
+        library.frontmostWindowID = windowID
+        library.saveIndex()
+        if GhosttyApp.shared.autoHideSidebarInactiveWindows {
+            library.applyInactiveWindowSidebarHiding()
+        }
+    }
+}

--- a/agterm/Control/ControlServer+Pick.swift
+++ b/agterm/Control/ControlServer+Pick.swift
@@ -8,11 +8,10 @@ extension ControlServer {
             guard controller.open(pick) else {
                 return ControlResponse(ok: false, error: "pick already pending")
             }
-            PickRegistry.shared.clearRetainedResult(for: windowID)
 
             if follow {
                 WindowRegistry.shared.raise(windowID)
-                selectPickWindow(windowID)
+                takeFrontmost(windowID)
             }
             if library.activeWindowID == windowID {
                 actions.palette?.close()
@@ -92,18 +91,6 @@ extension ControlServer {
                 return ControlResponse(ok: false, error: "no pick surface")
             }
             return body(controller, windowID)
-        }
-    }
-
-    /// Make a followed picker window the logical frontmost target as well as raising its live NSWindow.
-    /// AppKit does not publish `didBecomeKey` while the app is inactive, so control-driven presentation
-    /// must mirror the `window.select` bookkeeping synchronously.
-    private func selectPickWindow(_ windowID: WindowInfo.ID) {
-        guard library.frontmostWindowID != windowID else { return }
-        library.frontmostWindowID = windowID
-        library.saveIndex()
-        if GhosttyApp.shared.autoHideSidebarInactiveWindows {
-            library.applyInactiveWindowSidebarHiding()
         }
     }
 }

--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -631,6 +631,11 @@ extension ControlServer: ControlActions {
             guard let controller = TerminalZoomRegistry.shared.controller(for: resolved.windowID) else {
                 return ControlResponse(ok: false, error: "window not open — window.select it first")
             }
+            let want = mode.desiredValue(current: controller.target == resolved.target)
+            if want, controller.target != resolved.target,
+               PickRegistry.shared.controller(for: resolved.windowID)?.pending != nil {
+                return ControlResponse(ok: false, error: "pick pending")
+            }
             // `hide` is idempotent like the active-target arm: skip the availability check for `.off` —
             // the surface may have vanished since (an overlay exited, auto-clearing the zoom) and the
             // desired end state already holds; `set(.off, …)` on a non-matching target is a no-op.
@@ -652,6 +657,10 @@ extension ControlServer: ControlActions {
         case .success(let (windowID, store)):
             guard let controller = TerminalZoomRegistry.shared.controller(for: windowID) else {
                 return ControlResponse(ok: false, error: "window not open — window.select it first")
+            }
+            if controller.target == nil, mode != .off,
+               PickRegistry.shared.controller(for: windowID)?.pending != nil {
+                return ControlResponse(ok: false, error: "pick pending")
             }
             // this arm only picks the effective target — the current zoom when one is up (so
             // on/off/toggle act on it), else the resolved active surface — and shapes the response;

--- a/agterm/Control/ControlServer+SurfaceIO.swift
+++ b/agterm/Control/ControlServer+SurfaceIO.swift
@@ -244,9 +244,13 @@ extension ControlServer {
             (session.searchSurface as? GhosttySurfaceView)?.endSearch()
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
         }
-        if let windowID = library.windowID(forSession: id),
-           TerminalZoomRegistry.shared.controller(for: windowID)?.target != nil {
-            return ControlResponse(ok: false, error: "terminal zoom active")
+        if let windowID = library.windowID(forSession: id) {
+            if PickRegistry.shared.controller(for: windowID)?.pending != nil {
+                return ControlResponse(ok: false, error: "pick pending")
+            }
+            if TerminalZoomRegistry.shared.controller(for: windowID)?.target != nil {
+                return ControlResponse(ok: false, error: "terminal zoom active")
+            }
         }
 
         // open/needle/navigate need the bar + highlights visible, so select the target (also realizes a

--- a/agterm/Control/ControlServer+WindowCommands.swift
+++ b/agterm/Control/ControlServer+WindowCommands.swift
@@ -215,18 +215,21 @@ extension ControlServer {
     }
 
     /// Make `id` the logical frontmost window, the way `WindowAccessor.reportFrontmost` does on the GUI
-    /// path: record it, persist the index, and reconcile the auto-hidden sidebars.
+    /// path: record it, persist the index, and reconcile the auto-hidden sidebars. Shared by every
+    /// control path that presents a window — `window.select`, the minimize hand-off, `pick.open --follow`.
     ///
     /// The control channel needs its own path because `reportFrontmost` fires on `didBecomeKey`, which
     /// AppKit does not deliver while the app is inactive — exactly when a script is driving. Without the
     /// reconcile the window that just became visible keeps its sidebar collapsed until the user next
     /// activates agterm. Idempotent, and the reconcile resolves through `activeWindowID`, which returns
-    /// the id assigned just above.
-    private func takeFrontmost(_ id: WindowInfo.ID) {
+    /// the id assigned just above. The auto-hide gate reads the setting itself rather than the
+    /// `GhosttyApp` mirror `WindowAccessor` uses — same value, and the control server already holds the
+    /// settings model, so this path stays reachable without booting libghostty.
+    func takeFrontmost(_ id: WindowInfo.ID) {
         guard library.frontmostWindowID != id else { return }
         library.frontmostWindowID = id
         library.saveIndex()
-        if GhosttyApp.shared.autoHideSidebarInactiveWindows { library.applyInactiveWindowSidebarHiding() }
+        if settingsModel.settings.autoHideSidebarInactiveWindows == true { library.applyInactiveWindowSidebarHiding() }
     }
 
     /// Resolve a window id and rename it (the name lives in the index). Requires a name. Returns the id.

--- a/agterm/Control/ControlServer+WindowCommands.swift
+++ b/agterm/Control/ControlServer+WindowCommands.swift
@@ -222,14 +222,12 @@ extension ControlServer {
     /// AppKit does not deliver while the app is inactive — exactly when a script is driving. Without the
     /// reconcile the window that just became visible keeps its sidebar collapsed until the user next
     /// activates agterm. Idempotent, and the reconcile resolves through `activeWindowID`, which returns
-    /// the id assigned just above. The auto-hide gate reads the setting itself rather than the
-    /// `GhosttyApp` mirror `WindowAccessor` uses — same value, and the control server already holds the
-    /// settings model, so this path stays reachable without booting libghostty.
+    /// the id assigned just above.
     func takeFrontmost(_ id: WindowInfo.ID) {
         guard library.frontmostWindowID != id else { return }
         library.frontmostWindowID = id
         library.saveIndex()
-        if settingsModel.settings.autoHideSidebarInactiveWindows == true { library.applyInactiveWindowSidebarHiding() }
+        if GhosttyApp.shared.autoHideSidebarInactiveWindows { library.applyInactiveWindowSidebarHiding() }
     }
 
     /// Resolve a window id and rename it (the name lives in the index). Requires a name. Returns the id.

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -547,6 +547,9 @@ final class ControlServer {
             scratchFontSize: { ($0.scratchSurface as? GhosttySurfaceView)?.currentFontSize() },
             quickVisible: { windowID.flatMap { QuickTerminalRegistry.shared.controller(for: $0)?.isVisible } ?? false },
             zoomedSurface: { windowID.flatMap { TerminalZoomRegistry.shared.controller(for: $0)?.target?.controlID } },
+            // Resolve through the projected window's registry entry on every tree build. This is deliberately
+            // tree-only: window.list is cache-backed, so mirroring a GUI-resolved pick there would go stale.
+            pickPending: { windowID.flatMap { PickRegistry.shared.controller(for: $0)?.pending?.id } },
             dashboardMembers: {
                 guard let dashboard, dashboard.isOpen else { return nil }
                 return dashboard.members.map(\.controlRef)

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -385,7 +385,8 @@ final class ControlServer {
                 .sessionOverlayResult, .sessionBackground, .sessionText, .quick, .quickType, .quickText,
                 .windowNew, .windowList, .windowSelect,
                 .windowClose, .windowRename, .windowDelete, .windowResize, .windowMove, .windowZoom,
-                .windowFullscreen, .windowMinimize, .restoreClear, .dashboard:
+                .windowFullscreen, .windowMinimize, .pickOpen, .pickResult, .pickCancel,
+                .restoreClear, .dashboard:
             return ControlResponse(ok: false, error: "control dispatcher did not handle \(request.cmd.rawValue)")
         case .debugAppearance:
             return setDebugAppearance(args: request.args)

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -468,6 +468,9 @@ final class ControlServer {
                 controller.close()
                 return ControlResponse(ok: true)
             }
+            if PickRegistry.shared.controller(for: windowID)?.pending != nil {
+                return ControlResponse(ok: false, error: "pick pending")
+            }
             var sessionIDs: [UUID] = []
             var unresolved: [String] = []
             if mru {

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -385,11 +385,13 @@ final class ControlServer {
                 .sessionOverlayResult, .sessionBackground, .sessionText, .quick, .quickType, .quickText,
                 .windowNew, .windowList, .windowSelect,
                 .windowClose, .windowRename, .windowDelete, .windowResize, .windowMove, .windowZoom,
-                .windowFullscreen, .windowMinimize, .pickOpen, .pickResult, .pickCancel,
+                .windowFullscreen, .windowMinimize,
                 .restoreClear, .dashboard:
             return ControlResponse(ok: false, error: "control dispatcher did not handle \(request.cmd.rawValue)")
         case .debugAppearance:
             return setDebugAppearance(args: request.args)
+        case .pickOpen, .pickResult, .pickCancel:
+            preconditionFailure("pick command returned nil from ControlDispatcher")
         }
     }
 

--- a/agterm/Ghostty/GhosttyApp.swift
+++ b/agterm/Ghostty/GhosttyApp.swift
@@ -124,19 +124,8 @@ final class GhosttyApp {
     let callbacks = GhosttyCallbacks()
     private var resourcesDir: String?
 
-    /// True in an application-hosted unit-test run. XCTest sets `XCTestConfigurationFilePath` in the host
-    /// process it injects the test bundle into; an XCUITest launches the app fresh WITHOUT it, so the
-    /// end-to-end suites still exercise the real libghostty app.
-    private static var isUnitTestHost: Bool {
-        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
-    }
-
     private init() {
         resolveResources()
-        // hosted unit tests exercise the mirrored settings and the AppKit chrome, never a terminal
-        // surface. Booting libghostty for them buys nothing and is not survivable on a CI runner, so the
-        // settings mirrors below stay usable while `app` remains nil.
-        guard !Self.isUnitTestHost else { return }
         guard ghostty_init(UInt(CommandLine.argc), CommandLine.unsafeArgv) == GHOSTTY_SUCCESS else {
             logger.error("ghostty_init failed")
             return

--- a/agterm/Ghostty/GhosttyApp.swift
+++ b/agterm/Ghostty/GhosttyApp.swift
@@ -124,8 +124,19 @@ final class GhosttyApp {
     let callbacks = GhosttyCallbacks()
     private var resourcesDir: String?
 
+    /// True in an application-hosted unit-test run. XCTest sets `XCTestConfigurationFilePath` in the host
+    /// process it injects the test bundle into; an XCUITest launches the app fresh WITHOUT it, so the
+    /// end-to-end suites still exercise the real libghostty app.
+    private static var isUnitTestHost: Bool {
+        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    }
+
     private init() {
         resolveResources()
+        // hosted unit tests exercise the mirrored settings and the AppKit chrome, never a terminal
+        // surface. Booting libghostty for them buys nothing and is not survivable on a CI runner, so the
+        // settings mirrors below stay usable while `app` remains nil.
+        guard !Self.isUnitTestHost else { return }
         guard ghostty_init(UInt(CommandLine.argc), CommandLine.unsafeArgv) == GHOSTTY_SUCCESS else {
             logger.error("ghostty_init failed")
             return

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -629,7 +629,8 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
 
     /// Starts the bounded auto-focus retry (overlay only), if not already done/in-flight.
     private func requestAutoFocus(in window: NSWindow?) {
-        guard autoFocus, deckActive, !didAutoFocus, !autoFocusInFlight, let window else { return }
+        guard autoFocus, deckActive, !didAutoFocus, !autoFocusInFlight, let window,
+              !Self.pickOwnsFocus(in: window) else { return }
         autoFocusInFlight = true
         restoreAutoFocus(in: window, attempt: 0)
     }
@@ -638,7 +639,10 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     /// actually holds first responder, then marks it focused. Bounded so it never spins forever; gives
     /// up if the view is torn down or moved windows. macterm's FocusRestoration pattern.
     private func restoreAutoFocus(in window: NSWindow, attempt: Int) {
-        guard autoFocus, deckActive, !didAutoFocus, !isDestroyed else { autoFocusInFlight = false; return }
+        guard autoFocus, deckActive, !didAutoFocus, !isDestroyed, !Self.pickOwnsFocus(in: window) else {
+            autoFocusInFlight = false
+            return
+        }
         if self.window === window, surface != nil {
             if window.firstResponder !== self { window.makeFirstResponder(self) }
             if window.firstResponder === self {
@@ -669,7 +673,10 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     }
 
     private func retryReparentFocus(attempt: Int, heldFor: Int) {
-        guard !isDestroyed else { reparentFocusInFlight = false; return }
+        guard !isDestroyed, !Self.pickOwnsFocus(in: window) else {
+            reparentFocusInFlight = false
+            return
+        }
         var holds = false
         if let window, surface != nil {
             if window.firstResponder !== self { window.makeFirstResponder(self) }
@@ -684,6 +691,14 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.autoFocusRetryInterval) { [weak self] in
             self?.retryReparentFocus(attempt: attempt + 1, heldFor: nextHeld)
         }
+    }
+
+    /// A picker is modal to terminal keyboard focus in its own window. This check deliberately lives inside
+    /// both retry loops (not just their callers): a picker can open after a retry starts, and the next tick
+    /// must stop before it steals first responder from the picker field.
+    static func pickOwnsFocus(in window: NSWindow?) -> Bool {
+        guard let window, let windowID = WindowRegistry.shared.windowID(for: window) else { return false }
+        return PickRegistry.shared.controller(for: windowID)?.pending != nil
     }
 
     func destroySurface() {

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -5,6 +5,7 @@ description: >
   control socket. Use when running inside an agterm session and asked to control the terminal:
   create, rename, close, select, or reorder sessions and workspaces; split panes; toggle the
   per-session scratch terminal; open or close overlay terminals and read their exit status; display
+  the native fuzzy picker with caller-supplied choices and poll or cancel it; display
   an image inline via a bundled helper script; type
   into a session, copy its selection, or search its scrollback; post desktop notifications; manage windows (new, list,
   select, close, resize, move); change font size; or reload and edit the keymap and the agterm-scoped
@@ -15,7 +16,7 @@ description: >
   feature request / question as a GitHub Discussion.
 when_to_use: >
   Trigger on: agterm, agtermctl, agterm control socket, session.new, session.close, session.type,
-  session.split, session.scratch, session.focus, session.resize, surface.zoom, dashboard, session.go, session.copy, session.paste, session.selectall, session.text, session.search, session.status,
+  session.split, session.scratch, session.focus, session.resize, surface.zoom, dashboard, pick, pick.open, pick.result, pick.cancel, native picker, session.go, session.copy, session.paste, session.selectall, session.text, session.search, session.status,
   session.flag, session.seen, session.reveal, session.duplicate, session.background, session.overlay, workspace.new, workspace.select, workspace.move, workspace.focus, workspace.filter, window.new, window.list,
   window.select, window.resize, window.move, window.zoom, window.fullscreen, window.minimize, quick terminal, sidebar, sidebar.mode, sidebar.expand, sidebar.collapse, flagged, notify, font.inc, keymap.reload, keymap.list, config.reload,
   theme.set, theme.list, events, events.read, event subscription, select theme, edit keymap, show an image, display an image inline, show-image,

--- a/agterm/Resources/agent-skill/SKILL.md
+++ b/agterm/Resources/agent-skill/SKILL.md
@@ -142,7 +142,7 @@ prompt concatenates with yours, and the program starts on the merged line. (`--n
 focus, but the newline and shared-buffer hazards of `type`-as-launcher remain — `--command` is still the
 rule.) After `--command`, confirm in `tree --json` that the new node's `foreground` shows your program running, not a bare shell prompt.
 
-## Command summary (68 commands)
+## Command summary (71 commands)
 
 Run `agtermctl <area> <cmd> --help` for exact flags. Full detail in **reference.md**; recipes in
 **examples.md**.
@@ -178,6 +178,8 @@ the open dashboard shows, in grid order — `<session-id>:left` for a primary pa
 a split pane, so a split session appears as both), `dashboardHighlighted` (the highlighted cell's pane ref —
 the one Enter jumps into, focusing that exact pane), `dashboardFontSize` (the absolute font size in points
 applied to the cells, omitted when untouched), and `dashboardFontMode` (`auto`|`fixed`|`untouched`).
+The top level also carries `pickPending`, the id of the native picker currently awaiting an answer in
+that window, omitted when no pick is pending.
 
 **events**: continuously print control events, subscribing from the current tail when no cursor is
 given. Use `--json` for one bare event object per line; filter with repeatable or comma-separated
@@ -337,6 +339,14 @@ means no input, not no process effect. The most-recently-used grid also has a GU
 `dashboard` built-in action), **Navigate ▸ Dashboard**, and the command palette's **Dashboard** entry
 TOGGLE the frontmost window's MRU dashboard auto-sized (identical to `dashboard --mru --auto-size`); no new
 control command, the socket `dashboard` command is unchanged.
+
+**pick**: `pick [--prompt TEXT] [--allow-custom] [--follow] [--window W] [--no-block]` reads choices
+from stdin and opens the target window's native fuzzy picker. Supply nonblank lines (each line is both
+the id and label) or a JSON array of `{id,label,subtitle?}` items. The default blocks until the user
+chooses or cancels and prints the bare JSON result. `--no-block` prints the picker id instead;
+`pick result ID [--window W]` reads it later, and `pick cancel ID [--window W]` cancels it.
+Only one picker may be pending per window. It opens without raising a background target unless
+`--follow` is set. Read the live picker id from the tree's top-level `pickPending` field.
 
 **quick** — `[show|hide|toggle]` (visibility; read back from the tree's `quickVisible`) ·
 `type TEXT` (or `--stdin`) inject keystrokes into the frontmost window's quick terminal ·

--- a/agterm/Resources/agent-skill/examples.md
+++ b/agterm/Resources/agent-skill/examples.md
@@ -654,6 +654,52 @@ dashboard and terminal zoom are mutually exclusive (opening one closes the other
 each pane's pty to/from its cell, so a running program may redraw — view-only means no input, not no
 process effect.
 
+## Ask the user to choose from a generated list
+
+Pipe nonblank labels into `pick`. The call blocks until the user chooses or cancels, then prints a bare
+JSON result:
+
+```bash
+choice=$(
+  printf '%s\n' staging production |
+    agtermctl pick --prompt "Deploy where?"
+)
+
+case $(jq -r '.result' <<<"$choice") in
+  picked) jq -r '.id' <<<"$choice" ;;
+  custom) jq -r '.query' <<<"$choice" ;;
+esac
+```
+
+Use a JSON array when ids differ from labels or rows need subtitles. `--allow-custom` adds the current
+nonmatching query as a choice:
+
+```bash
+jq -n '[
+  {id: "stg", label: "Staging", subtitle: "staging.example.com"},
+  {id: "prod", label: "Production", subtitle: "production.example.com"}
+]' | agtermctl pick --prompt "Deploy target" --allow-custom
+```
+
+Open without blocking when another process owns the lifecycle. The picker id reads back from the target
+window's tree as `pickPending`; poll the same window, or cancel by exact id:
+
+```bash
+pick_id=$(
+  printf '%s\n' alpha beta gamma |
+    agtermctl pick --no-block --window "$AGTERM_WINDOW_ID" |
+    jq -r '.id'
+)
+
+agtermctl tree --json --window "$AGTERM_WINDOW_ID" |
+  jq -r '.result.tree.pickPending // empty'
+agtermctl pick result "$pick_id" --window "$AGTERM_WINDOW_ID"
+agtermctl pick cancel "$pick_id" --window "$AGTERM_WINDOW_ID"
+```
+
+Add `--follow` to raise a background target window when the picker opens. Without it, the picker waits in
+that window without stealing focus.
+
 ## Navigate and manage windows
 
 ```bash

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -81,7 +81,7 @@ SIGTERM use normal process behavior.
   `text`, `background`, `status`, `copy`, …) that must act on the session you run in — otherwise it hits
   whatever the user has selected. `overlay open` opens in the background without switching the user
   (both full and floating); pass `--follow` to additionally SELECT the target, switching the user to it.
-- `--window <id|prefix|active>` (on session/workspace/tree/font/notify commands) picks which window's
+- `--window <id|prefix|active>` (on session/workspace/tree/font/notify/pick commands) picks which window's
   tree to act on; default is the frontmost. With `--window` set, that window must be open. Without it,
   an id/prefix session target is matched across all open windows.
 - `window.*` commands take the window selector as a positional argument, default `active` (frontmost).
@@ -149,7 +149,7 @@ members), and `collapsed` (whether this workspace is COLLAPSED in the sidebar tr
 `workspace collapse`/`workspace expand` and `workspace new --collapsed`; `true` when collapsed, omitted
 when expanded, so an all-expanded tree carries no `collapsed` keys).
 
-The tree object itself carries eleven top-level read-only fields: `idleMs` (milliseconds since the last
+The tree object itself carries twelve top-level read-only fields: `idleMs` (milliseconds since the last
 user input in the window, omitted before any activity), `autoFollowMs` (the window's Auto-follow
 timeout in milliseconds, omitted when the setting is Disabled), `sidebarVisible` (whether the
 window's sidebar is currently shown — the read side of the write-only `sidebar` command, so a script
@@ -169,11 +169,13 @@ no dashboard is open): `dashboardMembers` (the pane refs the open dashboard show
 as both), `dashboardHighlighted` (the highlighted cell's pane ref — the one Enter jumps into, focusing
 that exact pane), `dashboardFontSize` (the absolute font size in points applied to the cells, omitted when
 the mode is `untouched`), and `dashboardFontMode` (`auto` for `--auto-size`, `fixed` for `--font-size`, or
-`untouched`). `idleMs` is live
+`untouched`), plus `pickPending` (the id of the native picker currently awaiting an answer in this
+window, omitted when none is pending). `idleMs` is live
 and grows while the window is idle, so it is on `tree` only, never `window.list`; `sidebarVisible` is on
-both; `sidebarMode`, `workspaceFilter`, `quickVisible`, `zoomedSurface`, and the four `dashboard*` fields
+both; `sidebarMode`, `workspaceFilter`, `quickVisible`, `zoomedSurface`, the four `dashboard*` fields, and
+`pickPending`
 are `tree`-only (a GUI/keyboard change would leave a cached copy stale).
-All eleven are read-only projections of GUI state.
+All twelve are read-only projections of GUI state.
 
 ## workspace
 
@@ -645,6 +647,45 @@ untouched.
 Invalid invocations error (rejected at the CLI and re-checked server-side): `--font-size` with
 `--auto-size`, a non-positive `--font-size`, `--close` combined with ids, `--mru`, or a font option,
 `--mru` combined with explicit ids, and an open with neither ids nor `--mru`.
+
+## pick
+
+`agtermctl pick [--prompt TEXT] [--allow-custom] [--follow] [--window W] [--no-block]` reads choices
+from stdin and opens a native fuzzy picker in the target window. `pick` defaults to the open subcommand,
+so `agtermctl pick open` is not required.
+
+The first non-whitespace input byte selects the format. `[` starts a JSON array of objects with required
+`id` and `label` strings plus an optional `subtitle`; any other input is split into lines, blank and
+whitespace-only lines are dropped, and each remaining line becomes both the id and label. Item ids must
+be unique, labels must not be empty, labels and subtitles may not contain control characters, and a
+picker accepts at most 1,000 items. An empty list is rejected.
+
+`--prompt` adds text above the query field. `--allow-custom` adds a row for a nonmatching query and
+returns it as a custom result. A background `--window` target is not raised by default; `--follow`
+raises it. Only one picker can be pending in a window, and a second open fails with
+`pick already pending`.
+
+The default call polls until the user answers and prints one bare JSON result:
+
+```json
+{"result":"picked","id":"production","label":"Production","index":1}
+{"result":"custom","query":"new target"}
+{"result":"cancelled"}
+```
+
+Picked and custom results exit 0. Cancellation exits 2. Protocol, validation, transport, and server
+failures exit 1. The blocking client polls every 100 ms for the first second, then every 500 ms.
+
+`--no-block` returns immediately with `{"id":"<pick-id>"}`. Use
+`agtermctl pick result <pick-id> [--window W]` for a one-shot read; it prints the same bare result JSON,
+including `{"result":"pending"}`, and exits 1 while pending. Use
+`agtermctl pick cancel <pick-id> [--window W]` to cancel it. Result and cancel require the exact picker
+id, and a wrong id returns `unknown pick: <id>`.
+
+Read the live picker id from the tree's top-level `pickPending` field. It is omitted after selection,
+custom input, cancellation, or window closure. Closing the picker, closing its window, ⌘W, and app
+termination resolve it as cancelled so a blocking caller can finish. A terminal result remains readable
+until the next picker opens in that window.
 
 ## quick
 

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -660,7 +660,7 @@ whitespace-only lines are dropped, and each remaining line becomes both the id a
 be unique, labels must not be empty, labels and subtitles may not contain control characters, and a
 picker accepts at most 1,000 items. An empty list is rejected.
 
-`--prompt` adds text above the query field. `--allow-custom` adds a row for a nonmatching query and
+`--prompt` sets the query field's placeholder text. `--allow-custom` adds a row for a nonmatching query and
 returns it as a custom result. A background `--window` target is not raised by default; `--follow`
 raises it. Only one picker can be pending in a window, and a second open fails with
 `pick already pending`.
@@ -680,12 +680,16 @@ failures exit 1. The blocking client polls every 100 ms for the first second, th
 `agtermctl pick result <pick-id> [--window W]` for a one-shot read; it prints the same bare result JSON,
 including `{"result":"pending"}`, and exits 1 while pending. Use
 `agtermctl pick cancel <pick-id> [--window W]` to cancel it. Result and cancel require the exact picker
-id, and a wrong id returns `unknown pick: <id>`.
+id. Without `--window`, the globally unique id keeps result/cancel pinned to its owning window even if
+the frontmost window changes. With `--window`, a live or close-retained result must belong to that
+window. A wrong id returns `unknown pick: <id>`.
 
 Read the live picker id from the tree's top-level `pickPending` field. It is omitted after selection,
-custom input, cancellation, or window closure. Closing the picker, closing its window, ⌘W, and app
-termination resolve it as cancelled so a blocking caller can finish. A terminal result remains readable
-until the next picker opens in that window.
+custom input, cancellation, or window closure. Closing the picker, closing its window, and ⌘W resolve it
+as cancelled. App termination cancels in-memory picker state before stopping the socket, but a client
+whose next poll races process shutdown may observe a transport failure instead of the final cancellation.
+A close-retained terminal result remains readable until the next picker opens in that window, including
+after permanent window deletion.
 
 ## quick
 

--- a/agterm/Resources/agent-skill/reference.md
+++ b/agterm/Resources/agent-skill/reference.md
@@ -688,8 +688,9 @@ Read the live picker id from the tree's top-level `pickPending` field. It is omi
 custom input, cancellation, or window closure. Closing the picker, closing its window, and ⌘W resolve it
 as cancelled. App termination cancels in-memory picker state before stopping the socket, but a client
 whose next poll races process shutdown may observe a transport failure instead of the final cancellation.
-A close-retained terminal result remains readable until the next picker opens in that window, including
-after permanent window deletion.
+A terminal result stays readable by its own id after the next picker opens in that window, and after the
+window closes — including permanent window deletion — so a blocking caller always reads back the answer
+it waited for. Results age out oldest-first: the 8 most recent per open window, and 32 across closed ones.
 
 ## quick
 

--- a/agterm/Views/DashboardView.swift
+++ b/agterm/Views/DashboardView.swift
@@ -36,6 +36,8 @@ struct DashboardView: View {
     /// The IDLE caption pill's TEXT — the theme's selection-foreground, readable over `pillColor`. A non-idle
     /// pill uses a luminance-contrasting black/white instead.
     let pillTextColor: Color
+    /// False while a control picker is above the dashboard, so its key catcher cannot steal focus.
+    let focusAllowed: Bool
     /// A single mouse click on a cell: the wiring flashes the active frame on it, then enters it after a brief
     /// delay, so the click is visibly acknowledged before the grid closes.
     let onClick: (DashboardMember) -> Void
@@ -84,7 +86,13 @@ struct DashboardView: View {
         .overlay(alignment: .top) { Rectangle().fill(highlightColor.opacity(0.1)).frame(height: 1) }
         // the key-catcher sits behind the cells so it never intercepts their click hit targets; it owns
         // first responder and swallows every key while open.
-        .background { DashboardKeyCatcher(onKey: handleKey) }
+        .background {
+            DashboardKeyCatcher(
+                focusRevision: controller.focusRevision,
+                focusAllowed: focusAllowed,
+                onKey: handleKey
+            )
+        }
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("dashboard")
         // no implicit animation on the grid geometry / highlight — a modal reparent overlay applies its
@@ -320,22 +328,28 @@ private enum DashboardKey {
 /// key-equivalents (⌘Q, ⌘W, …) still reach the menu bar — those go through `performKeyEquivalent` before
 /// keyDown, so the user is never trapped; only plain keystrokes to the terminal are blocked.
 private struct DashboardKeyCatcher: NSViewRepresentable {
+    let focusRevision: Int
+    let focusAllowed: Bool
     let onKey: (DashboardKey) -> Void
 
     func makeNSView(context _: Context) -> KeyCatcherView {
         let view = KeyCatcherView()
+        view.focusAllowed = focusAllowed
         view.onKey = onKey
         return view
     }
 
     func updateNSView(_ nsView: KeyCatcherView, context _: Context) {
+        _ = focusRevision
+        nsView.focusAllowed = focusAllowed
         nsView.onKey = onKey
         // re-assert first responder on every render so a cell click (or any focus reshuffle) can't leave the
         // overlay without the keyboard while it is open.
-        nsView.grabFocus()
+        if focusAllowed { nsView.grabFocus() }
     }
 
     final class KeyCatcherView: NSView {
+        var focusAllowed = true
         var onKey: ((DashboardKey) -> Void)?
 
         override var acceptsFirstResponder: Bool { true }
@@ -347,7 +361,7 @@ private struct DashboardKeyCatcher: NSViewRepresentable {
 
         /// Take first responder unless we already hold it (a redundant `makeFirstResponder` would churn).
         func grabFocus() {
-            guard let window, window.firstResponder !== self else { return }
+            guard focusAllowed, let window, window.firstResponder !== self else { return }
             window.makeFirstResponder(self)
         }
 

--- a/agterm/Views/Palette.swift
+++ b/agterm/Views/Palette.swift
@@ -183,6 +183,8 @@ struct CommandPalette: View {
                 Color.black.opacity(0.2)
                     .contentShape(Rectangle())
                     .onTapGesture { dismiss() }
+                    .accessibilityElement()
+                    .accessibilityIdentifier(explicitItems == nil ? "palette-scrim" : "pick-scrim")
                 panel
                     .frame(width: 520)
                     .padding(.top, geo.size.height * 0.12)
@@ -217,7 +219,7 @@ struct CommandPalette: View {
         .onAppear {
             fieldFocused = true
             updateFiltered()
-            syncThemeSession()
+            if explicitItems == nil { syncThemeSession() }
             // a palette opened from a title-bar button (the attention bell) mounts while that button
             // still holds first responder, so the synchronous focus above loses the race and the field
             // never takes the keyboard. re-assert on the next runloop tick — after the click settles —
@@ -225,8 +227,15 @@ struct CommandPalette: View {
             // this is a no-op (see swiftui focus-pattern: onAppear focus may need a main-async kick).
             DispatchQueue.main.async { fieldFocused = true }
         }
-        .onChange(of: controller.mode) { selection = 0; updateFiltered(); syncThemeSession() }
-        .onDisappear { actions.cancelThemePreview() }
+        .onChange(of: controller.mode) {
+            guard explicitItems == nil else { return }
+            selection = 0
+            updateFiltered()
+            syncThemeSession()
+        }
+        .onDisappear {
+            if explicitItems == nil { actions.cancelThemePreview() }
+        }
     }
 
     private var results: some View {

--- a/agterm/Views/Palette.swift
+++ b/agterm/Views/Palette.swift
@@ -83,6 +83,14 @@ final class PaletteController {
 struct CommandPalette: View {
     let controller: PaletteController
     let actions: AppActions
+    /// Caller-provided rows for a control-API pick. A non-nil array replaces the built-in mode's
+    /// catalog, including when the array is empty.
+    let explicitItems: [PaletteItem]?
+    /// Search-field prompt for an explicit picker; nil uses the neutral picker default.
+    let prompt: String?
+    /// Whether an unmatched, non-empty explicit-picker query can be submitted as free text.
+    let allowCustom: Bool
+    let onCustom: ((String) -> Void)?
 
     @State private var query = ""
     @State private var selection = 0
@@ -92,7 +100,18 @@ struct CommandPalette: View {
     @State private var filtered: [PaletteItem] = []
     @FocusState private var fieldFocused: Bool
 
+    init(controller: PaletteController, actions: AppActions, items: [PaletteItem]? = nil,
+         prompt: String? = nil, allowCustom: Bool = false, onCustom: ((String) -> Void)? = nil) {
+        self.controller = controller
+        self.actions = actions
+        self.explicitItems = items
+        self.prompt = prompt
+        self.allowCustom = allowCustom
+        self.onCustom = onCustom
+    }
+
     private var allItems: [PaletteItem] {
+        if let explicitItems { return explicitItems }
         switch controller.mode {
         case .actions: return actions.paletteActions()
         case .sessions: return actions.paletteSessions()
@@ -113,7 +132,7 @@ struct CommandPalette: View {
         // to the alphabetical tie-break below — every row scores 0 for an empty query, so that tie-break
         // would re-sort them A→Z and Return would jump to the alphabetically-first session, not the blocked
         // one. fuzzy filtering still applies once the user types.
-        if controller.mode == .attention, q.isEmpty {
+        if explicitItems == nil, controller.mode == .attention, q.isEmpty {
             filtered = allItems
             selection = filtered.isEmpty ? 0 : min(selection, filtered.count - 1)
             return
@@ -121,10 +140,16 @@ struct CommandPalette: View {
         filtered = fuzzyRank(query: q, items: allItems) { item in
             item.subtitle.map { [item.title, $0] } ?? [item.title]
         }
+        if explicitItems != nil,
+           let label = pickCustomRowLabel(query: q, filteredCount: filtered.count, allowCustom: allowCustom) {
+            let value = q
+            filtered = [PaletteItem(id: "pick-custom", title: label) { onCustom?(value) }]
+        }
         selection = filtered.isEmpty ? 0 : min(selection, filtered.count - 1)
     }
 
     private var placeholder: String {
+        if explicitItems != nil { return prompt ?? "Select…" }
         switch controller.mode {
         case .sessions: return "Go to session…"
         case .themes: return "Select a theme…"
@@ -139,7 +164,10 @@ struct CommandPalette: View {
     /// the current theme's row; leaving it (to another mode or closed) reverts any uncommitted preview.
     /// Idempotent — `AppActions` guards begin/cancel on its active flag.
     private func syncThemeSession() {
-        guard controller.mode == .themes else { actions.cancelThemePreview(); return }
+        guard explicitItems == nil, controller.mode == .themes else {
+            actions.cancelThemePreview()
+            return
+        }
         actions.beginThemePreview()
         if let index = filtered.firstIndex(where: { $0.id == actions.currentThemeID }) { selection = index }
     }
@@ -180,7 +208,7 @@ struct CommandPalette: View {
         .background { PalettePanelBackground() }
         .overlay(RoundedRectangle(cornerRadius: 12).strokeBorder(.white.opacity(0.1)))
         .shadow(radius: 24)
-        .accessibilityIdentifier("command-palette")
+        .accessibilityIdentifier(explicitItems == nil ? "command-palette" : "pick-palette")
         .onAppear {
             fieldFocused = true
             updateFiltered()
@@ -304,5 +332,6 @@ private struct PaletteRow: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(isSelected ? Color.accentColor.opacity(0.25) : Color.clear)
         .contentShape(Rectangle())
+        .accessibilityIdentifier("palette-item-\(item.id)")
     }
 }

--- a/agterm/Views/Palette.swift
+++ b/agterm/Views/Palette.swift
@@ -91,6 +91,9 @@ struct CommandPalette: View {
     /// Whether an unmatched, non-empty explicit-picker query can be submitted as free text.
     let allowCustom: Bool
     let onCustom: ((String) -> Void)?
+    /// Called when an explicit picker is dismissed or completes. Built-in palettes leave this nil and
+    /// continue to close through `PaletteController`; a pick uses it to resolve cancellation.
+    let onDismiss: (() -> Void)?
 
     @State private var query = ""
     @State private var selection = 0
@@ -101,13 +104,15 @@ struct CommandPalette: View {
     @FocusState private var fieldFocused: Bool
 
     init(controller: PaletteController, actions: AppActions, items: [PaletteItem]? = nil,
-         prompt: String? = nil, allowCustom: Bool = false, onCustom: ((String) -> Void)? = nil) {
+         prompt: String? = nil, allowCustom: Bool = false, onCustom: ((String) -> Void)? = nil,
+         onDismiss: (() -> Void)? = nil) {
         self.controller = controller
         self.actions = actions
         self.explicitItems = items
         self.prompt = prompt
         self.allowCustom = allowCustom
         self.onCustom = onCustom
+        self.onDismiss = onDismiss
     }
 
     private var allItems: [PaletteItem] {
@@ -177,7 +182,7 @@ struct CommandPalette: View {
             ZStack(alignment: .top) {
                 Color.black.opacity(0.2)
                     .contentShape(Rectangle())
-                    .onTapGesture { controller.close() }
+                    .onTapGesture { dismiss() }
                 panel
                     .frame(width: 520)
                     .padding(.top, geo.size.height * 0.12)
@@ -197,7 +202,7 @@ struct CommandPalette: View {
                     .onChange(of: query) { selection = 0; updateFiltered(); previewSelected() }
                     .onKeyPress(.downArrow) { move(1); return .handled }
                     .onKeyPress(.upArrow) { move(-1); return .handled }
-                    .onKeyPress(.escape) { controller.close(); return .handled }
+                    .onKeyPress(.escape) { dismiss(); return .handled }
             }
             .padding(12)
             Divider()
@@ -270,7 +275,12 @@ struct CommandPalette: View {
 
     private func runItem(_ item: PaletteItem) {
         item.run()
-        controller.close()
+        dismiss()
+    }
+
+    private func dismiss() {
+        if explicitItems == nil { controller.close() }
+        onDismiss?()
     }
 }
 

--- a/agterm/Views/QuickTerminal.swift
+++ b/agterm/Views/QuickTerminal.swift
@@ -38,6 +38,10 @@ final class QuickTerminalController {
     /// factories), which `destroySurface` nils on teardown.
     @ObservationIgnored var onUserInput: (() -> Void)?
 
+    /// Whether this cover may claim keyboard focus. The owning window disables it while a control picker
+    /// is above the quick terminal, stopping an in-flight show retry from stealing the picker's field.
+    @ObservationIgnored var focusAllowed: () -> Bool = { true }
+
     /// Toolbar-button action: show if hidden, hide if visible.
     func toggle() { isVisible.toggle() }
 
@@ -63,6 +67,7 @@ final class QuickTerminalController {
     /// Re-assert first responder on the surface for a short window so focus lands once the
     /// overlay is on-window (a one-shot would race the overlay's layout).
     func focus(attempt: Int = 0) {
+        guard focusAllowed() else { return }
         if let surfaceView, let window = surfaceView.window {
             window.makeFirstResponder(surfaceView)
         }

--- a/agterm/Views/WindowAccessor.swift
+++ b/agterm/Views/WindowAccessor.swift
@@ -151,6 +151,10 @@ struct WindowAccessor: NSViewRepresentable {
                         UserDefaults.standard.set(NSStringFromRect(window.frame), forKey: TitleProbeView.frameKey(windowID))
                     }
                     WindowRegistry.shared.unregister(windowID)
+                    // Unregister synchronously on the real AppKit close edge. The registry cancels any
+                    // pending pick and retains its result for a poll that arrives after this window and
+                    // its store have disappeared.
+                    PickRegistry.shared.unregister(windowID)
                     store.finalizeAllPendingCloses()
                     // flush cwd drift since the last structural mutation before dropping the store —
                     // AppStore doesn't save on a live `cd`, so a closed-then-reopened window would

--- a/agterm/Views/WindowContentView+Dashboard.swift
+++ b/agterm/Views/WindowContentView+Dashboard.swift
@@ -122,6 +122,7 @@ extension WindowContentView {
                 captionBackground: terminalColor,
                 pillColor: dashboardPillColor,
                 pillTextColor: dashboardPillTextColor,
+                focusAllowed: pick.pending == nil,
                 onClick: { clickDashboardMember($0) },
                 onSelect: { selectDashboardMember($0) },
                 onClose: { closeDashboardFromKeyboard() }

--- a/agterm/Views/WindowContentView+RecentSessions.swift
+++ b/agterm/Views/WindowContentView+RecentSessions.swift
@@ -22,8 +22,9 @@ extension WindowContentView {
     /// to switch to (only the current session). Opening a popover is interactive-only, so it's control-API
     /// keep-in-sync exempt (like the bell opening the attention palette).
     var recentSessionsButton: some View {
-        let enabled = !recentSessions.isEmpty
+        let enabled = !recentSessions.isEmpty && pick.pending == nil
         return Button {
+            guard pick.pending == nil else { return }
             recentSessionsShown.toggle()
         } label: {
             Label("Recent sessions", systemImage: "clock.arrow.circlepath")
@@ -100,6 +101,7 @@ extension WindowContentView {
     /// Commit a popover row click: note activity (so auto-follow can't pull the selection back), select the
     /// session, focus it, and close the popover — the mouse twin of the Ctrl-Tab release commit.
     private func selectRecent(_ id: UUID) {
+        guard pick.pending == nil else { return }
         store.noteUserActivity()
         store.selectSession(id)
         actions.focusActiveSession()
@@ -118,14 +120,16 @@ extension WindowContentView {
         let sessions = store.attentionSessions
         let blocked = sessions.contains { $0.agentIndicator.status == .blocked }
         let empty = sessions.isEmpty
+        let enabled = !empty && pick.pending == nil
         return Button {
+            guard pick.pending == nil else { return }
             attentionPopoverShown.toggle()
         } label: {
             Label("Attention", systemImage: blocked ? "bell.fill" : "bell")
         }
         .foregroundStyle(blocked ? Color(nsColor: GhosttyApp.shared.blockedStatusColor) : chromeText)
-        .opacity(empty ? 0.35 : 1)
-        .disabled(empty)
+        .opacity(enabled ? 1 : 0.35)
+        .disabled(!enabled)
         .help(helpHint(empty ? "No sessions need attention" : "Show sessions that need attention", .showAttention))
         .accessibilityIdentifier("attention-button")
         .accessibilityValue(empty ? "none" : (blocked ? "blocked" : "attention"))
@@ -172,6 +176,7 @@ extension WindowContentView {
     /// Commit an attention popover row click: select the session and reveal its blocked pane (the pane that
     /// set the status), then close the popover — the mouse twin of the ⌃⇧I palette's select-and-reveal.
     private func selectAttention(_ id: UUID) {
+        guard pick.pending == nil else { return }
         store.noteUserActivity()
         let indicator = store.selectSession(id)
         actions.revealActiveBlockedPane(captured: indicator)

--- a/agterm/Views/WindowContentView+Titlebar.swift
+++ b/agterm/Views/WindowContentView+Titlebar.swift
@@ -235,11 +235,12 @@ extension WindowContentView {
     /// Click the button again or the surrounding margin to hide; the shell stays alive until quit.
     private var quickTerminalButton: some View {
         Button {
-            quickTerminal.toggle()
+            actions.toggleQuickTerminal()
         } label: {
             Label("Quick Terminal", systemImage: "terminal")
         }
         .help(helpHint("Quick Terminal", .quickTerminal))
+        .disabled(pick.pending != nil)
         .accessibilityIdentifier("quick-terminal-toggle")
     }
 }

--- a/agterm/Views/WindowContentView+Zoom.swift
+++ b/agterm/Views/WindowContentView+Zoom.swift
@@ -3,6 +3,30 @@ import AppKit
 import SwiftUI
 
 extension WindowContentView {
+    /// Restore keyboard ownership to whichever full-window cover was already present below a picker.
+    /// The ordinary session focus helper intentionally refuses to cross these modal layers.
+    func restoreFocusAfterPick() {
+        if dashboard.isOpen {
+            dashboard.requestFocus()
+            return
+        }
+        if let target = terminalZoom.target {
+            switch target {
+            case .quick:
+                quickTerminal.focus()
+            case let .session(sessionID, surface):
+                guard let session = store.session(withID: sessionID) else { return }
+                focusZoomedSessionSurface(session: session, surface: surface)
+            }
+            return
+        }
+        if quickTerminal.isVisible {
+            quickTerminal.focus()
+            return
+        }
+        actions.focusActiveSession()
+    }
+
     /// The chrome above the zoomed terminal: the exit-zoom row, or — in hidden toolbar mode — the same
     /// invisible ~3px drag strip `customTitlebar` degrades to (no row; zoom exit stays on the keybinding
     /// and the control command), so hidden mode keeps its full-bleed terminal while zoomed.
@@ -168,6 +192,7 @@ extension WindowContentView {
     /// layer's `TerminalView` hasn't realized yet (e.g. zooming a scratch that was never shown); it
     /// dies as soon as the zoom target changes.
     func focusZoomedSessionSurface(session: Session, surface: TerminalZoomSurface, attempt: Int = 0) {
+        guard pick.pending == nil else { return }
         let expectedTarget = TerminalZoomTarget.session(session.id, surface)
         guard terminalZoom.target == expectedTarget else { return }
         let target: (any TerminalSurface)? = switch surface {

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -812,7 +812,9 @@ struct WindowContentView: View {
 
     /// A control picker is per-window rather than frontmost-global, so a caller may present one in a
     /// background window without duplicating it elsewhere. Selection preserves the caller's original
-    /// item index even though fuzzy filtering reorders the visible rows.
+    /// item index even though fuzzy filtering reorders the visible rows. Keyed by the pending id so one
+    /// picker replacing another in the same view update gets fresh palette state rather than keeping the
+    /// previous picker's rows, whose select closures capture the previous picker's items.
     @ViewBuilder private var pickPaletteOverlay: some View {
         if let pending = pick.pending {
             CommandPalette(
@@ -835,6 +837,7 @@ struct WindowContentView: View {
                 },
                 onDismiss: { pick.cancel() }
             )
+            .id(pending.id)
         }
     }
 

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -2,6 +2,24 @@ import agtermCore
 import AppKit
 import SwiftUI
 
+/// Window-local handoff between picker dismissal and the owning window becoming frontmost.
+/// A background window must not claim first responder, but its removed picker field cannot remain
+/// the responder when that window is activated later.
+struct PickFocusRestorationState {
+    private(set) var isDeferred = false
+
+    mutating func pickerResolved(isFrontmost: Bool) -> Bool {
+        isDeferred = !isFrontmost
+        return isFrontmost
+    }
+
+    mutating func windowBecameFrontmost(pickPending: Bool) -> Bool {
+        guard isDeferred, !pickPending else { return false }
+        isDeferred = false
+        return true
+    }
+}
+
 /// The actual per-window UI: the workspace/session sidebar + the active session's terminal, plus
 /// the quick-terminal / palette / switcher overlays. Holds the resolved non-optional `AppStore` so
 /// the binding-based wiring is unchanged from the single-window version; `ContentView` resolves the
@@ -32,6 +50,12 @@ struct WindowContentView: View {
     /// Per-window native picker presented through the shared palette view. Registered for control-socket
     /// lookup while this window is mounted; unlike `palette`, its pending state is window-scoped.
     @State var pick = PickController()
+    /// Tracks this view's balanced auto-follow suppression so window teardown can release it even when
+    /// SwiftUI removes the observer before the pick controller publishes its cancellation.
+    @State private var pickSuppressesAutoFollow = false
+    /// Defers picker focus restoration when a control request resolves in a background window. The
+    /// always-mounted frontmost observer consumes it without activating or ordering that window.
+    @State private var pickFocusRestoration = PickFocusRestorationState()
     /// The terminal background color, mirrored from the (non-observable) `GhosttyApp` into view
     /// state and used as the quick terminal's opaque backing, so a settings theme change (posting
     /// `.agtermAppearanceChanged`) re-renders it live.
@@ -86,10 +110,7 @@ struct WindowContentView: View {
             // the deck stays inset below the titlebar. While zoomed, keep that eager deck mounted so
             // background sessions and control-opened overlays still realize their terminal surfaces and run;
             // the zoom layer owns the visible window.
-            splitRoot
-                .padding(.top, titlebarHeight)
-                .opacity(terminalZoom.target == nil ? 1 : 0)
-                .allowsHitTesting(terminalZoom.target == nil)
+            alwaysMountedSplitLayer
             if let zoomTarget = terminalZoom.target {
                 terminalZoomLayer(zoomTarget)
                     .zIndex(10)
@@ -116,6 +137,11 @@ struct WindowContentView: View {
                         .zIndex(2)
                 }
             }
+            // A control picker is the window's topmost modal. It must stay visible and interactive even
+            // when terminal zoom or the dashboard was already active when the request arrived.
+            pickPaletteOverlay
+                .padding(.top, titlebarHeight)
+                .zIndex(20)
         }
         // with the title bar hidden (.hiddenTitleBar), pull our header to the very top so the traffic
         // lights overlay it as one row; no system title bar is left to clip the content.
@@ -166,6 +192,24 @@ struct WindowContentView: View {
                 store.suppressAutoFollow()
             }
         }
+        // A native picker owns keyboard focus just like a built-in palette. Pair auto-follow suppression
+        // per window, then return first responder to this window's terminal after every resolution path.
+        .onChange(of: pick.pending?.id) { old, new in
+            if old == nil, new != nil, !pickSuppressesAutoFollow {
+                // A socket-driven picker may arrive while either title-bar popover is already open.
+                // Dismiss both immediately so no second interactive surface remains above the modal picker.
+                recentSessionsShown = false
+                attentionPopoverShown = false
+                store.suppressAutoFollow()
+                pickSuppressesAutoFollow = true
+            } else if old != nil, new == nil, pickSuppressesAutoFollow {
+                store.resumeAutoFollow()
+                pickSuppressesAutoFollow = false
+                if pickFocusRestoration.pickerResolved(isFrontmost: isFrontmost) {
+                    restoreFocusAfterPick()
+                }
+            }
+        }
         // a settings appearance change isn't observable through GhosttyApp, so re-render on the
         // notification to pick up the new terminal color in the quick terminal backing.
         .onReceive(NotificationCenter.default.publisher(for: .agtermAppearanceChanged)) { _ in
@@ -192,6 +236,7 @@ struct WindowContentView: View {
             // typing in the quick terminal counts as activity, so an idle auto-follow fire can't change this
             // window's selected session behind the overlay while the user types (mirrors the overlay/scratch).
             quickTerminal.onUserInput = { [store] in store.noteUserActivity() }
+            quickTerminal.focusAllowed = { [pick] in pick.pending == nil }
             QuickTerminalRegistry.shared.register(windowID, controller: quickTerminal)
             terminalZoom.targetResolver = { [store, quickTerminal] in
                 TerminalZoomController.resolveTarget(store: store, quickTerminalVisible: quickTerminal.isVisible)
@@ -204,6 +249,10 @@ struct WindowContentView: View {
             QuickTerminalRegistry.shared.unregister(windowID)
             TerminalZoomRegistry.shared.unregister(windowID)
             tearDownDashboard()
+            if pickSuppressesAutoFollow {
+                store.resumeAutoFollow()
+                pickSuppressesAutoFollow = false
+            }
             PickRegistry.shared.unregister(windowID)
         }
     }
@@ -256,6 +305,23 @@ struct WindowContentView: View {
         // the mode switch below is safe to animate — it swaps sidebar CONTENT, not the split width, so
         // the detail column (and the deck) never resize.
         .animation(.easeInOut(duration: 0.15), value: store.sidebarMode)
+    }
+
+    /// The eager split/deck remains mounted behind every modal presentation, including terminal zoom.
+    /// Keep frontmost-driven cleanup here rather than on `windowOverlayLayer`, which is absent while
+    /// zoomed: otherwise a palette owned by the old front window can survive the handoff and remount
+    /// after the picker and zoom both close.
+    private var alwaysMountedSplitLayer: some View {
+        splitRoot
+            .padding(.top, titlebarHeight)
+            .opacity(terminalZoom.target == nil ? 1 : 0)
+            .allowsHitTesting(terminalZoom.target == nil)
+            .onChange(of: isFrontmost) { _, frontmost in
+                if frontmost, pick.pending != nil { palette.close() }
+                if frontmost, pickFocusRestoration.windowBecameFrontmost(pickPending: pick.pending != nil) {
+                    restoreFocusAfterPick()
+                }
+            }
     }
 
     private var sidebarColumn: some View {
@@ -691,7 +757,6 @@ struct WindowContentView: View {
         ZStack {
             quickTerminalOverlay
             commandPaletteOverlay
-            pickPaletteOverlay
             sessionSwitcherOverlay
             // the dashboard is the topmost window overlay: opening it closes the three above (mirrors the
             // zoom lifecycle), so ordering only settles the empty case, but it renders last for clarity.
@@ -740,7 +805,7 @@ struct WindowContentView: View {
     /// The command-palette overlay, mounted only while a palette is open in the frontmost window. Its
     /// content (search field + result list) is rebuilt from `palette.mode`.
     @ViewBuilder private var commandPaletteOverlay: some View {
-        if isFrontmost, palette.mode != nil {
+        if isFrontmost, pick.pending == nil, palette.mode != nil {
             CommandPalette(controller: palette, actions: actions)
         }
     }

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -29,6 +29,9 @@ struct WindowContentView: View {
     /// view-only grid. Registered in `DashboardControllerRegistry` on appear so the socket can drive it; the
     /// `+Dashboard` extension owns the overlay branch, deck yield, font override, and modal lifecycle.
     @State var dashboard = DashboardController()
+    /// Per-window native picker presented through the shared palette view. Registered for control-socket
+    /// lookup while this window is mounted; unlike `palette`, its pending state is window-scoped.
+    @State var pick = PickController()
     /// The terminal background color, mirrored from the (non-observable) `GhosttyApp` into view
     /// state and used as the quick terminal's opaque backing, so a settings theme change (posting
     /// `.agtermAppearanceChanged`) re-renders it live.
@@ -195,11 +198,13 @@ struct WindowContentView: View {
             }
             TerminalZoomRegistry.shared.register(windowID, controller: terminalZoom)
             registerDashboard()
+            PickRegistry.shared.register(windowID, controller: pick)
         }
         .onDisappear {
             QuickTerminalRegistry.shared.unregister(windowID)
             TerminalZoomRegistry.shared.unregister(windowID)
             tearDownDashboard()
+            PickRegistry.shared.unregister(windowID)
         }
     }
 
@@ -686,6 +691,7 @@ struct WindowContentView: View {
         ZStack {
             quickTerminalOverlay
             commandPaletteOverlay
+            pickPaletteOverlay
             sessionSwitcherOverlay
             // the dashboard is the topmost window overlay: opening it closes the three above (mirrors the
             // zoom lifecycle), so ordering only settles the empty case, but it renders last for clarity.
@@ -736,6 +742,34 @@ struct WindowContentView: View {
     @ViewBuilder private var commandPaletteOverlay: some View {
         if isFrontmost, palette.mode != nil {
             CommandPalette(controller: palette, actions: actions)
+        }
+    }
+
+    /// A control picker is per-window rather than frontmost-global, so a caller may present one in a
+    /// background window without duplicating it elsewhere. Selection preserves the caller's original
+    /// item index even though fuzzy filtering reorders the visible rows.
+    @ViewBuilder private var pickPaletteOverlay: some View {
+        if let pending = pick.pending {
+            CommandPalette(
+                controller: palette,
+                actions: actions,
+                items: pending.items.enumerated().map { index, item in
+                    PaletteItem(id: item.id, title: item.label, subtitle: item.subtitle) {
+                        pick.resolve(ControlPickResult(
+                            result: .picked,
+                            id: item.id,
+                            label: item.label,
+                            index: index
+                        ))
+                    }
+                },
+                prompt: pending.prompt,
+                allowCustom: pending.allowCustom,
+                onCustom: { query in
+                    pick.resolve(ControlPickResult(result: .custom, query: query))
+                },
+                onDismiss: { pick.cancel() }
+            )
         }
     }
 

--- a/agterm/WindowRegistry.swift
+++ b/agterm/WindowRegistry.swift
@@ -36,6 +36,12 @@ final class WindowRegistry {
         windows.values.contains { $0 === window }
     }
 
+    /// Returns the stable control-window id for a live AppKit window. Focus retry loops use this reverse
+    /// lookup to honor window-scoped modal state without coupling each terminal surface to `WindowLibrary`.
+    func windowID(for window: NSWindow) -> WindowInfo.ID? {
+        windows.first { $0.value === window }?.key
+    }
+
     /// Brings the window for `id` to the front if one is live. Returns whether a window was raised.
     @discardableResult
     func raise(_ id: WindowInfo.ID) -> Bool {

--- a/agterm/agtermApp+Menus.swift
+++ b/agterm/agtermApp+Menus.swift
@@ -63,14 +63,12 @@ extension agtermApp {
             // grouped by entity into three sections — Window, then Workspace, then Session. The
             // system Close / Close All commands stay below in their own group.
             CommandGroup(replacing: .newItem) {
-                // While terminal zoom OR the dashboard grid is up the UI is modal (the AppActions gate already
-                // no-ops these); the .disabled mirrors that gate so the items read as unavailable instead of
-                // dead. modalActive folds the dashboard into the same gate so its menu key-equivalents
-                // (which route through performKeyEquivalent, PAST the grid's keyDown-only key-catcher) can't
-                // mutate the deck behind the grid — the Dashboard toggle itself stays zoomed-only so ⌘⇧D can
-                // still close the grid.
+                // While terminal zoom, the dashboard grid, OR the topmost native picker is up, the UI is modal
+                // (the AppActions gate already no-ops these). `.disabled` mirrors that gate so items read as
+                // unavailable instead of dead and key equivalents cannot mutate the covered deck.
                 let zoomed = actions.terminalZoomActive
-                let modalActive = zoomed || (actions.frontmostDashboard?.isOpen ?? false)
+                let pickActive = actions.pickActive(for: library.activeWindowID)
+                let modalActive = zoomed || (actions.frontmostDashboard?.isOpen ?? false) || pickActive
                 // Window: create/open/rename/delete the top-level window bundles. Open Window lists
                 // the library with a checkmark on already-open ones (picking a closed one opens it,
                 // an open one raises it). Delete is disabled with one window left (keep-at-least-one).
@@ -187,10 +185,10 @@ extension agtermApp {
             // "Enter Full Screen" item has an icon, so every custom item carries an SF Symbol too —
             // otherwise they render as blank, indented slots.
             CommandGroup(after: .toolbar) {
-                // same modal-while-zoomed/dashboard mirror as the File group: grey out what the action gate
-                // no-ops (modalActive = zoomed OR the frontmost dashboard grid open).
+                // Mirror the File group's modal gate: zoom, dashboard, or the topmost native picker.
                 let zoomed = actions.terminalZoomActive
-                let modalActive = zoomed || (actions.frontmostDashboard?.isOpen ?? false)
+                let pickActive = actions.pickActive(for: library.activeWindowID)
+                let modalActive = zoomed || (actions.frontmostDashboard?.isOpen ?? false) || pickActive
                 Button { actions.increaseFontSize() } label: { Label("Increase Font Size", systemImage: "textformat.size.larger") }
                     .keyboardShortcut(shortcut(for: .increaseFontSize))
                 Button { actions.decreaseFontSize() } label: { Label("Decrease Font Size", systemImage: "textformat.size.smaller") }
@@ -305,10 +303,10 @@ extension agtermApp {
             // the spatial session stepping, and the pane focus. all drive the SAME AppActions the View items
             // did; only their menu home changed (the control API / palette / keymap surfaces are untouched).
             CommandMenu("Navigate") {
-                // same modal-while-zoomed/dashboard mirror as the File/View groups (modalActive = zoomed OR
-                // the frontmost dashboard grid open); the Dashboard toggle below stays zoomed-only.
+                // Mirror the File/View modal gate: zoom, dashboard, or the topmost native picker.
                 let zoomed = actions.terminalZoomActive
-                let modalActive = zoomed || (actions.frontmostDashboard?.isOpen ?? false)
+                let pickActive = actions.pickActive(for: library.activeWindowID)
+                let modalActive = zoomed || (actions.frontmostDashboard?.isOpen ?? false) || pickActive
                 Button { actions.toggleSessionPalette() } label: { Label("Go to Session", systemImage: "rectangle.stack") }
                     .keyboardShortcut(shortcut(for: .sessionPalette))
                     .disabled(modalActive)
@@ -323,10 +321,9 @@ extension agtermApp {
                     .disabled(modalActive)
                 Button { actions.toggleDashboard() } label: { Label("Dashboard", systemImage: "rectangle.split.2x2") }
                     .keyboardShortcut(shortcut(for: .dashboard))
-                    // stays zoomed-only, NOT modalActive: ⌘⇧D must still CLOSE an open dashboard, so this
-                    // toggle is the escape hatch and is never disabled by the dashboard being open
-                    // (toggleDashboard guards on !terminalZoomActive only, so it stays callable too).
-                    .disabled(zoomed)
+                    // Do not disable merely because the dashboard itself is open: ⌘⇧D remains its close
+                    // escape hatch. Zoom and a topmost native picker still block the toggle.
+                    .disabled(zoomed || pickActive)
                 Divider()
                 // step between sessions in the sidebar's flattened order. Prev/Next ride ⌥⌘↑/↓ (NOT bare
                 // ⌘+arrows, which shadow text-field caret nav in the rename/palette/settings fields); ⌥⌘↑/↓

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -360,6 +360,9 @@ struct agtermApp: App {
             // this END lands a tick later, so refocusing the deck's topmost surface here would steal
             // first responder back from the zoomed terminal (the zoom cover bails like the quick one).
             guard windowID.flatMap({ TerminalZoomRegistry.shared.controller(for: $0) })?.target == nil else { return }
+            // A control picker is the topmost modal. `session.search --to close` remains valid cleanup while
+            // one is pending, but its asynchronous END callback must not return focus behind the picker.
+            guard PickRegistry.shared.controller(for: windowID)?.pending == nil else { return }
             (session.topmostSurface as? GhosttySurfaceView)?.focusAfterReparent()
         }
         view.onSearchTotal = { total in store.session(withID: sessionID)?.searchTotal = total }

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -201,6 +201,7 @@ public final class AppStore {
                             scratchFontSize: (Session) -> Double? = { _ in nil },
                             quickVisible: () -> Bool? = { nil },
                             zoomedSurface: () -> String? = { nil },
+                            pickPending: () -> String? = { nil },
                             dashboardMembers: () -> [String]? = { nil },
                             dashboardHighlighted: () -> String? = { nil },
                             dashboardFontSize: () -> Double? = { nil },
@@ -259,7 +260,8 @@ public final class AppStore {
                            dashboardMembers: dashboardMembers(),
                            dashboardHighlighted: dashboardHighlighted(),
                            dashboardFontSize: dashboardFontSize(),
-                           dashboardFontMode: dashboardFontMode())
+                           dashboardFontMode: dashboardFontMode(),
+                           pickPending: pickPending())
     }
 
     /// Creates a workspace and appends it. When `revealNewWorkspace` (the default) and the focus filter is

--- a/agtermCore/Sources/agtermCore/ControlDispatcher+Pick.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher+Pick.swift
@@ -1,21 +1,5 @@
 import Foundation
 
-// Keeps existing hosts source-compatible while the picker surface is rolled out independently. A host
-// that supports pick commands supplies concrete witnesses; until then, routed commands fail safely.
-public extension ControlActions {
-    func openPick(_: PendingPick, window _: String?, follow _: Bool) -> ControlResponse {
-        ControlResponse(ok: false, error: "no pick surface")
-    }
-
-    func pickResult(_: String, window _: String?) -> ControlResponse {
-        ControlResponse(ok: false, error: "no pick surface")
-    }
-
-    func cancelPick(_: String, window _: String?) -> ControlResponse {
-        ControlResponse(ok: false, error: "no pick surface")
-    }
-}
-
 extension ControlDispatcher {
     /// Validates host-free picker arguments before handing window-scoped state to the app host.
     func dispatchPickCommand(_ request: ControlRequest) -> ControlResponse {

--- a/agtermCore/Sources/agtermCore/ControlDispatcher+Pick.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher+Pick.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+// Keeps existing hosts source-compatible while the picker surface is rolled out independently. A host
+// that supports pick commands supplies concrete witnesses; until then, routed commands fail safely.
+public extension ControlActions {
+    func openPick(_: PendingPick, window _: String?, follow _: Bool) -> ControlResponse {
+        ControlResponse(ok: false, error: "no pick surface")
+    }
+
+    func pickResult(_: String, window _: String?) -> ControlResponse {
+        ControlResponse(ok: false, error: "no pick surface")
+    }
+
+    func cancelPick(_: String, window _: String?) -> ControlResponse {
+        ControlResponse(ok: false, error: "no pick surface")
+    }
+}
+
+extension ControlDispatcher {
+    /// Validates host-free picker arguments before handing window-scoped state to the app host.
+    func dispatchPickCommand(_ request: ControlRequest) -> ControlResponse {
+        switch request.cmd {
+        case .pickOpen:
+            guard let items = request.args?.items, !items.isEmpty else {
+                return ControlResponse(ok: false, error: "pick.open requires at least one item")
+            }
+            guard items.count <= ControlPickItem.maxItems else {
+                return ControlResponse(ok: false, error: "too many items (max \(ControlPickItem.maxItems))")
+            }
+            guard items.allSatisfy({ !$0.label.isEmpty }) else {
+                return ControlResponse(ok: false, error: "pick item label must not be empty")
+            }
+
+            var ids = Set<String>()
+            guard items.allSatisfy({ ids.insert($0.id).inserted }) else {
+                return ControlResponse(ok: false, error: "pick item ids must be unique")
+            }
+            guard items.allSatisfy({ item in
+                !containsControlCharacters(item.label)
+                    && item.subtitle.map { !containsControlCharacters($0) } != false
+            }) else {
+                return ControlResponse(ok: false, error: "item text must not contain control characters")
+            }
+
+            let pick = PendingPick(
+                id: UUID().uuidString,
+                items: items,
+                prompt: request.args?.prompt,
+                allowCustom: request.args?.allowCustom == true
+            )
+            return actions.openPick(
+                pick,
+                window: request.args?.window,
+                follow: request.args?.follow == true
+            )
+
+        case .pickResult:
+            guard let target = request.target else {
+                return ControlResponse(ok: false, error: "pick.result requires a pick id")
+            }
+            return actions.pickResult(target, window: request.args?.window)
+
+        case .pickCancel:
+            guard let target = request.target else {
+                return ControlResponse(ok: false, error: "pick.cancel requires a pick id")
+            }
+            return actions.cancelPick(target, window: request.args?.window)
+
+        default:
+            preconditionFailure("dispatchPickCommand called for \(request.cmd.rawValue)")
+        }
+    }
+
+    private func containsControlCharacters(_ text: String) -> Bool {
+        text.unicodeScalars.contains { $0.value < 0x20 || $0.value == 0x7f }
+    }
+}

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -177,6 +177,9 @@ public struct ControlDispatcher {
         case .debugAppearance:
             // UI-test-only seam handled app-side in `ControlServer` (needs AppKit + `ContentView.isUITestLaunch`).
             return nil
+        case .pickOpen, .pickResult, .pickCancel:
+            // Picker state is window-scoped and is handled app-side once the picker registry exists.
+            return nil
         }
     }
 

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -82,6 +82,12 @@ public protocol ControlActions {
     func windowZoom(_ target: String?) -> ControlResponse
     func windowFullscreen(_ target: String?) -> ControlResponse
     func windowMinimize(_ target: String?, mode: ControlToggleMode) async -> ControlResponse
+    /// Open a native picker. The host owns window resolution, registry lookup, and presentation.
+    func openPick(_ pick: PendingPick, window: String?, follow: Bool) -> ControlResponse
+    /// Read a native picker's current result. The host owns window resolution and registry lookup.
+    func pickResult(_ target: String, window: String?) -> ControlResponse
+    /// Cancel a native picker. The host owns window resolution, registry lookup, and dismissal.
+    func cancelPick(_ target: String, window: String?) -> ControlResponse
     func clearRestoreCommands() -> ControlResponse
 }
 
@@ -140,7 +146,7 @@ public struct ControlSessionTextOptions: Equatable, Sendable {
 /// response shape; host actions keep target resolution, AppKit state, and terminal-surface side effects.
 @MainActor
 public struct ControlDispatcher {
-    private let actions: any ControlActions
+    let actions: any ControlActions
 
     public init(actions: any ControlActions) {
         self.actions = actions
@@ -178,8 +184,7 @@ public struct ControlDispatcher {
             // UI-test-only seam handled app-side in `ControlServer` (needs AppKit + `ContentView.isUITestLaunch`).
             return nil
         case .pickOpen, .pickResult, .pickCancel:
-            // Picker state is window-scoped and is handled app-side once the picker registry exists.
-            return nil
+            return dispatchPickCommand(request)
         }
     }
 

--- a/agtermCore/Sources/agtermCore/ControlPick.swift
+++ b/agtermCore/Sources/agtermCore/ControlPick.swift
@@ -41,13 +41,17 @@ public struct ControlPickResult: Codable, Sendable, Equatable {
     }
 }
 
-/// A completed picker result paired with the picker id that produced it.
+/// A completed picker result paired with the picker id that produced it. `sequence` orders results
+/// across windows so the app-wide retention evicts the oldest ANSWER rather than the oldest transfer;
+/// it is internal bookkeeping and never crosses the wire.
 public struct ResolvedPick: Codable, Sendable, Equatable {
     public let id: String
     public let result: ControlPickResult
+    public let sequence: Int
 
-    public init(id: String, result: ControlPickResult) {
+    public init(id: String, result: ControlPickResult, sequence: Int = 0) {
         self.id = id
         self.result = result
+        self.sequence = sequence
     }
 }

--- a/agtermCore/Sources/agtermCore/ControlPick.swift
+++ b/agtermCore/Sources/agtermCore/ControlPick.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// One caller-provided choice displayed by the native picker.
+public struct ControlPickItem: Codable, Sendable, Equatable {
+    public static let maxItems = 1_000
+
+    public let id: String
+    public let label: String
+    public let subtitle: String?
+
+    public init(id: String, label: String, subtitle: String? = nil) {
+        self.id = id
+        self.label = label
+        self.subtitle = subtitle
+    }
+}
+
+/// The state or terminal outcome returned by `pick.result`.
+public enum ControlPickOutcome: String, Codable, Sendable, CaseIterable {
+    case pending
+    case picked
+    case custom
+    case cancelled
+}
+
+/// The nested wire payload returned by `pick.result`.
+public struct ControlPickResult: Codable, Sendable, Equatable {
+    public let result: ControlPickOutcome
+    public let id: String?
+    public let label: String?
+    public let index: Int?
+    public let query: String?
+
+    public init(result: ControlPickOutcome, id: String? = nil, label: String? = nil,
+                index: Int? = nil, query: String? = nil) {
+        self.result = result
+        self.id = id
+        self.label = label
+        self.index = index
+        self.query = query
+    }
+}
+
+/// A completed picker result paired with the picker id that produced it.
+public struct ResolvedPick: Codable, Sendable, Equatable {
+    public let id: String
+    public let result: ControlPickResult
+
+    public init(id: String, result: ControlPickResult) {
+        self.id = id
+        self.result = result
+    }
+}

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -71,6 +71,9 @@ public enum Command: String, Codable, Sendable {
     case configReload = "config.reload"
     case themeSet = "theme.set"
     case themeList = "theme.list"
+    case pickOpen = "pick.open"
+    case pickResult = "pick.result"
+    case pickCancel = "pick.cancel"
     case restoreClear = "restore.clear"
     /// UI-TEST-ONLY: force the app-level appearance (`light`|`dark` via `args.name`) so an XCUITest can
     /// simulate a macOS light/dark flip; with NO name it READS the side the last config feed applied,
@@ -219,6 +222,12 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     /// opens in the background without changing the active session (the default for both full and
     /// floating overlays).
     public var follow: Bool?
+    /// The finished caller-provided choices for `pick.open`.
+    public var items: [ControlPickItem]?
+    /// Optional text shown above the query field for `pick.open`.
+    public var prompt: String?
+    /// Whether `pick.open` accepts the current query as a custom result.
+    public var allowCustom: Bool?
     /// Target window for session/workspace/tree/font commands: id / prefix / `active` (=frontmost).
     /// Selects the window whose tree the command operates on.
     public var window: String?
@@ -269,7 +278,8 @@ public struct ControlArgs: Codable, Sendable, Equatable {
                 noSelect: Bool? = nil,
                 text: String? = nil, select: Bool? = nil, mode: String? = nil,
                 command: String? = nil, wait: Bool? = nil, sizePercent: Int? = nil, full: Bool? = nil,
-                follow: Bool? = nil, window: String? = nil,
+                follow: Bool? = nil, items: [ControlPickItem]? = nil, prompt: String? = nil,
+                allowCustom: Bool? = nil, window: String? = nil,
                 pane: String? = nil, paneID: String? = nil, to: String? = nil,
                 after: String? = nil, before: String? = nil, run: String? = nil,
                 kinds: [String]? = nil, limit: Int? = nil,
@@ -299,6 +309,9 @@ public struct ControlArgs: Codable, Sendable, Equatable {
         self.sizePercent = sizePercent
         self.full = full
         self.follow = follow
+        self.items = items
+        self.prompt = prompt
+        self.allowCustom = allowCustom
         self.window = window
         self.pane = pane
         self.paneID = paneID
@@ -621,13 +634,15 @@ public struct ControlTree: Codable, Sendable, Equatable {
     /// nil/omitted when no dashboard is open. LIVE — resolved app-side per request from the window's
     /// `DashboardController` — the read side of the font flags. `tree`-only, like `dashboardMembers`.
     public let dashboardFontMode: String?
+    /// The id of the picker currently awaiting a choice, or nil when no picker is open.
+    public let pickPending: String?
 
     public init(workspaces: [ControlWorkspaceNode], idleMs: Int? = nil, autoFollowMs: Int? = nil,
                 sidebarVisible: Bool? = nil, sidebarMode: String? = nil, workspaceFilter: Bool? = nil,
                 quickVisible: Bool? = nil,
                 zoomedSurface: String? = nil, dashboardMembers: [String]? = nil,
                 dashboardHighlighted: String? = nil, dashboardFontSize: Double? = nil,
-                dashboardFontMode: String? = nil) {
+                dashboardFontMode: String? = nil, pickPending: String? = nil) {
         self.workspaces = workspaces
         self.idleMs = idleMs
         self.autoFollowMs = autoFollowMs
@@ -640,6 +655,7 @@ public struct ControlTree: Codable, Sendable, Equatable {
         self.dashboardHighlighted = dashboardHighlighted
         self.dashboardFontSize = dashboardFontSize
         self.dashboardFontMode = dashboardFontMode
+        self.pickPending = pickPending
     }
 }
 
@@ -752,13 +768,16 @@ public struct ControlResult: Codable, Sendable, Equatable {
     public var events: ControlEventBatch?
     /// The resolved keymap plus the live menu key equivalents, for `keymap.list`.
     public var keymap: ControlKeymap?
+    /// The current or terminal picker outcome for `pick.result`.
+    public var pick: ControlPickResult?
 
     public init(id: String? = nil, tree: ControlTree? = nil, text: String? = nil,
                 windows: [ControlWindowNode]? = nil, exitCode: Int? = nil, count: Int? = nil,
                 affected: Int? = nil,
                 theme: String? = nil, themes: [String]? = nil, ratio: Double? = nil,
                 sync: Bool? = nil, light: String? = nil, dark: String? = nil,
-                events: ControlEventBatch? = nil, keymap: ControlKeymap? = nil) {
+                events: ControlEventBatch? = nil, keymap: ControlKeymap? = nil,
+                pick: ControlPickResult? = nil) {
         self.id = id
         self.tree = tree
         self.text = text
@@ -774,6 +793,7 @@ public struct ControlResult: Codable, Sendable, Equatable {
         self.dark = dark
         self.events = events
         self.keymap = keymap
+        self.pick = pick
     }
 }
 

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -224,7 +224,7 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     public var follow: Bool?
     /// The finished caller-provided choices for `pick.open`.
     public var items: [ControlPickItem]?
-    /// Optional text shown above the query field for `pick.open`.
+    /// Optional placeholder text for `pick.open`'s query field.
     public var prompt: String?
     /// Whether `pick.open` accepts the current query as a custom result.
     public var allowCustom: Bool?

--- a/agtermCore/Sources/agtermCore/DashboardController.swift
+++ b/agtermCore/Sources/agtermCore/DashboardController.swift
@@ -71,6 +71,10 @@ public final class DashboardController {
     /// or closed. Set app-side via `setAppliedFontSize(_:)` when the override is applied; reset on close.
     public private(set) var appliedFontSize: Double?
 
+    /// Changes when an overlay above the dashboard releases keyboard ownership, prompting its AppKit
+    /// key catcher to reclaim first responder without changing dashboard content.
+    public private(set) var focusRevision = 0
+
     public init() {}
 
     /// Whether the dashboard is open, i.e. it holds at least one member.
@@ -119,6 +123,10 @@ public final class DashboardController {
     /// method (never a stray external write) mutates it; the wiring calls it on every font (re)apply.
     public func setAppliedFontSize(_ size: Double?) {
         appliedFontSize = size
+    }
+
+    public func requestFocus() {
+        focusRevision &+= 1
     }
 
     /// reconcile drops any member pane no longer present in `existing` (a member session closed, OR a split

--- a/agtermCore/Sources/agtermCore/DashboardController.swift
+++ b/agtermCore/Sources/agtermCore/DashboardController.swift
@@ -125,6 +125,9 @@ public final class DashboardController {
         appliedFontSize = size
     }
 
+    /// requestFocus bumps `focusRevision` so the dashboard's AppKit key catcher reclaims first responder
+    /// once an overlay above it (a control picker) resolves. Called by `restoreFocusAfterPick`; the value
+    /// itself carries no meaning beyond changing.
     public func requestFocus() {
         focusRevision &+= 1
     }

--- a/agtermCore/Sources/agtermCore/PaletteCustomRow.swift
+++ b/agtermCore/Sources/agtermCore/PaletteCustomRow.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Returns the synthetic free-text row label when a picker query has no item match.
+///
+/// Whitespace around the query is ignored so an empty search never becomes a selectable value.
+public func pickCustomRowLabel(query: String, filteredCount: Int, allowCustom: Bool) -> String? {
+    let value = query.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard allowCustom, filteredCount == 0, !value.isEmpty else { return nil }
+    return "Use \"\(value)\""
+}

--- a/agtermCore/Sources/agtermCore/Pick.swift
+++ b/agtermCore/Sources/agtermCore/Pick.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Observation
+
+/// One picker request currently presented by a window.
+public struct PendingPick: Equatable, Sendable {
+    public let id: String
+    public let items: [ControlPickItem]
+    public let prompt: String?
+    public let allowCustom: Bool
+
+    public init(id: String, items: [ControlPickItem], prompt: String? = nil, allowCustom: Bool = false) {
+        self.id = id
+        self.items = items
+        self.prompt = prompt
+        self.allowCustom = allowCustom
+    }
+}
+
+/// Owns the pending picker and most recent answer for one window.
+@Observable
+@MainActor
+public final class PickController {
+    public private(set) var pending: PendingPick?
+    public private(set) var lastResult: ResolvedPick?
+
+    public init() {}
+
+    /// Opens `pick` unless another picker is already pending.
+    @discardableResult
+    public func open(_ pick: PendingPick) -> Bool {
+        guard pending == nil else { return false }
+        pending = pick
+        lastResult = nil
+        return true
+    }
+
+    /// Completes the pending picker with `outcome`.
+    public func resolve(_ outcome: ControlPickResult) {
+        guard let pending else { return }
+        lastResult = ResolvedPick(id: pending.id, result: outcome)
+        self.pending = nil
+    }
+
+    /// Completes the pending picker as cancelled.
+    public func cancel() {
+        resolve(ControlPickResult(result: .cancelled))
+    }
+
+    /// Returns the current or retained result for the exact picker id.
+    public func result(for id: String) -> ControlPickResult? {
+        if pending?.id == id {
+            return ControlPickResult(result: .pending)
+        }
+        guard lastResult?.id == id else { return nil }
+        return lastResult?.result
+    }
+}
+
+/// Maps each window to the picker controller rendered in that window.
+@MainActor
+public final class PickRegistry {
+    public static let shared = PickRegistry()
+    private var controllers: [WindowInfo.ID: PickController] = [:]
+
+    private init() {}
+
+    public func register(_ id: WindowInfo.ID, controller: PickController) {
+        controllers[id] = controller
+    }
+
+    public func unregister(_ id: WindowInfo.ID) {
+        controllers[id] = nil
+    }
+
+    public func controller(for id: WindowInfo.ID?) -> PickController? {
+        guard let id else { return nil }
+        return controllers[id]
+    }
+}

--- a/agtermCore/Sources/agtermCore/Pick.swift
+++ b/agtermCore/Sources/agtermCore/Pick.swift
@@ -16,28 +16,37 @@ public struct PendingPick: Equatable, Sendable {
     }
 }
 
-/// Owns the pending picker and most recent answer for one window.
+/// Owns the pending picker and the recently answered pickers for one window.
 @Observable
 @MainActor
 public final class PickController {
+    /// How many terminal results stay readable per window. A blocking client polls every 500ms, so its
+    /// answer survives any plausible number of pickers opened in that window before the poll lands;
+    /// keying by pick id rather than one slot is what keeps `open` from discarding an unread answer.
+    static let retainedResultLimit = 8
+
     public private(set) var pending: PendingPick?
-    public private(set) var lastResult: ResolvedPick?
+    /// Terminal results in resolution order, oldest first, capped at `retainedResultLimit`.
+    public private(set) var recentResults: [ResolvedPick] = []
 
     public init() {}
 
-    /// Opens `pick` unless another picker is already pending.
+    /// Opens `pick` unless another picker is already pending. Prior results stay readable by their own id.
     @discardableResult
     public func open(_ pick: PendingPick) -> Bool {
         guard pending == nil else { return false }
         pending = pick
-        lastResult = nil
         return true
     }
 
-    /// Completes the pending picker with `outcome`.
+    /// Completes the pending picker with `outcome`, keeping it readable until it ages out.
     public func resolve(_ outcome: ControlPickResult) {
         guard let pending else { return }
-        lastResult = ResolvedPick(id: pending.id, result: outcome)
+        recentResults.removeAll { $0.id == pending.id }
+        recentResults.append(ResolvedPick(id: pending.id, result: outcome))
+        if recentResults.count > Self.retainedResultLimit {
+            recentResults.removeFirst(recentResults.count - Self.retainedResultLimit)
+        }
         self.pending = nil
     }
 
@@ -51,8 +60,7 @@ public final class PickController {
         if pending?.id == id {
             return ControlPickResult(result: .pending)
         }
-        guard lastResult?.id == id else { return nil }
-        return lastResult?.result
+        return recentResults.last { $0.id == id }?.result
     }
 }
 
@@ -60,8 +68,13 @@ public final class PickController {
 @MainActor
 public final class PickRegistry {
     public static let shared = PickRegistry()
+    /// How many results outlive their window across the whole app. Nothing frees an entry for a window
+    /// that never reopens, so scripted window churn would otherwise grow this without bound.
+    static let retainedResultLimit = 32
+
     private var controllers: [WindowInfo.ID: PickController] = [:]
-    private var retainedResults: [WindowInfo.ID: ResolvedPick] = [:]
+    /// Results whose window is gone, oldest first, capped at `retainedResultLimit`.
+    private var retainedResults: [(windowID: WindowInfo.ID, pick: ResolvedPick)] = []
 
     private init() {}
 
@@ -70,12 +83,13 @@ public final class PickRegistry {
     }
 
     /// Remove a window's live controller, cancelling a pending pick first and retaining its terminal
-    /// result so a control client whose next poll lands after window teardown can still read it.
+    /// results so a control client whose next poll lands after window teardown can still read them.
     public func unregister(_ id: WindowInfo.ID) {
         guard let controller = controllers.removeValue(forKey: id) else { return }
         controller.cancel()
-        if let result = controller.lastResult {
-            retainedResults[id] = result
+        retainedResults.append(contentsOf: controller.recentResults.map { (windowID: id, pick: $0) })
+        if retainedResults.count > Self.retainedResultLimit {
+            retainedResults.removeFirst(retainedResults.count - Self.retainedResultLimit)
         }
     }
 
@@ -91,15 +105,9 @@ public final class PickRegistry {
             .map { (windowID: $0.key, controller: $0.value) }
     }
 
-    /// The last result retained when a window unregistered, matched by the globally unique pick id.
+    /// A result retained when its window unregistered, matched by the globally unique pick id.
     public func retainedResult(for pickID: String) -> (windowID: WindowInfo.ID, result: ControlPickResult)? {
-        retainedResults.first { $0.value.id == pickID }
-            .map { (windowID: $0.key, result: $0.value.result) }
-    }
-
-    /// A successfully opened next pick replaces the prior retained result for that window, mirroring
-    /// `PickController.open` clearing its own `lastResult`.
-    public func clearRetainedResult(for id: WindowInfo.ID) {
-        retainedResults[id] = nil
+        retainedResults.last { $0.pick.id == pickID }
+            .map { (windowID: $0.windowID, result: $0.pick.result) }
     }
 }

--- a/agtermCore/Sources/agtermCore/Pick.swift
+++ b/agtermCore/Sources/agtermCore/Pick.swift
@@ -61,6 +61,7 @@ public final class PickController {
 public final class PickRegistry {
     public static let shared = PickRegistry()
     private var controllers: [WindowInfo.ID: PickController] = [:]
+    private var retainedResults: [WindowInfo.ID: ResolvedPick] = [:]
 
     private init() {}
 
@@ -68,12 +69,29 @@ public final class PickRegistry {
         controllers[id] = controller
     }
 
+    /// Remove a window's live controller, cancelling a pending pick first and retaining its terminal
+    /// result so a control client whose next poll lands after window teardown can still read it.
     public func unregister(_ id: WindowInfo.ID) {
-        controllers[id] = nil
+        guard let controller = controllers.removeValue(forKey: id) else { return }
+        controller.cancel()
+        if let result = controller.lastResult {
+            retainedResults[id] = result
+        }
     }
 
     public func controller(for id: WindowInfo.ID?) -> PickController? {
         guard let id else { return nil }
         return controllers[id]
+    }
+
+    /// The last result retained when a window unregistered, matched by the globally unique pick id.
+    public func retainedResult(for pickID: String) -> ControlPickResult? {
+        retainedResults.values.first { $0.id == pickID }?.result
+    }
+
+    /// A successfully opened next pick replaces the prior retained result for that window, mirroring
+    /// `PickController.open` clearing its own `lastResult`.
+    public func clearRetainedResult(for id: WindowInfo.ID) {
+        retainedResults[id] = nil
     }
 }

--- a/agtermCore/Sources/agtermCore/Pick.swift
+++ b/agtermCore/Sources/agtermCore/Pick.swift
@@ -25,6 +25,10 @@ public final class PickController {
     /// keying by pick id rather than one slot is what keeps `open` from discarding an unread answer.
     static let retainedResultLimit = 8
 
+    /// Monotonic across every controller, so results merged from different windows can be ordered by
+    /// when they were answered rather than by when their window closed.
+    private static var resolutionSequence = 0
+
     public private(set) var pending: PendingPick?
     /// Terminal results in resolution order, oldest first, capped at `retainedResultLimit`.
     public private(set) var recentResults: [ResolvedPick] = []
@@ -42,8 +46,9 @@ public final class PickController {
     /// Completes the pending picker with `outcome`, keeping it readable until it ages out.
     public func resolve(_ outcome: ControlPickResult) {
         guard let pending else { return }
+        Self.resolutionSequence += 1
         recentResults.removeAll { $0.id == pending.id }
-        recentResults.append(ResolvedPick(id: pending.id, result: outcome))
+        recentResults.append(ResolvedPick(id: pending.id, result: outcome, sequence: Self.resolutionSequence))
         if recentResults.count > Self.retainedResultLimit {
             recentResults.removeFirst(recentResults.count - Self.retainedResultLimit)
         }
@@ -88,9 +93,11 @@ public final class PickRegistry {
         guard let controller = controllers.removeValue(forKey: id) else { return }
         controller.cancel()
         retainedResults.append(contentsOf: controller.recentResults.map { (windowID: id, pick: $0) })
-        if retainedResults.count > Self.retainedResultLimit {
-            retainedResults.removeFirst(retainedResults.count - Self.retainedResultLimit)
-        }
+        guard retainedResults.count > Self.retainedResultLimit else { return }
+        // order by when each pick was ANSWERED before trimming: a window closing later arrives with a
+        // whole batch, and appending alone would evict a newer result an earlier-closing window held.
+        retainedResults.sort { $0.pick.sequence < $1.pick.sequence }
+        retainedResults.removeFirst(retainedResults.count - Self.retainedResultLimit)
     }
 
     public func controller(for id: WindowInfo.ID?) -> PickController? {

--- a/agtermCore/Sources/agtermCore/Pick.swift
+++ b/agtermCore/Sources/agtermCore/Pick.swift
@@ -84,9 +84,17 @@ public final class PickRegistry {
         return controllers[id]
     }
 
+    /// Locate a live picker by its globally unique id. Blocking clients intentionally use this lookup
+    /// when no window selector was supplied so a later frontmost-window change cannot orphan the request.
+    public func livePick(for pickID: String) -> (windowID: WindowInfo.ID, controller: PickController)? {
+        controllers.first { $0.value.result(for: pickID) != nil }
+            .map { (windowID: $0.key, controller: $0.value) }
+    }
+
     /// The last result retained when a window unregistered, matched by the globally unique pick id.
-    public func retainedResult(for pickID: String) -> ControlPickResult? {
-        retainedResults.values.first { $0.id == pickID }?.result
+    public func retainedResult(for pickID: String) -> (windowID: WindowInfo.ID, result: ControlPickResult)? {
+        retainedResults.first { $0.value.id == pickID }
+            .map { (windowID: $0.key, result: $0.value.result) }
     }
 
     /// A successfully opened next pick replaces the prior retained result for that window, mirroring

--- a/agtermCore/Sources/agtermctlKit/Commands.swift
+++ b/agtermCore/Sources/agtermctlKit/Commands.swift
@@ -91,7 +91,7 @@ public struct Agtermctl: ParsableCommand {
         commandName: "agtermctl",
         abstract: "Drive agterm over its control socket.",
         subcommands: [Tree.self, Events.self, Workspace.self, Session.self, Surface.self, Dashboard.self, Window.self, Quick.self,
-                      Sidebar.self, Notify.self, Font.self, Keymap.self, Config.self, Theme.self, Restore.self]
+                      Sidebar.self, Notify.self, Font.self, Keymap.self, Config.self, Theme.self, Pick.self, Restore.self]
     )
 
     public init() {}

--- a/agtermCore/Sources/agtermctlKit/MiscCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/MiscCommands.swift
@@ -274,6 +274,164 @@ struct Dashboard: RequestCommand {
     }
 }
 
+// MARK: - pick
+
+/// Native fuzzy-picker commands. `Open` is the default so the shell-friendly common case is simply
+/// `printf 'one\ntwo\n' | agtermctl pick`; explicit `result` and `cancel` verbs make `--no-block`
+/// useful without requiring callers to speak the socket protocol themselves.
+struct Pick: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Open, poll, or cancel a native fuzzy picker.",
+        subcommands: [Open.self, Result.self, Cancel.self],
+        defaultSubcommand: Open.self
+    )
+
+    struct Open: RequestCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Read choices from stdin and open a native fuzzy picker."
+        )
+
+        @Option(name: .long, help: "Text shown above the picker query field.") var prompt: String?
+        @Flag(name: .long, help: "Accept the current query as a custom result.") var allowCustom = false
+        @Flag(name: .long, help: "Raise the target window when the picker opens.") var follow = false
+        @Flag(name: .long, help: "Print the picker id and return without waiting for a result.") var noBlock = false
+        @OptionGroup var options: ClientOptions
+
+        func makeRequest() throws -> ControlRequest {
+            try makeRequest(input: FileHandle.standardInput.readDataToEndOfFile())
+        }
+
+        /// Build the open request from injected stdin bytes. Production passes standard input; tests pass
+        /// data directly so parsing and argument mapping never block on the process's real stdin.
+        func makeRequest(input: Data) throws -> ControlRequest {
+            let args = ControlArgs(
+                follow: follow ? true : nil,
+                items: try Self.parseItems(input),
+                prompt: prompt,
+                allowCustom: allowCustom ? true : nil
+            )
+            return ControlRequest(cmd: .pickOpen, args: options.withWindow(args))
+        }
+
+        /// Sniff stdin's first non-whitespace byte. JSON arrays preserve caller-supplied ids/subtitles;
+        /// bare lines use the label itself as the id and discard empty or whitespace-only lines.
+        static func parseItems(_ input: Data) throws -> [ControlPickItem] {
+            let whitespace = Set([UInt8(ascii: " "), UInt8(ascii: "\t"),
+                                  UInt8(ascii: "\n"), UInt8(ascii: "\r")])
+            if input.first(where: { !whitespace.contains($0) }) == UInt8(ascii: "[") {
+                return try JSONDecoder().decode([ControlPickItem].self, from: input)
+            }
+            guard let text = String(data: input, encoding: .utf8) else {
+                throw ValidationError("stdin must be UTF-8 text or a JSON item array")
+            }
+            return text.components(separatedBy: .newlines)
+                .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+                .map { ControlPickItem(id: $0, label: $0) }
+        }
+
+        func run() throws {
+            let client = SocketClient(path: options.socketPath())
+            try execute(
+                input: FileHandle.standardInput.readDataToEndOfFile(),
+                send: client.send,
+                sleep: Thread.sleep(forTimeInterval:),
+                output: { print($0) }
+            )
+        }
+
+        /// Execute open → poll with injectable I/O. The production wrapper supplies the socket, sleep,
+        /// stdin, and stdout; unit tests exercise the unbounded blocking flow without real delays or stdin.
+        func execute(
+            input: Data,
+            send: (ControlRequest) throws -> ControlResponse,
+            sleep: (TimeInterval) -> Void,
+            output: (String) -> Void
+        ) throws {
+            let opened = try send(makeRequest(input: input))
+            guard opened.ok else {
+                SocketClient.printResponse(opened, json: options.json)
+                throw ExitCode.failure
+            }
+            guard let pickID = opened.result?.id else {
+                Self.printProtocolError("pick.open result missing id")
+                throw ExitCode.failure
+            }
+            if noBlock {
+                output(try SocketClient.formatPickID(pickID))
+                return
+            }
+
+            var pendingPolls = 0
+            while true {
+                let response = try send(ControlRequest(
+                    cmd: .pickResult,
+                    target: pickID,
+                    args: options.withWindow()
+                ))
+                guard response.ok else {
+                    SocketClient.printResponse(response, json: options.json)
+                    throw ExitCode.failure
+                }
+                guard let result = response.result?.pick else {
+                    Self.printProtocolError("pick.result missing result")
+                    throw ExitCode.failure
+                }
+                if result.result == .pending {
+                    pendingPolls += 1
+                    sleep(SocketClient.pickPollDelay(afterPendingPoll: pendingPolls))
+                    continue
+                }
+
+                output(try SocketClient.formatPickResult(result))
+                let code = SocketClient.pickExitCode(for: result.result)
+                if code.rawValue != 0 { throw code }
+                return
+            }
+        }
+
+        private static func printProtocolError(_ message: String) {
+            FileHandle.standardError.write(Data("error: \(message)\n".utf8))
+        }
+    }
+
+    struct Result: RequestCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Print a picker's current or terminal result as JSON."
+        )
+        @Argument(help: "Exact picker id returned by pick open.") var id: String
+        @OptionGroup var options: ClientOptions
+
+        func makeRequest() throws -> ControlRequest {
+            ControlRequest(cmd: .pickResult, target: id, args: options.withWindow())
+        }
+
+        func run() throws {
+            let response = try SocketClient(path: options.socketPath()).send(makeRequest())
+            guard response.ok else {
+                SocketClient.printResponse(response, json: options.json)
+                throw ExitCode.failure
+            }
+            guard let result = response.result?.pick else {
+                FileHandle.standardError.write(Data("error: pick.result missing result\n".utf8))
+                throw ExitCode.failure
+            }
+            print(try SocketClient.formatPickResult(result))
+            let code = SocketClient.pickExitCode(for: result.result)
+            if code.rawValue != 0 { throw code }
+        }
+    }
+
+    struct Cancel: RequestCommand {
+        static let configuration = CommandConfiguration(abstract: "Cancel a pending picker.")
+        @Argument(help: "Exact picker id returned by pick open.") var id: String
+        @OptionGroup var options: ClientOptions
+
+        func makeRequest() throws -> ControlRequest {
+            ControlRequest(cmd: .pickCancel, target: id, args: options.withWindow())
+        }
+    }
+}
+
 // MARK: - sidebar
 
 struct Sidebar: ParsableCommand {

--- a/agtermCore/Sources/agtermctlKit/MiscCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/MiscCommands.swift
@@ -372,10 +372,12 @@ struct Pick: ParsableCommand {
                 ))
                 guard response.ok else {
                     Self.writeResponse(response, json: options.json, output: output, errorOutput: errorOutput)
+                    abandon(pickID, send: send)
                     throw ExitCode.failure
                 }
                 guard let result = response.result?.pick else {
                     errorOutput("error: pick.result missing result")
+                    abandon(pickID, send: send)
                     throw ExitCode.failure
                 }
                 if result.result == .pending {
@@ -389,6 +391,13 @@ struct Pick: ParsableCommand {
                 if code.rawValue != 0 { throw code }
                 return
             }
+        }
+
+        /// Dismiss the picker this command opened but can no longer wait on, so the window is not left
+        /// holding a picker whose owner is gone and the next `pick.open` there is not refused. Best effort:
+        /// the poll already failed, so a failing cancel adds nothing to report.
+        private func abandon(_ pickID: String, send: (ControlRequest) throws -> ControlResponse) {
+            _ = try? send(ControlRequest(cmd: .pickCancel, target: pickID))
         }
 
         private static func writeResponse(

--- a/agtermCore/Sources/agtermctlKit/MiscCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/MiscCommands.swift
@@ -291,7 +291,7 @@ struct Pick: ParsableCommand {
             abstract: "Read choices from stdin and open a native fuzzy picker."
         )
 
-        @Option(name: .long, help: "Text shown above the picker query field.") var prompt: String?
+        @Option(name: .long, help: "Placeholder text shown in the picker query field.") var prompt: String?
         @Flag(name: .long, help: "Accept the current query as a custom result.") var allowCustom = false
         @Flag(name: .long, help: "Raise the target window when the picker opens.") var follow = false
         @Flag(name: .long, help: "Print the picker id and return without waiting for a result.") var noBlock = false
@@ -335,25 +335,28 @@ struct Pick: ParsableCommand {
                 input: FileHandle.standardInput.readDataToEndOfFile(),
                 send: client.send,
                 sleep: Thread.sleep(forTimeInterval:),
-                output: { print($0) }
+                output: { print($0) },
+                errorOutput: Self.writeStandardError
             )
         }
 
         /// Execute open → poll with injectable I/O. The production wrapper supplies the socket, sleep,
-        /// stdin, and stdout; unit tests exercise the unbounded blocking flow without real delays or stdin.
+        /// stdin, stdout, and stderr; unit tests exercise the unbounded blocking flow without real delays
+        /// or process file descriptors.
         func execute(
             input: Data,
             send: (ControlRequest) throws -> ControlResponse,
             sleep: (TimeInterval) -> Void,
-            output: (String) -> Void
+            output: (String) -> Void,
+            errorOutput: (String) -> Void = Self.writeStandardError
         ) throws {
             let opened = try send(makeRequest(input: input))
             guard opened.ok else {
-                SocketClient.printResponse(opened, json: options.json)
+                Self.writeResponse(opened, json: options.json, output: output, errorOutput: errorOutput)
                 throw ExitCode.failure
             }
             guard let pickID = opened.result?.id else {
-                Self.printProtocolError("pick.open result missing id")
+                errorOutput("error: pick.open result missing id")
                 throw ExitCode.failure
             }
             if noBlock {
@@ -365,15 +368,14 @@ struct Pick: ParsableCommand {
             while true {
                 let response = try send(ControlRequest(
                     cmd: .pickResult,
-                    target: pickID,
-                    args: options.withWindow()
+                    target: pickID
                 ))
                 guard response.ok else {
-                    SocketClient.printResponse(response, json: options.json)
+                    Self.writeResponse(response, json: options.json, output: output, errorOutput: errorOutput)
                     throw ExitCode.failure
                 }
                 guard let result = response.result?.pick else {
-                    Self.printProtocolError("pick.result missing result")
+                    errorOutput("error: pick.result missing result")
                     throw ExitCode.failure
                 }
                 if result.result == .pending {
@@ -389,8 +391,22 @@ struct Pick: ParsableCommand {
             }
         }
 
-        private static func printProtocolError(_ message: String) {
-            FileHandle.standardError.write(Data("error: \(message)\n".utf8))
+        private static func writeResponse(
+            _ response: ControlResponse,
+            json: Bool,
+            output: (String) -> Void,
+            errorOutput: (String) -> Void
+        ) {
+            let line = SocketClient.formatResponse(response, json: json)
+            if json {
+                output(line)
+            } else {
+                errorOutput(line)
+            }
+        }
+
+        private static func writeStandardError(_ line: String) {
+            FileHandle.standardError.write(Data("\(line)\n".utf8))
         }
     }
 
@@ -406,18 +422,41 @@ struct Pick: ParsableCommand {
         }
 
         func run() throws {
-            let response = try SocketClient(path: options.socketPath()).send(makeRequest())
+            try execute(
+                send: SocketClient(path: options.socketPath()).send,
+                output: { print($0) },
+                errorOutput: Self.writeStandardError
+            )
+        }
+
+        /// Execute a one-shot read with injectable transport/stdout/stderr so every wire outcome and exit
+        /// mapping is covered without replacing process file descriptors.
+        func execute(
+            send: (ControlRequest) throws -> ControlResponse,
+            output: (String) -> Void,
+            errorOutput: (String) -> Void = Self.writeStandardError
+        ) throws {
+            let response = try send(makeRequest())
             guard response.ok else {
-                SocketClient.printResponse(response, json: options.json)
+                let line = SocketClient.formatResponse(response, json: options.json)
+                if options.json {
+                    output(line)
+                } else {
+                    errorOutput(line)
+                }
                 throw ExitCode.failure
             }
             guard let result = response.result?.pick else {
-                FileHandle.standardError.write(Data("error: pick.result missing result\n".utf8))
+                errorOutput("error: pick.result missing result")
                 throw ExitCode.failure
             }
-            print(try SocketClient.formatPickResult(result))
+            output(try SocketClient.formatPickResult(result))
             let code = SocketClient.pickExitCode(for: result.result)
             if code.rawValue != 0 { throw code }
+        }
+
+        private static func writeStandardError(_ line: String) {
+            FileHandle.standardError.write(Data("\(line)\n".utf8))
         }
     }
 

--- a/agtermCore/Sources/agtermctlKit/MiscCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/MiscCommands.swift
@@ -366,13 +366,21 @@ struct Pick: ParsableCommand {
 
             var pendingPolls = 0
             while true {
-                let response = try send(ControlRequest(
-                    cmd: .pickResult,
-                    target: pickID
-                ))
+                let response: ControlResponse
+                do {
+                    response = try send(ControlRequest(cmd: .pickResult, target: pickID))
+                } catch {
+                    // a transport failure mid-wait — a refused connect, a truncated or empty reply —
+                    // leaves the picker up with nobody waiting on it. every request opens its own
+                    // connection, so the cancel can still land even though this poll could not.
+                    abandon(pickID, send: send)
+                    throw error
+                }
+                // the poll carries no window selector, so a pending picker is always found by id and
+                // answers ok. a not-ok response therefore means the server no longer holds one, and
+                // there is nothing left to dismiss.
                 guard response.ok else {
                     Self.writeResponse(response, json: options.json, output: output, errorOutput: errorOutput)
-                    abandon(pickID, send: send)
                     throw ExitCode.failure
                 }
                 guard let result = response.result?.pick else {

--- a/agtermCore/Sources/agtermctlKit/SocketClient.swift
+++ b/agtermCore/Sources/agtermctlKit/SocketClient.swift
@@ -3,6 +3,7 @@ import Darwin
 #elseif canImport(Glibc)
 import Glibc
 #endif
+import ArgumentParser
 import Foundation
 import agtermCore
 
@@ -119,6 +120,32 @@ struct SocketClient {
             return
         }
         print(formatResponse(response, json: json, echoID: echoID))
+    }
+
+    /// Render the immediate `pick.open` response as the documented `{"id":"…"}` JSON object.
+    static func formatPickID(_ id: String) throws -> String {
+        String(decoding: try JSONEncoder().encode(ControlResult(id: id)), as: UTF8.self)
+    }
+
+    /// Render the nested `pick.result` payload itself, rather than the enclosing control response.
+    static func formatPickResult(_ result: ControlPickResult) throws -> String {
+        String(decoding: try JSONEncoder().encode(result), as: UTF8.self)
+    }
+
+    /// Map every picker state to a process status. `pending` is non-terminal in the blocking loop; if
+    /// observed by the one-shot `pick result` verb it uses the generic failure status.
+    static func pickExitCode(for outcome: ControlPickOutcome) -> ExitCode {
+        switch outcome {
+        case .picked, .custom: .success
+        case .pending: .failure
+        case .cancelled: ExitCode(rawValue: 2)
+        }
+    }
+
+    /// Human choices may take minutes, so poll quickly only for the first second (ten 100 ms waits),
+    /// then back off to 500 ms rather than hammering the server's serial accept loop indefinitely.
+    static func pickPollDelay(afterPendingPoll poll: Int) -> TimeInterval {
+        poll <= 10 ? 0.1 : 0.5
     }
 
     /// Render a response to a single string (no trailing newline): the raw JSON line with `json: true`,

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -1513,6 +1513,17 @@ struct AppStoreTests {
         #expect(store.controlTree(zoomedSurface: { "quick" }).zoomedSurface == "quick")
     }
 
+    @Test func controlTreeReportsPickPendingFromClosure() {
+        let store = makeStore()
+        #expect(store.controlTree(pickPending: { "pick-42" }).pickPending == "pick-42")
+    }
+
+    @Test func controlTreeOmitsPickPendingWithoutClosure() {
+        let store = makeStore()
+        #expect(store.controlTree().pickPending == nil)
+        #expect(store.controlTree(pickPending: { nil }).pickPending == nil)
+    }
+
     @Test func controlTreeReportsDashboardFieldsFromClosures() {
         let store = makeStore()
         // no closures (host-free / default) or nothing open: all four omitted (nil).

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherPickTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherPickTests.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+@MainActor
+struct ControlDispatcherPickTests {
+    @Test func openRejectsMissingAndEmptyItemsWithoutCallingHost() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let missing = await dispatcher.dispatch(ControlRequest(cmd: .pickOpen))
+        let empty = await dispatcher.dispatch(ControlRequest(cmd: .pickOpen, args: ControlArgs(items: [])))
+
+        let expected = ControlResponse(ok: false, error: "pick.open requires at least one item")
+        #expect(missing == expected)
+        #expect(empty == expected)
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test func openRejectsEmptyLabelWithoutCallingHost() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .pickOpen,
+            args: ControlArgs(items: [ControlPickItem(id: "empty", label: "")])
+        ))
+
+        #expect(response == ControlResponse(ok: false, error: "pick item label must not be empty"))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test func openRejectsDuplicateIDsWithoutCallingHost() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .pickOpen,
+            args: ControlArgs(items: [
+                ControlPickItem(id: "same", label: "One"),
+                ControlPickItem(id: "same", label: "Two")
+            ])
+        ))
+
+        #expect(response == ControlResponse(ok: false, error: "pick item ids must be unique"))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test func openRejectsItemsOverLimitWithoutCallingHost() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        let items = (0...ControlPickItem.maxItems).map {
+            ControlPickItem(id: "\($0)", label: "Item \($0)")
+        }
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .pickOpen,
+            args: ControlArgs(items: items)
+        ))
+
+        #expect(response == ControlResponse(ok: false, error: "too many items (max 1000)"))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test func openRejectsControlCharactersInLabelAndSubtitleWithoutCallingHost() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let label = await dispatcher.dispatch(ControlRequest(
+            cmd: .pickOpen,
+            args: ControlArgs(items: [ControlPickItem(id: "label", label: "bad\nlabel")])
+        ))
+        let subtitle = await dispatcher.dispatch(ControlRequest(
+            cmd: .pickOpen,
+            args: ControlArgs(items: [ControlPickItem(id: "subtitle", label: "Good", subtitle: "bad\u{7f}")])
+        ))
+
+        let expected = ControlResponse(ok: false, error: "item text must not contain control characters")
+        #expect(label == expected)
+        #expect(subtitle == expected)
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test func resultAndCancelRejectMissingTargetWithoutCallingHost() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let result = await dispatcher.dispatch(ControlRequest(cmd: .pickResult))
+        let cancel = await dispatcher.dispatch(ControlRequest(cmd: .pickCancel))
+
+        #expect(result == ControlResponse(ok: false, error: "pick.result requires a pick id"))
+        #expect(cancel == ControlResponse(ok: false, error: "pick.cancel requires a pick id"))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test func openRoutesValidatedPickAndReturnsHostResponse() async throws {
+        let actions = MockControlActions()
+        let expected = ControlResponse(ok: true, result: ControlResult(id: "pick-id"))
+        actions.nextPickOpenResponse = expected
+        let dispatcher = ControlDispatcher(actions: actions)
+        let items = [
+            ControlPickItem(id: "one", label: "One", subtitle: "First"),
+            ControlPickItem(id: "two", label: "Two")
+        ]
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .pickOpen,
+            args: ControlArgs(
+                follow: true,
+                items: items,
+                prompt: "Choose",
+                allowCustom: true,
+                window: "window-id"
+            )
+        ))
+
+        #expect(response == expected)
+        let call = try #require(actions.calls.first)
+        guard case let .pickOpen(pick, window, follow) = call else {
+            Issue.record("expected pick.open host call")
+            return
+        }
+        #expect(UUID(uuidString: pick.id) != nil)
+        #expect(pick.items == items)
+        #expect(pick.prompt == "Choose")
+        #expect(pick.allowCustom)
+        #expect(window == "window-id")
+        #expect(follow)
+    }
+
+    @Test func resultRoutesTargetAndReturnsNestedPickResponse() async {
+        let actions = MockControlActions()
+        let pick = ControlPickResult(result: .picked, id: "two", label: "Two", index: 1)
+        let expected = ControlResponse(ok: true, result: ControlResult(pick: pick))
+        actions.nextPickResultResponse = expected
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .pickResult,
+            target: "pick-id",
+            args: ControlArgs(window: "window-id")
+        ))
+
+        #expect(response == expected)
+        #expect(actions.calls == [.pickResult(target: "pick-id", window: "window-id")])
+    }
+
+    @Test func cancelRoutesTargetAndReturnsSuccessResponse() async {
+        let actions = MockControlActions()
+        let expected = ControlResponse(ok: true)
+        actions.nextPickCancelResponse = expected
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .pickCancel,
+            target: "pick-id",
+            args: ControlArgs(window: "window-id")
+        ))
+
+        #expect(response == expected)
+        #expect(actions.calls == [.pickCancel(target: "pick-id", window: "window-id")])
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -19,6 +19,64 @@ struct ControlProtocolTests {
         #expect(try roundTrip(request) == request)
     }
 
+    @Test func pickCommandsRoundTrip() throws {
+        let items = [
+            ControlPickItem(id: "first", label: "First choice", subtitle: "recommended"),
+            ControlPickItem(id: "second", label: "Second choice"),
+        ]
+        let cases: [ControlRequest] = [
+            ControlRequest(
+                cmd: .pickOpen,
+                args: ControlArgs(follow: true, items: items, prompt: "Choose one",
+                                  allowCustom: true, window: "window-id")
+            ),
+            ControlRequest(cmd: .pickResult, target: "pick-id"),
+            ControlRequest(cmd: .pickCancel, target: "pick-id"),
+        ]
+
+        for request in cases {
+            #expect(try roundTrip(request) == request)
+        }
+    }
+
+    @Test func pickResultRoundTripsEveryOutcomeShape() throws {
+        let cases = [
+            ControlPickResult(result: .pending),
+            ControlPickResult(result: .picked, id: "second", label: "Second choice", index: 1),
+            ControlPickResult(result: .custom, query: "A custom answer"),
+            ControlPickResult(result: .cancelled),
+        ]
+
+        for pick in cases {
+            let response = ControlResponse(ok: true, result: ControlResult(pick: pick))
+            #expect(try roundTrip(response) == response)
+        }
+    }
+
+    @Test func controlResultPickOmitsWhenNil() throws {
+        let result = ControlResult(id: "pick-id")
+        let json = String(decoding: try JSONEncoder().encode(result), as: UTF8.self)
+
+        #expect(!json.contains("\"pick\""), "a nil pick must be omitted from the JSON; got \(json)")
+        #expect(try JSONDecoder().decode(ControlResult.self, from: Data(json.utf8)).pick == nil)
+    }
+
+    @Test func controlTreePickPendingOmitsWhenNil() throws {
+        let tree = ControlTree(workspaces: [])
+        let json = String(decoding: try JSONEncoder().encode(tree), as: UTF8.self)
+
+        #expect(!json.contains("pickPending"), "a nil pending picker must be omitted from the JSON; got \(json)")
+        #expect(try JSONDecoder().decode(ControlTree.self, from: Data(json.utf8)).pickPending == nil)
+    }
+
+    @Test func controlPickItemSubtitleOmitsWhenNil() throws {
+        let item = ControlPickItem(id: "first", label: "First choice")
+        let json = String(decoding: try JSONEncoder().encode(item), as: UTF8.self)
+
+        #expect(!json.contains("subtitle"), "a nil subtitle must be omitted from the JSON; got \(json)")
+        #expect(try JSONDecoder().decode(ControlPickItem.self, from: Data(json.utf8)).subtitle == nil)
+    }
+
     @Test func workspaceCommandsRoundTrip() throws {
         let cases: [ControlRequest] = [
             ControlRequest(cmd: .workspaceNew, args: ControlArgs(name: "work")),

--- a/agtermCore/Tests/agtermCoreTests/DashboardControllerTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/DashboardControllerTests.swift
@@ -134,6 +134,18 @@ struct DashboardControllerTests {
         #expect(controller.appliedFontSize == 18)
     }
 
+    @Test func requestFocusAdvancesRevisionWithoutChangingDashboardState() {
+        let controller = DashboardController()
+        let member = primary(UUID())
+        controller.open(members: [member])
+
+        controller.requestFocus()
+
+        #expect(controller.focusRevision == 1)
+        #expect(controller.members == [member])
+        #expect(controller.highlighted == member)
+    }
+
     @Test func reopenOverSameMembersUpdatesFontMode() {
         // a same-members re-open with a new font mode must update the mode (the app-side wiring keys its
         // font re-apply off members+fontMode, so this is what a `dashboard A B --font-size 20` re-open sees).

--- a/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
+++ b/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
@@ -75,6 +75,9 @@ final class MockControlActions: ControlActions {
         case windowZoom(target: String?)
         case windowFullscreen(target: String?)
         case windowMinimize(target: String?, mode: ControlToggleMode)
+        case pickOpen(PendingPick, window: String?, follow: Bool)
+        case pickResult(target: String, window: String?)
+        case pickCancel(target: String, window: String?)
         case restoreClear
     }
 
@@ -135,6 +138,9 @@ final class MockControlActions: ControlActions {
     var nextWindowZoomResponse = ControlResponse(ok: true)
     var nextWindowFullscreenResponse = ControlResponse(ok: true)
     var nextWindowMinimizeResponse = ControlResponse(ok: true)
+    var nextPickOpenResponse = ControlResponse(ok: true)
+    var nextPickResultResponse = ControlResponse(ok: true)
+    var nextPickCancelResponse = ControlResponse(ok: true)
     var nextRestoreClearResponse = ControlResponse(ok: true)
     var nextSessionRestoreResponse = ControlResponse(ok: true)
 
@@ -487,6 +493,21 @@ final class MockControlActions: ControlActions {
     func windowMinimize(_ target: String?, mode: ControlToggleMode) async -> ControlResponse {
         calls.append(.windowMinimize(target: target, mode: mode))
         return nextWindowMinimizeResponse
+    }
+
+    func openPick(_ pick: PendingPick, window: String?, follow: Bool) -> ControlResponse {
+        calls.append(.pickOpen(pick, window: window, follow: follow))
+        return nextPickOpenResponse
+    }
+
+    func pickResult(_ target: String, window: String?) -> ControlResponse {
+        calls.append(.pickResult(target: target, window: window))
+        return nextPickResultResponse
+    }
+
+    func cancelPick(_ target: String, window: String?) -> ControlResponse {
+        calls.append(.pickCancel(target: target, window: window))
+        return nextPickCancelResponse
     }
 
     func clearRestoreCommands() -> ControlResponse {

--- a/agtermCore/Tests/agtermCoreTests/PickCustomRowTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/PickCustomRowTests.swift
@@ -1,0 +1,22 @@
+import Testing
+@testable import agtermCore
+
+struct PickCustomRowTests {
+    @Test func emptyQueryDoesNotOfferCustomRow() {
+        #expect(pickCustomRowLabel(query: "", filteredCount: 0, allowCustom: true) == nil)
+        #expect(pickCustomRowLabel(query: " \t ", filteredCount: 0, allowCustom: true) == nil)
+    }
+
+    @Test func unmatchedQueryOffersCustomRowWhenAllowed() {
+        #expect(pickCustomRowLabel(query: "new value", filteredCount: 0, allowCustom: true)
+            == "Use \"new value\"")
+    }
+
+    @Test func unmatchedQueryDoesNotOfferCustomRowWhenDisallowed() {
+        #expect(pickCustomRowLabel(query: "new value", filteredCount: 0, allowCustom: false) == nil)
+    }
+
+    @Test func matchingQueryDoesNotOfferCustomRow() {
+        #expect(pickCustomRowLabel(query: "one", filteredCount: 1, allowCustom: true) == nil)
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/PickTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/PickTests.swift
@@ -69,6 +69,7 @@ struct PickTests {
         let registry = PickRegistry.shared
         let id = UUID()
         let controller = PickController()
+        defer { registry.clearRetainedResult(for: id) }
         #expect(registry.controller(for: id) == nil)
 
         registry.register(id, controller: controller)
@@ -76,6 +77,27 @@ struct PickTests {
 
         registry.unregister(id)
         #expect(registry.controller(for: id) == nil)
+    }
+
+    @Test func registryUnregisterCancelsAndRetainsResultUntilNextOpen() {
+        let registry = PickRegistry.shared
+        let id = UUID()
+        let controller = PickController()
+        let pick = makePick(id: "closed-window")
+        defer {
+            registry.unregister(id)
+            registry.clearRetainedResult(for: id)
+        }
+        registry.register(id, controller: controller)
+        #expect(controller.open(pick))
+
+        registry.unregister(id)
+
+        #expect(registry.controller(for: id) == nil)
+        #expect(registry.retainedResult(for: pick.id) == ControlPickResult(result: .cancelled))
+
+        registry.clearRetainedResult(for: id)
+        #expect(registry.retainedResult(for: pick.id) == nil)
     }
 
     @Test func registryLookupWithNilIDReturnsNil() {

--- a/agtermCore/Tests/agtermCoreTests/PickTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/PickTests.swift
@@ -16,7 +16,8 @@ struct PickTests {
         controller.resolve(outcome)
 
         #expect(controller.pending == nil)
-        #expect(controller.recentResults == [ResolvedPick(id: pick.id, result: outcome)])
+        #expect(controller.recentResults.map(\.id) == [pick.id])
+        #expect(controller.recentResults.map(\.result) == [outcome])
         #expect(controller.result(for: pick.id) == outcome)
     }
 
@@ -105,6 +106,35 @@ struct PickTests {
         #expect(registry.controller(for: id) == nil)
         #expect(registry.retainedResult(for: pick.id)?.windowID == id)
         #expect(registry.retainedResult(for: pick.id)?.result == ControlPickResult(result: .cancelled))
+    }
+
+    @Test func registryTrimDropsTheOldestAnswerNotTheFirstTransferred() {
+        let registry = PickRegistry.shared
+        let marker = UUID().uuidString
+
+        // answer the fillers FIRST, so they are the older answers, but leave their windows open.
+        let fillers = (0..<PickRegistry.retainedResultLimit).map { index -> (UUID, PickController) in
+            let id = UUID()
+            let controller = PickController()
+            registry.register(id, controller: controller)
+            #expect(controller.open(makePick(id: "\(marker)-filler-\(index)")))
+            controller.cancel()
+            return (id, controller)
+        }
+        // answer the newest pick AFTER them, and close its window FIRST so it transfers to the front.
+        let newestWindow = UUID()
+        let newest = PickController()
+        registry.register(newestWindow, controller: newest)
+        #expect(newest.open(makePick(id: "\(marker)-newest")))
+        newest.cancel()
+        registry.unregister(newestWindow)
+
+        for (id, _) in fillers { registry.unregister(id) }
+
+        #expect(registry.retainedResult(for: "\(marker)-newest") != nil,
+                "trimming must not drop the newest answer just because its window closed first")
+        #expect(registry.retainedResult(for: "\(marker)-filler-0") == nil,
+                "the oldest answer is the one that goes")
     }
 
     @Test func registryRetainedResultsStopAtTheLimitDroppingTheOldest() {

--- a/agtermCore/Tests/agtermCoreTests/PickTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/PickTests.swift
@@ -94,7 +94,8 @@ struct PickTests {
         registry.unregister(id)
 
         #expect(registry.controller(for: id) == nil)
-        #expect(registry.retainedResult(for: pick.id) == ControlPickResult(result: .cancelled))
+        #expect(registry.retainedResult(for: pick.id)?.windowID == id)
+        #expect(registry.retainedResult(for: pick.id)?.result == ControlPickResult(result: .cancelled))
 
         registry.clearRetainedResult(for: id)
         #expect(registry.retainedResult(for: pick.id) == nil)
@@ -102,6 +103,26 @@ struct PickTests {
 
     @Test func registryLookupWithNilIDReturnsNil() {
         #expect(PickRegistry.shared.controller(for: nil) == nil)
+    }
+
+    @Test func permanentWindowRemovalKeepsRetainedResultForExternalPoll() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agterm-pick-registry-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let library = WindowLibrary(directory: directory)
+        let id = library.newWindow(name: "temporary").id
+        let controller = PickController()
+        let pick = makePick(id: "deleted-window")
+        PickRegistry.shared.register(id, controller: controller)
+        #expect(controller.open(pick))
+        PickRegistry.shared.unregister(id)
+        #expect(PickRegistry.shared.retainedResult(for: pick.id) != nil)
+
+        library.removeWindow(id)
+
+        #expect(PickRegistry.shared.retainedResult(for: pick.id)?.result ==
+            ControlPickResult(result: .cancelled))
+        PickRegistry.shared.clearRetainedResult(for: id)
     }
 
     private func makePick(id: String) -> PendingPick {

--- a/agtermCore/Tests/agtermCoreTests/PickTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/PickTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+@MainActor
+struct PickTests {
+    @Test func openAndResolveRetainsResultAfterPendingCloses() throws {
+        let controller = PickController()
+        let pick = makePick(id: "pick-1")
+        let outcome = ControlPickResult(result: .picked, id: "one", label: "One", index: 0)
+
+        #expect(controller.open(pick))
+        #expect(controller.pending == pick)
+        #expect(controller.result(for: pick.id) == ControlPickResult(result: .pending))
+
+        controller.resolve(outcome)
+
+        #expect(controller.pending == nil)
+        #expect(controller.lastResult == ResolvedPick(id: pick.id, result: outcome))
+        #expect(controller.result(for: pick.id) == outcome)
+    }
+
+    @Test func cancelRetainsCancelledResult() {
+        let controller = PickController()
+        let pick = makePick(id: "pick-cancel")
+
+        #expect(controller.open(pick))
+        controller.cancel()
+
+        #expect(controller.pending == nil)
+        #expect(controller.result(for: pick.id) == ControlPickResult(result: .cancelled))
+    }
+
+    @Test func openRejectsWhileAnotherPickIsPending() {
+        let controller = PickController()
+        let first = makePick(id: "first")
+        let second = makePick(id: "second")
+
+        #expect(controller.open(first))
+        #expect(!controller.open(second))
+        #expect(controller.pending == first)
+        #expect(controller.result(for: "second") == nil)
+    }
+
+    @Test func resultReturnsNilForUnknownID() {
+        let controller = PickController()
+        #expect(controller.open(makePick(id: "known")))
+
+        #expect(controller.result(for: "unknown") == nil)
+    }
+
+    @Test func nextOpenReplacesLastResult() {
+        let controller = PickController()
+        let first = makePick(id: "first")
+        let firstResult = ControlPickResult(result: .custom, query: "typed")
+        #expect(controller.open(first))
+        controller.resolve(firstResult)
+        #expect(controller.lastResult == ResolvedPick(id: first.id, result: firstResult))
+
+        let second = makePick(id: "second")
+        #expect(controller.open(second))
+
+        #expect(controller.lastResult == nil)
+        #expect(controller.result(for: first.id) == nil)
+        #expect(controller.result(for: second.id) == ControlPickResult(result: .pending))
+    }
+
+    @Test func registryRegistersLooksUpAndUnregisters() {
+        let registry = PickRegistry.shared
+        let id = UUID()
+        let controller = PickController()
+        #expect(registry.controller(for: id) == nil)
+
+        registry.register(id, controller: controller)
+        #expect(registry.controller(for: id) === controller)
+
+        registry.unregister(id)
+        #expect(registry.controller(for: id) == nil)
+    }
+
+    @Test func registryLookupWithNilIDReturnsNil() {
+        #expect(PickRegistry.shared.controller(for: nil) == nil)
+    }
+
+    private func makePick(id: String) -> PendingPick {
+        PendingPick(
+            id: id,
+            items: [ControlPickItem(id: "one", label: "One")],
+            prompt: "Choose",
+            allowCustom: true
+        )
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/PickTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/PickTests.swift
@@ -16,7 +16,7 @@ struct PickTests {
         controller.resolve(outcome)
 
         #expect(controller.pending == nil)
-        #expect(controller.lastResult == ResolvedPick(id: pick.id, result: outcome))
+        #expect(controller.recentResults == [ResolvedPick(id: pick.id, result: outcome)])
         #expect(controller.result(for: pick.id) == outcome)
     }
 
@@ -49,27 +49,39 @@ struct PickTests {
         #expect(controller.result(for: "unknown") == nil)
     }
 
-    @Test func nextOpenReplacesLastResult() {
+    @Test func nextOpenKeepsPriorResultReadableForItsOwnPoller() {
         let controller = PickController()
         let first = makePick(id: "first")
         let firstResult = ControlPickResult(result: .custom, query: "typed")
         #expect(controller.open(first))
         controller.resolve(firstResult)
-        #expect(controller.lastResult == ResolvedPick(id: first.id, result: firstResult))
 
         let second = makePick(id: "second")
         #expect(controller.open(second))
 
-        #expect(controller.lastResult == nil)
-        #expect(controller.result(for: first.id) == nil)
+        #expect(controller.result(for: first.id) == firstResult)
         #expect(controller.result(for: second.id) == ControlPickResult(result: .pending))
+    }
+
+    @Test func retainedResultsStopAtTheLimitDroppingTheOldest() {
+        let controller = PickController()
+        let total = PickController.retainedResultLimit + 2
+        for index in 0..<total {
+            #expect(controller.open(makePick(id: "pick-\(index)")))
+            controller.resolve(ControlPickResult(result: .picked, id: "one", label: "One", index: index))
+        }
+
+        #expect(controller.recentResults.count == PickController.retainedResultLimit)
+        #expect(controller.result(for: "pick-0") == nil)
+        #expect(controller.result(for: "pick-1") == nil)
+        #expect(controller.result(for: "pick-2")?.index == 2)
+        #expect(controller.result(for: "pick-\(total - 1)")?.index == total - 1)
     }
 
     @Test func registryRegistersLooksUpAndUnregisters() {
         let registry = PickRegistry.shared
         let id = UUID()
         let controller = PickController()
-        defer { registry.clearRetainedResult(for: id) }
         #expect(registry.controller(for: id) == nil)
 
         registry.register(id, controller: controller)
@@ -79,15 +91,12 @@ struct PickTests {
         #expect(registry.controller(for: id) == nil)
     }
 
-    @Test func registryUnregisterCancelsAndRetainsResultUntilNextOpen() {
+    @Test func registryUnregisterCancelsAndRetainsResultForItsPollers() {
         let registry = PickRegistry.shared
         let id = UUID()
         let controller = PickController()
         let pick = makePick(id: "closed-window")
-        defer {
-            registry.unregister(id)
-            registry.clearRetainedResult(for: id)
-        }
+        defer { registry.unregister(id) }
         registry.register(id, controller: controller)
         #expect(controller.open(pick))
 
@@ -96,9 +105,22 @@ struct PickTests {
         #expect(registry.controller(for: id) == nil)
         #expect(registry.retainedResult(for: pick.id)?.windowID == id)
         #expect(registry.retainedResult(for: pick.id)?.result == ControlPickResult(result: .cancelled))
+    }
 
-        registry.clearRetainedResult(for: id)
-        #expect(registry.retainedResult(for: pick.id) == nil)
+    @Test func registryRetainedResultsStopAtTheLimitDroppingTheOldest() {
+        let registry = PickRegistry.shared
+        let marker = UUID().uuidString
+        let total = PickRegistry.retainedResultLimit + 1
+        for index in 0..<total {
+            let id = UUID()
+            let controller = PickController()
+            registry.register(id, controller: controller)
+            #expect(controller.open(makePick(id: "\(marker)-\(index)")))
+            registry.unregister(id)
+        }
+
+        #expect(registry.retainedResult(for: "\(marker)-0") == nil)
+        #expect(registry.retainedResult(for: "\(marker)-\(total - 1)") != nil)
     }
 
     @Test func registryLookupWithNilIDReturnsNil() {
@@ -122,7 +144,6 @@ struct PickTests {
 
         #expect(PickRegistry.shared.retainedResult(for: pick.id)?.result ==
             ControlPickResult(result: .cancelled))
-        PickRegistry.shared.clearRetainedResult(for: id)
     }
 
     private func makePick(id: String) -> PendingPick {

--- a/agtermCore/Tests/agtermCoreTests/SkillInstallTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SkillInstallTests.swift
@@ -14,7 +14,7 @@ struct SkillInstallTests {
         let reference = try String(contentsOf: skillDirectory.appendingPathComponent("reference.md"), encoding: .utf8)
         let examples = try String(contentsOf: skillDirectory.appendingPathComponent("examples.md"), encoding: .utf8)
 
-        #expect(skill.contains("Command summary (68 commands)"))
+        #expect(skill.contains("Command summary (71 commands)"))
         #expect(skill.contains("`keymap list`"))
         #expect(reference.contains("`agtermctl keymap list`"))
         #expect(examples.contains("agtermctl keymap list"))

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -924,6 +924,93 @@ struct CommandsTests {
             ControlRequest(cmd: .surfaceZoom, target: "active", args: ControlArgs(mode: "hide", window: "win")))
     }
 
+    // MARK: - pick
+
+    @Test func pickDefaultsToOpen() throws {
+        #expect(try Agtermctl.parseAsRoot(["pick"]) is Pick.Open)
+    }
+
+    @Test func pickOpenSniffsJSONArray() throws {
+        let input = Data("""
+          [
+            {"id":"one","label":"One","subtitle":"First"},
+            {"id":"two","label":"Two"}
+          ]
+        """.utf8)
+
+        #expect(try Pick.Open.parseItems(input) == [
+            ControlPickItem(id: "one", label: "One", subtitle: "First"),
+            ControlPickItem(id: "two", label: "Two")
+        ])
+    }
+
+    @Test func pickOpenSniffsBareLines() throws {
+        #expect(try Pick.Open.parseItems(Data("One\nTwo\n".utf8)) == [
+            ControlPickItem(id: "One", label: "One"),
+            ControlPickItem(id: "Two", label: "Two")
+        ])
+    }
+
+    @Test func pickOpenDropsBlankLines() throws {
+        #expect(try Pick.Open.parseItems(Data("\nOne\n \t \n\nTwo\n".utf8)) == [
+            ControlPickItem(id: "One", label: "One"),
+            ControlPickItem(id: "Two", label: "Two")
+        ])
+    }
+
+    @Test func pickOpenAcceptsEmptyStdinAsNoItems() throws {
+        #expect(try Pick.Open.parseItems(Data()).isEmpty)
+    }
+
+    @Test func pickOpenRejectsMalformedJSON() {
+        #expect(throws: (any Error).self) {
+            try Pick.Open.parseItems(Data("[{\"id\":\"one\"".utf8))
+        }
+    }
+
+    @Test func pickOpenMapsEveryOptionToRequest() throws {
+        let command = try Pick.Open.parse([
+            "--prompt", "Choose one", "--allow-custom", "--follow",
+            "--window", "w1", "--no-block"
+        ])
+        let items = [ControlPickItem(id: "One", label: "One")]
+        let expected = ControlRequest(
+            cmd: .pickOpen,
+            args: ControlArgs(
+                follow: true, items: items, prompt: "Choose one",
+                allowCustom: true, window: "w1"
+            )
+        )
+
+        #expect(try command.makeRequest(input: Data("One\n".utf8)) == expected)
+        #expect(command.noBlock)
+    }
+
+    @Test func pickOpenDefaultsToBlockingWithoutOptionalArgs() throws {
+        let command = try Pick.Open.parse([])
+        let items = [ControlPickItem(id: "One", label: "One")]
+
+        #expect(try command.makeRequest(input: Data("One\n".utf8)) ==
+            ControlRequest(cmd: .pickOpen, args: ControlArgs(items: items)))
+        #expect(!command.noBlock)
+    }
+
+    @Test func pickResultMapsIDAndWindow() throws {
+        #expect(try request(["pick", "result", "pick-1", "--window", "w1"]) ==
+            ControlRequest(cmd: .pickResult, target: "pick-1", args: ControlArgs(window: "w1")))
+    }
+
+    @Test func pickCancelMapsIDAndWindow() throws {
+        #expect(try request(["pick", "cancel", "pick-1", "--window", "w1"]) ==
+            ControlRequest(cmd: .pickCancel, target: "pick-1", args: ControlArgs(window: "w1")))
+    }
+
+    @Test func pickOpenHasNoTimeoutOption() {
+        #expect(throws: (any Error).self) {
+            try Agtermctl.parseAsRoot(["pick", "--timeout", "60"])
+        }
+    }
+
     // MARK: - dashboard
 
     @Test func dashboardOpenWithIdsAndFontSize() throws {

--- a/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
@@ -356,7 +356,7 @@ struct SocketClientTests {
         )
 
         #expect(requests.dropFirst().allSatisfy {
-            $0 == ControlRequest(cmd: .pickResult, target: "pick-1", args: ControlArgs(window: "w1"))
+            $0 == ControlRequest(cmd: .pickResult, target: "pick-1")
         })
         #expect(sleeps == Array(repeating: 0.1, count: 10) + [0.5])
         let result = try JSONDecoder().decode(
@@ -397,14 +397,19 @@ struct SocketClientTests {
 
     @Test func pickBlockFailsForOpenErrorAndMalformedResult() throws {
         let command = try Pick.Open.parse([])
+        var errors: [String] = []
         #expect(throws: ExitCode.failure) {
             try command.execute(
                 input: Data("One\n".utf8),
                 send: { _ in ControlResponse(ok: false, error: "boom") },
                 sleep: { _ in },
-                output: { _ in }
+                output: { _ in Issue.record("a non-JSON server error must not use stdout") },
+                errorOutput: { errors.append($0) }
             )
         }
+        #expect(errors == ["error: boom"])
+
+        errors.removeAll()
         #expect(throws: ExitCode.failure) {
             try command.execute(
                 input: Data("One\n".utf8),
@@ -414,9 +419,117 @@ struct SocketClientTests {
                         : ControlResponse(ok: true)
                 },
                 sleep: { _ in },
-                output: { _ in }
+                output: { _ in Issue.record("a protocol error must not use stdout") },
+                errorOutput: { errors.append($0) }
             )
         }
+        #expect(errors == ["error: pick.result missing result"])
+    }
+
+    @Test func pickBlockRoutesJSONServerErrorThroughInjectedStdout() throws {
+        let command = try Pick.Open.parse(["--json"])
+        var output: [String] = []
+
+        #expect(throws: ExitCode.failure) {
+            try command.execute(
+                input: Data("One\n".utf8),
+                send: { _ in ControlResponse(ok: false, error: "boom") },
+                sleep: { _ in },
+                output: { output.append($0) },
+                errorOutput: { _ in Issue.record("a JSON server error must not use stderr") }
+            )
+        }
+
+        let response = try JSONDecoder().decode(ControlResponse.self, from: Data(#require(output.first).utf8))
+        #expect(!response.ok)
+        #expect(response.error == "boom")
+    }
+
+    @Test(arguments: [
+        (ControlPickOutcome.picked, Int32(0)),
+        (.custom, Int32(0)),
+        (.pending, Int32(1)),
+        (.cancelled, Int32(2)),
+    ])
+    func pickResultExecutesRequestPrintsJSONAndMapsExit(
+        _ outcome: ControlPickOutcome,
+        _ expectedExit: Int32
+    ) throws {
+        let command = try Pick.Result.parse(["pick-1", "--window", "w1"])
+        var request: ControlRequest?
+        var output: [String] = []
+        let run = {
+            try command.execute(
+                send: {
+                    request = $0
+                    return ControlResponse(ok: true, result: ControlResult(
+                        pick: ControlPickResult(result: outcome)
+                    ))
+                },
+                output: { output.append($0) }
+            )
+        }
+
+        if expectedExit == 0 {
+            try run()
+        } else {
+            do {
+                try run()
+                Issue.record("expected mapped exit \(expectedExit)")
+            } catch let code as ExitCode {
+                #expect(code.rawValue == expectedExit)
+            }
+        }
+        #expect(request == ControlRequest(
+            cmd: .pickResult,
+            target: "pick-1",
+            args: ControlArgs(window: "w1")
+        ))
+        #expect(try JSONDecoder().decode(
+            ControlPickResult.self,
+            from: Data(#require(output.first).utf8)
+        ).result == outcome)
+    }
+
+    @Test func pickResultRoutesServerAndProtocolErrorsThroughInjectedStderr() throws {
+        let command = try Pick.Result.parse(["pick-1"])
+        var errors: [String] = []
+
+        #expect(throws: ExitCode.failure) {
+            try command.execute(
+                send: { _ in ControlResponse(ok: false, error: "boom") },
+                output: { _ in Issue.record("a non-JSON server error must not use stdout") },
+                errorOutput: { errors.append($0) }
+            )
+        }
+        #expect(errors == ["error: boom"])
+
+        errors.removeAll()
+        #expect(throws: ExitCode.failure) {
+            try command.execute(
+                send: { _ in ControlResponse(ok: true) },
+                output: { _ in Issue.record("a protocol error must not use stdout") },
+                errorOutput: { errors.append($0) }
+            )
+        }
+        #expect(errors == ["error: pick.result missing result"])
+    }
+
+    @Test func pickResultRoutesJSONServerErrorThroughInjectedStdout() throws {
+        let command = try Pick.Result.parse(["pick-1", "--json"])
+        var output: [String] = []
+
+        #expect(throws: ExitCode.failure) {
+            try command.execute(
+                send: { _ in ControlResponse(ok: false, error: "boom") },
+                output: { output.append($0) },
+                errorOutput: { _ in Issue.record("a JSON server error must not use stderr") }
+            )
+        }
+
+        let response = try JSONDecoder().decode(ControlResponse.self, from: Data(#require(output.first).utf8))
+        #expect(!response.ok)
+        #expect(response.error == "boom")
     }
 
     @Test func formatResponseBareOk() {

--- a/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
@@ -429,17 +429,16 @@ struct SocketClientTests {
     @Test func pickBlockCancelsThePickerItCanNoLongerWaitOn() throws {
         let command = try Pick.Open.parse([])
         var sent: [ControlRequest] = []
-        let failingPoll: (ControlRequest) throws -> ControlResponse = { request in
+        // ok, but with no pick payload: the server still holds the picker, so it must be dismissed.
+        let malformedPoll: (ControlRequest) throws -> ControlResponse = { request in
             sent.append(request)
-            switch request.cmd {
-            case .pickOpen: return ControlResponse(ok: true, result: ControlResult(id: "pick-1"))
-            case .pickResult: return ControlResponse(ok: false, error: "boom")
-            default: return ControlResponse(ok: true)
-            }
+            return request.cmd == .pickOpen
+                ? ControlResponse(ok: true, result: ControlResult(id: "pick-1"))
+                : ControlResponse(ok: true)
         }
 
         #expect(throws: ExitCode.failure) {
-            try command.execute(input: Data("One\n".utf8), send: failingPoll,
+            try command.execute(input: Data("One\n".utf8), send: malformedPoll,
                                 sleep: { _ in }, output: { _ in }, errorOutput: { _ in })
         }
         #expect(sent.map(\.cmd) == [.pickOpen, .pickResult, .pickCancel],
@@ -452,13 +451,58 @@ struct SocketClientTests {
                 input: Data("One\n".utf8),
                 send: { request in
                     guard request.cmd != .pickCancel else { throw SocketClientError("socket gone") }
-                    return try failingPoll(request)
+                    return try malformedPoll(request)
                 },
                 sleep: { _ in }, output: { _ in }, errorOutput: { _ in }
             )
         }
         #expect(sent.map(\.cmd) == [.pickOpen, .pickResult],
                 "a failing cancel is best effort and must not replace the poll failure")
+    }
+
+    @Test func pickBlockDoesNotCancelWhenTheServerAlreadyLostThePicker() throws {
+        let command = try Pick.Open.parse([])
+        var sent: [ControlRequest] = []
+
+        #expect(throws: ExitCode.failure) {
+            try command.execute(
+                input: Data("One\n".utf8),
+                send: { request in
+                    sent.append(request)
+                    return request.cmd == .pickOpen
+                        ? ControlResponse(ok: true, result: ControlResult(id: "pick-1"))
+                        : ControlResponse(ok: false, error: "unknown pick: pick-1")
+                },
+                sleep: { _ in }, output: { _ in }, errorOutput: { _ in }
+            )
+        }
+
+        #expect(sent.map(\.cmd) == [.pickOpen, .pickResult],
+                "the poll carries no window selector, so a not-ok result means there is nothing left to cancel")
+    }
+
+    @Test func pickBlockCancelsWhenThePollItselfThrows() throws {
+        let command = try Pick.Open.parse([])
+        var sent: [ControlRequest] = []
+
+        #expect(throws: SocketClientError.self) {
+            try command.execute(
+                input: Data("One\n".utf8),
+                send: { request in
+                    sent.append(request)
+                    switch request.cmd {
+                    case .pickOpen: return ControlResponse(ok: true, result: ControlResult(id: "pick-1"))
+                    case .pickResult: throw SocketClientError("no response from /tmp/agterm.sock")
+                    default: return ControlResponse(ok: true)
+                    }
+                },
+                sleep: { _ in }, output: { _ in }, errorOutput: { _ in }
+            )
+        }
+
+        #expect(sent.map(\.cmd) == [.pickOpen, .pickResult, .pickCancel],
+                "a transport failure mid-wait must still dismiss the picker rather than leave it pending")
+        #expect(sent.last?.target == "pick-1")
     }
 
     @Test func pickBlockRoutesJSONServerErrorThroughInjectedStdout() throws {

--- a/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
@@ -271,6 +271,154 @@ struct SocketClientTests {
         #expect(throws: ExitCode.failure) { try command.run() }
     }
 
+    @Test func formatsPickIDAsJSON() throws {
+        let line = try SocketClient.formatPickID("pick-1")
+        let object = try #require(JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: String])
+
+        #expect(object == ["id": "pick-1"])
+    }
+
+    @Test func formatsPickResultAsJSON() throws {
+        let result = ControlPickResult(result: .picked, id: "two", label: "Two", index: 1)
+        let line = try SocketClient.formatPickResult(result)
+
+        #expect(try JSONDecoder().decode(ControlPickResult.self, from: Data(line.utf8)) == result)
+    }
+
+    @Test(arguments: [
+        (ControlPickOutcome.pending, Int32(1)),
+        (.picked, Int32(0)),
+        (.custom, Int32(0)),
+        (.cancelled, Int32(2))
+    ])
+    func pickExitCodeMapsEveryOutcome(_ outcome: ControlPickOutcome, _ expected: Int32) {
+        #expect(SocketClient.pickExitCode(for: outcome).rawValue == expected)
+    }
+
+    @Test func pickPollBackoffUsesTenFastSleepsThenSlowSleeps() {
+        #expect((1...10).map(SocketClient.pickPollDelay(afterPendingPoll:)) ==
+            Array(repeating: 0.1, count: 10))
+        #expect(SocketClient.pickPollDelay(afterPendingPoll: 11) == 0.5)
+        #expect(SocketClient.pickPollDelay(afterPendingPoll: 100) == 0.5)
+    }
+
+    @Test func pickNoBlockPrintsIDWithoutPolling() throws {
+        let command = try Pick.Open.parse(["--no-block"])
+        var requests: [ControlRequest] = []
+        var output: [String] = []
+
+        try command.execute(
+            input: Data("One\n".utf8),
+            send: { request in
+                requests.append(request)
+                return ControlResponse(ok: true, result: ControlResult(id: "pick-1"))
+            },
+            sleep: { _ in Issue.record("--no-block must not sleep") },
+            output: { output.append($0) }
+        )
+
+        #expect(requests == [
+            ControlRequest(
+                cmd: .pickOpen,
+                args: ControlArgs(items: [ControlPickItem(id: "One", label: "One")])
+            )
+        ])
+        #expect(try JSONSerialization.jsonObject(with: Data(#require(output.first).utf8)) as? [String: String] ==
+            ["id": "pick-1"])
+    }
+
+    @Test func pickBlockPollsWithBackoffPrintsResultAndExitsZero() throws {
+        let command = try Pick.Open.parse(["--window", "w1"])
+        var requests: [ControlRequest] = []
+        var sleeps: [TimeInterval] = []
+        var output: [String] = []
+        var polls = 0
+
+        try command.execute(
+            input: Data("One\n".utf8),
+            send: { request in
+                requests.append(request)
+                if request.cmd == .pickOpen {
+                    return ControlResponse(ok: true, result: ControlResult(id: "pick-1"))
+                }
+                polls += 1
+                if polls <= 11 {
+                    return ControlResponse(ok: true, result: ControlResult(
+                        pick: ControlPickResult(result: .pending)
+                    ))
+                }
+                return ControlResponse(ok: true, result: ControlResult(
+                    pick: ControlPickResult(result: .picked, id: "One", label: "One", index: 0)
+                ))
+            },
+            sleep: { sleeps.append($0) },
+            output: { output.append($0) }
+        )
+
+        #expect(requests.dropFirst().allSatisfy {
+            $0 == ControlRequest(cmd: .pickResult, target: "pick-1", args: ControlArgs(window: "w1"))
+        })
+        #expect(sleeps == Array(repeating: 0.1, count: 10) + [0.5])
+        let result = try JSONDecoder().decode(
+            ControlPickResult.self,
+            from: Data(#require(output.first).utf8)
+        )
+        #expect(result == ControlPickResult(result: .picked, id: "One", label: "One", index: 0))
+    }
+
+    @Test func pickBlockThrowsCancelledExitCodeAfterPrintingResult() throws {
+        let command = try Pick.Open.parse([])
+        var output: [String] = []
+
+        do {
+            try command.execute(
+                input: Data("One\n".utf8),
+                send: { request in
+                    request.cmd == .pickOpen
+                        ? ControlResponse(ok: true, result: ControlResult(id: "pick-1"))
+                        : ControlResponse(ok: true, result: ControlResult(
+                            pick: ControlPickResult(result: .cancelled)
+                        ))
+                },
+                sleep: { _ in Issue.record("a terminal result must not sleep") },
+                output: { output.append($0) }
+            )
+            Issue.record("expected the cancelled exit code")
+        } catch let code as ExitCode {
+            #expect(code.rawValue == 2)
+        }
+
+        let result = try JSONDecoder().decode(
+            ControlPickResult.self,
+            from: Data(#require(output.first).utf8)
+        )
+        #expect(result.result == .cancelled)
+    }
+
+    @Test func pickBlockFailsForOpenErrorAndMalformedResult() throws {
+        let command = try Pick.Open.parse([])
+        #expect(throws: ExitCode.failure) {
+            try command.execute(
+                input: Data("One\n".utf8),
+                send: { _ in ControlResponse(ok: false, error: "boom") },
+                sleep: { _ in },
+                output: { _ in }
+            )
+        }
+        #expect(throws: ExitCode.failure) {
+            try command.execute(
+                input: Data("One\n".utf8),
+                send: { request in
+                    request.cmd == .pickOpen
+                        ? ControlResponse(ok: true, result: ControlResult(id: "pick-1"))
+                        : ControlResponse(ok: true)
+                },
+                sleep: { _ in },
+                output: { _ in }
+            )
+        }
+    }
+
     @Test func formatResponseBareOk() {
         #expect(SocketClient.formatResponse(ControlResponse(ok: true), json: false) == "ok")
     }

--- a/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
@@ -426,6 +426,41 @@ struct SocketClientTests {
         #expect(errors == ["error: pick.result missing result"])
     }
 
+    @Test func pickBlockCancelsThePickerItCanNoLongerWaitOn() throws {
+        let command = try Pick.Open.parse([])
+        var sent: [ControlRequest] = []
+        let failingPoll: (ControlRequest) throws -> ControlResponse = { request in
+            sent.append(request)
+            switch request.cmd {
+            case .pickOpen: return ControlResponse(ok: true, result: ControlResult(id: "pick-1"))
+            case .pickResult: return ControlResponse(ok: false, error: "boom")
+            default: return ControlResponse(ok: true)
+            }
+        }
+
+        #expect(throws: ExitCode.failure) {
+            try command.execute(input: Data("One\n".utf8), send: failingPoll,
+                                sleep: { _ in }, output: { _ in }, errorOutput: { _ in })
+        }
+        #expect(sent.map(\.cmd) == [.pickOpen, .pickResult, .pickCancel],
+                "a poll that cannot continue must dismiss the picker it opened")
+        #expect(sent.last?.target == "pick-1")
+
+        sent.removeAll()
+        #expect(throws: ExitCode.failure) {
+            try command.execute(
+                input: Data("One\n".utf8),
+                send: { request in
+                    guard request.cmd != .pickCancel else { throw SocketClientError("socket gone") }
+                    return try failingPoll(request)
+                },
+                sleep: { _ in }, output: { _ in }, errorOutput: { _ in }
+            )
+        }
+        #expect(sent.map(\.cmd) == [.pickOpen, .pickResult],
+                "a failing cancel is best effort and must not replace the poll failure")
+    }
+
     @Test func pickBlockRoutesJSONServerErrorThroughInjectedStdout() throws {
         let command = try Pick.Open.parse(["--json"])
         var output: [String] = []

--- a/agtermTests/ControlServerPickTests.swift
+++ b/agtermTests/ControlServerPickTests.swift
@@ -41,7 +41,6 @@ final class ControlServerPickTests: XCTestCase {
         await MainActor.run {
             for id in registeredPickIDs {
                 PickRegistry.shared.unregister(id)
-                PickRegistry.shared.clearRetainedResult(for: id)
             }
             for id in registeredZoomIDs {
                 TerminalZoomRegistry.shared.unregister(id)
@@ -177,7 +176,7 @@ final class ControlServerPickTests: XCTestCase {
                 result: ControlResult(pick: ControlPickResult(result: .cancelled))
             )
         )
-        let resultBeforeUnknownRequests = controller.lastResult
+        let resultBeforeUnknownRequests = controller.recentResults
         XCTAssertEqual(
             server.pickResult("unknown", window: nil),
             ControlResponse(ok: false, error: "unknown pick: unknown")
@@ -187,9 +186,9 @@ final class ControlServerPickTests: XCTestCase {
             ControlResponse(ok: false, error: "unknown pick: unknown")
         )
         XCTAssertEqual(
-            controller.lastResult,
+            controller.recentResults,
             resultBeforeUnknownRequests,
-            "unknown result/cancel requests must not mutate the retained picker result"
+            "unknown result/cancel requests must not mutate the retained picker results"
         )
     }
 
@@ -338,7 +337,7 @@ final class ControlServerPickTests: XCTestCase {
         )
     }
 
-    func testNextOpenClearsClosedWindowRetainedResult() throws {
+    func testNextOpenKeepsClosedWindowRetainedResultReadable() throws {
         let windowID = try XCTUnwrap(library.activeWindowID)
         let firstController = registerPick(windowID)
         let first = makePick("old-closed-pick")
@@ -355,7 +354,33 @@ final class ControlServerPickTests: XCTestCase {
         XCTAssertEqual(replacement.pending, next)
         XCTAssertEqual(
             server.pickResult(first.id, window: nil),
-            ControlResponse(ok: false, error: "unknown pick: \(first.id)")
+            ControlResponse(ok: true, result: ControlResult(pick: ControlPickResult(result: .cancelled))),
+            "a later pick reusing that window must not erase an answer its own poller has not read yet"
+        )
+    }
+
+    func testResolvedPickStaysReadableAfterTheNextPickOpens() throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        let controller = registerPick(windowID)
+        let first = makePick("answered")
+        XCTAssertTrue(controller.open(first))
+        let answer = ControlPickResult(result: .picked, id: "one", label: "One", index: 0)
+        controller.resolve(answer)
+
+        let second = makePick("opened-before-the-poll-landed")
+        XCTAssertEqual(
+            server.openPick(second, window: nil, follow: false),
+            ControlResponse(ok: true, result: ControlResult(id: second.id))
+        )
+
+        XCTAssertEqual(
+            server.pickResult(first.id, window: nil),
+            ControlResponse(ok: true, result: ControlResult(pick: answer)),
+            "a blocking caller must still read its own answer when another pick opened before its poll landed"
+        )
+        XCTAssertEqual(
+            server.pickResult(second.id, window: nil),
+            ControlResponse(ok: true, result: ControlResult(pick: ControlPickResult(result: .pending)))
         )
     }
 

--- a/agtermTests/ControlServerPickTests.swift
+++ b/agtermTests/ControlServerPickTests.swift
@@ -423,6 +423,11 @@ final class ControlServerPickTests: XCTestCase {
         return controller
     }
 
+    /// `NSWindow`'s designated initializer defaults `isReleasedWhenClosed` to true, so `close()` sends a
+    /// release ARC never balances while this test still holds the window (here and in `WindowRegistry`).
+    /// The over-release frees it under the surviving references, and the next autorelease-pool pop on the
+    /// main queue crashes the test HOST rather than failing a test — nondeterministically, which is why it
+    /// only showed up on CI. Every window these tests own is closed in teardown, so all of them opt out.
     private func registerWindow(_ id: WindowInfo.ID) -> NSWindow {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
@@ -430,6 +435,7 @@ final class ControlServerPickTests: XCTestCase {
             backing: .buffered,
             defer: false
         )
+        window.isReleasedWhenClosed = false
         WindowRegistry.shared.register(id, window: window)
         registeredWindows[id] = window
         return window
@@ -442,6 +448,7 @@ final class ControlServerPickTests: XCTestCase {
             backing: .buffered,
             defer: false
         )
+        window.isReleasedWhenClosed = false
         let store = try XCTUnwrap(library.store(for: id))
         window.contentView = WindowAccessor.TitleProbeView(windowID: id, library: library, store: store)
         registeredWindows[id] = window

--- a/agtermTests/ControlServerPickTests.swift
+++ b/agtermTests/ControlServerPickTests.swift
@@ -1,0 +1,196 @@
+import AppKit
+import XCTest
+@testable import agterm
+import agtermCore
+
+/// Hosted coverage for the app-side picker seam: window resolution, per-window registry lookup,
+/// palette coordination, and the optional follow presentation all require the real app target.
+@MainActor
+final class ControlServerPickTests: XCTestCase {
+    private var stateDir: URL!
+    private var library: WindowLibrary!
+    private var actions: AppActions!
+    private var server: ControlServer!
+    private var registeredPickIDs: Set<WindowInfo.ID> = []
+    private var registeredWindows: [WindowInfo.ID: NSWindow] = [:]
+
+    override func setUp() async throws {
+        try await super.setUp()
+        await MainActor.run {
+            stateDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("agterm-control-pick-tests-\(UUID().uuidString)", isDirectory: true)
+            library = WindowLibrary(directory: stateDir)
+            actions = AppActions(library: library)
+            let settings = SettingsModel(
+                library: library,
+                settingsStore: SettingsStore(directory: stateDir)
+            )
+            server = ControlServer(
+                library: library,
+                actions: actions,
+                settingsModel: settings,
+                socketPath: stateDir.appendingPathComponent("control.sock").path
+            )
+        }
+    }
+
+    override func tearDown() async throws {
+        await MainActor.run {
+            for id in registeredPickIDs {
+                PickRegistry.shared.unregister(id)
+            }
+            for (id, window) in registeredWindows {
+                WindowRegistry.shared.unregister(id)
+                window.close()
+            }
+            registeredPickIDs.removeAll()
+            registeredWindows.removeAll()
+            server = nil
+            actions = nil
+            library = nil
+            try? FileManager.default.removeItem(at: stateDir)
+            stateDir = nil
+        }
+        try await super.tearDown()
+    }
+
+    func testOpenRejectsWhenNoWindowIsOpen() throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        library.closeWindow(windowID)
+
+        XCTAssertEqual(
+            server.openPick(makePick("pick"), window: nil, follow: false),
+            ControlResponse(ok: false, error: "no open window")
+        )
+    }
+
+    func testOpenRejectsWhenTargetWindowHasNoRegisteredPickSurface() throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+
+        XCTAssertEqual(
+            server.openPick(makePick("pick"), window: windowID.uuidString, follow: false),
+            ControlResponse(ok: false, error: "no pick surface")
+        )
+    }
+
+    func testOpenRejectsSecondPendingPickWithoutReplacingFirst() throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        let controller = registerPick(windowID)
+        let first = makePick("first")
+        XCTAssertTrue(controller.open(first))
+
+        XCTAssertEqual(
+            server.openPick(makePick("second"), window: nil, follow: false),
+            ControlResponse(ok: false, error: "pick already pending")
+        )
+        XCTAssertEqual(controller.pending, first)
+    }
+
+    func testOpenOnFrontmostWindowClosesBuiltInPaletteAndReturnsID() throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        let controller = registerPick(windowID)
+        let palette = PaletteController()
+        palette.open(.actions)
+        actions.palette = palette
+        let pick = makePick("frontmost")
+
+        XCTAssertEqual(
+            server.openPick(pick, window: nil, follow: false),
+            ControlResponse(ok: true, result: ControlResult(id: pick.id))
+        )
+        XCTAssertEqual(controller.pending, pick)
+        XCTAssertNil(palette.mode)
+    }
+
+    func testBackgroundOpenWithoutFollowLeavesWindowAndPaletteAlone() throws {
+        let backgroundID = try XCTUnwrap(library.activeWindowID)
+        let controller = registerPick(backgroundID)
+        let frontmostID = library.newWindow(name: "frontmost").id
+        let palette = PaletteController()
+        palette.open(.actions)
+        actions.palette = palette
+        let pick = makePick("background")
+
+        XCTAssertEqual(
+            server.openPick(pick, window: backgroundID.uuidString, follow: false),
+            ControlResponse(ok: true, result: ControlResult(id: pick.id))
+        )
+        XCTAssertEqual(controller.pending, pick)
+        XCTAssertEqual(library.activeWindowID, frontmostID)
+        XCTAssertEqual(palette.mode, .actions)
+    }
+
+    func testFollowRaisesSelectsAndClosesPaletteForBackgroundWindow() throws {
+        let targetID = try XCTUnwrap(library.activeWindowID)
+        let controller = registerPick(targetID)
+        _ = library.newWindow(name: "frontmost")
+        let palette = PaletteController()
+        palette.open(.sessions)
+        actions.palette = palette
+        let window = registerWindow(targetID)
+        let pick = makePick("followed")
+
+        XCTAssertEqual(
+            server.openPick(pick, window: targetID.uuidString, follow: true),
+            ControlResponse(ok: true, result: ControlResult(id: pick.id))
+        )
+        XCTAssertEqual(controller.pending, pick)
+        XCTAssertEqual(library.frontmostWindowID, targetID)
+        XCTAssertTrue(window.isVisible)
+        XCTAssertNil(palette.mode)
+    }
+
+    func testResultAndCancelAreScopedToRegisteredWindowController() throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        let controller = registerPick(windowID)
+        let pick = makePick("result")
+        XCTAssertTrue(controller.open(pick))
+
+        XCTAssertEqual(
+            server.pickResult(pick.id, window: nil),
+            ControlResponse(
+                ok: true,
+                result: ControlResult(pick: ControlPickResult(result: .pending))
+            )
+        )
+        XCTAssertEqual(server.cancelPick(pick.id, window: nil), ControlResponse(ok: true))
+        XCTAssertEqual(
+            server.pickResult(pick.id, window: nil),
+            ControlResponse(
+                ok: true,
+                result: ControlResult(pick: ControlPickResult(result: .cancelled))
+            )
+        )
+        XCTAssertEqual(
+            server.pickResult("unknown", window: nil),
+            ControlResponse(ok: false, error: "unknown pick: unknown")
+        )
+        XCTAssertEqual(
+            server.cancelPick("unknown", window: nil),
+            ControlResponse(ok: false, error: "unknown pick: unknown")
+        )
+    }
+
+    private func makePick(_ id: String) -> PendingPick {
+        PendingPick(id: id, items: [ControlPickItem(id: "item", label: "Item")])
+    }
+
+    private func registerPick(_ id: WindowInfo.ID) -> PickController {
+        let controller = PickController()
+        PickRegistry.shared.register(id, controller: controller)
+        registeredPickIDs.insert(id)
+        return controller
+    }
+
+    private func registerWindow(_ id: WindowInfo.ID) -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        WindowRegistry.shared.register(id, window: window)
+        registeredWindows[id] = window
+        return window
+    }
+}

--- a/agtermTests/ControlServerPickTests.swift
+++ b/agtermTests/ControlServerPickTests.swift
@@ -167,6 +167,7 @@ final class ControlServerPickTests: XCTestCase {
                 result: ControlResult(pick: ControlPickResult(result: .cancelled))
             )
         )
+        let resultBeforeUnknownRequests = controller.lastResult
         XCTAssertEqual(
             server.pickResult("unknown", window: nil),
             ControlResponse(ok: false, error: "unknown pick: unknown")
@@ -174,6 +175,11 @@ final class ControlServerPickTests: XCTestCase {
         XCTAssertEqual(
             server.cancelPick("unknown", window: nil),
             ControlResponse(ok: false, error: "unknown pick: unknown")
+        )
+        XCTAssertEqual(
+            controller.lastResult,
+            resultBeforeUnknownRequests,
+            "unknown result/cancel requests must not mutate the retained picker result"
         )
     }
 

--- a/agtermTests/ControlServerPickTests.swift
+++ b/agtermTests/ControlServerPickTests.swift
@@ -13,6 +13,7 @@ final class ControlServerPickTests: XCTestCase {
     private var server: ControlServer!
     private var registeredPickIDs: Set<WindowInfo.ID> = []
     private var registeredWindows: [WindowInfo.ID: NSWindow] = [:]
+    private var registeredZoomIDs: Set<WindowInfo.ID> = []
 
     override func setUp() async throws {
         try await super.setUp()
@@ -38,12 +39,17 @@ final class ControlServerPickTests: XCTestCase {
         await MainActor.run {
             for id in registeredPickIDs {
                 PickRegistry.shared.unregister(id)
+                PickRegistry.shared.clearRetainedResult(for: id)
+            }
+            for id in registeredZoomIDs {
+                TerminalZoomRegistry.shared.unregister(id)
             }
             for (id, window) in registeredWindows {
                 WindowRegistry.shared.unregister(id)
                 window.close()
             }
             registeredPickIDs.removeAll()
+            registeredZoomIDs.removeAll()
             registeredWindows.removeAll()
             server = nil
             actions = nil
@@ -171,6 +177,79 @@ final class ControlServerPickTests: XCTestCase {
         )
     }
 
+    func testCloseSessionChordCancelsPickAheadOfTerminalZoom() throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        let session = try XCTUnwrap(library.activeStore?.activeSession)
+        let controller = registerPick(windowID)
+        let zoom = TerminalZoomController()
+        TerminalZoomRegistry.shared.register(windowID, controller: zoom)
+        registeredZoomIDs.insert(windowID)
+        let pick = makePick("command-w")
+        XCTAssertTrue(controller.open(pick))
+        zoom.set(.on, target: .session(session.id, .primary))
+
+        XCTAssertTrue(actions.closeActiveSession())
+
+        XCTAssertEqual(
+            controller.result(for: pick.id),
+            ControlPickResult(result: .cancelled)
+        )
+        XCTAssertEqual(
+            zoom.target,
+            .session(session.id, .primary),
+            "the terminal zoom behind a pending pick must survive the first close-session chord"
+        )
+    }
+
+    func testWindowCloseResolvesPendingPickAsCancelled() throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        let controller = registerPick(windowID)
+        let window = try registerLifecycleWindow(windowID)
+        let pick = makePick("window-close")
+        XCTAssertTrue(controller.open(pick))
+
+        window.close()
+
+        XCTAssertFalse(library.isOpen(windowID))
+        XCTAssertNil(PickRegistry.shared.controller(for: windowID))
+        XCTAssertEqual(
+            server.pickResult(pick.id, window: windowID.uuidString),
+            ControlResponse(
+                ok: true,
+                result: ControlResult(pick: ControlPickResult(result: .cancelled))
+            ),
+            "a poll after the real window-close path must still observe the terminal cancellation"
+        )
+    }
+
+    func testApplicationTerminationCancelsEveryPendingPickWithoutChangingQuitCounts() throws {
+        let firstID = try XCTUnwrap(library.activeWindowID)
+        let first = registerPick(firstID)
+        let secondID = library.newWindow(name: "second").id
+        let second = registerPick(secondID)
+        let firstPick = makePick("quit-first")
+        let secondPick = makePick("quit-second")
+        XCTAssertTrue(first.open(firstPick))
+        XCTAssertTrue(second.open(secondPick))
+        let countsBeforeTermination = library.openCounts()
+
+        NotificationCenter.default.post(name: NSApplication.willTerminateNotification, object: NSApp)
+
+        XCTAssertEqual(first.result(for: firstPick.id), ControlPickResult(result: .cancelled))
+        XCTAssertEqual(second.result(for: secondPick.id), ControlPickResult(result: .cancelled))
+        let countsAfterTermination = library.openCounts()
+        XCTAssertEqual(
+            countsAfterTermination.windows,
+            countsBeforeTermination.windows,
+            "picker cancellation must not affect the window count that drives quit confirmation"
+        )
+        XCTAssertEqual(
+            countsAfterTermination.sessions,
+            countsBeforeTermination.sessions,
+            "picker cancellation must not affect the session count that drives quit confirmation"
+        )
+    }
+
     private func makePick(_ id: String) -> PendingPick {
         PendingPick(id: id, items: [ControlPickItem(id: "item", label: "Item")])
     }
@@ -190,6 +269,19 @@ final class ControlServerPickTests: XCTestCase {
             defer: false
         )
         WindowRegistry.shared.register(id, window: window)
+        registeredWindows[id] = window
+        return window
+    }
+
+    private func registerLifecycleWindow(_ id: WindowInfo.ID) throws -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let store = try XCTUnwrap(library.store(for: id))
+        window.contentView = WindowAccessor.TitleProbeView(windowID: id, library: library, store: store)
         registeredWindows[id] = window
         return window
     }

--- a/agtermTests/ControlServerPickTests.swift
+++ b/agtermTests/ControlServerPickTests.swift
@@ -14,6 +14,8 @@ final class ControlServerPickTests: XCTestCase {
     private var registeredPickIDs: Set<WindowInfo.ID> = []
     private var registeredWindows: [WindowInfo.ID: NSWindow] = [:]
     private var registeredZoomIDs: Set<WindowInfo.ID> = []
+    private var registeredQuickIDs: Set<WindowInfo.ID> = []
+    private var registeredDashboardIDs: Set<WindowInfo.ID> = []
 
     override func setUp() async throws {
         try await super.setUp()
@@ -44,12 +46,20 @@ final class ControlServerPickTests: XCTestCase {
             for id in registeredZoomIDs {
                 TerminalZoomRegistry.shared.unregister(id)
             }
+            for id in registeredQuickIDs {
+                QuickTerminalRegistry.shared.unregister(id)
+            }
+            for id in registeredDashboardIDs {
+                DashboardControllerRegistry.shared.unregister(id)
+            }
             for (id, window) in registeredWindows {
                 WindowRegistry.shared.unregister(id)
                 window.close()
             }
             registeredPickIDs.removeAll()
             registeredZoomIDs.removeAll()
+            registeredQuickIDs.removeAll()
+            registeredDashboardIDs.removeAll()
             registeredWindows.removeAll()
             server = nil
             actions = nil
@@ -183,6 +193,100 @@ final class ControlServerPickTests: XCTestCase {
         )
     }
 
+    func testUntargetedResultAndCancelFollowPickIDAcrossFrontmostChange() throws {
+        let ownerID = try XCTUnwrap(library.activeWindowID)
+        let owner = registerPick(ownerID)
+        let pick = makePick("globally-routed")
+        XCTAssertTrue(owner.open(pick))
+
+        let otherID = library.newWindow(name: "other").id
+        _ = registerPick(otherID)
+        XCTAssertEqual(library.activeWindowID, otherID)
+
+        XCTAssertEqual(
+            server.pickResult(pick.id, window: nil),
+            ControlResponse(ok: true, result: ControlResult(
+                pick: ControlPickResult(result: .pending)
+            ))
+        )
+        XCTAssertEqual(server.cancelPick(pick.id, window: nil), ControlResponse(ok: true))
+        XCTAssertEqual(
+            server.pickResult(pick.id, window: nil),
+            ControlResponse(ok: true, result: ControlResult(
+                pick: ControlPickResult(result: .cancelled)
+            ))
+        )
+    }
+
+    func testPendingPickRejectsControlDrivenCoversButAllowsDismissals() throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        let pick = registerPick(windowID)
+        XCTAssertTrue(pick.open(makePick("modal-owner")))
+
+        let quick = QuickTerminalController()
+        QuickTerminalRegistry.shared.register(windowID, controller: quick)
+        registeredQuickIDs.insert(windowID)
+        let zoom = TerminalZoomController()
+        TerminalZoomRegistry.shared.register(windowID, controller: zoom)
+        registeredZoomIDs.insert(windowID)
+        let dashboard = DashboardController()
+        DashboardControllerRegistry.shared.register(windowID, controller: dashboard)
+        registeredDashboardIDs.insert(windowID)
+        let sessionID = try XCTUnwrap(library.activeStore?.activeSession?.id)
+
+        XCTAssertEqual(
+            server.setQuickTerminal(mode: "show"),
+            ControlResponse(ok: false, error: "pick pending")
+        )
+        XCTAssertEqual(
+            server.setSurfaceZoom(nil, window: windowID.uuidString, mode: .on),
+            ControlResponse(ok: false, error: "pick pending")
+        )
+        XCTAssertEqual(
+            server.setDashboard(
+                targets: [sessionID.uuidString],
+                window: windowID.uuidString,
+                close: false,
+                fontMode: .untouched,
+                mru: false
+            ),
+            ControlResponse(ok: false, error: "pick pending")
+        )
+
+        XCTAssertEqual(server.setQuickTerminal(mode: "hide"), ControlResponse(ok: true))
+        XCTAssertEqual(
+            server.setSurfaceZoom(nil, window: windowID.uuidString, mode: .off),
+            ControlResponse(ok: true)
+        )
+        XCTAssertEqual(
+            server.setDashboard(
+                targets: [],
+                window: windowID.uuidString,
+                close: true,
+                fontMode: .untouched,
+                mru: false
+            ),
+            ControlResponse(ok: true)
+        )
+    }
+
+    func testPendingPickRejectsControlSearchNavigationButAllowsClose() async throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        let store = try XCTUnwrap(library.activeStore)
+        let sessionID = try XCTUnwrap(store.activeSession?.id)
+        let pick = registerPick(windowID)
+        XCTAssertTrue(pick.open(makePick("search-owner")))
+
+        let open = await server.searchSession(sessionID, store: store, text: "needle", to: nil)
+        XCTAssertEqual(open, ControlResponse(ok: false, error: "pick pending"))
+
+        let navigate = await server.searchSession(sessionID, store: store, text: nil, to: "next")
+        XCTAssertEqual(navigate, ControlResponse(ok: false, error: "pick pending"))
+
+        let close = await server.searchSession(sessionID, store: store, text: nil, to: "close")
+        XCTAssertEqual(close, ControlResponse(ok: true, result: ControlResult(id: sessionID.uuidString)))
+    }
+
     func testCloseSessionChordCancelsPickAheadOfTerminalZoom() throws {
         let windowID = try XCTUnwrap(library.activeWindowID)
         let session = try XCTUnwrap(library.activeStore?.activeSession)
@@ -225,6 +329,33 @@ final class ControlServerPickTests: XCTestCase {
                 result: ControlResult(pick: ControlPickResult(result: .cancelled))
             ),
             "a poll after the real window-close path must still observe the terminal cancellation"
+        )
+        let otherID = library.newWindow(name: "other").id
+        XCTAssertEqual(
+            server.pickResult(pick.id, window: otherID.uuidString),
+            ControlResponse(ok: false, error: "unknown pick: \(pick.id)"),
+            "an explicit window selector must match the retained pick's owner"
+        )
+    }
+
+    func testNextOpenClearsClosedWindowRetainedResult() throws {
+        let windowID = try XCTUnwrap(library.activeWindowID)
+        let firstController = registerPick(windowID)
+        let first = makePick("old-closed-pick")
+        XCTAssertTrue(firstController.open(first))
+        PickRegistry.shared.unregister(windowID)
+        registeredPickIDs.remove(windowID)
+
+        let replacement = registerPick(windowID)
+        let next = makePick("next-pick")
+        XCTAssertEqual(
+            server.openPick(next, window: windowID.uuidString, follow: false),
+            ControlResponse(ok: true, result: ControlResult(id: next.id))
+        )
+        XCTAssertEqual(replacement.pending, next)
+        XCTAssertEqual(
+            server.pickResult(first.id, window: nil),
+            ControlResponse(ok: false, error: "unknown pick: \(first.id)")
         )
     }
 

--- a/agtermTests/PickFocusGuardTests.swift
+++ b/agtermTests/PickFocusGuardTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import agterm
+import agtermCore
+
+/// Hosted coverage for the window-scoped predicate used by both terminal focus retry loops. The
+/// registry is app-side state, so this cannot live in agtermCore's host-free tests.
+@MainActor
+final class PickFocusGuardTests: XCTestCase {
+    private var stateDir: URL!
+    private var library: WindowLibrary!
+    private var actions: AppActions!
+    private var registeredWindowIDs: Set<UUID> = []
+
+    override func setUp() async throws {
+        try await super.setUp()
+        await MainActor.run {
+            stateDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("agterm-pick-focus-tests-\(UUID().uuidString)", isDirectory: true)
+            library = WindowLibrary(directory: stateDir)
+            actions = AppActions(library: library)
+        }
+    }
+
+    override func tearDown() async throws {
+        await MainActor.run {
+            for id in registeredWindowIDs {
+                PickRegistry.shared.unregister(id)
+            }
+            actions = nil
+            library = nil
+            try? FileManager.default.removeItem(at: stateDir)
+            stateDir = nil
+        }
+        try await super.tearDown()
+    }
+
+    func testPendingPickGuardsOnlyItsOwningWindow() throws {
+        let activeID = try XCTUnwrap(library.activeWindowID)
+        let backgroundID = library.newWindow(name: "background").id
+        let controller = registerPick(activeID)
+
+        XCTAssertFalse(actions.pickActive(for: activeID))
+        XCTAssertFalse(actions.pickActive(for: backgroundID))
+
+        XCTAssertTrue(controller.open(PendingPick(
+            id: "focus-guard",
+            items: [ControlPickItem(id: "one", label: "One")]
+        )))
+
+        XCTAssertTrue(actions.pickActive(for: activeID))
+        XCTAssertFalse(actions.pickActive(for: backgroundID),
+                       "a pick must not suppress session-addressed focus in another window")
+
+        controller.cancel()
+        XCTAssertFalse(actions.pickActive(for: activeID))
+    }
+
+    func testMissingWindowOrRegistrationDoesNotGuardFocus() {
+        XCTAssertFalse(actions.pickActive(for: nil))
+        XCTAssertFalse(actions.pickActive(for: UUID()))
+    }
+
+    private func registerPick(_ windowID: UUID) -> PickController {
+        let controller = PickController()
+        PickRegistry.shared.register(windowID, controller: controller)
+        registeredWindowIDs.insert(windowID)
+        return controller
+    }
+}

--- a/agtermTests/PickFocusGuardTests.swift
+++ b/agtermTests/PickFocusGuardTests.swift
@@ -26,7 +26,6 @@ final class PickFocusGuardTests: XCTestCase {
         await MainActor.run {
             for id in registeredWindowIDs {
                 PickRegistry.shared.unregister(id)
-                PickRegistry.shared.clearRetainedResult(for: id)
             }
             for (id, window) in registeredWindows {
                 WindowRegistry.shared.unregister(id)

--- a/agtermTests/PickFocusGuardTests.swift
+++ b/agtermTests/PickFocusGuardTests.swift
@@ -10,6 +10,7 @@ final class PickFocusGuardTests: XCTestCase {
     private var library: WindowLibrary!
     private var actions: AppActions!
     private var registeredWindowIDs: Set<UUID> = []
+    private var registeredWindows: [UUID: NSWindow] = [:]
 
     override func setUp() async throws {
         try await super.setUp()
@@ -25,7 +26,13 @@ final class PickFocusGuardTests: XCTestCase {
         await MainActor.run {
             for id in registeredWindowIDs {
                 PickRegistry.shared.unregister(id)
+                PickRegistry.shared.clearRetainedResult(for: id)
             }
+            for (id, window) in registeredWindows {
+                WindowRegistry.shared.unregister(id)
+                window.orderOut(nil)
+            }
+            registeredWindows.removeAll()
             actions = nil
             library = nil
             try? FileManager.default.removeItem(at: stateDir)
@@ -48,6 +55,8 @@ final class PickFocusGuardTests: XCTestCase {
         )))
 
         XCTAssertTrue(actions.pickActive(for: activeID))
+        XCTAssertFalse(actions.uiActionsEnabled(for: activeID),
+                       "a pending picker must participate in the shared modal action gate")
         XCTAssertFalse(actions.pickActive(for: backgroundID),
                        "a pick must not suppress session-addressed focus in another window")
 
@@ -60,10 +69,58 @@ final class PickFocusGuardTests: XCTestCase {
         XCTAssertFalse(actions.pickActive(for: UUID()))
     }
 
+    func testTerminalRetryGuardTracksPickerForOwningAppKitWindow() throws {
+        let ownerID = try XCTUnwrap(library.activeWindowID)
+        let otherID = library.newWindow(name: "other").id
+        let ownerWindow = registerWindow(ownerID)
+        let otherWindow = registerWindow(otherID)
+        let controller = registerPick(ownerID)
+
+        XCTAssertFalse(GhosttySurfaceView.pickOwnsFocus(in: ownerWindow))
+        XCTAssertTrue(controller.open(PendingPick(
+            id: "in-flight-focus",
+            items: [ControlPickItem(id: "one", label: "One")]
+        )))
+
+        XCTAssertTrue(GhosttySurfaceView.pickOwnsFocus(in: ownerWindow),
+                      "an already-running focus retry must stop once this window gains a picker")
+        XCTAssertFalse(GhosttySurfaceView.pickOwnsFocus(in: otherWindow),
+                       "a picker must not stop a retry in another window")
+        XCTAssertFalse(GhosttySurfaceView.pickOwnsFocus(in: nil))
+    }
+
+    func testDeferredPickFocusRestorationWaitsForOwningWindowToBecomeFrontmost() {
+        var state = PickFocusRestorationState()
+
+        XCTAssertFalse(state.pickerResolved(isFrontmost: false),
+                       "resolving a background picker must not steal focus")
+        XCTAssertTrue(state.isDeferred)
+        XCTAssertFalse(state.windowBecameFrontmost(pickPending: true),
+                       "a replacement picker must retain focus when the window activates")
+        XCTAssertTrue(state.isDeferred)
+        XCTAssertTrue(state.windowBecameFrontmost(pickPending: false),
+                      "the owning window should restore its underlying cover once it is frontmost")
+        XCTAssertFalse(state.isDeferred)
+        XCTAssertFalse(state.windowBecameFrontmost(pickPending: false),
+                       "the deferred restoration must be consumed exactly once")
+    }
+
     private func registerPick(_ windowID: UUID) -> PickController {
         let controller = PickController()
         PickRegistry.shared.register(windowID, controller: controller)
         registeredWindowIDs.insert(windowID)
         return controller
+    }
+
+    private func registerWindow(_ windowID: UUID) -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        WindowRegistry.shared.register(windowID, window: window)
+        registeredWindows[windowID] = window
+        return window
     }
 }

--- a/agtermTests/PickFocusGuardTests.swift
+++ b/agtermTests/PickFocusGuardTests.swift
@@ -111,6 +111,9 @@ final class PickFocusGuardTests: XCTestCase {
         return controller
     }
 
+    /// Opt out of `isReleasedWhenClosed` for the same reason `ControlServerPickTests` does: this suite only
+    /// hides its windows today, but a window it holds must not be released out from under ARC if one ever
+    /// gets closed.
     private func registerWindow(_ windowID: UUID) -> NSWindow {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
@@ -118,6 +121,7 @@ final class PickFocusGuardTests: XCTestCase {
             backing: .buffered,
             defer: false
         )
+        window.isReleasedWhenClosed = false
         WindowRegistry.shared.register(windowID, window: window)
         registeredWindows[windowID] = window
         return window

--- a/agtermUITests/ControlPickUITests.swift
+++ b/agtermUITests/ControlPickUITests.swift
@@ -43,6 +43,118 @@ final class ControlPickUITests: ControlAPITestCase {
         XCTAssertTrue(pickPalette.waitForNonExistence(timeout: 10), "cancellation should dismiss the picker")
     }
 
+    func testEscapeCancelsAndDismissesPicker() throws {
+        let pickID = try resultID(openPick([["id": "one", "label": "One"]]))
+        XCTAssertTrue(pickPalette.waitForExistence(timeout: 10))
+
+        app.typeKey(.escape, modifierFlags: [])
+
+        XCTAssertEqual(try awaitTerminalResult(id: pickID)["result"] as? String, "cancelled")
+        XCTAssertTrue(pickPalette.waitForNonExistence(timeout: 10))
+    }
+
+    func testScrimClickCancelsAndDismissesPicker() throws {
+        let pickID = try resultID(openPick([["id": "one", "label": "One"]]))
+        XCTAssertTrue(pickPalette.waitForExistence(timeout: 10))
+        let scrim = app.descendants(matching: .any).matching(identifier: "pick-scrim").firstMatch
+        XCTAssertTrue(scrim.waitForExistence(timeout: 5))
+
+        scrim.coordinate(withNormalizedOffset: CGVector(dx: 0.95, dy: 0.95)).click()
+
+        XCTAssertEqual(try awaitTerminalResult(id: pickID)["result"] as? String, "cancelled")
+        XCTAssertTrue(pickPalette.waitForNonExistence(timeout: 10))
+    }
+
+    func testPickKeepsKeyboardAfterClosingBuiltInPalette() throws {
+        app.menuBars.menuBarItems["Navigate"].click()
+        let commandPalette = app.menuItems["Command Palette"]
+        XCTAssertTrue(commandPalette.waitForExistence(timeout: 5))
+        commandPalette.click()
+        XCTAssertTrue(app.descendants(matching: .any)
+            .matching(identifier: "command-palette").firstMatch.waitForExistence(timeout: 5))
+
+        let query = "picker owns this text"
+        let pickID = try resultID(openPick(
+            [["id": "existing", "label": "Existing"]],
+            allowCustom: true
+        ))
+        XCTAssertTrue(pickPalette.waitForExistence(timeout: 10))
+        app.typeText(query)
+
+        XCTAssertTrue(paletteRow("pick-custom").waitForExistence(timeout: 5),
+                      "palette-close focus retries must not send picker input to the terminal")
+        app.typeKey(.return, modifierFlags: [])
+        XCTAssertEqual(try awaitTerminalResult(id: pickID)["query"] as? String, query)
+    }
+
+    func testPendingPickDisablesAndClosesRecentSessionsPopover() throws {
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.new"}"#)["ok"] as? Bool, true)
+        let recent = app.buttons["recent-sessions-button"]
+        XCTAssertTrue(recent.waitForExistence(timeout: 10))
+        XCTAssertTrue(poll(until: recent.isEnabled, timeout: 8))
+
+        recent.click()
+        let row = app.buttons["recent-session-row"]
+        XCTAssertTrue(row.waitForExistence(timeout: 5), "the recent-sessions popover should start open")
+
+        let pickID = try resultID(openPick([["id": "one", "label": "One"]]))
+        XCTAssertTrue(pickPalette.waitForExistence(timeout: 10))
+
+        XCTAssertTrue(poll(until: !recent.isEnabled, timeout: 5),
+                      "a pending picker must disable the recent-sessions popover button")
+        XCTAssertTrue(row.waitForNonExistence(timeout: 5),
+                      "a socket-driven picker must close an already-open title-bar popover")
+        XCTAssertEqual(try sendCommand(request(command: "pick.cancel", target: pickID))["ok"] as? Bool, true)
+        XCTAssertEqual(try awaitTerminalResult(id: pickID)["result"] as? String, "cancelled")
+    }
+
+    func testBackgroundZoomedPickerClosesPaletteWhenItsWindowBecomesFrontmost() throws {
+        let pickerWindow = try XCTUnwrap(try windowIDs().first)
+        let created = try sendCommand(#"{"cmd":"window.new","args":{"name":"palette-owner"}}"#)
+        let paletteWindow = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String)
+        XCTAssertTrue(poll(until: (try? windowNode(id: paletteWindow)?["active"] as? Bool) == true, timeout: 10))
+
+        app.menuBars.menuBarItems["Navigate"].click()
+        let commandPaletteItem = app.menuItems["Command Palette"]
+        XCTAssertTrue(commandPaletteItem.waitForExistence(timeout: 5))
+        commandPaletteItem.click()
+        let commandPalette = app.descendants(matching: .any).matching(identifier: "command-palette").firstMatch
+        XCTAssertTrue(commandPalette.waitForExistence(timeout: 5))
+
+        let zoom = try sendCommand(request(
+            command: "surface.zoom",
+            args: ["mode": "show", "window": pickerWindow]
+        ))
+        XCTAssertEqual(zoom["ok"] as? Bool, true, "the background picker window should start zoomed: \(zoom)")
+
+        let query = "background picker owns focus"
+        let pickID = try resultID(openPick(
+            [["id": "existing", "label": "Existing"]],
+            allowCustom: true,
+            window: pickerWindow
+        ))
+        XCTAssertEqual(
+            try sendCommand(#"{"cmd":"window.select","target":"\#(pickerWindow)"}"#)["ok"] as? Bool,
+            true
+        )
+        XCTAssertTrue(poll(until: (try? windowNode(id: pickerWindow)?["active"] as? Bool) == true, timeout: 10))
+        XCTAssertTrue(pickPalette.waitForExistence(timeout: 10))
+        XCTAssertTrue(commandPalette.waitForNonExistence(timeout: 5),
+                      "the old window's built-in palette must not remount under the picker")
+
+        app.typeText(query)
+        XCTAssertTrue(paletteRow("pick-custom").waitForExistence(timeout: 5),
+                      "the visible picker must retain keyboard focus after the window handoff")
+        XCTAssertEqual(try sendCommand(request(command: "pick.cancel", target: pickID))["ok"] as? Bool, true)
+        XCTAssertEqual(try awaitTerminalResult(id: pickID)["result"] as? String, "cancelled")
+        XCTAssertEqual(try sendCommand(request(
+            command: "surface.zoom",
+            args: ["mode": "hide", "window": pickerWindow]
+        ))["ok"] as? Bool, true)
+        XCTAssertTrue(commandPalette.waitForNonExistence(timeout: 3),
+                      "the stale built-in palette must stay closed after the picker resolves and zoom exits")
+    }
+
     func testSecondPickOnSameWindowIsRejected() throws {
         let pickID = try resultID(openPick([["id": "first", "label": "First"]]))
         XCTAssertTrue(pickPalette.waitForExistence(timeout: 10), "the first picker should be visible")
@@ -107,6 +219,35 @@ final class ControlPickUITests: ControlAPITestCase {
         XCTAssertEqual(cancelled["ok"] as? Bool, true, "targeted pick.cancel should succeed: \(cancelled)")
         XCTAssertEqual(try awaitTerminalResult(id: pickID, window: backID)["result"] as? String, "cancelled")
         XCTAssertNil(try treePickPending(window: backID), "the background tree should clear after cancellation")
+    }
+
+    func testConcurrentPicksResolveIndependentlyAcrossWindows() throws {
+        let frontID = try XCTUnwrap(try windowIDs().first)
+        let created = try sendCommand(#"{"cmd":"window.new","args":{"name":"pick-peer","minimized":true}}"#)
+        let backID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String)
+
+        let frontPick = try resultID(openPick(
+            [["id": "front", "label": "Front"]],
+            window: frontID
+        ))
+        let backPick = try resultID(openPick(
+            [["id": "back", "label": "Back"]],
+            window: backID
+        ))
+        XCTAssertEqual(try treePickPending(window: frontID), frontPick)
+        XCTAssertEqual(try treePickPending(window: backID), backPick)
+
+        XCTAssertEqual(try sendCommand(request(
+            command: "pick.cancel", target: frontPick, args: ["window": frontID]
+        ))["ok"] as? Bool, true)
+        XCTAssertEqual(try awaitTerminalResult(id: frontPick, window: frontID)["result"] as? String, "cancelled")
+        XCTAssertEqual(try treePickPending(window: backID), backPick,
+                       "resolving one window must leave the other picker pending")
+
+        XCTAssertEqual(try sendCommand(request(
+            command: "pick.cancel", target: backPick, args: ["window": backID]
+        ))["ok"] as? Bool, true)
+        XCTAssertEqual(try awaitTerminalResult(id: backPick, window: backID)["result"] as? String, "cancelled")
     }
 
     // MARK: - Picker helpers

--- a/agtermUITests/ControlPickUITests.swift
+++ b/agtermUITests/ControlPickUITests.swift
@@ -1,0 +1,199 @@
+import XCTest
+
+/// End-to-end coverage for the native control picker. The control socket opens, polls, and cancels
+/// real per-window `PickController` state, while XCUITest verifies the SwiftUI `pick-palette` and its
+/// supplied rows. The background-window case keeps its target minimized so an implementation that
+/// silently ignores `--window` is guaranteed to mutate the visible front window instead.
+@MainActor
+final class ControlPickUITests: ControlAPITestCase {
+    func testPickRendersRowsSelectsItemAndReportsTreeState() throws {
+        let opened = try openPick([
+            ["id": "alpha", "label": "Alpha", "subtitle": "first choice"],
+            ["id": "beta", "label": "Beta", "subtitle": "second choice"],
+        ], prompt: "Choose a target")
+        let pickID = try resultID(opened)
+
+        XCTAssertTrue(pickPalette.waitForExistence(timeout: 10), "pick.open should present the native picker")
+        XCTAssertTrue(paletteRow("alpha").waitForExistence(timeout: 5), "the supplied Alpha row should appear")
+        XCTAssertTrue(paletteRow("beta").waitForExistence(timeout: 5), "the supplied Beta row should appear")
+        XCTAssertTrue(app.staticTexts["Alpha"].exists, "the first supplied label should be visible")
+        XCTAssertTrue(app.staticTexts["Beta"].exists, "the second supplied label should be visible")
+        XCTAssertEqual(try treePickPending(), pickID, "tree should expose the live picker id")
+
+        paletteRow("beta").click()
+
+        let result = try awaitTerminalResult(id: pickID)
+        XCTAssertEqual(result["result"] as? String, "picked")
+        XCTAssertEqual(result["id"] as? String, "beta")
+        XCTAssertEqual(result["label"] as? String, "Beta")
+        XCTAssertEqual(result["index"] as? Int, 1, "the result index should preserve the input order")
+        XCTAssertTrue(pickPalette.waitForNonExistence(timeout: 10), "selection should dismiss the picker")
+        XCTAssertNil(try treePickPending(), "tree should omit pickPending after resolution")
+    }
+
+    func testPickCancelReportsCancelled() throws {
+        let pickID = try resultID(openPick([["id": "one", "label": "One"]]))
+        XCTAssertTrue(pickPalette.waitForExistence(timeout: 10), "pick.open should present the picker")
+
+        let cancelled = try sendCommand(request(command: "pick.cancel", target: pickID))
+        XCTAssertEqual(cancelled["ok"] as? Bool, true, "pick.cancel should succeed: \(cancelled)")
+
+        let result = try awaitTerminalResult(id: pickID)
+        XCTAssertEqual(result["result"] as? String, "cancelled")
+        XCTAssertTrue(pickPalette.waitForNonExistence(timeout: 10), "cancellation should dismiss the picker")
+    }
+
+    func testSecondPickOnSameWindowIsRejected() throws {
+        let pickID = try resultID(openPick([["id": "first", "label": "First"]]))
+        XCTAssertTrue(pickPalette.waitForExistence(timeout: 10), "the first picker should be visible")
+
+        let second = try openPick([["id": "second", "label": "Second"]])
+        XCTAssertEqual(second["ok"] as? Bool, false, "a window may host only one pending picker: \(second)")
+        XCTAssertEqual(second["error"] as? String, "pick already pending")
+
+        XCTAssertEqual(try sendCommand(request(command: "pick.cancel", target: pickID))["ok"] as? Bool, true)
+        XCTAssertEqual(try awaitTerminalResult(id: pickID)["result"] as? String, "cancelled")
+    }
+
+    func testAllowCustomReturnsNonMatchingQuery() throws {
+        let query = "brand new value"
+        let pickID = try resultID(openPick(
+            [["id": "existing", "label": "Existing choice"]],
+            prompt: "Choose or enter a value",
+            allowCustom: true
+        ))
+        XCTAssertTrue(pickPalette.waitForExistence(timeout: 10), "pick.open --allow-custom should present the picker")
+
+        let field = app.textFields.firstMatch
+        XCTAssertTrue(field.waitForExistence(timeout: 5), "the picker query field should exist")
+        field.click()
+        field.typeText(query)
+        XCTAssertTrue(paletteRow("pick-custom").waitForExistence(timeout: 5),
+                      "a non-matching query should offer the custom row")
+        app.typeKey(.return, modifierFlags: [])
+
+        let result = try awaitTerminalResult(id: pickID)
+        XCTAssertEqual(result["result"] as? String, "custom")
+        XCTAssertEqual(result["query"] as? String, query)
+    }
+
+    func testWindowOptionTargetsMinimizedBackgroundWindow() throws {
+        let frontID = try XCTUnwrap(try windowIDs().first, "the seeded front window should have an id")
+        let created = try sendCommand(#"{"cmd":"window.new","args":{"name":"pick-background","minimized":true}}"#)
+        XCTAssertEqual(created["ok"] as? Bool, true, "window.new --minimized should succeed: \(created)")
+        let backID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String,
+                                   "window.new should return the background window id")
+        XCTAssertTrue(poll(until: (try? windowNode(id: backID)?["minimized"] as? Bool) == true, timeout: 10),
+                      "the target window must remain minimized")
+
+        let pickID = try resultID(openPick(
+            [["id": "background", "label": "Background choice"]],
+            window: backID
+        ))
+
+        XCTAssertEqual(try treePickPending(window: backID), pickID,
+                       "--window should put the picker in the minimized background window")
+        XCTAssertNil(try treePickPending(window: frontID),
+                     "the visible front window must not receive the targeted picker")
+        // XCUITest continues to enumerate the accessibility tree of a minimized macOS window, so
+        // palette visibility is not a foreground-window oracle. The two independently targeted
+        // tree reads above are: ignoring `window` would set frontID and leave backID nil.
+
+        let cancelled = try sendCommand(request(
+            command: "pick.cancel",
+            target: pickID,
+            args: ["window": backID]
+        ))
+        XCTAssertEqual(cancelled["ok"] as? Bool, true, "targeted pick.cancel should succeed: \(cancelled)")
+        XCTAssertEqual(try awaitTerminalResult(id: pickID, window: backID)["result"] as? String, "cancelled")
+        XCTAssertNil(try treePickPending(window: backID), "the background tree should clear after cancellation")
+    }
+
+    // MARK: - Picker helpers
+
+    private var pickPalette: XCUIElement {
+        app.descendants(matching: .any).matching(identifier: "pick-palette").firstMatch
+    }
+
+    private func paletteRow(_ id: String) -> XCUIElement {
+        app.descendants(matching: .any).matching(identifier: "palette-item-\(id)").firstMatch
+    }
+
+    private func openPick(
+        _ items: [[String: Any]],
+        prompt: String? = nil,
+        allowCustom: Bool = false,
+        window: String? = nil
+    ) throws -> [String: Any] {
+        var args: [String: Any] = ["items": items]
+        if let prompt { args["prompt"] = prompt }
+        if allowCustom { args["allowCustom"] = true }
+        if let window { args["window"] = window }
+        return try sendCommand(request(command: "pick.open", args: args))
+    }
+
+    private func resultID(_ response: [String: Any]) throws -> String {
+        XCTAssertEqual(response["ok"] as? Bool, true, "pick.open should succeed: \(response)")
+        return try XCTUnwrap((response["result"] as? [String: Any])?["id"] as? String,
+                             "pick.open should return its id")
+    }
+
+    private func awaitTerminalResult(
+        id: String,
+        window: String? = nil,
+        timeout: TimeInterval = 10
+    ) throws -> [String: Any] {
+        let deadline = Date().addingTimeInterval(timeout)
+        var latest: [String: Any]?
+        repeat {
+            var args: [String: Any] = [:]
+            if let window { args["window"] = window }
+            let response = try sendCommand(request(
+                command: "pick.result",
+                target: id,
+                args: args.isEmpty ? nil : args
+            ))
+            XCTAssertEqual(response["ok"] as? Bool, true, "pick.result should succeed: \(response)")
+            latest = (response["result"] as? [String: Any])?["pick"] as? [String: Any]
+            if latest?["result"] as? String != "pending" { break }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        } while Date() < deadline
+        let result = try XCTUnwrap(latest, "pick.result should carry a pick result")
+        XCTAssertNotEqual(result["result"] as? String, "pending", "picker should resolve before timeout")
+        return result
+    }
+
+    // MARK: - Tree and window helpers
+
+    private func treePickPending(window: String? = nil) throws -> String? {
+        var args: [String: Any]?
+        if let window { args = ["window": window] }
+        let response = try sendCommand(request(command: "tree", args: args))
+        XCTAssertEqual(response["ok"] as? Bool, true, "tree should succeed: \(response)")
+        let result = try XCTUnwrap(response["result"] as? [String: Any], "tree should carry a result")
+        let tree = try XCTUnwrap(result["tree"] as? [String: Any], "tree result should carry a tree")
+        return tree["pickPending"] as? String
+    }
+
+    private func windowIDs() throws -> [String] {
+        let response = try sendCommand(#"{"cmd":"window.list"}"#)
+        let windows = try XCTUnwrap((response["result"] as? [String: Any])?["windows"] as? [[String: Any]],
+                                    "window.list should carry windows")
+        return windows.compactMap { $0["id"] as? String }
+    }
+
+    private func windowNode(id: String) throws -> [String: Any]? {
+        let response = try sendCommand(#"{"cmd":"window.list"}"#)
+        let windows = (response["result"] as? [String: Any])?["windows"] as? [[String: Any]]
+        return windows?.first { ($0["id"] as? String)?.lowercased() == id.lowercased() }
+    }
+
+    private func request(command: String, target: String? = nil,
+                         args: [String: Any]? = nil) -> String {
+        var object: [String: Any] = ["cmd": command]
+        if let target { object["target"] = target }
+        if let args { object["args"] = args }
+        let data = try! JSONSerialization.data(withJSONObject: object)
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/agtermUITests/ControlPickUITests.swift
+++ b/agtermUITests/ControlPickUITests.swift
@@ -26,9 +26,37 @@ final class ControlPickUITests: ControlAPITestCase {
         XCTAssertEqual(result["result"] as? String, "picked")
         XCTAssertEqual(result["id"] as? String, "beta")
         XCTAssertEqual(result["label"] as? String, "Beta")
-        XCTAssertEqual(result["index"] as? Int, 1, "the result index should preserve the input order")
+        XCTAssertEqual(result["index"] as? Int, 1, "clicking the second unfiltered row should report its input index")
         XCTAssertTrue(pickPalette.waitForNonExistence(timeout: 10), "selection should dismiss the picker")
         XCTAssertNil(try treePickPending(), "tree should omit pickPending after resolution")
+    }
+
+    /// With an empty query the palette skips ranking entirely, so filtered order equals input order and a
+    /// click there cannot tell the two apart. Typing a query that drops the earlier rows is what separates
+    /// them: the match is the only row on screen, at row position 0, while its caller index is 2.
+    func testFilteredSelectionReportsCallerIndexNotRowPosition() throws {
+        let pickID = try resultID(openPick([
+            ["id": "alpha", "label": "Alpha"],
+            ["id": "beta", "label": "Beta"],
+            ["id": "gamma", "label": "Gamma"],
+        ]))
+        XCTAssertTrue(pickPalette.waitForExistence(timeout: 10), "pick.open should present the picker")
+
+        let field = app.textFields.firstMatch
+        XCTAssertTrue(field.waitForExistence(timeout: 5), "the picker query field should exist")
+        field.click()
+        field.typeText("gam")
+        XCTAssertTrue(paletteRow("gamma").waitForExistence(timeout: 5), "the query should keep the matching row")
+        XCTAssertTrue(paletteRow("alpha").waitForNonExistence(timeout: 5),
+                      "the query should drop the non-matching rows, leaving the match alone on screen")
+
+        paletteRow("gamma").click()
+
+        let result = try awaitTerminalResult(id: pickID)
+        XCTAssertEqual(result["result"] as? String, "picked")
+        XCTAssertEqual(result["id"] as? String, "gamma")
+        XCTAssertEqual(result["index"] as? Int, 2,
+                       "the index must be the caller's array position, not the filtered row position 0")
     }
 
     func testPickCancelReportsCancelled() throws {
@@ -256,8 +284,13 @@ final class ControlPickUITests: ControlAPITestCase {
         app.descendants(matching: .any).matching(identifier: "pick-palette").firstMatch
     }
 
+    /// `PaletteRow` carries its identifier on the row, and SwiftUI propagates it to every text child, so a
+    /// row with a subtitle answers to it twice. The title child is never hittable — the row itself owns the
+    /// tap target — so take the first hittable match and fall back to `firstMatch` for existence waits,
+    /// which run before any element exists.
     private func paletteRow(_ id: String) -> XCUIElement {
-        app.descendants(matching: .any).matching(identifier: "palette-item-\(id)").firstMatch
+        let matches = app.descendants(matching: .any).matching(identifier: "palette-item-\(id)")
+        return matches.allElementsBoundByIndex.first { $0.isHittable } ?? matches.firstMatch
     }
 
     private func openPick(

--- a/agtermUITests/ControlPickUITests.swift
+++ b/agtermUITests/ControlPickUITests.swift
@@ -20,7 +20,7 @@ final class ControlPickUITests: ControlAPITestCase {
         XCTAssertTrue(app.staticTexts["Beta"].exists, "the second supplied label should be visible")
         XCTAssertEqual(try treePickPending(), pickID, "tree should expose the live picker id")
 
-        paletteRow("beta").click()
+        clickPaletteRow("beta")
 
         let result = try awaitTerminalResult(id: pickID)
         XCTAssertEqual(result["result"] as? String, "picked")
@@ -50,7 +50,7 @@ final class ControlPickUITests: ControlAPITestCase {
         XCTAssertTrue(paletteRow("alpha").waitForNonExistence(timeout: 5),
                       "the query should drop the non-matching rows, leaving the match alone on screen")
 
-        paletteRow("gamma").click()
+        clickPaletteRow("gamma")
 
         let result = try awaitTerminalResult(id: pickID)
         XCTAssertEqual(result["result"] as? String, "picked")
@@ -284,13 +284,18 @@ final class ControlPickUITests: ControlAPITestCase {
         app.descendants(matching: .any).matching(identifier: "pick-palette").firstMatch
     }
 
-    /// `PaletteRow` carries its identifier on the row, and SwiftUI propagates it to every text child, so a
-    /// row with a subtitle answers to it twice. The title child is never hittable — the row itself owns the
-    /// tap target — so take the first hittable match and fall back to `firstMatch` for existence waits,
-    /// which run before any element exists.
     private func paletteRow(_ id: String) -> XCUIElement {
+        app.descendants(matching: .any).matching(identifier: "palette-item-\(id)").firstMatch
+    }
+
+    /// `PaletteRow` carries its identifier on the row, and SwiftUI propagates it to every text child with
+    /// none of its own, so a row WITH a subtitle answers to it twice — and the title child is not hittable,
+    /// because the row itself owns the tap target. Click the first HITTABLE match rather than whichever the
+    /// query returns first. This stays separate from `paletteRow` because resolving the matches is eager:
+    /// doing it inside the existence waits, which run before the row exists, breaks them.
+    private func clickPaletteRow(_ id: String) {
         let matches = app.descendants(matching: .any).matching(identifier: "palette-item-\(id)")
-        return matches.allElementsBoundByIndex.first { $0.isHittable } ?? matches.firstMatch
+        (matches.allElementsBoundByIndex.first { $0.isHittable } ?? matches.firstMatch).click()
     }
 
     private func openPick(

--- a/docs/plans/20260728-control-pick.md
+++ b/docs/plans/20260728-control-pick.md
@@ -423,14 +423,16 @@ as a phantom.
 **Files:**
 - Modify: `agterm/Views/WindowContentView.swift`
 - Modify: `agterm/AppActions+Focus.swift`
+- Modify: `agterm/Views/Palette.swift`
+- Create: `agtermTests/PickFocusGuardTests.swift`
 
-- [ ] mount a pick-driven `CommandPalette` from `WindowContentView` observing the window's `PickController`
-- [ ] register and unregister that controller with `PickRegistry` on the window's lifecycle, alongside the existing registry registrations at `WindowContentView.swift:192-196`
-- [ ] resolve `picked` with id/label/index, `custom` with the query, and Esc or scrim tap with `cancelled`
-- [ ] extend the `focusActiveSession` guard (`AppActions+Focus.swift:118-135`) to bail while the window has a pending pick — a separate `PickController` does not trip the existing `palette?.mode != nil` term, and opening a pick CLOSES the built-in palette, which is exactly what starts the ~12×0.03s `makeFirstResponder` retry loop that would steal the pick's field focus
-- [ ] extend the same term in `focusSplitPane` (`AppActions+Focus.swift:186`)
-- [ ] verify `WindowContentView.swift` (was 844) is still under 1000 lines; split to `WindowContentView+Pick.swift` if not
-- [ ] gates: `swift test`, `make lint`, `make build`, `make test-app` — all must pass before task 8
+- [x] mount a pick-driven `CommandPalette` from `WindowContentView` observing the window's `PickController`
+- [x] register and unregister that controller with `PickRegistry` on the window's lifecycle, alongside the existing registry registrations at `WindowContentView.swift:192-196`
+- [x] resolve `picked` with id/label/index, `custom` with the query, and Esc or scrim tap with `cancelled`
+- [x] extend the `focusActiveSession` guard (`AppActions+Focus.swift:118-135`) to bail while the window has a pending pick — a separate `PickController` does not trip the existing `palette?.mode != nil` term, and opening a pick CLOSES the built-in palette, which is exactly what starts the ~12×0.03s `makeFirstResponder` retry loop that would steal the pick's field focus
+- [x] extend the same term in `focusSplitPane` (`AppActions+Focus.swift:186`)
+- [x] verify `WindowContentView.swift` (was 844) is still under 1000 lines; split to `WindowContentView+Pick.swift` if not
+- [x] gates: `swift test`, `make lint`, `make build`, `make test-app` — all must pass before task 8
 
 ### Task 8: Dismissal and lifetime
 

--- a/docs/plans/20260728-control-pick.md
+++ b/docs/plans/20260728-control-pick.md
@@ -409,14 +409,14 @@ as a phantom.
 **Files:**
 - Modify: `agterm/Views/Palette.swift`
 
-- [ ] change `CommandPalette.allItems` (`Palette.swift:96-105`) so an explicitly-supplied `[PaletteItem]` array takes precedence over the `controller.mode` switch, leaving all five existing modes untouched
-- [ ] render the synthetic `Use "<query>"` row when `allowCustom` is set and the filtered list is empty, selected so Enter resolves it
-- [ ] use the supplied `prompt` as the field placeholder, defaulting to `Select…` when absent — do NOT fall through to the `placeholder` switch's `default:` arm (`Palette.swift:134`), which returns the action-palette's `Run an action…` and would be plainly wrong on a pick
-- [ ] give the pick-driven instance the accessibility identifier `pick-palette` (distinct from the shared `command-palette` at `Palette.swift:182`) and give rows a per-item identifier, so task 11's e2e can address them
-- [ ] hoist the custom-row decision into a host-free helper in `agtermCore` (given a query and a filtered count, does a custom row exist and what is its label) so it is unit-testable — the SwiftUI view itself is not reachable from `swift test`
-- [ ] write host-free tests for that helper: empty query, query matching nothing with and without `allowCustom`, query matching something
-- [ ] verify the five existing palette modes still render and filter unchanged
-- [ ] gates: `swift test`, `make lint`, `make build`, `make test-app` — all must pass before task 7
+- [x] change `CommandPalette.allItems` (`Palette.swift:96-105`) so an explicitly-supplied `[PaletteItem]` array takes precedence over the `controller.mode` switch, leaving all five existing modes untouched
+- [x] render the synthetic `Use "<query>"` row when `allowCustom` is set and the filtered list is empty, selected so Enter resolves it
+- [x] use the supplied `prompt` as the field placeholder, defaulting to `Select…` when absent — do NOT fall through to the `placeholder` switch's `default:` arm (`Palette.swift:134`), which returns the action-palette's `Run an action…` and would be plainly wrong on a pick
+- [x] give the pick-driven instance the accessibility identifier `pick-palette` (distinct from the shared `command-palette` at `Palette.swift:182`) and give rows a per-item identifier, so task 11's e2e can address them
+- [x] hoist the custom-row decision into a host-free helper in `agtermCore` (given a query and a filtered count, does a custom row exist and what is its label) so it is unit-testable — the SwiftUI view itself is not reachable from `swift test`
+- [x] write host-free tests for that helper: empty query, query matching nothing with and without `allowCustom`, query matching something
+- [x] verify the five existing palette modes still render and filter unchanged
+- [x] gates: `swift test`, `make lint`, `make build`, `make test-app` — all must pass before task 7
 
 ### Task 7: Mount the pick palette and guard focus
 

--- a/docs/plans/20260728-control-pick.md
+++ b/docs/plans/20260728-control-pick.md
@@ -437,18 +437,22 @@ as a phantom.
 ### Task 8: Dismissal and lifetime
 
 **Files:**
+- Modify: `agtermCore/Sources/agtermCore/Pick.swift`
+- Modify: `agtermCore/Tests/agtermCoreTests/PickTests.swift`
 - Modify: `agterm/AppActions.swift`
+- Modify: `agterm/Control/ControlServer+Pick.swift`
+- Modify: `agterm/Views/WindowAccessor.swift`
 - Modify: `agterm/Views/WindowContentView.swift`
 - Modify: `agtermTests/ControlServerPickTests.swift`
 
-- [ ] add the pending-pick check as the FIRST branch of `closeActiveSession()` (`AppActions.swift:251`), ahead of terminal zoom, cancelling the pick and returning `true`
-- [ ] resolve a pending pick to `cancelled` when its window closes
-- [ ] resolve every pending pick to `cancelled` on app termination, alongside the existing quit flush
-- [ ] confirm a pick left pending never blocks quit or the quit-confirmation prompt
-- [ ] write a hosted test for the ⌘W precedence — a pending pick cancels ahead of an active terminal zoom, and the zoom survives
-- [ ] write a hosted test for window-close resolving a pending pick to `cancelled`
-- [ ] verify `WindowContentView.swift` is still under 1000 lines
-- [ ] gates: `swift test`, `make lint`, `make build`, `make test-app` — all must pass before task 9
+- [x] add the pending-pick check as the FIRST branch of `closeActiveSession()` (`AppActions.swift:251`), ahead of terminal zoom, cancelling the pick and returning `true`
+- [x] resolve a pending pick to `cancelled` when its window closes
+- [x] resolve every pending pick to `cancelled` on app termination, alongside the existing quit flush
+- [x] confirm a pick left pending never blocks quit or the quit-confirmation prompt
+- [x] write a hosted test for the ⌘W precedence — a pending pick cancels ahead of an active terminal zoom, and the zoom survives
+- [x] write a hosted test for window-close resolving a pending pick to `cancelled`
+- [x] verify `WindowContentView.swift` is still under 1000 lines
+- [x] gates: `swift test`, `make lint`, `make build`, `make test-app` — all must pass before task 9
 
 ### Task 9: Tree read-back
 

--- a/docs/plans/20260728-control-pick.md
+++ b/docs/plans/20260728-control-pick.md
@@ -367,16 +367,21 @@ Exit codes: **0** got an answer (`picked` or `custom`), **1** command failed, **
 - Modify: `agtermCore/Tests/agtermCoreTests/MockControlActions.swift`
 - Create: `agtermCore/Tests/agtermCoreTests/ControlDispatcherPickTests.swift`
 
-- [ ] widen `ControlDispatcher.actions` from `private` to internal (`ControlDispatcher.swift:143`) — `private` is FILE-scoped in Swift, so a `+Pick.swift` extension cannot reach it and the build fails
-- [ ] add `openPick`, `pickResult`, and `cancelPick` to the `ControlActions` protocol with doc comments naming what the host owns (registry lookup, window resolution, presentation)
-- [ ] create `ControlDispatcher+Pick.swift` holding `dispatchPickCommand`, owning all item validation, the missing-target checks, error strings, and the response shape
-- [ ] replace the three `return nil` stubs from task 2 with real routing to the new arm
-- [ ] add the three methods and their `Call` cases to `MockControlActions` — it is `final class MockControlActions: ControlActions` and will not compile until every requirement is satisfied
-- [ ] write tests for every validation rejection: empty items, empty label, duplicate ids, over `maxItems`, control characters, missing target on result/cancel
-- [ ] write tests asserting a rejection mutates nothing (the mock records no host call)
-- [ ] write tests for routing and for the success response shape of each command
-- [ ] verify `ControlDispatcher.swift` is still under 1000 lines
-- [ ] gates: `swift test`, `make lint`, `make build` — all must pass before task 5
+- [x] widen `ControlDispatcher.actions` from `private` to internal (`ControlDispatcher.swift:143`) — `private` is FILE-scoped in Swift, so a `+Pick.swift` extension cannot reach it and the build fails
+- [x] add `openPick`, `pickResult`, and `cancelPick` to the `ControlActions` protocol with doc comments naming what the host owns (registry lookup, window resolution, presentation)
+- [x] create `ControlDispatcher+Pick.swift` holding `dispatchPickCommand`, owning all item validation, the missing-target checks, error strings, and the response shape
+- [x] replace the three `return nil` stubs from task 2 with real routing to the new arm
+- [x] add the three methods and their `Call` cases to `MockControlActions` — it is `final class MockControlActions: ControlActions` and will not compile until every requirement is satisfied
+- [x] write tests for every validation rejection: empty items, empty label, duplicate ids, over `maxItems`, control characters, missing target on result/cancel
+- [x] write tests asserting a rejection mutates nothing (the mock records no host call)
+- [x] write tests for routing and for the success response shape of each command
+- [x] verify `ControlDispatcher.swift` is still under 1000 lines
+- [x] gates: `swift test`, `make lint`, `make build` — all must pass before task 5
+
+⚠️ Adding the three protocol requirements made the existing app-side `ControlServer` conformance fail
+before task 5, contradicting the per-task build gate. `ControlDispatcher+Pick.swift` therefore supplies
+explicit-failure `no pick surface` defaults for the intermediate state. Task 5 must add concrete
+`ControlServer` witnesses for all three methods; the mock already uses explicit witnesses.
 
 ### Task 5: App-side pick host
 

--- a/docs/plans/20260728-control-pick.md
+++ b/docs/plans/20260728-control-pick.md
@@ -493,14 +493,14 @@ as a phantom.
 **Files:**
 - Create: `agtermUITests/ControlPickUITests.swift`
 
-- [ ] create `ControlPickUITests` as a `ControlAPITestCase` subclass
-- [ ] test open → the `pick-palette` modal appears with the supplied rows → select → `pick.result` returns `picked` with the right id, label, and index
-- [ ] test open → `pick.cancel` → `pick.result` returns `cancelled`
-- [ ] test a second `pick.open` on the same window is rejected with `pick already pending`
-- [ ] test the `tree` read-back reports `pickPending` while open and omits it after resolution
-- [ ] test the free-text path: `--allow-custom` with a non-matching query returns `custom` carrying the query
-- [ ] test the `--window` leg drives a background window, using a MINIMIZED second window so an arm ignoring the selector lands on the wrong store
-- [ ] run the suite — must pass before task 12
+- [x] create `ControlPickUITests` as a `ControlAPITestCase` subclass
+- [x] test open → the `pick-palette` modal appears with the supplied rows → select → `pick.result` returns `picked` with the right id, label, and index
+- [x] test open → `pick.cancel` → `pick.result` returns `cancelled`
+- [x] test a second `pick.open` on the same window is rejected with `pick already pending`
+- [x] test the `tree` read-back reports `pickPending` while open and omits it after resolution
+- [x] test the free-text path: `--allow-custom` with a non-matching query returns `custom` carrying the query
+- [x] test the `--window` leg drives a background window, using a MINIMIZED second window so an arm ignoring the selector lands on the wrong store
+- [x] run the suite — must pass before task 12
 
 ### Task 12: Verify acceptance criteria
 

--- a/docs/plans/20260728-control-pick.md
+++ b/docs/plans/20260728-control-pick.md
@@ -504,16 +504,16 @@ as a phantom.
 
 ### Task 12: Verify acceptance criteria
 
-- [ ] verify all requirements from Overview are implemented
-- [ ] verify every validation rejection returns its documented error and mutates nothing
-- [ ] verify the four-point audit for EACH of the three commands: `Command` case + args, dispatcher arm, `agtermctl` subcommand, round-trip + e2e tests
-- [ ] verify the read-back obligation: `pickPending` shipped in the same change, with round-trip and populate tests
-- [ ] verify no file the plan touched crossed 1000 lines
-- [ ] run `cd agtermCore && swift test`
-- [ ] run `make test-app`
-- [ ] run the `agtermUITests` suite
-- [ ] run `make lint` — must report zero findings under `--strict`
-- [ ] run `make build`
+- [x] verify all requirements from Overview are implemented
+- [x] verify every validation rejection returns its documented error and mutates nothing
+- [x] verify the four-point audit for EACH of the three commands: `Command` case + args, dispatcher arm, `agtermctl` subcommand, round-trip + e2e tests
+- [x] verify the read-back obligation: `pickPending` shipped in the same change, with round-trip and populate tests
+- [x] verify no file the plan touched crossed 1000 lines
+- [x] run `cd agtermCore && swift test`
+- [x] run `make test-app`
+- [x] run the focused `ControlPickUITests` suite — the repository-wide UI suite is explicitly excluded by user instruction
+- [x] run `make lint` — must report zero findings under `--strict`
+- [x] run `make build`
 
 ### Task 13: [Final] Update documentation
 

--- a/docs/plans/20260728-control-pick.md
+++ b/docs/plans/20260728-control-pick.md
@@ -461,12 +461,12 @@ as a phantom.
 - Modify: `agterm/Control/ControlServer.swift`
 - Modify: `agtermCore/Tests/agtermCoreTests/AppStoreTests.swift`
 
-- [ ] add a `pickPending: () -> String?` closure parameter to `AppStore.controlTree`, defaulting to nil for host-free tests (the `quickVisible`/`zoomedSurface` seam)
-- [ ] populate it app-side in `buildTree` from the projected window's `PickController` via the registry
-- [ ] confirm the field is LIVE and `tree`-only — do NOT mirror it onto the cached `window.list` nodes
-- [ ] write a `controlTreeReportsPickPendingFromClosure` test and one asserting omission when no pick is pending
-- [ ] verify `AppStore.swift` (was 977, the closest of any touched file to the cap) is still under 1000 lines; split to `AppStore+Pick.swift` if not
-- [ ] gates: `swift test`, `make lint`, `make build` — all must pass before task 10
+- [x] add a `pickPending: () -> String?` closure parameter to `AppStore.controlTree`, defaulting to nil for host-free tests (the `quickVisible`/`zoomedSurface` seam)
+- [x] populate it app-side in `buildTree` from the projected window's `PickController` via the registry
+- [x] confirm the field is LIVE and `tree`-only — do NOT mirror it onto the cached `window.list` nodes
+- [x] write a `controlTreeReportsPickPendingFromClosure` test and one asserting omission when no pick is pending
+- [x] verify `AppStore.swift` (was 977, the closest of any touched file to the cap) is still under 1000 lines; split to `AppStore+Pick.swift` if not
+- [x] gates: `swift test`, `make lint`, `make build` — all must pass before task 10
 
 ### Task 10: agtermctl pick subcommands
 

--- a/docs/plans/20260728-control-pick.md
+++ b/docs/plans/20260728-control-pick.md
@@ -333,16 +333,16 @@ Exit codes: **0** got an answer (`picked` or `custom`), **1** command failed, **
 - Modify: `agterm/Control/ControlServer.swift`
 - Modify: `agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift`
 
-- [ ] create `ControlPick.swift` with `ControlPickItem`, `ControlPickOutcome`, `ControlPickResult`, `ResolvedPick`, and the `maxItems` constant
-- [ ] add `pickOpen`/`pickResult`/`pickCancel` cases to `Command` in `ControlProtocol.swift`
-- [ ] add `items`/`prompt`/`allowCustom` to `ControlArgs` (reuse the existing `window` and `follow` fields)
-- [ ] add `pick: ControlPickResult?` to `ControlResult` and `pickPending: String?` to `ControlTree`
-- [ ] route the three cases in `ControlDispatcher.dispatch` to `return nil` — the switch at `:150` is EXHAUSTIVE with no `default:`, so omitting this breaks the `agtermCore` build and makes this task's own `swift test` gate unrunnable
-- [ ] add the three cases to the fallthrough case list in `ControlServer.swift:374` — that switch is exhaustive too, so omitting this breaks the app target
-- [ ] write round-trip tests for all three commands and every `ControlPickResult` outcome shape
-- [ ] write `…OmitsWhenNil` tests for `ControlResult.pick`, `ControlTree.pickPending`, and `ControlPickItem.subtitle`
-- [ ] verify `ControlProtocol.swift` (was 806) and `ControlDispatcher.swift` (was 794) are still under 1000 lines
-- [ ] gates: `swift test`, `make lint`, `make build` — all must pass before task 3
+- [x] create `ControlPick.swift` with `ControlPickItem`, `ControlPickOutcome`, `ControlPickResult`, `ResolvedPick`, and the `maxItems` constant
+- [x] add `pickOpen`/`pickResult`/`pickCancel` cases to `Command` in `ControlProtocol.swift`
+- [x] add `items`/`prompt`/`allowCustom` to `ControlArgs` (reuse the existing `window` and `follow` fields)
+- [x] add `pick: ControlPickResult?` to `ControlResult` and `pickPending: String?` to `ControlTree`
+- [x] route the three cases in `ControlDispatcher.dispatch` to `return nil` — the switch at `:150` is EXHAUSTIVE with no `default:`, so omitting this breaks the `agtermCore` build and makes this task's own `swift test` gate unrunnable
+- [x] add the three cases to the fallthrough case list in `ControlServer.swift:374` — that switch is exhaustive too, so omitting this breaks the app target
+- [x] write round-trip tests for all three commands and every `ControlPickResult` outcome shape
+- [x] write `…OmitsWhenNil` tests for `ControlResult.pick`, `ControlTree.pickPending`, and `ControlPickItem.subtitle`
+- [x] verify `ControlProtocol.swift` (was 806) and `ControlDispatcher.swift` (was 794) are still under 1000 lines
+- [x] gates: `swift test`, `make lint`, `make build` — all must pass before task 3
 
 ### Task 3: PickController and PickRegistry
 

--- a/docs/plans/20260728-control-pick.md
+++ b/docs/plans/20260728-control-pick.md
@@ -476,17 +476,17 @@ as a phantom.
 - Modify: `agtermCore/Tests/agtermctlKitTests/CommandsTests.swift`
 - Modify: `agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift`
 
-- [ ] add a `pick` command group with `Open` (the default), `Result`, and `Cancel` subcommands, mirroring `session overlay`'s `[Open, Close, Resize, Result]` at `SessionCommands.swift:606` — all three control commands need a CLI verb to satisfy point 3 of the four-point audit, and without them `--no-block` is unusable
-- [ ] give `Open` the `--prompt`, `--allow-custom`, `--follow`, `--window`, `--no-block` options — there is deliberately NO `--timeout`, since a caller wanting a deadline writes `timeout 60 agtermctl pick …` and clears the orphaned modal with `pick cancel`
-- [ ] read stdin and sniff the first non-whitespace byte: `[` parses as a JSON item array, anything else is one label per line with blank lines dropped
-- [ ] implement the blocking path — open, poll `pick.result` until it leaves `pending`, print the result JSON on stdout — with `--no-block` printing the pick id instead
-- [ ] use a backing-off poll (0.1s for the first second, then 0.5s) rather than the overlay's flat 0.1s, which is tuned for sub-second programs and would hammer the serial accept loop across an unbounded human decision
-- [ ] map outcomes to exit codes 0 (picked/custom), 1 (failure), 2 (cancelled)
-- [ ] write tests for the stdin sniff across JSON, bare lines, blank lines, empty stdin, and malformed JSON
-- [ ] write tests for CLI-to-request argument mapping for all three subcommands
-- [ ] write tests for the exit-code mapping of every outcome, and for the poll backoff schedule
-- [ ] verify `MiscCommands.swift` (was 402) is still under 1000 lines
-- [ ] gates: `swift test`, `make lint`, `make build` — all must pass before task 11
+- [x] add a `pick` command group with `Open` (the default), `Result`, and `Cancel` subcommands, mirroring `session overlay`'s `[Open, Close, Resize, Result]` at `SessionCommands.swift:606` — all three control commands need a CLI verb to satisfy point 3 of the four-point audit, and without them `--no-block` is unusable
+- [x] give `Open` the `--prompt`, `--allow-custom`, `--follow`, `--window`, `--no-block` options — there is deliberately NO `--timeout`, since a caller wanting a deadline writes `timeout 60 agtermctl pick …` and clears the orphaned modal with `pick cancel`
+- [x] read stdin and sniff the first non-whitespace byte: `[` parses as a JSON item array, anything else is one label per line with blank lines dropped
+- [x] implement the blocking path — open, poll `pick.result` until it leaves `pending`, print the result JSON on stdout — with `--no-block` printing the pick id instead
+- [x] use a backing-off poll (0.1s for the first second, then 0.5s) rather than the overlay's flat 0.1s, which is tuned for sub-second programs and would hammer the serial accept loop across an unbounded human decision
+- [x] map outcomes to exit codes 0 (picked/custom), 1 (failure), 2 (cancelled)
+- [x] write tests for the stdin sniff across JSON, bare lines, blank lines, empty stdin, and malformed JSON
+- [x] write tests for CLI-to-request argument mapping for all three subcommands
+- [x] write tests for the exit-code mapping of every outcome, and for the poll backoff schedule
+- [x] verify `MiscCommands.swift` (was 402) is still under 1000 lines
+- [x] gates: `swift test`, `make lint`, `make build` — all must pass before task 11
 
 ### Task 11: End-to-end tests
 

--- a/docs/plans/20260728-control-pick.md
+++ b/docs/plans/20260728-control-pick.md
@@ -350,14 +350,14 @@ Exit codes: **0** got an answer (`picked` or `custom`), **1** command failed, **
 - Create: `agtermCore/Sources/agtermCore/Pick.swift`
 - Create: `agtermCore/Tests/agtermCoreTests/PickTests.swift`
 
-- [ ] create `Pick.swift` with `PendingPick`, `PickController` (`@Observable @MainActor`), and `PickRegistry` (`@MainActor`, `shared`), modeled on `TerminalZoom.swift:109-193`
-- [ ] implement `open` returning false when one is already pending, plus `resolve`, `cancel`, and `result(for:)`
-- [ ] retain exactly one `ResolvedPick` per controller so a late poll still gets its answer, overwritten on the next `open`
-- [ ] keep the file Foundation + Observation only — no AppKit, GhosttyKit, Metal, or CoreGraphics geometry
-- [ ] write tests for open/resolve/cancel, the already-pending rejection, and reading a result after resolution
-- [ ] write tests for `result(for:)` with an unknown id, and for `lastResult` being replaced by the next open
-- [ ] write registry tests for register/unregister/lookup and lookup with a nil id
-- [ ] gates: `swift test`, `make lint`, `make build` — all must pass before task 4
+- [x] create `Pick.swift` with `PendingPick`, `PickController` (`@Observable @MainActor`), and `PickRegistry` (`@MainActor`, `shared`), modeled on `TerminalZoom.swift:109-193`
+- [x] implement `open` returning false when one is already pending, plus `resolve`, `cancel`, and `result(for:)`
+- [x] retain exactly one `ResolvedPick` per controller so a late poll still gets its answer, overwritten on the next `open`
+- [x] keep the file Foundation + Observation only — no AppKit, GhosttyKit, Metal, or CoreGraphics geometry
+- [x] write tests for open/resolve/cancel, the already-pending rejection, and reading a result after resolution
+- [x] write tests for `result(for:)` with an unknown id, and for `lastResult` being replaced by the next open
+- [x] write registry tests for register/unregister/lookup and lookup with a nil id
+- [x] gates: `swift test`, `make lint`, `make build` — all must pass before task 4
 
 ### Task 4: Dispatcher arms, ControlActions surface, and mock
 

--- a/docs/plans/20260728-control-pick.md
+++ b/docs/plans/20260728-control-pick.md
@@ -380,8 +380,10 @@ Exit codes: **0** got an answer (`picked` or `custom`), **1** command failed, **
 
 ⚠️ Adding the three protocol requirements made the existing app-side `ControlServer` conformance fail
 before task 5, contradicting the per-task build gate. `ControlDispatcher+Pick.swift` therefore supplies
-explicit-failure `no pick surface` defaults for the intermediate state. Task 5 must add concrete
-`ControlServer` witnesses for all three methods; the mock already uses explicit witnesses.
+explicit-failure `no pick surface` defaults for the intermediate state. Task 5 removes those temporary
+defaults after adding concrete `ControlServer` witnesses for all three methods; the mock already uses
+explicit witnesses. The exhaustive app switch keeps a dedicated picker `preconditionFailure` arm after
+removing the commands from its generic dispatcher-failure fallthrough list.
 
 ### Task 5: App-side pick host
 
@@ -394,13 +396,13 @@ explicit-failure `no pick surface` defaults for the intermediate state. Task 5 m
 `no pick surface` for the whole window between this task and that one. That is expected — do not debug it
 as a phantom.
 
-- [ ] create `ControlServer+Pick.swift` implementing the three `ControlActions` methods
-- [ ] resolve the target store/window via `resolvePlacementStore(window)` (frontmost default), erroring `no open window` when there is none
-- [ ] look up the window's `PickController` through `PickRegistry` and return `pick already pending` when `open` refuses
-- [ ] close the built-in palette when the pick's window is frontmost, and raise + select the window only under `follow`
-- [ ] remove the three cases from the `ControlServer.swift:374` fallthrough list now that the dispatcher owns them
-- [ ] write hosted tests (`agtermTests`, the `DockMenuTests` precedent) for the no-window arm, the registry-miss arm, and the already-pending rejection
-- [ ] gates: `swift test`, `make lint`, `make build`, `make test-app` — all must pass before task 6
+- [x] create `ControlServer+Pick.swift` implementing the three `ControlActions` methods
+- [x] resolve the target store/window via `resolvePlacementStore(window)` (frontmost default), erroring `no open window` when there is none
+- [x] look up the window's `PickController` through `PickRegistry` and return `pick already pending` when `open` refuses
+- [x] close the built-in palette when the pick's window is frontmost, and raise + select the window only under `follow`
+- [x] remove the three cases from the `ControlServer.swift:374` fallthrough list now that the dispatcher owns them
+- [x] write hosted tests (`agtermTests`, the `DockMenuTests` precedent) for the no-window arm, the registry-miss arm, and the already-pending rejection
+- [x] gates: `swift test`, `make lint`, `make build`, `make test-app` — all must pass before task 6
 
 ### Task 6: CommandPalette accepts explicit items
 

--- a/docs/plans/20260728-control-pick.md
+++ b/docs/plans/20260728-control-pick.md
@@ -317,12 +317,12 @@ Exit codes: **0** got an answer (`picked` or `custom`), **1** command failed, **
 **Files:**
 - none (environment only)
 
-- [ ] `git fetch origin master` so the worktree forks the CURRENT remote tip, not a stale local ref
-- [ ] create the worktree via Claude Code's native support ("work in a worktree" / `EnterWorktree`), never a manual `git worktree add`
-- [ ] symlink `GhosttyKit.xcframework` from the main worktree
-- [ ] symlink `agterm/Resources/ghostty` and `agterm/Resources/terminfo` with ABSOLUTE targets
-- [ ] run `scripts/setup.sh` and confirm it prints `GhosttyKit and resources already present` (it must NOT rebuild libghostty)
-- [ ] `make build` succeeds in the worktree before any code changes
+- [x] `git fetch origin master` so the worktree forks the CURRENT remote tip, not a stale local ref
+- [x] create the worktree via Claude Code's native support ("work in a worktree" / `EnterWorktree`), never a manual `git worktree add` — Codex equivalent used an isolated Git worktree because it has no native `EnterWorktree` action
+- [x] symlink `GhosttyKit.xcframework` from the main worktree
+- [x] symlink `agterm/Resources/ghostty` and `agterm/Resources/terminfo` with ABSOLUTE targets
+- [x] run `scripts/setup.sh` and confirm it prints `GhosttyKit and resources already present` (it must NOT rebuild libghostty)
+- [x] `make build` succeeds in the worktree before any code changes
 
 ### Task 2: Pick wire types, protocol fields, and switch routing
 

--- a/docs/plans/completed/20260728-control-pick.md
+++ b/docs/plans/completed/20260728-control-pick.md
@@ -527,18 +527,18 @@ as a phantom.
 - Modify: `README.md`
 - Modify: `.claude/rules/control-api.md`
 
-- [ ] add the three commands to the bundled agent skill: SKILL.md summary, reference.md per-command detail, examples.md recipes
-- [ ] add three entries to `site/commands.html` in the right family section, each carrying invocation, arguments, and the `tree` read-back field
-- [ ] add a `pick.open`/`pick.result`/`pick.cancel` bullet to the command CATALOG list in `.claude/rules/control-api.md:287` — separate from the count bump and easy to miss
-- [ ] add the pick section to `.claude/rules/control-api.md` using semantic line breaks (one sentence per line)
-- [ ] bump the command count from 68 to 71 EVERYWHERE — grep for the PATTERN, never for the old or new number, since a surface already stale at a third value is invisible to a search for either
-- [ ] update the known count sites: `README.md:187`, `SKILL.md:145`, `site/docs.html:1124`, `site/commands.html:9,21,33,238`, `.claude/rules/control-api.md:209,287,316,1740`
-- [ ] update the hardcoded assertion in `SkillInstallTests.swift:17` (`#expect(skill.contains("Command summary (68 commands)"))`) — it is a required EDIT, not merely a detector, and `swift test` ends red without it
-- [ ] finish with `rg -n '\b[0-9]{2,3}\b' .claude/rules/control-api.md` and read every hit — the phrasings "the public command count stays N" and "`Command` has N cases" do not match a "N commands" grep and have survived a bump before
-- [ ] update `README.md` and `site/docs.html`
-- [ ] confirm `CHANGELOG.md` is UNTOUCHED (release-only) and no `cookbook/` recipe was swept (deliberately not a keep-in-sync surface)
-- [ ] gates: `swift test`, `make lint`, `make build`
-- [ ] move this plan to `docs/plans/completed/`
+- [x] add the three commands to the bundled agent skill: SKILL.md summary, reference.md per-command detail, examples.md recipes
+- [x] add three entries to `site/commands.html` in the right family section, each carrying invocation, arguments, and the `tree` read-back field
+- [x] add a `pick.open`/`pick.result`/`pick.cancel` bullet to the command CATALOG list in `.claude/rules/control-api.md:287` — separate from the count bump and easy to miss
+- [x] add the pick section to `.claude/rules/control-api.md` using semantic line breaks (one sentence per line)
+- [x] bump the command count from 68 to 71 EVERYWHERE — grep for the PATTERN, never for the old or new number, since a surface already stale at a third value is invisible to a search for either
+- [x] update the known count sites: `README.md:187`, `SKILL.md:145`, `site/docs.html:1124`, `site/commands.html:9,21,33,238`, `.claude/rules/control-api.md:209,287,316,1740`
+- [x] update the hardcoded assertion in `SkillInstallTests.swift:17` (`#expect(skill.contains("Command summary (68 commands)"))`) — it is a required EDIT, not merely a detector, and `swift test` ends red without it
+- [x] finish with `rg -n '\b[0-9]{2,3}\b' .claude/rules/control-api.md` and read every hit — the phrasings "the public command count stays N" and "`Command` has N cases" do not match a "N commands" grep and have survived a bump before
+- [x] update `README.md` and `site/docs.html`
+- [x] confirm `CHANGELOG.md` is UNTOUCHED (release-only) and no `cookbook/` recipe was swept (deliberately not a keep-in-sync surface)
+- [x] gates: focused `swift test --filter 'SkillInstallTests.bundledSkillDocumentsEventSubscriptionCommand'` substituted for broad `swift test` per user override; `make lint`; `make build`
+- [x] move this plan to `docs/plans/completed/`
 ## Post-Completion
 
 *Items requiring manual intervention — no checkboxes, informational only*

--- a/site/commands.html
+++ b/site/commands.html
@@ -6,7 +6,7 @@
     <title>Command reference — agterm | agtermctl control API</title>
     <meta
       name="description"
-      content="Complete agtermctl reference: all 68 control commands for agterm — sessions, workspaces, windows, overlays, the quick terminal, sidebar, agent status, themes, and keymaps, with arguments and return values."
+      content="Complete agtermctl reference: all 71 control commands for agterm, including sessions, workspaces, windows, overlays, the native picker, the quick terminal, sidebar, agent status, themes, and keymaps, with arguments and return values."
     />
     <meta
       name="keywords"
@@ -18,7 +18,7 @@
     <meta property="og:title" content="Command reference — agterm" />
     <meta
       property="og:description"
-      content="All 68 agtermctl control commands with arguments, return values, and errors."
+      content="All 71 agtermctl control commands with arguments, return values, and errors."
     />
     <meta property="og:url" content="https://agterm.com/commands" />
     <meta property="og:image" content="https://agterm.com/assets/agterm-og.png" />
@@ -30,7 +30,7 @@
     <meta name="twitter:title" content="Command reference — agterm" />
     <meta
       name="twitter:description"
-      content="All 68 agtermctl control commands with arguments, return values, and errors."
+      content="All 71 agtermctl control commands with arguments, return values, and errors."
     />
     <meta name="twitter:image" content="https://agterm.com/assets/agterm-og.png" />
     <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
@@ -193,6 +193,7 @@
             <a href="#window" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">window</a>
             <a href="#surface" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">surface zoom</a>
             <a href="#dashboard" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">dashboard</a>
+            <a href="#pick" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">pick</a>
             <a href="#quick" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">quick</a>
             <a href="#sidebar" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">sidebar</a>
             <a href="#notify" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">notify</a>
@@ -235,7 +236,7 @@
             Command reference
           </h1>
           <p style="font-size: 19px; line-height: 1.6; color: #bfbab0; margin: 0 0 8px">
-            All 68 commands of the agterm control API, with arguments and return values. Every one is reachable from the
+            All 71 commands of the agterm control API, with arguments and return values. Every one is reachable from the
             <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl</span> CLI and from the local
             control socket.
           </p>
@@ -342,7 +343,7 @@
             </p>
             <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 16px">
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc; white-space: nowrap">--window &lt;id|prefix|active&gt;</span>
-              (on session, workspace, tree, font, and notify commands) picks which window's tree to act on; the default is the
+              (on session, workspace, tree, font, notify, and pick commands) picks which window's tree to act on; the default is the
               frontmost. With it set, that window must be open; without it, an id/prefix session target is matched across all open
               windows. The <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">window.*</span> commands
               instead take the window selector as a positional argument, defaulting to
@@ -473,8 +474,10 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">sidebarMode</span>,
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">workspaceFilter</span> (whether the workspace focus
                 filter is applied — the flag half of the focus set, the read side of
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">workspace filter</span>), and
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">quickVisible</span>. All six are read-only
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">workspace filter</span>),
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">quickVisible</span>, and
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">pickPending</span> (the pending native picker's id,
+                omitted when none is open). All seven are read-only
                 projections of GUI state.
               </p>
             </div>
@@ -1671,6 +1674,94 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">dashboardFontSize</span> (the applied absolute size, omitted when
                 untouched), and <span style="font-family: &quot;JetBrains Mono&quot;, monospace">dashboardFontMode</span>
                 (<span style="font-family: &quot;JetBrains Mono&quot;, monospace">auto</span>/<span style="font-family: &quot;JetBrains Mono&quot;, monospace">fixed</span>/<span style="font-family: &quot;JetBrains Mono&quot;, monospace">untouched</span>).
+              </p>
+            </div>
+          </section>
+
+          <!-- PICK -->
+          <section id="pick" style="scroll-margin-top: 88px; padding-top: 56px">
+            <h2
+              style="
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-weight: 700;
+                font-size: 28px;
+                letter-spacing: -0.02em;
+                margin: 0 0 16px;
+                padding-bottom: 12px;
+                border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+              "
+            >
+              pick
+            </h2>
+            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 16px">
+              A caller-supplied fuzzy picker rendered by agterm. One picker may be pending in each window.
+            </p>
+
+            <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
+                agtermctl pick [--prompt TEXT] [--allow-custom] [--follow] [--window W] [--no-block]
+              </div>
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">pick.open</div>
+              <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
+                Read choices from stdin and open the target window's native picker. Nonblank input lines become items whose id equals
+                the label. Input whose first non-whitespace byte is
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">[</span> is a JSON array of
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">{id,label,subtitle?}</span> objects. Item ids must be
+                unique, labels must not be empty, and the list is capped at 1,000 items.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--prompt</span> adds text above the query field.
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--allow-custom</span> accepts a nonmatching query.
+                A background <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--window</span> target stays in the
+                background unless <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--follow</span> raises it. The
+                default blocks and prints a bare picked, custom, or cancelled JSON result.
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--no-block</span> prints
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">{"id":"…"}</span> immediately.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                <strong style="color: #bfbab0">Tree read-back:</strong> the target tree's top-level
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">pickPending</span> carries the returned picker id
+                while it waits and is omitted after resolution.
+              </p>
+            </div>
+
+            <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
+                agtermctl pick result &lt;id&gt; [--window W]
+              </div>
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">pick.result</div>
+              <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
+                Read one picker by its exact id in the frontmost or
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--window</span> window. Prints bare JSON with
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">result</span> set to
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">pending</span>,
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">picked</span>,
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">custom</span>, or
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">cancelled</span>. Picked and custom exit 0,
+                pending exits 1, and cancelled exits 2.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                <strong style="color: #bfbab0">Tree read-back:</strong>
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">pickPending</span> equals
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">&lt;id&gt;</span> while the result is pending and
+                disappears for every terminal result.
+              </p>
+            </div>
+
+            <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
+                agtermctl pick cancel &lt;id&gt; [--window W]
+              </div>
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">pick.cancel</div>
+              <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
+                Cancel the exact picker id in the frontmost or
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--window</span> window. The terminal result becomes
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">{"result":"cancelled"}</span>; cancelling an already
+                completed matching picker is a successful no-op, and an unknown id is an error.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                <strong style="color: #bfbab0">Tree read-back:</strong> cancellation removes
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">pickPending</span> from the target tree.
               </p>
             </div>
           </section>

--- a/site/commands.html
+++ b/site/commands.html
@@ -1710,7 +1710,7 @@
                 unique, labels must not be empty, and the list is capped at 1,000 items.
               </p>
               <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--prompt</span> adds text above the query field.
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--prompt</span> sets the query field placeholder.
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--allow-custom</span> accepts a nonmatching query.
                 A background <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--window</span> target stays in the
                 background unless <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--follow</span> raises it. The
@@ -1723,6 +1723,18 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">pickPending</span> carries the returned picker id
                 while it waits and is omitted after resolution.
               </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                <strong style="color: #bfbab0">Errors:</strong>
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">pick.open requires at least one item</span>,
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">too many items (max 1000)</span>,
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">pick item label must not be empty</span>,
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">pick item ids must be unique</span>, or
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">item text must not contain control characters</span>.
+                A second live picker returns <span style="font-family: &quot;JetBrains Mono&quot;, monospace">pick already pending</span>;
+                an unavailable target returns the standard window-resolution error,
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">no open window</span>, or
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">no pick surface</span>.
+              </p>
             </div>
 
             <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
@@ -1731,14 +1743,16 @@
               </div>
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">pick.result</div>
               <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
-                Read one picker by its exact id in the frontmost or
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--window</span> window. Prints bare JSON with
+                Read one picker by its globally unique exact id. Without
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--window</span>, lookup remains pinned to its
+                owning window even if the frontmost window changes; an explicit window must match. Prints bare JSON with
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">result</span> set to
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">pending</span>,
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">picked</span>,
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">custom</span>, or
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">cancelled</span>. Picked and custom exit 0,
                 pending exits 1, and cancelled exits 2.
+                A wrong id returns <span style="font-family: &quot;JetBrains Mono&quot;, monospace">unknown pick: &lt;id&gt;</span>.
               </p>
               <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
                 <strong style="color: #bfbab0">Tree read-back:</strong>
@@ -1754,10 +1768,11 @@
               </div>
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">pick.cancel</div>
               <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
-                Cancel the exact picker id in the frontmost or
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--window</span> window. The terminal result becomes
+                Cancel the globally unique exact picker id; an explicit
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--window</span> must match its owner. The terminal result becomes
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">{"result":"cancelled"}</span>; cancelling an already
-                completed matching picker is a successful no-op, and an unknown id is an error.
+                completed matching picker is a successful no-op, and an unknown id returns
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">unknown pick: &lt;id&gt;</span>.
               </p>
               <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
                 <strong style="color: #bfbab0">Tree read-back:</strong> cancellation removes

--- a/site/docs.html
+++ b/site/docs.html
@@ -1121,7 +1121,7 @@
               "
             >
               <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 0">
-                Looking for the full list? All 68 commands, with every argument, return value, and error, live on the
+                Looking for the full list? All 71 commands, with every argument, return value, and error, live on the
                 <a href="/commands" style="color: #6d82f3; font-weight: 500">Command reference →</a>
               </p>
             </div>
@@ -1157,6 +1157,52 @@
               or <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--socket PATH</span> to override
               the socket. The exit code is zero on success, non-zero on error.
             </p>
+
+            <h3
+              style="
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-weight: 600;
+                font-size: 16px;
+                color: #5ea1f2;
+                margin: 24px 0 12px;
+              "
+            >
+              Native picker
+            </h3>
+            <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 16px">
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl pick</span> reads nonblank
+              lines or a JSON array of
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">{id,label,subtitle?}</span> objects
+              from stdin and opens agterm's fuzzy picker. It blocks by default and prints the picked, custom, or cancelled result as
+              bare JSON. Add <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">--no-block</span> to
+              get the picker id immediately, then use
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">pick result</span> or
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">pick cancel</span>. The target tree's
+              top-level <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">pickPending</span> field
+              carries that id while the picker waits.
+            </p>
+            <div
+              style="
+                background: #15191c;
+                border: 1px solid rgba(255, 255, 255, 0.1);
+                border-radius: 10px;
+                padding: 18px 20px;
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-size: 13.5px;
+                line-height: 1.95;
+                overflow-x: auto;
+                color: #e6e1d7;
+              "
+            >
+              printf <span style="color: #f2b45c">'%s\n'</span> staging production | agtermctl pick --prompt
+              <span style="color: #f2b45c">"Deploy where?"</span><br /><br />
+              <span style="color: #6d82f3">id</span>=$(printf <span style="color: #f2b45c">'%s\n'</span> alpha beta |
+              agtermctl pick --no-block | jq -r <span style="color: #f2b45c">'.id'</span>)<br />
+              agtermctl pick result <span style="color: #f2b45c">"$id"</span><br />
+              agtermctl pick cancel <span style="color: #f2b45c">"$id"</span><br />
+              agtermctl tree --json | jq -r
+              <span style="color: #f2b45c">'.result.tree.pickPending // empty'</span>
+            </div>
 
             <h3
               style="


### PR DESCRIPTION
adds a native fuzzy picker driven by the control socket.

- accepts newline or structured JSON choices, optional free-form values, and per-window targeting
- exposes blocking and nonblocking `agtermctl pick` flows with result and cancel commands
- reports pending picks in `tree` and cancels them on window, session, or app lifecycle exits
- keeps picker focus above palettes, overlays, zoom, dashboard, and the quick terminal
- documents the command and adds picker-specific unit, hosted, and UI coverage
