### PR TITLE
refactor: apply the comment brevity rule across the repo

### DIFF
--- a/.claude/rules/app-icon.md
+++ b/.claude/rules/app-icon.md
@@ -6,38 +6,22 @@ paths:
 
 ## App icon
 
-- The icon is an **adaptive Icon Composer document** at `agterm/AppIcon.icon` (macOS 26 `.icon` format
-  — layered, with Liquid Glass + light/dark/clear/tinted appearances the system renders LIVE).
-  `ASSETCATALOG_COMPILER_APPICON_NAME` is `AppIcon`; `CFBundleIconName` ends up `AppIcon` (actool writes
-  it). actool compiles the `.icon` into `Assets.car` (the adaptive data) plus a legacy `AppIcon.icns`
-  fallback for macOS < 26 — no hand-made `.appiconset`/`.icns` needed.
-- **The `.icon` MUST be a target FILE, NOT nested inside `Assets.xcassets` (load-bearing).** actool only
-  compiles a `.icon` passed as a DIRECT input; a `.icon` dropped inside an `.xcassets` is treated as
-  an opaque folder and actool **silently emits nothing** (no error, no `Assets.car` — the app ends up
-  icon-less).
-  So `AppIcon.icon` lives at the top of the `agterm/` source dir (Xcode types it `wrapper.icon` and routes
-  it to actool alongside the catalog: `actool …/AppIcon.icon …/Assets.xcassets --compile …`).
-  To swap the design, replace `agterm/AppIcon.icon` (re-export from Icon Composer;
-  `xattr -cr` it first — the source carries quarantine/provenance).
-  A CONTENT swap recompiles on an incremental `make build`; but a STRUCTURAL asset-catalog change (adding/removing
-  the icon, or the appiconset↔`.icon` swap) can make xcodebuild SKIP actool entirely — a "BUILD SUCCEEDED"
-  with a STALE `Assets.car` and no new icon.
-  Force it with `make clean` and confirm `Contents/Resources/AppIcon.icns`'s mtime actually updated.
-- **xcodegen also lists the `.icon` in Copy Bundle Resources**, dropping a redundant LOOSE `AppIcon.icon`
-  in the bundle.
-  The `Bundle agtermctl CLI` postBuildScript `rm -rf`s it before the re-seal:
-  a loose source `.icon` renders as the generic Icon-Composer **placeholder grid** (so it must not win
-  over the compiled icon), and its source xattrs would trip `codesign --deep`.
-- **Do NOT set `NSApp.applicationIconImage`.**
-  `applicationIconImage` takes a STATIC `NSImage`, so setting it (even from the compiled asset) FREEZES
-  the Dock to one flat rendering and defeats the adaptive icon — the symptom is a flat,
-  non-glass, non-tinted Dock tile.
-  The shipped app lets LaunchServices render the bundle `.icon` live.
-  (An earlier `applicationWillFinishLaunching` override that set it for the ad-hoc Debug Dock tile was
-  removed for exactly this reason.)
-- **Debug builds from DerivedData may show a STALE Dock/Finder tile.**
-  Icon Services caches by bundle PATH and the DerivedData path is reused across rebuilds,
-  so a rebuilt dev app can show the prior (or placeholder) icon — NOT a bug.
-  The deployed app (fresh install path) renders correctly.
-  To verify a dev build's icon, copy the `.app` to a fresh path + `lsregister -f` it (or read `Contents/Resources/AppIcon.icns`
-  directly).
+- `agterm/AppIcon.icon` is a layered macOS 26 Icon Composer document with live Liquid Glass and
+  light/dark/clear/tinted appearances. `ASSETCATALOG_COMPILER_APPICON_NAME` and the actool-written
+  `CFBundleIconName` are `AppIcon`. actool emits adaptive data in `Assets.car` plus `AppIcon.icns` for
+  macOS < 26; do not add a hand-made `.appiconset` or `.icns`.
+- **Keep the `.icon` as a direct target file at `agterm/AppIcon.icon`, outside `Assets.xcassets`.**
+  Xcode types it `wrapper.icon` and passes it directly to actool. Inside a catalog it is an opaque folder,
+  and actool silently emits no `Assets.car`. Replace it with an Icon Composer export and run `xattr -cr`
+  first because exports carry quarantine/provenance.
+- Content replacements rebuild incrementally. After adding, removing, or switching catalog structure,
+  run `make clean`: xcodebuild can otherwise report success while skipping actool and retaining a stale
+  `Assets.car`. Confirm that `Contents/Resources/AppIcon.icns` has a new mtime.
+- xcodegen also copies a redundant loose `AppIcon.icon`. The `Bundle agtermctl CLI` post-build script
+  removes it before resealing because it can override the compiled icon with a placeholder grid and its
+  xattrs can fail `codesign --deep`.
+- **Never set `NSApp.applicationIconImage`.** It freezes the Dock to a static, flat `NSImage` and defeats
+  adaptive rendering. LaunchServices must render the bundle icon.
+- DerivedData reuses the bundle path, so Icon Services may show a stale Dock/Finder tile for a dev build.
+  Verify by reading `Contents/Resources/AppIcon.icns`, or copy the app to a fresh path and run
+  `lsregister -f`. A fresh installed path does not have this cache artifact.

--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -5,97 +5,43 @@ paths:
 
 ## CI (`ci.yml`)
 
-- **`ci.yml` runs on push/PR to `master`, gated by a `dorny/paths-filter`.**
-  Swift-impacting paths include `**/*.swift`, `agtermCore/**`, `agterm/**`, `plugins/**`, `.claude-plugin/**`, `.agents/**`, `project.yml`, `scripts/**`, the root/test SwiftLint configs, and `ci.yml`.
-  The three plugin entries are load-bearing and easy to lose: the agent skill and its Claude/Codex manifests live OUTSIDE `agterm/`, and `SkillInstallTests` asserts the bundled `SKILL.md` command count plus that every manifest path resolves and the three versions agree.
-  Without them a skill- or manifest-only commit — which is exactly what `release.sh`'s version-bump preflight produces — matches no filter entry and skips all four Swift jobs, so a stale command count or a disagreeing manifest version ships green.
-  The `test` job runs `swift test --enable-code-coverage` in `agtermCore`, exports lcov, and uploads it as an artifact.
-  The `coverage` job is the only Swift-gated `ubuntu-latest` job (the `cookbook` job below is the other Linux one)
-  and downloads that artifact for a best-effort Coveralls upload.
-  The `lint` job installs SwiftLint and runs `swiftlint lint --strict` without building.
-  The `build` job restores the libghostty/resource cache, installs xcodegen,
-  runs the Release `scripts/build.sh`,
-  and then runs the application-hosted `agtermTests` suite through `scripts/test-app.sh`.
-  The cache is an `actions/cache` keyed on `hashFiles('scripts/setup.sh')`,
-  so editing `setup.sh` invalidates it and pays the libghostty rebuild.
-  That job compiles the app TWICE by design, and the duplication is not removable.
-  `build.sh` is `-configuration Release`, which is what exercises the whole-module optimizer
-  (the SIL deserializer crash the module-boundary rule in `CLAUDE.md` describes only reproduces there).
-  `test-app.sh` builds Debug because `DockMenuTests` is `@testable import agterm`
-  and `ENABLE_TESTABILITY` is Debug-only,
-  so hosting the tests on the Release product would mean enabling testability in the shipped, notarized build.
-  Expect that job to run roughly twice as long as a plain build,
-  and do not "fix" it by unifying the configurations.
-  All macOS jobs run on `macos-26`, and workflow concurrency cancels an older run for the same ref.
-  There is NO `release.yml` — releases are cut locally; see `.claude/rules/release.md`.
-- **A second paths filter, `cookbook`, gates the one job that has nothing to do with Swift.**
-  The `changes` job carries a second output, `cookbook`, from a `cookbook: ["cookbook/**"]` filter,
-  and the `cookbook` job is `if: needs.changes.outputs.cookbook == 'true'`.
-  `cookbook/**` matches no entry in the `swift` filter,
-  so a recipe-only change runs zero macOS jobs and only the `cookbook` job on `ubuntu-latest`.
-  `.github/workflows/ci.yml` is listed in BOTH filters, and its membership in the `cookbook` one is load-bearing:
-  the cookbook checks are written inline in this workflow,
-  so a PR that edits only the check block must still run the job it changed.
-  Without that entry the `cookbook` job is skipped on exactly the change that needs it and a broken check ships green.
-  Its membership in the `swift` filter only pulls in the macOS jobs,
-  which an edit confined to the cookbook block does not affect.
-  The job is static verification of the recipe tree and builds nothing.
-  It compares the `cookbook/README.md` index table against the directory set in BOTH directions,
-  requires every recipe directory to be kebab-case and to carry a `README.md` with all six template headings,
-  requires every `.sh`/`.zsh` to start with a shebang,
-  then runs `shellcheck` over every `.sh`,
-  and finally parses every `.zsh` with `zsh -n`.
-  `shellcheck` is preinstalled on the `ubuntu-latest` image (it is in the runner-images apt package set),
-  so nothing is installed for it.
-  `zsh` is NOT on that image, so the job apt-installs it in a separate `Install zsh` step
-  placed immediately before the parse step.
-  The parse step needs `xargs -0 -r -n1`, unlike `shellcheck`:
-  `zsh -n` reads ONE script per invocation and treats every further path as that script's arguments,
-  so without `-n1` only the first `.zsh` file is checked and the rest pass silently.
-  A parse is all a `.zsh` recipe gets, since shellcheck cannot read zsh,
-  so nothing lints those files.
-- **Several details of the `cookbook` job are load-bearing and must not be "simplified".**
-  The explicit `shell: bash` on the layout, `shellcheck` and `zsh -n` steps is one of them.
-  GitHub's default `run` shell is `bash -e` WITHOUT `pipefail`,
-  while `shell: bash` runs the step under `bash -eo pipefail`,
-  which is what the blocks were verified against and what makes a failed `find` inside a pipeline red the step.
-  On the layout step it also guarantees the bash-only process substitution
-  rather than leaving it to default-shell resolution.
-  On the `shellcheck` and `zsh -n` steps it is what keeps a failed `find` from passing unnoticed:
-  without `pipefail` the pipeline's status comes from `xargs`,
-  which exits 0 on empty input under `-r`,
-  so the step would go green having checked nothing.
-  The `[ -d "$d" ] || continue` guard keeps the job green when `cookbook/` holds no recipe subdirectories:
-  without it `cookbook/*/` does not expand, `basename` yields `*`,
-  and the check errors on a directory named `*`.
-  The index comparison is two-directional and reads only lines starting with `|`,
-  so a link in prose or an HTML comment cannot satisfy it
-  and a row left behind by a deleted directory is reported as stale.
-  It reads lines, not rendered tables, so a **fenced example table row** in `cookbook/README.md` would satisfy it
-  just like a real row — which is why the sample index row lives in `cookbook/CONTRIBUTING.md`
-  and `cookbook/README.md` carries only real rows.
-  The `shellcheck` step uses `-print0 | xargs -0 -r`,
-  which tolerates whitespace in filenames and exits 0 on an empty match
-  instead of failing the step the way the earlier `files=$(find …)` form did.
-  The headings are matched with `grep -qxF`, so a heading must be the whole line.
-  Deliberately absent is any executable-bit check:
-  whether a script is executed or sourced is per-recipe intent,
-  so that rule lives in `cookbook/CONTRIBUTING.md` and the local verification set, not in CI.
-- **The Coveralls upload runs on Linux ON PURPOSE.**
-  `coverallsapp/github-action@v2` installs its reporter from a brew tap on macOS, which is blocked by Homebrew's tap-trust gate, but downloads a prebuilt binary on Linux.
-  The macOS `test` job therefore hands the lcov artifact to the Linux `coverage` job.
-  The `test` job rewrites `llvm-cov`'s absolute `SF:` paths to repo-relative paths,
-  stripping the `$GITHUB_WORKSPACE/` prefix,
-  so the reporter resolves them against its own checkout.
-  Get that rewrite wrong and the reporter matches nothing and prints `🚨 Nothing to report` while still exiting green.
-  That string is the symptom to look for; it is the only thing distinguishing this failure from a successful upload.
-  The lcov upload, artifact download, and Coveralls submission are all `continue-on-error`.
-  Core tests still gate the `test` job, and hosted AppKit tests independently gate the `build` job.
-  A masked coverage failure can therefore show green, so verify the actual Coveralls build/API after changing this path.
-- **CI runs application-hosted AppKit tests but not XCUITests.**
-  `scripts/test-app.sh` runs the `agtermTests` scheme against the real app `TEST_HOST` after the Release build.
-  The scheme's launch environment isolates state/config/socket access before `agtermApp.init()` and uses `AGTERM_HOSTED_TESTS=1` to avoid shells and the control server.
-  CI does not run the `agtermUITests` XCUITest scheme.
-  The Coveralls badge remains `agtermCore` coverage only because hosted app and XCUITest coverage are excluded.
-- **The `lint` job is `--strict`.**
-  Any SwiftLint warning fails the build; see the `make lint` note in the root `CLAUDE.md`.
+- `ci.yml` runs for pushes and PRs to `master`; concurrency cancels the older run for the same ref. All
+  macOS jobs use `macos-26`. Releases are local; see `.claude/rules/release.md`.
+- The `dorny/paths-filter` Swift set includes `**/*.swift`, `agtermCore/**`, `agterm/**`, `plugins/**`,
+  `.claude-plugin/**`, `.agents/**`, `project.yml`, `scripts/**`, both SwiftLint configs, and `ci.yml`.
+  Keep all three plugin paths: `SkillInstallTests` checks the bundled `SKILL.md` command count, every
+  manifest path, and agreement among the three versions. A skill/manifest-only release preflight commit
+  must run the four Swift jobs.
+- `test` runs `swift test --enable-code-coverage` in `agtermCore`, exports lcov, and uploads it.
+  `coverage`, the only Swift-gated Linux job, downloads it for best-effort Coveralls.
+  `lint` installs SwiftLint and runs `swiftlint lint --strict`; every warning fails.
+- `build` restores the libghostty/resource `actions/cache` keyed by `hashFiles('scripts/setup.sh')`,
+  installs xcodegen, runs Release `scripts/build.sh`, then Debug `scripts/test-app.sh`. Editing
+  `setup.sh` rebuilds libghostty. Keep both app builds: Release exercises the whole-module optimizer and
+  its SIL-deserializer failure; Debug provides `ENABLE_TESTABILITY` for
+  `DockMenuTests`'s `@testable import agterm`. Do not enable testability in the notarized Release app.
+- A separate `cookbook: ["cookbook/**"]` filter gates the Linux `cookbook` job. Recipe-only changes run
+  no macOS jobs. Keep `.github/workflows/ci.yml` in both filters: the inline cookbook checks must run when
+  changed; its Swift membership also runs macOS jobs.
+- The cookbook job builds nothing. It compares the `cookbook/README.md` table and recipe directories in
+  both directions; requires kebab-case directories, a `README.md` with all six exact
+  (`grep -qxF`) headings, and shebangs for `.sh`/`.zsh`; runs `shellcheck` on `.sh`; and parses `.zsh`
+  with `zsh -n`. `shellcheck` is preinstalled. Install absent `zsh` in a separate step immediately before
+  parsing; shellcheck cannot lint zsh.
+- Keep explicit `shell: bash` on the layout, shellcheck, and zsh steps. It supplies bash process
+  substitution and `bash -eo pipefail`; default `bash -e` can hide a failed `find` behind successful
+  `xargs -r`. Use `-print0 | xargs -0 -r` for whitespace and empty matches, plus `-n1` for `zsh -n`
+  because it parses only its first path. Keep `[ -d "$d" ] || continue` so an empty recipe tree does not
+  turn the unexpanded glob into directory `*`.
+- The two-way index scan accepts only lines starting with `|`, so prose links/comments cannot satisfy it
+  and deleted directories leave stale rows. It is line-based, so keep fenced sample rows in
+  `cookbook/CONTRIBUTING.md`, never `cookbook/README.md`. Executable-bit policy is per recipe and belongs
+  in `cookbook/CONTRIBUTING.md` plus local verification, not CI.
+- Coveralls runs on Linux because `coverallsapp/github-action@v2` uses a blocked Homebrew tap on macOS but
+  a prebuilt Linux binary. The macOS test job strips `$GITHUB_WORKSPACE/` from absolute lcov `SF:` paths
+  before transfer. A bad rewrite prints `🚨 Nothing to report` but exits green. Lcov upload, artifact
+  download, and Coveralls submission all use `continue-on-error`; inspect the Coveralls build/API after
+  changing this path. Core and hosted tests still gate their own jobs.
+- CI runs `agtermTests` against the real `TEST_HOST`, with launch-time state/config/socket isolation and
+  `AGTERM_HOSTED_TESTS=1` to suppress shells and the control server. It does not run `agtermUITests`.
+  The badge reports only `agtermCore` coverage.

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -19,1801 +19,350 @@ paths:
 
 ## Control API
 
-- A programmatic control channel lets an external script drive `agterm` over a local unix-domain socket,
-  via the companion `agtermctl` CLI.
-  It is a thin dispatcher onto the existing `AppActions`/`AppStore` seam — the third caller of that seam,
-  alongside the toolbar/bottom bar and the menu bar — so no business logic is duplicated.
-  Scope is personal scripting: fire-and-forget commands, plus a polled event feed
-  (`events.read`, behind `agtermctl events`) for watching status and lifecycle changes.
-  There is no terminal-output/scrollback streaming (out of scope by design).
-- **Three layers, matching the core/app split:**
-  1. **Protocol + pure logic in `agtermCore`**
-     (Foundation-only, `Codable`, `Sendable`): `ControlProtocol.swift` holds the `Command` enum,
-     `ControlArgs`, `ControlRequest`, the tree node types (`ControlSessionNode`/`ControlWorkspaceNode`/`ControlTree`),
-     `ControlResult`, and `ControlResponse`.
-     `ControlResolve.swift` holds the pure target resolver (`resolve(_:candidates:active:) -> TargetResolution`)
-     and the socket-path resolver (`socketPath(stateDir:appSupport:)`).
-     Shared by both the app and the CLI so the wire contract cannot drift.
-  2. **`ControlServer` in the app target**
-     (`agterm/Control/ControlServer.swift`, `@MainActor`): owns the POSIX unix socket.
-     The blocking accept/read loop runs on a background `DispatchQueue`;
-     each newline-delimited `ControlRequest` is decoded, hopped to `@MainActor`,
-     dispatched onto `AppActions`/`AppStore` (plus a thin `GhosttySurfaceView.inject(text:)` for input),
-     and the `ControlResponse` written back before the connection closes.
-  3. **`agtermctl` CLI**
-     in the `agtermCore` SwiftPM package: an `agtermctlKit` library (the `ParsableCommand` tree — root
-     `Agtermctl` + shared option/request plumbing in `Commands.swift`, subcommands split by family into
-     `SessionCommands.swift`/`WorkspaceCommands.swift`/`WindowCommands.swift`/`MiscCommands.swift` — and
-     the socket client in `SocketClient.swift`) plus a thin `agtermctl` executable.
-     It links `swift-argument-parser`; the `agtermCore` library target stays dependency-free.
-     Builds with `swift build`, needs no Xcode/GhosttyKit.
-- **New/changed control commands are dispatcher-first** (the `refactor`/`hoist` migration, #78 onward).
-  A host-free `ControlDispatcher` in `agtermCore` (`ControlDispatcher.swift`) now fronts layer 2's dispatch:
-  its `dispatch(_:)` owns command parsing, argument validation, error strings, and the success-response
-  shape, calling the app through the `ControlActions` protocol, which `ControlServer` conforms to and
-  which supplies ONLY target resolution and the AppKit/process side effects.
-  Commands migrate group-by-group; one the dispatcher doesn't yet own returns `nil` and falls through to
-  `ControlServer`'s existing switch, so that switch is a fallthrough for not-yet-migrated commands, NOT the
-  home for new ones.
-  So when adding or changing a command: put every host-free part (arg checks, error text, the payload) in
-  `ControlDispatcher` with a unit test, and put only the side effect behind a `ControlActions` method — do
-  NOT add fresh validation/response logic inline in the `ControlServer` switch.
-  (This is the control-channel case of the root `CLAUDE.md` "hoist host-free logic down into `agtermCore`"
-  module-boundary rule.)
-- **The four-point audit is the WRITE path; a state-mutating command also owes a READ-BACK field.**
-  Whenever a command SETS or MUTATES per-session state, surface that state on `ControlSessionNode` (or
-  the tree top-level) so a script can query the value it just wrote: record-then-restore, read-modify-write,
-  and idempotency all depend on reading back what a `set`/`resize`/`toggle` changed.
-  The read field is populated in `AppStore.controlTree` and, like the other optionals, omitted from the
-  JSON when nil.
-  Existing pairs to mirror: `session.background`/`background`, `notify`+`session.seen`/`unseen`,
-  `session.status`/`status`+`statusPane` (+`statusBlink`/`statusColor`/`statusShape` for
-  `--blink`/`--color`/`--shape`),
-  `session.flag`/`flagged`, `session.focus`/`splitFocused`, `session.resize`/`splitRatio`,
-  `session.restore`/`restoreCommand`+`splitRestoreCommand`,
-  `session.overlay.resize`/`overlaySizePercent`, `sidebar`/`sidebarVisible` (top-level),
-  `sidebar.mode`/`sidebarMode`, `workspace.focus`/`focused` (workspace node),
-  `workspace.filter`/`workspaceFilter` (top-level),
-  `workspace.collapse`+`workspace.expand`/`collapsed` (workspace node), `quick`/`quickVisible` (top-level),
-  `font.*`/`fontSize`+`splitFontSize`+`scratchFontSize` (the per-pane LIVE font size — the split/scratch
-  panes' fonts are otherwise unobservable, being live-only; supplied to `controlTree` by app-side closures
-  reading `GhosttySurfaceView.currentFontSize()`, since the host-free tree can't read a surface),
-  `window.move`+`window.resize`/`geometry`, `window.fullscreen`+`window.zoom`/`fullscreen`+`zoomed`,
-  `window.minimize`+`window.new --minimized`/`minimized` (the last four on `window.list`).
-  This is a SEPARATE obligation from the four-point audit (Command + arg + CLI + tests) and easy to forget:
-  `session.overlay.resize` shipped write-only and `overlaySizePercent` was added only later, when a
-  tmux-zoom script needed to restore an overlay's exact size.
-  When adding a state-mutating command, add its read-back field in the SAME change and cover it with a
-  `treeSessionNodeRoundTrips…`/`…OmitsWhenNil` round-trip test plus a `controlTree` populate test.
-- **Bundling + install.**
-  The `agterm` target's `Bundle agtermctl CLI` postBuildScript (`project.yml`) runs `swift build -c release --product agtermctl`,
-  copies it to `agterm.app/Contents/MacOS/agtermctl`, ad-hoc signs the helper,
-  then **re-signs the whole app `--deep`** — the phase can run AFTER Xcode's own code-sign on incremental
-  builds, so without the re-seal the injected helper breaks the signature (and a shallow re-sign chokes
-  on the Debug `agterm.debug.dylib`).
-  **Help ▸ Install Command Line Tool…** (`agtermApp` `CommandGroup(replacing: .help)` → `CLIInstaller.run()`)
-  symlinks the bundled binary into `/usr/local/bin` (first entry in macOS's default `/etc/paths`,
-  unlike `~/.local/bin`): a direct `FileManager` symlink when the dir is user-writable,
-  else a one-time GUI admin prompt via `osascript … with administrator privileges`.
-  Pure path/quote logic is `agtermCore.CLIInstall` (host-free, unit-tested);
-  the AppKit FS + auth glue is `CLIInstaller` (app-side, manually verified like the directory picker).
-  Install is GUI-only and keep-in-sync EXEMPT — driving it over the socket is meaningless (you'd need
-  `agtermctl` already installed to call it).
-- **Agent-status hooks install.**
-  A second Help entry, **Help ▸ Install Agent Status Hooks…** (`AgentHooksInstaller.run()`),
-  wires coding agents to `session.status`.
-  The hooks package bundles at `agterm/Resources/agent-status/`
-  (`agterm-agent-status.sh` generic wrapper,
-  `agterm-codex-status.sh` Codex adapter,
-  `shell/integration.sh`,
-  `shell/integration.fish`,
-  `pi/agterm-status.ts`,
-  `opencode/agterm-status.js`,
-  a `project.yml` Contents/Resources folder mirroring `Resources/ghostty`).
-  The installer copies them to `~/.config/agterm/agent-status/`, bakes the bundled `agtermctl`'s absolute
-  path (`Bundle.main.url(forAuxiliaryExecutable:)`) into both wrappers so the hooks fire even without the
-  CLI on PATH, appends a marker-guarded `source` line to `~/.zshrc` + `~/.bashrc`,
-  merges four Claude Code hooks into `~/.claude/settings.json` with a `.bak` (UserPromptSubmit→`active --blink`,
-  PostToolUse→`active --blink`, Stop→`completed --auto-reset`, Notification[`permission_prompt`]→`blocked`;
-  the unmatched PostToolUse re-asserts `active` after every tool so a `blocked` permission prompt clears
-  back to active when work resumes — Claude Code has no "permission answered" event,
-  and the gated tool's own PreToolUse fires BEFORE `blocked` is set, so the approved tool's PostToolUse
-  is the first hook afterwards), and merges SIX Codex lifecycle hooks into `~/.codex/config.toml` with a
-  `.bak`.
-  Those six events call the dedicated `agterm-codex-status.sh` adapter with lifecycle actions.
-  The adapter maps SessionStart to `idle` and UserPromptSubmit/PreToolUse/PostToolUse to `active --blink`.
-  On Stop it reads Codex's final assistant message: a message containing `?`
-  maps to `blocked`; every other message maps to `completed --auto-reset` through the generic wrapper.
-  `PermissionRequest` is only a candidate signal because Codex fires it before Auto Review decides whether
-  a person is needed.
-  A per-session/pane watcher reads the visible terminal footer through `agtermctl session text` and reports
-  `blocked` only after a real approval or structured-question dialog appears.
-  Automatic approvals and denials never become `blocked`.
-  This replaces a retired `codex-notify.sh` that broadly keyword-matched the turn's final message and
-  misfired both ways (issue #193; the merge also strips the old
-  `notify = [...codex-notify.sh...]` line).
-  The Codex merge PARSES the config with `TOMLDecoder` (a pure-Swift, spec-compliant parser — the one
-  dependency `agtermCore` links besides swift-argument-parser) to decide the outcome
-  (`AgentHooksInstall.CodexMergeOutcome`): a marker block carrying an older agterm wrapper is refreshed
-  while preserving Codex's trailing hook trust tables; a foreign marker block is unchanged;
-  the file already defines its own `hooks` → `.hooksExist`; the file isn't valid TOML → `.unparseable`;
-  else → `.merged`, a marker-guarded
-  append (the same `rcMarkerBegin`/`End` markers as the shell rc files, so comments/layout survive) plus
-  removal of a stale top-level `notify` ONLY when its PARSED value points at `codex-notify.sh` (a comment
-  merely naming the file, or the user's own notifier, is never touched).
-  On `.hooksExist`/`.unparseable` the app leaves the file untouched and surfaces the block for a manual
-  add; the merge is gated on `~/.codex` existing (like the fish rc gate).
-  Both the Codex and Claude write paths distinguish an ABSENT config from one that EXISTS-but-unreadable
-  (the app-side `readExistingConfig`), so a permission/encoding read failure leaves the file untouched
-  instead of clobbering it with no backup.
-  Codex requires new or changed command hooks to be reviewed (`/hooks`) before they run.
-  When `~/.pi/agent` exists, the installer copies the bundled `pi/agterm-status.ts` lifecycle extension to
-  `~/.pi/agent/extensions/agterm-status.ts`.
-  Pi's `agent_start` sends `active --blink`; its `agent_settled` sends `completed --auto-reset` only after
-  retries, compaction retries, and queued continuations finish.
-  Pi deliberately has no native permission/structured-question event, so the extension does NOT infer
-  `blocked` from agent prose.
-  The source carries `AgentHooksInstall.piExtensionMarker`; an unmarked same-named extension is user-owned
-  and left untouched, and Pi must restart or run `/reload` after installation.
-  When `~/.config/opencode` exists, the installer copies the bundled
-  `opencode/agterm-status.js` lifecycle plugin to
-  `~/.config/opencode/plugins/agterm-status.js`.
-  The file exports ONLY `AgtermStatusPlugin`
-  (OpenCode's legacy loader treats every export as a plugin and rejects non-functions).
-  OpenCode `session.status` `busy`/`retry` send `active --blink`
-  and remember the sessionID;
-  `idle` clears that id and sends `completed --auto-reset` only when the
-  active set is empty (a task subagent's busy/idle must not paint completed
-  onto a still-busy parent or sibling session).
-  `permission.asked`/`question.asked` send `blocked`.
-  For a session already reported busy, a turn-ending `session.error` sends
-  `blocked` and latches the sessionID so the following `session.status(idle)`
-  that halt always publishes is swallowed
-  (otherwise the serial report queue would overwrite blocked with completed).
-  The latch is set-wide, not per-id: the errored id STAYS latched through its own swallowed idle,
-  and a later sibling idle that finds the active set empty clears the latch and reports NOTHING
-  instead of `completed` —
-  every session of one OpenCode instance drives the SAME agterm pane, so a sibling finishing
-  cleanly must not erase a failed turn's blocked.
-  Abort (`MessageAbortedError`) is skipped unconditionally, so Esc ends on completed.
-  `ContextOverflowError` is ambiguous at error time and is instead recorded by id and reported as
-  nothing: a following `busy` means auto-compaction resumed (no blocked flash),
-  while a following `idle` means the turn actually ended (compaction disabled or given up) and sends
-  `blocked`.
-  `permission.replied`/`question.replied`/`question.rejected` send `active --blink`
-  so a blocked glyph clears when the user answers.
-  Deprecated `session.idle` is ignored so it does not double-fire with
-  `session.status(type=idle)`.
-  The source carries `AgentHooksInstall.opencodePluginMarker`
-  (named `*Plugin*` because OpenCode's host term is plugin —
-  intentional divergence from Pi's `piExtension*`);
-  an unmarked same-named plugin is user-owned and left untouched,
-  and OpenCode must restart after installation.
-  Idempotent + re-runnable
-  (re-run refreshes the baked path and the managed Pi extension / OpenCode plugin).
-  Like the CLI installer, the host-free JSON/TOML-merge / shell-rc-marker / backup-path /
-  Pi-and-OpenCode path-and-marker logic is `agtermCore.AgentHooksInstall` (unit-tested);
-  `AgentHooksInstaller` (app-side) owns the AppKit FS glue, manually verified.
-  Install is GUI-only and keep-in-sync EXEMPT — driving it over the socket is meaningless because the
-  integration being installed is itself what uses `agtermctl`.
-- **Agent skill install (Claude Code + Codex).**
-  A third Help entry, **Help ▸ Install Agent Skill…** (`SkillInstaller.run()`),
-  copies a bundled, personal-scope Agent Skill to `~/.claude/skills/agterm/` AND `~/.codex/skills/agterm/`
-  so a coding agent running INSIDE an agterm session knows how to drive the app over the control channel.
-  Claude Code and Codex use the SAME SKILL.md Agent-Skill format (`name`/`description`/`allowed-tools`
-  frontmatter + optional reference files; verified against the user's `~/.codex/skills/`),
-  so one authored skill serves both.
-  The skill is a REFERENCE/knowledge skill (both user-invocable via `/agterm` and model-triggered,
-  `allowed-tools: Bash(agtermctl *)`; the agent-neutral `description` carries the trigger nouns since
-  Codex may ignore the extra `when_to_use` field — unknown frontmatter is harmless),
-  authored at `plugins/agterm/skills/agterm/` (`SKILL.md` overview + model + addressing + 71-command
-  summary + the image-display helper + a troubleshooting/reporting pointer;
-  `reference.md` full per-command detail + keymap format; `examples.md` agtermctl recipes;
-  `troubleshooting.md` diagnosing the common problems (keymap editor, custom actions,
-  logs) + the bug-issue / feature-Discussion reporting workflow (draft-first,
-  scrub, never run `gh` without explicit user approval); `scripts/show-image.sh` the bundled image-display
-  helper), bundled via a `project.yml` Contents/Resources FOLDER reference like `agent-status` (the whole
-  dir, INCLUDING the `scripts/` subdir, copies verbatim; `SkillInstaller` uses `FileManager.copyItem`
-  so the subdir reaches both installs).
-  **Image display is NOT a control command** — it's a bundled shell helper:
-  `show-image.sh <image> [size%]` opens an overlay (a real pty) and renders the image via the kitty graphics
-  protocol, which the pinned ghostty draws NATIVELY — pure `base64` + chunked `\e_G` APC frames,
-  NO kitty binary and NO external image tool.
-  (The pinned ghostty renders ONLY the kitty graphics protocol; iTerm2 OSC-1337 inline images and sixel
-  are `unimplemented` in that build — verified in upstream `src/terminal/osc/parsers/iterm2.zig`,
-  the `.File`/`.FilePart`/`.FileEnd`/`.MultipartFile` keys land in the `unimplemented OSC 1337` bucket.
-  The agent CANNOT print graphics escapes to its own tool stdout — the harness escapes the control bytes
-  — nor run a viewer in its tool shell — no `/dev/tty`; the overlay sidesteps both,
-  so the method is agent-harness-agnostic and works identically for Codex.) It is invoked by a path
-  the agent RESOLVES against the directory it loaded `SKILL.md` from, NOT a hardcoded install path and
-  NOT `${CLAUDE_PLUGIN_ROOT}`.
-  Both alternatives break a real install: the skill now ships four ways (the app's copy into
-  `~/.claude/skills/agterm/` or `~/.codex/skills/agterm/`, and the two plugin caches), so a hardcoded
-  `~/.claude/skills/agterm/scripts/show-image.sh` is wrong for a plugin install;
-  `${CLAUDE_PLUGIN_ROOT}` does expand inside SKILL.md body text but is Claude-Code-only AND
-  plugin-only, so it would not resolve in the Codex copy nor in the app-installed one, and Codex has
-  no documented equivalent that expands in skill markdown.
-  The relative-to-`SKILL.md` phrasing is the ONE form correct in all four.
-  **Install policy:** write to each agent base that EXISTS (`~/.claude` and/or `~/.codex`);
-  if neither, fall back to creating `~/.claude` (`SkillInstall.installTargets`).
-  Pure file-drop (no manifest): per-target remove-then-copy for a clean reinstall,
-  best-effort per agent (one failing doesn't abort the other), but it REFUSES to clobber a same-named
-  skill the user authored (one whose `SKILL.md` lacks the `<!-- agterm-skill -->` marker — `SkillInstall.mayOverwrite`).
-  Host-free path/target/marker logic is `agtermCore.SkillInstall` (unit-tested);
-  `SkillInstaller` (app-side) owns the AppKit copy, manually verified.
-  Install is GUI-only and keep-in-sync EXEMPT (a skill that documents the socket isn't itself driven
-  over it).
-  **The skill directory is ALSO the source for the Claude Code and Codex PLUGIN published from this
-  repo — one directory, three consumers, no copy and no sync step.**
-  `plugins/agterm/skills/agterm/` is the single source: `project.yml` bundles that leaf as a folder
-  reference (landing at `Contents/Resources/agterm`, so `SkillInstaller.bundledFolder` reads
-  `SkillInstall.skillName` rather than a separate literal), while four manifests point at the same tree
-  — `.claude-plugin/marketplace.json` (`source: "./plugins/agterm"`),
-  `plugins/agterm/.claude-plugin/plugin.json` (`skills: ["./skills/agterm"]`, an ARRAY of dirs each
-  holding a SKILL.md), `.agents/plugins/marketplace.json` (Codex's marketplace location — NOT
-  `.codex-plugin/marketplace.json`, and its entry takes a `source` OBJECT
-  `{"source":"local","path":"./plugins/agterm"}`), and `plugins/agterm/.codex-plugin/plugin.json`
-  (`skills: "./skills/"`, a STRING naming a PARENT dir that Codex scans recursively for `SKILL.md`).
-  The two `skills` shapes differ per agent and are NOT interchangeable.
-  The leaf is named `agterm` on purpose: Claude's default `skills/` scan names a skill by its
-  DIRECTORY, so a leaf named anything else would install as that name on the path where the frontmatter
-  is not consulted.
-  The plugin ROOT is `plugins/agterm/` rather than the repo root because whatever the root is gets
-  copied wholesale into the install cache — a repo-root plugin would put the entire ~21 MiB checkout in
-  every user's cache.
-  Both plugin managers key their install cache on the manifest `version`, so `scripts/release.sh` bumps
-  all three versioned manifests in a preflight and STOPS for the diff to be committed (the tag is cut
-  from HEAD, so an unbumped manifest publishes a stale skill silently).
-  `SkillInstallTests.pluginManifestsPointAtTheBundledSkillDirectory` and
-  `…marketplacesPointAtThePluginRootAndAgreeOnVersion` are the drift gate: they assert every declared
-  path resolves to the real skill directory and that the three versions agree.
-  A user who installs BOTH ways gets two copies (`agterm` from the app, `agterm:agterm` from the Codex
-  plugin namespace); Codex lists both and does not define which wins, so the docs present the two routes
-  as alternatives rather than complements.
-  **KEEP-IN-SYNC (HARD): the bundled skill is a documentation mirror of the control surface — whenever
-  you change the Control API (commands/args/returns), the keymap format,
-  or the window/workspace/session/pane model, update `plugins/agterm/skills/agterm/` (SKILL.md + reference.md
-  + examples.md + `troubleshooting.md` + `scripts/`, incl. the command count) so the installed agent-driver
-  doc stays accurate.
-  It is the fourth keep-in-sync surface alongside the GUI/menu/CLI.
-  The skill's `troubleshooting.md` mirrors the user-facing `docs/troubleshooting.md`;
-  keep the two in step when a diagnostic path or the reporting workflow changes.**
-- **Socket path / lifecycle.**
-  The path is `<AGTERM_STATE_DIR>/agterm.sock` when `AGTERM_STATE_DIR` is set (state isolation),
-  else `<app support>/agterm.sock` (`~/Library/Application Support/agterm`),
-  via `ControlResolve.socketPath`.
-  `ControlServer.defaultSocketPath()` adds an `AGTERM_CONTROL_SOCKET` env override that takes precedence
-  (used by XCUITests, whose sandboxed `AGTERM_STATE_DIR` container path exceeds the `sun_path` ~104-byte
-  limit); the CLI's `--socket` flag is the user-facing equivalent.
-  The socket is `chmod 0600`.
-  Each accepted connection sets `SO_RCVTIMEO` (5 s, alongside `SO_NOSIGPIPE`) so a stalled client can't
-  wedge the serial accept loop — a timed-out `read()` returns `EAGAIN`, which `readLine` (any non-`EINTR`
-  `n < 0` = end-of-read) maps to nil → close → `accept()` resumes.
-  `start()` is idempotent (the scene `.task` may re-run) and unlinks any stale path before binding;
-  it is best-effort (a bind failure logs and the app still launches).
-  Lifecycle is asymmetric: started from the scene `.task`, stopped from `AppDelegate.applicationWillTerminate`;
-  a force-quit that skips that leaves a stale socket file, which the next launch's unlink-first handles.
-- **Protocol shape.**
-  One request per connection, newline-delimited JSON: `{"cmd":…,"target":…,"args":{…}}` → one `{"ok":…,"result":…|"error":…}`
-  → close.
-  Mutating commands return the affected/new id in `result.id` (create-then-use without a second round-trip);
-  `tree` returns `result.tree`.
-  An unknown `cmd` fails to decode and comes back as a structured error,
-  never a crash; a 1 MiB max-line cap bounds the read buffer.
-  In `agtermctl`'s human (non-`--json`) output, `result.id` is echoed ONLY for the create commands (`session/workspace/window new`,
-  via `RequestCommand.echoesResultID`) where the new id isn't known yet;
-  every other mutation prints `ok` (the id you already named is noise).
-  The id is always present under `--json`.
-  Batch session mutations return the number of sessions actually changed in `result.affected`; human
-  output is `1 session` / `N sessions`. `result.count` remains reserved for diagnostics and search.
-- **Addressing.**
-  UUID is canonical, with sugar: `active` (the selected session / current workspace),
-  exact `uuidString` (case-insensitive), or a git-style unique prefix.
-  Zero prefix hits → `notFound` error, ≥2 → `ambiguous` error listing the candidates.
-  `--target` defaults to `active`, so scripts rarely type an id and never for "the current one".
-  Batch-capable session commands (`session.close`, and `session.move` with workspace/after/before placement)
-  accept repeated `--target` flags in the CLI; on the wire these are `args.targets: [String]`. The batch is
-  scoped to one window/store: the first target resolves by the normal `--window`/frontmost/cross-window
-  rules, then remaining targets resolve inside that same store so one command never mutates multiple windows.
-  The top-level `target` also carries the first explicit batch target so a new CLI talking to a still-running
-  pre-batch server degrades to a named session instead of accidentally acting on `active`.
-- **Command catalog (71 commands):**
-  - `tree`
-  - `events.read` (the bounded per-app-run control event ring behind `agtermctl events`)
-  - `workspace.new`/`workspace.rename`/`workspace.delete`/`workspace.select`/`workspace.move`/`workspace.focus`/`workspace.filter`/`workspace.collapse`/`workspace.expand`
-  - `session.new`/`session.duplicate`/`session.close`/`session.select`/`session.rename`/`session.reveal`/`session.move`/`session.type`/`session.split`/`session.scratch`/`session.focus`/`session.resize`/`session.go`/`session.copy`/`session.paste`/`session.selectall`/`session.text`/`session.search`/`session.status`/`session.flag`/`session.seen`/`session.restore`/`session.background`/`session.overlay.open`/`session.overlay.close`/`session.overlay.resize`/`session.overlay.result`
-  - `surface.zoom`
-  - `dashboard`
-  - `pick.open`/`pick.result`/`pick.cancel`
-  - `quick`/`quick.type`/`quick.text`
-  - `sidebar`/`sidebar.mode`/`sidebar.expand`/`sidebar.collapse`
-  - `notify`
-  - `font.inc`/`font.dec`/`font.reset`
-  - `window.new`/`window.list`/`window.select`/`window.close`/`window.rename`/`window.delete`/`window.resize`/`window.move`/`window.zoom`/`window.fullscreen`/`window.minimize` (see the Windows section)
-  - `keymap.reload`/`keymap.list` (see the Keymap section)
-  - `config.reload` (see the Settings section)
-  - `theme.set`/`theme.list` (see the Theme picker section)
-  - `restore.clear` (see the Settings section)
+- `agtermctl` drives app/store actions over a local Unix socket. One-shot commands and polled
+  `events.read` are in scope; terminal-output streaming is not.
+- `agtermCore` owns protocol types, target/socket resolution, and host-free dispatch.
+  `ControlServer` owns the socket and app-side effects; blocking accept/read runs off-main and requests
+  hop to the main actor. SwiftPM `agtermctlKit` owns ArgumentParser and `SocketClient`.
+- New commands are dispatcher-first (#78). `ControlDispatcher` owns parsing, validation, error text, and
+  response shape; `ControlActions` supplies resolution and effects. Nil falls through only for unmigrated
+  commands. Never add validation to the fallback switch.
+- Every change needs protocol/round-trip types, dispatcher and app action, CLI, and dispatcher/CLI/e2e
+  tests. State writes also need tree/window read-back, nil omission tests, and population coverage.
 
-  One extra `Command` case is deliberately NOT part of the catalog: `debug.appearance` (`light`|`dark`
-  via `args.name`) is a UI-TEST-ONLY seam that sets `NSApp.appearance` so an XCUITest can simulate a
-  macOS light/dark flip (macOS XCUITest has no API for it); the arm ALSO posts
-  `.agtermSystemAppearanceChanged` directly so the flip pipeline runs deterministically without depending
-  on whether KVO fires on an explicit `NSApp.appearance` set (production follows the appearance via an
-  app-level KVO observer on `NSApplication.effectiveAppearance` — see the theme-picker/libghostty rules).
-  The `ControlServer` arm refuses it outside an XCUITest launch (`ContentView.isUITestLaunch`), it gets
-  NO `agtermctl` subcommand, and it stays out of the agent skill — a documented keep-in-sync EXEMPTION
-  (test scaffolding, not a control surface).
-  Setting echoes the resulting effective side in `result.text`; the BARE form (no name) reads the side
-  the last config feed applied (`SettingsModel.lastAppliedIsDark`), which the test polls to prove the
-  flip actually drove the reload.
-  `AppearanceFlipUITests` is its only consumer; the public command count stays 71
-  (`Command` has 72 cases, minus this one seam).
+## Installation and agent integrations
 
-  `workspace.delete` honors keep-at-least-one and returns an error instead of the GUI confirm alert (nothing
-  blocks on a modal).
-  `session.close` has a legacy single-target control path and a batch path. Single-target control close
-  continues to call `AppStore.closeSession` (hard close; backward-compatible with the original control
-  behavior). Repeated `--target` / `args.targets` is the GUI-equivalent batch close: it resolves all targets
-  in one store and honors `closeGraceUndoEnabled`. When enabled it calls `AppStore.softCloseSessions`,
-  producing one grace timer and one grouped undo/reopen record; when disabled it immediately hard-closes
-  each resolved session like the GUI. Both return the number actually closed in `result.affected`
-  (`ok` with the count — never an error for an empty result, matching the batch `session.move` shape).
-  Batch target resolution (`resolveBatchSessions`) is all-or-nothing and deduplicating: any unknown or
-  ambiguous target fails the WHOLE request before anything mutates
-  (`ControlAPIUITests.testSessionCloseBatchIsAllOrNothing`), and a batch that deduplicates to a single
-  session (e.g. `--target a --target a`) takes the single-target path — for close that is the legacy
-  HARD close (no grace window), consistent with the one-element `session.move` routing.
-  During the grace window, reopening any member restores the whole group but selects the specific Recent
-  item the user chose, matching workspace close grouping without losing selection intent. Keep-in-sync: `ControlArgs.targets`, the
-  `.sessionClose` dispatcher batch arm, `ControlActions.closeSessions`, `agtermctl session close --target`
-  repeat support, round-trip/dispatcher/CLI tests, and `ControlAPIUITests.testSessionCloseMultipleTargets`.
-  `session.move` is MODE-BEARING with THREE exclusive placement intents:
-  `args.to` (`up`|`down`|`top`|`bottom`) REORDERS the session within its own workspace (parses `ReorderDirection`,
-  drives `AppStore.reorderSession` → the existing `moveSession(at:)` primitive, returns the session id);
-  `args.workspace` RELOCATES it to another workspace (still APPENDS at the end);
-  and `args.after`/`args.before` (a session address — id / prefix / `active`) PLACE it directly after/before
-  an anchor session (`ControlSessionMove.place(anchor:after:)`).
-  The anchor CARRIES ITS OWN WORKSPACE — it is resolved against the store's FULL session set (all workspaces),
-  so it names the destination workspace itself and relocates + positions in one shot (cross-workspace
-  falls out for free).
-  Placement reuses the drag-drop index math host-free: `SidebarDrop.resolveRelative` (the tested "after
-  this row" `sessionIndex + 1` + the same-workspace post-removal off-by-one + the anchor==source no-op)
-  feeding `AppStore.moveSession(_:toWorkspace:at:)`.
-  Exactly one intent must be set: after+before is an error (`"use either --after or --before, not both"`),
-  after/before + `--to` is an error (`"session.move takes --after/--before or --to, not both"`),
-  after/before + a workspace is an error (`"session.move takes --after/--before or a workspace, not both"`
-  — the anchor already names the workspace), both `--to`+workspace and neither are errors,
-  and an invalid direction is an error.
-  Repeated `--target` / `args.targets` makes `session.move` a batch move for workspace relocation and
-  after/before placement. It uses the same host-free block semantics as sidebar multi-drag:
-  all moved sessions are resolved in visual tree order, removed first, then inserted as one block via
-  `SidebarDrop.resolveSessions`/`AppStore.moveSessions`. Batch `--to up|down|top|bottom` is deliberately
-  rejected (`"session.move --target can be repeated only with a workspace or --after/--before"`) because
-  relative one-step reorder is inherently per-session and order-dependent.
-  The response reports only sessions actually moved in `result.affected`; members already in a workspace
-  destination remain in place and are not counted. A one-element `args.targets` array is equivalent to the
-  singular form (the dispatcher routes it through `moveSession`), including the `result.id` response and
-  moving an existing destination member to the end.
-  Keep-in-sync: `ControlArgs.after`/`before` + `ControlSessionMove.place` in `ControlProtocol.swift`/`ControlModes.swift`,
-  the `.sessionMove` place-mode routing + guards in `ControlDispatcher`, the app-side `moveSession` place
-  case (`ControlServer+SessionActions.swift`, resolving both target + anchor locations and calling
-  `resolveRelative`), the `session move --after/--before` CLI, and round-trip / dispatcher / e2e
-  (`testSessionMovePlaceWithinWorkspace`, `testSessionMovePlaceCrossWorkspace`, the reject-* guards) tests.
-  Batch keep-in-sync additionally includes `ControlArgs.targets`, `ControlActions.moveSessions`,
-  `agtermctl session move --target` repeat support, and `ControlAPIUITests.testSessionMoveMultipleTargetsWithinWorkspaceBeforeAnchor`.
-  Keep-in-sync exemptions for sidebar batch actions: Flag/Unflag is loop-equivalent to repeated
-  `session.flag on|off --target <id>` (the plural store API only saves once).
-  The GUI's multi-select toggle is NOT a `toggle` loop: `AppActions.toggleFlags` computes ONE uniform
-  value for the whole set (`allSatisfy(\.flagged)` — flag all unless every target is already flagged)
-  and applies it, so on a mixed selection a per-row `session.flag toggle` loop diverges from the GUI.
-  A script wanting the GUI semantics reads `flagged` off `tree`, computes the uniform value, and loops
-  `on`/`off`.
-  Clear Status is loop-equivalent to repeated `session.status idle --target <id>` and intentionally adds
-  no batch command.
-  `workspace.move` is the workspace REORDER (control-native, no separate verb):
-  `args.to` (`up`|`down`|`top`|`bottom`) resolves the workspace target via the shared `resolveWorkspace`
-  (honoring the global `--window` selector like other workspace commands),
-  drives `AppStore.reorderWorkspace`, and returns the workspace id; a missing or invalid `to` is an error.
-  Drag-and-drop stays the precise (drop-between-rows) surface; the control path is relative-only,
-  mirroring `session.go --to`.
-  Four-point keep-in-sync audit for `workspace.move`: (1) `case workspaceMove = "workspace.move"` in
-  `ControlProtocol.swift` (reuses `ControlArgs.to`, no new field), (2) the `.workspaceMove` dispatch
-  arm in `ControlServer`, (3) the `workspace move --to` subcommand in `agtermctlKit`,
-  (4) round-trip tests in `ControlProtocolTests` plus the e2e in `ControlAPIUITests`.
-  NOTE on `workspace.move --target active`: `active` for a workspace resolves to `AppStore.currentWorkspaceID`,
-  which with NO selected session falls back to `workspaces.last` — so repeated `workspace.move --to top --target active`
-  on a session-less window targets a DIFFERENT (newly-last) workspace each call (consistent with the
-  `currentWorkspaceID` fallback contract; address a specific workspace by id/prefix to step the same
-  one).
-  `session.split` resolves the target id and drives `AppStore.toggleSplit` directly (NOT the argument-less
-  `AppActions.toggleSplit()`, which only acts on the active session) — `off` HIDES the split keep-alive,
-  mirroring ⌘D (the pane's surface is NOT torn down; `closeSplit` stays the shell-exit-only path,
-  so there is no on-demand destroy over the control channel, matching the GUI).
-  `session.scratch` (mode `on`|`off`|`toggle`, mirrors `session.split` exactly) shows/hides the **scratch
-  terminal** — a THIRD per-session login shell (alongside main + split) that RENDERS like a full overlay
-  (full-pane, hides the session, translucent) but BEHAVES like the split:
-  lazily spawned on first show, kept alive when hidden (`off` is `AppStore.toggleScratch` keep-alive,
-  never a teardown), recreated fresh after its shell's own `exit`.
-  NOT persisted (absent from `SessionSnapshot`, like the overlay) — `Session.scratchActive`/`scratchSurface`,
-  `AppStore.toggleScratch`/`closeScratch` (the latter only on `exit` + session/workspace/window teardown).
-  Full-overlay rendering only (never floating): a conditional `sessionDetail` ZStack sibling at `.zIndex(1)`
-  (the structural pattern the now-removed `if fullOverlay` sibling used), BELOW the ephemeral `overlayPanel`
-  (`.zIndex(3)` — a normal overlay launched over the scratch sits on top); the panes' opacity/hit-testing gate is `hideForOverlay = fullOverlay || scratchActive`
-  (still false for a FLOATING overlay, preserving the NSSplitView-overrun invariant).
-  GUI half: ⌘J (`BuiltinAction.toggleScratch`), title-bar `scratch-toggle` button,
-  View ▸ Show/Hide Scratch, the ⌃⇧P palette "Toggle Scratch" — all through `AppActions.toggleScratch()`.
-  The scratch surface is NOT operationally wired to the session (no `view.session`, like the overlay) so
-  its PWD/title never clobber the sidebar name; a separate weak `watermarkSession` link carries only the
-  owning session's visual config, so its background watermark/color renders on the scratch too. `autoFocus`
-  grabs first responder on show,
-  the detail pane's `.onChange(of: scratchActive)` reclaims it on hide.
-  Four-point keep-in-sync audit: (1) `case sessionScratch = "session.scratch"` + the new `ControlSessionNode.scratch`
-  flag in `ControlProtocol.swift` (reuses `ControlArgs.mode`), (2) the `.sessionScratch` dispatch arm
-  (`scratchSession`) in `ControlServer` + `scratch:` in the tree builder,
-  (3) the `session scratch` subcommand in `agtermctlKit`, (4) round-trip in `ControlProtocolTests` +
-  the e2e `testSessionScratchToggle` in `ControlOverlaySplitUITests`.
-  `session.focus` moves keyboard focus between the two split panes — `args.pane` is `left`|`right`|`other`
-  (`other` toggles, the default); it errors when the session has no split (works whether the split is
-  shown side-by-side or hidden — when hidden, focusing a pane swaps which one shows maximized),
-  drives `AppActions.setSplitFocus(_:of:)`, and is the control half of the ⌘⌥←/→ keyboard nav + the "Focus
-  Left/Right Pane" menu/palette items.
-  Its READ side is `ControlSessionNode.splitFocused` (`true`=split/right, `false`=main/left, nil=no split;
-  see the `tree` read-side fields below), so a script can record the focused pane and restore it.
-  `session.resize` moves the split DIVIDER — it is control-NATIVE (the divider is otherwise mouse-drag
-  only; NO GUI/menu/keymap action, so a key is bound by mapping a `command "agtermctl session resize …"`
-  custom action).
-  `args.ratio` sets the absolute left-pane fraction; `args.ratioDelta` is a signed relative nudge (the
-  CLI's `--grow-left`/`--grow-right` map to ±`ratioDelta`, applied to the current fraction,
-  `AppStore.splitRatioDefault` = 0.5 when never moved); exactly one must be set (neither/both error).
-  It errors when the session has no split (mirroring `session.focus`), clamps + persists via the host-free
-  `AppStore.applySplitRatio` (→ `AppStore.clampSplitRatio`, `splitRatioMin...splitRatioMax`),
-  then posts the object-scoped `.agtermApplySplitRatio` (object = the `Session`) so the matching `SplitProbeView`
-  (`SplitRatioAccessor.swift`) moves the LIVE divider via `setPosition` — a no-op when the split is hidden (no live
-  `NSSplitView`; the stored fraction applies on next show).
-  It echoes the applied (clamped) fraction in the new `ControlResult.ratio` (the CLI prints it as a bare
-  `%.3f` number, scriptable).
-  Four-point keep-in-sync audit for `session.resize`: (1) `case sessionResize = "session.resize"` +
-  `ControlArgs.ratio`/`ratioDelta` + `ControlResult.ratio` in `ControlProtocol.swift`,
-  (2) the `.sessionResize` dispatch arm (`resizeSplit`) in `ControlServer` (+ the `SplitProbeView` re-apply
-  observer in `SplitRatioAccessor`), (3) the `session resize --split-ratio|--grow-left|--grow-right` subcommand
-  (`Resize`, `validate()`-guarded exactly-one) in `agtermctlKit` + the `result.ratio` format arm in `SocketClient`,
-  (4) round-trip in `ControlProtocolTests` + `AppStoreTests` (clamp/apply) + `CommandsTests` (validate/mapping)
-  + `SocketClientTests` (format) + the e2e `testSessionResizeSplitDivider` in `ControlOverlaySplitUITests`.
-  `session.go` navigates BETWEEN sessions — `args.to` is `next`|`prev`|`first`|`last`|`next-attention`|`prev-attention`
-  and acts on the target store's CURRENT selection (it is RELATIVE, so it resolves the placement store
-  via `resolvePlacementStore` rather than a session target — there is NO `--target`),
-  WRAPS around on next/prev (an end lands on the opposite end, within the filtered set), jumps to the ends for first/last,
-  and for `next-attention`/`prev-attention` steps through ONLY the sessions needing attention (`AgentStatus.needsAttention`
-  = `blocked`/`completed`) WRAPPING around (skipping idle/active), drives `AppStore.navigateSession`,
-  and returns the newly-selected id in `result.id`.
-  It mirrors the `session.focus --pane` one-command-with-arg precedent and is the control half of the
-  ⌥⌘↑/⌥⌘↓ session-nav + ⌃⌥↑/⌃⌥↓ attention-nav menu/palette items (First/Last have no hotkey).
-  `notify` posts a desktop notification attributed to a session (default:
-  the active session of the frontmost window via `resolveSession`): `args.body` is required,
-  `args.title` defaults to the session name.
-  It is control-NATIVE (no GUI/menu equivalent, like `session.type`/`session.copy`) and goes through
-  `NotificationManager.send(toSession:title:body:)` — which, unlike the OSC 9/777 path,
-  does NOT focus-suppress (the caller asked for it) but still bumps the badge + carries the `<windowID>:<sessionID>:main`
-  click-to-reveal identity.
-  It is the ONLY app-level way to post a banner; the terminal OSC path remains the other source.
-  The banner is gated by `NotificationManager.bannersEnabled` (Settings ▸ Notifications ▸ Show notification
-  banners) while the badge is NOT, so a banners-off call succeeds having touched nothing OS-side.
-  A bare `ok` there is indistinguishable from a broken notification path (#286), so the arm returns the
-  shared host-free `ControlNotify.bannersOffNote` in `result.text` — the `session.restore`-note precedent,
-  and the CLI prints `result.text` in place of `ok` with no CLI change.
-  A DELIVERED notify carries no `result.text`, so a caller can treat its presence as "no banner appeared".
-  No new read-back is owed: the badge already reads back as `unseen` on the `tree` node.
-  Covered by the `NotifyBannersUITests` e2e (both polarities), which seeds `notificationsEnabled` via
-  `ControlAPITestCase.seededSettings` before launch — there is no `settings.*` control command.
-  `session.new` creates a session.
-  The destination workspace is addressed one of two MUTUALLY-EXCLUSIVE ways:
-  `args.workspace` (id / unique prefix / `active`, the default) OR `args.workspaceName` (the sidebar
-  label, name-matched first-exact-trimmed via `AppStore.workspace(named:)`) — the latter optionally with
-  `args.createWorkspace` to reuse-or-create the named workspace (idempotent;
-  `AppStore.ensureWorkspace(named:)`).
-  A `workspaceName` with no match and no `createWorkspace` errors, both addressing modes set is an error,
-  and `createWorkspace` without `workspaceName` is an error (nothing to create by id);
-  the same two rules are pre-validated CLI-side by `session new`'s `validate()`.
-  `args.after`/`args.before` (a session address — id / prefix / `active`) instead PLACE the new session
-  directly after/before an anchor session rather than appending at the end (`ControlSessionCreateOptions.after`/`before`).
-  The anchor CARRIES ITS OWN WORKSPACE (resolved across all workspaces), so it names the destination
-  itself — after/before is a self-contained placement mode, mutually exclusive with each other and with
-  `--workspace`/`--workspace-name` (errors: `"use either --after or --before, not both"` and
-  `"session.new takes --after/--before or a workspace, not both"`, dispatcher-owned + CLI-pre-validated).
-  The app-side `createSession` resolves the anchor, takes its `(workspace, index)`, and inserts via
-  `AppStore.addSession(…, at: before ? index : index + 1)` (the new optional `at index:`, clamped).
-  `agtermctl session new --after active` = create right after the current session in one round-trip.
-  `args.command` runs that command AS the session's process instead of the login shell (like kitty's
-  `launch <cmd>` / ghostty's `command`) — NO echoed command line, and the session closes when the command
-  exits (the normal single-pane `onExit` → `closePrimaryPane`).
-  `Session.initialCommand` is `@ObservationIgnored` but PERSISTED via `SessionSnapshot.initialCommand`, so it
-  re-runs on restore (through the same `config.command` exec path) when the **restore-running-command** opt-in
-  is on — gated via the transient `Session.wasRestored` so a fresh session always runs its command while a
-  restored one honors the toggle (default off → a restored session is a plain shell); a live captured
-  foreground preempts it, and `closePrimaryPane` clears it when a command pane exits and its split
-  survivor is promoted to the session's single pane.
-  The arm threads `request.args?.command` into `AppStore.addSession(…, command:)`,
-  which `makeSurface` passes to `GhosttySurfaceView(command:)` → `config.command` RAW (`strdup`,
-  NO wrapper). libghostty tokenizes it into argv (shell-like word-splitting that RESPECTS quotes) and
-  execs argv[0] DIRECTLY — there is NO `sh -c`, so shell operators (`;`,
-  `&&`, `|`, `$VAR`, redirects, globs) are NOT interpreted: `ssh host -p 22 -t "ssh inner"` works (the
-  nested command rides as one quoted arg, runs with no echo — verified empirically),
-  but `clear; ssh …` execs a program literally named `clear;` and fails.
-  This is NOT the overlay's path — `makeOverlaySurface` explicitly wraps its command in `sh -c '…'` (so
-  the overlay DOES get shell semantics); a session `--command` that needs shell features must wrap ITSELF,
-  e.g. `--command "sh -c '…'"`.
-  Either way the command runs under the app's GUI environment, whose `PATH` is the launchd default (no
-  `/opt/homebrew/bin`), NOT a login shell's PATH, so a bare Homebrew or other non-default binary is not
-  found and exits 127 — the session/overlay opens then vanishes and `session.overlay.result` reports 127.
-  The fix is an absolute path or a LOGIN-shell wrapper (`zsh -lc '…'`); a plain `sh -c` gets shell
-  operators but NOT the login PATH, so the overlay's built-in `sh -c` wrapper does not by itself solve it
-  (the bundled agent-skill documents this caveat on the three `--command`/overlay entries).
-  `args.noSelect` (the CLI's `--no-select`) creates the session in the BACKGROUND — `makeSessionResponse`
-  passes `select: !noSelect` to `AppStore.addSession` (which gates `selectedSessionID`/`disableFocusIfSelectionOutsideSet`/`recordRecency`
-  on `select`) AND suppresses the `focusActiveSession()` call, so the current selection and focus are left
-  untouched.
-  It ALSO threads through the workspace-focus filter: the `--create-workspace` path calls
-  `store.ensureWorkspace(named:, revealNewWorkspace: !options.noSelect)`, and `AppStore.addWorkspace`/`ensureWorkspace`
-  carry a `revealNewWorkspace: Bool = true` parameter gating the auto-reveal.
-  The MECHANISM changed with the focus SET: reveal no longer CLEARS the filter, it INSERTS the new workspace
-  into the marked set (`if revealNewWorkspace, focusEnabled { focusedWorkspaceIDs.insert(workspace.id) }`),
-  so a foreground create stays visible without blowing the rest of the filtered view open.
-  `--no-select --create-workspace` therefore does not WIDEN the set (the old wording, "does not DROP a
-  focused workspace", described the pre-set behavior); all GUI/other `addWorkspace` callers keep the default
-  `revealNewWorkspace: true`, unchanged.
-  The parameter was renamed because after the change `clearFocus` stated the opposite of what it does.
-  It is the inverse of the overlay's `--follow` (overlay opens in the background by default and opts INTO
-  selecting; `session.new` selects by default and opts OUT), and like `--follow` it rides the existing
-  command as a new optional ARG — NO new `Command` case.
-  It is state-mutating-with-read-back EXEMPT: `--no-select` is a creation-time behavior, not queryable
-  per-session state, and the read-back is the EXISTING `tree` `active` flag (the new node is not `active`),
-  so no new `ControlSessionNode` field is owed.
-  Do NOT overload the existing `ControlArgs.select` (that is `session.type --select`, opposite polarity) —
-  `noSelect` is its own opt-in-true bool, mirroring `createWorkspace`/`follow`.
-  Keep-in-sync: the `.sessionNew` case carries `ControlArgs.command` plus `ControlArgs.name` (custom
-  name) and `ControlArgs.workspaceName` + `ControlArgs.createWorkspace` (name-addressing + ensure) +
-  `ControlArgs.noSelect` (threaded into `ControlSessionCreateOptions.noSelect`);
-  the arm pre-validates the mutual-exclusion / create-needs-name rules and shares `makeSessionResponse`
-  across the id- and name-addressed paths; the `session new` CLI carries `--command`/`--name`/`--workspace-name`/`--create-workspace`/`--no-select`
-  (the two workspace flags also `validate()`-guarded); and round-trip + e2e (`testSessionNewWithCommandRunsAsProcess`,
-  `testSessionNewWithName`, `testSessionNewWorkspaceNameCreatesThenReuses`, `testSessionNewNoSelectKeepsActiveSelection`,
-  `testSessionNewNoSelectCreateWorkspacePreservesFocus`)
-  cover them.
-  `session.duplicate` (target = session) creates a fresh session in the SAME workspace as the target,
-  inserted directly AFTER it, rooted at the target's focused-pane cwd (`Session.focusedCwd` — the live
-  OSC 7 directory the sidebar row shows and `session.reveal` opens), then selects + focuses it and returns
-  the NEW id (`echoesResultID`, like `session.new`; it focuses only when the duplicate lands in the frontmost
-  window, the same rule `session.new` follows).
-  It is exactly `session.new --cwd <source cwd> --after <source>` in ONE atomic round-trip, so it takes NO
-  options beyond `--target` (default `active`) and the global `--window` — the target session names BOTH the
-  destination workspace and the cwd.
-  ONLY the directory carries over: the duplicate is a plain login shell with the auto basename and does NOT
-  inherit the source's `customName`, `initialCommand`, split, scratch, status, flag, font size, or watermark
-  — it is "New Session seeded with the source's cwd", NOT a clone of state.
-  Errors are the standard resolver ones for an unresolvable / ambiguous target, plus `could not duplicate
-  session` when creation fails.
-  It is the control half of the sidebar row's **Duplicate Session** context-menu item (SINGLE-selection only, like
-  Rename / Reveal in Finder — not batch-capable; see the Sidebar rule).
-  READ-BACK: it adds NO `ControlSessionNode` field — `tree` ITSELF is the read-back, since the new session
-  node appears directly after its source, which is what a script checks.
-  The duplicate's `cwd` is seeded from the source's `focusedCwd` (the focused pane), while `tree` reports
-  each node's `cwd` from `effectiveCwd` (always the PRIMARY pane), so the duplicate's `cwd` equals the
-  source node's `tree.cwd` for a non-split source (and a split focused ON its primary) but DIFFERS when the
-  source is a split focused OFF its primary pane — there the source node's `tree.cwd` shows the primary
-  while the duplicate carries the focused pane's directory.
-  `session.type` injects into the target surface.
-  `args.pane` picks the pane like `session.text` (`left`|`right`|`scratch`, no `other`):
-  omitted/`left` is the MAIN pane (omitted deliberately keeps the pre-pane behavior — always the main
-  pane, NOT the focused/on-screen one, so existing automation is unaffected);
-  `right` injects into the split surface, `session has no split pane` without one;
-  `scratch` injects into the session's scratch terminal, typable even while HIDDEN (its surface is kept
-  alive), `session has no scratch terminal` when none has been opened;
-  and an unknown value is an `invalid pane` error — all validated SERVER-SIDE in `injectText`
-  (mirroring the CLI `validate()`), so a raw socket client can't bypass it.
-  Every session is realized eagerly (the deck mounts all at startup), so any session is normally typable
-  WITHOUT `select`; `select:true` remains for the brief window before a just-created session is mounted
-  (select, then a bounded poll, the `focusSplitPane` idiom), with `session not realized` the fallback
-  if the surface still isn't up.
-  The realize/select path applies to the MAIN pane only — a split pane is never created by selecting,
-  so `pane:right`/`pane:scratch` inject into the existing surface or error.
-  Four-point keep-in-sync audit for `session.type --pane`: (1) reuses `ControlArgs.pane` in
-  `ControlProtocol.swift` (no new field), (2) the pane switch in `injectText`
-  (`ControlServer+SurfaceIO.swift`), (3) the `session type --pane left|right|scratch` option
-  (`validate()`-guarded) in `agtermctlKit`, (4) round-trip in `ControlProtocolTests` + CLI mapping in
-  `CommandsTests` + the e2e (`testSessionTypePaneRightReachesSplitPane`,
-  `testSessionTypePaneRightWithoutSplitErrors`, `testSessionTypeRejectsInvalidPaneServerSide`) in
-  `SessionTypePaneUITests` (a `ControlAPITestCase` subclass like `SessionTextUITests`).
-  `GhosttySurfaceView.inject(text:)` types via `ghostty_surface_key` keystrokes (printable runs as key-with-`text`,
-  each `\n`/`\r`/`\r\n` as a Return keypress, keycode 36) — NOT `ghostty_surface_text`,
-  whose bracketed-paste wrapping suppresses Enter and leaks `\e[200~`/`\e[201~` markers when fired rapidly.
-  Do not "simplify" it back to `ghostty_surface_text`.
-  `session.copy` reads the target surface's selection via `GhosttySurfaceView.readSelection()` (`ghostty_surface_has_selection`
-  + `ghostty_surface_read_selection`, freed with `ghostty_surface_free_text`) and returns it in `result.text`
-  — it does NOT touch the system clipboard (automation pipes the returned text into another `session.type`);
-  selection is surface state independent of focus, so any realized session can be read,
-  and no/empty selection is a `no selection` error.
-  `session.paste` pastes the SYSTEM clipboard (`NSPasteboard.general`) into the target session's MAIN
-  surface — the socket analogue of ⌘V / Edit ▸ Paste.
-  `session.selectall` selects the target's ENTIRE terminal buffer (main surface) — the analogue of ⌘A /
-  Edit ▸ Select All.
-  Both run a libghostty binding action on the resolved surface — `paste_from_clipboard` /
-  `select_all` — through the shared `ControlServer+SurfaceIO.surfaceBindingAction` helper
-  (resolve session → guard the surface is realized, `session not realized` otherwise → `performBindingAction`
-  → return the id), so paste takes the normal libghostty paste path (bracketed paste, PASTE requests are
-  ungated so no OSC-52 prompt) and select_all covers the whole grid.
-  They are the control half of the GUI Edit menu: agterm keeps the STANDARD SwiftUI Edit menu and
-  implements `copy:`/`paste:`/`selectAll:` + `validateMenuItem:` on `GhosttySurfaceView` (`+Input.swift`,
-  conforming to `NSMenuItemValidation`) so AppKit's automatic menu enabling routes Copy/Paste/Select All
-  to the terminal when it holds first responder — Copy enabled on `ghostty_surface_has_selection`, Paste
-  on `GhosttyCallbacks.hasPasteboardText()`, Select All on a realized surface (all three also require
-  the surface, since `performBindingAction` no-ops without one) — while a focused text field (rename/palette/Settings)
-  keeps its own editing (its field editor wins the responder chain), and Cut stays disabled for the terminal
-  (deliberately NOT implemented) yet works in text fields.
-  **Cut cannot be dropped on its own** — SwiftUI puts Cut/Copy/Paste/Delete/Select All in ONE `.pasteboard`
-  `CommandGroup`, and replacing that group is what would take ⌘C/⌘V/⌘A away from the rename/palette/Settings
-  fields.
-  **Undo/Redo ARE dropped** (`CommandGroup(replacing: .undoRedo) {}` in `agtermApp+Menus.swift`): they are
-  their own group, agterm registers no `NSUndoManager`, and their advertised ⌘Z is already owned by File ▸
-  Reopen Closed Item (`BuiltinAction.undoClose`), whose menu precedes Edit and wins the key-equivalent search —
-  so Edit ▸ Undo could only ever be CLICKED, never invoked by its own shortcut.
-  AppKit did enable it for the sidebar's inline rename field (whose field editor supplies an undo manager),
-  but a permanently-greyed item that duplicates another menu's shortcut for one narrow case is worse than no
-  item; `EditMenuUITests.testEditMenuHasNoUndoOrRedoItems` asserts NON-EXISTENCE (an `isEnabled == false`
-  check would pass vacuously on a missing element).
-  **Paste MUST validate with the same branches the paste path reads**, and must agree with it in BOTH
-  directions.
-  Two ways to get this wrong, both found in review:
-  a `canReadObject([NSString])` probe greys the item out for a Finder file copy (a file URL with NO string
-  representation, which `pasteboardText` turns into a shell-escaped path) while ⌘V pastes the path anyway;
-  and a `canReadObject([NSURL])` probe is a TYPE check, so a pasteboard merely DECLARING `public.file-url`
-  with no usable value enables Paste while the reader returns nil and the paste inserts nothing.
-  Either direction reintroduces the menu-vs-keyboard divergence these responders exist to remove.
-  So `hasPasteboardText` runs the reader's own URL branch, short-circuiting on the first usable URL
-  (`contains(where:)`) instead of mapping/escaping/joining the whole clipboard — validation fires on every
-  menu open and every ⌘V key-equivalent lookup, so it must not materialize a Finder copy of thousands of files.
-  Both share the single `urlText` helper so they cannot drift.
-  **Keep the predicate and the reader in step; this invariant has NO automated test** (verified instead with a
-  named-pasteboard probe across the empty / plain-text / empty-string / whitespace / file-url / web-url /
-  multi-url / declared-without-data shapes).
-  The file-URL case is NOT XCUITest-able: the runner is sandboxed (`com.apple.security.app-sandbox`), so a file
-  URL it writes to `NSPasteboard.general` never becomes visible to the app — instrumenting `hasPasteboardText`
-  showed the app reading `types=[]` for a full 8 s poll while the runner's own `canReadObject([NSURL])` returned
-  true from its in-process cache.
-  Such a test exercises the sandbox, not `validateMenuItem`, so it was removed rather than left red (verified
-  instead with a cross-process probe outside the runner).
-  Do not re-add it without an app-target `bundle.unit-test` (the project has only `bundle.ui-testing` today),
-  which could exercise `hasPasteboardText` against a NAMED pasteboard in-process.
-  A `NSPasteboard.general` read in the app also LAGS a writer process's `changeCount`, so any UI test that seeds
-  the clipboard must POLL rather than read once.
-  ⌘C/⌘V/⌘A therefore route through the Edit menu (fixed standard shortcuts, NOT rebindable — the maintainer's
-  call); the `ghostty-defaults.conf` `super+key_c`/`super+key_v`/`super+key_a` binds stay as a non-Latin-layout
-  backup.
-  The mechanism is that AppKit matches a menu key equivalent against the character the layout PRODUCES: on a
-  Cyrillic layout ⌘C yields `с`, no equivalent matches, the event reaches `keyDown` and the keycode-triggered
-  `super+key_c` fires. (A DISABLED item likewise doesn't consume its equivalent, so ⌘C with no selection also
-  falls through.) There is no AppKit "Latin fallback" doing this — the binds are load-bearing, not dead code.
-  **`super+key_a=select_all` is one of them**: without it ⌘A silently does nothing on a Cyrillic/Greek layout,
-  since libghostty's built-in `super+a` is character-matched too (found in review — the fallback set must cover
-  every shortcut the Edit menu owns, not just copy/paste).
-  **The session-scoped surface arms resolve `Session.addressableSurface`, not `Session.surface`.**
-  `session.copy`/`session.paste`/`session.selectall` act on "the session" rather than a named `--pane`
-  (and so does `font.*`'s omitted/`left` default — its `right`/`scratch` panes resolve `splitSurface`/`scratchSurface`
-  instead, via its own pane switch rather than `surfaceBindingAction`),
-  and `addressableSurface` is `surface ?? splitSurface`: identical to `surface` for every ordinary or split
-  session — including a PROMOTED SPLIT SURVIVOR, which `closePrimaryPane` moves into the main slot
-  (`AppStorePaneTests` asserts `splitSurface == nil` after promotion).
-  The `?? splitSurface` term is a defensive fallback only, kept so the arms answer (instead of
-  `session not realized`) should `surface` ever be nil while a split shell is still alive.
-  It is deliberately NOT focus-aware (unlike `activeSurface`) — a shown split keeps addressing the main
-  pane, which is what keeps `session.selectall` and its `session.copy` read-back on the SAME surface.
-  READ-BACK: neither adds a `ControlSessionNode` field — `session.selectall`'s read-back is `session.copy`
-  (reads the resulting selection) and `session.paste`'s is `session.text` (reads the inserted buffer), the
-  sibling-command pattern (like `quick.type`↔`quick.text`).
-  Four-point keep-in-sync audit: (1) `case sessionPaste = "session.paste"` + `case sessionSelectAll = "session.selectall"`
-  in `ControlProtocol.swift` (no new args/fields), (2) the `.sessionPaste`/`.sessionSelectAll` arms in
-  `ControlDispatcher.dispatchSessionSurfaceCommand` → `ControlActions.pasteSession`/`selectAllSession`
-  (app-side `ControlServer+SurfaceIO`), (3) the `session paste` / `session select-all` subcommands in
-  `agtermctlKit`, (4) round-trip in `ControlProtocolTests` + dispatcher routing in `ControlDispatcherTests`
-  + CLI mapping in `CommandsTests` + the e2e `testSessionSelectAllThenCopyReturnsBuffer` /
-  `testSessionPasteInsertsClipboardText` in `ControlAPIUITests`.
-  `session.text` reads the target surface's screen buffer as PLAIN TEXT (no ANSI) via `GhosttySurfaceView.readScreenText(all:lines:)`
-  (a `ghostty_selection_s` spanning VIEWPORT top-left→bottom-right by default,
-  SCREEN when `args.all || args.lines != nil`, `rectangle = false`;
-  `ghostty_surface_read_text` → copy out of `ghostty_text_s` → `ghostty_surface_free_text`) and returns it in `result.text`
-  — `args.all` adds scrollback, `args.lines N` keeps the last N CONTENT lines (trailing blank grid rows
-  trimmed so a non-scrolled screen returns content, not padding), and `args.pane` (`left`→main,
-  `right`→split-else-`session has no split` error, `scratch`→the scratch terminal's surface, readable even
-  while HIDDEN since it is kept alive (`session has no scratch terminal` when none opened),
-  omitted→the ON-SCREEN surface via the shared `Session.onScreenSurface` (scratch-when-covering else the
-  focused pane, the SAME resolution `session.search` uses), so a no-`pane` read returns what's visible,
-  not a pane hidden under the scratch) picks the pane.
-  `args.all`+`args.lines` are mutually exclusive and `args.lines` must be > 0 — validated SERVER-SIDE in
-  the dispatcher (`ControlDispatcher.dispatchSessionText`, mirroring the CLI `validate()`), NOT only CLI-side, so a raw socket client can't bypass it
-  (an unchecked `lines ≤ 0` would otherwise fall through to the full buffer).
-  UNLIKE `session.focus`, the `pane` here is `left|right|scratch` (no `other`).
-  A genuinely BLANK screen reads `ok` with an empty string (NOT an error, on purpose — differs from `session.copy`'s
-  `no selection`), but a FAILED `ghostty_surface_read_text` is a `failed to read surface buffer` error:
-  `readScreenText` returns `""` for the empty read and nil ONLY for a real failure, which the app-side `readSessionText` maps
-  to the error (so a caller can tell a blank terminal from a broken read).
-  Plain text only — the pinned libghostty exposes only `ghostty_surface_read_text` (no per-cell SGR),
-  so `--ansi` is out of scope until a styled surface read lands upstream and the pin is bumped.
-  Four-point keep-in-sync audit for `session.text`: (1) `case sessionText = "session.text"` + new `ControlArgs.all: Bool?`/`lines: Int?`
-  (reuses `pane` + `ControlResult.text`) in `ControlProtocol.swift`, (2) the `.sessionText` dispatcher arm —
-  `ControlDispatcher.dispatchSessionText` (validation + response shape) with the app-side `readSessionText` (the surface read) behind `ControlActions`,
-  (3) the `session text [--all] [--lines N] [--pane left|right|scratch]` subcommand in `agtermctlKit`
-  (`validate()` guards the flag combos, re-enforced SERVER-SIDE in the dispatcher), (4) round-trip tests in
-  `ControlProtocolTests` + the e2e (`testSessionTextReturnsBuffer`, `testSessionTextSplitPaneWithoutSplitErrors`,
-  `testSessionTextRejectsInvalidArgsServerSide`, `testSessionTextBlankScreenReturnsOkEmpty`) in `SessionTextUITests`
-  (a `ControlAPITestCase` subclass in its own file, sharing the harness base with the `Control*UITests` suites).
-  `session.search` searches the target session's live scrollback (target = session) — it SELECTS the
-  target (so the bar + match highlights render and the surface is realized,
-  bounded-realize-polled like `session.type`), then drives the FOCUSED surface over `ghostty_surface_binding_action`:
-  `args.text` is the needle (`sendSearchQuery`, opening search first via `startSearch` if not already
-  `searchActive`), `args.to` is `next`|`prev`|`close` (`navigateSearch(.next/.previous)`;
-  `close` → `endSearch()` returns ok with no counter).
-  The match count lands ASYNC via libghostty's `SEARCH_TOTAL` callback, so the arm bounded-polls `session.searchTotal`
-  (the overlay-result idiom) before returning `result.count` = total matches + `result.text` = the "N
-  of M" / "M matches" / "no matches" display string (`Session.searchDisplayText`,
-  host-free; an empty display maps to nil `text` so the CLI prints `ok`).
-  No needle + no `to` opens the empty bar.
-  The four search state fields (`searchActive`/`searchNeedle`/`searchTotal`/`searchSelected`) are ephemeral
-  on `Session`, absent from `SessionSnapshot`; the GUI bar (see the Menu/actions + ContentView placement
-  notes) and the control channel read/write the SAME fields so they can't drift.
-  Four-point keep-in-sync audit for `session.search`: (1) `case sessionSearch = "session.search"` in
-  `ControlProtocol.swift` (reuses `ControlArgs.text` = needle + `ControlArgs.to` = next|prev|close,
-  and `ControlResult.count` + `text` — no new field), (2) the `.sessionSearch` dispatch arm (`searchSession`)
-  in `ControlServer`, (3) the `session search [needle] --next|--prev|--close` subcommand in `agtermctlKit`
-  (`validate()` rejects flag combos), (4) round-trip tests in `ControlProtocolTests` + the e2e `testSessionSearch`
-  in `ControlAPIUITests`.
-  `session.overlay.open`/`session.overlay.close` run an ephemeral terminal on top of a session executing
-  one program (`args.command`, e.g. a TUI); by default it is full single-pane size,
-  hiding the single/split underneath, but `args.sizePercent` (1–100, clamped in `openOverlay`) makes
-  it a *floating* opaque framed panel at that percent of the pane with the session still visible.
-  `args.color` (`#rrggbb`, REUSING the `session.background` field — no new arg — validated by the shared
-  `WatermarkConfig.isValidColorHex` at BOTH the CLI `validate()` and the server arm) gives the overlay
-  pane its OWN solid background color, independent of the session's `session.background color`;
-  the overlay is sessionless, so it is applied to the overlay SURFACE (not via the session) as the SAME
-  `.color` per-surface config overlay (`WatermarkConfig.overlayText` → `configWithOverlay`,
-  honoring window translucency), built in `GhosttySurfaceView.applyOverlayBackgroundColor` from the
-  view's `overlayBackgroundColorHex` in `createSurface` — works identically for the full + floating variants.
-  `AppStore.openOverlay`/`closeOverlay` set non-persisted `Session.overlay*` state (incl.
-  `overlaySizePercent`, nil = full / non-nil = floating; and `overlayBackgroundColor`,
-  set at open / cleared at close), and the surface runs `config.command` with
-  `onExit → closeOverlay`.
-  Both variants render IN the per-session eager deck, so the overlay program runs regardless of which
-  session is active — the only visible difference is geometry.
-  The overlay is ONE always-present, CONSTANT-SHAPE ZStack sibling in `WindowContentView.sessionDetail`,
-  `overlayPanel(session:isActive:)` at `.zIndex(3)`, hosting BOTH variants from a single surface host (the
-  pre-unify split — a `fullOverlay`-gated `.zIndex(2)` sibling PLUS a separate `floatingOverlayPanel` at
-  `.zIndex(3)` — is GONE; `session.overlay.resize` below is why one host matters).
-  The panel content (the overlay surface; the opaque `terminalColor` backing + hairline frame + shadow; the
-  click-catcher) is gated INSIDE the always-present `GeometryReader` on `session.overlayActive`, so the
-  ZStack child COUNT stays constant across open/close/resize — the same SHAPE as no-overlay, which is what
-  keeps the AppKit `NSSplitView` from re-hosting and overrunning UP into the transparent titlebar.
-  (The panel used to mount OUTSIDE `sessionDetail` as a `detailPane` `.overlay` for exactly this reason;
-  the always-present constant-shape sibling holds the same invariant IN-deck.)
-  FULL (`overlaySizePercent` nil): fraction 1.0, drawn translucent + blurred with NO opaque backing and NO
-  chrome (`Color.clear` backing, 0 corner radius, 0 shadow), and the pane(s) behind hidden at `.opacity(0)`
-  + `.allowsHitTesting(false)` via `hideForOverlay` (= `fullOverlay || scratchActive`; kept MOUNTED, shells
-  alive like the deck's inactive sessions), so its transparency reveals the window backing (desktop, tint +
-  blur), not the session.
-  FLOATING (`overlaySizePercent` set): fraction = `percent/100`, drawn as an opaque `terminalColor`-backed,
-  hairline-framed, shadowed panel centered in the detail area with the pane(s) VISIBLE around it.
-  The modifier CHAIN is IDENTICAL across both variants — only the parameter VALUES flip (backing color,
-  corner radius, shadow radius, frame fraction) — so `session.overlay.resize` switching full<->% is a
-  value-update, never a child add/remove or a re-parent of the overlay surface NSView (a re-parent would
-  blank its Metal drawable).
-  Hit-testing on the PANES stays gated on `.allowsHitTesting(!hideForOverlay)` and must NOT flip when a
-  FLOATING overlay opens: changing the panes' OWN `allowsHitTesting` on overlay-open (e.g. to
-  `!session.overlayActive`) ALSO triggers the NSSplitView titlebar-overrun — the SAME class of perturbation
-  as changing the ZStack's shape, even though it looks like a pure interaction change (Codex insisted
-  hit-testing was layout-inert; a review-loop regression proved otherwise).
-  So a floating overlay leaves the panes hit-testable, and the overlay's focus is protected by a transparent
-  `Color.clear.contentShape(Rectangle())` catcher INSIDE `overlayPanel` that absorbs clicks AROUND the panel
-  so they can't reach the panes and steal the overlay program's first responder.
-  (Generalize the rule: ANYTHING in `sessionDetail`'s HSplitView-hosting subtree that CHANGES SHAPE when
-  `overlayActive` flips — adding/removing a sibling, a flattened ZStack, or a toggled pane modifier —
-  overruns the split into the titlebar; keep the subtree's shape identical across open/close/resize and gate
-  the panel content INSIDE the constant-shape sibling.)
-  This constant-shape invariant is load-bearing: a CONDITIONAL sibling inside `sessionDetail`'s ZStack (the
-  HSplitView-hosting subtree) made SwiftUI re-host it and the `NSSplitView` overrun UP into the
-  transparent titlebar, painting the split over the header (Codex-confirmed;
-  the quick terminal renders at this level for the same reason and never hit it).
-  `overlayPanel`'s `GeometryReader` reports the detail area EXACTLY — no manual sidebar/titlebar insets
-  (computing those at the window level mis-centered the panel one line low) — so it sizes the floating panel
-  to `sizePercent`% and centers it in the detail area, the pane(s) visible around it.
-  `isActive` gates the overlay surface's focus, so a background floating overlay RUNS but does not steal
-  focus (mirrors the full overlay).
-  Because both kinds mount in the eager deck, `ControlServer` does NOT select on open by default; it SELECTS
-  the target ONLY when the caller passes `--follow` (gated on `options.follow`, NOT on `sizePercent`) — the
-  user-facing "pull me to the overlay" switch.
-  Without `--follow` full and floating both open on `--target` and run in the background; a `--block` open
-  completes without changing the active session.
-  `follow` is a new optional ARG on the existing `overlay.open` command (NO new `Command` case): threaded
-  `ControlProtocol` (`ControlArgs.follow`) → `ControlDispatcher` `.sessionOverlayOpen`
-  (`ControlSessionOverlayOpenOptions.follow`) → `ControlServer` → the `agtermctl … --follow` flag,
-  omitted = false for back-compat.
-  On close an `.onChange(of: session.overlayActive)` drives `focusAfterReparent()` on the session's `activeSurface`
-  so first responder returns to the underlying terminal — the pane re-activating only does a single `makeFirstResponder`,
-  which loses the teardown/re-host race (same reason the open path needs the `autoFocus` retry).
-  Two libghostty gotchas (confirmed against cmux/macterm, see the gotchas section):
-  the surface must **handle `GHOSTTY_ACTION_SHOW_CHILD_EXITED`** (in `GhosttyCallbacks.action`) and return
-  `true` to suppress ghostty's "Process exited.
-  Press any key" prompt and close immediately — `config.wait_after_command` does NOT suppress it;
-  and the overlay must grab focus via a **bounded run-loop `makeFirstResponder` retry** (`autoFocus`),
-  since a single-shot loses the SwiftUI/AppKit responder race.
-  `--wait`/`overlayWait` keeps the prompt (returns `false` from the action so `close_surface_cb` closes
-  after a keypress).
-  `handleProcessExit` is idempotent (both the action and `close_surface_cb` can fire).
-  Both variants mount in the eager deck, so the caller does NOT need to select the target; `--follow`
-  selects it only when the user should be pulled to the overlay.
-  **Exit-status capture (`session.overlay.result` + `agtermctl … --block`).** `makeOverlaySurface` wraps
-  the command in a FIXED `sh -c '( eval "$AGTERM_OVL_CMD" ); echo $? > "$AGTERM_OVL_CODE"'` — the real
-  command + a per-surface temp path ride in env (`AGTERM_OVL_CMD`/`AGTERM_OVL_CODE`,
-  never interpolated), and crucially there is **NO stdout/stderr redirect** so a TUI renders normally;
-  only the exit status is captured.
-  (libghostty's `GHOSTTY_ACTION_SHOW_CHILD_EXITED.exit_code` reflects the login-shell wrapper — always
-  0 — so the status is taken from the wrapper's `echo $?`, NOT libghostty;
-  the subshell makes an inline `exit N` propagate.) the surface's teardown reads the temp file → `AppStore.recordOverlayExit`
-  (sets the non-persisted `Session.overlayExitCode`) → then deletes it, all in `GhosttySurfaceView.destroySurface`
-  (via `onExitCodeCaptured`), so EVERY in-process close path — natural exit,
-  explicit `session.overlay.close`, force-close (session/workspace/window) — captures the status before
-  the file is removed, and the file's lifetime tracks the surface (no registry/sweep);
-  `onExit` itself just drives `closeOverlay`.
-  `session.overlay.result` (target = session) returns `result.exitCode` once the overlay has closed (`OverlayResultError.stillRunning`
-  while up, `noResult` if none ran — both shared constants so the CLI poll matches exactly).
-  `agtermctl session overlay open <command> … --block` wraps open → poll `session.overlay.result` (retry
-  while still running; targets the returned id with NO window scope, so a frontmost-window change can't
-  desync the poll) → exit with the captured status into ONE blocking command (rejects `--block` + `--wait`
-  at parse via `validate()`); the program's OUTPUT is its own concern — a TUI like revdiff renders in
-  the overlay and writes results to its own `--output` file, which the caller reads (the control channel
-  does NOT capture stdout).
-  `session.overlay.resize` (target = session) resizes an ALREADY-OPEN overlay IN PLACE between full and
-  floating — the way to change size without closing and re-running the program.
-  Exactly one of `sizePercent` (1...100 → floating) or `full: true` (→ the full-pane overlay) must be set;
-  both, neither, or a percent outside 1...100 is a dispatcher error (mirrored by the CLI `validate()`), and
-  `no overlay` when none is open.
-  It is a NEW `Command` case (unlike the `--follow` arg, which rode the existing `overlay.open`) because it
-  needs its own arg validation, and `full` is a NEW `ControlArgs` field added to distinguish "switch to
-  full" (nil `overlaySizePercent`) from "unset" on the wire.
-  The arm mutates the non-persisted `Session.overlaySizePercent` via `AppStore.resizeOverlay` (clamping
-  1...100, guarding `overlayActive`), and the detail pane re-flows the SAME surface host: the unified
-  `WindowContentView.overlayPanel` now renders BOTH variants (full = translucent, no chrome, panes hidden by
-  `hideForOverlay`; floating = opaque framed panel over visible panes), so a full<->% switch never re-parents
-  the overlay NSView (which would blank its Metal drawable) nor changes the ZStack shape — the old
-  `if fullOverlay` z2 sibling is gone, and the always-present `overlayPanel` at z3 is the single host.
-  Four-point keep-in-sync audit for `session.overlay.resize`: (1) `case sessionOverlayResize = "session.overlay.resize"`
-  + `ControlArgs.full` in `ControlProtocol.swift`, (2) the `.sessionOverlayResize` dispatcher arm (exactly-one
-  + range validation) → the app-side `resizeSessionOverlay` (→ `AppStore.resizeOverlay`) behind `ControlActions`,
-  (3) the `session overlay resize --size-percent|--full` subcommand (`Resize`, `validate()`-guarded) in
-  `agtermctlKit`, (4) round-trip in `ControlProtocolTests` + dispatcher routing/validation in `ControlDispatcherTests`
-  + `AppStorePaneTests` (resize clamp/switch/no-overlay) + CLI mapping in `CommandsTests` + the e2e
-  `testOverlayResizeSwitchesFloatingAndFull` in `ControlOverlaySplitUITests`.
-  The READ side is `ControlSessionNode.overlaySizePercent` on each `tree` node (see the `tree` read-side
-  fields below) — populated in `AppStore.controlTree`, round-tripped by `treeSessionNodeRoundTripsWithOverlaySizePercent`/`…OmitsOverlaySizePercentWhenNil`
-  and `AppStorePaneTests.controlTreeReportsOverlaySizePercent`, and mirrored in the agent-skill `reference.md`
-  tree schema — so a script can record an overlay's size before zooming to `--full` and restore it exactly.
-  `surface.zoom` (mode `show`|`hide`|`toggle`) fills the target window with ONE terminal surface,
-  hiding the sidebar and collapsing the title bar to a slim strip (traffic lights + an exit button;
-  the zoomed terminal is inset below `titlebarHeight`, NOT borderless) — the control half of
-  ⌘⇧Return / View ▸ Toggle Terminal Zoom (`BuiltinAction.toggleTerminalZoom`) and the title-bar exit button.
-  Targets: omitted/`active` resolves the active surface (quick terminal first, else the active session's
-  overlay > scratch > focused-split > primary via `TerminalZoomController.resolveTarget`, which derives the
-  precedence from `TerminalZoomSurface.isActive`); an explicit `surface:<session-id>:<left|right|scratch|overlay>`
-  id (from `tree`'s `surfaces` nodes) zooms that surface — hidden-but-alive splits/scratches included — and
-  `quick` addresses a quick-terminal zoom (the API accepts the id it emits).
-  State lives in the per-window, host-free `TerminalZoomController` (`agtermCore/TerminalZoom.swift`,
-  registered in `TerminalZoomRegistry`); the app-side arm (`setSurfaceZoom`/`setActiveSurfaceZoom`) only
-  resolves the target and shapes the response — ALL mode-vs-state semantics stay in `TerminalZoomController.set`,
-  shared with the GUI toggle, so the three callers can't drift.
-  Zoom is a VIEW mode with hard invariants: it must not mutate split ratios, focus, sidebar state, or
-  split/scratch visibility (the zoom host mounts with `reportsFocusChange: false` → `suppressFocusChange`
-  on ALL `onFocusChange` paths, incl. `clearUnseenOnRefocus`), and the zoomed session's deck entry stays
-  mounted with a CONSTANT shape — only the zoom-owned slot swaps to its `deckHostsSurface` placeholder —
-  so control-opened split/scratch/overlay surfaces still realize and run behind the zoom layer.
-  Entering zoom closes the window's transient chrome (the palette — frontmost window only, it is
-  app-global — an active ⌘F search, and, for a session zoom, a visible quick terminal); a
-  notification-banner reveal exits zoom first; ⌘W exits zoom (the topmost cover, stepwise like the
-  quick/overlay/scratch dismissal); font commands stay live (they act on the focused = zoomed surface).
-  While zoomed, `quick show` and `session.search` (except `close`) are rejected; `quick hide` stays
-  idempotent (a zoomed quick terminal un-zooms first, so a script can always dismiss it), and an
-  explicit-target `surface.zoom hide` skips the availability check so hide is idempotent even after
-  the surface vanished.
-  The READ side is `ControlTree.zoomedSurface` at the tree TOP level — the zoomed surface's control id
-  (`surface:<session-id>:<kind>` or `quick`), nil/omitted when nothing is zoomed — LIVE, resolved
-  app-side in `buildTree` from the projected window's `TerminalZoomController.target?.controlID` and
-  threaded as a `zoomedSurface: () -> String?` closure on `AppStore.controlTree` (the `quickVisible`
-  seam), `tree`-only for the same staleness reason; so a script can check "is it already zoomed" and
-  record-then-restore. The per-session `surfaces` nodes are the ADDRESSING list, not the state read-back:
-  `ControlSurfaceNode.active`/`visible` derive from session flags (overlay/scratch/splitFocused), are
-  identical zoomed or not, and `visible` reads false for a pane behind a FLOATING overlay even though
-  that pane is visually on screen — documented as a caveat on the node type and in the skill.
-  Four-point keep-in-sync audit: (1) `case surfaceZoom = "surface.zoom"` + `ControlSurfaceNode`/`ControlSessionNode.surfaces`
-  + `ControlTree.zoomedSurface` in `ControlProtocol.swift`, (2) the `.surfaceZoom` arm (`setSurfaceZoom`) in `ControlServer+SessionActions.swift`
-  + the `surfaces`/`zoomedSurface` population in `AppStore.controlTree`/`buildTree`, (3) the `surface zoom` subcommand in `agtermctlKit`,
-  (4) round-trip in `ControlProtocolTests` (incl. `treeRoundTripsWithZoomedSurface`/`…OmitsZoomedSurfaceWhenNil`)
-  + `TerminalZoomTests` + the e2e `ControlSurfaceZoomUITests` (incl. the tree read-back and the
-  `--window`-scoped error paths).
-  `dashboard` opens a per-window, VIEW-ONLY grid of live PANE cells
-  (`agtermctl dashboard <ids…> [--font-size N | --auto-size] [--window W]`),
-  or populates it from the window's most-recently-used sessions instead of explicit ids
-  (`dashboard --mru [--font-size N | --auto-size] [--window W]`),
-  or CLOSES the open one (`dashboard --close [--window W]`).
-  The cell unit is a session+PANE (a `DashboardMember` = session UUID + `.primary`/`.split`): a non-split
-  session is ONE `.primary` cell, and a SPLIT session (`hasSplit`, both shells alive) expands into TWO cells —
-  its `.primary` and `.split` panes — so a split shows both panes side by side.
-  It is the N-surface generalization of `surface.zoom`'s reparent, with focus inverted (zoom focuses
-  its one surface; the dashboard focuses NONE while open).
-  It is reachable BOTH over the socket AND from the GUI:
-  the control open path is `dashboard`/`agtermctl dashboard` (unchanged),
-  and the GUI opener is `BuiltinAction.dashboard` (⌘⇧D), Navigate ▸ Dashboard, and the command palette
-  `Dashboard` entry — all TOGGLE the frontmost window's MRU grid auto-sized (the `dashboard --mru
-  --auto-size` equivalent), reusing the existing socket command with NO new control command, so the catalog
-  does not grow for it.
-  Once open, the keyboard drives it: arrows move the highlight, Enter jumps into the highlighted session
-  AND focuses that exact pane + closes, Esc closes.
-  Host-free geometry + navigation + auto-size math live in `DashboardLayout`
-  (`grid(count:) = ceil(sqrt(n))` cols, `move` clamped 2-D nav into a ragged last row,
-  `dashboardFontSize(cols:rows:base:)`), per-window state in the `@Observable @MainActor DashboardController`
-  (`members: [DashboardMember]`/`highlighted: DashboardMember?`/`fontMode`/`appliedFontSize`) reached through
-  `DashboardControllerRegistry` — the exact `TerminalZoomController`/`TerminalZoomRegistry` precedent.
-  Validation is host-free in `ControlDispatcher.dispatchDashboard`:
-  `--close` takes no ids, `--mru`, or font flags, `--font-size` is mutually exclusive with `--auto-size`,
-  a `--font-size` must be finite and positive, an open needs at least one id OR `--mru`,
-  and `--mru` cannot be combined with explicit ids (but composes with the font flags + `--window`).
-  **The 9-cell cap is NO LONGER in the dispatcher** — the cell unit is a PANE now, so a split session
-  expands to two cells and the cap counts PANES, which needs the store; the dispatcher forwards ALL raw ids
-  untouched and the cap lives APP-SIDE.
-  The dispatcher routes to `ControlActions.setDashboard(targets:window:close:fontMode:mru:)`;
-  the app-side `ControlServer` resolves ids via `ControlTargetResolver` inside `args.window ?? frontmost`,
-  DEDUPS by resolved UUID, drops unresolved, then EXPANDS each resolved session IN ORDER into pane cells
-  (always its `.primary`; plus `.split` when `hasSplit`), CAPS the resulting PANE list to
-  `DashboardLayout.maxCells` (9) — so the drop counts panes, reported as
-  `dropped N pane(s) beyond the 9-cell limit` in `result.text`, APPENDED to any `unresolved: …` text with
-  `; ` (neither clobbers the other) — closes any active zoom (zoom ↔ dashboard are reciprocally exclusive),
-  and drives that window's controller.
-  `WindowContentView` reparents each cell's OWN pane surface (`.primary` → `\.surface`, `.split` →
-  `\.splitSurface`) via the generalized `dashboardHostsSurface` (both panes of a split member are claimed,
-  each yielding its deck slot's `Color.clear` placeholder).
-  `--mru` skips the id-resolution entirely: it takes the sessions from `AppStore.recentSessions(limit:)`
-  (host-free, on `AppStore+Recency.swift` — the window's `sessionRecency.top(9, in:validIDs)`, most-recent
-  first, ≤ 9, fewer if fewer, stale/closed ids skipped) then expands + caps like the id path, erroring
-  `no recent sessions` on an empty window; the font flags still apply and nothing goes `unresolved`.
-  Enter (`selectDashboardMember`) selects the session, CLOSES the dashboard, then focuses the cell's EXACT
-  pane — the split pane via `focusSplitPane(_:wantSplit:true)` for a `.split` cell (mirroring
-  `revealActiveBlockedPane`'s `.right` branch), else the main pane; close-before-focus keeps the
-  `dashboardActive` focus guards from blocking it.
-  READ-BACK: FOUR `tree`-top-level fields (LIVE, `tree`-only like `zoomedSurface`) supplied to
-  `AppStore.controlTree(...)` as app-side closures reading the target window's controller through the registry —
-  `dashboardMembers` (PANE refs in grid order, `<session-id>:left`/`<session-id>:right` via
-  `DashboardMember.controlRef`, so a split session appears as both),
-  `dashboardHighlighted` (the highlighted cell's pane ref),
-  `dashboardFontSize` (the applied absolute size in points, nil = untouched),
-  and `dashboardFontMode` (`auto`/`fixed`/`untouched`).
-  `--mru` adds NO new read-back — the members it resolves ARE the existing `dashboardMembers`,
-  so a script reads back what it opened there (no tree field is owed for the mru intent itself).
-  Four-point keep-in-sync audit: (1) `case dashboard` + `ControlArgs.close`/`fontSize`/`autoSize`/`mru`
-  (ids reuse `targets`, window reuses `window`) + the four `ControlTree.dashboard*` fields in `ControlProtocol.swift`,
-  (2) the `.dashboard` dispatch arm (`dispatchDashboard`) → `ControlActions.setDashboard` (app-side
-  `ControlServer`) + the four read-back closures at the `controlTree` build site,
-  (3) the `dashboard` subcommand (`validate()`-guarded flag combos) in `agtermctlKit/MiscCommands.swift`,
-  (4) round-trip in `ControlProtocolTests` + dispatcher validation/routing in `ControlDispatcherTests`
-  (now asserting the dispatcher forwards ALL ids un-capped) + `DashboardLayoutTests`/`DashboardControllerTests`
-  (pane-cell open/move/highlight/reconcile, incl. a split member pruned when its split closes) +
-  `AppStoreTests` (the pane-ref read-back closures) + CLI mapping in `CommandsTests` + the e2e
-  `DashboardUITests` (incl. `testSplitSessionOpensTwoCellsAndEnterFocusesSplitPane`, which asserts the split
-  session's two `:left`/`:right` cells AND that Enter on the split cell flips the tree `splitFocused`).
-  The PANE expansion + the PANE cap + the dropped-pane text are app-side (`ControlServer.setDashboard`,
-  they need the store), build-verified + exercised by the e2e; the dispatcher no longer caps.
-  The `--mru` flag rides the same command with NO new command/read-back — its keep-in-sync is:
-  `ControlArgs.mru` (`ControlProtocol.swift`), the dispatcher `--mru` validation + routing
-  (`dispatchDashboard`, `--close`/id mutual-exclusion), the `mru:` param on `ControlActions.setDashboard`
-  + the app-side `AppStore.recentSessions(limit:)` lookup (`ControlServer`), the `--mru` CLI flag
-  (`MiscCommands.swift`), and its tests
-  (`AppStoreTests.recentSessions*`, `ControlProtocolTests` round-trip/omit, `ControlDispatcherTests`
-  `dashboardMru*`, `CommandsTests` `dashboardMru*`, and `DashboardUITests.testDashboardMruOpensRecentSessions`).
-  It is state-mutating-with-read-back EXEMPT: the resulting state IS `dashboardMembers`,
-  so no new tree field is owed.
-  See the `libghostty.md` dashboard note for the reparent/overlay/view-only + transient-font-override mechanics.
-  `pick.open` presents one caller-supplied, per-window native fuzzy picker and returns its globally unique id.
-  The wire request carries `ControlArgs.items` as 1 through 1,000 `{id,label,subtitle?}` records, optional `prompt`, `allowCustom`, `follow`, and the shared `window` selector.
-  Host-free validation in `ControlDispatcher.dispatchPickCommand` rejects an empty list, too many items, empty labels, duplicate ids, and control characters in labels or subtitles before it creates the `PendingPick`.
-  `ControlServer.openPick` resolves the target window's `PickController` through `PickRegistry`, rejects a second pending pick, and closes the built-in command palette only when the picker opens in the active window.
-  A background target stays background by default, while `follow` raises it and synchronizes `WindowLibrary.frontmostWindowID`.
-  `pick.result` requires the exact globally unique picker id and returns `pending`, `picked` with `id`/`label`/`index`, `custom` with `query`, or `cancelled`; without `window`, id lookup stays pinned to the owning window across frontmost changes.
-  `pick.cancel` uses the same id routing, cancels a pending picker, and succeeds without changing an already terminal result. An explicit `window` must match the live or close-retained pick's owner.
-  `ControlTree.pickPending` is the read-back, populated from the target window's controller and omitted when no picker is pending.
-  `WindowContentView` renders a pending pick through `CommandPalette(items:)`, and only one picker is mounted per window.
-  Selection, custom input, Esc, ⌘W, and window close resolve the request, with lifecycle exits mapping to `cancelled`.
-  App termination cancels picker state before socket shutdown, but a polling client can race process exit and receive a transport failure rather than the terminal result.
-  `PickController` keeps terminal results keyed by pick id (the 8 most recent), so a later picker in that window never erases an answer whose blocking caller has not polled it yet — the poll interval is 500 ms, which is long enough for the next `pick.open` to land.
-  `PickRegistry.unregister` moves a closed window's results into a 32-entry app-wide retention, so a poll following window teardown — including permanent window deletion — still reads them; both stores evict oldest-first and nothing else frees them.
-  The CLI group defaults to open, sniffs stdin as a JSON array when its first non-whitespace byte is `[`, and otherwise maps nonblank lines to items whose id equals the label.
-  Blocking `agtermctl pick` polls `pick.result` every 100 ms for the first second and every 500 ms afterward, prints the bare result JSON, and exits 0 for `picked`/`custom`, 2 for `cancelled`, or 1 for failures.
-  `--no-block` prints `{"id":"…"}`, while `pick result ID` and `pick cancel ID` expose the later one-shot operations with the same `--window` scope.
-  Keep-in-sync audit: `ControlProtocol.swift` owns the three cases, item/result types, args, and `pickPending`; `ControlDispatcher+Pick.swift` owns validation and routing; `ControlServer+Pick.swift`, `PickController`, `PickRegistry`, and `WindowContentView` own app state and presentation; `MiscCommands.swift` and `SocketClient.swift` own CLI input, polling, output, and exit codes.
-  Tests cover protocol round trips, dispatcher validation, controller state, hosted window/focus/lifetime paths, CLI parsing and backoff, palette rows, tree read-back, and focused `ControlPickUITests`.
-  Mode-bearing commands (`session.split`/`quick`) compute the delta against current state so `on`/`off`/`show`/`hide`
-  are idempotent, and an unknown mode is an error.
-  `quick`'s visibility reads back on `ControlTree.quickVisible` at the tree TOP level — LIVE, resolved
-  app-side in `buildTree` from the projected window's `QuickTerminalController.isVisible` (the window id
-  found by store identity, `library.openIDs().first { library.store(for:) === store }`, since the quick
-  terminal is per-window); `tree`-only like `sidebarMode` (the GUI ⌃` toggle bypasses the command path, so
-  a cached `window.list` copy would go stale), so a script can make the `quick` toggle idempotent.
-  Threaded as a `quickVisible: () -> Bool?` closure on `AppStore.controlTree` (defaulting nil for host-free
-  tests), covered by `treeRoundTripsWithQuickVisible`/`treeOmitsQuickVisibleWhenNil` +
-  `AppStoreTests.controlTreeReportsQuickVisibleFromClosure`; the app-side `QuickTerminalRegistry` read is build-verified.
-  `quick.type`/`quick.text` are the input/read-back pair for the quick terminal, the twins of `session.type`/`session.text`
-  (the quick terminal is the one typing surface the socket couldn't reach before — issue #170).
-  Both are frontmost-window-only (no `--target`/`--window`/`--pane`; the quick terminal is a single per-window surface),
-  dispatcher-owned via `ControlActions.typeQuick(text:)` / `readQuickText(all:lines:)` (both `async`), and inject/read
-  through the same `GhosttySurfaceView.inject(text:)` / `readScreenText(all:lines:)` primitives the session commands use.
-  They are `async` because `quick show` flips `isVisible` before SwiftUI mounts + libghostty realizes the surface, so
-  a bounded main-actor poll (12×30 ms, the `session.type` realize-poll pattern) waits out the mount — `quick show; quick
-  type` back-to-back is reliable rather than racing.
-  Fast-fail when NOT racing: `quick terminal not open` when the overlay has never been shown (no surface AND not visible,
-  so the poll returns at once), `quick terminal not realized` / `failed to read surface buffer` if a shown surface never
-  comes up within the poll, `no open window` when there is no window.
-  A shown-then-hidden quick terminal keeps its surface alive, so it types/reads while hidden (like `session.type --pane
-  scratch`).
-  `quick.text` is the read-back for `quick.type` (there is no NEW tree-node field — you read via the sibling `text`
-  command, exactly as `session.text` reads back `session.type`).
-  Covered by the `quickType*`/`quickText*` `ControlDispatcherTests` + the e2e `testQuickTypeAndReadText`
-  (type a marker, read it back off the quick surface).
-  `session.status` flags a per-session agent status on the sidebar row — `args.status` is `idle`|`active`|`completed`|`blocked`
-  (`AgentStatus(rawValue:)` → an `invalid status` error on anything else),
-  `args.blink` pulses the glyph, and `args.autoReset` (status-agnostic, caller-set,
-  symmetrical with `blink`) makes it clear back to idle once the session is visited.
-  `args.sound` plays a ONE-SHOT sound when the status is applied (caller-driven,
-  NOT stored on `AgentIndicator` — `default`/`beep` = `NSSound.beep()`, any other value = the named system
-  sound via `NSSound(named:)`, which also resolves custom sounds in `~/Library/Sounds`);
-  it is validated UP-FRONT against the app-side `StatusSoundPlayer.shared` (a singleton that caches resolved
-  `NSSound`s so a short clip isn't cut off when the local goes out of scope — also reused by the Settings
-  picker preview), so an unknown name is an `unknown sound: X` error that leaves the status UNCHANGED,
-  and the fire is inside `resolveSession` so a bad target still errors `notFound` without playing.
-  When NO per-call `args.sound` is given and a session TRANSITIONS into `blocked`,
-  the user's **Settings ▸ Appearance ▸ Agent Status ▸ Blocked sound** (`AppSettings.blockedStatusSoundName`,
-  GUI-only, default None) plays as a best-effort default.
-  The transition is gated by a `wasBlocked` read of the session's current status BEFORE `setAgentIndicator`,
-  so a REPEATED `blocked` set does not replay the default (and an empty per-call `args.sound` counts
-  as unset); the precedence is the host-free `AgentStatus.effectiveSound(perCall:blockedDefault:)` (explicit
-  per-call wins; the default is blocked-only), with the transition gate itself in the server.
-  That setting is keep-in-sync EXEMPT like the status colors, since the per-status sound already has
-  full control coverage via `--sound`.
-  `args.color` (`#rrggbb`, REUSING the `session.background`/`session.overlay.open` field — no new arg —
-  validated by the shared `WatermarkConfig.isValidColorHex` in the dispatcher, an `invalid color (expected #rrggbb)`
-  error that leaves the status UNCHANGED) is a per-call glyph-tint OVERRIDE.
-  It rides the ephemeral `AgentIndicator` (`AgentIndicator.color`), so — because `setSessionStatus` builds
-  a fresh indicator every call — the next `session.status` without a color naturally DISCARDS it (no explicit
-  clear); nil renders the Settings-configured status color.
-  Both glyph render sites resolve it through the SHARED `GhosttyApp.statusColor(for:override:)` (a valid
-  hex wins, nil/malformed falls back to `statusColor(for:)`): the AppKit sidebar `StatusIconView` and the
-  SwiftUI attention-list `StatusGlyph` (`PaletteItem.statusColor`), so they can't drift.
-  It is keep-in-sync EXEMPT like the status colors/sound — the per-call color has full control coverage
-  via `--color` and no GUI setter (the Settings colors are the app-wide default, not a per-session tint).
-  Setting a non-idle status is control-driven (the hooks/agents call it;
-  no GUI sets active/completed/blocked), but clearing to idle ALSO has a GUI — the **Clear Status** action
-  (see the Agent-status glyph note) — so the idle case is keep-in-sync covered by `session.status idle`.
-  Cross-window via the shared `resolveSession` (the install's Stop hook targets its own `$AGTERM_SESSION_ID`,
-  which may live in a non-frontmost window).
-  The arm (`setSessionStatus`) builds an `AgentIndicator{status, blink, autoReset, color}` (host-free,
-  ephemeral — never in `SessionSnapshot`) and drives the single `AppStore.setAgentIndicator(_:forSession:)`
-  mutation point (unknown id = clean no-op), returning the id.
-  Four-point keep-in-sync audit for `session.status --color`: (1) `ControlArgs.color` (reused) +
-  `AgentIndicator.color` + `ControlSessionStatusUpdate.color` in `agtermCore`, the dispatcher hex-validation,
-  (2) the `.sessionStatus` arm threading `update.color` into the indicator + the two render sites via
-  `GhosttyApp.statusColor(for:override:)`, (3) the `session status --color` option (`validate()`-guarded)
-  in `agtermctlKit`, (4) round-trip in `ControlProtocolTests` + dispatcher validation in `ControlDispatcherTests`
-  + `AgentStatusTests` (indicator color + Equatable) + CLI mapping in `CommandsTests` + the e2e
-  `testSessionStatusColorValidatesHex` in `ControlSidebarStatusUITests` (asserts the command path — the
-  glyph TINT itself is not accessibility-observable).
-  `args.shape` is the SILHOUETTE twin of `--color`, a NEW arg (nothing else carries a shape) whose value
-  is a `StatusShape` raw name — `circle`|`square`|`triangle`|`diamond`|`capsule`|`star`.
-  The dispatcher parses it to the typed enum, so an unknown value is rejected BEFORE any mutation with
-  `invalid shape: <raw> (circle|square|triangle|diamond|capsule|star)`, the accepted list DERIVED from
-  `allCases` via `StatusShape.validNamesList` so the message can never go stale (the `agtermctl` CLI
-  pre-rejects the same value locally, phrasing it from the comma-joined `StatusShape.validNamesPhrase`,
-  which also builds its `--shape` help text — the `WatermarkConfig.validFits` precedent).
-  It rides the ephemeral `AgentIndicator.shape` exactly like `color`, so the next `session.status`
-  without a shape discards it and falls back to the Settings shape for that status, else the built-in
-  plain `circle`; a `--shape` on `idle` is accepted and ignored, since `AgentStatus.symbolName`'s leading
-  idle guard returns the empty string before the shape is consulted.
-  Both render sites resolve it through the SHARED host-free `AgentStatus.symbolName(override:configured:)`
-  (reached app-side via `GhosttyApp.statusSymbolName(for:override:)`, the tint helper's twin), so the
-  AppKit `StatusIconView` and the SwiftUI `StatusGlyph` can't drift.
-  It mirrors every leg `--color` already has — the indicator, the dispatcher validation, the `tree`
-  read-back, the Settings fallback, the `.status` CONTROL EVENT payload, and the CLI's own presentation of
-  that event (`ControlEventPayload.color` and `EventFormatter.human`'s `color=` arm both predate this
-  feature).
-  The event payload and its formatter arm are the easy ones to miss.
-  `ControlEventPayload.shape` carries the per-call value because `AppStore.setAgentIndicator`'s
-  `guard previous != indicator` admits a shape-only change, so an `events.read` consumer would otherwise
-  receive an event it could not explain.
-  `EventFormatter.human` (`agtermctlKit/EventCommands.swift`) then prints `shape=<name>` beside
-  `color=<hex>` on the `status` line, so `agtermctl events` without `--json` shows the same field the
-  payload carries — a wire field with no formatter arm is invisible to every human reader of the stream.
-  The Settings shapes get NO control command of their own — keep-in-sync EXEMPT like the status
-  colors/sound (see the Settings rule), since `--shape` is the control surface.
-  That exemption is only from the COMMAND obligation: the pickers are still a surface this feature owns,
-  which is why they are point (5) of the audit below.
-  READ-BACK: `ControlSessionNode.statusShape`, gated on the same non-idle condition as `status` and
-  reporting the PER-CALL OVERRIDE ONLY — nil when the glyph draws the Settings shape or the default —
-  exactly matching `statusColor`, so a record-then-restore script treats the two alike.
-  It adds an ARGUMENT, not a command, so the catalog count is unchanged.
-  Five-point keep-in-sync audit for `session.status --shape`: (1) the `StatusShape` enum +
-  `AgentIndicator.shape` + `ControlArgs.shape` + `ControlSessionStatusUpdate.shape` +
-  `ControlSessionNode.statusShape` + `ControlEventPayload.shape` + the three `AppSettings.*StatusShape`
-  raw fields with `effectiveStatusShape(for:)` in `agtermCore`, plus the dispatcher parse/validation,
-  (2) the `.sessionStatus` arm folding `update.shape` into the indicator + the `statusShape` population in
-  `AppStore.controlTree` + the `shape:` payload in `AppStore+Status.swift` + the `GhosttyApp` shape mirror
-  and the two render sites, (3) the `session status --shape` option (`validate()`-guarded) plus the
-  `EventFormatter.human` `shape=` arm in `agtermctlKit`, (4) the tests below — every name spelled in
-  FULL so each one greps, since an abbreviated `…Name` survives a rename silently:
-  round-trip in `ControlProtocolTests` (`sessionStatusRoundTripsWithShape` /
-  `sessionStatusOmitsShapeWhenNil` / `treeSessionNodeRoundTripsWithStatusShape` /
-  `treeSessionNodeOmitsStatusShapeWhenNil`) + dispatcher parse/validation in `ControlDispatcherTests`
-  (`sessionStatusCarriesEveryValidShape` / `sessionStatusForwardsShapeOnlyWhenTheArgIsPresent` /
-  `sessionStatusRejectsInvalidShapeWithoutMutating` / `sessionStatusAcceptsShapeOnIdle` /
-  `sessionStatusValidatesColorThenShapeThenPane`, which pins the color-then-shape-then-pane REJECTION
-  ORDER so a shape error can never mask a bad color) +
-  `AgentStatusTests` (the resolver precedence + `symbolName` + indicator Equatable) + `AppSettingsTests`
-  (tolerant decode) + `AppStoreTests` (`controlTreeReportsStatusShapeOnlyForAPerCallOverride` /
-  `controlTreeDropsStatusShapeOnTheNextSetWithoutOne`, the read-back's ephemerality) +
-  `AppStoreEventTests` (`shapeOnlyStatusChangeEmitsAnEventCarryingTheShape`) + CLI mapping in
-  `CommandsTests` (incl. `sessionStatusShapeHelpListsEveryShape`, which pins the `--shape` help text to
-  `StatusShape.allCases`) + the formatter arm in `EventCommandsTests`
-  (`formattersCoverEveryKindAndNDJSONIsOneBareEvent`) + the e2e
-  `testSessionStatusShapeValidatesAndReadsBack` in `ControlSidebarStatusUITests`,
-  (5) the Settings ▸ Agent Status shape pickers — GUI-only, no control command of their own (see the
-  Settings rule).
-  `args.pane` (`left`|`right`|`scratch`, REUSING the shared `--pane` addressing vocabulary — parsed to the
-  host-free `StatusPane` and validated by the dispatcher, an `--pane must be left, right, or scratch` error
-  that leaves the status UNCHANGED) records WHICH pane set the status onto the ephemeral `AgentIndicator.statusPane`
-  (nil/omitted is treated as `left` = the main pane).
-  It drives two consumers.
-  (1) Pane-scoped keystroke-clear: the main/split/scratch surface factories each wire `onUserInputClearsStatus`
-  to a closure that clears only when the host-free `AgentIndicator.clearedBy(pane:isInterrupt:)` says the keystroke's
-  OWN pane owns the current status, so a `right`- or `scratch`-tagged block SURVIVES foreground typing in the
-  main pane (see the Notifications rule).
-  (2) Pane-aware attention navigation: when status needs attention, auto-follow and every GUI selection path reveal and focus the tagged pane instead of always the main pane.
-  Those paths are attention-nav, plain session nav, the command palettes, a sidebar row, and a Dock-menu session row.
-  `AppStore.selectSession` and `navigateSession` return the pre-auto-reset indicator, and each caller passes it to the shared `AppActions.revealActiveBlockedPane(captured:)`.
-  That helper flips to a tagged split, shows a hidden tagged scratch, or explicitly targets the primary pane for left/nil.
-  IDLE and ACTIVE selections use ordinary focus and preserve the current pane.
-  The `session.go next-attention|prev-attention` control arm (`goSession`) only drives `AppStore.navigateSession`
-  and does NOT call the reveal, so the socket steps the selection but does not itself move focus into the pane
-  (see the Menu/actions rule).
-  It reads back on each `tree` node as `ControlSessionNode.statusPane` (omitted when nil, gated on the SAME
-  non-idle condition as `status` so an idle node reports neither).
-  The `--blink` flag and the `--color`/`--shape` overrides read back the same way —
-  `ControlSessionNode.statusBlink` (`true` when blinking, omitted otherwise), `statusColor` (the
-  `#rrggbb`, omitted when using the configured color) and `statusShape` (the `StatusShape` raw name,
-  omitted when using the configured shape), all populated in the tree builder gated on the SAME non-idle
-  condition — so a script can record the FULL status (state + pane + blink + color + shape) and restore it.
-  Four-point keep-in-sync audit for `session.status --pane`: (1) the `StatusPane` enum + `AgentIndicator.statusPane`
-  + `AgentIndicator.clearedBy(pane:isInterrupt:)` + `ControlSessionStatusUpdate.pane` + `ControlSessionNode.statusPane`
-  + `SurfaceEnvironment.session(pane:)` (injects `AGTERM_PANE`) in `agtermCore`, plus the dispatcher `StatusPane`
-  parse/validation, (2) the `.sessionStatus` arm threading `update.pane` into the indicator + the per-factory
-  `AGTERM_PANE` env + the pane-scoped keystroke-clear closures + the `revealActiveBlockedPane` nav step,
-  (3) the `session status --pane` option (`validatePaneArgument`-guarded) + the hook wrapper forwarding
-  `$AGTERM_PANE` as `--pane`, (4) round-trip in `ControlProtocolTests` + dispatcher validation in `ControlDispatcherTests`
-  + `AgentStatusTests` (the `clearedBy` truth table) + `SurfaceEnvironmentTests` + `AgentStatusWrapperTests`
-  + CLI mapping in `CommandsTests` + the e2e in `PaneAwareStatusUITests`.
-  It is control-native for the tag itself (no GUI sets a pane), the same keep-in-sync footing as `--color`/`--sound`.
-  `session.status --pane-id <token>` is the robust companion to `--pane`, added for #199:
-  the baked `AGTERM_PANE` role goes STALE when a split survivor is promoted into the main pane and the
-  session is then re-split — both the promoted agent (baked `right`) and the fresh helper (baked `right`)
-  emit `--pane right` with `hasSplit == true`, so the `setAgentIndicator` `!hasSplit` coercion cannot tell
-  them apart and the block lands on the wrong pane.
-  The fix bakes a STABLE per-surface token (`AGTERM_PANE_ID`, distinct from the mutable role) that the hook
-  forwards as `--pane-id`; the app resolves it against the session's LIVE surfaces
-  (`Session.paneRole(forToken:)` — `.left`/`.right`/`.scratch` from which slot currently holds the matching
-  `TerminalSurface.paneToken`) and lets it OVERRIDE the stale `--pane`, falling back to `--pane` when the
-  token is absent or unknown (older shells, a torn-down surface).
-  This makes the status-SET path resolve the pane the same way the keystroke-clear already does via the
-  live `GhosttySurfaceView.isSplitPane` (see [[notifications]]) — a per-surface token is irreducibly
-  required because the role alone is degenerate once both live surfaces are baked `right`.
-  It carries NO new read-back — `--pane-id` is alternative ADDRESSING for the same `statusPane` state
-  (the RESOLVED role reads back on `ControlSessionNode.statusPane`), the `session.type --pane` pattern.
-  Keep-in-sync: (1) `ControlArgs.paneID` + `ControlSessionStatusUpdate.paneID` + `Session.paneRole(forToken:)`
-  + `TerminalSurface.paneToken` + `SurfaceEnvironment.session(paneToken:)` (injects `AGTERM_PANE_ID`) in
-  `agtermCore`, plus the dispatcher threading `paneID` un-validated (opaque token), (2) the `.sessionStatus`
-  arm resolving `update.paneID` to the live role in `setSessionStatus` + `GhosttySurfaceView.paneToken`
-  (computed from the baked env) + `surfaceEnv` generating a fresh token per session-owned pane,
-  (3) the `session status --pane-id` option + the hook wrapper forwarding `$AGTERM_PANE_ID`,
-  (4) round-trip in `ControlProtocolTests` + dispatcher threading in `ControlDispatcherTests` +
-  `SessionTests` (`paneRole` resolver, incl. the promote + re-split case) + `SurfaceEnvironmentTests`
-  (`AGTERM_PANE_ID` bake) + `AgentStatusWrapperTests` (`--pane-id` forwarding) + CLI mapping in `CommandsTests`
-  + the e2e `testPaneIDOverridesStaleRoleThenFallsBack` in `PaneAwareStatusUITests` (reads the pane's real
-  `$AGTERM_PANE_ID` and proves override + fallback).
-  Visibility is keep-state vs one-time, decided by `autoReset` alone: `AppStore.selectSession` resets
-  an `autoReset` indicator (the `completed` flash) to idle on BOTH the session visited AND the one left
-  (right after `clearUnseen`), so it never lingers on a row you switch away from,
-  and leaves a non-`autoReset` one untouched.
-  The glyph is NOT gated by selection — it shows on every non-idle session,
-  the selected one included (see below).
-  `keymap.reload` re-reads `keymap.conf` and returns the parse-diagnostic count in `result.count` (0
-  reads as a clean reload; `agtermctl keymap reload` prints `ok` then, else `N diagnostic(s)`).
-  It is the SAME `SettingsModel.reloadKeymap()` path the GUI's File ▸ Reload Keymap menu/palette item
-  drives, so the GUI half and the control half can't diverge — control-native only in the count it reports
-  back; no `--window` selector (the keymap is app-global — a single app-wide `SettingsModel`,
-  constructed once in `agtermApp.init` and shared with `ControlServer`).
-  Four-point keep-in-sync audit for `keymap.reload`: (1) `case keymapReload = "keymap.reload"` in `ControlProtocol.swift`
-  (returns the new `ControlResult.count: Int?`, no target/args), (2) the `.keymapReload` dispatch arm
-  in `ControlServer`, (3) the `keymap reload` subcommand in `agtermctlKit`,
-  (4) round-trip tests in `ControlProtocolTests` plus the e2e in `ControlAPIUITests`.
-  See the Keymap section for the parser/menu/monitor design.
-  `keymap.list` is `keymap.reload`'s READ side, and it reports TWO things that can disagree:
-  `result.keymap.actions` is every `BuiltinAction` with the chord the keymap RESOLVED for it (kitty
-  syntax, `overridden: true` when a `map` moved it off its default, keyless actions listed with no
-  chord), while `result.keymap.menu` is what the menu bar is actually DISPATCHING — every live
-  `NSMenuItem` key equivalent, with its menu, title and Objective-C selector.
-  The menu half is the point: SwiftUI defers its menu rebuild to the next app activation and resolves a
-  chord collision by unbinding agterm's own item, so a chord can be correct in `actions` and wrong in
-  `menu`, and a model-only listing would report a clean keymap while ⌘W closes the window.
-  Also carries `path` (which `keymap.conf` produced it), `commands` (custom commands, `shortcut` omitted
-  for a palette-only one), and `diagnostics` (line + message — `keymap.reload` returns only their COUNT).
-  App-global like `keymap.reload`, so no `--window` selector, and it takes no target or args.
-  The projection is host-free (`ControlKeymap.project`, `agtermCore/ControlKeymap.swift`); only the live
-  `menu` is app-side, since `NSApp.mainMenu` is AppKit.
-  Menu chords are rendered through the host-free `namedKey(forKeyEquivalent:)` (the character twin of
-  `namedKey(forKeyCode:)`) so an arrow or return prints `cmd+opt+up`, not `cmd+opt+` with the key
-  missing — without it the two lists cannot be compared, which is the command's whole job.
-  The globe/fn modifier renders as `fn+` even though the grammar has no such modifier: this section
-  reports reality, and dropping it would print AppKit's own fn-modified items as bare unmodified keys.
-  Four-point keep-in-sync audit for `keymap.list`: (1) `case keymapList = "keymap.list"` +
-  `ControlResult.keymap` + the `ControlKeymap`/`ControlKeymapAction`/`ControlKeymapCommand`/
-  `ControlKeymapDiagnostic`/`ControlKeymapMenuItem` types in `agtermCore`, (2) the `.keymapList`
-  dispatcher arm → `ControlActions.listKeymap` (app-side `ControlServer+AppCommands`, which supplies
-  `liveMenuKeyEquivalents()`), (3) the `keymap list` subcommand in `agtermctlKit` + `SocketClient.formatKeymap`,
-  (4) `ControlKeymapTests` (projection + round-trip) + `KeybindTests` (the character map pinned against
-  `bindableNamedKeys`) + `ControlDispatcherTests` (routing) + `CommandsTests` (CLI mapping) +
-  `SocketClientTests` (rendering) + the e2e `testKeymapListReportsResolvedChordsAndLiveMenu`.
-  `config.reload` re-reads the agterm-scoped `ghostty.conf` and returns the ghostty config-diagnostic
-  count in `result.count` (0 reads as a clean reload; `agtermctl config reload` prints `ok` then,
-  else `N diagnostic(s)`).
-  It is the SAME `AppActions.reloadGhosttyConfig()` path the GUI's File ▸ Reload Config menu/palette
-  item + the Edit-ghostty overlay close drive (which posts the warning banner on a malformed file),
-  so the GUI half and the control half can't diverge — control-native only in the count it reports back;
-  no `--window` selector (the config is app-global — one `SettingsModel` + one `GhosttyApp`,
-  shared with `ControlServer`).
-  The arm calls `actions.reloadGhosttyConfig()` then returns `GhosttyApp.shared.lastConfigDiagnosticsCount`.
-  Four-point keep-in-sync audit for `config.reload`: (1) `case configReload = "config.reload"` in `ControlProtocol.swift`
-  (reuses `ControlResult.count`, no target/args), (2) the `.configReload` dispatch arm (`reloadGhosttyConfig`)
-  in `ControlServer`, (3) the `config reload` subcommand in `agtermctlKit`,
-  (4) round-trip tests in `ControlProtocolTests` plus the e2e in `ControlAPIUITests`.
-  See the Settings section for the config layer + Edit/Reload.
-  `sidebar` (mode `show`|`hide`|`toggle`, default toggle, frontmost window — mirrors `quick`,
-  delta-computed so it's idempotent, unknown mode + no-open-window are errors) shows/hides the custom-split
-  sidebar — the per-window `AppStore.sidebarVisible` (persisted per-window in `Snapshot`,
-  restored on relaunch alongside `AppStore.sidebarWidth`; `toggleSidebar`/`setSidebar` call `save()`;
-  the custom split replaced `NavigationSplitView`, so there is no system toggle).
-  `AppActions.toggleSidebar()` flips `library.activeStore?.sidebarVisible` and `WindowContentView` animates
-  it (`splitRoot`'s `.animation(value:)`, so every caller animates uniformly — the toolbar button no
-  longer wraps its own `withAnimation`); shared by the title-bar `sidebar-toggle-button`,
-  View ▸ Show/Hide Sidebar, the ⌃⇧P palette "Toggle Sidebar", and the ⌃⌘S keymap action (`BuiltinAction.toggleSidebar`,
-  expressible so pure-`defaultChord`-driven).
-  Four-point keep-in-sync audit: (1) `case sidebar` in `ControlProtocol.swift` (reuses `ControlArgs.mode`),
-  (2) the `.sidebar` dispatch arm (`setSidebarVisibility`) in `ControlServer`, (3) the `sidebar` subcommand in
-  `agtermctlKit`, (4) round-trip in `ControlProtocolTests` + the e2e `testSidebarShowHideToggle` (sidebar
-  hide removes the `session-row`s from the AX tree) in `ControlSidebarStatusUITests`.
-  `theme.set` sets + persists a theme (see the Theme picker section) PER SLOT, mirroring the two Settings pickers over the shared `SettingsModel.setLightTheme`/`setDarkTheme`/`setSystemThemes`.
-  `args.name` (alias `args.light`; both together is an error) sets the light/single `theme` slot,
-  KEEPING the `darkTheme` slot if one is set (they are separate fields, no recompose);
-  nil/empty = ghostty's built-in / "default ghostty" (NOT the seeded `agterm` app default),
-  and a bare `theme set` clears BOTH slots + turns syncing off.
-  `args.dark` sets the `darkTheme` slot alone and turns appearance syncing ON (`followSystemAppearance`,
-  the light side seeds from the current theme, else `Builtin Light`);
-  the reserved value `none` clears the dark slot (syncing off, the light side survives as the plain theme).
-  The `.themes` palette commit maps to the CURRENT appearance's slot (NO live preview over the socket — preview is interactive-only).
-  An unknown name (not in `SettingsCatalog.themeNames()`) is an `unknown theme: X` error (a typo silently
-  doing nothing is worse than a fail); the response always echoes the full post-change state
-  (`result.theme`/`sync`/`light`/`dark`).
-  `theme.list` returns `result.themes` = the bundled names + `result.theme` = the plain current one (nil =
-  ghostty built-in; absent on a fresh install means the seeded `agterm` is current) + `result.sync`/`light`/`dark`;
-  while syncing `result.theme` is ABSENT — the state rides the three sync fields.
-  `agtermctl theme list` prints one name per line with a leading "default ghostty" row,
-  the active marked `* ` (both sides + a header while syncing), and `theme.set` prints `ok` (non-create mutation).
-  App-global like `keymap.reload` (one `SettingsModel`), so NO `--window` selector.
-  Four-point keep-in-sync audit: (1) `case themeSet = "theme.set"` + `case themeList = "theme.list"`
-  in `ControlProtocol.swift` (reuse `ControlArgs.name`; add `ControlResult.theme`/`themes`),
-  (2) the `.themeSet` (`setTheme`, with name validation) + `.themeList` dispatch arms in `ControlServer`,
-  (3) the `theme set [name] [--light] [--dark]` / `theme list` subcommands in `agtermctlKit` (+ `SocketClient.formatThemes`),
-  (4) round-trip in `ControlProtocolTests` + the e2e `testThemeListAndSet` in `ControlAPIUITests` and `testThemeSyncWithSystemAppearance` in `ControlAPIThemeUITests`.
-  See the Theme picker section for the GUI/preview half.
-  `session.flag` (target = session) flags/unflags a session for the flagged working-set view — `args.mode`
-  is `on`|`off`|`toggle`|`clear` (`clear` IGNORES the target and unflags every session in the resolved
-  store via `AppStore.clearFlags()`, mirroring `session.scratch`/`session.split`'s mode-bearing shape),
-  drives `AppStore.setFlag(_:forSession:)` (idempotent — no-op + no save when unchanged),
-  surfaces the `flagged` bool on `ControlSessionNode` in the `tree` builder,
-  and returns the session id; an unknown mode is an error.
-  It is the control half of the row context-menu Flag/Unflag + the View-menu/palette Flag Session/Clear
-  Flagged.
-  Pair with `sidebar.mode flagged` to view just the flagged sessions.
-  Four-point keep-in-sync audit for `session.flag`: (1) `case sessionFlag = "session.flag"` in `ControlProtocol.swift`
-  (reuses `ControlArgs.mode`; adds `flagged` to `ControlSessionNode`), (2) the `.sessionFlag` dispatch
-  arm (`setSessionFlag`) in `ControlServer`, (3) the `session flag on|off|toggle|clear` subcommand (`FlagCommand`)
-  in `agtermctlKit`, (4) round-trip in `ControlProtocolTests` + the e2e `testSessionFlagAndSidebarModeFlagged`
-  in `ControlSidebarStatusUITests`.
-  `session.seen` (target = session) clears a session's unseen-notification badge WITHOUT changing the
-  selection, focus, or agent status — the focus-free counterpart to `notify`, which raises the badge over
-  the socket while the only clear paths (`AppStore.selectSession`, a pane's `onFocusChange(true)`) are
-  both focus-coupled.
-  It drives the already-public `AppStore.clearUnseen(_:)` (the same primitive `selectSession` calls),
-  so it is idempotent (a no-op when already zero; the count is ephemeral, absent from `SessionSnapshot`,
-  so it triggers no save) and returns the session id; NO args beyond target/window (leaner than `session.flag`
-  — no mode).
-  It is control-NATIVE (no GUI/menu equivalent — visiting the session is the GUI's only "mark seen", and
-  it is inseparable from selecting) — the same footing as `notify`/`session.type`/`session.copy`.
-  The read side is the new `unseen` field on `ControlSessionNode` (the `session.unseenCount`, populated
-  in the `tree` builder, omitted when zero), so a script can query the count and clear it symmetrically.
-  Four-point keep-in-sync audit for `session.seen`: (1) `case sessionSeen = "session.seen"` +
-  `unseen: Int?` on `ControlSessionNode` in `ControlProtocol.swift` (no new `ControlArgs` field),
-  (2) the `.sessionSeen` dispatch arm (`markSessionSeen`) in `ControlDispatcher`/`ControlServer` + the
-  `unseen` population in `AppStore.controlTree`, (3) the `session seen` subcommand (`Seen`) in `agtermctlKit`,
-  (4) round-trip (`sessionSeenRoundTrips` + `treeSessionNodeRoundTripsWithUnseen`/`…OmitsUnseenWhenNil`)
-  in `ControlProtocolTests` + dispatcher routing in `ControlDispatcherTests` + `AppStoreTests`
-  (`controlTreeReportsUnseenCountWhenPositive`/`…OmitsUnseenCountWhenZero`) + CLI mapping in `CommandsTests`
-  + the e2e `testSessionSeenClearsBadgeWithoutFocus` in `ControlSidebarStatusUITests`.
-  `sidebar.mode` (frontmost window) flips the sidebar VIEW between the workspace tree and the flat flagged
-  working-set list — `args.mode` is `tree`|`flagged`|`toggle` (delta-computed against `AppStore.sidebarMode`
-  so it's idempotent, unknown mode = error), drives `setSidebarViewMode` → `AppStore.setSidebarMode`.
-  It is the control half of the bottom-bar `flagged-view-toggle` + the View-menu Show Flagged/Show All
-  + `BuiltinAction.toggleFlaggedView`; the existing `sidebar [show|hide|toggle]` is now the default `sidebar visibility`
-  subcommand alongside `sidebar mode`.
-  Its READ side is `ControlTree.sidebarMode` at the tree TOP level (`AppStore.sidebarMode.rawValue`,
-  `tree`|`flagged`), the read side of this write-only command so a script can record and restore the view
-  mode — the sibling of `sidebarVisible`, except `tree`-ONLY (not mirrored onto the cached `window.list`,
-  since the GUI `flagged-view-toggle` bypasses the command path and would leave a cached copy stale).
-  Four-point keep-in-sync audit: (1) `case sidebarMode = "sidebar.mode"` in `ControlProtocol.swift` (reuses
-  `ControlArgs.mode`), (2) the `.sidebarMode` dispatch arm (`setSidebarViewMode`) in `ControlServer`,
-  (3) the `sidebar mode tree|flagged|toggle` subcommand (`Mode`, alongside the `Visibility` default)
-  in `agtermctlKit`, (4) round-trip in `ControlProtocolTests` + the e2e `testSessionFlagAndSidebarModeFlagged`
-  in `ControlSidebarStatusUITests`.
-  `sidebar.expand`/`sidebar.collapse` expand every workspace / collapse all but the active one in a window's
-  sidebar TREE — `expand` drives `AppActions.expandAllWorkspaces(in:)`, `collapse` drives `collapseOtherWorkspaces(in:)`
-  (collapse keeps the ACTIVE session's workspace expanded and scrolls its row into view).
-  UNLIKE `sidebar`/`sidebar.mode` (frontmost-only, no selector), these honor the global `--window` selector
-  (`ControlArgs.window`): the arm resolves the target store via `resolvePlacementStore(window)` (frontmost
-  by default; a named window must be OPEN, else the closed-window error;
-  no open window at all → `no open window`), then posts a notification (`.agtermExpandWorkspaces`/`.agtermCollapseWorkspaces`)
-  carrying THAT `AppStore` as the object.
-  `WorkspaceSidebar.Coordinator` registers its observer with `object: store`,
-  so NotificationCenter delivers ONLY to that window's sidebar Coordinator — this object-scoping (the
-  rename notifications self-scope via the selected-session guard; expand/collapse have no such natural
-  guard) is exactly what lets the control path target a specific (even background) window while the GUI
-  menu/palette use the frontmost.
-  A graceful no-op in `flagged` mode (no workspace rows: `expandWorkspacesNotified` gates on tree mode,
-  `collapseOthers` gates internally); idempotent.
-  GUI half (frontmost only): View ▸ Expand/Collapse Workspaces (plain keyless items,
-  disabled with no active store or in flagged mode) + the ⌃⇧P palette "Expand Workspaces"/"Collapse Workspaces"
-  (tree-mode only).
-  Four-point keep-in-sync audit: (1) `case sidebarExpand = "sidebar.expand"` + `case sidebarCollapse = "sidebar.collapse"`
-  in `ControlProtocol.swift` (reuse `ControlArgs.window`, no new field),
-  (2) the `.sidebarExpand`/`.sidebarCollapse` dispatch arms (`expandSidebar(window:)`/`collapseSidebar(window:)`)
-  in `ControlServer`, (3) the `sidebar expand`/`sidebar collapse` subcommands (`Expand`/`Collapse` on
-  `ClientOptions` for `--window`, alongside the `Visibility` default + `Mode`) in `agtermctlKit`,
-  (4) round-trip (incl. the windowed variant) in `ControlProtocolTests` + the e2e `testSidebarExpandCollapse`
-  in `ControlSidebarStatusUITests`.
-  `workspace.focus` (target = workspace) MARKS a workspace in the sidebar focus SET — the filter is a
-  `Set<UUID>` of marked workspaces plus a separate on/off flag, not a single id (see the Sidebar section).
-  `args.mode` is `on`|`off`|`toggle`|`add`, parsed into the typed `ControlWorkspaceFocusMode` by
-  `ControlDispatcher` BEFORE the host runs, so an unknown mode is rejected without half-applying and the
-  accepted list in the message derives from `allCases` and cannot go stale:
-  - `on` — replace the set with the target and ENABLE the filter (the unchanged single-workspace zoom).
-  - `off` — remove the target from the set, disabling once the set empties; a no-op when it was never marked.
-  - `toggle` — replace-toggle: clears when the target is the ONLY marked workspace and the filter is on,
-    else replaces the set with it and enables.
-  - `add` — insert the target alongside the existing members and leave the filter FLAG EXACTLY AS IT WAS.
-    An `add` NEVER turns the filter on.
-    That is deliberate, not an omission: an add that enabled would collapse the tree onto the first marked
-    workspace and hide the rows the next `add` needs, so a set is built with repeated `add` calls and
-    applied ONCE with `workspace.filter on`.
-  There is deliberately no membership-TOGGLE mode — the row menu's membership item computes its own
-  direction from what it just read and maps to `add` or `off`, so a fifth mode would be dead weight.
-  Drives `focusWorkspace` → `AppStore.setFocusedWorkspace` (`on`/`toggle`) or `setFocusMembership`
-  (`add`/`off`), honors the global `--window` selector, and returns the workspace id.
-  Both store mutators it drives are delta-guarded, so every mode is idempotent.
-  Per-window + persisted, orthogonal to `sidebar.mode` (the flat flagged list ignores focus);
-  selecting a session outside the marked set DISABLES the filter while KEEPING the set (see the Sidebar section).
-  It is the control half of the workspace-row Focus/Unfocus + Add to/Remove from Focus,
-  `BuiltinAction.focusWorkspace`/`focusActiveWorkspace`, and the Add Workspace to Focus menu/palette item.
-  The menu's Clear Focus has NO single-command equivalent — it empties the WHOLE set, which over the socket
-  is one `workspace.focus off` per member (`workspace.filter off` only SUSPENDS the set, keeping it);
-  that is deliberate, since the set is the thing scripts want to build and restore, not discard.
-  Its READ side is `ControlWorkspaceNode.focused` on each `tree` workspace node
-  (`focusedWorkspaceIDs.contains(workspace.id) ? true : nil` in the tree builder — DISTINCT from `active`,
-  the selected workspace), which now means "is a MEMBER of the marked set" and is reported INDEPENDENTLY of
-  the filter flag: a workspace ROW is VISIBLE iff
-  `tree.sidebarVisible && tree.sidebarMode == "tree" && (!tree.workspaceFilter || focused)`.
-  All THREE terms are load-bearing, and every shorter form the docs have carried was wrong in a reachable
-  state.
-  `focused && workspaceFilter` reports nothing visible whenever the filter is OFF — where the whole tree
-  renders regardless of membership — and a script that "fixes" that with `workspace.focus on` REPLACES the
-  whole marked set and applies the filter, destroying the working set this feature exists to protect.
-  A bare `!workspaceFilter || focused` reports rows visible in `flagged` sidebar mode (a flat
-  flagged-session list with NO workspace rows at all) and behind a hidden sidebar.
-  State the predicate by ENUMERATING the states rather than patching the formula: sidebar hidden → nothing;
-  `flagged` → no workspace rows whatever the filter says; `tree` + filter off → every workspace;
-  `tree` + filter on → the members only.
-  The filter-ON term is exact rather than approximate because `enabled + empty` is unrepresentable (three
-  guards in the store, see the Sidebar section), so an applied filter always has at least one visible
-  member and a script can record the whole working set and restore it;
-  omitted on the unmarked ones and absent when nothing is marked.
-  Four-point keep-in-sync audit: (1) `case workspaceFocus = "workspace.focus"` in `ControlProtocol.swift`
-  (reuses `ControlArgs.mode`) + `ControlWorkspaceFocusMode` in `ControlModes.swift`, (2) the `.workspaceFocus`
-  dispatch arm parsing the mode + `ControlActions.focusWorkspace(_:window:mode:)` (typed `ControlWorkspaceFocusMode`,
-  NOT a raw `String?`) implemented in `ControlServer+WorkspaceCommands.swift`, whose whole mode-to-mutator
-  mapping is the host-free `AppStore.applyFocusMode(_:to:)` so the arm is left with target resolution alone
-  (and so the GUI's replace-toggle and the wire's `toggle` cannot mean different things),
-  (3) the `workspace focus on|off|toggle|add` subcommand (`Focus`) in `agtermctlKit`, whose abstract,
-  per-mode `--help` prose (`helpPhrase`/`helpSummary`, which state each mode's effect on the FILTER FLAG,
-  not just its effect on the set) and local `validate()` message are ALL derived from
-  `ControlWorkspaceFocusMode.allCases`,
-  (4) round-trip in `ControlProtocolTests`, mode routing + rejection in `ControlDispatcherWorkspaceTests`,
-  the four modes' behavior driven through the dispatcher against a live store in
-  `AppStoreFocusTests.workspaceFocusModesDriveTheStoreThroughTheControlPath`,
-  CLI mapping/help in `CommandsTests`, and the e2e `testWorkspaceFocusHidesOtherWorkspaces` +
-  `testWorkspaceFocusAddBuildsAMultiWorkspaceSet` in `ControlSidebarStatusUITests` plus the
-  `FocusWorkspaceUITests` XCUITest.
-  `workspace.filter` (NO target — window-scoped) applies or suspends that marked set WITHOUT touching it,
-  so peeking at the whole tree and coming back costs one call each way.
-  `args.mode` is `on`|`off`|`toggle` through the SHARED `ControlToggleMode.parse` the `sidebar` command
-  already uses (default `toggle`, unknown mode = error); note the wire tokens are `on|off|toggle`, NOT
-  `sidebar`'s `show|hide|toggle` spelling.
-  It resolves the target store via `resolvePlacementStore(window)` — so like `sidebar.expand`/`sidebar.collapse`
-  it can drive a BACKGROUND window, unlike the frontmost-only `sidebar`/`sidebar.mode` — and calls the
-  host-free `AppStore.applyWorkspaceFilter` (→ `setFocusEnabled`), which is delta-guarded and REFUSES to
-  enable an empty set.
-  So `workspace.filter on` with nothing marked succeeds having changed nothing, which is what keeps the
-  filter term of the row-visibility contract from ever lying.
-  No open window is an error rather than a silent no-op.
-  **`workspace.filter`, `workspace.focus`, `sidebar.mode` AND `session.flag` all carry a SELECTION side
-  effect**: when the visible set no longer holds the window's active session, the store moves the selection
-  to the most recent session still visible (`reselectIfSelectionHidden`, see [[sidebar]]).
-  That includes a command that GROWS the set and repairs an empty one — `workspace.focus add` of a populated
-  workspace while only session-less ones are marked, `session.flag on` into an empty flagged view.
-  `session.flag clear` never does (it empties the list), and neither does `session.new --no-select`, which
-  keeps its promise instead.
-  Read back off `ControlSessionNode.active`; no new field.
-  It is the control half of the bottom-bar `focus-filter-toggle`, the View-menu Toggle Workspace Filter,
-  and `BuiltinAction.toggleWorkspaceFilter`.
-  Its READ side is the TOP-LEVEL `ControlTree.workspaceFilter` (`focusEnabled` in the tree builder, always
-  populated on an app-produced tree, matching `sidebarVisible`), LIVE and `tree`-only — the GUI toggle
-  bypasses the command path, so a cached `window.list` copy would go stale.
-  Four-point keep-in-sync audit: (1) `case workspaceFilter = "workspace.filter"` + `ControlTree.workspaceFilter`
-  in `ControlProtocol.swift` (reuses `ControlArgs.mode`/`ControlArgs.window`, no new args field),
-  (2) the `.workspaceFilter` dispatch arm + `ControlActions.setWorkspaceFilter(window:mode:)` implemented in
-  `ControlServer+WorkspaceCommands.swift`, (3) the `workspace filter on|off|toggle` subcommand (`Filter`) in
-  `agtermctlKit` — `ClientOptions` for `--window`, deliberately NO `TargetOptions`,
-  (4) request + tree round-trip (incl. `treeOmitsWorkspaceFilterWhenNil`) in `ControlProtocolTests`,
-  routing/default/rejection in `ControlDispatcherWorkspaceTests`, CLI mapping (incl.
-  `workspaceFilterTakesNoTarget`) in `CommandsTests`, the empty-set refusal driven through the dispatcher in
-  `AppStoreFocusTests.workspaceFilterOnAnEmptySetLeavesTheFilterOffThroughTheControlPath`, and the e2e
-  `testWorkspaceFilterTogglesWithoutLosingTheSet` +
-  `testWorkspaceFilterDrivesABackgroundWindow` (the `--window` leg — a MINIMIZED second window keeps the
-  seeded one frontmost, so an arm that ignored the selector would land on the wrong store) in
-  `ControlSidebarStatusUITests`.
-  The dispatcher tests drive BOTH arms against a live `AppStore` through `MockControlActions.focusStore`,
-  which calls the same `applyWorkspaceFilter`/`applyFocusMode` helpers the app-side arms call — a test
-  double must never re-derive a mode's semantics, or the test proves only that the double works.
-  `workspace.collapse`/`workspace.expand` (target = workspace) collapse/expand ONE workspace's subtree in
-  the sidebar tree — the per-workspace analogue of the all-workspace `sidebar.expand`/`sidebar.collapse`
-  (scope by prefix: `sidebar.*` acts on every workspace, `workspace.*` on the addressed one).
-  They resolve the workspace via `resolveWorkspace` (honoring the global `--window` selector), drive
-  `setWorkspaceExpansion` → `AppActions.setWorkspaceExpanded(_:expanded:in:)`, and return the workspace id.
-  Unlike the GUI (a row click drives `expandItem`/`collapseItem` directly, keep-in-sync EXEMPT), there is
-  no GUI caller — the row click is the only GUI path — so this is a control-only pair.
-  The app-side flow keeps the source-of-truth persist OUT of the view: `AppActions.setWorkspaceExpanded(_:expanded:in:)`
-  writes `AppStore.setWorkspaceExpanded` (delta-guarded) FIRST, THEN posts `.agtermSetWorkspaceExpanded`
-  carrying the target `AppStore` as the object + the workspace id/desired-state in `userInfo`.
-  The persist must NOT ride the notification alone: `WindowContentView` mounts `WorkspaceSidebar` only
-  while `sidebarVisible`, so with the sidebar HIDDEN the Coordinator is torn down (its `.agtermSetWorkspaceExpanded`
-  observer removed in `isolated deinit`) and a notification-only write would silently drop, leaving the
-  `collapsed` read-back stale while the command still returns `ok` — the record-then-restore/toggle
-  contract the feature exists for.
-  So `WorkspaceSidebar.Coordinator.setWorkspaceExpandedNotified` is VIEW-SYNC ONLY: it keeps the tracked
-  `expandedWorkspaceIDs` in step — so the intent survives a collapsed/focused-away/flagged row and a
-  transient focus force-reveal — and drives the live outline row with `suppressExpansionPersist` when it
-  is on screen (tree mode, row resolved).
-  This mirrors `workspace.focus` (persists `setFocusedWorkspace` in the arm) and `session.resize`
-  (persists `applySplitRatio` in the arm, posts only to move the live divider).
-  Idempotent.
-  Its READ side is `ControlWorkspaceNode.collapsed` (`workspace.isExpanded ? nil : true` in the tree
-  builder, mirroring the persisted `WorkspaceSnapshot.collapsed`): `true` when collapsed, omitted when
-  expanded, so a script can record a workspace's open/closed state, restore it, or toggle by reading it first.
-  `workspace.new` gains a `--collapsed` flag (`ControlArgs.collapsed`, threaded into `AppStore.addWorkspace(name:collapsed:)`
-  → `Workspace(isExpanded: !collapsed)`): a runtime-added workspace with `isExpanded == false` renders
-  collapsed (the reconcile's `formUnion(filter(\.isExpanded))` excludes it), so it can be built and filled
-  with `session.new --no-select` without opening.
-  It ALSO threads `revealNewWorkspace: !collapsed`, so a `--collapsed` create stays OUT of the workspace
-  focus set: the flag means "build this quietly", and joining a marked set would put the workspace on
-  screen and mutate a working set the script did not ask to change (the same reasoning as
-  `session.new --no-select --create-workspace`).
-  A PLAIN `workspace.new` keeps the auto-reveal, matching the GUI's New Workspace button — a foreground
-  create must not land invisibly behind an applied filter.
-  Four-point keep-in-sync audit: (1) `case workspaceCollapse = "workspace.collapse"` + `case workspaceExpand = "workspace.expand"`
-  + `ControlArgs.collapsed` + `ControlWorkspaceNode.collapsed` in `ControlProtocol.swift`,
-  (2) the `.workspaceCollapse`/`.workspaceExpand` dispatch arms → `ControlActions.setWorkspaceExpansion`
-  (+ `createWorkspace(…collapsed:)`) in `ControlServer+WorkspaceCommands.swift`, the app-side
-  `AppActions.setWorkspaceExpanded(_:expanded:in:)` + `WorkspaceSidebar.Coordinator.setWorkspaceExpandedNotified`
-  (+ the `.agtermSetWorkspaceExpanded` name + the two userInfo keys) + the `collapsed` population in
-  `AppStore.controlTree`, (3) the `workspace collapse`/`workspace expand` subcommands + `workspace new --collapsed`
-  in `agtermctlKit`, (4) round-trip + omit-when-nil + raw-string decode in `ControlProtocolTests`,
-  dispatcher routing in `ControlDispatcherTests`, CLI mapping in `CommandsTests`,
-  `AppStoreTests.controlTreeReportsCollapsedWorkspace` + `AppStoreOrganizationTests.newWorkspaceCollapsedStartsCollapsed`,
-  and the e2e `testWorkspaceCollapseAndExpand` + `testWorkspaceNewCollapsedStaysClosedWhenFilled` in
-  `ControlSidebarStatusUITests`.
-  The workspace-command adapter arms (create/select/rename/delete/move/focus + this pair + the all-workspace
-  `expandWorkspaces`/`collapseWorkspaces` helpers) live in `ControlServer+WorkspaceCommands.swift`, split
-  out of `ControlServer+SessionActions.swift` (the `+WindowCommands.swift` family-split precedent) to keep
-  that file under the 1000-line limit; they still satisfy the `ControlActions` conformance declared there.
-  `tree` now also surfaces, on each `ControlSessionNode`, `foreground`/`splitForeground` — the LIVE foreground-process
-  argv of the main + split panes (nil/omitted at the shell prompt), the SAME `ForegroundProcess.command(for:shellBasename:)`
-  capture the restore-running-command feature uses (`ghostty_surface_foreground_pid` → `sysctl(KERN_PROCARGS2)`
-  → host-free `CommandRestore`), populated in the tree builder per session so a script can read "what
-  is each pane running".
-  It ALSO surfaces `background` on each node — the `BackgroundWatermark` spec set via `session.background`
-  (omitted when none), the read side of set/clear so a script can query the current watermark.
-  It ALSO surfaces `overlaySizePercent` on each node — an OPEN overlay's size (`session.overlayActive ? session.overlaySizePercent : nil`
-  in the tree builder): nil/omitted = the full-pane overlay OR no overlay (so gate on `overlay` first),
-  else the floating panel's percent (1...100).
-  It is the READ side of `session.overlay.resize` (which had only the write side), so a tmux-style zoom
-  script can record the current size before switching to `--full` and restore the EXACT original on un-zoom
-  (not a guessed default).
-  It ALSO surfaces `splitRatio` on each node — the left-pane divider fraction of a session that HAS a split
-  (`session.hasSplit ? session.splitRatio : nil` in the tree builder, so shown OR hidden splits report it),
-  nil/omitted when there is no split or the ratio was never explicitly set (divider then at the default 0.5).
-  It is the READ side of `session.resize` (whose applied ratio was echoed ONLY on the resize call's own
-  `ControlResult.ratio`), so a script can record the current ratio before maximizing a pane and restore the
-  exact divider even if the USER dragged it.
-  It ALSO surfaces `splitFocused` on each node — which pane holds focus in a session that HAS a split
-  (`session.hasSplit ? session.splitFocused : nil` in the tree builder, so shown OR hidden splits report it):
-  `true` = the split (right) pane, `false` = the main (left) pane, nil/omitted when there is no split.
-  It is the READ side of `session.focus` (write-only), so a script can record which pane was focused and
-  restore it via `session.focus --pane left|right` (a `false` is emitted, distinct from the nil no-split
-  case — the left pane being focused is real state).
-  `tree` ALSO carries, at the TOP level (alongside `idleMs`/`autoFollowMs`), `sidebarVisible` — the read
-  side of the write-only `sidebar` command (per-window sidebar visibility), populated LIVE from the
-  projected window's store in `AppStore.controlTree`.
-  The SAME field also rides each `ControlWindowNode` on `window.list` (read from `stores[id]?.sidebarVisible`,
-  omitted for a closed window), so a script can enumerate every window's sidebar state.
-  BUT `window.list` is served from the background-thread `cachedWindowNodes` cache
-  (refreshed after every dispatched command + on frontmost change), and a GUI-only ⌃⌘S toggle is neither —
-  so `AppStore.setSidebarVisible` posts `.agtermSidebarVisibilityChanged` (agtermCore) and `ControlServer`
-  observes it to `refreshWindowCache`, keeping the cached `sidebarVisible` honest.
-  A script that reads-then-acts (e.g. the tmux-style zoom that must restore the sidebar only if it was
-  visible) should still prefer `tree`'s LIVE `sidebarVisible` over the cached `window.list` one — the tree
-  is built on the main actor per request, so it can never lag.
-  Each `ControlWindowNode` ALSO carries `geometry` — the open window's live on-screen frame
-  (`ControlWindowFrame{x, y, width, height, display}`, omitted for a closed window with no NSWindow).
-  It is the READ side of the write-only `window.move`/`window.resize` (which set the frame but nothing
-  reported it), in the SAME coordinate system those accept: `x`/`y` are the top-left relative to `display`
-  (y down), `width`/`height` the frame size, so a read-back round-trips straight back through
-  `window.move`/`window.resize` (record → resize/move → restore the exact frame).
-  Because the frame lives in AppKit (`WindowLibrary` is host-free), `controlWindowNodes` takes an app-side
-  `geometry:` closure (default nil for tests) that `ControlServer.buildWindowList` fills from
-  `WindowRegistry.geometry(for:)` — the exact inverse of `move`'s forward math.
-  It rides the `cachedWindowNodes` cache (there is no LIVE tree copy — geometry is window-scoped, absent
-  from the session tree), and since a user drag/resize/zoom/fullscreen changes it with NO control command
-  AND a polling `window.list` is fast-path-served (so it never refreshes its own cache), `ControlServer`
-  observes the NSWindow `didMove`/`didResize`/`didEnterFullScreen`/`didExitFullScreen` notifications and
-  `refreshWindowCache`s on each (the fullscreen ones fire AFTER the async transition, so the settled
-  `styleMask` is captured) — mirroring the `.agtermSidebarVisibilityChanged` refresh for the GUI-only
-  sidebar toggle, so the read-back stays current.
-  The notification is IGNORED, not captured — a non-Sendable `Notification` can't cross into the
-  `MainActor.assumeIsolated` block under Swift 6 strict concurrency (the `sending 'note'` error), so the
-  refresh fires for ANY window rather than filtering to an agterm one; harmless, since a non-agterm panel
-  just rebuilds the same cheap agterm nodes.
-  The host-free plumbing (the closure + node field) is unit-tested (`controlWindowNodesIncludeGeometryFromClosure`,
-  the round-trips); the coordinate conversion + the NSWindow-notification cache refresh are app-side, build-verified.
-  Each `ControlWindowNode` ALSO carries `fullscreen`/`zoomed`/`minimized` — the read side of the write-only
-  `window.fullscreen`/`window.zoom`/`window.minimize` (so a script can act idempotently), filled by a PARALLEL
-  app-side `flags:` closure on `controlWindowNodes` (kept separate from `geometry:` so each stays a clean
-  addition) that `buildWindowList` reads from `WindowRegistry.windowFlags(for:)`
-  (`styleMask.contains(.fullScreen)` / `NSWindow.isZoomed` / `NSWindow.isMiniaturized`); all nil/omitted for a
-  closed window, on the cache like `geometry`. The closure plumbing is unit-tested (`controlWindowNodesIncludeFullscreenZoomFromClosure`
-  + the round-trips); the NSWindow reads are app-side, build-verified.
-  `minimized` is LIVE-ONLY, never persisted: nothing in `WindowEntry`/`Snapshot`/the UserDefaults frame
-  records it, per-window AppKit restoration is opted out (`WindowAccessor` sets `isRestorable = false`), and
-  `bringForward` deminiaturizes on attach — so every window reopens un-minimized and a script that parks
-  windows must re-apply after a relaunch.
-  `restore.clear` clears every open session's saved CAPTURED foreground command (`Session.foregroundCommand`/`splitForegroundCommand`)
-  and persists via `library.saveAllOpen()`, so the next restart restores plain shells for those panes instead
-  of re-running the captured commands (also closing the force-quit re-fire: the restored command is consumed
-  in memory but its on-disk copy lingers until the next save, which a force-quit skips).
-  It does NOT clear a `session.new --command` session's own `initialCommand` (the durable creation identity),
-  which still re-runs on restore when the setting is on — `restore.clear` is scoped to captured foreground
-  commands only.
-  App-global like `keymap.reload` (clears all open windows, no `--window`).
-  Four-point keep-in-sync audit for `restore.clear`: (1) `case restoreClear = "restore.clear"` in `ControlProtocol.swift`
-  (no target/args; `foreground`/`splitForeground` added to `ControlSessionNode`),
-  (2) the `.restoreClear` dispatcher arm → the app-side `ControlActions.clearRestoreCommands` + the foreground population
-  in the tree builder, (3) the `restore clear` subcommand (`Restore`) in `agtermctlKit`,
-  (4) round-trip (`restoreClearRoundTrips` + `treeSessionNodeRoundTripsWithForeground`/`…OmitsForegroundWhenNil`)
-  in `ControlProtocolTests` + the e2e (`testTreeExposesForegroundProcess`,
-  `testRestoreClearSucceeds`) in `ControlAPIUITests`.
-  `session.restore` (target = session) is the PER-SESSION, per-pane restore-command OVERRIDE — distinct
-  from the app-global `restore.clear`, which touches only the captured foreground.
-  It pins persisted state that WINS over the captured foreground at the next restore, and is the fix for
-  NON-IDEMPOTENT commands: `claude --resume <id> --fork-session` mints a NEW session on every restart, so
-  restoring it verbatim never reattaches the session the user was in (discussion #264).
-  Tri-state on a single `String?` per pane — `nil` = auto-capture (today's behavior), `""` = pinned to
-  nothing (a plain shell, suppressing both the capture and `initialCommand`), a command = run that shell
-  line — mapped from the wire `mode` `set`/`none`/`clear` via `ControlRestoreOverride`
-  (`pin(String)`/`pinNone`/`unpin`; `pinNone` is NOT spelled `none` to avoid the `Optional<T>.none` compiler
-  warning at the dispatcher's parse step).
-  It is SET now and CONSUMED on the next launch — writing it never touches the running session — and it is
-  STICKY: the override persists across restores and fires again on every restart until cleared, because a
-  `SessionStart` hook rewrites it to the live child id on every start.
-  This is the load-bearing safety property, split across two slots on `Session`: the PERSISTED
-  `restoreCommand`/`splitRestoreCommand` (its own slot, never the capture's — sharing `foregroundCommand`
-  would let the quit-time capture of the live `--fork-session` process clobber it) and the TRANSIENT
-  `pendingRestoreCommand`/`pendingSplitRestoreCommand`.
-  The surface factories read ONLY the pending slots (via `Session.takePendingRestoreOverride(pane:)`,
-  take-and-nil so a second split this launch is a plain shell); `setSessionRestore` writes ONLY the
-  persisted slots; and ONLY an app-bootstrap restore copies persisted → pending.
-  An implementation where the factory falls back to the persisted field reintroduces every re-fire hazard
-  (a socket write between `session.new` and the SwiftUI factory run would execute immediately).
-  Precedence lives in host-free `CommandRestore`: `restorePlan(_ inputs: RestoreInputs)` (an options struct,
-  since a 6th parameter fails `make lint --strict`) short-circuits on a present override — `command` is
-  always nil (never the exec path), `initialInput` comes from
-  `restoreInput(restoreEnabled:restoreOverride:capturedInput:)` — and reproduces today's logic byte-for-byte
-  when the override is nil.
-  It obeys the `restoreRunningCommand` setting (like `initialCommand`, so the toggle stays the single master
-  switch) but BYPASSES the denylist: `restore-denylist.conf` is a basename heuristic for BLIND capture,
-  while an override names its command deliberately, so it wins — the bypass is structural (the override
-  never routes through the app-side `restoreInitialInput` denylist gate).
-  The value is typed VERBATIM (never `shellQuotedLine`), so `cd x && claude --resume y` works as written; it
-  is arbitrary shell code that persists in `windows/<id>.json` and reads back via `tree`, so the docs say
-  plainly it may enter shell history and must not carry secrets (no privilege boundary — a same-UID client
-  can already inject keystrokes via `session.type` — but a buggy writer's mistake becomes durable).
-  Wire args reuse `ControlArgs.command` + `mode` + `pane` + `paneID` (no new wire args).
-  Dispatcher rejections (host-free, unit-tested): unknown or missing `mode` →
-  `invalid restore mode: <x> (set|none|clear)`; `set` with
-  no `command` → `session.restore set requires a command` (an EMPTY command is accepted, and is the same
-  pinned-to-nothing state as `none`); a `command` with control characters (tab included) →
-  `command must not contain control characters`; a `command` over `ControlRestoreOverride.maxCommandBytes` (1024 UTF-8
-  bytes via `command.utf8.count`) → `command too long (max 1024 bytes)`; a bad `pane` → the shared
-  `--pane must be left, right, or scratch`.
-  Shell metacharacters are deliberately NOT rejected — verbatim shell syntax is the point.
-  The app-side `setSessionRestore` (`ControlServer+SessionActions.swift`) resolves the session, then the
-  pane: `paneID` → `session.paneRole(forToken:)` first, else the baked `pane`, as `setSessionStatus` does —
-  with ONE deliberate divergence: an unresolvable `--pane-id` supplied WITHOUT an explicit `--pane` is an
-  ERROR (`unknown pane id: <token>`), not a silent `.left` fallback, because a silent default here would
-  overwrite the MAIN pane's persisted command when a hook meant the split (an EMPTY token counts as absent).
-  A `.scratch` pane (`the scratch terminal is never restored`) and a `.right` on a split-less session
-  (`session has no split`) are rejected; otherwise it calls `store.setRestoreCommand(value, pane:forSession:)`
-  (`AppStore+Restore.swift`), which persists immediately — the override must survive a SIGKILL
-  or a hook's write is lost — and does NOT touch the pending slots.
-  That write is the ONE store mutation whose failure is REPORTED rather than swallowed: `setRestoreCommand`
-  saves through the internal `AppStore.saveChecked()` (`save()` with the `Bool` kept, so the two can't drift),
-  ROLLS the in-memory field back to its previous value when the write throws, and returns whether the
-  requested value reached disk; the arm answers `failed to save the restore override, the previous value is
-  still in effect` when it did not.
-  The payload is what makes this different from `setFlag` and the rest of the swallow-and-log store: an
-  arbitrary shell line re-typed on every launch, so acking a `clear` that never landed would leave the old
-  command firing forever — and without the rollback the unchanged-value guard would swallow the retry as a
-  no-op success.
-  A successful `set` while `restoreRunningCommand` is OFF returns `ok` with a note in `result.text` so
-  a hook author sees why nothing will fire; `none`/`clear` carry no note, since their outcome (a plain shell
-  / back to auto-capture) is delivered regardless of the setting.
-  The `--pane` selector for both `session.status` and `session.restore` is parsed by the shared
-  `ControlDispatcher.parsePane`, so the rejection string cannot drift between them.
-  Pane lifecycle: `closePrimaryPane` migrates BOTH the persisted and pending right-pane values into the main
-  slots (mirroring the `foregroundCommand` migration); `closeSplit` clears both split slots; all three
-  soft-close entry points (`softCloseSession`/`softCloseSessions`/`softRemoveWorkspace`) clear the pending
-  slots via `clearPendingRestoreOverrides(of:)` before retaining the objects for undo; `session.duplicate`
-  copies neither.
-  Bootstrap seeding is gated by a `launchRestore` flag threaded through
-  `WindowLibrary.loadStore(for:launchRestore:)` → `AppStore.restore(from:launchRestore:)` →
-  `session(from:launchRestore:)`, passed `true` from ONLY the three `WindowLibrary` bootstrap sites (reopen,
-  its frontmost fallback, orphan recovery) so a mid-process window reload (`ContentView.resolveStore`) and
-  Reopen Closed Item arm nothing; and `pendingSplitRestoreCommand` is seeded only when
-  `snapshot.isSplit == true` (a hidden split has no right surface at bootstrap, so a pending payload would
-  fire on a later manual ⌘D — the same case the quit capture already dodges).
-  A hidden split's PERSISTED pin is DROPPED by the same rebuild rather than kept: the split is not restored
-  at all (`hasSplit` follows `isSplit`), so the pin describes a pane that no longer exists — keeping it
-  would leave a value `tree` reports but no write can clear (`--pane right` is rejected without a split) and
-  would re-arm into an unrelated fresh ⌘D split at the next quit.
-  This is the `closeSplit` rule (pane gone → drop the pin) applied to the restore path.
-  READ-BACK: `ControlSessionNode.restoreCommand`/`splitRestoreCommand`, populated in the tree builder from
-  the PERSISTED fields (never the pending slots), so a read after the override fired still reports what is
-  pinned; the tri-state survives JSON since `encodeIfPresent` omits `nil` while `""` emits an empty string.
-  Four-point keep-in-sync audit for `session.restore`: (1) `case sessionRestore = "session.restore"` +
-  `ControlRestoreOverride`/`ControlSessionRestoreUpdate` in `ControlProtocol.swift`/`ControlModes.swift`
-  (reusing `command`/`mode`/`pane`/`paneID`) + `restoreCommand`/`splitRestoreCommand` on `ControlSessionNode`
-  + the `Session`/`SessionSnapshot` persisted fields + `CommandRestore.RestoreInputs`/`restoreInput`,
-  (2) the `.sessionRestore` dispatcher arm (parse + validate + response shape) → the app-side
-  `ControlActions.setSessionRestore` (session/pane resolution + `AppStore.setRestoreCommand` + the off-setting
-  note) + the `controlTree` population, (3) the `session restore` subcommand (`Restore`, `validate()`-guarded
-  exactly-one-form) in `agtermctlKit/SessionCommands.swift`, (4) round-trip in `ControlProtocolTests` +
-  dispatcher happy/rejection/byte-cap paths in `ControlDispatcherTests` + `CommandRestoreTests` (precedence)
-  + `AppStoreRestoreTests`/`AppStoreRestoreSeedTests`/`AppStorePaneTests` (set/seed/lifecycle) +
-  `SessionTests` (`takePendingRestoreOverride` + stickiness) + `SnapshotRoundTripTests` + `CommandsTests`
-  (CLI mapping/validation) + the e2e in `RestoreCommandUITests` (incl. the two-relaunch stickiness and
-  force-quit persistence cases) and the `tree` read-back/error cases in `ControlAPIUITests`.
-  `session.background` (target = session) sets or clears a per-session background composited behind the
-  terminal grid — `args.mode` is `image`/`text`/`color`/`clear`.
-  `image`/`text` are watermarks driven by libghostty `background-image*` keys:
-  `image` needs `args.path` (PNG/JPEG, validated for format + existence + no control chars in the path),
-  `text` needs `args.text` (capped at 256 chars; + optional `args.color` #rrggbb, default the terminal
-  foreground), and both accept `args.opacity` (0...1)/`args.fit`/`args.position`/`args.repeats`.
-  `color` is a SOLID terminal background color driven by the `background` key: it needs `args.color` (#rrggbb)
-  and takes NO per-call opacity — it is drawn at the Settings WINDOW translucency (solid when off),
-  emitted as `background-opacity = <windowOpacity>` at apply time so the color honors the user's opacity/blur
-  instead of forcing itself opaque (unlike the image/text watermark, which pins `background-opacity = 1`
-  so the image shows).
-  opacity/color/fit/position validated against the shared host-free `WatermarkConfig`,
-  used by BOTH the CLI `validate()` and the server.
-  The `BackgroundWatermark` spec (host-free, `Codable`) is persisted in `SessionSnapshot` (survives restart)
-  via `AppStore.setBackgroundWatermark`, then applied to the session main + split + scratch surfaces as a PER-SURFACE
-  ghostty config overlay: `GhosttyApp.configWithOverlay` builds the same base files + an overlay file
-  (`WatermarkConfig.overlayText`: for image/text the `background-image*` lines + `background-opacity = 1`
-  so the image shows even under window translucency, which pins the global `background-opacity` to 0;
-  for `color` a `background = <hex>` line + `background-opacity = <windowOpacity>` (passed in from
-  `GhosttyApp.shared.windowOpacity`) so the color honors translucency instead of forcing itself opaque;
-  plus a `font-size` line so the per-session cmd-+/- zoom is not reset by the push), and `GhosttySurfaceView.applyWatermarkFromSession`
-  calls `ghostty_surface_update_config`, RETAINING each per-surface config in `ownedConfigs` and freeing
-  it only on surface teardown (safe — the consumer is gone — unlike the never-freed app-wide config).
-  libghostty auto-fits the image to the surface and RE-FITS on resize (no app-side resize code);
-  a `.text` watermark rasterizes to a PNG under `<stateDir>/watermarks/<sessionID>.png` via the app-side
-  `WatermarkRenderer` (AppKit; default tint = the live terminal foreground), regenerated on restore +
-  cleared on `clear`, on `text`→`image` switch, and on permanent session/workspace/window removal.
-  A global `config.reload`/settings change broadcasts the SHARED config (no image) to every surface via
-  `applyConfig`, WIPING any watermark — so `GhosttyApp.reloadConfig` re-resolves the theme colors and
-  then calls `reapplyWatermarkIfNeeded` on each surface AFTER the broadcast to re-assert it (the theme
-  colors first, so a default-tinted `.text` watermark re-renders with the new foreground, not the old).
-  A `.color` background bakes the window opacity into its `background-opacity` at apply time, so it must
-  RE-TRACK the Settings translucency slider: `SettingsModel.apply` re-asserts every `.color` surface
-  (`GhosttySurfaceView.reapplyColorBackgroundIfNeeded`, guarded to `.color` so image/text aren't rebuilt
-  per tick) right AFTER `applyWindowTranslucency` updates `GhosttyApp.windowOpacity`, on any opacity
-  change — the `reloadConfig` re-assert alone reads a STALE opacity (it runs before the update) and a
-  within-range drag doesn't reload at all, so neither path alone keeps a color session tracking the slider.
-  `BackgroundWatermark.fit`/`position` are typed `Fit`/`Position` `CaseIterable` enums (like `Kind`), not
-  raw `String` — the raw values match ghostty's keys so they serialize identically, and a bad value can't
-  reach a config line (`imagePath`/`colorHex` stay free text, re-validated on emit by `overlayText`, closing
-  the restore-path injection as defense-in-depth). The spec is READ back on each `tree` node's `background` field.
-  Four-point keep-in-sync audit for `session.background`: (1) `case sessionBackground = "session.background"`
-  + `ControlArgs.path`/`color`/`opacity`/`fit`/`position`/`repeats` in `ControlProtocol.swift` (+ `background`
-  on `ControlSessionNode` for the read-back),
-  (2) the `.sessionBackground` dispatcher arm — `ControlDispatcher.dispatchSessionBackground` validates + builds the spec,
-  the app-side `setSessionBackground` does the filesystem checks (`isSupportedImage`/`fileExists`) + `applyWatermark`
-  to the realized surfaces (+ `background:` populated in the tree builder), (3) the
-  `session background image|text|color|clear` subcommands in `agtermctlKit` (shared opacity/color/fit/position
-  `validate()`; `color` takes color only, no opacity), (4) round-trip in `ControlProtocolTests` (incl.
-  `treeSessionNodeRoundTripsWithBackground` + `backgroundWatermarkColorKindSerializes`)
-  + `WatermarkConfigTests` (incl. the `color*` overlay cases) + `WatermarkStorageTests` + `CommandsTests`
-  (CLI parse + bad-arg rejection) + the e2e `testSessionBackgroundSetClearAndValidation` in `ControlAPIUITests`
-  (image/text/color set/clear + tree read-back).
-  **Agent-skill mirror (HARD keep-in-sync, 4th surface):** all commands are documented in the bundled
-  `plugins/agterm/skills/agterm/` (SKILL.md summary, reference.md detail,
-  examples.md recipes) and the command count there is bumped to match.
-  It is a CODE gate too: `SkillInstallTests.bundledSkillDocumentsEventSubscriptionCommand` asserts the
-  `Command summary (N commands)` heading against the bundled `SKILL.md`, so a stale count fails `swift test`.
-  **Website mirror (HARD keep-in-sync):** the site's per-command reference `site/commands.html` documents
-  EVERY `agtermctl` control command — one inline-styled card per command carrying its invocation, its
-  arguments, and the `tree` read-back field, grouped into its command family's section.
-  A new `Command` case REQUIRES a new `site/commands.html` entry (a changed command an updated one, a
-  removed command a deleted one), in lockstep with the agent skill above and `README.md`/`site/docs.html`;
-  the page's "71 commands" copy must track the catalog count.
-  A bump is a grep, not a single edit: the count sits in FOUR spots in `commands.html` alone (the
-  `description` `<meta>`, the `og:description` and `twitter:description` `<meta>`s, plus the body copy),
-  and again in `README.md`, `site/docs.html`, the bundled `SKILL.md`, and the `SkillInstallTests`
-  assertion above.
-  Grep for the PATTERN, never for the old or new number: a site that is ALREADY stale at some third value
-  is invisible to a search for either, which is exactly how `commands.html`'s `description` `<meta>` sat at
-  65 through a 66 → 67 bump that corrected the other three.
-  Use something like `grep -rnE "\b[0-9]{2,3}\b[A-Za-z ,'-]{0,40}commands?\b"` scoped to `README.md`,
-  `site/`, `plugins/agterm/skills/agterm/`, and `.claude/rules/`, and reconcile EVERY hit against the
-  `Command` case count.
-  **That pattern requires the word "commands" AFTER the number and so misses the phrasings this very file
-  uses** — "the public command count stays N", "`Command` has N cases" — which is how BOTH of them
-  survived the 67 → 68 bump while the paragraph above them was corrected.
-  Finish with a bare `rg -n '\b[0-9]{2,3}\b' .claude/rules/control-api.md` over this file and read every
-  hit, or state the count once and reference it everywhere else.
-  Note also that counting `case x = "…"` lines UNDERCOUNTS by five: `tree`, `dashboard`, `quick`,
-  `sidebar` and `notify` carry IMPLICIT raw values, so count `case` lines instead.
-  It drifted once because the site keep-in-sync convention named only `docs.html`/`index.html`, so
-  `dashboard` and `surface.zoom` shipped undocumented here.
+- Xcode's CLI phase builds Release, copies/signs `agtermctl`, then deep re-signs the app; shallow signing
+  fails with `agterm.debug.dylib`. The Help installer links into `/usr/local/bin`, directly or through one
+  admin prompt. Host-free `CLIInstall` owns paths/quoting; app code owns filesystem/auth.
+- Agent Hooks installation copies generic, Claude, Codex, Pi, OpenCode, and shell assets under
+  `~/.config/agterm/agent-status`, baking the bundled CLI. Marker merges are idempotent and preserve
+  unrelated config; unreadable config is never treated as absent.
+- Claude maps prompt/tool work to `active --blink`, Stop to `completed --auto-reset`, and permission
+  prompt to blocked. PostToolUse clears a prior block because there is no answer event.
+- Codex maps SessionStart idle; prompt/pre/post tool active; Stop ending `?` blocked, otherwise completed.
+  `PermissionRequest` is insufficient under Auto Review, so a pane watcher reads `session.text` and blocks
+  only for visible approval/question UI. Remove stale issue #193 `codex-notify.sh` values, not comments or
+  foreign notifiers.
+- TOML merging refreshes managed markers while preserving trust tables. Leave foreign markers, existing
+  user hooks, and invalid TOML untouched; show manual instructions for the last two. Require `/hooks`
+  review for command-hook changes.
+- Install Pi only when `~/.pi/agent` exists. Start is active; settle only after retries, compaction, and
+  queued continuations. Pi exposes no reliable blocked event, so never infer it from prose.
+- Install OpenCode only when its config exists and export only `AgtermStatusPlugin`; the legacy loader
+  treats every export as a plugin. Busy/retry and replies are active; asked permission/question is blocked.
+  Latch a busy terminal error across sibling idle. Skip abort; defer ContextOverflow until idle unless busy
+  resumes. Ignore deprecated `session.idle`.
+- Preserve unmarked Pi/OpenCode files and require restart or reload. Host-free `AgentHooksInstall` owns
+  merge, marker, backup, and optional-agent policy.
+- Skill installation targets every existing Claude/Codex skill root, creating Claude only when neither
+  exists. Refuse an unmarked `SKILL.md`. The sole source is `plugins/agterm/skills/agterm/` with
+  `SKILL.md`, references, examples, troubleshooting, and `scripts/show-image.sh`.
+- `show-image.sh` opens a PTY overlay and emits chunked kitty APC/base64. Pinned Ghostty has no OSC-1337
+  or sixel, agent stdout escapes controls, and tool shells lack `/dev/tty`. Resolve relative to the loaded
+  skill; hardcoded install paths and `${CLAUDE_PLUGIN_ROOT}` fail across app/plugin copies.
+- Bundle the leaf at `Contents/Resources/agterm`. Claude uses array
+  `skills: ["./skills/agterm"]`; Codex uses string `skills: "./skills/"`; the marketplace shapes differ.
+  Keep plugin root `plugins/agterm` to avoid copying the roughly 21 MiB repository.
+- Release bumps all three manifest versions and stops for commit because caches key on version.
+  App-installed and plugin skills may coexist as `agterm` and `agterm:agterm` with undefined precedence.
+
+## Transport and addressing
+
+- Resolve socket from `AGTERM_CONTROL_SOCKET`, then `<AGTERM_STATE_DIR>/agterm.sock`, then Application
+  Support. CLI `--socket` overrides. Explicit short paths avoid Unix `sun_path` near 104 bytes. Use 0600.
+- Each connection sets `SO_NOSIGPIPE` and a 5-second receive timeout. Close on non-EINTR read failure,
+  including EAGAIN. Start is idempotent, unlinks stale paths, and logs bind failure without blocking launch.
+- One newline-delimited JSON request and response uses each connection, capped at 1 MiB. Unknown commands
+  return structured errors. Mutations may return `result.id`; trees use `result.tree`.
+- Human output shows IDs only for created session/workspace/window, retains them in JSON, uses
+  `result.affected` for session counts, and reserves `result.count` for diagnostics/search.
+- Targets accept active, case-insensitive UUID, or unique prefix. Batch targets resolve within the first
+  target's store, deduplicate, and fail atomically. Preserve the first target in the legacy top-level field
+  so old servers degrade to it rather than active.
+
+## Public catalog
+
+There are 71 public commands:
+
+- `tree`, `events.read`
+- `workspace.new`, `.rename`, `.delete`, `.select`, `.move`, `.focus`, `.filter`, `.collapse`, `.expand`
+- `session.new`, `.duplicate`, `.close`, `.select`, `.rename`, `.reveal`, `.move`, `.type`, `.split`,
+  `.scratch`, `.focus`, `.resize`, `.go`, `.copy`, `.paste`, `.selectall`, `.text`, `.search`, `.status`,
+  `.flag`, `.seen`, `.restore`, `.background`, `.overlay.open`, `.overlay.close`, `.overlay.resize`,
+  `.overlay.result`
+- `surface.zoom`, `dashboard`, `pick.open`, `pick.result`, `pick.cancel`
+- `quick`, `quick.type`, `quick.text`
+- `sidebar`, `sidebar.mode`, `sidebar.expand`, `sidebar.collapse`, `notify`
+- `font.inc`, `font.dec`, `font.reset`
+- `window.new`, `.list`, `.select`, `.close`, `.rename`, `.delete`, `.resize`, `.move`, `.zoom`,
+  `.fullscreen`, `.minimize`
+- `keymap.reload`, `keymap.list`, `config.reload`, `theme.set`, `theme.list`, `restore.clear`
+
+`debug.appearance` is a private 72nd `Command` case used only by `AppearanceFlipUITests`.
+It accepts light/dark, sets `NSApp.appearance`, posts `.agtermSystemAppearanceChanged`, echoes the effective
+side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provide no CLI or skill entry.
+
+## Organization commands
+
+- `workspace.delete` enforces at least one workspace and errors instead of showing the GUI alert.
+- `session.close` keeps legacy one-target hard close. Repeated targets are atomic and deduplicated; one
+  unique target remains the legacy hard path. Multi-target close follows `closeGraceUndoEnabled`, creates
+  one grouped undo/reopen record, and returns actual `affected`; selecting any recent group member restores
+  the group and selects that member.
+- `session.move` accepts exactly one placement intent:
+  - `--to up|down|top|bottom` reorders one session in its workspace.
+  - workspace relocates and appends.
+  - `--after`/`--before` resolves an anchor across the store, carrying destination workspace.
+  Relative placement uses host-free `SidebarDrop.resolveRelative`; batches use tree-order remove-first
+  `resolveSessions`. Reject batch `--to`. Count only actual moves. A one-member batch uses singular behavior.
+- Sidebar batch Flag computes one uniform value: flag all unless all are already flagged. This is not
+  equivalent to repeated toggle; scripts read state then loop on/off. Batch Clear Status is equivalent to
+  repeated `session.status idle` and needs no batch command.
+- `workspace.move --to up|down|top|bottom` reorders relative to the target. Drag remains the precise
+  between-row surface. On a sessionless window, `active` means current fallback `workspaces.last`, so
+  repeated moves may target a different workspace; use an ID to keep one target.
+- `session.split` drives the addressed session, not active-only `AppActions.toggleSplit`. Off hides and
+  retains the shell; only shell exit tears it down.
+- `session.scratch` is a third, nonpersisted login shell with on/off/toggle. It spawns lazily, survives
+  hiding, recreates after exit, and renders as a full translucent cover below overlay. It has no session
+  PWD/title link but a weak watermark link. GUI surfaces are Command-J, titlebar, View, and palette.
+- `session.focus --pane left|right|other` requires an existing split and works shown or hidden.
+  Read `splitFocused`.
+- `session.resize` accepts exactly one absolute ratio or relative grow-left/grow-right delta, defaulting
+  an unset ratio to 0.5. Require a split, clamp through store limits, persist, then post the object-scoped
+  live-divider notification. Hidden split stores for next show. Return clamped ratio as `%.3f`; read
+  `splitRatio`.
+- `session.go --to next|prev|first|last|next-attention|prev-attention` operates on current selection in
+  the placement store, wraps within filtered scope, and returns selected ID. It has no target.
+- `notify` requires body, defaults title and session, skips OSC focus suppression, increments unseen, and
+  uses click identity. When banners are disabled, return `ControlNotify.bannersOffNote` (#286); delivered
+  requests omit text. Read through `unseen`.
+
+## Session creation and duplication
+
+- `session.new` chooses one mutually exclusive destination:
+  - workspace ID/prefix/active;
+  - exact-trimmed workspace name, optionally create-or-reuse;
+  - `--after`/`--before` anchor, which supplies workspace and insertion index.
+  Reject both anchors, placement plus workspace, name plus ID, create without name, and missing name without
+  create. Insert indices are clamped.
+- `--command` becomes raw libghostty `config.command`, not shell input. Ghostty quote-splits into argv and
+  executes directly, so operators, expansion, redirection, and globs require an explicit `sh -c` or
+  `zsh -lc`. GUI launch PATH lacks `/opt/homebrew/bin`; missing binaries exit 127, so use absolute paths
+  or a login shell.
+- `initialCommand` persists and reruns only when restored-command support is enabled; fresh sessions always
+  run it. Captured foreground takes precedence. Promoting a split survivor clears the exited pane's initial
+  command.
+- `--no-select` neither changes selection/recency/focus nor reveals a newly created workspace into an
+  applied focus set. Foreground creates add their new workspace to the set instead of disabling filtering.
+  Do not overload the opposite-polarity `ControlArgs.select`.
+- `session.duplicate` atomically creates a plain login shell after the source in the same workspace from
+  `focusedCwd`. Copy no name, command, pane, status, flag, font, or background state. The new tree node is
+  the read-back. Source `tree.cwd` remains primary, so it can differ from the focused cwd copied.
+
+## Surface input, output, and search
+
+- `session.type --pane left|right|scratch` defaults to main for compatibility, not focused/on-screen.
+  Hidden live scratch is addressable; missing panes error. Main alone may select and bounded-poll a newly
+  unrealized session.
+- `inject` emits Ghostty key events and Return keycode 36 for newline/CR/CRLF. Never replace it with
+  `ghostty_surface_text`, whose bracketed paste suppresses Return and can expose `\e[200~`/`\e[201~`
+  markers under rapid use.
+- `session.copy` returns the addressed main selection without touching clipboard; empty is `no selection`.
+  `session.paste` and `.selectall` run Ghostty bindings on main. They use
+  `Session.addressableSurface = surface ?? splitSurface`, never focus-aware `activeSurface`, so select-all
+  and copy share one pane. Read paste through text and select-all through copy.
+- Keep standard SwiftUI Edit routing. `GhosttySurfaceView` implements Copy/Paste/Select All and validation;
+  focused text fields retain their behavior, terminal Cut stays absent. Do not replace the combined
+  pasteboard command group. Remove the separate Undo/Redo group because Command-Z belongs to Reopen Closed
+  Item; assert menu-item absence.
+- Paste validation must call the same URL/string branches as paste. Type-only probes disagree for Finder
+  URLs and declared-without-data pasteboards. Short-circuit on the first usable URL and share `urlText`;
+  validation must not materialize thousands of files. This has manual named-pasteboard coverage because
+  sandboxed XCUITest exposed no app-side types during an 8-second Finder-URL poll. Poll general pasteboard
+  after external writes.
+- Fixed Edit shortcuts use AppKit-produced characters. Retain Ghostty
+  `super+key_c/v/a` keycode fallbacks for non-Latin layouts and disabled menu items; there is no AppKit
+  Latin fallback. Paste requests are not OSC 52 reads and must not prompt.
+- `session.text` defaults to `onScreenSurface`: covering scratch, then focused pane. Explicit left/right/
+  scratch addresses that pane, including hidden scratch. Default reads viewport; `--all` includes
+  scrollback; `--lines N` returns last content lines after trimming blank grid rows. All and lines are
+  exclusive; N must be positive and dispatcher-validated. Blank returns empty success; API failure errors.
+  Output is plain text because pinned Ghostty exposes no styled-cell read.
+- `session.search` selects and realizes the target, then searches its focused surface. Text opens/updates;
+  to next/prev navigates; close ends; no arguments opens empty UI. Poll async SEARCH_TOTAL and return count
+  plus `searchDisplayText`. Search fields are ephemeral and shared with the GUI.
+- `quick.type`/`quick.text` mirror session input/read for the frontmost single quick surface, with no
+  window/target/pane. Poll up to 12 times at 30ms after quick show; distinguish not open, not realized,
+  read failure, and no open window. Hidden previously shown quick remains addressable (#170).
+  Text is type's read-back.
+
+## Overlay, zoom, dashboard, and picker
+
+- Overlay open runs one shell-wrapped program in a nonpersisted per-session surface. Size nil is full;
+  1...100 is floating. Optional color uses shared validated `#rrggbb` surface config and window opacity.
+  Background target runs without selection; `--follow` selects. `--wait` retains Ghostty's exit prompt.
+- Both full and floating use one always-present `overlayPanel` at z3. Gate content inside its
+  `GeometryReader`; never change the `sessionDetail`/HSplitView shape or pane modifiers on overlay state.
+  Full is translucent/chromeless and hides panes; floating is opaque/framed over visible panes with an
+  internal click catcher. Value-only resizing must not reparent the Metal surface.
+- Handle `GHOSTTY_ACTION_SHOW_CHILD_EXITED`. Return true for immediate close, false for wait; process-exit
+  handling must be idempotent. Use bounded first-responder retries and refocus underlying surface on close.
+- Exit status uses env-carried command/temp path in fixed
+  `sh -c '( eval "$AGTERM_OVL_CMD" ); echo $? > "$AGTERM_OVL_CODE"'`, without output redirection.
+  Read/delete during surface teardown before callbacks are cleared. `overlay.result` returns exit code,
+  still-running, or no-result. CLI `--block` polls returned session ID, rejects `--wait`, prints no process
+  output, and exits with captured status.
+- `overlay.resize` requires an open overlay and exactly one valid percent or `--full`; mutate the same
+  surface host. Read `overlaySizePercent`, gated by overlay-active because nil means either full or absent.
+- `surface.zoom show|hide|toggle` reparents exactly one surface below a slim titlebar. Active precedence is
+  quick, overlay, scratch, focused split, primary; explicit IDs are
+  `surface:<session-id>:<left|right|scratch|overlay>` or `quick`, including hidden live panes.
+- Host-free `TerminalZoomController` owns mode/state. Zoom must not change ratios, focus, sidebar, or pane
+  visibility; deck slots remain constant and focus reporting is suppressed. Opening closes palette/search
+  and conflicting quick terminal; banner reveal and Command-W exit. Font remains live. Reject quick show
+  and search-open while zoomed, but keep hides idempotent even if the target vanished. Read
+  top-level live `zoomedSurface`; surface node active/visible describes pane state, not zoom.
+- `dashboard` opens explicit IDs or `--mru`, or closes. Font-size and auto-size are exclusive; close accepts
+  no IDs/MRU/font; open needs IDs or MRU; fixed size must be finite positive.
+- A split expands to primary and split `DashboardMember`s. Resolve/deduplicate sessions in order, then cap
+  panes app-side at `DashboardLayout.maxCells` 9. Append dropped-pane text to unresolved text with `;`.
+  MRU takes up to nine valid recency entries before expansion and errors on an empty window.
+- Dashboard is per-window and view-only; GUI Command-Shift-D/menu/palette toggles MRU auto-size.
+  Arrows navigate ragged `ceil(sqrt(n))` grid, Enter closes then selects/focuses exact pane, Esc closes.
+  It is reciprocal with zoom. Read live `dashboardMembers`, highlighted member, applied font size, and
+  `auto|fixed|untouched` mode. See [[libghostty]] for reparent, input gates, and transient font.
+- `pick.open` accepts 1...1000 unique ID items with nonempty labels, optional subtitle/prompt/custom/follow.
+  Reject duplicates and control characters host-free. One picker may be pending per window. Background
+  remains background unless follow raises and publishes frontmost.
+- Global picker ID pins result/cancel to its owner across frontmost changes; explicit window must match.
+  Results are pending, picked with ID/label/index, custom with query, or cancelled. Cancel is idempotent
+  after terminal state. Tree exposes `pickPending`.
+- Selection/custom/Esc/Command-W/window close resolve. App termination may race polling. Retain eight
+  terminal results per controller; on unregister move them into a 32-entry app-wide oldest-first store so
+  deletion does not lose a pending poll.
+- CLI reads JSON array when stdin begins `[`, otherwise nonblank lines become ID=label. Blocking poll is
+  100ms for one second, then 500ms; print bare result JSON; exit 0 picked/custom, 2 cancelled, 1 failure.
+  `--no-block` prints picker ID JSON; result/cancel are one-shot commands.
+
+## Status, notifications, and flags
+
+- `session.status` accepts idle/active/completed/blocked, blink, auto-reset, optional sound, `#rrggbb`
+  color, fixed shape set, and pane. Build a fresh ephemeral indicator so omitted overrides clear.
+- Validate sound before mutation and target playback. `default`/`beep` beeps; named system/custom sounds
+  use cached `NSSound`. Without per-call sound, entering blocked may play configured default once;
+  repeated blocked does not. Explicit per-call wins via `AgentStatus.effectiveSound`.
+- Validate color and shape before mutation. Shapes are circle, square, triangle, diamond, capsule, star;
+  derive validation/help from `StatusShape.allCases`. Idle accepts but does not render shape.
+  AppKit and SwiftUI resolve through shared color/symbol helpers.
+- `ControlEventPayload` and `EventFormatter.human` must include every override; human status prints color
+  and shape. Tree reports state, pane, true blink, per-call color, and per-call shape only while non-idle.
+- Pane is left/right/scratch, nil meaning left. It controls pane-scoped keystroke clearing and GUI
+  blocked/completed reveal. Control attention navigation changes selection only.
+- `--pane-id` (#199) is a stable per-surface token that overrides stale baked role after promote/re-split,
+  then falls back to role when absent/unknown. Inject `AGTERM_PANE_ID`, resolve against live surface tokens,
+  and report only resolved `statusPane`. This alternative addressing adds no read-back field.
+- Auto-reset clears both session entered and session left. Status renders on selected sessions too.
+- `session.flag on|off|toggle|clear` is idempotent; clear ignores target and clears the store.
+  Read `flagged`.
+- `session.seen` clears unseen without selection/focus/status or persistence. Read nonzero `unseen`.
+
+## Keymap, config, theme, and sidebar
+
+- `keymap.reload` shares GUI reload and returns diagnostic count. `keymap.list` reports:
+  resolved built-in actions and override state; live AppKit menu equivalents/menu/title/selector; path;
+  custom commands; diagnostics. The two chord sets may differ during deferred rebuild or collision.
+  Host-free projection names arrow/return; represent AppKit globe as `fn+` even though grammar lacks it.
+- `config.reload` shares GUI/Edit-overlay reload and returns Ghostty diagnostic count. Keymap and config are
+  app-global and take no window.
+- `theme.set` operates on light and dark slots. Name/light aliases conflict; setting light preserves dark.
+  Nil/empty means Ghostty built-in, while bare set clears both and disables sync. Dark enables sync,
+  seeding missing light from current or Builtin Light; reserved `none` clears dark and sync but preserves
+  light. Validate bundled names and return full post-state. Palette commits current appearance slot only.
+- `theme.list` returns bundled names and plain or sync state. While syncing, omit plain theme and return
+  light/dark. CLI marks active entries and includes `default ghostty`. Theme is app-global.
+- `sidebar show|hide|toggle` is per-frontmost-window, persisted and animated from one root value.
+  It shares titlebar, View, palette, and Control-Shift-Command-S behavior.
+- `sidebar.mode tree|flagged|toggle` is frontmost and reads live `sidebarMode`.
+- `sidebar.expand` and `.collapse` target optional open window, post object-scoped store notifications, and
+  no-op in flagged mode. Collapse preserves/scrolls active workspace. GUI forms are frontmost only.
+- `workspace.focus on` replaces/enables; off removes and disables on empty; toggle clears sole applied
+  target or replaces/enables; add inserts without changing enabled state. There is no membership toggle.
+  Clear Focus loops off over members; `workspace.filter off` only suspends.
+- Read membership independently as `focused`. A workspace row is visible exactly when
+  `sidebarVisible && sidebarMode == "tree" && (!workspaceFilter || focused)`. Preserve all terms.
+- `workspace.filter on|off|toggle` targets optional window, changes only enabled state, and refuses to
+  enable empty membership. Read live top-level `workspaceFilter`.
+- Focus/filter/mode/flag narrowing reselects the most recent visible session. Growing an empty visible set
+  may also repair selection; flag clear and no-select creation do not.
+- `workspace.collapse`/`.expand` persist model first, then post view-sync notification so hidden sidebar
+  state is not lost. Coordinator updates tracked expansion under suppression. Read omitted/true `collapsed`.
+- `workspace.new --collapsed` starts collapsed and does not reveal into focus membership. Plain create
+  remains visible. Workspace adapters stay in `ControlServer+WorkspaceCommands.swift`.
+
+## Tree and window read-back
+
+- Session nodes include foreground/split foreground argv, background spec, overlay size, split ratio,
+  split focus, status fields, flag, unseen, restore pins, and surfaces. Foreground uses the same
+  pid/sysctl/host-free command extraction as restore capture.
+- Top-level tree includes idle/auto-follow, live sidebar visibility/mode, workspace filter, quick
+  visibility, zoom, dashboard, and picker state. Prefer live tree sidebar state over cached window list.
+- Window nodes include open/active, open-store sidebar/auto-follow, geometry, fullscreen, zoomed, minimized.
+  Closed live fields are omitted. Geometry is top-left display-relative y-down and round-trips move/resize.
+- Window list is cached. Refresh after commands and frontmost/sidebar/attachment/move/resize/fullscreen/
+  minimize changes. Ignore `Notification` payloads rather than carrying non-Sendable values into main actor.
+  Minimized is live-only; restoration always reopens unminimized.
+- Exact window behavior, readiness, cache ordering, and GUI interaction are owned by [[windows]].
+
+## Restore commands
+
+- `restore.clear` clears captured main/split foreground commands across open windows and saves immediately.
+  It never clears durable `initialCommand`; it is app-global.
+- `session.restore` pins per-session, per-pane next-launch behavior for discussion #264:
+  - nil/unpin/clear uses capture;
+  - empty/pinNone/none forces plain shell and suppresses capture plus initial command;
+  - command/set types that shell line.
+- Pins persist and repeat each launch until changed, but never affect the live shell. Keep persisted
+  `restoreCommand`/`splitRestoreCommand` separate from one-shot pending slots. Only bootstrap copies pins
+  to pending; factories take-and-clear pending. Never let factories fall back to persisted values.
+- `CommandRestore.restorePlan` owns precedence. Honor the master `restoreRunningCommand` setting, bypass
+  denylist for deliberate pins, and type text verbatim. Document that persisted shell code may enter
+  history and must not contain secrets.
+- Reuse command/mode/pane/paneID. Validate mode, required set command, no control characters including tab,
+  maximum 1024 UTF-8 bytes, and left/right/scratch. Shell metacharacters are allowed.
+- Pane ID resolves first. Unlike status, unknown pane ID without an explicit pane errors to avoid writing
+  main accidentally. Reject scratch and right without a split.
+- Save checked and roll back memory on failure; report that the previous value remains. This durable shell
+  payload must never acknowledge an unsaved clear. When restore setting is off, successful set returns an
+  explanatory note; none/clear do not.
+- Promotion moves persisted and pending right pins to main; split close clears both. Soft-close paths clear
+  pending before retaining objects; duplicate copies neither.
+- Seed pending only at the three library bootstrap paths. Seed split only when snapshot restores a shown
+  split. Drop hidden split pins because no pane exists to address or clear them.
+- Tree reads persisted pins, including empty string, never pending state.
+
+## Session backgrounds
+
+- `session.background image|text|color|clear` persists a host-free `BackgroundWatermark`.
+  Image requires existing PNG/JPEG path without controls. Text is capped at 256 characters and may set
+  color. Image/text accept opacity 0...1, typed fit, position, and repeats. Color requires `#rrggbb` and
+  uses window opacity, not a per-call value.
+- Apply to main, split, and scratch through retained per-surface config overlays. Image/text force
+  background opacity 1; solid color emits background plus current window opacity; include font size so
+  session zoom survives. Free configs only when surfaces die.
+- Text rasterizes under `<stateDir>/watermarks/<sessionID>.png` with live foreground default. Regenerate on
+  restore/theme change; remove on clear, text-to-image, and permanent deletion.
+- Shared config reload wipes surface overlays, so resolve theme colors then reapply. Opacity-slider changes
+  must reapply color after `windowOpacity` updates, including within-range drags that do not reload.
+- `Fit`/`Position` are CaseIterable typed enums. Revalidate free-text path/color during emission.
+  Tree reads the stored background specification. See [[libghostty]] for live OSC 11 precedence.
+
+## Documentation mirrors
+
+- Keep the bundled skill synchronized with commands, arguments, results, keymap, model, and command count.
+  `SkillInstallTests` checks its `Command summary (N commands)`.
+- `site/commands.html` documents every command, invocation, arguments, and read-back. Keep its four count
+  mentions, README, docs mirror, skill, and test aligned.
+- Search count patterns, not an assumed old/new value, then inspect every two/three-digit number in this
+  file. Counting only explicit raw-value assignments undercounts implicit cases.

--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -12,319 +12,116 @@ paths:
 
 ## Keymap
 
-- A user-editable, kitty-flavored keymap file (`<configDir>/keymap.conf`,
-  default `~/.config/agterm`) lets the user (1) **rebind built-in menu shortcuts** and (2) **define custom
-  shell commands** bound to keys, the latter listed in the action palette marked `custom`.
-  Like the Control API, the pure logic lives host-free in `agtermCore` and the app target wires it.
-  The feature is the keymap analogue of the toolbar/menu/control seam: the SAME parsed `Keymap` drives
-  the menu shortcuts, the custom-command monitor, and the palette, so the three can't drift.
-- **Two-section verb-based format (`parseKeymap`, host-free, never throws).**
-  `map <chord> <action>` overrides a built-in's shortcut (single chord only — a leader is a diagnostic);
-  `command "<name>" [chord] <shell...>` defines a custom command (quoted name with spaces;
-  the post-name token is the chord IFF `parseKeybind` accepts it AND it carries a modifier — a bare modifier-less
-  key is rejected with a diagnostic and the line falls back to palette-only,
-  so a custom shortcut can't shadow a plain terminal key and a palette-only shell line starting with
-  a single-char token isn't silently swallowed as a binding; else palette-only;
-  the shell remainder keeps `{AGT_X}` tokens verbatim — an EMPTY shell line is a diagnostic,
-  not a no-op binding).
-  Both verbs tokenize on GENERAL whitespace (space OR tab).
-  Blank lines and `#` comments are skipped (an inline `#` is a comment only when preceded by whitespace
-  AND outside a double-quoted span).
-  A malformed line becomes a `KeymapDiagnostic{line, message}` and is skipped — a bad line never discards
-  the rest of the file.
-  Pure types: `Modifier`/`Chord`/`Keybind`/`parseKeybind`/`keybindConflicts`/`reservedMonitorChords`
-  (`Keybind.swift`), `KeybindMatcher` (leader state machine), `CustomCommand`/`CommandContext` (the `{AGT_X}`
-  token table — single source of truth for both `{AGT_X}` expansion and the `$AGT_X` env),
-  `BuiltinAction` (the 42 rebindable actions + `defaultChord`, the count pinned by
-  `BuiltinActionTests.swift`), `Keymap`/`parseKeymap` (`Keymap.swift`),
-  `ConfigPaths` (the path resolver).
-  All unit-tested under `agtermCoreTests`.
-- **MENU-driven built-in override vs MONITOR-driven custom commands — two different mechanisms.** Built-ins
-  ride AppKit menu-key-equivalents: each built-in `Button` in `agtermApp`'s `.commands` reads `settingsModel.keymap.equivalent(for: .action)`
-  via the `shortcut(for:)` helper (`Chord` → SwiftUI `KeyboardShortcut?`,
-  applied only when non-nil so a keyless action stays keyless until mapped).
-  **`keymap` being `@Observable` does NOT make the menu track it live — do not assume a reload reaches the
-  key equivalents.**
-  SwiftUI defers its menu rebuild to the next app ACTIVATION, so after a `keymap reload` the live
-  `NSMenuItem` key equivalents keep the OLD chords until the app is deactivated and reactivated.
-  The rebuild is also where SwiftUI's conflict resolution runs, and it resolves a collision by unbinding
-  **agterm's** item, never the stock one.
-  So once the stock File ▸ Close (`performClose:`) holds ⌘W, giving `close_session` the chord back leaves
-  agterm's item with NO chord and ⌘W closing the whole window.
-  `AppDelegate.applyCloseSessionChord` asserts that split from AppKit: clear the stock item's ⌘W while the
-  keymap gives the chord to `close_session`, restore it while it does not.
-  Re-run it at launch, on `.agtermKeymapChanged`, on `didBecomeActive` (async, so it lands after SwiftUI's
-  rebuild), and on menu tracking — SwiftUI re-applies its resolution on every rebuild, so a one-shot does
-  not stick (the `removeNativeFullScreenMenuItem` pattern).
-  ⌘W is the only chord asserted this way because it is the only built-in chord with a stock competitor;
-  every other rebind takes effect on the next activation.
-  **Diagnose this class with `agtermctl keymap list`, not by reading the file.**
-  It returns BOTH what the keymap resolved (`actions`) and what the menu bar is dispatching (`menu`), so a
-  model-correct-but-menu-stale chord is one command away instead of an instrumented build.
-  Its menu chords go through the host-free `namedKey(forKeyEquivalent:)` so arrows and return render as
-  the same named keys the file uses and the two lists compare as strings; see the control-api rule.
-  **A change affecting menu shortcuts needs a RELOAD-path test — seeding `keymap.conf` before launch does
-  not exercise reload.**
-  Cover both in `agtermTests/CloseSessionChordTests.swift` and
+- `<configDir>/keymap.conf` (default `~/.config/agterm`) rebinds built-in menu shortcuts and defines
+  custom shell commands, which appear in the action palette as `custom`. One parsed `Keymap` drives the
+  menu, custom-command monitor, and palette; host-free logic lives in `agtermCore`.
+- `parseKeymap` never throws. `map <chord> <action>` accepts one chord, not a leader.
+  `command "<name>" [chord] <shell...>` treats the token after the quoted name as a shortcut only when
+  `parseKeybind` accepts it with a modifier; a bare key is diagnosed and the command stays palette-only.
+  Empty shell text is invalid. Both verbs split on spaces/tabs. Blank lines and comments are skipped;
+  inline `#` starts a comment only after whitespace and outside double quotes. Each bad line yields
+  `KeymapDiagnostic{line,message}` without stopping later lines. `{AGT_X}` text remains verbatim.
+- Pure types live in `Keybind.swift`, `KeybindMatcher`, `CustomCommand`/`CommandContext`,
+  `BuiltinAction` (42 cases, pinned by `BuiltinActionTests`), `Keymap`, and `ConfigPaths`.
+  `CommandContext` owns the shared expansion/environment token table.
+- Built-ins use AppKit menu key equivalents from `keymap.equivalent(for:)`; apply only non-nil
+  `KeyboardShortcut`s. SwiftUI rebuilds menu shortcuts on the next activation, not immediately after
+  `keymap reload`, and resolves stock collisions by unbinding agterm's item.
+- `AppDelegate.applyCloseSessionChord` clears stock File > Close ⌘W while `close_session` owns it and
+  restores it otherwise. Run at launch, `.agtermKeymapChanged`, asynchronously after `didBecomeActive`,
+  and during menu tracking because every rebuild can reapply the collision. ⌘W is the only built-in with
+  a stock competitor.
+- Diagnose live shortcut state with `agtermctl keymap list`, whose `actions` and `menu` expose parsed and
+  dispatched chords through host-free `namedKey(forKeyEquivalent:)`. Test the reload path, not only a
+  seeded file: see `CloseSessionChordTests` and
   `KeymapUITests.testCloseSessionReclaimsCommandWAfterReload`.
-  Custom commands ride an app-wide `NSEvent` local `.keyDown` monitor in `CustomCommandRunner` (the same
-  monitor pattern as the Ctrl-Tab switcher and Ctrl-1/2): it maps `NSEvent` → `Chord`,
-  feeds a `KeybindMatcher` (firing simple chords + leader sequences like `ctrl+a>g`,
-  1.5 s leader timeout, key-repeat ignored), and on `.fired` spawns a detached `/bin/sh -c` with the
-  focused pane's `CommandContext` (cwd + selection + `$AGT_*` env); a non-zero exit posts a failure banner
-  via `NotificationManager.notifyCommandFailure`.
-  It fires when the key window's first responder is a `GhosttySurfaceView` (context from that surface) OR
-  when the key window is an agterm terminal window whose focus is NOT on a text field — INCLUDING one
-  emptied to zero sessions (the SSH-disconnect state where every session's shell exited, `closeSession`
-  leaves the window open + empty, and no surface holds first responder).
-  It passes through — never eating keystrokes — for a focused text field (the responder is the window's
-  `NSText` field editor: Settings editor, inline rename, palette search) and for an auxiliary window
-  (Settings) whose focus sits off a text field (`WindowRegistry.contains(keyWindow)` gates the
-  no-surface fire to agterm terminal windows only).
-  It rebuilds its matcher on `.agtermKeymapChanged`.
-  The runner exposes a public `run(_:)` for the palette items; it resolves context from the active session
-  and NO-OPS when none is active — firing a session-scoped command with silently-empty tokens is unsafe
-  (an empty `{AGT_SESSION_PWD}` turns `rm -rf …/*` into a root glob, defeating even the quoted `$AGT_X`
-  form).
-  A chord fired with NO focused surface routes through `runNoSurface`: it runs the active session's
-  `run(_:)` if one exists (e.g. the dashboard key-catcher holds first responder, or a quick terminal over
-  a live session), else `spawnSessionless` fires a session-free context (empty `{AGT_SESSION_*}`, the
-  frontmost window id, the socket) so a launcher chord like `agtermctl session new --command "ssh …"`
-  stays usable after every session closes (`session.new` defaults to the frontmost window, so no id is
-  needed).
-  `spawnSessionless` GATES on `CommandContext.referencesSessionScopedContext`: a command whose body names
-  a session/workspace/selection token (`AGT_SESSION`/`AGT_WORKSPACE`/`AGT_SELECTION`, in `{…}` or `$…`
-  form) NO-OPS with a notice rather than expanding those tokens dangerously empty (an empty
-  `{AGT_SESSION_PWD}` makes `rm -rf …/*` a root glob, defeating even the quoted `$AGT_X` form) — the same
-  protection the palette's no-op gives, extended to the keybind; a launcher references only
-  `AGT_SOCKET`/`AGT_WINDOW`/`AGT_PANE`, so it still fires.
-  The sessionless-surface fallback (a quick terminal focused in an emptied window) routes through the
-  SAME `runNoSurface`, so a launcher works there too and a session-scoped command is inert there too.
-  `CommandContext.pane` (the `{AGT_PANE}`/`$AGT_PANE` token, `left`|`right`|`scratch`)
-  carries the fired-from pane: the keybind path derives it from the focused SURFACE's identity
-  (`splitSurface === focusedSurface` → `right`; the sessionless-surface branch `runFromSessionlessSurface`
-  identifies the active session's `scratchSurface` → `scratch`), the palette path from `session.splitFocused` —
-  so a script can feed it back as `agtermctl session type --pane "$AGT_PANE"` to type into the very
-  pane the shortcut was pressed in.
-  The scratch is the ONLY sessionless surface that reports a pane (the read leg of the `$AGT_PANE` →
-  `session type --pane scratch` round-trip, which `--pane` already accepted); the quick terminal and
-  overlays are NOT panes, so a chord fired from them takes the active-session palette path (their state
-  is queryable via `tree`'s `quickVisible`/`overlay`).
-  It reflects the pane's physical surface slot: `left` for any single-pane session, including a promoted
-  split survivor.
-  When the primary pane's shell exits, `closePrimaryPane` MOVES the surviving split pane from
-  `splitSurface` into the `surface` (main) slot and flips its `isSplitPane` flag off, so a
-  collapsed-to-single session reports `left` and `session.type --pane left` reaches it —
-  the survivor is no longer addressable as `right`, and a later split opens a fresh right pane beside it.
-- **Built-in override resolution is ORDER-INDEPENDENT, decided against the FINAL state (`resolveBuiltinOverrides`).**
-  Overrides are NOT folded incrementally against a partially-built map (that was order-sensitive — it
-  would reject `map cmd+d new_session` when toggle_split still owned cmd+d "so far",
-  even if a later line moved toggle_split off cmd+d).
-  Instead: (1) fold all overrides last-wins into a candidate map; (2) compute each action's final resolved
-  chord (override else `defaultChord`); (3) a chord that TWO DISTINCT actions resolve to is the only
-  real conflict — an override colliding with another action's UNMOVED default loses (the default owner
-  keeps the chord), two colliding OVERRIDES → the later-in-file one loses,
-  each with a diagnostic naming the kept owner.
-  So `map cmd+d new_session` + `map cmd+shift+d toggle_split` both succeed in EITHER order.
-  The dropped-override diagnostics are emitted sorted by file line for deterministic order.
-- **Cross-section validation + ownership-by-disjoint-registration (why there is NO precedence fight).**
-  `parseKeymap` runs a SINGLE final validation pass AFTER every line is parsed (NOT incremental — a custom
-  line parsed before a later keyless-built-in `map` must still be checked against the override that `map`
-  installs): it computes the active built-in chord set (`equivalent(for:)` over every `BuiltinAction`,
-  overrides applied) and drops a custom keybind whose FIRST chord collides with a built-in OR whose ANY
-  chord is a reserved monitor chord (the monitor consumes its chord wherever it lands in a leader,
-  so a later reserved chord like `ctrl+a>ctrl+1` is just as dead as a leading one) — clearing the command's
-  `shortcut` to `""`, keeping the palette entry, + a diagnostic — then drops both keybinds of any custom-vs-custom
-  conflict via `keybindConflicts`.
-  The reserved set is the PREDICATE `isReservedMonitorChord(_:)` (NOT a fixed list):
-  control+tab with ANY modifiers (the Ctrl-Tab switcher consumes Tab whenever Control is held — `ctrl+tab`
-  / `ctrl+shift+tab` / `ctrl+opt+tab` / `ctrl+cmd+tab`), plus control+1 / control+2 with Control as the
-  SOLE modifier (the Ctrl-1/2 pane monitor) — so all of these are un-rebindable.
-  The SAME predicate also rejects a built-in `map` line whose (single) chord is reserved (`parseMapLine`),
-  so neither a built-in nor a custom command can steal a monitor chord.
-  The reasoning: the NSEvent monitor only consumes chords registered in its matcher,
-  and validation guarantees those registered chords are disjoint from the active built-in (menu) chords
-  AND the reserved monitor chords.
-  So every physical chord is owned by exactly one mechanism — the menu OR a monitor,
-  never both — regardless of AppKit's menu-key-equivalent-vs-local-monitor dispatch order (the design
-  does NOT rely on asserting that order).
-  Caveat: validation covers agterm's own built-ins + reserved monitor chords,
-  NOT system/standard menu items (⌘Q/⌘C/⌘,); binding a custom command to one of those resolves by AppKit's
-  own dispatch — documented, not validated.
-- **`BuiltinAction.defaultChord` is the single source of truth for the built-in shortcuts (keep-in-sync
-  surface).** Task 9 collapsed the old `BuiltinAction` ↔ menu keep-in-sync convention:
-  EVERY built-in menu item reads `equivalent(for:)` (override else `defaultChord`) with NO hardcoded
-  `.keyboardShortcut` literal, so adding/changing a default chord happens in `defaultChord` alone.
-  ONE keyed built-in carries no menu shortcut at all: `undo_close` (File ▸ Reopen Closed Item) is
-  delivered by the `UndoCloseShortcut` NSEvent monitor instead, so native text undo keeps working in the
-  rename/palette/Settings fields — it resolves the SAME `equivalent(for:)`, just not as a key-equivalent.
-  There is NO exception any more: the six formerly arrow-bound actions (`focus_left_pane` ⌘⌥←,
-  `focus_right_pane` ⌘⌥→, `previous_session` ⌥⌘↑, `next_session` ⌥⌘↓, `previous_attention_session` ⌃⌥↑,
-  `next_attention_session` ⌃⌥↓) return their real chords from `defaultChord` now that `parseKeybind`
-  accepts the four arrows, so EVERY keyed built-in is pure-`defaultChord`-driven and the menu holds no
-  hardcoded `.keyboardShortcut` at all.
-  The old props are gone — `agtermApp.arrowShortcut(for:)`, `BuiltinAction.arrowGlyphFallback`, and
-  `glyphHint`'s `?? arrowGlyphFallback` were deleted, and the starter file's six `(no default)` lines
-  became real chords.
-  This also CLOSED a hole: `firstBuiltinCollision` and `validateCommands` resolve through `defaultChord`,
-  so while the six were nil their live ⌥⌘↑/↓/←/→ were invisible to the conflict checker — a `map cmd+opt+up new_session`
-  would have double-bound the chord silently.
-- **Shifted symbols bind as `shift+<base>` — the runner normalizes to the UNSHIFTED base key.**
-  `charactersIgnoringModifiers` KEEPS shift (shift+/ → "?", shift+= → "+"), and the old
-  `.lowercased()` only undid that for letters (shift+u → "u"), so punctuation landed on the shifted glyph
-  and never matched a `shift+/`-style binding.
-  `CustomCommandRunner.chord(from:)` now derives the base key via `characters(byApplyingModifiers: [])`
-  (the same call `GhosttySurfaceView` uses for unmodified key input), so the runtime chord for shift+/ is
-  `(shift, "/")` and matches the parser's `shift+/`.
-  So every shifted symbol is written `shift+<base>` (`shift+/` = `?`, `shift+=` = `+`, `shift+5` = `%`,
-  `shift+.` = `>`).
-  This is verified END-TO-END by `KeymapUITests.testCustomCommandShiftedSymbolFires` (a real synthesized
-  Shift+/ keypress fires a `shift+/`-bound command) — the host-free tests structurally can't reach
-  `chord(from:)`, which is exactly why the earlier parser-only version shipped a runtime that never fired.
-- **Arrows are bindable; a BARE arrow is not (`map` only).**
-  `bindableNamedKeys` carries `left`/`right`/`up`/`down` alongside `tab`/`space`/`return`/`delete`, and
-  `bindableArrowKeys` names the four separately for the one rule that treats them specially.
-  `parseMapLine` REJECTS a modifier-less arrow (`map left previous_session` → `bare arrow chord '<x>' needs a modifier; map skipped`)
-  because a built-in becomes an always-on menu key-equivalent with NO text-field pass-through — unlike
-  the custom-command monitor, which returns false for an `NSText` responder — so a bare arrow would
-  swallow the key in the terminal, both palettes, the dashboard grid's key-catcher, and every text field
-  at once.
-  `parseCommandLine` already required a modifier on every custom chord, so the two verbs now agree for
-  arrows; a bare NON-arrow key stays legal for `map` (pre-existing, `map a new_session`).
-  The grammar itself accepts a bare arrow — the modifier rule is a `map` rule, not a parse rule, so a
-  leader tail like `ctrl+a>left` still works.
-- **The keyCode→name half of `NSEvent`→`Chord` is ONE host-free function.**
-  `namedKey(forKeyCode:)` (`Keybind.swift`) is the single source of truth, used by BOTH app-side monitors
-  — `CustomCommandRunner.chord(from:)` and `UndoCloseShortcut.chord(from:)`, which each carried their own
-  copy of the table before.
-  This matters because a name the GRAMMAR accepts but the keyCode map can't produce parses fine and then
-  never fires: an arrow would fall through to the character branch, whose `characters(byApplyingModifiers: [])`
-  yields the private-use `NSUpArrowFunctionKey` glyph — a VALID `Chord` no keymap line can spell.
-  That is exactly the shifted-symbol failure mode that shipped once (see the shift-symbol note above),
-  which is why `KeybindTests` pins `namedKey(forKeyCode:)`'s range to equal `bindableNamedKeys` exactly,
-  and why the runner path has its own e2e (`KeymapUITests.testCustomCommandArrowChordFires`).
-- **A chord resolves per LAYOUT, not per key — `chordKey(forKeyCode:produced:layoutIsASCIICapable:)` owns the policy.**
-  A `keymap.conf` chord is spelled in Latin (`cmd+o`), but the character an `NSEvent` reports is whatever the ACTIVE input
-  source puts on that key, so matching the produced character alone left EVERY letter/digit chord dead on a Cyrillic/Greek/Hebrew
-  layout, where the O key yields `щ` (issue #306).
-  The app target reads ONE bit — `KeyboardLayout.isASCIICapable` (`agterm/Commands/KeyboardLayout.swift`,
-  `TISCopyCurrentKeyboardLayoutInputSource` + `kTISPropertyInputSourceIsASCIICapable`) — and the host-free
-  `chordKey` branches on it: an ASCII-capable layout (US, Dvorak, Colemak, US-International, French, German) binds the produced
-  character, EXACTLY as master did, so no existing user's binding changes; a layout that cannot type ASCII (every Russian variant,
-  Greek, Hebrew, Arabic, Thai, Ukrainian) binds by physical position via `latinKey(forKeyCode:)`, the ANSI table.
-  The property is read FRESH on every key press — measured at ~0.22 µs, so it needs no cache and no
-  `kTISNotifySelectedKeyboardInputSourceChanged` observer, and cannot go stale mid-session.
-  **Do NOT "optimize" this into a per-key ASCII test** (keep the produced character whenever it happens to be ASCII).
-  That was the first attempt and it is measurably wrong on real layout data: Greek types `;` on the physical Q and Hebrew types
-  `/` there, so Latin-spelled LETTER chords stayed dead on two of the three layouts the fix targets; and it let two physical keys
-  collapse onto one chord key — on Hebrew the `'` key produces `,` while the `,` key falls back to `,`, so one binding fired from
-  a key the user never pressed AND the monitor ate the keystroke (`handleKeyDown` returns true on `.fired`/`.armed`).
-  Resolving the whole layout at once keeps `latinKey`'s one-key-per-position mapping intact, so no two TABLE positions can
-  collapse.
-  Two positions OUTSIDE the table still need care, because an unclaimed key code keeps whatever it types and that can equal a
-  table value: the ISO section key (keyCode 10, the extra key an ISO keyboard has) types `\` on Ukrainian-PC and `;` on
-  Hebrew-PC, colliding with keyCodes 42 and 41 — it is therefore DROPPED on a non-ASCII layout (`isoSectionKeyCode`), and
-  removing that guard reintroduces the collapse.
-  The keypad also aliases (keypad `5` and the number row both give `"5"`), which is deliberate and pre-dates all of this — the
-  keypad's output does not vary by layout, so binding it by what it types is correct.
-  This is a DIFFERENT rule from `InterruptKeystroke.isInterrupt`, which tests the produced CHARACTER (is it a Latin letter?)
-  rather than the layout — do not "unify" them: that one classifies a single hardcoded key and needs no layout context, while a
-  chord needs the whole ANSI vocabulary including punctuation.
-  `latinKey` and `namedKey(forKeyCode:)` claim DISJOINT key codes (pinned by `KeybindTests`) because both monitors resolve the
-  named key first; every `latinKey` entry is pinned INDIVIDUALLY there too, since the aggregate set/uniqueness assertions hold
-  under any permutation and the real `kVK_ANSI_*` constants are non-monotonic at 4/5, 22/23 and 25/26/28/29.
-  Consequence to keep in mind: on a non-ASCII layout a chord can only be spelled by position, so such a layout cannot bind the
-  Cyrillic character it types.
-  **The NON-Latin branch of either monitor's `NSEvent` seam is NOT unit-testable — the branch is chosen by the LIVE input source.**
-  A test cannot set the machine's keyboard, so a hosted test runs on whatever the tester has (a Latin layout everywhere in
-  practice) and can only reach the ASCII-capable branch.
-  Two separate reasons, and both stand: `CustomCommandRunner.chord(from:)` additionally reads
-  `characters(byApplyingModifiers: [])`, which AppKit RE-TRANSLATES from the key code through the live input source — a
-  synthesized `NSEvent` carrying `characters: "щ"` comes back `"o"` on a Latin-layout machine (verified) — while
-  `UndoCloseShortcut.chord(from:)` reads `charactersIgnoringModifiers`, which a synthesized event DOES report verbatim.
-  So the hosted tests (`agtermTests/UndoCloseShortcutTests.swift`) pin the WIRING (right key code, right accessor, named keys win)
-  and `KeybindTests` carries the whole layout policy host-free, taking `layoutIsASCIICapable` as a parameter.
-  Do NOT "fix" the split by switching the runner to `charactersIgnoringModifiers` for testability — that reintroduces the
-  shifted-symbol bug (see the shift-symbol note above), and it would not make the non-Latin branch reachable anyway.
-  **The accessor split has a live consequence the shift-symbol bullet above does NOT cover: `undo_close` is exempt from
-  `shift+<base>` normalization.**
-  `charactersIgnoringModifiers` KEEPS shift, so a real Shift+/ press reaches `UndoCloseShortcut` as `(shift, "?")` while
-  `map shift+/ undo_close` parsed to `(shift, "/")` — the comparison fails and File ▸ Reopen Closed Item is silently dead, for
-  every shifted punctuation/digit (shifted LETTERS are fine, `chordKey` lowercases).
-  The deadness is pre-existing (master read the same accessor), but the layout branch now SPLITS it: on a non-ASCII layout the
-  press resolves through `latinKey`, which is shift-independent, so the identical `map` line FIRES on Cyrillic and stays dead on
-  US.
-  `undo_close` is the only built-in delivered by a monitor rather than a menu key-equivalent, so it is the only action this
-  reaches.
-  The hosted tests skip themselves when the tester's own layout is not ASCII-capable (`XCTSkipUnless`), so running `make
-  test-app` while hand-verifying on Russian reports skips rather than false failures.
-  VERIFIED BY HAND on a Russian-Phonetic layout against an isolated dev instance: a simple letter chord, a `cmd+r>t` leader, a real
-  `ctrl+a>d` leader from the maintainer's own keymap, and ⌘Z undo-close all fire on Cyrillic and keep working on U.S.
-  Re-run that way after touching either monitor's `chord(from:)` — the automated suites cannot catch a regression there.
-  Russian-Phonetic is the most FORGIVING layout in the set (every one of its punctuation positions emits correct ASCII), so it
-  alone does not exercise the Greek/Hebrew cases; those are covered by the host-free tests using measured layout data.
-- **A `keybind` in `ghostty.conf` does NOT get this treatment — that is libghostty's matcher, and its rule is different.**
-  ghostty parses a bare `g` as a UNICODE trigger and `key_g` as a PHYSICAL one, then matches physical → the produced utf8 → the
-  unshifted codepoint (`Binding.Set.getEvent`), so a unicode trigger cannot fire on a non-Latin layout.
-  agterm builds the key event exactly as Ghostty.app does (same `characters(byApplyingModifiers: [])` for `unshifted_codepoint`),
-  so this is upstream behavior, identical in Ghostty.app, and NOT fixable app-side — verified against the pinned rev AND
-  ghostty `main`.
-  The answer is the `key_` form, which is why `ghostty-defaults.conf` ships `super+key_c`/`key_v`/`key_a` (issue #30).
-  README + `site/docs.html` document the split; do not conflate the two files' chord grammars when answering a layout report.
-- **v1 scope cut (confirmed).**
-  Built-in rebinds are single-chord only (leaders only for custom commands).
-  The literal `+`/`>` still can't be a bare key TOKEN (they are the chord-joiner / leader separator), but
-  those keys ARE bindable as `shift+=`/`shift+.` (see the shift-symbol note above).
-  `increase_font_size`'s default ⌘+ still renders `(not expressible)` in the STARTER file: its stored
-  `Chord(key:"+")` can't round-trip through `displayString` (which emits the `+` glyph, `chordSyntax`
-  verifies the round-trip) — a display-side detail, separate from key MATCHING.
-  The Ctrl-Tab MRU switcher and Ctrl-1/Ctrl-2 pane focus are NOT rebindable (they are monitor-driven,
-  not menu items — folding them in would reintroduce a monitor-vs-monitor precedence question;
-  a custom command bound to one is dropped via `reservedMonitorChords`).
-  The palette shows a custom command's chord as raw kitty syntax (`cmd+shift+e`),
-  not the ⌘⇧E glyphs built-ins use.
-- **`{AGT_X}` tokens are substituted RAW into the `/bin/sh -c` line (`CommandContext.expand`).** This
-  is the intended raw interpolation (convenient), NOT shell-quoted — so dynamic content like `{AGT_SELECTION}`
-  can inject shell syntax.
-  `{AGT_SESSION_NAME}` and `{AGT_SESSION_PWD}` are equally unsafe, and worse than `{AGT_SELECTION}`
-  because they need no local interaction: a remote host sets the session title (OSC 0/1/2) and the
-  working directory (OSC 7), so either can carry attacker content silently.
-  OSC-reported title and pwd are stripped of control characters at ingestion (`TerminalText.sanitized`
-  in `GhosttySurfaceView.applyTitle`/`applyPwd`), so a newline can no longer split the `sh -c` line,
-  but visible metacharacters (`;`, `$()`, backticks) still pass through raw.
-  The safe alternative is already provided: the same values are exported as `$AGT_X` env vars (`CommandContext.environment()`),
-  naturally shell-quoted as `"$AGT_SELECTION"`.
-  The starter `keymap.conf` comments + README recommend `$AGT_X` (quoted) for untrusted content.
-  Do NOT add quoting to the `{AGT_X}` expansion — by design.
-- **Reload + control.**
-  `AppActions.reloadKeymap()` → `SettingsModel.reloadKeymap()` (re-read + re-parse + post `.agtermKeymapChanged`)
-  is exposed as File ▸ Reload Keymap, an action-palette entry, AND the `keymap.reload` control command
-  — all ONE path.
-  See the Control API catalog for the `keymap.reload` four-point audit.
-- **Edit Keymap (GUI-only).**
-  `AppActions.editKeymap()` (File ▸ Edit Keymap… + the ⌃⇧P palette) opens `keymap.conf` in the user's
-  editor inside a 95% FLOATING overlay over the active session via `AppStore.openOverlay(…, sizePercent: 95)`.
-  The command is the host-free, unit-tested `ConfigPaths.editorCommand(forPath:)` → `${SHELL:-/bin/zsh} -ilc 'exec /bin/sh -c '\''${VISUAL:-${EDITOR:-vi}} "$1"'\'' agterm-config-edit '<single-quoted path>''`
-  (the path comes from `SettingsModel.keymapPath`).
-  The user's INTERACTIVE login shell (`$SHELL -ilc`) runs first so it sources its rc and EXPORTS `$EDITOR`/`$VISUAL`,
-  then `exec`s a POSIX `/bin/sh` that does the actual `${VISUAL:-${EDITOR:-vi}} "$1"` resolution + launch
-  (the path is the inner `/bin/sh`'s positional `$1`, embedded single-quoted so spaces/quotes survive
-  — NOT passed positionally to `$SHELL`, which fish has no `$1` for).
-  TWO LOAD-BEARING reasons for the shape: (1) the `-ilc` sourcing — the overlay's own process is a bare
-  non-interactive `/bin/sh` (libghostty runs `config.command` via `sh -c`,
-  NOT the user's interactive shell) that sources none of the user's shell config,
-  so a direct `${EDITOR:-vi}` there always fell back to `vi`; (2) the inner-`/bin/sh` hop — `$SHELL`
-  may NOT be a POSIX shell (fish), which can't parse POSIX `${VAR:-default}` and died with `fish: ${ is not a valid variable`
-  (exit 127, overlay just flashed) when the resolution ran directly under `$SHELL` — the POSIX text now
-  rides inside single quotes that fish (and POSIX shells) pass through verbatim to `/bin/sh`.
-  Two known limits: it assumes `$SHELL` accepts `-ilc` and passes single-quoted text verbatim (true for
-  sh/bash/zsh/fish, NOT csh/tcsh, which reject `-ilc`); and it resolves `$EDITOR`/`$VISUAL` only when
-  EXPORTED (their entire convention) — a non-exported, shell-local value does not survive the `exec`
-  and falls to `vi`.
-  Cross-shell behavior is unit-tested (`ConfigPathsTests` runs the built command under zsh + fish-when-present
-  with a fake recorder editor, plus VISUAL-precedence and rc-sourcing cases).
-  On the editor exiting the keymap reloads automatically: `editKeymap` records the target in `AppActions.keymapEditOverlaySession`
-  and `WindowContentView`'s overlay-close `onChange` calls `reloadKeymap()` for it (then clears it).
-  NO control command — a script can already `agtermctl session overlay open "$EDITOR <path>" --size-percent 95`
-  (keep-in-sync exempt, like `reveal`, since it composes the controllable `session.overlay.open`).
-
+- `CustomCommandRunner` uses an app-wide local `.keyDown` monitor. Its `KeybindMatcher` supports simple
+  chords and leaders such as `ctrl+a>g`, ignores repeats, and times leaders out after 1.5 seconds.
+  `.fired` launches detached `/bin/sh -c` with cwd, selection, and `$AGT_*`; non-zero exit calls
+  `notifyCommandFailure`. Rebuild the matcher on `.agtermKeymapChanged`.
+- Fire with a focused `GhosttySurfaceView`, or in an agterm terminal window whose focus is not an `NSText`
+  field editor, including a zero-session window. Pass through text fields and auxiliary windows;
+  `WindowRegistry.contains(keyWindow)` gates no-surface dispatch.
+- Palette `run(_:)` no-ops without an active session. A no-surface chord uses the active session when
+  available; otherwise `spawnSessionless` supplies empty session fields plus frontmost window/socket so
+  launchers still work. If `referencesSessionScopedContext` finds any session/workspace/selection token
+  in `{...}` or `$...` form, no-op with notice; empty `{AGT_SESSION_PWD}` can turn `rm -rf .../*` into a
+  root glob. Commands using only `AGT_SOCKET`/`AGT_WINDOW`/`AGT_PANE` may run sessionless.
+- `{AGT_PANE}`/`$AGT_PANE` is `left`, `right`, or `scratch`, derived from the firing surface for keybinds
+  and `splitFocused` for palette runs. Scratch is the only sessionless surface with a pane; quick terminal
+  and overlays use active-session context. A single pane is always `left`. Primary exit promotes the
+  split into the main slot, clears `isSplitPane`, and makes it addressable only as `left`.
+- `resolveBuiltinOverrides` is order-independent: fold last-wins candidates, resolve all final chords,
+  then detect collisions. An override loses to another action's unmoved default; for two overrides, the
+  later line loses. Diagnostics name the owner and sort by line. Moving `toggle_split` off `cmd+d` lets
+  `new_session` take it in either line order.
+- Final cross-section validation runs after parsing all lines. A custom shortcut becomes palette-only
+  with a diagnostic when its first chord hits a final built-in, any chord is reserved, or
+  `keybindConflicts` finds another custom shortcut; both custom sides lose in the last case.
+  `isReservedMonitorChord` covers control+tab with any extra modifiers and control+1/2 with Control alone,
+  anywhere in a leader, and also rejects built-in maps. This keeps menu and monitor registrations
+  disjoint without relying on dispatch order. Standard menu items such as ⌘Q/⌘C/⌘, remain AppKit's
+  responsibility.
+- `BuiltinAction.defaultChord` is the sole built-in default. Every menu item resolves
+  override-or-default, including the six arrow actions. `undo_close` is the one keyed action delivered
+  by `UndoCloseShortcut`, not a menu equivalent, so native text undo still works.
+- Write shifted symbols as `shift+<base>`: `shift+/` for `?`, `shift+=` for `+`, `shift+5` for `%`, and
+  `shift+.` for `>`. `CustomCommandRunner` uses `characters(byApplyingModifiers: [])` to recover that
+  base; keep `KeymapUITests.testCustomCommandShiftedSymbolFires`.
+- Named keys are `left/right/up/down/tab/space/return/delete`. `parseMapLine` rejects modifier-less
+  arrows because an always-on menu equivalent would swallow navigation in terminals, palettes,
+  dashboard, and text fields. Bare non-arrow built-in maps remain legal, and a bare arrow can be a
+  leader tail such as `ctrl+a>left`; custom shortcuts always require modifiers.
+- Host-free `namedKey(forKeyCode:)` is shared by `CustomCommandRunner` and `UndoCloseShortcut`.
+  `KeybindTests` pins its range exactly to `bindableNamedKeys`; keep
+  `KeymapUITests.testCustomCommandArrowChordFires` because a private-use AppKit glyph can otherwise
+  create an unspellable runtime chord.
+- **Resolve chords per layout, not per produced key** (issue #306).
+  `KeyboardLayout.isASCIICapable` reads
+  `kTISPropertyInputSourceIsASCIICapable` on every keypress (about 0.22 microseconds, no cache/observer).
+  `chordKey` uses the produced character for ASCII-capable layouts and ANSI
+  `latinKey(forKeyCode:)` position for non-ASCII layouts. Do not use a per-key ASCII fallback: Greek Q
+  emits `;`, Hebrew Q emits `/`, and Hebrew can collapse two physical positions to `,`, causing false
+  firing plus consumed input.
+- Drop ISO section key code 10 on non-ASCII layouts because Ukrainian-PC `\` and Hebrew-PC `;` collide
+  with table codes 42/41. Keypad/number-row aliases are deliberate because keypad output is
+  layout-independent. Keep `latinKey` disjoint from named-key codes and pin every entry individually;
+  real ANSI constants are non-monotonic at 4/5, 22/23, and 25/26/28/29. Non-ASCII layouts can bind only
+  Latin positions, not their produced Cyrillic glyphs.
+- Do not merge this policy with `InterruptKeystroke`, which classifies one produced letter.
+  The live non-Latin monitor branch cannot be unit-tested because tests cannot change the input source.
+  `characters(byApplyingModifiers: [])` re-translates synthesized runner events through the live layout;
+  `UndoCloseShortcut` uses verbatim `charactersIgnoringModifiers`. Hosted tests pin wiring and named-key
+  precedence; host-free tests take `layoutIsASCIICapable`.
+- Do not switch the runner to `charactersIgnoringModifiers`: it breaks shifted-symbol normalization and
+  still cannot test the non-Latin branch. The accessor means `undo_close` cannot match shifted
+  punctuation/digits on ASCII layouts (`shift+/` parses `/`, but runtime reports `?`); shifted letters
+  work, and non-ASCII physical lookup works. Hosted tests skip when the machine layout is non-ASCII.
+  After monitor changes, manually verify a letter, `cmd+r>t`, `ctrl+a>d`, and ⌘Z on isolated
+  Russian-Phonetic and U.S. instances. Russian-Phonetic does not cover Greek/Hebrew punctuation, which
+  host-free measured-data tests cover.
+- `ghostty.conf` has a separate upstream grammar: bare `g` is Unicode and `key_g` physical; Unicode
+  triggers cannot fire on non-Latin layouts. agterm matches Ghostty.app and cannot fix this app-side.
+  Use `key_`, as `ghostty-defaults.conf` does for `super+key_c/key_v/key_a` (issue #30). README and
+  `site/docs.html` document the distinction.
+- Built-in leaders remain unsupported; leaders are custom-only. Literal `+`/`>` are separators and not
+  bare tokens, but bind as `shift+=`/`shift+.`. `increase_font_size`'s stored `Chord(key:"+")` cannot
+  round-trip and prints `(not expressible)` in the starter file. Ctrl-Tab and Ctrl-1/2 are reserved,
+  monitor-driven, and not rebindable. Palette custom hints use raw kitty syntax, not macOS glyphs.
+- **`{AGT_X}` interpolation is intentionally raw and unquoted.** Selection, OSC title, and OSC 7 pwd can
+  inject visible shell metacharacters. `TerminalText.sanitized` strips control characters, not `;`,
+  `$()`, or backticks. Prefer quoted exported `"$AGT_X"` variables for untrusted text. Do not add quoting
+  to `CommandContext.expand`.
+- File > Reload Keymap, the palette entry, and `keymap.reload` all call
+  `AppActions.reloadKeymap()` > `SettingsModel.reloadKeymap()`, which reparses and posts
+  `.agtermKeymapChanged`. Apply the Control API four-point audit.
+- Edit Keymap is GUI-only. `AppActions.editKeymap()` opens a 95% floating overlay with
+  `ConfigPaths.editorCommand(forPath:)`:
+  `${SHELL:-/bin/zsh} -ilc 'exec /bin/sh -c '\''${VISUAL:-${EDITOR:-vi}} "$1"'\'' agterm-config-edit '<path>''`.
+  The interactive login shell loads exported editor variables; inner POSIX `sh` handles
+  `${VAR:-default}` for fish and receives the single-quoted path as `$1`. Supported shells must accept
+  `-ilc` and preserve single quotes (sh/bash/zsh/fish, not csh/tcsh); non-exported editor variables fall
+  back to vi. Running POSIX expansion directly under fish exits 127. `ConfigPathsTests` cover zsh,
+  optional fish, VISUAL precedence, rc sourcing, and quoting.
+  Overlay close reloads only the recorded edit session. No control command is needed because scripts can
+  compose `session overlay open "$EDITOR <path>" --size-percent 95`.

--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -13,537 +13,176 @@ paths:
 
 ## libghostty gotchas
 
-- **Chrome colors track the terminal theme; `config_get` can't read the optional `selection-*` keys.**
-  The non-terminal chrome (sidebar row text + icons, title-bar text + buttons,
-  the bottom add-buttons) uses the theme's colors instead of system label colors:
-  `GhosttyApp.resolveThemeColors` reads `background`/`foreground` via `ghostty_config_get` and mirrors
-  `terminalForegroundColor` into the views (refreshed on `.agtermAppearanceChanged`,
-  like `terminalColor`).
-  But `ghostty_config_get` returns the non-optional `background`/`foreground` and **returns false for
-  the optional `selection-background`/`selection-foreground`** (verified:
-  `selBg=false` even when the theme sets them).
-  So the selection colors are resolved by `resolveSelectionColors()` — parsing the same config sources
-  `loadConfig` loads (defaults → `~/.config/ghostty/config` → the agterm settings conf,
-  last-wins) for `theme`/explicit `selection-*`, then reading the named theme file under `Bundle.main/ghostty/themes/<name>`.
-  The selected sidebar row draws the theme's `selection-background` pill with `selection-foreground`
-  text (a luminance-contrast black/white fallback when only the background is set).
-  The borderless New-Session `Menu` glyph ignores `foregroundStyle` on its label,
-  so it's tinted via `.tint(chromeText)`.
-- **Light/dark theme following is NATIVE — feed the raw dual value, don't pre-resolve.**
-  `theme = light:X,dark:Y` is a first-class runtime conditional in the pinned libghostty (verified on
-  `4dcb09ada`: `Config.zig` has `_conditional_state` + `changeConditionalState` and a light→dark test).
-  So `ghosttyConfigLines()` emits the dual value RAW while following (no `isDark` param, no side-pick) and
-  ghostty resolves the active side.
-  The switch is NOT fully autonomous on `set_color_scheme`: `ghostty_surface/app_set_color_scheme` only
-  RECORD the new conditional state and emit a SOFT `reload_config` action (which agterm does not handle,
-  so it is dropped); libghostty re-resolves only when the host re-feeds the config via `update_config`.
-  agterm therefore triggers the reload ITSELF on a flip.
-  The appearance side is single-sourced from the APP-level `NSApplication.effectiveAppearance`, observed
-  via KVO in `SystemAppearanceObserver` (the same mechanism Ghostty and the AppKit community use — Apple
-  exposes no notification API for appearance).
-  The observer posts `.agtermSystemAppearanceChanged` with the KVO-delivered `isDark` (`change.newValue`,
-  the SETTLED value, never re-read at receive time), and `SettingsModel.appearanceChanged` threads that
-  `isDark` straight into `reloadConfigPreservingSessionZoom` → `GhosttyApp.reloadConfig(surfaces:isDark:)`,
-  which sets the app + each surface scheme from it and re-feeds the config via `update_config` (NOT through
-  `apply()`/`writeGhosttyConfig`, whose text-diff would skip the reload — the raw dual file is byte-identical
-  across flips).
-  KVO is what makes this survive sleep/wake: it fires when the property SETTLES (including the belated
-  update after wake), so there is no dead callback to route around — unlike the old per-view
-  `viewDidChangeEffectiveAppearance` hook, which stopped firing in the wedge and left the terminal stuck
-  on the old theme (the wake-from-sleep bug).
-  Deliberately NOT `AppleInterfaceStyle` (wrong under macOS "Auto" scheduled switching) and NOT the
-  distributed `AppleInterfaceThemeChangedNotification` (fires before `effectiveAppearance` settles).
-  The flip reload PRESERVES each session's ⌘+/⌘− zoom (an automatic OS flip must not wipe it silently):
-  it skips `resetSessionFontSizesAllWindows`, and `reapplySessionConfigIfNeeded` (the widened watermark
-  re-assert) re-emits each zoomed session's `font-size` per surface after the shared-config broadcast.
-  Only the explicit reloads (File ▸ Reload / `config.reload` / a settings change) keep the documented
-  zoom-clearing contract via `reloadConfigClearingSessionZoom`.
-  Every reload records `lastAppliedIsDark` from the `isDark` it applied (the KVO-delivered side threaded
-  through `reloadConfig`), so "latch == applied side" holds by construction — there is ONE source now, so
-  the poster-vs-rendered divergence the old two-source (view + watchdog) design feared is gone.
-  `appearanceChanged` suppresses same-side re-posts via that latch (seeded `false` because a host-loaded
-  config starts light-sided), so the KVO `[.initial]` launch seed and any coalesced burst drive at most
-  one reload.
-  A zero-surface reload is chrome-correct: `reloadConfig` sets the APP scheme (`ghostty_app_set_color_scheme`)
-  before `update_config`, so the CONFIG_CHANGE clone resolves to the applied side even with no surfaces —
-  a dark launch re-sides the sidebar/titlebar before any surface exists.
-  The chrome retints on the same reload, but NOT from the host-loaded config: `ghostty_config_get` on
-  a config the host built always reads the DEFAULT (light) conditional side — there is no C API to
-  re-side a host config.
-  Instead ghostty replies to `ghostty_app_update_config` with a synchronous app-target `CONFIG_CHANGE`
-  action carrying the config it actually APPLIED (the dual resolved to the current side via
-  `changeConditionalState`) — the same channel Ghostty.app reads its chrome colors from.
-  `GhosttyCallbacks` clones that config into a lock-protected box (surface-target `CONFIG_CHANGE`s —
-  watermark overlays — are ignored), and `reloadConfig` takes it for `resolveThemeColors` and frees it;
-  so no `COLOR_CHANGE` callback is needed for this feature.
-- **The sidebar's disclosure triangle tracks the theme via `NSAppearance`, not a color we set.**
-  The expand/collapse triangle is drawn by `NSOutlineView` itself, colored from the view's `NSAppearance`
-  — which follows the macOS system light/dark setting, NOT the terminal theme.
-  So a light theme under macOS dark mode (or the mirror, a dark theme under macOS light mode) draws the
-  triangle in the wrong brightness and it vanishes against the themed sidebar background
-  (the row text/icons stay visible only because they're set explicitly to `terminalForegroundColor`).
-  `WorkspaceSidebar.Coordinator.applyThemeAppearance()` pins `outline.appearance` to `.darkAqua`/`.aqua`
-  from `GhosttyApp.terminalThemeIsDark`, called in `makeNSView` (launch) and `appearanceChanged` (live
-  theme switch — which the Sidebar-Tint slider also posts, so a tint change re-pins).
-  `terminalThemeIsDark` classifies the perceived luminance of the color the triangle actually sits on:
-  the theme background with the sidebar-tint wash applied (`ThemeBrightness.isDark(…, shiftAmount:)`,
-  host-free), NOT the raw background — so a strong tint that pushes a near-threshold theme across the
-  0.5 midpoint still picks the readable triangle.
-  The triangle color is not accessibility-observable, so this is verified by eye, not a UI test — like
-  the cursor solid/hollow case.
-- **Sidebar selection is drawn entirely by `SidebarRowView`, not AppKit.**
-  `outline.selectionHighlightStyle = .none` (set right after `style = .plain`,
-  which would otherwise reset it) so AppKit draws no selection of its own — otherwise it paints a gray
-  *unemphasized* capsule whenever the sidebar isn't first responder (the normal case,
-  since focus lives in the terminal), overriding any custom `drawSelection`.
-  The `.plain` style (chosen over `.sourceList` to drop the built-in ~10px top inset above the first row)
-  also reverts the outline's `backgroundColor` to an OPAQUE `controlBackgroundColor`, so
-  `outline.backgroundColor = .clear` is set alongside `scroll.drawsBackground = false` to keep the column
-  transparent over the terminal-colored/translucent window backing.
-  The row draws the themed pill in `drawBackground(in:)` for every state,
-  and the Coordinator's `refreshSelectionAppearance()` repaints the pills + re-tints the row text on
-  selection change (AppKit won't redraw rows on its own with `.none`) and on `.agtermAppearanceChanged`.
-  **The row view is the single source of truth for the cell's selection tint.**
-  The pill reads `isSelected` live at draw time, but the text/icon color is applied imperatively
-  (`SidebarCellView.setColors`), so the two can desync when a re-tint event is missed —
-  the cell builder's `row(forItem:)` can return -1 mid-reload/expand-collapse animation
-  (the constant OSC-title `reloadItem` ticks make this window easy to hit),
-  and on the ~1/3 of themes using the inverted-selection idiom (`selection-background == foreground`,
-  e.g. `Ghostty Default Style Dark`) a stale tint renders the row text fully INVISIBLE
-  (white-on-white pill, plus the previously-selected row dark-on-dark).
-  `SidebarRowView` therefore re-asserts `setColors` from its own live `isSelected`:
-  its `didSet` re-tints the hosted cell on every selection flip,
-  and `didAddSubview` tints a cell the moment it attaches (superseding the builder's build-time guess).
-  Rename `restore` reads the same row-view `isSelected` instead of recomputing via `row(for:)`.
-  Text color is not accessibility-observable, so this is verified by eye — like the disclosure-triangle
-  and cursor solid/hollow cases.
-  **`SidebarOutlineView.acceptsFirstResponder` is `false`** so a mouse click selects without stealing
-  first responder from the terminal — that responder bounce (terminal → outline → terminal,
-  via `mouseDown`'s `focusActiveTerminal`) otherwise makes AppKit re-set `SidebarRowView.isEmphasized`,
-  whose setter forces `needsDisplay`, and flicks the pill on every click (programmatic selection from
-  the palette/Ctrl-Tab never bounces, so it was already smooth).
-  **Reconcile splits SHAPE from CONTENT** (`TreeShape` ids/order → full `rebuildAndReload`;
-  `RowContent` name/icon/badge → per-row `reloadItem`) so a cwd-driven `displayName` change reloads only
-  its row instead of a full `reloadData` + re-expand that re-lays-out and horizontally jitters every
-  sidebar row.
-  **Inline rename** paints the edit field with the terminal theme's foreground-on-background (the row's
-  selection-foreground would be dark-on-dark in the system edit box), and `restore` re-applies the row's
-  selection-aware color when editing ends (a same-name commit doesn't reload the row).
-- **terminfo sibling dir.**
-  `GHOSTTY_RESOURCES_DIR` points at `Contents/Resources/ghostty`; libghostty derives `TERMINFO` as `dirname(...)/terminfo`
-  at shell spawn, so the compiled terminfo database must be a sibling at `Contents/Resources/terminfo`.
-  `GhosttyResources` sets only `GHOSTTY_RESOURCES_DIR` and never `TERMINFO` (libghostty overwrites it
-  at spawn).
-  If this layout breaks, `TERM=xterm-ghostty` fails and keys break.
-- **Surface lifecycle (EAGER deck).**
-  `Session` owns its `GhosttySurfaceView` (`@ObservationIgnored`).
-  The detail pane is a *deck* — `WindowContentView.detailPane` is a `ZStack` over EVERY session (`store.workspaces.flatMap(\.sessions)`),
-  each session's `TerminalView` mounted at once, with only the selected one at `opacity 1` + hit-testable.
-  So every session's shell spawns at startup (eager realization, not lazy-on-first-select),
-  and switching is a visibility + `isActive` flip, never an `.id` swap — re-hosting a surface invalidates
-  its Metal drawable and flickers the window.
-  `dismantleNSView` is a no-op; `ghostty_surface_free` runs only in `destroySurface()` (reached via `teardown()`
-  on close or pane-exit).
-  This single-owner, single-free rule is what makes passing the view as unretained `userdata` safe.
-  `destroySurface()` ALSO nils every `store`-capturing callback (`onExit`/`onExitCodeCaptured`/`onFocusChange`/`onUserInputClearsStatus`/`onFontSizeChange`/the
-  four `onSearch*`) at its END — AFTER `onExitCodeCaptured` is read for the overlay exit status (niling
-  it earlier would silently break `session.overlay.result`/`--block`) — to break the `store → session → surface → closure → store`
-  retain cycle on every window/session close.
-- **Drag-and-drop targets only the ON-SCREEN deck pane (`deckVisible` gates `registerForDraggedTypes`).**
-  Every session's surface is eagerly realized, so every one is a candidate file-drop target.
-  SwiftUI's `.opacity(0)` + `.allowsHitTesting(false)` on the inactive deck panes do NOT stop AppKit's
-  drag machinery: the NSView keeps `alphaValue == 1`, AND AppKit's drag-destination resolution does NOT
-  consult `hitTest` (verified: an off-screen surface whose `hitTest` returns nil STILL gets `draggingEntered`/`performDragOperation`).
-  So if every surface stayed registered, a file drop would land on whichever surface is topmost in z-order
-  (the ForEach/array order, NOT the selection) — an INVISIBLE background session — and inject the path
-  there, so the visible terminal shows nothing (single-session works, which is why #52 shipped with this
-  latent).
-  The fix is `GhosttySurfaceView.deckVisible` (set by `TerminalView` from the deck, = session selected
-  AND not hidden by a full overlay/scratch; NOT focus-gated, so BOTH panes of a visible split qualify —
-  unlike `deckActive`): its `didSet` calls `updateDropRegistration()` which `registerForDraggedTypes`
-  when visible and `unregisterDraggedTypes` otherwise, so only the on-screen pane is ever a drop target.
-  Not `hitTest` (AppKit drag ignores it) and not a `draggingEntered` reject (AppKit does not fall through
-  to the sibling behind a rejecting target — the drop is simply lost).
-- **A drop inserts as a bracketed paste, never typed keystrokes.**
-  `performDragOperation` routes the dropped text through `GhosttySurfaceView.insertPasted(text:)` (`ghostty_surface_text`),
-  whose bracketed-paste wrapping makes the running program treat the payload as literal text, so a multi-line
-  drop lands at the cursor without auto-submitting — the same behavior as ⌘V paste.
-  The no-submit guarantee tracks the program's bracketed-paste mode: a program with mode 2004 OFF (a raw
-  prompt, some TUIs) still submits a trailing newline, exactly the caveat ⌘V has — closing that residual is
-  the separate unsafe-paste-confirmation work, not this change.
-  This is deliberately NOT `inject(text:)`, which turns each `\n`/`\r` into a Return: a drop is a paste,
-  while `session.type` is automation that WANTS newline→Return.
-  Drop USED to reuse `inject(text:)`; this change splits it off so drop uses the bracketed-paste call and
-  `session.type` keeps `inject` — do not re-unify them (the control-api note "do not simplify inject back to
-  `ghostty_surface_text`" is about `session.type` only).
-  (`pasteboardText`, the pasteboard reader, is shared by the drop path and the ⌘V clipboard-paste path
-  `readPasteboardText`, NOT by `session.type`, which takes its text from the control request.)
-  `ShellEscape.path` still escapes file-URL paths so a path with spaces lands as one shell token on Enter;
-  the newline-escaping from #96 is now belt-and-suspenders under bracketed paste.
-- **Search bar placement (NSSplitView-overrun rule).**
-  The underlying rule: nothing may change `sessionDetail`'s ZStack SHAPE when a per-session toggle flips —
-  adding/removing a child (or flipping a pane modifier) inside that HSplitView-hosting subtree re-hosts the
-  `NSSplitView` and overruns it UP into the transparent titlebar.
-  Two surfaces obey it in two different ways.
-  The SEARCH BAR (`TerminalSearchBar`, `agterm/Views/`) stays OUT of `sessionDetail` entirely: it is anchored
-  on `detailPane` via `.overlay(alignment: .topTrailing) { searchBarLayer }`, NEVER inside any session's
-  `sessionDetail` subtree, so toggling it can't perturb the split at all.
-  The bar reads `store.activeSession?.searchActive` and shows only when set.
-  Because it is a `detailPane` `.overlay` it composites ABOVE the whole detail deck without any layout change
-  — the in-deck scratch (zIndex 1 inside `sessionDetail`) and the overlay panel (zIndex 3, hosting BOTH the
-  full and floating overlay) — so search-over-scratch shows the bar on top of the scratch with no HSplitView
-  perturbation.
-  The overlay takes the opposite route: it IS a `sessionDetail` ZStack sibling (`overlayPanel` at
-  `.zIndex(3)`), but an ALWAYS-PRESENT, constant-shape one — its panel content (surface + frame +
-  click-catcher) is gated INSIDE the sibling, so the ZStack child count never changes when an overlay
-  opens/closes/resizes and the `NSSplitView` is never re-hosted, even when a floating overlay leaves the
-  pane(s) VISIBLE behind its opaque panel.
-  (`overlayPanel` is per-session in the eager deck, so its program runs regardless of which session is
-  active — see the surface-lifecycle note.)
-- **Window overlays sit BELOW the custom titlebar, NOT as a body-level `.overlay` (transparent-titlebar-scrim
-  rule).** The quick terminal, command palettes, and Ctrl-Tab switcher render via `windowOverlayLayer`
-  — a ZStack sibling INSIDE the body's root ZStack, inset by `titlebarHeight` (`.padding(.top, titlebarHeight)`)
-  and at `.zIndex(1)`, with `customTitlebar` at `.zIndex(2)` ABOVE it.
-  They are NOT body-level `.overlay { … }` (which layer above EVERYTHING).
-  Reason: `customTitlebar` is transparent (no backing) AND AppKit's native titlebar backing is deliberately
-  hidden for translucency (`WindowAppearance`); a full-window overlay's dim scrim (`Color.black.opacity(0.2)`)
-  attached as a body `.overlay` composites OVER the titlebar and darkens/seams it — visible only in the
-  TALL non-compact (48px) titlebar (the cwd-subtitle strip lives in the content area below the native
-  titlebar band; the 30px compact bar stays within the band and hides it).
-  Keeping the titlebar at the highest zIndex means a scrim can never cover it;
-  insetting the overlays by `titlebarHeight` keeps them off the titlebar entirely.
-  The empty `windowOverlayLayer` (all three conditionals false) is a bare `.frame`-sized `ZStack` — an
-  empty frame is NOT hit-testable, so the terminal below stays interactive (do NOT put a `Color`/`contentShape`
-  at that level).
-  Diagnosed by codex; the fix preserves translucency (titlebar stays backing-free) and keeps the overlays
-  outside `detailPane`/`sessionDetail`/`HSplitView` (no split perturbation).
-  Do NOT "fix" this with a permanent `.background(terminalColor)` on `customTitlebar` — it masks the
-  symptom but breaks the opacity/blur chrome.
-- **Under window translucency every surface renders a fully transparent background — never leave a
-  surface visible beneath the FULL overlay.**
-  The translucency setting pins `background-opacity = 0` for every ghostty surface (the window's AppKit
-  backing supplies the tint), and the FULL overlay deliberately has no opaque SwiftUI backing.
-  Any surface left mounted at opacity 1 below it shows straight through — a "the overlay opened under
-  the scratch" report is SEE-THROUGH, not a z-order inversion (the layer compositing order was verified
-  correct in every open sequence: the overlay's layer sits above the scratch's).
-  `sessionDetail` therefore hides EVERY covered surface when `session.fullOverlayActive`:
-  the pane(s) via `hideForOverlay`, the scratch via its own `opacity(0)` + `allowsHitTesting(false)` +
-  a `deckVisible` gate (so a covered scratch is also not a file-drop target).
-  The FLOATING (sized) overlay and the quick terminal need none of this — both draw an opaque
-  `terminalColor`-backed panel, so nothing shows through them.
-- **OSC 11 dynamic background is honored PER-PANE via `GHOSTTY_ACTION_COLOR_CHANGE`.**
-  libghostty parses OSC 10/11/12 (set fg/bg/cursor) and applies the color to its own render state, then
-  fires the `GHOSTTY_ACTION_COLOR_CHANGE` action as a NOTIFICATION (the reference macOS apprt only posts
-  a NotificationCenter event from it; it does not paint the surface).
-  Under translucency the surface renders `background-opacity = 0`, so an OSC 11 background is invisible —
-  the terminal is transparent and the AppKit window backing (theme) shows through.
-  `GhosttyCallbacks` handles `COLOR_CHANGE` for the BACKGROUND kind and hands the color to
-  `GhosttySurfaceView.handleOSCBackgroundChange(_:)`, which routes it through the host-free
-  `OSCBackgroundPolicy` and then calls `applyOSCBackground(_:)` / `releaseOSCBackground()`.
-  The apply gives THIS surface its own config overlay carrying ONLY `background-opacity = windowOpacity`
-  (`WatermarkConfig.oscBackgroundOverlayText`), so the pane renders its tint translucently, per-pane,
-  without touching the window backing or any other surface.
-  **That overlay must never carry a `background` key** — see the OSC 111 paragraph below;
-  restating the OSC color there is what broke the reset in #309.
-  Held on `GhosttySurfaceView.oscBackgroundColorHex` and re-asserted across a config reload and a live
-  opacity change (`reapplySessionConfigIfNeeded`/`reapplyColorBackgroundIfNeeded`), and preserved across a
-  dashboard open/close (the `dashboardFontOverride` didSet re-emits it).
-  **A program's live OSC 11 owns the pane's rendered color; an explicit `session.background` CANNOT
-  override it against the pinned libghostty (codex-confirmed for commit `4dcb09ada`).**
-  libghostty's `DynamicRGB` (terminal `Colors.background`, `src/terminal/color.zig`) has two layers,
-  `override` (set by OSC 11 via `colors.background.set`) and `default` (seeded from the ghostty `background`
-  config key, `Termio.zig`), and the renderer draws `override orelse default`.
-  `session.background color` (and the `.color` overlay generally) only sets the config `default`, so while
-  an OSC 11 `override` is live it MASKS the explicit color and the pane keeps rendering the OSC color.
-  There is NO embedding C API to clear the `override`: config updates touch only `default`, the `reset`
-  binding action's `fullReset` (RIS) does NOT touch colors, `csi`/`esc`/`text` write to the child pty and
-  not the VT parser, and `COLOR_CHANGE` is outbound-only.
-  OSC 111 does not NULL the override either: in this pin `DynamicRGB.reset()` COPIES the current `default`
-  into `override`, so a reset renders whatever the config's `background` currently is.
-  **That is exactly why the OSC overlay must not restate the color.**
-  `ghostty_surface_update_config` reaches `Termio.changeConfig`, which re-seeds
-  `terminal.colors.background.default` from the config's `background` key on EVERY per-surface update
-  (`Termio.zig`) — so an overlay carrying `background = <the OSC color>` overwrites the default layer with
-  the program's own color, and the program's OSC 111 then "resets" to it.
-  That was #309: the pane stayed recolored after a TUI exited, and an OSC 11 QUERY still reported the
-  program's color, because `get()` = `override orelse default` and BOTH layers held it.
-  Lifting only `background-opacity` leaves `default` at the theme color, so the reset genuinely reverts.
-  The explicit spec is therefore the DEFAULT layer, visible only when no OSC override is live; `tree`'s
-  `background` reports the stored spec, which can differ from what a live OSC program is painting.
-  `oscBackgroundColorHex` mirrors the OSC color currently applied to THIS surface's overlay (nil when a
-  watermark/plain config is applied instead): it is BOTH the dedupe key (read by `OSCBackgroundPolicy`) and
-  the re-assert source across reload / opacity / dashboard.
-  `applyWatermarkFromSession` (every `session.background` set/clear) RELEASES the latch, because it installs
-  a config with no OSC overlay; without this, a re-`printf` of the SAME OSC 11 color right after `session
-  background clear/set` matches the stale latch, is deduped away, and never renders.
-  The reload / opacity / dashboard re-assert paths guard on the latch BEFORE calling
-  `applyWatermarkFromSession`, so a live OSC is preserved there, not dropped.
-  `session.background clear` does not reset the OSC override (nothing can): it emits an EMPTY overlay so the
-  surface falls back to the base config's pinned `background-opacity = 0`, the OSC color is re-HIDDEN behind
-  the window backing, the pane shows the theme background, and a later `printf` OSC 11 re-renders (the latch
-  was released).
-  `session.background color X` instead bumps the opacity back to `windowOpacity`, so the still-live OSC
-  override RESURFACES and masks X; and because `session.background` is session-scoped, every realized
-  session surface (main, split, and scratch) is affected even though the OSC tint was per-pane.
-  Only BACKGROUND is wired — OSC 10/12 (fg/cursor) render regardless of translucency.
-  **`OSCBackgroundPolicy` (agtermCore, unit-tested) owns the set-vs-reset routing and the dedupe**, because
-  libghostty reports both through the SAME action with no flag telling them apart — a reset simply carries
-  the terminal's default background.
-  So the BASELINE color identifies a reset — whichever color ghostty last seeded `default` from for this
-  surface (`OSCBackgroundPolicy.baseline`, fed by `baselineBackgroundHex()`).
-  With no OSC overlay installed that is the surface's OWN color: the session's `.color` watermark, a
-  sessionless overlay's `--background-color`, else the theme.
-  **While an OSC overlay IS installed it is always the THEME**, because that overlay emits no `background`
-  key, so the config in force is the base one and `default` holds the theme rather than the surface's color.
-  Getting this wrong routes a reset on a `.color` session (or a colored overlay) to `.apply` instead of
-  `.reset`: pixels are unaffected (the un-clearable `override` masks `default` either way), but the overlay
-  is never released and the latch stays pinned for a program that already exited, so every reload / opacity
-  tick / dashboard toggle re-installs it.
-  A reported color equal to it means reset → `releaseOSCBackground()` drops the overlay and restores the
-  surface's own config; an unchanged color means a per-prompt re-emit → ignored, so a shell re-asserting
-  OSC 11 every prompt does not rebuild the surface config each time; anything else applies.
-  A program that deliberately sets OSC 11 to the exact baseline color is indistinguishable from one
-  resetting to it, which is harmless — both render that color.
-  A pane/tab close clears the latch outright.
-  Diagnosed with codex; verified BY EYE (background color is not accessibility-observable, like the
-  cursor solid/hollow case), only visible under translucency (at 100% opacity ghostty renders the OSC bg
-  itself).
-- **Non-zero backing size.**
-  Create the surface only when the view has a non-zero backing size, else the Metal layer renders blank.
-  `pendingSurfaceCreation` defers creation until `setFrameSize` reports a real size.
-- **Re-parent invalidates the drawable → force a repaint.**
-  The split toggle re-hosts a surface between the `HSplitView` and a standalone host,
-  detaching/re-attaching the `NSView` and invalidating its Metal drawable.
-  `ghostty_app_tick` (demand-driven, coalesced on wakeup) only draws surfaces flagged dirty,
-  and `ghostty_surface_set_size` to an UNCHANGED grid is a no-op, so a re-attached pane keeps a blank
-  drawable even though its terminal buffer is intact (verified: `ghostty_surface_read_text` returns the
-  full screen while the pane shows blank).
-  `updateMetalLayerSize` calls `ghostty_surface_refresh` after every size push to force the redraw.
-  This is a DISPLAY fix, not a buffer fix.
-  The parked font-increase blank is ALSO buffer-intact (a `read_text` probe returns the full screen),
-  but is harder: it is NOT fixed by `refresh` or a forced `set_size` jitter,
-  and a font change doesn't resize the view so this `updateMetalLayerSize` path never fires for it —
-  still parked.
-- **Dashboard grid = the N-PANE generalization of terminal-zoom's reparent, focus inverted.**
-  Where `surface.zoom` reparents ONE session surface into the window and focuses it, the dashboard
-  (`DashboardView` + `WindowContentView+Dashboard.swift`, driven by the host-free `DashboardController`)
-  reparents up to `DashboardLayout.maxCells` (9) PANE surfaces into a `ceil(sqrt(n))`-wide grid and
-  focuses NONE while open — every cell is view-only.
-  The cell unit is a `DashboardMember` = session + `.primary`/`.split`: a non-split session is ONE
-  `.primary` cell, and a SPLIT session (`hasSplit`) shows as TWO cells — its `.primary` AND `.split`
-  panes — so the app-side expansion in `ControlServer.setDashboard` yields both, and the 9-cap counts PANES.
-  Each cell hosts its OWN pane surface — `.primary` → `\.surface` via `makeSurface`, `.split` →
-  `\.splitSurface` via `makeSplitSurface` — via `TerminalView(isActive: false, deckVisible: false,
-  reportsFocusChange: false, viewOnly: true)` with a stable slot `.id` (`-dashboard-primary`/`-dashboard-split`),
-  so the grid shows the LIVE shell, never a fresh one.
-  The generalized `dashboardHostsSurface` claims EACH member's pane slot (both panes of a split member),
-  so `deckHostsSurface` yields a `Color.clear` placeholder in each claimed deck slot — the SAME "keep the
-  deck mounted, swap only the hosted slot" contract zoom uses, generalized to N panes, so control-opened
-  split/scratch/overlay surfaces still realize behind the grid.
-  Enter on a cell selects the session, closes the dashboard, then focuses the cell's EXACT pane (the split
-  pane for a `.split` cell, else the main pane).
-- **Dashboard placement: a `windowOverlayLayer` branch, NOT a body-level `.overlay`.**
-  It renders while `controller.isOpen` at `zIndex 1`, inset by `titlebarHeight`, below the `customTitlebar`
-  — the same transparent-titlebar-scrim rule the quick terminal / palettes / switcher follow (see the
-  `windowOverlayLayer` note above); never a body-level `.overlay`, which would composite over the titlebar.
-- **Dashboard view-only is FIVE cooperating gates — hit-testing off alone is not enough.**
-  `isActive: false` only stops auto-focus; it does NOT disable `mouseDown`/first-responder eligibility
-  (see the surface-bridge note), so a click would still reach `mouseDown` and the retry loops would
-  re-grab the surface.
-  The full set:
-  - each cell's terminal is `.allowsHitTesting(false)`, with a transparent hit target ABOVE it that flashes
-    the highlight then enters that session+pane on a single click (the terminal itself takes no hits);
-  - `GhosttySurfaceView.viewOnly` (threaded via `TerminalView`) makes the member surface refuse to be
-    first responder (`acceptsFirstResponder = !viewOnly`) and drop hits (`hitTest` returns nil when
-    `viewOnly`), so even a stray reactivation click can't focus it;
-  - `deckInteractive` (`WindowContentView.swift`) is gated on `terminalZoom.target == nil &&
-    !dashboard.isOpen`, killing pane focus, scratch/overlay auto-focus, drag registration, and
-    background-click handling while the dashboard is up;
-  - an AppKit key-catcher owns first responder and CONSUMES every key (arrows → `controller.move`,
-    Enter → select+close, Esc → close, everything else swallowed), so no cell is ever first responder
-    and every cursor draws hollow;
-  - `AppActions.focusActiveSession` early-returns when `dashboardActive` (the window's controller
-    `isOpen`), mirroring its existing zoom/palette guards — without it the ~12×0.03s
-    `makeFirstResponder` retry would re-grab the active session's now-view-only grid cell and leak the
-    keyboard to the terminal (a real bug the e2e surfaced).
-- **Dashboard cell font uses a TRANSIENT `GhosttySurfaceView.dashboardFontOverride`, never a record-restore
-  of `session.fontSize`.**
-  There is no absolute font setter and a font round-trips through the model (`reportFontSize` →
-  `onFontSizeChange` → `store.setFontSize`), and a reload re-emits `session.fontSize` — so a
-  record-then-restore of the session font would be clobbered by a reload and would persist the dashboard
-  size.
-  Instead the per-surface config composer uses `dashboardFontOverride ?? session.fontSize`,
-  `reapplySessionConfigIfNeeded` REASSERTS the override across a config reload (so a File ▸ Reload while
-  the dashboard is open doesn't strand or clear the grid font), and `reportFontSize` is SUPPRESSED
-  (`guard dashboardFontOverride == nil`) while the override is set, so the CELL_SIZE round-trip can't
-  write the dashboard size into `session.fontSize`.
-  On open the wiring sets each member cell's OWN pane surface override from `fontMode` (`.auto` via
-  `DashboardLayout.dashboardFontSize`, base `AppSettings.fontSize ?? 13.0` ghostty default; `.fixed`
-  value; `.untouched` leaves it nil) — `.primary` → `\.surface`, `.split` → `\.splitSurface`; on close it
-  CLEARS the override with a store-wide sweep of BOTH `\.surface` AND `\.splitSurface` of every session
-  (a split member's two panes can each carry one) and rebuilds from the session model — no record-restore
-  dictionary.
-- **Zoom ↔ dashboard are reciprocally exclusive.**
-  `ControlServer.setDashboard` closes any active zoom before opening the grid, and
-  `WindowContentView`'s `.onChange(of: terminalZoom.target)` closes the dashboard when a zoom becomes
-  active — so the two view modes never stack.
-- **Opening/closing the dashboard resizes each member's pty — unavoidable.**
-  A cell is smaller than the full pane, so reparenting a member into (and back out of) its cell resizes
-  its surface, which resizes the pty; the program receives a `SIGWINCH`/resize event and may redraw.
-  "View-only" means no INPUT reaches the cell, NOT that the member's process is untouched — a full-screen
-  TUI reflows to the cell on open and back on close.
-- **strdup buffer lifetime.**
-  `working_directory` (and `initial_input`) `const char*` buffers must outlive `ghostty_surface_new`;
-  they are held in a `nonisolated(unsafe)` array and freed only in `destroySurface()`.
-- **Cursor shape is a config default, not set in code.**
-  `agterm/Resources/ghostty-defaults.conf` (loaded first in `GhosttyApp.loadConfig`,
-  so a user's `~/.config/ghostty/config` still overrides it) pins a steady block cursor with `cursor-style = block`
-  + `shell-integration-features = no-cursor,no-title`.
-  The shell-integration `cursor` feature re-emits a DECSCUSR bar (`\e[5 q`) on every prompt and resets
-  to the config default while a command runs, so setting `cursor-style` alone can't stop the bar-at-prompt
-  — disabling the feature with `no-cursor` is what keeps the cursor a block everywhere.
-  `no-title` disables the integration's auto-title (zsh `%(4~|…/%3~|%~)` / bash `\w`),
-  which would emit OSC 2 with the abbreviated cwd on every prompt and — since `Session.displayName` prefers
-  `oscTitle` over the cwd basename — always override the sidebar name with a noisy `…/a/b/c` path.
-  Explicit titles still win: a remote host over SSH or a user `PROMPT_COMMAND` emitting OSC 2 sets `oscTitle`,
-  and only local auto-titling is suppressed (OSC 7 pwd reporting is a separate feature,
-  unaffected).
-  **Caveat — a title is only kept while a foreground process HOLDS the local shell.** A one-shot local
-  `printf` OSC 2 sets `oscTitle`, but the shell immediately returns to its prompt where the title is
-  cleared again (the prompt cycle), so the sidebar name reverts to the cwd basename.
-  A real `ssh` keeps its title precisely because it BLOCKS the local prompt cycle (and its remote re-emits
-  each prompt); to reproduce that locally — e.g. in a test — hold the shell after setting the title:
-  `printf '\033]2;X\007'; cat`.
-  So a remote session's `oscTitle` (and the `subtitleDetail` second line that prefers it) is reliable,
-  but a quick local printf "looks broken" only because it isn't held.
-  See [[ui-tests]] for the test pattern.
-- **Cursor focus = window-key AND first-responder (`GhosttySurfaceView.liveFocus`).** libghostty draws
-  a solid (blinking) cursor only on a surface told it is focused via `ghostty_surface_set_focus`,
-  a hollow outline otherwise. agterm reports `liveFocus = window.isKeyWindow && window.firstResponder === self`
-  (the LIVE responder, NOT a cached flag), pushed through `updateGhosttyFocus()`.
-  The key-window gate is LOAD-BEARING: AppKit's first responder is PER-WINDOW and does NOT resign when
-  a window merely loses key, so without it EVERY window's active surface would keep a blinking cursor
-  at once.
-  Each surface observes `NSWindow.didBecomeKey/didResignKeyNotification` (`object: nil`,
-  re-evaluating its OWN `isKeyWindow` on any window's key change) and re-pushes focus,
-  so a background window goes hollow and the new key window's active surface goes solid.
-  `becomeFirstResponder`/`resignFirstResponder` push DIRECTLY (become gated on `isKeyWindow`),
-  because `window.firstResponder` is not yet self inside those calls; `createSurface`/`viewDidMoveToWindow`/the
-  auto-focus + reparent grabs read `liveFocus`, so a re-hosted pane reports its TRUE (non-)focus instead
-  of a stale latch — which is what left BOTH split panes solid on open before this.
-  `onFocusChange` (the `splitFocused` model tracking) stays tied to first-responder transitions,
-  NOT key state, so a session keeps its focused pane while its window is inactive.
-  The observers are removed in `destroySurface`/`deinit`; `focusObservers` is `nonisolated(unsafe)` for
-  the deinit read.
-  Cursor solid/hollow is not accessibility-observable, so it is NOT unit/UI-testable — verified by instrumenting
-  `set_focus` and reading `log show` across split-open + multi-window key switches (exactly one focused
-  surface app-wide in every case).
-- **A background window's LEFT reactivation click reaches the surface (`acceptsFirstMouse`), and `scrollWheel` self-syncs the mouse cell.**
-  `GhosttySurfaceView.acceptsFirstMouse(for:)` returns true ONLY for `.leftMouseDown`, so the click that
-  raises an inactive window also runs `mouseDown` — selecting the clicked split pane (`makeFirstResponder`
-  → `onFocusChange` → `splitFocused`), the counterpart to the first-responder path above, instead of AppKit
-  swallowing the click just to raise the window.
-  It is gated to the LEFT button on purpose: a first-mouse right/middle click would otherwise reach
-  `rightMouseDown`/`otherMouseDown`, which forward to libghostty, and with the default
-  `right-click-action = paste` (`AppSettings.rightClickPaste`, nil = paste) that would paste the clipboard
-  into a window you only meant to raise.
-  **EXCEPT under `autoHideSidebarInactiveWindows`: `acceptsFirstMouse` returns FALSE there.**
-  With that setting on, activating an inactive window expands its (hidden) sidebar and RESIZES the surface;
-  if the activating click also pressed the terminal button, the still-held press + the mid-gesture resize
-  land the release on a different cell → a phantom drag-selection.
-  Suppressing first-mouse in that mode makes the activating click ONLY raise the window (the sidebar still
-  expands via `didBecomeKey` → `reportFrontmost`); a follow-up click selects normally once the window is key.
-  The lost first-click pane-select is an accepted trade for that mode (verified by eye).
-  Separately, `mouse_scroll` reports at libghostty's LAST-KNOWN cell, and a no-mouse-move reactivation
-  (cmd-tab/keyboard, or scrolling to reactivate with the pointer already inside) fires no `mouseDown`/`mouseEntered`,
-  so the position is stale or `-1,-1` (from `mouseExited`).
-  `scrollWheel` therefore pushes `ghostty_surface_mouse_pos` from its own event before `mouse_scroll`, but
-  ONLY when the point is stale — it differs from `lastReportedMousePoint`, which every mouse handler updates
-  through the shared `reportMousePos` helper.
-  So the first scroll after a no-move reactivation lands at the real cell instead of doing nothing until you
-  nudge the mouse, while a normal already-synced scroll does NOT re-push the same cell on every packet —
-  which in an any-motion + sgr-pixel mouse-reporting TUI would otherwise emit a synthetic motion report per
-  packet.
-  It is the companion to the `mouseEntered` restore (which only covers cross-the-boundary re-entry).
-  Like the cursor-focus case, this input plumbing is not accessibility-observable and is verified by hand,
-  not a UI test.
-- **Only the ON-SCREEN deck pane may set the process-global cursor (`deckVisible` gates every cursor write).**
-  Every session's surface is eagerly realized with a `.mouseMoved`/`.cursorUpdate` tracking area, and AppKit
-  tracking ignores SwiftUI `.opacity(0)`/sibling overlap the SAME way drag-destination resolution does — a
-  hidden surface's `visibleRect` is NOT clipped by the visible pane stacked over it.
-  So several stacked surfaces receive the SAME `mouseMoved` and each ran `NSCursor.set()`; a hidden session
-  cached at a different mouse shape (a mouse-reporting TUI, or an OSC 22 pointer shape) then flickered its
-  shape over the visible terminal on every move — issue #225's arrow↔I-beam flicker, seen in RESTORED
-  sessions precisely because restore mounts MANY surfaces at once (one session shows no competition).
-  The fix gates the cursor on `deckVisible` (the same on-screen-pane flag drag registration uses) in TWO
-  places: `setupTrackingArea` installs the tracking area only while `deckVisible` (a hidden surface gets no
-  `mouseMoved` at all — this also stops the `reportMousePos` fan-out to every hidden TUI), AND the three
-  cursor-set sites (`mouseMoved`, `applyMouseShape`, `cursorUpdate`) each `guard deckVisible`.
-  The tracking-area gate ALONE is NOT enough: AppKit still delivers a `cursorUpdate` to a HIDDEN surface on
-  window activation, so a background pane cached at a stale shape would paint it on the reactivating click
-  without the `.set()`-site guards.
-  Conversely AppKit does NOT re-issue a `cursorUpdate` to the VISIBLE pane on bare activation, so
-  `reassertCursorOnActivation` (called from the `didBecomeKey` observer) re-asserts the visible pane's cursor
-  when its window becomes key — gated `deckVisible` + `isKeyWindow` + pointer-in-bounds, so it never paints
-  the terminal cursor over the sidebar or a background window, and it wins uncontested since hidden panes are
-  already muted.
-  `deckVisible` itself is computed in `WindowContentView.sessionDetail` (the pane's `visible`, plus the
-  scratch and overlay `deckVisible` expressions); each must exclude EVERY layer that covers the surface, or
-  the covered surface keeps `deckVisible = true` and competes anyway.
-  Full overlay / scratch drop it via `hideForOverlay`; the window-level quick terminal drops it via
-  `!quickTerminal.isVisible` on the pane, scratch, AND overlay expressions (it covers the deck WITHOUT
-  touching `deckInteractive`/`hideForOverlay`, so without that term the covered surfaces flicker against the
-  quick-terminal surface — issue #225's quick-terminal path).
-  Two residual cases remain, both far milder than the original many-surface flicker and both predating this
-  change.
-  A FLOATING overlay leaves the pane VISIBLE in the margin around the panel (so the pane legitimately keeps
-  `deckVisible = true`), and no boolean gate can scope the cursor to the panel-vs-margin split — over the
-  panel's overlap the pane and the overlay surface can still show competing shapes.
-  The command palette and Ctrl-Tab switcher (window-level SwiftUI overlays NOT in the `deckVisible`
-  predicate) likewise leave the covered pane `deckVisible = true`, so over them the covered terminal surface
-  can still write its cached cursor (cosmetic, plus a rare drop-through) — but that is ONE terminal surface
-  under a SwiftUI overlay, not two terminals fighting, and these are transient keyboard-driven overlays the
-  pointer rarely rests on.
-  Both are left as known limitations of the boolean approach rather than chasing every window-level overlay
-  into the predicate (the quick terminal is gated because it is the persistent, mouse-used one).
-  The tracking + pointer methods live in `GhosttySurfaceView+Tracking.swift` (`currentTrackingArea` is
-  `internal`, not `private`, so that extension can manage the stored area).
-  Cursor shape is not accessibility-observable, so this is verified BY EYE (like the cursor solid/hollow
-  case), reproduced deterministically with several stacked sessions given differing OSC 22 shapes
-  (`printf '\033]22;crosshair\007'`).
-  Do NOT "simplify" this to only the tracking-area gate (the refocus crosshair returns) or only the
-  `.set()`-site gates (hidden TUIs keep getting the `reportMousePos` fan-out).
-- **OSC 52 clipboard access is gated in OUR callbacks, not by a ghostty-internal dialog.**
-  A program reading (`\e]52;c;?\a`) or writing (`\e]52;c;<base64>\a`) the system clipboard reaches agterm
-  through `read_clipboard_cb`/`confirm_read_clipboard_cb` and `write_clipboard_cb` (`GhosttyCallbacks`).
-  libghostty delegates the `ask` policy to the host: the write callback carries a `confirm` bool (true
-  when `clipboard-write = ask`), and the read confirm callback carries a `ghostty_clipboard_request_e`
-  (`GHOSTTY_CLIPBOARD_REQUEST_OSC_52_READ` for a program read, `..._PASTE` for ⌘V) — only `OSC_52_READ`
-  is gated, so pastes never prompt.
-  `ClipboardPromptController` (`@MainActor`) owns an app-session-scoped host-free `ClipboardPromptPolicy`
-  (`ask`/`allow`/`deny` remembered per direction until agterm quits, shared across every window and
-  terminal session: the "don't ask again this session" choice) and shows an `NSAlert` sheet.
-  Coalescing is keyed by (requesting surface, direction), so a program looping OSC 52 collapses to one
-  prompt while a DIFFERENT surface's concurrent request gets its OWN prompt, so one Allow never authorizes
-  another surface's read (or, under `clipboard-write = ask`, its write: the write callback's userdata is
-  the surface too, recovered the same way as the read confirm's).
-  Two rules the build proved the hard way: the callback fires INSIDE a libghostty tick, so the sheet is
-  deferred via `DispatchQueue.main.async` (a modal run loop opened inside the tick re-enters it); and a
-  DENIED read must complete with an EMPTY string and `confirmed = true`, because completing with
-  `confirmed = false` leaves the request unconfirmed and libghostty just re-asks, LOOPING the dialog.
-  The clipboard callbacks run on the main actor inside the tick (verified), so the UNGATED write
-  (`clipboard-write = allow`, the default) sets the pasteboard SYNCHRONOUSLY: deferring it would let a
-  same-tick OSC 52 read observe the stale clipboard.
-  Read gating rides ghostty's own `clipboard-read = ask` default (verified: the confirm callback fires
-  with no explicit config); write stays `allow` by default (matches mainstream terminals, so a legit
-  remote yank isn't interrupted) and opts into `ask`/`deny` via the agterm-scoped `ghostty.conf`.
-  The deferred read completion captures the `GhosttySurfaceView` (NOT the raw surface pointer) and
-  re-reads `view.surface` on the main actor before completing, skipping the call when it is nil: a
-  session/window/pane close (or `session.close` over the control socket) can `ghostty_surface_free` the
-  surface WHILE the sheet is open, and completing on the freed pointer is a use-after-free.
-  Freeing the surface already discards its pending clipboard request, so skipping is safe and loop-free.
-  The ghostty request `state` is `nonisolated(unsafe)` (same lifetime as the surface, guarded by that same
-  `view.surface` check).
-  The dialog is AppKit and not unit-tested (only `ClipboardPromptPolicy` is); the gating was verified with
-  an isolated dev instance driving OSC 52 read/write by hand.
+## Theme and sidebar
 
+- Chrome reads background/foreground through `ghostty_config_get`. It cannot read optional
+  `selection-*` keys, even when set, so `resolveSelectionColors` parses the same last-wins config sources
+  and named bundled theme file. Selected rows use selection background/foreground, with black/white
+  luminance fallback. Tint borderless New Session through `.tint`; its label ignores foreground style.
+- Pass `theme = light:X,dark:Y` raw. Pinned libghostty `4dcb09ada` supports conditional themes, but
+  `set_color_scheme` only changes conditional state and emits an unhandled soft reload. agterm must set
+  app and surface schemes, then call `update_config`.
+- Observe app-level `NSApplication.effectiveAppearance` through KVO, not per-view appearance,
+  `AppleInterfaceStyle`, or the early distributed notification. Post the KVO-delivered settled `isDark`
+  and thread it through `reloadConfigPreservingSessionZoom`; do not use `apply`, whose unchanged text skips
+  the reload. KVO also survives sleep/wake.
+- Appearance reload preserves per-session zoom and reasserts it after shared config. Explicit File Reload,
+  `config.reload`, and settings changes use `reloadConfigClearingSessionZoom`. Record
+  `lastAppliedIsDark` from the applied value; suppress same-side repeats. Seed false so initial KVO causes
+  at most one dark reload.
+- Set the app color scheme before update even with zero surfaces. Host-built config getters always expose
+  the light conditional side. Instead, consume the synchronous app-target `CONFIG_CHANGE` config that
+  libghostty actually applied; clone it under a lock, ignore surface-target watermark config changes, use
+  it for chrome colors, then free it.
+- AppKit draws disclosure triangles from `NSAppearance`, not explicit tint. Pin outline appearance to
+  aqua/darkAqua from perceived luminance of the sidebar-tinted theme background, using the 0.5 midpoint.
+  Apply at creation and `.agtermAppearanceChanged`. Verify by eye.
+- Disable AppKit outline selection immediately after `.plain`, which otherwise restores it. Also clear
+  outline/scroll backgrounds; `.plain` avoids source-list's roughly 10px top inset but installs opaque
+  control background.
+- `SidebarRowView` alone draws selection and reapplies cell colors from live `isSelected` in `didSet` and
+  `didAddSubview`. Builder-time row lookup can be -1 during reload/animation, making inverted-selection
+  themes render invisible text. Rename restoration also uses row-view selection.
+- `SidebarOutlineView.acceptsFirstResponder` is false so clicks select without terminal-to-outline focus
+  bounce and pill flicker. Reconcile `TreeShape` changes with full reload and `RowContent` changes per row.
+  Inline rename uses theme foreground/background, then restores selection-aware colors. Visual tint cases
+  are manual-only.
+
+## Resources and lifecycle
+
+- `GHOSTTY_RESOURCES_DIR` points to `Contents/Resources/ghostty`; terminfo must be its sibling at
+  `Contents/Resources/terminfo`. Never set `TERMINFO`; libghostty derives and overwrites it at spawn.
+- Sessions own surfaces. The eager detail deck mounts every session once in a ZStack and toggles only
+  opacity, hit testing, and active state. Rehosting through identity changes invalidates Metal drawables.
+- `dismantleNSView` is a no-op. Free only through `destroySurface`. After reading overlay exit status,
+  nil every store-capturing callback to break the store/session/surface/closure cycle.
+- Create surfaces only with nonzero backing size; otherwise Metal stays blank. Defer through
+  `pendingSurfaceCreation` until `setFrameSize`.
+- `working_directory`, `initial_input`, and environment strdup buffers must outlive
+  `ghostty_surface_new`; retain them until destruction.
+- Reparenting invalidates the drawable while leaving terminal buffer intact. `set_size` with an unchanged
+  grid does nothing, so `updateMetalLayerSize` must call `ghostty_surface_refresh` after every size push.
+  The parked font-increase blank is also buffer-intact but is not fixed by refresh or size jitter.
+
+## Drag, paste, and overlays
+
+- Only `deckVisible` surfaces register for file drag. SwiftUI opacity/hit-testing does not stop AppKit
+  drag destination lookup, and rejecting in `draggingEntered` does not fall through. Visible split panes
+  both qualify; full overlay and scratch-covered panes do not. This closes the latent background-session
+  target shipped with single-session file drop in #52.
+- File drop uses `insertPasted`/`ghostty_surface_text`, preserving bracketed-paste behavior. It may still
+  submit a trailing newline when the program disables mode 2004. Do not reuse `inject`, which intentionally
+  translates newline/return into Return for `session.type`. `pasteboardText` remains shared with clipboard
+  paste, and `ShellEscape.path` keeps file paths one token; #96 newline escaping remains defense in depth.
+- Never change the `sessionDetail` ZStack shape for per-session toggles; doing so rehosts `NSSplitView`
+  into the titlebar. Search bar is a `detailPane` top-trailing overlay, above deck, scratch, and overlays.
+  Overlay panel stays an always-present `sessionDetail` sibling whose internal content changes.
+- Window-level quick terminal, palettes, switcher, and dashboard live in `windowOverlayLayer`, inset by
+  `titlebarHeight` below `customTitlebar`. A body overlay's 0.2-opacity black scrim darkens the transparent
+  tall titlebar.
+  The seam appears in 48px normal mode; 30px compact remains inside the native band.
+  Keep the empty overlay layer free of Color/contentShape so it cannot intercept hits. Do not add an opaque
+  titlebar background; it breaks translucent chrome.
+- With translucency, every surface has zero background opacity. A full overlay has no opaque SwiftUI
+  backing, so hide panes and scratch beneath it and remove their drop eligibility. Floating overlay and
+  quick terminal have opaque terminal-color panels.
+
+## OSC 11 backgrounds
+
+- Handle background `GHOSTTY_ACTION_COLOR_CHANGE` per pane. Under zero surface opacity, apply a surface
+  config overlay containing only `background-opacity = windowOpacity`; never include `background`.
+  Preserve and reassert the latch through reload, opacity, and dashboard font changes.
+- A live OSC 11 override masks config defaults in pinned libghostty `4dcb09ada`. No embedding API clears
+  it: RIS leaves colors, PTY writes bypass the parser, and COLOR_CHANGE is outbound-only.
+  `session.background color` changes only the default and cannot override live OSC.
+- OSC 111 copies current default into override. Per-surface update also reseeds default from a
+  `background` key. Restating OSC color in the overlay therefore made reset permanently retain it (#309).
+  Opacity-only overlay leaves theme as default, so reset returns to theme.
+- `tree.background` reports the stored specification and may differ from a live OSC-rendered color.
+  `oscBackgroundColorHex` is both dedupe key and reassert source. Applying/clearing session background
+  releases it so an identical later OSC value is not discarded.
+- `session.background clear` cannot clear the underlying OSC override; it installs an empty overlay,
+  returning opacity to zero and hiding OSC behind window backing. A later OSC re-renders. Setting a color
+  restores opacity, so the live OSC resurfaces and masks it across main, split, and scratch.
+- Host-free `OSCBackgroundPolicy` distinguishes set/reset because libghostty reports both identically.
+  Baseline is the surface's own color without an OSC overlay: session color, overlay color, or theme.
+  While the opacity-only OSC overlay is installed, baseline is theme. Baseline means reset, unchanged
+  means ignore repeated prompt emission, anything else applies. Equal-to-baseline deliberate sets are
+  harmless. Clear the latch on pane close. This behavior is visually verified.
+- Only background needs this; OSC 10/12 render despite transparency.
+  At 100% window opacity Ghostty renders OSC background itself, so the host fix is visible only when translucent.
+
+## Dashboard
+
+- Dashboard generalizes terminal zoom from one reparented focused surface to at most
+  `DashboardLayout.maxCells` (9) view-only pane surfaces in a `ceil(sqrt(n))`-wide grid. A split session
+  contributes primary and split cells, so the limit counts panes.
+- Each `DashboardMember` hosts its existing pane with stable primary/split slot identity. Claim each exact
+  slot through `dashboardHostsSurface`, leaving a clear placeholder in the eager deck so other surfaces
+  still realize. Enter selects, closes, then focuses that exact pane.
+- Place dashboard in `windowOverlayLayer`, never a body overlay.
+- View-only requires all five gates:
+  1. terminal hit testing off with a transparent click/highlight/enter layer above;
+  2. `viewOnly` rejects first responder and hits;
+  3. `deckInteractive` requires no zoom and no dashboard;
+  4. an AppKit key catcher owns responder, handles arrows/Enter/Esc, and swallows all other keys;
+  5. `focusActiveSession` returns while dashboard is active, preventing its roughly 12 by 0.03s
+     retry from focusing a grid cell.
+- Dashboard font uses transient per-surface `dashboardFontOverride`, never record/restore of
+  `session.fontSize`. Compose override before session font, reassert on reload, and suppress CELL_SIZE model
+  reporting while set. Auto uses `DashboardLayout.dashboardFontSize` with configured font or 13.0;
+  fixed uses its value; untouched remains nil. On close, clear both primary and split overrides store-wide.
+- Dashboard and terminal zoom are reciprocal: opening dashboard clears zoom; activating zoom closes
+  dashboard. Reparenting grid cells necessarily resizes PTYs and sends SIGWINCH; view-only promises no
+  input, not no process resize.
+
+## Cursor defaults and focus
+
+- Defaults load before user config and set `cursor-style = block` plus
+  `shell-integration-features = no-cursor,no-title`. `no-cursor` prevents prompt DECSCUSR bar resets;
+  `no-title` prevents abbreviated local cwd OSC 2 from overriding sidebar names. User/remote OSC titles
+  still work, and OSC 7 is unaffected.
+- A one-shot local OSC 2 is cleared by the next prompt. Hold the shell with
+  `printf '\033]2;X\007'; cat` to test; SSH works because it blocks the local prompt cycle.
+- `liveFocus` is key window and first responder. The key gate is essential because AppKit retains one
+  responder per inactive window. Observe all didBecomeKey/didResignKey events and reevaluate this window.
+  Push directly from responder callbacks because AppKit has not updated `window.firstResponder` yet.
+  Creation, attachment, and retry paths read live state, while `onFocusChange` tracks responder transitions,
+  not window key state. Remove observers on destruction. Verify the solid/hollow cursor manually.
+- `acceptsFirstMouse` permits left mouse only, so inactive-window clicks select a pane without permitting
+  default right-click paste. Under `autoHideSidebarInactiveWindows`, reject first mouse because sidebar
+  expansion resizes the surface mid-gesture and causes phantom selection; the next click selects.
+- Before `mouse_scroll`, report the event position only when it differs from `lastReportedMousePoint`.
+  This fixes stale/-1,-1 positions after keyboard activation without generating synthetic motion for every
+  scroll packet in mouse-reporting TUIs.
+
+## Process-global cursor
+
+- Every hidden eager surface otherwise receives tracking and can call process-global `NSCursor.set`,
+  causing issue #225 flicker, especially restored sessions and quick terminal.
+- Gate both sides with `deckVisible`: install tracking areas only while visible, and guard `mouseMoved`,
+  `applyMouseShape`, and `cursorUpdate`. Tracking alone is insufficient because hidden surfaces receive
+  activation `cursorUpdate`; setter guards alone leave hidden mouse-report fan-out.
+- On didBecomeKey, `reassertCursorOnActivation` for a visible, key-window, pointer-in-bounds surface because
+  AppKit does not update the visible cursor automatically. Every `deckVisible` expression must exclude full
+  overlay, scratch, and persistent quick terminal coverage.
+- Known limitations: a floating overlay shares pane-visible margins, and transient SwiftUI palette/switcher
+  overlays are absent from this boolean. One terminal may affect cursor over those regions; do not expand
+  the predicate without a more precise geometry model. Reproduce manually with stacked sessions and
+  `printf '\033]22;crosshair\007'`.
+
+## OSC 52 clipboard
+
+- Gate clipboard in host callbacks. Write carries `confirm` for `clipboard-write = ask`; read confirmation
+  identifies OSC 52 read versus paste. Prompt only OSC read, never Command-V.
+- `ClipboardPromptController` owns app-session-wide per-direction ask/allow/deny policy. Coalesce by
+  requesting surface plus direction so separate surfaces cannot inherit one decision.
+- Defer sheets to the next main turn because callbacks occur inside a libghostty tick and a modal loop
+  would reenter it. Denied reads must complete with empty text and `confirmed = true`; false causes an
+  endless re-prompt.
+- Default ungated writes are synchronous so a same-tick read sees them. Read defaults to ask; write defaults
+  allow and can be changed in agterm `ghostty.conf`.
+- Deferred completion captures `GhosttySurfaceView`, then rereads its live surface. If a pane closed while
+  the sheet was open, skip completion rather than use the freed raw pointer; freeing already discards the
+  request. Keep request state `nonisolated(unsafe)` under the same lifetime check.
+- AppKit dialog behavior is manual-only; unit-test `ClipboardPromptPolicy`.

--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -18,459 +18,161 @@ paths:
 
 ## Menu bar and actions
 
-- User actions live in `AppActions` (app target, `@MainActor`), shared by the toolbar/bottom-bar buttons
-  (`WindowContentView`), the menu bar (`agtermApp`'s `.commands`), and the control channel (`ControlServer`)
-  so the three never drift.
-  Trivial one-liners (quick-terminal toggle) call the controller/store directly;
-  `AppActions` owns the ones with real logic — new-session placement, the directory picker,
-  split + focus, and font.
-  `toggleQuickTerminal` gates on the full `uiActionsEnabled` (terminal zoom AND the dashboard grid),
-  not zoom alone.
-  This is defence in depth, not a gap being closed: all three callers of the method were already gated.
-  The View ▸ Quick Terminal item carries `.disabled(modalActive)`,
-  which also covers a `keymap.conf` rebind of the built-in, because that rebind IS the item's key equivalent;
-  the palette caller is gated by `runPaletteCommand`'s own `uiActionsEnabled` check;
-  and the Dock item rechecks `uiActionsEnabled(for:)` at invocation.
-  The control `quick` command never reaches this method at all, driving `QuickTerminalRegistry` directly.
-  The title-bar quick-terminal button is not a caller either — it toggles the controller directly,
-  and is unreachable while a modal is up because `WindowContentView+Dashboard` swaps the whole titlebar.
-  `WindowContentView+Dashboard` also force-hides a SHOWN quick terminal when the grid opens,
-  so the gate only ever blocks opening one over the grid, never strands one behind it.
-- **Application Dock menu (`AppDelegate.applicationDockMenu`).**
-  AppKit asks for a fresh menu when the Dock icon is right-clicked.
-  The menu exposes New Session, New Window, Quick Terminal, Dashboard, the captured window's MRU sessions, and that window's attention ordering.
-  **New Window is the one APP-LEVEL item and deliberately breaks the capture pattern** (Discussion #313): it captures no store or window id, and calls `AppActions.newWindow(ignoringModals: true)` to skip the frontmost-window modal gate.
-  Its enabled state reads `actions != nil` and NOTHING about the captured window — not "always true", which is the shape it started as.
-  `actions` is wired in the scene `.task`, so during the launch window every OTHER item is already disabled (nil library → nil `windowID` → false `actionsEnabled`) and an always-true New Window would be the only enabled item in the menu, one that runs `NSApp.activate` and then no-ops with no window and no feedback.
-  Pinned by `DockMenuTests.testNewWindowIsDisabledUntilTheActionHubIsWired`.
-  Creating a window touches no existing window's state, so a dashboard or terminal zoom in whatever window happened to be last active must not make it inert — being reachable while the app is busy or backgrounded is the whole point of driving it from the Dock.
-  The menu bar and palette keep the gate (File ▸ New Window mirrors it with `.disabled(modalActive)`), so the bypass is the Dock's alone.
-  It also calls `NSApp.unhide` + `NSApp.activate` itself: ordinary window presentation does NOT activate the app (`WindowAccessor.bringForward` unhides and activates only on the UI-test path), so without it the new window opens behind whatever app the user right-clicked the Dock from.
-  `newWindow` creates only when `openWindow` is wired, since `library.newWindow()` persists an entry marked open and an opener-less create would leave a window the app counts as open with no NSWindow — which `applicationShouldTerminateAfterLastWindowClosed` reads to decide whether to quit.
-  `AppStore.navigableRecentSessions(limit:)` supplies the same visible-scope, current-session-excluding MRU list used by the title-bar recent-session menu, capped by `SessionSwitcher.maxCandidates`.
-  AppKit sends Dock actions with a nil sender, and `NSMenuItem.target` is weak.
-  `AppDelegate.dockMenuActionTargets` is therefore the sole strong owner of one closure-backed target per dynamic item until the next menu build.
-  Session closures capture only the session UUID, never the `Session` or its terminal surfaces.
-  The next build invalidates the old targets before replacing that retention set, which also stops an already-loaded or in-flight stale target from dispatching.
-  Every top-level and session action captures the `AppStore` and window id present when AppKit builds the menu.
-  Invocation rechecks that window's per-window modal/controller state, raises it, synchronously publishes `WindowLibrary.frontmostWindowID` plus `.agtermWindowFrontmostChanged`, and only then selects or calls the shared `AppActions` path.
-  `AppStore.selectSession` and `navigateSession` return the pre-selection indicator because `autoReset` clears it on visit.
-  GUI selection callers pass that captured value to `revealActiveBlockedPane(captured:)`, which reveals a tagged pane only for `needsAttention` (`blocked`/`completed`) while `active` and `idle` use ordinary focus.
-  Synchronous publication is load-bearing because shared `AppActions` resolve through the frontmost store while AppKit can keep tracking a menu after another window becomes frontmost.
-  The per-window check is also load-bearing because window B's dashboard/zoom must not disable A, while a modal opened in captured window A after menu construction must make the stale action inert.
-  A Dashboard item built while A's dashboard is already open remains a valid close toggle, while one built closed becomes inert if A enters dashboard before invocation.
-  Hosted AppKit coverage lives in `agtermTests/DockMenuTests.swift`, including nil-sender dispatch, stale modal/closed/rebuilt actions, captured top-level/session actions, and pane-aware selection.
-  Run it with `make test-app`, whose dedicated scheme supplies isolated `AGTERM_STATE_DIR` and `AGTERM_CONTROL_SOCKET` values before `agtermApp.init()` and sets `AGTERM_HOSTED_TESTS=1`.
-  That sentinel renders a shell-free scene and never starts the control server.
-  Do not add the sentinel to the `agterm` scheme because its Test action launches the real app for `agtermUITests`.
-  The Dock surface composes the existing `session.new`, `window.new`, `quick`, `dashboard`, and `session.select` capabilities, so it is exempt from adding a new control command.
-- **Menu split: View vs Navigate.**
-  The menu bar has TWO custom menus (besides File/Help).
-  **View** (`CommandGroup(after: .toolbar)`) holds appearance + what-is-shown:
-  font/theme, sidebar show-hide + expand/collapse, the flagged-view + Flag/Clear-Flagged items, the four
-  workspace-focus items (Focus Workspace and Toggle Workspace Filter, both `BuiltinAction`-backed and so
-  rebindable; Add Workspace to Focus and Clear Focus, plain keyless items),
-  the surface toggles (Split/Scratch/Find/Quick Terminal), and Toggle Full Screen
-  (`toggle_fullscreen`, ⌃⌘F → `AppActions.toggleFullscreen()`, native `NSWindow.toggleFullScreen` on the
-  key window; the `window.fullscreen` control command is a fourth driver of native full screen, via
-  `WindowRegistry.fullscreen` with id resolution (not through `toggleFullscreen()`) — see control-api / windows).
-  agterm ships its OWN Toggle Full Screen item so full screen is rebindable/palette/control-drivable;
-  `AppDelegate` strips AppKit's auto-injected native "Enter Full Screen" item (re-injected on every menu
-  open) so the two don't render as a duplicate — see the `window.fullscreen` note in windows.md.
-  **None of the four workspace-focus items is gated on the SIDEBAR MODE** — the menu item, its palette
-  twin, the `focus_workspace` keybind, and the `workspace.focus`/`workspace.filter` control modes are all
-  mode-agnostic, because membership is model state the tree applies the moment it is shown again (and a
-  keybind-driven sibling could not be gated by a palette predicate anyway).
-  Only Expand/Collapse Workspaces carry the `!treeMode` gate, and they carry it in BOTH the menu and the
-  palette, since they manipulate rows the flagged view never renders.
-  A palette entry gated differently from its menu twin is exactly the drift the keep-in-sync convention
-  exists to stop — Add Workspace to Focus carried a palette-only tree-mode term for one review round.
-  **Navigate** (a separate top-level `CommandMenu("Navigate")`, placed right after the View group so
-  AppKit renders it after View) holds moving the selection/focus: the two palettes (Go to Session / Command
-  Palette), session stepping (Previous/Next, Previous/Next Attention, First/Last),
-  and Focus Left/Right Pane.
-  It also carries the **Dashboard** grid opener (⌘⇧D → `AppActions.toggleDashboard`,
-  the `dashboard` built-in action) — a toggle that opens the frontmost window's most-recently-used
-  dashboard grid (auto-sized, the `dashboard --mru --auto-size` control equivalent) or closes it,
-  inert while terminal zoom is active; it is ALSO a command-palette entry.
-  Unlike the pure placement split, this one IS a keep-in-sync-ish addition:
-  the `dashboard` built-in reuses the existing socket `dashboard` command (no NEW control command),
-  and the session→pane-cell expansion is hoisted into the shared host-free `AppStore.dashboardMembers(for:limit:)`
-  helper that both `ControlServer.setDashboard` and `toggleDashboard` call.
-  This is a pure menu-PLACEMENT split — every item still drives the SAME `AppActions`,
-  and the control/palette/keymap surfaces are untouched (so it is NOT a keep-in-sync change).
-  When adding a menu item, file it by intent: display state → View, moving between things → Navigate.
-  XCUITest helpers that open a menu by title must target the menu the item actually lives in (the `PaletteUITests`/`KeymapUITests`
-  `openPalette` helpers open **Navigate** for the palette items).
-- **Keep-in-sync convention (HARD).**
-  Any new user action added to `AppActions`/`AppStore` is not "done" until it is also drivable from the
-  control socket.
-  Shipping a new action requires all four of: (1) a `Command` case (plus any args) in `agtermCore`'s
-  control protocol, (2) a dispatch arm in `ControlServer`, (3) an `agtermctl` subcommand,
-  (4) protocol round-trip plus end-to-end tests for it.
-  This extends the toolbar/menu-bar "never drift" rule to the third surface — the control channel.
-  See the Control API section below.
-- Font menu items (⌘+/⌘−/⌘0) drive libghostty on the *focused* surface via `GhosttySurfaceView.performBindingAction("increase_font_size:1"/"decrease_font_size:1"/"reset_font_size")`.
-  `focusedSurface()` is the key window's first responder (main pane, split pane,
-  or quick terminal), else the active session's surface.
-  A menu-driven font change still rides the CELL_SIZE → persist path, like the keybind.
-- **In-terminal search (⌘F).**
-  `BuiltinAction.toggleSearch` (`defaultChord` = ⌘F, rebindable like every other built-in)
-  drives `AppActions.toggleSearch()` → `focusedSurface().startSearch()` (the `start_search`
-  binding action).
-  It is a real View ▸ Find… menu item (reading `equivalent(for: .toggleSearch)`,
-  no hardcoded shortcut) plus a ⌃⇧P palette "Find…" entry. libghostty replies with a `START_SEARCH` action;
-  the surface's `onSearchStart` closure TOGGLES — if the owning session's bar is already visible it calls
-  `endSearch()` (sends `end_search`, so libghostty actually exits search mode,
-  never just flips the flag), else opens the bar (`searchActive = true`,
-  seeds any returned needle) and focuses the field.
-  The `onSearchEnd` closure clears the four search fields and returns first responder to the terminal
-  (`focusAfterReparent`); `onSearchTotal`/`onSearchSelected` set `searchTotal`/`searchSelected` (negative
-  `ssize_t` → nil).
-  The four `GhosttySurfaceView` methods (`startSearch`/`sendSearchQuery`/`navigateSearch`/`endSearch`)
-  are thin wrappers over `performBindingAction`, the four callbacks are wired by ALL THREE in-tree surface
-  factories — `makeSurface`/`makeSplitSurface`/`makeScratchSurface` via the shared `wireSearchCallbacks`
-  helper (the `splitFocused` direct-write precedent) — and the four `GHOSTTY_ACTION_START_SEARCH`/`END_SEARCH`/`SEARCH_TOTAL`/`SEARCH_SELECTED`
-  arms in `GhosttyCallbacks.action` copy the needle to a `String` before the main hop and return `true`.
-  `AppActions` also owns `updateSearchNeedle(_:)`/`navigateSearch(_:)`/`endSearch()` for the bar.
-  The state is the four ephemeral `Session` fields + `searchDisplayText` (the "N of M" / "M matches"
-  / "no matches" computed), shared with the `session.search` control half (see the Control API catalog)
-  so the GUI and control surfaces can't drift.
-  **The SCRATCH terminal is searchable (the quick terminal + full overlay are NOT).** Wiring `makeScratchSurface`
-  makes the scratch `isSearchable`, so ⌘F over a shown scratch opens the bar on the scratch itself:
-  `coverHidesActiveSession` (the ⌘F open gate) blocks only the quick terminal + a FULL overlay (both
-  unsearchable, focus-stealing over a hidden pane) — NOT the scratch; and `searchTarget()` checks the
-  scratch-covers case FIRST (returns `topmostSurface` = the scratch when `scratchActive && !overlayActive`,
-  BEFORE consulting `focusedSurface()`), so a ⌘F while the scratch covers the session never opens on
-  the pane underneath — even when key-window focus sits off the surface (e.g. the sidebar),
-  where `focusedSurface()` would otherwise fall back to the hidden `activeSurface`.
-  A FLOATING overlay leaves the pane visible, so search there still targets the pane behind it (not the
-  unsearchable overlay surface).
-  Teardown: `AppStore.closeScratch` (the scratch shell's `exit`) clears search via `session.clearSearch()`
-  ONLY when the bar is pinned to the scratch being torn down (`searchSurface === scratchSurface`) — so
-  a search owned by the main/split pane survives the scratch teardown — mirroring the closeSplit/closePrimaryPane
-  clear; the full session/workspace/window teardowns destroy the session entirely so no surviving bar
-  can stick.
-- **Split panes (one session, two shells).**
-  Three observed flags on `Session`: `isSplit` = the split is shown side-by-side;
-  `hasSplit` = the session HAS a split pane at all (stays true while hidden,
-  cleared only by `closeSplit`); `splitFocused` = which pane holds focus.
-  The split (right) surface is wired to the session as `isSplitPane`, so its PWD/title go to `splitCwd`/`splitTitle`,
-  and the focus-aware `Session.displayName`/`focusedCwd` make the sidebar row AND the title bar track
-  whichever pane is focused — guarded on `splitFocused` alone (NOT `isSplit`),
-  so it follows a hidden-but-focused split pane.
-  `effectiveCwd` stays the PRIMARY pane's (non-focus-aware) for seeding new panes + the `AGTERM_SESSION_PWD`
-  token; `Session.activeSurface` is the focused pane's surface (the focus helpers + the collapsed detail
-  pane target it).
-  **Opening a NEW split moves focus to the new (right) pane** (`AppStore.toggleSplit` sets `splitFocused = true`
-  only when the split is genuinely new — `hasSplit` was false; hiding leaves it set so the focused pane
-  is the one shown maximized, and RE-showing a hidden split PRESERVES that pane rather than jerking focus
-  back to the right — so a hide/show round-trip, e.g. the tmux-style zoom script that drives `session split off`
-  then `on`, keeps whichever pane you had focused).
-  **Hiding the split (the toolbar toggle) keeps BOTH shells alive** and shows the focused pane maximized
-  — `detailPane`'s collapsed branch renders `\.splitSurface` when `splitFocused`,
-  else `\.surface` — so reopening restores the two panes in place; nothing is destroyed (`closeSplit`
-  only runs when the split shell exits).
-  **Exiting a pane's shell keeps the session, collapsed to the survivor:** the primary's `onExit` is
-  `AppStore.closePrimaryPane` (promotes the surviving split pane INTO the main slot as a single non-split
-  session — its cwd/title/foreground command migrate up) and the split's is `closeSplitPane` (collapses
-  to the primary only for a genuine two-pane split, else closes the session — the primary already exited,
-  or the promoted survivor's own exit, `splitSurface == nil`).
-  Only a single (non-split) session's exit closes it.
-  The collapse re-hosts the survivor (HSplitView → standalone), which drops focus,
-  so `GhosttySurfaceView.focusAfterReparent` re-grabs first responder until it sticks past the re-host.
-  `⌘⌥←`/`⌘⌥→` (+ the "Focus Left/Right Pane" menu items and palette entries,
-  + `session.focus`) move focus via `AppActions.focusPane(_:)`/`setSplitFocus(_:of:)` — ALL gated on
-  `hasSplit`, NOT `isSplit` (the menu items' `.disabled`, the palette gate,
-  the `setSplitFocus` guard, `revealSession`, and the `session.focus` control arm),
-  so pane navigation works whether the split is shown side-by-side OR hidden (maximized).
-  When hidden, focusing the other pane just flips `splitFocused`, which swaps which pane the collapsed
-  `detailPane` shows maximized (the "switch the zoomed pane with the other" behavior);
-  the single-pane (no-split) state still disables/no-ops them.
-  `⌃1`/`⌃2` are a direct-switch alias for the same `focusPane(.main)`/`focusPane(.split)` actions,
-  caught by `PaneShortcuts` (an app-wide `NSEvent` local monitor, like the Ctrl-Tab switcher — NOT a
-  SwiftUI shortcut, so they aren't duplicate menu items).
-  The monitor ALWAYS consumes `⌃1`/`⌃2` (reserved app shortcuts) so they never leak to the shell — on
-  a non-split session `focusPane` is a no-op rather than the terminal printing a literal "1" (the bug
-  from the first cut, which only consumed when split).
-  No new control command — `session.focus` already covers it.
-  Each pane persists its OWN cwd: `SessionSnapshot.splitCwd` + `Session.initialSplitCwd` seed the split
-  shell on restore.
-  The split's DIVIDER RATIO persists per-session too: `SessionSnapshot.splitRatio` (a 0...1 left-pane
-  fraction) is captured by `SplitRatioAccessor` (`agterm/Views/SplitRatioAccessor.swift`) — a `.background` `NSViewRepresentable`
-  on the PRIMARY pane (a background, not a third arranged pane; unconditional so it never perturbs the
-  split shape) that introspects the AppKit `NSSplitView` under the SwiftUI `HSplitView`,
-  since no SwiftUI API exposes the divider position.
-  It `setPosition`s the divider once the split has a real width (retried per `layout()` pass) and writes
-  the current fraction back to `Session.splitRatio` (`@ObservationIgnored`) on each `NSSplitView.didResizeSubviewsNotification`.
-  Persisted by a debounced `save()` ~0.4 s after the drag settles (coalescing one drag's resize ticks
-  via a cancel-and-reschedule `DispatchWorkItem`), plus the usual save points and the quit-flush,
-  so a force-quit keeps it too, symmetric with the sidebar WIDTH (which saves on the drag's `.onEnded`).
-  **`SplitRatioAccessor` ALSO clips the split's divider out of the titlebar strip (`updateDividerClip`).**
-  In COMPACT mode (`titlebarHeight` = 30) the SwiftUI `.padding(.top, titlebarHeight)` lands inside the
-  window's safe-area band, so the AppKit `NSSplitView` IGNORES it and grows to the FULL window height
-  (verified: its frame + both arranged panes span pt 0..windowHeight; the 48px non-compact inset clears
-  the band so normal mode is already bounded).
-  The panes' top strip is then empty terminal-bg (invisible against the window bg),
-  but the divider draws BLACK through it — a streak up through the transparent titlebar (only the DIVIDER
-  shows; the panes' content still starts at the content top because the terminal grid respects the safe
-  area).
-  The fix is a **CALayer mask on the `NSSplitView`** hiding its overrun strip — the overrun is computed
-  LIVE (`titlebarHeight - splitTopFromContentTop`, ~30 in compact, 0 in normal → mask dropped) so normal
-  mode is untouched and the clip tracks window resize.
-  Use a layer mask, NOT SwiftUI `.mask`/`.clipped()`: those reflow the terminal grid (scroll the top
-  row away — confirmed twice), while a layer mask is render-only; and NOT an opaque cover (would break
-  translucency — the mask reveals the window backing).
-  The detail `HSplitView` carries `.id("<session>-hsplit")` so its `NSSplitView`/divider can't leak across
-  session switches.
-  A session with a split shows a split-rectangle icon in the sidebar (`WorkspaceSidebar`,
-  keyed on `hasSplit` via `RowContent`), which persists while the split is hidden.
-  The title-bar split button is a 4-state glyph: an outline when there is no split, a filled
-  split-rectangle (`rectangle.split.2x1.fill`) while the split is shown side-by-side, and a half-filled
-  glyph naming the visible pane once the split is collapsed to one pane
-  (`rectangle.lefthalf.filled` = primary, `rectangle.righthalf.filled` = split pane, driven by `splitFocused`).
-- `Close Session` is ⌘W (terminal-style).
-  `AppActions.closeActiveSession()` first dismisses a focus-stealing cover in z-order — the frontmost
-  window's quick terminal (`hide`), else the active session's open overlay (`closeOverlay`,
-  full OR floating), else a shown scratch (`toggleScratch`) — and only closes the active session when
-  no cover is up; it returns whether it handled the keystroke, and the File ▸ Close Session menu item
-  falls back to `performClose` on the window ONLY when it returns false (no cover and no session,
-  e.g. a window emptied to zero sessions).
-  The cover guard lives in `closeActiveSession` rather than the menu on purpose:
-  the menu's old `if activeSession != nil` gate skipped the guard when a window had no session but the
-  quick terminal was up, closing the window instead of the cover.
-  `AppStore.currentWorkspaceID`/`defaultWorkspaceName` are the host-free placement/naming helpers behind
-  New Session / New Workspace.
-- **Closing the ACTIVE session returns to the most-recently-active SURVIVING session, not to a positional
-  neighbor** (Discussion #147).
-  `AppStore.closeReselectionTarget(after:)` (`AppStore+CloseReselection.swift`, host-free and unit-tested in
-  `AppStoreCloseReselectionTests`) is the single reselection pick for all three close paths — `closeSession`
-  plus the two undoable ones, `softCloseSession` / `softCloseSessions`.
-  It takes `sessionRecency.top(1, in: scope)` where `scope` = the closing session's OWN workspace's surviving
-  session ids, further ∩ the VISIBLE set (`navigableSessions`) — the flagged list in `.flagged` mode, and the
-  marked workspaces' sessions while the focus filter applies.
-  The workspace term is what keeps the close from being disorienting: an UNSCOPED "most recent survivor" could
-  yank the user into another workspace, which is worse than the positional neighbor it replaces.
-  The scope set is built from the TREE, not from the recency stack: the closing session is removed from
-  `workspaces` before reselection at every call site, so it can never be picked — which is what makes the
-  soft-close paths correct WITHOUT pruning `sessionRecency` at close time (they must not, since undo needs the
-  entry back; only `hardFinalizePendingSession` prunes, at grace expiry).
-  When the close leaves that workspace with NOTHING in scope — it emptied the workspace, or in `.flagged`
-  mode no other session there is flagged — the workspace term is dropped and the MRU widens: "stay in the current
-  workspace" has nothing left to mean, and the alternative is a positional jump into the FIRST workspace, which is
-  the disorientation the whole feature exists to remove.
-  The FLAGGED term survives that widening (`flaggedSessions` is cross-workspace by definition), so a
-  `.flagged`-mode close crosses workspaces rather than landing on an unflagged session the sidebar isn't rendering.
-- **The scope is `navigableSessions`, so BOTH narrowings apply — the flagged list AND the focus filter.**
-  Every mutator that NARROWS moves the active session inside the visible set (`reselectIfSelectionHidden`,
-  see [[sidebar]] for the gaps that do not), so a close that jumped OUT of it would strand the selection;
-  scoping is also what keeps a hand-curated working set alive through a ⌘W.
-  The widening runs in THREE levels, each reached only once the one before it is exhausted: the closing
-  workspace's visible sessions, then everything visible, then the WHOLE tree.
-  The third level is what makes "widen when exhausted" mean widen — without it an emptied visible scope returns a
-  nil MRU pick and the positional fallback jumps into the FIRST workspace, the disorientation this helper exists
-  to remove (pinned by `closeTheFocusedWorkspacesLastSessionPicksTheRecentSurvivorElsewhere`).
-  Landing outside the marked set at that last level is fine and needs no scoping defense: every caller runs
-  `disableFocusIfSelectionOutsideSet` on the pick, which switches the filter off (KEEPING the set) to reveal
-  the target.
-  In-set picking while the set still holds a survivor is pinned by `closeUnderAFocusFilterStaysInsideTheMarkedSet`.
-  Only an empty MRU after all three levels (a fresh restore before anything was activated, or the only recent entry
-  was the one just closed) falls back to a POSITIONAL walk — so the worst case is the old neighbor behavior,
-  never an empty selection.
-  WHICH walk depends on the MODE, not on how far the scope widened: `narrowed` is `sidebarMode == .flagged ||
-  focusEnabled`, so under either narrowing the flattened `nearestInScopeTarget` runs over whatever `scope`
-  ended up being, and the plain `reselectionTarget(after:)` is reached only with no narrowing applied at all.
-  The two differ once the closing workspace empties: the flat walk takes the adjacent row in the previous or
-  following workspace, `reselectionTarget` the first session of the first non-empty one.
-  Scoping the fallback matters because `reselectionTarget` walks the tree positionally and would otherwise land on
-  a row the sidebar has no entry for — an unflagged sibling, or an unmarked workspace's session (`syncSelection`
-  would then `deselectAll` and show nothing selected).
-  It stays POSITIONAL within the filter, and the walk runs over the tree FLATTENED in sidebar order: the in-scope
-  session that shifted into the removed slot, else the nearest in-scope one before it.
-  The walk spans workspaces because the scope can — once the closing workspace holds nothing in scope the scope has
-  widened to the whole flagged set, which the flagged sidebar renders as ONE flat cross-workspace list, so the
-  adjacent row there is the neighboring FLAGGED row even when it lives in another workspace.
-  (While the scope is still same-workspace it holds only that workspace's ids, so the flat walk collapses to the
-  in-workspace one.)
-  Taking merely "the first flagged row" instead would throw away the locality the fallback exists to preserve and
-  break the "worst case is the old neighbor behavior" promise above, jumping to the TOP of the flagged list when a
-  mid-list session closes.
-  Pinned by `closeActiveSessionInFlaggedModeWithAnEmptyScopedRecencyStaysWithinTheFlaggedSet`,
-  `closeActiveSessionInFlaggedModeWithAnEmptyScopedRecencyPicksTheNEARESTFlaggedSurvivor`, and
-  `closeTheWorkspacesLastFlaggedSessionWithAnEmptyRecencyPicksTheADJACENTFlaggedRow`.
-  The ONE case the flagged scoping cannot hold is closing the LAST flagged session anywhere: the visible scope is
-  then empty and the flagged sidebar renders no rows at all, so the scope widens to the whole tree and the MRU
-  there stands — selecting nothing would leave no terminal.
-  Pinned by `closeTheLastFlaggedSessionWidensToTheWholeTree`.
-  `reselectionTarget` has exactly ONE caller, this helper.
-  `removeWorkspace` / `softRemoveWorkspace` pick through `workspaceRemovalTarget(at:)` instead: the
-  "stay in the current workspace" term is meaningless when the workspace itself is what is being removed,
-  but the VISIBLE-set term is not, so both take the most recent still-visible session (else the first) and
-  fall back to the positional walk only when nothing is visible at all.
-  Pinned by `removingAMarkedWorkspaceStaysInsideTheMarkedSet`,
-  `removingTheActiveWorkspaceInFlaggedModeStaysInsideTheFlaggedSet`,
-  `softRemovingAMarkedWorkspaceStaysInsideTheMarkedSet` and
-  `removingAMarkedWorkspacePrefersTheMostRecentVisibleSurvivor`.
-  `softCloseSessions`' `removedBeforeActive` index adjustment is preserved verbatim — it now feeds only the
-  fallback.
-- **Session navigation (between sessions).**
-  Previous/Next Session sit on ⌥⌘↑/⌥⌘↓; First/Last Session have NO hotkey (menu + palette + `session.go`
-  only).
-  The keys deliberately AVOID the bare ⌘+arrow cluster: as always-enabled menu key-equivalents,
-  bare ⌘←/→/↑/↓ shadow standard text-field caret nav (line/doc start/end) in the inline rename field,
-  the palette search field, and Settings fields. ⌥⌘+arrows is not a text-field caret binding,
-  so it doesn't shadow editing; ⌥⌘↑/↓ for sessions also complements the existing ⌥⌘←/→ "Focus Left/Right
-  Pane" (left/right = panes, up/down = sessions), and first/last need no dedicated key.
-  They are real menu items (the Navigate menu — see the menu-split note below),
-  so AppKit menu dispatch swallows the shortcut before libghostty and nothing leaks to the shell.
-  The pure logic is `AppStore.navigateSession(_:)` (host-free, unit-tested):
-  it flattens the tree (`workspaces.flatMap(\.sessions)`), WRAPS around on next/prev (an end lands on the opposite end),
-  jumps to the ends for first/last, falls to first on no/invalid selection,
-  no-ops on an empty tree, and routes through `selectSession` (recency + badge + persist + workspace-derivation).
-  It is shared by the menu, the action palette, and the control channel (`session.go`) so the three can't
-  drift.
-  The four GUI actions (`AppActions.select{Next,Previous,First,Last}Session`)
-  are one-liners over the private `AppActions.navigatePlain(_:)`.
-  A step that MOVES the selection routes through `revealActiveBlockedPane(captured:)`,
-  which reveals the tagged pane when the moved-to session needs attention,
-  and otherwise falls through to `focusActiveSession()`,
-  so first responder follows into the moved-to terminal either way (the sidebar never steals focus).
-  A step that resolves to the session ALREADY selected skips the reveal and calls `focusActiveSession()` directly.
-  Both paths are still subject to the shared modal focus guards (zoom, dashboard, rename, palette, quick terminal),
-  which suppress the responder move in either branch.
-  `WorkspaceSidebar.syncSelection()` expands the owning workspace if collapsed and `scrollRowToVisible`s
-  the target so an off-screen row is revealed.
-  Distinct from the ⌃Tab MRU switcher (recency order) and the ⌃P fuzzy palette (search) — this is predictable
-  spatial stepping in the sidebar's visual order.
-  **Attention navigation** (⌃⌥↑/⌃⌥↓, a plain `defaultChord` like the session nav — arrows are part of the
-  keymap grammar, so both are rebindable) is the variant that steps through ONLY the sessions needing
-  attention (`AgentStatus.needsAttention` = `blocked`/`completed`), WRAPPING around and skipping idle/active.
-  It reuses `AppStore.navigateSession` (the `.nextAttention`/`.previousAttention` cases — host-free,
-  unit-tested) and is driven by Navigate ▸ Previous/Next Attention Session,
-  the action palette, and `session.go next-attention|prev-attention`; the two `BuiltinAction`s (`previous_attention_session`/`next_attention_session`)
-  carry ⌃⌥↑/↓ as their `defaultChord`.
-  EVERY user-initiated GUI selection of a status that NEEDS ATTENTION reveals the tagged PANE, not just the session.
-  The shared `AppActions.revealActiveBlockedPane(captured:)` focuses the pane recorded in the pre-reset indicator returned by `AppStore.selectSession` or `navigateSession`.
-  ATTENTION nav falls back to the active session's live indicator when `navigateSession` returns no target.
-  `attentionTarget` excludes the CURRENT session,
-  so when the sole session needing attention is the one already selected it returns nil and nothing is selected.
-  That fallback is the only reason ⌃⌥↑/↓ still reveals its tagged pane there.
-  PLAIN session nav has NO such fallback and reveals only when the selection actually MOVED.
-  A plain step resolving to the session already selected just re-focuses:
-  `next`/`previous` wrap inside a one-element filtered set, and `first`/`last` repeat while already at that end.
-  `selectSession` does not short-circuit a same-target select, so it still returns an indicator there,
-  and revealing on it would clear `splitFocused` and pull the user off the split pane he is typing in.
-  For `right`, it focuses the split surface via `focusSplitPane(_:wantSplit: true)`, gated on `splitSurface != nil`, and `onFocusChange` reasserts `splitFocused` to win the shown-split re-render race.
-  A promoted split survivor is not covered by that branch because promotion moves it into `surface` with `splitSurface == nil` and retags a `.right` block to `.left`.
-  For `left` or nil, it explicitly clears `splitFocused` and calls `focusSplitPane(_:wantSplit: false)` to target the primary pane.
-  For `scratch`, it shows a hidden scratch via `AppStore.toggleScratch` and then focuses it.
-  IDLE and ACTIVE selections call plain `focusActiveSession`, so informational working-state tags do not dismiss a shown scratch or change split focus.
-  The helper fires from attention-nav, plain session nav, the command palettes, a sidebar row click, a Dock-menu session row, and idle auto-follow.
-  Palette and sidebar paths dispatch asynchronously so reveal runs after their focus restoration settles.
-  All paths share the selection boundary and reveal helper so pre-reset status and pane semantics cannot drift.
-  Only the control `session.go next-attention|prev-attention` does NOT reveal (`goSession` just drives
-  `AppStore.navigateSession`), so the socket steps the selection without moving focus into the pane.
-- `Delete Workspace` lives once in `AppActions.deleteWorkspace(_:in:)` (confirm alert when the workspace
-  still has sessions, then `AppStore.removeWorkspace`) and is invoked from all three surfaces — the sidebar
-  workspace row's context menu, the menu bar, and the action palette (the latter two via `deleteActiveWorkspace()`,
-  which targets the frontmost store's `currentWorkspaceID` and owns the `uiActionsEnabled` gate).
-  It is STORE-SCOPED like every other workspace-row menu item (Close/Flag/Duplicate/Reveal/Focus): the row
-  menu passes its OWN window-local store, since the item's enabled state came from that store's
-  `canRemoveWorkspace` and a right-click does not raise a background window — routed through the frontmost
-  store the clicked id is absent, the lookup returns nil, and the item silently does nothing.
-  `AppStore.removeWorkspace` tears down each session's surfaces, prunes recency,
-  and reselects; `canRemoveWorkspace` (count > 1) enforces keep-at-least-one and gates the menu item
-  / palette entry.
-  The sidebar Coordinator takes `AppActions` so the row menu routes through it rather than duplicating
-  the confirm.
-- The command palettes (`Palette.swift`: `PaletteController` + `CommandPalette`) feed off `AppActions.paletteActions()`/`paletteSessions()`
-  and the host-free `fuzzyScore` (agtermCore, unit-tested).
-  The visible list is a `@State` array recomputed on query/mode change — NOT a computed property — so
-  the rendered rows and the Enter target can't drift out of sync; results sort by score then title. ⌃P
-  opens the session switcher, ⌃⇧P the action palette (the session/action shortcut split is deliberate).
-- **Built-in shortcut hints are one resolver, shared by the palette AND the toolbar/sidebar tooltips.**
-  `AppActions.shortcutGlyph(for:)` (formerly `paletteHint`) → the host-free `Keymap.glyphHint(for:)`
-  (`equivalent(for:)?.glyphString`, nil = no shortcut) renders an
-  action's CURRENT chord as macOS glyphs (`⌃⌘S`), tracking a `keymap.conf` rebind live.
-  `paletteActions()` reads it for the right-aligned palette hint; `WindowContentView.helpHint(_:_:)`
-  appends `" (<glyph>)"` to the `.help(…)` tooltip of the 10 `BuiltinAction`-backed toolbar/sidebar buttons
-  (a button with no configured shortcut shows just its label). One resolver so the two surfaces can't
-  drift — the display analogue of the `defaultChord`-single-source-of-truth rule. Tooltip text is pure
-  visual chrome, so it is control-API keep-in-sync EXEMPT (no command, nothing to drive headless).
-- **Attention list (the `.attention` palette mode).**
-  A fourth `PaletteMode` (`.attention`, placeholder "Go to a session that needs attention…") lists the
-  window's NON-IDLE sessions — broader than the ⌃⌥↑/↓ attention-NAV, which steps only `needsAttention`
-  (blocked/completed).
-  `AppActions.paletteAttention()` maps `AppStore.attentionSessions` (host-free,
-  per-window: all non-idle, sorted blocked→active→completed then `statusChangedAt` newest-first,
-  nil last) to `PaletteItem`s mirroring `paletteSessions()` (title=`displayName`,
-  subtitle="workspace · detail"), with the new `PaletteItem.status: AgentStatus?` set so `CommandPalette.row`
-  renders a leading `StatusGlyph`.
-  `PaletteItem` also carries the two per-call overrides the glyph needs — `statusColor: String?` and
-  `statusShape: StatusShape?` — which `StatusGlyph` resolves through the same shared
-  `GhosttyApp.statusSymbolName(for:override:)` + `.statusColor(for:override:)` pair the sidebar's
-  `StatusIconView` uses, so the palette and the sidebar cannot draw the same session differently;
-  `run` = `store.selectSession(id)`.
-  Empty-query order is the `attentionSessions` order (the palette re-sorts by fuzzy score only once the
-  user types); `.attention` needs no theme-preview wiring (`syncThemeSession` guards on `.themes`).
-  Opened three keyboard/menu ways: `BuiltinAction.showAttention` (rawValue `show_attention`,
-  `defaultChord` ⌃⇧I — a distinct chord swallowed before the terminal like ⌃⇧P/⌃⇧O)
-  → `AppActions.toggleAttentionPalette()` →
-  `palette.toggle(.attention)`, the **Navigate ▸ "Go to Attention…"** menu item (reading `equivalent(for: .showAttention)`),
-  and a **"Show Attention"** entry in `paletteActions()` (the ⌃⇧P launcher).
-  The title-bar bell is NOT a fourth palette opener: clicking it opens a MOUSE-form popover of the attention
-  sessions, not the palette (see the Notifications section + the recent/attention popover note below).
-  Opening a palette is interactive-only → keep-in-sync EXEMPT, like every other palette open.
-  **Button-open focus fix (`CommandPalette.onAppear`):** kept from when the bell opened the palette — a palette
-  opened from a title-bar BUTTON mounts while that button still holds first responder, so `onAppear`'s
-  synchronous `fieldFocused = true` loses the race and the field never takes the keyboard; the fix re-asserts
-  `fieldFocused = true` on the next runloop tick via `DispatchQueue.main.async`.
-  The bell now opens a popover, so no button currently opens the palette and the fix is DORMANT/defensive
-  (a no-op for the menu/hotkey/⌃P opens, which have no competing responder).
-- Inline rename has no direct handle from the menu/palette into the sidebar's editor,
-  so `AppActions.renameActive{Session,Workspace}()` post `.agtermBeginRenameSession`/`.agtermBeginRenameWorkspace`;
-  `WorkspaceSidebar.Coordinator` observes them and calls `beginEditing` on the selected row (async,
-  so the row is on screen after any palette overlay closes).
-  `AppActions.renamePending` keeps `focusActiveSession` (the palette/quick-terminal close focus-restore)
-  off the rename field for ~0.6 s.
-- The Ctrl-Tab session switcher (`SessionSwitcher` + `SessionSwitcherOverlay`) cycles a most-recently-used
-  list.
-  `AppStore.sessionRecency` (`RecencyStack<UUID>` in agtermCore — host-free,
-  unit-tested) is pushed on every selection and pruned on close;
-  the switcher snapshots it on `begin()` so cycling never reorders it (only the commit does,
-  via `selectSession`).
-  `begin()` CAPS the snapshot at the 10 most-recent (`SessionSwitcher.maxCandidates` fed to
-  `RecencyStack.top(_:in:)`) — Ctrl-Tab is a quick jump, not a full list (the ⌃P fuzzy palette covers
-  everything); the recency STORE keeps its full 100-item history.
-  The cap can't be observed through XCUITest (the overlay only shows while Ctrl is HELD and `typeKey`
-  always releases the modifier), so it's covered host-free by `RecencyStackTests.topCapsResultAtRequestedCount`.
-  The order is persisted (`Snapshot.sessionRecency`, an optional field like the other post-v1 additions)
-  and re-seeded on restore — stale ids dropped, the restored selection floated to the front — so the
-  switcher works right after a relaunch instead of starting empty (#110).
-  Persistence is pure model/restore behavior with no new user action,
-  so it is control-API keep-in-sync EXEMPT.
-  Keys come from app-wide `NSEvent` local monitors (`.keyDown` for Ctrl+Tab / Ctrl+Shift+Tab / Esc,
-  `.flagsChanged` to detect the Ctrl release = commit), NOT SwiftUI shortcuts — the interaction needs
-  Tab-while-Ctrl-held plus the modifier-release signal.
-  The overlay has no focusable control, so the terminal keeps first responder and selection-on-commit
-  re-focuses via `TerminalView`.
-- **Title-bar mouse popovers: the CLOCK is the mouse form of the Ctrl-Tab switcher, the BELL the mouse form
-  of the attention palette** (`WindowContentView+RecentSessions.swift`, split out to keep `WindowContentView.swift`
-  under 1000 lines; the `attentionButton` moved here too).
-  Both open a theme-tinted SwiftUI `.popover` of clickable session rows — the shared `SessionPopoverRow`:
-  a `SessionSwitcherRow` (now taking an optional themed `foreground` + an optional leading `status` glyph)
-  wrapped in a `Button` with `.onHover` highlight (the theme selection color), `.contentShape(Rectangle())`
-  for a full-row hit target, and `.presentationBackground(terminalColor)` + `chromeText` text so the panel
-  tracks the terminal theme like the sidebar/titlebar chrome.
-  The CLOCK's `recentSessions` = `sessionRecency.top(SessionSwitcher.maxCandidates, in:)` with the ACTIVE
-  session removed (it is not a jump target), so the button enables only with ≥2 sessions; a row click runs
-  `selectRecent` (`noteUserActivity` + `selectSession` + `focusActiveSession`).
-  The BELL's `attentionPopover` = `AppStore.attentionSessions` (all non-idle, INCLUDING the current), each
-  row carrying its `StatusGlyph`; a row click runs `selectAttention` (adds `AppActions.revealActiveBlockedPane`).
-  Both are control-API keep-in-sync EXEMPT (interactive popover opens, like the bell↔palette before).
-  **The row CLICK is not XCUITest-drivable** — a synthesized click (element OR coordinate) inside an
-  `NSPopover` does not fire a SwiftUI `Button` action (confirmed by instrumentation: the action never ran),
-  though a real mouse click does (it makes the popover key).
-  So the e2e (`RecentSessionsButtonUITests`, `AttentionButtonUITests.testAttentionButtonOpensPopoverListingAttention`)
-  asserts the popover OPENS and lists the right sessions; the click→select is verified by hand and covered
-  host-free by the selection APIs (see [[ui-tests]]).
+- `@MainActor AppActions` shares nontrivial behavior among titlebar/footer, menu, palette, and control:
+  placement, directory picking, split/focus, and font. Trivial toggles may call their owner directly.
+- `toggleQuickTerminal` gates on all `uiActionsEnabled`, including terminal zoom and dashboard. Menu
+  `.disabled(modalActive)` also gates rebound key equivalents; palette dispatch and Dock invocation recheck.
+  Control drives `QuickTerminalRegistry` directly. The titlebar button is replaced by dashboard chrome,
+  which hides an open quick terminal before showing the grid.
+- Every new action must satisfy the control contract in [[control-api]]: protocol, dispatch, CLI, and
+  protocol/end-to-end tests. Do not restate per-action audits here.
+
+## Dock menu
+
+- `applicationDockMenu` exposes New Session, New Window, Quick Terminal, Dashboard, captured-window MRU
+  sessions, and attention ordering.
+- New Window alone is app-scoped (Discussion #313): capture nothing, call
+  `newWindow(ignoringModals: true)`, enable only when `actions != nil`, and explicitly unhide/activate.
+  Do not mark it always enabled before the action hub is wired. Require `openWindow` before persisting an
+  open entry. Menu and palette New Window retain modal gating.
+- Other items capture store and window ID at build time. Recheck per-window modal/controller state, raise
+  that window, synchronously publish it frontmost, then dispatch. A stale closed/modal item is inert;
+  dashboard built open may close it, but one built closed becomes inert if it opens before invocation.
+- `NSMenuItem.target` is weak and AppKit sends nil sender. Retain closure targets until the next rebuild,
+  invalidate old targets first, and capture session IDs rather than `Session` or surfaces.
+- Selection uses the pre-reset indicator returned by store selection and reveals pane tags only for
+  blocked/completed. Active and idle use ordinary focus.
+- `navigableRecentSessions`, excluding current and capped by `SessionSwitcher.maxCandidates`, supplies
+  visible-scope MRU entries. Hosted coverage uses `make test-app`, isolated state/socket variables, and
+  `AGTERM_HOSTED_TESTS=1`; never add that sentinel to the UI-test scheme. Dock actions compose existing
+  control capabilities.
+
+## Menu organization and shortcuts
+
+- View contains display state: font/theme, sidebar and workspace expansion, flagged/focus controls,
+  split/scratch/find/quick terminal, and fullscreen. Navigate contains palettes, session/attention
+  stepping, pane focus, and Dashboard. File UI tests against the menu that owns the item.
+- Workspace focus controls are mode-agnostic because membership applies when tree mode returns.
+  Expand/Collapse Workspaces alone are disabled outside tree mode, in both menu and palette.
+- Dashboard uses Command-Shift-D, `BuiltinAction.dashboard`, and `toggleDashboard`; it toggles an MRU,
+  auto-sized grid unless terminal zoom is active. Share `dashboardMembers` with control.
+- Remove AppKit's reinjected fullscreen item as described in [[windows]]. agterm's own
+  `toggle_fullscreen` remains rebindable and control-drivable.
+- Font shortcuts call libghostty binding actions on the key window's first-responder surface, falling back
+  to the active session. Persistence still flows from cell-size callbacks.
+- `shortcutGlyph` delegates to host-free `Keymap.glyphHint`. Use it for palette hints and the ten built-in
+  toolbar/sidebar tooltips so rebinds update both. This visual text is keep-in-sync exempt.
+
+## Search
+
+- `BuiltinAction.toggleSearch` defaults to Command-F and drives the focused surface's `start_search`.
+  View > Find and the palette read its configured equivalent.
+- `START_SEARCH` toggles: if this session's bar is visible, send `end_search`; otherwise open, seed the
+  returned needle, and focus. `END_SEARCH` clears all four ephemeral fields and refocuses the terminal.
+  TOTAL/SELECTED convert negative `ssize_t` to nil. Copy callback strings before the main-actor hop.
+- Wire all four callbacks through `wireSearchCallbacks` for main, split, and scratch. Surface methods are
+  thin binding-action wrappers; `AppActions` owns GUI needle/navigation/end behavior. The same session
+  state and `searchDisplayText` back `session.search`.
+- Scratch is searchable; quick terminal and full overlay are not. `searchTarget` checks a covering scratch
+  before focused-surface fallback so sidebar focus cannot target the hidden pane. Floating overlay leaves
+  pane search available.
+- On scratch exit, clear search only when `searchSurface === scratchSurface`; pane-owned search survives.
+  Split/primary teardown follows the same ownership rule.
+
+## Split panes
+
+- `isSplit` means shown side-by-side, `hasSplit` means the second shell exists, and `splitFocused` chooses
+  focus. Split title/cwd feed focus-aware display name and focused cwd based on `splitFocused`, even hidden.
+  `effectiveCwd` remains primary for new panes and `AGTERM_SESSION_PWD`; `activeSurface` follows focus.
+- Creating a split focuses right. Hiding retains both shells and shows the focused pane maximized;
+  reshown splits preserve focus. `closePrimaryPane` promotes right into primary with cwd/title/foreground
+  command; `closeSplitPane` keeps primary when both exist and otherwise closes the session.
+  `focusAfterReparent` restores focus after the surviving view changes host.
+- Pane focus actions, menu/palette, and `session.focus` gate on `hasSplit`, not `isSplit`, so they also swap
+  the maximized hidden pane. Ctrl-1/Ctrl-2 use an app-wide event monitor and always consume these reserved
+  keys, even when no split exists.
+- Persist each pane cwd and the 0...1 left-pane `splitRatio`. `SplitRatioAccessor` is an unconditional
+  background representable on primary, introspects `NSSplitView`, retries until width exists, observes
+  `didResizeSubviews`, and debounces save by about 0.4 seconds. Regular saves and quit flush also persist it.
+- `SplitRatioAccessor` masks only the compact-titlebar divider overrun. At 30pt compact height, SwiftUI
+  padding lies inside the safe-area band and AppKit expands `NSSplitView` full height; normal 48px mode is
+  already bounded. Compute the live overrun and apply a CALayer mask, removing it at zero.
+  Do not use SwiftUI mask/clipping because it reflows and loses the terminal's top row; do not use an
+  opaque cover because it breaks translucency. Key `HSplitView` identity by session.
+- Sidebar icon follows `hasSplit`. The titlebar's four-state icon is outline with none,
+  `rectangle.split.2x1.fill` while shown, left-half filled for hidden primary, and right-half filled for
+  hidden split.
+
+## Close and reselection
+
+- Command-W first dismisses the frontmost cover: quick terminal, then overlay, then scratch. Only then close
+  the active session. If no cover or session exists, the menu performs window close. Keep the cover check
+  inside `closeActiveSession`, since a sessionless window can still show quick terminal.
+- All active-session close paths use host-free `closeReselectionTarget` (Discussion #147). Prefer the most
+  recent survivor in three widening scopes: same workspace intersected with `navigableSessions`, all
+  navigable sessions, then the whole tree. Build scopes from the post-removal tree; soft close retains
+  recency until grace finalization for undo.
+- This preserves the current workspace when possible, remains inside flagged/focused views while they
+  contain survivors, and lets `disableFocusIfSelectionOutsideSet` reveal a whole-tree fallback while
+  preserving membership.
+- If MRU is empty, narrowed modes use `nearestInScopeTarget` over flattened sidebar order; unfiltered tree
+  uses the sole `reselectionTarget` caller. Do not choose the first flagged row because it destroys locality.
+  Closing the last flagged session widens to the whole tree rather than leaving no terminal.
+- Workspace removal uses `workspaceRemovalTarget`: most recent visible, then first visible, then positional.
+  Preserve `softCloseSessions.removedBeforeActive` for fallback index adjustment. The named
+  close/reopen/filter tests in `AppStoreCloseReselectionTests` pin these scopes.
+- Delete Workspace centralizes confirmation in `AppActions.deleteWorkspace(_:in:)`, then removes surfaces,
+  recency, and reselection. Row menus pass their own store because right-clicking a background window does
+  not raise it. Menu/palette target active workspace and enforce `uiActionsEnabled`. Keep at least one workspace.
+
+## Navigation
+
+- Previous/Next Session default to Option-Command-Up/Down; First/Last have no hotkey. Avoid bare
+  Command-arrows because menu equivalents shadow caret navigation in rename, palette, and settings fields.
+  Option-Command-Left/Right remains pane focus.
+- `navigateSession` uses `navigableSessions`, wraps previous/next, selects ends for first/last, chooses
+  first on nil/invalid selection, and no-ops when empty. Menu, palette, and `session.go` share it.
+- When selection moves, GUI callers reveal a captured blocked/completed pane; unchanged plain navigation
+  only refocuses, preventing a one-item wrap from resetting split focus. Modal focus guards still apply.
+- Attention navigation defaults to Control-Option-Up/Down, includes blocked/completed only, wraps, and
+  excludes current. If it finds no other target, GUI callers may use the current live indicator solely to
+  reveal its tagged pane. Control changes selection only.
+- `revealActiveBlockedPane` focuses right only when the split surface exists, explicitly chooses primary
+  for left/nil, and shows/focuses scratch. Promotion retags right to left. Idle/active never change pane or
+  dismiss scratch. Navigation, palettes, sidebar, Dock menu, titlebar attention, and auto-follow share it.
+- Sidebar selection expansion/scroll makes the target visible. Spatial navigation is distinct from MRU
+  Ctrl-Tab and fuzzy Ctrl-P.
+
+## Palettes, rename, and switcher
+
+- `PaletteController`/`CommandPalette` consume `paletteActions`, `paletteSessions`, and host-free
+  `fuzzyScore`. Store the visible results in state on query/mode changes so rendering and Enter target
+  cannot diverge; sort by score then title. Ctrl-P opens sessions; Ctrl-Shift-P opens actions.
+- Attention mode lists every non-idle session, ordered blocked, active, completed and then newest
+  `statusChangedAt`, with nil last. Palette items carry status plus per-call color/shape, resolved by the
+  same helpers as sidebar glyphs. Empty query preserves this order; typed queries use fuzzy score.
+- Open attention through `show_attention` (Ctrl-Shift-I), Navigate > Go to Attention, or Show Attention
+  in the action palette. The titlebar bell opens a popover, not this palette. Palette opening is
+  keep-in-sync exempt.
+- Keep the next-runloop `fieldFocused = true` retry: button-opened palettes otherwise lose first responder,
+  even though no current titlebar button uses this path.
+- Rename actions post begin-edit notifications; the Coordinator edits the selected row asynchronously after
+  palette dismissal. `renamePending` suppresses terminal focus restoration for about 0.6 seconds.
+- Ctrl-Tab snapshots `sessionRecency` and cycles without reordering until commit. Limit candidates to 10
+  while retaining 100 history entries. Persist optional recency, drop stale IDs, and float restored
+  selection on load (#110). Host-free tests cover the cap because XCUITest releases Control.
+- Use app-wide key-down and flags-changed monitors for Ctrl-Tab, reverse, Esc, and release-to-commit.
+  The overlay has no focusable control, so terminal first responder remains.
+
+## Titlebar popovers
+
+- Keep clock and bell popovers in `WindowContentView+RecentSessions` so `WindowContentView.swift` remains
+  below 1000 lines. They use
+  `SessionPopoverRow`: optional status glyph, hover selection color, full-row hit target, terminal
+  background, and chrome text.
+- Clock lists up to `maxCandidates` recent visible sessions excluding active and enables only with at
+  least two sessions. Selection records activity, selects, and focuses.
+- Bell lists all non-idle sessions including current. Selection uses pane-aware reveal.
+- Popover opens are keep-in-sync exempt. Synthesized XCUITest clicks inside `NSPopover` do not fire the
+  SwiftUI button, though real clicks do; tests verify open/list contents, while selection is manual plus
+  host-free API coverage.

--- a/.claude/rules/notifications.md
+++ b/.claude/rules/notifications.md
@@ -7,304 +7,131 @@ paths:
 
 ## Notifications
 
-- Terminal desktop notifications (OSC 9 / 777).
-  `GhosttyCallbacks.action` handles `GHOSTTY_ACTION_DESKTOP_NOTIFICATION` — copies the `title`/`body`
-  C strings synchronously (only valid for the call), recovers the firing `GhosttySurfaceView` via the
-  existing `surfaceView(from:)`, and hops to `NotificationManager.shared.notify(surface:title:body:)`.
-  (The bell, `GHOSTTY_ACTION_RING_BELL`, is intentionally NOT a notification source.)
-- `NotificationManager` (`agterm/Notifications/`, `@MainActor` singleton + `UNUserNotificationCenterDelegate`,
-  `@preconcurrency` conformance like macterm) owns the macOS surface.
-  `notify` resolves the owning `Session` (the view's `weak var session`) + `PaneRole` (identity-compare
-  the view to the session's `surface`/`splitSurface`/`overlaySurface`), applies suppression,
-  **always bumps `session.unseenCount`** (the badge), then posts a `UNNotificationRequest` ONLY if `bannersEnabled`
-  (the General toggle) — so turning banners off still tracks the badge.
-  Registered + `requestAuthorization([.alert])` from the scene `.task` (alongside `controlServer.start()`);
-  auth is best-effort — the badge works even when banners are denied.
-  `willPresent` returns `[.banner, .list]` so banners show even while agterm is frontmost (the focused-pane
-  case is dropped at delivery, NOT in `willPresent`).
-  `clearDelivered(sessionID:)` removes a session's delivered banners (all three pane identifiers) when
-  you focus it, so a notification you've navigated to doesn't linger in Notification Center.
-  `send(toSession:title:body:)` is the control channel's entry point (the `notify` command / `agtermctl notify`):
-  same badge + banner + reveal-identity machinery, but NO focus-suppression (the caller asked for it)
-  and attributed to the `.main` pane.
-- **Every silent drop is LOGGED, and a banners-off `notify` says so in its response (#286).**
-  Both gates used to return without a trace: the OSC path's focus suppression and, in BOTH paths, the
-  `bannersEnabled` guard.
-  A user reading the documented `log show --predicate 'subsystem == "com.umputun.agterm"'` recipe therefore
-  got a COMPLETELY EMPTY log from a perfectly healthy notify — the success path logged nothing either —
-  and reasonably concluded notifications were broken (reproduced: banners-on delivery and banners-off
-  suppression produced byte-identical empty logs).
-  So `notify`/`send` now `logger.notice` on posting AND on each suppression, naming the setting.
-  Keep it at `.notice`, not `.debug`/`.info`: a notification is a rare user-driven event, and only the
-  default level is PERSISTED, so a `log show --last 30m` after the fact still finds it.
-  The control arm additionally returns the shared `ControlNotify.bannersOffNote` in `result.text` when
-  banners are off — `ok` alone is indistinguishable from a broken path, since the OS is never touched.
-  This is the `session.restore`-with-`restoreRunningCommand`-off note precedent (see [[control-api]]);
-  the CLI prints `result.text` in place of `ok` with no CLI change.
-  The e2e is `NotifyBannersUITests` (both polarities); it seeds `notificationsEnabled` into the isolated
-  state dir before launch via `ControlAPITestCase.seededSettings`, since there is no `settings.*` control
-  command to flip it at runtime.
-- **Suppression**
-  is the pure, agtermCore-tested `TerminalNotification.shouldDeliver(firingIsFocused:appActive:)`:
-  drop entirely only when the firing surface is the key window's first responder AND `NSApp.isActive`
-  (you're already looking at it).
-  The manager uses the strict first-responder check (NOT `AppActions.focusedSurface()`,
-  whose active-session fallback would wrongly count a sidebar-focused window as "looking at the pane").
-- **Identity / navigation.**
-  `TerminalNotification.identity`/`parseIdentity` (agtermCore) make the request identifier `"<sessionID>:<paneRole>"`
-  — it both coalesces repeats from the same pane (the OS replaces, doesn't stack) and carries the click
-  target (no `userInfo` needed).
-  `didReceive` parses it, `NSApp.activate`s, and calls `AppActions.reveal(sessionID:pane:)`:
-  `selectSession` (which clears the badge + derives the workspace) then `focusSplitPane` for the pane,
-  stale-safe (unknown session → just activate; a `.split` no longer split → primary).
-  `revealSession` ALSO raises the owning window (`WindowRegistry.raise`, which deminiaturizes first).
-  `NSApp.activate` brings the APP forward, and `makeFirstResponder` moves focus WITHIN a window, but
-  neither orders a window front — so without the raise a banner for a session in a MINIMIZED or merely
-  backgrounded window changed the selection invisibly and the click looked dead.
-  The closed-window branch already raised via `openWindow`; the open-window branch now matches.
-  This path has no automated coverage — its only caller is the `UNUserNotificationCenter` delegate, which
-  XCUITest cannot drive — so verify it by hand; the raise MECHANISM is pinned by
-  `testWindowMinimizeAndRestore`, which asserts `window.select` un-minimizes.
-  `reveal` is internal click-routing (not on toolbar/menu/palette) composing the already-controllable
-  `session.select`, so it has NO control command (keep-in-sync exempt, by user decision).
-- **Badge.**
-  `Session.unseenCount` (observed; ephemeral — `SessionSnapshot` doesn't capture it,
-  so it never persists).
-  `SidebarCellView.badge` is a custom-drawn `BadgeView` (an accent capsule,
-  count capped `99+`, accessibility role `.staticText` with id `notify-badge`) at the row's trailing
-  edge, with a `Workspace.unseenCount` roll-up on the workspace row so an unseen badge stays visible
-  when the workspace is collapsed.
-  `unseenCount` is folded into the sidebar's `updateNSView` dependency read,
-  and `reloadChangedBadgeRows`/`snapshotBadges` reload only the changed session + workspace rows.
-  Cleared by `AppStore.selectSession` and by a pane's `onFocusChange(true)` (which also calls `clearDelivered`
-  — focusing a pane means you've seen the session).
-  `onFocusChange(true)` fires on a first-responder TRANSITION, which does NOT happen when agterm merely
-  regains key focus (AppKit's per-window first responder never resigned while the app was backgrounded),
-  so refocusing the app onto the same on-screen session left the badge stuck (#155).
-  `GhosttySurfaceView.clearUnseenOnRefocus` closes that: the `didBecomeKey` observer (already re-pushing
-  the cursor's `liveFocus`) also re-runs the same `onFocusChange(true)` clear on the become-key edge, gated
-  on `liveFocus` (key window AND this pane is first responder) so it fires only for the ONE focused pane of
-  the now-key window — the inverse of the suppression condition below. A non-focused session's pill is
-  untouched (its `liveFocus` is false), so it stays until you select that session.
-  **The count pill rendering is gated by the `notificationBadgeEnabled` Settings toggle** (see the Settings
-  section): the Coordinator's `effectiveUnseen(_:)` returns 0 when the flag is off,
-  applied to BOTH the session badge and the workspace roll-up (and to `RowContent.unseen` so a toggle
-  reloads the rows).
-  This gates ONLY the red count pill — the agent-status glyph (drawn just left of it by `StatusIconView`)
-  is always on, never gated by this.
-- **Dock badge (`DockBadgeController`, app target).**
-  A `@MainActor` singleton (next to `NotificationManager`, wired in the scene `.task`) that shows the
-  app-wide unseen total on the Dock icon.
-  The total is the host-free `WindowLibrary.totalUnseenCount` (sum of every open window's sessions'
-  `unseenCount`, unit-tested); it's gated by the SAME `notificationBadgeEnabled` toggle as the sidebar
-  pill (badge count is 0 when off).
-  **Uses `UNUserNotificationCenter.setBadgeCount(_:)`, NOT `NSApp.dockTile.badgeLabel`.** For agterm the
-  legacy dock-tile label is silently suppressed — the value sets and persists on the tile but the Dock
-  never draws the pill — because it needs the `.badge` authorization option; `NotificationManager.start`
-  now requests `[.alert, .badge]`.
-  The modern UN badge renders correctly over the LIVE adaptive Icon Composer icon with no loss of
-  light/dark/tint/clear adaptivity, so there is NO `applicationIconImage` override.
-  Cleared to 0 on quit (`DockBadgeController.clear()` from `applicationWillTerminate`) — the OS badge
-  outlives the process and `unseenCount` is ephemeral, so without it a quit with unseen > 0 would leave a
-  stale count pinned on the Dock icon (the `willClose` poke can't do it: `isTerminating` makes `closeWindow`
-  no-op, so the total recomputes unchanged).
-  Reactivity is the Observation re-registration pattern (`apply()` reads `totalUnseenCount` inside
-  `withObservationTracking` and re-arms on change), with explicit `refresh()` pokes on the two
-  unobservable store mutations — a window CLOSE (`willClose` teardown in `ContentView`, `window.close` in
-  `ControlServer`) AND a window REOPEN (`ContentView.resolveStore` after `loadStore`, so a reopened
-  window's bumps aren't stale) — and an `.agtermAppearanceChanged` observer for the (non-`@Observable`)
-  toggle flip.
-  Keep-in-sync EXEMPT — pure derived chrome (`unseenCount` is already driven by `notify` / `session.select`),
-  nothing new to drive over the socket.
-- **Dock bounce (opt-in, off by default) — a three-mode picker.**
-  `AppSettings.dockBounce` (a `DockBounce` raw string `off`/`once`/`untilFocused`, nil = `off`, resolved
-  via `effectiveDockBounce`) chooses whether a delivered notification ALSO bounces the Dock icon:
-  `off` no bounce, `once` a single `NSApp.requestUserAttention(.informationalRequest)`, `untilFocused` a
-  `.criticalRequest` that bounces until agterm becomes active.
-  The default case is named `off` (not `none`) to avoid the `Optional.none` collision at the
-  `effectiveDockBounce` call site, matching the `AutoFollowAttention.off` precedent.
-  `.criticalRequest` is auto-cancelled by macOS the moment agterm activates, so `untilFocused` needs NO
-  `cancelUserAttentionRequest` bookkeeping — that free "until focused" stop, plus the one-shot `once`, is
-  why the picker exposes both modes instead of hard-coding one.
-  `NotificationManager.bounceDock()` switches on the mode and fires right after the `unseenCount` bump in
-  BOTH the OSC path (`notify`) and the control path (`send` / `agtermctl notify`), independent of
-  `bannersEnabled` — like the badge, a bounce can fire whether or not banners show.
-  It needs NO explicit app-active gate: BOTH request types are a no-op while agterm is the frontmost app,
-  so the OSC path's `shouldDeliver` suppression plus that no-op mean a bounce only ever fires for a
-  BACKGROUND notification — exactly "bounce when a notification arrives for a session you're not looking at".
-  The `NotificationManager.dockBounce` mirror of `AppSettings.effectiveDockBounce` is pushed by
-  `SettingsModel.applyDockBounce` alongside `applyNotificationsEnabled` (the other `NotificationManager`
-  mirror) — NOT a ghostty key and NOT a chrome mirror, so no `.agtermAppearanceChanged` re-render (nothing
-  renders it continuously; it is read on the next notification).
-  GUI-only and keep-in-sync EXEMPT (a settings picker; only `theme.set`/`config.reload` touch settings over
-  the socket).
-  The bounce animation is not accessibility-observable, so it is verified by eye like the cursor-focus /
-  disclosure-triangle cases; only the `AppSettings` round-trip / tolerant-decode and the settings-picker
-  persistence (`SettingsUITests.testDockBouncePickerPersists`) are tested.
-- **Notification sound (opt-in, None by default) — a system-sound picker, routed through the banner.**
-  `AppSettings.notificationSoundName` (nil/empty = silent, the default; else a system sound name) is
-  attached to the delivered banner as `content.sound` (`UNNotificationSound`) in BOTH the OSC path (`notify`)
-  and the control path (`send` / `agtermctl notify`) — deliberately NOT played via raw `NSSound` (review
-  decision on #232): riding the banner means the sound follows `bannersEnabled`, the macOS notification
-  authorization, AND Do Not Disturb / Focus, and a banners-off user is never audibly interrupted.
-  This is the OPPOSITE of the badge/bounce independence — a sound is an active interruption, not a
-  glance-level cue.
-  The name maps to a sound FILE: `.aiff` is assumed when the name has no extension (the system sounds'
-  format); `default`/`beep` map to `UNNotificationSound.default`; `start()` requests `.sound` in the
-  authorization options, and `willPresent` returns `[.banner, .list, .sound]` so a foreground banner
-  (a session you're NOT looking at) dings too — the focused-pane case is already dropped by `shouldDeliver`.
-  The `StatusSoundPlayer` throttle is NOT involved (the OS owns playback; same-pane repeats coalesce by
-  request identifier); the picker's selection preview still plays via `StatusSoundPlayer.action`.
-  The `NotificationManager.notificationSoundName` mirror is pushed by `SettingsModel.applyNotificationSound`
-  alongside `applyNotificationsEnabled`/`applyDockBounce` — read on the next notification, not rendered
-  continuously, so no `.agtermAppearanceChanged` re-render.
-  The Notifications tab's `Picker("Notification sound")` mirrors the Agent Status blocked-sound picker
-  (None maps back to nil to keep `settings.json` minimal; selecting a sound previews it).
-  GUI-only and keep-in-sync EXEMPT (a settings picker, like `dockBounce`); the control channel's per-call
-  audible nudge remains `session.status --sound`.
-- **Agent-status glyph.**
-  Mirrors the `notify-badge` cell pattern (see the Control API `session.status`).
-  `StatusIconView` (an `NSImageView` sibling of `BadgeView` in `WorkspaceSidebar`) draws the row's tinted
-  SF Symbol just LEFT of the count badge — a PLAIN filled silhouette carrying no interior mark,
-  `.idle`=hidden.
-  The three states share the built-in default `circle.fill` and are separated by TINT until a shape is
-  picked; the old marked circles (`ellipsis`/`exclamationmark`/`checkmark` knocked out of a circle) are
-  GONE, because a mark inside a 13pt symbol is legible only in the popup, which is exactly the complaint
-  the shapes answer (discussion #277).
-  The silhouette resolves through the shared host-free `AgentStatus.symbolName(override:configured:)`
-  (via `GhosttyApp.statusSymbolName(for:override:)`, the tint helper's twin): the ephemeral
-  `AgentIndicator.shape` per-call OVERRIDE (`session.status --shape`) wins, else the Settings shape for
-  that status (`GhosttyApp.{active,blocked,completed}StatusShape`, mirrored from
-  `AppSettings.effectiveStatusShape(for:)`), else `StatusShape.circle`.
-  Neither `symbolName` parameter is defaulted on purpose: a render site that forgot to pass the Settings
-  shape would silently draw the wrong glyph, so the omission has to be a compile error.
-  `StatusShape` is a fixed set of six — `circle`, `square`, `triangle`, `diamond`, `capsule`, `star` —
-  whose raw value IS the SF Symbol base name (`symbolName` = `"<raw>.fill"`); the set is capped there
-  because at the sidebar's 13pt render size in a 16pt slot `hexagon`/`octagon`/`pentagon`/`seal` are
-  indistinguishable from `circle`, `app` duplicates `square` and `rhombus` duplicates `diamond`, so a
-  wider picker would only let a user believe they had distinguished a status when they had not.
-  Adding a case is still not a one-line change: the `ControlArgs.shape` doc, the website command
-  reference and the agent skill each enumerate the set by hand (the dispatcher's rejection message and
-  the CLI's `--shape` help/rejection derive theirs from `StatusShape.validNamesList`/`validNamesPhrase`,
-  the `WatermarkConfig.validFits` precedent, so those three can't go stale).
-  `StatusShape.displayName` (the capitalized raw value) is the host-free picker label the Settings
-  options and the picker's accessibility value read, so the six names have ONE definition.
-  Each glyph is tinted via the shared `GhosttyApp.statusColor(for:override:)`: the ephemeral
-  `AgentIndicator.color` per-call OVERRIDE (`session.status --color`, a valid `#rrggbb` wins) else its
-  configurable Settings color (`GhosttyApp.{active,blocked,completed}StatusColor`,
-  default `#DBD9E6` muted lavender-grey / system amber / system green; see the Settings + Control API sections)
-  — the SwiftUI attention-list `StatusGlyph` resolves through the SAME two override helpers, tint and
-  silhouette alike, so the two render sites can't drift —
-  with accessibility role `.staticText`, id `agent-status`, value = the state name (so XCUITest matches `app.staticTexts["agent-status"]`;
-  neither the glyph TINT nor its SHAPE, per-call or not, is accessibility-observable, which is why the
-  e2e asserts the command path and the `tree` read-back rather than the drawn pixels),
-  and a `CABasicAnimation` `opacity` pulse added only while visible AND `blink` (the install's `UserPromptSubmit→active --blink`
-  hook pulses the in-progress glyph). `StatusIconView.apply` also requires
-  `!NSWorkspace.shared.accessibilityDisplayShouldReduceMotion`, so Reduce Motion keeps the glyph/color
-  visible but suppresses the indefinite pulse. `SystemAccessibilityObserver.start()` observes
-  `NSWorkspace.accessibilityDisplayOptionsDidChangeNotification` on `NSWorkspace.notificationCenter`
-  and posts app-local `.agtermAccessibilityDisplayOptionsChanged`; the sidebar Coordinator observes that
-  on `NotificationCenter.default` and calls `reapplyStatusGlyphs()` so every visible row updates live.
-  The dashboard's `DashboardCaptionPill` uses SwiftUI's `accessibilityReduceMotion` environment value to
-  gate its matching `repeatForever` wash, preserving the filled status pill without animation. Because
-  the model's `blink` request is retained, both pulses resume if Reduce Motion is disabled.
-  The glyph shows on EVERY non-idle session, the selected one INCLUDED — there is NO visibility gate.
-  (An earlier `isFrontmostWindow`-driven hide-on-the-selected-session gate was removed:
-  blanking the status on the row you're viewing read as confusing, since every other row carried a state;
-  the `isFrontmostWindow` plumbing went with it.) `effectiveIndicator(forSession:)` is just the session's
-  own `agentIndicator`; it rides in `RowContent` (Equatable) so a status/blink change reloads only that
-  row, and `agentIndicator` is folded into the `updateNSView` dependency read.
-  A one-time `completed --auto-reset` is cleared by `AppStore.selectSession` on BOTH the session visited
-  AND the one left (`clearAutoResetIndicator(new)` + `clearAutoResetIndicator(previous)`) so it never
-  lingers on the row you switch away from — a Claude Code hook can't do this,
-  it has no notion of the agterm selection.
-  `StatusIconView` owns its OWN width constraint (0 when `.idle`, glyph-width otherwise,
-  toggled in `apply`) so an idle row collapses the slot and reads full-width;
-  `BadgeView.intrinsicContentSize` likewise collapses to zero width at `count == 0` (so a hidden OSC
-  badge reserves no trailing slot and the glyph sits flush-right), with the glyph-to-badge gap baked
-  into the badge's leading edge so it only appears when the badge does.
-  **Clear Status** forces a session's indicator back to idle from the GUI:
-  the sidebar row's right-click menu (first item, only when non-idle), the menu bar,
-  and the ⌃⇧P palette — the row menu targets the clicked node id, the menu bar + palette go through `AppActions.clearActiveSessionStatus`
-  (the active session); all route to `AppStore.setAgentIndicator(AgentIndicator(), forSession:)`,
-  the GUI half of `session.status idle`.
-  **Typing also clears an attention glyph (pane-scoped):** `GhosttySurfaceView.keyDown` fires
-  `onUserInputClearsStatus(isInterrupt:)` UNCONDITIONALLY (it no longer reads `agentIndicator` itself),
-  and each surface factory — main (`left`), split (`right`), and scratch (`scratch`) — wires that closure
-  to the pane-scoped decision, clearing to idle via `setAgentIndicator(AgentIndicator(), …)` ONLY when the
-  host-free `AgentIndicator.clearedBy(pane:isInterrupt:)` says the keystroke's OWN pane owns the current status.
-  So a block set from a background pane (a `right`- or `scratch`-tagged `session status --pane`) SURVIVES
-  foreground typing in the main pane — only a keystroke in the owning pane clears it — and the scratch,
-  which has no `view.session`, still self-clears because the closure (not `keyDown`) owns the decision.
-  The per-status decision is host-free + unit-tested in `agtermCore` (`clearedBy` gates `clearedByKeystroke`
-  on the pane match): `blocked`/`completed` clear on ANY key (you've engaged with the prompt / finished result);
-  `active` clears ONLY on an interrupt keystroke — Escape (`keyCode == 53`) or a bare Ctrl-C —
-  so ordinary typing while the agent works does NOT wipe the "working" glyph,
-  but cancelling a prompt does; `idle` has no glyph.
-  The host-free `InterruptKeystroke.isInterrupt(keyCode:character:modifiers:)` (agtermCore) computes the
-  flag from primitives — Esc (`keyCode == 53`), or a bare Ctrl-C: `.control` held with no
-  command/option/shift and the base letter `c` OR the physical `c` key (`keyCode == 8`).
-  The keyCode fallback is load-bearing for non-Latin layouts: on a Cyrillic/Greek layout the physical C
-  key produces a non-Latin char (`с`), so character matching alone misses it — the same reason the
-  `super+key_c` binds are keycode-based (see [[libghostty]]).
-  The character check still covers Dvorak, where the `c` letter sits at a different physical key.
-  `.shift` is excluded so a copy-style Ctrl-Shift-C does not clear a working glyph.
-  `GhosttySurfaceView.isInterruptKeystroke` (app target, `keyDown`) is a thin `NSEvent` adapter over it;
-  the full truth table, including the negatives, is unit-tested host-free in `InterruptKeystrokeTests`.
-  This is the ONE input-driven clear (status is otherwise control-driven).
-  Because the clear is pane-SCOPED, a tag whose owning pane's shell EXITS would otherwise strand a glyph
-  no surviving surface can match, so `AppStore.closeSplit`/`closePrimaryPane`/`closeScratch` reconcile the
-  indicator on teardown — clearing a status owned by the destroyed pane (`.right` on closeSplit, `.left`/nil
-  on the primary→split promote, `.scratch` on closeScratch) — mirroring the `clearSearch()` reset on the
-  same paths (host-free, `AppStorePaneTests`).
-  It covers the Esc/Ctrl-C decline/interrupt case Claude Code fires NO hook for — the keystroke flows through
-  the surface's `keyDown` on its way to the agent's PTY, so it clears the stale glyph the moment you
-  deal with the prompt — and clears the `completed` flash once you re-engage.
-  The `active`-on-interrupt arm is load-bearing for the QUICK-cancel case: a pending question can still read
-  `active` when you cancel it, because Claude Code's `blocked` (`Notification[permission_prompt]`) fires on a
-  DELAY (~tens of seconds — its idle-notification timer, `messageIdleNotifThresholdMs`,
-  default 60000), so a fast Esc/Ctrl-C lands while the glyph is still `active`,
-  and the interrupt itself fires no hook (verified by a status-hook probe:
-  an Esc-cancel logs no hook at all; a manual decline fires neither `Stop` nor `PostToolUse`) — the keystroke
-  clear is the only signal.
-  The `PostToolUse→active --blink` install hook covers the answer-then-resume case (the agent's next
-  tool re-asserts `active`).
-  Peer terminals get the decline case for free by different means agterm avoids:
-  cmux owns the permission decision UI (a blocking hook round-trip captures accept/deny),
-  herdr scrapes the PTY (the prompt chrome leaving the screen clears it).
-- **Pane-aware selection reveal.**
-  The same `AgentIndicator.statusPane` tag set via `session.status --pane` decides WHERE a GUI selection lands when the status NEEDS ATTENTION.
-  Attention-nav, plain session nav, the command palettes, a sidebar row click, a Dock-menu session row, and idle auto-follow reveal and focus the pane that set the block.
-  The shared `AppActions.revealActiveBlockedPane(captured:)` flips to a tagged split, shows a hidden tagged scratch, or explicitly targets the primary pane for left/nil.
-  IDLE and ACTIVE selections use ordinary focus and preserve the existing pane choice.
-  The `session.go next-attention|prev-attention` control arm only steps the selection (`navigateSession`),
-  it does NOT itself run the reveal — the pane focus is a GUI/auto-follow concern.
-  So a `right`- or `scratch`-tagged block both survives foreground typing in another pane AND pulls you to
-  the waiting pane, not just the session.
-- **Titlebar attention bell (opt-in, window-wide aggregate of the glyph).**
-  When `attentionButtonEnabled` is on (Settings ▸ Notifications, default OFF — see the Settings section),
-  `customTitlebar` (`ContentView`) shows a bell icon in the trailing action cluster (after the
-  recent-sessions clock, before the divider and the scratch/split/quick-terminal buttons) that recovers
-  the per-session attention signal when the sidebar is hidden.
-  It derives THREE states from the window's `AppStore.attentionSessions` (the host-free per-window set
-  — ALL non-idle sessions, broader than `needsAttention`): empty → `bell`,
-  ~0.35 opacity, `.disabled(true)`; non-empty no-blocked → `bell`, `chromeText`,
-  enabled; any `.blocked` → `bell.fill` tinted `GhosttyApp.shared.blockedStatusColor`,
-  enabled.
-  No count, no pulse.
-  Reading `attentionSessions` registers the `agentIndicator` observation,
-  so the icon updates LIVE on status change.
-  Click → toggles the **attention popover** (`WindowContentView+RecentSessions.swift`, the MOUSE form): a
-  theme-tinted popover listing `AppStore.attentionSessions` as `SessionPopoverRow`s with a leading `StatusGlyph`,
-  sorted blocked→active→completed, hover-highlighted; a row click selects the session + reveals its blocked
-  pane (`selectAttention` → `selectSession` + `AppActions.revealActiveBlockedPane`).
-  ⌃⇧I / Navigate ▸ Go to Attention… / the ⌃⇧P "Show Attention" entry keep the SEARCHABLE `.attention` palette
-  (`toggleAttentionPalette`), so the bell is the mouse form and the palette the keyboard form — mirroring the
-  recent-sessions clock ↔ Ctrl-Tab split (see the Menu/actions section).
-  It carries `.accessibilityIdentifier("attention-button")`, a `.help` string,
-  and an `.accessibilityValue` of `none`|`attention`|`blocked` — mirroring `StatusIconView`'s state-name
-  value so XCUITest can read the otherwise-unobservable `bell`↔`bell.fill` highlight.
-  `WindowContentView` mirrors the chrome flag into `@State` (seeded from `GhosttyApp.shared.attentionButtonEnabled`,
-  refreshed on `.agtermAppearanceChanged`), NOT from `model.settings`.
-  The bell is pure visual chrome (it opens the attention popover, a mouse form of the already-controllable
-  attention list / `session.select`) — keep-in-sync EXEMPT, like the other titlebar buttons.
+- OSC 9/777 reaches `GHOSTTY_ACTION_DESKTOP_NOTIFICATION`; copy its call-scoped C strings immediately,
+  recover the `GhosttySurfaceView`, and call `NotificationManager.notify`. `GHOSTTY_ACTION_RING_BELL`
+  is not a notification source.
+- `NotificationManager` is an `@MainActor` singleton and `@preconcurrency`
+  `UNUserNotificationCenterDelegate`. It resolves `Session` and `PaneRole` by surface identity, applies
+  suppression, always increments `unseenCount`, and posts only when `bannersEnabled`. Authorization is
+  best-effort; request `[.alert, .badge, .sound]` from the scene task. `willPresent` returns
+  `[.banner, .list, .sound]`. `clearDelivered` removes all three pane IDs on focus.
+- `send(toSession:)`, used by `notify`, shares badge, banner, bounce, sound, and identity behavior but
+  deliberately skips focus suppression and attributes the request to `.main`.
+- Log every post and suppression at `.notice`, including the focus and banners-off gates (#286).
+  Lower levels are not persisted by default, so post-event `log show --last 30m` depends on notice.
+  When banners are off, return
+  `ControlNotify.bannersOffNote` in `result.text`; plain `ok` cannot distinguish suppression from failure.
+  This follows the `session.restore` note precedent. `NotifyBannersUITests` seeds
+  `notificationsEnabled` through `ControlAPITestCase.seededSettings`; there is no runtime settings command.
+- Suppress only when `TerminalNotification.shouldDeliver` sees both an active app and the firing surface
+  as the key window's first responder. Do not use `AppActions.focusedSurface()`: its active-session
+  fallback mistakes sidebar focus for viewing the pane.
+- `TerminalNotification.identity` encodes `"<sessionID>:<paneRole>"`, coalescing repeats and carrying the
+  click target without `userInfo`. `didReceive` activates the app and calls `AppActions.reveal`: select
+  the session, clear its badge, derive its workspace, focus the pane, and raise its window through
+  `WindowRegistry.raise`, which deminiaturizes first. Unknown sessions only activate; a missing split
+  falls back to primary. Activation and first-responder changes do not order a background window front.
+  XCUITest cannot drive the notification delegate, so verify clicks manually; `testWindowMinimizeAndRestore`
+  covers the raise mechanism. Internal `reveal` composes controllable selection and is keep-in-sync exempt.
+
+## Badges
+
+- `Session.unseenCount` is observed but excluded from `SessionSnapshot`. `BadgeView` draws an accent
+  capsule capped at `99+`, role `.staticText`, ID `notify-badge`; workspace rows roll up descendant counts.
+  Dependency reads plus `snapshotBadges`/`reloadChangedBadgeRows` limit reloads to changed rows.
+- Selection and pane focus clear unseen state and delivered banners. App activation does not transition
+  the retained first responder, which caused #155; the `didBecomeKey` observer therefore calls
+  `clearUnseenOnRefocus` only when `liveFocus` says this pane is the key window's first responder.
+- `notificationBadgeEnabled` gates session, workspace, and Dock counts through `effectiveUnseen`, including
+  `RowContent.unseen` so toggles reload rows. It never gates the agent-status glyph.
+- `DockBadgeController` shows host-free `WindowLibrary.totalUnseenCount`. Use
+  `UNUserNotificationCenter.setBadgeCount`, not `NSApp.dockTile.badgeLabel`, which stores but does not draw
+  agterm's value. The modern API preserves the adaptive icon, so never override `applicationIconImage`.
+  Clear the OS-persistent badge in `applicationWillTerminate`; `willClose` cannot do this because
+  `isTerminating` makes `closeWindow` a no-op.
+- `apply()` observes and re-arms on `totalUnseenCount`. Explicitly refresh after window close, control
+  `window.close`, and `ContentView.resolveStore` reopen; observe `.agtermAppearanceChanged` for the
+  non-observable toggle. This derived chrome is keep-in-sync exempt.
+
+## Bounce and sound
+
+- `DockBounce` is `off`, `once`, or `untilFocused`, with nil resolving to `off`; avoid `none` because it
+  collides with `Optional.none`. `once` requests `.informationalRequest`; `untilFocused` uses
+  `.criticalRequest`, which macOS cancels on activation, so no cancellation bookkeeping is needed.
+  Bounce after every unseen increment in OSC and control paths, independent of banners. Both requests are
+  no-ops while frontmost, so no extra app-active gate is needed.
+- `SettingsModel.applyDockBounce` mirrors the setting into `NotificationManager`; it is neither a Ghostty
+  key nor rendered chrome. The GUI-only picker is keep-in-sync exempt. Bounce is visually verified;
+  tests cover tolerant settings round-trip and `SettingsUITests.testDockBouncePickerPersists`.
+- `notificationSoundName` is nil/empty for silence or a system sound name. Attach it as
+  `UNNotificationSound` to both OSC and control banners; do not use raw `NSSound` (#232). Sound must obey
+  banners, authorization, and Focus, unlike badge and bounce. Assume `.aiff` without an extension;
+  `default` and `beep` use `.default`. Same-pane requests coalesce, and `StatusSoundPlayer` throttling is
+  irrelevant except for picker preview.
+- `SettingsModel.applyNotificationSound` mirrors the next-delivery value. The Notifications picker maps
+  None to nil and previews choices. It is keep-in-sync exempt; per-call sound remains
+  `session.status --sound`.
+
+## Agent status
+
+- `StatusIconView`, an `NSImageView` beside `BadgeView`, draws every non-idle session as a filled SF Symbol
+  in a 16pt slot at 13pt, with no selected-row hiding. Idle collapses its width to zero; a zero-count badge
+  also collapses, with the inter-item gap owned by the badge.
+- Default states share `circle.fill` and differ by tint. Discussion #277 rejected marked circles because
+  their interior marks are illegible at row size. `AgentStatus.symbolName(override:configured:)` resolves
+  per-call shape, configured status shape, then `circle`; require both arguments so omitted settings fail
+  compilation. The fixed useful set is `circle`, `square`, `triangle`, `diamond`, `capsule`, `star`.
+  `hexagon`/`octagon`/`pentagon`/`seal` resemble circle, `app` duplicates square, and `rhombus` duplicates
+  diamond at this size. Raw values form `"<raw>.fill"` and `displayName` is the shared picker label.
+  Keep `ControlArgs.shape`, website command docs, and agent skill lists synchronized; CLI and dispatcher
+  validation derive from `validNamesList`/`validNamesPhrase`.
+- `GhosttyApp.statusColor(for:override:)` similarly resolves per-call `#rrggbb`, configured status color,
+  then the muted lavender-grey `#DBD9E6`, system amber, or system green defaults. SwiftUI `StatusGlyph`
+  uses the same shape and tint helpers.
+- The glyph is `.staticText`, ID `agent-status`, accessibility value equal to the state. Color and shape
+  are not accessibility-observable, so end-to-end tests assert command and `tree` state, not pixels.
+  `RowContent.agentIndicator` and the update dependency read restrict reloads to changed rows.
+- Blink adds an opacity `CABasicAnimation` only while visible and when Reduce Motion is off.
+  `SystemAccessibilityObserver` translates the workspace notification to
+  `.agtermAccessibilityDisplayOptionsChanged`, and the sidebar reapplies visible glyphs. Dashboard pills
+  gate their SwiftUI repeat with `accessibilityReduceMotion`. Retain `blink` so both resume when re-enabled.
+- `completed --auto-reset` clears both the session entered and the session left in
+  `AppStore.selectSession`; hooks cannot infer agterm selection.
+- Clear Status is the first row-menu item when non-idle and also appears in the menu bar and palette.
+  Row menus target their node; global surfaces call `clearActiveSessionStatus`; all set an empty indicator.
+- `GhosttySurfaceView.keyDown` always calls `onUserInputClearsStatus(isInterrupt:)`. Main `.left`, split
+  `.right`, and scratch `.scratch` factories own the pane-scoped decision, allowing scratch to clear
+  without `view.session`. `AgentIndicator.clearedBy` clears blocked/completed on any key, active only on
+  interrupt, and only when the key's pane owns the status. Thus foreground typing cannot clear another
+  pane's status.
+- Interrupt means Esc (`keyCode == 53`) or bare Ctrl-C: control with no command/option/shift and either
+  character `c` or physical key code 8. Physical matching covers non-Latin layouts; character matching
+  covers Dvorak; excluding shift preserves Ctrl-Shift-C. Keep the full host-free truth table in
+  `InterruptKeystrokeTests`.
+- On pane teardown, `closeSplit`, `closePrimaryPane`, and `closeScratch` clear status owned by the removed
+  `.right`, `.left`/nil, or `.scratch` pane, respectively, as they do search state.
+- Input clearing covers the hookless Esc/Ctrl-C decline and completed re-engagement. It must also clear
+  active on quick interrupt: Claude's delayed `Notification[permission_prompt]` uses
+  `messageIdleNotifThresholdMs` (default 60000), and Esc/manual decline emits neither `Stop` nor
+  `PostToolUse`. `PostToolUse` reasserts `active --blink` after an answered prompt. cmux can observe its
+  own permission UI and herdr scrapes PTY state; agterm does neither.
+- `AgentIndicator.statusPane` also directs GUI selections needing attention. Attention and ordinary
+  navigation, palettes, sidebar and Dock rows, and idle auto-follow use
+  `revealActiveBlockedPane` to select split, reveal scratch, or target primary. Idle and active preserve
+  current pane choice. Control `session.go next-attention|prev-attention` changes only selection; pane
+  reveal remains a GUI/auto-follow concern.
+
+## Titlebar attention
+
+- With `attentionButtonEnabled` off by default, `customTitlebar` places a bell after recent sessions and
+  before scratch/split/quick-terminal controls. It derives live state from all non-idle
+  `AppStore.attentionSessions`: empty is disabled `bell` at about 0.35 opacity; non-blocked is enabled
+  `bell` in `chromeText`; any blocked is enabled `bell.fill` in `blockedStatusColor`. There is no count
+  or pulse.
+- Clicking opens the mouse popover of `SessionPopoverRow`s with `StatusGlyph`, ordered
+  blocked, active, completed; selection reveals the tagged blocked pane. Ctrl-Shift-I, Navigate > Go to
+  Attention, and Show Attention in the palette retain the searchable keyboard surface.
+- The button ID is `attention-button`, with help and value `none`, `attention`, or `blocked`.
+  `WindowContentView` mirrors `GhosttyApp.attentionButtonEnabled` into state and refreshes on
+  `.agtermAppearanceChanged`, not `model.settings`. This mouse form of controllable attention selection is
+  keep-in-sync exempt.

--- a/.claude/rules/release.md
+++ b/.claude/rules/release.md
@@ -5,34 +5,19 @@ paths:
 
 ## Release (`scripts/release.sh`)
 
-- **Releases are cut LOCALLY, not by CI — there is NO `release.yml`.**
-  `scripts/release.sh <version> --publish` runs on the maintainer's Mac, the only place the
-  `Developer ID Application: Brave Elk LLC` cert and the `agterm-notary` keychain profile live.
-  It builds Release, then signs + notarizes + staples the app AND the DMG (the DMG container is
-  codesigned before notarizing — `hdiutil`'s image is otherwise unsigned and fails the `spctl`
-  primary-signature check), creates the tag + GitHub release, uploads the DMG, and pushes the Homebrew
-  cask to `umputun/homebrew-apps` with the maintainer's own `gh` auth (no `HOMEBREW_TAP_PAT` needed).
-  A no-`--publish` run is a full dry-run (build → sign → notarize → staple → `spctl`) that stops before
-  uploading.
-- **At release time, run the new `CHANGELOG.md` version section through the `draft-approval` skill BEFORE
-  writing/committing it** — write the section to a temp file, open it in `draft-review.sh` (revdiff),
-  address annotations, then get an explicit in-chat go-ahead.
-  Do NOT just paste the section inline and ask — `scripts/release.sh` publishes that exact section as the
-  GitHub release body (release.sh:70-85), so it is outward-facing text and gets the full
-  draft-approval/revdiff flow, same as a `gh`/`glab` comment.
-- **Commit AND PUSH the changelog + website bump to `master` BEFORE `release.sh --publish`.**
-  `release.sh` runs `gh release create "$TAG"` with NO `--target` (release.sh:166), so `gh` creates the
-  tag at whatever `origin/master` HEAD currently points at — NOT the local HEAD.
-  So the `docs: update changelog for vX.Y.Z` commit (and any other pre-release change) must be pushed to
-  `origin/master` first, or the tag lands on the previous commit and the release ships without the
-  changelog.
-  `release.sh` does NOT push the main repo itself (it only commits + pushes the Homebrew cask in a cloned
-  tap dir); the maintainer pushes `master`.
-- **The website `softwareVersion` bump is a SEPARATE manual pre-release step `release.sh` does NOT do.**
-  Per the Website section in the root `CLAUDE.md`, bump `site/index.html`'s `SoftwareApplication`
-  `softwareVersion` to the new version and push it to `master` as part of the release (Cloudflare Pages
-  auto-deploys `site/` on push).
-  It is easy to miss because nothing in `release.sh` touches it — fold it into the same pre-`--publish`
-  push as the changelog.
-  The `.dmg` links on the site point at the GitHub "latest" release, so only `softwareVersion` needs the
-  bump.
+- **Releases are local; there is no `release.yml`.** Run `scripts/release.sh <version> --publish` on the
+  maintainer's Mac, which holds the `Developer ID Application: Brave Elk LLC` certificate and
+  `agterm-notary` keychain profile. The script builds Release, signs/notarizes/staples the app and DMG,
+  creates the tag and GitHub release, uploads the DMG, then pushes the Homebrew cask to
+  `umputun/homebrew-apps` using the maintainer's `gh` auth. It needs no `HOMEBREW_TAP_PAT`. The DMG
+  container must be codesigned before notarization or `spctl` rejects `hdiutil`'s unsigned image.
+  Without `--publish`, the full build/sign/notarize/staple/`spctl` dry-run stops before upload.
+- Before writing or committing a release section, put the exact `CHANGELOG.md` text in a temp file and
+  pass it through the `draft-approval` skill's `draft-review.sh`; address annotations and get explicit
+  chat approval. `release.sh:70-85` publishes that text as the GitHub release body.
+- **Commit and push the changelog and website version to `master` before `release.sh --publish`.**
+  `gh release create "$TAG"` has no `--target` (`release.sh:166`), so it tags `origin/master`, not local
+  `HEAD`. The script pushes only its cloned Homebrew tap; the maintainer must push the main repo.
+- Manually set `site/index.html`'s `SoftwareApplication.softwareVersion` in that same pre-release push;
+  `release.sh` does not edit it. Cloudflare Pages deploys `site/` on push, and the DMG links already use
+  GitHub's latest release.

--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -12,555 +12,135 @@ paths:
 
 ## Settings
 
-- Settings persist in agtermCore: `AppSettings` (Codable value type, optional fields,
-  NO version field — optionality is the forward-compat) + `SettingsStore` (JSON at `<stateDir>/settings.json`,
-  `AGTERM_STATE_DIR`-isolated, mirrors `PersistenceStore`).
-  Fields: `fontFamily`/`fontSize`/`theme`/`darkTheme`/`followSystemAppearance` + `backgroundOpacity` (0...1) / `backgroundBlur` (CGS radius)
-  + `notificationsEnabled` / `toolbarMode` / `notificationBadgeEnabled` / `attentionButtonEnabled` / `dockBounce` / `notificationSoundName`
-  + the agent-status glyph colors `activeStatusColorHex`/`blockedStatusColorHex`/`completedStatusColorHex`
-  + the agent-status glyph shapes `activeStatusShape`/`blockedStatusShape`/`completedStatusShape`
-  (nil defaults: `notificationsEnabled`/`notificationBadgeEnabled` = on,
-  `toolbarMode` = the three-state titlebar chrome `ToolbarMode { normal, compact, hidden }`,
-  stored raw as `String?` (like `newSessionDirectory`/`autoFollowAttention`) for tolerant forward-compat
-  decode — an unknown future value degrades to the default instead of nuking the whole `settings.json`.
-  nil = compact [the app default]; `.normal` adds the cwd subtitle line, `.hidden` drops the titlebar row
-  AND the traffic lights for a full-bleed terminal, leaving only an invisible ~3px top drag strip (thin so
-  it doesn't cover the terminal's first row, which is at window-padding-y = 6).
-  Resolved via `effectiveToolbarMode` = `toolbarMode.flatMap(ToolbarMode.init(rawValue:)) ?? (compactToolbar == false ? .normal : .compact)`;
-  `compactToolbar: Bool?` is RETAINED only as a legacy decode shim (the old two-state key: `false` = normal,
-  nil/true = compact) so pre-existing `settings.json` still opens right — writing a mode nils it, so it
-  evaporates on the next save.
-  `attentionButtonEnabled` = off, `dockBounce` = off, the `*ColorHex` = default tint, active `#DBD9E6` + blocked/completed
-  system orange/green; NOT ghostty keys) + `mouseScrollMultiplier` (ghostty `mouse-scroll-multiplier`)
-  + `inactivePaneMuteStrength` (0...10 inactive-split-pane text mute, nil = default 5,
-  NOT a ghostty key) + `sidebarBackgroundShift` (0...10 sidebar lighter/darker tint relative to the terminal,
-  nil = default 5 = neutral, NOT a ghostty key)
-  + `sidebarFontSize` (sidebar row-text point size, nil = default 13 = the historical `.body` size;
-  the row height scales with it via `AppSettings.sidebarRowHeight(fontSize:)` [clamped point size + 15pt
-  padding, so 13 → the historical 28pt row], the row icons/status glyphs keep their fixed sizes;
-  clamped to `AppSettings.sidebarFontSizeRange` [9...20], NOT a ghostty key)
-  + `rightClickPaste` (ghostty `right-click-action`, nil = on)
-  + `newSessionDirectory`/`newSessionCustomDirectory` (where a new ⌘T session opens: nil = home default,
-  else the current session's cwd or a fixed custom dir; NOT ghostty keys)
-  + `autoFollowAttention`/`autoFollowStayOnActive` (the per-window idle auto-follow-to-oldest-blocked policy:
-  `autoFollowAttention` an `AutoFollowAttention` raw string [nil = off/disabled], `autoFollowStayOnActive`
-  [nil/false = off] the "don't leave a running session" opt-in; NOT ghostty keys, save-only + fanned out into
-  every open window's `AppStore` via `SettingsModel.applyAutoFollow` → `AppStore.setAutoFollow`)
-  + `hiddenInterfaceElements` (raw names of title-bar / sidebar-footer chrome elements the user hid,
-  nil/empty = all shown; the `InterfaceElement` set; NOT a ghostty key — see its own bullet)
-  + `autoHideSidebarInactiveWindows` (only the frontmost window shows its sidebar, every other collapses;
-  nil = off; NOT a ghostty key — see its own bullet).
-  `theme`/`darkTheme`/`followSystemAppearance` are the macOS light/dark appearance-sync state: `theme` is the single/light-slot theme, `darkTheme` the dark slot, `followSystemAppearance` (nil = off) the toggle; when following, `ghosttyConfigLines()` emits ghostty's raw dual `theme = light:NAME,dark:NAME` conditional and libghostty resolves the side at runtime — `ghosttyConfigLines()` takes NO `isDark` arg (see the Theme picker rule; `ThemeResolution` is gone, the dual value is reduced to the active side for the sidebar selection colors by `ThemeName.resolved(from:isDark:)`).
-  The three `*StatusColorHex` (`#RRGGBB`, nil = active `#DBD9E6` muted lavender-grey + system amber/green)
-  color the sidebar agent-status glyph: `SettingsModel` passes the hex to `GhosttyApp.setAgentStatusColors`
-  which resolves to `NSColor` (so `SettingsModel` stays AppKit-free, the `NSColor`↔hex helper is `NSColor+AgtermHex`),
-  `StatusIconView` reads it when drawing, and a change rides `.agtermAppearanceChanged` → the Coordinator's
-  `reapplyStatusGlyphs()` sweep (the colors are global, not per-row, so `reconcile`'s diff can't see
-  them).
-  The three `*StatusShape` are the same idea for the glyph's SILHOUETTE, stored as `StatusShape` RAW
-  STRINGS (not the enum) so a hand-edited or future value decodes tolerantly: the single read point is
-  `AppSettings.effectiveStatusShape(for:)`, which does `raw.flatMap(StatusShape.init(rawValue:))` and
-  returns nil for `.idle` — the `effectiveDockBounce` precedent, so callers never touch the raw fields.
-  nil = the built-in default plain `circle`, so nil and an explicit `circle` render identically.
-  The mirror path matches the colors exactly:
-  `SettingsModel.setActiveStatusShape`/`setBlockedStatusShape`/`setCompletedStatusShape` persist and
-  apply, `applyAgentStatusShapes()` (called from the same two sites as `applyAgentStatusColors()`)
-  pushes them into `GhosttyApp.setAgentStatusShapes`, and a change rides the SAME `.agtermAppearanceChanged`
-  → `reapplyStatusGlyphs()` sweep, so no new notification was needed.
-  Both render sites resolve through the one host-free `AgentStatus.symbolName(override:configured:)`
-  (see the Notifications rule), with the per-call `session.status --shape` override winning over the
-  Settings shape.
-  Settings → Agent Status drives them with a Reset-to-defaults button (clears all three colors and all
-  three shapes to nil), plus a **Blocked sound** picker bound to `AppSettings.blockedStatusSoundName`
-  (nil/"None" = no sound, the default; else a system sound name).
-  `SettingsModel.setBlockedStatusSoundName` only SAVES (not a ghostty key,
-  nothing renders it continuously); `ControlServer.setSessionStatus` reads `settingsModel.settings.blockedStatusSoundName`
-  on demand and plays it via `StatusSoundPlayer.shared` ONLY when a session TRANSITIONS into `blocked`
-  (a `wasBlocked` read of the session's current status BEFORE the mutation gates it,
-  so a repeated `blocked` set does NOT replay the default) and no per-call `--sound` was given — the
-  precedence is the host-free `AgentStatus.effectiveSound(perCall:blockedDefault:)` (explicit per-call
-  wins; an empty per-call value counts as unset; the default is blocked-only and the transition gate
-  lives in the server).
-  The picker previews the sound on selection (plays it via `StatusSoundPlayer.shared`).
-  GUI-only and keep-in-sync EXEMPT, same as the status colors and shapes (only `theme.set`/`config.reload`
-  touch settings over the socket); the per-status sound already has full control coverage via
-  `session.status --sound`, and the per-status shape via `session.status --shape`.
-  `notificationBadgeEnabled` (nil = on) gates the sidebar's red unseen-count pill (session rows + workspace
-  roll-up), render-only — `unseenCount` keeps tracking so re-enabling instantly shows current counts;
-  distinct from `notificationsEnabled` (which gates the OS banner) and does NOT gate the always-on agent-status
-  glyph.
-  `AppSettings.ghosttyConfigLines()` (host-free, unit-tested) emits `key = value` lines RAW — no quotes,
-  because ghostty takes the whole line remainder as the value (confirmed against the bundled conf + theme
-  files), so names with spaces (`3024 Night`) must not be quoted.
-  TWO fields are always emitted (every other key is omitted when unset): `mouseScrollMultiplier` — nil
-  emits the default `mouse-scroll-multiplier = 3` (a bare value applied to both the notched wheel and
-  the trackpad) rather than being omitted, so the default speed is effective rather than ghostty's per-device
-  defaults (discrete 3 / precision 1) — a consequence is it overrides any `mouse-scroll-multiplier` in
-  the user's own `~/.config/ghostty/config`; and `rightClickPaste` — nil/on emits `right-click-action = paste`,
-  off emits `right-click-action = ignore`, so the toggle OWNS the key (the settings conf loads last, so
-  it wins over a `right-click-action` in the user's own `ghostty.conf` — for agterm, which has no terminal
-  context menu, paste-or-off is the whole meaningful choice).
-  The General → Mouse scroll-speed slider (1...10, default 3) maps 3 back to nil so `settings.json` stays
-  minimal; the emitted value is 3 either way.
-  The General → Mouse right-click toggle (default-ON binding, get `?? true` / set `$0 ? nil : false`,
-  like the other default-on toggles) drives `rightClickPaste` and is a real ghostty-key setter (`SettingsModel.setRightClickPaste`
-  → `persistAndApply` rewrites the conf and reloads surfaces live); GUI-only and keep-in-sync EXEMPT (only
-  `theme.set`/`config.reload` touch settings over the socket — the right-click FORWARDING itself is unconditional
-  in `GhosttySurfaceView`, this key only decides libghostty's action).
-  The Appearance → Window inactive-pane-mute slider (0...10, default 5) maps 5 back to nil the same way;
-  it drives `GhosttyApp.inactivePaneMuteStrength` (mirrored into `WindowContentView` view state on `.agtermAppearanceChanged`,
-  like `toolbarMode`/`notificationBadgeEnabled`), and `ContentView.paneDim` washes the inactive split
-  pane with `terminalColor` at `AppSettings.muteOpacity(strength:)` (host-free,
-  unit-tested: 0→0 renders nothing, 5→0.4 = the historical default, 10→0.8) so the inactive pane's TEXT
-  mutes toward the background (`bg→bg` unchanged, `text→bg` dimmer) while the background stays put —
-  the way other terminals dim an inactive pane.
-  NOT a ghostty key, so `writeGhosttyConfig` no-ops and no surface reload fires (only the `.agtermAppearanceChanged`
-  re-render).
-  Caveat: in translucent-window mode the surface background is transparent,
-  so the wash tints the inactive pane's see-through area slightly toward the theme color (the old `Color.black`
-  dim darkened it instead — not a regression).
-  The Appearance → Window → Sidebar Tint slider (0...10, default 5 = neutral) maps 5 back to nil the
-  same way; it drives `GhosttyApp.sidebarBackgroundShift` (mirrored into `WindowContentView.sidebarShift`
-  on `.agtermAppearanceChanged`, like `inactivePaneMuteStrength`), and `ContentView.sidebarTintWash`
-  washes the sidebar column with black (darker, >5) or white (lighter, <5) at `abs(AppSettings.sidebarShiftAmount(strength:))`
-  (host-free, unit-tested: signed, ±0.30 at the ends, 5→0) — a `.background` BEHIND the transparent outline
-  + bottom bar, so the whole column (NOT the title strip, deliberately left uniform with the terminal)
-  reads as one surface a touch lighter/darker WITHOUT tinting row text.
-  Compositing the wash over the window background equals blending the terminal color toward black/white
-  and works identically over an opaque OR a translucent+blurred backdrop,
-  so it composes with opacity/blur instead of fighting it; `WindowAppearance.syncSidebarBackground` keeps
-  the sidebar see-through (no AppKit fill — the wash is the single tint layer).
-  NOT a ghostty key (only the `.agtermAppearanceChanged` re-render).
-  Translucency is composited at the AppKit window level, NOT by the renderer:
-  when `backgroundOpacity < 1`, `ghosttyConfigLines()` pins `background-opacity = 0` + `background-blur = 0`
-  so ghostty draws fully transparent and the window's tinted background is the single translucent layer
-  (no double-tint); at full opacity those lines are omitted and the renderer paints its own background
-  as before. macOS Reduce Transparency is an effective presentation override only: it temporarily makes
-  the window and floating material panels opaque and unblurred while the saved opacity/blur and generated
-  renderer config stay unchanged, so disabling the system setting restores the requested presentation.
-- The app target's `SettingsModel` (`@Observable`) loads `AppSettings`, and on every change:
-  saves (the opacity/blur sliders are the exception — see the end of this bullet),
-  writes `ghostty-settings.conf` (loaded LAST in `GhosttyApp.loadConfig`,
-  so the UI wins over the user's `~/.config/ghostty/config` for the keys it manages).
-  It calls `GhosttyApp.reloadConfig` (rebuild + `ghostty_app_update_config` + `ghostty_surface_update_config`
-  on every live surface) + `AppStore.resetSessionFontSizes()` ONLY when the generated config TEXT actually
-  changed — a window-opacity drag within the translucent range, or a blur change,
-  leaves the config identical, so it skips the surface rebuild (and the zoom reset) and just re-syncs
-  the window.
-  The shared config resets every surface to the default size, so when it does reload,
-  per-session cmd-+/- overrides are cleared to match (user-approved simplification — no per-surface config
-  / zoom preservation).
-  Opacity/blur are NOT ghostty-resolved, so `SettingsModel` mirrors them into `GhosttyApp.windowOpacity`/`windowBlurRadius`
-  (the shared channel the window chrome reads) at launch and on every change.
-  The opacity/blur Settings sliders are the one exception to save-on-every-change:
-  their bindings call `previewBackgroundOpacity`/`previewBackgroundBlur` (apply WITHOUT save) on every
-  drag tick and DEBOUNCE the `settings.json` write (~0.3 s), so a drag coalesces to a single write on
-  settle — which also persists keyboard arrow adjustments that never fire the slider's `onEditingChanged`;
-  a mouse release flushes it immediately via `commitBackgroundSettings()`.
-- `GhosttyApp.reloadConfig` keeps the new config as `self.config` and does NOT free the previous one:
-  `update_config` has no documented ownership contract and the existing code never frees on success,
-  so this matches that (crash-safe over a negligible leak on a rare settings change).
-- The terminal color isn't observable, so a settings change posts `.agtermAppearanceChanged`:
-  `ContentView` mirrors the color into `terminalColor` view state (the quick terminal's opaque backing
-  re-renders with the new color) and `TitleProbeView` re-applies the window appearance.
-  Without this the chrome only refreshed when the window next re-keyed.
-  UI is the standard SwiftUI `Settings` scene (Cmd+,) with a 6-tab `TabView` (frame 540×590).
-  An explicit `TabView(selection:)` binding (`@State` default `.general`) suppresses SwiftUI's
-  `com_apple_SwiftUI_Settings_selectedTabIndex` auto-persistence, so the window always opens on General
-  instead of restoring the last-used tab.
-  **General** (a **Mouse** section with the scroll-speed slider + the right-click-pastes toggle,
-  a **Sessions** section with the new-session-directory picker (home / current session's directory / a
-  fixed custom folder, the last with a `Choose…` panel) + the restore-running-commands toggle + the
-  confirm-before-closing-a-session toggle,
-  and a **Ghostty Config** section with the inherit-global-config toggle).
-  **Appearance** (a **Terminal** section — font/size/theme via `NSFontManager` monospaced families +
-  the bundled `ghostty/themes` dir, `SettingsCatalog` — a **Window** section with the Normal/Compact/Hidden
-  toolbar-mode dropdown Picker (`settings-toolbar-mode`, bound to `effectiveToolbarMode` via `model.setToolbarMode`,
-  `.compact` mapping back to nil) + background opacity/blur sliders + the Sidebar Tint slider + the Sidebar
-  Font Size stepper (`settings-sidebar-font-size`, 9...20, `AppSettings.defaultSidebarFontSize` 13 mapping
-  back to nil, matching the terminal font-size stepper's style) + the inactive-pane-mute slider.
-  The formerly-separate **Panes** section was folded into **Window** so the tab still fits 540×590 without
-  scrolling after adding the font-size stepper).
-  **Interface** (per-element chrome visibility, grouped into a **Title Bar** section and a **Sidebar**
-  section — one default-on Toggle per `InterfaceElement`, laid out TWO per row (`twoColumnSection`) so the
-  tab keeps fitting 540×590 without scrolling as the element set grows; see the `hiddenInterfaceElements`
-  bullet — plus a **Multiple Windows** section with the single `autoHideSidebarInactiveWindows` toggle,
-  which is a plain default-OFF behavior Toggle, NOT an `InterfaceElement`).
-  **Notifications** (a **Notifications** section with the banner / badge / attention-indicator toggles plus the Dock-bounce mode and notification-sound pickers).
-  **Agent Status** (a **Colors and Shapes** section holding ONE ROW PER STATUS — a `LabeledContent`
-  labelled Active / Blocked / Completed whose trailing side carries that glyph's `ColorPicker`
-  (`settings-status-active`/`-blocked`/`-completed`) and its silhouette `Picker`
-  (`settings-status-shape-active`/`-blocked`/`-completed`) side by side, both `.labelsHidden()`;
-  the shape picker takes a fixed-width column (`shapePickerWidth` 80) with `alignment: .trailing`,
-  which is what makes the row FLUSH RIGHT — the reserved column keeps the three color wells in one
-  column (a menu button sizes to the glyph it currently shows, so the six silhouettes span 64.5–68pt
-  and an unreserved column would jog the wells between rows), while the trailing alignment pins the
-  button to that column's right edge so the row ends where every sibling section's control ends.
-  The column's default CENTER alignment is what left the cluster floating ~38pt inboard of the Sound
-  and Auto-follow pickers (a ragged right edge), so keep any width change paired with the trailing
-  alignment, and keep the column wider than the widest silhouette's button or the wells start jogging.
-  `SettingsUITests.testAgentStatusShapePickerRowLayoutAndOptions` asserts exactly that — every shape
-  picker's `maxX` equals the Sound picker's and the wells share a leading edge, measured twice (the
-  default shapes and the Blocked row switched to the widest silhouette).
-  The shape picker offers exactly `StatusShape.allCases`
-  — no "Default" entry, because nil and `circle` render the SAME plain circle, so `circle` maps back to
-  nil (the sound/toolbar-mode nil-mapping convention) and `settings.json` stays minimal.
-  Each option is the SYMBOL ALONE, drawn at the sidebar glyph's own `StatusIconView.glyphPointSize` (a
-  shared constant, so a preview looks like the glyph it installs) as a NON-template `NSImage` tinted
-  with that row's CURRENT color
-  (`NSImage.SymbolConfiguration(paletteColors:)` + `isTemplate = false`, read from the row's color
-  binding so a new color redraws the options): a menu recolors a template symbol to its own text color,
-  and SwiftUI's `.foregroundStyle` on an `Image(systemName:)` does NOT survive into the popup — verified,
-  it rendered grey.
-  The option images are built fresh on every redraw and deliberately NOT cached.
-  A color-well drag fires `setActiveStatusColorHex` → `persistAndApply` on every system colour-panel
-  tick, so a (shape, tint)-keyed cache would mint six `NSImage`s per tick for a tint the user is already
-  dragging past and retain them for the life of the process — unbounded growth buying eighteen small
-  SF Symbol lookups on a path that already writes `settings.json` and diffs the ghostty config per tick.
-  Both the color and the shape binding are DERIVED from the row's `AgentStatus` argument inside
-  `glyphRow(_:)` (a `switch` per getter/setter) rather than passed in positionally, so a row can never
-  label one status while driving another's setting.
-  The option's shape name (`Triangle`, the host-free `StatusShape.displayName`) survives only as its
-  `.accessibilityLabel`, which is ALSO what gives the `NSMenuItem` its AX title,
-  so `app.menuItems["Triangle"]` still finds it; the `Picker` carries
-  a matching `.accessibilityValue`, and the collapsed, text-free button reads back as the shape name
-  (`value: Circle`), which is what the e2e's post-relaunch assertion reads.
-  There is deliberately no separate Shapes section — color and shape belong to the same glyph, so they
-  share a row.
-  Then a **Sound** section with
-  the blocked-sound picker, an **Auto-follow** section with the idle-timeout Picker
-  (Disabled/5s/10s/30s/60s/5m) + the "Don't auto-follow away from a running session" Toggle, and a trailing
-  **Reset** that clears the colors, shapes and sound back to defaults — not the auto-follow settings).
-  **Key Mapping** (the config directory holding `keymap.conf` + a read-only diagnostics list + a Reload
-  button — see the Keymap section).
-  Captions under controls are dropped for self-explanatory controls, which is nearly all of them.
-  A caption is kept ONLY when it carries information the label can't — currently just two positions:
-  the blur hint (`Blur needs opacity below 100%`, replaced while Reduce Transparency is on by
-  `Reduce Transparency is on; saved opacity and blur apply when it is off.`) and the Ghostty-config
-  edit-path hint.
-  This keeps the busiest tab short enough that the 540×590 window fits every tab without scrolling.
-  The notification toggle (`AppSettings.notificationsEnabled`, nil = on) is mirrored to `NotificationManager.bannersEnabled`
-  by `SettingsModel`; it gates only the OS banner, never the badge, and is NOT a ghostty config key (no
-  reload).
-  The badge toggle (`AppSettings.notificationBadgeEnabled`, nil = on) is mirrored into the non-observable
-  `GhosttyApp.notificationBadgeEnabled` flag by `SettingsModel.applyNotificationBadgeEnabled`;
-  because that flag isn't `@Observable`, a flip rides the `.agtermAppearanceChanged` notification the
-  same way `toolbarMode` does — the sidebar Coordinator's `appearanceChanged` calls `reconcile()`,
-  and the gated `RowContent.unseen` (0 when off via `effectiveUnseen`) reloads the affected badge rows.
-  NOT a ghostty config key.
-- **Window translucency (`WindowAppearance.sync`).**
-  Below full opacity the window goes `isOpaque = false` with `backgroundColor = terminalColor.withAlphaComponent(opacity)`
-  (the single tinted layer), applies the blur via the private `CGSSetWindowBackgroundBlurRadius` SPI
-  (`dlsym`-resolved once, no-op if absent — adapted from macterm, its `fatalError` softened to a graceful
-  return), and hides `NSTitlebarBackgroundView` so the tint runs continuously under the titlebar;
-  at full opacity it restores the original opaque/solid path and clears the blur. The same opaque branch
-  wins whenever `NSWorkspace.shared.accessibilityDisplayShouldReduceTransparency` is true, without
-  mutating `WindowAppearance.Chrome` or `AppSettings`, so the saved opacity/blur return when the system
-  setting is disabled.
-  The macOS-26 `NavigationSplitView` sidebar is a Liquid Glass container (`NSContainerConcentricGlassEffectView : NSGlassEffectView`)
-  that WRAPS the sidebar content (an ancestor, so it can't be hidden), and is NOT flattenable to the
-  window tint; `sidebarGlass(in:)` finds it by walking up from the tagged `agterm-sidebar-scroll` view,
-  and when translucent sets its `style = .clear` (the see-through variant) + `tintColor = terminalColor.withAlphaComponent(opacity)`
-  so the sidebar reads as the same translucent surface (its blur stays Liquid Glass,
-  not the window CGS blur — close, not pixel-identical).
-  All of this re-applies on every `sync`, which `TitleProbeView` already drives on window key/main/fullscreen
-  transitions + `.agtermAppearanceChanged`. For live system-setting changes,
-  `SystemAccessibilityObserver.start()` observes
-  `NSWorkspace.accessibilityDisplayOptionsDidChangeNotification` on `NSWorkspace.notificationCenter`
-  and posts app-local `.agtermAccessibilityDisplayOptionsChanged`; each `WindowAccessor.Coordinator`
-  observes that on `NotificationCenter.default` and re-runs `applyTitlebarBlend`. SwiftUI's
-  `accessibilityReduceTransparency` environment value independently swaps the command palette and
-  Ctrl-Tab session switcher from `.regularMaterial` to opaque `.windowBackgroundColor`, and drives the
-  conditional Settings hint. All open windows and panels therefore update without a relaunch.
-- **`configDirectory` + the keymap (see the Keymap section).**
-  `AppSettings.configDirectory: String?` (nil = the default) holds the directory that contains `keymap.conf`.
-  `SettingsModel` resolves it through the host-free `ConfigPaths.configDirectory(setting:stateDir:home:)`
-  (explicit setting → `<AGTERM_STATE_DIR>/config` for test isolation → `~/.config/agterm`) and `ConfigPaths.keymapPath(...)`
-  (`<dir>/keymap.conf`), loads + `parseKeymap`s it at init into the `@Observable` `keymap`/`keymapDiagnostics`,
-  and on first launch writes a fully-commented starter `keymap.conf` (`ensureStarterKeymap` — never overwrites
-  an existing file; documents every `BuiltinAction` raw name + default chord and the `{AGT_X}` token
-  list, so a fresh file rebinds nothing).
-  `setConfigDirectory(_:)` persists + reloads; the Key Mapping tab's directory picker drives it.
-  Unlike the other settings, a keymap change is NOT a ghostty config rewrite (no `persistAndApply`/surface
-  reload) — it posts `.agtermKeymapChanged` (co-located in `GhosttyApp.swift`'s `Notification.Name` extension)
-  and the `@Observable keymap` drives the rest.
-- **`<configDir>/ghostty.conf` (agterm-scoped ghostty config, co-located with `keymap.conf`).** A config
-  layer between the (opt-in) global ghostty config and agterm's UI settings,
-  and the agterm customization point: `GhosttyApp.loadConfig` loads `ghostty-defaults.conf` → `~/.config/ghostty/config`
-  (ONLY when `inheritGlobalGhosttyConfig` is on — OFF by default; see that field) → `<configDir>/ghostty.conf`
-  → `ghostty-settings.conf` (UI), each overriding the last, so `ghostty.conf` overrides the bundled defaults
-  (and the global config when inherited) for ANY key, but agterm's UI-managed keys (font/theme/opacity/blur/scroll)
-  still WIN because the settings conf loads LAST.
-  The scoped `ghostty.conf` is ALWAYS loaded; skipped only when absent (the starter is comment-only,
-  so a fresh install is a no-op).
-  Scoped to agterm only — the standalone Ghostty.app never reads it.
-  `GhosttyApp.resolveConfigInputs()` (a FUNCTION, not a computed property,
-  since it reads `settings.json` via `SettingsStore().load()`) returns `ConfigInputs{scopedURL, inheritGlobalConfig}`
-  — resolving the scoped path SELF-CONTAINED (`configDirectory` + `ConfigPaths.configDirectory(setting:stateDir:home:)`
-  + the `ConfigPaths.ghosttyConfigPath` helper) AND the inherit flag in ONE settings load,
-  because `loadConfig` runs before any `SettingsModel` exists (its first `GhosttyApp.shared` touch is
-  inside `SettingsModel.init`).
-  It is resolved ONCE per config build and THREADED to `loadConfig(_:)` and `resolveSelectionColors(ghosttyConfigPath:inheritGlobalConfig:)`
-  (whose `sources` array gets the global path ONLY when inherited, then the scoped path,
-  then the settings conf), so a single reload reads `settings.json` at most once.
-  `SettingsModel.ensureStarterGhosttyConfig` (mirrors `ensureStarterKeymap`) seeds a comment-only starter
-  on first launch (header link to `https://ghostty.org/docs/config`, a commented `# macos-option-as-alt = true`,
-  a note that the UI keys win) — never overwrites an existing file, seeded at `SettingsModel.init` AFTER
-  `loadConfig` already ran (harmless, all comments).
-  **Edit/Reload mirror the keymap surfaces** (the keymap's `editorCommand(forKeymapPath:)` was generalized
-  to `editorCommand(forPath:)`, `$0` label `agterm-config-edit`, shared by both).
-  `AppActions.editGhosttyConfig` (File ▸ Edit ghostty.conf… + the ⌃⇧P palette,
-  GUI-only, keep-in-sync EXEMPT like Edit Keymap) opens `ghostty.conf` in `$EDITOR` via a 95% overlay;
-  the target + the file's opening contents ride `ghosttyEditOverlaySession`/`ghosttyEditOverlaySnapshot`
-  and `WindowContentView`'s overlay-close `onChange` calls `reloadGhosttyConfigIfEdited` on close (reloads
-  only when the file CHANGED since the editor opened, so a no-op editor session keeps per-session font
-  zoom) then clears it.
-  `AppActions.reloadGhosttyConfig` (`@discardableResult -> Int`, returning the diagnostic count;
-  File ▸ Reload Config + the palette + the overlay close + the `config.reload` control command) → `SettingsModel.reloadGhosttyConfig`
-  → `GhosttyApp.reloadConfig(surfaces:isDark:)` (`@discardableResult -> Int`, returning + caching `lastConfigDiagnosticsCount`; `isDark` = the side to resolve the dual theme to, from `currentIsDark()` on the explicit path)
-  + `resetSessionFontSizesAllWindows()` + `.agtermAppearanceChanged`; a non-zero count posts `NotificationManager.notifyConfigDiagnostics(count:)`
-  from `SettingsModel.reloadGhosttyConfig` (mirroring `reloadKeymap`, so EVERY caller surfaces it — incl.
-  a Key Mapping directory change via `setConfigDirectory`, which now reloads BOTH co-located files).
-  The count spans ALL config sources (libghostty diagnostics carry NO source-file attribution),
-  NOT just `ghostty.conf`, so the banner/godoc/`config.reload` say "ghostty config",
-  not "ghostty.conf".
-  The EXPLICIT Reload Config / `config.reload` reload is UNCONDITIONAL (`ghostty.conf` is edited externally,
-  so there is always something to re-read) and clears per-session ⌘+/⌘− zoom like any config reload;
-  only the editor round-trip is guarded by the unchanged-file check.
-  The whole-config diagnostics banner ALSO fires at launch (`agtermApp` posts `notifyConfigDiagnostics`
-  when `GhosttyApp.shared.lastConfigDiagnosticsCount > 0` after the first config build).
-  See the Control API catalog for the `config.reload` four-point audit.
-- **`restoreRunningCommand` (re-run the foreground command on restart, opt-in,
-  General tab).** `AppSettings.restoreRunningCommand: Bool?` (nil = off) gates capturing each pane's
-  foreground command at clean quit and re-running it on the next launch.
-  NOT a ghostty key (`writeGhosttyConfig` no-ops, no surface reload).
-  CAPTURE: `AppDelegate.applicationWillTerminate` — only when the flag is on — walks every open store's
-  session surfaces and sets `Session.foregroundCommand`/`splitForegroundCommand` (persisted on `SessionSnapshot`)
-  BEFORE `saveAllOpen()`, via `ForegroundProcess.command(for:shellBasename:)` (`ghostty_surface_foreground_pid`
-  → `sysctl(KERN_PROCARGS2)` → host-free `CommandRestore.parseProcArgs`;
-  returns nil only for an IDLE shell-at-prompt via `CommandRestore.isIdleShell` — a known shell with
-  NO payload argument after argv0, only option flags.
-  A shell RUNNING a script is NOT idle and IS captured: a `#!/bin/sh` wrapper like the `cld` claude-code
-  launcher has foreground argv `['/bin/sh', '/usr/local/bin/cld', …]`, which earlier was wrongly skipped
-  because `basename('/bin/sh')` is `sh` — `isIdleShell` keeps it because of the script-path argument).
-  The walk uses `WindowLibrary.allOpenSessions()` and captures the SPLIT command ONLY when `session.isSplit`
-  (a hidden split isn't recreated at restore, so capturing it would leave a stale command to fire on
-  the next manual ⌘D — `clearSavedCommands` shares the same `allOpenSessions` walk).
-  A login shell's argv0 is dash-decorated (`/usr/bin/login … exec -l /bin/zsh` → argv0 `-/bin/zsh`,
-  whose basename splits on `/` to `zsh`; `isKnownShell` ALSO strips a leading `-` so a bare `-zsh` form
-  is recognized too), so an idle pane captures nil and stays a plain shell — verified via `tree --json`.
-  A force-quit/crash skips `applicationWillTerminate`, so it loses commands (sessions + cwd still restore
-  from the debounced snapshot) — best-effort by design.
-  RESTORE: the surface factories (`makeSurface`/`makeSplitSurface`) read the persisted command,
-  gate on `GhosttyApp.shared.restoreRunningCommand` (mirrored by `SettingsModel.applyRestoreRunningCommand`,
-  like `notificationBadgeEnabled`) + the host-free `CommandRestore.shouldRestore(argv:denylist:)` check
-  against the user-editable `restore-denylist.conf` (NO built-in list — `SettingsModel.loadRestoreDenylist`
-  parses `<configDir>/restore-denylist.conf` at launch via `CommandRestore.parseDenylist` and mirrors
-  it into `GhosttyApp.shared.restoreDenylist`, seeded with the terminal multiplexers `tmux`/`screen`/`zellij`
-  by `ensureStarterRestoreDenylist`; everything not listed — `python manage.py runserver`,
-  `node server.js`, a REPL — restores), and feed it to the login shell via `config.initial_input` = `CommandRestore.shellQuotedLine(argv) + "\n"`
-  (NOT `config.command`, which would replace the shell + close on exit; `initial_input` re-runs inside
-  the shell so exit returns to a prompt).
-  The captured field is consumed run-once in the factory (read-then-nil,
-  like `scratchCommand`) so a later structural save can't re-fire it.
-  The SAME toggle ALSO gates the OTHER restore path: a `session.new --command` session persists its command
-  (`SessionSnapshot.initialCommand`) and re-runs it on restore via `config.command` (the shell-replacing,
-  close-on-exit path — the opposite of the foreground path's `initial_input`), because a command that
-  exec-replaces the shell is invisible to the foreground-pid capture.
-  That path is gated by the transient `Session.wasRestored` (a fresh command session always runs; a restored
-  one honors the toggle), and a live captured foreground preempts the persisted `initialCommand`.
-  Unlike `foregroundCommand`, `initialCommand` is NOT consumed — it is the durable creation identity,
-  re-emitted by every `snapshot()`, so the opt-out is per-restart (re-enabling the toggle brings the command
-  session back); it is dropped only when the command pane exits into a promoted split (`closePrimaryPane`).
-  All decision logic (parse/shell-detect/denylist/quote) is host-free in `CommandRestore` (unit-tested);
-  the app target owns only the C-boundary + Darwin syscall.
-  ONLY a single-process command restores faithfully — a typed pipeline/compound line captures one process.
-  The SETTINGS TOGGLE is GUI-only (no `settings.*` control surface; only `theme.set`/`config.reload`
-  touch settings), but the feature DOES have a control surface: `restore.clear` clears the saved commands
-  and live `foreground`/`splitForeground` ride `tree`/`ControlSessionNode` (see the Control API catalog's
-  `restore.clear` four-point audit) — the agent-skill was updated accordingly.
-- **`newSessionDirectory`/`newSessionCustomDirectory` (where a new ⌘T session opens, General tab).**
-  `AppSettings.newSessionDirectory: String?` (nil = the `home` default) holds a `NewSessionDirectory`
-  raw value (`home`/`currentSession`/`custom`); `newSessionCustomDirectory: String?` is the fixed dir for
-  the `custom` mode.
-  NOT ghostty keys (`ghosttyConfigLines()` never emits them).
-  The host-free `AppSettings.resolveNewSessionCwd(currentSessionCwd:home:)` maps the mode to a path: `home`
-  → home; `currentSession` → `currentSessionCwd` (else home); `custom` → `newSessionCustomDirectory` (else
-  home).
-  An unknown/nil mode, a nil/blank `currentSessionCwd`, and a nil/blank custom path all fall back to home
-  (both non-home arms guard emptiness symmetrically).
-  It is read ONCE at new-session creation via `AppActions.resolvedNewSessionCwd()` (which passes the active
-  session's `focusedCwd` as `currentSessionCwd`), so it only affects the NEXT session — no config rewrite
-  or surface reload.
-  `SettingsModel.setNewSessionDirectory`/`setNewSessionCustomDirectory` are save-only (like `setBlockedStatusSoundName`),
-  and the General → Sessions Picker maps `.home` back to nil to keep `settings.json` minimal.
-  ALL FOUR New Session entry points share `resolvedNewSessionCwd()` so none drift: the bottom-bar session
-  menu, the File menu, and the ⌃⇧P palette via `AppActions.newSession()`, and the sidebar workspace-row
-  right-click menu via `WorkspaceSidebar`'s `menuNewSession` (which calls `actions.resolvedNewSessionCwd()`
-  directly, since it places into the RIGHT-CLICKED workspace, not `currentWorkspaceID`).
-  GUI-only and keep-in-sync EXEMPT (only `theme.set`/`config.reload` touch settings over the socket); the
-  control-side `session.new --cwd` already covers "open a session in directory X" and keeps its explicit
-  `--cwd`-or-home default regardless of this setting.
-- **`inheritGlobalGhosttyConfig` (load the user's global `~/.config/ghostty/config`,
-  opt-in, General tab).** `AppSettings.inheritGlobalGhosttyConfig: Bool?` (nil = OFF) gates whether `loadConfig`
-  reads the user's GLOBAL ghostty config (see the `<configDir>/ghostty.conf` bullet for the layering).
-  OFF by default so agterm is self-contained: a config written for the standalone Ghostty.app does NOT
-  silently change agterm, which also keeps bug reports legible (the colors a user sees are agterm's own
-  unless they opt in).
-  The agterm-scoped `<configDir>/ghostty.conf` is ALWAYS loaded regardless and is the documented customization
-  point.
-  Resolved at config-LOAD time (via `resolveConfigInputs`), NOT a live `GhosttyApp` mirror and NOT a
-  `ghosttyConfigLines()` key — so `setInheritGlobalGhosttyConfig` saves `settings.json` then calls `reloadGhosttyConfig()`
-  UNCONDITIONALLY (like `setConfigDirectory`), because it changes WHICH files load and `persistAndApply`'s
-  text-diff guard would otherwise skip the reload.
-  The SETTINGS TOGGLE is GUI-only and keep-in-sync EXEMPT (like `restoreRunningCommand`'s toggle — only
-  `theme.set`/`config.reload` touch settings over the socket).
-  Default-off + round-trip covered host-free in `AppSettingsTests`; the file-gating itself is app-target
-  (manually/build verified, no app unit-test host).
-- **`attentionButtonEnabled` (titlebar attention bell, opt-in, Notifications tab).**
-  `AppSettings.attentionButtonEnabled: Bool?` (nil = OFF, the default-off precedent like `restoreRunningCommand`/`inheritGlobalGhosttyConfig`,
-  NOT `notificationBadgeEnabled`'s default-ON) gates the title-bar bell icon that reflects the window's
-  `AppStore.attentionSessions` at a glance (empty → dimmed/disabled, non-empty → enabled,
-  any blocked → filled-amber).
-  NOT a ghostty key (`writeGhosttyConfig` no-ops, no surface reload).
-  It is the non-observable chrome-mirror pattern: `SettingsModel.setAttentionButtonEnabled` saves + `applyAttentionButtonEnabled`
-  pushes `settings.attentionButtonEnabled ?? false` into the `GhosttyApp.attentionButtonEnabled` flag
-  (alongside `applyToolbarMode`/`applyNotificationBadgeEnabled`), so a flip rides `.agtermAppearanceChanged`
-  and `WindowContentView` re-reads the mirror to re-render the titlebar live — exactly like `toolbarMode`/`notificationBadgeEnabled`.
-  The Notifications tab's Notifications-section `Toggle("Show attention indicator")` uses the default-OFF binding (get
-  `?? false`, set `$0 ? true : nil`, mirroring `restoreRunningCommand`/`inheritGlobalGhosttyConfig`,
-  NOT `notificationBadgeEnabled`).
-  GUI-only and keep-in-sync EXEMPT (the bell just opens the already-controllable attention palette /
-  `session.select`; only `theme.set`/`config.reload` touch settings over the socket).
-  See the Notifications section for the bell's three states and the Menu/actions section for the `.attention`
-  palette it opens.
-- **`dockBounce` (bounce the Dock icon on a background notification, opt-in, Notifications tab).**
-  `AppSettings.dockBounce: String?` — a `DockBounce` RAW STRING (`off`/`once`/`untilFocused`, nil = `off`,
-  the default-off precedent like `attentionButtonEnabled`, NOT `notificationBadgeEnabled`'s
-  default-ON; the case is named `off` not `none` to dodge the `Optional.none` collision, like
-  `AutoFollowAttention.off`), resolved through `effectiveDockBounce` (an unknown/future value degrades to
-  `off`, the tolerant-decode rule shared with `toolbarMode`/`newSessionDirectory`).
-  NOT a ghostty key (`writeGhosttyConfig` no-ops, no surface reload).
-  Unlike the chrome-mirror settings it needs NO `.agtermAppearanceChanged` re-render: `SettingsModel.setDockBounce`
-  saves + `applyDockBounce` pushes `settings.effectiveDockBounce` into the `NotificationManager.dockBounce`
-  mirror (alongside `applyNotificationsEnabled`, the OTHER `NotificationManager` mirror), read on the NEXT
-  notification rather than rendered continuously.
-  `NotificationManager.bounceDock()` switches the mode to the matching `requestUserAttention` (`once` →
-  `.informationalRequest`, `untilFocused` → `.criticalRequest`, both a no-op while frontmost) after the badge
-  bump in both the OSC `notify` and the control `send` paths — see the Notifications rule for the full behavior.
-  The Notifications tab's `Picker("Bounce Dock icon")` mirrors the toolbar-mode picker binding (get
-  `effectiveDockBounce`, set `$0 == .off ? nil : $0` so None maps back to nil and keeps `settings.json` minimal).
-  GUI-only and keep-in-sync EXEMPT (only `theme.set`/`config.reload` touch settings over the socket).
-  Default + tolerant-decode covered host-free in `AppSettingsTests`; the bounce itself is app-target
-  (settings-picker persistence in `SettingsUITests`, the animation verified by eye — not accessibility-observable).
-- **`notificationSoundName` (a system sound on every delivered banner, opt-in, Notifications tab).**
-  `AppSettings.notificationSoundName: String?` (nil/empty = silent, the default) names the system sound
-  attached to the delivered banner (`UNNotificationSound`, so it follows the banner toggle and Do Not
-  Disturb), in BOTH the OSC and control paths.
-  NOT a ghostty key (`writeGhosttyConfig` no-ops, no surface reload).
-  Like `dockBounce` it needs NO `.agtermAppearanceChanged` re-render: `SettingsModel.setNotificationSoundName`
-  saves + `applyNotificationSound` pushes the value into the `NotificationManager.notificationSoundName`
-  mirror (alongside the other two `NotificationManager` mirrors), read on the NEXT notification.
-  The Notifications tab's `Picker("Notification sound")` mirrors the Agent Status blocked-sound picker
-  binding (None maps back to nil to keep `settings.json` minimal; selecting a sound previews it via
-  `StatusSoundPlayer`).
-  GUI-only and keep-in-sync EXEMPT (only `theme.set`/`config.reload` touch settings over the socket).
-  Default + round-trip covered host-free in `AppSettingsTests`; the picker persistence in `SettingsUITests`
-  (`testNotificationSoundPickerPersists`); the sound itself is app-target (verified by ear, like the
-  blocked sound).
-  See the Notifications rule for the delivery behavior.
-- **`confirmCloseSession` (confirm before closing a session, opt-in, General tab).**
-  `AppSettings.confirmCloseSession: Bool?` (nil = OFF, the default-off precedent like `restoreRunningCommand`)
-  gates a native `NSAlert` confirm before a GUI session close.
-  NOT a ghostty key (`SettingsModel.setConfirmCloseSession` is save-only, no config rewrite / surface reload).
-  Read ON DEMAND at close time by the private `AppActions.confirmCloseSession(_:)` — no `GhosttyApp` mirror
-  — which returns proceed-without-prompt when the setting is off OR under an XCUITest launch
-  (`ContentView.isUITestLaunch`, a modal would hang the test, like the clear-flagged / quit confirms).
-  It gates the two GUI close paths only: `AppActions.closeActiveSession()` (⌘W / File ▸ Close Session /
-  the ⌃⇧P palette) and the sidebar row's Close (routed through the new `AppActions.closeSession(_:in:)`);
-  the control channel's `session.close` calls `AppStore.closeSession` directly and stays silent.
-  The General → Sessions `Toggle("Confirm before closing a session")` uses the default-OFF binding (get
-  `?? false`, set `$0 ? true : nil`, like `restoreRunningCommand`).
-  GUI-only and keep-in-sync EXEMPT — a safety modal is meaningless to drive headless (`session.close`
-  must never prompt), like the quit-confirm.
-  Default-off + round-trip covered host-free in `AppSettingsTests`; the confirm itself is app-target
-  (manually/build verified, no app unit-test host, like `confirmDelete`/`confirmClearFlags`).
-- **`hiddenInterfaceElements` (per-element title-bar / sidebar-footer chrome visibility, Interface tab).**
-  `AppSettings.hiddenInterfaceElements: [String]?` (nil/empty = everything shown, the default) holds the
-  raw names of the chrome elements the user HID.
-  Stored as raw strings so an unknown future element name decodes tolerantly (dropped by
-  `resolvedHiddenInterfaceElements`) instead of failing the whole decode — the forward-compat rule shared
-  with `toolbarMode`/`dockBounce`.
-  NOT a ghostty key (`ghosttyConfigLines()` never emits it).
-  The toggleable elements are the host-free `InterfaceElement` enum (agtermCore): title bar —
-  `sidebarToggle`/`sessionName`/`windowName`/`recentSessions`/`scratch`/`split`/`dashboard`/`quickTerminal`;
-  sidebar — `newWorkspace`/`newSession`/`flaggedView`/`focusFilter` (the footer add/flag/filter controls)
-  + `workspaceAddSession`
-  (the hover-revealed "+" on each workspace ROW that adds a session there — a SEPARATE toggle from the
-  footer `newSession` button, though both run the same new-session action).
-  Each case carries its `section` (Title Bar / Sidebar) and `displayName` (the toggle label), so the
-  Interface tab iterates `InterfaceElement.allCases` grouped by section.
-  The attention bell is NOT in the set — it keeps its own `attentionButtonEnabled` opt-in (default OFF, not
-  ON), so it is not a per-element toggle.
-  It is the non-observable chrome-mirror pattern (like `attentionButtonEnabled`/`toolbarMode`):
-  `SettingsModel.setInterfaceElementVisible(_:visible:)` mutates the RAW string set (NOT
-  `resolvedHiddenInterfaceElements`, whose known-only filter would erase an unknown future element name a
-  newer build persisted; empty maps back to nil to keep `settings.json` minimal) + `persistAndApply` +
-  `applyInterfaceElements` pushes `settings.resolvedHiddenInterfaceElements` into the
-  `GhosttyApp.hiddenInterfaceElements` mirror, so a flip rides `.agtermAppearanceChanged` and every open
-  window re-reads the mirror (`WindowContentView.shows(_:)`) to gate each element live.
-  The SwiftUI title-bar / sidebar-FOOTER elements gate via `WindowContentView.shows(_:)`; the sidebar-ROW
-  `workspaceAddSession` is AppKit, so it gates in `SidebarCellView.mouseEntered` — which reads the
-  `GhosttyApp.hiddenInterfaceElements` mirror before revealing the "+", so a live toggle takes effect on
-  the next hover (the sidebar is never hovered while the Settings window holds the pointer, so a mid-hover
-  flip can't strand a visible "+").
-  The title-bar building moved to `WindowContentView+Titlebar.swift` (matching the `+Dashboard`/`+RecentSessions`/`+Zoom`
-  split) to keep `WindowContentView.swift` under the 1000-line limit; the session-vs-window title split lives
-  there in `titleText` (gated) vs `windowTitle` (always the OS window title), and the trailing button cluster
-  draws a group divider ONLY where two groups that each still show 2+ buttons meet (a group reduced to one
-  button flows in without a bracketing divider) — the rule is the host-free
-  `InterfaceElement.titlebarGroupDividers(countA:countB:countC:)`, unit-tested in `AppSettingsTests`.
-  GUI-only and keep-in-sync EXEMPT — pure visual chrome, and every gated element's ACTION already has full
-  control coverage (`sidebar`/`session.split`/`session.scratch`/`quick`/`dashboard`/`workspace.new`/`session.new`;
-  only `theme.set`/`config.reload` touch settings over the socket).
-  Default + round-trip + tolerant-decode covered host-free in `AppSettingsTests`; the picker persistence in
-  `SettingsUITests` (`testInterfaceElementTogglePersists`); the live gating is app-target (build/manually
-  verified, no app unit-test host).
-  **Adding a new toggleable element:** add the `InterfaceElement` case (+ its `section`/`displayName`) and
-  gate its render site on the mirror; the Interface tab picks it up automatically via `allCases`, and the
-  round-trip/tolerant-decode tests already iterate `allCases`.
-  Do this only AFTER the user agrees the element should be user-toggleable — some chrome is intentionally
-  always-on — per the propose-then-ask working-norm in the root `CLAUDE.md` (never automatic).
-- **`autoHideSidebarInactiveWindows` (only the frontmost window shows its sidebar, opt-in, Interface tab).**
-  `AppSettings.autoHideSidebarInactiveWindows: Bool?` (nil = OFF, the default-off precedent like
-  `restoreRunningCommand`/`attentionButtonEnabled`) makes the frontmost open window show its sidebar and
-  every OTHER open window collapse its own.
-  NOT a ghostty key (`writeGhosttyConfig` no-ops, no surface reload).
-  It is the non-observable chrome-mirror pattern (like `attentionButtonEnabled`): `SettingsModel.setAutoHideSidebarInactiveWindows`
-  saves + `applyAutoHideSidebarInactiveWindows` pushes `settings.autoHideSidebarInactiveWindows ?? false`
-  into the `GhosttyApp.autoHideSidebarInactiveWindows` flag.
-  The DRIVER is host-free: `WindowLibrary.applyInactiveWindowSidebarHiding()` sets the active window's
-  `sidebarVisible = true` and every other open store's to `false` (`setSidebarVisible` no-ops an already-correct
-  window, so only the windows that actually change write/persist/notify).
-  `WindowAccessor.reportFrontmost` reads the mirror and invokes the driver on EVERY window activation
-  (becomeKey/becomeMain), NOT gated by the `frontmostWindowID != id` change-guard — that guard now wraps
-  only the frontmost-id persist + the frontmost-changed post.
-  Running the driver unconditionally is what makes new-window creation (`newWindow()` pre-sets
-  `frontmostWindowID` before the window keys) and launch reconcile; it still fires only on
-  becomeKey/becomeMain and NEVER on a resign, so switching to another app leaves every sidebar untouched.
-  `setAutoHideSidebarInactiveWindows` also invokes the driver ONCE when the toggle flips ON, so it takes
-  effect immediately instead of waiting for the next window switch.
-  ABSOLUTE rule, no per-window intent memory: sidebar visibility is entirely focus-driven while on, so a
-  manual ⌃⌘S hide on the frontmost window is transient — it re-shows on the next refocus (the user-chosen
-  semantics; turning the feature OFF leaves background windows collapsed until manually reopened).
-  Because the driver writes the persisted per-window `sidebarVisible`, a GUI-only auto-hide is exactly the
-  `.agtermSidebarVisibilityChanged` case `ControlServer` already observes to refresh the `window.list` cache.
-  GUI-only and keep-in-sync EXEMPT (only `theme.set`/`config.reload` touch settings over the socket; the
-  sidebar capability itself already has full control coverage via the `sidebar` command + the `sidebarVisible`
-  read-back on `tree`/`window.list`).
-  Default-off + round-trip covered host-free in `AppSettingsTests`; the driver in `WindowLibraryTests`
-  (`applyInactiveWindowSidebarHiding*`); the mirror wiring is app-target (build/manually verified, no app
-  unit-test host).
-- **A Settings toggle's DESCRIPTION stays single-line short-form** — a terse hint, not a manual.
-  No detailed multi-line explanation of what the toggle does and no cross-refs to other toggles;
-  keep the minimal style (see also the flag-description convention).
+- `AppSettings` is a versionless Codable value in `agtermCore`; optional fields provide forward
+  compatibility. `SettingsStore` writes `<stateDir>/settings.json` and follows `AGTERM_STATE_DIR`.
+  Store enum-like settings as raw strings and resolve unknown values to defaults rather than failing the
+  file.
+- Theme slots and following are owned by the theme-picker rule. `ToolbarMode` is
+  `normal|compact|hidden`, stored raw; nil defaults compact. Normal adds cwd, hidden removes titlebar and
+  traffic lights but leaves an invisible roughly 3-point drag strip above the first row at padding 6.
+  `effectiveToolbarMode` falls back through legacy `compactToolbar` (`false` = normal, nil/true = compact);
+  writing a mode clears the legacy field.
+- Default-on nil fields are `notificationsEnabled`, `notificationBadgeEnabled`, and `rightClickPaste`.
+  Default-off nil fields include attention button, Dock bounce, restore commands, global config
+  inheritance, close confirmation, auto-follow, hidden inactive sidebars, and interface hiding.
+- `sidebarFontSize` is 9...20, default 13; row height is clamped size + 15, so 13 gives 28. Icons/status
+  glyphs stay fixed. Inactive-pane mute and sidebar tint are 0...10 with neutral/default 5.
+  `muteOpacity` maps 0/5/10 to 0/0.4/0.8. `sidebarShiftAmount` maps the endpoints to signed +/-0.30;
+  below 5 uses white, above 5 black, behind the transparent sidebar only, never the title strip/text.
+- `ghosttyConfigLines()` emits raw `key = value` with no quoting, including spaced names such as
+  `3024 Night`. It always owns and emits `mouse-scroll-multiplier` (nil = 3 for wheel and trackpad) and
+  `right-click-action` (nil/on = paste, off = ignore), overriding earlier config layers. Their Settings
+  controls map defaults back to nil; right-click changes reload surfaces.
+- Non-Ghostty settings update app mirrors and `.agtermAppearanceChanged`, not surfaces. Pane mute washes
+  text toward terminal color; with transparency it also tints the see-through area. Sidebar tint
+  composes over opaque or blurred backgrounds; AppKit must leave the sidebar unfilled.
+- Status colors default to active `#DBD9E6`, system amber, and system green. Shapes are raw
+  `StatusShape` strings resolved only by `effectiveStatusShape(for:)`; nil and circle render identically.
+  `SettingsModel` pushes both into `GhosttyApp`, then `.agtermAppearanceChanged` makes
+  `reapplyStatusGlyphs()` update both sidebar and attention list. Per-call `session.status` color/shape
+  overrides win.
+- Blocked sound is nil/"None" by default and previews through `StatusSoundPlayer`. On a transition into
+  blocked, the server plays it only when no non-empty per-call `--sound` exists; repeated blocked does
+  not replay. `AgentStatus.effectiveSound` owns precedence. Reset clears colors, shapes, and sound, not
+  auto-follow.
+- Auto-follow choices are Disabled, 5s, 10s, 30s, 60s, and 5m, plus the guard against leaving a running
+  session.
+- Notification badges gate only the sidebar pill/workspace roll-up and Dock total; counts keep tracking
+  while hidden. Banners are a separate `notificationsEnabled` mirror, and neither gates agent status.
+- `SettingsModel` saves and writes last-loaded `ghostty-settings.conf`. Reload app/surfaces and clear
+  per-session font zoom only when generated text changes. Opacity/blur are mirrored directly to window
+  chrome. Slider ticks preview without save and debounce persistence about 0.3 seconds; mouse release
+  flushes, and debouncing still catches keyboard changes.
+- Keep each successful replacement config in `GhosttyApp.config`; `update_config` has no ownership
+  contract, so freeing it risks a crash and the rare leak is accepted.
+- `.agtermAppearanceChanged` is required because terminal color is not observable; it updates
+  `terminalColor`, quick-terminal backing, title/window appearance, and non-observable chrome mirrors.
+- Settings is a 540x590 six-tab SwiftUI scene with explicit selection defaulting General, preventing
+  `com_apple_SwiftUI_Settings_selectedTabIndex` persistence. General holds Mouse, Sessions, and Ghostty
+  Config. Appearance holds Terminal and Window. Interface groups `InterfaceElement`s two per row plus
+  Multiple Windows. Notifications holds banner/badge/attention/bounce/sound. Agent Status holds
+  colors/shapes, sound, auto-follow, and Reset. Key Mapping holds config directory, diagnostics, and Reload.
+- Keep titlebar construction in `WindowContentView+Titlebar.swift` so `WindowContentView.swift` remains
+  below the 1000-line limit.
+- Keep Agent Status shape pickers in a trailing-aligned 80-point column wider than the 64.5...68-point
+  buttons; centered alignment leaves the cluster about 38 points inboard. Keep color wells aligned.
+  `testAgentStatusShapePickerRowLayoutAndOptions` checks picker `maxX`
+  against Sound and well alignment before/after the widest shape. Offer exactly `StatusShape.allCases`;
+  circle maps to nil. Use fresh non-template palette-colored `NSImage`s at
+  `StatusIconView.glyphPointSize`; template/SwiftUI tint does not survive into the popup. Do not cache
+  per-drag tint images. Derive both bindings from the row's `AgentStatus`. Keep display names as option
+  AX labels and picker AX values.
+- Keep captions only for facts labels cannot carry: the blur/Reduce Transparency hint and Ghostty config
+  path. The blur hint states that opacity must be below 100%. Settings descriptions are one short line,
+  never a mini-manual.
+- **Window translucency is one AppKit layer.** Below opacity 1, make the window non-opaque, set terminal
+  color with alpha, hide `NSTitlebarBackgroundView`, and call dynamically resolved
+  `CGSSetWindowBackgroundBlurRadius`; absence is a no-op. `ghosttyConfigLines()` pins renderer opacity and
+  blur to 0. At opacity 1, restore opaque rendering. Reduce Transparency temporarily forces opaque,
+  unblurred windows/panels without changing saved settings or config.
+- On macOS 26, find the wrapping `NSContainerConcentricGlassEffectView` by walking from
+  `agterm-sidebar-scroll`; for translucent windows use clear style plus terminal tint. Its Liquid Glass
+  blur is not pixel-identical to CGS blur. Reapply on key/main/fullscreen and appearance changes.
+  `SystemAccessibilityObserver` bridges workspace accessibility changes to every window; SwiftUI's
+  environment independently makes palettes/switcher opaque and changes the hint.
+- `configDirectory` resolution is explicit setting, else `<AGTERM_STATE_DIR>/config`, else
+  `~/.config/agterm`. It contains keymap, scoped Ghostty config, and restore denylist. Seed starter files
+  only when absent. Keymap starter documents every action/default and token but rebinds nothing; reload
+  posts `.agtermKeymapChanged`, never a surface config update.
+- Ghostty layers are bundled defaults, optional `~/.config/ghostty/config`, always-loaded scoped
+  `<configDir>/ghostty.conf`, then UI settings. Each overrides the previous; standalone Ghostty never
+  reads the scoped file. `resolveConfigInputs()` must load settings once before `SettingsModel` exists and
+  thread the scoped URL/inherit flag to config loading and selection-color resolution.
+- Seed scoped `ghostty.conf` as comments only, including docs URL, commented option-as-alt, and UI-wins
+  note. Edit Config opens it with the shared editor command in a 95% overlay, records original contents,
+  and reloads on close only if changed, preserving zoom after a no-op edit.
+- File/palette Reload Config and `config.reload` always re-read external sources, return/cache total
+  libghostty diagnostics across all sources, clear all session zoom, post appearance change, and notify
+  non-zero diagnostics. A config-directory change reloads both co-located files. Launch also reports
+  cached diagnostics.
+- **Restore running commands is opt-in and clean-quit only.** Before `saveAllOpen()`,
+  `applicationWillTerminate` captures each visible main/split foreground argv through
+  `ghostty_surface_foreground_pid`, `sysctl(KERN_PROCARGS2)`, and host-free parsing. Capture no hidden
+  split. A known shell with only flags is idle and omitted; scripts/payload args remain, including
+  `/bin/sh <script>`. Strip login `-` before shell recognition. Force quit preserves snapshots/cwd but
+  skips command capture.
+- Restore only when the toggle is on and basename is absent from user
+  `restore-denylist.conf`, seeded with `tmux`, `screen`, and `zellij`. Feed captured argv once through
+  shell-quoted `config.initial_input` so exit returns to the shell, then nil it. Only one foreground
+  process from a typed pipeline/compound command can be captured.
+- `session.new --command` persists durable `initialCommand` and restores through shell-replacing
+  `config.command`; fresh creation always runs, restored creation honors the toggle, and captured
+  foreground wins. Do not consume `initialCommand`; remove it only when primary exit promotes a split.
+  `restore.clear` and tree foreground fields are the control surface.
+- `newSessionDirectory` is raw `home|currentSession|custom`, with fixed custom path. Unknown/blank/missing
+  values fall back home. Resolve once from active session's `focusedCwd` for every GUI creation path,
+  including a right-clicked workspace; setters save only. Control `session.new --cwd` remains explicit
+  and ignores this setting.
+- `inheritGlobalGhosttyConfig` defaults off. It changes which files load, so its setter saves then reloads
+  unconditionally; it is not a config line or live mirror. Scoped config always loads.
+- `attentionButtonEnabled` defaults off and mirrors to `GhosttyApp` for live titlebar redraw. Its three
+  states belong to notifications.md; it opens an already-controllable attention surface.
+- `DockBounce` is raw `off|once|untilFocused`, nil/unknown = off. `off`, not `none`, avoids
+  `Optional.none`. Mirror it to `NotificationManager` for the next notification, without appearance
+  redraw. The picker maps off to nil; behavior belongs to notifications.md.
+- `notificationSoundName` is nil/empty silent. Mirror it to `NotificationManager`; it attaches to
+  delivered banners in OSC/control paths and follows notification authorization/Focus. Picker None maps
+  nil and previews.
+- `confirmCloseSession` defaults off and is read on demand, without a mirror. Prompt only for GUI active
+  close and sidebar row close; skip under XCUITest. Control `session.close` must never prompt.
+- `hiddenInterfaceElements` stores raw names and preserves unknown values while toggling known ones; empty
+  maps nil. Titlebar cases are `sidebarToggle`, `sessionName`, `windowName`, `recentSessions`, `scratch`,
+  `split`, `dashboard`, `quickTerminal`; sidebar cases are `newWorkspace`, `newSession`, `flaggedView`,
+  `focusFilter`, and row-level `workspaceAddSession`. Attention has its separate default-off setting.
+- `InterfaceElement` owns section/display name; the tab iterates `allCases`. Mutate the raw set, then push
+  resolved known values to `GhosttyApp`. SwiftUI gates with `shows(_:)`; the AppKit row "+" checks the
+  mirror on hover. Titlebar group dividers appear only between adjacent groups that each retain at least
+  two buttons, as computed by `titlebarGroupDividers`. Add a case/render gate only after user approval.
+- `autoHideSidebarInactiveWindows` defaults off. On every become-key/main, not resign,
+  `WindowLibrary.applyInactiveWindowSidebarHiding()` shows the active window and hides other open
+  sidebars, even when frontmost id was pre-set. Enabling applies immediately. While on, manual hide is
+  transient and refocus shows it; turning off leaves current hidden states. Persisted visibility changes
+  already refresh the window-list cache.
+- These settings are GUI-only unless the control catalog explicitly says otherwise. Do not add settings
+  commands merely to mirror chrome; user actions already have control coverage.

--- a/.claude/rules/sidebar.md
+++ b/.claude/rules/sidebar.md
@@ -14,496 +14,165 @@ paths:
 
 ## Sidebar
 
-- The sidebar is an AppKit `NSOutlineView` (`WorkspaceSidebar`, an `NSViewRepresentable`),
-  not a SwiftUI `List` — chosen for native cross-workspace drag-and-drop.
-  Its `@MainActor` `Coordinator` is the data source/delegate, backed by `AppStore`.
-  Outline items are cached reference-type `SidebarNode`s, reused across reloads for stable identity (expansion/selection
-  survive `reloadData`).
-- **Drag reorder (sessions AND workspaces).**
-  The Coordinator's `validateDrop`/`acceptDrop` now HONOR `proposedChildIndex` for sessions and feed the
-  host-free `SidebarDrop` helpers so validate and accept agree exactly instead of force-retargeting every
-  drop to `NSOutlineViewDropOnItemIndex` — enabling intra-workspace SESSION reorder (drop between rows for
-  a precise slot) AND precise cross-workspace placement (a cross-workspace drag now lands at the drop
-  position, no longer always-append).
-  Workspace ROWS are draggable too: a second pasteboard type `com.umputun.agterm.workspace` is added
-  to `registerForDraggedTypes` (LOAD-BEARING — without it AppKit never delivers validate/accept for workspace
-  drags) and `pasteboardWriterForItem` emits it (carrying the workspace UUID) for workspace nodes.
-  **Workspace reorder is a TOP-LEVEL move, but it does NOT use AppKit's proposed `item`/`childIndex`.**
-  With workspaces expanded their sessions fill the gaps between workspace rows,
-  so `NSOutlineView` only ever proposes drops INTO a workspace's children (`proposedItem != nil`) — never
-  the clean root between-rows slot — so the old `proposedItem == nil`-only gate rejected EVERY drop and
-  made workspace drag impossible once any workspace held sessions (the real-world state).
-  `resolveWorkspaceMove` therefore IGNORES the proposed item/index and derives the insert slot from the
-  CURSOR Y against the workspace ROWS' midpoints (`info.draggingLocation` → `rect(ofRow:).midY`,
-  sessions ignored): the slot is the count of RENDERED workspace rows whose midpoint sits above the cursor,
-  so the top half of a row drops before it and the bottom half after it — reachable everywhere.
-  **That slot counts VISIBLE rows, so it is NOT a `store.workspaces` index once the focus filter hides
-  workspaces** — with a non-contiguous marked set the two spaces diverge, and using the slot raw would drop
-  the dragged workspace at a full-array index no visible row corresponds to (aiming above the first visible
-  row resolved to 0, jumping it ahead of every hidden workspace before that row).
-  `SidebarDrop.workspaceInsertIndex(visibleIndices:slot:)` maps it back: above the first rendered row it
-  takes that row's own full index, otherwise the index just after the last rendered row above the cursor —
-  so a drop always lands ADJACENT to the row it was aimed at, and with nothing filtered
-  (`visibleIndices == Array(0..<count)`) it returns the slot unchanged.
-  The mapped index feeds the host-free `SidebarDrop.resolveWorkspace` for the post-removal/no-op math,
-  while `validateDrop`'s `setDropItem(nil, dropChildIndex:)` gets the VISIBLE-space slot — the outline's
-  root children are only the rendered workspaces, so the highlight and the store move deliberately travel in
-  different index spaces (identical only on an unfiltered tree).
-  Covered by `ReorderUITests.testReorderWorkspaceOntoSessionRow` (drag a workspace onto a session row
-  — the case the `proposedItem == nil` gate broke).
-  The session helper still HONORS `proposedChildIndex` (sessions are real same-level siblings,
-  so the outline proposes precise between-rows slots). It supports single-row and multi-row drags:
-  dragging from a selected session writes the full `sidebarSelectionIDs` block to the pasteboard in visual
-  order; dragging an unselected session writes just that row.
-  Both session and workspace drops feed `SidebarDrop`. For a single session, `resolveSession` applies the
-  same-parent downward `childIndex - 1` post-removal adjustment (only when `sourceIndex < childIndex`).
-  For a multi-selection, `resolveSessions` removes every dragged session first and inserts the whole block
-  at the post-removal slot, preserving the selected visual order and handling same-workspace / cross-workspace
-  mixes atomically. Workspace reorders use `resolveWorkspace` with the same remove-then-insert convention.
-  The PURE index arithmetic (drop-on-row `sessionIndex + 1` redirect, source-removal adjustment,
-  cross-workspace vs same-parent index spaces, batch block insertion, and no-op checks) lives host-free in
-  `agtermCore.SidebarDrop` (`resolveSession`/`resolveSessions`/`resolveWorkspace`), table-tested in
-  `SidebarDropTests`; the Coordinator helpers only do the AppKit/store glue (read the pasteboard, resolve
-  ids → indices via `AppStore.sessionLocation(ofSession:)`) and feed `SidebarDrop`, so the trickiest part
-  is unit-covered without the fragile XCUITest drag.
-- Add affordances live in a bottom bar in `WindowContentView`: a workspace button and a session menu (New Session
-  / Open Directory…).
-  The two session actions are also on each workspace row's right-click menu.
-  Each workspace ROW additionally carries a hover-revealed `+` (New Session) affordance (`SidebarCellView`'s
-  `addButton`, id `workspace-add-session`, shown on `mouseEntered`, same action as the footer New Session)
-  — a SEPARATE toggleable Interface element (`workspaceAddSession`, gated in `mouseEntered`; see [[settings]]).
-- **A single click anywhere on a workspace ROW toggles its expansion** (not just the disclosure triangle),
-  so the whole row is the hit target.
-  Wired via the outline's `action` (`Coordinator.handleSingleClick`) — which fires on a genuine click,
-  NEVER during a drag, so workspace drag-reorder is untouched — and guarded against the disclosure-triangle
-  region (`frameOfOutlineCell`) so a triangle click doesn't double-toggle.
-  The toggle is DEFERRED by `NSEvent.doubleClickInterval` and CANCELED by `handleDoubleClick`,
-  so a double-click (rename) doesn't flip the workspace open/closed on its way into edit mode
-  (instant-toggle was tried and rejected: AppKit commits the first click of a double before it knows a
-  second is coming, so instant forces a visible toggle-then-revert flicker on rename).
-  This is pure click-routing over the existing per-workspace `expandItem`/`collapseItem` (an exempt case
-  under the control keep-in-sync rule): the row click itself adds NO control command.
-  The per-workspace collapse/expand IS driven over the socket by `workspace.collapse`/`workspace.expand`
-  (distinct from the ALL-workspaces `sidebar.expand`/`sidebar.collapse`), but by a SEPARATE path that does
-  NOT route through this click handler: `AppActions.setWorkspaceExpanded` persists `isExpanded` on the
-  store DIRECTLY (source of truth, so it survives a hidden sidebar whose Coordinator is torn down), THEN
-  posts `.agtermSetWorkspaceExpanded` for the Coordinator's `setWorkspaceExpandedNotified` to sync only the
-  live outline row + tracked set (see the Control API rule).
-  Covered by `SidebarUITests.testClickWorkspaceRowTogglesExpansion`.
-- **A session ROW click reveals a blocked session's pane-tagged pane.**
-  `Coordinator.outlineViewSelectionDidChange` selects the clicked session (`selectSession`) then — async,
-  after the selection + the sidebar's own focus-restore settle — calls `AppActions.revealActiveBlockedPane(captured:)`
-  with the pre-reset indicator `selectSession` returned,
-  so clicking a session whose agent blocked in its split (right) or scratch pane lands you on THAT pane,
-  not the plain focused pane.
-  It is a no-op (plain `focusActiveSession`) for an IDLE or ACTIVE session, so ordinary clicks and
-  informational working-state tags are unaffected — the reveal never dismisses a merely-shown scratch
-  (a blocked/completed nil-tagged status is treated as `left`/main).
-  This matches attention-nav, plain session nav, the command palettes, a Dock-menu session row, the title-bar
-  bell popover, and idle auto-follow,
-  which all route through the same helper (see the Menu/actions + Notifications rules).
-  Covered by `PaneAwareStatusUITests.testSidebarClickRevealsBlockedSplitPane`.
-- Accessibility identifiers `session-row`, `workspace-row`, `edit-field`,
-  and `add-session` back the XCUITests.
-  Note the rename field surfaces as a `TextField` for sessions and a `StaticText` for workspaces,
-  so UI tests match `edit-field` by identifier across element types.
-- **Sidebar multi-selection.**
-  `AppStore.selectedSessionID` remains the durable active terminal. The broader sidebar selection is
-  a private transient array in host-free `AppStore`, exposed through `sidebarSelectionIDs` normalized to
-  the current visible session order so batch actions are deterministic in tree and flagged modes.
-  AppKit Shift-click and Command-click update the outline selection; `outlineViewSelectionDidChange`
-  mirrors it through `AppStore.setSidebarSelection(_:)`. `allowsEmptySelection` stays TRUE because the
-  visible set can hold NO sessions at all — a marked workspace with none, or the flagged view emptied —
-  and `syncSelection` must be able to `deselectAll(nil)` in that state, which the gaps listed with
-  `reselectIfSelectionHidden` below can also reach.
-  Right-click follows standard Mac list behavior: inside the current multi-selection it keeps the whole
-  selection for the context menu, outside it narrows to the clicked row. Context menu target resolution
-  is `AppStore.sidebarSelectionTargets(forContextSession:)`, which filters through the visible projection.
-  Batch row actions: move uses `AppStore.moveSessions`, close uses `AppActions.closeSessions(_:in:)` →
-  `AppStore.softCloseSessions`, flag uses `AppActions.toggleFlags(_:in:)` → `setFlag(_:forSessions:)`,
-  and clear-status loops `setAgentIndicator` once per selected session (loop-equivalent to `session status idle`).
-  SINGLE-selection-only row actions (shown only when the context menu resolves to exactly ONE session, since
-  they have no sensible batch meaning): Rename, **Duplicate Session** (right after Rename), and Reveal in Finder.
-  **Duplicate Session** creates a fresh session — a plain new login shell — in the SAME workspace, inserted directly
-  AFTER the source, rooted at the source's focused-pane cwd (`Session.focusedCwd`, the same directory the row
-  shows and Reveal in Finder opens), then selects + focuses it.
-  ONLY the directory carries over: the duplicate does NOT inherit the source's custom name, initial command,
-  split, scratch, status, flag, font size, or watermark — it is "New Session seeded with the source's cwd",
-  not a clone of state.
-  Its control half is `session.duplicate` (`agtermctl session duplicate [--target]`), which reads back off
-  `tree` as a new node right after its source carrying the source's focused-pane cwd — equal to the source
-  node's `tree.cwd` unless the source is a split focused off its primary pane (then `tree.cwd` reports the
-  primary and the two differ), see the Control API rule.
-- **Flagged working-set view (`AppStore.sidebarMode` `.tree`/`.flagged`).**
-  `SidebarMode` (`agtermCore/SidebarMode.swift`, `String`-backed `Codable`/`Sendable`) drives a per-window
-  MODE toggle between the normal two-level tree and a FLAT list of just the flagged sessions.
-  A session is flagged via the observed `Session.flagged: Bool`; the flat list is the PURE derived projection
-  `AppStore.flaggedSessions` (`workspaces.flatMap(\.sessions).filter(\.flagged)`,
-  already in tree order — workspace-then-session).
-  No second container: a session always has exactly one home workspace, the flag dies with the session
-  and survives a workspace move (the projection re-sorts).
-  The ONE `NSOutlineView` renders either source — `numberOfChildrenOfItem`/`child`/`isItemExpandable`
-  branch on `store.sidebarMode`; in `.flagged` the root's children are `flaggedSessions` as flat,
-  non-expandable rows labeled `session : workspace` (the session `displayName`,
-  then the owning workspace name) with the base leading icon — a plain terminal for a single session,
-  the split-rectangle for a split one so a split stays distinguishable (the FILLED flag variant is suppressed;
-  every row here is flagged) — plus the usual `StatusIconView` + `BadgeView`.
-  A row click routes through the existing `selectSession`.
-  BOTH mode flips re-select when they would hide the active session (`reselectIfSelectionHidden`, below):
-  into the flagged view when it is not flagged, and back to the tree when an applied workspace filter
-  excludes a session that was selected in the flagged view.
-  Otherwise view-only: an active session visible in the destination mode is left exactly where it is.
-  Drag-reorder is DISABLED in `.flagged` mode.
-  An empty flagged set shows a centered, non-scrolling empty-state hint ("No flagged sessions. / Right-click
-  a session → Flag.") overlaid in the scroll view, re-tinted on `.agtermAppearanceChanged` and toggled
-  by `updateEmptyStateHint` (visible only in `.flagged` with `flaggedSessions.isEmpty`).
-  Mutators: `AppStore.setFlag(_:forSession:)` / `setFlag(_:forSessions:)` (clean no-op + no save on
-  unknown ids or unchanged values, prune the transient selection when the current sidebar mode hides the
-  changed rows), `clearFlags()` (single save + prune), `setSidebarMode(_:)` (save).
-  GUI half: the bottom-bar `flagged-view-toggle` button (right of the trailing `Spacer()`,
-  2-state flag/checkmark glyph, tinted `chromeText`, flips `sidebarMode` and animates via `WindowContentView`'s
-  `.animation(value:)`), the row context-menu Flag/Unflag → `AppActions.toggleFlags(_:in:)`,
-  the View-menu Show Flagged/Show All + Flag Session + Clear Flagged, the ⌃⇧P palette entries,
-  and the two `BuiltinAction`s `toggleFlaggedView`/`toggleFlag` (expressible/keyless).
-  **Clear Flagged** is a plain menu/palette item (NOT a `BuiltinAction`,
-  mirroring Reload/Edit Keymap) → `AppActions.clearFlags()` with a light confirm alert when the set is
-  non-empty (skipped under the XCUITest launch, like the quit-confirm).
-- **Tree-mode flagged indicator (filled-icon variant).**
-  In `.tree` mode a flagged session's row swaps its leading icon to the FILLED SF Symbol variant of its
-  base glyph — `terminal.fill` for a single session, `rectangle.split.2x1.fill` for a split (the same
-  filled split symbol the titlebar shows for a SHOWN split; outline = unflagged,
-  filled = flagged) — via the cached `flaggedSessionIcon`/`flaggedSplitSessionIcon`
-  template images, tinted with the chrome/theme color.
-  It is a pure SF Symbol swap (`Self.rowIcon(...)`), NOT a composited corner badge — same-size,
-  so it is inherently layout-shift-free.
-  `flagged` is folded into the row's `RowContent` (Equatable), so a flag/unflag re-renders ONLY that
-  row (per-row `reloadItem`).
-  The filled variant is tree-mode only — the flat flagged view shows the unfilled base icon,
-  so a split session still gets the split-rectangle to stay distinguishable;
-  only the FILLED flag variant is suppressed there (every row is flagged).
-- **Focus filter — a marked SET plus an on/off flag (`AppStore.focusedWorkspaceIDs` + `focusEnabled`).**
-  Two stored fields on the class replace the old single `focusedWorkspaceID: UUID?`:
-  `focusedWorkspaceIDs: Set<UUID>` is the marked set, `focusEnabled: Bool` is whether the filter applies —
-  so the set survives being switched off and peeking at the whole tree costs one flip.
-  Everything else lives in `AppStore+Focus.swift`.
-  `visibleWorkspaces` is `guard focusEnabled else { return workspaces }` then the members in TREE order —
-  the source of truth the tree filters on (the data source maps `store.visibleWorkspaces` in `.tree`).
-  Its empty-result fallback to the full tree is defensive belt-and-braces, not a reachable path (see the
-  invariant below).
-  Focus is ORTHOGONAL to flagged: the flat flagged view ignores focus (it always shows the full cross-workspace
-  set).
-  Four mutators, all routed through ONE private write point, `commitFocus(ids:enabled:)`, which owns the
-  empty-set clamp, the delta guard (no write, no `save()`, when nothing changes, so every caller stays
-  idempotent), the sidebar-selection prune and the save — so a fifth mutator cannot reimplement any of them:
-  - `setFocusedWorkspace(_ id: UUID)` REPLACES the set with `{id}` and enables.
-    This is the single-workspace zoom — the row menu's Focus/Unfocus, `AppActions.focusWorkspace(_:)`,
-    `focusActiveWorkspace()` (targets `currentWorkspaceID`, wired to `BuiltinAction.focusWorkspace` +
-    a View-menu/palette "Focus Workspace"), and `workspace.focus on`.
-    It is INTERNAL: `on`/`toggle` reach it from inside `agtermCore`, and the app target has no caller.
-  - `clearFocus()` empties the set and disables — `AppActions.clearFocus()` (a plain menu/palette
-    "Clear Focus", NOT a `BuiltinAction`) and the clearing half of the replace-toggle.
-    It is the ONLY public half of the old `setFocusedWorkspace(_ id: UUID?)`, whose optional argument
-    encoded two unrelated operations.
-  - `setFocusMembership(_ id: UUID, member: Bool)` marks or unmarks ONE workspace, leaving the other members
-    alone — the row menu's "Add to Focus"/"Remove from Focus" and the View-menu "Add Workspace to Focus".
-  - `setFocusEnabled(_ on: Bool)` flips the flag WITHOUT touching the set — the bottom-bar toggle,
-    the View-menu "Toggle Workspace Filter", `BuiltinAction.toggleWorkspaceFilter`, and `workspace.filter`.
+- `WorkspaceSidebar` is an AppKit `NSOutlineView`, chosen over SwiftUI `List` for native
+  cross-workspace drag-and-drop. Its `@MainActor` Coordinator caches reference-type `SidebarNode`s so
+  reloads retain identity, expansion, and selection.
 
-  Both MARKING mutators refuse an id that names no workspace (the `setWorkspaceExpanded` rule), so a caller
-  that skipped its own existence check cannot persist a phantom member; un-marking is never gated, so a
-  stale id already in the set stays removable.
-  Both stored fields are `public internal(set)`, so only `agtermCore` can write them directly — the
-  invariant below cannot be broken from the app target at all.
-  Everything the surfaces need on top of those is a helper in the SAME file, so no menu/arm re-spells it.
-  **`soleFocusedWorkspaceID` is the ONE predicate for "the workspace the tree is zoomed to"** — the sole
-  marked workspace while the filter APPLIES, else nil — and the three consumers that used to spell it out
-  independently all read it now: `isSoleFocus(_:)` is `soleFocusedWorkspaceID == id` (the semantic
-  definition of "Unfocus" — the row menu's label, the View-menu label and the replace-toggle),
-  `WorkspaceSidebar`'s force-expand of a zoomed-to workspace, and the empty-space Finder-drop fallback
-  (`SidebarDrop.resolveDirectoryWorkspace`'s `fallbackWorkspaceID`, which the accessor was originally named
-  `dropFallbackWorkspaceID` for).
-  Three spellings of one predicate is how the `focusEnabled` term goes missing from one of them.
-  The rest: `toggleFocusedWorkspace(_:)` (the replace-toggle itself, shared by `AppActions.focusWorkspace`
-  and `workspace.focus toggle`), `isCurrentWorkspaceSoleFocus` / `isCurrentWorkspaceFocusMember` (the same
-  two facts for the keyless View-menu items, which target `currentWorkspaceID`), `applyFocusMode(_:to:)`
-  and `applyWorkspaceFilter(_:)` (the host-free halves of the two control arms, leaving them only target
-  resolution), and the internal lifecycle set `dropFocusMember(_:)` / `revealNewFocusMember(_:)` /
-  `markFocusMember(_:)`, which is where the remove/add/restore paths get the invariant from instead of
-  writing the two fields inline.
-- **Marking MARKS ONLY — an add never switches the filter on.**
-  `setFocusMembership`'s `wantEnabled` is `wantIDs.isEmpty ? false : focusEnabled`, i.e. the flag is carried
-  through untouched while the set is non-empty.
-  This is load-bearing, not a detail: an add that enabled would collapse the tree onto the first marked
-  workspace, so the rows of every workspace still to be marked are gone and each extra member costs a toggle
-  off and back — three toggles to build a three-workspace set, exactly the friction the set exists to remove.
-  So a set is built member by member with the whole tree on screen and applied ONCE.
-  Removal still disables as the set empties, and `setFocusedWorkspace` (the REPLACING Focus) still enables
-  immediately, so the single-workspace zoom is unchanged.
-  Pinned by `AppStoreFocusTests.addingToTheSetNeverTurnsTheFilterOn` (both polarities).
-- **`enabled + empty` is UNREPRESENTABLE, and three guards keep it that way.**
-  The documented control read-back contract is "a workspace ROW is visible iff
-  `sidebarVisible && sidebarMode == "tree" && (!workspaceFilter || focused)`" — every term on the same `tree`
-  response, so a script evaluates it in one read.
-  Enumerated: the sidebar hidden renders nothing; `flagged` mode renders a flat flagged-session list and NO
-  workspace rows whatever the filter says; `tree` mode with the filter OFF renders the whole tree regardless
-  of membership; `tree` mode with the filter ON narrows to the members.
-  Write it in FULL — neither shorter form is safe.
-  `focused && workspaceFilter` claims nothing is visible whenever the filter is off, and a script correcting
-  for it reaches for `workspace.focus on`, which REPLACES the marked set.
-  A bare `!workspaceFilter || focused` claims rows are visible in flagged mode and behind a hidden sidebar,
-  where no workspace row renders at all.
-  The guards below make the filter-ON term exact; the `!workspaceFilter` term is unconditional, and the
-  sidebar-visible / tree-mode terms are the view's, not the store's.
-  An enabled-but-empty filter would make the ON half lie (`workspaceFilter` true while no workspace reports
-  `focused`, yet the whole tree on screen).
-  The guards: (1) `setFocusEnabled(true)` is a no-op on an empty set, matching the bottom-bar toggle, which
-  is disabled in exactly that state, so the GUI and the control path agree;
-  (2) `setFocusMembership` disables as the set empties;
-  (3) `restoreFocus(from:)` PRUNES member ids absent from the restored tree and disables when the pruned set
-  comes back empty, so an all-stale set collapses instead of restoring as an invisible filter.
-  Covered by `setFocusEnabledRefusesAnEmptySet`, `restorePrunesAnAllStaleSetToEmptyAndDisabled`, and
-  `workspaceFilterOnAnEmptySetLeavesTheFilterOffThroughTheControlPath` (driven through
-  `ControlDispatcher.dispatch` so the mode parse and the refusal are both exercised, not the mutator alone).
-- **Two focus lifecycle rules.**
-  A cross-set select DISABLES the filter but KEEPS the set (`disableFocusIfSelectionOutsideSet`, see the
-  contract bullet below) — the tree reveals exactly as the old auto-unfocus did, but a hand-curated working
-  set is not destroyed by a passive notification click, and re-enabling is one click.
-  Creating a workspace while the filter is ON ADDS it to the set (`addWorkspace`/`ensureWorkspace`'s
-  `revealNewWorkspace: Bool = true` gates the insert, via `revealNewFocusMember`), preserving the "a new
-  workspace is immediately visible"
-  contract WITHOUT blowing the filtered view open; mutating the set is acceptable here because the user
-  initiated the creation, unlike the passive reveal above.
-  The two BACKGROUND creates opt out — `session.new --no-select --create-workspace` and
-  `workspace.new --collapsed` (which passes `revealNewWorkspace: !collapsed`): a quiet build must not widen
-  a script's marked set, and `--collapsed` exists precisely to say "build this without it opening".
-  `removeWorkspace` and the `AppStore+PendingClose` soft-remove path prune the id and disable when the set
-  empties (`dropFocusMember`), and BOTH restore paths — the soft-remove's UNDO and Reopen Closed Item —
-  re-mark the workspace through the SAME `markFocusMember(_:)`.
-  **They are twins on purpose: both MARK ONLY, and neither touches `focusEnabled`.**
-  Membership belongs to the closed workspace and is restored with it; the filter FLAG is CURRENT WINDOW
-  STATE, not a property of the thing being restored, so no restore may set it.
-  Two independent reasons, one per leg.
-  The undo's `PendingWorkspaceClose` lives on THIS `AppStore` and dies with the 3-second grace, which looks
-  like it makes a captured flag safe — but the user can suspend the filter INSIDE that grace with one click
-  on the bottom-bar toggle (which stays enabled while the set is non-empty), and a flag-restoring undo then
-  switched it back on, a 3-second-old snapshot beating his most recent explicit action.
-  It was also one-directional (it only ever set `true`, never cleared), so it could override him in exactly
-  one direction.
-  Reopen Closed Item's `RecentClosedWorkspace` is neither window-scoped nor time-scoped — `WindowLibrary`
-  builds ONE `RecentClosedStore` shared by every window's store, the list is never partitioned by window,
-  and an entry survives indefinitely — so a stored flag would let a record written in window A under an
-  applied filter switch window B's filter on, collapsing B's own curated set onto `B's members + this one`,
-  and would do the same single-window from a days-old entry.
-  Marking without enabling also honors the marking rule above (an add never applies the filter) and keeps
-  `enabled + empty` unreachable, since an insert-only path can never enable.
-  The trade-off is deliberate: undoing the close of the LAST member brings the set back with the filter
-  still off (`dropFocusMember` disabled it as the set emptied), so the restored workspace renders alongside
-  everything else until one flip of the toggle re-applies the set.
-  That is the same end state Reopen Closed Item has always had, and it is preferred over an undo that can
-  contradict a toggle the user just made.
-  The two legs cover disjoint windows: the pending record dies at grace expiry, after which the
-  recent-closed entry (written by the same `softRemoveWorkspace`, and by `removeWorkspace`) is the ONLY
-  route back, so fixing one alone leaves the defect live for every restore past three seconds.
-  Without the leg an empty member workspace came back unmarked while the filter still applied, so its row
-  never reappeared and the restore looked like a no-op; a non-empty one instead dropped the whole filter
-  through `disableFocusIfSelectionOutsideSet`.
-  Neither record carries a filter flag: `PendingWorkspaceClose` and `RecentClosedWorkspace` both hold
-  `focusMember` ALONE.
-  On `RecentClosedWorkspace` it is OPTIONAL because the struct is persisted in `recent-closed.json` and
-  `RecentClosedStore.load()` maps a decode failure onto an EMPTY list — a required key would silently wipe
-  the user's recent list on the first launch after the upgrade (the `Snapshot.focusedWorkspaceIDs` rule);
-  nil restores unmarked.
-- **A superseded pending close carries its membership into the record that absorbs it.**
-  `foldingPendingCloses(of:)` exists because undoing a session close rebuilds a missing workspace as a
-  SHELL, so re-closing that shell while the earlier workspace record still waits out its grace would leave
-  two pending records — and one Open Recent entry — on a single workspace id.
-  It therefore returns the absorbed records' `focusMember` ORed together, and `softRemoveWorkspace` ORs
-  that into its own `focusedWorkspaceIDs.contains(id)` read.
-  The OR is load-bearing, not defensive: by the time the fold runs the LIVE set no longer holds the
-  membership (the first close's `dropFocusMember` took it, and `rebuiltWorkspaceShell` does not re-mark),
-  so the absorbed record is its only surviving copy.
-  Losing it killed BOTH recovery routes at once, because `RecentClosedStore.record` dedupes on the
-  workspace snapshot id and the newer entry overwrites the older one.
-  `rebuiltWorkspaceShell` is deliberately NOT the place to fix this: its inputs are an id and a name, it
-  has no membership to restore, and it also serves a recent-closed SESSION reopen whose entry carries none
-  — the pending record that does know is still live, and its own undo re-marks correctly.
-  Pinned by `reClosingAWorkspaceRebuiltByASessionUndoKeepsItsMembership`.
-  The restore contract as a whole is pinned by the `undoing…`/`suspendingTheFilterDuringTheGrace…` group
-  and the six `reopening…` tests in `AppStoreFocusTests` (which cover a reopen with the target window's
-  filter OFF and a record carrying a foreign applied flag), plus `workspaceEntryWithoutFocusFieldsStillDecodes`
-  and `workspaceEntryWithALegacyFocusEnabledKeyStillDecodes` in `RecentClosedTests`.
-- **Membership is drawn on the row, and the bottom-bar toggle replaced the pill.**
-  A marked workspace row draws the cached `focusedWorkspaceIcon` instead of the outline `workspaceIcon`.
-  It is the SAME `square.grid.2x2` symbol at `.black` weight, NOT the `.fill` variant — deliberately
-  unlike the flagged session rows, which do use the filled-SF-Symbol idiom.
-  Weight rather than fill keeps ONE identity on every workspace row (a workspace always reads as an
-  outlined grid, marked or not) and keeps the two markers distinguishable: fill means a flagged SESSION,
-  black means a marked WORKSPACE.
-  `rowIcon(_:weight:)` takes the weight, defaulting to `.regular`, so this is still a plain cached
-  template image `setColors` tints.
-  The black variant renders 1pt larger than the regular one (16x15 vs 15x14 — the same size `.heavy`
-  gave, so the weight bump is pure stroke), but the cell's icon
-  `NSImageView` is pinned to a fixed 16x16 box with `scaleProportionallyUpOrDown`, so the swap moves
-  nothing — layout-shift-free for the same reason the `.fill` swaps are, not because the images match.
-  The choice is on MEMBERSHIP alone, independent of `focusEnabled`, so a marked row reads black while the
-  filter is off — which is what makes a set visible while it is being built.
-  Membership rides `RowContent.focusMember` (Equatable, a SEPARATE field from the session-only `flagged`),
-  so marking/unmarking re-renders just that row via `reloadItem`.
-  The single-workspace `focus-pill` is DELETED: with a set it would have to render "N workspaces",
-  duplicating what the tree already shows.
-  The bottom-bar `focus-filter-toggle` replaces it and is both the indicator and the control — a 2-state grid
-  glyph (filled while the filter applies), `.disabled` + `.opacity(0.35)` on an empty set (the explicit
-  `chromeText` foregroundStyle defeats SwiftUI's default disabled dimming, so it is muted by hand — the
-  flagged toggle's rule), and `accessibilityValue` `"on"`/`"off"`, which is the only accessibility-observable
-  read of the filter state now that the pill is gone.
-  It is the only affordance that also works while the filter is OFF.
-  Host-free-gated by `InterfaceElement.focusFilter` ("Workspace filter"), so Settings ▸ Interface can hide it.
-- **Scoped session navigation (the VISIBLE/FILTERED set).**
-  Session navigation operates over `AppStore.navigableSessions`, NOT the whole tree:
-  `sidebarMode == .flagged ? flaggedSessions : visibleWorkspaces.flatMap(\.sessions)` — i.e. the flagged
-  set in `.flagged` mode, the MARKED workspaces' sessions while the focus filter is on (tree mode),
-  else ALL sessions.
-  Generalizing `visibleWorkspaces` to the set is what made the multi-workspace case free here: nav walks
-  every marked workspace in tree order and skips the unmarked ones, with no count term anywhere
-  (`AppStoreNavigationTests.navigateScopesToEveryMemberOfAMultiWorkspaceSet` and its attention-nav twin
-  pin a NON-contiguous 2-of-3 set).
-  Computed LIVE (`visibleWorkspaces` already collapses to the marked set or the full tree), so clearing the
-  flag or switching the filter off naturally restores the full set.
-  `navigateSession(_:)` flattens `navigableSessions` for EVERY direction — next/prev/first/last AND attention-nav
-  (next-attention/prev-attention scope to the filtered set too) — keeping the same "no/invalid selection
-  → first of the filtered list", "next/prev WRAP within the filtered set (like attention-nav)" semantics
-  over the filtered list.
-  This is shared by `session.go` (control, no ControlServer change — it already routes through `navigateSession`),
-  the ⌥⌘↑/↓ + ⌃⌥↑/↓ menu/palette nav, the Ctrl-Tab MRU switcher (`SessionSwitcher.begin()` scopes its
-  candidate set to `store.navigableSessions.map(\.id)`; the MRU ORDER still comes from `sessionRecency`),
-  AND the ⌃P fuzzy session palette (`AppActions.paletteSessions()` lists `store.navigableSessions`,
-  so the searchable set matches the visible sidebar — with the filter on ⌃P shows only the marked
-  workspaces' sessions, in flagged mode only the flagged ones).
-  This SUPERSEDES the earlier "global nav reveals its target" behavior.
-- **Focus×selection contract (load-bearing, the cross-set safety net).** Because nav
-  is scoped, its targets are ALWAYS in-set, so nav never crosses the focus boundary.
-  `selectSession` calls `disableFocusIfSelectionOutsideSet` (renamed from `autoUnfocusIfOutsideFocus`),
-  which switches the filter OFF — KEEPING the marked set — when the newly selected session's workspace is
-  not a member (`focusedWorkspaceIDs.contains(owner)` fails → `focusEnabled = false`).
-  Keeping the set is the deliberate change from the old clear-everything behavior: the visual result is the
-  same (the tree reveals) but a hand-curated working set is not destroyed by a passive reveal, and one flip
-  of the bottom-bar toggle brings it back.
-  It fires only for an EXPLICIT cross-set select: `session.select <id>` of a hidden session,
-  a notification reveal, or a move/close that reselects elsewhere.
-  This keeps the active session inside the visible set for those cases, which also keeps `currentWorkspaceID`
-  (new-session placement) consistent with NO special-case.
-  No-op when the filter is off, when nothing is selected, or when the selection sits in a member workspace.
-  **Also a no-op in `.flagged` mode** (load-bearing, not defensive): the flat flagged list is
-  cross-workspace and ignores the marked set, so a selection landing outside the set there has not
-  navigated past the filter and there is nothing to reveal. Without the term, entering the flagged view
-  with the only flagged session in an unmarked workspace silently switches the filter off.
-  Returning to `.tree` re-applies it, and the reselect moves the selection back inside.
-  Pinned by `switchingToTheFlaggedViewNeverDisablesTheWorkspaceFilter`.
-  The contract is SYMMETRIC: a cross-set SELECT widens the view to reveal its target
-  (`disableFocusIfSelectionOutsideSet`, above), and a NARROWING that hides the active session moves the
-  selection into the view (`reselectIfSelectionHidden`, below).
-  **Invariant: the mutators below keep the active session inside a non-empty visible set** — the gap
-  those mutators do not cover is named there.
-- **`reselectIfSelectionHidden` — the selection half.**
-  Runs in `commitFocus`, `setSidebarMode`, both `setFlag` overloads, and at the END of `restore(from:)` —
-  after `sessionRecency` is re-seeded, since the pick is MRU.
-  Every GUI and control entry point funnels through those mutators, so nothing needs per-caller wiring and
-  the socket inherits it; the read-back is the existing `ControlSessionNode.active`.
-  Target: the most recent session within `navigableSessions` (`navigableRecentSessions`), else the first
-  visible one — MRU rather than positional keeps a filter-off-then-on round trip in place.
-  No-op on a nil selection (a restore clears a dangling one on purpose) and on an empty visible set.
-  Because the empty set is a no-op rather than a permanent exemption, one of these mutators running while
-  the set is empty DOES move the selection: flagging into an empty flagged view, or marking a populated
-  workspace while only session-less ones are marked.
-  `clearFlags` needs no call — it empties the list, so nothing is visible to move to.
-  KNOWN GAP: `addSession(select: false)` and `moveSession` of a non-active session grow the visible set
-  without reselecting, leaving a row rendered with nothing selected. `--no-select` promising not to touch
-  the selection wins over the invariant; the `addSession` half is pinned by
-  `aBackgroundInsertionIntoAnEmptyVisibleSetDoesNotRepairIt`, the `moveSession` half by nothing.
-  Every EXPLICIT select in `.flagged` mode is a third: `selectSession` of an unflagged session — from
-  `session.select`, a notification reveal, or an `addSession(select: true)` — only runs
-  `disableFocusIfSelectionOutsideSet`, which returns early there, so the session goes active while the
-  flagged list renders no row for it.
-  Deliberate: the flagged view has no set to suspend, so revealing would mean leaving the mode, and a
-  notification click would drop the user out of the working set they are in. Flagged mode stays sticky.
-  **Keyboard focus needs no app-target bridge**: `TerminalView.updateNSView` drops first responder from the
-  surface going inactive and `focusIfNeeded` takes it for the new one. Auto-follow posts a notification
-  because it reveals a specific PANE, which the deck cannot infer; a narrowing has no pane to reveal.
-- **Mode/focus-aware reconcile signal.**
-  The reconcile `TreeShape` is computed from the MODE-selected/filtered roots:
-  in `.tree` it is `visibleWorkspaces` → `(workspaceID, sessionIDs)` (so a focus flip re-shapes),
-  in `.flagged` it is a SINGLE flat group keyed on a stable pseudo-id (`flaggedShapeID`,
-  so within flagged mode only a change to the flagged list — not a fresh per-call id — rebuilds).
-  A `lastMode` flip swaps the whole data source and forces a `rebuildAndReload` regardless of the shape
-  diff; `sidebarMode`, BOTH focus fields, and each session's `flagged` are folded into the `updateNSView`
-  dependency read so a mode/focus/flag change is seen.
-  The focus dependency is DUAL and both halves are load-bearing: `updateNSView` reads
-  `store.focusedWorkspaceIDs` (a mark/unmark must redraw the row icon) AND `store.focusEnabled` (a filter
-  flip must re-shape the tree).
-  With only one read the other change is invisible to `@Observable` and the sidebar does not redraw.
-  **Task 9 expansion-restore fix:** `NSOutlineView` discards the expansion state of items DROPPED from
-  the data source during a flagged-mode reload, so expanded workspace ids are tracked independently in
-  `expandedWorkspaceIDs` via the `outlineViewItemDidExpand`/`outlineViewItemDidCollapse` delegate callbacks
-  (and `expandAll`) and re-applied in `rebuildAndReload` (`expandItem` for each tracked id),
-  surviving the round-trip through flagged mode.
-- **Expand / collapse all workspaces (per-window).**
-  Two sidebar tree operations: **Expand Workspaces** (`AppActions.expandAllWorkspaces(in:)` → the Coordinator's
-  existing `expandAll`, every workspace open) and **Collapse Workspaces** (`collapseOtherWorkspaces(in:)`
-  → the Coordinator's `collapseOthers`, every workspace collapsed EXCEPT the active session's `currentWorkspaceID`,
-  kept expanded + `scrollRowToVisible`'d).
-  Both keep `expandedWorkspaceIDs` in sync (so the state survives a flagged-mode round-trip).
-  Per-window scoping rides a notification (`.agtermExpandWorkspaces`/`.agtermCollapseWorkspaces`) posted
-  with the TARGET window's `AppStore` as the object; each Coordinator registers its observer with `object: store`,
-  so only the matching window's sidebar acts (unlike the rename notifications,
-  which self-scope via the selected-session guard).
-  This object-scoping is what lets the control path target ANY open window.
-  Graceful no-op in `flagged` mode (no workspace rows).
-  GUI surfaces (frontmost window): View ▸ Expand/Collapse Workspaces (plain keyless items,
-  disabled with no store or in flagged mode) + the ⌃⇧P palette (tree-mode only).
-  Control: `sidebar.expand`/`sidebar.collapse` resolve the target store via `resolvePlacementStore(window)`
-  (frontmost by default, the global `--window` selector for any open window) and call the `(in:)` variants
-  — so unlike the frontmost-only `sidebar`/`sidebar.mode`, these can drive a background window's tree
-  (see the Control API catalog).
-- **Persistence (per-window, no version bump).**
-  `Session.flagged` persists via `SessionSnapshot.flagged: Bool?` (decode → `false`),
-  `sidebarMode` via `Snapshot.sidebarMode: SidebarMode?` (→ `.tree`), the focus filter via
-  `Snapshot.focusedWorkspaceIDs: [UUID]?` (→ `[]`) + `Snapshot.focusEnabled: Bool?` (→ `false`), and each
-  workspace's expand/collapse state via `WorkspaceSnapshot.collapsed: Bool?` (decode → `false` → expanded).
-  All Optional fields, so legacy JSON with none of the keys decodes to the unflagged / `.tree`
-  / unfiltered / expanded defaults without throwing (the load-fresh-on-decode-failure contract) — no `Snapshot`
-  version bump.
-  `Snapshot.focusedWorkspaceID: UUID?` survives as a DECODE-ONLY legacy key, dropped from the memberwise init
-  and never populated, so the synthesized `encodeIfPresent` omits it automatically: a snapshot written by an
-  older release migrates inside the existing custom `init(from:)` to `[legacy]` with `focusEnabled = true`
-  ONLY when the new `focusedWorkspaceIDs` key is absent, so the set always wins.
-  The set is written in TREE order rather than `Set` order, so the on-disk list does not follow the hash seed.
-  `AppStore.restore(from:)` then calls `restoreFocus(from:)` once the tree is rebuilt, which intersects the
-  restored ids with the present workspaces — the third `enabled + empty` guard above.
-  `collapsed` is stored as the INVERSE of `Workspace.isExpanded` and only WRITTEN when collapsed (`true`);
-  an expanded workspace omits it, so an all-expanded tree serializes byte-identically to a legacy snapshot,
-  and "lack of the field = expanded" holds.
-  The sidebar Coordinator seeds `expandedWorkspaceIDs` from `Workspace.isExpanded` in `makeNSView`
-  (`seedExpansionFromModel`, replacing the old unconditional `expandAll`) so a collapsed workspace restores
-  collapsed.
-  **Only a GENUINE user toggle persists.**
-  The `outlineViewItemDidExpand`/`DidCollapse` callbacks write back via `AppStore.setWorkspaceExpanded(_:expanded:)`
-  (a PER-workspace mutator, so toggling one row never rewrites another's saved state), and `expandAll`/`collapseOthers`
-  persist the whole tree once via `setWorkspacesExpanded(_:)`.
-  A `suppressExpansionPersist` flag is set around every PROGRAMMATIC `expandItem`/`collapseItem` — the launch/`rebuildAndReload`
-  re-apply, the `syncSelection` reveal, and the SINGLE-member force-expand
-  (`focusEnabled && focusedWorkspaceIDs.count == 1 ? focusedWorkspaceIDs : []`) — so those update the
-  VISUAL `expandedWorkspaceIDs`
-  (needed for the flagged-mode round-trip) WITHOUT touching the persisted `isExpanded`.
-  The force-expand STOPS at one member on purpose: a one-workspace filter is a "zoom in", so its sessions
-  must show even from a collapsed row, but with a working SET the tree is a list of workspaces and
-  re-expanding every member on each `rebuildAndReload` (any session add/close/move re-shapes the tree)
-  would undo the user's collapse of a member over and over while `tree` still reported it `collapsed` — a
-  visible read-back divergence.
-  This is what makes a deliberate collapse durable: revealing a session inside a collapsed workspace (nav,
-  notification click, or the launch-time active-session reveal) or focusing it shows the row but does NOT
-  un-collapse it on disk — the collapse survives until the user expands the row themselves.
-  The active session is still force-revealed on launch (`syncSelection`), so it is never hidden inside a
-  collapsed workspace; the row just re-collapses on the next launch (its persisted state is untouched).
-  Round-trips + legacy-decode (incl. explicit `collapsed:false`) covered in `PersistenceTests`,
-  per-workspace + whole-tree mutators / no-op-no-write in `AppStoreOrganizationTests`, and the
-  collapse-survives-relaunch + reveal-does-not-repersist end-to-end cases in `SidebarUITests`.
+## Drag and row actions
+
+- Session drops honor `proposedChildIndex`; `SidebarDrop.resolveSession` applies the same-parent
+  downward `childIndex - 1` adjustment. A selected-row drag writes all `sidebarSelectionIDs` in visual
+  order; an unselected-row drag writes only itself. `resolveSessions` removes the entire mixed-source
+  block before inserting it atomically in visual order.
+- Workspace rows use pasteboard type `com.umputun.agterm.workspace`, which must remain registered or
+  AppKit will not call validate/accept. Do not use AppKit's proposed item/index for workspace moves:
+  expanded session rows make every gap appear inside a workspace. Instead, count workspace-row midpoints
+  above `draggingLocation`, ignoring sessions.
+- Under a focus filter, that cursor slot is in visible space. Map it through
+  `workspaceInsertIndex(visibleIndices:slot:)`: before the first visible row uses that row's full index;
+  otherwise insert after the last visible row above the cursor. Give the visible slot to
+  `setDropItem` for highlighting and the full-array index to `resolveWorkspace`.
+- Keep all remove/insert, drop-on-row, no-op, and index-space arithmetic host-free in `SidebarDrop`;
+  the Coordinator only maps pasteboard IDs and store locations. `SidebarDropTests` table-test it, and
+  `testReorderWorkspaceOntoSessionRow` covers the expanded-workspace failure.
+- The footer provides workspace creation and New Session/Open Directory. Workspace row menus repeat the
+  session actions. Hover shows `workspace-add-session` only when `InterfaceElement.workspaceAddSession`
+  is enabled.
+- A workspace-row click toggles expansion through the outline action, excluding the disclosure frame.
+  Defer by `NSEvent.doubleClickInterval` and cancel on double-click so rename does not flicker through a
+  toggle. This click routing is keep-in-sync exempt. Control expansion instead persists through
+  `AppActions.setWorkspaceExpanded`, then posts `.agtermSetWorkspaceExpanded` to synchronize a live outline.
+- A session-row click selects, then asynchronously calls `revealActiveBlockedPane` with the captured
+  pre-reset indicator. Blocked/completed pane tags reveal split, scratch, or primary; idle and active use
+  ordinary focus and never dismiss a merely shown scratch. `testSidebarClickRevealsBlockedSplitPane`
+  covers the split case.
+- Accessibility IDs are `session-row`, `workspace-row`, `edit-field`, and `add-session`. Rename appears
+  as `TextField` for sessions but `StaticText` for workspaces, so tests match the identifier across types.
+
+## Multi-selection and flagged view
+
+- `selectedSessionID` remains the active terminal. Transient `sidebarSelectionIDs` is normalized to
+  visible order. Shift/Command selection mirrors from AppKit; `allowsEmptySelection` must stay true
+  because filtered views can contain no sessions.
+- Right-click inside a selection preserves it; outside narrows to the clicked row.
+  `sidebarSelectionTargets` filters through the visible projection. Batch move, soft close, flag, and
+  clear-status operate on all targets.
+- Rename, Duplicate Session, and Reveal in Finder appear only for one target. Duplicate inserts a fresh
+  login-shell session immediately after the source in the same workspace, using only
+  `Session.focusedCwd`. It does not copy name, command, panes, status, flag, font size, or watermark.
+  `session.duplicate` provides the control form; its `tree.cwd` can differ from focused cwd when a split's
+  non-primary pane is focused.
+- `SidebarMode` is per-window `.tree` or `.flagged`. `flaggedSessions` is the derived tree-order
+  projection; sessions keep one owning workspace and flags survive moves but not deletion.
+- Flagged mode renders one flat, non-expandable outline using `session : workspace`, base terminal/split
+  icons, status, and badge. It ignores workspace focus, disables drag reorder, and shows the tinted
+  non-scrolling hint `No flagged sessions. / Right-click a session → Flag.` when empty.
+- Mode flips call `reselectIfSelectionHidden` only when the active session would disappear. Mutators
+  no-op without saving on unknown/unchanged IDs and prune transient selection when rows disappear.
+- GUI surfaces are `flagged-view-toggle`, row Flag/Unflag, View-menu Show Flagged/Show All, Flag Session,
+  Clear Flagged, palette entries, and keyless built-ins `toggleFlaggedView`/`toggleFlag`. Clear Flagged
+  is not a built-in and confirms unless under XCUITest.
+- In tree mode, flagged rows swap to `terminal.fill` or `rectangle.split.2x1.fill`; flagged mode retains
+  unfilled base icons because every row is flagged. This same-size symbol swap avoids layout shift.
+  `RowContent.flagged` limits reload to the changed row.
+
+## Workspace focus
+
+- Focus state is `focusedWorkspaceIDs: Set<UUID>` plus `focusEnabled`; turning the filter off preserves
+  the marked set. `visibleWorkspaces` returns tree-order members only while enabled, with a defensive
+  full-tree fallback. Flagged mode ignores focus.
+- Route every mutation through `commitFocus(ids:enabled:)`, which clamps empty sets, avoids unchanged
+  writes/saves, prunes sidebar selection, and saves:
+  - `setFocusedWorkspace` replaces the set with one ID and enables it. It backs row Focus/Unfocus,
+    `focusActiveWorkspace`, `BuiltinAction.focusWorkspace`, and `workspace.focus on/toggle`.
+  - `clearFocus` empties and disables; it backs the plain Clear Focus menu/palette item.
+  - `setFocusMembership` changes one member without disturbing others.
+  - `setFocusEnabled` changes only the flag; it backs the footer, menu, built-in, and `workspace.filter`.
+- Reject nonexistent IDs when adding or replacing; always allow removal. Keep both fields
+  `public internal(set)`.
+- `soleFocusedWorkspaceID` is the only predicate for an applied one-workspace zoom. Use it for
+  `isSoleFocus`, force expansion, and empty-space Finder-drop fallback. Keep target-resolution helpers
+  and lifecycle helpers in `AppStore+Focus.swift`.
+- Marking never enables the filter. Preserve `focusEnabled` while members remain; disable only when the
+  last member leaves. This lets users build a set while the full tree stays visible.
+- `focusEnabled && focusedWorkspaceIDs.isEmpty` is forbidden:
+  1. enabling an empty set is a no-op and the footer toggle is disabled;
+  2. removing the last member disables;
+  3. restore prunes stale IDs and disables if none remain.
+- The complete row-visibility contract is
+  `sidebarVisible && sidebarMode == "tree" && (!workspaceFilter || focused)`. Do not shorten it:
+  `focused && workspaceFilter` fails when filtering is off, while `!workspaceFilter || focused` ignores
+  hidden-sidebar and flagged-mode rendering.
+- Selecting outside the applied set disables filtering but preserves membership. Creating a visible
+  workspace while filtering adds it to the set. Background `session.new --no-select --create-workspace`
+  and `workspace.new --collapsed` opt out. Removal prunes membership and disables on empty.
+- Pending-close undo and Reopen Closed Item restore membership but never `focusEnabled`; the flag is
+  current window state, not restored-item state. This avoids a three-second pending snapshot overriding
+  a newer toggle and a shared, indefinitely persisted `RecentClosedWorkspace` from window A changing
+  window B. Restoring the last removed member therefore returns with filtering off until explicitly enabled.
+- Both `PendingWorkspaceClose` and `RecentClosedWorkspace` store only `focusMember`. The recent field is
+  optional because missing required keys would make `RecentClosedStore.load()` discard the entire legacy
+  list; nil means unmarked. Keep both restore legs because pending state expires after three seconds.
+- `foldingPendingCloses` ORs absorbed `focusMember` values into a replacement close. The live set has
+  already lost the first membership, and recent-close deduplication overwrites by workspace ID.
+  `rebuiltWorkspaceShell` lacks membership input and also serves session reopen, so it must not restore it.
+  `reClosingAWorkspaceRebuiltByASessionUndoKeepsItsMembership`, focus undo/reopen tests, and legacy recent
+  decode tests pin this contract.
+- Marked workspace rows use the same `square.grid.2x2` at `.black` weight, not a fill: fill identifies a
+  flagged session, weight identifies focus membership. The 16x15 black image and 15x14 regular image sit
+  in a fixed 16x16 `NSImageView`, so the 1pt size difference does not move layout. Render membership even while filtering
+  is off. `RowContent.focusMember` limits reload to that row.
+- `focus-filter-toggle` replaces the deleted single-workspace pill. It uses a filled grid when active,
+  manual 0.35 opacity and disabled state when the set is empty, and accessibility value `on`/`off`.
+  It remains usable while filtering is off and is gated by `InterfaceElement.focusFilter`.
+
+## Navigation and selection
+
+- `navigableSessions` is flagged sessions in flagged mode, sessions of visible workspaces in filtered
+  tree mode, otherwise all sessions. All next/previous/first/last and attention navigation use this live
+  set; next/previous wrap, and missing/invalid selection chooses its first item.
+- The same scope drives `session.go`, menu/palette navigation, Ctrl-Tab candidates (while preserving MRU
+  order), and the Ctrl-P session palette. This supersedes global navigation that revealed hidden targets.
+- `selectSession` calls `disableFocusIfSelectionOutsideSet`. An explicit hidden selection, notification,
+  move, or close disables filtering but keeps the set, keeping active session and
+  `currentWorkspaceID` visible. It is a no-op while filtering is off, selection is nil/in-set, or mode is
+  flagged; flagged mode is cross-workspace and sticky.
+- Narrowing calls `reselectIfSelectionHidden` from `commitFocus`, `setSidebarMode`, both flag setters, and
+  the end of restore after MRU seeding. Choose the most recent navigable session, then the first. Nil
+  selection and an empty visible set remain unchanged.
+- Known gaps are intentional: background `addSession(select: false)` and non-active `moveSession` can
+  populate an empty visible set without selecting it. Explicit selection of an unflagged session while
+  flagged also remains invisible rather than forcing a mode change.
+- Terminal focus needs no app bridge: `TerminalView.updateNSView` resigns inactive surfaces and
+  `focusIfNeeded` claims the active one. Auto-follow alone posts a pane-specific notification.
+
+## Reconciliation and expansion
+
+- `TreeShape` reflects visible workspace/session roots in tree mode and one stable `flaggedShapeID` group
+  in flagged mode. Mode changes always rebuild. Observation must read mode, both focus fields, and every
+  session flag: membership redraws icons; enabled state reshapes the tree.
+- Track expansion independently in `expandedWorkspaceIDs`. `NSOutlineView` drops expansion when items
+  leave the data source, so expand/collapse delegate callbacks and `expandAll` update the set and
+  `rebuildAndReload` reapplies it after flagged-mode round trips.
+- Expand Workspaces opens all. Collapse Workspaces closes all except the active workspace and scrolls it
+  visible. Scope notifications by the target `AppStore` object so only that window's Coordinator acts.
+  Both no-op in flagged mode. Menus/palette target frontmost; `sidebar.expand`/`sidebar.collapse` resolve
+  `--window` and can target background windows.
+
+## Persistence
+
+- Optional snapshot fields preserve legacy decode without a version bump: `SessionSnapshot.flagged`
+  defaults false, `sidebarMode` tree, focus IDs empty, focus disabled, and `WorkspaceSnapshot.collapsed`
+  false/expanded.
+- `focusedWorkspaceID` remains decode-only. When the new IDs key is absent, migrate a legacy ID to a
+  one-member enabled set; the new key wins. Encode IDs in tree order, then intersect them with restored
+  workspaces through `restoreFocus`.
+- Store `collapsed` as the inverse of `isExpanded` and only encode true, keeping all-expanded snapshots
+  byte-compatible. Seed `expandedWorkspaceIDs` from the model in `makeNSView`.
+- Persist only genuine user toggles through per-workspace `setWorkspaceExpanded` or one
+  `setWorkspacesExpanded` save. Wrap programmatic expansion/collapse during restore, rebuild, selection
+  reveal, and sole-focus force expansion in `suppressExpansionPersist`.
+- Force expansion only for a sole focused workspace. For a multi-workspace set, repeatedly expanding
+  every member after tree changes would undo deliberate collapses and diverge from `tree` read-back.
+  Revealing a session may expand visually without changing disk state; launch still reveals the active
+  session, and its row may re-collapse next launch.

--- a/.claude/rules/theme-picker.md
+++ b/.claude/rules/theme-picker.md
@@ -8,86 +8,51 @@ paths:
 
 ## Theme picker
 
-- **A live-preview theme picker as a third command-palette mode.**
-  The `.themes` `PaletteMode` (alongside `.actions`/`.sessions`, `Palette.swift`) reuses the SAME `CommandPalette`
-  fuzzy-search/list/nav view; only theme mode carries the live preview.
-  Its rows = `AppActions.paletteThemes()` (a leading "default ghostty" = nil/no-theme + one per `SettingsCatalog.themeNames()`,
-  the current one badged `current`).
-  The theme NAMES never pollute the action palette — only a single **"Select Theme…"** launcher item
-  appears in `paletteActions()` (and the View ▸ Select Theme… menu item + the keyless `BuiltinAction.selectTheme`).
-  The launcher opens the picker via `AppActions.openThemePalette()` → `palette.open(.themes)` dispatched
-  ASYNC (the launcher runs inside the action palette's `runItem`, which closes that palette right after;
-  the async open lets `.themes` re-open a tick later as a FRESH view — empty query,
-  not the launcher's search text).
-- **Preview/commit/cancel, themes-only.**
-  Two optional hooks the View invokes ONLY when `mode == .themes`: `PaletteItem.onSelect` (fired on selection
-  change → `AppActions.previewTheme(name)`) and a mode-level cancel.
-  `previewTheme` = `SettingsModel.previewTheme` sets `settings.theme = name` immediately but DEBOUNCES
-  the live `apply()` (~0.07 s) so a burst of nav/typing previews coalesces to one surface reload — applied
-  WITHOUT `settingsStore.save` (`persistAndApply` was split into `save(); apply()` so preview can apply-without-persist).
-  Enter/click commits via `commitThemePreview()` → `SettingsModel.commitTheme(nonActiveOriginal:)`,
-  which FLUSHES the pending debounced apply (so the active slot's latest value is live NOW), RESTORES the
-  off-screen slot to its captured original (so a value browsed into it during a mid-preview flip can't
-  commit — the commit-side twin of the Esc revert; re-applies only in that flip case so the dual line on
-  disk matches), then `save()`s.
-  Any dismiss without a commit — Esc, scrim tap, switch to another palette mode,
-  unmount — reverts via `cancelThemePreview()` → `revertThemePreview(theme:darkTheme:)`,
-  which CANCELS the pending debounce and restores BOTH slots captured on open SYNCHRONOUSLY (no debounce
-  lag, no stuck last-preview).
-  `beginThemePreview` snapshots the WHOLE `(theme, darkTheme)` pair (not just the on-screen slot) so the
-  revert stays correct even if macOS flips appearance mid-preview — otherwise the Esc revert would re-resolve
-  the slot at flip-time and write the captured value into the wrong side, stranding both slots.
-  `AppActions` owns the session state (`themePreviewActive` + `themePreviewOriginal`, the captured pair);
-  `SettingsModel` stays stateless about it.
-  The View wires it through `syncThemeSession()` (begin + select the current theme's row on enter,
-  cancel on leave — called from `.onAppear`/`.onChange(of: mode)`) + `.onDisappear { cancelThemePreview() }`
-  + the `onChange(of: selection)` preview call.
-  The picker opens with the CURRENT theme's row selected (via `currentThemeID`),
-  so it doesn't preview-jump to "default ghostty".
-  **Typing also previews:** `onChange(of: query)` resets `selection = 0` then calls `previewSelected()`
-  — because a filter re-orders the list so the item AT index 0 changes while `selection` STAYS 0,
-  `onChange(of: selection)` doesn't fire, so the new top match would never preview on filtering alone
-  (only on arrow-nav).
-  `previewSelected()` fires `filtered[selection].onSelect?()` explicitly (a no-op for non-theme palettes,
-  whose items carry no `onSelect`).
-- **Focus invariant (load-bearing).**
-  `AppActions.focusActiveSession` early-returns when `palette?.mode != nil` — NEVER grab terminal first
-  responder while a palette is open.
-  Without it, the launcher path breaks: closing the action palette fires `WindowContentView`'s close-restore
-  (`onChange(palette.mode == nil) { focusActiveSession() }`), whose ~12×0.03s `makeFirstResponder(terminal)`
-  RETRY loop out-races the just-opened picker's field focus, so the picker can't be typed into (the terminal
-  behind it eats the keys).
-  The guard also kills the retry the instant `.themes` opens AND blocks any focus steal during a live
-  preview reload.
-- **Default theme = the bundled `agterm` theme (NOT ghostty's built-in).**
-  `AppSettings.defaultTheme = "agterm"` (host-free), and `SettingsStore.load()` seeds it on a fresh install
-  (missing/corrupt `settings.json` → `AppSettings(theme: defaultTheme)`).
-  It is NOT baked into the `AppSettings()` memberwise default — that stays `theme == nil` so `ghosttyConfigLines()`'s
-  "nil = no theme line" invariant (and its tests) hold; the seed lives ONLY in the fresh-load path.
-  So `theme == nil` means ghostty's built-in (the picker's "default ghostty" row);
-  the agterm default is a real seeded value, and the picker opens on the "agterm" row for a fresh install.
-  An EXISTING `settings.json` with `theme` absent decodes to nil (ghostty built-in) — an existing user
-  is never silently re-themed.
-  `theme.set` with no name still sets nil (ghostty built-in / "default ghostty"),
-  distinct from the seeded app default.
-- **Appearance sync = two theme slots + an explicit toggle; emission is the RAW dual value.**
-  Three `AppSettings` fields hold it: `theme` (the single/base theme, and the LIGHT slot while following), `darkTheme` (the DARK slot), and `followSystemAppearance` (nil/false = off, the default).
-  `ghosttyConfigLines()` (no `isDark` param) emits ONE line: while following it is ghostty's own dual conditional `theme = light:NAME,dark:NAME` written RAW; otherwise the single theme — one `if`, no parsing.
-  libghostty resolves the active side itself at runtime, but the SWITCH is host-driven: `SystemAppearanceObserver` (an app-level KVO observer on `NSApplication.effectiveAppearance`) posts `.agtermSystemAppearanceChanged` with the KVO-delivered `isDark`; `SettingsModel.appearanceChanged` (guarded on following + both slots set, AND on the posted side differing from the last config feed) threads that `isDark` into `reloadConfigPreservingSessionZoom` → `GhosttyApp.reloadConfig(surfaces:isDark:)`, which sets `ghostty_app_set_color_scheme` + each surface's `ghostty_surface_set_color_scheme` from it and re-feeds via `update_config` DIRECTLY — the raw dual file text is stable across flips, so `writeGhosttyConfig`'s text-diff would otherwise skip the reload.
-  The flip reload KEEPS each session's ⌘+/⌘− zoom (`reapplySessionConfigIfNeeded` re-emits the zoomed sessions' `font-size` after the broadcast); only the explicit reloads clear it.
-  The side comes from the APP-level `NSApplication.effectiveAppearance` via KVO (`change.newValue`, the settled value), never from a view — the old per-view hook wedged after sleep/wake and stuck the terminal on the old theme (see the libghostty rule for the mechanism; `AppearanceFlipUITests` pins the zoom-preserving flip via the UI-test-only `debug.appearance` seam).
-  `AppSettings.activeTheme(isDark:)` (dark slot in dark mode, else `theme`) is now used ONLY by the palette badge/selection; emission never resolves a side.
-  The one surviving dual PARSE is `ThemeName.resolved(from:isDark:)` (host-free, from #146) — used only to pick the active side for the sidebar selection colors (`GhosttyApp.resolveSelectionColors`, which reads the raw `theme` line back out of the config); `ThemeResolution`, the branch's own `AppSettings.dualThemeSides`, and the legacy dual-string migration are gone.
-  Settings UI: picker 1 ("Theme", stable AX id `settings-theme`) edits the current-appearance slot via `setThemeForCurrentAppearance`; a `Toggle("Follow system appearance")` (`settings-follow-appearance`, default OFF) drives `setFollowSystemAppearance` (ON seeds the other slot from the current theme so both start equal; OFF collapses to the on-screen theme, no visual flip); and — only while following — an alternate picker (`settings-theme-dark`, labeled for the OTHER appearance) drives `setAlternateTheme`.
-  The primary picker offers the "default ghostty" (nil) row only when NOT following, since a dual conditional needs two named themes.
-  A palette PREVIEW writes the CURRENT-appearance slot (`previewTheme` writes the dark slot while following in dark mode, else `theme`), so the on-screen render reflects it and Esc restores the captured slot pair (both slots, snapshotted on open — flip-safe).
-  COMMIT (`AppActions.commitThemePreview` → `SettingsModel.commitTheme(nonActiveOriginal:)`) persists the active (on-screen) slot's browsed value and RESTORES the off-screen slot to its pre-preview original, so a value browsed into the other slot during a mid-preview flip never commits; save-only in the common no-flip case (nothing to restore), one reload in the flip case to rewrite the dual line.
-  The picker badges/opens on the EFFECTIVE theme (`activeTheme(isDark:)` — the on-screen slot), so the open-row preview is a config no-op.
-- **Control parity = the commit, not the preview**
-  (preview is interactive-only): `theme.set`/`theme.list` (see the Control API catalog for the four-point
-  audit).
-  The font-zoom reset on a theme change (any `apply()` that changes the config text runs `resetSessionFontSizesAllWindows`)
-  applies to the preview too — navigating the picker clears per-session ⌘+/⌘− zoom and Esc does not bring
-  it back; accepted (matches the Settings-picker behavior, a colors-only reload isn't cheaply available
-  from libghostty).
-
+- `.themes` is the live-preview `PaletteMode` beside `.actions` and `.sessions`. It reuses
+  `CommandPalette`; `AppActions.paletteThemes()` supplies "default ghostty" (`nil`), catalog themes, and
+  the `current` badge. Theme names stay out of the action palette, which contains only keyless
+  `BuiltinAction.selectTheme` ("Select Theme..."); the View menu exposes the same launcher.
+  `openThemePalette()` dispatches `palette.open(.themes)` asynchronously so the action palette can close
+  before a fresh theme view opens with an empty query.
+- Theme-only `PaletteItem.onSelect` and mode-cancel hooks implement preview. `previewTheme` changes the
+  active slot immediately and debounces `apply()` by about 0.07 seconds without saving. Enter/click
+  flushes the pending apply, restores a mid-preview off-screen slot from
+  `nonActiveOriginal`, reapplies only when that restoration changes the dual line, then saves. Any other
+  dismissal cancels the debounce and synchronously restores both slots captured at open.
+- `AppActions` owns `themePreviewActive` and the captured `(theme, darkTheme)` pair;
+  `SettingsModel` is stateless. `syncThemeSession()` begins/selects on enter and cancels on leave through
+  `.onAppear`, mode changes, and `.onDisappear`. The full pair is required when macOS changes appearance
+  mid-preview. The picker opens on `currentThemeID`, not "default ghostty".
+- Query changes reset `selection` to 0 and call `previewSelected()` explicitly. Filtering can replace
+  index 0 without changing its numeric selection, so selection observation alone misses typing previews.
+  Non-theme items have no `onSelect`.
+- **`focusActiveSession` must return while any palette mode is open.** Closing the action palette starts
+  a roughly 12 x 0.03-second terminal-focus retry; without the guard it outraces the new search field and
+  also steals focus during preview reloads.
+- `AppSettings.defaultTheme` is bundled `"agterm"`, seeded only by `SettingsStore.load()` for
+  missing/corrupt settings. Keep the memberwise `AppSettings()` default at `theme == nil`, which means no
+  config line and Ghostty's built-in theme. Existing files with no theme remain nil; `theme.set` without
+  a name also chooses nil.
+- Appearance following uses `theme` as the single/light slot, `darkTheme` as the dark slot, and
+  `followSystemAppearance` (`nil`/false by default). `ghosttyConfigLines()` has no `isDark`; it emits
+  either one raw `theme = light:NAME,dark:NAME` conditional or the single theme.
+- `SystemAppearanceObserver` watches app-level `NSApplication.effectiveAppearance` via KVO and posts the
+  settled `isDark`. When following with both slots set and the side differs from the last feed,
+  `SettingsModel.appearanceChanged` calls `reloadConfigPreservingSessionZoom`, which sets app and surface
+  color schemes and directly re-feeds `update_config`. Direct feeding is required because the raw config
+  text does not change. It reapplies per-session `font-size`; only explicit reloads clear zoom. Never move
+  this to a view observer, which can wedge after sleep/wake. `AppearanceFlipUITests` uses
+  `debug.appearance`.
+- `activeTheme(isDark:)` selects the palette badge/row only. `ThemeName.resolved(from:isDark:)`, from #146, is the
+  sole dual parser, used by `GhosttyApp.resolveSelectionColors` for sidebar colors from the raw theme
+  line. Do not restore `ThemeResolution`, `AppSettings.dualThemeSides`, or legacy dual-string migration.
+- Settings `settings-theme` edits the current slot. `settings-follow-appearance` starts off; enabling
+  seeds the other slot, disabling collapses to the visible theme without a flip.
+  `settings-theme-dark` appears only while following and edits the other appearance. The primary picker
+  offers nil only when not following because dual conditionals need two named themes.
+- Palette preview writes the visible slot; commit persists it and restores the captured off-screen slot.
+  The effective row opens selected, so its initial preview is a no-op. A config-changing preview also
+  clears per-session font zoom, and cancel does not restore zoom; this matches Settings because
+  libghostty has no cheap colors-only reload.
+- Control parity applies to commits through `theme.set`/`theme.list`, not interactive previews. Use the
+  Control API four-point audit.

--- a/.claude/rules/ui-tests.md
+++ b/.claude/rules/ui-tests.md
@@ -6,251 +6,100 @@ paths:
 
 ## Application-hosted tests (`agtermTests/`)
 
-These run INSIDE the real app, so a mistake here kills the process instead of failing an assertion.
+These run inside the app, so a mistake can kill the host instead of failing an assertion.
 
-- **A window a test owns MUST set `isReleasedWhenClosed = false`.**
-  `NSWindow`'s designated initializer defaults it to true, so `close()` sends a release ARC never
-  balances while the suite still holds the window (a `registeredWindows` dictionary, `WindowRegistry`).
-  The over-release frees it under its surviving references and the next autorelease-pool pop on the main
-  queue dereferences freed memory.
-  The symptom is NOT a test failure: the host dies, xcodebuild says `Restarting after unexpected exit,
-  crash, or test timeout` with no assertion and no signal, and the suite restarts and finishes.
-  Freed memory is reused nondeterministically, so it passes locally and dies on the runner — and adding
-  unrelated tests to the same class can be what makes a latent one start firing.
-  `orderOut(nil)` does not trigger it; only `close()` does.
-- **Read a dead host, do not infer it.**
-  The streamed CI log names nothing useful.
-  `xcrun xcresulttool get test-results tests --path <xcresult>` gives the real message (e.g. "The test
-  runner exited with code 1 before finishing running tests").
-  The STACK comes from ghostty's crash handler: `~/.local/state/ghostty/crash/*.ghosttycrash` is a sentry
-  envelope whose attachment is a minidump — split the envelope (header line, then item-header/payload
-  pairs), write the `.dmp`, and read it with `lldb -b -o "bt all" -c <dmp>`.
-  CI discards both, so add a temporary `upload-artifact` step with `if: failure()` covering the crash
-  directory and `build/DerivedData/Logs/Test/*.xcresult`, then remove it once the cause is known.
-  Reaching for the artifact after the FIRST failed fix is cheaper than a second guess.
-- **Never stub out `GhosttyApp` to make a hosted test quieter.**
-  Ghostty's handler is the app's crash reporter; suppressing its init deletes the only record of why the
-  host died and converts an immediate death into a silent one.
-- **The hosted host is not the app you think.**
-  `AGTERM_HOSTED_TESTS=1` (set by the `agtermTests` scheme in `project.yml`) makes the scene render
-  `Color.clear`, which skips the `.task` that assigns `appDelegate.library` — so the delegate's `library`
-  is nil for the whole run, and code keying off it behaves differently than in the real app.
-  `NSApp.delegate as? AppDelegate` is also nil (SwiftUI wraps it in `@NSApplicationDelegateAdaptor`), so
-  reach the delegate another way rather than asserting on that cast.
-  Locally the placeholder window IS presented (`NSApp.windows.count == 1`, titled "Agterm"); launched by
-  another process on CI it is not — the same FB11763863 shape as the UI-test note below, and the reason
-  window-count assumptions differ between the two environments.
+- **Set `isReleasedWhenClosed = false` on every test-owned `NSWindow`.** The initializer defaults true;
+  `close()` can over-release a window still held by `registeredWindows`/`WindowRegistry`, then crash at
+  the main-queue autorelease-pool pop. xcodebuild reports `Restarting after unexpected exit, crash, or
+  test timeout`, may restart and finish, and can fail only on CI or after unrelated tests alter reuse.
+  `orderOut(nil)` is safe.
+- For a dead host, inspect `xcrun xcresulttool get test-results tests --path <xcresult>`.
+  `~/.local/state/ghostty/crash/*.ghosttycrash` is a sentry envelope: split its header and
+  item-header/payload pairs, write the minidump attachment as `.dmp`, then run
+  `lldb -b -o "bt all" -c <dmp>`. CI discards both sources, so temporarily upload the crash directory
+  and `build/DerivedData/Logs/Test/*.xcresult` under `if: failure()`, then remove the step.
+- Never stub `GhosttyApp`; its handler is the only crash record.
+- `AGTERM_HOSTED_TESTS=1`, set by the `agtermTests` scheme, renders `Color.clear` and skips the scene task
+  that assigns `appDelegate.library`; it stays nil. SwiftUI's `@NSApplicationDelegateAdaptor` also makes
+  `NSApp.delegate as? AppDelegate` nil, so obtain the delegate another way. The local placeholder window
+  exists (`NSApp.windows.count == 1`, title "Agterm"), but another-process CI launch may hit FB11763863
+  and create none.
 
 ## UI tests
 
-- `agtermUITests/` is an XCUITest target that launches the real app and drives the sidebar (rename,
-  close, move, drag, add-session) through the accessibility API — the coverage the host-free `agtermCore`
-  unit tests can't provide.
+- `agtermUITests/` launches the real app and drives UI behavior unavailable to host-free tests.
   Run with `xcodebuild test -project agterm.xcodeproj -scheme agterm -destination 'platform=macOS'`.
-- Tests pass `AGTERM_STATE_DIR` (a temp dir) via launch environment to isolate persistence;
-  the app honors it in `agtermApp.restoredStore()`.
-  The native `Open Directory…` panel is system UI, verified manually rather than in XCUITest.
-- **Launch the app with `app.launchForUITest()` — never bare `app.launch()`.**
-  Apple bug **FB11763863**: on macOS 15+/Xcode 16+ (incl.
-  26) a SwiftUI `WindowGroup` app launched by another process (XCUITest,
-  launchd) frequently **never auto-presents its window** — dock icon shows,
-  no window, the scene's `.task`/`.onAppear` never fire, `NSApp.windows` stays empty,
-  so elements exist in the AX tree (`waitForExistence` passes) but are un-hittable and every interaction
-  silently no-ops.
-  It is OS-version dependent, so the SAME app code "worked before" a macOS upgrade and breaks after.
-  The fix lives in `AppDelegate.bringUITestWindowsForward` (UITest path):
-  when no real window exists it fires a programmatic **reopen** — `NSWorkspace.shared.open(Bundle.main.bundleURL)`,
-  the same event a dock click sends — and SwiftUI then creates the window.
-  `XCUIApplication.activate()` / `NSApp.activate()` / `orderFrontRegardless()` / `.defaultLaunchBehavior(.presented)`
-  do NOT help (the window is never created, not just un-focused).
-  `launchForUITest()` (in `XCUIApplicationSidebarIsolation.swift`) feeds the `AGTERM_UITEST_FORCE_SIDEBAR_VISIBLE`
-  sentinel via launch **environment** (NOT `launchArguments` — args trip a related variant),
-  launches, and `activate()`s.
-  The reopen re-triggers macOS state restoration, so the `Settings` window is marked **non-restorable**
-  (`SettingsView`'s `NonRestorableWindow`) or a stale Settings window resurrects and steals key focus.
-  To diagnose this class of bug, `NSLog` `NSApp.windows.count` on a timer and read it via `log show --predicate 'eventMessage CONTAINS "…"'`;
-  `total=0` for seconds = "never created".
-  See [[reference_swiftui-windowgroup-no-window-xcuitest]].
-- **Open a Settings tab via the retrying `settingsControl(tab:control:)` helper,
-  not a one-shot `app.buttons[tab].click()`.** The reopen can leave a half-open/non-key Settings window
-  that silently drops the first tab click; `settingsControl` re-clicks each tick until the expected control
-  is hittable, which is what makes the Settings tests non-flaky.
-- **Add a UI test when you add UI functionality**
-  — don't ship UI behavior with only `agtermCore` model-level unit tests.
-  For behavior the accessibility tree can't observe (the Metal `GhosttySurfaceView`,
-  transient non-persisted state), drive it through an observable side effect:
-  e.g. the split test types `tty > <file>` into the focused pane and compares the written tty to verify
-  which shell received the keystrokes and that focus follows.
-- **Simulating a macOS light/dark flip: the `debug.appearance` control seam.**
-  macOS XCUITest has no API to change the system appearance, so `AppearanceFlipUITests` drives the
-  UI-test-only `debug.appearance` command (`light`|`dark`), which sets `NSApp.appearance` AND posts
-  `.agtermSystemAppearanceChanged` directly, driving the REAL flip path (scheme sync → debounced
-  zoom-preserving reload) end to end.
-  Production follows the appearance via an app-level KVO observer on `NSApplication.effectiveAppearance`
-  (`SystemAppearanceObserver`); the seam posts the notification itself so the test does not depend on
-  whether KVO fires on an explicit `NSApp.appearance` set.
-  The arm is refused outside an XCUITest launch and is keep-in-sync EXEMPT (see [[control-api]]).
-  Set an explicit STARTING side first so the test is independent of the machine's appearance,
-  assert the response's echoed side to prove the flip reached the app,
-  and poll the seam's BARE (read) form — it reports the last-applied side — to prove the flip actually
-  drove the reload (a suppressed flip leaves it on the old side).
-  Gotcha: on the current libghostty pin `update_config` does NOT reset the runtime font zoom,
-  so a wrongly-routed zoom-clearing flip only BLIPS the persisted `fontSize` nil for ~0.4 s before the
-  surface's CELL_SIZE report re-persists it — assert zoom preservation by SAMPLING the snapshot
-  continuously, never by one settled read (it would pass on the broken path).
-- **Driving an OSC terminal title in a test (and reading it back).**
-  `Session.oscTitle`/`subtitleDetail` are ephemeral (never persisted) and the second line renders as
-  a SwiftUI `Text`, so test through observable side effects, not the snapshot.
-  Set a title by typing/injecting `printf '\033]2;TITLE\007'; cat` into the session — the trailing `; cat`
-  is **LOAD-BEARING**: a one-shot printf sets the title but the local shell returns to its prompt where
-  the title is cleared again (the prompt cycle), so it reverts to the cwd basename;
-  `cat` holds the foreground so no prompt redraw fires, mirroring why a real `ssh` keeps its title but
-  a quick local printf "looks broken" (see [[libghostty]]).
-  Type **LITERAL** `\033`/`\007` (Swift `"printf '\\033]2;…\\007'"`) so the SESSION shell's printf expands
-  them — do NOT pre-expand to raw ESC/BEL bytes (e.g. a host-side `printf` building the string),
-  which injects control bytes the shell's line editor reads as keystrokes and garbles the command (it
-  can even fire history/ZLE widgets and run an unrelated history command).
-  Read the result through an observable: **line 1** (displayName) via the `session-row` static-text **VALUE**
-  (not label — see `SidebarUITests`); **line 2** (`subtitleDetail`) via the `palette-subtitle` AX id
-  read as VALUE in the Go-to-Session palette.
-  Gotcha: `FileManager.default.homeDirectoryForCurrentUser` resolves DIFFERENTLY in the XCUITest runner
-  process vs the app, so assert a cwd second line against a stable marker like `/Users/`,
-  NOT the runner's own home.
-  (`agtermctl session.type` is the control-channel equivalent of the typed injection;
-  `agtermctl tree --json` now carries the raw `title`, which an e2e can poll instead of reading the AX
-  tree.
-  See `SessionSubtitleUITests` + `ControlAPIUITests.testTreeExposesOscTitle`.)
-- **Driving an `NSOutlineView` row drag from XCUITest needs three things,
-  ALL load-bearing (see `ReorderUITests.dragRow`).** Getting any one wrong means the drag silently does
-  nothing — `validateDrop`/`acceptDrop` never fire and the model never mutates:
-  (1) **SELECT the source row first** (`from.click()` + a short run-loop drain) — the outline only begins
-  a drag from the *selected* row, so dragging an unselected row (e.g. a middle row that wasn't the last
-  one touched) never starts a drag session at all.
-  This was the actual cause of a "downward drag doesn't work" red herring — the up-drag happened to drag
-  the just-renamed (hence selected) row, the down-drag dragged an unselected one.
-  (2) **Drag via `coordinate(withNormalizedOffset:)`, NOT element-to-element** — a row's AX element is
-  the recycled `NSTextField` inside the cell, while the drag tracking lives in the outline;
-  a coordinate drag targets the outline machinery directly.
-  (3) **Use the mouse-native `click(forDuration:thenDragTo:withVelocity:thenHoldForDuration:)`,
-  NOT the touch `press(forDuration:thenDragTo:)`** — `pressForDuration:` is the touch-events API and
-  delivers an `NSDraggingInfo` only intermittently to AppKit.
-  One drag per test launch is the reliable unit — a *second chained* native drag in the same method does
-  not reliably re-start a drag session (it ends up testing XCTest's event injector,
-  not the drop delegate), so cover a second direction in a separate `func test…` (fresh launch),
-  never by chaining.
-  To diagnose a non-delivering drag, `NSLog` from `validateDrop`/`acceptDrop` and read it with `log show --last 90s --predicate 'eventMessage CONTAINS "…"'`:
-  *zero* events = the drag never started (selection/gesture problem); events present but the wrong `dest`
-  = a drop-resolution bug in the delegate.
-- **NEVER run XCUITests while the user is interacting with a handed-off dev build — it HIJACKS their
-  screen.** XCUITest launches/activates app instances and synthesizes REAL keyboard + mouse events on
-  the live screen (`typeText`/`typeKey`/`click` drive the actual cursor and focus),
-  so a UI run while the user is trying a build types into their windows and steals focus — it interrupts
-  their work, hard.
-  When you hand the user a build to try ("try it", a launched demo instance),
-  do NOT start any `xcodebuild test` (UI target) until they say they're done.
-  Run UI tests BEFORE handing off, or AFTER the user is finished — never concurrently with their hands-on
-  testing, and never "in parallel/background" (background only hides the output,
-  not the on-screen event synthesis).
-  Host-free `swift test` is fine anytime (no screen interaction).
-- **Test cadence — ASK before a full UI run; don't default to it.**
-  The host-free `cd agtermCore && swift test` is fast (~0.2 s) — always run it.
-  The XCUITest suite is SLOW (~75 s for one class, ~460 s for all 77) and re-runs unaffected tests,
-  so a full UI run is NOT a default pre-commit gate.
-  For an isolated change, scope to the EXACT affected test METHODS — one `-only-testing:agtermUITests/<Class>/<method>`
-  flag per method (e.g. `…/SettingsUITests/testInterfaceElementTogglePersists`),
-  NOT the whole enclosing class, and NEVER an adjacent class "for extra confidence" on a pure refactor.
-  A refactor/extraction that preserves accessibility ids and behavior needs NO UI test at all — `make build`
-  + `make lint` already cover it (a code MOVE with identical ids is not "shared-chrome" work that warrants
-  a broad run).
-  Before committing UI-affecting work, ASK which UI-test scope is wanted and RECOMMEND one:
-  the specific new/changed methods for a self-contained change; a full class or broader run ONLY for
-  foundational/cross-concern work that actually changes behavior (app launch, signing/bundle, the eager
-  deck, window/scene wiring), never merely because a file under shared chrome was touched.
-  Don't burn minutes re-running the whole suite (or unrelated classes) when the change is self-contained —
-  running too many unrelated tests is a repeat offense the user has interrupted.
-- **After editing a TEST file, rebuild the test bundle with `build-for-testing` — `test-without-building`
-  runs the STALE bundle.**
-  `xcodebuild build` (or `make build`) builds only the APP target, NOT the `agtermUITests` bundle.
-  So `xcodebuild build` then `test-without-building` runs the OLD compiled test against the NEW app —
-  the source edit is silently ignored.
-  The symptom is confusing: the run reports `Executed 0 tests` with a crash/`Restarting after unexpected
-  exit` line and the named test under "Failing tests", which looks like an app launch crash — but the
-  xcresult `Failure Message` is an ordinary `XCTAssertTrue failed` from the OLD assertion (e.g. it still
-  looks for a control the new UI renamed).
-  Fix: run `xcodebuild build-for-testing …` (builds app + test bundle) before `test-without-building`, or
-  just `xcodebuild test …` (builds then tests).
-  Read the real reason from the xcresult (`xcrun xcresulttool get test-results tests --path <xcresult>`,
-  find the `Failure Message` node) rather than trusting the "0 tests / crash" summary.
-- **A palette row answers to its identifier more than once, and the match you get first cannot be clicked.**
-  `PaletteRow` sets `palette-item-<id>` on the row, and SwiftUI propagates an identifier to every text
-  child that has none of its own, so a row WITH a subtitle exposes two matching elements.
-  `matching(identifier:).firstMatch` returns the title `StaticText`, which is never hittable — the row owns
-  the tap target, so the AX hit test at the title's center does not resolve to the title — while the
-  subtitle child right below it IS.
-  A row with no subtitle collapses to the full-width row element and clicks fine, which is what makes this
-  look intermittent: the same helper works until an item carries a subtitle.
-  CLICK a row through a helper that picks the first HITTABLE match
-  (`allElementsBoundByIndex.first { $0.isHittable } ?? matches.firstMatch`) and keep the plain lazy
-  `firstMatch` helper for the existence waits — see `ControlPickUITests.clickPaletteRow` vs `paletteRow`.
-  Keep the two SEPARATE: `allElementsBoundByIndex` resolves eagerly, and folding it into the helper the
-  `waitForExistence` calls use broke `testPickKeepsKeyboardAfterClosingBuiltInPalette`, whose row does not
-  exist yet when the helper is called.
-  The symptom is a fast `Not hittable: StaticText …` failure, NOT the slow synthesize-event timeout that
-  means occlusion; it reproduces with HazeOver quit and on a clean checkout.
-- **Driving a Picker in XCUITest depends on its style.**
-  A `.segmented` Picker exposes each option as a hittable descendant by label — match
-  `picker.descendants(matching: .any).matching(label == "X").firstMatch` and `.click()` it directly.
-  A default/menu Picker (macOS Form dropdown, e.g. Font/Theme/Toolbar) does NOT — `picker.click()` to
-  open the popup, then click `app.menuItems["X"]` (see `SettingsUITests.testNewSessionDirectoryPickerPersists`
-  / `testToolbarModePickerPersists`).
-  Changing a Picker's style therefore requires updating its test's interaction, not just the label.
-- **XCUITest can NOT click a SwiftUI `Button` inside a `.popover` (`NSPopover`).**
-  A synthesized click — element `.click()` OR `coordinate(withNormalizedOffset:).click()` — reaches the row
-  (the trace shows "Click … Button", the event synthesizes) but the SwiftUI action NEVER fires (confirmed by
-  instrumenting the action to a `/tmp` marker: the app is un-sandboxed so it can write, and the marker stayed
-  empty across both click styles + retries).
-  A real mouse click works because it makes the transient popover key first; the synthesized one doesn't.
-  So a `.popover`-hosted control is only e2e-testable up to OPEN + CONTENTS, not the click:
-  assert the popover opens and lists the right elements (find the row `Button` by `accessibilityIdentifier`
-  once no PARENT carries an id — a SwiftUI id on a container propagates to and OVERRIDES its descendants'
-  ids, so the popover container must have NONE), and verify the click→action by hand + host-free unit tests.
-  Also the transient popover can dismiss before the first AX snapshot, so RETRY the open (click the anchor
-  only while no row is showing, so an already-open popover is never toggled shut).
-  See `RecentSessionsButtonUITests` / `AttentionButtonUITests` and the recent/attention popover note in
+- Pass a temporary `AGTERM_STATE_DIR` in the launch environment; `agtermApp.restoredStore()` honors it.
+  Verify the native `Open Directory...` panel manually.
+- **Use `app.launchForUITest()`, never `app.launch()`.** FB11763863 on macOS 15+/Xcode 16+, including
+  Xcode 26, can leave a
+  process-launched SwiftUI `WindowGroup` with a Dock icon and AX elements but no `NSWindow`, task, or
+  `onAppear`; activation/order-front APIs cannot create the missing window.
+  `AppDelegate.bringUITestWindowsForward` responds by reopening
+  `Bundle.main.bundleURL`. `launchForUITest()` sets `AGTERM_UITEST_FORCE_SIDEBAR_VISIBLE` in the
+  environment, not arguments, launches, and activates. Keep Settings non-restorable because reopen
+  retriggers restoration. Diagnose with timed `NSApp.windows.count` logging; persistent zero means
+  "never created". See [[reference_swiftui-windowgroup-no-window-xcuitest]].
+- Use retrying `settingsControl(tab:control:)`; reopen can leave a non-key Settings window that drops the
+  first tab click.
+- Add UI coverage for UI behavior. For Metal/transient state absent from AX, assert an observable side
+  effect, such as `tty > <file>` identifying the focused pane.
+- `AppearanceFlipUITests` uses XCUITest-only `debug.appearance light|dark`, which sets
+  `NSApp.appearance` and posts `.agtermSystemAppearanceChanged`; production uses app-level KVO.
+  Refuse the command outside XCUITest and exempt it from keep-in-sync. Set a starting side, assert the
+  echoed response, and poll the bare form's last-applied side. To catch a zoom-clearing misroute, sample
+  `fontSize` continuously: current libghostty `update_config` does not reset runtime zoom, so CELL_SIZE
+  can repersist it about 0.4 seconds after a brief nil.
+- For OSC titles, type literal `printf '\\033]2;TITLE\\007'; cat`; let the session shell expand escapes.
+  `cat` prevents the next prompt from clearing the title. Raw ESC/BEL bytes can trigger line-editor
+  keystrokes. Read display name from the `session-row` static text's value, and subtitle from
+  `palette-subtitle`'s value. Assert cwd against `/Users/`, not the runner's different home.
+  `tree --json` exposes raw `title`; see `SessionSubtitleUITests` and
+  `ControlAPIUITests.testTreeExposesOscTitle`.
+- `ReorderUITests.dragRow` must select the source and drain the run loop, drag between normalized
+  coordinates, and use mouse-native
+  `click(forDuration:thenDragTo:withVelocity:thenHoldForDuration:)`. Element-to-element targets the
+  recycled cell text; touch `press(forDuration:thenDragTo:)` delivers AppKit dragging intermittently.
+  Run one drag per fresh launch. For failures, log `validateDrop`/`acceptDrop`: no events means the
+  gesture never started; wrong `dest` means delegate resolution. Query the last 90s of unified logs.
+- **Never run XCUITests while the user is testing a handed-off build.** They activate apps and send real
+  keyboard/mouse events even in the background. Run them before handoff or after the user finishes.
+  Host-free tests are safe.
+- Always run `cd agtermCore && swift test`, normally about 0.2 seconds. Ask before XCUITest.
+  The suite is about 75 seconds per
+  class and 460 seconds for all 77; target exact affected methods with one
+  `-only-testing:agtermUITests/<Class>/<method>` each. A behavior-preserving extraction with unchanged AX
+  identifiers needs `make build` and lint, not UI tests. Recommend a class/broader run only for changed
+  cross-cutting behavior such as launch, signing/bundle, eager-deck, or scene/window wiring.
+- After changing a test, run `build-for-testing`; app-only `xcodebuild build` leaves a stale XCUITest
+  bundle for `test-without-building`. A stale assertion may appear as `Executed 0 tests` plus restart and
+  a named failure. Read the xcresult failure message, or use `xcodebuild test`.
+- Palette identifiers propagate to text children, so a subtitle row can have duplicate matches whose
+  `firstMatch` title is not hittable. Click
+  `allElementsBoundByIndex.first { $0.isHittable } ?? matches.firstMatch`, but keep lazy `firstMatch` for
+  existence waits; eager resolution before the row exists breaks
+  `testPickKeepsKeyboardAfterClosingBuiltInPalette`. Fast `Not hittable: StaticText` is this issue, not
+  the slow occlusion timeout. See `ControlPickUITests.clickPaletteRow`.
+- For `.segmented` Picker, click the labeled descendant. For a default/menu Picker, click the picker then
+  `app.menuItems["X"]`. Update the interaction when changing style; see the Settings picker tests.
+- XCUITest-synthesized clicks do not fire a SwiftUI `Button` inside `NSPopover`; a real click makes the
+  popover key. Test open and contents, then verify selection manually and through host-free APIs. Put AX
+  ids on rows, not a parent that would override descendant ids. Retry opening only while no row is
+  visible, since the popover can dismiss before the first snapshot. See the recent/attention tests and
   [[menu-actions]].
-- **A screen-occluding overlay app (HazeOver) makes `app.typeText`/`typeKey` fail with `Failed to synthesize event: Timed out while synthesizing event`**
-  — a ~90 s hang that ends the test with NO `XCTAssert` failure (the keyboard event never reaches the
-  covered window; the run log shows `Synthesize event` → `Failed: Timed out` ~64 s apart).
-  It is ENVIRONMENTAL, not a test-logic or app bug: the SAME test passes in ~13 s once HazeOver is quit.
-  Treat a `synthesize event` / `Unable to find hit point` timeout (as opposed to a real assertion failure)
-  as an occlusion symptom — quit HazeOver and clear covered/minimized/Spaces windows,
-  then re-run before suspecting the test or the fix.
-  Distinct from FB11763863 (window never created → AX tree empty); here the window exists but is covered.
-- **`XCUIApplication.terminate()` HARD-KILLS — it does NOT fire `applicationWillTerminate`.** A test
-  that needs the app's graceful-quit path (anything in `applicationWillTerminate`:
-  the restore-running-command capture, a quit-flush write) must quit with **⌘Q** (`app.typeKey("q", modifierFlags: .command)`
-  then `app.wait(for: .notRunning, timeout:)`), NOT `terminate()`.
-  The quit-confirm modal is auto-skipped under XCUITest (`ContentView.isUITestLaunch` → `.terminateNow`),
-  so ⌘Q quits cleanly AND runs `applicationWillTerminate`.
-  Verified by instrumenting the top of `applicationWillTerminate` to a `/tmp` file:
-  empty under `terminate()`, written under ⌘Q.
-  (`MultiWindowUITests` survives `terminate()` only because the open-set is also saved by in-session
-  structural saves, NOT because the quit-flush ran.) This is the same write-to-a-temp-FILE diagnostic
-  the project uses for launch-time values — `NSLog` doesn't reach the unified log from an `open -n`/XCUITest
-  dev build.
-- **`ghostty_surface_foreground_pid` returns the actual FOREGROUND process,
-  not the session's shell.** Confirmed empirically (`tee <file>` → the captured pid/argv is `tee`,
-  not `zsh`).
-  The restore-running-command capture skips ONLY an IDLE shell-at-prompt (`CommandRestore.isIdleShell`:
-  a known-shell argv0 with no payload argument, only `-flags`).
-  A shell RUNNING something IS captured: a `#!/bin/sh` wrapper script (its foreground is `/bin/sh <script>`,
-  the real-world `cld` claude-code bug) and a `sh -c '…'` BOTH carry a payload argument and are captured
-  — only a bare `-zsh`/`/bin/zsh` prompt is dropped.
-  `tee <file>` is still the cleanest e2e marker: it creates its output file on start and blocks reading
-  the pty, so it's the live foreground at quit, and re-running it recreates the file (a delete-then-relaunch-then-exists
-  cycle is the observable proof).
-  `RestoreCommandUITests.testRestoreReRunsShellScriptWrapper` covers the shell-with-payload case via
-  `sh -c 'tee …; true'` (a compound list keeps `sh` the foreground) — NOT an executable script file,
-  since the runner writes its sandboxed temp dir and the app can't exec a script from there (a plain
-  `tee` marker writes there fine, but exec is blocked).
-
+- `Failed to synthesize event: Timed out while synthesizing event` or `Unable to find hit point` after
+  about 90 seconds, with no assertion, indicates window occlusion such as HazeOver. The observed keyboard
+  failure occurred about 64 seconds after synthesis began and the same test passed in about 13 seconds
+  without HazeOver. Quit overlays and
+  clear covered/minimized/other-Space windows before debugging the test. FB11763863 instead has no
+  window/AX tree.
+- `XCUIApplication.terminate()` does not call `applicationWillTerminate`. Use ⌘Q plus
+  `wait(for: .notRunning, timeout:)` for restore-command or quit-flush tests; XCUITest auto-skips the
+  quit-confirm modal. `MultiWindowUITests` survives hard termination only because structural saves
+  already persist the open set. Use a temp file, not unreliable `NSLog`, to instrument the callback.
+- `ghostty_surface_foreground_pid` returns the actual foreground process. Restore skips only a known idle
+  shell with no payload arguments except flags; shell scripts and `sh -c` payloads are captured. Use
+  blocking `tee <file>` as the e2e marker and prove relaunch by delete/recreate.
+  `RestoreCommandUITests.testRestoreReRunsShellScriptWrapper` uses `sh -c 'tee ...; true'` so `sh` remains
+  foreground. Do not execute a script from the runner's sandboxed temp dir; the app can write there but
+  cannot exec it.

--- a/.claude/rules/windows.md
+++ b/.claude/rules/windows.md
@@ -14,421 +14,158 @@ paths:
   - "agtermTests/DockMenuTests.swift"
 ---
 
-## Windows (multi-window)
+## Windows
 
-A **window** is the top level above the workspace tree: a named, persisted bundle of workspaces + sessions,
-each rendered in its own on-screen macOS window.
-The user keeps a library of windows (e.g. "work", "personal"), opens one per on-screen window,
-and the set open at quit reopens on next launch.
-Strict 1:1 — a bundle shows in exactly one on-screen window, never two windows for one bundle,
-never two bundles in one window.
-**No** shared/cross-window live state and **no** cross-window session drag (out of scope by the 1:1 model).
+A window is a named, persisted workspace/session bundle rendered in exactly one macOS window. One bundle
+never appears in two windows, and one window never holds two bundles. Shared live state and cross-window
+session drag are out of scope.
 
-- **Dock-menu window scope.**
-  `AppDelegate.applicationDockMenu` snapshots the last-active `AppStore` when AppKit opens the Dock menu.
-  `NSMenuItem.target` is weak, so the delegate's target array is the sole strong owner for the active menu.
-  The delegate invalidates the old target set on rebuild to stop an already-loaded or in-flight stale target from dispatching.
-  Every top-level and session closure keeps the captured store/window scope even if window B becomes frontmost before a window A item is chosen.
-  Invocation rechecks A's per-window modal/controller state, raises A, and synchronously writes `library.frontmostWindowID` plus posts `.agtermWindowFrontmostChanged` before shared actions resolve their store.
-  New Session, Quick Terminal, Dashboard, selection, and pane-aware reveal therefore all target A.
-  New Window is the ONE item outside that scheme — it captures nothing and skips the modal gate, because a new window belongs to no existing window, and its enabled state reads the action hub rather than the captured window; see the Dock-menu bullet in `menu-actions.md` for why, and for the activation it has to do itself.
-  Do not defer that publication to `WindowAccessor`'s key-window notification because all action work must target A during the same Dock invocation.
-  Recheck the captured window instead of invocation-time frontmost B because modal state is per-window.
-  A stale item becomes inert if A closes or enters dashboard/terminal zoom while the menu is open.
-  A Dashboard item built while A's dashboard is already open remains a valid close toggle, while one built closed becomes inert if the dashboard opens before invocation.
-  The Dock surface composes the existing `session.new`, `window.new`, `quick`, `dashboard`, and `session.select` control capabilities, so it requires no new control command.
+- The Dock menu snapshots the last-active store and strongly retains item targets because `NSMenuItem.target`
+  is weak. Invalidate previous targets on rebuild. Every item except New Window keeps its captured scope,
+  rechecks that window's modal/dashboard/zoom state, raises it, and synchronously publishes
+  `frontmostWindowID` before invoking shared actions. Stale items become inert. New Window captures no
+  store and bypasses modal gating. Do not defer scope publication to key-window notifications.
+- Dock actions compose existing session/window/quick/dashboard/select capabilities and need no new command.
 
-- **Model (`agtermCore`, host-free).**
-  `WindowLibrary.swift` holds `WindowInfo {id: UUID, name: String}` (named `WindowInfo`,
-  NOT `Window`, to avoid the SwiftUI/AppKit clash) and the persisted Codables `WindowsIndex {version, frontmost: UUID?, windows: [WindowEntry]}`
-  / `WindowEntry {id, name, isOpen}` (the index carries its OWN `version`,
-  independent of `Snapshot.version`).
-  `WindowLibrary` is `@Observable @MainActor` like `AppStore`: it owns the ordered `windows: [WindowInfo]`,
-  the live per-window `stores: [UUID: AppStore]` (`@ObservationIgnored`),
-  `frontmostWindowID`, and per-window + index persistence.
-  A window is "open" iff its `AppStore` is loaded (`stores[id] != nil`).
-- **`AppStore` stays the per-window unit**
-  — it already is one tree + one selection, so internals are unchanged; `WindowLibrary` just owns one
-  store per open window, lazily loaded.
-  `store(for:)` returns an open window's store; `loadStore(for:)` lazily builds/caches it from `windows/<id>.json`;
-  `newWindow(name:)` seeds a fresh window (one "workspace 1" + one `$HOME` session — the seeding that
-  used to live in the dropped `agtermApp.restoredStore()`); `closeWindow`/`renameWindow`/`removeWindow`
-  (`canRemoveWindow` = count > 1, keep-at-least-one) mutate + persist; `openIDs()` is the persisted open-set
-  for launch reopen; `applyInactiveWindowSidebarHiding()` is the host-free auto-hide-inactive-sidebars
-  driver (shows the active window's sidebar, collapses the rest) — see the `autoHideSidebarInactiveWindows`
-  bullet in `settings.md`.
-- **Persistence layout**
-  under `<stateDir>` (`AGTERM_STATE_DIR`-aware, else `~/Library/Application Support/agterm`):
-  `windows.json` is the index, `windows/<uuid>.json` is each window's `Snapshot` (the same shape `workspaces.json`
-  had), and the legacy `workspaces.json` is left dormant after migration.
-  `PersistenceStore` gained an optional `fileName:` init param (default `workspaces.json`) so a per-window
-  store targets `windows/<id>.json` without breaking existing callers.
-  A per-mutation `saveIndex()` rewrites only `windows.json`; each store's own `save()` rewrites only
-  its file.
-- **Migration + recovery (on `WindowLibrary` init `bootstrap()`; never throws,
-  mirrors `PersistenceStore.load()`):** valid `windows.json` → load it; absent index but legacy `workspaces.json`
-  present → wrap it into one window ("window 1", marked open/frontmost);
-  neither → seed one empty window.
-  A corrupt or `version`-mismatched `windows.json` is treated as absent,
-  but BEFORE the legacy-else-seed fallback `recoverOrphanedWindows()` (run in `bootstrap()` between `loadIndex()`
-  and `migrateLegacy()`) enumerates any `windows/<uuid>.json` files (skipping non-UUID names),
-  appends them ALL to `windows` FIRST (`loadStore` guards on `windows.contains(id)`),
-  default-names them (`window N`), `loadStore`s each, and marks them all open with the first frontmost
-  — so a future index schema bump RECOVERS the user's sessions instead of resurrecting stale `workspaces.json`
-  or seeding empty; only with NO per-window files does the migrate-from-legacy-else-seed path run.
-  A missing/corrupt `windows/<id>.json` opens that window with an empty `Snapshot` (one default workspace
-  + session).
-  Net: the app always reaches a valid, non-empty window set, never windowless at launch.
-- **Scene + restoration — ⚠️ deviates from the planned `WindowGroup(for:)`.**
-  A *value-based* `WindowGroup(for:)` does NOT auto-open any window at launch when SwiftUI window restoration
-  is off (the scene `.task` never runs, so `openWindow(value:)` can't bootstrap).
-  The scene is therefore a **plain `WindowGroup(id: "terminal")`** (auto-opens one window at launch +
-  one per `openWindow(id:)`).
-  `WindowLibrary` is the single source of truth for the open-set; each appearing SwiftUI window claims
-  the next id from a FIFO **claim queue** (`consumeReopen()` seeds it launch-window-first,
-  `claimNextWindowID()` pops, `enqueueClaim(_:)` appends for a brand-new window),
-  and a window beyond the open set (a SwiftUI-restored stray) gets no id and `dismiss()`es itself.
-  **No `.restorationBehavior`:** it is macOS 15+ and `SceneBuilder` rejects `if #available` entirely
-  (verified — `@ViewBuilder` accepts it, `@SceneBuilder` does not, and there is no `AnyScene` eraser),
-  and the deployment floor is macOS 14, so the mechanism is **dedup-by-id only** (claim queue + dismiss-stray),
-  uniform across 14 and 15.
-  `reopenWindows()` in the scene `.task` opens one window per *remaining* open id (SwiftUI auto-opened
-  the first), once via the `hasReopened` latch.
-  `TitleProbeView` sets `frameAutosaveName("agterm-window-<id>")` so AppKit restores geometry per window.
-- **Frontmost-store resolution + quit-flush.**
-  `AppActions` takes the `WindowLibrary`, not a fixed store: its mutating methods resolve `library.activeStore`
-  (the frontmost open store, falling back to the first open store; backed by `activeWindowID`,
-  the same resolution the quick terminal uses) and no-op when nil.
-  The app `.commands` builder and `paletteActions()` build-time reads go through the same accessor —
-  reactive because `WindowLibrary` is `@Observable`.
-  `ControlServer`/`SettingsModel`/`SessionSwitcher` are likewise wired to the library.
-  `TitleProbeView` reports frontmost (`didBecomeKey/Main` → `library.frontmostWindowID` + `saveIndex()`)
-  and close (`willClose` → tear down that window's surfaces + `library.closeWindow`).
-  The quit-flush replaces the dropped single-store `AppDelegate.store.save()`:
-  `applicationWillTerminate` sets `library.isTerminating` (so the per-window `willClose` close-reporting
-  can't zero the open-set as windows tear down on quit) then `library.saveAllOpen()` + `library.saveIndex()`
-  — load-bearing because `AppStore` does NOT save on a live `cd`, so cwd changes since the last structural
-  mutation are flushed here.
-  `selectSession`/`setFontSize` also persist via a debounced `scheduleSave()` (~0.3 s,
-  host-free `Debouncer`) instead of an immediate `save()` — structural mutations (add/close/move/rename/addWorkspace)
-  still `save()` synchronously, and `save()` cancels any pending scheduled save so this quit-flush captures
-  the latest selection/font (same lose-last-change-on-SIGKILL tradeoff as the split-ratio debounce).
-- **Quit confirmation.**
-  `AppDelegate.applicationShouldTerminate` gates a menu/⌘Q quit behind a standard warning `NSAlert` (Quit
-  / Cancel → `.terminateNow`/`.terminateCancel`), reporting how many windows + sessions the quit closes
-  (closing them ends every shell, the same loss `deleteWorkspace`/`deleteActiveWindow` confirm).
-  Counts come from the host-free `WindowLibrary.openCounts()` (open windows + total sessions across them)
-  and the message from the host-free `QuitPrompt.message(windows:sessions:)` (both unit-tested);
-  the AppKit alert is the app-side glue, manually verified like the other `confirmDelete` alerts.
-  Skips the prompt (`.terminateNow`) when nothing is open (the auto-quit after the last window closed
-  — `applicationShouldTerminateAfterLastWindowClosed` already gates that on the model open-set) OR under
-  an XCUITest launch (`ContentView.isUITestLaunch` — a modal would hang the test's terminate;
-  the dialog is therefore manually verified, not XCUITest-covered).
-  `let library else .terminateNow` is a safety fallback: a quit before the scene `.task` wired the library
-  (sub-~4 s after launch) allows termination rather than deadlocking.
-  Keep-in-sync EXEMPT — a quit-confirm modal is GUI-only chrome with nothing to drive over the socket
-  (there is no `app.quit` control command).
-- **`WindowRegistry`**
-  (`agterm/WindowRegistry.swift`, app-side, `@MainActor` singleton) maps a `WindowInfo.ID` to its live `NSWindow`
-  — `WindowLibrary` is host-free (no AppKit), so the NSWindow handles live app-side.
-  `TitleProbeView` registers/unregisters on attach/close; `raise(_:)` brings an already-open window forward
-  (the dedup-by-id raise path), `close(_:)` runs `performClose` (driving the standard `willClose` teardown,
-  used by `window.close`).
-- **Per-window quick terminal.**
-  `QuickTerminalController` is no longer a `static let shared` singleton — it is a per-window instance
-  owned by `WindowContentView` (as `@State`), registered in the app-side `QuickTerminalRegistry` (`Views/QuickTerminal.swift`,
-  `@MainActor` singleton) keyed by `WindowInfo.ID` on appear, unregistered on disappear.
-  Its `cwdProvider`/`envProvider` bind to that window's active session.
-  The frontmost-window call sites resolve via `QuickTerminalRegistry.controller(for: library.activeWindowID)`
-  (the toggle goes through `AppActions.toggleQuickTerminal()`; `ControlServer`'s `quick` arm errors with
-  `no open window` when none is open); the settings broadcast reaches every window's quick terminal via
-  `allControllers()`.
-  Zero `QuickTerminalController.shared` references remain.
-  **A visible quick terminal OWNS first responder, so no deck surface may be `isActive` behind it.**
-  `WindowContentView`'s `focusable` (`deckInteractive && isActive && !quickTerminal.isVisible`) gates the
-  pane, split, maximized-split, scratch and overlay hosts alike — without it an automatic reselection
-  (`reselectIfSelectionHidden`, auto-follow) flips a covered surface active and `TerminalView.updateNSView`
-  grabs focus, sending keystrokes to a session hidden behind the cover.
-  The quick terminal is an IN-WINDOW overlay, not a separate window, so first responder is shared.
-- **Cross-window notification reveal.**
-  The notification identity (`TerminalNotification.identity`/`parseIdentity` in agtermCore) is now `"<windowID>:<sessionID>:<paneRole>"`
-  — the windowID lets a banner clicked after its window closed know which window to reopen.
-  The capture side (`NotificationManager.notify`/`clearDelivered`) resolves the firing window via `library.windowID(forSession:)`.
-  `AppActions.reveal(windowID:sessionID:pane:)` uses `library.store(forSession:)`;
-  if the owning window is closed it reopens it via the `actions.openWindow` closure (`agtermApp` wires
-  it to `WindowRegistry.raise` else `enqueueClaim` + `openWindow(id:)`),
-  polls for the store to load, then `selectSession` + focus the pane (stale-safe:
-  unknown window/session → just activate).
-  `reveal` stays a keep-in-sync exemption (internal click-routing, not on toolbar/menu/palette).
-- **Spawned-shell `AGTERM_*` env (per surface).**
-  `GhosttySurfaceView.init` takes `env: [String: String] = [:]`; it strdups each key/value into the existing
-  `configCStrings` and builds a `nonisolated(unsafe) var envVars: [ghostty_env_var_s]` field set as `config.env_vars`/`config.env_var_count`
-  — the struct array must outlive `ghostty_surface_new` and can't live in `configCStrings` (wrong element
-  type), so `ghostty_surface_new` is called *inside* the `envVars.withUnsafeMutableBufferPointer` closure
-  (no env → plain path) and the array is cleared in `destroySurface`/`deinit` alongside the strdup frees.
-  Tree surfaces (main/split/overlay, via `agtermApp.surfaceEnv(for:)`) inject `AGTERM_ENABLED=1`,
-  `AGTERM_WINDOW_ID` (`library.windowID(forSession:)`), `AGTERM_WORKSPACE_ID` (`store.workspace(forSession:)`),
-  `AGTERM_SESSION_ID`, `AGTERM_SOCKET`; split/overlay inherit the parent session's ids.
-  The quick terminal (`quickTerminalEnv(for:)`) gets only `AGTERM_ENABLED` + `AGTERM_WINDOW_ID` + `AGTERM_SOCKET`
-  (scratch, not in the tree).
-  `AGTERM_SOCKET` is the path `ControlServer` *actually bound* (`ControlServer.boundSocketPath`,
-  nil before bind → the var is omitted), so a test-overridden `AGTERM_CONTROL_SOCKET` and the injected
-  env agree.
-- **`window.zoom` (maximize-to-screen toggle, control + double-click-header GUI).** `WindowRegistry.zoom(_:)`
-  drives the standard `NSWindow.zoom(nil)` — toggles between the normal frame and the screen's visible frame
-  (NOT native fullscreen); a second call restores.
-  Unlike `resize`/`move` it has a GUI surface: a custom-titlebar SwiftUI view can't receive the OS
-  double-click handling, so `WindowControlArea` (an `NSViewRepresentable` behind `customTitlebar`'s decorative
-  regions in `agterm/Views/WindowControlArea.swift`) handles `mouseDown` — `clickCount == 2` runs the user's configured title-bar
-  action, else `performDrag` (also making the FULL header draggable, not just the native top band);
-  `mouseDownCanMoveWindow = false` so our handler sees the double-click.
-  The double-click honors the macOS **Desktop & Dock ▸ "Double-click a window's title bar to"** setting
-  (`AppleActionOnDoubleClick` in `NSGlobalDomain`, read LIVE per click): Zoom/Fill → `window.zoom(nil)`,
-  Minimize → `performMiniaturize`, "Do Nothing" → no-op; the key is absent until the user changes it from the
-  macOS default (Zoom), so an untouched system still zooms (the prior behavior).
-  So the GUI double-click is NOT always-zoom — only the `window.zoom` control command unconditionally zooms.
-  A UITest env override (`AGTERM_UITEST_DOUBLECLICK_ACTION`, read ahead of the system default) pins the action
-  so the gesture tests are hermetic regardless of the host setting; it rides the environment, not launch
-  arguments (FB11763863 — see `ui-tests.md`).
-  The header's decorative parts (the traffic-light spacer, the divider gap, the title text) opt out via
-  `.allowsHitTesting(false)` so their region falls through to the layer; the buttons stay in front.
-  Requires the window OPEN (closed → the `window not open` error), like `resize`/`move`.
-  Its READ side is `ControlWindowNode.zoomed` on `window.list` (via `WindowRegistry.windowFlags(for:)` →
-  `NSWindow.isZoomed`), so a script can toggle idempotently.
-  Four-point keep-in-sync audit: (1) `case windowZoom = "window.zoom"` in `ControlProtocol.swift`,
-  (2) the `.windowZoom` dispatch arm (`windowZoom`) in `ControlServer` → `WindowRegistry.shared.zoom`,
-  (3) the `window zoom <id>` subcommand in `agtermctlKit`, (4) `.windowZoom` in `windowCommandsRoundTrip`
-  (`ControlProtocolTests`) + the e2e `testWindowZoom` plus the gesture tests
-  `testDoubleClickHeaderZoomsAndRestores` / `testDoubleClickHeaderHonorsNoneSetting` /
-  `testHeaderButtonsStillReceiveClicksOverControlArea` / `testDragHeaderMovesWindow` in `ControlWindowUITests`.
-- **`window.fullscreen` (native macOS full screen — control + View-menu / green-button / ⌃⌘F GUI).**
-  `WindowRegistry.fullscreen(_:)` drives the standard `NSWindow.toggleFullScreen(nil)` — enters/exits NATIVE
-  full screen (a separate Space, auto-hidden menu bar); a second call exits.
-  Distinct from `window.zoom`, which only maximizes the frame in the SAME Space.
-  It has a GUI surface across all four keep-in-sync callers: the **View ▸ Toggle Full Screen** menu item and
-  the ⌃⇧P palette "Toggle Full Screen" both drive `AppActions.toggleFullscreen()` →
-  `NSApp.keyWindow?.toggleFullScreen(nil)` (the KEY window, no id resolution — the menu/palette/keymap
-  always act on the frontmost), `BuiltinAction.toggleFullscreen` gives it the ⌃⌘F default (expressible,
-  rebindable via `keymap.conf`), and the green traffic-light button already toggles the same native path.
-  The control command instead resolves a window id like `zoom` (`active`/prefix/id) and requires the window
-  OPEN (closed → the `window not open` error).
-  **AppKit auto-injects its OWN "Enter Full Screen" item (Globe+F / ⌃⌘F) into the View menu for any
-  fullscreen-capable window and RE-INJECTS it every time the menu opens, so agterm's own item would render
-  a DUPLICATE.** `AppDelegate` strips the native one — `removeNativeFullScreenMenuItem` removes the menu item
-  whose action is `toggleFullScreen:` (agterm's item uses a SwiftUI closure action, a different selector, so
-  only the native one matches).
-  It runs once at launch AND on every `NSMenu.didBeginTrackingNotification` (the point AppKit re-injects it) —
-  a launch-time one-shot does NOT stick because of the re-injection; a menu delegate is NOT used (it would
-  clobber SwiftUI's dynamic View-menu updates).
-  Guarded by the e2e `testViewMenuHasSingleFullScreenItem` in `MenuUITests` (View menu shows Toggle Full
-  Screen, NOT the native Enter Full Screen).
-  Its READ side is `ControlWindowNode.fullscreen` on `window.list` (via `WindowRegistry.windowFlags(for:)` →
-  `styleMask.contains(.fullScreen)`), so a script can enter/exit only when needed.
-  Four-point keep-in-sync audit: (1) `case windowFullscreen = "window.fullscreen"` in `ControlProtocol.swift`
-  + `case toggleFullscreen = "toggle_fullscreen"` (⌃⌘F `defaultChord`) in `BuiltinAction`,
-  (2) the `.windowFullscreen` dispatch arm (`windowFullscreen`) in `ControlServer` →
-  `WindowRegistry.shared.fullscreen`, plus `AppActions.toggleFullscreen()`, the View menu item, and
-  `PaletteCommand.toggleFullscreen`,
-  (3) the `window fullscreen <id>` subcommand in `agtermctlKit`, (4) `.windowFullscreen` in
-  `windowCommandsRoundTrip` (`ControlProtocolTests`) +
-  `windowCommandsRouteParsedInputsAndKeepActionResponses` (`ControlDispatcherTests`) + the CLI mapping in
-  `CommandsTests` + the e2e `testWindowFullscreen` in `ControlWindowUITests`.
-- **`window.minimize` (Dock-minimize toggle — control + ⌘M / yellow button / title-bar double-click GUI).**
-  `WindowRegistry.minimize(_:mode:)` drives the standard `NSWindow.miniaturize`/`deminiaturize`.
-  It is MODE-BEARING (`on`|`off`|`toggle`, default toggle via `ControlToggleMode.parse`), unlike the bare
-  `window.zoom`/`window.fullscreen` toggles, because the workflow it exists for — park every window except
-  the one you're on — needs a deterministic minimize without reading state first.
-  It is NOT control-native: ⌘M (AppKit's own Window menu, which agterm never replaces), the yellow
-  traffic-light button, and the Minimize title-bar double-click action all drive the same AppKit path.
-  That is exactly why the read-back needs the `NSWindow.didMiniaturize`/`didDeminiaturize` observers in
-  `ControlServer` — three GUI drivers mutate it with no control command.
-  It requires the window OPEN (closed → the `window not open` error) and REJECTS a window in native full
-  screen (`cannot minimize a full-screen window — window.fullscreen it first`): AppKit no-ops `miniaturize`
-  there, so applying it would report success having done nothing.
-  The arm is `async` and settle-POLLS `WindowRegistry.isMinimized(id) == desired` before replying, because
-  miniaturize/deminiaturize are ANIMATED — without the poll the `defer`-ed `refreshWindowCache()` captures
-  the pre-animation value and the next `window.list` reports the state the caller just changed away from.
-  Its READ side is `ControlWindowNode.minimized` on `window.list`, and a minimized window still reports its
-  `geometry` — the frame it comes back to — which needs `WindowRegistry.resolvedScreen(for:)`, since
-  `NSWindow.screen` is nil while miniaturized.
-  That resolver (`window.screen` → `WindowGeometry.bestDisplayIndex` largest-overlap → `NSScreen.main`) is
-  SHARED by `geometry`, `move`, and `resize` on purpose: a read resolved by overlap and a write resolved
-  against `NSScreen.main` would disagree on the display index, so a minimized window's frame would stop
-  round-tripping back through `window.move`.
-  Parking the FRONTMOST window HANDS `frontmostWindowID` off to a still-visible open window
-  (`handOffFrontmost`).
-  `activeWindowID` only falls back when the frontmost window's STORE is gone, and a minimized window keeps
-  its store, so without the handoff `tree`, `session.new`, `quick`, the palette, and the menu bar all keep
-  routing into a window sitting in the Dock — exactly the state a park-all-but-one script produces.
-  AppKit keys another window on a minimize only while the APP is active, so a background script never gets
-  that handoff for free; when AppKit DID hand off, `reportFrontmost` already moved the id and the guard
-  skips.
-  With every open window minimized there is no candidate, so the pointer stays put rather than being
-  cleared.
-  `minimized` is LIVE-ONLY (never persisted — see the control-api rule), so a parking script re-applies
-  after a relaunch.
-  Both GUI directions keep the read-back honest, verified: a ⌘M/menu minimize
-  (`testMenuMinimizeReadsBackOverControl`) and a Dock-icon click restore (AppKit's default reopen handling
-  — agterm implements no `applicationShouldHandleReopen`) each flip the flag with no control command in
-  play.
-  Four-point keep-in-sync audit: (1) `case windowMinimize = "window.minimize"` + `minimized` on
-  `ControlWindowNode` in `ControlProtocol.swift` (reuses `ControlArgs.mode`),
-  (2) the `.windowMinimize` dispatcher arm (mode parse + error string) → `ControlActions.windowMinimize`
-  (app-side `ControlServer+WindowCommands`) → `WindowRegistry.minimize`, plus the two miniaturize
-  notifications in the `ControlServer` observer array,
-  (3) the `window minimize <id> [on|off|toggle]` subcommand in `agtermctlKit`,
-  (4) `.windowMinimize` in `windowCommandsRoundTrip` + `windowNodeRoundTripsWithMinimized`/`…OmitsMinimizedWhenNil`
-  (`ControlProtocolTests`) + `windowCommandsRouteParsedInputsAndKeepActionResponses` /
-  `…RejectInvalidInputsBeforeCallingActions` (`ControlDispatcherTests`) +
-  `controlWindowNodesIncludeFullscreenZoomFromClosure` (`WindowLibraryTests`) + the CLI mapping in
-  `CommandsTests` + the e2e `testWindowMinimizeAndRestore` in `ControlWindowUITests`.
-  **CLI positional note:** every `window` subcommand takes the id as its first positional, so `minimize`'s
-  mode is a SECOND optional positional and a bare `window minimize on` would bind the mode word to the id.
-  A window address is a hex UUID prefix or `active` and can never be a mode word, so `makeRequest` recovers
-  that case by targeting `active` — covered by `windowMinimizeBareModeTargetsActive`.
-  Do NOT "fix" it by copying `surface zoom`'s mode-first-plus-`--target` shape; that is a different family
-  convention.
-- **`window.new --minimized` creates a window already parked.**
-  It rides the existing command as an ARG (`ControlArgs.minimized`), so there is no new `Command` case and
-  the catalog count is unchanged — the `session.new --no-select` precedent, and like it the read-back is
-  the EXISTING field (`window.list`'s `minimized`), so no new node field is owed.
-  Ordering inside the arm is load-bearing: `WindowAccessor` presents a new window BOTH synchronously in
-  `viewDidMoveToWindow` and again on the next main-queue turn, and that second present deminiaturizes — so
-  `park` waits one poll tick after registration before minimizing, else the park is silently undone.
-  It then hands frontmost off (the same `handOffFrontmost`), because `newWindow()` pre-sets
-  `frontmostWindowID` and a window in the Dock must not be where untargeted commands land.
-  It ALSO required fixing `bringForwardForUITests` (`WindowAccessor`): its guard returned WITHOUT latching
-  for an already-presented window, leaving all six ticks of the 0.95 s schedule armed to fight a later
-  deliberate minimize — the same oscillation hazard its own comment warns about.
-  It now latches as soon as the window is on screen.
-  Verified load-bearing: reverting that latch fails `testWindowNewMinimizedStaysParked`.
-- **A control command that changes which window is frontmost must SAY SO — `takeFrontmost`, not AppKit.**
-  `library.frontmostWindowID` is normally written by `WindowAccessor.reportFrontmost` on `didBecomeKey`,
-  and AppKit does not deliver that while the app is INACTIVE — which is exactly the state a driving script
-  is in.
-  So `window.select` used to `raise` the window, reply `ok`, and leave frontmost on the PREVIOUS window;
-  every untargeted command that followed (`session.new`, `tree`, the palette, the quick terminal) then
-  routed into the window the caller had just navigated away from.
-  Both `windowSelect` and `handOffFrontmost` now go through `takeFrontmost(_:)`, which records the id,
-  persists the index, and runs the auto-hidden-sidebar reconcile — the same three things `reportFrontmost`
-  does, minus the notification the dispatch path already covers.
-  **This path has NO XCUITest coverage, deliberately.** Reproducing it requires agterm to be inactive, and
-  every way to arrange that from XCUITest disturbs the user's session — activating another app jumps to
-  whatever Space that app's window is on.
-  A test written without deactivating the app passes with OR without the fix (verified: it did), so it
-  would guard nothing.
-  Verify by hand on an ISOLATED instance instead: open two windows, leave agterm in the background, run
-  `window select <the non-active one>`, then check `window list` reports it `active` and that an untargeted
-  `session new` lands in it.
-- **`window.new` replies only once its NSWindow has ATTACHED — the open-vs-attached distinction.**
-  A window is "open" the moment its `AppStore` loads (`WindowLibrary.isOpen` = `stores[id] != nil`), which
-  `newWindow()` does SYNCHRONOUSLY. The NSWindow lands much later: registration happens in
-  `TitleProbeView.viewDidMoveToWindow`, which needs `ContentView` to resolve its store (`Color.clear` until
-  then), `.onAppear` → `resolveStore`, and a SECOND render pass before the accessor attaches.
-  So `window.new` used to return with `open: true` and no NSWindow, and an immediate
-  `window.resize <new id>` — the shipped `examples.md` recipe — failed with `window not open`.
-  `windowNew` is therefore `async` and polls `WindowRegistry.isRegistered(id)`; `windowSelect` polls
-  `library.isOpen(id) && isRegistered(id)` (the CONJUNCTION — `isOpen` alone is what `tree --window` needs
-  and stays, but it flips a render pass before the NSWindow exists).
-  Never gate a readiness poll on `isOpen` alone for anything that touches the NSWindow.
-- **The `window.list` cache must refresh on ATTACH, not just on frontmost change.**
-  `window.list` is fast-path-served from `cachedWindowNodes` and never rebuilds its own cache, so the node
-  captured right after `window.new` (no geometry, no flags) stuck FOREVER for a polling script: `newWindow()`
-  pre-sets `frontmostWindowID`, so the new window's first `didBecomeKey` computes `changed == false` and
-  skips `.agtermWindowFrontmostChanged`, and a brand-new id has no saved frame, so `restoreSavedFrame`
-  early-returns and no `didMove`/`didResize` fires either.
-  `WindowRegistry.register`/`unregister` therefore post `.agtermWindowAttachmentChanged`
-  (`GhosttyApp.swift`, app-side — the poster is app-side), which `ControlServer` observes to
-  `refreshWindowCache`.
-  It also covers the paths the `window.new` poll cannot: GUI New Window (⌘⌥N), launch reopen-all, and a
-  red-button close (whose `willClose` unregisters with no command in play).
-  Use `queue: .main`, NOT the `queue: nil` the sidebar observer uses: `unregister` runs near the TOP of the
-  `willClose` block and `library.closeWindow` at the BOTTOM, so a synchronous refresh would capture
-  `open: true` + `geometry: nil` and never refresh again.
-- **`window.*` control additions (eight commands, plus `window.zoom`/`window.fullscreen`/`window.minimize`).**
-  `window.new` (returns the new id + opens its window), `window.list` (returns `windows` with each window's
-  `open`/`active` flag, plus `autoFollowMs` and `sidebarVisible` read from the open window's store, and
-  `geometry` — the live NSWindow frame `{x, y, width, height, display}` in `window.move`/`window.resize`'s
-  own coordinate system (top-left relative to the display, y down) so a read-back round-trips through them,
-  read app-side via `WindowRegistry.geometry(for:)` — plus `fullscreen`/`zoomed` (the read side of
-  `window.fullscreen`/`window.zoom`, read via `WindowRegistry.windowFlags(for:)` so a script can make
-  those toggles idempotent) — all omitted for a closed window),
-  `window.select` (raise-or-open), `window.close` (`WindowRegistry.close` →
-  standard teardown), `window.rename`, `window.delete` (`canRemoveWindow` keep-at-least-one → error,
-  not a GUI confirm).
-  `window.list` is answered from the background-thread `cachedWindowNodes` cache (see the fast-path note
-  above), refreshed after every dispatched command + on `.agtermWindowFrontmostChanged`.
-  `sidebarVisible` is the first frequently-GUI-mutated field on that node, so a GUI-only ⌃⌘S sidebar
-  toggle (no control command, no frontmost change) would otherwise leave it stale — `AppStore.setSidebarVisible`
-  posts `.agtermSidebarVisibilityChanged` and `ControlServer` observes it to `refreshWindowCache`.
-  The live, never-cached copy of `sidebarVisible` is on `tree`'s top level (main-actor per request);
-  prefer it for read-then-act scripts.
-  The node's `geometry`/`fullscreen`/`zoomed` are the SAME problem writ larger — live NSWindow state that a
-  user drag/resize/zoom/fullscreen changes with no command, and (unlike `sidebarVisible`) with NO live tree
-  copy, so a polling `window.list` would read them stale forever. `ControlServer` therefore observes the
-  NSWindow `didMove`/`didResize`/`didEnterFullScreen`/`didExitFullScreen` notifications (object nil) and
-  `refreshWindowCache`s on each — the fullscreen enter/exit fire AFTER the async transition, so the settled
-  `styleMask` is captured; a drag's storm just keeps the cache current.
-  The notification is IGNORED (`_ in`), NOT captured: a non-Sendable `Notification` can't cross into the
-  `MainActor.assumeIsolated` region under Swift 6 (the `sending 'note'` error — which a Debug build compiles
-  clean but the Release WMO rejects, so verify app-target concurrency changes with a Release build), so the
-  refresh can't filter to an agterm window by the notification's object; a non-agterm panel firing it just
-  rebuilds the same cheap agterm nodes.
-  `window.resize` (`args.width`/`height` → the window's frame size in points) and `window.move` (`args.x`/`y`
-  → the top-left relative to display `args.display`, default the window's current display;
-  y from the display top, so multiple displays are addressed by index) drive the app-side `WindowRegistry.resize`/`move`
-  (the NSWindow handles, since `WindowLibrary` is host-free); both require the window OPEN (a closed
-  window errors) and are control-NATIVE (no GUI surface — the native title bar already drags-to-resize).
-  Both CLAMP the request via the host-free `WindowGeometry` (`clampSize` into `[window.minSize, screen.visibleFrame]`,
-  `clampOrigin` keeps a grabbable on-screen strip) applied INSIDE `WindowRegistry` (the only place with
-  the live `NSWindow`/`NSScreen`); `ControlServer` keeps only the `>0` guard.
-  `WindowGeometry` is agtermCore's first CoreGraphics types (CG ≠ AppKit/Metal,
-  Foundation-provided on Darwin).
-  Window-id resolution reuses the pure `ControlResolve.resolve` over `library.windows` (active=frontmost
-  / exact / prefix / ambiguous / not-found); a window need NOT be open to be a `window.*` target.
-  The global `--window <id>` selector (`ControlArgs.window`) targets a session/workspace command at a
-  *specific* window's tree: with `args.window` set, the window must be open (else `window not open — window.select it first`);
-  without it, `active`/placement default to the frontmost store, but an id/prefix session/workspace target
-  is matched across ALL open stores (`resolveTargetAcrossWindows`) and mapped back to its owning `AppStore`.
-  See the Control API section for the catalog and the keep-in-sync four-point audit (all eight window
-  commands satisfy it).
-- **`open -a agterm /path` (the OS "open terminal here" integration — Discussion #230) is WARM-ONLY on purpose.**
-  `AppDelegate.application(_:open:)` resolves each URL to a directory (host-free `OpenPathResolver`:
-  a folder → itself, a file → its parent, nil for a non-file / missing path), queues it in
-  `pendingOpenDirectories`, and `drainPendingOpenDirectories` grafts a session into the last-active window
-  via `AppActions.openSession(atDirectory:)` (which mirrors `newSession()` — note-activity + select +
-  focus — but seeds the cwd from the path and targets `library.activeStore`, the SAME window the control
-  channel's `session.new` defaults to).
-  The drain gates on `library.activeStore?.currentWorkspaceID != nil` and retries on a bounded 0.1 s
-  backoff (dropping the queue after 50 ticks so a stray folder can't wedge a timer); the scene `.task`
-  hands the delegate `actions` and calls the drain once, and `application(_:open:)` calls it inline for
-  the running instance.
-  After a session lands it `WindowRegistry.raise`s `library.activeWindowID` (deminiaturize + make-key) so
-  an "open here" into a MINIMIZED last-active window is actually visible — `NSApp.activate()` alone only
-  brings the app forward and would leave the window in the Dock; a no-op for an already-frontmost window.
-  `CFBundleDocumentTypes`/`LSItemContentTypes = public.folder` (role Viewer) in `Info.plist` is what puts
-  agterm in Finder's right-click **Open With ▸ agterm** for folders; it is NOT required for `open -a`
-  routing (odoc delivers the folder either way) — only for the Finder listing.
-  **The COLD case (agterm NOT running) is deliberately unsupported and flashes-then-quits, and this is a
-  hard SwiftUI-`WindowGroup` limitation, not a missing feature — do NOT re-attempt an in-process fix.**
-  On a cold `open -a agterm /path` (an `odoc` AppleEvent) SwiftUI auto-opens the `WindowGroup` window,
-  lets it FULLY initialize (it adopts a launch id, runs the scene `.task`, starts the control server,
-  runs `consumeReopen()` so `hasReopened` is already true), then RETRACTS the un-presented window
-  (SwiftUI's "don't keep an untitled window on a document launch" behavior) BEFORE delivering the open
-  event — and macOS then reaps the windowless odoc process (verified: `applicationShouldTerminateAfterLastWindowClosed`
-  returning `false` does NOT stop it, and no `applicationWillTerminate` fires).
-  This was proven NOT to be the deployed daily-driver twin (a fully-independent bundle id fails
-  identically) and is NOT fixable by the reference tricks: a forced `NSWorkspace.open` reopen never gets a
-  window-less moment and the claim queue strays the re-presented window (`adoptedLaunchID` is stuck +
-  `hasReopened` true); `applicationShouldOpenUntitledFile`/`applicationShouldHandleReopen` are never even
-  consulted on odoc; and `WindowGroup.defaultLaunchBehavior(.presented)` (the intended API) is macOS 15+
-  while the floor is macOS 14 and `SceneBuilder` rejects `if #available`.
-  The reference terminals confirm the shape: AppKit ones (Ghostty, iTerm, kitty, conterm) create
-  `NSWindow`s manually and never hit the retract; the SwiftUI-`WindowGroup` one that ships folder-open
-  (Muxy) routes it through its OWN CLI (socket when warm, argv/`oapp` when cold), never odoc.
-  The ONLY clean cold path is a relaunch (odoc → `oapp`), deliberately NOT taken (a double-launch flicker
-  for the rare not-running case; agterm is a daily driver, so warm covers ~all real use).
-  KEEP-IN-SYNC EXEMPT: `openSession(atDirectory:)` is the OS-`open` entry point onto a capability the
-  socket ALREADY exposes (`session.new --cwd <path>`, frontmost-defaulted), so it needs no new `Command`
-  case / `agtermctl` subcommand / `commands.html` entry — call it out as the exemption it is, like
-  `reveal`.
+## Model and persistence
+
+- Host-free `WindowLibrary` owns ordered `WindowInfo` values, live stores, and `frontmostWindowID`.
+  Use `WindowInfo`, not `Window`, to avoid framework name collisions. `WindowsIndex` has its own version,
+  independent of `Snapshot.version`; `WindowEntry` stores ID, name, and open state.
+- A window is open when its store is loaded. `loadStore` lazily caches `windows/<id>.json`; `newWindow`
+  seeds workspace 1 and a `$HOME` session. Keep at least one library entry. `openIDs` drives relaunch.
+  `applyInactiveWindowSidebarHiding` shows the active sidebar and hides other windows' sidebars.
+- State lives under `AGTERM_STATE_DIR` or Application Support: `windows.json` plus
+  `windows/<uuid>.json`. Legacy `workspaces.json` remains dormant after migration. `PersistenceStore.fileName`
+  defaults to `workspaces.json`; index and window mutations save only their own files.
+- Bootstrap never throws. Load a valid index; otherwise recover every UUID-named per-window file before
+  considering legacy migration or an empty seed. Recovered files are appended before `loadStore`, named
+  `window N`, all opened, and the first made frontmost. Missing/corrupt window snapshots open with a
+  default workspace/session. The library is never empty after launch.
+
+## Scene lifecycle
+
+- Use plain `WindowGroup(id: "terminal")`, not value-based `WindowGroup(for:)`: with restoration off,
+  the value form opens no launch window and its task never bootstraps. The library owns the open set.
+- Appearing windows claim IDs from a FIFO queue: seed launch first, pop with `claimNextWindowID`, enqueue
+  new windows, and dismiss SwiftUI-restored strays. `reopenWindows` opens remaining IDs once behind
+  `hasReopened`.
+- Do not use `.restorationBehavior`; it requires macOS 15, the floor is 14, and `SceneBuilder` rejects
+  availability conditionals without an `AnyScene` eraser. Deduplicate by ID on both systems.
+- `TitleProbeView` sets `frameAutosaveName("agterm-window-<id>")`, reports key/main changes, and on close
+  tears down surfaces before `closeWindow`.
+- `AppActions`, commands, palette construction, `ControlServer`, `SettingsModel`, and `SessionSwitcher`
+  resolve through observable `WindowLibrary.activeStore`: frontmost open store, then first open store.
+- On termination, set `isTerminating` before windows close, then `saveAllOpen` and `saveIndex`. This preserves
+  live cwd changes, which structural saves may not capture. Selection and font use a roughly 0.3-second
+  `Debouncer`; structural mutations save synchronously and cancel pending saves.
+- Quit uses `applicationShouldTerminate` and a warning alert with host-free `openCounts` and
+  `QuitPrompt.message`. Skip it for no open windows, XCUITest, or an unwired library during the first
+  roughly four seconds. The GUI-only prompt is keep-in-sync exempt and manually verified.
+- App-side `WindowRegistry` maps IDs to `NSWindow`. Register/unregister through `TitleProbeView`;
+  `raise` deminiaturizes and fronts, and `close` uses `performClose` so standard teardown runs.
+
+## Quick terminal, notifications, and environment
+
+- `QuickTerminalController` is per-window state registered by ID, never a singleton. Providers bind to
+  that window; frontmost calls use `activeWindowID`, control reports `no open window`, and settings
+  broadcast to all controllers.
+- While quick terminal is visible, no deck surface may be active. Gate main, split, maximized split,
+  scratch, and overlay with `deckInteractive && isActive && !quickTerminal.isVisible`; the overlay shares
+  the containing window's first responder.
+- Notification identity is `"<windowID>:<sessionID>:<paneRole>"`. Capture resolves the owning window.
+  Reveal reopens a closed window through raise or enqueue/open, polls until its store loads, then selects
+  and focuses the pane. Unknown window/session only activates. This internal route is keep-in-sync exempt.
+- `GhosttySurfaceView` accepts an environment dictionary. `strdup` keys/values, retain a
+  `[ghostty_env_var_s]` beside `configCStrings`, call `ghostty_surface_new` inside its mutable-buffer
+  lifetime, and clear it with the strdup storage on destroy/deinit.
+- Tree surfaces inject `AGTERM_ENABLED`, window/workspace/session IDs, and `AGTERM_SOCKET`; split/overlay
+  inherit the session IDs. Quick terminal gets enabled, window, and socket only. Use
+  `ControlServer.boundSocketPath`, omitting the variable before bind, so overridden sockets match children.
+
+## Window state controls
+
+- `window.zoom` uses `NSWindow.zoom`: visible-frame maximize, not native fullscreen. The control toggle
+  requires an open window. Read back `isZoomed` on `window.list`.
+- `WindowControlArea` handles titlebar dragging and double-click because SwiftUI titlebar views do not
+  receive native handling. Set `mouseDownCanMoveWindow = false`; double-click reads live
+  `AppleActionOnDoubleClick`: Zoom/Fill zooms, Minimize miniaturizes, Do Nothing does nothing, and an absent
+  key defaults to Zoom. `AGTERM_UITEST_DOUBLECLICK_ACTION` overrides via environment because launch
+  arguments hit FB11763863. Decorative titlebar regions disable hit testing; buttons remain above them.
+- `window.fullscreen` uses `toggleFullScreen`, a distinct native Space. GUI surfaces are View > Toggle Full
+  Screen, palette, `BuiltinAction.toggleFullscreen` with Ctrl-Command-F, and the green button. Control
+  resolves an open ID; read back the `.fullScreen` style mask.
+- AppKit reinjects its own `toggleFullScreen:` menu item whenever View opens. Remove only that selector at
+  launch and every `NSMenu.didBeginTrackingNotification`; do not install a menu delegate that would replace
+  SwiftUI updates. `testViewMenuHasSingleFullScreenItem` pins this.
+- `window.minimize` accepts `on`, `off`, or `toggle` through `ControlToggleMode`, defaulting to toggle.
+  Deterministic modes support park-all-but-one. GUI Command-M, yellow button, and titlebar preference use
+  AppKit directly, so observe `didMiniaturize`/`didDeminiaturize` to keep control read-back current.
+- Reject closed or full-screen windows for minimize; AppKit silently ignores full-screen miniaturize.
+  Poll the animated transition until `isMinimized == desired` before refreshing the cache. Retain geometry
+  for minimized windows through shared `resolvedScreen`: live screen, largest-overlap display, then main.
+  Geometry reads, move, and resize must share this resolver to preserve display-index round trips.
+- Minimizing the frontmost window calls `handOffFrontmost` to a visible open window. A minimized store
+  remains loaded, so `activeWindowID` cannot correct it. Background scripts receive no AppKit key-window
+  handoff; if all windows are minimized, retain the pointer. Minimized state is live-only.
+- CLI window subcommands normally take ID first. A bare `window minimize on` would parse `on` as the ID;
+  recover mode words by targeting `active`, as pinned by `windowMinimizeBareModeTargetsActive`. Do not copy
+  the mode-first `surface zoom --target` convention.
+- `window.new --minimized` reuses the existing command argument and `window.list.minimized`. Wait one poll
+  tick after registration before parking because `WindowAccessor` presents again on the next main turn.
+  Then hand frontmost off. `bringForwardForUITests` must latch as soon as the window is already presented;
+  otherwise its six ticks over 0.95 seconds undo a deliberate minimize.
+- Control changes to frontmost state must call `takeFrontmost`, which records, persists, and reconciles
+  auto-hidden sidebars. Inactive apps do not receive `didBecomeKey`, so relying on AppKit makes following
+  untargeted commands hit the previous window. This requires manual isolated verification: background
+  agterm, select the non-active window, confirm list marks it active and untargeted session creation lands
+  there. XCUITest cannot deactivate without disturbing the user's Space.
+
+## Attachment and cache
+
+- `window.new` is not ready when its store becomes open. Its `NSWindow` registers only after store
+  resolution, a second render, and `viewDidMoveToWindow`. Poll `WindowRegistry.isRegistered`; selection
+  waits for both open and registered. Never gate NSWindow work on `isOpen` alone.
+- `window.list` is served from `cachedWindowNodes`. Registration and unregistration post
+  `.agtermWindowAttachmentChanged`; observe it on `.main`, not synchronously, because unregister precedes
+  `closeWindow` and an immediate refresh captures `open: true` without geometry.
+- Refresh on every command, frontmost change, sidebar visibility change, attachment, and NSWindow
+  move/resize/fullscreen/minimize transitions. Ignore notification payloads: carrying non-Sendable
+  `Notification` into a main-actor region fails Swift 6 Release WMO even when Debug passes.
+
+## Control catalog
+
+- Commands are `window.new`, `window.list`, `window.select`, `window.close`, `window.rename`,
+  `window.delete`, `window.resize`, `window.move`, `window.zoom`, `window.fullscreen`, and
+  `window.minimize`. Keep their protocol cases, dispatch/actions, CLI mappings, and tests synchronized
+  per the repository-wide control contract.
+- `window.list` returns ID/name/open/active plus open-store auto-follow/sidebar state and live
+  geometry/fullscreen/zoom/minimize. Closed-window live fields are omitted. Geometry is top-left,
+  display-relative, y-down, matching move/resize.
+- Delete enforces at least one library entry without GUI confirmation. `window.select` raises or opens.
+  Window ID resolution accepts active, exact ID, unique prefix, ambiguity, and not found; most library
+  commands can address closed entries.
+- `window.resize` and `window.move` are control-native and require open windows. Validate positive sizes,
+  then clamp inside `WindowRegistry` with host-free `WindowGeometry`: size to min/visible frame, origin to
+  a grabbable screen strip. `WindowGeometry` may use CoreGraphics but not AppKit/Metal.
+- Global `--window` requires that window open. Without it, untargeted operations use active placement,
+  while an explicit session/workspace ID resolves across all open stores and returns its owning store.
+- For exact coverage names and command inventory, see [[control-api]]; do not duplicate its audit here.
+
+## Finder open
+
+- Warm `open -a agterm /path` (Discussion #230) resolves folders to themselves and files to parents,
+  queues them, and drains into the active store through `openSession(atDirectory:)`. Gate on a current
+  workspace and retry every 0.1 seconds for at most 50 ticks. After insertion, raise the active window so
+  a minimized target becomes visible.
+- `CFBundleDocumentTypes` with `public.folder` and Viewer role adds Finder's Open With entry; it is not
+  required for the `odoc` event itself.
+- Cold `open -a` is deliberately unsupported. SwiftUI fully initializes then retracts its auto-created
+  `WindowGroup` before delivering `odoc`, and macOS reaps the windowless process without
+  `applicationWillTerminate`. Independent bundle IDs reproduce it; preventing last-window termination,
+  forced reopen, untitled/reopen delegates, and in-process claim tricks do not solve it.
+- AppKit terminals create windows manually; Muxy's SwiftUI implementation routes cold opens through its
+  CLI. The clean workaround is an `odoc` to `oapp` relaunch, rejected because it double-launches and
+  flickers for the rare cold case. `defaultLaunchBehavior(.presented)` requires macOS 15 and cannot be
+  conditionally expressed in the macOS 14 `SceneBuilder`.
+- Finder open composes `session.new --cwd` with frontmost placement, so it is keep-in-sync exempt.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,556 +1,171 @@
-# agterm — project notes
+# agterm project notes
 
-`agterm` is a native macOS SwiftUI terminal on libghostty, with a two-level workspace -> session vertical
-sidebar.
-Read `README.md` for the overview and `ARCHITECTURE.md` for the module split,
-surface ownership, and the C-boundary concurrency contract before changing the bridge.
+agterm is a native macOS SwiftUI terminal on libghostty with a workspace-to-session sidebar.
+Read `README.md` for product behavior and `ARCHITECTURE.md` for modules, surface ownership, and C-boundary
+concurrency before changing the bridge.
 
 ## Working norms
 
-- The maintainer and most expected contributors are NOT SwiftUI / macOS UI-UX experts.
-  When a UI request is non-standard, risky, or trickier than it sounds (custom window chrome,
-  fighting `NavigationSplitView`, reaching into private AppKit views, layout-direction hacks,
-  etc.), push back gently FIRST: explain what it actually takes and the trade-offs,
-  and offer the simpler/standard alternative.
-  If the user still wants it after that, do it — the user is the boss.
-- **Propose control-API/CLI coverage for every new feature (aim for completeness).** When adding ANY
-  feature or capability, evaluate what of it makes sense to drive over the control channel and PROACTIVELY
-  propose adding it — a `Command` case + `ControlServer` arm + `agtermctl` subcommand + round-trip/e2e
-  tests.
-  The goal is the most complete control-API coverage possible (the API is a first-class surface,
-  not an afterthought), not merely parity with the GUI.
-  This generalizes the HARD keep-in-sync convention (which covers GUI actions in `AppActions`/`AppStore`)
-  to features with NO GUI surface at all — `notify`/`session.copy`/`session.type` are control-native.
-  Only skip when exposure is genuinely meaningless (pure rendering/visual chrome with nothing to drive).
-- **Propose a Settings ▸ Interface toggle for a new toggleable UI/chrome element — ask first, never
-  automatic.** When adding a title-bar or sidebar affordance the user might want to hide (a button, a
-  hover glyph like the workspace-row add-session "+", a status/indicator element), evaluate whether it
-  should join the host-free `InterfaceElement` set so it gets a live Settings ▸ Interface toggle (a new
-  case auto-appears in the tab via `allCases`, gated through the `GhosttyApp.hiddenInterfaceElements`
-  mirror — the detail is the `hiddenInterfaceElements` bullet in `.claude/rules/settings.md`).
-  Unlike the control-API norm above, do NOT add it proactively — PROPOSE it and let the user decide,
-  since some chrome is intentionally always-on; skip only when a toggle is genuinely meaningless
-  (transient/decorative chrome with nothing to hide).
-- **Use the Swift skills for Swift/SwiftUI work — proactively, from the START,
-  not only when stuck.** agterm is Swift 6 + SwiftUI + AppKit; activate the relevant skill before/while
-  working: `swiftui-expert` for any SwiftUI/AppKit view, layout, `@Observable`/state,
-  focus, animation, or rendering work (this whole `ContentView`/window-chrome/overlay surface);
-  `swift-testing-expert` for writing or modernizing Swift tests; `swift-concurrency` for actor / `@MainActor`
-  / `Sendable` / async work (esp. across the C-callback boundary).
-  Don't wait for a failure to reach for them.
-- **"Show me" / "show it" for a UI feature = BUILD + RUN the app for the user to look at,
-  NOT a screenshot.** When the user asks to see a visual change, `make build` then launch an ISOLATED
-  dev instance (`open -n --env AGTERM_STATE_DIR=<tmp> --env AGTERM_CONTROL_SOCKET=<tmp>/agterm.sock build/DerivedData/.../Debug/agterm.app`)
-  so it coexists with the deployed daily-driver and never touches the real `workspaces.json` — then leave
-  it running and tell the user how to reach the feature.
-  Do NOT take a screenshot (`screencapture`) or capture an image via XCUITest (`XCUIScreen.screenshot`/`XCTAttachment`)
-  — the user wants to interact with the running app themselves.
-  The XCUITest runner is sandboxed and can't write `/tmp` anyway.
-- **Dev instance that must run the user's REAL custom commands / keymap = COPY the config into the
-  isolated state dir; don't rely on `AGTERM_STATE_DIR` alone.**
-  An isolated `AGTERM_STATE_DIR` ALSO redirects the config dir to `<stateDir>/config` (`ConfigPaths`
-  precedence: explicit `AppSettings.configDirectory` → `<stateDir>/config` when the state dir is set →
-  `~/.config/agterm`), so an isolated dev instance does NOT read `~/.config/agterm/keymap.conf` and loses
-  every custom command.
-  Keep them with `cp ~/.config/agterm/{keymap,ghostty,restore-denylist}.conf <stateDir>/config/` before
-  launch — there is NO env var that overrides the config dir independently of the state dir.
-  Two more gotchas: (1) do NOT set an `AGTERM_CONTROL_SOCKET` whose path differs from `<stateDir>/agterm.sock`
-  — a custom command's spawned `agtermctl` derives its socket from the inherited `AGTERM_STATE_DIR`
-  (`<stateDir>/agterm.sock`), so a server bound elsewhere is unreachable; set ONLY `AGTERM_STATE_DIR` (a
-  SHORT `/tmp` path) and let the app + CLI derive the same socket.
-  (2) to make custom commands use the freshly-BUILT `agtermctl` (not the deployed one on PATH), launch with
-  `--env PATH="<devApp>/Contents/MacOS:/opt/homebrew/bin:/usr/bin:/bin:…"` — `CustomCommandRunner` runs
-  `/bin/sh -c` over `ProcessInfo.processInfo.environment`, so the prepended PATH reaches the command; a
-  session shell's login rc re-prioritizes PATH back to the deployed `agtermctl`, so a MANUAL `agtermctl` in
-  a dev session needs the full dev-binary path while keybinding commands resolve the dev binary automatically.
-- **After launching a dev instance for the user to test, default to HANDS-OFF.**
-  For the user's MANUAL test (the common case — "run it for me to test",
-  "I'll test manually"), do NOT touch the running instance after launch:
-  no `agtermctl` calls, no `session status` pokes, no state changes — poking it mid-test corrupts what
-  the user is observing.
-  For an ASSISTED experiment (you drive part of it — e.g. set a session's status via `agtermctl` so the
-  user can then act on it), acting is fine, but ANNOUNCE each action as you do it so the user can follow
-  and help.
-  When in doubt, treat it as manual and ask before touching.
-- **Non-trivial work goes in an ISOLATED git worktree, cleaned up after merge.**
-  See the worktree rule under "Build and test commands" for the mandate, the artifact-symlink setup a
-  fresh worktree needs, and the post-merge cleanup (which must never switch the main checkout's branch).
-- **Comments and docs are a liability, not a deliverable — keep them SHORT.**
-  A comment earns its place only by saying what the code cannot: a non-obvious constraint, a rejected
-  alternative, a reason it is not the obvious thing.
-  Never narrate what the code already shows, never state one fact in two places, never write a paragraph
-  where a clause does.
-  25 lines of logic do not need 100 lines of comment; when it looks like they do, the code is wrong.
-  The same holds for `.claude/rules/*.md`, README and the published references: state a contract ONCE in
-  the file that owns it and cross-reference, instead of restating it on every surface.
-  Never narrate a change's own history ("was X, now Y", "this was tried and removed") — describe what the
-  code does now.
-- **Comments in TESTS are RARE.**
-  A test name states the behavior and the body shows the setup, so almost every test comment is a
-  restatement.
-  Write one only when the code is genuinely cryptic — the goal cannot be read off the name and the setup —
-  and then keep it to a single short line.
-  Never comment an assertion with what it asserts, never narrate the arrange/act/expect steps, never
-  explain why a test exists.
-- **Review severity tracks USER-VISIBLE consequence.**
-  critical = data loss or a broken primary path; major = a wrong result or a broken secondary path a user
-  will hit; minor = everything else.
-  **A comment, godoc or documentation inaccuracy is NEVER critical or major** — it cannot break anything
-  at runtime.
-  This binds when reviewing, and when writing a review scope or configuring a reviewer.
-  A review round that comes back mostly documentation findings means the code is done and the prose is
-  overgrown: cut the prose, do not write more of it.
+- For nonstandard or risky UI requests, first explain the AppKit/SwiftUI cost and offer the standard
+  alternative. Proceed if the user still prefers the custom behavior.
+- For every new capability, propose useful control API/CLI coverage: protocol command and arguments,
+  dispatch, `agtermctl`, read-back, and tests. Control-native features count; skip only chrome with nothing
+  meaningful to drive.
+- For each hideable titlebar/sidebar element, ask whether it should join host-free `InterfaceElement` and
+  Settings > Interface. Never add that preference without approval.
+- Start Swift work with the relevant skills: `swiftui-expert` for UI/AppKit/Observation/rendering,
+  `swift-testing-expert` for tests, and `swift-concurrency` for actors, Sendable, async, and C callbacks.
+- “Show me” means build and launch a separate interactive Debug instance, not a screenshot. Use isolated
+  state and socket paths, leave it running, and explain how to reach the feature.
+- An isolated state dir also redirects config to `<stateDir>/config`. Copy
+  `keymap.conf`, `ghostty.conf`, and `restore-denylist.conf` when real custom behavior is required.
+  Set only a short `/tmp` `AGTERM_STATE_DIR` so app and inherited CLI derive the same socket.
+  Prepend the Debug app's `Contents/MacOS` to PATH for custom commands; login shells may restore the
+  deployed CLI, so manual commands should use the Debug binary's full path.
+- After launching an instance for manual testing, do not touch it. For an assisted experiment, announce
+  every action. Ask before acting when unclear.
+- Put nontrivial work in an isolated worktree and remove it after merge. See the build section for artifact
+  links and cleanup.
+- Comments and docs are liabilities kept short. Keep only non-obvious constraints, rejected alternatives,
+  or reasons the obvious implementation fails. Never narrate code, repeat a fact across surfaces, use a
+  paragraph where a clause works, or preserve change history. Own each contract once and cross-reference it.
+  If 25 lines of logic seem to need 100 lines of comment, fix the code.
+- Test comments are rare and one line. Add one only when neither the test name nor setup reveals the goal.
+  Never label arrange/act/assert, restate an assertion, or explain why a test exists.
+- Review severity follows user-visible consequences: critical for data loss or broken primary paths, major
+  for wrong results or broken secondary paths, minor otherwise. Documentation inaccuracies are never
+  critical or major. Documentation-heavy review findings usually call for less prose.
 
-## Toolchain
+## Toolchain and gates
 
-- The app target is generated with `xcodegen` and built with `xcodebuild` (Xcode 26).
-  `mise` is not used; call `xcodegen`, `xcodebuild`, and `swift` directly through the scripts.
-- The `agtermCore` package is built and tested with `swift test` (Swift 6,
-  strict concurrency `complete`).
-  It is independent of Xcode and libghostty.
-- `scripts/setup.sh` builds libghostty from upstream ghostty source, so it needs `git`,
-  Homebrew (for the `zig@0.15` keg = zig 0.15.2, what ghostty pins), and Xcode's Metal Toolchain (auto-downloaded
-  on first run via `xcodebuild -downloadComponent MetalToolchain`).
-  The build is one-time — cached by the present-check — so day-to-day work pays nothing.
+- Xcodegen creates the app project; Xcode 26 builds it. Call `xcodegen`, `xcodebuild`, and `swift`
+  directly through repository scripts; `mise` is unused.
+- Swift 6 `agtermCore` uses complete concurrency checking and has no Xcode/libghostty dependency.
+- `scripts/setup.sh` builds pinned libghostty with Homebrew zig 0.15.2 and Xcode's Metal Toolchain.
+  It is idempotent after artifacts exist.
+- Commands:
+  - `scripts/run.sh`: setup, generate, Debug build, launch.
+  - `scripts/build.sh`: setup, generate, Release build.
+  - `cd agtermCore && swift test`: host-free tests; `scripts/test.sh` wraps it.
+  - `scripts/test-app.sh`: isolated hosted AppKit tests.
+  - `make prep|build|run|release|deploy|test|test-app|lint|clean`; `make dist VERSION=x.y.z [PUBLISH=1]`.
+- `make lint` runs strict SwiftLint from the root. Root limits are 200-column lines, 1000-line source
+  files, and 800-line types; test configs raise file/type limits to 2000 and inherit all other rules.
+  Disabled/tuned rules reflect deliberate conventions. Zero findings are required.
+- Every change must build, pass `swift test`, `make test-app`, and `make lint`.
+- For maintainer work, ask before splitting a touched long file and do not raise limits reflexively.
+  Contributors need not refactor preexisting length; mention it without blocking or suggesting a limit bump.
 
-## Build and test commands
+## Worktrees and local builds
 
-- `scripts/setup.sh` — build `GhosttyKit.xcframework` and the ghostty resources from upstream ghostty
-  source (pinned SHA, zig 0.15.2).
-  Idempotent; skips the build if both are already present.
-  First run takes a few minutes plus a one-time Metal Toolchain download.
-- `scripts/run.sh` — setup, `xcodegen generate`, `xcodebuild` Debug, then launch.
-- `scripts/build.sh` — same but Release, no launch.
-- `cd agtermCore && swift test` — run the host-free unit tests (`scripts/test.sh` wraps this).
-- `scripts/test-app.sh` — run the application-hosted AppKit unit tests with the isolated `agtermTests` scheme.
-- `Makefile` — a thin front door over the scripts: `make prep`/`build` (Debug,
-  no launch)/`run`/`release`/`deploy` (Release build + copy to `~/Applications`)/`test`/`test-app`/`lint`/`dist VERSION=x.y.z [PUBLISH=1]`
-  (the `release.sh` DMG)/`clean`; a bare `make` lists them.
-  The scripts stay the source of truth — only `build`, `deploy`, and `lint` carry their own recipe.
-- `make lint` runs `swiftlint lint --strict` over the tree, configured by `.swiftlint.yml` at the repo
-  root.
-  The config disables only rules that fight deliberate conventions (`identifier_name`,
-  `trailing_comma`, `force_try`, `optional_data_string_conversion` — the last keeps the lossy `String(decoding:as:)`
-  for terminal/process bytes), exempts the deliberately-named `agtermApp`/`Go` types,
-  tunes `line_length` (200) and `cyclomatic_complexity` (`ignores_case_statements`,
-  so the flat 44-arm command dispatch isn't "complex"), allows 2-deep type nesting,
-  and caps source files at 1000 lines / 800-line type bodies.
-  Test files get a 2000-line budget via nested `.swiftlint.yml` configs in `agtermCore/Tests/`,
-  `agtermTests/`, and `agtermUITests/`.
-  Those configs override only `file_length`/`type_body_length` and inherit everything else from the root.
-  `--strict` promotes warnings to failures, so the tree must stay swiftlint-clean (zero findings).
+- Fetch `origin master` before creating a native Claude worktree so it forks the current remote tip.
+  Do not manually `git worktree add`.
+- Fresh worktrees lack ignored `GhosttyKit.xcframework` and
+  `agterm/Resources/{ghostty,terminfo}`. Symlink all three from the main checkout instead of rebuilding;
+  use absolute targets for resources. They remain untracked and disappear with worktree removal.
+- After merge, verify the PR merge commit on fetched `origin/master`, then remove the worktree without
+  changing the main checkout's branch. Squash/rebase makes removal report unmerged commits; after
+  verification, discard the worktree safely. Native removal may leave a renamed branch, which must be
+  deleted separately after checking the remote.
+- Debug Swift code lives in `agterm.debug.dylib`; inspect it or object files, not the stub executable.
+- For throwaway launch-time probes, append to a temp file. `NSLog` from `open -n` is unreliable; production
+  logging uses `os.Logger`.
+- `scripts/run.sh` activates an existing instance instead of loading a rebuild. Use a distinct isolated
+  launch for current code.
+- `make deploy` copies Release to `~/Applications`, whose app, PATH CLI, and installed hooks shadow Debug.
+  Test fresh CLI/hooks with the Debug binary or redeploy and reinstall them. Debug uses
+  `com.umputun.agterm.debug`, distinct from Release, but state/socket paths still require isolation.
 
-The app must build, `swift test` and `make test-app` must stay green, and `make lint` must pass after every change.
+## Protect the live terminal
 
-- **Manage file sizes for real — source files stay under 1000 lines, tests under a hard 2000 (= 2×).**
-  In OUR OWN work: when you touch a long file, PROPOSE splitting/relocating it toward that rather than
-  growing it further — but ALWAYS ask the user first, never restructure a file unprompted; and don't
-  reflexively bump the swiftlint `file_length`/`type_body_length` limits to fit new code.
-  For a CONTRIBUTOR's PR: do NOT force this — a contributor shouldn't have to refactor a pre-existing long
-  file to land their change; NOTIFY that a file is getting long and SUGGEST keeping it under 1000, but
-  never make them address the line count or block the PR on it.
-  And when REVIEWING a contributor's PR, never suggest the contributor RAISE a `file_length`/`type_body_length`
-  (or any lint) limit to fit their change — bumping a size limit is a maintainer decision,
-  so at most note the file is getting long, never offer the limit bump as the fix.
+- Never run a mutating `agtermctl` command on the default socket. It controls the user's live deployed
+  terminal. Read-only `tree` and `window list` are tolerable; writes require explicit isolated socket.
+  Never execute bundled recipes against the default instance.
+- Every delegated agent that might touch the app or CLI must receive verbatim:
+  “never execute `agterm`/`agtermctl` against the default socket, never launch or quit the app, static
+  reading only.”
+- Never kill or relaunch `~/Applications/agterm.app`, and never `pkill agterm` or `osascript … to quit`
+  (both also reach dev instances). Deployment replaces files but the user decides when to restart.
+- Manual Debug UI work uses a separate `open -n` instance with isolated state and short socket. Address
+  its CLI with `--socket` after the subcommand. Stop only its known PID with SIGTERM; clean quit triggers
+  the visible quit-confirmation alert. Use clean quit only when testing its final cwd/running-command flush.
+- Unix socket paths cap near 104 bytes. A long scratch path lets the app launch while control bind fails.
+- Use absolute repo-root paths for existence checks. Tool cwd persists across calls and often drifts into
+  `agtermCore`.
+- CI and release mechanics live in `.claude/rules/ci.md` and `release.md`. `CHANGELOG.md` is release-only;
+  feature PRs update relevant product, skill, or engineering docs instead.
 
-- **Feature development and any non-trivial fix/change SHOULD go through an ISOLATED git worktree,
-  cleaned up after merge.**
-  A trivial one-file edit can stay on the main checkout; anything larger gets its own worktree so a
-  build/test/dev-launch iteration never disturbs the deployed daily driver or the main checkout's branch.
-  Create it with Claude Code's NATIVE support ("work in a worktree" runs `EnterWorktree`, or
-  `claude --worktree <name>`), never a manual `git worktree add` (global rule), then do the artifact
-  SYMLINK setup in the next bullet BEFORE building (a fresh worktree lacks the gitignored
-  `GhosttyKit.xcframework` / `agterm/Resources/{ghostty,terminfo}`).
-  **Before creating the worktree, `git fetch origin master` so it forks the CURRENT remote tip, not a
-  stale local `origin/master`.**
-  `EnterWorktree`'s `fresh` base is the LOCAL `origin/master` ref, which goes stale when the remote
-  advances during a long session; forking from a stale base means the PR conflicts at merge time against
-  whatever landed meanwhile (this bit once — a worktree forked 5 commits behind and had to
-  rebase-and-resolve against a merged PR that touched the same `session.new` command).
-  AFTER the PR merges, remove the worktree (`git worktree remove --force <wt>`, or `ExitWorktree`),
-  which drops the worktree + its symlinks without touching the main repo's artifacts.
-  Cleanup must NEVER switch the main checkout's branch (the user may be working there in another window),
-  and `gh pr merge --delete-branch` run FROM the worktree switches it, so merge / branch-delete from the
-  main checkout, not the worktree.
-  **A squash (or rebase) merge makes `ExitWorktree` `remove` (and a manual `git worktree remove`) REFUSE
-  with "N commits will be discarded permanently"** — git can't recognize the worktree branch as merged,
-  because the squash rewrote its commits into one new commit on `master`.
-  This is the SAME snag every worktree cleanup after a squash merge; it is expected, not a failure.
-  Once you have VERIFIED the squash landed on `origin/master` (its tip is the PR's merge commit — check
-  with `gh pr view <n> --json state,mergeCommit` + `git fetch origin master`), re-invoke `ExitWorktree`
-  with `discard_changes: true`: the branch work is safe inside the squash, so discarding the loose commits
-  loses nothing.
-  Second gotcha: `ExitWorktree`'s message and its `remove` reference the ORIGINAL branch name
-  (`worktree-<name>`) even after you renamed the branch to `<name>`, so the renamed local `<name>` branch
-  SURVIVES the worktree removal and must be deleted separately with `git branch -D <name>` from the main
-  checkout (and GitHub's auto-delete-head-branch may already have removed the remote one — confirm with
-  `git ls-remote --heads origin <name>` before any `git push origin --delete`).
-- **Working in a git WORKTREE: SYMLINK the prebuilt artifacts, don't re-run setup.** A fresh `git worktree`
-  does NOT contain the gitignored `GhosttyKit.xcframework`, `agterm/Resources/ghostty`,
-  or `agterm/Resources/terminfo` (they're build outputs, never committed).
-  Running `scripts/setup.sh` there would REBUILD libghostty from upstream (a few minutes + the Metal
-  Toolchain).
-  Instead symlink all three from the main worktree, then `setup.sh`'s present-check skips the rebuild
-  (prints `GhosttyKit and resources already present`): `ln -s <main>/GhosttyKit.xcframework GhosttyKit.xcframework`
-  and `ln -s <main>/agterm/Resources/{ghostty,terminfo}` into the worktree's `agterm/Resources/`.
-  **Use ABSOLUTE targets for the two Resources symlinks** — the relative depth from `<wt>/agterm/Resources/`
-  is easy to miscount (`../../` lands inside the worktree, not the sibling).
-  The symlinks show as untracked (`??`) in the worktree and never need committing;
-  `git worktree remove --force <wt>` removes the worktree + its symlinks WITHOUT touching the symlink
-  targets in the main repo.
-  Build with the same `xcodegen generate` + `xcodebuild … -derivedDataPath build/DerivedData` as usual.
-- **Debug build code lives in `agterm.debug.dylib`, NOT the main `agterm` executable.** Xcode Debug builds
-  emit the Swift code (and its string literals) into a sibling `…/Contents/MacOS/agterm.debug.dylib`;
-  the main `agterm` binary is a thin stub.
-  So to verify that an edit/instrumentation actually compiled into the running app,
-  `grep -a` the **dylib** (or the per-file `…/Objects-normal/arm64/<File>.o`),
-  not the main executable — grepping `agterm` for a string you added will falsely come back empty.
-- **For launch-time value capture, write to a temp FILE, not `NSLog`.**
-  `NSLog` from a dev build launched via `open -n` does NOT reliably reach the unified log (`log show`
-  showed only the `log show` command's own echoes, never the app's lines,
-  even with the string confirmed present in the dylib and a window on screen).
-  A tiny file appender (`FileHandle` append to `/tmp/<tag>.log`) is bulletproof and independent of unified-log
-  capture — the reliable way to read what a value resolved to at `init` / first view render.
-  (`os.Logger` with a subsystem is the production channel; this is just for throwaway investigation.)
-- **`run.sh` re-activates a stale instance.**
-  `scripts/run.sh` ends in `open agterm.app` with no kill, so if an instance is already running macOS
-  just brings it to front — the freshly built binary is NOT loaded.
-  To actually test a rebuild, fully quit the running app first (then `open`,
-  or launch `…/Debug/agterm.app` directly / `open -n`); otherwise visual verification runs against the
-  old build and a real fix looks like it failed.
-- **A `make deploy`'d copy in `~/Applications` SHADOWS the dev build — for the CLI,
-  the hooks, AND the app.** This machine has agterm installed via `make deploy` (Release → `~/Applications/agterm.app`),
-  and the Help-menu installers run off that copy point `/usr/local/bin/agtermctl` and the agent-status
-  hooks' baked `AGTERMCTL` (in `~/.config/agterm/agent-status/agterm-agent-status.sh`) at it.
-  So once deployed, a bare `agtermctl …` on PATH, the agent-status hooks,
-  AND a plain launch/activate (LaunchServices resolves `com.umputun.agterm` to `~/Applications`) all
-  hit the DEPLOYED build — NOT whatever you just rebuilt into `build/DerivedData`.
-  When iterating on `agtermctl` or the hook scripts, the change is therefore NOT exercised by the PATH
-  CLI / the hooks until you either (a) invoke the fresh binary by full path — `build/DerivedData/Build/Products/Debug/agterm.app/Contents/MacOS/agtermctl …`
-  (or `export AGTERMCTL=` to it for the hooks), or (b) `make deploy` again and re-run Help ▸ Install
-  Command Line Tool… + Install Agent Status Hooks… to re-point PATH and the hooks at the new build.
-  For APP-code changes, do NOT quit the deployed app (see the next note — it is the user's live daily
-  driver); Debug builds carry a DISTINCT bundle id (`com.umputun.agterm.debug`,
-  project.yml per-config) so they run as a SEPARATE instance alongside the deployed Release.
-  The XCUITests no longer collide either: the `.debug` bundle id means XCUITest's launch-time terminate
-  hits only the `.debug` instance, not the deployed `com.umputun.agterm`,
-  and they still use an isolated `AGTERM_STATE_DIR`/socket.
-- **NEVER run a MUTATING `agtermctl` command against the DEFAULT socket — that socket is the user's LIVE
-  daily driver.**
-  The kill/relaunch ban below is only part of the rule: a bare `agtermctl window move|resize|minimize|new`,
-  `session new|close|type`, `workspace …` reaches the DEPLOYED app, because `agtermctl` on PATH is the
-  deployed copy and its socket auto-resolves to `~/Library/Application Support/agterm/agterm.sock`.
-  This has already cost real damage: a review subagent "checked" the bundled `skills/agterm/examples.md`
-  window-stacking recipe by RUNNING it and restacked all four of the user's live windows onto one frame.
-  Read-only probes (`tree`, `window list`) are tolerable; anything that WRITES must target an isolated
-  instance with an explicit `--socket <tmp>/agterm.sock`.
-  **Never "test" a bundled recipe or doc example by executing it** — read it statically, or run it against
-  an isolated instance.
-- **Every DISPATCHED SUBAGENT must carry that constraint VERBATIM in its prompt.**
-  A subagent inherits the same PATH and socket default, so it reaches the daily driver exactly as easily as
-  you do, and it never reads this file unless told to.
-  Any agent prompt that could plausibly lead to running the app or its CLI must state: never execute
-  `agterm`/`agtermctl` against the default socket, never launch or quit the app, static reading only.
-- **NEVER kill or relaunch the deployed `~/Applications/agterm.app` — it is the user's REAL,
-  in-use daily terminal with LIVE sessions.** BANNED: `pkill agterm` / `pkill -x agterm`,
-  `osascript -e 'tell application "agterm" to quit'`, and ANY quit-then-relaunch of the deployed app
-  (including the quit+`open` after `make deploy`).
-  After `make deploy` the Release build is COPIED into `~/Applications`,
-  but the RUNNING instance keeps the old code until the USER relaunches it on their own schedule (so
-  their live sessions survive) — just report it's installed; do NOT relaunch it.
-  For dev-build UI acceptance / socket probes, open a SEPARATE ISOLATED instance that coexists with the
-  deployed app: `open -n --env AGTERM_STATE_DIR=<tmp> --env AGTERM_CONTROL_SOCKET=<tmp>/agterm.sock build/DerivedData/Build/Products/Debug/agterm.app`
-  (verified: launches a second instance with the deployed app untouched and its socket not stolen).
-  Probe via the temp socket (`agtermctl tree --socket <tmp>/agterm.sock` — `--socket` is a per-subcommand
-  option, so it goes AFTER the subcommand, never before it) and quit ONLY that instance BY PID (`kill <pid>`,
-  never `pkill`).
-  **Use `kill <pid>` (SIGTERM), NOT a clean quit (`osascript … to quit` / ⌘Q), to tear down a dev instance
-  mid-experiment — a clean quit pops the "Quit Agterm?" confirmation modal on the USER's screen and
-  interrupts them.**
-  `AppDelegate.applicationShouldTerminate` shows that alert whenever a window is open (skipped only under
-  XCUITest or with nothing open), and `osascript … to quit` routes through it exactly like ⌘Q;
-  `kill <pid>` bypasses `applicationShouldTerminate`, so no dialog.
-  For a RESTORE test this loses nothing: the session tree is persisted INCREMENTALLY (`windows/<id>.json` is
-  written on session creation, BEFORE any quit), so a SIGTERM-killed instance still restores its sessions on
-  relaunch — the clean-quit flush (`applicationWillTerminate` → `library.saveAllOpen`) only adds
-  cwd-changes-since-the-last-structural-mutation and restore-running-command capture.
-  Do a clean quit ONLY when the experiment specifically needs that final flush.
-  The Debug bundle id (`com.umputun.agterm.debug`) makes the dev/test build a distinct LaunchServices
-  identity from the deployed `com.umputun.agterm`, which is what lets XCUITest (it terminates the app-under-test's
-  bundle-id instance on launch) run WITHOUT killing the deployed app — verified,
-  the e2e leaves it alive.
-  But state + socket are PATH-based (NOT bundle-id-derived, both default to `~/Library/Application Support/agterm/`),
-  so the `AGTERM_STATE_DIR`/`AGTERM_CONTROL_SOCKET` env overrides are STILL required for a manual dev
-  launch even with the distinct id — otherwise the dev instance reads/writes the user's real `workspaces.json`
-  AND steals the deployed app's socket (its `start()` unlinks-then-binds the default path).
-  **The socket override must be a SHORT path** (unix sockets cap the path at ~104 bytes):
-  a long temp dir (e.g. a Claude session scratchpad) fails with `socket path too long` and the control
-  server never binds, while the app itself launches fine — so keep the state dir wherever,
-  but point the socket at something like `/tmp/<name>.sock`.
-- **Anchor path/existence checks at an ABSOLUTE repo-root path — the Bash cwd DRIFTS.** The shell working
-  directory persists across tool calls and silently drifts (e.g. a `cd agtermCore` for `swift test` leaves
-  you there), so a later relative `find .github`/`ls`/`cd` runs from the WRONG place and returns a FALSE
-  negative.
-  NEVER assert "file/dir X doesn't exist" from a relative `find`/`ls` — confirm with an absolute path
-  (`/Users/umputun/dev.umputun/agterm/...`) or `git -C <root> ls-files`,
-  especially before claiming infra facts (CI presence, config files).
-  The repo root vs the `agtermCore` SwiftPM subpackage makes root-vs-subdir confusion easy;
-  verify the directory, don't trust a negative relative result.
-- **CI and release mechanics live in path-scoped rules** — `.claude/rules/ci.md` (scoped to
-  `.github/workflows/**`) for the `ci.yml` job graph (`test` → `coverage` uploading to Coveralls on Linux,
-  the `SF:`-path rewrite, `lint`, `build`), and `.claude/rules/release.md` (scoped to `scripts/release.sh`)
-  for the LOCAL, maintainer-only sign/notarize/staple + Homebrew-cask flow (there is NO `release.yml` —
-  release is NOT CI).
-  Read the matching rule before touching CI or the release script.
-  One guardrail stays in this root file because it binds during FEATURE work, when no CI/release file is
-  open to trigger those rules:
-  **`CHANGELOG.md` is RELEASE-ONLY — never touch it in a feature PR.**
-  It is written only at release time (the `docs: update changelog for vX.Y.Z` commit / the release flow).
-  A feature's own doc updates go to `README.md`, the bundled `plugins/agterm/skills/agterm/`,
-  and the relevant `.claude/rules/*.md` note — not the changelog.
+## GhosttyKit
 
-## GhosttyKit.xcframework
+- `scripts/setup.sh` builds upstream `ghostty-org/ghostty` at `GHOSTTY_REV` using
+  `zig build -Demit-xcframework=true -Dxcframework-target=native`. No fork or disposable daily build is used.
+- The pin stays at or before `4dcb09ada` (2026-04-30) because later renderer builds blank scrollback on
+  font-size increase; decrease works and no app-side fix exists. Re-test increase before advancing.
+- Setup stages the xcframework and `zig-out/share/{ghostty,terminfo}`. All are ignored build artifacts.
+- Link the xcframework with `embed: false`; embedding breaks non-Developer-ID signatures.
 
-- Source: **built from upstream `ghostty-org/ghostty` source** by `scripts/setup.sh`,
-  pinned to the `GHOSTTY_REV` SHA (`zig build -Demit-xcframework=true -Dxcframework-target=native …`
-  with zig 0.15.2).
-  Self-owned: the only inputs are upstream ghostty at a pinned commit and the zig/Metal toolchains —
-  no third-party fork, no daily-build release that can be pruned.
-  Bump `GHOSTTY_REV` deliberately when adopting a newer libghostty.
-- **The pin is a pre-regression commit on purpose.**
-  A libghostty `main` renderer regression introduced after `4dcb09ada` (2026-04-30) blanks the scrollback
-  on a font-size *increase* (decrease is fine); it is NOT an agterm bug and no app-side change fixes
-  it.
-  Every thdxg/ghostty daily build (which agterm used to download) has it.
-  Re-test the font-increase case before bumping past it.
-- `setup.sh` stages the freshly-built `macos/GhosttyKit.xcframework` plus `zig-out/share/{ghostty,terminfo}`
-  resources.
-  The xcframework, `agterm/Resources/ghostty`, and `agterm/Resources/terminfo` are gitignored and never
-  committed.
-- The xcframework is linked with `embed: false` in `project.yml`.
-  Never embed it; embedding breaks the signature on non-Developer-ID builds.
+## Module and callback boundaries
 
-## Module boundary
+- `agtermCore` imports no GhosttyKit, AppKit, Metal, or CoreGraphics. Use Double-backed geometry and
+  convert in the app target. Darwin Foundation can expose CG types that pass Debug/tests but crash Xcode
+  26.5 Release WMO deserialization with an unresolved CoreFoundation cross-reference.
+- Put model, persistence, parsing, validation, routing, response shaping, and static catalogs in
+  `agtermCore`; keep the app target a side-effect adapter, continuing the #78 hoist series. Control uses `ControlDispatcher` plus
+  `ControlActions`, with unmigrated commands returning nil to the app switch. Installers, status sound,
+  and watermark follow the same split.
+- `GhosttyCallbacks` is `@unchecked Sendable`, not `@MainActor`. C closures capture nothing and reach
+  `GhosttyApp.shared`. Copy `char*` before hopping; every main-actor touch uses
+  `DispatchQueue.main.async`.
+- Rendering is demand-driven. Wakeup coalesces through an `OSAllocatedUnfairLock` into one main-queue
+  `ghostty_app_tick`; RENDER calls `renderNow`. Never restore the rejected continuous 120Hz poll or use
+  `assumeIsolated`.
+- `close_surface_cb` only recovers the view and dispatches; it never frees synchronously.
 
-- `agtermCore` must not import GhosttyKit, AppKit, or Metal.
-  Keeping it host-free is what lets `swift test` run with no app host.
-  Model, persistence, and naming logic go here; the surface contract is the `TerminalSurface` protocol,
-  which the app target's `GhosttySurfaceView` conforms to.
-- The app target owns all SwiftUI and libghostty code.
-- **Also keep `agtermCore` CoreGraphics-free — no `CGSize`/`CGPoint`/`CGRect`/`CGFloat`.** They're Foundation-reachable
-  on Darwin and compile + `swift test` fine, but a CoreGraphics member reference (e.g. `CGSize.width`)
-  in a Foundation-only module serializes as an unresolvable cross-reference that crashes the app target's
-  **release** whole-module-optimizer SIL deserializer (`*** DESERIALIZATION FAILURE *** Cross-reference to module 'CoreFoundation'`,
-  Xcode 26.5) — so it passes Debug + tests but breaks `make release`/`make deploy`.
-  Use plain `Double`-backed structs in `agtermCore` (see `WindowGeometry.Size`/`Point`/`Rect`) and convert
-  to/from CG at the app-target call site.
-  Treat CoreGraphics geometry types as if they were on the banned list above.
-- **Hoist host-free logic DOWN into `agtermCore`; keep the app target a thin side-effect adapter.**
-  The sustained refactor direction (the `refactor`/`hoist` PR series, #78 onward) moves command validation,
-  argument parsing, dispatch routing, response shaping, and static catalogs OUT of the app target INTO
-  `agtermCore`, so `swift test` exercises them with no app host.
-  For the control channel this is the `ControlDispatcher` + `ControlActions` seam
-  (`agtermCore/Sources/agtermCore/ControlDispatcher.swift`): `dispatch(_:)` owns parsing + validation +
-  response shape, and the app-target `ControlServer` conforms to `ControlActions` supplying ONLY target
-  resolution and AppKit/process side effects.
-  Commands are migrated group-by-group; a command the dispatcher doesn't yet own returns `nil` and falls
-  through to `ControlServer`'s existing switch.
-  The same "logic host-free, side effects app-side" split already governs the installers
-  (`CLIInstall`/`AgentHooksInstall`/`SkillInstall`), the status sound (`AgentStatus.effectiveSound`), and
-  the watermark (`WatermarkConfig`).
-  When adding a feature, ask which parts are host-free and put those in `agtermCore` by default — see the
-  dispatcher-first rule in `.claude/rules/control-api.md` for the control-command case.
+## Cross-surface contracts
 
-## C-callback isolation
-
-- `GhosttyCallbacks` is `@unchecked Sendable`, not `@MainActor`.
-  C closures capture nothing and reach Swift via `GhosttyApp.shared`.
-- Copy any `char*` into a Swift `String` before hopping; every `@MainActor` touch goes through `DispatchQueue.main.async`.
-- **Rendering is demand-driven, no poll timer.**
-  `GhosttyCallbacks.wakeup` coalesces libghostty wakeups into one `DispatchQueue.main.async` `ghostty_app_tick`
-  (an `OSAllocatedUnfairLock` flag dedupes the wakeup storm), and `GHOSTTY_ACTION_RENDER` draws the surface
-  via `renderNow()` (`ghostty_surface_draw`).
-  Mirrors Ghostty.app/conterm — an idle terminal does no work (the old 120Hz poll ticked continuously).
-  The C callbacks never use `assumeIsolated`; every `@MainActor` touch hops through `DispatchQueue.main.async`.
-- `close_surface_cb` only recovers the view and dispatches to the main actor;
-  it never frees synchronously.
-
-## Keep-in-sync conventions (HARD)
-
-These cross-subsystem contracts apply when editing ANY feature, not just the files that own them.
-They are restated in detail in the relevant path-scoped rules, but the principle lives here so it is
-always in context:
-
-- **A new user action is not "done" until it is drivable from the control socket.** Any action added
-  to `AppActions`/`AppStore` requires all four: (1) a `Command` case (+ args) in `agtermCore`'s `ControlProtocol`,
-  (2) a dispatch arm in `ControlServer`, (3) an `agtermctl` subcommand, (4) protocol round-trip + end-to-end
-  tests.
-  The toolbar/bottom-bar, the menu bar, and the control channel are three callers of the SAME `AppActions`/`AppStore`
-  seam and must never drift.
-  (The Working-norms bullet above generalizes this to control-native features with no GUI surface.) Genuinely
-  meaningless exposure (pure visual chrome with nothing to drive — quit-confirm,
-  CLI/skill installers, click-routing `reveal`) is the only exemption, and must be called out as such.
-- **A command that WRITES or sets session state owes a matching READ-BACK on the `tree` node.**
-  The four-point audit above covers only the WRITE path.
-  A command that mutates or sets per-session state must ALSO surface that state on `ControlSessionNode`
-  (or the tree top-level), so a script can query what it just changed: record-then-restore,
-  read-modify-write, and idempotency checks all need the read leg.
-  Every state-mutating command pairs with a read field:
-  `session.background`/`background`, `notify`+`session.seen`/`unseen`,
-  `session.status`/`status`+`statusPane` (+`statusBlink`/`statusColor`/`statusShape` for
-  `--blink`/`--color`/`--shape`),
-  `session.flag`/`flagged`, `session.focus`/`splitFocused`, `session.resize`/`splitRatio`,
-  `session.overlay.resize`/`overlaySizePercent`, `sidebar`/`sidebarVisible`, `sidebar.mode`/`sidebarMode`,
-  `workspace.focus`/`focused`, `quick`/`quickVisible`,
-  `window.move`+`window.resize`/`geometry`, `window.fullscreen`+`window.zoom`/`fullscreen`+`zoomed`,
-  `window.minimize`/`minimized`.
-  When adding a state-mutating command, ask "how does a script read back what I just set?" and add that
-  field in the SAME change.
-  `session.overlay.resize` shipped write-only and the `overlaySizePercent` read-back was missed until a
-  tmux-zoom script needed record-then-restore, so it went in as a separate follow-up.
-- **An argument whose value rides a control EVENT owes the CLI's human line too, not just the payload
-  field.**
-  When you audit the legs of a per-call argument, count `EventFormatter.human`
-  (`agtermctlKit/EventCommands.swift`) as one of them: a value added to `ControlEventPayload` with no
-  matching arm there is silently dropped from `agtermctl events` in its default, non-`--json` mode, so
-  the human reader of the stream cannot explain a change the payload does describe.
-  `session.status --shape` was tracked as five legs and turned out to have six — the formatter was found
-  only during the final acceptance sweep, after every other leg was already in.
-- **The bundled agent skill is the fourth keep-in-sync surface.**
-  Whenever you change the Control API (commands/args/returns), the keymap format,
-  or the window/workspace/session/pane model, update `plugins/agterm/skills/agterm/` (SKILL.md + reference.md
-  + examples.md + troubleshooting.md + scripts, incl. the command count) so the installed agent-driver
-  doc stays accurate.
-  The app-repo `plugins/agterm/skills/agterm/` is the SINGLE source of truth — edit ONLY there.
-  NEVER edit, copy into, or "mirror" the installed copies at `~/.claude/skills/agterm/` or `~/.codex/skills/agterm/`;
-  they are install OUTPUTS that Help ▸ Install Agent Skill (`SkillInstaller`) regenerates from the bundle,
-  so a manual edit there is wrong and must never even be offered (`~/.claude/skills/agterm/` is snapshotted
-  in the dot-files repo, but that does not make it a source).
-- **The website (`site/`) is the fifth keep-in-sync surface.**
-  `site/docs.html` is a hand-authored mirror of `README.md` — when you add features, flags,
-  keybindings, or modes, update both.
-  `site/index.html` (the features grid and install copy) and the `softwareVersion` in its
-  `SoftwareApplication` JSON-LD must reflect major features and the latest release.
-  `site/commands.html` is the per-command `agtermctl` control reference — it documents the FULL
-  control-command catalog, each entry carrying the invocation, arguments, and the `tree` read-back field.
-  It MUST gain, lose, or update an entry for EVERY control-command add/change/remove, in lockstep with
-  the agent skill and `.claude/rules/control-api.md` (a new `Command` case owes a new commands.html entry).
-  See the `## Website` section below for the deploy model.
-- **The cookbook (`cookbook/`) is deliberately NOT a keep-in-sync surface — do not add it as a sixth.**
-  It is full of `agtermctl` invocations, so the reflex on a control-API change is to sweep it like the skill
-  and the site; that reflex is wrong here, and the exemption is a decision, not an oversight.
-  Recipes are pinned snapshots: each one's *Requirements* names the MINIMUM agterm version it needs,
-  and that pin is the contract.
-  A recipe is fixed reactively — when someone reports it broke — and dropped if it stays broken and nobody
-  claims it.
-  So a control-API change carries NO obligation to sweep `cookbook/`, and a PR is not incomplete for
-  leaving it alone.
-  The control API grows by addition, so real breakage is rare, and an honest reactive contract beats a
-  per-feature tax that would quietly stop being paid.
-  The `cookbook` CI job (`.claude/rules/ci.md`) checks layout, index, headings and shell hygiene only;
-  nothing checks a recipe against the current command surface.
+- A new user action is incomplete until protocol, dispatcher, CLI, and protocol/end-to-end tests exist.
+  Toolbar/footer, menu, and control share the same action/store seam. Call out genuine visual-only exemptions.
+- A state-setting command must expose its result on `ControlSessionNode`, window node, or tree top level.
+  Examples include background, unseen, status and overrides, flag, split focus/ratio, overlay size,
+  sidebar state/mode, workspace focus, quick visibility, geometry, fullscreen, zoom, and minimize.
+- Event arguments must appear in `EventFormatter.human`, not only JSON payloads.
+- Control API, keymap, and model changes also update bundled
+  `plugins/agterm/skills/agterm/`, the sole source for installed Claude/Codex copies.
+- `site/docs.html` mirrors README. `site/index.html` reflects major features and current
+  `softwareVersion`; `site/commands.html` mirrors every command, arguments, and read-back field.
+- `cookbook/` is not a synchronized surface. Recipes pin a minimum version and are fixed reactively;
+  its CI checks structure and shell hygiene, not current API parity.
 
 ## Website
 
-`agterm.com` is a hand-authored static site in `site/`, deployed via Cloudflare Pages with no build step
-(the revdiff pattern).
-Cloudflare's Git integration auto-deploys `site/` on every push to `master`; there is no wrangler config
-and no deploy workflow in the repo.
-All Cloudflare wiring — the Pages project, the `agterm.com` custom domain, and the output directory (`site`)
-— lives in the Cloudflare dashboard, not in git, so it is not reproducible from the repo.
-Cloudflare Pages strips `.html` and 308-redirects `/docs.html` to `/docs`, so every canonical link,
-`og:url`, and `sitemap.xml` entry uses the extensionless `https://agterm.com/docs`.
+- `agterm.com` is the static `site/` directory on Cloudflare Pages with no build step or repository deploy
+  config. Dashboard-owned wiring deploys every master push. Canonical URLs omit `.html` because Pages
+  redirects with 308.
+- Assets are self-hosted: CSS, latin woff2 fonts, WebP screenshots, 1200x630 social card, and favicons.
+  Inline page styles come from a design-tool export whose source archive is on the maintainer's Desktop.
+- Hero images must match the fixed `1187 / 696` ratio, about 1.70:1; capture dense dashboards at that
+  ratio before WebP conversion; existing shots are 2374x1392. Dashboard images may floor near 200k versus
+  85-172k for single-window shots. Crossfade duration is slides times 5 seconds, delays advance by
+  5 seconds, and the opaque keyframe plateau is about `1/slides`.
+- Auto-fit feature grids can strand orphan cards. Use a fixed column count, explicit spans, and narrow
+  media fallbacks as in `.surfaces-grid`.
 
-The site is lean and self-contained — nothing is embedded.
-`site/style.css` holds the reset, keyframes, `@font-face`, and the hover classes;
-the two pages keep the design's inline styles.
-Assets are self-hosted under `site/assets/`: latin `woff2` fonts in `site/assets/fonts/`,
-screenshots as `webp`, plus a generated 1200×630 `agterm-og.png` social card and favicons.
-The pages were converted from a design-tool bundle export whose source zip lives on the maintainer's
-Desktop, not in the repo, so a visual redesign means re-exporting the design and re-running that conversion.
+## Path-scoped rules
 
-Two recurring screenshot/layout gotchas when editing the pages.
-The hero carousel (`.hero-gallery` in `site/index.html`) is a FIXED-aspect crop box:
-`aspect-ratio: 1187 / 696` (≈1.70:1) with `object-fit: cover` (`site/style.css`),
-so a screenshot added to it must be captured at ~1.70:1 (existing shots are 2374×1392) or `cover` crops its
-top and bottom.
-A dense multi-pane shot (the dashboard's grid) is taller by nature — resize the agterm window to ~1.70:1
-BEFORE capturing rather than letting the crop eat rows, and expect its `webp` to floor around ~200k
-(vs the 85–172k of single-window shots), so tune `cwebp -q`/`-m 6` for size, not the usual quality.
-Adding a slide also means re-timing the crossfade in `style.css`:
-the loop duration is `slides × 5s`, each image needs its own `nth-child(N)` `animation-delay` on the 5s
-stagger, and the `heroGallery`/`heroGalleryFirst` keyframe plateau (the `opacity: 1` hold) is ≈`1/slides` of
-the cycle — leave the old percentages and adjacent slides double-expose.
+Read the matching `.claude/rules/*.md` before subsystem work, including cross-cutting hub-file changes.
+Keep these notes in semantic lines: one sentence per line, split long clauses near 100 columns, keep code
+spans intact, and format long catalogs as lists.
 
-Feature-card grids that use `repeat(auto-fit, minmax(…))` strand an ORPHAN card on the last row when the
-card count does not divide evenly into the resolved column count (five surface cards rendered 4 + 1, the
-Dashboard card stranded alone).
-For an even row, switch that block to a fixed `grid-template-columns: repeat(N, minmax(0, 1fr))` and give the
-wide/odd item a `grid-column: span M`, with `@media` fallbacks for narrow widths — see `.surfaces-grid`,
-where row 1 holds the four surface cards and row 2 pairs the Dashboard card with the Windows callout spanning
-three columns.
-
-## Subsystem notes (path-scoped rules)
-
-Detailed per-subsystem engineering notes live in `.claude/rules/*.md`, each scoped with `paths:` frontmatter
-so it loads into context only when you read a matching source file — that is what keeps this root file
-lean.
-When starting work on a subsystem, read its rule first: the auto-trigger covers the subsystem-owned files,
-but a cross-cutting edit that touches only a hub file (`AppStore.swift`,
-`ContentView.swift`, `agtermApp.swift`) may not match a glob, so consult this index and open the rule
-yourself.
-
-**When writing or editing these notes — this file and `.claude/rules/*.md` — use semantic line breaks: one sentence per line, never a giant single-line bullet.**
-Break after every sentence (split a long sentence further at clause boundaries, around 100 columns), keep inline-code spans intact, and render any long enumeration (e.g. a command catalog) as a real markdown list rather than one inline run.
-This only changes raw-text line breaks — the rendered markdown is identical — but it keeps a diff scoped to the sentence that changed and stops two branches that edit the same note from conflicting on the whole paragraph.
-
-- `sidebar.md` — `NSOutlineView` sidebar: drag-reorder (sessions + workspaces),
-  flagged working-set view, focus filter, scoped session nav, reconcile signal,
-  persistence.
-  Triggers on `WorkspaceSidebar.swift`, `SidebarDrop`/`SidebarMode`/`Reorder`,
-  and the sidebar/reorder/flagged/focus UI tests.
-- `menu-actions.md` — the `AppActions` seam: View vs Navigate menu split,
-  split panes (one session two shells), session navigation, command palettes,
-  Ctrl-Tab MRU switcher, inline rename, font/in-terminal-search.
-  Triggers on `AppActions.swift`, `agtermApp.swift`, `Palette`/`PaneShortcuts`/`SessionSwitcher`,
-  `RecencyStack`/`Fuzzy`, and the menu/palette/nav/switcher/split UI tests.
-- `windows.md` — multi-window model: `WindowLibrary`, scene + claim-queue restoration,
-  per-window quick terminal, frontmost-store resolution + quit-flush, quit confirmation,
-  `window.*` control.
-  Triggers on `WindowLibrary`/`WindowGeometry`/`QuitPrompt`, `QuickTerminal.swift`,
-  and the multi-window/quick-terminal UI tests.
-- `control-api.md` — the full control-command catalog, the three protocol layers,
-  addressing, and the CLI/hooks/skill installers.
-  Triggers on `ControlServer.swift`, `ControlProtocol`/`ControlResolve`,
-  `agtermctlKit`/`agtermctl`, the three installers + their host-free `*Install` logic,
-  `plugins/agterm/skills/agterm/`, and the control UI tests.
-- `settings.md` — `AppSettings`/`SettingsModel`, the 6-tab Settings scene,
-  ghostty-config emission, window translucency.
-  Triggers on `SettingsModel.swift`, `SettingsView`/`SettingsCatalog`/`WindowAppearance`/`NSColor+AgtermHex`,
-  `AppSettings`/`SettingsStore`, and the settings UI tests.
-- `theme-picker.md` — the live-preview theme palette mode, preview/commit/cancel,
-  the seeded default theme.
-  Triggers on `Palette.swift`, `SettingsModel`/`SettingsCatalog`, `AppActions.swift`.
-- `keymap.md` — the kitty-flavored `keymap.conf` parser, built-in-override resolution,
-  custom-command monitor, `{AGT_X}` tokens, reload + Edit Keymap.
-  Triggers on `Keybind`/`KeybindMatcher`/`Keymap`/`BuiltinAction`/`CustomCommand`/`ConfigPaths`,
-  `CustomCommandRunner.swift`, and the keymap UI tests.
-- `notifications.md` — terminal OSC 9/777 + control `notify`, suppression,
-  click-to-reveal identity, the unseen badge, the agent-status glyph.
-  Triggers on `NotificationManager.swift`, `Notifications`/`AgentStatus`.
-- `ui-tests.md` — XCUITest patterns: `launchForUITest` (FB11763863), Settings-tab retry helper,
-  driving an `NSOutlineView` drag, the occlusion-timeout symptom, test cadence.
-  Triggers on any `agtermUITests/` file.
-- `libghostty.md` — rendering / AppKit gotchas: the eager-deck surface lifecycle,
-  the NSSplitView-titlebar-overrun rule, cursor focus, theme-tracking chrome colors,
-  search-bar / overlay placement, reparent repaint.
-  Triggers on the `Ghostty/` surfaces, `ContentView.swift`, `TerminalView`/`TerminalSearchBar`.
-- `app-icon.md` — the adaptive Icon Composer `.icon` build rules.
-  Triggers on `AppIcon.icon/`, `project.yml`.
-- `ci.md` — the `ci.yml` job graph: the `test`/`coverage`/`lint`/`build` split,
-  coverage → Coveralls-on-Linux with the `SF:`-path rewrite, the paths-filter, and the badge scope.
-  Triggers on `.github/workflows/**`.
-- `release.md` — the LOCAL, maintainer-only `scripts/release.sh` flow:
-  sign/notarize/staple the app + DMG, tag + GitHub release, Homebrew-cask push, the release-time
-  changelog draft-approval.
-  Triggers on `scripts/release.sh`.
+- `sidebar.md`: outline, reorder, flagged/focus views, scoped navigation, reconciliation, persistence.
+- `menu-actions.md`: actions, menus, split panes, navigation, palettes, MRU, rename, search.
+- `windows.md`: window library, restoration, quick terminal, active-store resolution, quit, controls.
+- `control-api.md`: protocol layers, catalog, addressing, CLI/hooks/skill installers.
+- `settings.md`: settings model/UI, Ghostty config emission, translucency.
+- `theme-picker.md`: preview/commit/cancel and seeded default.
+- `keymap.md`: keymap parser, built-ins, custom commands/tokens, reload/edit.
+- `notifications.md`: OSC/control notifications, suppression, reveal, badges, status.
+- `ui-tests.md`: launch isolation including FB11763863, AppKit/XCUITest traps, cadence.
+- `libghostty.md`: surfaces, rendering, AppKit, theme, overlays, cursor.
+- `app-icon.md`: adaptive Icon Composer build.
+- `ci.md`: jobs, filters, coverage, badge.
+- `release.md`: local signing, notarization, release, Homebrew, changelog.

--- a/agterm/AgentHooksInstaller.swift
+++ b/agterm/AgentHooksInstaller.swift
@@ -1,18 +1,17 @@
 import AppKit
 import agtermCore
 
-/// Installs the bundled agent-status hooks package into the user's home: copies the scripts from the
-/// app bundle into `~/.config/agterm/agent-status/`, bakes the bundled `agtermctl`'s absolute path
-/// into the wrapper, appends a marker-guarded `source` line to `~/.zshrc`, `~/.bashrc`, and `~/.config/fish/config.fish`, merges
-/// the four Claude Code hooks into `~/.claude/settings.json`, merges the six Codex lifecycle hooks into
-/// `~/.codex/config.toml`, installs Pi's lifecycle extension into `~/.pi/agent/extensions/` when Pi
-/// is configured, and installs OpenCode's lifecycle plugin into `~/.config/opencode/plugins/` when
-/// OpenCode is configured. Claude/Codex configs write a `.bak` first; the Codex step parses TOML and falls back to
-/// surfacing a manual block when the file already has hooks or does not parse. The host-free string/JSON/
-/// TOML transforms and Pi/OpenCode ownership policy live in `agtermCore.AgentHooksInstall`; this type owns the
-/// AppKit filesystem glue.
-/// Idempotent and re-runnable: re-running refreshes the baked `agtermctl` path (healing a
-/// moved/reinstalled bundle) and is a clean no-op for already-present rc/settings/config entries.
+/// Installs the bundled agent-status hooks package into the user's home: copies the scripts from the app
+/// bundle into `~/.config/agterm/agent-status/`, bakes the bundled `agtermctl`'s absolute path into the
+/// wrapper, appends a marker-guarded `source` line to `~/.zshrc`/`~/.bashrc`/`~/.config/fish/config.fish`,
+/// merges the four Claude Code hooks into `~/.claude/settings.json` and the six Codex lifecycle hooks into
+/// `~/.codex/config.toml`, and — when each is configured — installs Pi's lifecycle extension into
+/// `~/.pi/agent/extensions/` and OpenCode's plugin into `~/.config/opencode/plugins/`. Claude/Codex configs
+/// write a `.bak` first; the Codex step parses TOML and surfaces a manual block instead when the file
+/// already has hooks or does not parse. The host-free string/JSON/TOML transforms and Pi/OpenCode ownership
+/// policy live in `agtermCore.AgentHooksInstall`; this type owns the AppKit filesystem glue. Re-running is
+/// idempotent: it refreshes the baked `agtermctl` path (healing a moved/reinstalled bundle) and is a clean
+/// no-op for already-present rc/settings/config entries.
 @MainActor
 enum AgentHooksInstaller {
     private struct InstallError: Error { let message: String }
@@ -46,8 +45,7 @@ enum AgentHooksInstaller {
         }
     }
 
-    // the Pi extension-install outcome, mirroring CodexResult: installed/alreadyConfigured/noPi are
-    // informational; the warning cases mean agterm could not safely write and left the destination as-is.
+    // the Pi extension-install outcome, mirroring CodexResult.
     private enum PiResult {
         case installed, alreadyConfigured, userOwned, unreadable, writeFailed, noPi
 
@@ -99,9 +97,7 @@ enum AgentHooksInstaller {
         }
     }
 
-    // settingsSkipped is true when the Claude settings merge was SKIPPED because ~/.claude/settings.json
-    // isn't valid JSON or couldn't be read (it is left untouched); codex/pi/opencode report their
-    // respective integration outcomes. Every step still runs regardless.
+    // every step runs regardless of an earlier one's outcome; each reports its own result.
     private static func install() throws -> InstallOutcome {
         try copyBundledFolder()
         try bakeAgtermctlPath()
@@ -113,8 +109,6 @@ enum AgentHooksInstaller {
         return InstallOutcome(settingsSkipped: settingsSkipped, codex: codex, pi: pi, opencode: opencode)
     }
 
-    // copy the bundled agent-status folder into ~/.config/agterm/agent-status, overwriting any prior
-    // install so a re-run is clean.
     private static func copyBundledFolder() throws {
         guard let source = bundledFolder, FileManager.default.fileExists(atPath: source.path) else {
             throw InstallError(message: "The agent-status scripts are not bundled in this build.")
@@ -130,11 +124,10 @@ enum AgentHooksInstaller {
     // and replaces it so the path is refreshed rather than duplicated.
     private static let agtermctlMarker = "# >>> agterm agtermctl path (installer-baked) >>>"
 
-    // bake the bundled agtermctl's absolute path into the installed wrappers so the hooks fire even when
-    // the CLI was never symlinked into PATH. `[ -n "${AGTERMCTL:-}" ] || AGTERMCTL='<path>'` sets it only
-    // when AGTERMCTL is unset, so an explicit env override still wins (resolution order 1 > 2 > PATH); the
-    // path is single-quoted (shellQuote) so spaces / shell metacharacters in the bundle path are inert.
-    // refreshed on every run: any prior baked block is stripped first, healing a moved bundle.
+    // bake the bundled agtermctl's absolute path into the installed wrappers so the hooks fire even when the
+    // CLI was never symlinked into PATH. `[ -n "${AGTERMCTL:-}" ] ||` sets it only when AGTERMCTL is unset,
+    // so an explicit env override still wins (resolution order 1 > 2 > PATH); the path is single-quoted
+    // (shellQuote) so spaces / shell metacharacters in the bundle path are inert.
     private static func bakeAgtermctlPath() throws {
         guard let tool = bundledTool else { return } // no bundled CLI: leave the PATH fallback in place
         for name in [AgentHooksInstall.wrapperName, AgentHooksInstall.codexWrapperName] {
@@ -147,7 +140,6 @@ enum AgentHooksInstaller {
         }
     }
 
-    // remove a previously baked AGTERMCTL block (the marker line plus the assignment line under it).
     private static func stripBakedBlock(from text: String) -> String {
         let lines = text.components(separatedBy: "\n")
         var result: [String] = []
@@ -160,7 +152,6 @@ enum AgentHooksInstaller {
         return result.joined(separator: "\n")
     }
 
-    // insert the baked block right after the shebang (or at the top when there is none).
     private static func insertAfterShebang(_ text: String, block: String) -> String {
         var lines = text.components(separatedBy: "\n")
         let insertAt = lines.first?.hasPrefix("#!") == true ? 1 : 0
@@ -168,11 +159,10 @@ enum AgentHooksInstaller {
         return lines.joined(separator: "\n")
     }
 
-    // write text to a path, PRESERVING an existing symlink: when the path is a symlink (e.g. a
-    // dotfiles-managed `~/.claude/settings.json` or `~/.zshrc`), write atomically to its resolved
-    // target so the symlink and the user's dotfiles stay intact, instead of an atomic rename
-    // replacing the symlink with a standalone regular file. when `posixMode` is non-nil the resolved
-    // target inherits that mode so a restrictive (chmod-600) file isn't widened by the atomic rewrite.
+    // write text to a path, PRESERVING an existing symlink: for a symlink (e.g. a dotfiles-managed
+    // `~/.claude/settings.json` or `~/.zshrc`) write atomically to its resolved target, so the link and the
+    // user's dotfiles stay intact instead of an atomic rename replacing it with a regular file. a non-nil
+    // `posixMode` is applied to the resolved target, so a chmod-600 file isn't widened by the rewrite.
     private static func writePreservingSymlink(_ text: String, to url: URL, posixMode: NSNumber? = nil) throws {
         let target = symlinkTarget(of: url) ?? url
         try AgentHooksInstall.writeFile(text, toPath: target.path, posixMode: posixMode)
@@ -186,10 +176,9 @@ enum AgentHooksInstaller {
         return url.resolvingSymlinksInPath()
     }
 
-    // read an existing config file's contents. Returns nil when the file is ABSENT (a fresh install);
-    // the raw contents when present and readable; and THROWS `UnreadableExisting` when the file EXISTS
-    // but cannot be read (permission / non-UTF8), so callers leave it untouched instead of clobbering it
-    // with no backup — the destructive path that `(try? String(contentsOf:)) ?? ""` silently took.
+    // read an existing config file: nil when ABSENT (a fresh install), the raw contents when readable, and
+    // a thrown `UnreadableExisting` when it EXISTS but cannot be read (permission / non-UTF8) — so callers
+    // leave it untouched instead of clobbering it with no backup, as `(try? String(contentsOf:)) ?? ""` did.
     private struct UnreadableExisting: Error {}
     private static func readExistingConfig(at url: URL) throws -> String? {
         guard FileManager.default.fileExists(atPath: url.path) else { return nil }
@@ -220,15 +209,15 @@ enum AgentHooksInstaller {
         }
         guard merged.changed else { return false }
         try FileManager.default.createDirectory(at: claudeDir, withIntermediateDirectories: true)
-        // resolve the symlink target FIRST (so a dotfiles-managed settings.json link survives) and read
-        // its mode once, so the rewrite AND the .bak inherit the original (possibly chmod-600) mode
-        // instead of an atomic rename widening a secret file to 0644.
+        // resolve the symlink target FIRST (so a dotfiles-managed settings.json link survives) and read its
+        // mode once, so the rewrite AND the .bak inherit the original (possibly chmod-600) mode instead of
+        // an atomic rename widening a secret file to 0644.
         let target = symlinkTarget(of: settings) ?? settings
         let mode = AgentHooksInstall.posixMode(ofFile: target.path)
         if let existing { // back up the prior file before overwriting it, with the source's mode
-            // keep the .bak next to ~/.claude/settings.json (the symlink), NOT next to the resolved
-            // target — a dotfiles-managed link resolves into a git-tracked dir we must not litter; only
-            // the MODE comes from the resolved target.
+            // keep the .bak next to ~/.claude/settings.json (the symlink), NOT the resolved target — a
+            // dotfiles-managed link resolves into a git-tracked dir we must not litter; only the MODE
+            // comes from the resolved target.
             let backup = AgentHooksInstall.backupPath(for: settings.path)
             try AgentHooksInstall.writeFile(existing, toPath: backup, posixMode: mode)
         }
@@ -236,7 +225,8 @@ enum AgentHooksInstaller {
         return false
     }
 
-    // append the marker-guarded source line to ~/.zshrc, ~/.bashrc, and ~/.config/fish/config.fish (idempotent per file).
+    // append the marker-guarded source line to ~/.zshrc, ~/.bashrc and ~/.config/fish/config.fish
+    // (idempotent per file).
     private static func appendShellRC() throws {
         let home = FileManager.default.homeDirectoryForCurrentUser
         for name in [".zshrc", ".bashrc", ".config/fish/config.fish"] {
@@ -253,10 +243,10 @@ enum AgentHooksInstaller {
         }
     }
 
-    // Install Pi's auto-discovered global extension only when Pi has already created ~/.pi/agent. A
-    // same-named, unmarked extension is user-owned and left untouched; an agterm-managed one refreshes
-    // from the newly copied package. Pi has no config merge, and its extension carries no user state, so
-    // unlike Claude/Codex config we do not create a backup for a managed refresh.
+    // install Pi's auto-discovered global extension only when Pi has already created ~/.pi/agent. a
+    // same-named UNMARKED extension is user-owned and left untouched; an agterm-managed one refreshes from
+    // the copied package. no backup, unlike Claude/Codex config: Pi has no config merge and its extension
+    // carries no user state.
     private static func installPiExtension() throws -> PiResult {
         let fm = FileManager.default
         let home = fm.homeDirectoryForCurrentUser
@@ -273,9 +263,9 @@ enum AgentHooksInstaller {
         }
 
         let destination = URL(fileURLWithPath: AgentHooksInstall.piExtensionPath(home: home.path))
-        // read the destination the same way the Claude/Codex merges read their configs: nil = absent,
-        // throw = exists-but-unreadable (folded to .unreadable). Reusing readExistingConfig means a
-        // non-ENOENT stat error can't masquerade as "absent" and slip past the ownership-marker gate.
+        // read the destination like the Claude/Codex merges: nil = absent, throw = exists-but-unreadable
+        // (folded to .unreadable). reusing readExistingConfig stops a non-ENOENT stat error masquerading
+        // as "absent" and slipping past the ownership-marker gate.
         let existing: String?
         do {
             existing = try readExistingConfig(at: destination)
@@ -287,9 +277,8 @@ enum AgentHooksInstaller {
         }
         guard existing != sourceContents else { return .alreadyConfigured }
 
-        // a filesystem error on ~/.pi/agent/extensions degrades to a warning like every sibling
-        // integration, rather than throwing and aborting the whole install (which would hide that the
-        // Claude/Codex/shell steps already ran).
+        // a filesystem error on ~/.pi/agent/extensions degrades to a warning like every sibling integration
+        // rather than aborting the whole install, which would hide that the Claude/Codex/shell steps ran.
         do {
             try fm.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
             let target = symlinkTarget(of: destination) ?? destination
@@ -341,10 +330,10 @@ enum AgentHooksInstaller {
         return .installed
     }
 
-    // merge the Codex lifecycle hooks into ~/.codex/config.toml, writing a .bak first when the merge
-    // changes anything. Gated on ~/.codex existing (like the fish rc gate) so a non-Codex user's home
-    // isn't seeded with a config.toml. The host-free `AgentHooksInstall.mergeCodexConfig` PARSES the file
-    // to decide the outcome; this method only reads/writes and maps the outcome to a `CodexResult`.
+    // merge the Codex lifecycle hooks into ~/.codex/config.toml, writing a .bak first when the merge changes
+    // anything. gated on ~/.codex existing (like the fish rc gate) so a non-Codex home isn't seeded with a
+    // config.toml. the host-free `AgentHooksInstall.mergeCodexConfig` PARSES the file to decide the outcome;
+    // this only reads/writes and maps it to a `CodexResult`.
     private static func mergeCodexConfig() throws -> CodexResult {
         let codexDir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".codex")
         guard FileManager.default.fileExists(atPath: codexDir.path) else { return .noCodex }
@@ -363,8 +352,8 @@ enum AgentHooksInstaller {
         case .unparseable:
             return .unparseable
         case .merged(let contents):
-            // resolve the symlink target FIRST (so a dotfiles-managed config.toml link survives) and read
-            // its mode once, so the rewrite AND the .bak inherit the original mode instead of widening it.
+            // resolve the symlink target FIRST (so a dotfiles-managed config.toml link survives) and read its
+            // mode once, so the rewrite AND the .bak inherit the original mode instead of widening it.
             let target = symlinkTarget(of: config) ?? config
             let mode = AgentHooksInstall.posixMode(ofFile: target.path)
             if let existing, !existing.isEmpty { // back up the prior file before overwriting it
@@ -376,8 +365,8 @@ enum AgentHooksInstaller {
         }
     }
 
-    // the success-alert text. Explains what was left out when the Claude settings merge was skipped, or
-    // when the Codex/Pi/OpenCode integrations could not safely update a user-owned or unreadable file.
+    // the success-alert text: what was left out when the Claude settings merge was skipped, or when the
+    // Codex/Pi/OpenCode integrations could not safely update a user-owned or unreadable file.
     private static func successText(_ outcome: InstallOutcome) -> String {
         let claudeLine = outcome.settingsSkipped
             ? "Your ~/.claude/settings.json isn't valid JSON (or couldn't be read), so the Claude Code hooks were NOT added "

--- a/agterm/AgentHooksInstaller.swift
+++ b/agterm/AgentHooksInstaller.swift
@@ -1,23 +1,22 @@
 import AppKit
 import agtermCore
 
-/// Installs the bundled agent-status hooks package into the user's home: copies the scripts from the app
-/// bundle into `~/.config/agterm/agent-status/`, bakes the bundled `agtermctl`'s absolute path into the
-/// wrapper, appends a marker-guarded `source` line to `~/.zshrc`/`~/.bashrc`/`~/.config/fish/config.fish`,
-/// merges the four Claude Code hooks into `~/.claude/settings.json` and the six Codex lifecycle hooks into
-/// `~/.codex/config.toml`, and — when each is configured — installs Pi's lifecycle extension into
-/// `~/.pi/agent/extensions/` and OpenCode's plugin into `~/.config/opencode/plugins/`. Claude/Codex configs
-/// write a `.bak` first; the Codex step parses TOML and surfaces a manual block instead when the file
-/// already has hooks or does not parse. The host-free string/JSON/TOML transforms and Pi/OpenCode ownership
-/// policy live in `agtermCore.AgentHooksInstall`; this type owns the AppKit filesystem glue. Re-running is
-/// idempotent: it refreshes the baked `agtermctl` path (healing a moved/reinstalled bundle) and is a clean
-/// no-op for already-present rc/settings/config entries.
+/// Installs the bundled agent-status hooks package into the user's home: the scripts into
+/// `~/.config/agterm/agent-status/`, the bundled `agtermctl`'s absolute path baked into the wrapper, a
+/// marker-guarded `source` line in `~/.zshrc`/`~/.bashrc`/`~/.config/fish/config.fish`, the four Claude Code
+/// hooks merged into `~/.claude/settings.json`, the six Codex lifecycle hooks into `~/.codex/config.toml`,
+/// and — when each is configured — Pi's lifecycle extension into `~/.pi/agent/extensions/` and OpenCode's
+/// plugin into `~/.config/opencode/plugins/`. Claude/Codex configs get a `.bak` first; the Codex step parses
+/// TOML and surfaces a manual block instead when that file already has hooks or does not parse. The
+/// host-free string/JSON/TOML transforms and the Pi/OpenCode ownership policy live in
+/// `agtermCore.AgentHooksInstall`; this type owns the AppKit filesystem glue. Idempotent: a re-run refreshes
+/// the baked `agtermctl` path (healing a moved bundle) and no-ops on already-present entries.
 @MainActor
 enum AgentHooksInstaller {
     private struct InstallError: Error { let message: String }
 
-    /// The bundled source folder at `Contents/Resources/agent-status`, or nil when this build skipped
-    /// the resource bundling (e.g. a bare `swift build`).
+    /// The bundled `Contents/Resources/agent-status`, nil when the build skipped bundling (a bare
+    /// `swift build`).
     private static var bundledFolder: URL? {
         Bundle.main.resourceURL?.appendingPathComponent("agent-status")
     }
@@ -25,7 +24,6 @@ enum AgentHooksInstaller {
     /// The bundled `agtermctl` at `Contents/MacOS/agtermctl`, or nil when this build skipped bundling.
     private static var bundledTool: URL? { Bundle.main.url(forAuxiliaryExecutable: CLIInstall.toolName) }
 
-    /// The install destination, `~/.config/agterm/agent-status/`.
     private static var destinationFolder: URL {
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".config/agterm/agent-status")
@@ -35,8 +33,7 @@ enum AgentHooksInstaller {
     private enum CodexResult {
         case merged, alreadyConfigured, hooksExist, unparseable, unreadable, noCodex
 
-        // a warning-level outcome: agterm could not auto-merge and the user must act (add the block by
-        // hand, or fix/inspect their config). merged/already/noCodex are informational.
+        // warning: agterm could not auto-merge and the user must act (add the block by hand, or fix config).
         var isWarning: Bool {
             switch self {
             case .hooksExist, .unparseable, .unreadable: return true
@@ -49,8 +46,7 @@ enum AgentHooksInstaller {
     private enum PiResult {
         case installed, alreadyConfigured, userOwned, unreadable, writeFailed, noPi
 
-        // a warning-level outcome: agterm could not update the extension and the user must act (move the
-        // user-owned file, or fix the unreadable/unwritable path). installed/already/noPi are informational.
+        // warning: the user must act (move the user-owned file, or fix the unreadable/unwritable path).
         var isWarning: Bool {
             switch self {
             case .userOwned, .unreadable, .writeFailed: return true
@@ -71,7 +67,7 @@ enum AgentHooksInstaller {
         }
     }
 
-    // Aggregates per-integration outcomes so `install()` stays under the large_tuple lint (max 3 members).
+    // aggregates per-integration outcomes so `install()` stays under the large_tuple lint (max 3 members).
     private struct InstallOutcome {
         let settingsSkipped: Bool
         let codex: CodexResult
@@ -116,18 +112,16 @@ enum AgentHooksInstaller {
         let fm = FileManager.default
         let destination = destinationFolder
         try fm.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try? fm.removeItem(at: destination) // drop a prior install (ignore if absent) so copy can't collide
+        try? fm.removeItem(at: destination) // drop a prior install so copy can't collide
         try fm.copyItem(at: source, to: destination)
     }
 
-    // the sentinel line marking the installer-baked AGTERMCTL default in the wrapper; a re-run finds
-    // and replaces it so the path is refreshed rather than duplicated.
+    // sentinel for the installer-baked AGTERMCTL default; a re-run replaces it instead of duplicating it.
     private static let agtermctlMarker = "# >>> agterm agtermctl path (installer-baked) >>>"
 
     // bake the bundled agtermctl's absolute path into the installed wrappers so the hooks fire even when the
-    // CLI was never symlinked into PATH. `[ -n "${AGTERMCTL:-}" ] ||` sets it only when AGTERMCTL is unset,
-    // so an explicit env override still wins (resolution order 1 > 2 > PATH); the path is single-quoted
-    // (shellQuote) so spaces / shell metacharacters in the bundle path are inert.
+    // CLI was never symlinked into PATH. `[ -n "${AGTERMCTL:-}" ] ||` assigns only when unset, so an explicit
+    // env override still wins (order 1 > 2 > PATH); shellQuote keeps spaces / metacharacters inert.
     private static func bakeAgtermctlPath() throws {
         guard let tool = bundledTool else { return } // no bundled CLI: leave the PATH fallback in place
         for name in [AgentHooksInstall.wrapperName, AgentHooksInstall.codexWrapperName] {
@@ -159,26 +153,25 @@ enum AgentHooksInstaller {
         return lines.joined(separator: "\n")
     }
 
-    // write text to a path, PRESERVING an existing symlink: for a symlink (e.g. a dotfiles-managed
-    // `~/.claude/settings.json` or `~/.zshrc`) write atomically to its resolved target, so the link and the
-    // user's dotfiles stay intact instead of an atomic rename replacing it with a regular file. a non-nil
-    // `posixMode` is applied to the resolved target, so a chmod-600 file isn't widened by the rewrite.
+    // write text PRESERVING an existing symlink: a dotfiles-managed link (`~/.claude/settings.json`,
+    // `~/.zshrc`) is written through to its resolved target, since an atomic rename would replace the link
+    // with a regular file. `posixMode` applies to that target, so a chmod-600 file isn't widened.
     private static func writePreservingSymlink(_ text: String, to url: URL, posixMode: NSNumber? = nil) throws {
         let target = symlinkTarget(of: url) ?? url
         try AgentHooksInstall.writeFile(text, toPath: target.path, posixMode: posixMode)
     }
 
-    // the resolved target if `url` itself is a symlink (following a chain), else nil. Uses
-    // `attributesOfItem` (which does NOT follow the final link) to detect the symlink.
+    // the resolved target if `url` is itself a symlink (chain followed), else nil. detection uses
+    // `attributesOfItem`, which does NOT follow the final link.
     private static func symlinkTarget(of url: URL) -> URL? {
         guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
               (attrs[.type] as? FileAttributeType) == .typeSymbolicLink else { return nil }
         return url.resolvingSymlinksInPath()
     }
 
-    // read an existing config file: nil when ABSENT (a fresh install), the raw contents when readable, and
-    // a thrown `UnreadableExisting` when it EXISTS but cannot be read (permission / non-UTF8) — so callers
-    // leave it untouched instead of clobbering it with no backup, as `(try? String(contentsOf:)) ?? ""` did.
+    // read an existing config file: nil when ABSENT (a fresh install), the contents when readable, a thrown
+    // `UnreadableExisting` when it EXISTS but can't be read (permission / non-UTF8) — so callers leave it
+    // untouched instead of clobbering it with no backup.
     private struct UnreadableExisting: Error {}
     private static func readExistingConfig(at url: URL) throws -> String? {
         guard FileManager.default.fileExists(atPath: url.path) else { return nil }
@@ -189,9 +182,8 @@ enum AgentHooksInstaller {
         }
     }
 
-    // merge the four Claude Code hooks into ~/.claude/settings.json, writing a .bak first when the
-    // merge changes anything. returns true if the merge was SKIPPED because the existing file is not
-    // valid JSON, or exists but can't be read (it is left untouched rather than overwritten).
+    // merge the four Claude Code hooks into ~/.claude/settings.json, writing a .bak first when anything
+    // changes. returns true when the merge was SKIPPED (invalid JSON, or unreadable) and the file left as is.
     private static func mergeClaudeSettings() throws -> Bool {
         let claudeDir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".claude")
         let settings = claudeDir.appendingPathComponent("settings.json")
@@ -199,25 +191,23 @@ enum AgentHooksInstaller {
         do {
             existing = try readExistingConfig(at: settings)
         } catch {
-            return true // exists but unreadable: leave it untouched rather than clobber it with no backup
+            return true // unreadable: leave it untouched rather than clobber it with no backup
         }
         let merged: (json: String, changed: Bool)
         do {
             merged = try AgentHooksInstall.mergeClaudeSettings(existing: existing, scriptDir: destinationFolder.path)
         } catch AgentHooksInstall.MergeError.malformedExistingSettings {
-            return true // invalid settings.json: leave it untouched rather than overwrite the user's file
+            return true // invalid JSON: leave the user's file untouched
         }
         guard merged.changed else { return false }
         try FileManager.default.createDirectory(at: claudeDir, withIntermediateDirectories: true)
-        // resolve the symlink target FIRST (so a dotfiles-managed settings.json link survives) and read its
-        // mode once, so the rewrite AND the .bak inherit the original (possibly chmod-600) mode instead of
-        // an atomic rename widening a secret file to 0644.
+        // resolve the symlink target FIRST (a dotfiles-managed link must survive) and read its mode once, so
+        // the rewrite AND the .bak inherit it instead of an atomic rename widening a chmod-600 file to 0644.
         let target = symlinkTarget(of: settings) ?? settings
         let mode = AgentHooksInstall.posixMode(ofFile: target.path)
-        if let existing { // back up the prior file before overwriting it, with the source's mode
-            // keep the .bak next to ~/.claude/settings.json (the symlink), NOT the resolved target — a
-            // dotfiles-managed link resolves into a git-tracked dir we must not litter; only the MODE
-            // comes from the resolved target.
+        if let existing { // back up before overwriting, with the source's mode
+            // keep the .bak beside the symlink, NOT the resolved target — that resolves into a git-tracked
+            // dotfiles dir we must not litter; only the MODE comes from the target.
             let backup = AgentHooksInstall.backupPath(for: settings.path)
             try AgentHooksInstall.writeFile(existing, toPath: backup, posixMode: mode)
         }
@@ -225,14 +215,13 @@ enum AgentHooksInstaller {
         return false
     }
 
-    // append the marker-guarded source line to ~/.zshrc, ~/.bashrc and ~/.config/fish/config.fish
-    // (idempotent per file).
+    // append the marker-guarded source line to ~/.zshrc, ~/.bashrc, ~/.config/fish/config.fish (idempotent).
     private static func appendShellRC() throws {
         let home = FileManager.default.homeDirectoryForCurrentUser
         for name in [".zshrc", ".bashrc", ".config/fish/config.fish"] {
             let rc = home.appendingPathComponent(name)
             if name.hasSuffix(".fish") {
-                // Only create/append to config.fish if the user already has a ~/.config/fish directory
+                // only touch config.fish when the user already has a ~/.config/fish directory
                 guard FileManager.default.fileExists(atPath: rc.deletingLastPathComponent().path) else { continue }
             }
             let existing = (try? String(contentsOf: rc, encoding: .utf8)) ?? ""
@@ -243,10 +232,9 @@ enum AgentHooksInstaller {
         }
     }
 
-    // install Pi's auto-discovered global extension only when Pi has already created ~/.pi/agent. a
-    // same-named UNMARKED extension is user-owned and left untouched; an agterm-managed one refreshes from
-    // the copied package. no backup, unlike Claude/Codex config: Pi has no config merge and its extension
-    // carries no user state.
+    // install Pi's auto-discovered global extension only when Pi has already created ~/.pi/agent. an UNMARKED
+    // same-named extension is user-owned and left untouched; a marked one refreshes from the copied package.
+    // no backup, unlike the Claude/Codex configs: the extension carries no user state.
     private static func installPiExtension() throws -> PiResult {
         let fm = FileManager.default
         let home = fm.homeDirectoryForCurrentUser
@@ -263,9 +251,8 @@ enum AgentHooksInstaller {
         }
 
         let destination = URL(fileURLWithPath: AgentHooksInstall.piExtensionPath(home: home.path))
-        // read the destination like the Claude/Codex merges: nil = absent, throw = exists-but-unreadable
-        // (folded to .unreadable). reusing readExistingConfig stops a non-ENOENT stat error masquerading
-        // as "absent" and slipping past the ownership-marker gate.
+        // nil = absent, throw = exists-but-unreadable (folded to .unreadable): reusing readExistingConfig
+        // stops a non-ENOENT stat error masquerading as "absent" and slipping past the ownership-marker gate.
         let existing: String?
         do {
             existing = try readExistingConfig(at: destination)
@@ -277,8 +264,8 @@ enum AgentHooksInstaller {
         }
         guard existing != sourceContents else { return .alreadyConfigured }
 
-        // a filesystem error on ~/.pi/agent/extensions degrades to a warning like every sibling integration
-        // rather than aborting the whole install, which would hide that the Claude/Codex/shell steps ran.
+        // a filesystem error degrades to a warning like every sibling integration, rather than aborting the
+        // whole install and hiding that the Claude/Codex/shell steps ran.
         do {
             try fm.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
             let target = symlinkTarget(of: destination) ?? destination
@@ -290,8 +277,8 @@ enum AgentHooksInstaller {
         return .installed
     }
 
-    // Install OpenCode's auto-discovered global plugin only when ~/.config/opencode exists. Same
-    // ownership / degrade-to-warning policy as Pi; no backup (managed plugin carries no user state).
+    // install OpenCode's auto-discovered global plugin only when ~/.config/opencode exists. same ownership /
+    // degrade-to-warning policy as Pi, and no backup.
     private static func installOpenCodePlugin() throws -> OpenCodeResult {
         let fm = FileManager.default
         let home = fm.homeDirectoryForCurrentUser
@@ -330,10 +317,9 @@ enum AgentHooksInstaller {
         return .installed
     }
 
-    // merge the Codex lifecycle hooks into ~/.codex/config.toml, writing a .bak first when the merge changes
-    // anything. gated on ~/.codex existing (like the fish rc gate) so a non-Codex home isn't seeded with a
-    // config.toml. the host-free `AgentHooksInstall.mergeCodexConfig` PARSES the file to decide the outcome;
-    // this only reads/writes and maps it to a `CodexResult`.
+    // merge the Codex lifecycle hooks into ~/.codex/config.toml, writing a .bak first when anything changes.
+    // gated on ~/.codex existing so a non-Codex home isn't seeded with a config.toml. the host-free
+    // `AgentHooksInstall.mergeCodexConfig` PARSES the file and decides the outcome; this only reads/writes.
     private static func mergeCodexConfig() throws -> CodexResult {
         let codexDir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".codex")
         guard FileManager.default.fileExists(atPath: codexDir.path) else { return .noCodex }
@@ -342,7 +328,7 @@ enum AgentHooksInstaller {
         do {
             existing = try readExistingConfig(at: config)
         } catch {
-            return .unreadable // exists but unreadable: leave it untouched rather than clobber it
+            return .unreadable // unreadable: leave it untouched rather than clobber it
         }
         switch AgentHooksInstall.mergeCodexConfig(existing: existing ?? "", scriptDir: destinationFolder.path) {
         case .unchanged:
@@ -352,8 +338,7 @@ enum AgentHooksInstaller {
         case .unparseable:
             return .unparseable
         case .merged(let contents):
-            // resolve the symlink target FIRST (so a dotfiles-managed config.toml link survives) and read its
-            // mode once, so the rewrite AND the .bak inherit the original mode instead of widening it.
+            // same symlink-target-then-mode handling as mergeClaudeSettings.
             let target = symlinkTarget(of: config) ?? config
             let mode = AgentHooksInstall.posixMode(ofFile: target.path)
             if let existing, !existing.isEmpty { // back up the prior file before overwriting it
@@ -365,8 +350,7 @@ enum AgentHooksInstaller {
         }
     }
 
-    // the success-alert text: what was left out when the Claude settings merge was skipped, or when the
-    // Codex/Pi/OpenCode integrations could not safely update a user-owned or unreadable file.
+    // the success-alert text, calling out anything an integration could not safely update and left alone.
     private static func successText(_ outcome: InstallOutcome) -> String {
         let claudeLine = outcome.settingsSkipped
             ? "Your ~/.claude/settings.json isn't valid JSON (or couldn't be read), so the Claude Code hooks were NOT added "
@@ -384,8 +368,7 @@ enum AgentHooksInstaller {
         """
     }
 
-    // the Codex portion of the alert, per merge outcome. The hooks-exist and unparseable cases include
-    // the block so the user can add it by hand.
+    // the Codex portion of the alert; hooks-exist and unparseable include the block for a manual add.
     private static func codexText(_ codex: CodexResult) -> String {
         let approve = "Run /hooks in Codex to review and approve them before they take effect."
         switch codex {
@@ -406,7 +389,7 @@ enum AgentHooksInstaller {
         }
     }
 
-    // Describe Pi's extension-install outcome. Pi extensions auto-discover on the next startup or `/reload`.
+    // Pi's extension-install outcome. Pi extensions auto-discover on the next startup or `/reload`.
     private static func piText(_ pi: PiResult) -> String {
         switch pi {
         case .installed:
@@ -424,7 +407,7 @@ enum AgentHooksInstaller {
         }
     }
 
-    // Describe OpenCode's plugin-install outcome. Plugins load on the next OpenCode start.
+    // OpenCode's plugin-install outcome. plugins load on the next OpenCode start.
     private static func opencodeText(_ opencode: OpenCodeResult) -> String {
         switch opencode {
         case .installed:

--- a/agterm/AppActions+Focus.swift
+++ b/agterm/AppActions+Focus.swift
@@ -2,21 +2,18 @@ import agtermCore
 import AppKit
 import SwiftUI
 
-/// Session/pane focus mechanics for `AppActions`: moving first responder into the active session or a
-/// split pane, revealing a blocked or notification-clicked session's waiting pane, and the modal guards
-/// (terminal zoom and the dashboard overlay) that keep those focus moves off a hidden surface. Split out
-/// of the main `AppActions` declaration to keep each file focused; an extension on the same type reaches
-/// all of its members.
+/// Session/pane focus mechanics split out of the main `AppActions` declaration: moving first responder into
+/// the active session or a split pane, revealing a blocked or notification-clicked session's waiting pane,
+/// and the modal guards (terminal zoom, dashboard overlay) that keep those moves off a hidden surface.
 extension AppActions {
     // MARK: - Notification bridges
 
     /// Bridge for `.agtermAutoFollowed`: an idle auto-follow has moved some window's selection to a blocked
-    /// session. Selection alone does NOT move first responder (the eager deck keeps the prior surface as
-    /// responder), so pull focus into the newly selected session — but ONLY when the firing window is key.
-    /// A non-key window keeps just the selection change and focuses normally when it next becomes key.
-    /// `revealActiveBlockedPane` targets the frontmost (= key) store — the firing window here since we gate
-    /// on its being key — and reveals the pane that set the status (split/scratch), so the initial jump lands
-    /// on the waiting pane, not just the session's plain focused pane.
+    /// session. Selection alone does NOT move first responder (the eager deck keeps the prior surface), so
+    /// pull focus into the newly selected session, but ONLY when the firing window is key — a non-key window
+    /// keeps just the selection and focuses when it next becomes key. `revealActiveBlockedPane` targets the
+    /// frontmost (= key) store, the firing window given that gate, and reveals the pane that set the status
+    /// (split/scratch), so the jump lands on the waiting pane, not the session's plain focused pane.
     func autoFollowed(_ sessionID: UUID?, indicator: AgentIndicator?) {
         guard let sessionID, let windowID = library.windowID(forSession: sessionID),
               WindowRegistry.shared.isKeyWindow(windowID) else { return }
@@ -52,12 +49,11 @@ extension AppActions {
     }
 
     /// Whether the dashboard overlay is open in the window OWNING this session — the session-scoped twin of
-    /// the frontmost `dashboardActive`, mirroring `terminalZoomActive(for:)`. The right gate for
-    /// `focusSplitPane`, whose callers (⌃1/⌃2, ⌘D, the control `session.focus --pane`) can target a session
-    /// in ANY window: while that window's dashboard is up its key-catcher owns first responder, and a
-    /// NON-member deck surface behind the modal is NOT view-only, so grabbing first responder for it would
-    /// steal keystrokes from the catcher into a hidden terminal. Gates on the session's window, not the
-    /// frontmost one, for the same cross-window reason as `terminalZoomActive(for:)`.
+    /// the frontmost `dashboardActive`, mirroring `terminalZoomActive(for:)` and gating on the session's
+    /// window for the same cross-window reason. `focusSplitPane`'s callers (⌃1/⌃2, ⌘D, the control
+    /// `session.focus --pane`) can target ANY window, and while that window's dashboard is up its
+    /// key-catcher owns first responder while a NON-member deck surface behind the modal is NOT view-only,
+    /// so grabbing first responder for it would steal keystrokes into a hidden terminal.
     private func dashboardActive(for session: Session) -> Bool {
         guard let windowID = library.windowID(forSession: session.id) else { return false }
         return DashboardControllerRegistry.shared.controller(for: windowID)?.isOpen == true
@@ -65,11 +61,10 @@ extension AppActions {
 
     /// Whether the quick terminal is showing in the window OWNING this session — the session-scoped twin of
     /// `frontmostQuickTerminal`, completing the set with `terminalZoomActive(for:)`/`dashboardActive(for:)`.
-    /// Each window owns its own quick-terminal controller, so the FRONTMOST one is the wrong question for
-    /// `focusSplitPane`: a cover up in the frontmost window would silently drop the focus step for a
-    /// `session.focus --pane` aimed at a BACKGROUND window (leaving that window's `splitFocused` and its
-    /// real first responder disagreeing), while a cover actually showing in that background window — the
-    /// one that does own its focus — would be missed.
+    /// Each window owns its own controller, so the FRONTMOST one is the wrong question for `focusSplitPane`:
+    /// a cover in the frontmost window would drop the focus step for a `session.focus --pane` aimed at a
+    /// BACKGROUND one (leaving that window's `splitFocused` and its real first responder disagreeing), while
+    /// a cover actually showing there — the one that does own its focus — would be missed.
     private func quickTerminalActive(for session: Session) -> Bool {
         guard let windowID = library.windowID(forSession: session.id) else { return false }
         return QuickTerminalRegistry.shared.controller(for: windowID)?.isVisible == true
@@ -79,43 +74,35 @@ extension AppActions {
 
     /// Reveal and focus the active session's blocked pane, reading its agent-status pane tag so navigation
     /// lands on the pane actually waiting for input rather than the session's plain focused pane. Called on
-    /// every user-initiated selection — the auto-follow jump, attention navigation (⌃⌥↑/↓), plain session
-    /// nav (⌥⌘↑/↓/first/last), the ⌃P / attention command palette, a sidebar row click, a title-bar bell
-    /// popover row, and a Dock-menu session row — so however you
-    /// reach a blocked session you land on its waiting pane; it is a no-op (plain `focusActiveSession`) for an
-    /// idle or active session, so ordinary selections and a working agent's informational pane tag do not
-    /// change the user's pane selection. `.right` — only WHEN the split surface exists
-    /// (`splitSurface != nil`) — flips `splitFocused` then focuses the split surface via
+    /// every user-initiated selection — the auto-follow jump, attention nav (⌃⌥↑/↓), plain session nav
+    /// (⌥⌘↑/↓/first/last), the ⌃P / attention palette, a sidebar row click, a title-bar bell popover row, a
+    /// Dock-menu session row — and a no-op (plain `focusActiveSession`) for an idle or active session, so
+    /// ordinary selections and a working agent's informational pane tag never move the pane selection.
+    /// `.right`, only when `splitSurface != nil`, flips `splitFocused` then focuses the split surface via
     /// `focusSplitPane(wantSplit: true)` — a FIXED target, NOT the `splitFocused`-following
     /// `focusActiveSession`: a SHOWN (side-by-side) split's deck re-render churns first responder onto the
-    /// main pane, whose `onFocusChange` writes `splitFocused = false`, and a follow-the-flag focus target
-    /// then chases the wrong pane; re-asserting the split surface directly wins the race (its `onFocusChange`
-    /// re-sets `splitFocused = true`). The gate is `splitSurface != nil` (NOT `hasSplit`), so a promoted
-    /// split survivor (which `closePrimaryPane` moves into `surface` with `splitSurface == nil`, re-tagging a
-    /// `.right` block to `.left`) explicitly targets the session's sole main pane, and a STALE `right` tag on
-    /// a genuinely single-pane session (a manual `session.status --pane right`, or after the split collapsed)
-    /// does the same, instead of setting `splitFocused = true` with no split surface (the `splitFocused`
-    /// invariant is "true only while the split pane exists"). `.scratch` shows the
-    /// scratch only when hidden (a show-if-hidden guard, never a bare toggle that could HIDE a shown one) so
-    /// `topmostSurface` resolves to the scratch; `.left`/nil explicitly clear `splitFocused` and target the
-    /// primary surface, even when the right pane held focus before the session was selected. The retry loops
-    /// cover a split/scratch surface that materializes a beat after the reveal.
-    /// The INVERSE of the `.scratch` show-if-hidden guard: for a NON-scratch target (`left`/`right`/nil)
-    /// with the scratch currently SHOWN, hide the covering scratch (keep-alive `toggleScratch`) FIRST so the
-    /// requested pane becomes the visible/topmost surface — otherwise `focusSplitPane`/`focusActiveSession`
-    /// both resolve to the covering scratch (`topmostSurface`) and nav never reaches the blocked pane. Only
-    /// the scratch cover is dismissed; an active overlay is left alone (closing a running overlay would kill
-    /// its program).
-    /// Selection callers pass the indicator returned by `AppStore.selectSession` / `navigateSession`,
-    /// captured before either clears an `autoReset` status. This keeps pane routing identical across the
-    /// Dock, navigation, palettes, sidebar/popover clicks, and auto-follow.
+    /// main pane, whose `onFocusChange` writes `splitFocused = false`, so a follow-the-flag target chases the
+    /// wrong pane while re-asserting the split surface wins the race (its `onFocusChange` re-sets true). The
+    /// gate is `splitSurface != nil`, NOT `hasSplit`, so a promoted split survivor (`closePrimaryPane` moves
+    /// it into `surface` with `splitSurface == nil`, re-tagging a `.right` block to `.left`) and a STALE
+    /// `right` tag on a genuinely single-pane session (a manual `session.status --pane right`, or a collapsed
+    /// split) both target the sole main pane instead of setting `splitFocused = true` with no split surface —
+    /// the invariant is "true only while the split pane exists". `.scratch` shows the scratch only when
+    /// hidden (a show-if-hidden guard, never a bare toggle that could HIDE a shown one) so `topmostSurface`
+    /// resolves to it; `.left`/nil clear `splitFocused` and target the primary surface even when the right
+    /// pane held focus before selection, and the retry loops cover a split/scratch surface materializing a
+    /// beat later. Inversely, a NON-scratch target (`left`/`right`/nil) with the scratch SHOWN hides the
+    /// covering scratch (keep-alive `toggleScratch`) FIRST, or `focusSplitPane`/`focusActiveSession` both
+    /// resolve to it as `topmostSurface` and nav never reaches the blocked pane; only the scratch cover is
+    /// dismissed, since closing a running overlay would kill its program. Selection callers pass the
+    /// indicator from `AppStore.selectSession`/`navigateSession`, captured before either clears an
+    /// `autoReset` status, so pane routing is identical across the Dock, nav, palettes, clicks, and auto-follow.
     func revealActiveBlockedPane(captured indicator: AgentIndicator?) {
         guard let indicator else { focusActiveSession(); return }
         guard let session = store?.activeSession else { focusActiveSession(); return }
-        // reveal is a no-op unless the status needs attention: scratch-hide / split-focus side effects
-        // must never fire on plain navigation to a session that merely has its (keep-alive) scratch shown
-        // or whose agent is still active. a status needing attention with no `--pane` tag is treated as
-        // `left` and still reveals the main pane.
+        // a no-op unless the status needs attention: the scratch-hide / split-focus side effects must never
+        // fire on plain navigation to a session merely showing its keep-alive scratch, or still active. a
+        // needs-attention status with no `--pane` tag counts as `left` and still reveals the main pane.
         guard indicator.status.needsAttention else { focusActiveSession(); return }
         let pane = indicator.statusPane
         // a shown scratch covers the panes and masks a non-scratch block; hide it first so the requested
@@ -134,20 +121,19 @@ extension AppActions {
         }
     }
 
-    /// Move first responder back to the active session's topmost surface (used after the quick terminal
-    /// or a palette/rename field closes). Targets `topmostSurface` (overlay > scratch > active pane) so a
-    /// palette close re-focuses whatever is actually visible — the scratch or overlay if one is up, else
-    /// the focused pane — never a pane hidden under a cover. Re-asserts briefly since the target view may
-    /// not be on-window yet. Bails only for the quick terminal: it is a window-level cover that owns focus
-    /// and re-focuses the session on its own hide, so don't fight it here.
+    /// Move first responder back to the active session's topmost surface (after the quick terminal or a
+    /// palette/rename field closes). Targets `topmostSurface` (overlay > scratch > active pane), so a close
+    /// re-focuses whatever is actually visible — the scratch or overlay if one is up, else the focused pane
+    /// — never a pane hidden under a cover, and re-asserts briefly since the target view may not be
+    /// on-window yet. Bails only for the quick terminal: a window-level cover that owns focus and re-focuses
+    /// the session on its own hide.
     func focusActiveSession(attempt: Int = 0) {
         if terminalZoomActive { return }
         if dashboardActive { return }
         if renamePending { return }
-        // never grab terminal focus while a command palette is open — the palette owns the keyboard.
-        // this also kills the retry loop the instant a palette (re)opens, so the action-palette "Select
-        // Theme…" launcher (which closes the action palette, then opens the .themes picker a tick later)
-        // can't have its field focus stolen back by the close-restore's retry.
+        // never grab terminal focus while a command palette is open — it owns the keyboard. this also kills
+        // the retry loop the instant a palette (re)opens, so the action-palette "Select Theme…" launcher
+        // (which closes that palette, then opens the .themes picker a tick later) keeps its field focus.
         if palette?.mode != nil { return }
         if pickActive(for: library.activeWindowID) { return }
         if frontmostQuickTerminal?.isVisible == true { return }
@@ -160,22 +146,20 @@ extension AppActions {
         }
     }
 
-    /// Move first responder to the split (right) pane on open, or the primary on close.
-    /// Re-asserts over a short window because the split surface materializes a beat after the
-    /// toggle and the HSplitView collapse churns the primary view. While a full-coverage surface
-    /// (scratch or overlay) is up, the requested pane is hidden beneath it, so keep first responder on
-    /// the visible `topmostSurface` instead — the caller has already set `splitFocused`, so the correct
-    /// pane shows once the cover is dismissed.
+    /// Move first responder to the split (right) pane on open, or the primary on close, re-asserting over a
+    /// short window because the split surface materializes a beat after the toggle and the HSplitView
+    /// collapse churns the primary view. Under a full-coverage surface (scratch or overlay) the requested
+    /// pane is hidden, so keep first responder on the visible `topmostSurface` — the caller has already set
+    /// `splitFocused`, so the correct pane shows once the cover is dismissed.
     func focusSplitPane(_ session: Session, wantSplit: Bool, attempt: Int = 0, generation: Int? = nil) {
-        // each fresh call SUPERSEDES any in-flight retry loop in the SAME WINDOW. without this, two calls
-        // with opposite targets (focus-left then focus-right) each run their own 12x30ms
-        // `makeFirstResponder` loop concurrently and ping-pong first responder between the panes for
-        // ~400ms - both surfaces redraw on every flip, the split-focus flicker. the counter is keyed by the
-        // owning WINDOW: one NSWindow has one first responder, so a newer focus op anywhere in it supersedes
-        // an older loop there (last-focus-wins), while different windows stay independent (never cancel each
-        // other's still-materializing retries). the surviving loop still re-asserts through the
-        // split-materialize / reparent churn (a lone loop's re-asserts are no-ops once its target is first
-        // responder), so the retry keeps its original purpose.
+        // each fresh call SUPERSEDES any in-flight retry loop in the SAME WINDOW: without this, two calls
+        // with opposite targets each run their own 12x30ms `makeFirstResponder` loop, ping-ponging first
+        // responder between the panes for ~400ms and redrawing both surfaces per flip (the split-focus
+        // flicker). the counter is keyed by the owning WINDOW — one NSWindow has one first responder, so a
+        // newer focus op there supersedes an older loop (last-focus-wins) while other windows stay
+        // independent and never cancel each other's still-materializing retries. the surviving loop still
+        // re-asserts through the split-materialize / reparent churn, its re-asserts being no-ops once its
+        // target holds focus.
         let gen: Int
         let scope = library.windowID(forSession: session.id) ?? session.id // fall back to session id when windowless
         if let generation {
@@ -185,29 +169,22 @@ extension AppActions {
             gen = (focusGeneration[scope] ?? 0) + 1
             focusGeneration[scope] = gen
         }
-        // gate on the SESSION's window, not the frontmost one: this path is cross-window (the control
-        // channel focuses sessions in background windows), where the frontmost window's zoom is irrelevant.
         if terminalZoomActive(for: session) { return }
-        // the dashboard grid overlay is modal too, and gated on the SESSION's window for the same cross-window
-        // reason: while it's up its key-catcher owns first responder, and a NON-member deck surface behind it
-        // is not view-only, so grabbing first responder here would leak keystrokes into a hidden terminal.
         if dashboardActive(for: session) { return }
         if pickActive(for: library.windowID(forSession: session.id)) { return }
-        // the inline rename field and an open palette own the keyboard, exactly as in `focusActiveSession`,
-        // which re-checks both on every one of its retries. this loop needs them for the same reason: the
-        // `.left`/nil reveal routes here (a plain `session status blocked` with no `--pane` lands in that
-        // branch), so a sidebar row click followed within the ~360ms retry window by ⌘R or a palette open
-        // would otherwise pull first responder off the field and type the name into the terminal.
-        // SCOPED to the session's own window like the two gates above, and for the same cross-window reason:
-        // both flags are app-GLOBAL (one `renamePending`, one `PaletteController` shared by every window),
-        // so unscoped they would let a palette open in the frontmost window silently skip the responder move
-        // for a `session.focus` aimed at a background one — leaving that window's `splitFocused` and its real
-        // first responder disagreeing, with the control command still reporting ok. Scoping costs the
-        // protection nothing because only the KEY window receives keystrokes, so the race actually guarded
-        // here — a retry stealing the field the user is typing into — is frontmost-only by construction.
-        // (A BACKGROUND window can still hold an inline editor, since the rename notifications fan out to
-        // every window's sidebar coordinator; nobody is typing into that one, and the fan-out itself is a
-        // separate, older defect.)
+        // the inline rename field and an open palette own the keyboard, as in `focusActiveSession`, which
+        // re-checks both on every retry; this loop needs it because the `.left`/nil reveal routes here (a
+        // plain `session status blocked` with no `--pane`), so a sidebar row click followed inside the
+        // ~360ms retry window by ⌘R or a palette open would pull first responder off the field and type the
+        // name into the terminal. SCOPED to the session's own window like the two gates above, for the same
+        // cross-window reason: both flags are app-GLOBAL (one `renamePending`, one `PaletteController`
+        // shared by every window), so unscoped a frontmost palette would silently skip the responder move
+        // for a `session.focus` aimed at a background window, leaving its `splitFocused` and real first
+        // responder disagreeing while the control command still reports ok. scoping costs nothing — only
+        // the KEY window receives keystrokes, so the race guarded here (a retry stealing the field being
+        // typed into) is frontmost-only. a BACKGROUND window can still hold an inline editor, since rename
+        // notifications fan out to every window's sidebar coordinator, but nobody types into it and that
+        // fan-out is a separate, older defect.
         if library.windowID(forSession: session.id) == library.activeWindowID {
             if renamePending { return }
             if palette?.mode != nil { return }
@@ -215,9 +192,6 @@ extension AppActions {
         // the quick terminal is a window-level cover above the session; while it's up it owns focus, so
         // don't move first responder to a pane behind it (its own hide restores the session). The caller
         // has already set `splitFocused`, so the right pane shows once the quick terminal is dismissed.
-        // Gated on the SESSION's window like the zoom/dashboard pair above, not the frontmost one — each
-        // window owns its own quick terminal, so this is the only one of the four gates whose per-window
-        // answer was already available and simply wasn't being asked.
         if quickTerminalActive(for: session) { return }
         let target: (any TerminalSurface)? = (session.overlayActive || session.scratchActive)
             ? session.topmostSurface
@@ -232,11 +206,10 @@ extension AppActions {
     }
 
     /// Bring a session/pane to the foreground from a notification click: surface the owning window
-    /// (reopening it when the banner was clicked after the window closed), select the session (which
-    /// clears its unseen badge and derives its workspace), and focus the firing pane. Stale-safe: an
-    /// unknown session in an open window resolves directly; an unknown window/session just leaves the
-    /// app active (the caller has already activated it). A `.split` pane that is no longer split
-    /// falls back to the primary.
+    /// (reopening it when the banner was clicked after the window closed), select the session (clearing its
+    /// unseen badge and deriving its workspace), and focus the firing pane. Stale-safe: an unknown session
+    /// in an open window resolves directly, an unknown window/session leaves the app active (the caller has
+    /// activated it), and a `.split` pane that is no longer split falls back to the primary.
     func reveal(windowID: UUID, sessionID: UUID, pane: PaneRole) {
         // window already open: select + focus right away.
         if let store = library.store(forSession: sessionID) {
@@ -273,14 +246,12 @@ extension AppActions {
         if let windowID, let zoom = TerminalZoomRegistry.shared.controller(for: windowID), zoom.target != nil {
             zoom.clear()
         }
-        // and raise the owning window, which `makeFirstResponder` alone does not do. `NSApp.activate` in
-        // the notification handler brings the APP forward, not a window minimized to the Dock or sitting
-        // behind another one — so without this the selection would change invisibly. The closed-window
-        // branch already raises via `openWindow`; this makes the open-window branch symmetric.
+        // raise the owning window, which `makeFirstResponder` alone does not do: `NSApp.activate` in the
+        // notification handler brings the APP forward, not a window minimized to the Dock or behind another,
+        // so the selection would change invisibly. the closed-window branch already raises via `openWindow`.
         if let windowID { WindowRegistry.shared.raise(windowID) }
-        // clicking a notification banner is a user-initiated selection: note activity on the SAME (owning)
-        // store it selects into — reveal can cross windows — so it buys the full idle grace before
-        // auto-follow can pull the selection away.
+        // a banner click is a user-initiated selection: note activity on the SAME (owning) store it selects
+        // into — reveal can cross windows — so it buys the full idle grace before auto-follow pulls away.
         store.noteUserActivity()
         store.selectSession(session.id)
         let wantSplit = pane == .split && session.hasSplit

--- a/agterm/AppActions+Focus.swift
+++ b/agterm/AppActions+Focus.swift
@@ -8,27 +8,27 @@ import SwiftUI
 extension AppActions {
     // MARK: - Notification bridges
 
-    /// Bridge for `.agtermAutoFollowed`: an idle auto-follow has moved some window's selection to a blocked
+    /// Bridge for `.agtermAutoFollowed`: an idle auto-follow moved some window's selection to a blocked
     /// session. Selection alone does NOT move first responder (the eager deck keeps the prior surface), so
-    /// pull focus into the newly selected session, but ONLY when the firing window is key — a non-key window
-    /// keeps just the selection and focuses when it next becomes key. `revealActiveBlockedPane` targets the
-    /// frontmost (= key) store, the firing window given that gate, and reveals the pane that set the status
-    /// (split/scratch), so the jump lands on the waiting pane, not the session's plain focused pane.
+    /// pull focus in, but ONLY when the firing window is key — a non-key window keeps just the selection and
+    /// focuses when it next becomes key, which is also what makes `revealActiveBlockedPane`'s frontmost (=
+    /// key) store the firing window. It reveals the pane that set the status (split/scratch), so the jump
+    /// lands on the waiting pane, not the plain focused one.
     func autoFollowed(_ sessionID: UUID?, indicator: AgentIndicator?) {
         guard let sessionID, let windowID = library.windowID(forSession: sessionID),
               WindowRegistry.shared.isKeyWindow(windowID) else { return }
-        // never reveal behind the zoom layer: the reveal mutates scratch visibility / splitFocused,
-        // exactly the hidden-state writes zoom forbids. The auto-follow SELECTION stands (the user
-        // lands on the blocked session when they exit zoom); only the pane reveal is skipped.
+        // never reveal behind the zoom layer: the reveal mutates scratch visibility / splitFocused, exactly
+        // the hidden-state writes zoom forbids. the auto-follow SELECTION stands (the user lands on the
+        // blocked session when they exit zoom); only the pane reveal is skipped.
         guard TerminalZoomRegistry.shared.controller(for: windowID)?.target == nil else { return }
         revealActiveBlockedPane(captured: indicator)
     }
 
     // MARK: - Modal focus guards
 
-    /// Whether the frontmost window's dashboard grid overlay is open. Like a zoom or an open palette, the
-    /// dashboard is modal and its key-catcher owns first responder, so `focusActiveSession` must not grab
-    /// the active session's surface while it is up (that surface is a view-only grid cell).
+    /// Whether the frontmost window's dashboard grid overlay is open. Like a zoom or an open palette it is
+    /// modal and its key-catcher owns first responder, so `focusActiveSession` must not grab the active
+    /// session's surface while it is up (that surface is a view-only grid cell).
     private var dashboardActive: Bool {
         DashboardControllerRegistry.shared.controller(for: library.activeWindowID)?.isOpen == true
     }
@@ -39,32 +39,29 @@ extension AppActions {
         PickRegistry.shared.controller(for: windowID)?.pending != nil
     }
 
-    /// Whether terminal zoom is active in the window OWNING this session. The right gate for the
-    /// session-addressed focus paths: control commands resolve sessions across ALL windows, so gating
-    /// them on the FRONTMOST window's zoom would silently drop the focus step for an un-zoomed
-    /// background window (and miss a zoomed non-frontmost one).
+    /// Whether terminal zoom is active in the window OWNING this session — the right gate for the
+    /// session-addressed focus paths, since control commands resolve sessions across ALL windows: gating on
+    /// the FRONTMOST window's zoom would silently drop the focus step for an un-zoomed background window,
+    /// and miss a zoomed non-frontmost one.
     private func terminalZoomActive(for session: Session) -> Bool {
         guard let windowID = library.windowID(forSession: session.id) else { return false }
         return TerminalZoomRegistry.shared.controller(for: windowID)?.target != nil
     }
 
     /// Whether the dashboard overlay is open in the window OWNING this session — the session-scoped twin of
-    /// the frontmost `dashboardActive`, mirroring `terminalZoomActive(for:)` and gating on the session's
-    /// window for the same cross-window reason. `focusSplitPane`'s callers (⌃1/⌃2, ⌘D, the control
-    /// `session.focus --pane`) can target ANY window, and while that window's dashboard is up its
-    /// key-catcher owns first responder while a NON-member deck surface behind the modal is NOT view-only,
-    /// so grabbing first responder for it would steal keystrokes into a hidden terminal.
+    /// the frontmost `dashboardActive`, window-scoped for the same cross-window reason as
+    /// `terminalZoomActive(for:)` (`focusSplitPane`'s callers can target ANY window). Unlike the frontmost
+    /// case's grid cell, a NON-member deck surface behind the modal is NOT view-only, so grabbing first
+    /// responder for it would steal keystrokes into a hidden terminal.
     private func dashboardActive(for session: Session) -> Bool {
         guard let windowID = library.windowID(forSession: session.id) else { return false }
         return DashboardControllerRegistry.shared.controller(for: windowID)?.isOpen == true
     }
 
     /// Whether the quick terminal is showing in the window OWNING this session — the session-scoped twin of
-    /// `frontmostQuickTerminal`, completing the set with `terminalZoomActive(for:)`/`dashboardActive(for:)`.
-    /// Each window owns its own controller, so the FRONTMOST one is the wrong question for `focusSplitPane`:
-    /// a cover in the frontmost window would drop the focus step for a `session.focus --pane` aimed at a
-    /// BACKGROUND one (leaving that window's `splitFocused` and its real first responder disagreeing), while
-    /// a cover actually showing there — the one that does own its focus — would be missed.
+    /// `frontmostQuickTerminal`, window-scoped like `terminalZoomActive(for:)` since each window owns its own
+    /// controller: gating on the frontmost would both drop the focus step for a background target (leaving
+    /// its `splitFocused` and real first responder disagreeing) and miss a cover actually showing there.
     private func quickTerminalActive(for session: Session) -> Bool {
         guard let windowID = library.windowID(forSession: session.id) else { return false }
         return QuickTerminalRegistry.shared.controller(for: windowID)?.isVisible == true
@@ -73,40 +70,35 @@ extension AppActions {
     // MARK: - Reveal & focus
 
     /// Reveal and focus the active session's blocked pane, reading its agent-status pane tag so navigation
-    /// lands on the pane actually waiting for input rather than the session's plain focused pane. Called on
-    /// every user-initiated selection — the auto-follow jump, attention nav (⌃⌥↑/↓), plain session nav
-    /// (⌥⌘↑/↓/first/last), the ⌃P / attention palette, a sidebar row click, a title-bar bell popover row, a
-    /// Dock-menu session row — and a no-op (plain `focusActiveSession`) for an idle or active session, so
-    /// ordinary selections and a working agent's informational pane tag never move the pane selection.
-    /// `.right`, only when `splitSurface != nil`, flips `splitFocused` then focuses the split surface via
-    /// `focusSplitPane(wantSplit: true)` — a FIXED target, NOT the `splitFocused`-following
-    /// `focusActiveSession`: a SHOWN (side-by-side) split's deck re-render churns first responder onto the
-    /// main pane, whose `onFocusChange` writes `splitFocused = false`, so a follow-the-flag target chases the
-    /// wrong pane while re-asserting the split surface wins the race (its `onFocusChange` re-sets true). The
-    /// gate is `splitSurface != nil`, NOT `hasSplit`, so a promoted split survivor (`closePrimaryPane` moves
-    /// it into `surface` with `splitSurface == nil`, re-tagging a `.right` block to `.left`) and a STALE
-    /// `right` tag on a genuinely single-pane session (a manual `session.status --pane right`, or a collapsed
-    /// split) both target the sole main pane instead of setting `splitFocused = true` with no split surface —
-    /// the invariant is "true only while the split pane exists". `.scratch` shows the scratch only when
-    /// hidden (a show-if-hidden guard, never a bare toggle that could HIDE a shown one) so `topmostSurface`
-    /// resolves to it; `.left`/nil clear `splitFocused` and target the primary surface even when the right
-    /// pane held focus before selection, and the retry loops cover a split/scratch surface materializing a
-    /// beat later. Inversely, a NON-scratch target (`left`/`right`/nil) with the scratch SHOWN hides the
-    /// covering scratch (keep-alive `toggleScratch`) FIRST, or `focusSplitPane`/`focusActiveSession` both
-    /// resolve to it as `topmostSurface` and nav never reaches the blocked pane; only the scratch cover is
-    /// dismissed, since closing a running overlay would kill its program. Selection callers pass the
-    /// indicator from `AppStore.selectSession`/`navigateSession`, captured before either clears an
-    /// `autoReset` status, so pane routing is identical across the Dock, nav, palettes, clicks, and auto-follow.
+    /// lands on the pane actually waiting for input, not the plain focused pane. Called on every user-initiated
+    /// selection — auto-follow, attention nav (⌃⌥↑/↓), session nav (⌥⌘↑/↓/first/last), the ⌃P/attention
+    /// palettes, a sidebar row click, a title-bar bell popover row, a Dock-menu session row — and a no-op
+    /// (plain `focusActiveSession`) for an idle or active session, so ordinary selections and a working agent's
+    /// informational pane tag never move the pane selection. `.right`, only when `splitSurface != nil`, flips
+    /// `splitFocused` then focuses the split surface via `focusSplitPane(wantSplit: true)` — a FIXED target,
+    /// NOT the `splitFocused`-following `focusActiveSession`: a SHOWN split's deck re-render churns first
+    /// responder onto the main pane, whose `onFocusChange` writes `splitFocused = false`, so a follow-the-flag
+    /// target chases the wrong pane while re-asserting the split surface wins the race (its `onFocusChange`
+    /// re-sets true). The gate is `splitSurface != nil`, NOT `hasSplit`, so a promoted split survivor
+    /// (`closePrimaryPane` re-tags its `.right` block to `.left`) and a STALE `right` tag on a single-pane
+    /// session (a manual `session.status --pane right`, or a collapsed split) both target the sole main pane
+    /// instead of setting `splitFocused = true` with no split surface — true only while the split pane exists.
+    /// `.scratch` shows the scratch only when hidden (never a bare toggle, which could HIDE a shown one) so
+    /// `topmostSurface` resolves to it; `.left`/nil clear `splitFocused` and target the primary even when the
+    /// right pane held focus before selection, the retry loops covering a surface materializing a beat later.
+    /// Inversely, a NON-scratch target with the scratch SHOWN hides it (keep-alive `toggleScratch`) FIRST, or
+    /// both focus paths resolve to it as `topmostSurface` and nav never reaches the blocked pane; only the
+    /// scratch cover is dismissed — closing a running overlay would kill its program. Callers pass the
+    /// indicator from `AppStore.selectSession`/`navigateSession`, captured before either clears an `autoReset`
+    /// status, so pane routing is identical across every entry point.
     func revealActiveBlockedPane(captured indicator: AgentIndicator?) {
         guard let indicator else { focusActiveSession(); return }
         guard let session = store?.activeSession else { focusActiveSession(); return }
         // a no-op unless the status needs attention: the scratch-hide / split-focus side effects must never
-        // fire on plain navigation to a session merely showing its keep-alive scratch, or still active. a
-        // needs-attention status with no `--pane` tag counts as `left` and still reveals the main pane.
+        // fire on plain navigation to a still-active session, or one merely showing its keep-alive scratch.
         guard indicator.status.needsAttention else { focusActiveSession(); return }
         let pane = indicator.statusPane
-        // a shown scratch covers the panes and masks a non-scratch block; hide it first so the requested
-        // pane is revealed. overlays are deliberately not touched — closing a running overlay is destructive.
+        // a shown scratch masks a non-scratch block; overlays are deliberately left alone.
         if pane != .scratch, session.scratchActive { store?.toggleScratch(session.id) }
         switch pane {
         case .right where session.splitSurface != nil:
@@ -123,17 +115,16 @@ extension AppActions {
 
     /// Move first responder back to the active session's topmost surface (after the quick terminal or a
     /// palette/rename field closes). Targets `topmostSurface` (overlay > scratch > active pane), so a close
-    /// re-focuses whatever is actually visible — the scratch or overlay if one is up, else the focused pane
-    /// — never a pane hidden under a cover, and re-asserts briefly since the target view may not be
-    /// on-window yet. Bails only for the quick terminal: a window-level cover that owns focus and re-focuses
-    /// the session on its own hide.
+    /// re-focuses whatever is actually visible and never a pane hidden under a cover, and re-asserts briefly
+    /// since the target view may not be on-window yet. Bails only for the quick terminal: a window-level
+    /// cover that owns focus and re-focuses the session on its own hide.
     func focusActiveSession(attempt: Int = 0) {
         if terminalZoomActive { return }
         if dashboardActive { return }
         if renamePending { return }
-        // never grab terminal focus while a command palette is open — it owns the keyboard. this also kills
-        // the retry loop the instant a palette (re)opens, so the action-palette "Select Theme…" launcher
-        // (which closes that palette, then opens the .themes picker a tick later) keeps its field focus.
+        // never grab terminal focus while a palette is open — it owns the keyboard. this also kills the retry
+        // loop the instant a palette (re)opens, so the "Select Theme…" launcher (which closes the action
+        // palette, then opens the .themes picker a tick later) keeps its field focus.
         if palette?.mode != nil { return }
         if pickActive(for: library.activeWindowID) { return }
         if frontmostQuickTerminal?.isVisible == true { return }
@@ -152,14 +143,13 @@ extension AppActions {
     /// pane is hidden, so keep first responder on the visible `topmostSurface` — the caller has already set
     /// `splitFocused`, so the correct pane shows once the cover is dismissed.
     func focusSplitPane(_ session: Session, wantSplit: Bool, attempt: Int = 0, generation: Int? = nil) {
-        // each fresh call SUPERSEDES any in-flight retry loop in the SAME WINDOW: without this, two calls
-        // with opposite targets each run their own 12x30ms `makeFirstResponder` loop, ping-ponging first
-        // responder between the panes for ~400ms and redrawing both surfaces per flip (the split-focus
-        // flicker). the counter is keyed by the owning WINDOW — one NSWindow has one first responder, so a
-        // newer focus op there supersedes an older loop (last-focus-wins) while other windows stay
-        // independent and never cancel each other's still-materializing retries. the surviving loop still
-        // re-asserts through the split-materialize / reparent churn, its re-asserts being no-ops once its
-        // target holds focus.
+        // each fresh call SUPERSEDES any in-flight retry loop in the SAME WINDOW: otherwise two calls with
+        // opposite targets each run their own 12x30ms `makeFirstResponder` loop, ping-ponging first responder
+        // between the panes for ~400ms and redrawing both surfaces per flip (the split-focus flicker). keyed
+        // by the owning WINDOW — one NSWindow has one first responder, so a newer focus op supersedes an
+        // older loop (last-focus-wins) while other windows never cancel each other's still-materializing
+        // retries. the survivor still re-asserts through the split-materialize / reparent churn, a no-op
+        // once its target holds focus.
         let gen: Int
         let scope = library.windowID(forSession: session.id) ?? session.id // fall back to session id when windowless
         if let generation {
@@ -172,26 +162,21 @@ extension AppActions {
         if terminalZoomActive(for: session) { return }
         if dashboardActive(for: session) { return }
         if pickActive(for: library.windowID(forSession: session.id)) { return }
-        // the inline rename field and an open palette own the keyboard, as in `focusActiveSession`, which
-        // re-checks both on every retry; this loop needs it because the `.left`/nil reveal routes here (a
-        // plain `session status blocked` with no `--pane`), so a sidebar row click followed inside the
-        // ~360ms retry window by ⌘R or a palette open would pull first responder off the field and type the
-        // name into the terminal. SCOPED to the session's own window like the two gates above, for the same
-        // cross-window reason: both flags are app-GLOBAL (one `renamePending`, one `PaletteController`
+        // the inline rename field and an open palette own the keyboard. this loop needs the gate because the
+        // `.left`/nil reveal routes here (a plain `session status blocked` with no `--pane`), so a sidebar
+        // row click followed inside the ~360ms retry window by ⌘R or a palette open would pull first
+        // responder off the field and type the name into the terminal. SCOPED to the session's own window
+        // like the two gates above: both flags are app-GLOBAL (one `renamePending`, one `PaletteController`
         // shared by every window), so unscoped a frontmost palette would silently skip the responder move
         // for a `session.focus` aimed at a background window, leaving its `splitFocused` and real first
-        // responder disagreeing while the control command still reports ok. scoping costs nothing — only
-        // the KEY window receives keystrokes, so the race guarded here (a retry stealing the field being
-        // typed into) is frontmost-only. a BACKGROUND window can still hold an inline editor, since rename
-        // notifications fan out to every window's sidebar coordinator, but nobody types into it and that
-        // fan-out is a separate, older defect.
+        // responder disagreeing while the control command still reports ok. scoping is safe because only the
+        // KEY window receives keystrokes — a background window can still hold an inline editor (rename
+        // notifications fan out to every sidebar coordinator), but nobody types into it, a separate defect.
         if library.windowID(forSession: session.id) == library.activeWindowID {
             if renamePending { return }
             if palette?.mode != nil { return }
         }
-        // the quick terminal is a window-level cover above the session; while it's up it owns focus, so
-        // don't move first responder to a pane behind it (its own hide restores the session). The caller
-        // has already set `splitFocused`, so the right pane shows once the quick terminal is dismissed.
+        // the quick terminal is a window-level cover that owns focus; its own hide restores the session.
         if quickTerminalActive(for: session) { return }
         let target: (any TerminalSurface)? = (session.overlayActive || session.scratchActive)
             ? session.topmostSurface
@@ -205,26 +190,25 @@ extension AppActions {
         }
     }
 
-    /// Bring a session/pane to the foreground from a notification click: surface the owning window
-    /// (reopening it when the banner was clicked after the window closed), select the session (clearing its
-    /// unseen badge and deriving its workspace), and focus the firing pane. Stale-safe: an unknown session
-    /// in an open window resolves directly, an unknown window/session leaves the app active (the caller has
-    /// activated it), and a `.split` pane that is no longer split falls back to the primary.
+    /// Bring a session/pane to the foreground from a notification click: surface the owning window (reopening
+    /// a closed one), select the session (clearing its unseen badge and deriving its workspace), and focus
+    /// the firing pane. Stale-safe: a session in an open window resolves directly, an unknown window/session
+    /// leaves the app active (the caller has activated it), and a `.split` pane that is no longer split falls
+    /// back to the primary.
     func reveal(windowID: UUID, sessionID: UUID, pane: PaneRole) {
-        // window already open: select + focus right away.
         if let store = library.store(forSession: sessionID) {
             revealSession(sessionID, pane: pane, in: store)
             return
         }
-        // window closed: reopen it, then select once its store has loaded (the surface materializes
-        // a beat after the window appears, so retry like focusSplitPane does).
+        // window closed: reopen it, then select once its store has loaded (the surface materializes a beat
+        // after the window appears, so retry like `focusSplitPane` does).
         guard library.windows.contains(where: { $0.id == windowID }) else { return }
         openWindow?(windowID)
         revealAfterOpen(windowID: windowID, sessionID: sessionID, pane: pane)
     }
 
-    /// Polls for a reopened window's store to load, then reveals the session. Bounded so a stale id
-    /// (the window never materializes) gives up instead of looping forever.
+    /// Polls for a reopened window's store to load, then reveals the session. Bounded, so a stale id (the
+    /// window never materializes) gives up instead of looping forever.
     private func revealAfterOpen(windowID: UUID, sessionID: UUID, pane: PaneRole, attempt: Int = 0) {
         if let store = library.store(for: windowID), store.session(withID: sessionID) != nil {
             revealSession(sessionID, pane: pane, in: store)
@@ -236,19 +220,18 @@ extension AppActions {
         }
     }
 
-    /// Selects a session in its owning store and focuses the firing pane.
     private func revealSession(_ sessionID: UUID, pane: PaneRole, in store: AppStore) {
         guard let session = store.session(withID: sessionID) else { return }
         let windowID = library.windowID(forSession: session.id)
-        // a banner click is an explicit "take me there": if the owning window is zoomed, exit zoom
-        // first so the reveal is visible — otherwise the selection change happens behind the opaque
-        // zoom layer and the click looks dead (every other UI entry point is gated or exits zoom).
+        // a banner click is an explicit "take me there", so exit a zoomed owning window first, or the
+        // selection changes behind the opaque zoom layer and the click looks dead (every other UI entry point
+        // is gated or exits zoom).
         if let windowID, let zoom = TerminalZoomRegistry.shared.controller(for: windowID), zoom.target != nil {
             zoom.clear()
         }
-        // raise the owning window, which `makeFirstResponder` alone does not do: `NSApp.activate` in the
-        // notification handler brings the APP forward, not a window minimized to the Dock or behind another,
-        // so the selection would change invisibly. the closed-window branch already raises via `openWindow`.
+        // raise the owning window, which `makeFirstResponder` does not: `NSApp.activate` in the notification
+        // handler brings the APP forward, not a window minimized to the Dock or behind another, so the
+        // selection would change invisibly. the closed-window branch already raises via `openWindow`.
         if let windowID { WindowRegistry.shared.raise(windowID) }
         // a banner click is a user-initiated selection: note activity on the SAME (owning) store it selects
         // into — reveal can cross windows — so it buys the full idle grace before auto-follow pulls away.

--- a/agterm/AppActions+Palette.swift
+++ b/agterm/AppActions+Palette.swift
@@ -1,18 +1,16 @@
 import agtermCore
 import Foundation
 
-/// Command palettes (action / session / attention / custom-command feeds) and the live-preview theme
-/// picker for `AppActions`. The theme-preview session state (`themePreviewActive`/`themePreviewOriginal`)
-/// lives on the main `AppActions` declaration — an extension can hold no stored properties — while the
-/// preview/commit/cancel logic that drives it lives here.
+/// Command palettes (action / session / attention / custom-command feeds) and the live-preview theme picker
+/// for `AppActions`. The theme-preview state (`themePreviewActive`/`themePreviewOriginal`) lives on the main
+/// `AppActions` declaration — an extension can hold no stored properties — while its logic lives here.
 extension AppActions {
     // MARK: - Command palettes
 
-    /// The macOS glyph string for a rebindable built-in's CURRENT shortcut (`⌘N`, `⌃⌘S`) — tracking
-    /// rebinds, reading like the menu equivalent — or `nil` when the action has no shortcut. The SINGLE
-    /// resolver behind both the action-palette hints and the toolbar/sidebar tooltips, so the two can't
-    /// drift. `glyphHint` resolves the live keymap (override else shipped default); before `settingsModel`
-    /// is wired, the shipped default alone.
+    /// The macOS glyph string for a rebindable built-in's CURRENT shortcut (`⌘N`, `⌃⌘S`), reading like the menu
+    /// equivalent, or nil when the action has no shortcut. The SINGLE resolver behind both the action-palette
+    /// hints and the toolbar/sidebar tooltips, so the two can't drift. `glyphHint` resolves the live keymap
+    /// (override else shipped default); before `settingsModel` is wired, the shipped default alone.
     func shortcutGlyph(for action: BuiltinAction) -> String? {
         guard let keymap = settingsModel?.keymap else { return action.defaultChord?.glyphString }
         return keymap.glyphHint(for: action)
@@ -123,9 +121,8 @@ extension AppActions {
         return items
     }
 
-    /// The user-defined keymap commands as palette items, showing the bound chord (if any). Running one
-    /// delegates to the runner, which resolves the active session's context and spawns the shell line.
-    /// `badge` tags each entry (`custom` in the mixed action palette); the custom-only palette passes nil.
+    /// The user-defined keymap commands as palette items with their bound chord; running one delegates to the
+    /// runner, which resolves the active session's context and spawns the shell line. `badge` tags each entry.
     private func customCommandItems(badge: String?) -> [PaletteItem] {
         (settingsModel?.keymap.commands ?? []).map { command in
             PaletteItem(id: "custom-\(command.id)", title: command.name,
@@ -137,27 +134,23 @@ extension AppActions {
         }
     }
 
-    /// Only the user-defined keymap commands, for the `.customCommands` palette. Same rows as the
-    /// `custom` subset of `paletteActions()` but WITHOUT the `custom` badge — the whole list is custom.
+    /// The user-defined keymap commands alone, for the `.customCommands` palette: unbadged, all are custom.
     func paletteCustomCommands() -> [PaletteItem] {
         customCommandItems(badge: nil)
     }
 
-    /// The VISIBLE/FILTERED sessions as palette items (the ⌃P switcher); choosing one selects it. Scoped
-    /// to `navigableSessions` — the MARKED workspaces' sessions while the focus filter is applied, the
-    /// flagged set in flagged mode, else all — so the ⌃P list matches the sidebar (and the Ctrl-Tab MRU
-    /// switcher and `session.go` nav, which filter the same way). The subtitle leads with the owning
-    /// workspace (telling same-named sessions apart, and searchable), then `subtitleDetail` — the focused
-    /// pane's terminal title for a remote session, else its cwd.
+    /// The VISIBLE/FILTERED sessions as palette items (the ⌃P switcher); choosing one selects it. Scoped to
+    /// `navigableSessions` — the MARKED workspaces' sessions under the focus filter, the flagged set in flagged
+    /// mode, else all — so ⌃P matches the sidebar, the Ctrl-Tab MRU switcher and `session.go`. The subtitle
+    /// leads with the owning workspace, telling same-named sessions apart and searchable, then `subtitleDetail`.
     func paletteSessions() -> [PaletteItem] {
         guard let store else { return [] }
         return store.navigableSessions.map { paletteItem(for: $0, in: store) }
     }
 
-    /// The window's non-idle sessions as palette items (the `.attention` mode), each row carrying the
-    /// session's agent-status glyph. Sourced from `store.attentionSessions` (blocked→active→completed,
-    /// newest status-change first) so the empty-query order matches that ranking; choosing one selects it.
-    /// Same subtitle shape as `paletteSessions()` (owning workspace · `subtitleDetail`).
+    /// The window's non-idle sessions as palette items (`.attention` mode), each row carrying the session's
+    /// agent-status glyph. `store.attentionSessions` orders blocked→active→completed, newest status-change
+    /// first, so the empty-query order matches; choosing one selects it. Subtitle as in `paletteSessions()`.
     func paletteAttention() -> [PaletteItem] {
         guard let store else { return [] }
         return store.attentionSessions.map {
@@ -166,10 +159,9 @@ extension AppActions {
         }
     }
 
-    /// Maps one session to a palette row — title=`displayName`, subtitle="`workspace` · `subtitleDetail`",
-    /// `run` selects it. Shared by `paletteSessions()` (status nil) and `paletteAttention()` (status set so
-    /// `CommandPalette.row` renders the leading `StatusGlyph`, tinted and shaped by the session's per-call
-    /// `statusColor`/`statusShape`).
+    /// Maps one session to a palette row — title `displayName`, subtitle "`workspace` · `subtitleDetail`", run
+    /// selects it. Shared by `paletteSessions()` (status nil) and `paletteAttention()`, where a set status makes
+    /// `CommandPalette.row` render the leading `StatusGlyph` in the per-call `statusColor`/`statusShape`.
     private func paletteItem(for session: Session, in store: AppStore, status: AgentStatus? = nil,
                              statusColor: String? = nil, statusShape: StatusShape? = nil) -> PaletteItem {
         let id = session.id
@@ -178,27 +170,26 @@ extension AppActions {
         return PaletteItem(id: id.uuidString, title: session.displayName, subtitle: subtitle,
                            status: status, statusColor: statusColor, statusShape: statusShape) { [weak self] in
             guard self?.uiActionsEnabled == true else { return }
-            // picking a session from the ⌃P / attention palette is a user-initiated selection: note activity
-            // so it buys the full idle grace before auto-follow can pull the selection back.
+            // a palette pick is user-initiated: note activity so it buys the full idle grace before
+            // auto-follow can pull the selection back.
             store.noteUserActivity()
             let indicator = store.selectSession(id)
-            // reveal the picked session's blocked pane (a no-op unless it carries a pane-tagged block),
-            // async so it runs AFTER the palette closes and its focus-restore, winning the focus race.
+            // reveal the picked session's blocked pane (no-op without a pane-tagged block), async so it runs
+            // AFTER the palette closes and its focus-restore, winning the focus race.
             DispatchQueue.main.async { self?.revealActiveBlockedPane(captured: indicator) }
         }
     }
 
-    /// Toggle the `.attention` command palette (the window's non-idle sessions). Driven by the ⌃⇧I
-    /// `BuiltinAction.showAttention`, Navigate ▸ Go to Attention…, and the titlebar bell icon — none route
-    /// through the action palette's `runItem`, so a synchronous toggle is correct. The ⌃⇧P launcher uses
-    /// `openAttentionPalette()` instead (it must reopen async).
+    /// Toggle the `.attention` palette. Driven by ⌃⇧I `BuiltinAction.showAttention`, Navigate ▸ Go to
+    /// Attention…, and the titlebar bell — none route through the action palette's `runItem`, so a synchronous
+    /// toggle is correct; the ⌃⇧P launcher uses `openAttentionPalette()`, which must reopen async.
     func toggleAttentionPalette() {
         guard !terminalZoomActive, !pickActive(for: library.activeWindowID) else { return }
         palette?.toggle(.attention)
     }
 
-    /// Menu/keymap palette launchers route through actions, not direct `palette.toggle`, so terminal zoom's
-    /// modal UI guard is applied consistently to the keyboard shortcut and menu paths.
+    /// Menu/keymap palette launchers route through actions, not `palette.toggle`, so terminal zoom's modal UI
+    /// guard applies consistently to the keyboard-shortcut and menu paths.
     func toggleSessionPalette() {
         guard !terminalZoomActive, !pickActive(for: library.activeWindowID) else { return }
         palette?.toggle(.sessions)
@@ -214,10 +205,9 @@ extension AppActions {
         palette?.toggle(.customCommands)
     }
 
-    /// Open the `.attention` command palette from the action-palette "Show Attention" launcher, on the next
-    /// runloop tick (mirroring `openThemePalette()`): the launcher runs inside the open action palette's
-    /// `runItem`, which calls `controller.close()` right after this returns, so a synchronous `toggle`
-    /// would be undone. The async `open` lets `.attention` reopen a tick later as a fresh view.
+    /// Open `.attention` from the action-palette "Show Attention" launcher on the next runloop tick, like
+    /// `openThemePalette()`: the launcher runs inside the action palette's `runItem`, which calls
+    /// `controller.close()` right after this returns, so a synchronous toggle would be undone.
     func openAttentionPalette() {
         guard !terminalZoomActive, !pickActive(for: library.activeWindowID) else { return }
         DispatchQueue.main.async { [weak self] in
@@ -229,10 +219,9 @@ extension AppActions {
 
     // MARK: - Theme picker
 
-    /// Open the `.themes` command palette (the live-preview theme picker). Invoked by the action-palette
-    /// "Select Theme…" launcher and View ▸ Select Theme…, on the next runloop tick: when launched from the
-    /// open action palette, that palette's run handler closes itself right after this returns, so
-    /// reopening async lets `.themes` survive the close (the rename actions reopen the same way).
+    /// Open the `.themes` palette (the live-preview theme picker), from the action-palette "Select Theme…"
+    /// launcher or View ▸ Select Theme…, on the next runloop tick: launched from the open action palette, that
+    /// palette's run handler closes itself right after this returns, so only an async reopen survives it.
     func openThemePalette() {
         guard !terminalZoomActive, !pickActive(for: library.activeWindowID) else { return }
         DispatchQueue.main.async { [weak self] in
@@ -256,27 +245,23 @@ extension AppActions {
                         })
         }
         // the nil row is ghostty's built-in default (no theme file); the app's own default is the bundled
-        // "agterm" theme, listed like any other. While following the system appearance the nil row is
-        // OMITTED (mirroring the Settings picker): a dual conditional needs two NAMED themes, so previewing
-        // nil would blank a slot and wedge the following state.
+        // "agterm" theme, listed like any other. While following the system appearance the nil row is OMITTED:
+        // a dual conditional needs two NAMED themes, so previewing nil blanks a slot and wedges that state.
         let entries = ThemeCatalog(names: SettingsCatalog.themeNames()).entries
         return (followsSystemAppearance ? entries.filter { !$0.isDefault } : entries).map(item)
     }
 
-    /// The palette-item id of the currently-applied theme, so the picker opens with that row selected
-    /// (and previews it — a no-op — rather than jumping to "Default").
+    /// The applied theme's palette-item id, so the picker opens on that row (a no-op preview), not "Default".
     var currentThemeID: String { ThemeCatalog.id(for: effectiveTheme) }
 
-    /// The theme currently ON SCREEN: the dark slot while following in dark mode, else `theme`. The
-    /// palette badges/opens on this and previews/commits target the same slot, so the open-row preview
-    /// matches what is rendering.
+    /// The theme currently ON SCREEN: the dark slot while following in dark mode, else `theme`. The palette
+    /// badges/opens on it and previews/commits target the same slot, so the open-row preview matches rendering.
     private var effectiveTheme: String? {
         settingsModel?.settings.activeTheme(isDark: GhosttyApp.currentIsDark())
     }
 
-    /// Capture BOTH theme slots so Esc/cancel can restore the pre-preview pair — snapshotting the whole
-    /// pair (not just the on-screen slot) keeps the revert correct even if macOS flips appearance
-    /// mid-preview (see `cancelThemePreview`). Idempotent while a preview is active.
+    /// Capture BOTH theme slots, not just the on-screen one, so Esc/cancel restores the pre-preview pair even
+    /// if macOS flips appearance mid-preview. Idempotent while a preview is active.
     func beginThemePreview() {
         guard let settingsModel, !themePreviewActive else { return }
         themePreviewOriginal = (settingsModel.settings.theme, settingsModel.settings.darkTheme)
@@ -289,11 +274,10 @@ extension AppActions {
         settingsModel?.previewTheme(name)
     }
 
-    /// Persist the previewed theme (Enter/click), ending the preview so the subsequent palette close can't
-    /// revert it. The preview already wrote the current-appearance slot (dark slot while following in dark
-    /// mode, else `theme`), so only that slot commits — the captured pair is passed back so the OTHER slot
-    /// is restored to its pre-preview value, else a value browsed into it during a mid-preview appearance
-    /// flip would leak in on commit (the flip-safe twin of `cancelThemePreview`).
+    /// Persist the previewed theme (Enter/click), ending the preview so the palette close can't revert it. The
+    /// preview already wrote the current-appearance slot, so only that slot commits; the captured pair goes
+    /// back so the OTHER slot returns to its pre-preview value, else a value browsed into it during a
+    /// mid-preview appearance flip would leak in on commit.
     func commitThemePreview() {
         guard themePreviewActive else { return }
         if let original = themePreviewOriginal {
@@ -303,11 +287,10 @@ extension AppActions {
         themePreviewOriginal = nil
     }
 
-    /// Restore BOTH captured slots and end the preview (Esc / scrim / mode switch / unmount without a
-    /// commit); no-op when no preview is active (e.g. right after a commit). Routes through the IMMEDIATE
-    /// (non-debounced) revert so Esc restores the original pair instantly — the navigation preview is
-    /// debounced, so `previewTheme` here would lag or leave the last previewed theme stuck applied.
-    /// Reverting the WHOLE pair is flip-safe: a mid-preview flip can't strand a value in the wrong slot.
+    /// Restore BOTH captured slots and end the preview (Esc / scrim / mode switch / unmount without a commit);
+    /// no-op when no preview is active. Routes through the IMMEDIATE (non-debounced) revert so Esc restores the
+    /// original pair instantly — the debounced navigation preview would lag or leave the last theme stuck
+    /// applied. Reverting the WHOLE pair is flip-safe: a mid-preview flip can't strand a value in a wrong slot.
     func cancelThemePreview() {
         guard themePreviewActive else { return }
         if let original = themePreviewOriginal {
@@ -332,8 +315,8 @@ extension AppActions {
     var currentLightTheme: String? { followsSystemAppearance ? settingsModel?.settings.theme : nil }
     var currentDarkTheme: String? { followsSystemAppearance ? settingsModel?.settings.darkTheme : nil }
 
-    /// Set the light/single slot, keeping a dark side if present — the control channel's
-    /// `theme.set <name>` (the persist+apply path, no live preview). nil clears everything.
+    /// Set the light/single slot, keeping any dark side — `theme.set <name>`: persist+apply, no live preview;
+    /// nil clears everything.
     func setLightTheme(_ name: String?) { settingsModel?.setLightTheme(name) }
 
     /// Set (or with nil, clear) the dark slot — the control channel's `theme.set --dark`.

--- a/agterm/AppActions+Palette.swift
+++ b/agterm/AppActions+Palette.swift
@@ -1,18 +1,18 @@
 import agtermCore
 import Foundation
 
-/// Command palettes (action / session / attention / custom-command feeds) and the live-preview
-/// theme picker for `AppActions`. The theme-preview session state (`themePreviewActive` /
-/// `themePreviewOriginal`) lives on the main `AppActions` declaration — stored properties cannot
-/// live in an extension — while the preview/commit/cancel logic that drives it lives here.
+/// Command palettes (action / session / attention / custom-command feeds) and the live-preview theme
+/// picker for `AppActions`. The theme-preview session state (`themePreviewActive`/`themePreviewOriginal`)
+/// lives on the main `AppActions` declaration — an extension can hold no stored properties — while the
+/// preview/commit/cancel logic that drives it lives here.
 extension AppActions {
     // MARK: - Command palettes
 
     /// The macOS glyph string for a rebindable built-in's CURRENT shortcut (`⌘N`, `⌃⌘S`) — tracking
     /// rebinds, reading like the menu equivalent — or `nil` when the action has no shortcut. The SINGLE
-    /// resolver behind both the action-palette hints and the toolbar/sidebar tooltips, so the two
-    /// surfaces can't drift. `glyphHint` resolves the live keymap (override else shipped default);
-    /// before `settingsModel` is wired, the shipped default alone.
+    /// resolver behind both the action-palette hints and the toolbar/sidebar tooltips, so the two can't
+    /// drift. `glyphHint` resolves the live keymap (override else shipped default); before `settingsModel`
+    /// is wired, the shipped default alone.
     func shortcutGlyph(for action: BuiltinAction) -> String? {
         guard let keymap = settingsModel?.keymap else { return action.defaultChord?.glyphString }
         return keymap.glyphHint(for: action)
@@ -95,8 +95,6 @@ extension AppActions {
     /// The app's commands as palette items, sharing the same logic as the menu/buttons. Includes a
     /// "Move Session to …" item per other workspace (when there's an active session to move).
     func paletteActions() -> [PaletteItem] {
-        // built-in shortcut hints read the live keymap (`shortcutGlyph`) so a rebind updates them too,
-        // matching the data-driven menu key-equivalents; custom commands show their raw shortcut below.
         let context = paletteContext
         var items = PaletteCommand.allCases
             .filter { $0.isVisible(in: context) }
@@ -121,15 +119,13 @@ extension AppActions {
                 })
             }
         }
-        // user-defined keymap commands: marked `custom`, showing the bound chord (if any).
         items.append(contentsOf: customCommandItems(badge: "custom"))
         return items
     }
 
     /// The user-defined keymap commands as palette items, showing the bound chord (if any). Running one
     /// delegates to the runner, which resolves the active session's context and spawns the shell line.
-    /// `badge` tags each entry (`custom` in the mixed action palette); the custom-only palette passes nil
-    /// since every row there is already a custom command.
+    /// `badge` tags each entry (`custom` in the mixed action palette); the custom-only palette passes nil.
     private func customCommandItems(badge: String?) -> [PaletteItem] {
         (settingsModel?.keymap.commands ?? []).map { command in
             PaletteItem(id: "custom-\(command.id)", title: command.name,
@@ -149,10 +145,10 @@ extension AppActions {
 
     /// The VISIBLE/FILTERED sessions as palette items (the ⌃P switcher); choosing one selects it. Scoped
     /// to `navigableSessions` — the MARKED workspaces' sessions while the focus filter is applied, the
-    /// flagged set in flagged mode, else all — so the ⌃P list matches the sidebar (and the Ctrl-Tab MRU switcher
-    /// and `session.go` nav, which already filter the same way). The subtitle leads with the owning
-    /// workspace (so you can tell sessions of the same name apart, and search by workspace) followed by
-    /// `subtitleDetail` (the focused pane's terminal title for a remote session, else its cwd).
+    /// flagged set in flagged mode, else all — so the ⌃P list matches the sidebar (and the Ctrl-Tab MRU
+    /// switcher and `session.go` nav, which filter the same way). The subtitle leads with the owning
+    /// workspace (telling same-named sessions apart, and searchable), then `subtitleDetail` — the focused
+    /// pane's terminal title for a remote session, else its cwd.
     func paletteSessions() -> [PaletteItem] {
         guard let store else { return [] }
         return store.navigableSessions.map { paletteItem(for: $0, in: store) }
@@ -160,8 +156,8 @@ extension AppActions {
 
     /// The window's non-idle sessions as palette items (the `.attention` mode), each row carrying the
     /// session's agent-status glyph. Sourced from `store.attentionSessions` (blocked→active→completed,
-    /// newest status-change first) so the empty-query order matches that ranking; choosing one selects
-    /// it. Same subtitle shape as `paletteSessions()` (owning workspace · `subtitleDetail`).
+    /// newest status-change first) so the empty-query order matches that ranking; choosing one selects it.
+    /// Same subtitle shape as `paletteSessions()` (owning workspace · `subtitleDetail`).
     func paletteAttention() -> [PaletteItem] {
         guard let store else { return [] }
         return store.attentionSessions.map {
@@ -172,8 +168,8 @@ extension AppActions {
 
     /// Maps one session to a palette row — title=`displayName`, subtitle="`workspace` · `subtitleDetail`",
     /// `run` selects it. Shared by `paletteSessions()` (status nil) and `paletteAttention()` (status set so
-    /// `CommandPalette.row` renders the leading `StatusGlyph`, tinted by the session's per-call `statusColor`
-    /// and shaped by its per-call `statusShape`).
+    /// `CommandPalette.row` renders the leading `StatusGlyph`, tinted and shaped by the session's per-call
+    /// `statusColor`/`statusShape`).
     private func paletteItem(for session: Session, in store: AppStore, status: AgentStatus? = nil,
                              statusColor: String? = nil, statusShape: StatusShape? = nil) -> PaletteItem {
         let id = session.id
@@ -193,9 +189,9 @@ extension AppActions {
     }
 
     /// Toggle the `.attention` command palette (the window's non-idle sessions). Driven by the ⌃⇧I
-    /// `BuiltinAction.showAttention`, the Navigate ▸ Go to Attention… menu item, and the titlebar bell
-    /// icon — none of these route through the action palette's `runItem`, so a synchronous toggle is
-    /// correct. The ⌃⇧P launcher uses `openAttentionPalette()` instead (it must reopen async).
+    /// `BuiltinAction.showAttention`, Navigate ▸ Go to Attention…, and the titlebar bell icon — none route
+    /// through the action palette's `runItem`, so a synchronous toggle is correct. The ⌃⇧P launcher uses
+    /// `openAttentionPalette()` instead (it must reopen async).
     func toggleAttentionPalette() {
         guard !terminalZoomActive, !pickActive(for: library.activeWindowID) else { return }
         palette?.toggle(.attention)
@@ -218,11 +214,10 @@ extension AppActions {
         palette?.toggle(.customCommands)
     }
 
-    /// Open the `.attention` command palette from the action-palette "Show Attention" launcher. Opened on
-    /// the next runloop tick (mirroring `openThemePalette()`): the launcher runs inside the open action
-    /// palette's `runItem`, which calls `controller.close()` right after this returns, so a synchronous
-    /// `toggle` would be undone by that close. The async `open` lets `.attention` reopen a tick later as a
-    /// fresh view that survives the close.
+    /// Open the `.attention` command palette from the action-palette "Show Attention" launcher, on the next
+    /// runloop tick (mirroring `openThemePalette()`): the launcher runs inside the open action palette's
+    /// `runItem`, which calls `controller.close()` right after this returns, so a synchronous `toggle`
+    /// would be undone. The async `open` lets `.attention` reopen a tick later as a fresh view.
     func openAttentionPalette() {
         guard !terminalZoomActive, !pickActive(for: library.activeWindowID) else { return }
         DispatchQueue.main.async { [weak self] in
@@ -235,10 +230,9 @@ extension AppActions {
     // MARK: - Theme picker
 
     /// Open the `.themes` command palette (the live-preview theme picker). Invoked by the action-palette
-    /// "Select Theme…" launcher and the View ▸ Select Theme… menu item. Opened on the next runloop tick:
-    /// when launched from the open action palette, that palette's run handler closes itself right after
-    /// this returns, so reopening async lets `.themes` survive the close (the rename actions reopen the
-    /// same way).
+    /// "Select Theme…" launcher and View ▸ Select Theme…, on the next runloop tick: when launched from the
+    /// open action palette, that palette's run handler closes itself right after this returns, so
+    /// reopening async lets `.themes` survive the close (the rename actions reopen the same way).
     func openThemePalette() {
         guard !terminalZoomActive, !pickActive(for: library.activeWindowID) else { return }
         DispatchQueue.main.async { [weak self] in
@@ -261,10 +255,10 @@ extension AppActions {
                             self?.commitThemePreview()
                         })
         }
-        // the nil row is ghostty's built-in default (no theme file); the app's own default is the
-        // bundled "agterm" theme, which appears in the named list like any other. While following the
-        // system appearance the nil row is OMITTED (mirroring the Settings picker): a dual conditional
-        // needs two NAMED themes, so previewing nil would blank a slot and wedge the following state.
+        // the nil row is ghostty's built-in default (no theme file); the app's own default is the bundled
+        // "agterm" theme, listed like any other. While following the system appearance the nil row is
+        // OMITTED (mirroring the Settings picker): a dual conditional needs two NAMED themes, so previewing
+        // nil would blank a slot and wedge the following state.
         let entries = ThemeCatalog(names: SettingsCatalog.themeNames()).entries
         return (followsSystemAppearance ? entries.filter { !$0.isDefault } : entries).map(item)
     }
@@ -280,9 +274,9 @@ extension AppActions {
         settingsModel?.settings.activeTheme(isDark: GhosttyApp.currentIsDark())
     }
 
-    /// Capture BOTH theme slots so Esc/cancel can restore the pre-preview pair. Snapshotting the whole
+    /// Capture BOTH theme slots so Esc/cancel can restore the pre-preview pair — snapshotting the whole
     /// pair (not just the on-screen slot) keeps the revert correct even if macOS flips appearance
-    /// mid-preview — see `cancelThemePreview`. Idempotent while a preview is active.
+    /// mid-preview (see `cancelThemePreview`). Idempotent while a preview is active.
     func beginThemePreview() {
         guard let settingsModel, !themePreviewActive else { return }
         themePreviewOriginal = (settingsModel.settings.theme, settingsModel.settings.darkTheme)
@@ -295,11 +289,11 @@ extension AppActions {
         settingsModel?.previewTheme(name)
     }
 
-    /// Persist the previewed theme (Enter/click). Ends the preview so the subsequent palette close can't
-    /// revert it. The preview already wrote the current-appearance slot (dark slot while following in
-    /// dark mode, else `theme`), so only that slot commits — the captured pair is passed back so the
-    /// OTHER slot is restored to its pre-preview value, otherwise a value browsed into it during a
-    /// mid-preview appearance flip would leak in on commit (the flip-safe twin of `cancelThemePreview`).
+    /// Persist the previewed theme (Enter/click), ending the preview so the subsequent palette close can't
+    /// revert it. The preview already wrote the current-appearance slot (dark slot while following in dark
+    /// mode, else `theme`), so only that slot commits — the captured pair is passed back so the OTHER slot
+    /// is restored to its pre-preview value, else a value browsed into it during a mid-preview appearance
+    /// flip would leak in on commit (the flip-safe twin of `cancelThemePreview`).
     func commitThemePreview() {
         guard themePreviewActive else { return }
         if let original = themePreviewOriginal {
@@ -310,11 +304,10 @@ extension AppActions {
     }
 
     /// Restore BOTH captured slots and end the preview (Esc / scrim / mode switch / unmount without a
-    /// commit). No-op when no preview is active (e.g. right after a commit). Routes through the IMMEDIATE
+    /// commit); no-op when no preview is active (e.g. right after a commit). Routes through the IMMEDIATE
     /// (non-debounced) revert so Esc restores the original pair instantly — the navigation preview is
-    /// debounced, so calling `previewTheme` here would lag or leave the last previewed theme stuck
-    /// applied. Reverting the WHOLE pair (not the on-screen slot) is flip-safe: an appearance flip
-    /// mid-preview can't strand a previewed value in the wrong slot.
+    /// debounced, so `previewTheme` here would lag or leave the last previewed theme stuck applied.
+    /// Reverting the WHOLE pair is flip-safe: a mid-preview flip can't strand a value in the wrong slot.
     func cancelThemePreview() {
         guard themePreviewActive else { return }
         if let original = themePreviewOriginal {

--- a/agterm/AppActions+WorkspaceFocus.swift
+++ b/agterm/AppActions+WorkspaceFocus.swift
@@ -5,28 +5,26 @@ import Foundation
 /// keybind/menu/palette entry point, and Clear Focus. Distinct from `AppActions+Focus.swift`, which owns
 /// SESSION/PANE first-responder mechanics; this file only drives `AppStore`'s tree filter.
 extension AppActions {
-    /// Focus (or unfocus) a workspace in `store`'s window — collapses that sidebar's tree to the
-    /// workspace's subtree, or clears focus when it is already the only marked workspace AND the filter is
-    /// applied (marked-but-not-filtering re-applies instead of clearing, so the item still narrows). A
-    /// replace-toggle: any other marked set is replaced by this one workspace. Driven by the sidebar
-    /// workspace row's "Focus"/"Unfocus" context-menu item, which passes its OWN window-local store (like
-    /// Close/Flag/Duplicate/Reveal) so a background window's row menu toggles the tree it was opened over
-    /// rather than the frontmost window's. The toggle semantic itself lives in
-    /// `AppStore.toggleFocusedWorkspace`, shared with `workspace.focus toggle`, so the GUI and the wire
-    /// cannot mean different things by "toggle". Clean no-op on an unknown id (the store guards it).
-    /// Ungated like the other store-scoped sidebar actions: a window renders no sidebar while its terminal
-    /// zoom or dashboard is up, so the row menu is unreachable in exactly the state the gate covers, and
-    /// the frontmost window's modal must not block a background window's row.
+    /// Focus (or unfocus) a workspace in `store`'s window — collapses that sidebar's tree to the workspace's
+    /// subtree, or clears focus when it is already the only marked workspace AND the filter is applied
+    /// (marked-but-not-filtering re-applies instead, so the item still narrows). A replace-toggle: any other
+    /// marked set is replaced by this one workspace. The sidebar row's "Focus"/"Unfocus" context-menu item
+    /// drives it, passing its OWN window-local store (like Close/Flag/Duplicate/Reveal) so a background
+    /// window's row menu toggles the tree it was opened over, not the frontmost one's. The toggle semantic
+    /// lives in `AppStore.toggleFocusedWorkspace`, shared with `workspace.focus toggle`, so GUI and wire
+    /// cannot diverge. Clean no-op on an unknown id (store-guarded). Ungated like the other store-scoped
+    /// sidebar actions: no sidebar renders while a window's terminal zoom or dashboard is up, so the row menu
+    /// is unreachable in exactly the state a gate covers, and a frontmost modal must not block a background
+    /// window's row.
     func focusWorkspace(_ id: UUID, in store: AppStore) {
         store.toggleFocusedWorkspace(id)
     }
 
-    /// Add or remove one workspace from `store`'s marked set, leaving the other members alone — the
-    /// sidebar workspace row's "Add to Focus"/"Remove from Focus" context-menu item, which computes its
-    /// own direction from that same store and so needs no toggle mode. Adding MARKS ONLY, never switching
-    /// the filter on, so the rows of the workspaces still to be marked stay on screen; removing disables
-    /// the filter once the set empties. Store-scoped and ungated for the same reasons as
-    /// `focusWorkspace(_:in:)`. Clean no-op on an unknown id (the store guards it).
+    /// Add or remove one workspace from `store`'s marked set, leaving the others alone — the sidebar row's
+    /// "Add to Focus"/"Remove from Focus" context-menu item, which computes its own direction from that same
+    /// store and so needs no toggle mode. Adding MARKS ONLY, never switching the filter on, so the rows still
+    /// to be marked stay on screen; removing disables the filter once the set empties. Store-scoped and
+    /// ungated like `focusWorkspace(_:in:)`; clean no-op on an unknown id.
     func setFocusMembership(_ id: UUID, member: Bool, in store: AppStore) {
         store.setFocusMembership(id, member: member)
     }
@@ -39,31 +37,28 @@ extension AppActions {
         focusWorkspace(id, in: store)
     }
 
-    /// Mark the current workspace (the one new sessions land in) as a set member, leaving the other
-    /// members alone — the View menu and action-palette entry point, which have no clicked row and so
-    /// target the frontmost window. The additive sibling of `focusActiveWorkspace`, which REPLACES the set
-    /// with the current workspace. No-op when there is no current workspace.
+    /// Mark the current workspace (the one new sessions land in) as a set member, leaving the others alone —
+    /// the View menu and action-palette entry point, which have no clicked row and so target the frontmost
+    /// window. The additive sibling of `focusActiveWorkspace`, which REPLACES the set. No-op with none.
     func addActiveWorkspaceToFocus() {
         guard uiActionsEnabled, let store, let id = store.currentWorkspaceID else { return }
         setFocusMembership(id, member: true, in: store)
     }
 
     /// Flip the focus filter on or off WITHOUT touching the marked set — the bottom-bar grid toggle, so
-    /// peeking at the whole tree and coming back costs one click each way. The store refuses to enable an
-    /// empty set, which is the same state the toggle renders disabled in, so the two agree by construction.
-    /// Frontmost-scoped rather than taking a store: its callers are the menu bar and the palette (frontmost
-    /// by definition) plus a bottom-bar BUTTON, and the click that fires a button in a background window
-    /// has already made that window key — so the frontmost store is the clicked one. Only the row context
-    /// menu, which a right-click opens WITHOUT raising the window, needs the explicit-store treatment.
+    /// peeking at the whole tree and back costs one click each way. The store refuses to enable an empty
+    /// set, the same state the toggle renders disabled in, so the two agree by construction. Frontmost-scoped
+    /// rather than store-taking: its callers are the menu bar and the palette (frontmost by definition) plus
+    /// a bottom-bar BUTTON, whose click has already made its window key. Only the row context menu, which a
+    /// right-click opens WITHOUT raising the window, needs the explicit-store treatment.
     func toggleFocusFilter() {
         guard uiActionsEnabled, let store else { return }
         store.setFocusEnabled(!store.focusEnabled)
     }
 
     /// Clear the marked workspace set entirely, restoring the full tree. A plain menu/palette "Clear Focus"
-    /// item — no sidebar row drives it, so it is frontmost-scoped like `toggleFocusFilter`. The store's own
-    /// mutator is a clean no-op when nothing is marked. Distinct from `toggleFocusFilter`, which keeps the
-    /// set and only stops applying it.
+    /// item — no sidebar row drives it, so frontmost-scoped like `toggleFocusFilter`, which by contrast keeps
+    /// the set and only stops applying it. The store's own mutator is a no-op when nothing is marked.
     func clearFocus() {
         guard uiActionsEnabled, let store else { return }
         store.clearFocus()

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -2,35 +2,30 @@ import agtermCore
 import AppKit
 import SwiftUI
 
-/// User actions shared by the toolbar / bottom-bar buttons (`ContentView`) and the menu bar
-/// (`agtermApp`'s `.commands`) so the two never drift; `@MainActor`, holds the store and resolves the
-/// focused terminal for font commands. Trivial one-liners (quick-terminal / status-bar toggle) call the
-/// controller/store directly instead; this owns the actions with real logic — new-session placement, the
-/// directory picker, split/focus/font.
+/// User actions shared by the toolbar / bottom-bar buttons and the menu bar so the two never drift: the
+/// ones with real logic — new-session placement, the directory picker, split/focus/font. Trivial one-liners
+/// (quick-terminal / status-bar toggle) call the controller/store directly instead.
 @MainActor
 final class AppActions {
-    /// The window library. The seam resolves the frontmost window's store per call rather than holding a
-    /// fixed one, so menu bar / palette / control channel all drive the window the user is looking at.
+    /// The window library. Resolves the frontmost window's store per call rather than holding a fixed one,
+    /// so menu bar / palette / control channel all drive the window the user is looking at.
     let library: WindowLibrary
 
-    /// The store of the frontmost open window — the target of every mutating action. Nil only in
-    /// the degenerate all-windows-closed state (quitting), in which case the callers no-op.
+    /// The frontmost open window's store, the target of every mutating action. Nil only with all windows
+    /// closed (quitting), where callers no-op.
     var store: AppStore? { library.activeStore }
 
-    /// The frontmost window's quick-terminal controller (each window owns its own), resolved through
-    /// the same frontmost-window accessor as `store`. Nil when no window is open.
+    /// The frontmost window's quick-terminal controller (one per window). Nil when no window is open.
     var frontmostQuickTerminal: QuickTerminalController? {
         QuickTerminalRegistry.shared.controller(for: library.activeWindowID)
     }
 
-    /// The frontmost window's terminal-zoom controller. The host-free controller tracks the per-window
-    /// zoom target; `WindowContentView` renders that target above this window's chrome.
+    /// The frontmost window's zoom controller; `WindowContentView` renders its target above the chrome.
     private var frontmostTerminalZoom: TerminalZoomController? {
         TerminalZoomRegistry.shared.controller(for: library.activeWindowID)
     }
 
-    /// The frontmost window's dashboard controller (each window owns its own), resolved on `activeWindowID`
-    /// like the quick-terminal/zoom ones. Nil when no window is open.
+    /// The frontmost window's dashboard controller (one per window). Nil when no window is open.
     var frontmostDashboard: DashboardController? {
         DashboardControllerRegistry.shared.controller(for: library.activeWindowID)
     }
@@ -39,15 +34,14 @@ final class AppActions {
         frontmostTerminalZoom?.target != nil
     }
 
-    /// Frontmost-window shorthand for the modal gate: while terminal zoom, the dashboard grid, or a pending
+    /// Frontmost-window shorthand for the modal gate: while terminal zoom, the dashboard grid or a pending
     /// native picker is up, keyboard/menu/palette actions must not mutate the deck behind it. Dismissal stays
-    /// callable so the user is never trapped — the dashboard toggle survives its own grid, while zoom/dashboard
-    /// toggles are blocked behind a picker. With no window open `library.activeWindowID` is nil and the gate
-    /// DENIES, so no deck action runs against no window while the app tears down.
+    /// callable so the user is never trapped (the dashboard toggle survives its own grid; zoom/dashboard
+    /// toggles are blocked behind a picker). With no window open it DENIES, so nothing runs during teardown.
     var uiActionsEnabled: Bool { uiActionsEnabled(for: library.activeWindowID) }
 
-    /// The modal gate for a specific window. Session-addressed entry points use this instead of the
-    /// frontmost-only property when their target may have changed while an external menu was tracking.
+    /// The modal gate for a specific window — for session-addressed entry points whose target may have
+    /// changed while an external menu was tracking.
     func uiActionsEnabled(for windowID: WindowInfo.ID?) -> Bool {
         guard let windowID else { return false }
         return TerminalZoomRegistry.shared.controller(for: windowID)?.target == nil
@@ -55,50 +49,43 @@ final class AppActions {
             && PickRegistry.shared.controller(for: windowID)?.pending == nil
     }
 
-    /// Set briefly while a rename is being started, so the focus-restore that runs when a palette
-    /// or the quick terminal closes doesn't steal first responder from the inline rename field.
+    /// Set while a rename starts, so the palette / quick-terminal close focus-restore skips the rename field.
     var renamePending = false
 
     /// Opens (or raises) a window by id. SwiftUI's `openWindow` is an `@Environment` value reachable only
-    /// inside the scene, so `agtermApp` wires this at launch (`enqueueClaim` + `openWindow(id:)`, raising an
-    /// already-open one via `WindowRegistry`). Used by the cross-window notification reveal for a
-    /// banner-clicked session whose window had closed. Nil before the scene `.task` runs.
+    /// inside the scene, so `agtermApp` wires this at launch. Used by the cross-window notification reveal
+    /// for a banner-clicked session whose window had closed. Nil before the scene `.task` runs.
     var openWindow: ((WindowInfo.ID) -> Void)?
 
     /// The settings model, holding the parsed keymap whose custom commands feed the action palette. It and
-    /// `customCommandRunner` are built AFTER `actions` in `agtermApp.init`, so both are settable and wired in
-    /// the scene `.task` (the `NotificationManager.shared.actions` precedent) rather than passed to
-    /// `init(library:)`, which would be an init-order break. Nil until that `.task` runs.
+    /// `customCommandRunner` are built AFTER `actions` in `agtermApp.init`, so both are wired from the scene
+    /// `.task` rather than passed to `init(library:)` — an init-order break. Nil until that `.task` runs.
     var settingsModel: SettingsModel?
 
-    /// The custom-command runner that the palette's custom items invoke (`run(_:)`). Wired in the
-    /// scene `.task` alongside `settingsModel` for the same construction-order reason.
+    /// The custom-command runner the palette's custom items invoke. Wired in the scene `.task` like `settingsModel`.
     var customCommandRunner: CustomCommandRunner?
 
-    /// The command-palette controller, so the "Select Theme…" action and the View menu item can open
-    /// the `.themes` palette. Wired in the scene `.task` (the controller is `agtermApp` `@State`).
+    /// The command-palette controller, so "Select Theme…" and the View menu item can open the `.themes`
+    /// palette. Wired in the scene `.task`.
     var palette: PaletteController?
 
     /// Both theme slots captured when the picker opened, restored on Esc/cancel. Snapshotting the WHOLE pair
-    /// (not just the on-screen slot) is what makes the revert flip-safe across a mid-preview macOS appearance
-    /// switch, whichever slot the preview wrote. `themePreviewActive` gates preview/commit/cancel so the
-    /// hooks are inert outside the picker.
+    /// keeps the revert flip-safe across a mid-preview macOS appearance switch, whichever slot the preview
+    /// wrote. `themePreviewActive` gates preview/commit/cancel so the hooks are inert outside the picker.
     var themePreviewActive = false
     var themePreviewOriginal: (theme: String?, dark: String?)?
 
-    /// The `.agtermAutoFollowed` observer token. Installed once in `init` (the app builds one `AppActions`)
-    /// so an idle auto-follow in the key window moves first responder into the newly selected session.
+    /// The `.agtermAutoFollowed` observer token, installed once in `init` so an idle auto-follow in the key
+    /// window moves first responder into the newly selected session.
     private var autoFollowObserver: NSObjectProtocol?
 
-    /// Cancels every window-scoped picker when AppKit begins termination — the same synchronous notification
-    /// as the delegate's quit flush, but never `applicationShouldTerminate`: a caller waiting on a pick gets
-    /// `cancelled` without delaying the quit-confirmation prompt or termination.
+    /// Cancels every window-scoped picker on the synchronous `willTerminate`, never on
+    /// `applicationShouldTerminate`: a waiting pick caller gets `cancelled` without delaying quit.
     private var terminationObserver: NSObjectProtocol?
 
     init(library: WindowLibrary) {
         self.library = library
-        // agtermCore can't call `focusActiveSession`, so `AppStore.autoFollowFire` posts and we resolve +
-        // focus here, on the main queue.
+        // agtermCore can't call `focusActiveSession`, so `AppStore` posts and we resolve + focus here.
         autoFollowObserver = NotificationCenter.default.addObserver(
             forName: .agtermAutoFollowed, object: nil, queue: .main
         ) { [weak self] note in
@@ -113,8 +100,7 @@ final class AppActions {
         }
     }
 
-    // isolated so it can read the `@MainActor` non-Sendable observer tokens registered in init. AppActions
-    // is app-lifetime (one per app), so this rarely runs, but an unbalanced addObserver is a latent leak.
+    // isolated to read init's `@MainActor` non-Sendable tokens; rare (app-lifetime) but an unbalanced leak.
     isolated deinit {
         if let autoFollowObserver { NotificationCenter.default.removeObserver(autoFollowObserver) }
         if let terminationObserver { NotificationCenter.default.removeObserver(terminationObserver) }
@@ -133,18 +119,15 @@ final class AppActions {
         guard let store, let workspaceID = store.currentWorkspaceID,
               let session = store.addSession(toWorkspace: workspaceID, cwd: resolvedNewSessionCwd())
         else { return }
-        // a user-initiated selection: note activity so it buys the full idle grace before auto-follow can
-        // pull the selection off the just-made session.
+        // note activity so the new session buys the full idle grace before auto-follow moves the selection.
         store.noteUserActivity()
         store.selectSession(session.id)
         focusActiveSession()
     }
 
-    /// The cwd for a new session, resolved from the new-session-directory setting (home / the current
-    /// session's cwd / a fixed custom dir) against the active session's focused-pane cwd; home when
-    /// `settingsModel` isn't wired yet or the setting resolves there. Shared by `newSession()` and the
-    /// sidebar row's New Session. Read as the `addSession` argument, so it captures the cwd BEFORE the new
-    /// session exists.
+    /// The cwd for a new session: the new-session-directory setting (home / the current session's cwd / a
+    /// fixed custom dir) resolved against the active session's focused-pane cwd, home when `settingsModel`
+    /// isn't wired. Read as the `addSession` argument, so it captures the cwd BEFORE the new session exists.
     func resolvedNewSessionCwd() -> String {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         return settingsModel?.settings.resolveNewSessionCwd(
@@ -169,12 +152,10 @@ final class AppActions {
         focusActiveSession()
     }
 
-    /// Opens a new session at `directory` in the last-active window — the target of `open -a agterm /path`
-    /// (the OS "open terminal here" integration). Mirrors `newSession()` (note-activity + select + focus)
-    /// but seeds the cwd from `directory`. Resolves `library.activeStore` (the frontmost/last-active window,
-    /// the control channel's `session.new` default) and is NOT `uiActionsEnabled` gated: an external OS
-    /// command, like a socket command, must land through a modal zoom/dashboard. Returns whether a session
-    /// was created, so the delegate's drain can retry until the frontmost store resolves.
+    /// Opens a new session at `directory` in the last-active window — the target of `open -a agterm /path`,
+    /// the OS "open terminal here" integration. Mirrors `newSession()` but seeds the cwd from `directory`.
+    /// NOT `uiActionsEnabled` gated: an external OS command, like a socket command, must land through a modal
+    /// zoom/dashboard. Returns whether one was created, so the delegate's drain retries until a store resolves.
     func openSession(atDirectory directory: String) -> Bool {
         guard let store, let workspaceID = store.currentWorkspaceID,
               let session = store.addSession(toWorkspace: workspaceID, cwd: directory)
@@ -186,10 +167,8 @@ final class AppActions {
     }
 
     /// Duplicates a session — a fresh shell in the source's directory, placed right after it. Store-scoped
-    /// like the other sidebar row actions, so a background window's context menu acts on its own row, not
-    /// the frontmost store's session. The directory-only contract is `AppStore.duplicateSession`'s; this
-    /// adds the select + focus New Session does. Returns nothing (like `newSession`/`openDirectory`) — the
-    /// control path calls `store.duplicateSession` directly for the id.
+    /// like the other sidebar row actions, so a background window's context menu acts on its own row. Adds
+    /// the select + focus New Session does; the control path calls `store.duplicateSession` for the id.
     func duplicateSession(_ id: UUID, in store: AppStore) {
         guard let session = store.duplicateSession(id) else { return }
         store.noteUserActivity()
@@ -197,17 +176,15 @@ final class AppActions {
         focusActiveSession()
     }
 
-    /// Duplicate the ACTIVE session — the entry point for the menu bar, the ⌃P palette, and a
-    /// `duplicate_session` keymap binding (mirroring `renameActiveSession()` vs the sidebar's row-scoped
-    /// `duplicateSession(_:in:)`), acting on the frontmost store's selected session.
+    /// Duplicate the ACTIVE session (the frontmost store's selection) — the menu bar, ⌃P palette and
+    /// `duplicate_session` entry point, against the sidebar's row-scoped `duplicateSession(_:in:)`.
     func duplicateActiveSession() {
         guard uiActionsEnabled else { return }
         guard let store, let id = store.selectedSessionID else { return }
         duplicateSession(id, in: store)
     }
 
-    /// Reveal the active session's focused-pane cwd in Finder. Finder gets the directory itself selected
-    /// (rather than opening arbitrary terminal output), matching "Reveal in Finder" behavior elsewhere on Mac.
+    /// Reveal the active session's focused-pane cwd in Finder — the directory selected, as elsewhere on Mac.
     func revealActiveSessionInFinder() {
         guard let store, let id = store.selectedSessionID else { return }
         revealSessionInFinder(id, in: store)
@@ -223,8 +200,7 @@ final class AppActions {
         return DirectoryPanelDefaults.existingDirectoryURL(for: session.focusedCwd) != nil
     }
 
-    /// Reveal a specific session's focused-pane cwd in Finder, scoped to the caller's store so a sidebar
-    /// context menu in a background window still acts on the clicked row in that window.
+    /// Reveal a session's focused-pane cwd in Finder, store-scoped so a background row menu acts on its row.
     @discardableResult
     func revealSessionInFinder(_ id: UUID, in store: AppStore) -> Bool {
         guard let session = store.session(withID: id),
@@ -234,29 +210,26 @@ final class AppActions {
         return true
     }
 
-    // closes the active session, or dismisses a focus-stealing cover over it; returns whether it handled
-    // the keystroke, so the ⌘W menu item falls back to closing the window only with no cover and no
-    // session. precedence is z-order: the window-topmost quick terminal (works with no active session),
-    // then a session's overlay above its scratch. the overlay is DESTROYED (closeOverlay, run-once
-    // ephemeral) while quick/scratch are hidden keep-alive; a floating overlay holds first responder too,
-    // so ANY overlay is dismissed, not only a full one.
+    // closes the active session, or dismisses a focus-stealing cover over it; returns whether it handled the
+    // keystroke, so the ⌘W menu item closes the window only with no cover and no session. precedence is
+    // z-order: the window-topmost quick terminal (works with no active session), then a session's overlay
+    // above its scratch. the overlay is DESTROYED (run-once ephemeral) while quick/scratch are hidden
+    // keep-alive, and a floating overlay holds first responder too, so ANY overlay is dismissed, not only full.
     @discardableResult
     func closeActiveSession() -> Bool {
-        // A pick is an external caller waiting on an answer, so it is the first ⌘W layer even when a
-        // terminal is zoomed behind it. Resolve rather than merely hiding it so the caller can finish.
+        // a pick is an external caller waiting on an answer: the first ⌘W layer even behind a zoomed terminal,
+        // and resolved rather than hidden so the caller can finish.
         if cancelPendingPick(for: library.activeWindowID) { return true }
         // zoom is the topmost cover: ⌘W dismisses it stepwise (a zoomed quick terminal un-zooms first, the
-        // next ⌘W hides it) instead of swallowing the keystroke, never mutating hidden session/window state
-        // behind it. the dashboard grid is the other modal cover (mutually exclusive with zoom) — close it
-        // and refocus rather than closing the session behind it.
+        // next ⌘W hides it), never mutating hidden session/window state behind it. the dashboard grid is the
+        // other modal cover (mutually exclusive with zoom) — close and refocus, don't close the session.
         if terminalZoomActive { frontmostTerminalZoom?.clear(); return true }
         if let dashboard = frontmostDashboard, dashboard.isOpen { dashboard.close(); focusActiveSession(); return true }
         if let quick = frontmostQuickTerminal, quick.isVisible { quick.hide(); return true }
         guard let store, let session = store.activeSession else { return false }
         if session.overlayActive { store.closeOverlay(session.id); return true }
         if session.scratchActive { store.toggleScratch(session.id); return true }
-        // ⌘W was handled either way — on cancel we return true so the File menu doesn't fall back to
-        // closing the whole window.
+        // handled either way — returning true on cancel keeps the File menu from closing the whole window.
         guard confirmCloseSession(session) else { return true }
         closeSessionAfterConfirmation(session.id, in: store)
         focusActiveSession()
@@ -283,9 +256,8 @@ final class AppActions {
     }
 
     /// Close session `id` in `store` from a GUI surface (the sidebar row's Close), honoring the "Confirm
-    /// before closing a session" setting. `store` is passed in, not resolved from the frontmost
-    /// `activeStore`: a background window's sidebar must close ITS session. ⌘W/menu/palette instead use
-    /// `closeActiveSession` (the frontmost active session); the control `session.close` closes with no prompt.
+    /// before closing a session" setting. `store` is passed in so a background window's sidebar closes ITS
+    /// session; ⌘W/menu/palette use `closeActiveSession`, and the control `session.close` never prompts.
     func closeSession(_ id: UUID, in store: AppStore) {
         guard uiActionsEnabled else { return }
         guard let session = store.session(withID: id) else { return }
@@ -320,9 +292,8 @@ final class AppActions {
         library.clearRecentClosedItems()
     }
 
-    /// A native warning confirm before closing `session`, gated by `AppSettings.confirmCloseSession`.
-    /// Returns whether to proceed with the close: true immediately (no prompt) when the setting is off, or
-    /// under an XCUITest launch (a modal would hang the test, like the clear-flagged/quit confirms).
+    /// A native warning confirm before closing `session`, gated by `AppSettings.confirmCloseSession`. Returns
+    /// whether to proceed: true with no prompt when the setting is off or under XCUITest (a modal hangs it).
     private func confirmCloseSession(_ session: Session) -> Bool {
         guard settingsModel?.settings.confirmCloseSession == true,
               !ContentView.shouldBypassCloseConfirmation else { return true }
@@ -351,27 +322,24 @@ final class AppActions {
         }
     }
 
-    /// Clear the active session's agent-status indicator back to idle (the same effect as `agtermctl
-    /// session status idle` and the sidebar row's "Clear Status"). No-op when nothing is selected.
+    /// Clear the active session's agent-status indicator to idle, like `agtermctl session status idle` and
+    /// the sidebar row's "Clear Status". No-op when nothing is selected.
     func clearActiveSessionStatus() {
         guard uiActionsEnabled else { return }
         guard let store, let id = store.selectedSessionID else { return }
         store.setAgentIndicator(AgentIndicator(), forSession: id)
     }
 
-    /// Re-read and re-parse `keymap.conf`, re-rendering the data-driven menu shortcuts and rebuilding the
-    /// custom-command runner + the palette's custom items. Shared by the View menu item, the action palette,
-    /// and `keymap.reload`. No-op before the scene wires the settings model.
+    /// Re-read `keymap.conf`, re-rendering the menu shortcuts and rebuilding the custom-command runner +
+    /// palette items. Shared by the View menu, the palette and `keymap.reload`; no-op before the model wires.
     func reloadKeymap() { settingsModel?.reloadKeymap() }
 
-    /// The session whose currently-open overlay is the keymap editor, so `WindowContentView`'s overlay
-    /// onChange can reload the keymap when that overlay closes. Nil when no keymap-edit overlay is up.
+    /// The session whose open overlay is the keymap editor, so its close reloads the keymap. Nil when none.
     var keymapEditOverlaySession: UUID?
 
     /// Open `keymap.conf` in the user's editor (`$VISUAL`/`$EDITOR`, else `vi`) in a 95% floating overlay
-    /// over the active session, through the login shell so an `$EDITOR` exported from login-shell startup is
-    /// honored. The editor exiting reloads the keymap (`WindowContentView`'s overlay-close onChange). No-op
-    /// with no active session, before the settings model is wired, or with an overlay already open.
+    /// over the active session, via the login shell so an exported `$EDITOR` is honored; exiting reloads the
+    /// keymap. No-op with no active session, before the settings model is wired, or with an overlay open.
     func editKeymap() {
         guard uiActionsEnabled else { return }
         guard let store, let id = store.selectedSessionID, let path = settingsModel?.keymapPath else { return }
@@ -380,28 +348,25 @@ final class AppActions {
         }
     }
 
-    /// Re-read the ghostty config and rebroadcast it to every live surface (`SettingsModel.reloadGhosttyConfig`
-    /// posts the diagnostics warning banner, mirroring `reloadKeymap`). Returns the config-diagnostic count
-    /// (0 = clean, and 0 before the scene wires the settings model) so the control channel reports what the
-    /// reload actually produced. Shared by File ▸ Reload Config, the action palette, the Edit-ghostty overlay
-    /// close, and `config.reload`.
+    /// Re-read the ghostty config and rebroadcast it to every live surface; `SettingsModel` posts the
+    /// diagnostics banner, mirroring `reloadKeymap`. Returns the diagnostic count (0 = clean, and 0 before the
+    /// model is wired) so the control channel reports what the reload produced. Shared by File ▸ Reload
+    /// Config, the palette, the Edit-ghostty overlay close, and `config.reload`.
     @discardableResult
     func reloadGhosttyConfig() -> Int {
         settingsModel?.reloadGhosttyConfig() ?? 0
     }
 
-    /// The session whose currently-open overlay is the ghostty.conf editor, so `WindowContentView`'s overlay
-    /// onChange can reload the config when that overlay closes. Nil when no ghostty-edit overlay is up.
+    /// The session whose open overlay is the ghostty.conf editor, so its close reloads the config. Nil when none.
     var ghosttyEditOverlaySession: UUID?
 
-    /// The `ghostty.conf` contents captured when the Edit-ghostty overlay opened, so the close path can skip
-    /// the reload (and its per-session font-zoom reset) on a no-op editor session. Nil when none is up.
+    /// The `ghostty.conf` contents captured when the Edit overlay opened, so a no-op editor session skips the
+    /// reload and its per-session font-zoom reset. Nil when none is up.
     private var ghosttyEditOverlaySnapshot: String?
 
     /// Open `ghostty.conf` in the user's editor in a 95% floating overlay over the active session, mirroring
-    /// `editKeymap` (login shell, so an exported `$VISUAL`/`$EDITOR` is honored, else `vi`; the editor
-    /// exiting reloads the config via `WindowContentView`'s overlay-close onChange). Captures the file
-    /// contents so that path reloads only on a real change. Same no-ops as `editKeymap`.
+    /// `editKeymap` (login shell, exported `$VISUAL`/`$EDITOR` else `vi`; exiting reloads the config).
+    /// Captures the file contents so that path reloads only on a real change. Same no-ops as `editKeymap`.
     func editGhosttyConfig() {
         guard uiActionsEnabled else { return }
         guard let store, let id = store.selectedSessionID, let path = settingsModel?.ghosttyConfigPath else { return }
@@ -411,9 +376,8 @@ final class AppActions {
         }
     }
 
-    /// On Edit-ghostty overlay close: reload only if the file changed since the editor opened, so a no-op
-    /// open/close does not clear per-session ⌘+/⌘− zoom (the reload's font reset). Explicit File ▸ Reload
-    /// Config / `config.reload` stay unconditional — the guard covers only the editor round-trip.
+    /// On Edit-ghostty overlay close: reload only if the file changed, so a no-op open/close does not clear
+    /// per-session ⌘+/⌘− zoom (the reload's font reset). File ▸ Reload Config / `config.reload` stay unconditional.
     func reloadGhosttyConfigIfEdited() {
         let before = ghosttyEditOverlaySnapshot
         ghosttyEditOverlaySnapshot = nil
@@ -422,22 +386,19 @@ final class AppActions {
         reloadGhosttyConfig()
     }
 
-    /// Step the selection prev/next, or to first/last, in the sidebar's flattened visual order — the logic
-    /// is `navigateSession`'s, so the GUI, palette and control channel can't drift. Routes through
-    /// `selectSession` (recency/badge/persist/workspace), then moves first responder into the moved-to
-    /// session's focused pane, and notes the manual nav as user activity so it buys the full idle grace
-    /// against auto-follow (the control `session.go` drives `navigateSession` directly and stays silent).
-    /// A step resolving to the ALREADY-selected session reveals nothing and just re-focuses: next/previous
-    /// wrap inside the filtered set (a one-element set re-selects), first/last repeat at that end, and
-    /// `selectSession` does not short-circuit a same-target select, so it still returns an indicator —
-    /// revealing on it would clear `splitFocused` and yank first responder onto the primary pane on a
-    /// keystroke that moved nothing, off the split being typed in. Attention nav DOES reveal on its no-op;
-    /// see below for why.
+    /// Step the selection prev/next/first/last in the sidebar's flattened visual order, through shared
+    /// `navigateSession` so GUI, palette and control can't drift, then `selectSession`
+    /// (recency/badge/persist/workspace) and first responder into the moved-to session's focused pane. Notes
+    /// the manual nav as user activity for the full idle grace against auto-follow; control `session.go`
+    /// drives `navigateSession` directly and stays silent. A step landing on the ALREADY-selected session only
+    /// re-focuses (next/previous wrap inside the filtered set, first/last repeat at that end): `selectSession`
+    /// still returns an indicator for a same-target select, and revealing on it would clear `splitFocused` and
+    /// yank first responder onto the primary pane, off the split being typed in. Attention nav DOES reveal.
     private func navigatePlain(_ direction: SessionNavigation) {
         guard uiActionsEnabled else { return }
         store?.noteUserActivity()
         let before = store?.selectedSessionID
-        // no live-indicator fallback here (unlike attention nav): a plain direction returns nil only when
+        // no live-indicator fallback (unlike attention nav): a plain direction returns nil only when
         // `navigableSessions` is EMPTY, and then nothing was selected, which the moved-check below catches.
         let indicator = store?.navigateSession(direction)
         guard store?.selectedSessionID != before else { focusActiveSession(); return }
@@ -449,16 +410,15 @@ final class AppActions {
     func selectFirstSession() { navigatePlain(.first) }
     func selectLastSession() { navigatePlain(.last) }
 
-    /// Step to the next/previous session needing attention (`blocked`/`completed`), wrapping around and
-    /// skipping idle/active. Shares `navigateSession` with the GUI, palette, and `session.go
-    /// next-attention|prev-attention`. Notes user activity like plain nav, then `revealActiveBlockedPane`
-    /// focuses the split/scratch pane that SET the status, not just the session's plain focused pane.
-    /// Unlike plain nav this DOES reveal on a selection no-op, and only the `?? activeSession?.agentIndicator`
-    /// fallback makes it: `attentionTarget` EXCLUDES the current session, so when the sole session needing
-    /// attention is the selected one it returns nil and `navigateSession` selects nothing. Without the
-    /// fallback the reveal degrades to plain `focusActiveSession` and ⌃⌥↑/↓ stops landing on that session's
-    /// tagged pane — constant for an agent, since a pane-scoped block is not cleared by typing in the OTHER
-    /// pane. Do not drop it as redundant.
+    /// Step to the next/previous session needing attention (`blocked`/`completed`), wrapping and skipping
+    /// idle/active, through `navigateSession` shared with the palette and `session.go next-attention|prev-attention`.
+    /// Notes user activity like plain nav, then `revealActiveBlockedPane` focuses the split/scratch pane that
+    /// SET the status. Unlike plain nav this DOES reveal on a selection no-op, and only the
+    /// `?? activeSession?.agentIndicator` fallback makes it: `attentionTarget` EXCLUDES the current session,
+    /// so when the sole session needing attention is the selected one, `navigateSession` selects nothing.
+    /// Without the fallback the reveal degrades to plain `focusActiveSession` and ⌃⌥↑/↓ stops landing on that
+    /// session's tagged pane — constant for an agent, since a pane-scoped block is not cleared by typing in
+    /// the OTHER pane. Keep it.
     func selectNextAttentionSession() {
         guard uiActionsEnabled else { return }
         store?.noteUserActivity()
@@ -472,14 +432,12 @@ final class AppActions {
         revealActiveBlockedPane(captured: indicator)
     }
 
-    /// Delete a workspace and all its sessions from `store`'s window. Confirms when it still has sessions
-    /// (the delete ends their shells); an empty one deletes without a prompt; no-op when only one workspace
-    /// remains — one is always kept. Driven by the row's "Delete Workspace" item, which passes its OWN
-    /// window-local store (like Close/Flag/Duplicate/Focus): the item's enabled state came from that store,
-    /// and the frontmost one would find no such id and silently do nothing. Ungated like the other
-    /// store-scoped row actions — a window renders no sidebar while its zoom or dashboard is up, so the row
-    /// menu is unreachable in exactly the state the gate covers, and a frontmost modal must not block a
-    /// background window's row.
+    /// Delete a workspace and all its sessions from `store`'s window. Confirms while it still has sessions
+    /// (the delete ends their shells), no prompt when empty, no-op when only one workspace remains — one is
+    /// always kept. The row's "Delete Workspace" passes its OWN window-local store: the frontmost one would
+    /// find no such id and silently do nothing. Ungated like the other store-scoped row actions — a window
+    /// renders no sidebar while its zoom or dashboard is up, so the row menu is unreachable in exactly the
+    /// state the gate covers, and a frontmost modal must not block a background window's row.
     func deleteWorkspace(_ workspaceID: UUID, in store: AppStore) {
         guard store.canRemoveWorkspace,
               let workspace = store.workspaces.first(where: { $0.id == workspaceID }) else { return }
@@ -493,8 +451,8 @@ final class AppActions {
         }
     }
 
-    /// Delete the current workspace (the one new sessions land in) — used by the menu bar and the
-    /// action palette, which have no clicked row and so act on the frontmost window by definition.
+    /// Delete the current workspace (where new sessions land) — the menu-bar/palette path, which has no
+    /// clicked row and so acts on the frontmost window.
     func deleteActiveWorkspace() {
         guard uiActionsEnabled, let store, let id = store.currentWorkspaceID else { return }
         deleteWorkspace(id, in: store)
@@ -529,8 +487,7 @@ final class AppActions {
 
     // MARK: - Sidebar tree expansion
 
-    /// Expand every workspace in the frontmost window's sidebar (the GUI menu/palette target). No-op when
-    /// no window is open.
+    /// Expand every workspace in the frontmost window's sidebar. No-op when no window is open.
     func expandAllWorkspaces() {
         guard uiActionsEnabled else { return }
         guard let store else { return }
@@ -538,15 +495,13 @@ final class AppActions {
     }
 
     /// Expand every workspace in `store`'s window sidebar. The sidebar owns the outline, so this posts a
-    /// notification carrying that store as the object and `WorkspaceSidebar.Coordinator` observes with
-    /// `object: store`, so only that window's sidebar acts — how `sidebar.expand` targets a specific
-    /// (default frontmost) window. A graceful no-op in flagged mode (no workspace rows).
+    /// store-scoped notification and only that window's `WorkspaceSidebar.Coordinator` acts — how
+    /// `sidebar.expand` targets a specific (default frontmost) window. No-op in flagged mode (no rows).
     func expandAllWorkspaces(in store: AppStore) {
         NotificationCenter.default.post(name: .agtermExpandWorkspaces, object: store)
     }
 
-    /// Collapse every workspace except the active one in the frontmost window's sidebar (the GUI
-    /// menu/palette target). No-op when no window is open.
+    /// Collapse every workspace except the active one in the frontmost window's sidebar. No-op with no window.
     func collapseOtherWorkspaces() {
         guard uiActionsEnabled else { return }
         guard let store else { return }
@@ -554,22 +509,19 @@ final class AppActions {
     }
 
     /// Collapse every workspace except the active session's in `store`'s window sidebar, keeping that one
-    /// expanded and scrolled into view. Store-object-scoped to that window's Coordinator (see
-    /// `expandAllWorkspaces(in:)`), a graceful no-op in flagged mode, and how `sidebar.collapse` targets a
-    /// specific (default frontmost) window.
+    /// expanded and scrolled into view. Store-scoped like `expandAllWorkspaces(in:)`, no-op in flagged mode,
+    /// and how `sidebar.collapse` targets a specific (default frontmost) window.
     func collapseOtherWorkspaces(in store: AppStore) {
         NotificationCenter.default.post(name: .agtermCollapseWorkspaces, object: store)
     }
 
     /// Collapse/expand a SINGLE workspace in `store`'s window sidebar — the `workspace.collapse`/`.expand`
-    /// control path, distinct from the all-workspace pair above, and its only caller (a GUI row click drives
-    /// the outline directly). Persists `Workspace.isExpanded` DIRECTLY on the store (source of truth for the
-    /// `collapsed` read-back, delta-guarded so it's idempotent), THEN posts a store-scoped notification so
-    /// the matching `WorkspaceSidebar.Coordinator` syncs the live outline row + its tracked expansion set
-    /// (`setWorkspaceExpandedNotified`). The persist must NOT ride the notification: `WindowContentView`
-    /// mounts the Coordinator only while `sidebarVisible`, so with the sidebar hidden a notification-only
-    /// write drops silently and leaves the read-back stale. Mirrors `workspace.focus`/`session.resize`,
-    /// which also persist in the arm and post only for the live view.
+    /// control path and its only caller (a GUI row click drives the outline directly). Persists
+    /// `Workspace.isExpanded` DIRECTLY on the store (source of truth for the `collapsed` read-back,
+    /// delta-guarded so it's idempotent), THEN posts a store-scoped notification so that window's Coordinator
+    /// syncs the live outline row and its tracked expansion set. The persist must NOT ride the notification:
+    /// the Coordinator is mounted only while `sidebarVisible`, so with the sidebar hidden a notification-only
+    /// write drops silently and leaves the read-back stale. Mirrors `workspace.focus`/`session.resize`.
     func setWorkspaceExpanded(_ id: UUID, expanded: Bool, in store: AppStore) {
         store.setWorkspaceExpanded(id, expanded: expanded)
         NotificationCenter.default.post(
@@ -580,24 +532,22 @@ final class AppActions {
 
     // MARK: - Flagged working-set
 
-    /// Toggle a session's flagged membership (the durable working-set the flat sidebar view projects); clean
-    /// no-op on an unknown id. Driven by the sidebar row's "Flag"/"Unflag" context-menu item.
+    /// Toggle a session's flagged membership (the durable working-set the flat sidebar view projects), from
+    /// the row's "Flag"/"Unflag" item; clean no-op on an unknown id.
     func toggleFlag(_ sessionID: UUID) {
         guard uiActionsEnabled else { return }
         guard let store, let session = store.session(withID: sessionID) else { return }
         store.setFlag(!session.flagged, forSession: sessionID)
     }
 
-    /// Toggle the active session's flag — used by the menu bar and the action palette, which have no
-    /// clicked row. No-op when nothing is selected.
+    /// Toggle the active session's flag, for the menu bar and palette (no clicked row). No-op with none selected.
     func toggleFlagActiveSession() {
         guard let id = store?.selectedSessionID else { return }
         toggleFlag(id)
     }
 
-    /// Flip the sidebar between the normal workspace tree and the flat flagged working-set list.
-    /// Shared by the bottom-bar toggle, the View menu item, the action palette, and the `sidebar.mode`
-    /// control command. The view animates the switch via `ContentView`'s `.animation(value:)`.
+    /// Flip the sidebar between the workspace tree and the flat flagged working-set list. Shared by the
+    /// bottom-bar toggle, the View menu, the palette and `sidebar.mode`; `ContentView` animates the switch.
     func toggleFlaggedView() {
         guard uiActionsEnabled else { return }
         guard let store else { return }
@@ -613,8 +563,7 @@ final class AppActions {
         store.clearFlags()
     }
 
-    /// A standard warning confirm for clearing the flagged working-set (`count` flagged sessions).
-    /// Returns whether the user confirmed.
+    /// A warning confirm for clearing the flagged working-set (`count` sessions). Returns whether confirmed.
     private func confirmClearFlags(count: Int) -> Bool {
         let alert = NSAlert()
         alert.alertStyle = .warning
@@ -629,32 +578,29 @@ final class AppActions {
 
     // MARK: - Windows
 
-    /// Create a fresh window (one default workspace + session) and open it via the scene's window opener
-    /// (the seam the control channel uses). No-op before the scene `.task` wires the opener.
+    /// Create a fresh window (one default workspace + session) and open it via the scene's window opener,
+    /// the seam the control channel uses. No-op before the scene `.task` wires the opener.
     ///
     /// `ignoringModals` skips the frontmost-window modal gate. Creating a window touches no existing
-    /// window's state, so the Dock item passes true — a dashboard or terminal zoom in whatever window
-    /// happened to be last active must not make it inert, the whole point of driving agterm from the Dock.
-    /// The menu bar and palette keep the gate (File ▸ New Window mirrors it with `.disabled(modalActive)`).
+    /// window's state, so the Dock item passes true — a dashboard or zoom in whatever window happened to be
+    /// last active must not make it inert. Menu bar and palette keep the gate (`.disabled(modalActive)`).
     func newWindow(ignoringModals: Bool = false) {
         guard ignoringModals || uiActionsEnabled else { return }
-        // `library.newWindow()` persists an entry marked open, so creating without an opener would leave a
-        // window the app counts as open with no NSWindow behind it.
+        // `library.newWindow()` persists an open entry, so with no opener the app counts a window that has
+        // no NSWindow behind it.
         guard let openWindow else { return }
         let info = library.newWindow()
         openWindow(info.id)
     }
 
-    /// Surface a window: raise it if already open, else open it (the opener claims its id + spawns a
-    /// new on-screen window). Used by the File ▸ Open Window submenu and the palette.
+    /// Surface a window: raise it if already open, else open it. Used by File ▸ Open Window and the palette.
     func openWindow(_ id: WindowInfo.ID) {
         guard uiActionsEnabled else { return }
         openWindow?(id)
     }
 
-    /// Rename the frontmost window via a one-shot `NSAlert` with an accessory text field pre-filled with the
-    /// current name — inline rename is sidebar-row-only and a window has no row, so the alert is the
-    /// standard, minimal fit. The rename flows through `library.renameWindow`, the control channel's seam.
+    /// Rename the frontmost window via an `NSAlert` with a pre-filled accessory field — inline rename is
+    /// sidebar-row-only and a window has no row. Flows through `library.renameWindow`, the control seam.
     func renameActiveWindow() {
         guard uiActionsEnabled else { return }
         guard let id = library.activeWindowID,
@@ -673,9 +619,8 @@ final class AppActions {
         library.renameWindow(id, to: field.stringValue)
     }
 
-    /// Delete the frontmost window and its sessions. Confirms first when the window still has sessions
-    /// (the delete ends their shells); an empty window deletes without a prompt. No-ops when only one
-    /// window remains — one is always kept. Closes its on-screen window first so the teardown runs.
+    /// Delete the frontmost window and its sessions: confirms while it still has sessions (the delete ends
+    /// their shells), no-op when only one window remains. Closes the on-screen window first so teardown runs.
     func deleteActiveWindow() {
         guard uiActionsEnabled else { return }
         guard library.canRemoveWindow, let id = library.activeWindowID,
@@ -690,11 +635,9 @@ final class AppActions {
 
     /// Start an inline rename of the active session. The sidebar owns the edit field, so this posts a
     /// notification it observes; `renamePending` keeps the palette-close focus restore off the field while
-    /// the edit starts. The post carries the frontmost STORE as its object and `WorkspaceSidebar.Coordinator`
-    /// registers with `object: store`, so only that window edits (the `expandAllWorkspaces(in:)` scoping).
-    /// A nil object reached EVERY open window's coordinator — their `selectedSessionID` guard scopes
-    /// nothing, since every window has a selection — so each opened an unused editor and leaked one
-    /// unbalanced `suppressAutoFollow`.
+    /// the edit starts. The post is store-scoped so only that window edits: a nil object reaches EVERY open
+    /// window's coordinator (their `selectedSessionID` guard scopes nothing, every window has a selection),
+    /// each opening an unused editor and leaking one unbalanced `suppressAutoFollow`.
     func renameActiveSession() {
         guard uiActionsEnabled else { return }
         guard let store, store.activeSession != nil else { return }
@@ -703,8 +646,7 @@ final class AppActions {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { [weak self] in self?.renamePending = false }
     }
 
-    /// Start an inline rename of the active session's workspace (the same one new sessions land in).
-    /// Store-scoped like `renameActiveSession` above, for the same reason.
+    /// Inline-rename the current workspace (where new sessions land). Store-scoped like the session rename.
     func renameActiveWorkspace() {
         guard uiActionsEnabled else { return }
         guard let store, store.currentWorkspaceID != nil else { return }
@@ -716,9 +658,9 @@ final class AppActions {
     // MARK: - Split
 
     /// Toggle the active session's split. A NEW split shows both panes and focuses the new (right) one;
-    /// closing HIDES it (both shells stay alive, nothing destroyed) and shows the focused pane maximized, so
-    /// reopening restores both in their original positions with the SAME pane focused. Focus follows
-    /// `splitFocused`, which `AppStore.toggleSplit` moves only for a genuinely new split.
+    /// closing only HIDES it (both shells stay alive) and maximizes the focused pane, so reopening restores
+    /// both in their original positions with the SAME pane focused — focus follows `splitFocused`, which
+    /// `AppStore.toggleSplit` moves only for a genuinely new split.
     func toggleSplit() {
         guard uiActionsEnabled else { return }
         guard let store, let session = store.activeSession else { return }
@@ -726,38 +668,34 @@ final class AppActions {
         focusSplitPane(session, wantSplit: session.splitFocused)
     }
 
-    /// Show/hide the active session's scratch terminal — a third, full-overlay login shell. Focus is
-    /// handled by the surface's `autoFocus` on show and the detail pane's scratch-hide focus reclaim,
-    /// so this just flips the flag. The control channel drives `AppStore.toggleScratch` directly.
+    /// Show/hide the active session's scratch terminal, a third full-overlay login shell. Focus rides the
+    /// surface's `autoFocus` and the detail pane's hide reclaim, so this only flips the flag; control drives
+    /// `AppStore.toggleScratch` directly.
     func toggleScratch() {
         guard uiActionsEnabled else { return }
         guard let store, let session = store.activeSession else { return }
         store.toggleScratch(session.id)
     }
 
-    /// Show/hide the frontmost window's sidebar. The custom split owns visibility (no system toggle), so
-    /// this flips the active store's per-window `sidebarVisible` (an instant toggle — the width is
-    /// intentionally not animated, see WindowContentView.splitRoot) and `AppStore` persists it. Shared by
-    /// the toolbar button, the View menu item, the palette, and the `sidebar` control command.
+    /// Show/hide the frontmost window's sidebar. The custom split owns visibility (no system toggle), so this
+    /// flips the store's per-window `sidebarVisible`, persisted by `AppStore`; the width is intentionally not
+    /// animated (see WindowContentView.splitRoot). Shared by toolbar, View menu, palette and `sidebar`.
     func toggleSidebar() {
         guard uiActionsEnabled else { return }
         guard let store else { return }
         store.toggleSidebarVisible()
     }
 
-    /// Move keyboard focus to a pane of the active session's split: `.split` -> the right pane, anything
-    /// else -> the left/primary. No-op when the active session has no split; works whether the split is shown
-    /// side-by-side or hidden (maximized). Drives the keyboard shortcuts, the View menu items, and the palette.
+    /// Focus a pane of the active session's split: `.split` -> right, anything else -> left/primary; no-op with no split.
     func focusPane(_ pane: PaneRole) {
         guard uiActionsEnabled else { return }
         guard let session = store?.activeSession else { return }
         setSplitFocus(pane == .split, of: session)
     }
 
-    /// Set which pane of a session's split holds focus and move first responder there. Shared by the GUI
-    /// `focusPane` and the control channel (which may target a non-active session). Updates `splitFocused`
-    /// so the pane dim, sidebar and title bar follow. Works shown side-by-side or hidden — when hidden,
-    /// flipping `splitFocused` swaps which pane shows maximized. No-op only when the session has no split.
+    /// Set which pane of a session's split holds focus and move first responder there. Shared by `focusPane`
+    /// and the control channel (which may target a non-active session). Updates `splitFocused`, so pane dim,
+    /// sidebar and title bar follow and a hidden split swaps which pane shows maximized. No-op with no split.
     func setSplitFocus(_ toSplit: Bool, of session: Session) {
         guard session.hasSplit else { return }
         session.splitFocused = toSplit
@@ -766,11 +704,10 @@ final class AppActions {
 
     // MARK: - Quick terminal (frontmost window)
 
-    /// Toggle the frontmost window's quick terminal (each window owns its own controller). Gated on the full
-    /// `uiActionsEnabled` (zoom, dashboard AND native picker), not zoom alone — defence in depth, not a gap
-    /// being closed, since all three callers already gate: View ▸ Quick Terminal's `.disabled(modalActive)`
-    /// (which covers a `keymap.conf` rebind too, that rebind being the item's own key equivalent), the
-    /// palette's `runPaletteCommand` check, and the Dock item's invocation-time `uiActionsEnabled(for:)`.
+    /// Toggle the frontmost window's quick terminal. Gated on the full `uiActionsEnabled` (zoom, dashboard
+    /// AND native picker), not zoom alone — defence in depth, since all three callers already gate: View ▸
+    /// Quick Terminal's `.disabled(modalActive)` (which also covers a `keymap.conf` rebind, that being the
+    /// item's own key equivalent), the palette's `runPaletteCommand`, and the Dock item's invocation check.
     func toggleQuickTerminal() {
         guard uiActionsEnabled else { return }
         frontmostQuickTerminal?.toggle()
@@ -783,11 +720,10 @@ final class AppActions {
         frontmostTerminalZoom?.toggle()
     }
 
-    /// Toggle the frontmost window's dashboard — the ⌘⇧D / Navigate ▸ Dashboard opener for the MRU grid,
-    /// equivalent to `agtermctl dashboard --mru --auto-size`. Inert while terminal zoom or a pending native
-    /// picker is up (mirroring the GUI siblings and menu disablement), but NOT while the dashboard itself is
-    /// open, so the grid stays its own close escape hatch. Open → close and refocus the active session;
-    /// closed → open over the window's most-recently-used sessions, auto-sized; no-op with no recent sessions.
+    /// Toggle the frontmost window's dashboard — the ⌘⇧D / Navigate ▸ Dashboard MRU grid, equivalent to
+    /// `agtermctl dashboard --mru --auto-size`. Inert while terminal zoom or a pending picker is up, but NOT
+    /// while the dashboard itself is open, so the grid stays its own escape hatch. Open → close and refocus;
+    /// closed → open over the window's most-recently-used sessions, auto-sized; no-op with none.
     func toggleDashboard() {
         guard !terminalZoomActive, !pickActive(for: library.activeWindowID) else { return }
         guard let dashboard = frontmostDashboard else { return }
@@ -801,21 +737,19 @@ final class AppActions {
         guard !members.isEmpty else { return }
         dashboard.open(members: members, fontMode: .auto)
         // set the applied size synchronously (the SwiftUI onChange applies surface overrides a runloop turn
-        // later), through the same DashboardFontMode seam as ControlServer.setDashboard so the GUI and
-        // control opens land on the identical auto size.
+        // later), through the same DashboardFontMode seam as the control arm so both land on one auto size.
         let base = settingsModel?.settings.fontSize ?? DashboardLayout.ghosttyDefaultFontSize
         dashboard.setAppliedFontSize(DashboardFontMode.auto.appliedFontSize(memberCount: members.count, base: base))
     }
 
-    /// Toggle native macOS full screen for the key window (the frontmost terminal window): it matches the
-    /// green traffic-light button and moves the window to its own Space, a second invocation exits. Shared
-    /// by View ▸ Toggle Full Screen (⌃⌘F), the ⌃⇧P palette, `toggle_fullscreen`, and `window.fullscreen`.
+    /// Toggle native macOS full screen for the key window: the green traffic-light behavior, moving the window
+    /// to its own Space; a second invocation exits. Shared by ⌃⌘F, the palette, `toggle_fullscreen`, `window.fullscreen`.
     func toggleFullscreen() { NSApp.keyWindow?.toggleFullScreen(nil) }
 
     // MARK: - Font (on the focused terminal)
 
-    // deliberately NOT zoom-gated: font commands act on the FOCUSED surface — while zoomed that is the
-    // zoomed terminal the user is reading — and never touch hidden deck state, so ⌘+/⌘−/⌘0 keep working.
+    // NOT zoom-gated: font commands act on the FOCUSED surface — while zoomed that is the zoomed terminal —
+    // and never touch hidden deck state, so ⌘+/⌘−/⌘0 keep working.
     func increaseFontSize() {
         focusedSurface()?.performBindingAction("increase_font_size:1")
     }
@@ -828,12 +762,11 @@ final class AppActions {
 
     // MARK: - Search (on the surface that opened it)
 
-    /// The search-capable target. A covering SCRATCH wins FIRST (`topmostSurface` while `scratchActive` with
-    /// no overlay), so ⌘F over a scratch never opens the bar on the hidden pane beneath — even with key-window
-    /// focus off the surface (e.g. the sidebar), where `focusedSurface()` would fall back to the hidden
-    /// `activeSurface`. Else the focused surface IFF searchable (the main/split pane), else the active
-    /// session's focused pane. Full overlay and quick terminal are unsearchable (blocked by
-    /// `coverHidesActiveSession`); a FLOATING overlay leaves the pane visible, so search targets that pane.
+    /// The search-capable target. A covering SCRATCH wins FIRST, so ⌘F over a scratch never opens the bar on
+    /// the hidden pane beneath — even with key-window focus off the surface (e.g. the sidebar), where
+    /// `focusedSurface()` would fall back to the hidden `activeSurface`. Else the focused surface IFF
+    /// searchable, else the active session's focused pane. Full overlay and quick terminal are unsearchable
+    /// (blocked by `coverHidesActiveSession`); a FLOATING overlay leaves the pane visible, so it targets it.
     private func searchTarget() -> GhosttySurfaceView? {
         if let session = store?.activeSession, session.scratchActive, !session.overlayActive {
             return session.topmostSurface as? GhosttySurfaceView
@@ -842,10 +775,9 @@ final class AppActions {
         return store?.activeSession?.activeSurface as? GhosttySurfaceView
     }
 
-    /// Whether a cover BLOCKS ⌘F — the frontmost window's quick terminal, or the active session's FULL
-    /// overlay. Neither is searchable, so the bar would strand over a hidden pane. The scratch is NOT a
-    /// blocker: it IS searchable, so ⌘F opens the bar over the scratch itself. The ⌘F-again CLOSE still runs
-    /// regardless of any cover.
+    /// Whether a cover BLOCKS ⌘F — the frontmost quick terminal or the active session's FULL overlay, neither
+    /// searchable, so the bar would strand over a hidden pane. The scratch IS searchable, so it never blocks
+    /// and ⌘F opens the bar over it; the ⌘F-again CLOSE runs regardless of any cover.
     private var coverHidesActiveSession: Bool {
         if frontmostQuickTerminal?.isVisible == true { return true }
         guard let session = store?.activeSession else { return false }
@@ -854,12 +786,11 @@ final class AppActions {
     }
 
     /// Toggle the search bar for the active session; shared by the Find menu item, the palette, and ⌘F.
-    /// CLOSE (search already active): send `end_search` DIRECTLY to the session's pinned `searchSurface` (the
-    /// surface that opened search) so the END callback clears the fields and refocuses — never a re-resolved
-    /// target or a `start_search` round-trip, which on a split with focus moved to the OTHER pane would put
-    /// that pane into search mode while `onSearchStart` closes only the pinned owner, stranding it. OPEN:
-    /// no-op with no searchable surface (never bar-less search on a quick/scratch/overlay surface) or behind
-    /// a cover, else `start_search` on the search target, whose `onSearchStart` opens the bar and pins it.
+    /// CLOSE: `end_search` DIRECTLY to the pinned `searchSurface` (the surface that opened search) so the END
+    /// callback clears the fields and refocuses — never a re-resolved target or a `start_search` round-trip,
+    /// which on a split with focus moved to the OTHER pane puts that pane into search mode while
+    /// `onSearchStart` closes only the pinned owner, stranding it. OPEN: no-op with no searchable surface or
+    /// behind a cover, else `start_search` on the search target, whose `onSearchStart` opens and pins the bar.
     func toggleSearch() {
         guard !pickActive(for: library.activeWindowID) else { return }
         if store?.activeSession?.searchActive == true {
@@ -871,11 +802,11 @@ final class AppActions {
         target.startSearch()
     }
 
-    /// Set the current query: mirror it into the active session's `searchNeedle` (keeping the bar's field in
-    /// sync) then send `search:<needle>` to the pinned `searchSurface`, which replies with the new match
-    /// count. Driving the pinned owner rather than a re-resolved focused surface keeps the bar on the pane
-    /// that opened search after a split focus move. An empty needle clears count/selected eagerly, so the
-    /// counter blanks at once instead of flashing the stale "N of M" until libghostty's async teardown lands.
+    /// Set the current query: mirror it into `searchNeedle` (keeping the bar's field in sync), then send
+    /// `search:<needle>` to the pinned `searchSurface`, which replies with the match count — the pinned owner
+    /// rather than a re-resolved focused surface keeps the bar on the pane that opened search after a split
+    /// focus move. An empty needle clears count/selected eagerly, so the counter blanks at once instead of
+    /// flashing a stale "N of M" through libghostty's async teardown.
     func updateSearchNeedle(_ needle: String) {
         guard let session = store?.activeSession else { return }
         session.searchNeedle = needle
@@ -886,31 +817,27 @@ final class AppActions {
         (session.searchSurface as? GhosttySurfaceView)?.sendSearchQuery(needle)
     }
 
-    /// Step to the next/previous match (the up/down buttons, Enter/Shift-Enter in the bar), on the active
-    /// session's pinned `searchSurface`.
+    /// Step to the next/previous match (the bar's up/down, Enter/Shift-Enter) on the pinned `searchSurface`.
     func navigateSearch(_ direction: GhosttySurfaceView.SearchDirection) {
         (store?.activeSession?.searchSurface as? GhosttySurfaceView)?.navigateSearch(direction)
     }
 
-    /// Close search: send `end_search` to the session's pinned `searchSurface` so it really exits search mode
-    /// (never just flips the flag). The END_SEARCH callback is the single clear point — it clears the
-    /// session's fields and the pinned owner and returns first responder to the terminal — so this only
-    /// sends the binding action.
+    /// Close search: `end_search` to the pinned `searchSurface` so it really exits search mode, never just
+    /// flips the flag. END_SEARCH is the single clear point (fields, pinned owner, first responder back).
     func endSearch() {
         (store?.activeSession?.searchSurface as? GhosttySurfaceView)?.endSearch()
     }
 
     // MARK: - Focus
 
-    /// Per-window focus generation counters (keyed by owning window id, bumped in AppActions+Focus). A fresh
-    /// `focusSplitPane` bumps its window's counter so a superseded in-flight retry loop in the SAME window
-    /// cancels itself — killing the opposite-target ping-pong flicker, last-focus-wins per window. Keyed by
-    /// window (one NSWindow = one first responder) so one window's focus op never cancels another's
-    /// still-materializing retry.
+    /// Per-window focus generation counters (bumped in AppActions+Focus). A fresh `focusSplitPane` bumps its
+    /// window's counter so a superseded in-flight retry loop in the SAME window cancels itself, killing the
+    /// opposite-target ping-pong flicker — last-focus-wins per window. Keyed by window (one NSWindow = one
+    /// first responder) so one window's focus op never cancels another's still-materializing retry.
     var focusGeneration: [UUID: Int] = [:]
 
-    /// The focused terminal: the key window's first responder if it's a surface (covers the main
-    /// pane, the split pane, and the quick terminal), else the active session's focused pane.
+    /// The focused terminal: the key window's first responder if a surface (main, split or quick terminal),
+    /// else the active session's focused pane.
     private func focusedSurface() -> GhosttySurfaceView? {
         if let view = NSApp.keyWindow?.firstResponder as? GhosttySurfaceView { return view }
         return store?.activeSession?.activeSurface as? GhosttySurfaceView

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -2,18 +2,15 @@ import agtermCore
 import AppKit
 import SwiftUI
 
-/// The user-facing actions shared by the toolbar / bottom-bar buttons (`ContentView`) and the
-/// menu bar (`agtermApp`'s `.commands`), so the two never drift. `@MainActor`; holds the store, and
-/// resolves the focused terminal for font commands.
-///
-/// Trivial one-liners (quick-terminal toggle, status-bar toggle) are not here — their callers
-/// invoke the controller/store directly. This type owns the actions that carry real logic:
-/// new-session placement, the directory picker, and the split/focus/font handling.
+/// User actions shared by the toolbar / bottom-bar buttons (`ContentView`) and the menu bar
+/// (`agtermApp`'s `.commands`) so the two never drift; `@MainActor`, holds the store and resolves the
+/// focused terminal for font commands. Trivial one-liners (quick-terminal / status-bar toggle) call the
+/// controller/store directly instead; this owns the actions with real logic — new-session placement, the
+/// directory picker, split/focus/font.
 @MainActor
 final class AppActions {
-    /// The window library; the action seam resolves the frontmost window's store per call rather
-    /// than holding a fixed store, so the menu bar / palette / control channel all drive the
-    /// window the user is looking at.
+    /// The window library. The seam resolves the frontmost window's store per call rather than holding a
+    /// fixed one, so menu bar / palette / control channel all drive the window the user is looking at.
     let library: WindowLibrary
 
     /// The store of the frontmost open window — the target of every mutating action. Nil only in
@@ -32,8 +29,8 @@ final class AppActions {
         TerminalZoomRegistry.shared.controller(for: library.activeWindowID)
     }
 
-    /// The frontmost window's dashboard controller (each window owns its own), resolved through the same
-    /// `activeWindowID` accessor as `frontmostQuickTerminal`/`frontmostTerminalZoom`. Nil when no window is open.
+    /// The frontmost window's dashboard controller (each window owns its own), resolved on `activeWindowID`
+    /// like the quick-terminal/zoom ones. Nil when no window is open.
     var frontmostDashboard: DashboardController? {
         DashboardControllerRegistry.shared.controller(for: library.activeWindowID)
     }
@@ -42,14 +39,11 @@ final class AppActions {
         frontmostTerminalZoom?.target != nil
     }
 
-    /// While terminal zoom, the dashboard grid, OR the topmost native picker is active, the UI is modal:
-    /// keyboard/menu/palette actions must not mutate the deck behind it. Dismissal paths remain independently
-    /// callable so the user is never trapped: the dashboard toggle stays available while its grid is the
-    /// topmost modal, while zoom/dashboard toggles are blocked behind a picker. This is the frontmost-window
-    /// shorthand below, resolved on
-    /// `library.activeWindowID` like the zoom target. With NO window open that id is nil and the gate DENIES
-    /// (the per-window check's `guard let windowID else { return false }`), so a deck action can't run against
-    /// no window while the app is tearing down.
+    /// Frontmost-window shorthand for the modal gate: while terminal zoom, the dashboard grid, or a pending
+    /// native picker is up, keyboard/menu/palette actions must not mutate the deck behind it. Dismissal stays
+    /// callable so the user is never trapped — the dashboard toggle survives its own grid, while zoom/dashboard
+    /// toggles are blocked behind a picker. With no window open `library.activeWindowID` is nil and the gate
+    /// DENIES, so no deck action runs against no window while the app tears down.
     var uiActionsEnabled: Bool { uiActionsEnabled(for: library.activeWindowID) }
 
     /// The modal gate for a specific window. Session-addressed entry points use this instead of the
@@ -65,18 +59,16 @@ final class AppActions {
     /// or the quick terminal closes doesn't steal first responder from the inline rename field.
     var renamePending = false
 
-    /// Opens (or raises) the on-screen window for a window id. The scene's `openWindow` is a SwiftUI
-    /// `@Environment` value only reachable inside the scene, so `agtermApp` wires this at launch
-    /// (`enqueueClaim` + `openWindow(id:)`, raising an already-open one via `WindowRegistry`). Used by
-    /// the cross-window notification reveal to surface a banner-clicked session whose window had
-    /// closed. Nil before the scene `.task` runs (no window to reveal into yet anyway).
+    /// Opens (or raises) a window by id. SwiftUI's `openWindow` is an `@Environment` value reachable only
+    /// inside the scene, so `agtermApp` wires this at launch (`enqueueClaim` + `openWindow(id:)`, raising an
+    /// already-open one via `WindowRegistry`). Used by the cross-window notification reveal for a
+    /// banner-clicked session whose window had closed. Nil before the scene `.task` runs.
     var openWindow: ((WindowInfo.ID) -> Void)?
 
-    /// The settings model, holding the parsed keymap whose custom commands feed the action palette.
-    /// Both this and `customCommandRunner` are constructed AFTER `actions` in `agtermApp.init`, so they
-    /// are settable properties wired in the scene `.task` (like `NotificationManager.shared.actions`)
-    /// rather than init parameters — keeping the `init(library:)` signature and dodging the init-order
-    /// break. Nil before the scene `.task` runs (no custom commands in the palette yet).
+    /// The settings model, holding the parsed keymap whose custom commands feed the action palette. It and
+    /// `customCommandRunner` are built AFTER `actions` in `agtermApp.init`, so both are settable and wired in
+    /// the scene `.task` (the `NotificationManager.shared.actions` precedent) rather than passed to
+    /// `init(library:)`, which would be an init-order break. Nil until that `.task` runs.
     var settingsModel: SettingsModel?
 
     /// The custom-command runner that the palette's custom items invoke (`run(_:)`). Wired in the
@@ -87,11 +79,10 @@ final class AppActions {
     /// the `.themes` palette. Wired in the scene `.task` (the controller is `agtermApp` `@State`).
     var palette: PaletteController?
 
-    /// Both theme slots captured when the theme picker opened, restored on Esc/cancel. Snapshotting the
-    /// WHOLE pair (not just the on-screen slot) is what makes the revert flip-safe: if macOS switches
-    /// appearance mid-preview, restoring both slots reverts correctly regardless of which slot the
-    /// preview wrote. `themePreviewActive` gates the preview/commit/cancel so the hooks are inert outside
-    /// the picker (the palette's other modes never touch them).
+    /// Both theme slots captured when the picker opened, restored on Esc/cancel. Snapshotting the WHOLE pair
+    /// (not just the on-screen slot) is what makes the revert flip-safe across a mid-preview macOS appearance
+    /// switch, whichever slot the preview wrote. `themePreviewActive` gates preview/commit/cancel so the
+    /// hooks are inert outside the picker.
     var themePreviewActive = false
     var themePreviewOriginal: (theme: String?, dark: String?)?
 
@@ -99,16 +90,15 @@ final class AppActions {
     /// so an idle auto-follow in the key window moves first responder into the newly selected session.
     private var autoFollowObserver: NSObjectProtocol?
 
-    /// Cancels every window-scoped picker when AppKit begins termination. This observer runs on the
-    /// same synchronous notification as the delegate's quit flush, but never participates in
-    /// `applicationShouldTerminate`: a caller waiting on a pick gets `cancelled` without delaying either
-    /// the quit-confirmation prompt or termination itself.
+    /// Cancels every window-scoped picker when AppKit begins termination — the same synchronous notification
+    /// as the delegate's quit flush, but never `applicationShouldTerminate`: a caller waiting on a pick gets
+    /// `cancelled` without delaying the quit-confirmation prompt or termination.
     private var terminationObserver: NSObjectProtocol?
 
     init(library: WindowLibrary) {
         self.library = library
-        // bridge the host-free `AppStore.autoFollowFire` post to the app-target focus move: agtermCore can't
-        // call `focusActiveSession`, so it posts and we resolve + focus here. runs on the main queue.
+        // agtermCore can't call `focusActiveSession`, so `AppStore.autoFollowFire` posts and we resolve +
+        // focus here, on the main queue.
         autoFollowObserver = NotificationCenter.default.addObserver(
             forName: .agtermAutoFollowed, object: nil, queue: .main
         ) { [weak self] note in
@@ -123,9 +113,8 @@ final class AppActions {
         }
     }
 
-    // isolated so it can read the `@MainActor` non-Sendable observer token; balances the block-based
-    // observer registered in init. AppActions is app-lifetime (one per app), so this rarely runs, but an
-    // unbalanced addObserver(forName:) is a latent leak either way.
+    // isolated so it can read the `@MainActor` non-Sendable observer tokens registered in init. AppActions
+    // is app-lifetime (one per app), so this rarely runs, but an unbalanced addObserver is a latent leak.
     isolated deinit {
         if let autoFollowObserver { NotificationCenter.default.removeObserver(autoFollowObserver) }
         if let terminationObserver { NotificationCenter.default.removeObserver(terminationObserver) }
@@ -144,19 +133,18 @@ final class AppActions {
         guard let store, let workspaceID = store.currentWorkspaceID,
               let session = store.addSession(toWorkspace: workspaceID, cwd: resolvedNewSessionCwd())
         else { return }
-        // creating + selecting a session is a user-initiated selection: note activity so it buys the full
-        // idle grace before auto-follow can pull the selection away from the just-made session.
+        // a user-initiated selection: note activity so it buys the full idle grace before auto-follow can
+        // pull the selection off the just-made session.
         store.noteUserActivity()
         store.selectSession(session.id)
         focusActiveSession()
     }
 
-    /// The working directory a new session should open in, resolved from the new-session-directory setting
-    /// (home / the current session's cwd / a fixed custom dir) against the active session's focused-pane
-    /// cwd. Shared by `newSession()` and the sidebar's workspace-row New Session so both entry points honor
-    /// the setting. Falls back to home when `settingsModel` isn't wired yet (before the scene `.task`) or
-    /// the setting resolves there. Read as the `addSession` argument, so it captures the active session's
-    /// cwd BEFORE the new session exists.
+    /// The cwd for a new session, resolved from the new-session-directory setting (home / the current
+    /// session's cwd / a fixed custom dir) against the active session's focused-pane cwd; home when
+    /// `settingsModel` isn't wired yet or the setting resolves there. Shared by `newSession()` and the
+    /// sidebar row's New Session. Read as the `addSession` argument, so it captures the cwd BEFORE the new
+    /// session exists.
     func resolvedNewSessionCwd() -> String {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         return settingsModel?.settings.resolveNewSessionCwd(
@@ -176,50 +164,42 @@ final class AppActions {
         guard panel.runModal() == .OK, let url = panel.url,
               let session = store.addSession(toWorkspace: workspaceID, cwd: url.path)
         else { return }
-        // creating + selecting a session is a user-initiated selection: note activity so it buys the full
-        // idle grace before auto-follow can pull the selection away from the just-made session.
         store.noteUserActivity()
         store.selectSession(session.id)
         focusActiveSession()
     }
 
     /// Opens a new session at `directory` in the last-active window — the target of `open -a agterm /path`
-    /// (the OS "open terminal here" integration). Mirrors `newSession()`
-    /// (note-activity + select + focus) but seeds the cwd from the passed directory instead of the
-    /// new-session-directory setting. Resolves `library.activeStore` (the frontmost/last-active window,
-    /// the same target the control channel's `session.new` defaults to), so it is NOT gated on
-    /// `uiActionsEnabled` — an external OS command, like a socket command, must land regardless of a
-    /// modal zoom/dashboard. Returns whether a session was created, so the delegate's drain can retry
-    /// until the frontmost store resolves.
+    /// (the OS "open terminal here" integration). Mirrors `newSession()` (note-activity + select + focus)
+    /// but seeds the cwd from `directory`. Resolves `library.activeStore` (the frontmost/last-active window,
+    /// the control channel's `session.new` default) and is NOT `uiActionsEnabled` gated: an external OS
+    /// command, like a socket command, must land through a modal zoom/dashboard. Returns whether a session
+    /// was created, so the delegate's drain can retry until the frontmost store resolves.
     func openSession(atDirectory directory: String) -> Bool {
         guard let store, let workspaceID = store.currentWorkspaceID,
               let session = store.addSession(toWorkspace: workspaceID, cwd: directory)
         else { return false }
-        // creating + selecting a session is a user-initiated selection: note activity so it buys the full
-        // idle grace before auto-follow can pull the selection away from the just-made session.
         store.noteUserActivity()
         store.selectSession(session.id)
         focusActiveSession()
         return true
     }
 
-    /// Duplicates a session — a fresh shell in the source's directory, placed right after it. Scoped to the
-    /// caller's store (like the other sidebar row actions) so a background window's context menu acts on its
-    /// own row, not the frontmost store's session. `AppStore.duplicateSession` carries the directory-only
-    /// contract; this adds the same select + focus the sidebar's New Session does. Returns nothing (matching
-    /// `newSession`/`openDirectory`) — the control path calls `store.duplicateSession` directly for the id.
+    /// Duplicates a session — a fresh shell in the source's directory, placed right after it. Store-scoped
+    /// like the other sidebar row actions, so a background window's context menu acts on its own row, not
+    /// the frontmost store's session. The directory-only contract is `AppStore.duplicateSession`'s; this
+    /// adds the select + focus New Session does. Returns nothing (like `newSession`/`openDirectory`) — the
+    /// control path calls `store.duplicateSession` directly for the id.
     func duplicateSession(_ id: UUID, in store: AppStore) {
         guard let session = store.duplicateSession(id) else { return }
-        // creating + selecting a session is a user-initiated selection: note activity so it buys the full
-        // idle grace before auto-follow can pull the selection away from the just-made session.
         store.noteUserActivity()
         store.selectSession(session.id)
         focusActiveSession()
     }
 
-    /// Duplicate the ACTIVE session — the active-session entry point for the menu bar, the ⌃P command
-    /// palette, and a `duplicate_session` keymap binding, mirroring `renameActiveSession()` vs the sidebar's
-    /// row-scoped `duplicateSession(_:in:)`. Acts on the frontmost window's store and its selected session.
+    /// Duplicate the ACTIVE session — the entry point for the menu bar, the ⌃P palette, and a
+    /// `duplicate_session` keymap binding (mirroring `renameActiveSession()` vs the sidebar's row-scoped
+    /// `duplicateSession(_:in:)`), acting on the frontmost store's selected session.
     func duplicateActiveSession() {
         guard uiActionsEnabled else { return }
         guard let store, let id = store.selectedSessionID else { return }
@@ -254,23 +234,21 @@ final class AppActions {
         return true
     }
 
-    // closes the active session, or dismisses a focus-stealing cover on top of it. returns whether it
-    // handled the keystroke, so the ⌘W menu item falls back to closing the window only when nothing was
-    // dismissed or closed (no cover, no session). precedence follows the z-order: the quick terminal is
-    // window-topmost (works even with no active session), then within a session an overlay sits above the
-    // scratch. the overlay is destroyed (closeOverlay, run-once ephemeral) while the quick terminal and
-    // scratch are hidden keep-alive; a floating overlay also holds first responder, so ANY overlay is
-    // dismissed, not only a full one.
+    // closes the active session, or dismisses a focus-stealing cover over it; returns whether it handled
+    // the keystroke, so the ⌘W menu item falls back to closing the window only with no cover and no
+    // session. precedence is z-order: the window-topmost quick terminal (works with no active session),
+    // then a session's overlay above its scratch. the overlay is DESTROYED (closeOverlay, run-once
+    // ephemeral) while quick/scratch are hidden keep-alive; a floating overlay holds first responder too,
+    // so ANY overlay is dismissed, not only a full one.
     @discardableResult
     func closeActiveSession() -> Bool {
         // A pick is an external caller waiting on an answer, so it is the first ⌘W layer even when a
         // terminal is zoomed behind it. Resolve rather than merely hiding it so the caller can finish.
         if cancelPendingPick(for: library.activeWindowID) { return true }
-        // terminal zoom is the window-topmost cover of all: ⌘W dismisses it like the covers below
-        // (stepwise — a zoomed quick terminal un-zooms first, the next ⌘W hides it) rather than
-        // swallowing the keystroke, and still never mutates hidden session/window state behind it. the
-        // dashboard grid is the other modal cover (mutually exclusive with zoom): ⌘W dismisses it the same
-        // way — close the grid and refocus the session — rather than closing the session behind it.
+        // zoom is the topmost cover: ⌘W dismisses it stepwise (a zoomed quick terminal un-zooms first, the
+        // next ⌘W hides it) instead of swallowing the keystroke, never mutating hidden session/window state
+        // behind it. the dashboard grid is the other modal cover (mutually exclusive with zoom) — close it
+        // and refocus rather than closing the session behind it.
         if terminalZoomActive { frontmostTerminalZoom?.clear(); return true }
         if let dashboard = frontmostDashboard, dashboard.isOpen { dashboard.close(); focusActiveSession(); return true }
         if let quick = frontmostQuickTerminal, quick.isVisible { quick.hide(); return true }
@@ -296,21 +274,18 @@ final class AppActions {
         return true
     }
 
-    /// Resolve all open windows' pending pickers during the synchronous app-termination notification.
-    /// The window library deliberately retains its open ids through quit teardown, so every mounted
-    /// controller remains addressable here.
+    /// Resolve every open window's pending picker during the synchronous app-termination notification. The
+    /// library retains its open ids through quit teardown, so every mounted controller is still addressable.
     func cancelAllPendingPicks() {
         for windowID in library.openIDs() {
             cancelPendingPick(for: windowID)
         }
     }
 
-    /// Close the session with `id` in `store` from a GUI surface (the sidebar row's Close), honoring the
-    /// "Confirm before closing a session" setting. `store` is the caller's own window-local store — a
-    /// background window's sidebar must close ITS session, not the frontmost window's — so it is passed in
-    /// rather than resolved via the frontmost `activeStore`. The ⌘W/menu/palette path uses
-    /// `closeActiveSession` (which acts on the frontmost active session); the control channel's
-    /// `session.close` closes directly, without a prompt.
+    /// Close session `id` in `store` from a GUI surface (the sidebar row's Close), honoring the "Confirm
+    /// before closing a session" setting. `store` is passed in, not resolved from the frontmost
+    /// `activeStore`: a background window's sidebar must close ITS session. ⌘W/menu/palette instead use
+    /// `closeActiveSession` (the frontmost active session); the control `session.close` closes with no prompt.
     func closeSession(_ id: UUID, in store: AppStore) {
         guard uiActionsEnabled else { return }
         guard let session = store.session(withID: id) else { return }
@@ -384,10 +359,9 @@ final class AppActions {
         store.setAgentIndicator(AgentIndicator(), forSession: id)
     }
 
-    /// Re-read and re-parse `keymap.conf`, re-rendering the data-driven menu shortcuts and rebuilding
-    /// the custom-command runner + the palette's custom items. Shared by the View menu item, the
-    /// action palette, and the control channel (`keymap.reload`). No-op before the scene wires the
-    /// settings model.
+    /// Re-read and re-parse `keymap.conf`, re-rendering the data-driven menu shortcuts and rebuilding the
+    /// custom-command runner + the palette's custom items. Shared by the View menu item, the action palette,
+    /// and `keymap.reload`. No-op before the scene wires the settings model.
     func reloadKeymap() { settingsModel?.reloadKeymap() }
 
     /// The session whose currently-open overlay is the keymap editor, so `WindowContentView`'s overlay
@@ -395,10 +369,9 @@ final class AppActions {
     var keymapEditOverlaySession: UUID?
 
     /// Open `keymap.conf` in the user's editor (`$VISUAL`/`$EDITOR`, else `vi`) in a 95% floating overlay
-    /// over the active session. The overlay runs through the login shell, so an `$EDITOR` exported from
-    /// the user's login-shell startup is honored. On the editor exiting, the keymap is reloaded (the
-    /// overlay-close onChange in `WindowContentView`). No-op with no active session, before the settings
-    /// model is wired, or when an overlay is already open.
+    /// over the active session, through the login shell so an `$EDITOR` exported from login-shell startup is
+    /// honored. The editor exiting reloads the keymap (`WindowContentView`'s overlay-close onChange). No-op
+    /// with no active session, before the settings model is wired, or with an overlay already open.
     func editKeymap() {
         guard uiActionsEnabled else { return }
         guard let store, let id = store.selectedSessionID, let path = settingsModel?.keymapPath else { return }
@@ -407,11 +380,11 @@ final class AppActions {
         }
     }
 
-    /// Re-read the ghostty config and rebroadcast it to every live surface (the warning banner on
-    /// diagnostics is posted by `SettingsModel.reloadGhosttyConfig`, mirroring `reloadKeymap`). Returns the
-    /// config-diagnostic count (0 = clean, or 0 before the scene wires the settings model) so the control
-    /// channel can report the value the reload actually produced. Shared by the File ▸ Reload Config menu
-    /// item, the action palette, the Edit-ghostty overlay close, and the `config.reload` control channel.
+    /// Re-read the ghostty config and rebroadcast it to every live surface (`SettingsModel.reloadGhosttyConfig`
+    /// posts the diagnostics warning banner, mirroring `reloadKeymap`). Returns the config-diagnostic count
+    /// (0 = clean, and 0 before the scene wires the settings model) so the control channel reports what the
+    /// reload actually produced. Shared by File ▸ Reload Config, the action palette, the Edit-ghostty overlay
+    /// close, and `config.reload`.
     @discardableResult
     func reloadGhosttyConfig() -> Int {
         settingsModel?.reloadGhosttyConfig() ?? 0
@@ -421,17 +394,14 @@ final class AppActions {
     /// onChange can reload the config when that overlay closes. Nil when no ghostty-edit overlay is up.
     var ghosttyEditOverlaySession: UUID?
 
-    /// The `ghostty.conf` contents captured when the Edit-ghostty overlay opened, so the overlay-close path
-    /// can skip the reload (and its per-session font-zoom reset) on a no-op editor session. Nil when no
-    /// ghostty-edit overlay is up.
+    /// The `ghostty.conf` contents captured when the Edit-ghostty overlay opened, so the close path can skip
+    /// the reload (and its per-session font-zoom reset) on a no-op editor session. Nil when none is up.
     private var ghosttyEditOverlaySnapshot: String?
 
-    /// Open `ghostty.conf` in the user's editor (`$VISUAL`/`$EDITOR`, else `vi`) in a 95% floating overlay
-    /// over the active session, mirroring `editKeymap`. The overlay runs through the login shell, so an
-    /// `$EDITOR` exported from the user's login-shell startup is honored. Captures the file contents so the
-    /// overlay-close path can reload only when the file actually changed. On the editor exiting, the config
-    /// is reloaded (the overlay-close onChange in `WindowContentView`). No-op with no active session, before
-    /// the settings model is wired, or when an overlay is already open.
+    /// Open `ghostty.conf` in the user's editor in a 95% floating overlay over the active session, mirroring
+    /// `editKeymap` (login shell, so an exported `$VISUAL`/`$EDITOR` is honored, else `vi`; the editor
+    /// exiting reloads the config via `WindowContentView`'s overlay-close onChange). Captures the file
+    /// contents so that path reloads only on a real change. Same no-ops as `editKeymap`.
     func editGhosttyConfig() {
         guard uiActionsEnabled else { return }
         guard let store, let id = store.selectedSessionID, let path = settingsModel?.ghosttyConfigPath else { return }
@@ -441,10 +411,9 @@ final class AppActions {
         }
     }
 
-    /// Called when the Edit-ghostty overlay closes: reload the config only if the file actually changed
-    /// since the editor opened, so a no-op open/close does not clear per-session ⌘+/⌘− zoom (the reload's
-    /// font reset). The explicit File ▸ Reload Config / `config.reload` paths stay unconditional by design
-    /// (the user asked to reload); this guard covers only the editor round-trip.
+    /// On Edit-ghostty overlay close: reload only if the file changed since the editor opened, so a no-op
+    /// open/close does not clear per-session ⌘+/⌘− zoom (the reload's font reset). Explicit File ▸ Reload
+    /// Config / `config.reload` stay unconditional — the guard covers only the editor round-trip.
     func reloadGhosttyConfigIfEdited() {
         let before = ghosttyEditOverlaySnapshot
         ghosttyEditOverlaySnapshot = nil
@@ -453,18 +422,17 @@ final class AppActions {
         reloadGhosttyConfig()
     }
 
-    /// Step the selection to the previous/next session, or jump to the first/last, in the sidebar's
-    /// flattened visual order (`navigateSession` owns the logic so the GUI, palette, and control
-    /// channel can't drift). Each routes through `selectSession` (recency/badge/persist/workspace)
-    /// then moves first responder into the moved-to session's focused pane. Each also notes the manual
-    /// navigation as user activity so it buys the full idle grace before auto-follow can pull the
-    /// selection back (the control `session.go` drives `navigateSession` directly, so it stays silent).
-    /// A step that resolves to the session ALREADY selected reveals nothing and just re-focuses: `next`/`previous`
-    /// wrap inside the filtered set, so a one-element set re-selects the current session, and `first`/`last`
-    /// do the same while you are already at that end. `selectSession` does not short-circuit a same-target
-    /// select, so it still returns an indicator there — revealing on it would clear `splitFocused` and yank
-    /// first responder onto the primary pane on a keystroke that moved nothing, off the split the user is
-    /// typing in. Attention nav deliberately DOES reveal on its no-op; see it below for why.
+    /// Step the selection prev/next, or to first/last, in the sidebar's flattened visual order — the logic
+    /// is `navigateSession`'s, so the GUI, palette and control channel can't drift. Routes through
+    /// `selectSession` (recency/badge/persist/workspace), then moves first responder into the moved-to
+    /// session's focused pane, and notes the manual nav as user activity so it buys the full idle grace
+    /// against auto-follow (the control `session.go` drives `navigateSession` directly and stays silent).
+    /// A step resolving to the ALREADY-selected session reveals nothing and just re-focuses: next/previous
+    /// wrap inside the filtered set (a one-element set re-selects), first/last repeat at that end, and
+    /// `selectSession` does not short-circuit a same-target select, so it still returns an indicator —
+    /// revealing on it would clear `splitFocused` and yank first responder onto the primary pane on a
+    /// keystroke that moved nothing, off the split being typed in. Attention nav DOES reveal on its no-op;
+    /// see below for why.
     private func navigatePlain(_ direction: SessionNavigation) {
         guard uiActionsEnabled else { return }
         store?.noteUserActivity()
@@ -481,18 +449,16 @@ final class AppActions {
     func selectFirstSession() { navigatePlain(.first) }
     func selectLastSession() { navigatePlain(.last) }
 
-    /// Step to the next/previous session needing attention (status `blocked` or `completed`), wrapping
-    /// around and skipping idle/active sessions. Shares `navigateSession` with the GUI, palette, and the
-    /// `session.go next-attention|prev-attention` control command. Notes user activity like the plain
-    /// session nav (a manual step to an attention session buys the idle grace too), then reveals and focuses
-    /// the moved-to session's blocked pane (`revealActiveBlockedPane`) so nav lands on the split/scratch pane
-    /// that set the status, not just the session's plain focused pane.
-    /// Unlike the plain nav above, this DOES reveal on a selection no-op, and the `?? activeSession?.agentIndicator`
-    /// fallback is the only thing that makes it: `attentionTarget` EXCLUDES the current session, so when the
-    /// sole session needing attention is the one already selected it returns nil and `navigateSession` selects
-    /// nothing. Without the fallback the reveal degrades to plain `focusActiveSession` and ⌃⌥↑/↓ stops taking
-    /// you to that session's tagged split/scratch pane — the case an agent hits constantly, since a pane-scoped
-    /// block is not cleared by typing in the OTHER pane. Do not drop it as redundant.
+    /// Step to the next/previous session needing attention (`blocked`/`completed`), wrapping around and
+    /// skipping idle/active. Shares `navigateSession` with the GUI, palette, and `session.go
+    /// next-attention|prev-attention`. Notes user activity like plain nav, then `revealActiveBlockedPane`
+    /// focuses the split/scratch pane that SET the status, not just the session's plain focused pane.
+    /// Unlike plain nav this DOES reveal on a selection no-op, and only the `?? activeSession?.agentIndicator`
+    /// fallback makes it: `attentionTarget` EXCLUDES the current session, so when the sole session needing
+    /// attention is the selected one it returns nil and `navigateSession` selects nothing. Without the
+    /// fallback the reveal degrades to plain `focusActiveSession` and ⌃⌥↑/↓ stops landing on that session's
+    /// tagged pane — constant for an agent, since a pane-scoped block is not cleared by typing in the OTHER
+    /// pane. Do not drop it as redundant.
     func selectNextAttentionSession() {
         guard uiActionsEnabled else { return }
         store?.noteUserActivity()
@@ -506,16 +472,14 @@ final class AppActions {
         revealActiveBlockedPane(captured: indicator)
     }
 
-    /// Delete a workspace from `store`'s window and all of its sessions. Confirms first when the workspace
-    /// still has sessions (the delete ends their shells); an empty workspace deletes without a prompt.
-    /// No-ops when only one workspace remains — one is always kept. Driven by the sidebar workspace row's
-    /// "Delete Workspace" context-menu item, which passes its OWN window-local store (like
-    /// Close/Flag/Duplicate/Focus) so a background window's row deletes the workspace it was opened over —
-    /// the item's enabled state was read from that same store, and routing through the frontmost one would
-    /// find no such id and silently do nothing. Ungated like the other store-scoped sidebar actions: a
-    /// window renders no sidebar while its terminal zoom or dashboard is up, so the row menu is unreachable
-    /// in exactly the state the gate covers, and the frontmost window's modal must not block a background
-    /// window's row.
+    /// Delete a workspace and all its sessions from `store`'s window. Confirms when it still has sessions
+    /// (the delete ends their shells); an empty one deletes without a prompt; no-op when only one workspace
+    /// remains — one is always kept. Driven by the row's "Delete Workspace" item, which passes its OWN
+    /// window-local store (like Close/Flag/Duplicate/Focus): the item's enabled state came from that store,
+    /// and the frontmost one would find no such id and silently do nothing. Ungated like the other
+    /// store-scoped row actions — a window renders no sidebar while its zoom or dashboard is up, so the row
+    /// menu is unreachable in exactly the state the gate covers, and a frontmost modal must not block a
+    /// background window's row.
     func deleteWorkspace(_ workspaceID: UUID, in store: AppStore) {
         guard store.canRemoveWorkspace,
               let workspace = store.workspaces.first(where: { $0.id == workspaceID }) else { return }
@@ -540,9 +504,8 @@ final class AppActions {
         confirmDelete(name: workspace.name, sessionCount: workspace.sessions.count)
     }
 
-    /// A standard warning confirm for deleting a named container (workspace or window) that still
-    /// holds `sessionCount` sessions — the delete ends their running shells. Returns whether the user
-    /// confirmed.
+    /// A standard warning confirm for deleting a named container (workspace or window) still holding
+    /// `sessionCount` sessions — the delete ends their running shells. Returns whether the user confirmed.
     private func confirmDelete(name: String, sessionCount: Int) -> Bool {
         let alert = NSAlert()
         alert.alertStyle = .warning
@@ -574,11 +537,10 @@ final class AppActions {
         expandAllWorkspaces(in: store)
     }
 
-    /// Expand every workspace in `store`'s window's sidebar. The sidebar owns the outline, so this posts a
-    /// notification carrying that store as the object; `WorkspaceSidebar.Coordinator` registers its
-    /// observer with `object: store`, so only that one window's sidebar acts. A graceful no-op in flagged
-    /// mode (no workspace rows). The `sidebar.expand` control command targets a specific (default
-    /// frontmost) window's store this way.
+    /// Expand every workspace in `store`'s window sidebar. The sidebar owns the outline, so this posts a
+    /// notification carrying that store as the object and `WorkspaceSidebar.Coordinator` observes with
+    /// `object: store`, so only that window's sidebar acts — how `sidebar.expand` targets a specific
+    /// (default frontmost) window. A graceful no-op in flagged mode (no workspace rows).
     func expandAllWorkspaces(in store: AppStore) {
         NotificationCenter.default.post(name: .agtermExpandWorkspaces, object: store)
     }
@@ -591,25 +553,23 @@ final class AppActions {
         collapseOtherWorkspaces(in: store)
     }
 
-    /// Collapse every workspace except the active one (the workspace of the active session) in `store`'s
-    /// window's sidebar, keeping that workspace expanded and scrolled into view. Scoped by the store
-    /// object to that window's Coordinator (see `expandAllWorkspaces(in:)`); a graceful no-op in flagged
-    /// mode. The `sidebar.collapse` control command targets a specific (default frontmost) window this way.
+    /// Collapse every workspace except the active session's in `store`'s window sidebar, keeping that one
+    /// expanded and scrolled into view. Store-object-scoped to that window's Coordinator (see
+    /// `expandAllWorkspaces(in:)`), a graceful no-op in flagged mode, and how `sidebar.collapse` targets a
+    /// specific (default frontmost) window.
     func collapseOtherWorkspaces(in store: AppStore) {
         NotificationCenter.default.post(name: .agtermCollapseWorkspaces, object: store)
     }
 
-    /// Collapse or expand a SINGLE workspace in `store`'s window sidebar — the per-workspace control path
-    /// (`workspace.collapse`/`workspace.expand`), distinct from the all-workspace `expandAllWorkspaces`/`collapseOtherWorkspaces`
-    /// above. Persists `Workspace.isExpanded` DIRECTLY on the store (the source of truth for the `collapsed`
-    /// read-back, delta-guarded so it's idempotent), THEN posts a store-scoped notification so the matching
-    /// window's `WorkspaceSidebar.Coordinator` syncs the live outline row + its tracked expansion set (see
-    /// `setWorkspaceExpandedNotified`). The persist must NOT depend on the sidebar Coordinator: it is torn
-    /// down when the window's sidebar is hidden (`WindowContentView` mounts it only while `sidebarVisible`),
-    /// so a notification-only write would silently drop with the sidebar hidden and leave the read-back stale.
-    /// Mirrors `workspace.focus`/`session.resize`, which likewise persist in the arm and post only for the
-    /// live view. There is no GUI caller — a row click drives the outline directly — so this exists only for
-    /// the control channel.
+    /// Collapse/expand a SINGLE workspace in `store`'s window sidebar — the `workspace.collapse`/`.expand`
+    /// control path, distinct from the all-workspace pair above, and its only caller (a GUI row click drives
+    /// the outline directly). Persists `Workspace.isExpanded` DIRECTLY on the store (source of truth for the
+    /// `collapsed` read-back, delta-guarded so it's idempotent), THEN posts a store-scoped notification so
+    /// the matching `WorkspaceSidebar.Coordinator` syncs the live outline row + its tracked expansion set
+    /// (`setWorkspaceExpandedNotified`). The persist must NOT ride the notification: `WindowContentView`
+    /// mounts the Coordinator only while `sidebarVisible`, so with the sidebar hidden a notification-only
+    /// write drops silently and leaves the read-back stale. Mirrors `workspace.focus`/`session.resize`,
+    /// which also persist in the arm and post only for the live view.
     func setWorkspaceExpanded(_ id: UUID, expanded: Bool, in store: AppStore) {
         store.setWorkspaceExpanded(id, expanded: expanded)
         NotificationCenter.default.post(
@@ -620,16 +580,14 @@ final class AppActions {
 
     // MARK: - Flagged working-set
 
-    /// Toggle a session's flagged membership (the durable flagged working-set the flat sidebar view
-    /// projects). Flips the current state; clean no-op on an unknown id. Driven by the sidebar row's
-    /// "Flag"/"Unflag" context-menu item.
+    /// Toggle a session's flagged membership (the durable working-set the flat sidebar view projects); clean
+    /// no-op on an unknown id. Driven by the sidebar row's "Flag"/"Unflag" context-menu item.
     func toggleFlag(_ sessionID: UUID) {
         guard uiActionsEnabled else { return }
         guard let store, let session = store.session(withID: sessionID) else { return }
         store.setFlag(!session.flagged, forSession: sessionID)
     }
 
-    /// Toggle one or more session flags in a specific window-local store. This mirrors `closeSessions`:
     /// Toggle the active session's flag — used by the menu bar and the action palette, which have no
     /// clicked row. No-op when nothing is selected.
     func toggleFlagActiveSession() {
@@ -646,9 +604,8 @@ final class AppActions {
         store.setSidebarMode(store.sidebarMode == .flagged ? .tree : .flagged)
     }
 
-    /// Unflag every session across all workspaces. Confirms first when at least one session is flagged
-    /// (clearing the working-set is a bulk change worth confirming); does nothing when nothing is
-    /// flagged. Skips the confirm under an XCUITest launch (a modal would hang the test).
+    /// Unflag every session across all workspaces, confirming first when at least one is flagged (a bulk
+    /// change) and doing nothing when none is. Skips the confirm under an XCUITest launch — a modal hangs it.
     func clearFlags() {
         guard uiActionsEnabled else { return }
         guard let store, !store.flaggedSessions.isEmpty else { return }
@@ -672,20 +629,17 @@ final class AppActions {
 
     // MARK: - Windows
 
-    /// Create a fresh window (one default workspace + session) and open its on-screen window via the
-    /// scene's window opener (the same seam the control channel uses). No-op if the opener isn't wired
-    /// yet (before the scene `.task` runs there's no window to open into).
+    /// Create a fresh window (one default workspace + session) and open it via the scene's window opener
+    /// (the seam the control channel uses). No-op before the scene `.task` wires the opener.
     ///
-    /// `ignoringModals` skips the frontmost-window modal gate. Creating a window is app-level — it
-    /// touches no existing window's state — so the Dock item passes true: a dashboard or terminal zoom
-    /// in whatever window happened to be last active must not make it inert, which is the whole point
-    /// of driving agterm from the Dock. The menu bar and palette keep the gate, and File ▸ New Window
-    /// mirrors it with `.disabled(modalActive)`.
+    /// `ignoringModals` skips the frontmost-window modal gate. Creating a window touches no existing
+    /// window's state, so the Dock item passes true — a dashboard or terminal zoom in whatever window
+    /// happened to be last active must not make it inert, the whole point of driving agterm from the Dock.
+    /// The menu bar and palette keep the gate (File ▸ New Window mirrors it with `.disabled(modalActive)`).
     func newWindow(ignoringModals: Bool = false) {
         guard ignoringModals || uiActionsEnabled else { return }
-        // create only when there is somewhere to open into: `library.newWindow()` persists an entry
-        // marked open, so creating without an opener would leave a window the app counts as open with
-        // no NSWindow behind it.
+        // `library.newWindow()` persists an entry marked open, so creating without an opener would leave a
+        // window the app counts as open with no NSWindow behind it.
         guard let openWindow else { return }
         let info = library.newWindow()
         openWindow(info.id)
@@ -698,10 +652,9 @@ final class AppActions {
         openWindow?(id)
     }
 
-    /// Rename the frontmost window via a one-shot standard `NSAlert` with an accessory text field
-    /// pre-filled with the current name. The app has no generic inline-prompt affordance (inline rename
-    /// is sidebar-row-only, and a window has no sidebar row), so the alert is the standard, minimal fit.
-    /// The rename itself flows through `library.renameWindow`, the same seam the control channel uses.
+    /// Rename the frontmost window via a one-shot `NSAlert` with an accessory text field pre-filled with the
+    /// current name — inline rename is sidebar-row-only and a window has no row, so the alert is the
+    /// standard, minimal fit. The rename flows through `library.renameWindow`, the control channel's seam.
     func renameActiveWindow() {
         guard uiActionsEnabled else { return }
         guard let id = library.activeWindowID,
@@ -735,15 +688,13 @@ final class AppActions {
 
     // MARK: - Inline rename
 
-    /// Start an inline rename of the active session. The sidebar owns the edit field, so this posts
-    /// a notification it observes; `renamePending` keeps the palette-close focus restore off the
-    /// field while the edit starts.
-    /// The post carries the frontmost STORE as its object, and `WorkspaceSidebar.Coordinator` registers
-    /// with `object: store`, so only that window's sidebar starts an edit — the same per-window scoping
-    /// `expandAllWorkspaces(in:)` uses. Posting with a nil object instead reached EVERY open window's
-    /// coordinator, and their `selectedSessionID` guard does not scope anything (every window has a
-    /// selection), so each one opened an editor nobody was typing into and each leaked one unbalanced
-    /// `suppressAutoFollow`.
+    /// Start an inline rename of the active session. The sidebar owns the edit field, so this posts a
+    /// notification it observes; `renamePending` keeps the palette-close focus restore off the field while
+    /// the edit starts. The post carries the frontmost STORE as its object and `WorkspaceSidebar.Coordinator`
+    /// registers with `object: store`, so only that window edits (the `expandAllWorkspaces(in:)` scoping).
+    /// A nil object reached EVERY open window's coordinator — their `selectedSessionID` guard scopes
+    /// nothing, since every window has a selection — so each opened an unused editor and leaked one
+    /// unbalanced `suppressAutoFollow`.
     func renameActiveSession() {
         guard uiActionsEnabled else { return }
         guard let store, store.activeSession != nil else { return }
@@ -764,11 +715,10 @@ final class AppActions {
 
     // MARK: - Split
 
-    /// Toggle the active session's split. Opening a NEW split shows both panes and moves focus to the
-    /// new (right) pane; closing HIDES the split (both shells stay alive, nothing is destroyed) and shows
-    /// the focused pane maximized, so reopening restores the two panes in their original positions with
-    /// the SAME pane focused. Either way focus follows `splitFocused`, which `AppStore.toggleSplit` sets
-    /// to the new pane only when the split is genuinely new (a re-show preserves the prior focused pane).
+    /// Toggle the active session's split. A NEW split shows both panes and focuses the new (right) one;
+    /// closing HIDES it (both shells stay alive, nothing destroyed) and shows the focused pane maximized, so
+    /// reopening restores both in their original positions with the SAME pane focused. Focus follows
+    /// `splitFocused`, which `AppStore.toggleSplit` moves only for a genuinely new split.
     func toggleSplit() {
         guard uiActionsEnabled else { return }
         guard let store, let session = store.activeSession else { return }
@@ -795,21 +745,19 @@ final class AppActions {
         store.toggleSidebarVisible()
     }
 
-    /// Move keyboard focus to a pane of the active session's split: `.split` -> the right pane,
-    /// anything else -> the left/primary. No-op when the active session has no split. Works whether the
-    /// split is shown side-by-side or hidden (maximized). Drives the keyboard shortcuts, the View menu
-    /// items, and the action palette.
+    /// Move keyboard focus to a pane of the active session's split: `.split` -> the right pane, anything
+    /// else -> the left/primary. No-op when the active session has no split; works whether the split is shown
+    /// side-by-side or hidden (maximized). Drives the keyboard shortcuts, the View menu items, and the palette.
     func focusPane(_ pane: PaneRole) {
         guard uiActionsEnabled else { return }
         guard let session = store?.activeSession else { return }
         setSplitFocus(pane == .split, of: session)
     }
 
-    /// Set which pane of a session's split holds focus and move first responder there. Shared by the
-    /// GUI `focusPane` and the control channel (which may target a session that isn't the active one).
-    /// Updates `splitFocused` so the pane dim, sidebar, and title bar follow. Works whether the split is
-    /// shown side-by-side or hidden: when hidden, flipping `splitFocused` swaps which pane is shown
-    /// maximized. No-op only when the session has no split.
+    /// Set which pane of a session's split holds focus and move first responder there. Shared by the GUI
+    /// `focusPane` and the control channel (which may target a non-active session). Updates `splitFocused`
+    /// so the pane dim, sidebar and title bar follow. Works shown side-by-side or hidden — when hidden,
+    /// flipping `splitFocused` swaps which pane shows maximized. No-op only when the session has no split.
     func setSplitFocus(_ toSplit: Bool, of session: Session) {
         guard session.hasSplit else { return }
         session.splitFocused = toSplit
@@ -819,11 +767,10 @@ final class AppActions {
     // MARK: - Quick terminal (frontmost window)
 
     /// Toggle the frontmost window's quick terminal (each window owns its own controller). Gated on the full
-    /// `uiActionsEnabled` (zoom, dashboard, AND native picker), not zoom alone — defence in depth rather
-    /// than a gap being closed, since all three callers already gate: the View ▸ Quick Terminal item's
-    /// `.disabled(modalActive)` (which covers a `keymap.conf` rebind too, because that rebind is the item's
-    /// own key equivalent), the palette's `runPaletteCommand` check, and the Dock item's invocation-time
-    /// `uiActionsEnabled(for:)`.
+    /// `uiActionsEnabled` (zoom, dashboard AND native picker), not zoom alone — defence in depth, not a gap
+    /// being closed, since all three callers already gate: View ▸ Quick Terminal's `.disabled(modalActive)`
+    /// (which covers a `keymap.conf` rebind too, that rebind being the item's own key equivalent), the
+    /// palette's `runPaletteCommand` check, and the Dock item's invocation-time `uiActionsEnabled(for:)`.
     func toggleQuickTerminal() {
         guard uiActionsEnabled else { return }
         frontmostQuickTerminal?.toggle()
@@ -836,12 +783,11 @@ final class AppActions {
         frontmostTerminalZoom?.toggle()
     }
 
-    /// Toggle the frontmost window's dashboard — the keyboard/menu/palette opener for the MRU dashboard grid
-    /// (the ⌘⇧D / Navigate ▸ Dashboard equivalent of `agtermctl dashboard --mru --auto-size`). Inert while
-    /// terminal zoom or the topmost native picker is active (mirrors the GUI siblings and menu disablement).
-    /// Dashboard state alone does not block the toggle, so an open grid remains its own close escape hatch.
-    /// Open → close it and refocus the active session; closed → open it over the window's most-recently-used
-    /// sessions, auto-sized. A no-op when the window has no recent sessions.
+    /// Toggle the frontmost window's dashboard — the ⌘⇧D / Navigate ▸ Dashboard opener for the MRU grid,
+    /// equivalent to `agtermctl dashboard --mru --auto-size`. Inert while terminal zoom or a pending native
+    /// picker is up (mirroring the GUI siblings and menu disablement), but NOT while the dashboard itself is
+    /// open, so the grid stays its own close escape hatch. Open → close and refocus the active session;
+    /// closed → open over the window's most-recently-used sessions, auto-sized; no-op with no recent sessions.
     func toggleDashboard() {
         guard !terminalZoomActive, !pickActive(for: library.activeWindowID) else { return }
         guard let dashboard = frontmostDashboard else { return }
@@ -854,17 +800,16 @@ final class AppActions {
         let members = store.dashboardMRUMembers(limit: DashboardLayout.maxCells)
         guard !members.isEmpty else { return }
         dashboard.open(members: members, fontMode: .auto)
-        // set the applied font size synchronously (the SwiftUI onChange applies the surface overrides a runloop
-        // turn later), resolving through the same DashboardFontMode seam as ControlServer.setDashboard so the
-        // GUI and control opens land on the identical auto size.
+        // set the applied size synchronously (the SwiftUI onChange applies surface overrides a runloop turn
+        // later), through the same DashboardFontMode seam as ControlServer.setDashboard so the GUI and
+        // control opens land on the identical auto size.
         let base = settingsModel?.settings.fontSize ?? DashboardLayout.ghosttyDefaultFontSize
         dashboard.setAppliedFontSize(DashboardFontMode.auto.appliedFontSize(memberCount: members.count, base: base))
     }
 
-    /// Toggle native macOS full screen for the key window (the frontmost terminal window). Native full
-    /// screen matches the green traffic-light button and moves the window to its own Space; a second
-    /// invocation exits. Shared by the View ▸ Toggle Full Screen menu item (⌃⌘F), the ⌃⇧P palette, the
-    /// `toggle_fullscreen` keymap action, and the `window.fullscreen` control command.
+    /// Toggle native macOS full screen for the key window (the frontmost terminal window): it matches the
+    /// green traffic-light button and moves the window to its own Space, a second invocation exits. Shared
+    /// by View ▸ Toggle Full Screen (⌃⌘F), the ⌃⇧P palette, `toggle_fullscreen`, and `window.fullscreen`.
     func toggleFullscreen() { NSApp.keyWindow?.toggleFullScreen(nil) }
 
     // MARK: - Font (on the focused terminal)
@@ -883,13 +828,12 @@ final class AppActions {
 
     // MARK: - Search (on the surface that opened it)
 
-    /// The search-capable target. A covering SCRATCH wins FIRST — the scratch surface (`topmostSurface` while
-    /// `scratchActive` with no overlay) — so a ⌘F while the scratch covers the session always opens the bar on
-    /// the scratch, never on the hidden pane underneath, even when key-window focus sits off the surface (e.g.
-    /// the sidebar), where `focusedSurface()` would otherwise fall back to the hidden `activeSurface`. Else the
-    /// focused surface IFF it is searchable (the main/split pane), else the active session's focused pane. The
-    /// full overlay/quick terminal are not searchable (blocked by `coverHidesActiveSession`); a FLOATING
-    /// overlay leaves the pane visible, so search targets the pane behind it (not the unsearchable overlay).
+    /// The search-capable target. A covering SCRATCH wins FIRST (`topmostSurface` while `scratchActive` with
+    /// no overlay), so ⌘F over a scratch never opens the bar on the hidden pane beneath — even with key-window
+    /// focus off the surface (e.g. the sidebar), where `focusedSurface()` would fall back to the hidden
+    /// `activeSurface`. Else the focused surface IFF searchable (the main/split pane), else the active
+    /// session's focused pane. Full overlay and quick terminal are unsearchable (blocked by
+    /// `coverHidesActiveSession`); a FLOATING overlay leaves the pane visible, so search targets that pane.
     private func searchTarget() -> GhosttySurfaceView? {
         if let session = store?.activeSession, session.scratchActive, !session.overlayActive {
             return session.topmostSurface as? GhosttySurfaceView
@@ -898,10 +842,10 @@ final class AppActions {
         return store?.activeSession?.activeSurface as? GhosttySurfaceView
     }
 
-    /// Whether a covering surface hides the active session in a way that BLOCKS ⌘F — the frontmost window's
-    /// quick terminal is up, or the active session shows a FULL overlay. Neither is searchable, so opening the
-    /// bar would strand it over a hidden pane. The scratch is NOT a blocker: it IS searchable now, so ⌘F opens
-    /// the bar over the scratch itself. The ⌘F-again CLOSE still runs regardless (no cover blocks it).
+    /// Whether a cover BLOCKS ⌘F — the frontmost window's quick terminal, or the active session's FULL
+    /// overlay. Neither is searchable, so the bar would strand over a hidden pane. The scratch is NOT a
+    /// blocker: it IS searchable, so ⌘F opens the bar over the scratch itself. The ⌘F-again CLOSE still runs
+    /// regardless of any cover.
     private var coverHidesActiveSession: Bool {
         if frontmostQuickTerminal?.isVisible == true { return true }
         guard let session = store?.activeSession else { return false }
@@ -909,15 +853,13 @@ final class AppActions {
         return session.fullOverlayActive
     }
 
-    /// Toggle the search bar for the active session. CLOSE branch (search already active): send
-    /// `end_search` DIRECTLY to the session's pinned `searchSurface` (the surface that opened search), so
-    /// the END callback clears the fields and refocuses — it does NOT re-resolve a target or round-trip
-    /// `start_search`, which on a split with focus moved to the OTHER pane would put that pane into search
-    /// mode while `onSearchStart` closes only the pinned owner, stranding it. OPEN branch (search inactive):
-    /// no-op when no searchable surface exists (never enters bar-less search on a quick/scratch/overlay
-    /// surface) or while a covering surface hides the session, else send `start_search` to the search
-    /// target — `onSearchStart` opens the bar and pins the surface. Shared by the Find menu item, the
-    /// palette, and ⌘F.
+    /// Toggle the search bar for the active session; shared by the Find menu item, the palette, and ⌘F.
+    /// CLOSE (search already active): send `end_search` DIRECTLY to the session's pinned `searchSurface` (the
+    /// surface that opened search) so the END callback clears the fields and refocuses — never a re-resolved
+    /// target or a `start_search` round-trip, which on a split with focus moved to the OTHER pane would put
+    /// that pane into search mode while `onSearchStart` closes only the pinned owner, stranding it. OPEN:
+    /// no-op with no searchable surface (never bar-less search on a quick/scratch/overlay surface) or behind
+    /// a cover, else `start_search` on the search target, whose `onSearchStart` opens the bar and pins it.
     func toggleSearch() {
         guard !pickActive(for: library.activeWindowID) else { return }
         if store?.activeSession?.searchActive == true {
@@ -929,12 +871,11 @@ final class AppActions {
         target.startSearch()
     }
 
-    /// Set the current query: mirror it into the active session's `searchNeedle` (so the bar's field stays
-    /// in sync) then send `search:<needle>` to the session's pinned `searchSurface`, which replies with the
-    /// new match count. Driving the pinned owner (not a re-resolved focused surface) keeps the bar bound to
-    /// the pane that opened search even after split focus moves. Clearing the field (empty needle) clears
-    /// the count/selected eagerly so the counter blanks at once rather than flashing the stale "N of M"
-    /// until libghostty's async teardown callback lands.
+    /// Set the current query: mirror it into the active session's `searchNeedle` (keeping the bar's field in
+    /// sync) then send `search:<needle>` to the pinned `searchSurface`, which replies with the new match
+    /// count. Driving the pinned owner rather than a re-resolved focused surface keeps the bar on the pane
+    /// that opened search after a split focus move. An empty needle clears count/selected eagerly, so the
+    /// counter blanks at once instead of flashing the stale "N of M" until libghostty's async teardown lands.
     func updateSearchNeedle(_ needle: String) {
         guard let session = store?.activeSession else { return }
         session.searchNeedle = needle
@@ -951,9 +892,9 @@ final class AppActions {
         (store?.activeSession?.searchSurface as? GhosttySurfaceView)?.navigateSearch(direction)
     }
 
-    /// Close search: send `end_search` to the session's pinned `searchSurface` so it exits search mode
-    /// (never just flips the flag). The resulting END_SEARCH callback clears the session's fields, the
-    /// pinned owner, and returns first responder to the terminal — the single clear point, so this only
+    /// Close search: send `end_search` to the session's pinned `searchSurface` so it really exits search mode
+    /// (never just flips the flag). The END_SEARCH callback is the single clear point — it clears the
+    /// session's fields and the pinned owner and returns first responder to the terminal — so this only
     /// sends the binding action.
     func endSearch() {
         (store?.activeSession?.searchSurface as? GhosttySurfaceView)?.endSearch()
@@ -961,11 +902,11 @@ final class AppActions {
 
     // MARK: - Focus
 
-    /// Per-window generation counters (keyed by the owning window id; bumped in AppActions+Focus). A fresh
-    /// `focusSplitPane` call bumps its window's counter so an older in-flight retry loop in the SAME window
-    /// cancels itself when superseded, stopping the opposite-target ping-pong flicker and giving
-    /// last-focus-wins within a window. Keyed by window (one NSWindow = one first responder) so a focus op
-    /// in one window never cancels another window's still-materializing focus retry.
+    /// Per-window focus generation counters (keyed by owning window id, bumped in AppActions+Focus). A fresh
+    /// `focusSplitPane` bumps its window's counter so a superseded in-flight retry loop in the SAME window
+    /// cancels itself — killing the opposite-target ping-pong flicker, last-focus-wins per window. Keyed by
+    /// window (one NSWindow = one first responder) so one window's focus op never cancels another's
+    /// still-materializing retry.
     var focusGeneration: [UUID: Int] = [:]
 
     /// The focused terminal: the key window's first responder if it's a surface (covers the main

--- a/agterm/AppDelegate+DockMenu.swift
+++ b/agterm/AppDelegate+DockMenu.swift
@@ -2,7 +2,7 @@ import agtermCore
 import AppKit
 
 /// A retained target for one Dock-menu command. The Dock invokes menu actions with a nil sender, so a
-/// recent/attention session's identity lives in this target's closure instead of in `representedObject`.
+/// recent/attention session's identity lives in this closure instead of in `representedObject`.
 @MainActor
 final class DockMenuActionTarget: NSObject {
     private let action: () -> Void
@@ -43,8 +43,8 @@ private enum DockSessionGroup {
 
 extension AppDelegate {
     /// Builds the app-specific portion of the Dock icon's contextual menu from the last-active window.
-    /// AppKit asks for this menu when the user opens the Dock menu, so MRU order and attention state are
-    /// current without maintaining a second observed menu model.
+    /// AppKit asks for it when the user opens the Dock menu, so MRU order and attention state are current
+    /// without maintaining a second observed menu model.
     func applicationDockMenu(_: NSApplication) -> NSMenu? {
         dockMenuActionTargets.forEach { $0.invalidate() }
         dockMenuActionTargets.removeAll(keepingCapacity: true)
@@ -68,14 +68,13 @@ extension AppDelegate {
             actions?.newSession()
         }
 
-        // The one app-level item: a new window belongs to no existing window, so unlike its neighbours it
-        // captures nothing, is always enabled, and skips the frontmost-window modal gate. It activates the
-        // app itself because ordinary window presentation does not — `WindowAccessor.bringForward` unhides
-        // and activates only on the UI-test path — so without this the new window opens behind whatever app
-        // the user right-clicked the Dock from.
+        // the one app-level item: a new window belongs to no existing window, so unlike its neighbours it
+        // captures nothing and skips the frontmost-window modal gate. It activates the app itself because
+        // ordinary window presentation does not (`WindowAccessor.bringForward` unhides and activates only on
+        // the UI-test path), else the new window opens behind whatever app the Dock was right-clicked from.
         // Enabled on the action hub alone, never on the captured window: `actions` is wired in the scene
-        // `.task`, so before that runs every other item is disabled (nil library → nil windowID) and this
-        // one would be the only enabled item in the menu — activating the app and then doing nothing.
+        // `.task`, so before that runs every other item is disabled (nil library → nil windowID) and an
+        // always-enabled one here would be the menu's only live item, activating the app and doing nothing.
         addDockMenuItem("New Window", enabled: actions != nil, to: menu) { [weak self] in
             guard let self else { return }
             NSApp.unhide(nil)
@@ -184,16 +183,16 @@ extension AppDelegate {
     }
 
     /// Dock commands do not activate or unhide the app automatically. Raise and synchronously publish the
-    /// window captured when AppKit built the menu, so every top-level and session action stays scoped to
-    /// that window even when a different window becomes frontmost while the menu is tracking.
+    /// window captured when AppKit built the menu, keeping every top-level and session action scoped to it
+    /// even when another window becomes frontmost while the menu is tracking.
     @discardableResult
     private func activate(windowID: UUID, store: AppStore) -> Bool {
         guard let library, library.store(for: windowID) === store else { return false }
         NSApp.unhide(nil)
         NSApp.activate()
         WindowRegistry.shared.raise(windowID)
-        // WindowAccessor reports ordinary key-window changes asynchronously. Publish this Dock-driven
-        // change now so shared AppActions resolve through the captured store during this same invocation.
+        // WindowAccessor reports ordinary key-window changes asynchronously; publish this Dock-driven one
+        // now so shared AppActions resolve through the captured store during this same invocation.
         if library.frontmostWindowID != windowID {
             library.frontmostWindowID = windowID
             library.saveIndex()
@@ -202,9 +201,9 @@ extension AppDelegate {
         return true
     }
 
-    /// Selects a session captured when the Dock menu was built. The store is captured as well, so the action
-    /// remains correctly window-scoped; synchronously marking that window frontmost lets the shared action
-    /// hub focus the selected session and reveal the pane that raised its status, when present.
+    /// Selects a session captured when the Dock menu was built. Its store is captured too, keeping the
+    /// action window-scoped; synchronously marking that window frontmost lets the shared action hub focus
+    /// the selected session and reveal the pane that raised its status, when present.
     private func activate(_ sessionID: UUID, in store: AppStore) {
         guard store.session(withID: sessionID) != nil,
               let library,

--- a/agterm/AppDelegate.swift
+++ b/agterm/AppDelegate.swift
@@ -3,47 +3,39 @@ import AppKit
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
-    /// The app-global window library, set once the scene appears so terminate can flush every window's state.
+    /// App-global window library, set on scene appear; terminate flushes every window's state.
     var library: WindowLibrary?
 
-    /// The control channel, set once the scene appears so terminate can stop the listener and unlink the socket.
+    /// Control channel, set on scene appear; terminate stops the listener and unlinks the socket.
     var controlServer: ControlServer?
 
-    /// The custom-command key-monitor runner, set on scene appear; terminate removes its monitor + observer.
+    /// Custom-command key-monitor runner, set on scene appear; terminate removes its monitor + observer.
     var customCommandRunner: CustomCommandRunner?
 
-    /// The settings model, set on scene appear so terminate can flush its pending debounced `settings.json`
-    /// writes (opacity/blur, theme preview).
+    /// Settings model, set on scene appear; terminate flushes its pending debounced `settings.json` writes.
     var settingsModel: SettingsModel?
 
-    /// The action hub, handed over once the scene appears so `application(_:open:)` can open a session at
-    /// a folder path passed by `open -a agterm /path`. Nil before the scene `.task` runs.
+    /// Action hub, set on scene appear so `application(_:open:)` can open a session at an `open -a` path.
     var actions: AppActions?
 
-    /// Strongly retains the target objects for the current Dock menu so nil-sender dispatch never depends
-    /// on AppKit's target lifetime. Each dynamic session command already knows which action to perform;
-    /// the set is invalidated and replaced whenever the Dock asks for a fresh menu.
+    /// Strongly retains the current Dock menu's target objects so nil-sender dispatch never depends on
+    /// AppKit's target lifetime; replaced whenever the Dock asks for a fresh menu.
     var dockMenuActionTargets: [DockMenuActionTarget] = []
 
-    /// Directories from `open -a agterm /path` (the OS "open terminal here" integration) not yet turned into
-    /// sessions — queued until the frontmost window's store resolves, so a `session new`-style graft lands in
-    /// the last-active window.
+    /// Directories from `open -a agterm /path` not yet turned into sessions — queued until the frontmost
+    /// store resolves, so the new session lands in the last-active window.
     private var pendingOpenDirectories: [String] = []
 
     private var restoreObserver: NSObjectProtocol?
     private var scheduledReconciliationReasons: Set<String> = []
 
     func applicationWillFinishLaunching(_: Notification) {
-        // agterm has its own multi-window model and no native window tabs; disabling automatic tabbing
-        // strips AppKit's injected "Show Tab Bar" / "Show All Tabs" / "Move Tab to New Window" items and
-        // the tab affordances. Must be set before any window is created.
+        // no native window tabs: this strips AppKit's injected "Show Tab Bar" / "Show All Tabs" / "Move Tab
+        // to New Window" items and the tab affordances. Must be set before any window is created.
         NSWindow.allowsAutomaticWindowTabbing = false
-        // do NOT set NSApp.applicationIconImage: the icon is the adaptive Icon Composer `AppIcon.icon`,
-        // which the system renders LIVE in the Dock per appearance (light/dark/clear/tinted, Liquid Glass),
-        // while applicationIconImage takes a STATIC NSImage and would freeze the Dock to one flat
-        // rendering. Let LaunchServices render the bundle icon. The Dock unseen-count badge uses
-        // `UNUserNotificationCenter.setBadgeCount` (`DockBadgeController`), which draws over the live
-        // adaptive icon without touching `applicationIconImage`.
+        // do NOT set NSApp.applicationIconImage: the adaptive Icon Composer `AppIcon.icon` is rendered LIVE
+        // per appearance (light/dark/clear/tinted, Liquid Glass), and a STATIC NSImage would freeze the Dock
+        // to one flat rendering. The unseen badge draws over it via `UNUserNotificationCenter.setBadgeCount`.
         restoreObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.didFinishRestoringWindowsNotification,
             object: NSApp,
@@ -62,20 +54,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         } else {
             NSApp.activate()
         }
-        // Boot libghostty: init, config, app_new, 120fps tick.
+        // boot libghostty: init, config, app_new.
         _ = GhosttyApp.shared
         scheduleRestoredWindowReconciliation(reason: "did-finish-launching")
-        // AppKit auto-adds its own "Enter Full Screen" item (Globe+F / ⌃⌘F) to the View menu for any
-        // fullscreen-capable window and RE-INJECTS it each time the menu opens, duplicating agterm's own
-        // rebindable "Toggle Full Screen" (which is what makes full screen drivable from the keymap, action
-        // palette and control channel). Strip the native one whenever a menu begins tracking — the point of
-        // re-injection, so a launch-time one-shot does NOT stick.
+        // AppKit auto-adds its own "Enter Full Screen" item (Globe+F / ⌃⌘F) to the View menu and RE-INJECTS
+        // it whenever the menu opens, duplicating agterm's rebindable "Toggle Full Screen" (what makes full
+        // screen drivable from keymap, palette and control). Strip the native one on every menu-tracking
+        // start — a launch-time one-shot does NOT stick.
         AppDelegate.removeNativeFullScreenMenuItem()
         NotificationCenter.default.addObserver(self, selector: #selector(menuBeganTracking),
                                                name: NSMenu.didBeginTrackingNotification, object: nil)
         // SwiftUI defers its menu rebuild to the next app ACTIVATION, and that rebuild is what lets the
-        // stock File ▸ Close claim ⌘W. Reconcile after it (async, so we run once SwiftUI has rebuilt) and
-        // on every keymap change, so a `keymap reload` takes effect on the chord immediately.
+        // stock File ▸ Close claim ⌘W. Reconcile after it (async, once SwiftUI has rebuilt) and on every
+        // keymap change, so a `keymap reload` takes effect on the chord immediately.
         NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActive),
                                                name: NSApplication.didBecomeActiveNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keymapChanged),
@@ -102,12 +93,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// Keep ⌘W with agterm's File ▸ Close Session whenever the keymap says it owns that chord.
     ///
-    /// SwiftUI hands the stock File ▸ Close (`performClose:`) a ⌘W key equivalent the moment agterm's item
-    /// vacates the chord (a `map cmd+<other> close_session` plus `keymap reload` is enough), and putting
-    /// `close_session` back does NOT reclaim it: SwiftUI resolves the collision by dropping the shortcut from
-    /// its OWN item, leaving Close Session unbound and ⌘W closing the whole window until relaunch (issue
-    /// #296). So agterm asserts the split itself, from the AppKit side like `removeNativeFullScreenMenuItem`
-    /// — there is no SwiftUI API for either half.
+    /// SwiftUI hands the stock File ▸ Close (`performClose:`) a ⌘W equivalent the moment agterm's item
+    /// vacates the chord, and putting `close_session` back does NOT reclaim it: SwiftUI drops the shortcut
+    /// from its OWN item, leaving Close Session unbound and ⌘W closing the whole window until relaunch
+    /// (issue #296). agterm asserts the split from the AppKit side — no SwiftUI API does either half.
     private func reconcileCloseSessionChord() {
         guard let keymap = settingsModel?.keymap else { return }
         AppDelegate.applyCloseSessionChord(keymap, in: NSApp.mainMenu)
@@ -116,14 +105,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Split ⌘W between agterm's Close Session item and the stock `performClose:` one, following `keymap`.
     /// Operates on whichever submenu holds `performClose:`; a menu without both items is left alone.
     ///
-    /// The stock item may hold ⌘W only while NO built-in resolves to it; `close_session` alone is not enough,
-    /// since `parseKeymap` rejects a chord only when two DISTINCT actions claim it — `map cmd+e close_session`
-    /// plus `map cmd+w new_session` is a clean keymap where another action legitimately owns ⌘W, and arming
-    /// the stock item there would advertise the chord twice and let SwiftUI's next rebuild unbind agterm's
-    /// own item, the failure this reconcile exists to prevent.
+    /// The stock item may hold ⌘W only while NO built-in resolves to it — `close_session` alone is not
+    /// enough, since another action can legitimately own ⌘W (`parseKeymap` rejects a chord only when two
+    /// DISTINCT actions claim it), and arming the stock item there advertises the chord twice, letting
+    /// SwiftUI's next rebuild unbind agterm's own item.
     ///
-    /// agterm's item is a SwiftUI closure button with no distinguishing selector, so it is matched by title;
-    /// scoping that match to the submenu owning `performClose:` keeps it narrow.
+    /// agterm's item is a SwiftUI closure button with no distinguishing selector, so it is matched by title.
     static func applyCloseSessionChord(_ keymap: Keymap, in mainMenu: NSMenu?) {
         let closeSessionOwns = keymap.equivalent(for: .closeSession) == commandW
         let anyBuiltinOwns = BuiltinAction.allCases.contains { keymap.equivalent(for: $0) == commandW }
@@ -133,9 +120,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                   let stockClose = submenu.items.first(where: { $0.action == closeSelector }),
                   let ours = submenu.items.first(where: { $0.title == closeSessionItemTitle })
             else { continue }
-            // our item carries ⌘W exactly while close_session owns it; clearing a stale one matters because
-            // SwiftUI defers its rebuild to the next activation, so straight after a reload that rebound
-            // close_session away our item still advertises the chord the stock item is about to take.
+            // clear a stale ⌘W on our item: SwiftUI defers its rebuild to the next activation, so right after
+            // a reload that rebound close_session away ours still advertises the chord the stock item takes.
             if closeSessionOwns {
                 ours.keyEquivalent = "w"
                 ours.keyEquivalentModifierMask = .command
@@ -156,9 +142,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     static let closeSessionItemTitle = "Close Session"
     private static let commandW = Chord(mods: [.command], key: "w")
 
-    /// Remove AppKit's auto-injected fullscreen item — the one whose action is `toggleFullScreen:`. agterm's
-    /// own item uses a SwiftUI closure action (a different selector), so only the native one matches and our
-    /// "Toggle Full Screen" survives. Finds the owning submenu by content, not by the localized "View" title.
+    /// Remove AppKit's auto-injected fullscreen item (action `toggleFullScreen:`); agterm's own is a SwiftUI
+    /// closure action, so only the native one matches. Finds the submenu by content, not a localized title.
     @MainActor
     private static func removeNativeFullScreenMenuItem() {
         let selector = #selector(NSWindow.toggleFullScreen(_:))
@@ -170,10 +155,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// `open -a agterm /path` (the OS "open terminal here" integration): macOS delivers the URLs here. Each
-    /// resolves to a directory (folder → itself, file → its parent, via host-free `OpenPathResolver`), which
-    /// is queued and drained into a new session in the last-active window. Serves the WARM case — agterm
-    /// already running (its daily-driver norm), so the instance has a window and grafts immediately.
+    /// `open -a agterm /path` (the OS "open terminal here" integration): each URL resolves to a directory
+    /// (folder → itself, file → its parent, via `OpenPathResolver`), queued and drained into a new session
+    /// in the last-active window. WARM case only — a running instance already has a window to graft into.
     func application(_: NSApplication, open urls: [URL]) {
         let directories = urls.compactMap { OpenPathResolver.directory(for: $0) }
         guard !directories.isEmpty else { return }
@@ -181,10 +165,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         drainPendingOpenDirectories()
     }
 
-    /// Turn every queued `open -a` directory into a new session in the last-active window, one at a time,
-    /// dropping each entry only once its session lands (a transient failure keeps it queued). No-op on an
-    /// empty queue; when the frontmost store isn't resolvable yet, retries on a 0.1 s backoff, bounded so a
-    /// folder can't wedge a stuck timer.
+    /// Turn every queued `open -a` directory into a new session in the last-active window, dropping an
+    /// entry only once its session lands (a transient failure keeps it queued). Until the frontmost store
+    /// resolves, retries every 0.1 s, bounded so a folder can't wedge a stuck timer.
     func drainPendingOpenDirectories(retry: Int = 0) {
         guard !pendingOpenDirectories.isEmpty else { return }
         guard let actions, library?.activeStore?.currentWorkspaceID != nil else {
@@ -199,10 +182,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         while let directory = pendingOpenDirectories.first, actions.openSession(atDirectory: directory) {
             pendingOpenDirectories.removeFirst()
         }
-        // raise the window the session landed in: `NSApp.activate()` only fronts the app, so an "open
-        // terminal here" into a minimized last-active window would stay in the Dock showing nothing.
-        // `WindowRegistry.raise` deminiaturizes + makes key, a no-op for an already-frontmost window; only
-        // when a session actually landed.
+        // raise the window the session landed in: `NSApp.activate()` only fronts the app, so a minimized
+        // last-active window would stay in the Dock. `raise` deminiaturizes + makes key, a frontmost no-op.
         if pendingOpenDirectories.count < beforeCount, let windowID = library?.activeWindowID {
             WindowRegistry.shared.raise(windowID)
         }
@@ -223,9 +204,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// On macOS 15+ a SwiftUI WindowGroup app launched by another process (XCUITest, launchd) often never
-    /// auto-presents its window (FB11763863): the dock icon shows, no window appears, the scene's
+    /// auto-presents its window (FB11763863): dock icon shows, no window appears, and the scene's
     /// `.task`/`.onAppear` never fire. A reopen event (what a dock click sends) creates it — fire one once
-    /// when no real window exists, then bring whatever appears forward.
+    /// when no real window exists.
     private func bringUITestWindowsForward() {
         if !didForceReopen, NSApp.windows.allSatisfy({ $0 is NSPanel }) {
             didForceReopen = true
@@ -233,10 +214,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         NSApp.setActivationPolicy(.regular)
         NSApp.unhide(nil)
-        // present the launch window ONCE (FB11763863), then latch off: the windows are isRestorable=false
-        // so they won't re-minimize, and re-fronting every tick would oscillate the key window and fight a
-        // deliberate window.select (which made multi-window control tests flaky). A runtime window.new
-        // presents via its own per-window retry instead.
+        // present the launch window ONCE (FB11763863), then latch off: the windows are isRestorable=false so
+        // they won't re-minimize, and re-fronting every tick oscillates the key window and fights a deliberate
+        // window.select (which made multi-window control tests flaky). A runtime window.new has its own retry.
         guard !didPresentUITestWindow else { return }
         NSApp.activate()
         for window in NSApp.windows where window.canBecomeKey {
@@ -247,15 +227,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// One-shot latch: true once the launch UI-test window is presented, so the retry schedule stops re-fronting.
+    /// One-shot latch: set once the launch UI-test window is presented, stopping the retry schedule.
     private var didPresentUITestWindow = false
 
     private var didForceReopen = false
 
-    /// SwiftUI/AppKit can restore stale plain-WindowGroup windows before the app's own `WindowLibrary`
-    /// reopen pass finishes. Closing them from inside the stray view races that restoration machinery, so
-    /// reconcile after AppKit's restoration-complete notification and after the real windows have had time
-    /// to register through `TitleProbeView`.
+    /// SwiftUI/AppKit can restore stale plain-WindowGroup windows before `WindowLibrary`'s reopen pass ends,
+    /// and closing them from inside the stray view races that restoration machinery — so reconcile after
+    /// AppKit's restoration-complete notification and after the real windows register via `TitleProbeView`.
     func scheduleRestoredWindowReconciliation(reason: String) {
         guard scheduledReconciliationReasons.insert(reason).inserted else { return }
         for delay in [0, 0.05, 0.15, 0.35, 0.7, 1.2, 2.0] {
@@ -308,9 +287,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// Confirm a quit (menu Quit / ⌘Q) before the app tears down its windows — that ends every session's
-    /// shell with no undo, the same loss the workspace/window delete actions confirm. Reports the
-    /// open-window and session counts; proceeds without asking when nothing is open (the auto-quit after the
-    /// last window closed) or under an XCUITest launch, where a modal would hang the test's terminate.
+    /// shell with no undo. Reports the open-window and session counts; skips the prompt with nothing open
+    /// (the auto-quit after the last window closed) or under XCUITest, where a modal would hang terminate.
     func applicationShouldTerminate(_: NSApplication) -> NSApplication.TerminateReply {
         guard !ContentView.isUITestLaunch, let library else { return .terminateNow }
         let counts = library.openCounts()
@@ -330,32 +308,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         actions?.cancelAllPendingPicks()
         controlServer?.stop()
         customCommandRunner?.stop()
-        // clear the OS-level Dock badge — it outlives the process and unseenCount is ephemeral, so a quit
-        // with unseen > 0 would pin a stale count on the icon (the willClose refresh() poke can't:
-        // isTerminating below makes closeWindow no-op, so the total recomputes unchanged).
+        // clear the OS-level Dock badge — it outlives the process while unseenCount is ephemeral, so a quit
+        // with unseen > 0 pins a stale count (the willClose refresh() can't: isTerminating no-ops closeWindow).
         DockBadgeController.shared.clear()
-        // mark terminating so the per-window willClose close-reporting can't zero the open-set as each
-        // window tears down during quit — the set must survive for the next launch's reopen-all.
+        // mark terminating so per-window willClose can't zero the open-set during quit — it must survive
+        // for the next launch's reopen-all.
         library?.isTerminating = true
-        // restore-running-command: capture each pane's live foreground command into the session fields
-        // BEFORE the snapshot save below, so a restored pane can re-run it. Only when the feature is on; a
-        // force-quit/crash skips it (sessions + cwd still restore from the debounced snapshot).
+        // restore-running-command: capture each pane's live foreground command BEFORE the snapshot save so a
+        // restored pane can re-run it. A force-quit/crash skips it (sessions + cwd still restore).
         if settingsModel?.settings.restoreRunningCommand == true, let library {
             captureForegroundCommands(library: library)
         }
         library?.finalizeAllPendingCloses()
-        // flush every open window's store (per-window cwd changes since the last structural mutation
-        // aren't auto-persisted) and the index.
+        // flush the stores + index: cwd changes since the last structural mutation aren't auto-persisted.
         library?.saveAllOpen()
         library?.saveIndex()
-        // flush the settings model's pending debounced writes (a keyboard-driven opacity/blur change
-        // holds a ~0.3s deferred save that no drag-end commit fires) so they survive ⌘Q.
+        // flush pending debounced settings writes (a keyboard-driven opacity/blur change holds a ~0.3s save
+        // no drag-end commit fires) so they survive ⌘Q.
         settingsModel?.flushPendingSaves()
     }
 
-    /// Capture every open pane's foreground command (main + split) into its `Session` fields, so the snapshot
-    /// save persists them for the next launch's restore. `ForegroundProcess` returns nil for a pane sitting
-    /// at its shell prompt, so plain shells stay plain.
+    /// Capture every open pane's foreground command (main + split) into its `Session` fields for the snapshot
+    /// save. `ForegroundProcess` returns nil for a pane at its shell prompt, so plain shells stay plain.
     @MainActor
     private func captureForegroundCommands(library: WindowLibrary) {
         let shellBasename = ProcessInfo.processInfo.environment["SHELL"].map(CommandRestore.basename)
@@ -363,8 +337,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             if let view = session.surface as? GhosttySurfaceView {
                 session.foregroundCommand = ForegroundProcess.command(for: view, shellBasename: shellBasename)
             }
-            // only a SHOWN split is recreated on restore (the factory runs when isSplit is true), so gate on
-            // isSplit: capturing a HIDDEN split's command would leave it stale, to fire on the next ⌘D.
+            // only a SHOWN split is recreated on restore, so gate on isSplit — a hidden split's captured
+            // command would sit stale until the next ⌘D fires it.
             if session.isSplit, let split = session.splitSurface as? GhosttySurfaceView {
                 session.splitForegroundCommand = ForegroundProcess.command(for: split, shellBasename: shellBasename)
             }
@@ -372,10 +346,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_: NSApplication) -> Bool {
-        // key termination off the model open-set, NOT AppKit's transient window count: closing one window
-        // (or a re-render that briefly drops the surviving NSWindow) can leave a momentary zero-window state
-        // while the library still has one open, and quitting there would kill the app and the control server
-        // mid-session.
+        // key termination off the model open-set, NOT AppKit's transient window count: a close or a re-render
+        // that briefly drops the surviving NSWindow leaves a momentary zero-window state while the library
+        // still has one open, and quitting there would kill the app and the control server mid-session.
         guard let library else { return true }
         return library.openIDs().isEmpty
     }

--- a/agterm/AppDelegate.swift
+++ b/agterm/AppDelegate.swift
@@ -3,20 +3,17 @@ import AppKit
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
-    /// The app-global window library, handed over once the scene appears so the delegate can
-    /// flush every open window's state on terminate.
+    /// The app-global window library, set once the scene appears so terminate can flush every window's state.
     var library: WindowLibrary?
 
-    /// The control channel, handed over once the scene appears so the delegate can
-    /// stop the listener and unlink the socket on terminate.
+    /// The control channel, set once the scene appears so terminate can stop the listener and unlink the socket.
     var controlServer: ControlServer?
 
-    /// The custom-command key-monitor runner, handed over once the scene appears so the delegate can
-    /// remove its `NSEvent` monitor and observer on terminate.
+    /// The custom-command key-monitor runner, set on scene appear; terminate removes its monitor + observer.
     var customCommandRunner: CustomCommandRunner?
 
-    /// The settings model, handed over once the scene appears so the delegate can flush its pending
-    /// debounced `settings.json` writes (opacity/blur, theme preview) on terminate.
+    /// The settings model, set on scene appear so terminate can flush its pending debounced `settings.json`
+    /// writes (opacity/blur, theme preview).
     var settingsModel: SettingsModel?
 
     /// The action hub, handed over once the scene appears so `application(_:open:)` can open a session at
@@ -28,26 +25,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// the set is invalidated and replaced whenever the Dock asks for a fresh menu.
     var dockMenuActionTargets: [DockMenuActionTarget] = []
 
-    /// Directories requested via `open -a agterm /path` (the OS "open terminal here" integration) that
-    /// haven't become sessions yet — queued until the frontmost window's store resolves, so a `session
-    /// new`-style graft lands in the last-active window.
+    /// Directories from `open -a agterm /path` (the OS "open terminal here" integration) not yet turned into
+    /// sessions — queued until the frontmost window's store resolves, so a `session new`-style graft lands in
+    /// the last-active window.
     private var pendingOpenDirectories: [String] = []
 
     private var restoreObserver: NSObjectProtocol?
     private var scheduledReconciliationReasons: Set<String> = []
 
     func applicationWillFinishLaunching(_: Notification) {
-        // agterm has its own multi-window model and does NOT support native window tabs; disabling
-        // automatic tabbing removes AppKit's injected "Show Tab Bar" / "Show All Tabs" / "Move Tab to
-        // New Window" menu items and the tab affordances. Must be set before any window is created.
+        // agterm has its own multi-window model and no native window tabs; disabling automatic tabbing
+        // strips AppKit's injected "Show Tab Bar" / "Show All Tabs" / "Move Tab to New Window" items and
+        // the tab affordances. Must be set before any window is created.
         NSWindow.allowsAutomaticWindowTabbing = false
-        // NOTE: do NOT set NSApp.applicationIconImage. The app icon is the adaptive Icon Composer
-        // `AppIcon.icon`, which the system renders LIVE in the Dock with the current appearance
-        // (light/dark/clear/tinted, Liquid Glass). applicationIconImage takes a STATIC NSImage, so
-        // setting it (even from the compiled asset) freezes the Dock to one flat rendering and defeats
-        // the adaptive icon. Let LaunchServices render the bundle icon. (The Dock unseen-count badge is
-        // the modern `UNUserNotificationCenter.setBadgeCount` — see `DockBadgeController` — which renders
-        // over the live adaptive icon without touching `applicationIconImage`.)
+        // do NOT set NSApp.applicationIconImage: the icon is the adaptive Icon Composer `AppIcon.icon`,
+        // which the system renders LIVE in the Dock per appearance (light/dark/clear/tinted, Liquid Glass),
+        // while applicationIconImage takes a STATIC NSImage and would freeze the Dock to one flat
+        // rendering. Let LaunchServices render the bundle icon. The Dock unseen-count badge uses
+        // `UNUserNotificationCenter.setBadgeCount` (`DockBadgeController`), which draws over the live
+        // adaptive icon without touching `applicationIconImage`.
         restoreObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.didFinishRestoringWindowsNotification,
             object: NSApp,
@@ -70,11 +66,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         _ = GhosttyApp.shared
         scheduleRestoredWindowReconciliation(reason: "did-finish-launching")
         // AppKit auto-adds its own "Enter Full Screen" item (Globe+F / ⌃⌘F) to the View menu for any
-        // fullscreen-capable window, and RE-INJECTS it each time the menu opens. agterm ships its OWN
-        // rebindable "Toggle Full Screen" item (so full screen is drivable from the keymap, action palette,
-        // and control channel), so leaving AppKit's item renders a duplicate. Strip the native one
-        // just-in-time whenever a menu begins tracking (the point AppKit re-injects it); a launch-time
-        // one-shot does NOT stick because of the re-injection.
+        // fullscreen-capable window and RE-INJECTS it each time the menu opens, duplicating agterm's own
+        // rebindable "Toggle Full Screen" (which is what makes full screen drivable from the keymap, action
+        // palette and control channel). Strip the native one whenever a menu begins tracking — the point of
+        // re-injection, so a launch-time one-shot does NOT stick.
         AppDelegate.removeNativeFullScreenMenuItem()
         NotificationCenter.default.addObserver(self, selector: #selector(menuBeganTracking),
                                                name: NSMenu.didBeginTrackingNotification, object: nil)
@@ -107,13 +102,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// Keep ⌘W with agterm's File ▸ Close Session whenever the keymap says it owns that chord.
     ///
-    /// SwiftUI hands the stock File ▸ Close (`performClose:`) a ⌘W key equivalent the moment agterm's own
-    /// item vacates the chord — a `map cmd+<other> close_session` plus `keymap reload` is enough. Putting
-    /// `close_session` back on ⌘W does NOT reclaim it: SwiftUI resolves the collision by dropping the
-    /// shortcut from its OWN item, leaving Close Session unbound and ⌘W closing the whole window until the
-    /// app is relaunched (issue #296). So agterm asserts the split itself rather than leaving it to
-    /// SwiftUI's one-time conflict resolution. Reconciled from the AppKit side, like
-    /// `removeNativeFullScreenMenuItem`, because there is no SwiftUI API for either half.
+    /// SwiftUI hands the stock File ▸ Close (`performClose:`) a ⌘W key equivalent the moment agterm's item
+    /// vacates the chord (a `map cmd+<other> close_session` plus `keymap reload` is enough), and putting
+    /// `close_session` back does NOT reclaim it: SwiftUI resolves the collision by dropping the shortcut from
+    /// its OWN item, leaving Close Session unbound and ⌘W closing the whole window until relaunch (issue
+    /// #296). So agterm asserts the split itself, from the AppKit side like `removeNativeFullScreenMenuItem`
+    /// — there is no SwiftUI API for either half.
     private func reconcileCloseSessionChord() {
         guard let keymap = settingsModel?.keymap else { return }
         AppDelegate.applyCloseSessionChord(keymap, in: NSApp.mainMenu)
@@ -122,14 +116,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Split ⌘W between agterm's Close Session item and the stock `performClose:` one, following `keymap`.
     /// Operates on whichever submenu holds `performClose:`; a menu without both items is left alone.
     ///
-    /// The stock item may hold ⌘W only while NO built-in resolves to it. Deciding that from `close_session`
-    /// alone is not enough: `parseKeymap` rejects a chord only when two DISTINCT actions resolve to it, so
-    /// `map cmd+e close_session` plus `map cmd+w new_session` is a clean keymap in which another action
-    /// legitimately owns ⌘W, and arming the stock item there would advertise the chord twice and let
-    /// SwiftUI's next rebuild unbind agterm's own item — the very failure this reconcile exists to prevent.
+    /// The stock item may hold ⌘W only while NO built-in resolves to it; `close_session` alone is not enough,
+    /// since `parseKeymap` rejects a chord only when two DISTINCT actions claim it — `map cmd+e close_session`
+    /// plus `map cmd+w new_session` is a clean keymap where another action legitimately owns ⌘W, and arming
+    /// the stock item there would advertise the chord twice and let SwiftUI's next rebuild unbind agterm's
+    /// own item, the failure this reconcile exists to prevent.
     ///
-    /// agterm's item is a SwiftUI closure button with no distinguishing selector, so it can only be matched
-    /// by title — scoping that match to the submenu that owns `performClose:` keeps it narrow.
+    /// agterm's item is a SwiftUI closure button with no distinguishing selector, so it is matched by title;
+    /// scoping that match to the submenu owning `performClose:` keeps it narrow.
     static func applyCloseSessionChord(_ keymap: Keymap, in mainMenu: NSMenu?) {
         let closeSessionOwns = keymap.equivalent(for: .closeSession) == commandW
         let anyBuiltinOwns = BuiltinAction.allCases.contains { keymap.equivalent(for: $0) == commandW }
@@ -139,7 +133,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                   let stockClose = submenu.items.first(where: { $0.action == closeSelector }),
                   let ours = submenu.items.first(where: { $0.title == closeSessionItemTitle })
             else { continue }
-            // our item carries ⌘W exactly while close_session owns it. Clearing a stale one matters because
+            // our item carries ⌘W exactly while close_session owns it; clearing a stale one matters because
             // SwiftUI defers its rebuild to the next activation, so straight after a reload that rebound
             // close_session away our item still advertises the chord the stock item is about to take.
             if closeSessionOwns {
@@ -162,10 +156,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     static let closeSessionItemTitle = "Close Session"
     private static let commandW = Chord(mods: [.command], key: "w")
 
-    /// Remove AppKit's auto-injected fullscreen menu item — the one whose action is `toggleFullScreen:`.
-    /// agterm's own item uses a SwiftUI closure action (a different selector), so only the native item
-    /// matches and our "Toggle Full Screen" is left intact. Finds the owning submenu by content rather than
-    /// by the localized "View" title.
+    /// Remove AppKit's auto-injected fullscreen item — the one whose action is `toggleFullScreen:`. agterm's
+    /// own item uses a SwiftUI closure action (a different selector), so only the native one matches and our
+    /// "Toggle Full Screen" survives. Finds the owning submenu by content, not by the localized "View" title.
     @MainActor
     private static func removeNativeFullScreenMenuItem() {
         let selector = #selector(NSWindow.toggleFullScreen(_:))
@@ -177,11 +170,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// `open -a agterm /path` (the OS "open terminal here" integration): macOS delivers the folder/file
-    /// URLs here. Each resolves to a directory (a folder → itself, a file → its parent, via the host-free
-    /// `OpenPathResolver`), which is queued and drained into a new session in the last-active window.
-    /// This serves the WARM case — agterm already running (its daily-driver norm) — where the running
-    /// instance has a window and grafts the session immediately.
+    /// `open -a agterm /path` (the OS "open terminal here" integration): macOS delivers the URLs here. Each
+    /// resolves to a directory (folder → itself, file → its parent, via host-free `OpenPathResolver`), which
+    /// is queued and drained into a new session in the last-active window. Serves the WARM case — agterm
+    /// already running (its daily-driver norm), so the instance has a window and grafts immediately.
     func application(_: NSApplication, open urls: [URL]) {
         let directories = urls.compactMap { OpenPathResolver.directory(for: $0) }
         guard !directories.isEmpty else { return }
@@ -190,9 +182,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// Turn every queued `open -a` directory into a new session in the last-active window, one at a time,
-    /// dropping each entry only after its session lands (a transient failure keeps it queued). No-op when
-    /// the queue is empty. When the frontmost store isn't resolvable yet it retries on a 0.1 s backoff,
-    /// giving up after a bounded number of ticks so a folder can't wedge a stuck timer.
+    /// dropping each entry only once its session lands (a transient failure keeps it queued). No-op on an
+    /// empty queue; when the frontmost store isn't resolvable yet, retries on a 0.1 s backoff, bounded so a
+    /// folder can't wedge a stuck timer.
     func drainPendingOpenDirectories(retry: Int = 0) {
         guard !pendingOpenDirectories.isEmpty else { return }
         guard let actions, library?.activeStore?.currentWorkspaceID != nil else {
@@ -207,10 +199,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         while let directory = pendingOpenDirectories.first, actions.openSession(atDirectory: directory) {
             pendingOpenDirectories.removeFirst()
         }
-        // raise/deminiaturize the window the session landed in — `NSApp.activate()` only brings the app
-        // forward, so an "open terminal here" into a minimized last-active window would otherwise leave it
-        // in the Dock and show nothing. `WindowRegistry.raise` deminiaturizes + makes key; a no-op for an
-        // already-frontmost window. Only when a session actually landed.
+        // raise the window the session landed in: `NSApp.activate()` only fronts the app, so an "open
+        // terminal here" into a minimized last-active window would stay in the Dock showing nothing.
+        // `WindowRegistry.raise` deminiaturizes + makes key, a no-op for an already-frontmost window; only
+        // when a session actually landed.
         if pendingOpenDirectories.count < beforeCount, let windowID = library?.activeWindowID {
             WindowRegistry.shared.raise(windowID)
         }
@@ -230,10 +222,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// On macOS 15+ a SwiftUI WindowGroup app launched by another process (XCUITest, launchd) often
-    /// never auto-presents its window (FB11763863): the dock icon shows but no window appears and the
-    /// scene's `.task`/`.onAppear` never fire. A reopen event — what a dock click sends — creates it.
-    /// Fire that reopen once when no real window exists, then bring whatever windows appear forward.
+    /// On macOS 15+ a SwiftUI WindowGroup app launched by another process (XCUITest, launchd) often never
+    /// auto-presents its window (FB11763863): the dock icon shows, no window appears, the scene's
+    /// `.task`/`.onAppear` never fire. A reopen event (what a dock click sends) creates it — fire one once
+    /// when no real window exists, then bring whatever appears forward.
     private func bringUITestWindowsForward() {
         if !didForceReopen, NSApp.windows.allSatisfy({ $0 is NSPanel }) {
             didForceReopen = true
@@ -241,10 +233,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         NSApp.setActivationPolicy(.regular)
         NSApp.unhide(nil)
-        // present the launch window ONCE (FB11763863), then latch off. The windows are
-        // isRestorable=false so they won't re-minimize, and continuing to re-front every tick would
-        // oscillate the key window and fight a deliberate window.select (which made multi-window control
-        // tests flaky). A runtime window.new presents via its own per-window retry instead.
+        // present the launch window ONCE (FB11763863), then latch off: the windows are isRestorable=false
+        // so they won't re-minimize, and re-fronting every tick would oscillate the key window and fight a
+        // deliberate window.select (which made multi-window control tests flaky). A runtime window.new
+        // presents via its own per-window retry instead.
         guard !didPresentUITestWindow else { return }
         NSApp.activate()
         for window in NSApp.windows where window.canBecomeKey {
@@ -255,16 +247,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// One-shot latch: true once the launch UI-test window has been presented, so the activation retry
-    /// schedule stops re-fronting (which would oscillate the key window).
+    /// One-shot latch: true once the launch UI-test window is presented, so the retry schedule stops re-fronting.
     private var didPresentUITestWindow = false
 
     private var didForceReopen = false
 
-    /// SwiftUI/AppKit can restore stale plain-WindowGroup windows before the app's own
-    /// `WindowLibrary` reopen pass has finished. Closing them from inside the stray view races that
-    /// restoration machinery, so reconcile after AppKit posts its restoration-complete notification
-    /// and after the real windows have had time to register through `TitleProbeView`.
+    /// SwiftUI/AppKit can restore stale plain-WindowGroup windows before the app's own `WindowLibrary`
+    /// reopen pass finishes. Closing them from inside the stray view races that restoration machinery, so
+    /// reconcile after AppKit's restoration-complete notification and after the real windows have had time
+    /// to register through `TitleProbeView`.
     func scheduleRestoredWindowReconciliation(reason: String) {
         guard scheduledReconciliationReasons.insert(reason).inserted else { return }
         for delay in [0, 0.05, 0.15, 0.35, 0.7, 1.2, 2.0] {
@@ -316,11 +307,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// Confirm a quit (menu Quit / ⌘Q) before the app tears down its windows — closing them ends every
-    /// session's running shell with no undo, the same loss the workspace/window delete actions confirm.
-    /// Reports the open-window and session counts in the prompt; proceeds without asking when nothing is
-    /// open (the auto-quit after the last window closed) or under an XCUITest launch (a modal would hang
-    /// the test's terminate).
+    /// Confirm a quit (menu Quit / ⌘Q) before the app tears down its windows — that ends every session's
+    /// shell with no undo, the same loss the workspace/window delete actions confirm. Reports the
+    /// open-window and session counts; proceeds without asking when nothing is open (the auto-quit after the
+    /// last window closed) or under an XCUITest launch, where a modal would hang the test's terminate.
     func applicationShouldTerminate(_: NSApplication) -> NSApplication.TerminateReply {
         guard !ContentView.isUITestLaunch, let library else { return .terminateNow }
         let counts = library.openCounts()
@@ -335,27 +325,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_: Notification) {
-        // Resolve in-memory picker state before closing the socket. A client that is already polling may
-        // observe cancellation; process exit still means a later poll can race socket teardown.
+        // resolve in-memory picker state before closing the socket: a client already polling may observe
+        // cancellation, but a later poll can still race socket teardown at process exit.
         actions?.cancelAllPendingPicks()
         controlServer?.stop()
         customCommandRunner?.stop()
-        // clear the OS-level Dock badge — it outlives the process, and unseenCount is ephemeral, so a quit
-        // with unseen > 0 would leave a stale count pinned on the Dock icon (the willClose refresh() poke
-        // can't: isTerminating below makes closeWindow no-op, so the total recomputes unchanged).
+        // clear the OS-level Dock badge — it outlives the process and unseenCount is ephemeral, so a quit
+        // with unseen > 0 would pin a stale count on the icon (the willClose refresh() poke can't:
+        // isTerminating below makes closeWindow no-op, so the total recomputes unchanged).
         DockBadgeController.shared.clear()
         // mark terminating so the per-window willClose close-reporting can't zero the open-set as each
         // window tears down during quit — the set must survive for the next launch's reopen-all.
         library?.isTerminating = true
         // restore-running-command: capture each pane's live foreground command into the session fields
-        // BEFORE the snapshot save below, so a restored pane can re-run it. Only when the feature is on;
-        // a force-quit/crash skips this (sessions + cwd still restore from the debounced snapshot).
+        // BEFORE the snapshot save below, so a restored pane can re-run it. Only when the feature is on; a
+        // force-quit/crash skips it (sessions + cwd still restore from the debounced snapshot).
         if settingsModel?.settings.restoreRunningCommand == true, let library {
             captureForegroundCommands(library: library)
         }
         library?.finalizeAllPendingCloses()
         // flush every open window's store (per-window cwd changes since the last structural mutation
-        // aren't auto-persisted) and the index. replaces the single-store save.
+        // aren't auto-persisted) and the index.
         library?.saveAllOpen()
         library?.saveIndex()
         // flush the settings model's pending debounced writes (a keyboard-driven opacity/blur change
@@ -363,9 +353,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         settingsModel?.flushPendingSaves()
     }
 
-    /// Capture every open pane's foreground command (main + split) into its `Session` fields, so the
-    /// snapshot save persists them for the next launch's restore. `ForegroundProcess` returns nil for a
-    /// pane sitting at its shell prompt, so plain shells stay plain on restore.
+    /// Capture every open pane's foreground command (main + split) into its `Session` fields, so the snapshot
+    /// save persists them for the next launch's restore. `ForegroundProcess` returns nil for a pane sitting
+    /// at its shell prompt, so plain shells stay plain.
     @MainActor
     private func captureForegroundCommands(library: WindowLibrary) {
         let shellBasename = ProcessInfo.processInfo.environment["SHELL"].map(CommandRestore.basename)
@@ -373,9 +363,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             if let view = session.surface as? GhosttySurfaceView {
                 session.foregroundCommand = ForegroundProcess.command(for: view, shellBasename: shellBasename)
             }
-            // only a SHOWN split is recreated on restore (the factory runs when isSplit is true), so
-            // capturing a HIDDEN split's command would leave it stale to fire on the next manual ⌘D.
-            // Gate on isSplit so capture and restore agree.
+            // only a SHOWN split is recreated on restore (the factory runs when isSplit is true), so gate on
+            // isSplit: capturing a HIDDEN split's command would leave it stale, to fire on the next ⌘D.
             if session.isSplit, let split = session.splitSurface as? GhosttySurfaceView {
                 session.splitForegroundCommand = ForegroundProcess.command(for: split, shellBasename: shellBasename)
             }
@@ -383,10 +372,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_: NSApplication) -> Bool {
-        // key termination off the model open-set, NOT AppKit's transient window count: closing one
-        // window (or a re-render that briefly drops the surviving NSWindow) can leave a momentary
-        // zero-window state while the library still has an open window, and quitting there would kill
-        // the app (and the control server) mid-session. Quit only when no window is open in the model.
+        // key termination off the model open-set, NOT AppKit's transient window count: closing one window
+        // (or a re-render that briefly drops the surviving NSWindow) can leave a momentary zero-window state
+        // while the library still has one open, and quitting there would kill the app and the control server
+        // mid-session.
         guard let library else { return true }
         return library.openIDs().isEmpty
     }

--- a/agterm/CLIInstaller.swift
+++ b/agterm/CLIInstaller.swift
@@ -1,11 +1,10 @@
 import AppKit
 import agtermCore
 
-/// Installs the bundled `agtermctl` CLI into the user's PATH by symlinking it from the app bundle
-/// into `/usr/local/bin`. Tries a direct symlink first (no prompt when the dir is user-writable);
-/// falls back to a one-time GUI admin prompt via `osascript` when it isn't (a clean Apple Silicon
-/// Mac has a root-owned `/usr/local/bin`). The host-free path/command logic lives in
-/// `agtermCore.CLIInstall`; this type owns the AppKit filesystem + authorization glue.
+/// Installs the bundled `agtermctl` CLI into the user's PATH by symlinking it from the app bundle into
+/// `/usr/local/bin`: a direct symlink when the dir is user-writable (no prompt), else a one-time GUI admin
+/// prompt via `osascript` (a clean Apple Silicon Mac has a root-owned `/usr/local/bin`). Host-free
+/// path/command logic is `agtermCore.CLIInstall`; this owns the AppKit filesystem + authorization glue.
 @MainActor
 enum CLIInstaller {
     enum InstallResult {
@@ -14,8 +13,8 @@ enum CLIInstaller {
         case cancelled
     }
 
-    /// The bundled helper at `Contents/MacOS/agtermctl`, or nil when this build skipped the bundling
-    /// phase (e.g. a bare `swift build`).
+    /// The bundled helper at `Contents/MacOS/agtermctl`, or nil when this build skipped the bundling phase
+    /// (e.g. a bare `swift build`).
     static var bundledTool: URL? { Bundle.main.url(forAuxiliaryExecutable: CLIInstall.toolName) }
 
     /// Run the install and show a result alert (a cancelled admin prompt shows nothing).
@@ -39,12 +38,12 @@ enum CLIInstaller {
         return elevatedSymlink(source: source)
     }
 
-    /// Replace any existing link and symlink the bundled tool into place. Succeeds only when the
-    /// target directory is user-writable; any error (typically a root-owned dir) returns false so
-    /// the caller escalates.
+    /// Replace any existing link and symlink the bundled tool into place. Succeeds only when the target
+    /// directory is user-writable; any error (typically a root-owned dir) returns false so the caller
+    /// escalates.
     private static func directSymlink(source: String) -> Bool {
         let fm = FileManager.default
-        try? fm.removeItem(atPath: CLIInstall.installPath) // remove a prior link if present (ignore if absent)
+        try? fm.removeItem(atPath: CLIInstall.installPath)
         do {
             try fm.createSymbolicLink(atPath: CLIInstall.installPath, withDestinationPath: source)
             return true
@@ -53,8 +52,8 @@ enum CLIInstaller {
         }
     }
 
-    /// Create the symlink through a single GUI admin prompt. Returns `.cancelled` when the user
-    /// dismisses the authorization dialog (AppleScript error -128).
+    /// Create the symlink through a single GUI admin prompt. Returns `.cancelled` when the user dismisses
+    /// the authorization dialog (AppleScript error -128).
     private static func elevatedSymlink(source: String) -> InstallResult {
         let command = CLIInstall.privilegedInstallCommand(source: source)
         let apple = "do shell script \(appleScriptString(command)) with administrator privileges"

--- a/agterm/Commands/CustomCommandRunner.swift
+++ b/agterm/Commands/CustomCommandRunner.swift
@@ -6,15 +6,13 @@ private let logger = Logger(subsystem: "com.umputun.agterm", category: "CustomCo
 
 /// Drives user-defined custom commands: an app-wide `NSEvent` local key monitor turns key presses into
 /// chords, a `CustomCommandEngine` resolves them (simple chords and leader sequences like `ctrl+a > g`), and
-/// a fired command runs detached as `/bin/sh -c` with the active session's context in both `{AGT_X}` tokens
-/// and `$AGT_X` environment.
+/// a fired command runs detached as `/bin/sh -c` with the session's context in `{AGT_X}` tokens and `$AGT_X`
+/// environment.
 ///
-/// `@MainActor`, constructed once as `@State` in `agtermApp`. `start()`/`stop()` install/remove the monitor
-/// (the asymmetric lifecycle the control server uses); `start()` is idempotent because the scene `.task`
-/// fires once per window, and the matcher rebuilds from the keymap there and on `.agtermKeymapChanged`.
-/// Pure parsing/matching/expansion lives in agtermCore; this class only maps `NSEvent` → agtermCore types,
-/// owns the leader timeout timer, resolves the focused surface's owning session via the host-free
-/// `WindowLibrary`, and spawns the process.
+/// Constructed once as `@State` in `agtermApp`. `start()`/`stop()` install/remove the monitor; `start()` is
+/// idempotent because the scene `.task` fires once per window, and the matcher rebuilds there and on
+/// `.agtermKeymapChanged`. Pure parsing/matching/expansion lives in agtermCore; this maps `NSEvent` → core
+/// types, owns the leader timer, resolves the surface's session via the host-free `WindowLibrary`, and spawns.
 @MainActor
 final class CustomCommandRunner {
     private let library: WindowLibrary
@@ -36,8 +34,7 @@ final class CustomCommandRunner {
         self.socketProvider = socketProvider
     }
 
-    /// Install the local `.keyDown` monitor (idempotent), build the keybind map from the current
-    /// keymap, and observe `.agtermKeymapChanged` to rebuild on a keymap reload.
+    /// Install the local `.keyDown` monitor (idempotent), build the keybind map, observe `.agtermKeymapChanged`.
     func start() {
         guard keyMonitor == nil else { return }
         rebuild()
@@ -63,9 +60,8 @@ final class CustomCommandRunner {
     }
 
     /// Rebuild the matcher and the id→command map from the current keymap, skipping empty shortcuts
-    /// (palette-only commands have none). `parseKeymap`'s cross-section validation already clears the
-    /// shortcut of a command whose first chord collides with a built-in or another custom one, so a
-    /// conflicted bind arrives with an empty shortcut and drops out of the matcher.
+    /// (palette-only commands have none). `parseKeymap`'s cross-section validation already empties the
+    /// shortcut of a command colliding with a built-in or another custom one, so it drops out of the matcher.
     private func rebuild() {
         let commands = settings.keymap.commands
         for command in commands where !command.shortcut.isEmpty {
@@ -77,26 +73,24 @@ final class CustomCommandRunner {
         cancelLeaderTimer()
     }
 
-    /// The Esc virtual keycode the matcher treats specially (the leader abort); Return is a bindable
-    /// base key handled via `namedKey(forKeyCode:)`, not here.
+    /// The Esc virtual keycode the matcher treats specially (the leader abort); Return is bindable and goes
+    /// through `namedKey(forKeyCode:)`.
     private static let escapeKeyCode: UInt16 = 53
 
-    /// Feed one key event to the matcher; returns whether it was consumed (so the caller drops it). Esc
-    /// while armed resets, `.fired` runs, `.armed` arms the leader timer — all consumed; `.unmatched`
-    /// passes through to the terminal.
+    /// Feed one key event to the matcher; returns whether it was consumed (so the caller drops it). Esc while
+    /// armed resets, `.fired` runs, `.armed` arms the leader timer — all consumed; `.unmatched` passes through.
     ///
-    /// Acts when the key window's first responder is a terminal surface (context from that surface), OR
-    /// when the key window is an agterm terminal window whose focus is NOT on a text field — including one
-    /// emptied to zero sessions (the SSH-disconnect state where every session's shell exited). Passes
-    /// through for a focused text field (Settings editor, inline rename, palette search) so a bound chord
-    /// never eats those keystrokes, and for an auxiliary window (Settings) focused off a text field. A key
-    /// repeat is ignored, so a held-down shortcut spawns one process rather than one per OS repeat.
+    /// Acts when the key window's first responder is a terminal surface (context from that surface), or when
+    /// the key window is an agterm terminal window whose focus is NOT on a text field — including one emptied
+    /// to zero sessions. Passes through for a focused text field (Settings editor, inline rename, palette
+    /// search) so a bound chord never eats those keystrokes, and for an auxiliary window focused off a text
+    /// field. A key repeat is ignored, so a held-down shortcut spawns one process, not one per OS repeat.
     private func handleKeyDown(_ event: NSEvent) -> Bool {
         guard !event.isARepeat else { return false }
         guard let keyWindow = NSApp.keyWindow else { return false }
         let responder = keyWindow.firstResponder
-        // a focused text field becomes the window's NSText field editor and must keep its keystrokes:
-        // drop any half-typed leader and pass through.
+        // a focused text field is the window's NSText field editor and must keep its keystrokes: drop the
+        // half-typed leader, pass through.
         if responder is NSText {
             if commandEngine.isArmed {
                 commandEngine.reset()
@@ -105,8 +99,7 @@ final class CustomCommandRunner {
             return false
         }
         let focusedSurface = responder as? GhosttySurfaceView
-        // with no focused surface, fire ONLY from an agterm terminal window (an empty one qualifies),
-        // never from an auxiliary window like Settings.
+        // with no focused surface, fire ONLY from an agterm terminal window (empty qualifies), never Settings.
         guard focusedSurface != nil || WindowRegistry.shared.contains(keyWindow) else {
             if commandEngine.isArmed {
                 commandEngine.reset()
@@ -114,8 +107,8 @@ final class CustomCommandRunner {
             }
             return false
         }
-        // Esc abandons a half-typed leader (the same call the timeout makes) and is not a bindable base
-        // key, so handle it before deriving a chord.
+        // esc abandons a half-typed leader (the call the timeout makes) and is not bindable, so it comes
+        // before the chord.
         if event.keyCode == Self.escapeKeyCode {
             guard commandEngine.isArmed else { return false }
             commandEngine.reset()
@@ -146,10 +139,9 @@ final class CustomCommandRunner {
         }
     }
 
-    /// Map an `NSEvent` key-down to an agtermCore `Chord`, or nil when it carries no usable base key.
-    /// Modifiers map to the agtermCore `Modifier` set; the base key is the named special key (for the keys
-    /// the parser names), else the key `chordKey(forKeyCode:produced:layoutIsASCIICapable:)` resolves —
-    /// the unmodified character on a layout that can type ASCII, the physical position on one that cannot.
+    /// Map an `NSEvent` key-down to an agtermCore `Chord`, or nil when it carries no usable base key. The base
+    /// key is the named special key, else what `chordKey` resolves — the unmodified character on a layout that
+    /// can type ASCII, the physical position on one that cannot.
     private func chord(from event: NSEvent) -> Chord? {
         var mods: Modifier = []
         let flags = event.modifierFlags
@@ -161,12 +153,11 @@ final class CustomCommandRunner {
         if let named = namedKey(forKeyCode: event.keyCode) {
             return Chord(mods: mods, key: named)
         }
-        // `characters(byApplyingModifiers: [])` applies NO modifiers, giving the UNSHIFTED base key for any
-        // key (shift+/ → "/", shift+5 → "5", shift+u → "u") and matching how the keymap spells `shift+<base>`
-        // — the same call `GhosttySurfaceView` uses for unmodified input. `charactersIgnoringModifiers`
-        // instead KEEPS shift (shift+/ → "?", shift+= → "+") and `.lowercased()` undoes that only for
-        // letters, so punctuation would land on the shifted glyph and never match a `shift+/` binding.
-        // `chordKey` then applies the layout rule, so `cmd+o` still fires on a Cyrillic layout (key types `щ`).
+        // `characters(byApplyingModifiers: [])` gives the UNSHIFTED base key (shift+/ → "/"), matching how
+        // the keymap spells `shift+<base>`. `charactersIgnoringModifiers` instead KEEPS shift (shift+/ → "?")
+        // and `.lowercased()` undoes that only for letters, so punctuation would land on the shifted glyph
+        // and never match a `shift+/` binding. `chordKey` then applies the layout rule, so `cmd+o` still
+        // fires on a Cyrillic layout (the key types `щ`).
         let produced = event.characters(byApplyingModifiers: []) ?? event.charactersIgnoringModifiers
         guard let key = chordKey(forKeyCode: event.keyCode, produced: produced,
                                  layoutIsASCIICapable: KeyboardLayout.isASCIICapable) else { return nil }
@@ -190,21 +181,19 @@ final class CustomCommandRunner {
     }
 
     /// Run a command fired from the PALETTE: context from the active session (the palette has no first
-    /// responder to key off). Detached `/bin/sh -c` with the `AGT_*` env, notifying on a spawn error or
-    /// non-zero exit. No-op when no window/session is active — a session-scoped command with silently-empty
+    /// responder to key off). No-op with no window/session — a session-scoped command with silently-empty
     /// tokens is unsafe (an empty `{AGT_SESSION_PWD}` turns `rm -rf …/*` into a root glob), so only the
-    /// deliberate empty-window KEYBIND path fires a session-free launcher via `sessionlessContext()`.
+    /// deliberate empty-window KEYBIND path fires a session-free launcher.
     func run(_ command: CustomCommand) {
         guard let store = library.activeStore, let session = store.activeSession else {
             logger.notice("custom command \"\(command.name, privacy: .public)\" fired with no active session; ignored")
             return
         }
-        // selection + pane come from the active session's focused pane; with no fired-from surface the
-        // focus flag is the source, gated on the split surface EXISTING (the `Session.onScreenSurface`
-        // idiom). In the window right after `session split on`, `splitFocused` is already true while
-        // `splitSurface` is still nil, so a bare flag would report `.right` and read the selection off the
-        // nil surface while `session.type --pane right` still errors "no split pane". A promoted survivor
-        // sits in the `surface` slot with both nil/false, so it reports `.left` — the pane `--pane left` reaches.
+        // selection + pane come from the active session's focused pane; with no fired-from surface the focus
+        // flag is the source, gated on the split surface EXISTING. right after `session split on`,
+        // `splitFocused` is already true while `splitSurface` is still nil, so a bare flag would report
+        // `.right` off a nil surface while `session.type --pane right` still errors "no split pane". a
+        // promoted survivor sits in the `surface` slot with both nil/false, so `.left`.
         let onSplit = session.splitFocused && session.splitSurface != nil
         let selectionSurface = (onSplit ? session.splitSurface : session.surface) as? GhosttySurfaceView
         let context = self.context(for: session, in: store, selectionSurface: selectionSurface,
@@ -212,28 +201,25 @@ final class CustomCommandRunner {
         spawn(command, context: context)
     }
 
-    /// Run a command fired by KEYBIND: context from the surface that had focus at key-down, so a chord
-    /// fired from a split/scratch (or during a window-switch race) runs against THAT surface's
-    /// session/cwd/window and reads its selection. Session/store come from the surface's `session` resolved
-    /// through the host-free `WindowLibrary` (no AppKit in core). A sessionless focused surface (quick
-    /// terminal / overlay / scratch) routes through `runFromSessionlessSurface`.
+    /// Run a command fired by KEYBIND: context from the surface that had focus at key-down, so a chord from a
+    /// split/scratch (or during a window-switch race) runs against THAT surface's session/cwd/window and reads
+    /// its selection. A sessionless focused surface routes through `runFromSessionlessSurface`.
     func runFromKeybind(_ command: CustomCommand, focusedSurface: GhosttySurfaceView) {
         guard let session = focusedSurface.session, let store = library.store(forSession: session.id) else {
             runFromSessionlessSurface(command, focusedSurface: focusedSurface)
             return
         }
-        // the pane is the surface's identity, not the focus flag, so a chord fired from a pane the flag
-        // hasn't caught up to still reports the pane it was typed in.
+        // the pane is the surface's identity, not the focus flag, so a chord reports the pane it was typed in
+        // even before the flag catches up.
         let pane: CommandContext.Pane = (session.splitSurface as? GhosttySurfaceView) === focusedSurface ? .right : .left
         let context = self.context(for: session, in: store, selectionSurface: focusedSurface, pane: pane)
         spawn(command, context: context)
     }
 
-    /// The keybind fallback for a sessionless focused surface (no `view.session`: quick terminal, overlay,
-    /// scratch). The scratch belongs to the ACTIVE session, so a chord from it runs against that session
-    /// with `pane = .scratch` and reads the scratch's own selection — the read leg of `$AGT_PANE` →
-    /// `session type --pane scratch`. The others are not panes (`tree` queries their state) and take the
-    /// plain palette path.
+    /// The keybind fallback for a sessionless focused surface (quick terminal, overlay, scratch). The scratch
+    /// belongs to the ACTIVE session, so a chord from it runs against that session with `pane = .scratch` and
+    /// reads the scratch's own selection — the read leg of `$AGT_PANE` → `session type --pane scratch`. The
+    /// others are not panes and take the plain palette path.
     private func runFromSessionlessSurface(_ command: CustomCommand, focusedSurface: GhosttySurfaceView) {
         if let store = library.activeStore, let session = store.activeSession,
            (session.scratchSurface as? GhosttySurfaceView) === focusedSurface {
@@ -244,9 +230,8 @@ final class CustomCommandRunner {
         runNoSurface(command)
     }
 
-    /// Keybind fire with NO usable fired-from session — an emptied window, or focus off any surface (the
-    /// dashboard key-catcher, a quick terminal / overlay with no owning session). Uses the active session's
-    /// context when one exists, like the palette, else the session-free `spawnSessionless`.
+    /// Keybind fire with NO usable fired-from session — an emptied window, or focus off any surface. Uses the
+    /// active session's context when one exists, like the palette, else `spawnSessionless`.
     private func runNoSurface(_ command: CustomCommand) {
         if library.activeStore?.activeSession != nil {
             run(command)
@@ -256,10 +241,9 @@ final class CustomCommandRunner {
     }
 
     /// Fire `command` with a session-free context (the empty-window launcher path) — UNLESS its body names
-    /// session-scoped tokens, which expand dangerously empty (an empty `{AGT_SESSION_PWD}` makes
-    /// `rm -rf …/*` a root glob, defeating even the quoted `$AGT_X` form); that NO-OPS with a notice like
-    /// the palette's `run(_:)`. A launcher naming only `AGT_SOCKET`/`AGT_WINDOW`/`AGT_PANE`, e.g.
-    /// `agtermctl session new --command "ssh …"`, still fires.
+    /// session-scoped tokens, which expand dangerously empty (an empty `{AGT_SESSION_PWD}` makes `rm -rf …/*`
+    /// a root glob, defeating even the quoted `$AGT_X` form); that NO-OPS with a notice. A launcher naming
+    /// only `AGT_SOCKET`/`AGT_WINDOW`/`AGT_PANE` still fires.
     private func spawnSessionless(_ command: CustomCommand) {
         guard !CommandContext.referencesSessionScopedContext(command.command) else {
             logger.notice("custom command \"\(command.name, privacy: .public)\" references session context but no session is active; ignored")
@@ -268,9 +252,9 @@ final class CustomCommandRunner {
         spawn(command, context: sessionlessContext())
     }
 
-    /// Resolve every `{AGT_X}` token for the given session: ids + cwd from the model, the names from
-    /// the owning workspace/window, the selection from `selectionSurface` (the exact focused surface),
-    /// the fired-from pane (`left`|`right`|`scratch`) from the caller, and the socket from the control server.
+    /// Resolve every `{AGT_X}` token for the given session: ids + cwd from the model, names from the owning
+    /// workspace/window, the selection from `selectionSurface`, the fired-from pane from the caller
+    /// (`left`|`right`|`scratch`), the socket from the control server.
     private func context(for session: Session, in store: AppStore, selectionSurface: GhosttySurfaceView?,
                          pane: CommandContext.Pane) -> CommandContext {
         let workspace = store.workspace(forSession: session.id)
@@ -291,25 +275,24 @@ final class CustomCommandRunner {
     }
 
     /// A session-free `CommandContext` (an emptied window, or none open): every `{AGT_SESSION_*}`/
-    /// `{AGT_WORKSPACE_*}` token and the selection resolve empty, the window id/name come from the frontmost
-    /// window when there is one, and the socket lets a launcher chord reach `agtermctl` for a fresh session.
+    /// `{AGT_WORKSPACE_*}` token and the selection resolve empty, window id/name come from the frontmost
+    /// window if any, and the socket lets a launcher chord reach `agtermctl` for a fresh session.
     private func sessionlessContext() -> CommandContext {
         let windowID = library.activeWindowID
         return CommandContext(windowID: windowID?.uuidString ?? "", windowName: library.windowName(for: windowID),
                               socket: socketProvider())
     }
 
-    /// Spawn the expanded command as a detached `/bin/sh -c`, exporting `$AGT_*` on top of the app's
-    /// environment and running in the session's cwd. A thrown spawn error or a non-zero exit posts a
-    /// failure banner; there is no output capture and no success banner.
+    /// Spawn the expanded command as a detached `/bin/sh -c`, exporting `$AGT_*` over the app environment and
+    /// running in the session's cwd. A spawn error or non-zero exit posts a failure banner; no output
+    /// capture, no success banner.
     private func spawn(_ command: CustomCommand, context: CommandContext) {
         let line = context.expand(command.command)
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/sh")
         process.arguments = ["-c", line]
         process.environment = ProcessInfo.processInfo.environment.merging(context.environment()) { _, new in new }
-        // fire-and-forget: no output capture, so pin stdio to /dev/null rather than inherit the app's fds,
-        // which vary by launch method.
+        // fire-and-forget: pin stdio to /dev/null rather than inherit the app's fds, which vary by launch.
         process.standardInput = FileHandle.nullDevice
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice

--- a/agterm/Commands/CustomCommandRunner.swift
+++ b/agterm/Commands/CustomCommandRunner.swift
@@ -4,17 +4,17 @@ import os
 
 private let logger = Logger(subsystem: "com.umputun.agterm", category: "CustomCommandRunner")
 
-/// Drives user-defined custom commands: an app-wide `NSEvent` local key monitor turns key presses
-/// into chords, a `CustomCommandEngine` resolves them to a command (firing simple chords and leader
-/// sequences like `ctrl+a > g`), and a fired command is run as a detached `/bin/sh -c` with the
-/// active session's context available as both `{AGT_X}` template tokens and `$AGT_X` environment.
+/// Drives user-defined custom commands: an app-wide `NSEvent` local key monitor turns key presses into
+/// chords, a `CustomCommandEngine` resolves them (simple chords and leader sequences like `ctrl+a > g`), and
+/// a fired command runs detached as `/bin/sh -c` with the active session's context in both `{AGT_X}` tokens
+/// and `$AGT_X` environment.
 ///
-/// `@MainActor` and constructed once as `@State` in `agtermApp`. `start()`/`stop()` install/remove
-/// the monitor (the asymmetric lifecycle the control server uses); `start()` is idempotent because
-/// the scene `.task` fires once per window. The matcher is rebuilt from the keymap on `start()` and
-/// on the `.agtermKeymapChanged` notification. Pure parsing/matching/expansion lives in agtermCore;
-/// this class only maps `NSEvent` → agtermCore types, owns the leader timeout timer, resolves the
-/// focused surface's owning session via the host-free `WindowLibrary`, and spawns the process.
+/// `@MainActor`, constructed once as `@State` in `agtermApp`. `start()`/`stop()` install/remove the monitor
+/// (the asymmetric lifecycle the control server uses); `start()` is idempotent because the scene `.task`
+/// fires once per window, and the matcher rebuilds from the keymap there and on `.agtermKeymapChanged`.
+/// Pure parsing/matching/expansion lives in agtermCore; this class only maps `NSEvent` → agtermCore types,
+/// owns the leader timeout timer, resolves the focused surface's owning session via the host-free
+/// `WindowLibrary`, and spawns the process.
 @MainActor
 final class CustomCommandRunner {
     private let library: WindowLibrary
@@ -63,9 +63,9 @@ final class CustomCommandRunner {
     }
 
     /// Rebuild the matcher and the id→command map from the current keymap, skipping empty shortcuts
-    /// (palette-only commands have none). Cross-section validation in `parseKeymap` already clears the
-    /// shortcut of any command whose first chord collides with a built-in or another custom command,
-    /// so a conflicted bind arrives here with an empty shortcut and is dropped from the matcher.
+    /// (palette-only commands have none). `parseKeymap`'s cross-section validation already clears the
+    /// shortcut of a command whose first chord collides with a built-in or another custom one, so a
+    /// conflicted bind arrives with an empty shortcut and drops out of the matcher.
     private func rebuild() {
         let commands = settings.keymap.commands
         for command in commands where !command.shortcut.isEmpty {
@@ -81,23 +81,22 @@ final class CustomCommandRunner {
     /// base key handled via `namedKey(forKeyCode:)`, not here.
     private static let escapeKeyCode: UInt16 = 53
 
-    /// Feed one key event to the matcher. Returns whether the event was consumed (so the caller drops
-    /// it). Esc while armed resets and is consumed; a `.fired` runs and is consumed; `.armed` arms the
-    /// leader timer and is consumed; `.unmatched` passes through to the terminal.
+    /// Feed one key event to the matcher; returns whether it was consumed (so the caller drops it). Esc
+    /// while armed resets, `.fired` runs, `.armed` arms the leader timer — all consumed; `.unmatched`
+    /// passes through to the terminal.
     ///
     /// Acts when the key window's first responder is a terminal surface (context from that surface), OR
-    /// when the key window is an agterm terminal window whose focus is NOT on a text field — including
-    /// one emptied to zero sessions (the SSH-disconnect state where every session's shell exited). It
-    /// passes through for a focused text field (Settings editor, inline rename, palette search) so a
-    /// bound chord never eats those keystrokes, and for an auxiliary window (Settings) whose focus is off
-    /// a text field. A key repeat is ignored so a held-down shortcut spawns one process, not one per OS
-    /// repeat.
+    /// when the key window is an agterm terminal window whose focus is NOT on a text field — including one
+    /// emptied to zero sessions (the SSH-disconnect state where every session's shell exited). Passes
+    /// through for a focused text field (Settings editor, inline rename, palette search) so a bound chord
+    /// never eats those keystrokes, and for an auxiliary window (Settings) focused off a text field. A key
+    /// repeat is ignored, so a held-down shortcut spawns one process rather than one per OS repeat.
     private func handleKeyDown(_ event: NSEvent) -> Bool {
         guard !event.isARepeat else { return false }
         guard let keyWindow = NSApp.keyWindow else { return false }
         let responder = keyWindow.firstResponder
-        // a focused text field (Settings editor, inline rename, palette search) becomes the window's
-        // NSText field editor; it must keep its keystrokes, so drop any half-typed leader and pass through.
+        // a focused text field becomes the window's NSText field editor and must keep its keystrokes:
+        // drop any half-typed leader and pass through.
         if responder is NSText {
             if commandEngine.isArmed {
                 commandEngine.reset()
@@ -106,8 +105,8 @@ final class CustomCommandRunner {
             return false
         }
         let focusedSurface = responder as? GhosttySurfaceView
-        // with no focused terminal surface, fire ONLY from an agterm terminal window (an empty one still
-        // qualifies) — never from an auxiliary window like Settings whose focus sits off a text field.
+        // with no focused surface, fire ONLY from an agterm terminal window (an empty one qualifies),
+        // never from an auxiliary window like Settings.
         guard focusedSurface != nil || WindowRegistry.shared.contains(keyWindow) else {
             if commandEngine.isArmed {
                 commandEngine.reset()
@@ -115,8 +114,8 @@ final class CustomCommandRunner {
             }
             return false
         }
-        // Esc abandons a half-typed leader sequence (the same call the timeout makes); it never
-        // advances the matcher (Esc is not a bindable base key), so handle it before deriving a chord.
+        // Esc abandons a half-typed leader (the same call the timeout makes) and is not a bindable base
+        // key, so handle it before deriving a chord.
         if event.keyCode == Self.escapeKeyCode {
             guard commandEngine.isArmed else { return false }
             commandEngine.reset()
@@ -131,13 +130,10 @@ final class CustomCommandRunner {
         case .fired(let command):
             cancelLeaderTimer()
             if let focusedSurface {
-                // resolve context from the surface that actually had focus at key-down time, NOT the
-                // frontmost active session — firing from a split/overlay/quick terminal (or during a
-                // window-switch race) must run against THAT surface's session/cwd/selection.
+                // context from the surface that had focus at key-down, not the frontmost active session.
                 runFromKeybind(command, focusedSurface: focusedSurface)
             } else {
-                // no fired-from surface (an emptied window, or focus off any surface in a terminal
-                // window): use the active session if one exists, else the session-free launcher path.
+                // no fired-from surface: the active session if one exists, else the launcher path.
                 runNoSurface(command)
             }
             return true
@@ -165,15 +161,12 @@ final class CustomCommandRunner {
         if let named = namedKey(forKeyCode: event.keyCode) {
             return Chord(mods: mods, key: named)
         }
-        // Derive the UNSHIFTED base key so every key normalizes the same way. `charactersIgnoringModifiers`
-        // KEEPS shift (shift+/ → "?", shift+= → "+"), and `.lowercased()` only undoes that for letters, so
-        // punctuation would otherwise land on the shifted glyph and never match a `shift+/`-style binding.
-        // `characters(byApplyingModifiers: [])` applies NO modifiers, giving the base char for any key
-        // (shift+/ → "/", shift+5 → "5", shift+u → "u"), matching how the keymap spells chords as
-        // `shift+<base>` (same call `GhosttySurfaceView` uses for unmodified key input).
-        // `chordKey` then resolves the whole layout: a layout that cannot type ASCII binds by physical
-        // position, so a `cmd+o` command still fires on a Cyrillic layout (where that key types `щ`),
-        // while a Latin layout keeps binding by the character it produces.
+        // `characters(byApplyingModifiers: [])` applies NO modifiers, giving the UNSHIFTED base key for any
+        // key (shift+/ → "/", shift+5 → "5", shift+u → "u") and matching how the keymap spells `shift+<base>`
+        // — the same call `GhosttySurfaceView` uses for unmodified input. `charactersIgnoringModifiers`
+        // instead KEEPS shift (shift+/ → "?", shift+= → "+") and `.lowercased()` undoes that only for
+        // letters, so punctuation would land on the shifted glyph and never match a `shift+/` binding.
+        // `chordKey` then applies the layout rule, so `cmd+o` still fires on a Cyrillic layout (key types `щ`).
         let produced = event.characters(byApplyingModifiers: []) ?? event.charactersIgnoringModifiers
         guard let key = chordKey(forKeyCode: event.keyCode, produced: produced,
                                  layoutIsASCIICapable: KeyboardLayout.isASCIICapable) else { return nil }
@@ -196,25 +189,22 @@ final class CustomCommandRunner {
         leaderTimer = nil
     }
 
-    /// Run a command fired from the PALETTE: resolve context from the active session (the palette has no
-    /// first responder to key off). Detached `/bin/sh -c` with the `AGT_*` env, notifying on a spawn
-    /// error or non-zero exit. No-op when no window/session is active — firing a session-scoped command
-    /// with silently-empty tokens is unsafe (an empty `{AGT_SESSION_PWD}` turns `rm -rf …/*` into a root
-    /// glob), so only the deliberate empty-window KEYBIND path (handleKeyDown) fires a session-free
-    /// launcher via `sessionlessContext()`.
+    /// Run a command fired from the PALETTE: context from the active session (the palette has no first
+    /// responder to key off). Detached `/bin/sh -c` with the `AGT_*` env, notifying on a spawn error or
+    /// non-zero exit. No-op when no window/session is active — a session-scoped command with silently-empty
+    /// tokens is unsafe (an empty `{AGT_SESSION_PWD}` turns `rm -rf …/*` into a root glob), so only the
+    /// deliberate empty-window KEYBIND path fires a session-free launcher via `sessionlessContext()`.
     func run(_ command: CustomCommand) {
         guard let store = library.activeStore, let session = store.activeSession else {
             logger.notice("custom command \"\(command.name, privacy: .public)\" fired with no active session; ignored")
             return
         }
-        // palette path: selection + pane both come from the active session's focused pane. the palette has
-        // no fired-from surface to key off, so the focus flag is the source — but gated on the split surface
-        // EXISTING (the `Session.onScreenSurface` idiom, `splitFocused && splitSurface != nil`): in the
-        // window right after `session split on`, `splitFocused` is already true while `splitSurface` is
-        // still nil, so a bare flag would report `.right` (and read the selection from the nil split
-        // surface) when `session.type --pane right` still errors "no split pane". A promoted survivor now
-        // lives in the `surface` slot with `splitSurface == nil` and `splitFocused == false`, so `onSplit`
-        // is false and it reports `.left` — the pane `--pane left` reaches.
+        // selection + pane come from the active session's focused pane; with no fired-from surface the
+        // focus flag is the source, gated on the split surface EXISTING (the `Session.onScreenSurface`
+        // idiom). In the window right after `session split on`, `splitFocused` is already true while
+        // `splitSurface` is still nil, so a bare flag would report `.right` and read the selection off the
+        // nil surface while `session.type --pane right` still errors "no split pane". A promoted survivor
+        // sits in the `surface` slot with both nil/false, so it reports `.left` — the pane `--pane left` reaches.
         let onSplit = session.splitFocused && session.splitSurface != nil
         let selectionSurface = (onSplit ? session.splitSurface : session.surface) as? GhosttySurfaceView
         let context = self.context(for: session, in: store, selectionSurface: selectionSurface,
@@ -222,30 +212,28 @@ final class CustomCommandRunner {
         spawn(command, context: context)
     }
 
-    /// Run a command fired by KEYBIND: resolve context from the surface that actually had focus at
-    /// key-down time, so a chord fired from a split/scratch (or during a window-switch race) runs
-    /// against THAT surface's session/cwd/window and reads the selection from THAT exact surface. The
-    /// owning session/store come from the focused surface's `session` resolved through the host-free
-    /// `WindowLibrary` (no AppKit lives in core). A sessionless focused surface (quick terminal /
-    /// overlay / scratch) routes through `runFromSessionlessSurface`, which reports `.scratch` for the
-    /// active session's scratch and otherwise takes the palette path.
+    /// Run a command fired by KEYBIND: context from the surface that had focus at key-down, so a chord
+    /// fired from a split/scratch (or during a window-switch race) runs against THAT surface's
+    /// session/cwd/window and reads its selection. Session/store come from the surface's `session` resolved
+    /// through the host-free `WindowLibrary` (no AppKit in core). A sessionless focused surface (quick
+    /// terminal / overlay / scratch) routes through `runFromSessionlessSurface`.
     func runFromKeybind(_ command: CustomCommand, focusedSurface: GhosttySurfaceView) {
         guard let session = focusedSurface.session, let store = library.store(forSession: session.id) else {
             runFromSessionlessSurface(command, focusedSurface: focusedSurface)
             return
         }
-        // the fired-from pane is the surface's identity, not the session's focus flag — a chord fired
-        // from a pane the focus flag hasn't caught up to still reports the pane it was typed in.
+        // the pane is the surface's identity, not the focus flag, so a chord fired from a pane the flag
+        // hasn't caught up to still reports the pane it was typed in.
         let pane: CommandContext.Pane = (session.splitSurface as? GhosttySurfaceView) === focusedSurface ? .right : .left
         let context = self.context(for: session, in: store, selectionSurface: focusedSurface, pane: pane)
         spawn(command, context: context)
     }
 
-    /// The keybind fallback for a sessionless focused surface (no `view.session`: the quick terminal,
-    /// an overlay, or the scratch). The scratch belongs to the ACTIVE session, so a chord fired from it
-    /// runs against that session with `pane = .scratch` and reads the scratch's own selection — the read
-    /// leg of the `$AGT_PANE` → `session type --pane scratch` round-trip. The quick terminal and overlays
-    /// are not panes (their state is queryable via `tree`), so they take the plain palette path.
+    /// The keybind fallback for a sessionless focused surface (no `view.session`: quick terminal, overlay,
+    /// scratch). The scratch belongs to the ACTIVE session, so a chord from it runs against that session
+    /// with `pane = .scratch` and reads the scratch's own selection — the read leg of `$AGT_PANE` →
+    /// `session type --pane scratch`. The others are not panes (`tree` queries their state) and take the
+    /// plain palette path.
     private func runFromSessionlessSurface(_ command: CustomCommand, focusedSurface: GhosttySurfaceView) {
         if let store = library.activeStore, let session = store.activeSession,
            (session.scratchSurface as? GhosttySurfaceView) === focusedSurface {
@@ -256,10 +244,9 @@ final class CustomCommandRunner {
         runNoSurface(command)
     }
 
-    /// Run a command fired by keybind with NO usable fired-from session — an emptied window, or focus off
-    /// any surface (the dashboard key-catcher, a quick terminal / overlay with no owning session). Uses
-    /// the active session's context when one exists (like the palette), else the session-free launcher
-    /// path via `spawnSessionless`.
+    /// Keybind fire with NO usable fired-from session — an emptied window, or focus off any surface (the
+    /// dashboard key-catcher, a quick terminal / overlay with no owning session). Uses the active session's
+    /// context when one exists, like the palette, else the session-free `spawnSessionless`.
     private func runNoSurface(_ command: CustomCommand) {
         if library.activeStore?.activeSession != nil {
             run(command)
@@ -268,11 +255,11 @@ final class CustomCommandRunner {
         }
     }
 
-    /// Fire `command` with a session-free context (the empty-window launcher path) — UNLESS its body
-    /// references session-scoped tokens, which expand dangerously empty with no session (an empty
-    /// `{AGT_SESSION_PWD}` makes `rm -rf …/*` a root glob, defeating even the quoted `$AGT_X` form). Such
-    /// a command NO-OPS with a notice, exactly like the palette's `run(_:)`; a launcher (referencing only
-    /// `AGT_SOCKET`/`AGT_WINDOW`/`AGT_PANE`, e.g. `agtermctl session new --command "ssh …"`) still fires.
+    /// Fire `command` with a session-free context (the empty-window launcher path) — UNLESS its body names
+    /// session-scoped tokens, which expand dangerously empty (an empty `{AGT_SESSION_PWD}` makes
+    /// `rm -rf …/*` a root glob, defeating even the quoted `$AGT_X` form); that NO-OPS with a notice like
+    /// the palette's `run(_:)`. A launcher naming only `AGT_SOCKET`/`AGT_WINDOW`/`AGT_PANE`, e.g.
+    /// `agtermctl session new --command "ssh …"`, still fires.
     private func spawnSessionless(_ command: CustomCommand) {
         guard !CommandContext.referencesSessionScopedContext(command.command) else {
             logger.notice("custom command \"\(command.name, privacy: .public)\" references session context but no session is active; ignored")
@@ -303,10 +290,9 @@ final class CustomCommandRunner {
         )
     }
 
-    /// A session-free `CommandContext` for a command fired with no active session (an emptied window, or
-    /// none open): every `{AGT_SESSION_*}`/`{AGT_WORKSPACE_*}` token and the selection resolve empty, the
-    /// window id/name come from the frontmost window when there is one, and the socket lets a launcher
-    /// chord reach `agtermctl` to create a fresh session.
+    /// A session-free `CommandContext` (an emptied window, or none open): every `{AGT_SESSION_*}`/
+    /// `{AGT_WORKSPACE_*}` token and the selection resolve empty, the window id/name come from the frontmost
+    /// window when there is one, and the socket lets a launcher chord reach `agtermctl` for a fresh session.
     private func sessionlessContext() -> CommandContext {
         let windowID = library.activeWindowID
         return CommandContext(windowID: windowID?.uuidString ?? "", windowName: library.windowName(for: windowID),
@@ -322,8 +308,8 @@ final class CustomCommandRunner {
         process.executableURL = URL(fileURLWithPath: "/bin/sh")
         process.arguments = ["-c", line]
         process.environment = ProcessInfo.processInfo.environment.merging(context.environment()) { _, new in new }
-        // fire-and-forget: no output capture, so pin stdio to /dev/null rather than inheriting the
-        // app's fds (which vary by launch method).
+        // fire-and-forget: no output capture, so pin stdio to /dev/null rather than inherit the app's fds,
+        // which vary by launch method.
         process.standardInput = FileHandle.nullDevice
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice

--- a/agterm/Commands/KeyboardLayout.swift
+++ b/agterm/Commands/KeyboardLayout.swift
@@ -14,9 +14,9 @@ import Foundation
 /// records a conflicting account for ⌘C/⌘V/⌘A. Do not cite this type as evidence either way.
 enum KeyboardLayout {
     /// Whether the active keyboard layout can type ASCII. Read fresh on every key press — the query costs
-    /// well under a microsecond, so it needs no cache and no input-source-changed observer, and can never
-    /// go stale mid-session. Falls back to true (bind by produced character) when the layout cannot be
-    /// resolved, which is how every Latin layout already behaves.
+    /// well under a microsecond, so it needs no cache and no input-source-changed observer and can never go
+    /// stale mid-session. An unresolvable layout falls back to true (bind by produced character), which is
+    /// how every Latin layout already behaves.
     static var isASCIICapable: Bool {
         guard let source = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue(),
               let value = TISGetInputSourceProperty(source, kTISPropertyInputSourceIsASCIICapable)

--- a/agterm/ContentView.swift
+++ b/agterm/ContentView.swift
@@ -2,27 +2,23 @@ import agtermCore
 import AppKit
 import SwiftUI
 
-/// Top-level per-window entry point: resolves this window's `AppStore` from the
-/// `WindowLibrary` claim queue on appear, then hands off to `WindowContentView`
-/// for the actual layout (a stray restored window with no id closes itself via
-/// `StrayWindowCloser`).
+/// Top-level per-window entry point: resolves this window's `AppStore` from the `WindowLibrary` claim queue
+/// on appear, then hands off to `WindowContentView` for the layout (a stray restored window with no id
+/// closes itself via `StrayWindowCloser`).
 ///
-/// The detail pane (in `WindowContentView`) is an EAGER deck — every session's
-/// `TerminalView` is mounted at once and switching flips visibility/`isActive`,
-/// never an `.id(session.id)` re-host (which would invalidate the Metal drawable
-/// and flicker), so the session-owned surfaces survive switching. The sidebar is
-/// an AppKit `NSOutlineView` (`WorkspaceSidebar`) for native cross-workspace
-/// drag-and-drop; the bottom bar holds a workspace button and a session menu
-/// (New Session / Open Directory…).
+/// The detail pane (in `WindowContentView`) is an EAGER deck — every session's `TerminalView` is mounted at
+/// once and switching flips visibility/`isActive`, never an `.id(session.id)` re-host (which would
+/// invalidate the Metal drawable and flicker), so session-owned surfaces survive switching. The sidebar is
+/// an AppKit `NSOutlineView` (`WorkspaceSidebar`) for native cross-workspace drag-and-drop; the bottom bar
+/// holds a workspace button and a session menu (New Session / Open Directory…).
 struct ContentView: View {
     let library: WindowLibrary
     let makeSurface: (Session, AppStore) -> GhosttySurfaceView
     let makeSplitSurface: (Session, AppStore) -> GhosttySurfaceView
     let makeOverlaySurface: (Session, AppStore) -> GhosttySurfaceView
     let makeScratchSurface: (Session, AppStore) -> GhosttySurfaceView
-    /// The `AGTERM_*` environment a window's quick terminal exposes (ENABLED + WINDOW_ID + SOCKET),
-    /// resolved per window id. Threaded down so `WindowContentView` can bind its quick terminal's
-    /// `envProvider` with its own window id.
+    /// The `AGTERM_*` environment a window's quick terminal exposes (ENABLED + WINDOW_ID + SOCKET), per
+    /// window id. Threaded down so `WindowContentView` binds its quick terminal's `envProvider` with its own id.
     let quickTerminalEnv: (WindowInfo.ID) -> [String: String]
     let actions: AppActions
     let palette: PaletteController
@@ -35,20 +31,18 @@ struct ContentView: View {
     /// reporting and the frame autosave name.
     @State private var resolvedID: WindowInfo.ID?
 
-    /// Set when this window is a SwiftUI-restored stray with no library id to claim. The stray branch
-    /// then closes the NSWindow via AppKit — SwiftUI's `@Environment(\.dismiss)` is unreliable for
-    /// restored WindowGroup windows (they linger on screen as empty windows).
+    /// Set when this window is a SwiftUI-restored stray with no library id to claim; the stray branch then
+    /// closes the NSWindow via AppKit, since `@Environment(\.dismiss)` is unreliable for restored
+    /// WindowGroup windows (they linger on screen as empty windows).
     @State private var isStray = false
 
-    /// True when running under an isolated XCUITest (`AGTERM_STATE_DIR` set AND the
-    /// `AGTERM_UITEST_FORCE_SIDEBAR_VISIBLE` env sentinel present). Gates the FB11763863 window-present
-    /// workaround. The custom sidebar is always visible, so this no longer forces sidebar state; the
-    /// env var keeps its historical name.
+    /// True under an isolated XCUITest (`AGTERM_STATE_DIR` set AND the `AGTERM_UITEST_FORCE_SIDEBAR_VISIBLE`
+    /// sentinel present), gating the FB11763863 window-present workaround. The custom sidebar is always
+    /// visible, so this forces no sidebar state — the env var only keeps that name.
     static var isUITestLaunch: Bool {
         let process = ProcessInfo.processInfo
-        // the sentinel rides launch ENVIRONMENT, not launch arguments: a process-launched SwiftUI
-        // WindowGroup app fails to present its window under some launch-arg patterns on macOS 15+
-        // (FB11763863). Env sidesteps that.
+        // the sentinel rides launch ENVIRONMENT, not arguments: a process-launched SwiftUI WindowGroup app
+        // fails to present its window under some launch-arg patterns on macOS 15+ (FB11763863).
         return process.environment["AGTERM_STATE_DIR"] != nil
             && process.environment["AGTERM_UITEST_FORCE_SIDEBAR_VISIBLE"] != nil
     }
@@ -86,12 +80,11 @@ struct ContentView: View {
         .onAppear(perform: resolveStore)
     }
 
-    /// Resolves the window's store once on appear by claiming the next open window id from the
-    /// library's queue (the scene is a plain `WindowGroup`, so a window has no presented id). The
-    /// launch window claims the launch id, additional `openWindow()`-opened windows claim the rest in
-    /// order. A window beyond the open set — a SwiftUI-restored extra (Task 0 dedup-by-id) — gets no
-    /// id and dismisses itself, so stale restoration state can't pile up windows. Idempotent —
-    /// re-running with an already-resolved store is a no-op.
+    /// Resolves the window's store once on appear by claiming the next open window id from the library's
+    /// queue (the scene is a plain `WindowGroup`, so a window has no presented id): the launch window claims
+    /// the launch id, additional `openWindow()` windows the rest in order. A window beyond the open set — a
+    /// SwiftUI-restored extra — gets no id and dismisses itself, so stale restoration state can't pile up
+    /// windows. Idempotent: re-running with an already-resolved store is a no-op.
     private func resolveStore() {
         guard store == nil, !isStray else { return }
         guard let id = claimWindowID(),
@@ -109,23 +102,20 @@ struct ContentView: View {
         DockBadgeController.shared.refresh()
     }
 
-    /// The window id this view adopts: normally the next id in the library's claim queue. If the
-    /// queue is empty before the launch reopen-all has seeded it (the scene `.task` may not have run
-    /// `consumeReopen()` when this `.onAppear` fires), adopt the launch id rather than dismissing the
-    /// launch window — `adoptLaunchWindowID()` records it so the later `consumeReopen()` excludes it
-    /// from the seeded queue (no second window claims it). Once the queue has been seeded
-    /// (`hasReopened`), an empty queue genuinely means this is a SwiftUI-restored stray, so return nil
-    /// and let the caller dismiss it.
+    /// The window id this view adopts: normally the next in the library's claim queue. When the queue is
+    /// empty before the launch reopen-all seeded it (the scene `.task` may not have run `consumeReopen()`
+    /// when this `.onAppear` fires), adopt the launch id rather than dismissing the launch window —
+    /// `adoptLaunchWindowID()` records it so the later `consumeReopen()` excludes it and no second window
+    /// claims it. Once seeded (`hasReopened`), an empty queue means a SwiftUI-restored stray: return nil.
     private func claimWindowID() -> WindowInfo.ID? {
         if let id = library.claimNextWindowID() { return id }
         return library.hasReopened ? nil : library.adoptLaunchWindowID()
     }
 }
 
-/// Closes a SwiftUI-restored stray `WindowGroup` window via AppKit. SwiftUI's `@Environment(\.dismiss)`
-/// is unreliable for restored windows — they linger on screen as empty windows — so this reaches the
-/// backing `NSWindow` and `close()`s it directly. It also clears `isRestorable` so SwiftUI stops
-/// persisting + re-restoring this stray on the next launch.
+/// Closes a SwiftUI-restored stray `WindowGroup` window via AppKit: `@Environment(\.dismiss)` is unreliable
+/// for restored windows (they linger on screen as empty windows), so this reaches the backing `NSWindow` and
+/// `close()`s it. It also clears `isRestorable` so SwiftUI stops re-restoring the stray on the next launch.
 private struct StrayWindowCloser: NSViewRepresentable {
     func makeNSView(context _: Context) -> ClosingView { ClosingView() }
     func updateNSView(_ view: ClosingView, context _: Context) { view.closeIfNeeded() }

--- a/agterm/Control/ControlServer+AppCommands.swift
+++ b/agterm/Control/ControlServer+AppCommands.swift
@@ -3,9 +3,9 @@ import Foundation
 import agtermCore
 
 /// `ControlServer` APP-GLOBAL action adapter arms — no session/workspace target, acting on a whole window or
-/// the app: the `tree` projection, sidebar visibility/view-mode and expand/collapse, keymap +
-/// ghostty-config reload, the theme slots, and the per-window quick terminal. Split out of
-/// `ControlServer+SessionActions.swift` (session-, workspace- and surface-scoped) for the file size limit.
+/// the app: the `tree` projection, sidebar visibility/view-mode and expand/collapse, keymap + ghostty-config
+/// reload, theme slots, per-window quick terminal. Split out of the session-, workspace- and surface-scoped
+/// `ControlServer+SessionActions.swift` for the file size limit.
 extension ControlServer {
     func controlTree(window: String?) -> ControlResponse {
         resolver.resolvePlacementStore(window) { store in
@@ -20,7 +20,7 @@ extension ControlServer {
     // MARK: - Sidebar
 
     /// Show / hide / toggle the frontmost window's sidebar (the custom split owns visibility — no system
-    /// toggle). Flips only on a differing state; unknown mode and no open window are errors, not no-ops.
+    /// toggle). Flips only on a differing state; unknown mode and no open window are errors.
     func setSidebarVisibility(_ mode: ControlToggleMode) -> ControlResponse {
         guard let store = library.activeStore else {
             return ControlResponse(ok: false, error: "no open window")
@@ -47,8 +47,8 @@ extension ControlServer {
     }
 
     /// Expand every workspace in a window's sidebar tree; `--window` picks the OPEN target, default frontmost.
-    /// Graceful no-op in flagged mode (no workspace rows) and idempotent. Drives the same
-    /// `AppActions.expandAllWorkspaces(in:)` the View menu / palette drive; a closed or absent window errors.
+    /// Idempotent, and a graceful no-op in flagged mode (no workspace rows); a closed or absent window errors.
+    /// Drives the same `AppActions.expandAllWorkspaces(in:)` the View menu / palette drive.
     func expandSidebar(window: String?) -> ControlResponse {
         resolver.resolveOpenPlacementStore(window) { store in
             actions.expandAllWorkspaces(in: store)
@@ -56,9 +56,8 @@ extension ControlServer {
         }
     }
 
-    /// Collapse every workspace except the active session's, which stays expanded and scrolled into view.
-    /// `--window` picks the OPEN target, default frontmost. Drives `AppActions.collapseOtherWorkspaces(in:)`;
-    /// graceful no-op in flagged mode, idempotent, and a closed or absent window errors.
+    /// Collapse every workspace except the active session's, which stays expanded and scrolled into view; same
+    /// window selector and flagged-mode/idempotency/error behavior as `expandSidebar`.
     func collapseSidebar(window: String?) -> ControlResponse {
         resolver.resolveOpenPlacementStore(window) { store in
             actions.collapseOtherWorkspaces(in: store)
@@ -68,16 +67,16 @@ extension ControlServer {
 
     // MARK: - Keymap
 
-    /// Re-read and re-parse `keymap.conf`, returning the parse-diagnostic count. The SAME `reloadKeymap()`
-    /// path File ▸ Reload Keymap drives, so the two can't diverge — only the reported count is control-native.
+    /// Re-read and re-parse `keymap.conf`, returning the parse-diagnostic count. The SAME `reloadKeymap()` path
+    /// File ▸ Reload Keymap drives; only the reported count is control-native.
     func reloadKeymap() -> ControlResponse {
         settingsModel.reloadKeymap()
         return ControlResponse(ok: true, result: ControlResult(count: settingsModel.keymapDiagnostics.count))
     }
 
     /// The read side of `keymap.reload`: what the keymap resolved, plus what the menu bar is dispatching. The
-    /// two can disagree — SwiftUI defers its menu rebuild to the next app activation, so a chord correct in
-    /// the model can be stale in the menu. App-global like `keymap.reload`, so no `--window` selector.
+    /// two can disagree — SwiftUI defers its menu rebuild to the next app activation, so a chord correct in the
+    /// model can be stale in the menu. App-global, so no `--window` selector.
     func listKeymap() -> ControlResponse {
         let payload = ControlKeymap.project(keymap: settingsModel.keymap,
                                             diagnostics: settingsModel.keymapDiagnostics,
@@ -97,13 +96,12 @@ extension ControlServer {
 
     /// Every key equivalent in `submenu`, RECURSING into nested submenus. AppKit's `performKeyEquivalent`
     /// recurses, so a nested chord is just as live and can shadow an agterm binding — App ▸ Services is the
-    /// reachable case, carrying whatever shortcuts the user assigned in System Settings. Top-level-only
-    /// reporting would let a caller conclude nothing holds a chord when something does.
-    ///
-    /// `menu` stays the TOP-LEVEL title throughout, so a nested item is attributed to the menu-bar entry the
-    /// reader can find it under. Internal rather than private so `CloseSessionChordTests`' companion can drive
-    /// it over a hand-built nested menu: agterm's own submenus carry no key equivalents and Services entries
-    /// depend on the user's system settings, so no nested chord exists for an e2e to assert against.
+    /// reachable case, carrying whatever the user assigned in System Settings; top-level-only reporting would
+    /// let a caller conclude nothing holds a chord when something does. `menu` stays the TOP-LEVEL title
+    /// throughout, so a nested item is attributed to the menu-bar entry the reader can find it under. Internal
+    /// rather than private so `CloseSessionChordTests`' companion can drive it over a hand-built nested menu:
+    /// agterm's own submenus carry no key equivalents and Services entries depend on the user's system
+    /// settings, so no real nested chord exists to assert against.
     @MainActor
     static func collectKeyEquivalents(in submenu: NSMenu, menu: String) -> [ControlKeymapMenuItem] {
         submenu.items.flatMap { item -> [ControlKeymapMenuItem] in
@@ -120,24 +118,21 @@ extension ControlServer {
     }
 
     /// An `NSMenuItem`'s key equivalent in kitty syntax (`cmd+shift+e`), in `Chord.displayString`'s modifier
-    /// order so the two render identically and compare as strings.
-    ///
-    /// Two AppKit spellings must be translated or the chord is uncomparable. Arrows and return/tab/space/delete
-    /// arrive as function-key or control CHARACTERS, rendering the key blank (`cmd+opt+` for the keymap's
-    /// `cmd+opt+up`), so they go through `namedKey(forKeyEquivalent:)`; a shift-typed equivalent arrives as the
-    /// SHIFTED character with `.shift` set (⇧E is `"E"`), so an ordinary key is lowercased to the grammar's base.
-    ///
-    /// The globe/fn modifier has no keymap spelling (the grammar knows ctrl/cmd/opt/shift only) but renders as
-    /// `fn+` anyway: this reports what the menu bar carries, and dropping it would print AppKit's ⌥⌘F-style
-    /// items as bare unmodified keys, reading as a binding that does not exist. A `fn+` chord never matches an
-    /// action's chord, which is correct.
+    /// order so the two render identically and compare as strings. Two AppKit spellings must be translated or
+    /// the chord is uncomparable: arrows and return/tab/space/delete arrive as function-key or control
+    /// CHARACTERS, rendering the key blank (`cmd+opt+` for the keymap's `cmd+opt+up`), so they go through
+    /// `namedKey(forKeyEquivalent:)`; a shift-typed equivalent arrives as the SHIFTED character with `.shift`
+    /// set (⇧E is `"E"`), so an ordinary key is lowercased to the grammar's base. The globe/fn modifier has no
+    /// keymap spelling (the grammar knows ctrl/cmd/opt/shift only) but renders as `fn+` anyway — dropping it
+    /// would print AppKit's ⌥⌘F-style items as bare unmodified keys, reading as a binding that does not exist;
+    /// a `fn+` chord never matches an action's chord, which is correct.
     @MainActor
     private static func chordSyntax(for item: NSMenuItem) -> String {
         let mods = item.keyEquivalentModifierMask
         let key = item.keyEquivalent
         // an UPPERCASE key equivalent carries shift implicitly whatever the mask says: AppKit matches `"C"` +
-        // [.command] against ⇧⌘C, not ⌘C. agterm's own items never spell it that way (`toShortcut` puts shift
-        // in the mask), but this walk reports third-party items, where lowercasing would name an unfirable chord.
+        // [.command] against ⇧⌘C, not ⌘C. agterm's own items never spell it that way (`toShortcut` puts shift in
+        // the mask), but this walk reports third-party items, where lowercasing would name an unfirable chord.
         let impliedShift = key.count == 1 && key.first?.isUppercase == true
         var parts: [String] = []
         if mods.contains(.function) { parts.append("fn") }
@@ -151,24 +146,22 @@ extension ControlServer {
 
     // MARK: - Config
 
-    /// Re-read and apply the ghostty config, returning the diagnostic count (0 = clean) across ALL sources
-    /// (bundled defaults, `~/.config/ghostty/config`, the agterm-scoped `ghostty.conf`, the UI settings conf)
-    /// — libghostty diagnostics carry no source-file attribution. The SAME `AppActions.reloadGhosttyConfig()`
-    /// File ▸ Reload Config drives (posting the warning banner), so the two can't diverge; the count is what
-    /// that reload produced, not a re-read. App-global (one settings model + one GhosttyApp), so no `--window`.
+    /// Re-read and apply the ghostty config, returning the diagnostic count (0 = clean) across ALL sources —
+    /// libghostty diagnostics carry no source-file attribution. Drives the SAME
+    /// `AppActions.reloadGhosttyConfig()` File ▸ Reload Config drives (posting the warning banner); the count is
+    /// what that reload produced, not a re-read. App-global (one settings model + one GhosttyApp), no `--window`.
     func reloadGhosttyConfig() -> ControlResponse {
         ControlResponse(ok: true, result: ControlResult(count: actions.reloadGhosttyConfig()))
     }
 
     // MARK: - Theme
 
-    /// Set + persist a theme PER SLOT — the control half of the Settings pickers / `.themes` palette commit
-    /// (no live preview over the socket). `args.name` (alias `args.light`; both is an error) sets the
-    /// light/single slot, keeping any dark one; `args.dark` sets the dark slot and turns macOS-appearance
-    /// syncing ON (the stored value becomes ghostty's dual `light:,dark:`, light side seeded), and `none`
-    /// (any case) clears it, syncing off. A nil/empty name picks ghostty's built-in colors ("default ghostty"),
-    /// NOT the seeded `agterm` default; any other name must be a bundled theme, else an error (a typo doing
-    /// nothing silently is worse). Echoes `theme`/`sync`/`light`/`dark`. App-global, so no `--window`.
+    /// Set + persist a theme PER SLOT — the control half of the Settings pickers / `.themes` palette commit (no
+    /// live preview over the socket), app-global so no `--window`. `args.name` (alias `args.light`; both is an
+    /// error) sets the light/single slot, keeping any dark one; `args.dark` sets the dark slot and turns
+    /// macOS-appearance syncing ON (stored as ghostty's dual `light:,dark:`, light side seeded), and `none` (any
+    /// case) clears it, syncing off. A nil/empty name picks ghostty's built-in colors ("default ghostty"), NOT
+    /// the seeded `agterm` default; any other must be a bundled theme, else an error (a silent typo is worse).
     func setTheme(args: ControlArgs?) -> ControlResponse {
         let name = ThemeCatalog.resolvedName(args?.name)
         let light = ThemeCatalog.resolvedName(args?.light)
@@ -210,8 +203,8 @@ extension ControlServer {
 
     // MARK: - Quick terminal
 
-    /// Show / hide / toggle the frontmost window's quick terminal (each window owns one), flipping only when
-    /// the state differs from `isVisible`. Unknown mode and no open window are errors, not silent no-ops.
+    /// Show / hide / toggle the frontmost window's quick terminal (each window owns one), flipping only when the
+    /// state differs from `isVisible`. Unknown mode and no open window are errors.
     func setQuickTerminal(mode: String?) -> ControlResponse {
         guard let controller = QuickTerminalRegistry.shared.controller(for: library.activeWindowID) else {
             return ControlResponse(ok: false, error: "no open window")
@@ -225,9 +218,9 @@ extension ControlServer {
             return ControlResponse(ok: false, error: "pick pending")
         }
         if let zoom = TerminalZoomRegistry.shared.controller(for: library.activeWindowID), zoom.target != nil {
-            // a script must always be able to DISMISS the quick terminal — hide is a guaranteed-ok idempotent
-            // no-op cleanup code relies on — so hiding un-zooms a zoomed one first, then hides. only SHOWING
-            // one under/over the zoom layer stays blocked, which would strand an unmounted-but-visible cover.
+            // a script must always be able to DISMISS the quick terminal (cleanup relies on hide being a
+            // guaranteed-ok idempotent no-op), so hiding un-zooms a zoomed one first. Only SHOWING one under the
+            // zoom layer stays blocked — that would strand an unmounted-but-visible cover.
             guard !want else {
                 return ControlResponse(ok: false, error: "terminal zoom active")
             }
@@ -242,25 +235,22 @@ extension ControlServer {
     }
 
     /// Inject `text` as literal keystrokes into the frontmost window's quick terminal, the twin of
-    /// `session.type` (input goes where the user is typing while the overlay is up). `quick show` flips
-    /// `isVisible` before SwiftUI mounts + libghostty realizes the surface, so this polls briefly (like
-    /// `session.type`'s realize poll) rather than racing a back-to-back `quick show; quick type`. Fails fast
-    /// with `quick terminal not open` when never shown (no surface AND not visible), `quick terminal not
-    /// realized` if a shown surface never comes up within the poll, `no open window` when there is no window.
+    /// `session.type`. `quick show` flips `isVisible` before SwiftUI mounts + libghostty realizes the surface,
+    /// so this polls briefly rather than racing a back-to-back `quick show; quick type`. Fails fast with `quick
+    /// terminal not open` when never shown (no surface AND not visible), else `quick terminal not realized`.
     func typeQuick(text: String) async -> ControlResponse {
         guard let controller = QuickTerminalRegistry.shared.controller(for: library.activeWindowID) else {
             return ControlResponse(ok: false, error: "no open window")
         }
-        // probe first (fast path), then sleep-then-probe up to 12 more times — a probe follows every sleep
-        // so the full ~360ms window is used, matching `session.type`'s realize poll (no wasted trailing sleep).
+        // probe first, then sleep-then-probe up to 12 more times — a probe follows every sleep, so the full
+        // ~360ms window is used (no wasted trailing sleep), matching `session.type`'s realize poll.
         for attempt in 0...12 {
             if attempt > 0 {
                 try? await Task.sleep(nanoseconds: 30_000_000)
             }
             if let surface = controller.currentSurface() {
-                // a false inject means the view exists but its surface isn't realized — keep polling, don't
-                // report a silent-drop ok. a shown-then-hidden surface stays alive and realized, typing while
-                // hidden like `--pane scratch`, so it lands here at once.
+                // a false inject means the view exists but its surface isn't realized — keep polling rather than
+                // report a silent-drop ok. a shown-then-hidden surface stays alive and typable, succeeding here.
                 if surface.inject(text: text) {
                     return ControlResponse(ok: true)
                 }
@@ -273,21 +263,21 @@ extension ControlServer {
     }
 
     /// Read the frontmost window's quick-terminal screen as plain text, the twin of `session.text` and the
-    /// read-back for `quick.type`. `all` adds scrollback, `lines` keeps the last N; one surface, so no
-    /// `--pane`. Polls for mount + realization like `typeQuick`; fails fast with `quick terminal not open`
-    /// when never shown, `failed to read surface buffer` if a shown surface never realizes, `no open window`.
+    /// read-back for `quick.type`. `all` adds scrollback, `lines` keeps the last N; one surface, so no `--pane`.
+    /// Polls for mount + realization like `typeQuick`; a never-shown quick errors, an unrealized one gives
+    /// `failed to read surface buffer`.
     func readQuickText(all: Bool, lines: Int?) async -> ControlResponse {
         guard let controller = QuickTerminalRegistry.shared.controller(for: library.activeWindowID) else {
             return ControlResponse(ok: false, error: "no open window")
         }
-        // probe first, then sleep-then-probe up to 12 more times (a probe follows every sleep), like `typeQuick`.
+        // same probe-then-sleep poll shape as `typeQuick`.
         for attempt in 0...12 {
             if attempt > 0 {
                 try? await Task.sleep(nanoseconds: 30_000_000)
             }
             if let surface = controller.currentSurface() {
-                // readScreenText returns nil only for an unrealized surface ("" for a realized blank
-                // screen), so a non-nil result means the surface is up — return it.
+                // readScreenText returns nil only for an unrealized surface ("" for a realized blank screen),
+                // so a non-nil result means the surface is up.
                 if let text = surface.readScreenText(all: all, lines: lines) {
                     return ControlResponse(ok: true, result: ControlResult(text: text))
                 }

--- a/agterm/Control/ControlServer+AppCommands.swift
+++ b/agterm/Control/ControlServer+AppCommands.swift
@@ -2,11 +2,10 @@ import AppKit
 import Foundation
 import agtermCore
 
-/// `ControlServer` APP-GLOBAL action adapter arms — the ones that take no session/workspace target and
-/// act on a whole window or the app itself: the `tree` projection, the sidebar visibility/view-mode and
-/// expand/collapse arms, keymap + ghostty-config reload, the theme slots, and the per-window quick
-/// terminal. Split out of `ControlServer+SessionActions.swift` (which keeps the session-, workspace-, and
-/// surface-scoped arms) to keep both files under the swiftlint size limit.
+/// `ControlServer` APP-GLOBAL action adapter arms — no session/workspace target, acting on a whole window or
+/// the app: the `tree` projection, sidebar visibility/view-mode and expand/collapse, keymap +
+/// ghostty-config reload, the theme slots, and the per-window quick terminal. Split out of
+/// `ControlServer+SessionActions.swift` (session-, workspace- and surface-scoped) for the file size limit.
 extension ControlServer {
     func controlTree(window: String?) -> ControlResponse {
         resolver.resolvePlacementStore(window) { store in
@@ -20,21 +19,19 @@ extension ControlServer {
 
     // MARK: - Sidebar
 
-    /// Show / hide / toggle the frontmost window's sidebar (the custom split owns visibility, so there's
-    /// no system toggle). Flips only when the requested state differs; an unknown mode is an error, and no
-    /// open window is an error rather than a silent no-op.
+    /// Show / hide / toggle the frontmost window's sidebar (the custom split owns visibility — no system
+    /// toggle). Flips only on a differing state; unknown mode and no open window are errors, not no-ops.
     func setSidebarVisibility(_ mode: ControlToggleMode) -> ControlResponse {
         guard let store = library.activeStore else {
             return ControlResponse(ok: false, error: "no open window")
         }
         let want = mode.desiredValue(current: store.sidebarVisible)
-        store.setSidebarVisible(want) // no-op + no save when unchanged (idempotent)
+        store.setSidebarVisible(want)
         return ControlResponse(ok: true)
     }
 
-    /// Set the frontmost window's sidebar VIEW mode (the tree vs the flat flagged list) — distinct from
-    /// `setSidebarVisibility`. `mode` is `tree|flagged|toggle`, delta-computed so a no-op mode skips
-    /// the write (idempotent), via `AppStore.setSidebarMode`. An unknown mode + no-open-window are errors.
+    /// Set the frontmost window's sidebar VIEW mode (tree vs the flat flagged list), distinct from
+    /// `setSidebarVisibility`. Delta-computed so a no-op mode skips the write; unknown mode + no window error.
     func setSidebarViewMode(_ mode: ControlSidebarViewMode) -> ControlResponse {
         guard let store = library.activeStore else {
             return ControlResponse(ok: false, error: "no open window")
@@ -45,15 +42,13 @@ extension ControlServer {
         case .flagged: want = .flagged
         case .toggle: want = store.sidebarMode == .tree ? .flagged : .tree
         }
-        store.setSidebarMode(want) // no-op + no save when unchanged (idempotent)
+        store.setSidebarMode(want)
         return ControlResponse(ok: true)
     }
 
-    /// Expand every workspace in a window's sidebar tree — the `--window` selector picks the (OPEN) target,
-    /// defaulting to the frontmost window (a graceful no-op in flagged mode, which has no workspace rows).
-    /// Drives `AppActions.expandAllWorkspaces(in:)` (the same path the View menu / palette drive on the
-    /// frontmost). Idempotent (expanding when all are already expanded is a clean no-op); a named-but-closed
-    /// window errors, and no open window at all errors rather than silently no-opping.
+    /// Expand every workspace in a window's sidebar tree; `--window` picks the OPEN target, default frontmost.
+    /// Graceful no-op in flagged mode (no workspace rows) and idempotent. Drives the same
+    /// `AppActions.expandAllWorkspaces(in:)` the View menu / palette drive; a closed or absent window errors.
     func expandSidebar(window: String?) -> ControlResponse {
         resolver.resolveOpenPlacementStore(window) { store in
             actions.expandAllWorkspaces(in: store)
@@ -61,11 +56,9 @@ extension ControlServer {
         }
     }
 
-    /// Collapse every workspace except the active one (the active session's workspace) in a window's
-    /// sidebar, keeping that workspace expanded and scrolled into view. The `--window` selector picks the
-    /// (OPEN) target, defaulting to the frontmost. Drives `AppActions.collapseOtherWorkspaces(in:)`.
-    /// Graceful no-op in flagged mode; idempotent; a named-but-closed window errors, and no open window
-    /// at all errors.
+    /// Collapse every workspace except the active session's, which stays expanded and scrolled into view.
+    /// `--window` picks the OPEN target, default frontmost. Drives `AppActions.collapseOtherWorkspaces(in:)`;
+    /// graceful no-op in flagged mode, idempotent, and a closed or absent window errors.
     func collapseSidebar(window: String?) -> ControlResponse {
         resolver.resolveOpenPlacementStore(window) { store in
             actions.collapseOtherWorkspaces(in: store)
@@ -75,18 +68,16 @@ extension ControlServer {
 
     // MARK: - Keymap
 
-    /// Re-read and re-parse `keymap.conf`, returning the count of parse diagnostics. The SAME
-    /// `reloadKeymap()` path the GUI's File ▸ Reload Keymap menu/palette item drives, so the menu/palette
-    /// and `keymap.reload` never diverge — control-native here only in the count it reports back.
+    /// Re-read and re-parse `keymap.conf`, returning the parse-diagnostic count. The SAME `reloadKeymap()`
+    /// path File ▸ Reload Keymap drives, so the two can't diverge — only the reported count is control-native.
     func reloadKeymap() -> ControlResponse {
         settingsModel.reloadKeymap()
         return ControlResponse(ok: true, result: ControlResult(count: settingsModel.keymapDiagnostics.count))
     }
 
-    /// The read side of `keymap.reload`: what the keymap resolved, plus what the menu bar is actually
-    /// dispatching. The two halves can disagree — SwiftUI defers its menu rebuild to the next app
-    /// activation, so a chord correct in the model can be stale in the menu, which is the divergence a
-    /// bare model listing cannot show. App-global like `keymap.reload`, so no `--window` selector.
+    /// The read side of `keymap.reload`: what the keymap resolved, plus what the menu bar is dispatching. The
+    /// two can disagree — SwiftUI defers its menu rebuild to the next app activation, so a chord correct in
+    /// the model can be stale in the menu. App-global like `keymap.reload`, so no `--window` selector.
     func listKeymap() -> ControlResponse {
         let payload = ControlKeymap.project(keymap: settingsModel.keymap,
                                             diagnostics: settingsModel.keymapDiagnostics,
@@ -95,9 +86,8 @@ extension ControlServer {
         return ControlResponse(ok: true, result: ControlResult(keymap: payload))
     }
 
-    /// Every menu-bar item carrying a key equivalent, rendered in the same kitty syntax the keymap uses so
-    /// a caller can compare the two lists directly. Only the app target can read `NSApp.mainMenu`, so this
-    /// is the app-side half of the otherwise host-free `keymap.list` payload.
+    /// Every menu-bar item carrying a key equivalent, in the same kitty syntax the keymap uses so a caller can
+    /// compare the lists. Only the app target reads `NSApp.mainMenu`, so this is `keymap.list`'s app-side half.
     @MainActor
     private static func liveMenuKeyEquivalents() -> [ControlKeymapMenuItem] {
         (NSApp.mainMenu?.items ?? []).flatMap { topItem in
@@ -105,18 +95,15 @@ extension ControlServer {
         }
     }
 
-    /// Every key equivalent in `submenu`, RECURSING into nested submenus. AppKit's own
-    /// `performKeyEquivalent` recurses, so a chord one level down is just as live and can just as easily
-    /// shadow an agterm binding — App ▸ Services is the reachable case, since its entries carry whatever
-    /// shortcuts the user assigned in System Settings. Reporting only the top level would let a caller
-    /// compare the two lists and conclude nothing holds a chord when something does.
+    /// Every key equivalent in `submenu`, RECURSING into nested submenus. AppKit's `performKeyEquivalent`
+    /// recurses, so a nested chord is just as live and can shadow an agterm binding — App ▸ Services is the
+    /// reachable case, carrying whatever shortcuts the user assigned in System Settings. Top-level-only
+    /// reporting would let a caller conclude nothing holds a chord when something does.
     ///
-    /// `menu` stays the TOP-LEVEL menu's title throughout, so a nested item is still attributed to the
-    /// menu-bar entry the reader can find it under.
-    ///
-    /// Internal rather than private so `CloseSessionChordTests`' companion can drive it over a hand-built
-    /// nested menu: agterm's own submenus carry no key equivalents and Services entries depend on the
-    /// user's system settings, so there is no nested chord an e2e could assert against.
+    /// `menu` stays the TOP-LEVEL title throughout, so a nested item is attributed to the menu-bar entry the
+    /// reader can find it under. Internal rather than private so `CloseSessionChordTests`' companion can drive
+    /// it over a hand-built nested menu: agterm's own submenus carry no key equivalents and Services entries
+    /// depend on the user's system settings, so no nested chord exists for an e2e to assert against.
     @MainActor
     static func collectKeyEquivalents(in submenu: NSMenu, menu: String) -> [ControlKeymapMenuItem] {
         submenu.items.flatMap { item -> [ControlKeymapMenuItem] in
@@ -132,27 +119,25 @@ extension ControlServer {
         }
     }
 
-    /// An `NSMenuItem`'s key equivalent in kitty syntax (`cmd+shift+e`), matching `Chord.displayString`'s
-    /// modifier order so the two render identically and a caller can compare them as strings.
+    /// An `NSMenuItem`'s key equivalent in kitty syntax (`cmd+shift+e`), in `Chord.displayString`'s modifier
+    /// order so the two render identically and compare as strings.
     ///
-    /// Two AppKit spellings have to be translated or the chord comes out uncomparable. Arrows and
-    /// return/tab/space/delete arrive as function-key or control CHARACTERS, which would render the key
-    /// blank (`cmd+opt+` for what the keymap calls `cmd+opt+up`), so they go through
-    /// `namedKey(forKeyEquivalent:)`. And a shift-typed equivalent arrives as the SHIFTED character with
-    /// `.shift` set (⇧E is `"E"`), so an ordinary key is lowercased to the unshifted base the grammar uses.
+    /// Two AppKit spellings must be translated or the chord is uncomparable. Arrows and return/tab/space/delete
+    /// arrive as function-key or control CHARACTERS, rendering the key blank (`cmd+opt+` for the keymap's
+    /// `cmd+opt+up`), so they go through `namedKey(forKeyEquivalent:)`; a shift-typed equivalent arrives as the
+    /// SHIFTED character with `.shift` set (⇧E is `"E"`), so an ordinary key is lowercased to the grammar's base.
     ///
-    /// The globe/fn modifier has NO keymap spelling (the grammar knows ctrl/cmd/opt/shift only), but it is
-    /// rendered as `fn+` anyway: this section reports what the menu bar really carries, and dropping the
-    /// modifier would print AppKit's own ⌥⌘F-style items as bare unmodified keys, which reads as a binding
-    /// that does not exist. A `fn+` chord simply never matches an action's chord, which is correct.
+    /// The globe/fn modifier has no keymap spelling (the grammar knows ctrl/cmd/opt/shift only) but renders as
+    /// `fn+` anyway: this reports what the menu bar carries, and dropping it would print AppKit's ⌥⌘F-style
+    /// items as bare unmodified keys, reading as a binding that does not exist. A `fn+` chord never matches an
+    /// action's chord, which is correct.
     @MainActor
     private static func chordSyntax(for item: NSMenuItem) -> String {
         let mods = item.keyEquivalentModifierMask
         let key = item.keyEquivalent
-        // an UPPERCASE key equivalent carries shift implicitly, whether or not the mask says so: AppKit
-        // matches `"C"` + [.command] against ⇧⌘C and not ⌘C. agterm's own items never spell it that way
-        // (`toShortcut` always puts shift in the mask), but this walk reports third-party items too, and
-        // lowercasing without adding shift would name a chord that item can never fire.
+        // an UPPERCASE key equivalent carries shift implicitly whatever the mask says: AppKit matches `"C"` +
+        // [.command] against ⇧⌘C, not ⌘C. agterm's own items never spell it that way (`toShortcut` puts shift
+        // in the mask), but this walk reports third-party items, where lowercasing would name an unfirable chord.
         let impliedShift = key.count == 1 && key.first?.isUppercase == true
         var parts: [String] = []
         if mods.contains(.function) { parts.append("fn") }
@@ -166,28 +151,24 @@ extension ControlServer {
 
     // MARK: - Config
 
-    /// Re-read and apply the ghostty config, returning the config-diagnostic count (0 = clean), counted
-    /// across ALL config sources (bundled defaults, the global `~/.config/ghostty/config`, the agterm-scoped
-    /// `ghostty.conf`, and the UI settings conf) — libghostty diagnostics carry no source-file attribution.
-    /// The SAME `AppActions.reloadGhosttyConfig()` path the GUI's File ▸ Reload Config menu/palette item
-    /// drives (which posts the warning banner on diagnostics), so the GUI and `config.reload` never diverge
-    /// — control-native here only in the count it reports back. The count is the value the reload actually
-    /// produced (threaded back from the reload), not a separate re-read. App-global (one settings model +
-    /// one GhosttyApp), so no `--window` selector, like `keymap.reload`.
+    /// Re-read and apply the ghostty config, returning the diagnostic count (0 = clean) across ALL sources
+    /// (bundled defaults, `~/.config/ghostty/config`, the agterm-scoped `ghostty.conf`, the UI settings conf)
+    /// — libghostty diagnostics carry no source-file attribution. The SAME `AppActions.reloadGhosttyConfig()`
+    /// File ▸ Reload Config drives (posting the warning banner), so the two can't diverge; the count is what
+    /// that reload produced, not a re-read. App-global (one settings model + one GhosttyApp), so no `--window`.
     func reloadGhosttyConfig() -> ControlResponse {
         ControlResponse(ok: true, result: ControlResult(count: actions.reloadGhosttyConfig()))
     }
 
     // MARK: - Theme
 
-    /// Set + persist a theme PER SLOT — the control half of the Settings pickers / the `.themes` palette
-    /// commit (no live preview over the socket). `args.name` (alias `args.light`; both is an error) sets the
-    /// light/single slot, keeping any dark slot; `args.dark` sets the dark slot and turns macOS-appearance
-    /// syncing ON (the stored value becomes ghostty's dual `light:,dark:`, light side seeded), and the
-    /// reserved value `none` (any case) clears it (syncing off). A nil/empty name selects ghostty's built-in colors
-    /// ("default ghostty"), NOT the seeded `agterm` app default; any other name must be a bundled theme, else
-    /// an error (a typo silently doing nothing is worse than a fail). Echoes the full post-change state
-    /// (`theme`/`sync`/`light`/`dark`). App-global: one `SettingsModel`, so no `--window` selector.
+    /// Set + persist a theme PER SLOT — the control half of the Settings pickers / `.themes` palette commit
+    /// (no live preview over the socket). `args.name` (alias `args.light`; both is an error) sets the
+    /// light/single slot, keeping any dark one; `args.dark` sets the dark slot and turns macOS-appearance
+    /// syncing ON (the stored value becomes ghostty's dual `light:,dark:`, light side seeded), and `none`
+    /// (any case) clears it, syncing off. A nil/empty name picks ghostty's built-in colors ("default ghostty"),
+    /// NOT the seeded `agterm` default; any other name must be a bundled theme, else an error (a typo doing
+    /// nothing silently is worse). Echoes `theme`/`sync`/`light`/`dark`. App-global, so no `--window`.
     func setTheme(args: ControlArgs?) -> ControlResponse {
         let name = ThemeCatalog.resolvedName(args?.name)
         let light = ThemeCatalog.resolvedName(args?.light)
@@ -229,9 +210,8 @@ extension ControlServer {
 
     // MARK: - Quick terminal
 
-    /// Show / hide / toggle the frontmost window's quick terminal (each window owns its own),
-    /// flipping only when the requested state differs from the current `isVisible`. An unknown mode
-    /// is an error, not a silent no-op; no open window is an error rather than a silent no-op.
+    /// Show / hide / toggle the frontmost window's quick terminal (each window owns one), flipping only when
+    /// the state differs from `isVisible`. Unknown mode and no open window are errors, not silent no-ops.
     func setQuickTerminal(mode: String?) -> ControlResponse {
         guard let controller = QuickTerminalRegistry.shared.controller(for: library.activeWindowID) else {
             return ControlResponse(ok: false, error: "no open window")
@@ -245,10 +225,9 @@ extension ControlServer {
             return ControlResponse(ok: false, error: "pick pending")
         }
         if let zoom = TerminalZoomRegistry.shared.controller(for: library.activeWindowID), zoom.target != nil {
-            // a script must always be able to DISMISS the quick terminal (hide was a guaranteed-ok
-            // idempotent no-op pre-zoom, and cleanup code relies on that): hiding un-zooms a zoomed
-            // quick terminal first, then hides it. Only SHOWING one under/over the zoom layer stays
-            // blocked — that would strand an unmounted-but-visible cover.
+            // a script must always be able to DISMISS the quick terminal — hide is a guaranteed-ok idempotent
+            // no-op cleanup code relies on — so hiding un-zooms a zoomed one first, then hides. only SHOWING
+            // one under/over the zoom layer stays blocked, which would strand an unmounted-but-visible cover.
             guard !want else {
                 return ControlResponse(ok: false, error: "terminal zoom active")
             }
@@ -262,13 +241,12 @@ extension ControlServer {
         return ControlResponse(ok: true)
     }
 
-    /// Inject `text` as literal keystrokes into the frontmost window's quick terminal, the quick-terminal
-    /// twin of `session.type` (input goes where the user is typing when the overlay is up). `quick show`
-    /// flips `isVisible` before SwiftUI mounts + libghostty realizes the surface, so `quick show; quick
-    /// type` would otherwise race the mount — this polls briefly (like `session.type`'s realize poll) so a
-    /// back-to-back script types reliably. Fails fast with `quick terminal not open` when the overlay has
-    /// never been shown (no surface AND not visible), `quick terminal not realized` if a shown surface
-    /// never comes up within the poll, `no open window` when there is no window.
+    /// Inject `text` as literal keystrokes into the frontmost window's quick terminal, the twin of
+    /// `session.type` (input goes where the user is typing while the overlay is up). `quick show` flips
+    /// `isVisible` before SwiftUI mounts + libghostty realizes the surface, so this polls briefly (like
+    /// `session.type`'s realize poll) rather than racing a back-to-back `quick show; quick type`. Fails fast
+    /// with `quick terminal not open` when never shown (no surface AND not visible), `quick terminal not
+    /// realized` if a shown surface never comes up within the poll, `no open window` when there is no window.
     func typeQuick(text: String) async -> ControlResponse {
         guard let controller = QuickTerminalRegistry.shared.controller(for: library.activeWindowID) else {
             return ControlResponse(ok: false, error: "no open window")
@@ -280,9 +258,9 @@ extension ControlServer {
                 try? await Task.sleep(nanoseconds: 30_000_000)
             }
             if let surface = controller.currentSurface() {
-                // a false inject means the view exists but its libghostty surface isn't realized yet — keep
-                // polling rather than reporting a silent-drop false ok. A shown-then-hidden surface stays
-                // alive and realized (types while hidden, like `--pane scratch`), so it lands here at once.
+                // a false inject means the view exists but its surface isn't realized — keep polling, don't
+                // report a silent-drop ok. a shown-then-hidden surface stays alive and realized, typing while
+                // hidden like `--pane scratch`, so it lands here at once.
                 if surface.inject(text: text) {
                     return ControlResponse(ok: true)
                 }
@@ -294,12 +272,10 @@ extension ControlServer {
         return ControlResponse(ok: false, error: "quick terminal not realized")
     }
 
-    /// Read the frontmost window's quick-terminal screen as plain text, the quick-terminal twin of
-    /// `session.text` — the read-back for `quick.type`. `all` reads the full screen + scrollback, `lines`
-    /// keeps only the last N; the quick terminal has a single surface, so there's no `--pane`. Polls for
-    /// mount + realization like `typeQuick` so `quick show; quick text` doesn't race the mount; fails fast
-    /// with `quick terminal not open` when never shown, `failed to read surface buffer` if a shown surface
-    /// never realizes within the poll, `no open window` when there is no window.
+    /// Read the frontmost window's quick-terminal screen as plain text, the twin of `session.text` and the
+    /// read-back for `quick.type`. `all` adds scrollback, `lines` keeps the last N; one surface, so no
+    /// `--pane`. Polls for mount + realization like `typeQuick`; fails fast with `quick terminal not open`
+    /// when never shown, `failed to read surface buffer` if a shown surface never realizes, `no open window`.
     func readQuickText(all: Bool, lines: Int?) async -> ControlResponse {
         guard let controller = QuickTerminalRegistry.shared.controller(for: library.activeWindowID) else {
             return ControlResponse(ok: false, error: "no open window")

--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -1,10 +1,9 @@
 import Foundation
 import agtermCore
 
-/// `ControlServer`'s target-bearing action arms. Target-dependent parsing stays here with `resolver` and
-/// app-owned commands call nearby helpers; dispatcher-routed ones parse in agtermCore where that preserves
-/// the old response order. Split from `ControlServer.swift` for the swiftlint size limit — the app-global
-/// arms (tree, sidebar, keymap/config reload, theme, quick terminal) are in `ControlServer+AppCommands.swift`.
+/// `ControlServer`'s target-bearing action arms; the app-global ones (tree, sidebar, keymap/config reload,
+/// theme, quick terminal) are in `ControlServer+AppCommands.swift`, split for the swiftlint size limit.
+/// Target-dependent parsing stays here; dispatcher-routed ones parse in agtermCore, keeping response order.
 extension ControlServer: ControlActions {
     func typeSession(_ target: String?, window: String?, options: ControlSessionTypeOptions) async -> ControlResponse {
         // resolve first (cross-window without `args.window`), then realize-and-inject: the async
@@ -30,9 +29,8 @@ extension ControlServer: ControlActions {
                                     backgroundColor: options.backgroundColor) else {
                 return ControlResponse(ok: false, error: "overlay already open")
             }
-            // both overlay kinds run in the per-session eager deck whatever is active (the floating panel
-            // is a constant-shape sibling in `sessionDetail`), so opening never needs an implicit select —
-            // this one is the user-facing `--follow`, a no-op when the target is already active.
+            // both overlay kinds run in the per-session eager deck whatever is active, so opening never
+            // needs an implicit select — this is `--follow`, a no-op when the target is already active.
             if options.follow {
                 store.selectSession(id)
             }
@@ -73,8 +71,8 @@ extension ControlServer: ControlActions {
         }
     }
 
-    /// Destination workspace addressing is mutually exclusive: `workspace` (id / unique prefix / `active`,
-    /// the default) or `workspaceName` (the sidebar label) plus optional `createWorkspace` — create needs a
+    /// Destination addressing is mutually exclusive: `workspace` (id / unique prefix / `active`, the
+    /// default) or `workspaceName` (the sidebar label) plus optional `createWorkspace` — create needs a
     /// name, there is nothing to create by id. cwd/command/name are applied in `makeSessionResponse`.
     func createSession(_ options: ControlSessionCreateOptions) -> ControlResponse {
         resolver.resolvePlacementStore(options.window) { store in
@@ -89,13 +87,11 @@ extension ControlServer: ControlActions {
             }
             // name addressing: reuse-or-create with `createWorkspace`, else require an existing match.
             if let name = options.workspaceName {
-                // a blank name can neither be found nor created, so don't suggest --create-workspace,
-                // which rejects it too.
+                // a blank name can neither be found nor created (--create-workspace rejects it too).
                 guard !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                     return ControlResponse(ok: false, error: "workspace name must not be blank")
                 }
-                // a --no-select create must not widen the focus set via addWorkspace's auto-reveal; like the
-                // rest of --no-select it leaves the current view untouched.
+                // --no-select must not widen the focus set via addWorkspace's auto-reveal.
                 let workspace = options.createWorkspace == true
                     ? store.ensureWorkspace(named: name, revealNewWorkspace: !options.noSelect)
                     : store.workspace(named: name)
@@ -113,9 +109,9 @@ extension ControlServer: ControlActions {
         }
     }
 
-    /// Resolve an `--after`/`--before` anchor across the whole store (all workspaces, so it names its own
-    /// destination workspace) and hand its `(workspace, index, count)` to `body`. Unresolved/ambiguous yields
-    /// the shared resolver error; the location guard is defense-in-depth — the id came from the store's list.
+    /// Resolve an `--after`/`--before` anchor across all workspaces (so it names its own destination) and
+    /// hand its `(workspace, index, count)` to `body`. Unresolved/ambiguous yields the shared resolver
+    /// error; the location guard is defense-in-depth — the id came from the store's own list.
     private func resolveAnchorLocation(_ anchor: String, in store: AppStore,
                                        _ body: ((workspace: UUID, index: Int, count: Int)) -> ControlResponse) -> ControlResponse {
         resolver.resolve(anchor, candidates: store.workspaces.flatMap { $0.sessions.map(\.id) },
@@ -128,10 +124,9 @@ extension ControlServer: ControlActions {
     }
 
     /// The control half of the sidebar row's "Duplicate": a fresh shell in the target's directory, inserted
-    /// right after it in its own workspace. No options — the target names both — and like `session.new` it
-    /// focuses the duplicate when it lands in the frontmost window and returns its id. Read-back is `tree`,
-    /// where the new node appears after its source; its cwd is the source's FOCUSED pane, so it differs from
-    /// the source node's (primary) `tree.cwd` when the source is a split focused off its primary.
+    /// right after it in its own workspace, focused when it lands in the frontmost window. Read-back is
+    /// `tree`; the duplicate's cwd is the source's FOCUSED pane, so it differs from the source node's
+    /// (primary) `tree.cwd` when the source is a split focused off its primary.
     func duplicateSession(_ target: String?, window: String?) -> ControlResponse {
         resolver.resolveSession(target, window: window) { store, id in
             guard let session = store.duplicateSession(id) else {
@@ -176,18 +171,17 @@ extension ControlServer: ControlActions {
             }
             let affected: Int
             if settingsModel.settings.closeGraceUndoEnabled ?? true {
-                // One grouped grace record is the batch behavior scripts cannot reproduce by looping.
+                // one grouped grace record is the batch behavior scripts cannot reproduce by looping.
                 affected = store.softCloseSessions(ids) ? ids.count : 0
             } else {
-                // Match the GUI's immediate batch-close path when grace undo is disabled.
+                // match the GUI's immediate batch-close path when grace undo is disabled.
                 affected = ids.reduce(into: 0) { count, id in
                     guard store.session(withID: id) != nil else { return }
                     store.closeSession(id)
                     count += 1
                 }
             }
-            // `ok` with the count (0 included) mirrors `placeSessions`: every id already resolved, so an
-            // error arm here would be dead code.
+            // `ok` with the count (0 included) mirrors `placeSessions` — every id resolved, so no error arm.
             return ControlResponse(ok: true, result: ControlResult(affected: affected))
         }
     }
@@ -208,10 +202,9 @@ extension ControlServer: ControlActions {
         }
     }
 
-    /// Drive the split on the target's OWN store, not the argument-less `AppActions.toggleSplit()` (which
-    /// acts only on the active session). `mode` `on|off|toggle` is computed against `isSplit`, so `on`/`off`
-    /// are idempotent. Always `AppStore.toggleSplit` — a ⌘D-style keep-alive hide/show that never tears the
-    /// hidden pane's surface down (`closeSplit` stays shell-exit-only). Focus follows via `focusSplitPane`.
+    /// Drive the split on the target's OWN store, not active-only `AppActions.toggleSplit()`. `on|off|toggle`
+    /// is computed against `isSplit`, so both are idempotent. Always `AppStore.toggleSplit` — a ⌘D-style
+    /// keep-alive hide/show that never tears the hidden pane's surface down (`closeSplit` is shell-exit-only).
     func splitSession(_ target: String?, window: String?, mode: String?) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
             guard let session = store.session(withID: id) else {
@@ -229,12 +222,10 @@ extension ControlServer: ControlActions {
         }
     }
 
-    /// Show/hide the target's scratch terminal — a third, full-overlay shell. `mode` `on|off|toggle` is
-    /// computed against `scratchActive`, so `on`/`off` are idempotent. Like the split, hiding keeps the
-    /// shell alive (`toggleScratch`); the `closeScratch` teardown is reserved for the shell's own `exit`.
-    /// `command` (meaningful only when showing) runs that program as the scratch's process instead of a
-    /// login shell, run-once like `session.new --command`: a scratch is expendable, so a live one is torn
-    /// down and respawned with it — otherwise the flag would be silently inert.
+    /// Show/hide the target's scratch terminal, a third full-overlay shell. `on|off|toggle` is computed
+    /// against `scratchActive`, so both are idempotent; hiding keeps the shell alive, the `closeScratch`
+    /// teardown being reserved for the shell's own `exit`. `command` (only when showing) runs that program
+    /// instead of a login shell, run-once: a live scratch is torn down and respawned with it, else inert.
     func scratchSession(_ target: String?, window: String?, mode: String?,
                         command: String?) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
@@ -246,15 +237,13 @@ extension ControlServer: ControlActions {
             }
             let want = parsedMode.desiredValue(current: session.scratchActive)
             if want, let command, !command.isEmpty {
-                // closeScratch clears scratchActive, so the toggle below re-shows it and the factory
-                // consumes scratchCommand.
+                // closeScratch clears scratchActive, so the toggle below re-shows it and the factory uses it.
                 if session.scratchSurface != nil { store.closeScratch(id) }
                 session.scratchCommand = command
             }
             if want, store.selectedSessionID != id {
-                // the scratch is full-coverage and grabs focus on show, so it must be on the active session
-                // — select the target first. Unlike the overlay (which runs in the eager deck without
-                // selecting), a non-active target's scratch would steal first responder while hidden.
+                // the scratch is full-coverage and grabs focus on show, so select the target first — unlike
+                // the overlay (eager deck, no select), a non-active scratch would steal focus while hidden.
                 store.selectSession(id)
             }
             if want != session.scratchActive {
@@ -264,8 +253,7 @@ extension ControlServer: ControlActions {
         }
     }
 
-    /// Move keyboard focus to a split session's left/right pane. `pane` is `left`|`right`|`other`
-    /// (`other` toggles). Errors when the session isn't split or the pane value is unknown.
+    /// Move keyboard focus to a split session's pane: `pane` is `left`|`right`|`other` (`other` toggles).
     func focusSessionPane(_ target: String?, window: String?, pane: String?) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
             guard let session = store.session(withID: id) else {
@@ -285,10 +273,10 @@ extension ControlServer: ControlActions {
 
     /// Resize a split's divider (control-native — the GUI only drags it). `ratio` is an absolute left-pane
     /// fraction, `delta` a signed nudge (positive grows the left pane) on the current fraction (0.5 when
-    /// never moved); exactly one must be set. `AppStore.applySplitRatio` clamps + persists, then
+    /// never moved); exactly one must be set. `applySplitRatio` clamps + persists, then
     /// `.agtermApplySplitRatio` pokes the session's `SplitProbeView` to move the live divider — a no-op
-    /// while the split is hidden, where the stored value applies on next show. Errors without a split, like
-    /// `session.focus`; echoes the applied (clamped) fraction in `result.ratio`.
+    /// while the split is hidden, where the stored value applies on next show. Errors without a split, and
+    /// echoes the clamped fraction in `result.ratio`.
     func resizeSplit(_ target: String?, window: String?, resize: ControlSplitResize) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
             guard let session = store.session(withID: id) else {
@@ -312,18 +300,16 @@ extension ControlServer: ControlActions {
         }
     }
 
-    /// Set the target's agent-status indicator (control-native, like `notify`/`session.type`/`session.copy`).
-    /// `status` is `idle|active|completed|blocked`, else a structured `invalid status` error; `blink`
-    /// (default false) pulses the glyph, `autoReset` (default false) clears to idle once the session is
-    /// visited. A non-empty `sound` plays once on apply (`default`/`beep` = system alert, else a named
-    /// system sound) and is validated up-front, so an unknown name errors `unknown sound` leaving the
-    /// status unchanged; empty counts as none, and with none given a TRANSITION into `blocked` plays the
-    /// Settings "Blocked sound" (`blockedStatusSoundName`). `update.color` (`#rrggbb` glyph tint,
-    /// hex-validated in the dispatcher) and `update.shape` (silhouette, parsed there) ride the EPHEMERAL
-    /// indicator, so each lasts only until the next `session.status` without it. `update.pane`
-    /// (`StatusPane`, dispatcher-validated, nil = `left`/main) records the pane that set the status,
-    /// driving the pane-scoped keystroke-clear and the pane-aware attention reveal. The indicator renders
-    /// on every non-idle session.
+    /// Set the target's agent-status indicator (control-native). `status` is `idle|active|completed|blocked`,
+    /// else a structured `invalid status` error; `blink` (default false) pulses the glyph, `autoReset`
+    /// (default false) clears to idle once the session is visited. A non-empty `sound` plays once on apply
+    /// (`default`/`beep` = system alert, else a named system sound), validated up-front so an unknown name
+    /// errors `unknown sound` leaving the status unchanged; empty counts as none, and with none given a
+    /// TRANSITION into `blocked` plays the Settings "Blocked sound" (`blockedStatusSoundName`).
+    /// `update.color` (`#rrggbb` glyph tint) and `update.shape` (silhouette) are dispatcher-validated and
+    /// ride the EPHEMERAL indicator, lasting only until the next `session.status` without them.
+    /// `update.pane` (`StatusPane`, dispatcher-validated, nil = `left`/main) records the pane that set the
+    /// status, driving the pane-scoped keystroke-clear and pane-aware reveal. Renders on every non-idle one.
     func setSessionStatus(_ target: String?, window: String?, update: ControlSessionStatusUpdate) -> ControlResponse {
         // validated before any mutation; an empty value counts as none, matching `AgentStatus.effectiveSound`.
         if let sound = update.sound, !sound.isEmpty, StatusSoundPlayer.shared.action(for: sound) == nil {
@@ -334,16 +320,14 @@ extension ControlServer: ControlActions {
             let session = store.session(withID: id)
             // capture the status BEFORE mutating so the Settings default plays only on a real transition.
             let wasBlocked = session?.agentIndicator.status == .blocked
-            // `--pane-id` resolves against the session's LIVE surfaces and overrides the stale role `--pane`,
-            // so a promoted-then-re-split pane lands on its CURRENT slot (#199); an absent/unknown token
-            // falls back to the baked `--pane`, the pre-token behavior.
+            // `--pane-id` resolves against the LIVE surfaces and overrides the stale role `--pane`, so a
+            // promoted-then-re-split pane lands on its CURRENT slot (#199); absent/unknown falls back to it.
             let resolvedPane = update.paneID.flatMap { session?.paneRole(forToken: $0) } ?? update.pane
             store.setAgentIndicator(AgentIndicator(status: update.status, blink: update.blink ?? false,
                                                    autoReset: update.autoReset ?? false,
                                                    color: update.color, shape: update.shape,
                                                    statusPane: resolvedPane), forSession: id)
-            // per-call sound wins on any status; the Settings default plays only on a NEW entry into
-            // `blocked`, not on a repeated `blocked` set.
+            // per-call sound wins on any status; the Settings default plays only on a NEW entry into `blocked`.
             let blockedDefault = wasBlocked ? nil : self.settingsModel.settings.blockedStatusSoundName
             if let name = update.status.effectiveSound(perCall: update.sound, blockedDefault: blockedDefault) {
                 StatusSoundPlayer.shared.play(name)
@@ -353,22 +337,19 @@ extension ControlServer: ControlActions {
     }
 
     /// Pin (or unpin) the target pane's restore-command override — the per-pane shell line that wins over
-    /// the captured foreground on the NEXT launch. Write-now, consume-next-launch: only the PERSISTED field
-    /// is touched, so nothing runs in the current session. `update.pin` maps to the tri-state stored value
-    /// (`pin(cmd)` → the line, `pinNone` → `""` = a plain shell, `unpin` → nil = back to auto-capture) and
-    /// `AppStore.setRestoreCommand` saves immediately, so a hook's write survives a force-quit. That save is
-    /// the ONE store write whose failure is reported rather than swallowed — acking a `clear` that never
-    /// reached disk would leave the old command firing on every launch — so the arm answers `ok: false`
-    /// with the rolled-back value still in effect, for the caller to retry the same request.
+    /// the captured foreground on the NEXT launch. Only the PERSISTED field is touched, so nothing runs in
+    /// the current session. `update.pin` is tri-state (`pin(cmd)` → the line, `pinNone` → `""` = a plain
+    /// shell, `unpin` → nil = back to auto-capture), saved immediately so a hook's write survives a
+    /// force-quit. That save is the ONE store write whose failure is reported rather than swallowed —
+    /// acking a `clear` that never reached disk would leave the old command firing on every launch — so the
+    /// arm answers `ok: false`, the rolled-back value still in effect.
     ///
     /// The pane resolves like `setSessionStatus` (`update.paneID` against the LIVE surfaces first, then the
-    /// baked role `update.pane`, defaulting to main) with ONE deliberate divergence: an unresolvable
-    /// `--pane-id` supplied WITHOUT an explicit `--pane` is an ERROR here, since a bad fallback would
-    /// overwrite the MAIN pane's persisted command when a hook meant the split (for a status it only puts a
-    /// glyph on the wrong row). `.scratch` and a `.right` without a split are rejected too. A `set` while
-    /// the restore-running-command setting is off still succeeds, with a note in `result.text` so a hook
-    /// author sees why nothing will fire; `none`/`clear` get no note — their outcome (a plain shell / back
-    /// to auto-capture) lands regardless of the setting.
+    /// baked role `update.pane`, defaulting to main) with ONE divergence: an unresolvable `--pane-id`
+    /// WITHOUT an explicit `--pane` is an ERROR here, since a bad fallback would overwrite the MAIN pane's
+    /// persisted command when a hook meant the split (a status only puts a glyph on the wrong row).
+    /// `.scratch` and a `.right` without a split are rejected too. A `set` while restore-running-command is
+    /// off still succeeds with a note in `result.text`; `none`/`clear` get none — their outcome lands anyway.
     func setSessionRestore(_ target: String?, window: String?,
                            update: ControlSessionRestoreUpdate) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
@@ -376,8 +357,8 @@ extension ControlServer: ControlActions {
                 return ControlResponse(ok: false, error: "no such session: \(target ?? "active")")
             }
             let pane: StatusPane
-            // an EMPTY token (an older shell exporting no `AGTERM_PANE_ID`) counts as absent, taking the
-            // plain `--pane`/main-pane path rather than erroring.
+            // an EMPTY token (an older shell exporting no `AGTERM_PANE_ID`) counts as absent: the plain
+            // `--pane`/main-pane path, not an error.
             if let token = update.paneID, !token.isEmpty {
                 guard let resolved = session.paneRole(forToken: token) ?? update.pane else {
                     return ControlResponse(ok: false, error: "unknown pane id: \(token)")
@@ -410,10 +391,9 @@ extension ControlServer: ControlActions {
         }
     }
 
-    /// Flag/unflag the target for the flagged working-set view (the durable `Session.flagged` membership
-    /// the flat sidebar mode projects). `mode` `on|off|toggle|clear` is computed against `flagged`, so
-    /// `on`/`off` are idempotent; `clear` ignores the target, unflags every session in the resolved store
-    /// (frontmost or `--window`) via `AppStore.clearFlags()`, and reports ok with no id. Unknown mode errors.
+    /// Flag/unflag the target for the flagged working-set view (the durable `Session.flagged` the flat
+    /// sidebar mode projects). `on|off|toggle` is computed against `flagged`, so both are idempotent;
+    /// `clear` ignores the target, unflags every session in the resolved store, and reports ok with no id.
     func setSessionFlag(_ target: String?, window: String?, mode: String?) -> ControlResponse {
         let mode = mode ?? "toggle"
         if mode == "clear" {
@@ -439,8 +419,8 @@ extension ControlServer: ControlActions {
     }
 
     /// Clear a session's unseen-notification badge without touching selection, focus, or agent status — the
-    /// focus-free counterpart to `notify`, whose badge nothing else could lower without visiting the session.
-    /// Idempotent: `clearUnseen` just assigns 0, and the count is ephemeral so it triggers no save.
+    /// counterpart to `notify`, whose badge nothing else lowers without visiting. Idempotent, and the count
+    /// is ephemeral so it triggers no save.
     func markSessionSeen(_ target: String?, window: String?) -> ControlResponse {
         resolver.resolveSession(target, window: window) { store, id in
             store.clearUnseen(id)
@@ -450,8 +430,7 @@ extension ControlServer: ControlActions {
 
     /// Mode-bearing `session.move`: `to` (`up`|`down`|`top`|`bottom`) reorders within the session's own
     /// workspace, `workspace` relocates to another one (appending), `place` relocates + positions against an
-    /// anchor session (which carries its own workspace). Exactly one form is required (enforced in the
-    /// dispatcher); an invalid `to` direction errors.
+    /// anchor session (which carries its own workspace). Exactly one form, enforced in the dispatcher.
     func moveSession(_ target: String?, window: String?, move: ControlSessionMove) -> ControlResponse {
         switch move {
         case .reorder(let dir):
@@ -460,8 +439,7 @@ extension ControlServer: ControlActions {
                 return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
             }
         case .workspace(let workspace):
-            // both must live in the same store: resolve the session first (fixing the store), then the
-            // workspace within it.
+            // both must live in the same store: resolve the session first (fixing it), then the workspace.
             return resolver.resolveSession(target, window: window) { store, sessionID in
                 resolver.resolve(workspace, candidates: store.workspaces.map(\.id),
                         active: store.currentWorkspaceID, noun: "workspace") { workspaceID in
@@ -492,8 +470,7 @@ extension ControlServer: ControlActions {
     }
 
     /// Resolve the moved session and its anchor in one store, then relocate + position via the host-free
-    /// `SidebarDrop.resolveRelative` drop math. The anchor resolves across all workspaces, so it names the
-    /// destination itself; a nil resolution (anchor==self, or an already-in-place move) is a successful no-op.
+    /// `SidebarDrop.resolveRelative` math. A nil resolution (anchor==self, already in place) is a no-op.
     private func placeSession(_ target: String?, window: String?, anchor: String, after: Bool) -> ControlResponse {
         resolver.resolveSession(target, window: window) { store, sessionID in
             guard let source = store.sessionLocation(ofSession: sessionID) else {
@@ -511,9 +488,8 @@ extension ControlServer: ControlActions {
         }
     }
 
-    /// Batch variant of `placeSession`: resolve every moved session in one store, compute the
-    /// post-removal insertion slot with the same host-free drop math as sidebar drag, then move the block
-    /// with a single `AppStore.moveSessions` call.
+    /// Batch variant of `placeSession`: compute the post-removal insertion slot with the same host-free
+    /// drop math as sidebar drag, then move the block with one `AppStore.moveSessions` call.
     private func placeSessions(_ targets: [String], window: String?, anchor: String, after: Bool) -> ControlResponse {
         resolveBatchSessions(targets, window: window) { store, ids in
             let sources = ids.compactMap { id -> SidebarDrop.SessionSource? in
@@ -570,14 +546,12 @@ extension ControlServer: ControlActions {
         }
     }
 
-    /// Post a desktop notification attributed to a session (default: the frontmost window's active one, via
-    /// `resolveSession`). `title` defaults to the session name, `body` is required; errors when no open
-    /// window owns the resolved session.
+    /// Post a desktop notification attributed to a session (default: the frontmost window's active one).
+    /// `title` defaults to the session name, `body` is required; errors when no open window owns it.
     ///
-    /// With banners off the post still returns `ok`, plus a note in `result.text` — the badge tracks but no
-    /// banner appears, and a bare `ok` for a call that posts nothing to the OS is indistinguishable from a
-    /// broken notification path (issue #286). Same note `session.restore` returns with
-    /// `restoreRunningCommand` off.
+    /// With banners off the post still returns `ok` plus a note in `result.text`: the badge still tracks,
+    /// but a bare `ok` for a call that posts nothing to the OS is indistinguishable from a broken
+    /// notification path (issue #286).
     func sendNotification(_ target: String?, window: String?, title: String?, body: String) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
             guard let session = store.session(withID: id) else {
@@ -594,9 +568,8 @@ extension ControlServer: ControlActions {
         }
     }
 
-    /// Show / hide / toggle zoom for an addressable terminal surface. The default target is the active
-    /// surface in the frontmost (or `--window`) window; explicit targets are `surface:<session-id>:<kind>`
-    /// ids copied from `tree`.
+    /// Show / hide / toggle zoom for an addressable terminal surface — `surface:<session-id>:<kind>` ids
+    /// from `tree`, or the default: the active surface in the frontmost (or `--window`) window.
     func setSurfaceZoom(_ target: String?, window: String?, mode: ControlToggleMode) -> ControlResponse {
         let rawTarget = trimmed(target) ?? "active"
         if rawTarget == "active" {
@@ -614,9 +587,9 @@ extension ControlServer: ControlActions {
                PickRegistry.shared.controller(for: resolved.windowID)?.pending != nil {
                 return ControlResponse(ok: false, error: "pick pending")
             }
-            // `hide` is idempotent like the active-target arm: skip the availability check for `.off`, since
-            // the surface may have vanished (an exited overlay auto-clears the zoom) while the desired end
-            // state already holds — `set(.off, …)` on a non-matching target is a no-op.
+            // `hide` is idempotent: skip the availability check for `.off`, since the surface may have
+            // vanished (an exited overlay auto-clears the zoom) while the end state holds; `set(.off, …)`
+            // on a non-matching target is a no-op.
             if mode != .off {
                 guard TerminalZoomController.isTargetValid(resolved.target, in: resolved.store,
                                                            quickTerminalVisible: quickVisible(in: resolved.windowID)) else {
@@ -640,10 +613,9 @@ extension ControlServer: ControlActions {
                PickRegistry.shared.controller(for: windowID)?.pending != nil {
                 return ControlResponse(ok: false, error: "pick pending")
             }
-            // this arm only picks the effective target — the current zoom when one is up, so on/off/toggle
-            // act on it, else the resolved active surface — and shapes the response; mode-vs-state semantics
-            // live in the one host-free `TerminalZoomController.set`, shared with the GUI toggle and the
-            // explicit-target path.
+            // this arm only picks the effective target (the current zoom when one is up, so on/off/toggle
+            // act on it, else the resolved active surface) and shapes the response; mode-vs-state semantics
+            // live in host-free `TerminalZoomController.set`, shared with the GUI and explicit-target paths.
             let effectiveTarget: TerminalZoomTarget
             if let current = controller.target {
                 effectiveTarget = current

--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -1,16 +1,14 @@
 import Foundation
 import agtermCore
 
-/// `ControlServer` session/workspace/surface action adapter arms — the target-bearing ones. Dispatcher-routed
-/// commands parse in agtermCore when that preserves the old response order; target-dependent parsing stays
-/// here with `resolver`. App-owned commands still call nearby helpers. Split out of `ControlServer.swift` to
-/// keep that file under the swiftlint size limit; the app-global arms (tree, sidebar, keymap/config reload,
-/// theme, quick terminal) live in `ControlServer+AppCommands.swift`.
+/// `ControlServer`'s target-bearing action arms. Target-dependent parsing stays here with `resolver` and
+/// app-owned commands call nearby helpers; dispatcher-routed ones parse in agtermCore where that preserves
+/// the old response order. Split from `ControlServer.swift` for the swiftlint size limit — the app-global
+/// arms (tree, sidebar, keymap/config reload, theme, quick terminal) are in `ControlServer+AppCommands.swift`.
 extension ControlServer: ControlActions {
     func typeSession(_ target: String?, window: String?, options: ControlSessionTypeOptions) async -> ControlResponse {
-        // Resolve first (cross-window when no `args.window`), then realize-and-inject; the realize
-        // path is async (bounded poll), so this can't go through the synchronous `resolveSession`
-        // helper. The not-found / ambiguous error strings must stay in sync with `resolve(...)`.
+        // resolve first (cross-window without `args.window`), then realize-and-inject: the async
+        // bounded-poll realize rules out the synchronous `resolveSession`. Error strings must match `resolve(...)`.
         switch resolver.resolveSessionTarget(target, window: window) {
         case .failure(let response):
             return response
@@ -32,10 +30,9 @@ extension ControlServer: ControlActions {
                                     backgroundColor: options.backgroundColor) else {
                 return ControlResponse(ok: false, error: "overlay already open")
             }
-            // Both overlay kinds mount and run in the per-session eager deck regardless of which session
-            // is active (the floating panel is a constant-shape sibling in `sessionDetail`), so opening
-            // never needs an implicit select. The select is now the user-facing `--follow`: the caller
-            // asked to jump to the target, so switch to it (a no-op when it's already active).
+            // both overlay kinds run in the per-session eager deck whatever is active (the floating panel
+            // is a constant-shape sibling in `sessionDetail`), so opening never needs an implicit select —
+            // this one is the user-facing `--follow`, a no-op when the target is already active.
             if options.follow {
                 store.selectSession(id)
             }
@@ -76,15 +73,13 @@ extension ControlServer: ControlActions {
         }
     }
 
-    /// The destination workspace is addressed one of two mutually-exclusive ways: `workspace`
-    /// (id / unique prefix / `active`, the default) or `workspaceName` (the sidebar label),
-    /// the latter optionally with `createWorkspace` to add it when absent. create needs a name —
-    /// there is nothing to create by id. cwd/command/name are applied in makeSessionResponse.
+    /// Destination workspace addressing is mutually exclusive: `workspace` (id / unique prefix / `active`,
+    /// the default) or `workspaceName` (the sidebar label) plus optional `createWorkspace` — create needs a
+    /// name, there is nothing to create by id. cwd/command/name are applied in `makeSessionResponse`.
     func createSession(_ options: ControlSessionCreateOptions) -> ControlResponse {
         resolver.resolvePlacementStore(options.window) { store in
-            // anchor-relative placement (`--after`/`--before`): the anchor sid names its own workspace,
-            // so this bypasses the `--workspace`/`--workspace-name` addressing entirely. `before` inserts
-            // at the anchor's slot, `after` just past it (clamped in `AppStore.addSession`).
+            // anchor-relative placement: the anchor names its own workspace, bypassing `--workspace`/
+            // `--workspace-name`. `before` takes the anchor's slot, `after` the next (clamped in `addSession`).
             if let anchor = options.after ?? options.before {
                 let placeBefore = options.before != nil
                 return resolveAnchorLocation(anchor, in: store) { location in
@@ -94,13 +89,13 @@ extension ControlServer: ControlActions {
             }
             // name addressing: reuse-or-create with `createWorkspace`, else require an existing match.
             if let name = options.workspaceName {
-                // a blank name can neither be found NOR created — report that directly rather than
-                // suggesting --create-workspace (which would also reject a blank name).
+                // a blank name can neither be found nor created, so don't suggest --create-workspace,
+                // which rejects it too.
                 guard !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                     return ControlResponse(ok: false, error: "workspace name must not be blank")
                 }
-                // a --no-select create must not widen the workspace-focus set (addWorkspace's auto-reveal),
-                // so the background create leaves the current view untouched like the rest of --no-select.
+                // a --no-select create must not widen the focus set via addWorkspace's auto-reveal; like the
+                // rest of --no-select it leaves the current view untouched.
                 let workspace = options.createWorkspace == true
                     ? store.ensureWorkspace(named: name, revealNewWorkspace: !options.noSelect)
                     : store.workspace(named: name)
@@ -118,10 +113,9 @@ extension ControlServer: ControlActions {
         }
     }
 
-    /// Resolve an anchor session address (`--after`/`--before`) across the store's whole session set (all
-    /// workspaces, so the anchor names its own destination workspace) and hand its `(workspace, index,
-    /// count)` location to `body`. An unresolved or ambiguous anchor yields the shared resolver error; the
-    /// location guard is defense-in-depth (the id came from the store's own list, so it always resolves).
+    /// Resolve an `--after`/`--before` anchor across the whole store (all workspaces, so it names its own
+    /// destination workspace) and hand its `(workspace, index, count)` to `body`. Unresolved/ambiguous yields
+    /// the shared resolver error; the location guard is defense-in-depth — the id came from the store's list.
     private func resolveAnchorLocation(_ anchor: String, in store: AppStore,
                                        _ body: ((workspace: UUID, index: Int, count: Int)) -> ControlResponse) -> ControlResponse {
         resolver.resolve(anchor, candidates: store.workspaces.flatMap { $0.sessions.map(\.id) },
@@ -134,11 +128,10 @@ extension ControlServer: ControlActions {
     }
 
     /// The control half of the sidebar row's "Duplicate": a fresh shell in the target's directory, inserted
-    /// right after it in its own workspace. Takes no options — the target names both the workspace and the
-    /// cwd — and, like `session.new`, focuses the duplicate when it lands in the frontmost window and returns
-    /// its id. The read-back is `tree`: the new session appears after its source, carrying the source's
-    /// focused-pane cwd — equal to the source node's `tree.cwd` unless the source is a split focused off its
-    /// primary pane (then `tree.cwd` reports the primary and the two differ).
+    /// right after it in its own workspace. No options — the target names both — and like `session.new` it
+    /// focuses the duplicate when it lands in the frontmost window and returns its id. Read-back is `tree`,
+    /// where the new node appears after its source; its cwd is the source's FOCUSED pane, so it differs from
+    /// the source node's (primary) `tree.cwd` when the source is a split focused off its primary.
     func duplicateSession(_ target: String?, window: String?) -> ControlResponse {
         resolver.resolveSession(target, window: window) { store, id in
             guard let session = store.duplicateSession(id) else {
@@ -157,8 +150,7 @@ extension ControlServer: ControlActions {
     }
 
     func goSession(window: String?, direction: SessionNavigation) -> ControlResponse {
-        // relative navigation acts on the store's current selection, so no session target -- just
-        // the frontmost-or-`--window` store.
+        // relative nav acts on the store's current selection: no session target, just the frontmost/`--window` store.
         resolver.resolvePlacementStore(window) { store in
             store.navigateSession(direction)
             guard let id = store.selectedSessionID else {
@@ -194,8 +186,8 @@ extension ControlServer: ControlActions {
                     count += 1
                 }
             }
-            // `ok` with the count (0 included) mirrors `placeSessions` — every id already resolved, so
-            // an error arm here would be dead code.
+            // `ok` with the count (0 included) mirrors `placeSessions`: every id already resolved, so an
+            // error arm here would be dead code.
             return ControlResponse(ok: true, result: ControlResult(affected: affected))
         }
     }
@@ -216,12 +208,10 @@ extension ControlServer: ControlActions {
         }
     }
 
-    /// Resolve the target session and drive the split directly on its owning store (NOT the
-    /// argument-less `AppActions.toggleSplit()`, which only acts on the active session). `mode` is
-    /// `on|off|toggle`, computed against the session's current `isSplit` so `on`/`off` are
-    /// idempotent. Always via `AppStore.toggleSplit` — a keep-alive hide/show that mirrors ⌘D and
-    /// never tears the hidden pane's surface down (`closeSplit` stays the shell-exit-only path).
-    /// Focus follows via `AppActions.focusSplitPane`.
+    /// Drive the split on the target's OWN store, not the argument-less `AppActions.toggleSplit()` (which
+    /// acts only on the active session). `mode` `on|off|toggle` is computed against `isSplit`, so `on`/`off`
+    /// are idempotent. Always `AppStore.toggleSplit` — a ⌘D-style keep-alive hide/show that never tears the
+    /// hidden pane's surface down (`closeSplit` stays shell-exit-only). Focus follows via `focusSplitPane`.
     func splitSession(_ target: String?, window: String?, mode: String?) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
             guard let session = store.session(withID: id) else {
@@ -232,20 +222,19 @@ extension ControlServer: ControlActions {
             }
             let want = parsedMode.desiredValue(current: session.isSplit)
             if want != session.isSplit {
-                store.toggleSplit(id) // mirror ⌘D: keep-alive hide/show, never destroys the hidden pane
+                store.toggleSplit(id)
             }
             actions.focusSplitPane(session, wantSplit: session.splitFocused)
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
         }
     }
 
-    /// Resolve the target session and show/hide its scratch terminal — a third, full-overlay shell.
-    /// `mode` is `on|off|toggle`, computed against the session's current `scratchActive` so `on`/`off`
-    /// are idempotent. Like the split, hiding keeps the shell alive (`toggleScratch`); `closeScratch`
-    /// (tear down) is reserved for the shell's own `exit`. `command` (only meaningful when showing) runs
-    /// that program as the scratch's process instead of a login shell, run-once like `session.new
-    /// --command`: a scratch is expendable, so if one is already alive it is torn down and respawned
-    /// with the command (otherwise the flag would be silently inert).
+    /// Show/hide the target's scratch terminal — a third, full-overlay shell. `mode` `on|off|toggle` is
+    /// computed against `scratchActive`, so `on`/`off` are idempotent. Like the split, hiding keeps the
+    /// shell alive (`toggleScratch`); the `closeScratch` teardown is reserved for the shell's own `exit`.
+    /// `command` (meaningful only when showing) runs that program as the scratch's process instead of a
+    /// login shell, run-once like `session.new --command`: a scratch is expendable, so a live one is torn
+    /// down and respawned with it — otherwise the flag would be silently inert.
     func scratchSession(_ target: String?, window: String?, mode: String?,
                         command: String?) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
@@ -257,21 +246,19 @@ extension ControlServer: ControlActions {
             }
             let want = parsedMode.desiredValue(current: session.scratchActive)
             if want, let command, !command.isEmpty {
-                // run the command as the scratch process: respawn if one is already alive (a scratch is
-                // expendable), so the command is never silently ignored. closeScratch clears scratchActive,
-                // so the toggle below re-shows it and the factory consumes scratchCommand.
+                // closeScratch clears scratchActive, so the toggle below re-shows it and the factory
+                // consumes scratchCommand.
                 if session.scratchSurface != nil { store.closeScratch(id) }
                 session.scratchCommand = command
             }
             if want, store.selectedSessionID != id {
-                // the scratch is a full-coverage surface that grabs focus on show; it only makes sense on
-                // the visible session, so select the target first. Unlike the overlay (which runs in the
-                // eager deck without selecting), the scratch must be on the active session -- otherwise a
-                // non-active target's scratch surface would steal first responder while hidden.
+                // the scratch is full-coverage and grabs focus on show, so it must be on the active session
+                // — select the target first. Unlike the overlay (which runs in the eager deck without
+                // selecting), a non-active target's scratch would steal first responder while hidden.
                 store.selectSession(id)
             }
             if want != session.scratchActive {
-                store.toggleScratch(id) // keep-alive hide/show, mirrors ⌘J; never tears the shell down
+                store.toggleScratch(id)
             }
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
         }
@@ -296,13 +283,12 @@ extension ControlServer: ControlActions {
         }
     }
 
-    /// Resize a split session's divider (control-native: no GUI/menu equivalent — the GUI resizes by
-    /// dragging the divider). `ratio` is an absolute left-pane fraction; `delta` is a signed relative nudge
-    /// (positive grows the left pane) applied to the session's current fraction (0.5 when never moved).
-    /// Exactly one must be set. The clamped fraction is stored + persisted via `AppStore.applySplitRatio`,
-    /// then `.agtermApplySplitRatio` pokes the session's `SplitProbeView` to move the live divider (a no-op
-    /// when the split is hidden — the stored value applies on next show). Errors when the session has no
-    /// split, mirroring `session.focus`. Echoes the applied (clamped) fraction in `result.ratio`.
+    /// Resize a split's divider (control-native — the GUI only drags it). `ratio` is an absolute left-pane
+    /// fraction, `delta` a signed nudge (positive grows the left pane) on the current fraction (0.5 when
+    /// never moved); exactly one must be set. `AppStore.applySplitRatio` clamps + persists, then
+    /// `.agtermApplySplitRatio` pokes the session's `SplitProbeView` to move the live divider — a no-op
+    /// while the split is hidden, where the stored value applies on next show. Errors without a split, like
+    /// `session.focus`; echoes the applied (clamped) fraction in `result.ratio`.
     func resizeSplit(_ target: String?, window: String?, resize: ControlSplitResize) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
             guard let session = store.session(withID: id) else {
@@ -326,24 +312,20 @@ extension ControlServer: ControlActions {
         }
     }
 
-    /// Set the target session's agent-status indicator (control-native: no GUI/menu equivalent, like
-    /// `notify`/`session.type`/`session.copy`). `status` is `idle|active|completed|blocked`; an unknown
-    /// value is the structured `invalid status` error. `blink` (default false) pulses the glyph;
-    /// `autoReset` (default false) clears the indicator to idle once the session is visited. `sound`, when
-    /// non-empty, plays a one-shot sound once the status is applied (`default`/`beep` = system alert, any
-    /// other value = named system sound); it is validated up-front so an unknown name is an `unknown sound`
-    /// error that leaves the status unchanged (an empty value is treated as no per-call sound). When no
-    /// per-call `sound` is given and the session TRANSITIONS into `blocked`, the user's configured Settings
-    /// "Blocked sound" (`blockedStatusSoundName`) plays as a best-effort default. `update.color`, when set,
-    /// is a `#rrggbb` glyph-tint override (hex-validated in the dispatcher) that rides the ephemeral
-    /// indicator, so it lasts only until the next `session.status` without a color; `update.shape` is the
-    /// matching silhouette override (parsed in the dispatcher), ephemeral the same way. `update.pane`
-    /// (`StatusPane`, validated in the dispatcher) is threaded onto the indicator's `statusPane` — the pane
-    /// that set the status — driving the pane-scoped keystroke-clear and the pane-aware attention reveal;
-    /// nil is treated as `left`/main. The indicator is ephemeral and rendered on every non-idle session.
+    /// Set the target's agent-status indicator (control-native, like `notify`/`session.type`/`session.copy`).
+    /// `status` is `idle|active|completed|blocked`, else a structured `invalid status` error; `blink`
+    /// (default false) pulses the glyph, `autoReset` (default false) clears to idle once the session is
+    /// visited. A non-empty `sound` plays once on apply (`default`/`beep` = system alert, else a named
+    /// system sound) and is validated up-front, so an unknown name errors `unknown sound` leaving the
+    /// status unchanged; empty counts as none, and with none given a TRANSITION into `blocked` plays the
+    /// Settings "Blocked sound" (`blockedStatusSoundName`). `update.color` (`#rrggbb` glyph tint,
+    /// hex-validated in the dispatcher) and `update.shape` (silhouette, parsed there) ride the EPHEMERAL
+    /// indicator, so each lasts only until the next `session.status` without it. `update.pane`
+    /// (`StatusPane`, dispatcher-validated, nil = `left`/main) records the pane that set the status,
+    /// driving the pane-scoped keystroke-clear and the pane-aware attention reveal. The indicator renders
+    /// on every non-idle session.
     func setSessionStatus(_ target: String?, window: String?, update: ControlSessionStatusUpdate) -> ControlResponse {
-        // an explicit per-call sound is validated up-front: an unknown name errors without changing status.
-        // an empty value is treated as no per-call sound, matching `AgentStatus.effectiveSound`.
+        // validated before any mutation; an empty value counts as none, matching `AgentStatus.effectiveSound`.
         if let sound = update.sound, !sound.isEmpty, StatusSoundPlayer.shared.action(for: sound) == nil {
             let hint = StatusSoundPlayer.standardNames.joined(separator: ", ")
             return ControlResponse(ok: false, error: "unknown sound: \(sound) (use 'default', 'beep', or one of: \(hint))")
@@ -352,16 +334,16 @@ extension ControlServer: ControlActions {
             let session = store.session(withID: id)
             // capture the status BEFORE mutating so the Settings default plays only on a real transition.
             let wasBlocked = session?.agentIndicator.status == .blocked
-            // a `--pane-id` that resolves against the session's LIVE surfaces overrides the stale role
-            // `--pane`, so a status set from a promoted-then-re-split pane lands on the pane's CURRENT slot
-            // (#199); an absent/unknown token falls back to the baked `--pane` (the pre-token behavior).
+            // `--pane-id` resolves against the session's LIVE surfaces and overrides the stale role `--pane`,
+            // so a promoted-then-re-split pane lands on its CURRENT slot (#199); an absent/unknown token
+            // falls back to the baked `--pane`, the pre-token behavior.
             let resolvedPane = update.paneID.flatMap { session?.paneRole(forToken: $0) } ?? update.pane
             store.setAgentIndicator(AgentIndicator(status: update.status, blink: update.blink ?? false,
                                                    autoReset: update.autoReset ?? false,
                                                    color: update.color, shape: update.shape,
                                                    statusPane: resolvedPane), forSession: id)
-            // explicit per-call sound wins on any status; the Settings default plays only when a session
-            // newly enters `blocked`, not on a repeated `blocked` set.
+            // per-call sound wins on any status; the Settings default plays only on a NEW entry into
+            // `blocked`, not on a repeated `blocked` set.
             let blockedDefault = wasBlocked ? nil : self.settingsModel.settings.blockedStatusSoundName
             if let name = update.status.effectiveSound(perCall: update.sound, blockedDefault: blockedDefault) {
                 StatusSoundPlayer.shared.play(name)
@@ -371,23 +353,22 @@ extension ControlServer: ControlActions {
     }
 
     /// Pin (or unpin) the target pane's restore-command override — the per-pane shell line that wins over
-    /// the captured foreground on the NEXT launch. Write-now, consume-next-launch: it touches only the
-    /// PERSISTED field, so nothing runs in the current session. `update.pin` maps to the tri-state stored
-    /// value (`pin(cmd)` → the line, `pinNone` → `""` = a plain shell, `unpin` → nil = back to
-    /// auto-capture) and `AppStore.setRestoreCommand` saves immediately, so a hook's write survives a
-    /// force-quit. That save is the ONE store write whose failure is reported rather than swallowed: the
-    /// arm answers `ok: false` when it did not land, since acking a `clear` that never reached disk would
-    /// leave the old command firing on every launch. The rolled-back value is still in effect, so the
-    /// caller retries the same request.
+    /// the captured foreground on the NEXT launch. Write-now, consume-next-launch: only the PERSISTED field
+    /// is touched, so nothing runs in the current session. `update.pin` maps to the tri-state stored value
+    /// (`pin(cmd)` → the line, `pinNone` → `""` = a plain shell, `unpin` → nil = back to auto-capture) and
+    /// `AppStore.setRestoreCommand` saves immediately, so a hook's write survives a force-quit. That save is
+    /// the ONE store write whose failure is reported rather than swallowed — acking a `clear` that never
+    /// reached disk would leave the old command firing on every launch — so the arm answers `ok: false`
+    /// with the rolled-back value still in effect, for the caller to retry the same request.
     ///
-    /// The pane resolves like `setSessionStatus` — `update.paneID` against the session's LIVE surfaces
-    /// first, then the baked role `update.pane`, defaulting to the main pane — with ONE deliberate
-    /// divergence: an unresolvable `--pane-id` supplied WITHOUT an explicit `--pane` is an ERROR here. For
-    /// a status a bad fallback costs a glyph on the wrong row; here it would overwrite the MAIN pane's
-    /// persisted restore command when a hook meant the split. `.scratch` and a `.right` without a split are
-    /// rejected too. A `set` while the restore-running-command setting is off still succeeds, with a note
-    /// in `result.text` so a hook author can see why nothing will fire; `none` and `clear` get no note —
-    /// their outcome (a plain shell / back to auto-capture) is delivered regardless of the setting.
+    /// The pane resolves like `setSessionStatus` (`update.paneID` against the LIVE surfaces first, then the
+    /// baked role `update.pane`, defaulting to main) with ONE deliberate divergence: an unresolvable
+    /// `--pane-id` supplied WITHOUT an explicit `--pane` is an ERROR here, since a bad fallback would
+    /// overwrite the MAIN pane's persisted command when a hook meant the split (for a status it only puts a
+    /// glyph on the wrong row). `.scratch` and a `.right` without a split are rejected too. A `set` while
+    /// the restore-running-command setting is off still succeeds, with a note in `result.text` so a hook
+    /// author sees why nothing will fire; `none`/`clear` get no note — their outcome (a plain shell / back
+    /// to auto-capture) lands regardless of the setting.
     func setSessionRestore(_ target: String?, window: String?,
                            update: ControlSessionRestoreUpdate) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
@@ -395,8 +376,8 @@ extension ControlServer: ControlActions {
                 return ControlResponse(ok: false, error: "no such session: \(target ?? "active")")
             }
             let pane: StatusPane
-            // an EMPTY token counts as absent (an older shell exporting no `AGTERM_PANE_ID`), so it takes
-            // the plain `--pane`/main-pane path rather than erroring.
+            // an EMPTY token (an older shell exporting no `AGTERM_PANE_ID`) counts as absent, taking the
+            // plain `--pane`/main-pane path rather than erroring.
             if let token = update.paneID, !token.isEmpty {
                 guard let resolved = session.paneRole(forToken: token) ?? update.pane else {
                     return ControlResponse(ok: false, error: "unknown pane id: \(token)")
@@ -429,11 +410,10 @@ extension ControlServer: ControlActions {
         }
     }
 
-    /// Flag/unflag the target session for the flagged working-set view (the durable `Session.flagged`
-    /// membership the flat sidebar mode projects). `mode` is `on|off|toggle|clear`, computed against the
-    /// session's current `flagged` so `on`/`off` are idempotent. `clear` ignores the target and unflags
-    /// every session in the resolved store (frontmost or `--window`), via `AppStore.clearFlags()` — it
-    /// reports ok with no id. An unknown mode is an error.
+    /// Flag/unflag the target for the flagged working-set view (the durable `Session.flagged` membership
+    /// the flat sidebar mode projects). `mode` `on|off|toggle|clear` is computed against `flagged`, so
+    /// `on`/`off` are idempotent; `clear` ignores the target, unflags every session in the resolved store
+    /// (frontmost or `--window`) via `AppStore.clearFlags()`, and reports ok with no id. Unknown mode errors.
     func setSessionFlag(_ target: String?, window: String?, mode: String?) -> ControlResponse {
         let mode = mode ?? "toggle"
         if mode == "clear" {
@@ -458,10 +438,9 @@ extension ControlServer: ControlActions {
         }
     }
 
-    /// Clears a session's unseen-notification badge without changing the selection, focus, or agent
-    /// status — the focus-free counterpart to `notify`, which raises the badge over the socket but
-    /// which nothing could lower without visiting the session. Idempotent (a no-op when already zero,
-    /// since `clearUnseen` just assigns 0; the count is ephemeral so it triggers no save).
+    /// Clear a session's unseen-notification badge without touching selection, focus, or agent status — the
+    /// focus-free counterpart to `notify`, whose badge nothing else could lower without visiting the session.
+    /// Idempotent: `clearUnseen` just assigns 0, and the count is ephemeral so it triggers no save.
     func markSessionSeen(_ target: String?, window: String?) -> ControlResponse {
         resolver.resolveSession(target, window: window) { store, id in
             store.clearUnseen(id)
@@ -469,10 +448,10 @@ extension ControlServer: ControlActions {
         }
     }
 
-    /// Mode-bearing `session.move`: `to` reorders the session within its own workspace
-    /// (`up`|`down`|`top`|`bottom`), `workspace` relocates it to another workspace (appending), `place`
-    /// relocates + positions relative to an anchor session (the anchor carries its own workspace). Exactly
-    /// one form is required (enforced in the dispatcher). An invalid `to` direction errors.
+    /// Mode-bearing `session.move`: `to` (`up`|`down`|`top`|`bottom`) reorders within the session's own
+    /// workspace, `workspace` relocates to another one (appending), `place` relocates + positions against an
+    /// anchor session (which carries its own workspace). Exactly one form is required (enforced in the
+    /// dispatcher); an invalid `to` direction errors.
     func moveSession(_ target: String?, window: String?, move: ControlSessionMove) -> ControlResponse {
         switch move {
         case .reorder(let dir):
@@ -481,8 +460,8 @@ extension ControlServer: ControlActions {
                 return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
             }
         case .workspace(let workspace):
-            // the session and the destination workspace must live in the same store: resolve the
-            // session first (which fixes the store), then the workspace within that same store.
+            // both must live in the same store: resolve the session first (fixing the store), then the
+            // workspace within it.
             return resolver.resolveSession(target, window: window) { store, sessionID in
                 resolver.resolve(workspace, candidates: store.workspaces.map(\.id),
                         active: store.currentWorkspaceID, noun: "workspace") { workspaceID in
@@ -512,10 +491,9 @@ extension ControlServer: ControlActions {
         }
     }
 
-    /// Resolve the moved session and its anchor within the same store, then relocate + position via the
-    /// host-free `SidebarDrop.resolveRelative` drop math. The anchor is resolved across the whole store
-    /// (all workspaces), so it self-identifies the destination workspace. A nil resolution (anchor==self
-    /// or an already-in-place move) is a successful no-op.
+    /// Resolve the moved session and its anchor in one store, then relocate + position via the host-free
+    /// `SidebarDrop.resolveRelative` drop math. The anchor resolves across all workspaces, so it names the
+    /// destination itself; a nil resolution (anchor==self, or an already-in-place move) is a successful no-op.
     private func placeSession(_ target: String?, window: String?, anchor: String, after: Bool) -> ControlResponse {
         resolver.resolveSession(target, window: window) { store, sessionID in
             guard let source = store.sessionLocation(ofSession: sessionID) else {
@@ -592,14 +570,14 @@ extension ControlServer: ControlActions {
         }
     }
 
-    /// Post a desktop notification attributed to a session (default: the active session of the
-    /// frontmost window, via `resolveSession`). `title` defaults to the session name; `body` is
-    /// required. Errors when no open window owns the resolved session.
+    /// Post a desktop notification attributed to a session (default: the frontmost window's active one, via
+    /// `resolveSession`). `title` defaults to the session name, `body` is required; errors when no open
+    /// window owns the resolved session.
     ///
-    /// A successful post while banners are off returns `ok` with a note in `result.text` — the badge
-    /// still tracks, but no banner appears, and a bare `ok` for a call that posts nothing to the OS
-    /// is indistinguishable from a broken notification path (issue #286). Mirrors the same note
-    /// `session.restore` returns when `restoreRunningCommand` is off.
+    /// With banners off the post still returns `ok`, plus a note in `result.text` — the badge tracks but no
+    /// banner appears, and a bare `ok` for a call that posts nothing to the OS is indistinguishable from a
+    /// broken notification path (issue #286). Same note `session.restore` returns with
+    /// `restoreRunningCommand` off.
     func sendNotification(_ target: String?, window: String?, title: String?, body: String) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
             guard let session = store.session(withID: id) else {
@@ -636,9 +614,9 @@ extension ControlServer: ControlActions {
                PickRegistry.shared.controller(for: resolved.windowID)?.pending != nil {
                 return ControlResponse(ok: false, error: "pick pending")
             }
-            // `hide` is idempotent like the active-target arm: skip the availability check for `.off` —
-            // the surface may have vanished since (an overlay exited, auto-clearing the zoom) and the
-            // desired end state already holds; `set(.off, …)` on a non-matching target is a no-op.
+            // `hide` is idempotent like the active-target arm: skip the availability check for `.off`, since
+            // the surface may have vanished (an exited overlay auto-clears the zoom) while the desired end
+            // state already holds — `set(.off, …)` on a non-matching target is a no-op.
             if mode != .off {
                 guard TerminalZoomController.isTargetValid(resolved.target, in: resolved.store,
                                                            quickTerminalVisible: quickVisible(in: resolved.windowID)) else {
@@ -662,10 +640,10 @@ extension ControlServer: ControlActions {
                PickRegistry.shared.controller(for: windowID)?.pending != nil {
                 return ControlResponse(ok: false, error: "pick pending")
             }
-            // this arm only picks the effective target — the current zoom when one is up (so
-            // on/off/toggle act on it), else the resolved active surface — and shapes the response;
-            // the mode-vs-state semantics live in the one host-free state machine,
-            // `TerminalZoomController.set`, shared with the GUI toggle and the explicit-target path.
+            // this arm only picks the effective target — the current zoom when one is up, so on/off/toggle
+            // act on it, else the resolved active surface — and shapes the response; mode-vs-state semantics
+            // live in the one host-free `TerminalZoomController.set`, shared with the GUI toggle and the
+            // explicit-target path.
             let effectiveTarget: TerminalZoomTarget
             if let current = controller.target {
                 effectiveTarget = current
@@ -697,9 +675,8 @@ extension ControlServer: ControlActions {
 
     private func resolveSurfaceZoom(_ target: String, window: String?)
         -> ControlTargetResolver.Resolution<SurfaceZoomResolution> {
-        // `quick` is the control id this command itself returns for a quick-terminal zoom — accept it
-        // back as an explicit target (the API must accept every address it emits). Validity (the quick
-        // terminal actually visible) is checked by the caller's shared `isTargetValid` gate.
+        // `quick` is the control id this command emits for a quick-terminal zoom, so it must be accepted
+        // back as a target; visibility is checked by the caller's shared `isTargetValid` gate.
         if target == "quick" {
             switch resolveOpenWindow(window) {
             case .failure(let response):

--- a/agterm/Control/ControlServer+SurfaceIO.swift
+++ b/agterm/Control/ControlServer+SurfaceIO.swift
@@ -1,15 +1,13 @@
 import Foundation
 import agtermCore
 
-/// `ControlServer` surface-I/O action arms — font size, selection copy, background watermark, buffer read,
-/// in-terminal search, and text injection. These reach into the live `GhosttySurfaceView`, so they own the
-/// surface-touching half of the dispatch. Split out of `ControlServer.swift` for the swiftlint size limit.
+/// `ControlServer` arms that reach into a live `GhosttySurfaceView` — font size, selection copy, background
+/// watermark, buffer read, in-terminal search, text injection. Split out for the swiftlint size limit.
 extension ControlServer {
-    /// Resolve the target session and run a libghostty binding action on its addressable surface (a SPECIFIC
-    /// surface, unlike the menu path, which only hits the focused one). Shared by the clipboard/selection
-    /// arms (`session.paste`/`session.selectall`). `addressableSurface` is the main pane, falling back to a
-    /// promoted split survivor whose primary shell exited (which nils `surface`) — else a session the user is
-    /// actively typing in would report "session not realized". A never-shown session has no surface → error.
+    /// Runs a libghostty binding action on the target's addressable surface — a SPECIFIC one, unlike the menu
+    /// path's focused pane. Shared by `session.paste`/`session.selectall`. `addressableSurface` falls back to
+    /// a promoted split survivor whose primary shell exited (which nils `surface`), else a session the user
+    /// is typing in reports "session not realized"; a never-shown session has no surface at all → error.
     private func surfaceBindingAction(_ target: String?, window: String?, action: String) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
             guard let surface = store.session(withID: id)?.addressableSurface as? GhosttySurfaceView else {
@@ -20,18 +18,15 @@ extension ControlServer {
         }
     }
 
-    /// Run a font binding action (`font.inc`/`font.dec`/`font.reset`) on a pane of the target session; a
-    /// menu-driven font change rides the same CELL_SIZE → persist path as the keybind. `pane` picks the
-    /// surface like `session.type`/`session.text` (`left`|`right`|`scratch`, no `other`): omitted/`left` is
-    /// the main pane (`addressableSurface`, so a promoted split survivor whose primary shell exited is still
-    /// reached — the pre-pane behavior); `right` is the split pane (`session has no split pane` without one);
-    /// `scratch` is the scratch terminal (`session has no scratch terminal` when none was opened), whose
-    /// surface is kept alive so its font is settable while hidden. An unknown value is an `invalid pane`
-    /// error, validated here as well as in the CLI `validate()` so a raw socket client can't bypass it. A
-    /// resolved-but-unrealized pane returns `session not realized` (the `performBindingAction` Bool), so a
-    /// split/scratch request in the layout beat after the pane is shown never silently no-ops. Only the main
-    /// pane's size persists — the split/scratch `onFontSizeChange` is deliberately unwired, so their cmd +/-
-    /// changes aren't saved (matching a GUI font change on them).
+    /// Runs a font binding action (`font.inc`/`font.dec`/`font.reset`) on a pane of the target session; a
+    /// menu-driven change rides the same CELL_SIZE → persist path as the keybind. `pane` follows
+    /// `session.type`/`session.text` (`left`|`right`|`scratch`, no `other`): omitted/`left` is the main pane
+    /// via `addressableSurface` (the pre-pane behavior, still reaching a promoted split survivor); `scratch`
+    /// is settable while hidden, its surface kept alive. An unknown value is rejected here as well as in the
+    /// CLI `validate()`, so a raw socket client can't bypass it, and a resolved-but-unrealized pane returns
+    /// `session not realized` rather than silently no-opping in the layout beat after the pane is shown.
+    /// Only the main pane's size persists — the split/scratch `onFontSizeChange` is deliberately unwired,
+    /// matching a GUI font change on them.
     func font(_ target: String?, window: String?, pane: String?, action: String) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
             // resolveSession already resolved `id` from this store, so `session(withID:)` is non-nil.
@@ -58,8 +53,7 @@ extension ControlServer {
             guard let surface = chosen as? GhosttySurfaceView else {
                 return ControlResponse(ok: false, error: "session not realized")
             }
-            // a false return = the surface isn't realized yet; report that rather than a false ok,
-            // matching session.type's inject() Bool contract.
+            // a false return = surface not realized yet; report it, not a false ok (session.type's contract).
             guard surface.performBindingAction(action) else {
                 return ControlResponse(ok: false, error: "session not realized")
             }
@@ -67,22 +61,20 @@ extension ControlServer {
         }
     }
 
-    /// Paste the system clipboard into the target session's surface (`session.paste`, the control analogue of
-    /// ⌘V / Edit ▸ Paste), via `paste_from_clipboard` — the same libghostty path the keyboard takes
-    /// (bracketed paste, no OSC-52 prompt). Read the result back with `session.text`.
+    /// The ⌘V / Edit ▸ Paste analogue (`session.paste`): the same libghostty `paste_from_clipboard` the
+    /// keyboard takes, so bracketed paste applies and no OSC-52 prompt appears. Read back with `session.text`.
     func pasteSession(_ target: String?, window: String?) -> ControlResponse {
         surfaceBindingAction(target, window: window, action: "paste_from_clipboard")
     }
 
-    /// Select the target session's entire terminal buffer (`session.selectall`, the control analogue of
-    /// ⌘A / Edit ▸ Select All). Runs `select_all`; read the resulting selection back with `session.copy`.
+    /// Selects the target session's entire terminal buffer (`session.selectall`, the ⌘A / Edit ▸ Select All
+    /// analogue); read the resulting selection back with `session.copy`.
     func selectAllSession(_ target: String?, window: String?) -> ControlResponse {
         surfaceBindingAction(target, window: window, action: "select_all")
     }
 
-    /// Resolve the target session and return its surface's current selection text in the response (it does
-    /// NOT write the system clipboard — automation pipes the returned text into another `session.type`). A
-    /// never-shown session has no surface yet → error; an empty or absent selection → "no selection".
+    /// Returns the surface's current selection text in the response, NOT to the system clipboard (automation
+    /// pipes it into another `session.type`). No surface → error; empty or absent selection → "no selection".
     func copySelection(_ target: String?, window: String?) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
             // `addressableSurface`, not `surface`: must resolve the SAME pane `session.selectall` acted on,
@@ -97,11 +89,10 @@ extension ControlServer {
         }
     }
 
-    /// Set or clear a session's background watermark (`session.background`, mode `image|text|clear`): validate
-    /// the inputs (shared `WatermarkConfig` enum checks; image format + existence), build the
-    /// `BackgroundWatermark` spec (nil for `clear`), persist it on the session (`AppStore`, so it rides
-    /// `SessionSnapshot`), then apply it to the realized surface(s). A never-shown session keeps the spec and
-    /// applies it itself when its surface is created. Returns the session id.
+    /// Sets or clears a session's background watermark (mode `image|text|clear`): validate the inputs (shared
+    /// `WatermarkConfig` enum checks; image format + existence), persist the spec on the session so it rides
+    /// `SessionSnapshot`, then apply it to the realized surface(s). A never-shown session keeps the spec and
+    /// applies it itself on surface creation. Returns the session id.
     func setSessionBackground(_ target: String?, window: String?,
                               options: ControlSessionBackgroundOptions) -> ControlResponse {
         let watermark = options.watermark
@@ -141,13 +132,11 @@ extension ControlServer {
     }
 
     /// Returns a pane's terminal buffer as plain text: the visible screen by default, screen + scrollback
-    /// with `all`, or the last `lines` lines (reads the screen, then trims). `pane` picks the surface (`left`
-    /// main, `right` split, `scratch` the scratch terminal — readable while hidden, since its surface is kept
-    /// alive — or the on-screen pane when omitted); `right` errors without a split, `scratch` errors `session
-    /// has no scratch terminal` when none was opened. `all` and `lines` are mutually exclusive and `lines`
-    /// must be > 0, validated here as well as in the CLI `validate()` so a raw socket client can't bypass it
-    /// (an unchecked `lines <= 0` would silently fall through to the full buffer). A genuinely blank screen
-    /// reads ok with an empty string; a failed surface read is an error, not a silent empty.
+    /// with `all`, or the last `lines` lines (reads the screen, then trims). `pane` picks left/right/scratch
+    /// (the scratch readable while hidden, its surface kept alive), or the on-screen pane when omitted. `all`
+    /// and `lines` are mutually exclusive and `lines` must be > 0, rejected here as well as in the CLI so a
+    /// raw socket client can't bypass it (an unchecked `lines <= 0` would fall through to the full buffer).
+    /// A genuinely blank screen reads ok with an empty string; a failed read is an error, not a silent empty.
     func readSessionText(_ target: String?, window: String?, options: ControlSessionTextOptions) -> ControlResponse {
         let pane = options.pane, all = options.all, lines = options.lines
         if all, lines != nil {
@@ -163,8 +152,8 @@ extension ControlServer {
             let chosen: (any TerminalSurface)?
             switch pane {
             case nil:
-                // omitted = the surface ON SCREEN, the same `Session.onScreenSurface` resolution
-                // `session.search` uses, so it never reads a pane hidden under the scratch.
+                // omitted = the ON-SCREEN surface (as `session.search` resolves it), never a pane hidden
+                // under the scratch.
                 chosen = session.onScreenSurface
             case "left": chosen = session.surface
             case "right":
@@ -190,22 +179,16 @@ extension ControlServer {
         }
     }
 
-    /// Drive in-terminal search on the session `id`, mirroring the GUI bar and the `session.type`/
-    /// floating-overlay arms. `close` drives the pinned `searchSurface` WITHOUT selecting, so closing a
-    /// background session's bar never yanks the user's visible selection (`endSearch()` is a
-    /// side-effect-free exit, like `session.copy`). open/needle/navigate SELECT the target so the bar +
-    /// highlights are visible and the surface mounts, open search on the focused pane if not already active
-    /// (`startSearch`, whose START callback pins it as `searchSurface`; bounded realize-poll for a never-shown
-    /// session), then set the needle from `text` (`sendSearchQuery`) and step on `to == next|prev`
-    /// (`navigateSearch`) — both on the PINNED owner, so a split focus move after open can't retarget them.
-    /// `to` must be next/prev/close (else an `invalid` error). The count lands asynchronously via libghostty's
-    /// SEARCH_TOTAL callback; `searchTotal`/`searchSelected` are cleared before the query so the bounded
-    /// main-actor poll waits for the FRESH count, then `count` + the "N of M" string are returned in `text`.
+    /// Drives in-terminal search on session `id`, mirroring the GUI bar. `close` exits without selecting;
+    /// open/needle/navigate select the target, open search on the focused pane if not already active, then
+    /// set the needle and step on `to == next|prev` — all on the PINNED `searchSurface`, so a split focus
+    /// move after open can't retarget them. `to` must be next/prev/close. The count lands asynchronously via
+    /// libghostty's SEARCH_TOTAL callback, so a bounded main-actor poll waits for it before returning
+    /// `count` + the "N of M" string in `text`.
     func searchSession(_ target: String?, window: String?, text: String?, to: String?) async -> ControlResponse {
-        // resolve first (cross-window when no `window`), then select + realize; the realize path is async
-        // (bounded poll), so it can't use the synchronous `resolveSession` helper. error strings stay in
-        // sync with `resolve(...)`, and target lookup wins over `to` validation to preserve the
-        // pre-dispatcher error order.
+        // resolve first (cross-window when no `window`), then select + realize: the realize path is async
+        // (bounded poll), so the synchronous `resolveSession` helper can't serve. Error strings stay in sync
+        // with `resolve(...)`; target lookup must win over `to` validation.
         switch resolver.resolveSessionTarget(target, window: window) {
         case .failure(let response):
             return response
@@ -223,10 +206,10 @@ extension ControlServer {
             return ControlResponse(ok: false, error: "no such session")
         }
 
-        // close exits search without selecting: a background session's surface is already realized while
-        // hidden and end_search has no visible side effect, so don't disturb the active session. drive the
-        // PINNED `searchSurface`, not a re-resolved `activeSurface` — after a split focus move that is the
-        // wrong pane and would strand the owner. with no open search there's no owner, so close no-ops.
+        // close exits without selecting: a hidden session's surface is already realized and end_search has no
+        // visible side effect, so don't disturb the active session. Drive the PINNED `searchSurface`, not a
+        // re-resolved `activeSurface` — after a split focus move that is the wrong pane and strands the
+        // owner; with no open search there is no owner, so close no-ops.
         if to == "close" {
             (session.searchSurface as? GhosttySurfaceView)?.endSearch()
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
@@ -241,9 +224,8 @@ extension ControlServer {
         }
 
         // open/needle/navigate need the bar + highlights visible, so select the target (which also realizes
-        // a never-shown surface). the OPEN uses the search target — a covering scratch (scratchActive, no
-        // overlay) wins, mirroring AppActions.searchTarget(), else the focused pane; the factory pins it as
-        // `searchSurface`, and once open needle/navigate target the pinned owner so they can't drift.
+        // a never-shown surface). The OPEN uses the search target — a covering scratch wins, mirroring
+        // `AppActions.searchTarget()`, else the focused pane; the factory pins it as `searchSurface`.
         store.selectSession(id)
         // `onScreenSurface` is the shared pane-vs-scratch resolution, also used by `session.text`.
         var openSurface = session.onScreenSurface as? GhosttySurfaceView
@@ -271,11 +253,10 @@ extension ControlServer {
         if let text {
             // on a needle CHANGE an OLDER query's SEARCH_TOTAL may still be queued on the main loop
             // (callbacks hop via DispatchQueue.main.async), so drain one run-loop turn to deliver it BEFORE
-            // clearing — then the settle-poll below waits for THIS needle's callback, not a stale count. the
-            // SAME needle must NOT drain/clear: libghostty does not re-emit SEARCH_TOTAL for an unchanged
-            // query, so clearing would leave the count nil (the retry idiom re-sends it while the scrollback
-            // renders). residual race: a callback more than one run-loop turn late (behind heavy render
-            // work) still lands after the clear; only a per-query epoch through libghostty closes that.
+            // clearing; the settle-poll then waits for THIS needle's callback, not a stale count. The SAME
+            // needle must NOT drain/clear: libghostty does not re-emit SEARCH_TOTAL for an unchanged query,
+            // so clearing would leave the count nil. Residual race: a callback more than one turn late
+            // (behind heavy render work) still lands after the clear; only a per-query epoch closes that.
             if needleChanged {
                 await Task.yield()
                 try? await Task.sleep(nanoseconds: 30_000_000)
@@ -285,8 +266,8 @@ extension ControlServer {
             session.searchNeedle = text
             surface.sendSearchQuery(text)
             // an explicitly-empty needle clears the query: libghostty tears the search thread down and emits
-            // no fresh SEARCH_TOTAL (its quit event resets the count), so reset count/selected here and skip
-            // the settle-poll — nothing to wait for, and polling would burn the full timeout.
+            // no fresh SEARCH_TOTAL, so reset count/selected here and skip the settle-poll (it would burn
+            // the full timeout waiting for nothing).
             if text.isEmpty {
                 session.searchTotal = nil
                 session.searchSelected = nil
@@ -303,27 +284,24 @@ extension ControlServer {
             try? await Task.sleep(nanoseconds: 30_000_000)
             if session.searchTotal != nil { break }
         }
-        // an empty display string (the bar opened with no query yet) maps to a nil `text` so the CLI
-        // prints `ok` rather than a blank line; the count is nil until a query runs.
+        // an empty display string (the bar opened with no query yet) maps to nil so the CLI prints `ok`
+        // rather than a blank line; the count is nil until a query runs.
         let display = session.searchDisplayText
         return ControlResponse(ok: true, result: ControlResult(text: display.isEmpty ? nil : display,
                                                                count: session.searchTotal))
     }
 
-    /// Inject `text` into session `id`'s surface. A surface is created lazily (deferred until it has a
+    /// Injects `text` into session `id`'s surface. A surface is created lazily (deferred until it has a
     /// non-zero backing size, so a never-shown session has `surface == nil`). `inject(text:)` sends the text
     /// as `ghostty_surface_key` keystrokes (NOT `ghostty_surface_text` — see its doc for why), which write to
     /// the child pty; the kernel buffers the pty, so text is never lost even before the first prompt.
-    /// `pane` picks the pane like `session.text` (`left`|`right`|`scratch`, no `other`): omitted/`left` is
-    /// the main pane, NOT the focused one — the pre-pane behavior, so existing automation is unaffected;
-    /// `right` is the split pane (`session has no split pane` without one); `scratch` is the scratch
-    /// terminal, typable even while hidden since its surface is kept alive (`session has no scratch
-    /// terminal` when none has been opened). The realize/select path below is main-pane only — selecting
-    /// never creates a split pane, so `right`/`scratch` inject into the existing surface or error.
-    /// - surface already realized → inject immediately, ok.
-    /// - never realized, `select:true` → select it, then poll for the surface (bounded: 12 × 0.03 s, the
-    ///   `focusSplitPane` idiom) and inject on the first realized attempt; never realized → error (never a
-    ///   false ok).
+    /// `pane` follows `session.text` (`left`|`right`|`scratch`, no `other`): omitted/`left` is the main pane,
+    /// NOT the focused one — the pre-pane behavior, so existing automation is unaffected; `scratch` is
+    /// typable while hidden since its surface is kept alive. Selecting never creates a split pane, so the
+    /// realize/select path below is main-pane only and `right`/`scratch` inject or error.
+    /// - already realized → inject immediately, ok.
+    /// - never realized, `select:true` → select it, then poll (bounded: 12 × 0.03 s, the `focusSplitPane`
+    ///   idiom) and inject on the first realized attempt; still unrealized → error, never a false ok.
     /// - never realized, no select → an immediate "use select" error.
     func injectText(_ text: String, into id: UUID, store: AppStore, select: Bool, pane: String?) async -> ControlResponse {
         switch pane {
@@ -340,8 +318,8 @@ extension ControlServer {
             }
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
         case "scratch":
-            // as with `right`, a false `inject` (not yet realized in the ms after `session.scratch on`,
-            // before layout) reports `session not realized` rather than silently dropping the keystrokes.
+            // as with `right`, a false `inject` (the ms after `session.scratch on`, before layout) reports
+            // `session not realized` rather than silently dropping the keystrokes.
             guard let scratch = store.session(withID: id)?.scratchSurface else {
                 return ControlResponse(ok: false, error: "session has no scratch terminal")
             }
@@ -349,8 +327,7 @@ extension ControlServer {
                 return ControlResponse(ok: false, error: "session not realized")
             }
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
-        // `session.type` accepts left|right|scratch, with no `other` toggle like `session.focus`
-        // (mirroring `session.text`).
+        // `session.type` accepts left|right|scratch, with no `other` toggle (mirroring `session.text`).
         case .some(let value):
             return ControlResponse(ok: false, error: "invalid pane: \(value)")
         }
@@ -366,7 +343,7 @@ extension ControlServer {
         for _ in 0..<12 {
             try? await Task.sleep(nanoseconds: 30_000_000)
             // poll for the surface AND its realization (a false inject keeps polling), so a just-selected
-            // never-shown session isn't reported ok before its libghostty surface is up.
+            // session isn't reported ok before its libghostty surface is up.
             if let surface = store.session(withID: id)?.surface as? GhosttySurfaceView, surface.inject(text: text) {
                 return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
             }

--- a/agterm/Control/ControlServer+SurfaceIO.swift
+++ b/agterm/Control/ControlServer+SurfaceIO.swift
@@ -5,12 +5,11 @@ import agtermCore
 /// in-terminal search, and text injection. These reach into the live `GhosttySurfaceView`, so they own the
 /// surface-touching half of the dispatch. Split out of `ControlServer.swift` for the swiftlint size limit.
 extension ControlServer {
-    /// Resolve the target session and run a libghostty binding action on its addressable surface (targets a
-    /// specific surface, unlike the menu path which only hits the focused one). Shared by the clipboard /
-    /// selection arms (`session.paste`/`session.selectall`). `addressableSurface` is the main pane, falling
-    /// back to a promoted split survivor whose primary shell exited (which nils `surface`) — otherwise a
-    /// session the user is actively typing in would report "session not realized". A never-shown session has
-    /// no surface at all → error.
+    /// Resolve the target session and run a libghostty binding action on its addressable surface (a SPECIFIC
+    /// surface, unlike the menu path, which only hits the focused one). Shared by the clipboard/selection
+    /// arms (`session.paste`/`session.selectall`). `addressableSurface` is the main pane, falling back to a
+    /// promoted split survivor whose primary shell exited (which nils `surface`) — else a session the user is
+    /// actively typing in would report "session not realized". A never-shown session has no surface → error.
     private func surfaceBindingAction(_ target: String?, window: String?, action: String) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
             guard let surface = store.session(withID: id)?.addressableSurface as? GhosttySurfaceView else {
@@ -21,19 +20,18 @@ extension ControlServer {
         }
     }
 
-    /// Run a font binding action (`font.inc`/`font.dec`/`font.reset`) on a pane of the target session. A
+    /// Run a font binding action (`font.inc`/`font.dec`/`font.reset`) on a pane of the target session; a
     /// menu-driven font change rides the same CELL_SIZE → persist path as the keybind. `pane` picks the
     /// surface like `session.type`/`session.text` (`left`|`right`|`scratch`, no `other`): omitted/`left` is
     /// the main pane (`addressableSurface`, so a promoted split survivor whose primary shell exited is still
-    /// reached — preserving the pre-pane behavior); `right` is the split pane (`session has no split pane`
-    /// without one); `scratch` is the session's scratch terminal (`session has no scratch terminal` when none
-    /// has been opened), whose surface is kept alive so its font is settable even while hidden. An unknown
-    /// value is an `invalid pane` error — validated here (mirroring the CLI `validate()`) so a raw socket
-    /// client can't bypass it. A resolved pane whose libghostty surface isn't realized yet returns `session
-    /// not realized` (the `performBindingAction` Bool), so a split/scratch font request in the layout beat
-    /// after the pane is shown never silently no-ops. Only the main pane's size persists: the split/scratch
-    /// surfaces' `onFontSizeChange` is deliberately unwired, so their cmd +/- changes aren't saved (matching
-    /// a GUI font change on them).
+    /// reached — the pre-pane behavior); `right` is the split pane (`session has no split pane` without one);
+    /// `scratch` is the scratch terminal (`session has no scratch terminal` when none was opened), whose
+    /// surface is kept alive so its font is settable while hidden. An unknown value is an `invalid pane`
+    /// error, validated here as well as in the CLI `validate()` so a raw socket client can't bypass it. A
+    /// resolved-but-unrealized pane returns `session not realized` (the `performBindingAction` Bool), so a
+    /// split/scratch request in the layout beat after the pane is shown never silently no-ops. Only the main
+    /// pane's size persists — the split/scratch `onFontSizeChange` is deliberately unwired, so their cmd +/-
+    /// changes aren't saved (matching a GUI font change on them).
     func font(_ target: String?, window: String?, pane: String?, action: String) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
             // resolveSession already resolved `id` from this store, so `session(withID:)` is non-nil.
@@ -60,9 +58,8 @@ extension ControlServer {
             guard let surface = chosen as? GhosttySurfaceView else {
                 return ControlResponse(ok: false, error: "session not realized")
             }
-            // a false return = the view exists but its libghostty surface isn't realized yet (a split or
-            // scratch pane in the layout beat right after it's shown); report that instead of a false ok,
-            // matching session.type's inject() Bool contract so the action is never silently dropped.
+            // a false return = the surface isn't realized yet; report that rather than a false ok,
+            // matching session.type's inject() Bool contract.
             guard surface.performBindingAction(action) else {
                 return ControlResponse(ok: false, error: "session not realized")
             }
@@ -70,9 +67,9 @@ extension ControlServer {
         }
     }
 
-    /// Paste the system clipboard into the target session's surface (`session.paste`, the control analogue
-    /// of ⌘V / Edit ▸ Paste). Runs `paste_from_clipboard`, so it takes the same libghostty paste path
-    /// (bracketed paste, no OSC-52 prompt) the keyboard uses. Read the result back with `session.text`.
+    /// Paste the system clipboard into the target session's surface (`session.paste`, the control analogue of
+    /// ⌘V / Edit ▸ Paste), via `paste_from_clipboard` — the same libghostty path the keyboard takes
+    /// (bracketed paste, no OSC-52 prompt). Read the result back with `session.text`.
     func pasteSession(_ target: String?, window: String?) -> ControlResponse {
         surfaceBindingAction(target, window: window, action: "paste_from_clipboard")
     }
@@ -88,8 +85,8 @@ extension ControlServer {
     /// never-shown session has no surface yet → error; an empty or absent selection → "no selection".
     func copySelection(_ target: String?, window: String?) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
-            // `addressableSurface`, not `surface`: it must resolve the SAME pane `session.selectall` acted on,
-            // including a promoted split survivor, or the documented selectall -> copy read-back breaks.
+            // `addressableSurface`, not `surface`: must resolve the SAME pane `session.selectall` acted on,
+            // promoted split survivor included, or the documented selectall -> copy read-back breaks.
             guard let surface = store.session(withID: id)?.addressableSurface as? GhosttySurfaceView else {
                 return ControlResponse(ok: false, error: "session not realized")
             }
@@ -100,11 +97,11 @@ extension ControlServer {
         }
     }
 
-    /// Set or clear a session's background watermark (`session.background`, mode `image|text|clear`):
-    /// validate the inputs (shared `WatermarkConfig` enum checks; image format + existence), build the
+    /// Set or clear a session's background watermark (`session.background`, mode `image|text|clear`): validate
+    /// the inputs (shared `WatermarkConfig` enum checks; image format + existence), build the
     /// `BackgroundWatermark` spec (nil for `clear`), persist it on the session (`AppStore`, so it rides
-    /// `SessionSnapshot`), then apply it to the session's realized surface(s). A never-shown session keeps
-    /// the spec and applies it itself when its surface is created. Returns the session id.
+    /// `SessionSnapshot`), then apply it to the realized surface(s). A never-shown session keeps the spec and
+    /// applies it itself when its surface is created. Returns the session id.
     func setSessionBackground(_ target: String?, window: String?,
                               options: ControlSessionBackgroundOptions) -> ControlResponse {
         let watermark = options.watermark
@@ -124,8 +121,7 @@ extension ControlServer {
                 return ControlResponse(ok: false, error: "no such session")
             }
             // gate on a real change: applyWatermark RETAINS a per-surface config freed only on teardown, so
-            // re-applying an unchanged spec (a scripted set-loop) would leak owned configs. The store no-ops
-            // its own write the same way.
+            // re-applying an unchanged spec (a scripted set-loop) leaks owned configs. the store no-ops too.
             guard store.setBackgroundWatermark(watermark, forSession: id) else {
                 return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
             }
@@ -136,23 +132,22 @@ extension ControlServer {
         }
     }
 
-    /// Apply a session's current watermark spec to its realized main + split + scratch surfaces. A never-realized
-    /// surface (nil) is skipped — it applies the spec itself on creation (`GhosttySurfaceView.createSurface`).
+    /// Apply a session's watermark spec to its realized main + split + scratch surfaces. A never-realized one
+    /// (nil) is skipped — it applies the spec itself on creation (`GhosttySurfaceView.createSurface`).
     private func applyWatermark(to session: Session) {
         for surface in [session.surface, session.splitSurface, session.scratchSurface] {
             (surface as? GhosttySurfaceView)?.applyWatermarkFromSession()
         }
     }
 
-    /// Returns a pane's terminal buffer as plain text: the visible screen by default, the full screen plus
-    /// scrollback with `all`, or the last `lines` lines (reads the screen, then trims). `pane` picks the
-    /// surface (`left` main, `right` split, `scratch` the session's scratch terminal — readable even while
-    /// hidden, since its surface is kept alive — or the on-screen pane when omitted); `right` errors when
-    /// the session has no split, `scratch` errors `session has no scratch terminal` when none has been
-    /// opened. `all` and `lines` are mutually exclusive and `lines` must be > 0 — validated
-    /// here too, not only in the CLI `validate()`, so a raw socket client can't bypass it (an unchecked
-    /// `lines <= 0` would silently fall through to the full buffer). A genuinely blank screen reads ok with
-    /// an empty string; a failed surface read is an error, not a silent empty.
+    /// Returns a pane's terminal buffer as plain text: the visible screen by default, screen + scrollback
+    /// with `all`, or the last `lines` lines (reads the screen, then trims). `pane` picks the surface (`left`
+    /// main, `right` split, `scratch` the scratch terminal — readable while hidden, since its surface is kept
+    /// alive — or the on-screen pane when omitted); `right` errors without a split, `scratch` errors `session
+    /// has no scratch terminal` when none was opened. `all` and `lines` are mutually exclusive and `lines`
+    /// must be > 0, validated here as well as in the CLI `validate()` so a raw socket client can't bypass it
+    /// (an unchecked `lines <= 0` would silently fall through to the full buffer). A genuinely blank screen
+    /// reads ok with an empty string; a failed surface read is an error, not a silent empty.
     func readSessionText(_ target: String?, window: String?, options: ControlSessionTextOptions) -> ControlResponse {
         let pane = options.pane, all = options.all, lines = options.lines
         if all, lines != nil {
@@ -162,16 +157,14 @@ extension ControlServer {
             return ControlResponse(ok: false, error: "--lines must be greater than 0")
         }
         return resolver.resolveSession(target, window: window) { store, id in
-            // resolveSession already resolved `id` from this store, so `session(withID:)` is non-nil.
             guard let session = store.session(withID: id) else {
                 return ControlResponse(ok: false, error: "session not realized")
             }
             let chosen: (any TerminalSurface)?
             switch pane {
             case nil:
-                // omitted = the surface ON SCREEN (scratch-aware), the SAME `Session.onScreenSurface`
-                // resolution `session.search` uses, so a no-`--pane` read returns what's visible, not a
-                // pane hidden under the scratch.
+                // omitted = the surface ON SCREEN, the same `Session.onScreenSurface` resolution
+                // `session.search` uses, so it never reads a pane hidden under the scratch.
                 chosen = session.onScreenSurface
             case "left": chosen = session.surface
             case "right":
@@ -180,14 +173,11 @@ extension ControlServer {
                 }
                 chosen = split
             case "scratch":
-                // the scratch terminal's surface is kept alive while hidden, so this reads it whether or not
-                // it's on screen (unlike the no-`--pane` on-screen resolution above).
                 guard let scratch = session.scratchSurface else {
                     return ControlResponse(ok: false, error: "session has no scratch terminal")
                 }
                 chosen = scratch
-            // an unknown pane value errors here; `session.text` accepts left|right|scratch, with no `other`
-            // toggle like `session.focus`.
+            // `session.text` accepts left|right|scratch, with no `other` toggle like `session.focus`.
             case .some(let value): return ControlResponse(ok: false, error: "invalid pane: \(value)")
             }
             guard let surface = chosen as? GhosttySurfaceView else {
@@ -200,24 +190,22 @@ extension ControlServer {
         }
     }
 
-    /// Drive in-terminal search on the session `id`, mirroring the GUI bar and the
-    /// `session.type`/floating-overlay arms. On the `close` path it drives the session's pinned
-    /// `searchSurface` WITHOUT selecting (so closing a background session's bar never yanks the user's
-    /// visible selection — `endSearch()` is a side-effect-free exit, like `session.copy`). For
-    /// open/needle/navigate it SELECTS the target so the bar + highlights are visible and the surface
-    /// mounts, opens search on the focused pane if not already active (`startSearch`, whose START callback
-    /// pins it as `searchSurface`; bounded realize-poll if a never-shown session), then sets the needle if
-    /// `text` is present (`sendSearchQuery`) and steps the selection if `to == next|prev` (`navigateSearch`)
-    /// — both on the PINNED owner, so a split focus move after open can't retarget them.
-    /// `to` must be one of next/prev/close (else an `invalid` error). The match count lands asynchronously
-    /// via libghostty's SEARCH_TOTAL callback; `searchTotal`/`searchSelected` are cleared before the query so
-    /// the bounded main-actor poll waits for the FRESH count (not a stale prior needle's), then `count` + the
-    /// "N of M" display string are returned in `text`.
+    /// Drive in-terminal search on the session `id`, mirroring the GUI bar and the `session.type`/
+    /// floating-overlay arms. `close` drives the pinned `searchSurface` WITHOUT selecting, so closing a
+    /// background session's bar never yanks the user's visible selection (`endSearch()` is a
+    /// side-effect-free exit, like `session.copy`). open/needle/navigate SELECT the target so the bar +
+    /// highlights are visible and the surface mounts, open search on the focused pane if not already active
+    /// (`startSearch`, whose START callback pins it as `searchSurface`; bounded realize-poll for a never-shown
+    /// session), then set the needle from `text` (`sendSearchQuery`) and step on `to == next|prev`
+    /// (`navigateSearch`) — both on the PINNED owner, so a split focus move after open can't retarget them.
+    /// `to` must be next/prev/close (else an `invalid` error). The count lands asynchronously via libghostty's
+    /// SEARCH_TOTAL callback; `searchTotal`/`searchSelected` are cleared before the query so the bounded
+    /// main-actor poll waits for the FRESH count, then `count` + the "N of M" string are returned in `text`.
     func searchSession(_ target: String?, window: String?, text: String?, to: String?) async -> ControlResponse {
-        // Resolve first (cross-window when no `window`), then select + realize the surface; the realize
-        // path is async (bounded poll), so this can't go through the synchronous `resolveSession`
-        // helper. Error strings stay in sync with `resolve(...)`, and target lookup preserves the
-        // pre-dispatcher error order by winning over `to` validation.
+        // resolve first (cross-window when no `window`), then select + realize; the realize path is async
+        // (bounded poll), so it can't use the synchronous `resolveSession` helper. error strings stay in
+        // sync with `resolve(...)`, and target lookup wins over `to` validation to preserve the
+        // pre-dispatcher error order.
         switch resolver.resolveSessionTarget(target, window: window) {
         case .failure(let response):
             return response
@@ -236,10 +224,9 @@ extension ControlServer {
         }
 
         // close exits search without selecting: a background session's surface is already realized while
-        // hidden, and end_search has no visible side effect, so don't disturb the user's active session.
-        // drive the PINNED `searchSurface` (the pane that opened search), not a re-resolved `activeSurface`
-        // — if split focus moved after open, `activeSurface` is the wrong pane and would strand the owner.
-        // with no open search there's no owner, so close is a clean no-op.
+        // hidden and end_search has no visible side effect, so don't disturb the active session. drive the
+        // PINNED `searchSurface`, not a re-resolved `activeSurface` — after a split focus move that is the
+        // wrong pane and would strand the owner. with no open search there's no owner, so close no-ops.
         if to == "close" {
             (session.searchSurface as? GhosttySurfaceView)?.endSearch()
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
@@ -253,13 +240,12 @@ extension ControlServer {
             }
         }
 
-        // open/needle/navigate need the bar + highlights visible, so select the target (also realizes a
-        // never-shown surface). the OPEN uses the search target — a covering scratch (scratchActive, no
+        // open/needle/navigate need the bar + highlights visible, so select the target (which also realizes
+        // a never-shown surface). the OPEN uses the search target — a covering scratch (scratchActive, no
         // overlay) wins, mirroring AppActions.searchTarget(), else the focused pane; the factory pins it as
         // `searchSurface`, and once open needle/navigate target the pinned owner so they can't drift.
         store.selectSession(id)
-        // a covering scratch is searchable and sits above the pane, so drive it, not the hidden pane beneath
-        // (`onScreenSurface` is the shared pane-vs-scratch resolution, also used by `session.text`).
+        // `onScreenSurface` is the shared pane-vs-scratch resolution, also used by `session.text`.
         var openSurface = session.onScreenSurface as? GhosttySurfaceView
         if openSurface == nil {
             // a never-shown session realizes a beat after select — bounded poll like `injectText`.
@@ -283,15 +269,13 @@ extension ControlServer {
         let surface = (session.searchSurface as? GhosttySurfaceView) ?? openSurface
         let needleChanged = text != nil && text != session.searchNeedle
         if let text {
-            // on a needle CHANGE, an OLDER query's SEARCH_TOTAL callback can still be queued on the main
-            // loop (callbacks hop via DispatchQueue.main.async). drain one run-loop turn FIRST so any such
-            // stale callback is delivered, THEN clear — so the settle-poll below waits for THIS needle's
-            // callback (sent AFTER the clear) rather than reading a stale count. re-sending the SAME needle
-            // must NOT drain/clear: libghostty does not re-emit SEARCH_TOTAL for an unchanged query, so
-            // clearing would leave the count nil (the retry idiom re-sends the same needle while the
-            // scrollback renders). residual race: a stale callback delivered more than one run-loop turn
-            // late (blocked behind heavy render work) could still land after the clear; a per-query epoch
-            // through libghostty would close it fully but is out of scope here.
+            // on a needle CHANGE an OLDER query's SEARCH_TOTAL may still be queued on the main loop
+            // (callbacks hop via DispatchQueue.main.async), so drain one run-loop turn to deliver it BEFORE
+            // clearing — then the settle-poll below waits for THIS needle's callback, not a stale count. the
+            // SAME needle must NOT drain/clear: libghostty does not re-emit SEARCH_TOTAL for an unchanged
+            // query, so clearing would leave the count nil (the retry idiom re-sends it while the scrollback
+            // renders). residual race: a callback more than one run-loop turn late (behind heavy render
+            // work) still lands after the clear; only a per-query epoch through libghostty closes that.
             if needleChanged {
                 await Task.yield()
                 try? await Task.sleep(nanoseconds: 30_000_000)
@@ -300,10 +284,9 @@ extension ControlServer {
             }
             session.searchNeedle = text
             surface.sendSearchQuery(text)
-            // an explicitly-empty needle clears the query: libghostty tears the search thread down and
-            // emits no fresh SEARCH_TOTAL (its quit event resets the count), so reset the count/selected
-            // here and skip the settle-poll below — there is nothing to wait for, and polling would just
-            // burn the full timeout reading a count that never lands.
+            // an explicitly-empty needle clears the query: libghostty tears the search thread down and emits
+            // no fresh SEARCH_TOTAL (its quit event resets the count), so reset count/selected here and skip
+            // the settle-poll — nothing to wait for, and polling would burn the full timeout.
             if text.isEmpty {
                 session.searchTotal = nil
                 session.searchSelected = nil
@@ -327,18 +310,16 @@ extension ControlServer {
                                                                count: session.searchTotal))
     }
 
-    /// Inject `text` into the session `id`'s surface. A session's surface is created lazily (deferred until
-    /// it has a non-zero backing size — a never-shown session has `surface == nil`). `inject(text:)` sends
-    /// the text as `ghostty_surface_key` keystrokes (NOT `ghostty_surface_text` — see its doc for why),
-    /// which write to the child pty; the kernel buffers the pty, so text is never lost even before the
-    /// first prompt.
+    /// Inject `text` into session `id`'s surface. A surface is created lazily (deferred until it has a
+    /// non-zero backing size, so a never-shown session has `surface == nil`). `inject(text:)` sends the text
+    /// as `ghostty_surface_key` keystrokes (NOT `ghostty_surface_text` — see its doc for why), which write to
+    /// the child pty; the kernel buffers the pty, so text is never lost even before the first prompt.
     /// `pane` picks the pane like `session.text` (`left`|`right`|`scratch`, no `other`): omitted/`left` is
-    /// the main pane (omitted keeps the pre-pane behavior — always the main pane, NOT the focused one, so
-    /// existing automation is unaffected); `right` is the split pane, `session has no split pane` without
-    /// one; `scratch` is the session's scratch terminal, typable even while hidden (its surface is kept
-    /// alive), `session has no scratch terminal` when none has been opened. The realize/select path below
-    /// applies to the main pane only — a split pane is never created by selecting, so `right`/`scratch`
-    /// inject into the existing surface or error.
+    /// the main pane, NOT the focused one — the pre-pane behavior, so existing automation is unaffected;
+    /// `right` is the split pane (`session has no split pane` without one); `scratch` is the scratch
+    /// terminal, typable even while hidden since its surface is kept alive (`session has no scratch
+    /// terminal` when none has been opened). The realize/select path below is main-pane only — selecting
+    /// never creates a split pane, so `right`/`scratch` inject into the existing surface or error.
     /// - surface already realized → inject immediately, ok.
     /// - never realized, `select:true` → select it, then poll for the surface (bounded: 12 × 0.03 s, the
     ///   `focusSplitPane` idiom) and inject on the first realized attempt; never realized → error (never a
@@ -352,16 +333,14 @@ extension ControlServer {
             guard let split = store.session(withID: id)?.splitSurface else {
                 return ControlResponse(ok: false, error: "session has no split pane")
             }
-            // inject returns false when the view exists but its libghostty surface isn't realized yet
-            // (there is no realize/select path for the split pane) — report that instead of a false ok.
+            // inject returns false when the view exists but its libghostty surface isn't realized yet (there
+            // is no realize/select path for the split pane) — report that instead of a false ok.
             guard let surface = split as? GhosttySurfaceView, surface.inject(text: text) else {
                 return ControlResponse(ok: false, error: "session not realized")
             }
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
         case "scratch":
-            // the scratch terminal's surface is kept alive while hidden, so this types into it whether or
-            // not it's on screen; `session has no scratch terminal` when none has been opened. As with
-            // `right`, a false `inject` (surface not yet realized in the ms after `session.scratch on`,
+            // as with `right`, a false `inject` (not yet realized in the ms after `session.scratch on`,
             // before layout) reports `session not realized` rather than silently dropping the keystrokes.
             guard let scratch = store.session(withID: id)?.scratchSurface else {
                 return ControlResponse(ok: false, error: "session has no scratch terminal")
@@ -370,13 +349,13 @@ extension ControlServer {
                 return ControlResponse(ok: false, error: "session not realized")
             }
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
-        // an unknown pane value errors here; `session.type` accepts left|right|scratch, with no `other`
-        // toggle like `session.focus` (mirroring `session.text`).
+        // `session.type` accepts left|right|scratch, with no `other` toggle like `session.focus`
+        // (mirroring `session.text`).
         case .some(let value):
             return ControlResponse(ok: false, error: "invalid pane: \(value)")
         }
-        // main pane: inject if realized; a false return (the view exists but its libghostty surface isn't
-        // up yet) falls through to the select/poll path rather than returning a silent-drop false ok.
+        // main pane: inject if realized; a false return (view exists, libghostty surface not up yet) falls
+        // through to the select/poll path rather than returning a silent-drop false ok.
         if let surface = store.session(withID: id)?.surface as? GhosttySurfaceView, surface.inject(text: text) {
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
         }
@@ -387,7 +366,7 @@ extension ControlServer {
         for _ in 0..<12 {
             try? await Task.sleep(nanoseconds: 30_000_000)
             // poll for the surface AND its realization (a false inject keeps polling), so a just-selected
-            // never-shown session isn't reported ok before its libghostty surface is actually up.
+            // never-shown session isn't reported ok before its libghostty surface is up.
             if let surface = store.session(withID: id)?.surface as? GhosttySurfaceView, surface.inject(text: text) {
                 return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
             }

--- a/agterm/Control/ControlServer+WindowCommands.swift
+++ b/agterm/Control/ControlServer+WindowCommands.swift
@@ -2,22 +2,20 @@ import AppKit
 import Foundation
 import agtermCore
 
-/// `ControlServer` window-command action arms — create, list, select, close, resize, move, zoom, rename,
-/// and delete on-screen windows via `WindowRegistry` + the `WindowLibrary`. Split out of
-/// `ControlServer.swift` for the swiftlint size limit.
+/// `ControlServer` window-command action arms — create, list, select, close, resize, move, zoom, rename and
+/// delete on-screen windows via `WindowRegistry` + `WindowLibrary`. Split out of `ControlServer.swift` for
+/// the swiftlint size limit.
 extension ControlServer {
-    /// Create a new window (library) and open its on-screen window via the action hub's window opener
-    /// (the same `enqueueClaim` + `openWindow(id:)` path the menu uses). Returns the new window id.
+    /// Create a new window (library) and open its on-screen window via the action hub's window opener (the
+    /// same `enqueueClaim` + `openWindow(id:)` path the menu uses). Returns the new window id.
     ///
-    /// Bounded-polls for the NSWindow to ATTACH before replying, so `window.new` followed immediately by
-    /// `window.resize`/`move`/`zoom` works — those need a registered window and would otherwise fail. The
-    /// poll must gate on `WindowRegistry.isRegistered`, NOT `library.isOpen`: `newWindow()` loads the store
-    /// synchronously, so `isOpen` is already true and would prove nothing, while the NSWindow only attaches
-    /// after SwiftUI resolves the store and runs a second render pass. Fire-and-forget like the other
-    /// polls — a window that never renders times out and the command still replies ok.
-    ///
-    /// `minimized` creates the window and THEN parks it in the Dock, so a script can build a set of
-    /// project windows and be left on one it can still see.
+    /// Bounded-polls for the NSWindow to ATTACH before replying, so an immediately following
+    /// `window.resize`/`move`/`zoom` — which needs a registered window — works. The poll must gate on
+    /// `WindowRegistry.isRegistered`, NOT `library.isOpen`: `newWindow()` loads the store synchronously so
+    /// `isOpen` is already true and proves nothing, while the NSWindow attaches only after SwiftUI resolves
+    /// the store and runs a second render pass. Fire-and-forget like the other polls — a window that never
+    /// renders times out and the command still replies ok. `minimized` parks it in the Dock AFTER creating,
+    /// so a script can build project windows and be left on one it can still see.
     func windowNew(name: String?, minimized: Bool) async -> ControlResponse {
         let info = library.newWindow(name: trimmed(name))
         actions.openWindow?(info.id)
@@ -28,15 +26,13 @@ extension ControlServer {
 
     /// Park a freshly created window: minimize it, wait out the animation, and hand frontmost back.
     ///
-    /// The wait before minimizing is load-bearing. `WindowAccessor` presents the window on attach BOTH
+    /// The wait BEFORE minimizing is load-bearing: `WindowAccessor` presents the window on attach both
     /// synchronously and again on the next main-queue turn, and that second present deminiaturizes — so
-    /// minimizing the instant registration lands would simply be undone. One poll tick yields the main
-    /// actor long enough for the queued present to drain first.
-    ///
-    /// The attach poll above is bounded and fire-and-forget, so a window that never rendered reaches here
-    /// unregistered and `minimize` answers `.notOpen`. LOG that rather than swallowing it: the window is
-    /// then still on screen holding focus while the caller was told it was parked. Frontmost is handed off
-    /// only when the park actually applied — an unparked window is visible, so nothing is owed.
+    /// minimizing the instant registration lands would be undone. One poll tick yields the main actor long
+    /// enough for the queued present to drain first. A window that never rendered reaches here unregistered
+    /// (the attach poll is bounded and fire-and-forget) and `minimize` answers `.notOpen`; LOG that rather
+    /// than swallow it, since the window is then still on screen holding focus while the caller was told it
+    /// was parked. Frontmost is handed off only when the park applied — an unparked window is visible.
     private func park(_ id: WindowInfo.ID) async {
         try? await Task.sleep(nanoseconds: 50_000_000)
         guard case .applied = WindowRegistry.shared.minimize(id, mode: .on) else {
@@ -47,8 +43,7 @@ extension ControlServer {
         handOffFrontmost(from: id)
     }
 
-    /// Project the window library into the `window.list` response: every window with its open flag and
-    /// whether it is the frontmost (active) window.
+    /// Project the window library into `window.list`: every window with its open + frontmost (active) flags.
     func buildWindowList() -> [ControlWindowNode] {
         library.controlWindowNodes(geometry: { WindowRegistry.shared.geometry(for: $0) },
                                    flags: { WindowRegistry.shared.windowFlags(for: $0) })
@@ -58,21 +53,20 @@ extension ControlServer {
         ControlResponse(ok: true, result: ControlResult(windows: buildWindowList()))
     }
 
-    /// Resolve a window id and surface it: raise an already-open window, or open a closed one (the
-    /// action hub's opener claims its id + spawns the window). This bounded-polls for the NSWindow to
-    /// ATTACH before replying — a script can then immediately target it (`tree --window <id>`, or a
-    /// frame command) without racing the window appearing. Returns the window id.
+    /// Resolve a window id and surface it: raise an already-open window, or open a closed one (the action
+    /// hub's opener claims its id + spawns the window). Returns the window id.
     ///
-    /// The poll waits for BOTH the store and the NSWindow. `library.isOpen` alone only reports that the
-    /// store loaded — which is what `tree --window` needs, so it stays — but it flips a render pass before
-    /// the NSWindow exists, so a frame command issued right after would still hit `window not open`. An
-    /// already-open, already-attached window satisfies both on the first iteration.
+    /// Bounded-polls for BOTH the store and the NSWindow before replying, so a script can immediately target
+    /// it (`tree --window <id>`, a frame command) without racing the window appearing. `library.isOpen` alone
+    /// reports only that the store loaded — what `tree --window` needs, so it stays — but flips a render pass
+    /// before the NSWindow exists, so a frame command right after would hit `window not open`. An
+    /// already-attached window satisfies both on the first iteration.
     ///
-    /// Selecting also takes frontmost EXPLICITLY. `raise` makes the window key, but `frontmostWindowID` is
-    /// only updated by `WindowAccessor.reportFrontmost` on `didBecomeKey`, which AppKit does not deliver
-    /// while the app is inactive — so a background `window select` used to reply ok while every untargeted
-    /// command kept routing into the previously-active window. Same asymmetry `handOffFrontmost` fixes on
-    /// the minimize path, and the same reconcile is owed.
+    /// Selecting also takes frontmost EXPLICITLY: `raise` makes the window key, but `frontmostWindowID` is
+    /// updated only by `WindowAccessor.reportFrontmost` on `didBecomeKey`, which AppKit does not deliver
+    /// while the app is inactive — so a background `window select` would reply ok while untargeted commands
+    /// kept routing into the previously-active window. Same asymmetry `handOffFrontmost` fixes on the
+    /// minimize path, and the same reconcile is owed.
     func windowSelect(_ target: String?) async -> ControlResponse {
         switch resolver.resolveWindowID(target) {
         case .failure(let response): return response
@@ -84,18 +78,16 @@ extension ControlServer {
         }
     }
 
-    /// Resolve a window id and close its on-screen window (the registry's `performClose` runs the
-    /// standard teardown + `closeWindow` path, which fires asynchronously). Bounded-polls for the
-    /// library to mark it closed before replying, so an immediate follow-up command sees it closed. A
-    /// no-op for an already-closed window still reports ok with the id. Returns the window id.
+    /// Resolve a window id and close its on-screen window (the registry's `performClose` runs the standard
+    /// teardown + `closeWindow` path, asynchronously). Bounded-polls for the library to mark it closed, so
+    /// an immediate follow-up sees it closed. An already-closed window still reports ok. Returns the id.
     func windowClose(_ target: String?) async -> ControlResponse {
         switch resolver.resolveWindowID(target) {
         case .failure(let response): return response
         case .success(let id):
-            // close the on-screen window if it's registered (drives the willClose teardown), then a
-            // semantic fallback: if it isn't registered yet (window.close racing window.new before the
-            // NSWindow attaches) or willClose hasn't flipped the flag, drop the store directly so the
-            // window is reliably marked closed regardless of the attach timing.
+            // close the registered window (driving the willClose teardown), then a semantic fallback: when
+            // it isn't registered yet (window.close racing window.new before the NSWindow attaches) or
+            // willClose hasn't flipped the flag, drop the store so it is marked closed whatever the timing.
             let hadWindow = WindowRegistry.shared.close(id)
             if hadWindow {
                 await pollUntil { !self.library.isOpen(id) }
@@ -110,10 +102,10 @@ extension ControlServer {
     }
 
     /// Bounded poll for an asynchronous window lifecycle transition (open after `window.select`, closed
-    /// after `window.close`): the SwiftUI scene opens/closes the window off this dispatch, so the
-    /// library flag flips a beat later. 30 × 0.05 s (≈1.5 s) of `Task.sleep` yields the main actor
-    /// between checks — it never blocks the accept loop. Returns when `done()` holds or the budget is
-    /// spent (the caller replies ok regardless: fire-and-forget, the poll only narrows the race).
+    /// after `window.close`): the SwiftUI scene opens/closes off this dispatch, so the library flag flips a
+    /// beat later. 30 × 0.05 s (≈1.5 s) of `Task.sleep` yields the main actor between checks, never blocking
+    /// the accept loop. Returns when `done()` holds or the budget is spent — the caller replies ok either
+    /// way, so the poll only narrows the race.
     private func pollUntil(_ done: () -> Bool) async {
         for _ in 0..<30 {
             if done() { return }
@@ -121,9 +113,9 @@ extension ControlServer {
         }
     }
 
-    /// Resolve a window id and resize its on-screen window to `width` x `height` points (frame size).
-    /// The window must be open; a closed window errors (resize it after `window.select`). Control-native
-    /// (no GUI surface — the native title bar already drags-to-resize).
+    /// Resolve a window id and resize its on-screen window to `width` x `height` points (frame size). Open
+    /// windows only; a closed one errors (resize after `window.select`). Control-native — no GUI surface,
+    /// the native title bar already drags-to-resize.
     func windowResize(_ target: String?, width: Int, height: Int) -> ControlResponse {
         return resolver.resolveWindowID(target) { id in
             guard WindowRegistry.shared.resize(id, width: width, height: height) else {
@@ -133,9 +125,9 @@ extension ControlServer {
         }
     }
 
-    /// Resolve a window id and move its on-screen window so its top-left corner is at (`x`, `y`) points in
-    /// the global top-left space (origin = the primary display's top-left, spanning all displays). The
-    /// window must be open; a closed window errors. Control-native (no GUI surface).
+    /// Resolve a window id and move its top-left corner to (`x`, `y`) points in the global top-left space
+    /// (origin = the primary display's top-left, spanning all displays). Open only; a closed window errors.
+    /// Control-native (no GUI surface).
     func windowMove(_ target: String?, x: Int, y: Int, display: Int?) -> ControlResponse {
         if let display, display < 0 || display >= NSScreen.screens.count {
             return ControlResponse(ok: false, error: "display \(display) out of range (have \(NSScreen.screens.count))")
@@ -148,9 +140,9 @@ extension ControlServer {
         }
     }
 
-    /// Resolve a window id and zoom (maximize-to-screen toggle) its on-screen window. The window must be
-    /// open; a closed window errors. The control half of the double-click-header gesture (a plain green-button
-    /// click does native full screen, not zoom) — drives the same `NSWindow.zoom` as `WindowRegistry.zoom`.
+    /// Resolve a window id and zoom (maximize-to-screen toggle) its on-screen window; a closed window errors.
+    /// The control half of the double-click-header gesture — a plain green-button click does native full
+    /// screen, not zoom.
     func windowZoom(_ target: String?) -> ControlResponse {
         return resolver.resolveWindowID(target) { id in
             guard WindowRegistry.shared.zoom(id) else {
@@ -160,9 +152,8 @@ extension ControlServer {
         }
     }
 
-    /// Resolve a window id and toggle native macOS full screen on its on-screen window. The window must be
-    /// open; a closed window errors. The control half of the View ▸ Toggle Full Screen menu item / the green
-    /// traffic-light button — drives the same `NSWindow.toggleFullScreen` as `WindowRegistry.fullscreen`.
+    /// Resolve a window id and toggle native macOS full screen on it; a closed window errors. The control
+    /// half of the View ▸ Toggle Full Screen menu item / the green traffic-light button.
     func windowFullscreen(_ target: String?) -> ControlResponse {
         return resolver.resolveWindowID(target) { id in
             guard WindowRegistry.shared.fullscreen(id) else {
@@ -172,14 +163,13 @@ extension ControlServer {
         }
     }
 
-    /// Resolve a window id and minimize it to the Dock, or restore it, per the mode. The window must be
-    /// open; a closed window errors, as does one in native full screen (AppKit no-ops `miniaturize` there,
-    /// so reporting ok would be a lie). The control half of ⌘M / the yellow traffic-light button / the
-    /// Minimize title-bar double-click action.
+    /// Resolve a window id and minimize it to the Dock, or restore it, per the mode. A closed window errors,
+    /// as does one in native full screen (AppKit no-ops `miniaturize` there, so ok would be a lie). The
+    /// control half of ⌘M / the yellow traffic-light button / the Minimize title-bar double-click action.
     ///
-    /// Miniaturize and deminiaturize are ANIMATED, so `isMiniaturized` lags the call — without the settle
-    /// poll the `defer`-ed window-cache refresh would capture the OLD value and the very next
-    /// `window.list` would report the state the caller just changed away from.
+    /// Miniaturize and deminiaturize are ANIMATED, so `isMiniaturized` lags the call: without the settle
+    /// poll the `defer`-ed window-cache refresh captures the OLD value and the next `window.list` reports
+    /// the state the caller just changed away from.
     func windowMinimize(_ target: String?, mode: ControlToggleMode) async -> ControlResponse {
         switch resolver.resolveWindowID(target) {
         case .failure(let response): return response
@@ -200,13 +190,12 @@ extension ControlServer {
 
     /// After parking the FRONTMOST window, point `frontmostWindowID` at a window the user can still see.
     ///
-    /// `activeWindowID` only falls back when the frontmost window's STORE is gone (i.e. closed), and a
-    /// minimized window keeps its store — so without this every untargeted command (`tree`, `session.new`,
-    /// `quick`, the palette, the menu bar) keeps routing into a window sitting in the Dock. AppKit keys
-    /// another window on a minimize only while the APP is active, so a script parking windows in the
-    /// background never gets that handoff; when AppKit DID hand off, `reportFrontmost` already moved the
-    /// id and the guard below skips. With every open window minimized there is nothing to hand to, so the
-    /// pointer stays put rather than being cleared.
+    /// `activeWindowID` falls back only when the frontmost window's STORE is gone (closed), and a minimized
+    /// window keeps its store — so without this every untargeted command (`tree`, `session.new`, `quick`,
+    /// the palette, the menu bar) keeps routing into a window sitting in the Dock. AppKit keys another
+    /// window on a minimize only while the APP is active, so a script parking windows in the background
+    /// never gets that handoff; when AppKit DID hand off, `reportFrontmost` already moved the id and the
+    /// guard below skips. With every open window minimized there is nothing to hand to, so the pointer stays.
     private func handOffFrontmost(from id: WindowInfo.ID) {
         guard library.frontmostWindowID == id else { return }
         guard let next = library.openIDs().first(where: { $0 != id && !WindowRegistry.shared.isMinimized($0) })
@@ -214,15 +203,14 @@ extension ControlServer {
         takeFrontmost(next)
     }
 
-    /// Make `id` the logical frontmost window, the way `WindowAccessor.reportFrontmost` does on the GUI
-    /// path: record it, persist the index, and reconcile the auto-hidden sidebars. Shared by every
-    /// control path that presents a window — `window.select`, the minimize hand-off, `pick.open --follow`.
+    /// Make `id` the logical frontmost window the way `WindowAccessor.reportFrontmost` does on the GUI path:
+    /// record it, persist the index, reconcile the auto-hidden sidebars. Shared by every control path that
+    /// presents a window — `window.select`, the minimize hand-off, `pick.open --follow`.
     ///
     /// The control channel needs its own path because `reportFrontmost` fires on `didBecomeKey`, which
-    /// AppKit does not deliver while the app is inactive — exactly when a script is driving. Without the
-    /// reconcile the window that just became visible keeps its sidebar collapsed until the user next
-    /// activates agterm. Idempotent, and the reconcile resolves through `activeWindowID`, which returns
-    /// the id assigned just above.
+    /// AppKit does not deliver while the app is inactive — exactly when a script is driving; without the
+    /// reconcile the newly visible window keeps its sidebar collapsed until the user next activates agterm.
+    /// Idempotent, and the reconcile resolves through `activeWindowID`, which returns the id assigned above.
     func takeFrontmost(_ id: WindowInfo.ID) {
         guard library.frontmostWindowID != id else { return }
         library.frontmostWindowID = id

--- a/agterm/Control/ControlServer+WindowCommands.swift
+++ b/agterm/Control/ControlServer+WindowCommands.swift
@@ -3,19 +3,16 @@ import Foundation
 import agtermCore
 
 /// `ControlServer` window-command action arms — create, list, select, close, resize, move, zoom, rename and
-/// delete on-screen windows via `WindowRegistry` + `WindowLibrary`. Split out of `ControlServer.swift` for
-/// the swiftlint size limit.
+/// delete on-screen windows via `WindowRegistry` + `WindowLibrary`. Split out for the swiftlint size limit.
 extension ControlServer {
-    /// Create a new window (library) and open its on-screen window via the action hub's window opener (the
-    /// same `enqueueClaim` + `openWindow(id:)` path the menu uses). Returns the new window id.
-    ///
-    /// Bounded-polls for the NSWindow to ATTACH before replying, so an immediately following
-    /// `window.resize`/`move`/`zoom` — which needs a registered window — works. The poll must gate on
-    /// `WindowRegistry.isRegistered`, NOT `library.isOpen`: `newWindow()` loads the store synchronously so
-    /// `isOpen` is already true and proves nothing, while the NSWindow attaches only after SwiftUI resolves
-    /// the store and runs a second render pass. Fire-and-forget like the other polls — a window that never
-    /// renders times out and the command still replies ok. `minimized` parks it in the Dock AFTER creating,
-    /// so a script can build project windows and be left on one it can still see.
+    /// Create a new window and open it through the action hub's opener (the `enqueueClaim` + `openWindow(id:)`
+    /// path the menu uses); returns the new window id. `minimized` parks it in the Dock AFTER creating, so a
+    /// script building project windows is left on one it can still see. Bounded-polls for the NSWindow to
+    /// ATTACH before replying, so an immediately following `window.resize`/`move`/`zoom` finds it registered:
+    /// the poll must gate on `WindowRegistry.isRegistered`, NOT `library.isOpen`, since `newWindow()` loads
+    /// the store synchronously (so `isOpen` proves nothing) while the NSWindow attaches only after SwiftUI
+    /// resolves the store and runs a second render pass. Fire-and-forget like the other polls — a window that
+    /// never renders times out and the command still replies ok.
     func windowNew(name: String?, minimized: Bool) async -> ControlResponse {
         let info = library.newWindow(name: trimmed(name))
         actions.openWindow?(info.id)
@@ -25,14 +22,12 @@ extension ControlServer {
     }
 
     /// Park a freshly created window: minimize it, wait out the animation, and hand frontmost back.
-    ///
     /// The wait BEFORE minimizing is load-bearing: `WindowAccessor` presents the window on attach both
-    /// synchronously and again on the next main-queue turn, and that second present deminiaturizes — so
-    /// minimizing the instant registration lands would be undone. One poll tick yields the main actor long
-    /// enough for the queued present to drain first. A window that never rendered reaches here unregistered
-    /// (the attach poll is bounded and fire-and-forget) and `minimize` answers `.notOpen`; LOG that rather
-    /// than swallow it, since the window is then still on screen holding focus while the caller was told it
-    /// was parked. Frontmost is handed off only when the park applied — an unparked window is visible.
+    /// synchronously and again on the next main-queue turn, and that second present deminiaturizes — the
+    /// sleep yields the main actor long enough for the queued present to drain first. A window that never
+    /// rendered arrives here unregistered (the attach poll is bounded and fire-and-forget) and `minimize`
+    /// answers `.notOpen`; LOG that rather than swallow it — the window is then still on screen holding focus
+    /// while the caller was told it was parked. Frontmost is handed off only when the park applied.
     private func park(_ id: WindowInfo.ID) async {
         try? await Task.sleep(nanoseconds: 50_000_000)
         guard case .applied = WindowRegistry.shared.minimize(id, mode: .on) else {
@@ -54,19 +49,14 @@ extension ControlServer {
     }
 
     /// Resolve a window id and surface it: raise an already-open window, or open a closed one (the action
-    /// hub's opener claims its id + spawns the window). Returns the window id.
-    ///
+    /// hub's opener claims its id + spawns it). Returns the window id. Selecting also calls `takeFrontmost`
+    /// EXPLICITLY — `raise` alone leaves `frontmostWindowID` stale, so a background `window select` would
+    /// reply ok while untargeted commands kept routing into the previously-active window.
     /// Bounded-polls for BOTH the store and the NSWindow before replying, so a script can immediately target
-    /// it (`tree --window <id>`, a frame command) without racing the window appearing. `library.isOpen` alone
-    /// reports only that the store loaded — what `tree --window` needs, so it stays — but flips a render pass
-    /// before the NSWindow exists, so a frame command right after would hit `window not open`. An
-    /// already-attached window satisfies both on the first iteration.
-    ///
-    /// Selecting also takes frontmost EXPLICITLY: `raise` makes the window key, but `frontmostWindowID` is
-    /// updated only by `WindowAccessor.reportFrontmost` on `didBecomeKey`, which AppKit does not deliver
-    /// while the app is inactive — so a background `window select` would reply ok while untargeted commands
-    /// kept routing into the previously-active window. Same asymmetry `handOffFrontmost` fixes on the
-    /// minimize path, and the same reconcile is owed.
+    /// it (`tree --window <id>`, a frame command) without racing. `library.isOpen` alone reports only that the
+    /// store loaded — what `tree --window` needs, so it stays — but flips a render pass before the NSWindow
+    /// exists, so a frame command right after would hit `window not open`; an already-attached window
+    /// satisfies both on the first iteration.
     func windowSelect(_ target: String?) async -> ControlResponse {
         switch resolver.resolveWindowID(target) {
         case .failure(let response): return response
@@ -79,15 +69,14 @@ extension ControlServer {
     }
 
     /// Resolve a window id and close its on-screen window (the registry's `performClose` runs the standard
-    /// teardown + `closeWindow` path, asynchronously). Bounded-polls for the library to mark it closed, so
-    /// an immediate follow-up sees it closed. An already-closed window still reports ok. Returns the id.
+    /// teardown + `closeWindow` path, asynchronously). Bounded-polls for the library to mark it closed, so an
+    /// immediate follow-up sees it closed. An already-closed window still reports ok. Returns the id.
     func windowClose(_ target: String?) async -> ControlResponse {
         switch resolver.resolveWindowID(target) {
         case .failure(let response): return response
         case .success(let id):
-            // close the registered window (driving the willClose teardown), then a semantic fallback: when
-            // it isn't registered yet (window.close racing window.new before the NSWindow attaches) or
-            // willClose hasn't flipped the flag, drop the store so it is marked closed whatever the timing.
+            // close the registered window (driving willClose teardown), then a fallback for one not yet
+            // registered (window.close racing window.new) or an unflipped flag: drop the store to mark it closed.
             let hadWindow = WindowRegistry.shared.close(id)
             if hadWindow {
                 await pollUntil { !self.library.isOpen(id) }
@@ -101,11 +90,10 @@ extension ControlServer {
         }
     }
 
-    /// Bounded poll for an asynchronous window lifecycle transition (open after `window.select`, closed
-    /// after `window.close`): the SwiftUI scene opens/closes off this dispatch, so the library flag flips a
-    /// beat later. 30 × 0.05 s (≈1.5 s) of `Task.sleep` yields the main actor between checks, never blocking
-    /// the accept loop. Returns when `done()` holds or the budget is spent — the caller replies ok either
-    /// way, so the poll only narrows the race.
+    /// Bounded poll for an asynchronous window lifecycle transition: the SwiftUI scene opens/closes off this
+    /// dispatch, so the library flag flips a beat later. 30 × 0.05 s (≈1.5 s) of `Task.sleep` yields the main
+    /// actor between checks, never blocking the accept loop. Returns when `done()` holds or the budget is
+    /// spent — the caller replies ok either way, so the poll only narrows the race.
     private func pollUntil(_ done: () -> Bool) async {
         for _ in 0..<30 {
             if done() { return }
@@ -113,9 +101,8 @@ extension ControlServer {
         }
     }
 
-    /// Resolve a window id and resize its on-screen window to `width` x `height` points (frame size). Open
-    /// windows only; a closed one errors (resize after `window.select`). Control-native — no GUI surface,
-    /// the native title bar already drags-to-resize.
+    /// Resize the resolved window to `width` x `height` points (frame size). Open windows only; a closed one
+    /// errors. Control-native — no GUI surface, the native title bar already drags-to-resize.
     func windowResize(_ target: String?, width: Int, height: Int) -> ControlResponse {
         return resolver.resolveWindowID(target) { id in
             guard WindowRegistry.shared.resize(id, width: width, height: height) else {
@@ -125,9 +112,8 @@ extension ControlServer {
         }
     }
 
-    /// Resolve a window id and move its top-left corner to (`x`, `y`) points in the global top-left space
-    /// (origin = the primary display's top-left, spanning all displays). Open only; a closed window errors.
-    /// Control-native (no GUI surface).
+    /// Move the resolved window's top-left corner to (`x`, `y`) points in the global top-left space (origin =
+    /// the primary display's top-left, spanning all displays). Open only. Control-native (no GUI surface).
     func windowMove(_ target: String?, x: Int, y: Int, display: Int?) -> ControlResponse {
         if let display, display < 0 || display >= NSScreen.screens.count {
             return ControlResponse(ok: false, error: "display \(display) out of range (have \(NSScreen.screens.count))")
@@ -140,9 +126,8 @@ extension ControlServer {
         }
     }
 
-    /// Resolve a window id and zoom (maximize-to-screen toggle) its on-screen window; a closed window errors.
-    /// The control half of the double-click-header gesture — a plain green-button click does native full
-    /// screen, not zoom.
+    /// Zoom (maximize-to-screen toggle) the resolved window; a closed one errors. The control half of the
+    /// double-click-header gesture — a plain green-button click does native full screen, not zoom.
     func windowZoom(_ target: String?) -> ControlResponse {
         return resolver.resolveWindowID(target) { id in
             guard WindowRegistry.shared.zoom(id) else {
@@ -152,8 +137,8 @@ extension ControlServer {
         }
     }
 
-    /// Resolve a window id and toggle native macOS full screen on it; a closed window errors. The control
-    /// half of the View ▸ Toggle Full Screen menu item / the green traffic-light button.
+    /// Toggle native macOS full screen on the resolved window; a closed one errors. The control half of
+    /// View ▸ Toggle Full Screen / the green traffic-light button.
     func windowFullscreen(_ target: String?) -> ControlResponse {
         return resolver.resolveWindowID(target) { id in
             guard WindowRegistry.shared.fullscreen(id) else {
@@ -163,13 +148,12 @@ extension ControlServer {
         }
     }
 
-    /// Resolve a window id and minimize it to the Dock, or restore it, per the mode. A closed window errors,
-    /// as does one in native full screen (AppKit no-ops `miniaturize` there, so ok would be a lie). The
-    /// control half of ⌘M / the yellow traffic-light button / the Minimize title-bar double-click action.
-    ///
-    /// Miniaturize and deminiaturize are ANIMATED, so `isMiniaturized` lags the call: without the settle
-    /// poll the `defer`-ed window-cache refresh captures the OLD value and the next `window.list` reports
-    /// the state the caller just changed away from.
+    /// Minimize the resolved window to the Dock, or restore it, per the mode. A closed window errors, as does
+    /// one in native full screen (AppKit no-ops `miniaturize` there, so ok would be a lie). The control half
+    /// of ⌘M / the yellow traffic-light button / the Minimize title-bar double-click. Miniaturize and
+    /// deminiaturize are ANIMATED, so `isMiniaturized` lags the call: without the settle poll the `defer`-ed
+    /// window-cache refresh captures the OLD value and the next `window.list` reports the state the caller
+    /// just changed away from.
     func windowMinimize(_ target: String?, mode: ControlToggleMode) async -> ControlResponse {
         switch resolver.resolveWindowID(target) {
         case .failure(let response): return response
@@ -189,13 +173,12 @@ extension ControlServer {
     }
 
     /// After parking the FRONTMOST window, point `frontmostWindowID` at a window the user can still see.
-    ///
-    /// `activeWindowID` falls back only when the frontmost window's STORE is gone (closed), and a minimized
-    /// window keeps its store — so without this every untargeted command (`tree`, `session.new`, `quick`,
-    /// the palette, the menu bar) keeps routing into a window sitting in the Dock. AppKit keys another
-    /// window on a minimize only while the APP is active, so a script parking windows in the background
-    /// never gets that handoff; when AppKit DID hand off, `reportFrontmost` already moved the id and the
-    /// guard below skips. With every open window minimized there is nothing to hand to, so the pointer stays.
+    /// `activeWindowID` falls back only when the frontmost window's STORE is gone, and a minimized window
+    /// keeps its store — so without this every untargeted command (`tree`, `session.new`, `quick`, the
+    /// palette, the menu bar) keeps routing into a window sitting in the Dock. AppKit keys another window on
+    /// a minimize only while the APP is active, so a script parking windows in the background never gets that
+    /// handoff; when AppKit DID hand off, `reportFrontmost` already moved the id and the guard below skips.
+    /// With every open window minimized there is nothing to hand to, so the pointer stays.
     private func handOffFrontmost(from id: WindowInfo.ID) {
         guard library.frontmostWindowID == id else { return }
         guard let next = library.openIDs().first(where: { $0 != id && !WindowRegistry.shared.isMinimized($0) })
@@ -205,12 +188,11 @@ extension ControlServer {
 
     /// Make `id` the logical frontmost window the way `WindowAccessor.reportFrontmost` does on the GUI path:
     /// record it, persist the index, reconcile the auto-hidden sidebars. Shared by every control path that
-    /// presents a window — `window.select`, the minimize hand-off, `pick.open --follow`.
-    ///
-    /// The control channel needs its own path because `reportFrontmost` fires on `didBecomeKey`, which
-    /// AppKit does not deliver while the app is inactive — exactly when a script is driving; without the
-    /// reconcile the newly visible window keeps its sidebar collapsed until the user next activates agterm.
-    /// Idempotent, and the reconcile resolves through `activeWindowID`, which returns the id assigned above.
+    /// presents a window — `window.select`, the minimize hand-off, `pick.open --follow`. The control channel
+    /// needs its own path because `reportFrontmost` fires on `didBecomeKey`, which AppKit does not deliver
+    /// while the app is inactive — exactly when a script is driving; without the reconcile the newly visible
+    /// window keeps its sidebar collapsed until the user next activates agterm. Idempotent, and the reconcile
+    /// resolves through `activeWindowID`, which returns the id assigned above.
     func takeFrontmost(_ id: WindowInfo.ID) {
         guard library.frontmostWindowID != id else { return }
         library.frontmostWindowID = id
@@ -226,8 +208,8 @@ extension ControlServer {
         }
     }
 
-    /// Resolve a window id and delete it, honoring keep-at-least-one (an error instead of the GUI
-    /// confirm). Closes its on-screen window first if open. Returns the id.
+    /// Resolve a window id and delete it, honoring keep-at-least-one (an error instead of the GUI confirm).
+    /// Closes its on-screen window first if open. Returns the id.
     func windowDelete(_ target: String?) -> ControlResponse {
         return resolver.resolveWindowID(target) { id in
             guard library.canRemoveWindow else {

--- a/agterm/Control/ControlServer+WorkspaceCommands.swift
+++ b/agterm/Control/ControlServer+WorkspaceCommands.swift
@@ -1,21 +1,17 @@
 import Foundation
 import agtermCore
 
-/// `ControlServer` workspace-command adapter arms (create/select/rename/delete/move/focus and the
-/// per-workspace collapse/expand). Split out of `ControlServer+SessionActions.swift` to keep that file
-/// under the swiftlint size limit; these satisfy the `ControlActions` requirements whose conformance is
-/// declared there. Each does only target resolution + the AppKit/store side effect — all validation/response
-/// shaping lives host-free in `ControlDispatcher`. (The all-workspace `sidebar.expand`/`sidebar.collapse`
-/// arms live in `ControlServer+AppCommands.swift`.)
+/// `ControlServer` workspace-command adapter arms (create/select/rename/delete/move/focus and per-workspace
+/// collapse/expand), split out of `ControlServer+SessionActions.swift` for the file size limit; they satisfy
+/// the `ControlActions` conformance declared there. Each does only target resolution + the AppKit/store side
+/// effect — validation/response shaping is host-free in `ControlDispatcher`, and the all-workspace
+/// `sidebar.expand`/`sidebar.collapse` arms live in `ControlServer+AppCommands.swift`.
 extension ControlServer {
     func createWorkspace(window: String?, name: String?, collapsed: Bool) -> ControlResponse {
-        // placement target: the window's frontmost store (or `args.window`'s). name defaults to
-        // the auto-generated workspace name when none is given. `collapsed` seeds the workspace closed
-        // so a script can fill it with `session.new --no-select` without it opening — and, for the same
-        // reason, keeps it OUT of the workspace focus set (`revealNewWorkspace: false`): a `--collapsed`
-        // create is by definition a quiet background build, so widening a script's carefully marked set
-        // would contradict the flag. A PLAIN `workspace.new` keeps the auto-reveal, matching the GUI's
-        // New Workspace button — a foreground create must not land invisibly behind an applied filter.
+        // `collapsed` seeds the workspace closed so a script can fill it with `session.new --no-select`
+        // without it opening, and for the same reason keeps it OUT of the focus set — widening a script's
+        // marked set would contradict the flag. a plain create keeps the auto-reveal, matching the GUI's New
+        // Workspace button: a foreground create must not land invisibly behind an applied filter.
         resolver.resolvePlacementStore(window) { store in
             let name = trimmed(name) ?? store.defaultWorkspaceName
             let workspace = store.addWorkspace(name: name, collapsed: collapsed, revealNewWorkspace: !collapsed)
@@ -52,9 +48,8 @@ extension ControlServer {
         }
     }
 
-    /// `workspace.move`: reorder a workspace among its siblings (`up`|`down`|`top`|`bottom`). `to` is
-    /// required; an invalid direction errors. Resolves the workspace target via `resolveWorkspace`
-    /// (honoring the global `--window` selector like other workspace commands).
+    /// `workspace.move`: reorder a workspace among its siblings (`up`|`down`|`top`|`bottom`); `to` is required
+    /// and an invalid direction errors. Resolved via `resolveWorkspace`, honoring the `--window` selector.
     func moveWorkspace(_ target: String?, window: String?, direction dir: ReorderDirection) -> ControlResponse {
         return resolver.resolveWorkspace(target, window: window) { store, id in
             store.reorderWorkspace(id, dir)
@@ -62,16 +57,14 @@ extension ControlServer {
         }
     }
 
-    /// Mark or unmark a workspace in the sidebar focus SET. `mode` arrives already parsed and validated by
-    /// `ControlDispatcher`, and only two of the four modes touch the filter flag: `on` replaces the set
-    /// with the target and APPLIES the filter, `toggle` replace-toggles (clearing when the target is the
-    /// only marked workspace and the filter applies, else replacing the set with it and applying), `off`
-    /// drops the target from the set (the filter switches off once it empties; a no-op when it was never
-    /// marked), and `add` inserts the target alongside the existing members leaving the flag EXACTLY as it
-    /// was — marking only, so a script builds a set with repeated `add` calls and applies it with one
-    /// `workspace.filter on`. The whole mapping is host-free in `AppStore.applyFocusMode`, so this arm is
-    /// only target resolution; the mutators there are delta-guarded, so every mode is idempotent. The
-    /// control half of the workspace row's Focus/Unfocus + Add to/Remove from Focus menu.
+    /// Mark or unmark a workspace in the sidebar focus SET; `mode` arrives parsed and validated by
+    /// `ControlDispatcher`. `on` replaces the set with the target and APPLIES the filter; `toggle`
+    /// replace-toggles, clearing when the target is the only marked workspace and the filter applies, else
+    /// replacing and applying; `off` drops the target (the filter switches off once the set empties, a no-op
+    /// when never marked); `add` inserts alongside existing members leaving the flag EXACTLY as it was, so a
+    /// script builds a set with repeated `add` calls and applies it with one `workspace.filter on`. The whole
+    /// mapping is host-free in `AppStore.applyFocusMode` (delta-guarded, so every mode is idempotent), leaving
+    /// this arm target resolution. Control half of the row's Focus/Unfocus + Add to/Remove from Focus menu.
     func focusWorkspace(_ target: String?, window: String?, mode: ControlWorkspaceFocusMode) -> ControlResponse {
         resolver.resolveWorkspace(target, window: window) { store, id in
             store.applyFocusMode(mode, to: id)
@@ -79,13 +72,11 @@ extension ControlServer {
         }
     }
 
-    /// `workspace.filter`: turn a window's workspace focus filter on/off/toggle WITHOUT touching the
-    /// marked set, so peeking at the whole tree and coming back costs one call. Window-scoped (no
-    /// workspace target) — the `--window` selector picks the target like `sidebar.expand`/`sidebar.collapse`,
-    /// defaulting to the frontmost. `AppStore.setFocusEnabled` is delta-guarded and REFUSES to enable an
-    /// empty set, so `on` with nothing marked succeeds having changed nothing, keeping the documented
-    /// row-visibility read-back contract (`ControlWorkspaceNode.focused`) exact. No open window is an
-    /// error rather than a silent no-op.
+    /// `workspace.filter`: turn a window's focus filter on/off/toggle WITHOUT touching the marked set, so
+    /// peeking at the whole tree and back costs one call. Window-scoped (no workspace target); `--window`
+    /// picks it like `sidebar.expand`/`sidebar.collapse`, default frontmost. `AppStore.setFocusEnabled` is
+    /// delta-guarded and REFUSES to enable an empty set, so `on` with nothing marked succeeds having changed
+    /// nothing, keeping the `ControlWorkspaceNode.focused` row-visibility contract exact. No window is an error.
     func setWorkspaceFilter(window: String?, mode: ControlToggleMode) -> ControlResponse {
         resolver.resolveOpenPlacementStore(window) { store in
             store.applyWorkspaceFilter(mode)
@@ -93,14 +84,12 @@ extension ControlServer {
         }
     }
 
-    /// Collapse (`expanded: false`) or expand (`expanded: true`) a SINGLE workspace in a window's sidebar
-    /// tree — the per-workspace analogue of the all-workspace `sidebar.expand`/`sidebar.collapse`. Resolves
-    /// the target workspace via `resolveWorkspace` (honoring the global `--window` selector), then drives
-    /// `AppActions.setWorkspaceExpanded(_:expanded:in:)`, which persists `Workspace.isExpanded` on the store
-    /// directly (the source of truth for the `collapsed` read-back, so it works even when the target
-    /// window's sidebar is hidden) and posts a store-scoped notification for the live outline sync.
-    /// Idempotent (the store mutator is delta-guarded). Returns the workspace id; the read-back is the
-    /// `tree` workspace node's `collapsed` field.
+    /// Collapse (`expanded: false`) or expand (`expanded: true`) a SINGLE workspace in a window's sidebar tree
+    /// — the per-workspace analogue of `sidebar.expand`/`sidebar.collapse`. Resolved via `resolveWorkspace`
+    /// (honoring `--window`), then `AppActions.setWorkspaceExpanded(_:expanded:in:)` persists
+    /// `Workspace.isExpanded` on the store directly — the source of truth for the `collapsed` read-back, so it
+    /// works with that window's sidebar hidden — and posts a store-scoped notification for the live outline
+    /// sync. Idempotent (the store mutator is delta-guarded); returns the workspace id.
     func setWorkspaceExpansion(_ target: String?, window: String?, expanded: Bool) -> ControlResponse {
         resolver.resolveWorkspace(target, window: window) { store, id in
             actions.setWorkspaceExpanded(id, expanded: expanded, in: store)

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -3,21 +3,19 @@ import agtermCore
 import Darwin
 import Foundation
 
-/// The programmatic control channel: a POSIX unix-domain-socket listener that turns newline-delimited
-/// JSON `ControlRequest`s into calls on the existing `AppActions` / `AppStore` seam — the same seam the
-/// toolbar, menu bar, and palettes use. One request per connection: read a line, dispatch, write one
-/// `ControlResponse`, close.
+/// The programmatic control channel: a POSIX unix-domain-socket listener turning newline-delimited JSON
+/// `ControlRequest`s into calls on the `AppActions`/`AppStore` seam the toolbar, menu bar and palettes
+/// share. One request per connection: read a line, dispatch, write one `ControlResponse`, close.
 ///
-/// `@MainActor`: lifecycle and dispatch run on the main actor (the store is main-actor isolated). Only
-/// the blocking accept/read loop runs on a background `DispatchQueue`; each decoded request hops back to
-/// the main actor to execute. Best-effort: a bind failure logs and the app still launches.
+/// `@MainActor` because the store is: only the blocking accept/read loop runs on a background
+/// `DispatchQueue`, and each decoded request hops back to execute. Best-effort — a bind failure logs and
+/// the app still launches.
 @MainActor
 final class ControlServer {
-    /// The window library; commands dispatch onto a per-request target window's store. A `tree` or a
-    /// placement/`active` command with no `args.window` targets the frontmost window; with
-    /// `args.window` it targets that window (which must be open). An id/prefix session/workspace
-    /// target with no `args.window` is resolved across ALL open windows so a captured id resolves
-    /// regardless of which window is frontmost. The `window.*` commands drive the library itself.
+    /// The window library; commands dispatch onto a per-request target window's store. `tree` and
+    /// placement/`active` commands take `args.window` else the frontmost, and a named window must be open.
+    /// An id/prefix session/workspace target with no `args.window` resolves across ALL open windows, so a
+    /// captured id resolves regardless of which is frontmost. `window.*` drives the library itself.
     let library: WindowLibrary
     let actions: AppActions
     let settingsModel: SettingsModel
@@ -34,19 +32,17 @@ final class ControlServer {
     /// not started).
     var boundSocketPath: String? { listenFD >= 0 ? socketPath : nil }
 
-    /// The path the listener will bind (it's resolved at init via `defaultSocketPath()`, honoring a
-    /// test's `AGTERM_CONTROL_SOCKET` override). The surface factories read this into `AGTERM_SOCKET` so a
-    /// shell spawned BEFORE `start()` binds (the launch window's surfaces can materialize first) still
-    /// sees the socket it will be able to reach — `boundSocketPath` would be nil for those, leaking
-    /// AGTERM_SOCKET permanently. Equal to `boundSocketPath` once bound.
+    /// The path the listener will bind, resolved at init via `defaultSocketPath()` (honoring a test's
+    /// `AGTERM_CONTROL_SOCKET`). The surface factories read it into `AGTERM_SOCKET`: the launch window's
+    /// surfaces can materialize BEFORE `start()` binds, and `boundSocketPath` would be nil for those,
+    /// leaking `AGTERM_SOCKET` permanently. Equal to `boundSocketPath` once bound.
     var resolvedSocketPath: String { socketPath }
     /// The background queue running the blocking accept loop.
     private let acceptQueue = DispatchQueue(label: "com.umputun.agterm.control.accept")
 
-    /// Thread-safe cached window list, refreshed on the main actor after every dispatched command and
-    /// read (under the lock) from the background accept loop. Lets `window.list` / `tree --window`
-    /// queries be answered without the main actor, so a brief main-thread stall after a window close
-    /// can't make the serial control server unresponsive to polls.
+    /// Thread-safe window-list cache: refreshed on the main actor after every dispatched command, read
+    /// under the lock from the background accept loop. Answers `window.list` / `tree --window` without the
+    /// main actor, so a post-window-close main-thread stall can't wedge the serial server against polls.
     private let cacheLock = NSLock()
     nonisolated(unsafe) private var cachedWindowNodes: [ControlWindowNode] = []
 
@@ -60,10 +56,9 @@ final class ControlServer {
         cacheLock.lock(); cachedWindowNodes = nodes; cacheLock.unlock()
     }
 
-    /// A cache-only response for read-only window queries, or nil to fall through to the main actor.
-    /// Falls through on a cold cache (the main-actor path will populate it) and for `tree --window`
-    /// targeting an OPEN window (building the tree needs the main actor); only the closed-window error
-    /// and `window.list` are answered here.
+    /// A cache-only response for read-only window queries, or nil to fall through to the main actor — on a
+    /// cold cache (the main-actor path populates it) and for `tree --window` targeting an OPEN window
+    /// (building the tree needs the main actor). Only the closed-window error and `window.list` land here.
     nonisolated func fastPathResponse(for request: ControlRequest) -> ControlResponse? {
         let nodes = cachedWindows()
         guard !nodes.isEmpty else { return nil }
@@ -82,31 +77,27 @@ final class ControlServer {
         }
     }
 
-    /// 1 MiB cap on a single request line — far above any realistic `session.type` payload. A line that
-    /// exceeds it is rejected and the connection closed, so a bad client can never grow the buffer
-    /// unbounded.
+    /// 1 MiB cap on a request line — far above any realistic `session.type` payload. Over it, the line is
+    /// rejected and the connection closed, so a bad client can never grow the buffer unbounded.
     nonisolated private static let maxLineBytes = 1 << 20
 
     /// Seconds a blocking client read may stall before it times out (EAGAIN → connection closed), so a
     /// stalled client can't park the serial accept loop forever.
     nonisolated private static let readTimeoutSeconds = 5
 
-    /// Seconds a blocking response `write()` may stall before it times out, so a client that stops reading
-    /// can't park the serial accept loop — `session.text --all` responses can be multi-MB and won't fit
-    /// the socket buffer in one write, so an unresponsive reader would otherwise block indefinitely.
+    /// Seconds a blocking response `write()` may stall before it times out. A multi-MB `session.text --all`
+    /// response won't fit the socket buffer in one write, so a client that stops reading would otherwise
+    /// park the serial accept loop indefinitely.
     nonisolated private static let writeTimeoutSeconds = 5
 
-    /// Overall seconds a single connection's request read may take before it's abandoned. `readTimeoutSeconds`
-    /// only bounds each `read()`, so a slow-loris client trickling one byte per interval (each under the
-    /// per-read timeout) never sends a newline yet keeps the serial accept loop busy indefinitely. This caps
-    /// the total read time; a legit one-line request arrives in milliseconds, far under the cap.
+    /// Overall cap on a connection's request read. `readTimeoutSeconds` bounds each `read()` only, so a
+    /// slow-loris trickling a byte per interval never trips it, never sends a newline, and holds the serial
+    /// accept loop forever. A legit one-line request arrives in milliseconds.
     nonisolated private static let readDeadlineSeconds = 10
 
-    /// Overall seconds a single response write may take before it's abandoned. `SO_SNDTIMEO` only bounds
-    /// each `write()`, so a slow-drip reader draining a multi-MB `session.text --all` a few bytes per
-    /// interval keeps every write making progress and never trips the per-write timeout, parking the serial
-    /// accept loop. This caps the total write time, symmetric with `readDeadlineSeconds`; a normal reader
-    /// drains a response in milliseconds, far under the cap.
+    /// Overall cap on a response write, symmetric with `readDeadlineSeconds`. `SO_SNDTIMEO` bounds each
+    /// `write()` only, so a slow-drip reader draining a multi-MB `session.text --all` keeps every write
+    /// progressing, never trips it, and parks the serial accept loop. A normal reader drains in milliseconds.
     nonisolated private static let writeDeadlineSeconds = 10
 
     init(library: WindowLibrary, actions: AppActions, settingsModel: SettingsModel, socketPath: String? = nil) {
@@ -115,27 +106,25 @@ final class ControlServer {
         self.settingsModel = settingsModel
         self.resolver = ControlTargetResolver(library: library)
         self.socketPath = socketPath ?? ControlServer.defaultSocketPath()
-        // keep the read cache's `active` flag fresh across async frontmost changes (this server lives
-        // for the app's lifetime, so the observer doesn't need removal).
+        // keep the cache's `active` flag fresh across async frontmost changes; the server lives for the
+        // app's lifetime, so the observer needs no removal.
         NotificationCenter.default.addObserver(forName: .agtermWindowFrontmostChanged, object: nil, queue: .main) { [weak self] _ in
             MainActor.assumeIsolated { self?.refreshWindowCache() }
         }
-        // a GUI-only sidebar toggle (⌃⌘S / toolbar / menu / palette) mutates sidebarVisible without a
-        // control command, so refresh the cache on it too — otherwise window.list's sidebarVisible lags.
-        // queue nil (NOT .main) delivers synchronously on the posting thread: setSidebarVisible is
-        // @MainActor, so the refresh runs on the main actor BEFORE the toggle returns. An async .main hop
-        // would leave a window where a background window.list fast-path read still sees the stale cache.
+        // a GUI-only sidebar toggle (⌃⌘S / toolbar / menu / palette) mutates sidebarVisible with no control
+        // command, so window.list's copy would lag. queue nil (NOT .main) delivers synchronously on the
+        // posting thread — setSidebarVisible is @MainActor, so the refresh lands before the toggle returns;
+        // an async .main hop leaves a window where a background fast-path read sees the stale cache.
         NotificationCenter.default.addObserver(forName: .agtermSidebarVisibilityChanged, object: nil, queue: nil) { [weak self] _ in
             MainActor.assumeIsolated { self?.refreshWindowCache() }
         }
-        // window.list carries LIVE NSWindow geometry + fullscreen/zoom state, read at cache-build time. A
-        // user drag/resize/zoom/fullscreen changes it with NO control command, and a polling window.list is
-        // fast-path-served so it never refreshes its own cache — so observe the AppKit window notifications
-        // and refresh the cache on each. The fullscreen enter/exit notifications fire AFTER the async
-        // transition, so the refreshed cache sees the settled `styleMask`. The notification is ignored (not
-        // captured — a non-Sendable `Notification` can't cross into the `assumeIsolated` region under Swift 6);
-        // it fires for ANY window, but a non-agterm panel just rebuilds the same cheap agterm nodes, and a
-        // drag's didMove/didResize storm just keeps the cache current.
+        // window.list carries LIVE NSWindow geometry + fullscreen/zoom read at cache-build time, which a
+        // user drag/resize/zoom/fullscreen changes with NO control command — and a polling window.list is
+        // fast-path-served, so it never refreshes its own cache. The fullscreen notifications fire AFTER
+        // the async transition, so the settled `styleMask` is captured. The notification is ignored rather
+        // than captured (a non-Sendable `Notification` can't cross into `assumeIsolated` under Swift 6), so
+        // this fires for ANY window — harmless: a foreign panel rebuilds the same cheap agterm nodes, and a
+        // drag's didMove/didResize storm only keeps the cache current.
         for name in [NSWindow.didMoveNotification, NSWindow.didResizeNotification,
                      NSWindow.didEnterFullScreenNotification, NSWindow.didExitFullScreenNotification,
                      NSWindow.didMiniaturizeNotification, NSWindow.didDeminiaturizeNotification] {
@@ -143,20 +132,19 @@ final class ControlServer {
                 MainActor.assumeIsolated { self?.refreshWindowCache() }
             }
         }
-        // a window's NSWindow attaches a render pass or two AFTER its store loads, so the node cached right
-        // after window.new carries no geometry/flags — and nothing else refreshes it on that path (see the
-        // .agtermWindowAttachmentChanged doc comment). Refresh on attach/detach so the cache is honest for
-        // every opener, including GUI New Window and launch reopen-all, which run no control command at all.
+        // an NSWindow attaches a render pass or two AFTER its store loads, so the node cached right after
+        // window.new carries no geometry/flags and nothing else refreshes it there (see the
+        // .agtermWindowAttachmentChanged doc comment). Refreshing on attach/detach also covers GUI New
+        // Window and launch reopen-all, which run no control command at all.
         NotificationCenter.default.addObserver(forName: .agtermWindowAttachmentChanged, object: nil,
                                                queue: .main) { [weak self] _ in
             MainActor.assumeIsolated { self?.refreshWindowCache() }
         }
     }
 
-    /// The socket path the app and the CLI rendezvous on. `AGTERM_CONTROL_SOCKET` is an explicit override
-    /// (used by tests, whose sandboxed `AGTERM_STATE_DIR` container path is too long for `sun_path`'s
-    /// ~104-byte limit). Otherwise it is `<AGTERM_STATE_DIR>/agterm.sock` when that var is set (state
-    /// isolation), else `<app support>/agterm.sock`.
+    /// The socket path the app and the CLI rendezvous on. `AGTERM_CONTROL_SOCKET` overrides (tests need it
+    /// — their sandboxed `AGTERM_STATE_DIR` container path exceeds `sun_path`'s ~104 bytes); else
+    /// `<AGTERM_STATE_DIR>/agterm.sock` when that var is set (state isolation), else `<app support>/agterm.sock`.
     static func defaultSocketPath() -> String {
         let env = ProcessInfo.processInfo.environment
         if let explicit = env["AGTERM_CONTROL_SOCKET"] { return explicit }
@@ -165,9 +153,8 @@ final class ControlServer {
 
     // MARK: - Lifecycle
 
-    /// Bind and start listening. Idempotent: a no-op if already listening (the scene `.task` may re-run if
-    /// the window is recreated, so a second `start()` must not attempt a second `bind`). On any failure it
-    /// logs and returns, leaving the app to launch normally.
+    /// Bind and start listening. Idempotent — the scene `.task` may re-run when a window is recreated, and
+    /// a second `bind` must not be attempted. Any failure logs and returns, leaving the app to launch.
     func start() {
         guard listenFD < 0 else { return }
 
@@ -207,7 +194,6 @@ final class ControlServer {
             return
         }
 
-        // owner-only access (0600).
         chmod(socketPath, 0o600)
 
         guard listen(fd, 8) == 0 else {
@@ -231,9 +217,8 @@ final class ControlServer {
 
     // MARK: - Accept / read loop
 
-    /// Run the blocking accept loop on the background queue. Each accepted connection is handled inline
-    /// (one request → one response → close); connections are rare and short, so a per-connection thread is
-    /// unnecessary.
+    /// Run the blocking accept loop on the background queue, each connection handled inline (one request →
+    /// one response → close): connections are rare and short, so a per-connection thread is unnecessary.
     private func acceptLoop(fd: Int32) {
         acceptQueue.async {
             while true {
@@ -249,8 +234,8 @@ final class ControlServer {
     }
 
     /// Read one newline-delimited request from `conn`, decode it, dispatch it on `server` (main actor),
-    /// write the encoded response back, and close. A decode failure replies with a structured error rather
-    /// than crashing. Runs on the background queue (called from `acceptLoop`).
+    /// write the response back, close. A decode failure replies with a structured error rather than
+    /// crashing. Runs on the background queue.
     nonisolated private static func handleConnection(_ conn: Int32, server: ControlServer) {
         defer { close(conn) }
         // never let a write to a client that already hung up raise SIGPIPE (default-fatal) — that would
@@ -258,13 +243,9 @@ final class ControlServer {
         var noSigPipe: Int32 = 1
         setsockopt(conn, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, socklen_t(MemoryLayout<Int32>.size))
 
-        // bound the blocking read so a stalled client can't park the serial accept loop forever — a
-        // timed-out read returns EAGAIN, which readLine treats as a read error and closes the connection.
         var readTimeout = timeval(tv_sec: readTimeoutSeconds, tv_usec: 0)
         setsockopt(conn, SOL_SOCKET, SO_RCVTIMEO, &readTimeout, socklen_t(MemoryLayout<timeval>.size))
 
-        // bound the blocking response write too — a large `session.text --all` reply may not fit the socket
-        // buffer in one write, so a client that stopped reading would otherwise wedge the accept loop.
         var writeTimeout = timeval(tv_sec: writeTimeoutSeconds, tv_usec: 0)
         setsockopt(conn, SOL_SOCKET, SO_SNDTIMEO, &writeTimeout, socklen_t(MemoryLayout<timeval>.size))
 
@@ -281,17 +262,17 @@ final class ControlServer {
             return
         }
 
-        // fast-path read-only window queries from a thread-safe cache, WITHOUT hopping to the main
-        // actor: a window close can briefly stall the main thread (surface teardown / re-render), and
-        // the serial accept loop would otherwise go unresponsive to `window.list` polls behind it.
+        // answer read-only window queries from the cache without a main-actor hop: a window close briefly
+        // stalls the main thread (surface teardown / re-render), which would leave the serial accept loop
+        // unresponsive to `window.list` polls behind it.
         if let cached = server.fastPathResponse(for: request) {
             writeResponse(conn, cached)
             return
         }
 
-        // hop to the main actor to execute, blocking this background thread until it returns. dispatch
-        // refreshes the window cache itself (single main-actor execution), so the fast path reflects
-        // this command's mutations without a second hop that could queue behind a post-close stall.
+        // hop to the main actor, blocking this background thread. dispatch refreshes the window cache in
+        // that same execution, so the fast path sees this command's mutations without a second hop that
+        // could queue behind a post-close stall.
         let response = runBlocking { await server.dispatch(request) }
         writeResponse(conn, response)
     }
@@ -301,8 +282,6 @@ final class ControlServer {
     nonisolated private static func readLine(_ conn: Int32) -> Data? {
         var buffer = Data()
         var byte: UInt8 = 0
-        // overall deadline: SO_RCVTIMEO bounds each read, but a slow trickle (a byte per sub-timeout
-        // interval) would otherwise loop forever without a newline. cap the total read time too.
         let deadline = DispatchTime.now() + .seconds(readDeadlineSeconds)
         while true {
             if DispatchTime.now() > deadline { return nil }
@@ -325,8 +304,6 @@ final class ControlServer {
         data.withUnsafeBytes { raw in
             var offset = 0
             let base = raw.bindMemory(to: UInt8.self).baseAddress!
-            // overall deadline: SO_SNDTIMEO bounds each write(), but a slow-drip reader making a few bytes
-            // of progress per interval never trips it, so cap the total write time like readLine's deadline.
             let deadline = DispatchTime.now() + .seconds(writeDeadlineSeconds)
             while offset < data.count {
                 if DispatchTime.now() > deadline { return }
@@ -341,9 +318,8 @@ final class ControlServer {
         }
     }
 
-    /// Run an async closure to completion on a fresh task, blocking the calling (background) thread until it
-    /// finishes. Used to bridge the synchronous read loop to the main-actor dispatch without an actor hop on
-    /// the loop thread itself.
+    /// Run an async closure on a fresh task, blocking the calling background thread until it finishes —
+    /// bridges the synchronous read loop to the main-actor dispatch without hopping the loop thread itself.
     nonisolated private static func runBlocking<T: Sendable>(_ body: @escaping @Sendable () async -> T) -> T {
         let semaphore = DispatchSemaphore(value: 0)
         let box = ResultBox<T>()
@@ -365,8 +341,8 @@ final class ControlServer {
     /// Execute a request against the store/actions seam. Never throws across the socket: any failure is a
     /// `{"ok":false,"error":…}` response.
     private func dispatch(_ request: ControlRequest) async -> ControlResponse {
-        // refresh the read cache within this same main-actor execution (a window mutation just ran), so
-        // the background fast path sees the new state without a separate hop that could stall.
+        // refresh the read cache in this same main-actor execution (a window mutation just ran), so the
+        // background fast path sees the new state without a separate, stallable hop.
         defer { refreshWindowCache() }
         if let response = await ControlDispatcher(actions: self).dispatch(request) {
             return response
@@ -395,17 +371,16 @@ final class ControlServer {
         }
     }
 
-    /// UI-TEST-ONLY seam: force the app-level appearance so an XCUITest can simulate a macOS light/dark
-    /// flip deterministically (macOS XCUITest has no API to change the system appearance). Setting
-    /// `NSApp.appearance` changes `NSApp.effectiveAppearance`; this arm ALSO posts
-    /// `.agtermSystemAppearanceChanged` directly, so the REAL flip path (scheme sync → debounced
-    /// zoom-preserving reload) is exercised end to end without depending on whether KVO fires on an
-    /// explicit set (production relies on the KVO observer firing on a genuine system flip). Refused
-    /// outside an XCUITest launch, and deliberately EXEMPT from the four-point keep-in-sync (no agtermctl
-    /// subcommand, absent from the catalog/skill) — test scaffolding, not a control surface. Setting
-    /// echoes the resulting effective side in `result.text`; the BARE form (no name) reads the side the
-    /// last config feed applied (`SettingsModel.lastAppliedIsDark`), which a test polls to assert the
-    /// flip actually drove the reload — a suppressed flip leaves it on the old side.
+    /// UI-TEST-ONLY seam: forces the app-level appearance so an XCUITest can simulate a macOS light/dark
+    /// flip deterministically (XCUITest has no API for it). Setting `NSApp.appearance` moves
+    /// `effectiveAppearance`, and this arm ALSO posts `.agtermSystemAppearanceChanged` so the REAL flip
+    /// path (scheme sync → debounced zoom-preserving reload) runs end to end without depending on KVO
+    /// firing for an explicit set (production relies on KVO for a genuine system flip). Refused outside an
+    /// XCUITest launch, and deliberately EXEMPT from the four-point keep-in-sync — test scaffolding, so no
+    /// `agtermctl` subcommand and absent from the catalog/skill. Setting echoes the effective side in
+    /// `result.text`; the BARE form (no name) reads the side the last config feed applied
+    /// (`SettingsModel.lastAppliedIsDark`), which a test polls to prove the flip drove the reload — a
+    /// suppressed flip leaves it on the old side.
     private func setDebugAppearance(args: ControlArgs?) -> ControlResponse {
         guard ContentView.isUITestLaunch else {
             return ControlResponse(ok: false, error: "debug.appearance is a UI-test-only seam")
@@ -417,9 +392,8 @@ final class ControlServer {
         guard let side = trimmed(args?.name), side == "light" || side == "dark" else {
             return ControlResponse(ok: false, error: "debug.appearance requires light|dark")
         }
-        // take the validated `side` directly — do NOT re-read `currentIsDark()`, whose
-        // `effectiveAppearance` may not have settled synchronously right after the set (the same
-        // "take the delivered value, never re-read" rule the production `SystemAppearanceObserver` follows).
+        // take the validated `side`, never re-read `currentIsDark()` — `effectiveAppearance` may not have
+        // settled right after the set (the production `SystemAppearanceObserver`'s never-re-read rule).
         let isDark = side == "dark"
         NSApp.appearance = NSAppearance(named: isDark ? .darkAqua : .aqua)
         // drive the flip pipeline directly (a duplicate KVO post, if any, is same-side-suppressed).
@@ -428,11 +402,11 @@ final class ControlServer {
         return ControlResponse(ok: true, result: ControlResult(text: isDark ? "dark" : "light"))
     }
 
-    /// Clear every open session's saved foreground command (the restore-running-command capture) and
-    /// persist, so the next launch restores plain shells. The live fields are normally already nil
-    /// (consumed at restore); the SAVE is what wipes the on-disk copy from the last quit, also closing
-    /// the force-quit re-fire window. Drives `restore.clear` / `agtermctl restore clear`. App-global like
-    /// `keymap.reload` (no `--window` selector — it clears every open window).
+    /// Clear every open session's captured foreground command and persist, so the next launch restores
+    /// plain shells. The live fields are normally already nil (consumed at restore) — the SAVE is what
+    /// wipes the on-disk copy from the last quit, closing the force-quit re-fire window. Drives
+    /// `restore.clear` / `agtermctl restore clear`; app-global like `keymap.reload`, so no `--window`
+    /// selector and every open window is cleared.
     func clearRestoreCommands() -> ControlResponse {
         for session in library.allOpenSessions() {
             session.foregroundCommand = nil
@@ -443,20 +417,19 @@ final class ControlServer {
     }
 
     /// Open or close the target window's dashboard overlay — the app side of the host-free `dashboard`
-    /// command (the dispatcher validated the args and built `fontMode`; it no longer caps the ids). Resolves
-    /// `window ?? frontmost` to an OPEN window's store. With `mru` it pulls up to `DashboardLayout.maxCells`
-    /// of that window's most-recently-used sessions from the store's recency (fewer if it has fewer; nothing
-    /// goes unresolved); otherwise it resolves each id to a session in THAT store, deduping by resolved UUID
-    /// (order preserved) and reporting any that don't resolve in `result.text` (never a silent drop). It then
-    /// EXPANDS each resolved session IN ORDER into pane cells — always its `.primary` pane, plus a `.split`
-    /// cell when the session `hasSplit` (both shells alive) — so a split session shows as TWO cells. The
-    /// `DashboardLayout.maxCells` (9) cap now counts PANES, applied here after expansion; any dropped panes
-    /// are reported alongside `unresolved` (joined with "; "). Each cell reparents its OWN pane surface
-    /// (`.primary` → `\.surface`, `.split` → `\.splitSurface`) app-side in `WindowContentView`. Opening closes
-    /// any active terminal zoom for the window (zoom and dashboard are mutually exclusive) and drives that
-    /// window's `DashboardController` via the registry; `--close` calls `close()`. The per-window controller
-    /// is registered by `WindowContentView`; until it is (or while the window is tearing down) the registry
-    /// returns nil and this reports the window isn't open.
+    /// command (the dispatcher validated the args and built `fontMode`; it does not cap the ids). Resolves
+    /// `window ?? frontmost` to an OPEN window's store. `mru` takes up to `DashboardLayout.maxCells` of that
+    /// window's most-recently-used sessions from the store's recency (fewer if it has fewer, nothing
+    /// unresolved); otherwise each id resolves to a session in THAT store, deduped by resolved UUID in
+    /// order, with misses reported in `result.text` rather than silently dropped. Each resolved session then
+    /// EXPANDS in order into pane cells — always `.primary`, plus `.split` when the session `hasSplit` (both
+    /// shells alive), so a split shows as TWO cells — and the `DashboardLayout.maxCells` (9) cap counts
+    /// PANES, applied here after expansion, dropped ones reported alongside `unresolved` (joined with "; ").
+    /// Each cell reparents its OWN pane surface (`.primary` → `\.surface`, `.split` → `\.splitSurface`)
+    /// app-side in `WindowContentView`. Opening closes the window's active terminal zoom (zoom and dashboard
+    /// are mutually exclusive) and drives its `DashboardController` via the registry; `--close` calls
+    /// `close()`. `WindowContentView` registers that controller, so until it does (or while the window tears
+    /// down) the registry returns nil and this reports the window isn't open.
     func setDashboard(targets: [String], window: String?, close: Bool,
                       fontMode: DashboardFontMode, mru: Bool) -> ControlResponse {
         resolver.resolvePlacementStore(window) { store in
@@ -474,8 +447,6 @@ final class ControlServer {
             var sessionIDs: [UUID] = []
             var unresolved: [String] = []
             if mru {
-                // --mru: pull the window's most-recently-used sessions (≤ maxCells) from the store's recency;
-                // there are no explicit ids to resolve, so nothing goes unresolved.
                 sessionIDs = store.recentSessions(limit: DashboardLayout.maxCells)
                 guard !sessionIDs.isEmpty else {
                     return ControlResponse(ok: false, error: "no recent sessions")
@@ -496,22 +467,17 @@ final class ControlServer {
                     return ControlResponse(ok: false, error: "no dashboard sessions resolved")
                 }
             }
-            // expand each resolved session into pane cells (always the primary pane, plus the split pane when the
-            // session hasSplit) and cap the resulting PANE list to the 9-cell limit — the shared host-free
-            // AppStore helper, so this expansion+cap has one implementation with AppActions.toggleDashboard.
+            // the shared host-free helper: ONE expansion+cap implementation with AppActions.toggleDashboard.
             let (members, droppedPanes) = store.dashboardMembers(for: sessionIDs, limit: DashboardLayout.maxCells)
-            // zoom and dashboard are mutually exclusive: drop any active zoom for this window on open.
             TerminalZoomRegistry.shared.controller(for: windowID)?.clear()
             controller.open(members: members, fontMode: fontMode)
-            // set the applied font size SYNCHRONOUSLY so the `dashboardFontSize` tree read-back is
-            // authoritative at command return: the SwiftUI onChange that applies the surface overrides runs a
-            // runloop turn later, and open() never resets appliedFontSize — an untouched re-open would
-            // otherwise leak the prior fixed/auto size. Idempotent with the wiring, which resolves the same
-            // (base, member-count, mode) through the shared DashboardFontMode.appliedFontSize seam.
+            // set the applied size SYNCHRONOUSLY so the `dashboardFontSize` read-back is authoritative at
+            // command return: the SwiftUI onChange applying the surface overrides runs a runloop turn later,
+            // and open() never resets appliedFontSize, so an untouched re-open would leak the prior
+            // fixed/auto size. Idempotent with the wiring — both resolve the same (base, member-count, mode)
+            // through the shared DashboardFontMode.appliedFontSize seam.
             let base = settingsModel.settings.fontSize ?? DashboardLayout.ghosttyDefaultFontSize
             controller.setAppliedFontSize(fontMode.appliedFontSize(memberCount: members.count, base: base))
-            // combine "unresolved: …" (ids that didn't resolve) with a dropped-panes note (panes past the
-            // 9-cell cap) into one message, joined with "; " — neither clobbers the other.
             var notes: [String] = []
             if !unresolved.isEmpty { notes.append("unresolved: \(unresolved.joined(separator: ", "))") }
             if droppedPanes > 0 {
@@ -527,12 +493,12 @@ final class ControlServer {
     func buildTree(in store: AppStore) -> ControlTree {
         let shellBasename = ProcessInfo.processInfo.environment["SHELL"].map(CommandRestore.basename)
         // the projected window owns its quick terminal; find its id by store identity to read the live
-        // QuickTerminalController.isVisible (a nil controller — never opened, or the window is tearing
-        // down — reads as not visible).
+        // QuickTerminalController.isVisible (a nil controller — never opened, or tearing down — reads as
+        // not visible).
         let windowID = library.windowID(for: store)
-        // the projected window's dashboard controller (nil until WindowContentView registers it), read
-        // LIVE for the four dashboard read-backs — tree-only, since the keyboard-driven dashboard bypasses
-        // the command path and a cached copy would go stale (same reason as zoomedSurface/quickVisible).
+        // the window's dashboard controller (nil until WindowContentView registers it), read LIVE for the
+        // four dashboard read-backs — tree-only, since the keyboard-driven dashboard bypasses the command
+        // path and a cached copy would go stale (as for zoomedSurface/quickVisible).
         let dashboard = DashboardControllerRegistry.shared.controller(for: windowID)
         return store.controlTree(
             foreground: { session in
@@ -577,11 +543,11 @@ final class ControlServer {
     }
 
     /// Creates a session in `workspaceID` of `store` with the `session.new` args (cwd default $HOME,
-    /// optional command/name), focuses it when it lands in the frontmost window (so a keymap `session new`
-    /// opens focused like the GUI New Session; a background `--window` target keeps focus), and returns the
-    /// new id. Shared by the id- and name-addressed paths of the `.sessionNew` arm. `at` is the anchor-relative
-    /// insertion slot for `--after`/`--before` (clamped in `AppStore`); nil appends. With `options.noSelect`
-    /// the session is created in the background — `addSession` skips selecting it and the focus call is
+    /// optional command/name), focuses it only when it lands in the frontmost window — so a keymap
+    /// `session new` opens focused like the GUI New Session while a background `--window` target keeps
+    /// focus — and returns the new id. Shared by the id- and name-addressed `.sessionNew` paths. `at` is the
+    /// anchor-relative `--after`/`--before` insertion slot (clamped in `AppStore`); nil appends.
+    /// `options.noSelect` creates in the background: `addSession` skips selecting and the focus call is
     /// suppressed, leaving the current selection and focus untouched.
     func makeSessionResponse(in store: AppStore, workspaceID: UUID,
                              options: ControlSessionCreateOptions, at index: Int? = nil) -> ControlResponse {

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -7,15 +7,14 @@ import Foundation
 /// `ControlRequest`s into calls on the `AppActions`/`AppStore` seam the toolbar, menu bar and palettes
 /// share. One request per connection: read a line, dispatch, write one `ControlResponse`, close.
 ///
-/// `@MainActor` because the store is: only the blocking accept/read loop runs on a background
-/// `DispatchQueue`, and each decoded request hops back to execute. Best-effort — a bind failure logs and
-/// the app still launches.
+/// `@MainActor` because the store is: only the blocking accept/read loop runs on a background queue, each
+/// decoded request hopping back to execute. Best-effort — a bind failure logs and the app still launches.
 @MainActor
 final class ControlServer {
     /// The window library; commands dispatch onto a per-request target window's store. `tree` and
-    /// placement/`active` commands take `args.window` else the frontmost, and a named window must be open.
-    /// An id/prefix session/workspace target with no `args.window` resolves across ALL open windows, so a
-    /// captured id resolves regardless of which is frontmost. `window.*` drives the library itself.
+    /// placement/`active` commands take `args.window` else the frontmost (a named window must be open); an
+    /// id/prefix session/workspace target without `args.window` resolves across ALL open windows, so a
+    /// captured id works regardless of which is frontmost. `window.*` drives the library itself.
     let library: WindowLibrary
     let actions: AppActions
     let settingsModel: SettingsModel
@@ -28,21 +27,18 @@ final class ControlServer {
     /// The listening socket fd, or -1 when not listening. `start()` is idempotent on this.
     private var listenFD: Int32 = -1
 
-    /// The socket path the listener actually bound, or nil when it isn't listening (bind failed or
-    /// not started).
+    /// The bound socket path, nil when not listening (bind failed or never started).
     var boundSocketPath: String? { listenFD >= 0 ? socketPath : nil }
 
-    /// The path the listener will bind, resolved at init via `defaultSocketPath()` (honoring a test's
-    /// `AGTERM_CONTROL_SOCKET`). The surface factories read it into `AGTERM_SOCKET`: the launch window's
-    /// surfaces can materialize BEFORE `start()` binds, and `boundSocketPath` would be nil for those,
-    /// leaking `AGTERM_SOCKET` permanently. Equal to `boundSocketPath` once bound.
+    /// The path the listener will bind, resolved at init via `defaultSocketPath()`. The surface factories
+    /// read it into `AGTERM_SOCKET`: the launch window's surfaces can materialize BEFORE `start()` binds,
+    /// and a nil `boundSocketPath` would leak `AGTERM_SOCKET` permanently. Equals it once bound.
     var resolvedSocketPath: String { socketPath }
-    /// The background queue running the blocking accept loop.
     private let acceptQueue = DispatchQueue(label: "com.umputun.agterm.control.accept")
 
-    /// Thread-safe window-list cache: refreshed on the main actor after every dispatched command, read
-    /// under the lock from the background accept loop. Answers `window.list` / `tree --window` without the
-    /// main actor, so a post-window-close main-thread stall can't wedge the serial server against polls.
+    /// Thread-safe window-list cache: refreshed on the main actor after every dispatched command, read under
+    /// the lock from the background accept loop, so a post-window-close main-thread stall can't wedge the
+    /// serial server against `window.list` / `tree --window` polls.
     private let cacheLock = NSLock()
     nonisolated(unsafe) private var cachedWindowNodes: [ControlWindowNode] = []
 
@@ -56,9 +52,9 @@ final class ControlServer {
         cacheLock.lock(); cachedWindowNodes = nodes; cacheLock.unlock()
     }
 
-    /// A cache-only response for read-only window queries, or nil to fall through to the main actor — on a
-    /// cold cache (the main-actor path populates it) and for `tree --window` targeting an OPEN window
-    /// (building the tree needs the main actor). Only the closed-window error and `window.list` land here.
+    /// A cache-only response for read-only window queries, nil to fall through to the main actor: on a cold
+    /// cache (which the main-actor path populates) and for `tree --window` on an OPEN window (building the
+    /// tree needs the main actor). Only the closed-window error and `window.list` land here.
     nonisolated func fastPathResponse(for request: ControlRequest) -> ControlResponse? {
         let nodes = cachedWindows()
         guard !nodes.isEmpty else { return nil }
@@ -77,27 +73,25 @@ final class ControlServer {
         }
     }
 
-    /// 1 MiB cap on a request line — far above any realistic `session.type` payload. Over it, the line is
-    /// rejected and the connection closed, so a bad client can never grow the buffer unbounded.
+    /// 1 MiB cap on a request line, far above any realistic `session.type` payload; over it the line is
+    /// rejected and the connection closed, so a bad client can't grow the buffer unbounded.
     nonisolated private static let maxLineBytes = 1 << 20
 
-    /// Seconds a blocking client read may stall before it times out (EAGAIN → connection closed), so a
-    /// stalled client can't park the serial accept loop forever.
+    /// Seconds a blocking client read may stall before timing out (EAGAIN → connection closed), so a stalled
+    /// client can't park the serial accept loop forever.
     nonisolated private static let readTimeoutSeconds = 5
 
-    /// Seconds a blocking response `write()` may stall before it times out. A multi-MB `session.text --all`
-    /// response won't fit the socket buffer in one write, so a client that stops reading would otherwise
-    /// park the serial accept loop indefinitely.
+    /// Seconds a blocking response `write()` may stall before timing out: a multi-MB `session.text --all`
+    /// response won't fit the socket buffer in one write, so a client that stops reading would park the loop.
     nonisolated private static let writeTimeoutSeconds = 5
 
-    /// Overall cap on a connection's request read. `readTimeoutSeconds` bounds each `read()` only, so a
-    /// slow-loris trickling a byte per interval never trips it, never sends a newline, and holds the serial
-    /// accept loop forever. A legit one-line request arrives in milliseconds.
+    /// Overall cap on a connection's request read: `readTimeoutSeconds` bounds each `read()` only, so a
+    /// slow-loris trickling a byte per interval, never a newline, never trips it and holds the loop forever.
     nonisolated private static let readDeadlineSeconds = 10
 
-    /// Overall cap on a response write, symmetric with `readDeadlineSeconds`. `SO_SNDTIMEO` bounds each
+    /// Overall cap on a response write, symmetric with `readDeadlineSeconds`: `SO_SNDTIMEO` bounds each
     /// `write()` only, so a slow-drip reader draining a multi-MB `session.text --all` keeps every write
-    /// progressing, never trips it, and parks the serial accept loop. A normal reader drains in milliseconds.
+    /// progressing and parks the accept loop. A normal reader drains in milliseconds.
     nonisolated private static let writeDeadlineSeconds = 10
 
     init(library: WindowLibrary, actions: AppActions, settingsModel: SettingsModel, socketPath: String? = nil) {
@@ -106,25 +100,23 @@ final class ControlServer {
         self.settingsModel = settingsModel
         self.resolver = ControlTargetResolver(library: library)
         self.socketPath = socketPath ?? ControlServer.defaultSocketPath()
-        // keep the cache's `active` flag fresh across async frontmost changes; the server lives for the
-        // app's lifetime, so the observer needs no removal.
+        // keep the `active` flag fresh across async frontmost changes; the server lives for the app's
+        // lifetime, so the observer needs no removal.
         NotificationCenter.default.addObserver(forName: .agtermWindowFrontmostChanged, object: nil, queue: .main) { [weak self] _ in
             MainActor.assumeIsolated { self?.refreshWindowCache() }
         }
-        // a GUI-only sidebar toggle (⌃⌘S / toolbar / menu / palette) mutates sidebarVisible with no control
-        // command, so window.list's copy would lag. queue nil (NOT .main) delivers synchronously on the
-        // posting thread — setSidebarVisible is @MainActor, so the refresh lands before the toggle returns;
-        // an async .main hop leaves a window where a background fast-path read sees the stale cache.
+        // a GUI-only sidebar toggle runs no control command, so window.list's cached copy would lag. queue
+        // nil (NOT .main) delivers synchronously on the posting @MainActor thread, so the refresh lands
+        // before the toggle returns; an async .main hop leaves a window for a stale fast-path read.
         NotificationCenter.default.addObserver(forName: .agtermSidebarVisibilityChanged, object: nil, queue: nil) { [weak self] _ in
             MainActor.assumeIsolated { self?.refreshWindowCache() }
         }
-        // window.list carries LIVE NSWindow geometry + fullscreen/zoom read at cache-build time, which a
-        // user drag/resize/zoom/fullscreen changes with NO control command — and a polling window.list is
-        // fast-path-served, so it never refreshes its own cache. The fullscreen notifications fire AFTER
-        // the async transition, so the settled `styleMask` is captured. The notification is ignored rather
-        // than captured (a non-Sendable `Notification` can't cross into `assumeIsolated` under Swift 6), so
-        // this fires for ANY window — harmless: a foreign panel rebuilds the same cheap agterm nodes, and a
-        // drag's didMove/didResize storm only keeps the cache current.
+        // window.list carries LIVE NSWindow geometry + fullscreen/zoom read at cache-build time, which a user
+        // drag/resize/zoom/fullscreen changes with NO control command — and a polling window.list is
+        // fast-path-served, so it never refreshes its own cache. the fullscreen notifications fire AFTER the
+        // async transition, so the settled `styleMask` is captured. the non-Sendable `Notification` is
+        // ignored, not captured (it can't cross into `assumeIsolated` under Swift 6), so this fires for ANY
+        // window — harmless, a foreign panel just rebuilds the same cheap agterm nodes.
         for name in [NSWindow.didMoveNotification, NSWindow.didResizeNotification,
                      NSWindow.didEnterFullScreenNotification, NSWindow.didExitFullScreenNotification,
                      NSWindow.didMiniaturizeNotification, NSWindow.didDeminiaturizeNotification] {
@@ -133,18 +125,17 @@ final class ControlServer {
             }
         }
         // an NSWindow attaches a render pass or two AFTER its store loads, so the node cached right after
-        // window.new carries no geometry/flags and nothing else refreshes it there (see the
-        // .agtermWindowAttachmentChanged doc comment). Refreshing on attach/detach also covers GUI New
-        // Window and launch reopen-all, which run no control command at all.
+        // window.new carries no geometry/flags. attach/detach also covers GUI New Window and launch
+        // reopen-all, which run no control command at all.
         NotificationCenter.default.addObserver(forName: .agtermWindowAttachmentChanged, object: nil,
                                                queue: .main) { [weak self] _ in
             MainActor.assumeIsolated { self?.refreshWindowCache() }
         }
     }
 
-    /// The socket path the app and the CLI rendezvous on. `AGTERM_CONTROL_SOCKET` overrides (tests need it
-    /// — their sandboxed `AGTERM_STATE_DIR` container path exceeds `sun_path`'s ~104 bytes); else
-    /// `<AGTERM_STATE_DIR>/agterm.sock` when that var is set (state isolation), else `<app support>/agterm.sock`.
+    /// The socket path the app and the CLI rendezvous on. `AGTERM_CONTROL_SOCKET` wins (tests need it —
+    /// their sandboxed `AGTERM_STATE_DIR` container path exceeds `sun_path`'s ~104 bytes), then
+    /// `<AGTERM_STATE_DIR>/agterm.sock` (state isolation), then `<app support>/agterm.sock`.
     static func defaultSocketPath() -> String {
         let env = ProcessInfo.processInfo.environment
         if let explicit = env["AGTERM_CONTROL_SOCKET"] { return explicit }
@@ -153,8 +144,8 @@ final class ControlServer {
 
     // MARK: - Lifecycle
 
-    /// Bind and start listening. Idempotent — the scene `.task` may re-run when a window is recreated, and
-    /// a second `bind` must not be attempted. Any failure logs and returns, leaving the app to launch.
+    /// Bind and start listening. Idempotent — the scene `.task` re-runs when a window is recreated and a
+    /// second `bind` must not be attempted. Any failure logs and returns, leaving the app to launch.
     func start() {
         guard listenFD < 0 else { return }
 
@@ -207,7 +198,6 @@ final class ControlServer {
         acceptLoop(fd: fd)
     }
 
-    /// Close the listener and unlink the socket file.
     func stop() {
         guard listenFD >= 0 else { return }
         close(listenFD)
@@ -233,13 +223,12 @@ final class ControlServer {
         }
     }
 
-    /// Read one newline-delimited request from `conn`, decode it, dispatch it on `server` (main actor),
-    /// write the response back, close. A decode failure replies with a structured error rather than
-    /// crashing. Runs on the background queue.
+    /// Read one newline-delimited request from `conn`, decode it, dispatch it on `server` (main actor), write
+    /// the response back, close. A decode failure replies with a structured error. Runs on the background queue.
     nonisolated private static func handleConnection(_ conn: Int32, server: ControlServer) {
         defer { close(conn) }
-        // never let a write to a client that already hung up raise SIGPIPE (default-fatal) — that would
-        // take the whole app down mid-request; SO_NOSIGPIPE turns it into a normal EPIPE write error.
+        // a write to a client that already hung up would raise the default-fatal SIGPIPE and take the whole
+        // app down mid-request; SO_NOSIGPIPE turns it into a normal EPIPE write error.
         var noSigPipe: Int32 = 1
         setsockopt(conn, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, socklen_t(MemoryLayout<Int32>.size))
 
@@ -263,22 +252,20 @@ final class ControlServer {
         }
 
         // answer read-only window queries from the cache without a main-actor hop: a window close briefly
-        // stalls the main thread (surface teardown / re-render), which would leave the serial accept loop
-        // unresponsive to `window.list` polls behind it.
+        // stalls the main thread (surface teardown / re-render), wedging the accept loop against polls.
         if let cached = server.fastPathResponse(for: request) {
             writeResponse(conn, cached)
             return
         }
 
-        // hop to the main actor, blocking this background thread. dispatch refreshes the window cache in
-        // that same execution, so the fast path sees this command's mutations without a second hop that
-        // could queue behind a post-close stall.
+        // hop to the main actor, blocking this background thread. dispatch refreshes the window cache in that
+        // same execution, so the fast path sees this command's mutations without a second, stallable hop.
         let response = runBlocking { await server.dispatch(request) }
         writeResponse(conn, response)
     }
 
-    /// Read bytes from `conn` up to (and excluding) the first newline, capping at `maxLineBytes`. Returns
-    /// nil on EOF-before-newline, read error, the `maxLineBytes` cap, or the `readDeadlineSeconds` overall cap.
+    /// Read bytes from `conn` up to (and excluding) the first newline. Returns nil on EOF-before-newline, a
+    /// read error, the `maxLineBytes` cap, or the `readDeadlineSeconds` overall cap.
     nonisolated private static func readLine(_ conn: Int32) -> Data? {
         var buffer = Data()
         var byte: UInt8 = 0
@@ -341,8 +328,8 @@ final class ControlServer {
     /// Execute a request against the store/actions seam. Never throws across the socket: any failure is a
     /// `{"ok":false,"error":…}` response.
     private func dispatch(_ request: ControlRequest) async -> ControlResponse {
-        // refresh the read cache in this same main-actor execution (a window mutation just ran), so the
-        // background fast path sees the new state without a separate, stallable hop.
+        // refresh the read cache in this same main-actor execution, so the background fast path sees the new
+        // state without a separate, stallable hop.
         defer { refreshWindowCache() }
         if let response = await ControlDispatcher(actions: self).dispatch(request) {
             return response
@@ -371,16 +358,14 @@ final class ControlServer {
         }
     }
 
-    /// UI-TEST-ONLY seam: forces the app-level appearance so an XCUITest can simulate a macOS light/dark
-    /// flip deterministically (XCUITest has no API for it). Setting `NSApp.appearance` moves
-    /// `effectiveAppearance`, and this arm ALSO posts `.agtermSystemAppearanceChanged` so the REAL flip
-    /// path (scheme sync → debounced zoom-preserving reload) runs end to end without depending on KVO
-    /// firing for an explicit set (production relies on KVO for a genuine system flip). Refused outside an
-    /// XCUITest launch, and deliberately EXEMPT from the four-point keep-in-sync — test scaffolding, so no
-    /// `agtermctl` subcommand and absent from the catalog/skill. Setting echoes the effective side in
-    /// `result.text`; the BARE form (no name) reads the side the last config feed applied
-    /// (`SettingsModel.lastAppliedIsDark`), which a test polls to prove the flip drove the reload — a
-    /// suppressed flip leaves it on the old side.
+    /// UI-TEST-ONLY seam: forces the app-level appearance so an XCUITest can simulate a macOS light/dark flip
+    /// deterministically (XCUITest has no API for it). `NSApp.appearance` moves `effectiveAppearance`, and
+    /// this arm ALSO posts `.agtermSystemAppearanceChanged` so the REAL flip path (scheme sync → debounced
+    /// zoom-preserving reload) runs end to end without waiting on KVO, which production relies on for a
+    /// genuine system flip. Refused outside an XCUITest launch, and EXEMPT from the four-point keep-in-sync
+    /// as test scaffolding — no `agtermctl` subcommand, absent from the catalog/skill. A set echoes the
+    /// effective side in `result.text`; the BARE form reads `SettingsModel.lastAppliedIsDark`, which a test
+    /// polls to prove the flip drove the reload — a suppressed flip leaves it on the old side.
     private func setDebugAppearance(args: ControlArgs?) -> ControlResponse {
         guard ContentView.isUITestLaunch else {
             return ControlResponse(ok: false, error: "debug.appearance is a UI-test-only seam")
@@ -402,11 +387,10 @@ final class ControlServer {
         return ControlResponse(ok: true, result: ControlResult(text: isDark ? "dark" : "light"))
     }
 
-    /// Clear every open session's captured foreground command and persist, so the next launch restores
-    /// plain shells. The live fields are normally already nil (consumed at restore) — the SAVE is what
-    /// wipes the on-disk copy from the last quit, closing the force-quit re-fire window. Drives
-    /// `restore.clear` / `agtermctl restore clear`; app-global like `keymap.reload`, so no `--window`
-    /// selector and every open window is cleared.
+    /// Clear every open session's captured foreground command and persist, so the next launch restores plain
+    /// shells. The live fields are usually already nil (consumed at restore); the SAVE is what wipes the
+    /// on-disk copy from the last quit, closing the force-quit re-fire window. App-global like
+    /// `keymap.reload`: no `--window` selector, every open window is cleared.
     func clearRestoreCommands() -> ControlResponse {
         for session in library.allOpenSessions() {
             session.foregroundCommand = nil
@@ -417,19 +401,17 @@ final class ControlServer {
     }
 
     /// Open or close the target window's dashboard overlay — the app side of the host-free `dashboard`
-    /// command (the dispatcher validated the args and built `fontMode`; it does not cap the ids). Resolves
+    /// command (the dispatcher validated the args and built `fontMode`, but does not cap the ids). Resolves
     /// `window ?? frontmost` to an OPEN window's store. `mru` takes up to `DashboardLayout.maxCells` of that
-    /// window's most-recently-used sessions from the store's recency (fewer if it has fewer, nothing
-    /// unresolved); otherwise each id resolves to a session in THAT store, deduped by resolved UUID in
-    /// order, with misses reported in `result.text` rather than silently dropped. Each resolved session then
-    /// EXPANDS in order into pane cells — always `.primary`, plus `.split` when the session `hasSplit` (both
-    /// shells alive), so a split shows as TWO cells — and the `DashboardLayout.maxCells` (9) cap counts
-    /// PANES, applied here after expansion, dropped ones reported alongside `unresolved` (joined with "; ").
-    /// Each cell reparents its OWN pane surface (`.primary` → `\.surface`, `.split` → `\.splitSurface`)
-    /// app-side in `WindowContentView`. Opening closes the window's active terminal zoom (zoom and dashboard
-    /// are mutually exclusive) and drives its `DashboardController` via the registry; `--close` calls
-    /// `close()`. `WindowContentView` registers that controller, so until it does (or while the window tears
-    /// down) the registry returns nil and this reports the window isn't open.
+    /// store's most-recently-used sessions (fewer if it has fewer, nothing unresolved); otherwise each id
+    /// resolves within THAT store, deduped by resolved UUID in order, misses reported in `result.text`. Each
+    /// resolved session then EXPANDS in order into pane cells — always `.primary`, plus `.split` when it
+    /// `hasSplit` (both shells alive), so a split shows as TWO cells — and the `maxCells` (9) cap counts
+    /// PANES, applied here after expansion, its drops reported alongside `unresolved` (joined with "; ").
+    /// Each cell reparents its OWN pane surface (`\.surface` / `\.splitSurface`) app-side in
+    /// `WindowContentView`. Opening closes the window's terminal zoom (mutually exclusive); `--close` calls
+    /// `close()`. The registry returns nil until `WindowContentView` registers the controller (or while the
+    /// window tears down), reported as the window not being open.
     func setDashboard(targets: [String], window: String?, close: Bool,
                       fontMode: DashboardFontMode, mru: Bool) -> ControlResponse {
         resolver.resolvePlacementStore(window) { store in
@@ -474,8 +456,7 @@ final class ControlServer {
             // set the applied size SYNCHRONOUSLY so the `dashboardFontSize` read-back is authoritative at
             // command return: the SwiftUI onChange applying the surface overrides runs a runloop turn later,
             // and open() never resets appliedFontSize, so an untouched re-open would leak the prior
-            // fixed/auto size. Idempotent with the wiring — both resolve the same (base, member-count, mode)
-            // through the shared DashboardFontMode.appliedFontSize seam.
+            // fixed/auto size. idempotent with the wiring — both go through DashboardFontMode.appliedFontSize.
             let base = settingsModel.settings.fontSize ?? DashboardLayout.ghosttyDefaultFontSize
             controller.setAppliedFontSize(fontMode.appliedFontSize(memberCount: members.count, base: base))
             var notes: [String] = []
@@ -493,12 +474,10 @@ final class ControlServer {
     func buildTree(in store: AppStore) -> ControlTree {
         let shellBasename = ProcessInfo.processInfo.environment["SHELL"].map(CommandRestore.basename)
         // the projected window owns its quick terminal; find its id by store identity to read the live
-        // QuickTerminalController.isVisible (a nil controller — never opened, or tearing down — reads as
-        // not visible).
+        // QuickTerminalController.isVisible (a nil controller — never opened, or tearing down — reads false).
         let windowID = library.windowID(for: store)
-        // the window's dashboard controller (nil until WindowContentView registers it), read LIVE for the
-        // four dashboard read-backs — tree-only, since the keyboard-driven dashboard bypasses the command
-        // path and a cached copy would go stale (as for zoomedSurface/quickVisible).
+        // the window's dashboard controller (nil until WindowContentView registers it), read LIVE for the four
+        // dashboard read-backs: the keyboard-driven dashboard bypasses the command path, so a cache goes stale.
         let dashboard = DashboardControllerRegistry.shared.controller(for: windowID)
         return store.controlTree(
             foreground: { session in
@@ -516,8 +495,8 @@ final class ControlServer {
             scratchFontSize: { ($0.scratchSurface as? GhosttySurfaceView)?.currentFontSize() },
             quickVisible: { windowID.flatMap { QuickTerminalRegistry.shared.controller(for: $0)?.isVisible } ?? false },
             zoomedSurface: { windowID.flatMap { TerminalZoomRegistry.shared.controller(for: $0)?.target?.controlID } },
-            // Resolve through the projected window's registry entry on every tree build. This is deliberately
-            // tree-only: window.list is cache-backed, so mirroring a GUI-resolved pick there would go stale.
+            // resolved through the projected window's registry entry on every tree build, and tree-only:
+            // window.list is cache-backed, so mirroring a GUI-resolved pick there would go stale.
             pickPending: { windowID.flatMap { PickRegistry.shared.controller(for: $0)?.pending?.id } },
             dashboardMembers: {
                 guard let dashboard, dashboard.isOpen else { return nil }
@@ -542,13 +521,12 @@ final class ControlServer {
         )
     }
 
-    /// Creates a session in `workspaceID` of `store` with the `session.new` args (cwd default $HOME,
-    /// optional command/name), focuses it only when it lands in the frontmost window — so a keymap
-    /// `session new` opens focused like the GUI New Session while a background `--window` target keeps
-    /// focus — and returns the new id. Shared by the id- and name-addressed `.sessionNew` paths. `at` is the
-    /// anchor-relative `--after`/`--before` insertion slot (clamped in `AppStore`); nil appends.
-    /// `options.noSelect` creates in the background: `addSession` skips selecting and the focus call is
-    /// suppressed, leaving the current selection and focus untouched.
+    /// Creates a session in `workspaceID` of `store` with the `session.new` args (cwd default $HOME, optional
+    /// command/name) and returns its id; shared by the id- and name-addressed `.sessionNew` paths. Focuses it
+    /// only when it lands in the frontmost window, so a keymap `session new` opens focused like GUI New
+    /// Session while a background `--window` target keeps focus. `at` is the anchor-relative
+    /// `--after`/`--before` slot (clamped in `AppStore`), nil appends; `options.noSelect` creates in the
+    /// background, selection and focus untouched.
     func makeSessionResponse(in store: AppStore, workspaceID: UUID,
                              options: ControlSessionCreateOptions, at index: Int? = nil) -> ControlResponse {
         let cwd = options.cwd ?? FileManager.default.homeDirectoryForCurrentUser.path
@@ -568,8 +546,8 @@ final class ControlServer {
         return result.isEmpty ? nil : result
     }
 
-    /// Internal, not private: the command arms live in `ControlServer+*.swift` extensions, which cannot
-    /// reach a private member declared here.
+    /// Internal, not private: the `ControlServer+*.swift` extensions holding the command arms cannot reach a
+    /// private member declared here.
     func log(_ message: @autoclosure () -> String) {
         NSLog("agterm: %@", message())
     }

--- a/agterm/Control/ControlTargetResolver.swift
+++ b/agterm/Control/ControlTargetResolver.swift
@@ -21,17 +21,16 @@ final class ControlTargetResolver {
 
     // MARK: - Window resolution & cross-window targeting
 
-    /// A resolution outcome carrying either the resolved value or the structured error response to
-    /// return. (`ControlResponse` isn't an `Error`, so this stands in for `Result` with the same case
-    /// names.)
+    /// The resolved value or the structured error response to return. (`ControlResponse` isn't an `Error`,
+    /// so this stands in for `Result` with the same case names.)
     enum Resolution<T> {
         case success(T)
         case failure(ControlResponse)
     }
 
-    /// The open store a placement/`active` command targets: with `window` set, the resolved open
-    /// window's store (an error response when it isn't open / can't be resolved); without it, the
-    /// frontmost window's store. Runs `body` with that store on success.
+    /// The open store a placement/`active` command targets: the resolved window's store with `window` set
+    /// (an error response when it isn't open or can't be resolved), else the frontmost window's. Runs
+    /// `body` with that store on success.
     func resolvePlacementStore(_ window: String?, _ body: (AppStore) -> ControlResponse) -> ControlResponse {
         switch resolveWindowStore(window) {
         case .failure(let response): return response
@@ -39,11 +38,10 @@ final class ControlTargetResolver {
         }
     }
 
-    /// `resolvePlacementStore` for the window-scoped commands that must FAIL rather than silently no-op
-    /// when nothing is open. Without `window` the placement default is the frontmost store, which falls
-    /// back to a throwaway `emptyStore` once every window is closed — a command driven onto that store
-    /// would answer `ok` having changed nothing. A named window already errors when it isn't open, so this
-    /// only adds the nil-window case.
+    /// `resolvePlacementStore` for window-scoped commands that must FAIL rather than silently no-op when
+    /// nothing is open: with no `window` the frontmost default falls back to the throwaway `emptyStore`
+    /// once every window is closed, and a command driven onto that answers `ok` having changed nothing. A
+    /// named window already errors when it isn't open, so this only adds the nil-window case.
     func resolveOpenPlacementStore(_ window: String?, _ body: (AppStore) -> ControlResponse) -> ControlResponse {
         if trimmed(window) == nil, library.activeStore == nil {
             return ControlResponse(ok: false, error: "no open window")
@@ -68,10 +66,10 @@ final class ControlTargetResolver {
 
     // MARK: - Session / workspace target resolution
 
-    /// Resolve `target` (defaulting to `active`) to a session and its owning store, then run `body`.
-    /// With `window` set, the search is scoped to that open window's store; without it, `active`
-    /// resolves against the frontmost store while an id/prefix is matched across ALL open stores so a
-    /// captured id resolves regardless of which window is frontmost.
+    /// Resolve `target` (defaulting to `active`) to a session and its owning store, then run `body`. With
+    /// `window` set the search is scoped to that open window's store; without it `active` resolves against
+    /// the frontmost store while an id/prefix matches across ALL open stores, so a captured id resolves
+    /// regardless of which window is frontmost.
     func resolveSession(_ target: String?, window: String?,
                         _ body: (AppStore, UUID) -> ControlResponse) -> ControlResponse {
         switch resolveSessionTarget(target, window: window) {

--- a/agterm/Control/StatusSoundPlayer.swift
+++ b/agterm/Control/StatusSoundPlayer.swift
@@ -1,24 +1,17 @@
 import AppKit
 import agtermCore
 
-/// StatusSoundPlayer plays the one-shot sound requested by `session.status --sound`. It is a thin AppKit
-/// wrapper over `NSSound`: a shared `@MainActor` singleton used by `ControlServer` (the per-call and
-/// blocked-default status sounds) and by the Settings sound pickers' selection previews.
+/// StatusSoundPlayer plays the one-shot sound requested by `session.status --sound`: a thin `@MainActor`
+/// singleton over `NSSound`, used by `ControlServer` (the per-call and blocked-default status sounds) and
+/// by the Settings sound pickers' selection previews.
 ///
-/// `action(for:)` resolves a sound name to its play closure (or nil when a named sound can't be found),
-/// so the caller can validate before mutating the indicator and surface an `unknown sound` error. The
-/// `default`/`beep` value maps to the system alert sound; any other value is a named system sound via
-/// `NSSound(named:)`, which also resolves custom sounds in `~/Library/Sounds`. `play(_:)` resolves AND
-/// plays, but de-bounces a replay of the same sound within a short window (`SoundThrottle`) so a burst of
-/// rapid status sets can't machine-gun an identical clip.
-///
-/// Resolved `NSSound` instances are cached and thus retained for the app's lifetime — both to skip
-/// reloading and to avoid the AppKit gotcha where a locally-scoped `NSSound` is deallocated mid-play and
-/// the clip is cut off.
+/// `action(for:)` resolves a name without playing it, so the caller can validate before mutating the
+/// indicator and surface an `unknown sound` error; `NSSound(named:)` also resolves `~/Library/Sounds`.
+/// Resolved sounds are cached, so they are retained for the app's lifetime — skipping a reload, and dodging
+/// the AppKit gotcha where a locally-scoped `NSSound` is deallocated mid-play and the clip is cut off.
 @MainActor
 final class StatusSoundPlayer {
-    /// Shared player so the control server (per-call + blocked-default sounds) and the Settings picker
-    /// preview share one `NSSound` cache.
+    /// Shared so every caller reuses one `NSSound` cache.
     static let shared = StatusSoundPlayer()
 
     private var cache: [String: NSSound] = [:]
@@ -27,9 +20,8 @@ final class StatusSoundPlayer {
     /// transitions) doesn't stutter the same clip; the Settings preview bypasses this and always sounds.
     private var throttle = SoundThrottle(window: .milliseconds(200))
 
-    /// The standard macOS system sound names: the option list of the Settings sound pickers (the
-    /// blocked-status and notification sounds), and the suggested valid values in the `unknown sound`
-    /// error; any name `NSSound(named:)` can resolve is accepted, not just these.
+    /// The standard macOS system sound names: the Settings sound pickers' option list (blocked-status and
+    /// notification) and the `unknown sound` error's suggestions; any name `NSSound(named:)` resolves works.
     static let standardNames = ["Basso", "Blow", "Bottle", "Frog", "Funk", "Hero", "Morse",
                                 "Ping", "Pop", "Purr", "Sosumi", "Submarine", "Tink", "Glass"]
 
@@ -43,11 +35,11 @@ final class StatusSoundPlayer {
         return { sound.stop(); sound.play() }
     }
 
-    /// Resolve and play `name`, suppressing a replay of the SAME sound within the throttle window so a
-    /// burst of rapid status sets doesn't machine-gun an identical clip. Returns false ONLY when the name
-    /// can't be resolved (so the caller can surface `unknown sound`); a throttled replay returns true
-    /// (resolvable, just intentionally silent). The control server's play path uses this; the Settings
-    /// picker preview calls `action(for:)` directly so a deliberate preview click always sounds.
+    /// Resolve and play `name`, suppressing a replay of the SAME sound within the throttle window so a burst
+    /// of rapid status sets doesn't machine-gun an identical clip. Returns false ONLY when the name can't be
+    /// resolved (so the caller can surface `unknown sound`); a throttled replay returns true — resolvable,
+    /// just intentionally silent. The control server plays through this; the Settings picker preview calls
+    /// `action(for:)` directly so a deliberate click always sounds.
     @discardableResult
     func play(_ name: String) -> Bool {
         guard let action = action(for: name) else { return false }

--- a/agterm/Ghostty/ClipboardPromptController.swift
+++ b/agterm/Ghostty/ClipboardPromptController.swift
@@ -1,16 +1,16 @@
 import AppKit
 import agtermCore
 
-/// ClipboardPromptController gates OSC 52 clipboard access a terminal program requests. One shared
+/// ClipboardPromptController gates the OSC 52 clipboard access a terminal program requests. One shared
 /// instance holds an app-session-scoped `ClipboardPromptPolicy` (the remembered allow/deny spans every
-/// window and terminal session until agterm quits): a remembered choice resolves immediately, otherwise
-/// it shows a warning sheet. Requests from the SAME (surface, direction) coalesce behind that one prompt
-/// so a program looping OSC 52 can't stack a wall of sheets, while a request from a DIFFERENT surface
-/// always gets its own prompt, so one Allow never authorizes another surface's read or write.
+/// window and terminal session until agterm quits): a remembered choice resolves immediately, else a
+/// warning sheet is shown. Requests from the SAME (surface, direction) coalesce behind that one prompt so
+/// a program looping OSC 52 can't stack a wall of sheets, while a DIFFERENT surface always gets its own,
+/// so one Allow never authorizes another surface's read or write.
 ///
-/// `@MainActor`: it touches AppKit and the controller's shared mutable state. The C clipboard callbacks reach it by
-/// hopping through `DispatchQueue.main.async`, which also defers the sheet past the current libghostty
-/// tick so the modal run loop never re-enters it.
+/// `@MainActor`: it touches AppKit and shared mutable state. The C clipboard callbacks reach it through
+/// `DispatchQueue.main.async`, which also defers the sheet past the current libghostty tick so the modal
+/// run loop never re-enters it.
 @MainActor
 final class ClipboardPromptController {
     static let shared = ClipboardPromptController()
@@ -23,9 +23,8 @@ final class ClipboardPromptController {
     }
 
     /// A pending prompt: the waiters plus a STRONG reference to the requester, held until the sheet
-    /// resolves. Retaining the requester stops its `ObjectIdentifier` from being reused by a newly
-    /// allocated surface while the prompt is open, which would otherwise let that new surface's request
-    /// hash to the same `PromptKey` and ride this prompt's decision.
+    /// resolves — retaining it stops its `ObjectIdentifier` being reused by a surface allocated while the
+    /// prompt is open, whose request would then hash to the same `PromptKey` and ride this decision.
     private struct Pending {
         let requester: AnyObject?
         var waiters: [(Bool) -> Void]
@@ -49,7 +48,6 @@ final class ClipboardPromptController {
 
     private func enqueue(_ key: PromptKey, requester: AnyObject?, completion: @escaping (Bool) -> Void) {
         if pending[key] != nil {
-            // a sheet for this (surface, direction) is already up — ride its decision instead of stacking.
             pending[key]?.waiters.append(completion)
             return
         }
@@ -78,7 +76,7 @@ final class ClipboardPromptController {
             for waiter in entry?.waiters ?? [] { waiter(allowed) }
         }
 
-        // attach to the REQUESTING surface's own window when we can, so the prompt lands on the terminal
+        // attach to the REQUESTING surface's own window when possible, so the prompt lands on the terminal
         // whose program triggered it (not some other key window); fall back to key/main.
         let requesterWindow = (pending[key]?.requester as? NSView)?.window
         if let window = requesterWindow ?? NSApp.keyWindow ?? NSApp.mainWindow {

--- a/agterm/Ghostty/GhosttyApp.swift
+++ b/agterm/Ghostty/GhosttyApp.swift
@@ -15,99 +15,85 @@ final class GhosttyApp {
 
     private(set) var app: ghostty_app_t?
     private(set) var config: ghostty_config_t?
-    /// Config diagnostics (parse errors / invalid keys) from the most recent `loadConfig`, reset each load.
-    /// Spans ALL sources (bundled defaults, `~/.config/ghostty/config`, the agterm-scoped `ghostty.conf`, the
-    /// UI settings conf) — libghostty attributes none of them to a file, so this is NOT `ghostty.conf`-specific.
-    /// `reloadConfig` surfaces it so File ▸ Reload Config / `config.reload` can warn; the Console log shows the
-    /// offending line.
+    /// Parse diagnostics from the most recent `loadConfig`, reset each load, across ALL sources (bundled
+    /// defaults, `~/.config/ghostty/config`, the agterm-scoped `ghostty.conf`, the UI settings conf) —
+    /// libghostty attributes none to a file. `reloadConfig` surfaces it for the Reload Config /
+    /// `config.reload` warning; the Console log names the offending line.
     private(set) var lastConfigDiagnosticsCount = 0
-    /// The terminal background from the resolved config, tinting the window so the title bar blends with the
-    /// terminal instead of the default titlebar material. Nil when the color couldn't be read.
+    /// Terminal background from the resolved config; tints the window so the title bar blends with the
+    /// terminal instead of the default titlebar material. Nil when unread.
     private(set) var terminalBackgroundColor: NSColor?
-    /// The terminal foreground from the resolved config. The chrome (sidebar row text + icons, title-bar text
-    /// + buttons) uses it so non-terminal text tracks the theme, not the system label color. Nil when unread.
+    /// Terminal foreground from the resolved config. The chrome (sidebar rows, title-bar text + buttons) uses
+    /// it so non-terminal text tracks the theme, not the system label color. Nil when unread.
     private(set) var terminalForegroundColor: NSColor?
-    /// Whether the active theme reads as dark, by the perceived luminance of the WASHED sidebar background
-    /// (theme background plus the sidebar-tint wash) — the color the disclosure triangle actually sits on, so a
-    /// strong tint pushing a near-threshold theme across the midpoint still classifies correctly. Pins
-    /// AppKit-drawn chrome (the sidebar disclosure triangle) to the theme rather than the macOS system
-    /// appearance, so a light theme under macOS dark mode still draws dark, visible chrome. Defaults to dark
-    /// (the app's default chrome) when the background couldn't be read.
+    /// Whether the active theme reads as dark, by perceived luminance of the WASHED sidebar background (theme
+    /// background plus sidebar-tint wash) — the color the disclosure triangle sits on, so a strong tint pushing
+    /// a near-threshold theme past the midpoint still classifies right. Pins AppKit-drawn chrome to the theme,
+    /// not the macOS appearance, so a light theme under dark mode draws dark, visible chrome. Dark when unread.
     var terminalThemeIsDark: Bool {
         guard let bg = terminalBackgroundColor?.usingColorSpace(.sRGB) else { return true }
         let shiftAmount = AppSettings.sidebarShiftAmount(strength: sidebarBackgroundShift)
         return ThemeBrightness.isDark(red: Double(bg.redComponent), green: Double(bg.greenComponent),
                                       blue: Double(bg.blueComponent), shiftAmount: shiftAmount)
     }
-    /// The theme's `selection-background`; the selected sidebar row draws its pill in it so it matches the
-    /// terminal's own selection. Nil when the theme doesn't set it (the row falls back to a soft white wash).
+    /// The theme's `selection-background`; the selected sidebar row's pill uses it to match the terminal's own
+    /// selection. Nil when the theme doesn't set it (the row falls back to a soft white wash).
     private(set) var terminalSelectionBackgroundColor: NSColor?
-    /// The selected sidebar row's text color: the theme `selection-foreground`, or a black/white
-    /// contrast of the selection-background when the theme sets only the background. Nil if neither set.
+    /// The selected sidebar row's text: theme `selection-foreground`, else a black/white contrast of the
+    /// selection-background when only that is set. Nil if neither is set.
     private(set) var terminalSelectionForegroundColor: NSColor?
     /// Window translucency the chrome composites at the AppKit level — background opacity (0...1) + CGS blur
     /// radius, opaque by default. NOT ghostty-resolved: `WindowAppearance.sync` reads, `SettingsModel` writes.
     private(set) var windowOpacity: Double = 1
     private(set) var windowBlurRadius: Int = 0
-    /// The title-bar row state: normal stacks the cwd subtitle, compact is one short row, hidden drops the row
-    /// and the traffic lights for a full-bleed terminal. NOT ghostty-resolved: `WindowContentView`/
-    /// `WindowAppearance.sync` read it, `SettingsModel` writes it. Defaults `.compact` (a nil
-    /// `settings.toolbarMode` resolves to it).
+    /// Title-bar row state: normal stacks the cwd subtitle, compact is one short row, hidden drops the row and
+    /// the traffic lights for a full-bleed terminal; defaults `.compact` (a nil `settings.toolbarMode`). NOT
+    /// ghostty-resolved: `SettingsModel` writes, the reader (`WindowContentView` / `WindowAppearance.sync`)
+    /// mirrors it into view state, the re-render rides `.agtermAppearanceChanged` — the settings-mirrored
+    /// pattern the properties below share.
     private(set) var toolbarMode: ToolbarMode = .compact
-    /// Whether the sidebar draws the red unseen-notification count badge. NOT ghostty-resolved: the sidebar
-    /// Coordinator reads it (gating the count to 0 when off), `SettingsModel` writes it; the re-render rides
-    /// `.agtermAppearanceChanged`, like `toolbarMode`.
+    /// Whether the sidebar draws the red unseen-notification count badge. The sidebar Coordinator reads it
+    /// (gating the count to 0 when off); settings-mirrored like `toolbarMode`.
     private(set) var notificationBadgeEnabled: Bool = true
-    /// Whether a restored pane re-runs its last clean-quit foreground command
-    /// (`AppSettings.restoreRunningCommand`). The surface factories read it to decide whether to feed that
-    /// command as `initial_input`; `SettingsModel` writes it. Not ghostty-resolved, and it affects only the
-    /// next restore — no live re-render notification.
+    /// Whether a restored pane re-runs its last clean-quit foreground command; the surface factories read it to
+    /// decide whether to feed that command as `initial_input`. Affects only the next restore — no live
+    /// re-render notification.
     private(set) var restoreRunningCommand: Bool = false
-    /// Whether the window title bar shows the attention bell icon; off by default. NOT ghostty-resolved: the
-    /// title bar reads it via `WindowContentView`'s mirrored chrome state, `SettingsModel` writes it; the
-    /// re-render rides `.agtermAppearanceChanged`, like `toolbarMode`.
+    /// Whether the window title bar shows the attention bell icon; off by default. The title bar reads it via
+    /// `WindowContentView`'s mirrored chrome state; settings-mirrored like `toolbarMode`.
     private(set) var attentionButtonEnabled: Bool = false
-    /// Which title-bar / sidebar chrome elements are hidden (`AppSettings.hiddenInterfaceElements`), empty by
-    /// default. NOT ghostty-resolved: `WindowContentView` mirrors it into view state and gates each element,
-    /// `SettingsModel` writes it; the re-render rides `.agtermAppearanceChanged`, like `toolbarMode`.
+    /// Which title-bar / sidebar chrome elements are hidden, empty by default. `WindowContentView` gates each
+    /// element from its mirror; settings-mirrored like `toolbarMode`.
     private(set) var hiddenInterfaceElements: Set<InterfaceElement> = []
-    /// Whether only the frontmost window shows its sidebar, collapsing every other open window's
-    /// (`AppSettings.autoHideSidebarInactiveWindows`), off by default. NOT ghostty-resolved:
-    /// `WindowAccessor.reportFrontmost` reads it on every frontmost change to gate the `WindowLibrary` driver,
-    /// `SettingsModel` writes it.
+    /// Whether only the frontmost window shows its sidebar, collapsing every other open window's; off by
+    /// default. `WindowAccessor.reportFrontmost` reads it per frontmost change to gate the `WindowLibrary`.
     private(set) var autoHideSidebarInactiveWindows: Bool = false
-    /// Program basenames NOT to re-run on restore — the parsed user-editable `restore-denylist.conf` (seeded
-    /// with the terminal multiplexers), read at launch only. The surface factories consult it via
-    /// `CommandRestore.shouldRestore`; `SettingsModel` parses the file and writes it.
+    /// Program basenames NOT to re-run on restore: the parsed user-editable `restore-denylist.conf` (seeded
+    /// with the terminal multiplexers), read at launch only; consulted via `CommandRestore.shouldRestore`.
     private(set) var restoreDenylist: Set<String> = []
-    /// Inactive-split-pane text mute strength on the 0...10 scale. NOT ghostty-resolved: the detail pane's
-    /// `paneDim` overlay reads it (via `AppSettings.muteOpacity`), `SettingsModel` writes it; the re-render
-    /// rides `.agtermAppearanceChanged`, like `toolbarMode`.
+    /// Inactive-split-pane text mute strength on the 0...10 scale. The detail pane's `paneDim` overlay reads
+    /// it (via `AppSettings.muteOpacity`); settings-mirrored like `toolbarMode`.
     private(set) var inactivePaneMuteStrength: Int = AppSettings.defaultInactivePaneMuteStrength
-    /// How much darker/lighter the sidebar background is than the terminal (0...10, 5 = neutral). NOT
-    /// ghostty-resolved: `ContentView` mirrors it into view state and renders the sidebar wash (via
-    /// `AppSettings.sidebarShiftAmount`), `SettingsModel` writes it; re-render rides `.agtermAppearanceChanged`.
+    /// How much darker/lighter the sidebar background is than the terminal (0...10, 5 = neutral). `ContentView`
+    /// renders the wash via `AppSettings.sidebarShiftAmount`; settings-mirrored like `toolbarMode`.
     private(set) var sidebarBackgroundShift: Int = AppSettings.defaultSidebarBackgroundShift
-    /// The sidebar row-text point size. NOT ghostty-resolved: the sidebar Coordinator reads it for each row's
-    /// font and the derived row height (via `AppSettings.sidebarRowHeight`), `SettingsModel` writes it; the
-    /// re-render rides `.agtermAppearanceChanged`, like `toolbarMode`.
+    /// The sidebar row-text point size. The sidebar Coordinator reads it for each row's font and the derived
+    /// row height (via `AppSettings.sidebarRowHeight`); settings-mirrored like `toolbarMode`.
     private(set) var sidebarFontSize: CGFloat = CGFloat(AppSettings.defaultSidebarFontSize)
-    /// The base terminal font size in points (the Settings default; nil → the ghostty built-in), written by
-    /// `SettingsModel` at launch and on every change. NOT a value the renderer reads — it is the size a session
-    /// with a nil `session.fontSize` reverts to, which the dashboard font-override clear needs to recognize its
-    /// own async CELL_SIZE report (see `GhosttySurfaceView.pendingFontRestore`).
+    /// The base terminal font size in points (the Settings default; nil → the ghostty built-in). The renderer
+    /// never reads it — it is the size a session with a nil `session.fontSize` reverts to, which the dashboard
+    /// font-override clear needs to recognize its own async CELL_SIZE report (`pendingFontRestore`).
     private(set) var baseFontSize: Double = DashboardLayout.ghosttyDefaultFontSize
     /// The agent-status glyph colors — active defaults to a muted lavender-grey (`#DBD9E6`), blocked/completed
-    /// to system orange/green. NOT ghostty-resolved: `StatusIconView` reads them when building the glyph,
-    /// `SettingsModel` writes them (from the user's hex or the default); the sidebar re-render rides
-    /// `.agtermAppearanceChanged`.
+    /// to system orange/green. `StatusIconView` reads them when building the glyph, `SettingsModel` writes
+    /// them (from the user's hex or the default); settings-mirrored like `toolbarMode`.
     static let defaultActiveStatusColor: NSColor = NSColor(agtermHex: "#DBD9E6") ?? .systemBlue
     private(set) var activeStatusColor: NSColor = GhosttyApp.defaultActiveStatusColor
     private(set) var blockedStatusColor: NSColor = .systemOrange
     private(set) var completedStatusColor: NSColor = .systemGreen
-    /// The agent-status glyph silhouettes, nil meaning the built-in plain circle. NOT ghostty-resolved: the two
-    /// render sites read them through `statusSymbolName(for:override:)`, `SettingsModel` writes them (tolerantly
-    /// decoded from `AppSettings`); the sidebar re-render rides `.agtermAppearanceChanged`, like the colors.
+    /// The agent-status glyph silhouettes, nil meaning the built-in plain circle. The two render sites read
+    /// them through `statusSymbolName(for:override:)`, `SettingsModel` writes them (tolerantly decoded from
+    /// `AppSettings`); settings-mirrored like `toolbarMode`.
     private(set) var activeStatusShape: StatusShape?
     private(set) var blockedStatusShape: StatusShape?
     private(set) var completedStatusShape: StatusShape?
@@ -147,11 +133,10 @@ final class GhosttyApp {
         }
         app = createdApp
         config = cfg
-        // boot-time: no surface exists yet, so the NSApp read is the only side source, and nothing has rendered
-        // that it could disagree with.
+        // boot: no surface yet, so the NSApp read is the only side source and nothing rendered can disagree.
         resolveThemeColors(from: cfg, inputs: configInputs, isDark: Self.currentIsDark())
-        // demand-driven, no poll timer: ticks come from libghostty wakeups (coalesced in GhosttyCallbacks.wakeup)
-        // and surfaces draw on GHOSTTY_ACTION_RENDER, like Ghostty.app/conterm — an idle terminal does no work.
+        // demand-driven, no poll timer (like Ghostty.app/conterm): ticks come from libghostty wakeups
+        // (coalesced in GhosttyCallbacks.wakeup), surfaces draw on GHOSTTY_ACTION_RENDER — idle costs nothing.
     }
 
     func tick() {
@@ -166,61 +151,50 @@ final class GhosttyApp {
         windowBlurRadius = blurRadius
     }
 
-    /// Set the title-bar row state (normal/compact/hidden); the window re-syncs on `.agtermAppearanceChanged`.
     func setToolbarMode(_ mode: ToolbarMode) {
         toolbarMode = mode
     }
 
-    /// Set whether the sidebar draws the notification count badge.
     func setNotificationBadgeEnabled(_ enabled: Bool) {
         notificationBadgeEnabled = enabled
     }
 
-    /// Set whether restored panes re-run their captured foreground command.
     func setRestoreRunningCommand(_ enabled: Bool) {
         restoreRunningCommand = enabled
     }
 
-    /// Set whether the title bar shows the attention bell icon.
     func setAttentionButtonEnabled(_ enabled: Bool) {
         attentionButtonEnabled = enabled
     }
 
-    /// Set which title-bar / sidebar-footer chrome elements are hidden.
     func setHiddenInterfaceElements(_ elements: Set<InterfaceElement>) {
         hiddenInterfaceElements = elements
     }
 
-    /// Set whether only the frontmost window shows its sidebar.
     func setAutoHideSidebarInactiveWindows(_ enabled: Bool) {
         autoHideSidebarInactiveWindows = enabled
     }
 
-    /// Set the parsed restore denylist (program basenames not to re-run).
     func setRestoreDenylist(_ denylist: Set<String>) {
         restoreDenylist = denylist
     }
 
-    /// Set the inactive-split-pane mute strength (0...10).
     func setInactivePaneMuteStrength(_ strength: Int) {
         inactivePaneMuteStrength = strength
     }
 
-    /// Set the sidebar background shift (0...10, 5 = neutral); the window re-syncs on the same notification.
     func setSidebarBackgroundShift(_ strength: Int) {
         sidebarBackgroundShift = strength
     }
 
-    /// Set the base terminal font size (the Settings default; nil → the ghostty built-in).
     func setBaseFontSize(_ size: Double?) {
         baseFontSize = size ?? DashboardLayout.ghosttyDefaultFontSize
     }
 
-    /// Set the sidebar row-text point size.
     func setSidebarFontSize(_ size: Double) {
-        // clamp here so both readers (the row font AND the row height) see an in-range value. the Settings
-        // stepper already bounds 9...20, but a hand-edited or future-range settings.json must not render a
-        // giant font inside the clamped row (sidebarRowHeight clamps its own copy for the height).
+        // clamp so both readers (row font AND row height) see an in-range value: the Settings stepper bounds
+        // 9...20, but a hand-edited settings.json must not draw a giant font in the clamped row
+        // (sidebarRowHeight clamps its own copy).
         sidebarFontSize = CGFloat(AppSettings.clampSidebarFontSize(size))
     }
 
@@ -231,19 +205,16 @@ final class GhosttyApp {
         completedStatusColor = NSColor(agtermHex: completedHex) ?? .systemGreen
     }
 
-    /// Set the agent-status glyph silhouettes from the user's Settings; nil keeps that status on the default
-    /// plain circle.
     func setAgentStatusShapes(active: StatusShape?, blocked: StatusShape?, completed: StatusShape?) {
         activeStatusShape = active
         blockedStatusShape = blocked
         completedStatusShape = completed
     }
 
-    /// The SF Symbol for a status glyph, honoring an optional per-call shape OVERRIDE from
-    /// `session.status --shape` (set on the ephemeral `AgentIndicator`). The precedence — override, else this
-    /// status's Settings shape, else the default plain circle — is the host-free
-    /// `AgentStatus.symbolName(override:configured:)`; this only supplies the mirrored Settings value. Shared by
-    /// the AppKit sidebar `StatusIconView` and the SwiftUI `StatusGlyph` so the two can't drift.
+    /// The SF Symbol for a status glyph, honoring a per-call shape OVERRIDE from `session.status --shape` (on
+    /// the ephemeral `AgentIndicator`). Precedence — override, else this status's Settings shape, else the
+    /// plain circle — lives in host-free `AgentStatus.symbolName(override:configured:)`; this supplies only the
+    /// mirrored Settings value. Shared by the sidebar `StatusIconView` and SwiftUI `StatusGlyph` against drift.
     func statusSymbolName(for status: AgentStatus, override shape: StatusShape?) -> String {
         let configured: StatusShape?
         switch status {
@@ -255,9 +226,8 @@ final class GhosttyApp {
         return status.symbolName(override: shape, configured: configured)
     }
 
-    /// The configured tint for a status glyph, shared by the AppKit sidebar `StatusIconView` and the SwiftUI
-    /// `StatusGlyph` so the two can't drift. `idle` never renders a glyph (it is filtered out before any glyph
-    /// is built), so its `.clear` is a benign unused default.
+    /// The configured tint for a status glyph. `idle` never renders a glyph (filtered out before any glyph is
+    /// built), so its `.clear` is a benign unused default.
     func statusColor(for status: AgentStatus) -> NSColor {
         switch status {
         case .active: return activeStatusColor
@@ -267,18 +237,17 @@ final class GhosttyApp {
         }
     }
 
-    /// The tint for a status glyph, honoring an optional per-call `#rrggbb` OVERRIDE from
-    /// `session.status --color` (set on the ephemeral `AgentIndicator`); a valid override wins, nil or malformed
-    /// falls back to the Settings-configured `statusColor(for:)`. Shared by the AppKit sidebar `StatusIconView`
-    /// and the SwiftUI `StatusGlyph` so the two can't drift.
+    /// The tint for a status glyph, honoring a per-call `#rrggbb` OVERRIDE from `session.status --color` (set
+    /// on the ephemeral `AgentIndicator`); a valid override wins, nil or malformed falls back to the
+    /// Settings-configured `statusColor(for:)`.
     func statusColor(for status: AgentStatus, override hex: String?) -> NSColor {
         NSColor(agtermHex: hex) ?? statusColor(for: status)
     }
 
     // MARK: - Config
 
-    /// Path to agterm's generated ghostty config (font/size/theme from the Settings window), in the
-    /// same state directory as the workspace snapshot (honors `AGTERM_STATE_DIR` for tests).
+    /// Path to agterm's generated ghostty config (font/size/theme from the Settings window), in the same state
+    /// directory as the workspace snapshot (honors `AGTERM_STATE_DIR` for tests).
     static var settingsConfigURL: URL {
         let dir = ProcessInfo.processInfo.environment["AGTERM_STATE_DIR"]
             .map { URL(fileURLWithPath: $0, isDirectory: true) } ?? PersistenceStore.defaultDirectory
@@ -286,13 +255,12 @@ final class GhosttyApp {
     }
 
     /// The config inputs resolved from `settings.json` in ONE read: the agterm-scoped `ghostty.conf` URL
-    /// (`<configDir>/ghostty.conf`, beside `keymap.conf`) and whether to inherit the user's GLOBAL
-    /// `~/.config/ghostty/config` (`inheritGlobalGhosttyConfig`, default off). Resolved ONCE per config build
-    /// and threaded to `loadConfig`/`resolveSelectionColors`, so a reload reads `settings.json` at most once.
-    /// Self-contained because `loadConfig` runs before any `SettingsModel` exists (whose init is the first touch
-    /// of `GhosttyApp.shared`): it reads the persisted `configDirectory` + flag from a `SettingsStore` rooted the
-    /// SAME way `agtermApp.init` builds it (via `settingsStore()`), with the keymap's precedence (explicit
-    /// setting → `AGTERM_STATE_DIR/config` → `~/.config/agterm`).
+    /// (`<configDir>/ghostty.conf`, beside `keymap.conf`) and whether to inherit the GLOBAL
+    /// `~/.config/ghostty/config` (`inheritGlobalGhosttyConfig`, default off). Resolved once per config build
+    /// and threaded onward, so a reload reads `settings.json` at most once. Self-contained because
+    /// `loadConfig` runs before any `SettingsModel` exists (its init is the first touch of `GhosttyApp.shared`):
+    /// reads the persisted `configDirectory` + flag via `settingsStore()`, keymap precedence (explicit setting
+    /// → `AGTERM_STATE_DIR/config` → `~/.config/agterm`).
     struct ConfigInputs {
         let scopedURL: URL
         let inheritGlobalConfig: Bool
@@ -309,69 +277,59 @@ final class GhosttyApp {
     }
 
     /// The persisted settings store, rooted the SAME way `agtermApp.init` builds it: `AGTERM_STATE_DIR` when
-    /// set (test isolation), else the default Application Support directory — so it resolves the SAME
-    /// `settings.json` the active `SettingsModel` does. A bare `SettingsStore()` would read the app-support file
-    /// even under `AGTERM_STATE_DIR` isolation, ignoring an explicit `configDirectory` in the state-dir settings
-    /// (and leaking a production one into an isolated run), pointing GhosttyApp and SettingsModel at different
-    /// `ghostty.conf` files.
+    /// set (test isolation), else Application Support — the SAME `settings.json` the active `SettingsModel`
+    /// reads. A bare `SettingsStore()` would read the app-support file even under `AGTERM_STATE_DIR` isolation,
+    /// ignoring (or leaking in) an explicit `configDirectory` and pointing the two at different `ghostty.conf`.
     private static func settingsStore() -> SettingsStore {
         ProcessInfo.processInfo.environment["AGTERM_STATE_DIR"]
             .map { SettingsStore(directory: URL(fileURLWithPath: $0, isDirectory: true)) } ?? SettingsStore()
     }
 
     /// Rebuilds the config (re-reading the agterm settings file) and broadcasts it to the app and the given
-    /// live surfaces — a live appearance change. Keeps the new config as `self.config`; the previous one is
-    /// intentionally NOT freed — settings changes are rare and `update_config` has no documented ownership
-    /// contract, so this follows the never-free pattern rather than risk a use-after-free. Returns the rebuilt
-    /// config's diagnostic count (0 = clean) so a Reload Config can warn about a malformed `ghostty.conf`.
+    /// live surfaces. Keeps the new config as `self.config`; the previous one is never freed — `update_config`
+    /// has no documented ownership contract and settings changes are rare, so leaking beats risking a
+    /// use-after-free. Returns the rebuilt config's diagnostic count (0 = clean) so Reload Config can warn.
     @discardableResult
     func reloadConfig(surfaces: [GhosttySurfaceView], isDark: Bool) -> Int {
-        // no app (called before `ghostty_app_new` succeeded) or a `ghostty_config_new` allocation failure:
-        // nothing was re-read, so report the last known count. Both are unreachable in practice — boot always
-        // precedes a reachable reload, and config allocation only fails under OOM.
+        // no app (pre-`ghostty_app_new`) or a failed config allocation: nothing was re-read, so report the last
+        // known count. Both unreachable in practice — boot precedes any reload, allocation fails only on OOM.
         guard let app else { return lastConfigDiagnosticsCount }
         let inputs = Self.resolveConfigInputs()
         guard let newConfig = loadConfig(inputs) else { return lastConfigDiagnosticsCount }
-        // re-assert the app + each surface's light/dark scheme from the authoritative `isDark` (the
-        // KVO-delivered side, else `currentIsDark()`) BEFORE feeding the config: libghostty re-resolves a dual
-        // `theme = light:,dark:` against the recorded conditional state, so a stale side derives the wrong
-        // theme. Setting the APP scheme (not only per surface) makes a ZERO-surface reload chrome-correct — the
-        // CONFIG_CHANGE clone below then resolves to `isDark` too, so a dark launch re-sides the
-        // sidebar/titlebar before any surface exists. Cheap (each set no-ops when unchanged); the config
-        // re-feed is what actually re-renders.
+        // re-assert the app + each surface's light/dark scheme from the authoritative `isDark` (KVO-delivered,
+        // else `currentIsDark()`) BEFORE feeding the config: libghostty re-resolves a dual `theme =
+        // light:,dark:` against the recorded conditional state, so a stale side derives the wrong theme.
+        // Setting the APP scheme too keeps a ZERO-surface reload chrome-correct — the CONFIG_CHANGE clone below
+        // resolves to `isDark`, re-siding the sidebar/titlebar on a dark launch before any surface exists.
+        // Each set no-ops when unchanged; the config re-feed is what re-renders.
         ghostty_app_set_color_scheme(app, isDark ? GHOSTTY_COLOR_SCHEME_DARK : GHOSTTY_COLOR_SCHEME_LIGHT)
         for surface in surfaces { surface.syncColorScheme(isDark: isDark) }
         ghostty_app_update_config(app, newConfig)
-        // ghostty replies to update_config with a synchronous app-target CONFIG_CHANGE carrying the config it
-        // APPLIED — the dual `theme = light:,dark:` resolved to the current appearance side. Read the chrome
-        // colors from THAT clone: newConfig is always finalized with the default (light) conditional state, so
-        // reading it directly while following in dark mode tints the sidebar/titlebar with the LIGHT slot while
-        // the terminal renders the dark one. Falls back to newConfig when nothing was stashed (no conditional).
+        // ghostty answers update_config with a synchronous app-target CONFIG_CHANGE carrying the config it
+        // APPLIED (the dual theme resolved to the current appearance side). Read the chrome colors from THAT
+        // clone: newConfig is always finalized with the default LIGHT conditional state, so reading it in dark
+        // mode tints the sidebar/titlebar light while the terminal renders dark. Nil without a conditional.
         let derivedConfig = callbacks.takeDerivedAppConfig()
         for surface in surfaces { surface.applyConfig(newConfig) }
         config = newConfig
-        // refresh the chrome colors from the NEW config BEFORE the watermark re-assert below: a default-tinted
-        // `.text` watermark re-renders its PNG from `terminalForegroundColor`, so a stale foreground lags one
-        // reload behind a theme change. the selection colors re-side from the authoritative `isDark` passed in
-        // (the side the app + surfaces were just set to), NOT re-read from any view.
+        // refresh the chrome colors BEFORE the watermark re-assert below: a default-tinted `.text` watermark
+        // re-renders its PNG from `terminalForegroundColor`, so a stale foreground lags one reload behind a
+        // theme change. The selection colors re-side from the passed-in `isDark`, never re-read from a view.
         resolveThemeColors(from: derivedConfig ?? newConfig, inputs: inputs, isDark: isDark)
         if let derivedConfig { ghostty_config_free(derivedConfig) }
-        // the broadcast above pushes the shared config (no background image, default font size) to every
-        // surface, wiping any per-surface watermark and zoom — so re-assert each affected surface's overlay
-        // after. No-op without either; on the zoom-clearing reload paths the per-session fontSize was already
-        // nil'd, so only watermarks re-apply there.
+        // the broadcast pushes the shared config (no background image, default font size) to every surface,
+        // wiping per-surface watermarks and zoom — re-assert them after. No-op without either; on the
+        // zoom-clearing reload paths the per-session fontSize was already nil'd, so only watermarks re-apply.
         for surface in surfaces { surface.reapplySessionConfigIfNeeded() }
         return lastConfigDiagnosticsCount
     }
 
-    /// The inputs of the most recent config load, cached so `refreshSelectionColors` can re-resolve the
-    /// selection colors after a live color change without a full config reload.
+    /// Inputs of the most recent config load, cached so `refreshSelectionColors` can re-resolve the selection
+    /// colors after a live color change without a full config reload.
     private var lastConfigInputs: ConfigInputs?
 
-    /// Re-read the chrome colors (background, foreground, selection background/foreground) from a resolved
-    /// config; called at init and on every settings reload. `background`/`foreground` come from the config, the
-    /// selection colors separately (see below) — `ghostty_config_get` does not expose the optional
-    /// `selection-*` keys.
+    /// Re-read the chrome colors from a resolved config; called at init and on every settings reload.
+    /// `background`/`foreground` come from the config, the selection colors via `resolveSelectionColors`.
     private func resolveThemeColors(from config: ghostty_config_t, inputs: ConfigInputs, isDark: Bool) {
         lastConfigInputs = inputs
         terminalBackgroundColor = Self.color(from: config, key: "background")
@@ -380,9 +338,8 @@ final class GhosttyApp {
     }
 
     /// Re-resolve the selection chrome colors for the given appearance side, so the selected-row pill follows a
-    /// light/dark theme flip. Used by the full config load AND the appearance-flip reload (which re-resolves
-    /// the theme's colors). `isDark` is explicit at every call site (the reload threads the KVO-delivered side)
-    /// — no defaulted appearance read a future caller could silently pick up. No-op until a config has loaded.
+    /// light/dark theme flip. `isDark` is explicit at every call site (the reload threads the KVO-delivered
+    /// side) — no defaulted appearance read a future caller could pick up. No-op until a config has loaded.
     func refreshSelectionColors(isDark: Bool) {
         guard let inputs = lastConfigInputs else { return }
         let (selectionBackground, selectionForeground) = Self.resolveSelectionColors(
@@ -395,24 +352,21 @@ final class GhosttyApp {
 
     /// Whether the app is currently in the dark appearance. `NSApp` is an implicitly-unwrapped global still nil
     /// during the very early `GhosttyApp.shared` init (it boots from `SettingsModel.init`, before AppKit wires
-    /// `NSApp`), so chain through it safely; that early window resolves no theme (the config emits the raw dual
-    /// value and ghostty picks the side from the color scheme set at surface creation), so a light default
-    /// there is harmless.
+    /// `NSApp`), so chain through it safely; that early window resolves no theme (ghostty picks the side from
+    /// the color scheme set at surface creation), so the light default there is harmless.
     static func currentIsDark() -> Bool {
         guard let appearance = NSApp?.effectiveAppearance else { return false }
         return appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
     }
 
     /// `ghostty_config_get` doesn't expose the optional `selection-background`/`selection-foreground` keys, so
-    /// resolve them by reading the same config sources `loadConfig` loads — in the same order — plus the active
-    /// theme file. An explicit `selection-*` line wins over the theme's; either color may be nil when unset.
-    /// The `theme` value may be the `light:…,dark:…` auto-switch form, resolved to the active side via
-    /// `isDark`, and the user's global `~/.config/ghostty/config` is a source ONLY when `inheritGlobalConfig`
-    /// is on, matching `loadConfig`'s gate.
+    /// resolve them by re-reading the sources `loadConfig` loads, in the same order, plus the active theme
+    /// file. An explicit `selection-*` line wins over the theme's; either may be nil. A `light:…,dark:…` theme
+    /// resolves via `isDark`; the global config counts only when `inheritGlobalConfig` is on, as in `loadConfig`.
     ///
-    /// Known limitation: only the top-level config files are scanned — the `config-file` includes
-    /// `ghostty_config_load_recursive_files` expands are NOT followed, so a `selection-*` delegated through an
-    /// include is missed and the sidebar pill falls back.
+    /// Known limitation: only top-level files are scanned — the `config-file` includes
+    /// `ghostty_config_load_recursive_files` expands are NOT followed, so a `selection-*` behind one is missed
+    /// and the sidebar pill falls back.
     private static func resolveSelectionColors(ghosttyConfigPath: String, inheritGlobalConfig: Bool,
                                                isDark: Bool) -> (NSColor?, NSColor?) {
         var sources: [String] = []
@@ -438,9 +392,8 @@ final class GhosttyApp {
                 }
             }
         }
-        // the theme file fills any selection color not set explicitly above; our settings conf carries the raw
-        // dual `theme = light:,dark:` (ghostty picks the terminal side itself), so pick the side matching the
-        // current appearance for the pill.
+        // the theme file fills any selection color not set explicitly above; the settings conf carries the raw
+        // dual `theme = light:,dark:` (ghostty picks the terminal side itself), so pick the appearance side.
         if selBg == nil || selFg == nil, let themeName, !themeName.isEmpty,
            let themesDir = Bundle.main.url(forResource: "ghostty", withExtension: nil)?
                .appendingPathComponent("themes", isDirectory: true) {
@@ -453,8 +406,8 @@ final class GhosttyApp {
         return (selBg, selFg)
     }
 
-    /// Parse a ghostty-style config file into its `key = value` pairs in file order, skipping blank
-    /// and `#` comment lines. Missing/unreadable files yield no pairs.
+    /// Parse a ghostty-style config file into its `key = value` pairs in file order, skipping blank and `#`
+    /// comment lines. Missing/unreadable files yield no pairs.
     private static func keyValues(ofFileAt path: String) -> [(String, String)] {
         guard let text = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
         return text.split(separator: "\n").compactMap { raw in
@@ -466,8 +419,8 @@ final class GhosttyApp {
         }
     }
 
-    /// Parse a `#rrggbb` or `#rgb` hex color (with or without the leading `#`) to an opaque sRGB
-    /// `NSColor`, or nil if it isn't a valid hex triplet.
+    /// Parse a `#rrggbb` or `#rgb` hex color (with or without the leading `#`) to an opaque sRGB `NSColor`,
+    /// or nil if it isn't a valid hex triplet.
     private static func parseHexColor(_ value: String) -> NSColor? {
         var hex = value.hasPrefix("#") ? String(value.dropFirst()) : value
         if hex.count == 3 { hex = hex.map { "\($0)\($0)" }.joined() }
@@ -478,11 +431,10 @@ final class GhosttyApp {
                        alpha: 1)
     }
 
-    /// Black or white, whichever gives higher contrast against `color`, by WCAG relative luminance. Used by the
+    /// Black or white, whichever contrasts better with `color` by WCAG relative luminance — used by the
     /// selected-row text when the theme sets a selection-background but no selection-foreground, and by the
-    /// dashboard status pill over an arbitrary status-color fill. The gamma-linearized WCAG luminance (not a
-    /// raw luma average) is what makes a saturated mid-tone like `systemGreen` correctly pick BLACK — a plain
-    /// luma cutoff reads green as "dark" and picks unreadable white-on-green.
+    /// dashboard status pill over an arbitrary fill. Gamma-linearized luminance, not a raw luma average: a
+    /// plain cutoff reads a saturated mid-tone like `systemGreen` as "dark" and picks unreadable white-on-green.
     static func contrastingText(for color: NSColor) -> NSColor {
         let c = color.usingColorSpace(.sRGB) ?? color
         func linear(_ v: CGFloat) -> Double {
@@ -495,13 +447,12 @@ final class GhosttyApp {
         return luminance > 0.179 ? .black : .white
     }
 
-    /// Build a per-surface config = the SAME base files as `loadConfig` plus a small overlay (a session's
-    /// `background-image*` + font-size lines, from `WatermarkConfig.overlayText`), written to a temp file,
+    /// A per-surface config: the SAME base files as `loadConfig` plus an overlay (a session's
+    /// `background-image*` + font-size lines, from `WatermarkConfig.overlayText`) written to a temp file,
     /// loaded LAST so it wins over the settings conf, then deleted (`load_file` reads synchronously). The
-    /// caller (`GhosttySurfaceView`) owns the returned config and frees it on surface teardown. An empty
-    /// overlay yields the plain base config (used to CLEAR a watermark). The app-wide
-    /// `lastConfigDiagnosticsCount` is preserved — a per-surface build must not clobber what `config.reload`
-    /// reports. Returns nil on allocation failure.
+    /// caller (`GhosttySurfaceView`) owns and frees the returned config. An empty overlay yields the plain base
+    /// config (used to CLEAR a watermark). `lastConfigDiagnosticsCount` is preserved so a per-surface build
+    /// can't clobber what `config.reload` reports. Nil on allocation failure.
     func configWithOverlay(_ overlayText: String) -> ghostty_config_t? {
         var overlayPath: String?
         if !overlayText.isEmpty {
@@ -523,16 +474,14 @@ final class GhosttyApp {
     private func loadConfig(_ inputs: ConfigInputs, extraOverlayPath: String? = nil) -> ghostty_config_t? {
         guard let cfg = ghostty_config_new() else { return nil }
 
-        // app's built-in defaults (terminal padding, etc.) first, so the agterm-scoped ghostty.conf (and the
-        // global config, when opted in) still override them.
+        // app defaults (terminal padding, etc.) first, so the scoped and opted-in global configs override them.
         if let defaults = Bundle.main.url(forResource: "ghostty-defaults", withExtension: "conf") {
             defaults.path.withCString { ghostty_config_load_file(cfg, $0) }
         }
 
-        // the user's GLOBAL ~/.config/ghostty/config is OFF by default (agterm is self-contained — a config
-        // written for the standalone Ghostty.app must not silently change agterm), loaded only when
-        // `inheritGlobalGhosttyConfig` is opted in. libghostty does NOT read the XDG config on its own, so load
-        // it explicitly when present; `config-file` includes resolve below.
+        // the user's GLOBAL ~/.config/ghostty/config is OFF by default — a config written for the standalone
+        // Ghostty.app must not silently change agterm. libghostty does NOT read the XDG config on its own, so
+        // load it explicitly when opted in; `config-file` includes resolve below.
         if inputs.inheritGlobalConfig {
             let userPath = (NSHomeDirectory() as NSString).appendingPathComponent(".config/ghostty/config")
             if FileManager.default.fileExists(atPath: userPath) {
@@ -542,25 +491,23 @@ final class GhosttyApp {
             }
         }
 
-        // agterm-scoped ghostty config (`<configDir>/ghostty.conf`, beside keymap.conf) — the place for agterm
-        // overrides. ALWAYS loaded regardless of the inherit toggle, after the optional global config so it
-        // wins over the bundled defaults + the user's global config for any key, but BEFORE agterm's UI
-        // settings so the Settings picker still wins for what it manages. Skipped when absent (the starter is
-        // comment-only, so a fresh install is a no-op).
+        // agterm-scoped ghostty.conf (beside keymap.conf), ALWAYS loaded regardless of the inherit toggle:
+        // after the optional global config so it wins over that and the bundled defaults for any key, but
+        // BEFORE agterm's UI settings so the Settings picker still wins for what it manages. Skipped when
+        // absent; the seeded starter is comment-only, so a fresh install is a no-op.
         let scopedPath = inputs.scopedURL.path
         if FileManager.default.fileExists(atPath: scopedPath) {
             scopedPath.withCString { ghostty_config_load_file(cfg, $0) }
         }
 
-        // agterm's own appearance settings (Settings window: font / size / theme), loaded last so
-        // they win over the user's ghostty config for the keys the UI manages.
+        // agterm's own appearance settings (font/size/theme), loaded last so the UI-managed keys win.
         let settingsConf = Self.settingsConfigURL.path
         if FileManager.default.fileExists(atPath: settingsConf) {
             settingsConf.withCString { ghostty_config_load_file(cfg, $0) }
         }
 
-        // a per-surface overlay (a session's background-image / font-size lines), loaded LAST so it wins
-        // over everything above. Only `configWithOverlay` passes this; the app/global build leaves it nil.
+        // a per-surface overlay, loaded LAST so it wins over everything above; only `configWithOverlay` passes
+        // it, the app/global build leaves it nil.
         if let extraOverlayPath, FileManager.default.fileExists(atPath: extraOverlayPath) {
             extraOverlayPath.withCString { ghostty_config_load_file(cfg, $0) }
         }
@@ -579,8 +526,8 @@ final class GhosttyApp {
         return cfg
     }
 
-    /// Reads a named color key (e.g. `background`, `foreground`) from the resolved config as an
-    /// opaque `NSColor`, or nil if the key isn't set.
+    /// A named color key (e.g. `background`, `foreground`) from the resolved config as an opaque `NSColor`,
+    /// or nil if the key isn't set.
     private static func color(from config: ghostty_config_t, key: String) -> NSColor? {
         var color = ghostty_config_color_s()
         let got = key.withCString { ghostty_config_get(config, &color, $0, UInt(key.utf8.count)) }
@@ -593,10 +540,9 @@ final class GhosttyApp {
 
     // MARK: - Resources
 
-    /// Candidate ghostty resource dirs, highest priority first. agterm ships the ghostty resources in its own
-    /// bundle (produced by setup.sh) under `Contents/Resources/ghostty`, mirroring a real Ghostty.app, with the
-    /// compiled terminfo DB at the sibling `Contents/Resources/terminfo`. The installed Ghostty.app dirs remain
-    /// as fallbacks for an unprepared dev checkout.
+    /// Candidate ghostty resource dirs, highest priority first. agterm ships its own (from setup.sh) at
+    /// `Contents/Resources/ghostty`, mirroring a real Ghostty.app, with the compiled terminfo DB at the sibling
+    /// `Contents/Resources/terminfo`; the installed Ghostty.app dirs are dev-checkout fallbacks.
     private static let resourcePaths: [String] = {
         var paths: [String] = []
         if let resources = Bundle.main.resourceURL?.path {
@@ -608,11 +554,10 @@ final class GhosttyApp {
     }()
 
     private func resolveResources() {
-        // always resolve from our own candidates (bundle first), ignoring any inherited GHOSTTY_RESOURCES_DIR —
-        // a stale value would shadow our complete bundle and leave libghostty deriving a broken TERMINFO.
-        // TERMINFO itself is NOT set here on purpose: libghostty unconditionally overwrites it at shell spawn
-        // with dirname(GHOSTTY_RESOURCES_DIR)/terminfo, clobbering any setenv. Our resources dir is
-        // .../Resources/ghostty, so that derivation lands on the sibling .../Resources/terminfo we ship.
+        // resolve from our own candidates (bundle first), ignoring any inherited GHOSTTY_RESOURCES_DIR: a stale
+        // one shadows our complete bundle and leaves libghostty deriving a broken TERMINFO. TERMINFO itself is
+        // never set here — libghostty overwrites it at shell spawn with dirname(GHOSTTY_RESOURCES_DIR)/terminfo,
+        // clobbering any setenv, and our .../Resources/ghostty makes that land on the terminfo we ship beside it.
         let resolver = GhosttyResourceResolver(
             candidates: Self.resourcePaths,
             fileExists: { FileManager.default.fileExists(atPath: $0) }
@@ -627,41 +572,39 @@ final class GhosttyApp {
 }
 
 extension Notification.Name {
-    /// Posted after the ghostty config is reloaded from a settings change, so the SwiftUI chrome (the quick
-    /// terminal backing) and the AppKit window appearance (title bar + window background → sidebar) re-read the
-    /// new `GhosttyApp.terminalBackgroundColor` immediately instead of waiting for the window to re-key.
+    /// Posted after a settings-driven config reload, so the SwiftUI chrome (the quick-terminal backing) and the
+    /// AppKit window appearance (title bar + window background → sidebar) re-read the new
+    /// `GhosttyApp.terminalBackgroundColor` at once instead of waiting for the window to re-key.
     static let agtermAppearanceChanged = Notification.Name("agterm.appearanceChanged")
 
-    /// Posted by `SystemAppearanceObserver` (an app-level KVO observer on `NSApplication.effectiveAppearance`)
-    /// on every macOS light/dark change and once at launch, carrying the resolved `isDark` in userInfo.
-    /// `SettingsModel` re-resolves the active side of a `theme = light:,dark:` pair and rewrites+reloads the
-    /// config — this pinned libghostty doesn't switch the dual conditional at runtime, so agterm drives the
-    /// swap itself. KVO because it delivers the settled value across sleep/wake, unlike a per-view
-    /// `viewDidChangeEffectiveAppearance` hook, which wedges. Also posted by the `debug.appearance` UI-test
-    /// seam. This is the system→settings direction; `agtermAppearanceChanged` is settings→chrome.
+    /// Posted by `SystemAppearanceObserver` (app-level KVO on `NSApplication.effectiveAppearance`) on every
+    /// macOS light/dark change and once at launch, carrying the resolved `isDark` in userInfo. `SettingsModel`
+    /// then re-resolves the active side of a `theme = light:,dark:` pair and rewrites+reloads the config — the
+    /// pinned libghostty doesn't switch the dual conditional at runtime, so agterm drives the swap. KVO
+    /// delivers the settled value across sleep/wake, unlike per-view `viewDidChangeEffectiveAppearance`, which
+    /// wedges. Also posted by the `debug.appearance` UI-test seam. System→settings, vs settings→chrome above.
     static let agtermSystemAppearanceChanged = Notification.Name("agterm.systemAppearanceChanged")
 
-    /// Posted by `SystemAccessibilityObserver` when a macOS accessibility display option changes.
-    /// AppKit consumers then re-read Reduce Transparency / Reduce Motion directly from `NSWorkspace`;
-    /// SwiftUI views use their native accessibility environment values.
+    /// Posted by `SystemAccessibilityObserver` on a macOS accessibility display-option change. AppKit consumers
+    /// re-read Reduce Transparency / Reduce Motion from `NSWorkspace`; SwiftUI views use their native
+    /// accessibility environment values.
     static let agtermAccessibilityDisplayOptionsChanged =
         Notification.Name("agterm.accessibilityDisplayOptionsChanged")
 
-    /// Posted when a window becomes frontmost (the change is async, via the window's didBecomeKey), so the
-    /// control server can refresh its cached `window.list` — whose `active` flag would otherwise stay stale
-    /// until the next dispatched command.
+    /// Posted when a window becomes frontmost (async, via the window's didBecomeKey), so the control server can
+    /// refresh its cached `window.list` — its `active` flag would otherwise stay stale until the next command.
     static let agtermWindowFrontmostChanged = Notification.Name("agterm.windowFrontmostChanged")
 
     /// Posted by `WindowRegistry` when a window's NSWindow attaches or detaches, so the control server can
     /// refresh its cached `window.list`. A window is "open" (its store loaded) well before its NSWindow exists,
-    /// so `window.new` builds its cached node with no `geometry`/`fullscreen`/`zoomed`/`minimized` and nothing
-    /// else refreshes it on that path: `newWindow()` pre-sets `frontmostWindowID`, so the first `didBecomeKey`
-    /// is a no-change that skips `.agtermWindowFrontmostChanged`, and a brand-new window has no saved frame to
-    /// restore, so no `didMove`/`didResize` fires either.
+    /// so `window.new` caches a node with no `geometry`/`fullscreen`/`zoomed`/`minimized` and nothing else
+    /// refreshes it: `newWindow()` pre-sets `frontmostWindowID`, so the first `didBecomeKey` is a no-change
+    /// skipping `.agtermWindowFrontmostChanged`, and a new window has no saved frame, so no `didMove`/
+    /// `didResize` fires either.
     static let agtermWindowAttachmentChanged = Notification.Name("agterm.windowAttachmentChanged")
 
     /// Posted after `keymap.conf` is (re)loaded and reparsed, so the custom-command runner rebuilds its matcher
     /// and the action palette re-reads the custom commands. The data-driven menu shortcuts re-render on their
-    /// own, reading the `@Observable` keymap directly.
+    /// own from the `@Observable` keymap.
     static let agtermKeymapChanged = Notification.Name("agterm.keymapChanged")
 }

--- a/agterm/Ghostty/GhosttyApp.swift
+++ b/agterm/Ghostty/GhosttyApp.swift
@@ -15,109 +15,99 @@ final class GhosttyApp {
 
     private(set) var app: ghostty_app_t?
     private(set) var config: ghostty_config_t?
-    /// The number of config diagnostics (parse errors / invalid keys) from the most recent `loadConfig`,
-    /// counted across ALL loaded sources (bundled defaults, `~/.config/ghostty/config`, the agterm-scoped
-    /// `ghostty.conf`, and the UI settings conf). libghostty diagnostics carry no source-file attribution,
-    /// so this is NOT specific to `ghostty.conf`. Surfaced by `reloadConfig` so File ▸ Reload Config (and
-    /// `config.reload`) can warn the user when the resolved config has problems; the Console log shows the
-    /// offending line. Reset on each `loadConfig`.
+    /// Config diagnostics (parse errors / invalid keys) from the most recent `loadConfig`, reset each load.
+    /// Spans ALL sources (bundled defaults, `~/.config/ghostty/config`, the agterm-scoped `ghostty.conf`, the
+    /// UI settings conf) — libghostty attributes none of them to a file, so this is NOT `ghostty.conf`-specific.
+    /// `reloadConfig` surfaces it so File ▸ Reload Config / `config.reload` can warn; the Console log shows the
+    /// offending line.
     private(set) var lastConfigDiagnosticsCount = 0
-    /// The terminal background color parsed from the resolved config. Used to tint the
-    /// window so the title bar blends with the terminal instead of drawing the default
-    /// titlebar material. Nil if the color couldn't be read.
+    /// The terminal background from the resolved config, tinting the window so the title bar blends with the
+    /// terminal instead of the default titlebar material. Nil when the color couldn't be read.
     private(set) var terminalBackgroundColor: NSColor?
-    /// The terminal foreground (text) color parsed from the resolved config. The chrome (sidebar row
-    /// text + icons, title bar text + buttons) uses it so non-terminal text tracks the theme instead
-    /// of the system label color. Nil if the color couldn't be read.
+    /// The terminal foreground from the resolved config. The chrome (sidebar row text + icons, title-bar text
+    /// + buttons) uses it so non-terminal text tracks the theme, not the system label color. Nil when unread.
     private(set) var terminalForegroundColor: NSColor?
-    /// Whether the active terminal theme reads as dark, by the perceived luminance of the sidebar
-    /// background the disclosure triangle sits on — the theme background with the sidebar-tint wash
-    /// applied. Pins AppKit-drawn chrome (the sidebar disclosure triangle) to the theme instead of the
-    /// macOS system appearance, so a light theme under macOS dark mode still draws dark, visible chrome.
-    /// Classifying the washed color (not the raw background) keeps it correct when a strong sidebar tint
-    /// pushes a near-threshold theme across the midpoint. Defaults to dark when the background couldn't
-    /// be read (the app's default chrome).
+    /// Whether the active theme reads as dark, by the perceived luminance of the WASHED sidebar background
+    /// (theme background plus the sidebar-tint wash) — the color the disclosure triangle actually sits on, so a
+    /// strong tint pushing a near-threshold theme across the midpoint still classifies correctly. Pins
+    /// AppKit-drawn chrome (the sidebar disclosure triangle) to the theme rather than the macOS system
+    /// appearance, so a light theme under macOS dark mode still draws dark, visible chrome. Defaults to dark
+    /// (the app's default chrome) when the background couldn't be read.
     var terminalThemeIsDark: Bool {
         guard let bg = terminalBackgroundColor?.usingColorSpace(.sRGB) else { return true }
         let shiftAmount = AppSettings.sidebarShiftAmount(strength: sidebarBackgroundShift)
         return ThemeBrightness.isDark(red: Double(bg.redComponent), green: Double(bg.greenComponent),
                                       blue: Double(bg.blueComponent), shiftAmount: shiftAmount)
     }
-    /// The terminal selection-background color (theme `selection-background`). The selected sidebar row
-    /// draws its pill in this color so it matches the terminal's own selection. Nil if the theme
-    /// doesn't set it (the row falls back to a soft white wash).
+    /// The theme's `selection-background`; the selected sidebar row draws its pill in it so it matches the
+    /// terminal's own selection. Nil when the theme doesn't set it (the row falls back to a soft white wash).
     private(set) var terminalSelectionBackgroundColor: NSColor?
     /// The selected sidebar row's text color: the theme `selection-foreground`, or a black/white
     /// contrast of the selection-background when the theme sets only the background. Nil if neither set.
     private(set) var terminalSelectionForegroundColor: NSColor?
-    /// Window translucency the chrome composites at the AppKit level — the background opacity
-    /// (0...1) and CGS blur radius the Settings window last applied. NOT ghostty-resolved:
-    /// `WindowAppearance.sync` reads these, `SettingsModel` writes them. Defaults are opaque.
+    /// Window translucency the chrome composites at the AppKit level — background opacity (0...1) + CGS blur
+    /// radius, opaque by default. NOT ghostty-resolved: `WindowAppearance.sync` reads, `SettingsModel` writes.
     private(set) var windowOpacity: Double = 1
     private(set) var windowBlurRadius: Int = 0
-    /// The custom title bar row state (normal/compact/hidden): normal stacks the cwd subtitle, compact is a
-    /// single short row, hidden drops the row and the traffic lights for a full-bleed terminal. NOT
-    /// ghostty-resolved: `WindowContentView`/`WindowAppearance.sync` read it, `SettingsModel` writes it.
-    /// Defaults to compact (the app default; `settings.toolbarMode == nil` resolves to `.compact`).
+    /// The title-bar row state: normal stacks the cwd subtitle, compact is one short row, hidden drops the row
+    /// and the traffic lights for a full-bleed terminal. NOT ghostty-resolved: `WindowContentView`/
+    /// `WindowAppearance.sync` read it, `SettingsModel` writes it. Defaults `.compact` (a nil
+    /// `settings.toolbarMode` resolves to it).
     private(set) var toolbarMode: ToolbarMode = .compact
-    /// Whether the sidebar draws the red unseen-notification count badge. NOT ghostty-resolved: the
-    /// sidebar Coordinator reads it (gating the count to 0 when off), `SettingsModel` writes it. The
-    /// re-render rides the `.agtermAppearanceChanged` notification, like `toolbarMode`.
+    /// Whether the sidebar draws the red unseen-notification count badge. NOT ghostty-resolved: the sidebar
+    /// Coordinator reads it (gating the count to 0 when off), `SettingsModel` writes it; the re-render rides
+    /// `.agtermAppearanceChanged`, like `toolbarMode`.
     private(set) var notificationBadgeEnabled: Bool = true
-    /// Whether a restored pane re-runs the command it had in the foreground at the last clean quit
-    /// (`AppSettings.restoreRunningCommand`). The surface factories read it to decide whether to feed the
-    /// captured command as `initial_input`; `SettingsModel` writes it. Not ghostty-resolved, and it only
-    /// affects the next restore, so no live re-render notification.
+    /// Whether a restored pane re-runs its last clean-quit foreground command
+    /// (`AppSettings.restoreRunningCommand`). The surface factories read it to decide whether to feed that
+    /// command as `initial_input`; `SettingsModel` writes it. Not ghostty-resolved, and it affects only the
+    /// next restore — no live re-render notification.
     private(set) var restoreRunningCommand: Bool = false
-    /// Whether the window title bar shows the attention bell icon. NOT ghostty-resolved: the title bar
-    /// reads it (via `WindowContentView`'s mirrored chrome state), `SettingsModel` writes it. The
-    /// re-render rides the `.agtermAppearanceChanged` notification, like `toolbarMode`. Defaults off.
+    /// Whether the window title bar shows the attention bell icon; off by default. NOT ghostty-resolved: the
+    /// title bar reads it via `WindowContentView`'s mirrored chrome state, `SettingsModel` writes it; the
+    /// re-render rides `.agtermAppearanceChanged`, like `toolbarMode`.
     private(set) var attentionButtonEnabled: Bool = false
-    /// Which title-bar / sidebar chrome elements are hidden (`AppSettings.hiddenInterfaceElements`).
-    /// NOT ghostty-resolved: `WindowContentView` mirrors it into view state and gates each element,
-    /// `SettingsModel` writes it. The re-render rides the `.agtermAppearanceChanged` notification, like
-    /// `toolbarMode`. Empty by default (everything shown).
+    /// Which title-bar / sidebar chrome elements are hidden (`AppSettings.hiddenInterfaceElements`), empty by
+    /// default. NOT ghostty-resolved: `WindowContentView` mirrors it into view state and gates each element,
+    /// `SettingsModel` writes it; the re-render rides `.agtermAppearanceChanged`, like `toolbarMode`.
     private(set) var hiddenInterfaceElements: Set<InterfaceElement> = []
     /// Whether only the frontmost window shows its sidebar, collapsing every other open window's
-    /// (`AppSettings.autoHideSidebarInactiveWindows`). NOT ghostty-resolved: `WindowAccessor.reportFrontmost`
-    /// reads it on every frontmost change to gate the `WindowLibrary` driver, `SettingsModel` writes it.
-    /// Off by default.
+    /// (`AppSettings.autoHideSidebarInactiveWindows`), off by default. NOT ghostty-resolved:
+    /// `WindowAccessor.reportFrontmost` reads it on every frontmost change to gate the `WindowLibrary` driver,
+    /// `SettingsModel` writes it.
     private(set) var autoHideSidebarInactiveWindows: Bool = false
-    /// Program basenames NOT to re-run on restore — the parsed user-editable `restore-denylist.conf`
-    /// (seeded with the terminal multiplexers). The surface factories read it via
-    /// `CommandRestore.shouldRestore`; `SettingsModel` parses the file and writes it. Read at launch only.
+    /// Program basenames NOT to re-run on restore — the parsed user-editable `restore-denylist.conf` (seeded
+    /// with the terminal multiplexers), read at launch only. The surface factories consult it via
+    /// `CommandRestore.shouldRestore`; `SettingsModel` parses the file and writes it.
     private(set) var restoreDenylist: Set<String> = []
-    /// Inactive-split-pane text mute strength on the 0...10 scale. NOT ghostty-resolved: the detail
-    /// pane's `paneDim` overlay reads it (via `AppSettings.muteOpacity`), `SettingsModel` writes it. The
-    /// re-render rides the `.agtermAppearanceChanged` notification, like `toolbarMode`.
+    /// Inactive-split-pane text mute strength on the 0...10 scale. NOT ghostty-resolved: the detail pane's
+    /// `paneDim` overlay reads it (via `AppSettings.muteOpacity`), `SettingsModel` writes it; the re-render
+    /// rides `.agtermAppearanceChanged`, like `toolbarMode`.
     private(set) var inactivePaneMuteStrength: Int = AppSettings.defaultInactivePaneMuteStrength
     /// How much darker/lighter the sidebar background is than the terminal (0...10, 5 = neutral). NOT
     /// ghostty-resolved: `ContentView` mirrors it into view state and renders the sidebar wash (via
-    /// `AppSettings.sidebarShiftAmount`), `SettingsModel` writes it. The re-render rides the
-    /// `.agtermAppearanceChanged` notification, like `toolbarMode`.
+    /// `AppSettings.sidebarShiftAmount`), `SettingsModel` writes it; re-render rides `.agtermAppearanceChanged`.
     private(set) var sidebarBackgroundShift: Int = AppSettings.defaultSidebarBackgroundShift
-    /// The sidebar row-text point size. NOT ghostty-resolved: the sidebar Coordinator reads it when
-    /// building each row's font and deriving the row height (via `AppSettings.sidebarRowHeight`),
-    /// `SettingsModel` writes it. The re-render rides the `.agtermAppearanceChanged` notification, like
-    /// `toolbarMode`.
+    /// The sidebar row-text point size. NOT ghostty-resolved: the sidebar Coordinator reads it for each row's
+    /// font and the derived row height (via `AppSettings.sidebarRowHeight`), `SettingsModel` writes it; the
+    /// re-render rides `.agtermAppearanceChanged`, like `toolbarMode`.
     private(set) var sidebarFontSize: CGFloat = CGFloat(AppSettings.defaultSidebarFontSize)
-    /// The base terminal font size in points (the Settings default; nil → the ghostty built-in). NOT a
-    /// value the renderer reads — it is the size a session whose `session.fontSize` is nil reverts to,
-    /// which the dashboard font-override clear needs to recognize its own async CELL_SIZE report (see
-    /// `GhosttySurfaceView.pendingFontRestore`). `SettingsModel` writes it at launch and on every change.
+    /// The base terminal font size in points (the Settings default; nil → the ghostty built-in), written by
+    /// `SettingsModel` at launch and on every change. NOT a value the renderer reads — it is the size a session
+    /// with a nil `session.fontSize` reverts to, which the dashboard font-override clear needs to recognize its
+    /// own async CELL_SIZE report (see `GhosttySurfaceView.pendingFontRestore`).
     private(set) var baseFontSize: Double = DashboardLayout.ghosttyDefaultFontSize
-    /// The agent-status glyph colors (active/blocked/completed). NOT ghostty-resolved: `StatusIconView`
-    /// reads them when building the glyph, `SettingsModel` writes them (resolved from the user's hex or
-    /// the default). The sidebar re-render rides the `.agtermAppearanceChanged` notification. The active
-    /// default is a muted lavender-grey (`#DBD9E6`); blocked/completed default to system orange/green.
+    /// The agent-status glyph colors — active defaults to a muted lavender-grey (`#DBD9E6`), blocked/completed
+    /// to system orange/green. NOT ghostty-resolved: `StatusIconView` reads them when building the glyph,
+    /// `SettingsModel` writes them (from the user's hex or the default); the sidebar re-render rides
+    /// `.agtermAppearanceChanged`.
     static let defaultActiveStatusColor: NSColor = NSColor(agtermHex: "#DBD9E6") ?? .systemBlue
     private(set) var activeStatusColor: NSColor = GhosttyApp.defaultActiveStatusColor
     private(set) var blockedStatusColor: NSColor = .systemOrange
     private(set) var completedStatusColor: NSColor = .systemGreen
-    /// The agent-status glyph silhouettes (active/blocked/completed), nil meaning the built-in plain
-    /// circle. NOT ghostty-resolved: the two render sites read them through `statusSymbolName(for:override:)`,
-    /// `SettingsModel` writes them (tolerantly decoded from `AppSettings`). The sidebar re-render rides
-    /// the `.agtermAppearanceChanged` notification, like the colors above.
+    /// The agent-status glyph silhouettes, nil meaning the built-in plain circle. NOT ghostty-resolved: the two
+    /// render sites read them through `statusSymbolName(for:override:)`, `SettingsModel` writes them (tolerantly
+    /// decoded from `AppSettings`); the sidebar re-render rides `.agtermAppearanceChanged`, like the colors.
     private(set) var activeStatusShape: StatusShape?
     private(set) var blockedStatusShape: StatusShape?
     private(set) var completedStatusShape: StatusShape?
@@ -157,12 +147,11 @@ final class GhosttyApp {
         }
         app = createdApp
         config = cfg
-        // boot-time: no surface exists yet, so the NSApp read is the only side source (and nothing has
-        // rendered, so it cannot disagree with a surface).
+        // boot-time: no surface exists yet, so the NSApp read is the only side source, and nothing has rendered
+        // that it could disagree with.
         resolveThemeColors(from: cfg, inputs: configInputs, isDark: Self.currentIsDark())
-        // demand-driven: no poll timer. ticks come from libghostty wakeups (coalesced in
-        // GhosttyCallbacks.wakeup) and surfaces draw on GHOSTTY_ACTION_RENDER, matching Ghostty.app/conterm
-        // — an idle terminal does no work, where a 120Hz poll ticked continuously.
+        // demand-driven, no poll timer: ticks come from libghostty wakeups (coalesced in GhosttyCallbacks.wakeup)
+        // and surfaces draw on GHOSTTY_ACTION_RENDER, like Ghostty.app/conterm — an idle terminal does no work.
     }
 
     func tick() {
@@ -170,76 +159,64 @@ final class GhosttyApp {
         ghostty_app_tick(app)
     }
 
-    /// Set the window translucency the chrome applies. Called by `SettingsModel` at launch and on
-    /// every change; the actual window re-sync rides the `.agtermAppearanceChanged` notification.
+    /// Set the window translucency the chrome applies. `SettingsModel` calls this and every setter below at
+    /// launch and on each change; the window re-syncs on `.agtermAppearanceChanged`.
     func setWindowTranslucency(opacity: Double, blurRadius: Int) {
         windowOpacity = opacity
         windowBlurRadius = blurRadius
     }
 
-    /// Set the custom title bar row state (normal/compact/hidden). Called by `SettingsModel` at launch
-    /// and on every change; the window re-sync rides the `.agtermAppearanceChanged` notification.
+    /// Set the title-bar row state (normal/compact/hidden); the window re-syncs on `.agtermAppearanceChanged`.
     func setToolbarMode(_ mode: ToolbarMode) {
         toolbarMode = mode
     }
 
-    /// Set whether the sidebar draws the notification count badge. Called by `SettingsModel` at launch
-    /// and on every change; the sidebar re-reconcile rides the `.agtermAppearanceChanged` notification.
+    /// Set whether the sidebar draws the notification count badge.
     func setNotificationBadgeEnabled(_ enabled: Bool) {
         notificationBadgeEnabled = enabled
     }
 
-    /// Set whether restored panes re-run their captured foreground command. Called by `SettingsModel` at
-    /// launch and on every change; read by the surface factories at restore time.
+    /// Set whether restored panes re-run their captured foreground command.
     func setRestoreRunningCommand(_ enabled: Bool) {
         restoreRunningCommand = enabled
     }
 
-    /// Set whether the title bar shows the attention bell icon. Called by `SettingsModel` at launch and on
-    /// every change; the title-bar re-render rides the `.agtermAppearanceChanged` notification.
+    /// Set whether the title bar shows the attention bell icon.
     func setAttentionButtonEnabled(_ enabled: Bool) {
         attentionButtonEnabled = enabled
     }
 
-    /// Set which title-bar / sidebar-footer chrome elements are hidden. Called by `SettingsModel` at launch
-    /// and on every change; the chrome re-render rides the `.agtermAppearanceChanged` notification.
+    /// Set which title-bar / sidebar-footer chrome elements are hidden.
     func setHiddenInterfaceElements(_ elements: Set<InterfaceElement>) {
         hiddenInterfaceElements = elements
     }
 
-    /// Set whether only the frontmost window shows its sidebar. Called by `SettingsModel` at launch and on
-    /// every change; read by `WindowAccessor.reportFrontmost` to gate the auto-hide driver.
+    /// Set whether only the frontmost window shows its sidebar.
     func setAutoHideSidebarInactiveWindows(_ enabled: Bool) {
         autoHideSidebarInactiveWindows = enabled
     }
 
-    /// Set the parsed restore denylist (program basenames not to re-run). Called by `SettingsModel` at
-    /// launch from `restore-denylist.conf`; read by the surface factories at restore time.
+    /// Set the parsed restore denylist (program basenames not to re-run).
     func setRestoreDenylist(_ denylist: Set<String>) {
         restoreDenylist = denylist
     }
 
-    /// Set the inactive-split-pane mute strength (0...10). Called by `SettingsModel` at launch and on
-    /// every change; the detail-pane re-render rides the `.agtermAppearanceChanged` notification.
+    /// Set the inactive-split-pane mute strength (0...10).
     func setInactivePaneMuteStrength(_ strength: Int) {
         inactivePaneMuteStrength = strength
     }
 
-    /// Set the sidebar background shift (0...10, 5 = neutral). Called by `SettingsModel` at launch and on
-    /// every change; the window re-sync rides the `.agtermAppearanceChanged` notification.
+    /// Set the sidebar background shift (0...10, 5 = neutral); the window re-syncs on the same notification.
     func setSidebarBackgroundShift(_ strength: Int) {
         sidebarBackgroundShift = strength
     }
 
-    /// Set the base terminal font size (the Settings default; nil → the ghostty built-in). Called by
-    /// `SettingsModel` at launch and on every change, so the dashboard font-override clear can compute the
-    /// size a default-following session reverts to.
+    /// Set the base terminal font size (the Settings default; nil → the ghostty built-in).
     func setBaseFontSize(_ size: Double?) {
         baseFontSize = size ?? DashboardLayout.ghosttyDefaultFontSize
     }
 
-    /// Set the sidebar row-text point size. Called by `SettingsModel` at launch and on every change; the
-    /// sidebar re-render (fonts + row height) rides the `.agtermAppearanceChanged` notification.
+    /// Set the sidebar row-text point size.
     func setSidebarFontSize(_ size: Double) {
         // clamp here so both readers (the row font AND the row height) see an in-range value. the Settings
         // stepper already bounds 9...20, but a hand-edited or future-range settings.json must not render a
@@ -247,18 +224,15 @@ final class GhosttyApp {
         sidebarFontSize = CGFloat(AppSettings.clampSidebarFontSize(size))
     }
 
-    /// Set the agent-status glyph colors from the user's hex settings (nil/malformed → the system
-    /// default). Called by `SettingsModel` at launch and on every change; the sidebar re-renders the
-    /// glyphs on the `.agtermAppearanceChanged` notification.
+    /// Set the agent-status glyph colors from the user's hex settings; nil or malformed → the system default.
     func setAgentStatusColors(activeHex: String?, blockedHex: String?, completedHex: String?) {
         activeStatusColor = NSColor(agtermHex: activeHex) ?? GhosttyApp.defaultActiveStatusColor
         blockedStatusColor = NSColor(agtermHex: blockedHex) ?? .systemOrange
         completedStatusColor = NSColor(agtermHex: completedHex) ?? .systemGreen
     }
 
-    /// Set the agent-status glyph silhouettes from the user's Settings (nil keeps that status on the
-    /// default plain circle). Called by `SettingsModel` at launch and on every change; the sidebar
-    /// re-renders the glyphs on the `.agtermAppearanceChanged` notification.
+    /// Set the agent-status glyph silhouettes from the user's Settings; nil keeps that status on the default
+    /// plain circle.
     func setAgentStatusShapes(active: StatusShape?, blocked: StatusShape?, completed: StatusShape?) {
         activeStatusShape = active
         blockedStatusShape = blocked
@@ -266,11 +240,10 @@ final class GhosttyApp {
     }
 
     /// The SF Symbol for a status glyph, honoring an optional per-call shape OVERRIDE from
-    /// `session.status --shape` (set on the ephemeral `AgentIndicator`). The override wins, else this
-    /// status's Settings shape, else the default plain circle — the precedence itself is the host-free
-    /// `AgentStatus.symbolName(override:configured:)`, so this only supplies the mirrored Settings value.
-    /// The single resolver the AppKit sidebar `StatusIconView` and the SwiftUI `StatusGlyph` share, so
-    /// the two can't drift.
+    /// `session.status --shape` (set on the ephemeral `AgentIndicator`). The precedence — override, else this
+    /// status's Settings shape, else the default plain circle — is the host-free
+    /// `AgentStatus.symbolName(override:configured:)`; this only supplies the mirrored Settings value. Shared by
+    /// the AppKit sidebar `StatusIconView` and the SwiftUI `StatusGlyph` so the two can't drift.
     func statusSymbolName(for status: AgentStatus, override shape: StatusShape?) -> String {
         let configured: StatusShape?
         switch status {
@@ -282,9 +255,9 @@ final class GhosttyApp {
         return status.symbolName(override: shape, configured: configured)
     }
 
-    /// The configured tint for a status glyph, shared by the AppKit sidebar `StatusIconView` and the
-    /// SwiftUI `StatusGlyph` so the two can't drift. `idle` never renders a glyph (it is filtered out
-    /// before any glyph is built), so its color is unused — it returns `.clear` as a benign default.
+    /// The configured tint for a status glyph, shared by the AppKit sidebar `StatusIconView` and the SwiftUI
+    /// `StatusGlyph` so the two can't drift. `idle` never renders a glyph (it is filtered out before any glyph
+    /// is built), so its `.clear` is a benign unused default.
     func statusColor(for status: AgentStatus) -> NSColor {
         switch status {
         case .active: return activeStatusColor
@@ -295,9 +268,9 @@ final class GhosttyApp {
     }
 
     /// The tint for a status glyph, honoring an optional per-call `#rrggbb` OVERRIDE from
-    /// `session.status --color` (set on the ephemeral `AgentIndicator`). A valid override wins; nil or
-    /// malformed falls back to the Settings-configured `statusColor(for:)`. Shared by the AppKit sidebar
-    /// `StatusIconView` and the SwiftUI `StatusGlyph` so the two can't drift.
+    /// `session.status --color` (set on the ephemeral `AgentIndicator`); a valid override wins, nil or malformed
+    /// falls back to the Settings-configured `statusColor(for:)`. Shared by the AppKit sidebar `StatusIconView`
+    /// and the SwiftUI `StatusGlyph` so the two can't drift.
     func statusColor(for status: AgentStatus, override hex: String?) -> NSColor {
         NSColor(agtermHex: hex) ?? statusColor(for: status)
     }
@@ -313,14 +286,13 @@ final class GhosttyApp {
     }
 
     /// The config inputs resolved from `settings.json` in ONE read: the agterm-scoped `ghostty.conf` URL
-    /// (`<configDir>/ghostty.conf`, co-located with `keymap.conf`) and whether to inherit the user's GLOBAL
-    /// `~/.config/ghostty/config` (`inheritGlobalGhosttyConfig`, default off). Callers resolve this ONCE per
-    /// config build and thread it to `loadConfig`/`resolveSelectionColors`, so a single reload reads
-    /// `settings.json` at most once. Resolved self-contained because `loadConfig` runs before any
-    /// `SettingsModel` exists (its first touch of `GhosttyApp.shared` is inside `SettingsModel.init`): it
-    /// reads the persisted `configDirectory` + flag from a `SettingsStore` rooted the SAME way
-    /// `agtermApp.init` builds it (via `settingsStore()`), applying the keymap's precedence
-    /// (explicit setting → `AGTERM_STATE_DIR/config` → `~/.config/agterm`).
+    /// (`<configDir>/ghostty.conf`, beside `keymap.conf`) and whether to inherit the user's GLOBAL
+    /// `~/.config/ghostty/config` (`inheritGlobalGhosttyConfig`, default off). Resolved ONCE per config build
+    /// and threaded to `loadConfig`/`resolveSelectionColors`, so a reload reads `settings.json` at most once.
+    /// Self-contained because `loadConfig` runs before any `SettingsModel` exists (whose init is the first touch
+    /// of `GhosttyApp.shared`): it reads the persisted `configDirectory` + flag from a `SettingsStore` rooted the
+    /// SAME way `agtermApp.init` builds it (via `settingsStore()`), with the keymap's precedence (explicit
+    /// setting → `AGTERM_STATE_DIR/config` → `~/.config/agterm`).
     struct ConfigInputs {
         let scopedURL: URL
         let inheritGlobalConfig: Bool
@@ -336,63 +308,58 @@ final class GhosttyApp {
                             inheritGlobalConfig: settings.inheritGlobalGhosttyConfig ?? false)
     }
 
-    /// The persisted settings store, rooted the SAME way `agtermApp.init` builds it: `AGTERM_STATE_DIR`
-    /// when set (test isolation), else the default Application Support directory. `ghosttyConfigURL`
-    /// reads `configDirectory` through this so it resolves the SAME `settings.json` the active
-    /// `SettingsModel` does. A bare `SettingsStore()` would read the default app-support file even under
-    /// `AGTERM_STATE_DIR` isolation, so an explicit `configDirectory` in the state-dir settings would be
-    /// ignored (and a production one could leak into an isolated run), pointing GhosttyApp and
-    /// SettingsModel at different `ghostty.conf` files.
+    /// The persisted settings store, rooted the SAME way `agtermApp.init` builds it: `AGTERM_STATE_DIR` when
+    /// set (test isolation), else the default Application Support directory — so it resolves the SAME
+    /// `settings.json` the active `SettingsModel` does. A bare `SettingsStore()` would read the app-support file
+    /// even under `AGTERM_STATE_DIR` isolation, ignoring an explicit `configDirectory` in the state-dir settings
+    /// (and leaking a production one into an isolated run), pointing GhosttyApp and SettingsModel at different
+    /// `ghostty.conf` files.
     private static func settingsStore() -> SettingsStore {
         ProcessInfo.processInfo.environment["AGTERM_STATE_DIR"]
             .map { SettingsStore(directory: URL(fileURLWithPath: $0, isDirectory: true)) } ?? SettingsStore()
     }
 
-    /// Rebuilds the config (re-reading the agterm settings file) and broadcasts it to the app and the
-    /// given live surfaces — a live appearance change. Keeps the new config as `self.config`; the
-    /// previous config is intentionally NOT freed: settings changes are rare and `update_config`
-    /// has no documented ownership contract, so this matches the existing never-free pattern over
-    /// risking a use-after-free. Returns the rebuilt config's diagnostic count (0 = clean) so a
-    /// Reload Config can warn the user about a malformed `ghostty.conf`.
+    /// Rebuilds the config (re-reading the agterm settings file) and broadcasts it to the app and the given
+    /// live surfaces — a live appearance change. Keeps the new config as `self.config`; the previous one is
+    /// intentionally NOT freed — settings changes are rare and `update_config` has no documented ownership
+    /// contract, so this follows the never-free pattern rather than risk a use-after-free. Returns the rebuilt
+    /// config's diagnostic count (0 = clean) so a Reload Config can warn about a malformed `ghostty.conf`.
     @discardableResult
     func reloadConfig(surfaces: [GhosttySurfaceView], isDark: Bool) -> Int {
-        // no app (called before `ghostty_app_new` succeeded) or `ghostty_config_new` allocation failure:
-        // nothing was re-read, so report the last known count. The property name is "from the most recent
-        // loadConfig", and both paths are effectively unreachable in practice (the app is always booted
-        // before a reload is reachable, and config allocation only fails under OOM).
+        // no app (called before `ghostty_app_new` succeeded) or a `ghostty_config_new` allocation failure:
+        // nothing was re-read, so report the last known count. Both are unreachable in practice — boot always
+        // precedes a reachable reload, and config allocation only fails under OOM.
         guard let app else { return lastConfigDiagnosticsCount }
         let inputs = Self.resolveConfigInputs()
         guard let newConfig = loadConfig(inputs) else { return lastConfigDiagnosticsCount }
-        // Re-assert the app + each surface's light/dark scheme from the authoritative `isDark` (the
-        // KVO-delivered side, else `currentIsDark()`) BEFORE feeding the config: libghostty re-resolves a
-        // dual `theme = light:,dark:` to the side matching the recorded conditional state, so a stale side
-        // would re-derive the wrong theme. Setting the APP scheme here (not only per surface) makes a
-        // ZERO-surface reload chrome-correct — the CONFIG_CHANGE clone below resolves to `isDark` even with
-        // no surfaces, so a dark launch re-sides the sidebar/titlebar before any surface exists. Cheap
-        // (each set no-ops when unchanged); the config re-feed below is what actually re-renders.
+        // re-assert the app + each surface's light/dark scheme from the authoritative `isDark` (the
+        // KVO-delivered side, else `currentIsDark()`) BEFORE feeding the config: libghostty re-resolves a dual
+        // `theme = light:,dark:` against the recorded conditional state, so a stale side derives the wrong
+        // theme. Setting the APP scheme (not only per surface) makes a ZERO-surface reload chrome-correct — the
+        // CONFIG_CHANGE clone below then resolves to `isDark` too, so a dark launch re-sides the
+        // sidebar/titlebar before any surface exists. Cheap (each set no-ops when unchanged); the config
+        // re-feed is what actually re-renders.
         ghostty_app_set_color_scheme(app, isDark ? GHOSTTY_COLOR_SCHEME_DARK : GHOSTTY_COLOR_SCHEME_LIGHT)
         for surface in surfaces { surface.syncColorScheme(isDark: isDark) }
         ghostty_app_update_config(app, newConfig)
-        // ghostty replies to update_config with a synchronous app-target CONFIG_CHANGE carrying the
-        // config it APPLIED — the dual `theme = light:,dark:` resolved to the current appearance side.
-        // Read the chrome colors from THAT clone below: newConfig itself is always finalized with the
-        // default (light) conditional state, so reading it directly while following in dark mode would
-        // tint the sidebar/titlebar with the LIGHT slot while the terminal renders the dark one. Falls
-        // back to newConfig when nothing was stashed (no conditional in play).
+        // ghostty replies to update_config with a synchronous app-target CONFIG_CHANGE carrying the config it
+        // APPLIED — the dual `theme = light:,dark:` resolved to the current appearance side. Read the chrome
+        // colors from THAT clone: newConfig is always finalized with the default (light) conditional state, so
+        // reading it directly while following in dark mode tints the sidebar/titlebar with the LIGHT slot while
+        // the terminal renders the dark one. Falls back to newConfig when nothing was stashed (no conditional).
         let derivedConfig = callbacks.takeDerivedAppConfig()
         for surface in surfaces { surface.applyConfig(newConfig) }
         config = newConfig
         // refresh the chrome colors from the NEW config BEFORE the watermark re-assert below: a default-tinted
-        // `.text` watermark re-renders its PNG reading `terminalForegroundColor`, so the foreground must already
-        // reflect the new theme — otherwise the text watermark's color lags one reload behind a theme change.
-        // the selection colors re-side from the authoritative `isDark` passed in (the side the app +
-        // surfaces were just set to), NOT re-read from any view.
+        // `.text` watermark re-renders its PNG from `terminalForegroundColor`, so a stale foreground lags one
+        // reload behind a theme change. the selection colors re-side from the authoritative `isDark` passed in
+        // (the side the app + surfaces were just set to), NOT re-read from any view.
         resolveThemeColors(from: derivedConfig ?? newConfig, inputs: inputs, isDark: isDark)
         if let derivedConfig { ghostty_config_free(derivedConfig) }
         // the broadcast above pushes the shared config (no background image, default font size) to every
-        // surface, wiping any per-surface watermark and zoom — so re-assert each affected surface's
-        // overlay afterwards. No-op for the surfaces without either; on the zoom-clearing reload paths
-        // the per-session fontSize was already nil'd, so only watermarks re-apply there.
+        // surface, wiping any per-surface watermark and zoom — so re-assert each affected surface's overlay
+        // after. No-op without either; on the zoom-clearing reload paths the per-session fontSize was already
+        // nil'd, so only watermarks re-apply there.
         for surface in surfaces { surface.reapplySessionConfigIfNeeded() }
         return lastConfigDiagnosticsCount
     }
@@ -401,10 +368,10 @@ final class GhosttyApp {
     /// selection colors after a live color change without a full config reload.
     private var lastConfigInputs: ConfigInputs?
 
-    /// Re-read the chrome colors (background, foreground, selection background/foreground) from a
-    /// resolved config. Called at init and on every settings reload. `background`/`foreground` come
-    /// from the resolved config; the selection colors are resolved separately (see below) because
-    /// `ghostty_config_get` does not expose the optional `selection-*` keys.
+    /// Re-read the chrome colors (background, foreground, selection background/foreground) from a resolved
+    /// config; called at init and on every settings reload. `background`/`foreground` come from the config, the
+    /// selection colors separately (see below) — `ghostty_config_get` does not expose the optional
+    /// `selection-*` keys.
     private func resolveThemeColors(from config: ghostty_config_t, inputs: ConfigInputs, isDark: Bool) {
         lastConfigInputs = inputs
         terminalBackgroundColor = Self.color(from: config, key: "background")
@@ -412,11 +379,10 @@ final class GhosttyApp {
         refreshSelectionColors(isDark: isDark)
     }
 
-    /// Re-resolve the selection chrome colors for the given appearance side. Used by the full config
-    /// load AND by the appearance-flip reload (which re-resolves the theme's colors), so the
-    /// selected-row pill follows a light/dark theme flip. `isDark` is explicit at every call site (the
-    /// reload threads the KVO-delivered side) — no defaulted appearance read a future caller could
-    /// silently pick up. No-op until a config has loaded.
+    /// Re-resolve the selection chrome colors for the given appearance side, so the selected-row pill follows a
+    /// light/dark theme flip. Used by the full config load AND the appearance-flip reload (which re-resolves
+    /// the theme's colors). `isDark` is explicit at every call site (the reload threads the KVO-delivered side)
+    /// — no defaulted appearance read a future caller could silently pick up. No-op until a config has loaded.
     func refreshSelectionColors(isDark: Bool) {
         guard let inputs = lastConfigInputs else { return }
         let (selectionBackground, selectionForeground) = Self.resolveSelectionColors(
@@ -427,34 +393,32 @@ final class GhosttyApp {
             ?? selectionBackground.map(Self.contrastingText(for:))
     }
 
-    /// Whether the app is currently in the dark appearance. `NSApp` is an implicitly-unwrapped global
-    /// that is still nil during the very early `GhosttyApp.shared` init (it boots from `SettingsModel.init`
-    /// before AppKit finishes wiring `NSApp`), so chain through it safely; that early window no longer
-    /// resolves a theme (the config emits the raw dual value and ghostty picks the side from the color
-    /// scheme set at surface creation), so a light default there is harmless.
+    /// Whether the app is currently in the dark appearance. `NSApp` is an implicitly-unwrapped global still nil
+    /// during the very early `GhosttyApp.shared` init (it boots from `SettingsModel.init`, before AppKit wires
+    /// `NSApp`), so chain through it safely; that early window resolves no theme (the config emits the raw dual
+    /// value and ghostty picks the side from the color scheme set at surface creation), so a light default
+    /// there is harmless.
     static func currentIsDark() -> Bool {
         guard let appearance = NSApp?.effectiveAppearance else { return false }
         return appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
     }
 
-    /// The selection colors can't be read back through `ghostty_config_get` (it doesn't expose the
-    /// optional `selection-background`/`selection-foreground` keys), so resolve them by reading the
-    /// same config sources `loadConfig` loads — in the same order — plus the active theme file. An
-    /// explicit `selection-*` line wins over the theme's; either color may be nil when unset. The `theme`
-    /// value may be the `light:…,dark:…` auto-switch form, resolved to the active side via `isDark`.
+    /// `ghostty_config_get` doesn't expose the optional `selection-background`/`selection-foreground` keys, so
+    /// resolve them by reading the same config sources `loadConfig` loads — in the same order — plus the active
+    /// theme file. An explicit `selection-*` line wins over the theme's; either color may be nil when unset.
+    /// The `theme` value may be the `light:…,dark:…` auto-switch form, resolved to the active side via
+    /// `isDark`, and the user's global `~/.config/ghostty/config` is a source ONLY when `inheritGlobalConfig`
+    /// is on, matching `loadConfig`'s gate.
     ///
-    /// Known limitation: this scans only the top-level config files; it does NOT follow `config-file`
-    /// includes that `ghostty_config_load_recursive_files` expands, so a `selection-*` delegated through
-    /// an include is missed and the sidebar pill falls back. A known edge case (it pre-dates the
-    /// agterm-scoped `ghostty.conf`). The user's global `~/.config/ghostty/config` is a source ONLY when
-    /// `inheritGlobalConfig` is on, matching `loadConfig`'s gate.
+    /// Known limitation: only the top-level config files are scanned — the `config-file` includes
+    /// `ghostty_config_load_recursive_files` expands are NOT followed, so a `selection-*` delegated through an
+    /// include is missed and the sidebar pill falls back.
     private static func resolveSelectionColors(ghosttyConfigPath: String, inheritGlobalConfig: Bool,
                                                isDark: Bool) -> (NSColor?, NSColor?) {
         var sources: [String] = []
         if let defaults = Bundle.main.url(forResource: "ghostty-defaults", withExtension: "conf") {
             sources.append(defaults.path)
         }
-        // the user's global ~/.config/ghostty/config is a source only when inheritance is opted in
         if inheritGlobalConfig {
             sources.append((NSHomeDirectory() as NSString).appendingPathComponent(".config/ghostty/config"))
         }
@@ -474,13 +438,12 @@ final class GhosttyApp {
                 }
             }
         }
-        // the theme file fills any selection color not set explicitly above. Our own settings conf now
-        // carries the raw dual `theme = light:,dark:` value (ghostty resolves the terminal side itself),
-        // so pick the side matching the current appearance here for the pill.
+        // the theme file fills any selection color not set explicitly above; our settings conf carries the raw
+        // dual `theme = light:,dark:` (ghostty picks the terminal side itself), so pick the side matching the
+        // current appearance for the pill.
         if selBg == nil || selFg == nil, let themeName, !themeName.isEmpty,
            let themesDir = Bundle.main.url(forResource: "ghostty", withExtension: nil)?
                .appendingPathComponent("themes", isDirectory: true) {
-            // `theme` may be the `light:…,dark:…` form; reduce to the active name.
             let effectiveName = ThemeName.resolved(from: themeName, isDark: isDark)
             for (key, value) in keyValues(ofFileAt: themesDir.appendingPathComponent(effectiveName).path) {
                 if key == "selection-background", selBg == nil { selBg = parseHexColor(value) }
@@ -515,12 +478,11 @@ final class GhosttyApp {
                        alpha: 1)
     }
 
-    /// Black or white, whichever gives higher contrast against `color`, decided by WCAG relative luminance.
-    /// The selected-row text falls back to this when the theme sets a selection-background but no
-    /// selection-foreground, and the dashboard status pill uses it to keep its name readable over an
-    /// arbitrary status-color fill. WCAG relative luminance (gamma-linearized channels, not a raw luma
-    /// average) is what makes a saturated mid-tone like `systemGreen` correctly pick BLACK: a plain luma
-    /// cutoff reads green as "dark" and picks unreadable white-on-green.
+    /// Black or white, whichever gives higher contrast against `color`, by WCAG relative luminance. Used by the
+    /// selected-row text when the theme sets a selection-background but no selection-foreground, and by the
+    /// dashboard status pill over an arbitrary status-color fill. The gamma-linearized WCAG luminance (not a
+    /// raw luma average) is what makes a saturated mid-tone like `systemGreen` correctly pick BLACK — a plain
+    /// luma cutoff reads green as "dark" and picks unreadable white-on-green.
     static func contrastingText(for color: NSColor) -> NSColor {
         let c = color.usingColorSpace(.sRGB) ?? color
         func linear(_ v: CGFloat) -> Double {
@@ -534,12 +496,12 @@ final class GhosttyApp {
     }
 
     /// Build a per-surface config = the SAME base files as `loadConfig` plus a small overlay (a session's
-    /// `background-image*` + font-size lines, from `WatermarkConfig.overlayText`). The overlay is written
-    /// to a temp file, loaded LAST (so it wins over the settings conf), then deleted (`load_file` reads
-    /// synchronously). The caller (`GhosttySurfaceView`) owns the returned config and frees it on surface
-    /// teardown. An empty overlay yields the plain base config (used to CLEAR a watermark). The app-wide
-    /// `lastConfigDiagnosticsCount` is preserved (a per-surface build must not clobber what `config.reload`
-    /// reports). Returns nil on allocation failure.
+    /// `background-image*` + font-size lines, from `WatermarkConfig.overlayText`), written to a temp file,
+    /// loaded LAST so it wins over the settings conf, then deleted (`load_file` reads synchronously). The
+    /// caller (`GhosttySurfaceView`) owns the returned config and frees it on surface teardown. An empty
+    /// overlay yields the plain base config (used to CLEAR a watermark). The app-wide
+    /// `lastConfigDiagnosticsCount` is preserved — a per-surface build must not clobber what `config.reload`
+    /// reports. Returns nil on allocation failure.
     func configWithOverlay(_ overlayText: String) -> ghostty_config_t? {
         var overlayPath: String?
         if !overlayText.isEmpty {
@@ -561,16 +523,16 @@ final class GhosttyApp {
     private func loadConfig(_ inputs: ConfigInputs, extraOverlayPath: String? = nil) -> ghostty_config_t? {
         guard let cfg = ghostty_config_new() else { return nil }
 
-        // app's built-in defaults (terminal padding, etc.), loaded first so the
-        // agterm-scoped ghostty.conf (and the global config, when opted in) still overrides them.
+        // app's built-in defaults (terminal padding, etc.) first, so the agterm-scoped ghostty.conf (and the
+        // global config, when opted in) still override them.
         if let defaults = Bundle.main.url(forResource: "ghostty-defaults", withExtension: "conf") {
             defaults.path.withCString { ghostty_config_load_file(cfg, $0) }
         }
 
-        // the user's GLOBAL ~/.config/ghostty/config is OFF by default (agterm is self-contained): a
-        // config written for the standalone Ghostty.app must not silently change agterm. It is loaded
-        // only when `inheritGlobalGhosttyConfig` is opted in. libghostty does NOT read the XDG config on
-        // its own, so we load it explicitly when present; `config-file` includes resolve below.
+        // the user's GLOBAL ~/.config/ghostty/config is OFF by default (agterm is self-contained — a config
+        // written for the standalone Ghostty.app must not silently change agterm), loaded only when
+        // `inheritGlobalGhosttyConfig` is opted in. libghostty does NOT read the XDG config on its own, so load
+        // it explicitly when present; `config-file` includes resolve below.
         if inputs.inheritGlobalConfig {
             let userPath = (NSHomeDirectory() as NSString).appendingPathComponent(".config/ghostty/config")
             if FileManager.default.fileExists(atPath: userPath) {
@@ -580,11 +542,11 @@ final class GhosttyApp {
             }
         }
 
-        // agterm-scoped ghostty config (`<configDir>/ghostty.conf`, co-located with keymap.conf) — the
-        // place for agterm overrides/customizations. ALWAYS loaded (regardless of the inherit toggle),
-        // after the optional global config so it overrides the bundled defaults + the user's global
-        // config for any key, but BEFORE agterm's UI settings so the Settings picker still wins for what
-        // it manages. Skipped when absent (the starter is comment-only, so a fresh install is a no-op).
+        // agterm-scoped ghostty config (`<configDir>/ghostty.conf`, beside keymap.conf) — the place for agterm
+        // overrides. ALWAYS loaded regardless of the inherit toggle, after the optional global config so it
+        // wins over the bundled defaults + the user's global config for any key, but BEFORE agterm's UI
+        // settings so the Settings picker still wins for what it manages. Skipped when absent (the starter is
+        // comment-only, so a fresh install is a no-op).
         let scopedPath = inputs.scopedURL.path
         if FileManager.default.fileExists(atPath: scopedPath) {
             scopedPath.withCString { ghostty_config_load_file(cfg, $0) }
@@ -631,12 +593,10 @@ final class GhosttyApp {
 
     // MARK: - Resources
 
-    /// Candidate ghostty resource dirs, highest priority first. agterm ships the
-    /// ghostty resources in its own bundle (downloaded by setup.sh) under
-    /// `Contents/Resources/ghostty`, mirroring a real Ghostty.app, with the
-    /// compiled terminfo DB at the sibling `Contents/Resources/terminfo`. The
-    /// installed Ghostty.app dirs remain as fallbacks for an unprepared dev
-    /// checkout.
+    /// Candidate ghostty resource dirs, highest priority first. agterm ships the ghostty resources in its own
+    /// bundle (produced by setup.sh) under `Contents/Resources/ghostty`, mirroring a real Ghostty.app, with the
+    /// compiled terminfo DB at the sibling `Contents/Resources/terminfo`. The installed Ghostty.app dirs remain
+    /// as fallbacks for an unprepared dev checkout.
     private static let resourcePaths: [String] = {
         var paths: [String] = []
         if let resources = Bundle.main.resourceURL?.path {
@@ -648,15 +608,11 @@ final class GhosttyApp {
     }()
 
     private func resolveResources() {
-        // Always resolve from our own candidates (bundle first), ignoring any
-        // inherited GHOSTTY_RESOURCES_DIR. A stale value would otherwise shadow
-        // our complete bundle and leave libghostty deriving a broken TERMINFO.
-        //
-        // We only set GHOSTTY_RESOURCES_DIR. TERMINFO is NOT set here on
-        // purpose: libghostty unconditionally overwrites it at shell spawn with
-        // dirname(GHOSTTY_RESOURCES_DIR)/terminfo, so any setenv here would be
-        // clobbered. Because our resources dir is .../Resources/ghostty, that
-        // derivation lands on .../Resources/terminfo — the sibling dir we ship.
+        // always resolve from our own candidates (bundle first), ignoring any inherited GHOSTTY_RESOURCES_DIR —
+        // a stale value would shadow our complete bundle and leave libghostty deriving a broken TERMINFO.
+        // TERMINFO itself is NOT set here on purpose: libghostty unconditionally overwrites it at shell spawn
+        // with dirname(GHOSTTY_RESOURCES_DIR)/terminfo, clobbering any setenv. Our resources dir is
+        // .../Resources/ghostty, so that derivation lands on the sibling .../Resources/terminfo we ship.
         let resolver = GhosttyResourceResolver(
             candidates: Self.resourcePaths,
             fileExists: { FileManager.default.fileExists(atPath: $0) }
@@ -671,20 +627,18 @@ final class GhosttyApp {
 }
 
 extension Notification.Name {
-    /// Posted after the ghostty config is reloaded from a settings change, so the SwiftUI chrome
-    /// (the quick terminal backing) and the AppKit window appearance (title bar + window background →
-    /// sidebar) re-read the new `GhosttyApp.terminalBackgroundColor` immediately instead of waiting
-    /// for the window to re-key.
+    /// Posted after the ghostty config is reloaded from a settings change, so the SwiftUI chrome (the quick
+    /// terminal backing) and the AppKit window appearance (title bar + window background → sidebar) re-read the
+    /// new `GhosttyApp.terminalBackgroundColor` immediately instead of waiting for the window to re-key.
     static let agtermAppearanceChanged = Notification.Name("agterm.appearanceChanged")
 
     /// Posted by `SystemAppearanceObserver` (an app-level KVO observer on `NSApplication.effectiveAppearance`)
-    /// when the macOS light/dark appearance changes, and once at launch, carrying the resolved `isDark` in
-    /// userInfo. `SettingsModel` re-resolves the active side of a `theme = light:,dark:` pair and
-    /// rewrites+reloads the config — this pinned libghostty doesn't switch the dual conditional at runtime,
-    /// so agterm drives the swap itself. KVO delivers the settled value across sleep/wake, unlike the old
-    /// per-view `viewDidChangeEffectiveAppearance` hook that wedged. Also posted by the `debug.appearance`
-    /// UI-test seam. Distinct from `agtermAppearanceChanged` (the settings→chrome direction); this is the
-    /// system→settings direction.
+    /// on every macOS light/dark change and once at launch, carrying the resolved `isDark` in userInfo.
+    /// `SettingsModel` re-resolves the active side of a `theme = light:,dark:` pair and rewrites+reloads the
+    /// config — this pinned libghostty doesn't switch the dual conditional at runtime, so agterm drives the
+    /// swap itself. KVO because it delivers the settled value across sleep/wake, unlike a per-view
+    /// `viewDidChangeEffectiveAppearance` hook, which wedges. Also posted by the `debug.appearance` UI-test
+    /// seam. This is the system→settings direction; `agtermAppearanceChanged` is settings→chrome.
     static let agtermSystemAppearanceChanged = Notification.Name("agterm.systemAppearanceChanged")
 
     /// Posted by `SystemAccessibilityObserver` when a macOS accessibility display option changes.
@@ -693,21 +647,21 @@ extension Notification.Name {
     static let agtermAccessibilityDisplayOptionsChanged =
         Notification.Name("agterm.accessibilityDisplayOptionsChanged")
 
-    /// Posted when a window becomes frontmost (the active-window change is async, via the window's
-    /// didBecomeKey), so the control server can refresh its cached `window.list` — whose `active` flag
-    /// would otherwise stay stale until the next dispatched command.
+    /// Posted when a window becomes frontmost (the change is async, via the window's didBecomeKey), so the
+    /// control server can refresh its cached `window.list` — whose `active` flag would otherwise stay stale
+    /// until the next dispatched command.
     static let agtermWindowFrontmostChanged = Notification.Name("agterm.windowFrontmostChanged")
 
     /// Posted by `WindowRegistry` when a window's NSWindow attaches or detaches, so the control server can
-    /// refresh its cached `window.list`. A window is "open" (its store loaded) well before its NSWindow
-    /// exists, so `window.new` builds its cached node with no `geometry`/`fullscreen`/`zoomed`/`minimized`;
-    /// nothing else refreshes it afterwards on that path — `newWindow()` pre-sets `frontmostWindowID`, so
-    /// the first `didBecomeKey` is a no-change and skips `.agtermWindowFrontmostChanged`, and a brand-new
-    /// window has no saved frame to restore, so no `didMove`/`didResize` fires either.
+    /// refresh its cached `window.list`. A window is "open" (its store loaded) well before its NSWindow exists,
+    /// so `window.new` builds its cached node with no `geometry`/`fullscreen`/`zoomed`/`minimized` and nothing
+    /// else refreshes it on that path: `newWindow()` pre-sets `frontmostWindowID`, so the first `didBecomeKey`
+    /// is a no-change that skips `.agtermWindowFrontmostChanged`, and a brand-new window has no saved frame to
+    /// restore, so no `didMove`/`didResize` fires either.
     static let agtermWindowAttachmentChanged = Notification.Name("agterm.windowAttachmentChanged")
 
-    /// Posted after `keymap.conf` is (re)loaded and reparsed, so the custom-command runner rebuilds its
-    /// matcher and the action palette re-reads the custom commands. The data-driven menu shortcuts
-    /// re-render on their own because they read the `@Observable` keymap directly.
+    /// Posted after `keymap.conf` is (re)loaded and reparsed, so the custom-command runner rebuilds its matcher
+    /// and the action palette re-reads the custom commands. The data-driven menu shortcuts re-render on their
+    /// own, reading the `@Observable` keymap directly.
     static let agtermKeymapChanged = Notification.Name("agterm.keymapChanged")
 }

--- a/agterm/Ghostty/GhosttyCallbacks.swift
+++ b/agterm/Ghostty/GhosttyCallbacks.swift
@@ -7,15 +7,13 @@ import os
 
 /// Routes libghostty runtime callbacks to the appropriate terminal views.
 ///
-/// `@unchecked Sendable` and NOT `@MainActor`: the C closures run synchronously off whatever thread
-/// libghostty calls from, and this router holds no mutable state. Every `@MainActor` touch hops via
-/// `DispatchQueue.main.async`, and any C string is copied into a Swift `String` *before* the hop — the
-/// `char*` is valid only for the synchronous callback duration.
+/// `@unchecked Sendable`, NOT `@MainActor`: the C closures run synchronously off whatever thread libghostty
+/// calls from, and this router holds no mutable state. Every `@MainActor` touch hops via
+/// `DispatchQueue.main.async`, copying any C string first — the `char*` lives only for that callback.
 final class GhosttyCallbacks: @unchecked Sendable {
     /// Coalesces libghostty wakeups into one queued main-thread tick: `wakeup_cb` fires off-main far faster
     /// than the runloop drains, and a single `ghostty_app_tick` drains all pending work. The flag clears
-    /// before the tick so a wakeup arriving during it re-schedules instead of being dropped. agterm is
-    /// demand-driven — there is no poll timer.
+    /// before the tick so a wakeup arriving during it re-schedules instead of being dropped.
     private let tickScheduled = OSAllocatedUnfairLock(initialState: false)
 
     func wakeup() {
@@ -39,15 +37,14 @@ final class GhosttyCallbacks: @unchecked Sendable {
             DispatchQueue.main.async { view.applyPwd(pwd) }
             return true
         case GHOSTTY_ACTION_SET_TITLE:
-            // OSC 0/1/2 title, often from a PROMPT_COMMAND or a remote host over SSH. displayName prefers
-            // it over the cwd basename.
+            // OSC 0/1/2 title, often from PROMPT_COMMAND or SSH; displayName prefers it to the cwd basename.
             guard let view = surfaceView(from: target), let ptr = action.action.set_title.title else { return true }
             let title = String(cString: ptr)
             DispatchQueue.main.async { view.applyTitle(title) }
             return true
         case GHOSTTY_ACTION_CELL_SIZE:
-            // the cell pixel size changed (cmd +/- font size, or DPI). used only as a trigger: the view
-            // reads the live font size and the app persists it.
+            // the cell pixel size changed (cmd +/- font size, or DPI): a trigger only — the view reads the
+            // live font size and the app persists it.
             guard let view = surfaceView(from: target) else { return true }
             DispatchQueue.main.async { view.reportFontSize() }
             return true
@@ -65,10 +62,9 @@ final class GhosttyCallbacks: @unchecked Sendable {
             DispatchQueue.main.async { NotificationManager.shared.notify(surface: view, title: title, body: body) }
             return true
         case GHOSTTY_ACTION_SHOW_CHILD_EXITED:
-            // the child exited. ghostty prints its "Process exited. Press any key to close" fallback unless
-            // the host consumes this action: an overlay that should vanish closes now and returns true to
-            // suppress the prompt, while a wait-opt-in overlay (and every other surface) returns false so
-            // the prompt shows and close_surface_cb handles the close.
+            // ghostty prints its "Process exited. Press any key to close" fallback unless the host consumes
+            // this action: an overlay that should vanish returns true to suppress the prompt; a wait-opt-in
+            // overlay (and every other surface) returns false, so the prompt shows and close_surface_cb closes.
             guard let view = surfaceView(from: target), view.shouldCloseOnChildExitAction else { return false }
             DispatchQueue.main.async { view.handleProcessExit() }
             return true
@@ -98,49 +94,42 @@ final class GhosttyCallbacks: @unchecked Sendable {
             DispatchQueue.main.async { view.onSearchSelected?(value) }
             return true
         case GHOSTTY_ACTION_CONFIG_CHANGE:
-            // ghostty replies to `ghostty_app_update_config` with the config it actually APPLIED — for the
-            // app target the dual `theme = light:,dark:` conditional resolved to the current side, which the
-            // host-loaded config can never show (`ghostty_config_get` on it always reads the default = light
-            // side). clone synchronously (the core frees its derived copy once this returns) and stash it for
-            // `GhosttyApp.reloadConfig` to read chrome colors from. only the app target is stashed —
-            // surface-targeted changes (per-surface watermark overlays) must not repaint app-level chrome.
+            // ghostty replies to `ghostty_app_update_config` with the config it APPLIED: for the app target
+            // the dual `theme = light:,dark:` resolved to the current side, which the host config can't show
+            // (`ghostty_config_get` reads the light default). Clone synchronously (the core frees its copy on
+            // return) and stash for `reloadConfig`; app target only, so per-surface overlays can't repaint.
             guard target.tag == GHOSTTY_TARGET_APP,
                   let cfg = action.action.config_change.config,
                   let clone = ghostty_config_clone(cfg) else { return true }
             stashDerivedAppConfig(clone)
             return true
         case GHOSTTY_ACTION_MOUSE_VISIBILITY:
-            // the host is asked to hide/show the pointer — the mechanism behind mouse-hide-while-typing, the
-            // core never touches the cursor. setHiddenUntilMouseMoves auto-reveals on the next mouse move,
-            // so only the hidden case needs acting on; show resets it.
+            // the host hides/shows the pointer — the core never touches the cursor (mouse-hide-while-typing).
+            // setHiddenUntilMouseMoves auto-reveals on the next mouse move, so show just resets it.
             let hidden = action.action.mouse_visibility == GHOSTTY_MOUSE_HIDDEN
             DispatchQueue.main.async { NSCursor.setHiddenUntilMouseMoves(hidden) }
             return true
         case GHOSTTY_ACTION_MOUSE_SHAPE:
-            // a cursor shape for this surface — pointing hand over a detected link / OSC-8 hyperlink, I-beam
-            // over the grid, resize/crosshair in the matching modes.
+            // pointing hand over a detected link / OSC-8 hyperlink, I-beam over the grid, resize/crosshair.
             guard let view = surfaceView(from: target) else { return true }
             let shape = action.action.mouse_shape
             DispatchQueue.main.async { view.applyMouseShape(shape) }
             return true
         case GHOSTTY_ACTION_OPEN_URL:
-            // a click opened a detected link / OSC-8 hyperlink. copy the URL out of the LENGTH-DELIMITED C
-            // buffer synchronously (valid only for this call, and `open_url.url` is a Zig slice, NOT
-            // NUL-terminated — honor `.len`, since `String(cString:)` would over-read into adjacent
-            // hyperlink storage), then open it scheme-validated on the main actor.
+            // copy the URL out of the LENGTH-DELIMITED buffer synchronously (valid only for this call):
+            // `open_url.url` is a Zig slice, NOT NUL-terminated, so honor `.len` — `String(cString:)` would
+            // over-read into adjacent hyperlink storage. Then open it scheme-validated on the main actor.
             let openURL = action.action.open_url
             guard let view = surfaceView(from: target), let ptr = openURL.url else { return true }
             let link = String(decoding: UnsafeRawBufferPointer(start: ptr, count: Int(openURL.len)), as: UTF8.self)
             DispatchQueue.main.async { view.openLink(link) }
             return true
         case GHOSTTY_ACTION_COLOR_CHANGE:
-            // a dynamic terminal color set or RESET via OSC 10/11/12 (fg/bg/cursor) or their 110/111/112
-            // resets. libghostty already applied it to its own render state, but under window translucency
-            // every surface renders background-opacity 0 (the AppKit window backing supplies the tint), so
-            // an OSC 11 BACKGROUND stays invisible until THIS surface's opacity is lifted — a per-pane tint.
-            // only background needs acting on; foreground/cursor render regardless of translucency. copy the
-            // color out synchronously (the struct is valid only for this call), then hop to the main actor,
-            // which decides the set-vs-reset routing and the per-prompt dedupe.
+            // a dynamic color set or RESET via OSC 10/11/12 (fg/bg/cursor) or their 110/111/112 resets,
+            // already applied by libghostty; but under translucency every surface renders background-opacity
+            // 0 (the window backing supplies the tint), so an OSC 11 BACKGROUND is invisible until THIS
+            // surface's opacity is lifted — fg/cursor render regardless. The main actor routes set-vs-reset
+            // and dedupes per prompt.
             guard let view = surfaceView(from: target) else { return true }
             let change = action.action.color_change
             guard change.kind == GHOSTTY_ACTION_COLOR_KIND_BACKGROUND else { return true }
@@ -152,9 +141,8 @@ final class GhosttyCallbacks: @unchecked Sendable {
         }
     }
 
-    /// The app-target CONFIG_CHANGE clone awaiting pickup, as a bit pattern (raw pointers aren't Sendable,
-    /// so the lock holds `UInt`; 0 = none). Written synchronously by the CONFIG_CHANGE arm during
-    /// `ghostty_app_update_config`, taken right after by `GhosttyApp.reloadConfig`.
+    /// The app-target CONFIG_CHANGE clone awaiting pickup, as a bit pattern (raw pointers aren't Sendable, so
+    /// the lock holds `UInt`; 0 = none). Written during `ghostty_app_update_config`, taken by `reloadConfig`.
     private let pendingAppConfig = OSAllocatedUnfairLock<UInt>(initialState: 0)
 
     /// Stash the cloned app-level derived config, freeing any stale one left from a take-less update
@@ -185,11 +173,9 @@ final class GhosttyCallbacks: @unchecked Sendable {
         return true
     }
 
-    /// Returns the text for a pasteboard: file/web URLs (a Finder copy or a drag-drop) become shell-escaped
-    /// paths, space-joined, so a path with spaces lands as one argument; otherwise the plain string
-    /// verbatim, NOT escaped, since it may be a command the user means to run. Shared by the clipboard
-    /// paste path (`readPasteboardText`) and the drag-drop handler, so a dropped file inserts like a pasted
-    /// one.
+    /// The text for a pasteboard: file/web URLs (a Finder copy or a drag-drop) become shell-escaped paths,
+    /// space-joined; a plain string comes back verbatim, NOT escaped, since it may be a command the user
+    /// means to run. Shared by the clipboard paste path and the drag-drop handler, so a drop inserts as a paste.
     static func pasteboardText(_ pb: NSPasteboard) -> String? {
         if let urls = pb.readObjects(forClasses: [NSURL.self]) as? [URL] {
             let parts = urls.map(urlText).filter { !$0.isEmpty }
@@ -199,9 +185,8 @@ final class GhosttyCallbacks: @unchecked Sendable {
     }
 
     /// The text one pasteboard URL contributes: a shell-escaped path for a file URL (so a path with spaces
-    /// lands as one argument), else the escaped absolute string. The SINGLE definition shared by
-    /// `pasteboardText` and `hasPasteboardText`, so the reader and the menu gate cannot drift — an invariant
-    /// with no automated test (the file-URL case is not XCUITest-able; see the Control API rule).
+    /// lands as one argument), else the escaped absolute string. The SINGLE definition shared by the reader
+    /// and the menu gate, so they cannot drift — untestable in XCUITest (see the Control API rule).
     private static func urlText(_ url: URL) -> String {
         ShellEscape.path(url.isFileURL ? url.path(percentEncoded: false) : url.absoluteString)
     }
@@ -209,14 +194,12 @@ final class GhosttyCallbacks: @unchecked Sendable {
     /// Pasted text from the general clipboard (the libghostty paste callback).
     static func readPasteboardText() -> String? { pasteboardText(.general) }
 
-    /// Whether `pasteboardText` would return something, without building the joined result. Menu validation
-    /// runs on every Edit-menu open and every ⌘V key-equivalent lookup, so this short-circuits on the first
-    /// usable URL instead of mapping, escaping and joining the whole clipboard.
+    /// Whether `pasteboardText` would return something, without building the joined result: menu validation
+    /// runs on every Edit-menu open and ⌘V key-equivalent lookup, so it short-circuits on the first usable URL.
     ///
-    /// It must agree with `pasteboardText` in BOTH directions, which a bare `canReadObject([NSURL])` probe
-    /// does not: that is a TYPE check, so a pasteboard merely DECLARING `public.file-url` with no usable
-    /// value enables Paste while the reader returns nil and the paste inserts nothing (verified against a
-    /// named pasteboard). Hence the same `urlText` + non-empty filter the reader applies.
+    /// It must agree with `pasteboardText` BOTH ways, which a bare `canReadObject([NSURL])` TYPE check does
+    /// not: a pasteboard merely DECLARING `public.file-url` with no usable value would enable Paste while
+    /// the reader returns nil (verified with a named pasteboard). Hence the same `urlText` + non-empty filter.
     static func hasPasteboardText(_ pb: NSPasteboard = .general) -> Bool {
         if let urls = pb.readObjects(forClasses: [NSURL.self]) as? [URL],
            urls.contains(where: { !urlText($0).isEmpty }) {
@@ -235,11 +218,10 @@ final class GhosttyCallbacks: @unchecked Sendable {
             return
         }
         guard let ud else { return }
-        // capture the VIEW, not the raw surface pointer: a session/window/pane close (or `session.close`
-        // over the socket) can free the surface via destroySurface() WHILE the sheet is open. re-read
-        // `view.surface` on the main actor at completion and skip if it's gone — freeing it already
-        // discarded the pending request, so there is nothing to complete and no loop. the view also scopes
-        // the prompt's coalescing to this surface.
+        // capture the VIEW, not the raw surface pointer: a close (GUI or `session.close`) can free the surface
+        // via destroySurface() WHILE the sheet is open. Re-read `view.surface` at completion and skip if it's
+        // gone — freeing already discarded the request, so there is nothing to complete and no loop. The view
+        // also scopes the prompt's coalescing to this surface.
         let view = Unmanaged<GhosttySurfaceView>.fromOpaque(ud).takeUnretainedValue()
         let text = content.map { String(cString: $0) } ?? "" // copy now; nil content reads as empty
         nonisolated(unsafe) let requestState = state
@@ -263,16 +245,14 @@ final class GhosttyCallbacks: @unchecked Sendable {
             break
         }
         guard let text else { return }
-        // confirm == false: ghostty's clipboard-write policy already allowed it (the `allow` default). this
-        // callback runs on the main actor (verified), so write SYNCHRONOUSLY — deferring lets a following
-        // OSC 52 read in the same tick observe the stale clipboard.
+        // confirm == false: ghostty's `allow` clipboard-write policy already permitted it. This callback runs
+        // on the main actor (verified), so write SYNCHRONOUSLY — a same-tick OSC 52 read would see stale data.
         guard confirm else {
             Self.setClipboard(text)
             return
         }
         // confirm == true: clipboard-write = ask. Gate behind the user, scoping coalescing to this surface
-        // (the write callback's userdata is the surface, same pointer as the read confirm) so one Allow
-        // can't authorize a different surface's queued write.
+        // (userdata is the surface, as in the read confirm) so one Allow can't authorize another's write.
         guard let ud else { return }
         let view = Unmanaged<GhosttySurfaceView>.fromOpaque(ud).takeUnretainedValue()
         DispatchQueue.main.async {

--- a/agterm/Ghostty/GhosttyCallbacks.swift
+++ b/agterm/Ghostty/GhosttyCallbacks.swift
@@ -7,16 +7,15 @@ import os
 
 /// Routes libghostty runtime callbacks to the appropriate terminal views.
 ///
-/// `@unchecked Sendable` and NOT `@MainActor`: the C closures run synchronously
-/// off whatever thread libghostty calls from. This router holds no mutable
-/// state. Every `@MainActor` touch hops via `DispatchQueue.main.async`, and any
-/// C string is copied to a Swift `String` value *before* the hop (the `char*`
-/// is only valid for the synchronous callback duration).
+/// `@unchecked Sendable` and NOT `@MainActor`: the C closures run synchronously off whatever thread
+/// libghostty calls from, and this router holds no mutable state. Every `@MainActor` touch hops via
+/// `DispatchQueue.main.async`, and any C string is copied into a Swift `String` *before* the hop — the
+/// `char*` is valid only for the synchronous callback duration.
 final class GhosttyCallbacks: @unchecked Sendable {
-    /// Coalesces libghostty wakeups into one queued main-thread tick. `wakeup_cb` fires off-main far faster
-    /// than the runloop drains; a single `ghostty_app_tick` drains all pending work. The flag clears before
-    /// the tick so a wakeup arriving during it re-schedules instead of being dropped. (Replaces the dropped
-    /// 120Hz poll timer — agterm is demand-driven now.)
+    /// Coalesces libghostty wakeups into one queued main-thread tick: `wakeup_cb` fires off-main far faster
+    /// than the runloop drains, and a single `ghostty_app_tick` drains all pending work. The flag clears
+    /// before the tick so a wakeup arriving during it re-schedules instead of being dropped. agterm is
+    /// demand-driven — there is no poll timer.
     private let tickScheduled = OSAllocatedUnfairLock(initialState: false)
 
     func wakeup() {
@@ -40,30 +39,25 @@ final class GhosttyCallbacks: @unchecked Sendable {
             DispatchQueue.main.async { view.applyPwd(pwd) }
             return true
         case GHOSTTY_ACTION_SET_TITLE:
-            // the shell or a program set the terminal title (OSC 0/1/2 — often from a PROMPT_COMMAND
-            // or a remote host over SSH). recover the surface, copy the title out of the C string,
-            // and apply it to the session; displayName prefers it over the cwd basename.
+            // OSC 0/1/2 title, often from a PROMPT_COMMAND or a remote host over SSH. displayName prefers
+            // it over the cwd basename.
             guard let view = surfaceView(from: target), let ptr = action.action.set_title.title else { return true }
             let title = String(cString: ptr)
             DispatchQueue.main.async { view.applyTitle(title) }
             return true
         case GHOSTTY_ACTION_CELL_SIZE:
-            // fires when the cell pixel size changes (font-size change via cmd +/-, or DPI
-            // change). used only as a trigger: the view reads the live font size and the app
-            // persists it.
+            // the cell pixel size changed (cmd +/- font size, or DPI). used only as a trigger: the view
+            // reads the live font size and the app persists it.
             guard let view = surfaceView(from: target) else { return true }
             DispatchQueue.main.async { view.reportFontSize() }
             return true
         case GHOSTTY_ACTION_RENDER:
-            // libghostty signals this surface has a frame ready to paint. agterm is demand-driven (no poll
-            // timer), so service it by drawing now.
+            // a frame is ready to paint. agterm is demand-driven (no poll timer), so draw now.
             guard let view = surfaceView(from: target) else { return true }
             DispatchQueue.main.async { view.renderNow() }
             return true
         case GHOSTTY_ACTION_DESKTOP_NOTIFICATION:
-            // a program emitted an OSC 9 / 777 desktop notification. recover the firing surface and
-            // copy the title/body out of the C strings synchronously (only valid for this call),
-            // then hop to the manager (which resolves the session/pane and applies suppression).
+            // an OSC 9 / 777 desktop notification. the manager resolves the session/pane and suppresses.
             guard let view = surfaceView(from: target) else { return true }
             let note = action.action.desktop_notification
             let title = note.title.flatMap { String(cString: $0) } ?? ""
@@ -71,28 +65,26 @@ final class GhosttyCallbacks: @unchecked Sendable {
             DispatchQueue.main.async { NotificationManager.shared.notify(surface: view, title: title, body: body) }
             return true
         case GHOSTTY_ACTION_SHOW_CHILD_EXITED:
-            // the child process exited. ghostty prints its "Process exited. Press any key to close"
-            // fallback unless the host consumes this action. an overlay that should vanish closes
-            // immediately and returns true to suppress the prompt; a wait-opt-in overlay (and any other
-            // surface) returns false so ghostty shows the prompt and close_surface_cb handles the close.
+            // the child exited. ghostty prints its "Process exited. Press any key to close" fallback unless
+            // the host consumes this action: an overlay that should vanish closes now and returns true to
+            // suppress the prompt, while a wait-opt-in overlay (and every other surface) returns false so
+            // the prompt shows and close_surface_cb handles the close.
             guard let view = surfaceView(from: target), view.shouldCloseOnChildExitAction else { return false }
             DispatchQueue.main.async { view.handleProcessExit() }
             return true
         case GHOSTTY_ACTION_START_SEARCH:
-            // libghostty entered search mode. recover the firing surface and copy the optional needle out
-            // of the C string synchronously (only valid for this call), then hop to the view's toggle.
+            // libghostty entered search mode; the needle it reports back is optional.
             guard let view = surfaceView(from: target) else { return true }
             let needle = action.action.start_search.needle.flatMap { String(cString: $0) }
             DispatchQueue.main.async { view.onSearchStart?(needle) }
             return true
         case GHOSTTY_ACTION_END_SEARCH:
-            // libghostty exited search mode. recover the surface and hop to the view's clear/refocus.
+            // libghostty exited search mode; the view clears the fields and refocuses the terminal.
             guard let view = surfaceView(from: target) else { return true }
             DispatchQueue.main.async { view.onSearchEnd?() }
             return true
         case GHOSTTY_ACTION_SEARCH_TOTAL:
-            // libghostty reported the total match count (ssize_t; negative means no query). map a negative
-            // to nil, else carry the count.
+            // the total match count (ssize_t; negative means no query) — a negative maps to nil.
             guard let view = surfaceView(from: target) else { return true }
             let raw = action.action.search_total.total
             let value = raw < 0 ? nil : Int(raw)
@@ -106,37 +98,35 @@ final class GhosttyCallbacks: @unchecked Sendable {
             DispatchQueue.main.async { view.onSearchSelected?(value) }
             return true
         case GHOSTTY_ACTION_CONFIG_CHANGE:
-            // ghostty replies to `ghostty_app_update_config` with the config it actually APPLIED — for
-            // the app target that is the dual `theme = light:,dark:` conditional resolved to the current
-            // appearance side, which the host-loaded config can never show (`ghostty_config_get` on it
-            // always reads the default = light side). Clone it synchronously (the core frees its derived
-            // copy right after this callback returns) and stash it for `GhosttyApp.reloadConfig` to read
-            // the chrome colors from. Surface-targeted changes (per-surface watermark overlays) must not
-            // repaint app-level chrome, so only the app target is stashed.
+            // ghostty replies to `ghostty_app_update_config` with the config it actually APPLIED — for the
+            // app target the dual `theme = light:,dark:` conditional resolved to the current side, which the
+            // host-loaded config can never show (`ghostty_config_get` on it always reads the default = light
+            // side). clone synchronously (the core frees its derived copy once this returns) and stash it for
+            // `GhosttyApp.reloadConfig` to read chrome colors from. only the app target is stashed —
+            // surface-targeted changes (per-surface watermark overlays) must not repaint app-level chrome.
             guard target.tag == GHOSTTY_TARGET_APP,
                   let cfg = action.action.config_change.config,
                   let clone = ghostty_config_clone(cfg) else { return true }
             stashDerivedAppConfig(clone)
             return true
         case GHOSTTY_ACTION_MOUSE_VISIBILITY:
-            // libghostty asks the host to hide/show the pointer — the mechanism behind
-            // mouse-hide-while-typing (the core never touches the cursor itself). setHiddenUntilMouseMoves
-            // auto-reveals on the next mouse move, so the hidden case is all that needs acting on; show resets it.
+            // the host is asked to hide/show the pointer — the mechanism behind mouse-hide-while-typing, the
+            // core never touches the cursor. setHiddenUntilMouseMoves auto-reveals on the next mouse move,
+            // so only the hidden case needs acting on; show resets it.
             let hidden = action.action.mouse_visibility == GHOSTTY_MOUSE_HIDDEN
             DispatchQueue.main.async { NSCursor.setHiddenUntilMouseMoves(hidden) }
             return true
         case GHOSTTY_ACTION_MOUSE_SHAPE:
-            // libghostty requests a mouse cursor shape for this surface — the pointing hand over a detected
-            // link / OSC-8 hyperlink, the I-beam over the grid, resize/crosshair in the matching modes.
-            // recover the surface and apply the mapped NSCursor.
+            // a cursor shape for this surface — pointing hand over a detected link / OSC-8 hyperlink, I-beam
+            // over the grid, resize/crosshair in the matching modes.
             guard let view = surfaceView(from: target) else { return true }
             let shape = action.action.mouse_shape
             DispatchQueue.main.async { view.applyMouseShape(shape) }
             return true
         case GHOSTTY_ACTION_OPEN_URL:
             // a click opened a detected link / OSC-8 hyperlink. copy the URL out of the LENGTH-DELIMITED C
-            // buffer synchronously (only valid for this call; `open_url.url` is NOT NUL-terminated — it is a
-            // Zig slice, so honor `.len` instead of `String(cString:)`, which would over-read into adjacent
+            // buffer synchronously (valid only for this call, and `open_url.url` is a Zig slice, NOT
+            // NUL-terminated — honor `.len`, since `String(cString:)` would over-read into adjacent
             // hyperlink storage), then open it scheme-validated on the main actor.
             let openURL = action.action.open_url
             guard let view = surfaceView(from: target), let ptr = openURL.url else { return true }
@@ -144,13 +134,13 @@ final class GhosttyCallbacks: @unchecked Sendable {
             DispatchQueue.main.async { view.openLink(link) }
             return true
         case GHOSTTY_ACTION_COLOR_CHANGE:
-            // a program set or RESET a dynamic terminal color via OSC 10/11/12 (fg/bg/cursor) or their
-            // 110/111/112 resets. libghostty already applied it to its own render state, but under window
-            // translucency every surface renders background-opacity 0 (the AppKit window backing supplies
-            // the tint), so an OSC 11 BACKGROUND stays invisible until we lift THIS surface's opacity — a
-            // per-pane tint. Only background needs acting on; foreground/cursor render regardless of
-            // translucency. Copy the color out synchronously (the struct is only valid for this call), then
-            // hop to the main actor, where the set-vs-reset routing and the per-prompt dedupe are decided.
+            // a dynamic terminal color set or RESET via OSC 10/11/12 (fg/bg/cursor) or their 110/111/112
+            // resets. libghostty already applied it to its own render state, but under window translucency
+            // every surface renders background-opacity 0 (the AppKit window backing supplies the tint), so
+            // an OSC 11 BACKGROUND stays invisible until THIS surface's opacity is lifted — a per-pane tint.
+            // only background needs acting on; foreground/cursor render regardless of translucency. copy the
+            // color out synchronously (the struct is valid only for this call), then hop to the main actor,
+            // which decides the set-vs-reset routing and the per-prompt dedupe.
             guard let view = surfaceView(from: target) else { return true }
             let change = action.action.color_change
             guard change.kind == GHOSTTY_ACTION_COLOR_KIND_BACKGROUND else { return true }
@@ -162,9 +152,9 @@ final class GhosttyCallbacks: @unchecked Sendable {
         }
     }
 
-    /// The app-target CONFIG_CHANGE clone awaiting pickup, as a bit pattern (raw pointers aren't
-    /// Sendable, so the lock holds `UInt`; 0 = none). Written synchronously by the CONFIG_CHANGE arm
-    /// during `ghostty_app_update_config`, taken right after by `GhosttyApp.reloadConfig`.
+    /// The app-target CONFIG_CHANGE clone awaiting pickup, as a bit pattern (raw pointers aren't Sendable,
+    /// so the lock holds `UInt`; 0 = none). Written synchronously by the CONFIG_CHANGE arm during
+    /// `ghostty_app_update_config`, taken right after by `GhosttyApp.reloadConfig`.
     private let pendingAppConfig = OSAllocatedUnfairLock<UInt>(initialState: 0)
 
     /// Stash the cloned app-level derived config, freeing any stale one left from a take-less update
@@ -195,11 +185,11 @@ final class GhosttyCallbacks: @unchecked Sendable {
         return true
     }
 
-    /// Returns the text for a pasteboard: file/web URLs (Finder copy, or a drag-drop) become shell-escaped
-    /// paths, space-joined for multiple, so a path with spaces lands as one argument; otherwise the plain
-    /// string verbatim (it may be a command the user means to run, so it is NOT escaped). Shared by the
-    /// clipboard paste path (`readPasteboardText`) and the drag-drop handler (`GhosttySurfaceView`), so a
-    /// dropped file inserts its path exactly like a pasted one.
+    /// Returns the text for a pasteboard: file/web URLs (a Finder copy or a drag-drop) become shell-escaped
+    /// paths, space-joined, so a path with spaces lands as one argument; otherwise the plain string
+    /// verbatim, NOT escaped, since it may be a command the user means to run. Shared by the clipboard
+    /// paste path (`readPasteboardText`) and the drag-drop handler, so a dropped file inserts like a pasted
+    /// one.
     static func pasteboardText(_ pb: NSPasteboard) -> String? {
         if let urls = pb.readObjects(forClasses: [NSURL.self]) as? [URL] {
             let parts = urls.map(urlText).filter { !$0.isEmpty }
@@ -208,10 +198,10 @@ final class GhosttyCallbacks: @unchecked Sendable {
         return pb.string(forType: .string).flatMap { !$0.isEmpty ? $0 : nil }
     }
 
-    /// The text one pasteboard URL contributes to a paste: a shell-escaped path for a file URL (so a path
-    /// with spaces lands as one argument), else the escaped absolute string. The SINGLE definition shared by
-    /// `pasteboardText` and `hasPasteboardText`, so the reader and the menu gate cannot drift apart — an
-    /// invariant with no automated test (the file-URL case is not XCUITest-able; see the Control API rule).
+    /// The text one pasteboard URL contributes: a shell-escaped path for a file URL (so a path with spaces
+    /// lands as one argument), else the escaped absolute string. The SINGLE definition shared by
+    /// `pasteboardText` and `hasPasteboardText`, so the reader and the menu gate cannot drift — an invariant
+    /// with no automated test (the file-URL case is not XCUITest-able; see the Control API rule).
     private static func urlText(_ url: URL) -> String {
         ShellEscape.path(url.isFileURL ? url.path(percentEncoded: false) : url.absoluteString)
     }
@@ -220,13 +210,13 @@ final class GhosttyCallbacks: @unchecked Sendable {
     static func readPasteboardText() -> String? { pasteboardText(.general) }
 
     /// Whether `pasteboardText` would return something, without building the joined result. Menu validation
-    /// runs on every Edit-menu open and on every ⌘V key-equivalent lookup, so the Paste gate short-circuits on
-    /// the first usable URL instead of mapping, escaping and joining the whole clipboard.
+    /// runs on every Edit-menu open and every ⌘V key-equivalent lookup, so this short-circuits on the first
+    /// usable URL instead of mapping, escaping and joining the whole clipboard.
     ///
-    /// It must agree with `pasteboardText` in BOTH directions. A bare `canReadObject([NSURL])` probe does not:
-    /// that is a TYPE check, so a pasteboard merely DECLARING `public.file-url` with no usable value enables
-    /// Paste while the reader returns nil and the paste inserts nothing (verified against a named pasteboard).
-    /// Hence the same `urlText` + non-empty filter the reader applies.
+    /// It must agree with `pasteboardText` in BOTH directions, which a bare `canReadObject([NSURL])` probe
+    /// does not: that is a TYPE check, so a pasteboard merely DECLARING `public.file-url` with no usable
+    /// value enables Paste while the reader returns nil and the paste inserts nothing (verified against a
+    /// named pasteboard). Hence the same `urlText` + non-empty filter the reader applies.
     static func hasPasteboardText(_ pb: NSPasteboard = .general) -> Bool {
         if let urls = pb.readObjects(forClasses: [NSURL.self]) as? [URL],
            urls.contains(where: { !urlText($0).isEmpty }) {
@@ -238,7 +228,7 @@ final class GhosttyCallbacks: @unchecked Sendable {
     func confirmReadClipboard(ud: UnsafeMutableRawPointer?, content: UnsafePointer<CChar>?, state: UnsafeMutableRawPointer?,
                               request: ghostty_clipboard_request_e) {
         // only a real OSC 52 read (a program reading the system clipboard into the terminal stream) is
-        // gated; a paste keeps auto-approving so ⌘V never prompts.
+        // gated; a paste auto-approves so ⌘V never prompts.
         guard request == GHOSTTY_CLIPBOARD_REQUEST_OSC_52_READ else {
             guard let content else { return }
             ghostty_surface_complete_clipboard_request(surface(from: ud), content, state, true)
@@ -246,10 +236,10 @@ final class GhosttyCallbacks: @unchecked Sendable {
         }
         guard let ud else { return }
         // capture the VIEW, not the raw surface pointer: a session/window/pane close (or `session.close`
-        // over the control socket) can free the surface via destroySurface() WHILE the sheet is open. We
-        // re-read `view.surface` on the main actor at completion and skip if it's gone (freeing the surface
-        // already discarded its pending request, so there is nothing to complete and no loop). The view
-        // also scopes the prompt's coalescing to this surface.
+        // over the socket) can free the surface via destroySurface() WHILE the sheet is open. re-read
+        // `view.surface` on the main actor at completion and skip if it's gone — freeing it already
+        // discarded the pending request, so there is nothing to complete and no loop. the view also scopes
+        // the prompt's coalescing to this surface.
         let view = Unmanaged<GhosttySurfaceView>.fromOpaque(ud).takeUnretainedValue()
         let text = content.map { String(cString: $0) } ?? "" // copy now; nil content reads as empty
         nonisolated(unsafe) let requestState = state
@@ -273,8 +263,8 @@ final class GhosttyCallbacks: @unchecked Sendable {
             break
         }
         guard let text else { return }
-        // confirm == false: ghostty's clipboard-write policy already allowed it (the `allow` default). This
-        // callback runs on the main actor (verified), so write SYNCHRONOUSLY — deferring it lets a following
+        // confirm == false: ghostty's clipboard-write policy already allowed it (the `allow` default). this
+        // callback runs on the main actor (verified), so write SYNCHRONOUSLY — deferring lets a following
         // OSC 52 read in the same tick observe the stale clipboard.
         guard confirm else {
             Self.setClipboard(text)
@@ -299,10 +289,8 @@ final class GhosttyCallbacks: @unchecked Sendable {
 
     func closeSurface(ud: UnsafeMutableRawPointer?) {
         guard let ud else { return }
-        // The Session retains the view until destroySurface() runs (the only
-        // place ghostty_surface_free is called), so takeUnretainedValue() is
-        // safe here. Recover the view and hop to the main actor — never close
-        // or free synchronously from this callback.
+        // the Session retains the view until destroySurface() runs (the only place ghostty_surface_free is
+        // called), so takeUnretainedValue() is safe. never close or free synchronously from this callback.
         let view = Unmanaged<GhosttySurfaceView>.fromOpaque(ud).takeUnretainedValue()
         DispatchQueue.main.async { view.handleProcessExit() }
     }

--- a/agterm/Ghostty/GhosttyResources.swift
+++ b/agterm/Ghostty/GhosttyResources.swift
@@ -2,31 +2,25 @@
 
 import Foundation
 
-/// Pure, side-effect-free selection of the ghostty resources directory for
-/// `GHOSTTY_RESOURCES_DIR`.
-///
-/// agterm ships the ghostty resources in its bundle under
-/// `Contents/Resources/ghostty` (themes + shell-integration), with the compiled
-/// terminfo DB at the sibling `Contents/Resources/terminfo` — the same layout a
-/// real Ghostty.app uses. libghostty reads shell-integration/themes from
-/// `GHOSTTY_RESOURCES_DIR` and derives `TERMINFO` as
-/// `dirname(GHOSTTY_RESOURCES_DIR)/terminfo` at shell spawn, so pointing the env
-/// var at `.../Resources/ghostty` makes terminfo resolve to
-/// `.../Resources/terminfo` automatically. Missing/incorrect terminfo breaks key
-/// input and TERM=xterm-ghostty.
-///
-/// This type contains only the *selection* logic — which candidate dir wins. The
-/// `setenv`/`Bundle.main` side effects live in `GhosttyApp`, which feeds
+/// Pure, side-effect-free selection of the ghostty resources directory for `GHOSTTY_RESOURCES_DIR` — only
+/// which candidate dir wins; the `setenv`/`Bundle.main` side effects live in `GhosttyApp`, which feeds the
 /// candidates and a filesystem probe in here.
+///
+/// agterm ships the ghostty resources in its bundle under `Contents/Resources/ghostty` (themes +
+/// shell-integration), with the compiled terminfo DB at the sibling `Contents/Resources/terminfo` — the layout
+/// a real Ghostty.app uses. libghostty reads shell-integration/themes from `GHOSTTY_RESOURCES_DIR` and derives
+/// `TERMINFO` as `dirname(GHOSTTY_RESOURCES_DIR)/terminfo` at shell spawn, so pointing the env var at
+/// `.../Resources/ghostty` resolves terminfo to `.../Resources/terminfo` automatically. Missing or incorrect
+/// terminfo breaks key input and TERM=xterm-ghostty.
 struct GhosttyResourceResolver {
     /// Candidate resource dirs, highest priority first.
     let candidates: [String]
     /// Filesystem existence probe. Injected so tests don't touch disk.
     let fileExists: (String) -> Bool
 
-    /// Pick the first candidate that contains `shell-integration/` (the marker
-    /// that the ghostty resources are actually present). Returns nil when no
-    /// candidate qualifies — caller should then unset `GHOSTTY_RESOURCES_DIR`.
+    /// Pick the first candidate containing `shell-integration/` (the marker that the ghostty resources are
+    /// actually present). Nil when no candidate qualifies — the caller should then unset
+    /// `GHOSTTY_RESOURCES_DIR`.
     func resolve() -> String? {
         candidates.first { fileExists($0 + "/shell-integration") }
     }

--- a/agterm/Ghostty/GhosttySurfaceView+Config.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Config.swift
@@ -16,25 +16,24 @@ extension GhosttySurfaceView {
     }
 
     /// Builds this session's background-watermark config overlay (base files + `background-image*` lines +
-    /// the font from `currentEffectiveFontSize()`, via `WatermarkConfig`/`WatermarkRenderer`)
-    /// and pushes it to the surface, retaining the config for teardown. Scratch surfaces inherit their
-    /// owner's visual config through `watermarkSession` while remaining operationally sessionless; overlay
-    /// and quick-terminal surfaces carry neither link. A nil watermark with no font override
-    /// yields the plain base config, which CLEARS a previously-applied image. The `.text` PNG is (re)rendered
-    /// here so it always matches the current string/color. Main-actor; reads the session imperatively.
+    /// the font from `currentEffectiveFontSize()`, via `WatermarkConfig`/`WatermarkRenderer`) and pushes
+    /// it to the surface, retaining the config for teardown. Scratch surfaces inherit their owner's visual
+    /// config through `watermarkSession` while staying operationally sessionless; overlay and
+    /// quick-terminal surfaces carry neither link. A nil watermark with no font override yields the plain
+    /// base config, CLEARING a previously-applied image; the `.text` PNG is (re)rendered here to match the
+    /// current string/color. Main-actor, reading the session imperatively.
     ///
-    /// The font deliberately falls through to the LIVE size, not just `session.fontSize`: a split or
-    /// scratch pane has its `onFontSizeChange` unwired (see `ControlServer+SurfaceIO.font`), so its
-    /// cmd-+/- zoom is never persisted and is readable only from the surface. Composing from
-    /// `session.fontSize` alone snapped those panes back to the session's size (or the config default) on
-    /// every re-apply — a `session.background` set/clear, and now also an OSC reset.
+    /// The font falls through to the LIVE size, not just `session.fontSize`: a split or scratch pane has
+    /// its `onFontSizeChange` unwired (see `ControlServer+SurfaceIO.font`), so its cmd-+/- zoom is never
+    /// persisted and is readable only from the surface — composing from `session.fontSize` alone snapped
+    /// those panes back to the session size (or the config default) on every re-apply (a
+    /// `session.background` set/clear, and now an OSC reset).
     func applyWatermarkFromSession() {
         guard let surface, let session = session ?? watermarkSession else { return }
-        // this installs a watermark/plain config with NO OSC-11 overlay, so release the OSC latch: it is the
-        // dedupe key in the COLOR_CHANGE handler, and a stale value makes a subsequent identical OSC 11 (a
-        // re-`printf` right after `session background clear/set`) get skipped and never render. the reload /
-        // opacity / dashboard re-assert paths guard on the latch BEFORE calling this, so they never reach here
-        // with a live OSC to drop.
+        // this installs a config with NO OSC-11 overlay, so release the OSC latch: it is the dedupe key in
+        // the COLOR_CHANGE handler, and a stale value skips an identical follow-up OSC 11 (a re-`printf`
+        // right after `session background clear/set`) so it never renders. the reload / opacity / dashboard
+        // re-assert paths guard on the latch BEFORE calling this, so no live OSC is dropped here.
         oscBackgroundColorHex = nil
         let resolvedImagePath = WatermarkRenderer.materialize(session.backgroundWatermark, sessionID: session.id)
         let overlay = WatermarkConfig.overlayText(watermark: session.backgroundWatermark,
@@ -45,21 +44,19 @@ extension GhosttySurfaceView {
             return
         }
         ghostty_surface_update_config(surface, config)
-        // free the PRIOR per-surface config(s) and keep only this one: after `update_config` installs the
-        // new config the surface no longer references the old, so freeing it here is safe AND caps the
-        // retain at one per surface. Without this, `config.reload` (scriptable) re-applies each watermarked
-        // surface every reload and would grow `ownedConfigs` unbounded on a reload loop.
+        // free the PRIOR per-surface config(s), keeping only this one: after `update_config` the surface no
+        // longer references the old, so freeing is safe and caps the retain at one per surface. Without it,
+        // scriptable `config.reload` re-applies each watermarked surface and grows `ownedConfigs` unbounded.
         ownedConfigs.forEach { ghostty_config_free($0) }
         ownedConfigs = [config]
     }
 
-    /// Re-assert the session's per-surface config (watermark and/or font zoom) after a global config
-    /// reload broadcast the shared config to this surface via `applyConfig`, wiping both. No-op when the
-    /// session carries neither (so a plain surface isn't needlessly rebuilt). Called from
-    /// `GhosttyApp.reloadConfig`; on the zoom-CLEARING reload paths `session.fontSize` was already nil'd
-    /// before the broadcast, so only a watermark re-applies there — the appearance-flip reload skips the
-    /// reset, and this is what carries each session's zoom across the flip. It ALSO re-emits an active
-    /// `dashboardFontOverride`, so a reload while the dashboard is open can't strand the transient font.
+    /// Re-assert the session's per-surface config (watermark and/or font zoom) after a global reload
+    /// broadcast the shared config here via `applyConfig`, wiping both. No-op when the session carries
+    /// neither, so a plain surface isn't rebuilt. Called from `GhosttyApp.reloadConfig`; the zoom-CLEARING
+    /// paths nil `session.fontSize` before the broadcast, so only a watermark re-applies there, while the
+    /// appearance flip (which skips the reset) carries each session's zoom across. Also re-emits an active
+    /// `dashboardFontOverride`, so a reload with the dashboard open can't strand the transient font.
     func reapplySessionConfigIfNeeded() {
         // a transient OSC-11 background wins over the persisted watermark and must survive a config reload
         // that broadcast the shared config to this surface (which wiped it).
@@ -71,11 +68,11 @@ extension GhosttySurfaceView {
         applyWatermarkFromSession()
     }
 
-    /// Re-assert a SOLID-color session background after a window-opacity change. A `.color` background
-    /// bakes the current window opacity into its per-surface `background-opacity` at apply time (see
-    /// `WatermarkConfig.overlayText`), so a live opacity change must re-emit it to keep the color tracking
-    /// the slider. No-op unless the session carries a `.color` background — an image/text watermark has a
-    /// fixed opacity and must NOT re-render (a `.text` PNG rebuild) on every opacity tick.
+    /// Re-assert a SOLID-color session background after a window-opacity change: a `.color` background
+    /// bakes the window opacity into its per-surface `background-opacity` at apply time
+    /// (`WatermarkConfig.overlayText`), so a live change must re-emit to keep tracking the slider. No-op
+    /// otherwise — an image/text watermark has a fixed opacity and must NOT re-render (a `.text` PNG
+    /// rebuild) on every opacity tick.
     func reapplyColorBackgroundIfNeeded() {
         // an OSC-11 background bakes the window opacity like a `.color` watermark, so a live opacity change
         // must re-emit it to keep the tint tracking the slider.
@@ -86,15 +83,13 @@ extension GhosttySurfaceView {
 
     /// Applies a solid background color to a sessionless OVERLAY surface (`session.overlay.open
     /// --background-color`). Mirrors `applyWatermarkFromSession`'s `.color` path but reads the overlay's
-    /// own `overlayBackgroundColorHex` instead of a session — the overlay carries no `session`, so that
-    /// path skips it. Bakes the window translucency into `background-opacity` at open
-    /// time (the ephemeral overlay gets no live updates, so it does not re-track a later opacity change —
-    /// unlike a session `.color`). A no-op — or a malformed hex, rejected by the leading `isValidColorHex`
-    /// guard — leaves the plain base config. Retains the per-surface config in `ownedConfigs`, freed on teardown.
-    ///
-    /// The font comes from `currentEffectiveFontSize()`, NOT the creation size: this also runs on the OSC
-    /// reset path, where the overlay may have been zoomed with cmd-+/- since it opened, and restating the
-    /// creation size there would snap the pane back.
+    /// own `overlayBackgroundColorHex`, since an overlay carries no `session`. Bakes the window
+    /// translucency into `background-opacity` at open time — the ephemeral overlay gets no live updates,
+    /// so unlike a session `.color` it does not re-track a later opacity change. A no-op, or a malformed
+    /// hex rejected by the leading `isValidColorHex` guard, leaves the plain base config; the per-surface
+    /// config is retained in `ownedConfigs` and freed on teardown. The font comes from
+    /// `currentEffectiveFontSize()`, NOT the creation size: this also runs on the OSC reset path, where
+    /// restating the creation size would snap back an overlay cmd-+/- zoomed since it opened.
     func applyOverlayBackgroundColor() {
         guard let surface, let hex = overlayBackgroundColorHex, WatermarkConfig.isValidColorHex(hex) else { return }
         let overlay = WatermarkConfig.overlayText(watermark: BackgroundWatermark(kind: .color, colorHex: hex),
@@ -110,11 +105,10 @@ extension GhosttySurfaceView {
     }
 
     /// Route a dynamic background color libghostty reported for THIS surface (`GHOSTTY_ACTION_COLOR_CHANGE`,
-    /// kind background). The action carries no set-vs-reset flag — OSC 111 simply reports the terminal's
-    /// default background — so the surface's own baseline color is what identifies a reset: the session's
-    /// `.color` watermark, a sessionless overlay's `--background-color`, else the theme background. That is
-    /// exactly what ghostty seeded the terminal's `default` color layer from, so a reported color equal to
-    /// it means the program reset. `OSCBackgroundPolicy` owns the decision (and the per-prompt dedupe).
+    /// kind background). The action carries no set-vs-reset flag — OSC 111 just reports the terminal's
+    /// default background — so the surface's own baseline (the session's `.color` watermark, a sessionless
+    /// overlay's `--background-color`, else the theme) identifies a reset: it is what ghostty seeded the
+    /// `default` color layer from. `OSCBackgroundPolicy` owns the decision and the per-prompt dedupe.
     func handleOSCBackgroundChange(_ hex: String) {
         switch OSCBackgroundPolicy.decide(incoming: hex, themeBackground: baselineBackgroundHex(),
                                           current: oscBackgroundColorHex) {
@@ -126,8 +120,8 @@ extension GhosttySurfaceView {
 
     /// What ghostty seeded the terminal's `default` color layer from when it last took this surface's
     /// config — the color a reported change must equal to count as a reset. `OSCBackgroundPolicy.baseline`
-    /// owns the rule, including why an installed OSC overlay makes the answer the theme rather than this
-    /// surface's own color; here we only gather the two inputs.
+    /// owns the rule (including why an installed OSC overlay makes it the theme, not this surface's own
+    /// color); here we only gather the two inputs.
     private func baselineBackgroundHex() -> String? {
         OSCBackgroundPolicy.baseline(oscOverlayActive: oscBackgroundColorHex != nil,
                                      surfaceBackground: surfaceOwnBackgroundHex(),
@@ -145,21 +139,19 @@ extension GhosttySurfaceView {
     }
 
     /// Apply the dynamic background color a program set on THIS surface via OSC 11. libghostty already
-    /// stored the color in the terminal's dynamic `override` layer and the renderer draws
-    /// `override orelse default`, so the color itself needs no restating — but under window translucency
-    /// the surface renders `background-opacity = 0` (the AppKit window backing supplies the tint), which
-    /// makes the OSC color invisible. This gives the surface its OWN overlay lifting the opacity back to
-    /// the window's, so the pane renders its tint (translucent, honoring the opacity slider), per-pane,
-    /// without touching the window backing, the chrome, or any other surface.
+    /// stored it in the terminal's dynamic `override` layer and the renderer draws `override orelse
+    /// default`, so the color needs no restating — but under window translucency the surface renders
+    /// `background-opacity = 0` (the AppKit window backing supplies the tint), which hides it. This gives
+    /// the surface its OWN overlay lifting the opacity back to the window's, so the pane renders its tint
+    /// per-pane, honoring the opacity slider, without touching the window backing, the chrome, or any
+    /// other surface.
     ///
-    /// The overlay deliberately carries no `background` key: that would re-seed the terminal's `default`
-    /// color layer with the OSC color, and since OSC 111 resets the override TO that default, the program's
-    /// reset would restore its own color and strand the pane recolored (issue #309).
-    ///
-    /// Reads the current font (dashboard override / session zoom / live zoom / initial) so the config
-    /// re-apply can't reset the pane's font — including a sessionless scratch/overlay whose live cmd-+/-
-    /// zoom would otherwise reset. A malformed hex is rejected. Retains the per-surface config in
-    /// `ownedConfigs`, freed on teardown.
+    /// The overlay deliberately carries NO `background` key: that would re-seed the terminal's `default`
+    /// color layer with the OSC color, and since OSC 111 resets the override TO that default, the
+    /// program's own reset would restore its color and strand the pane recolored (issue #309). Reads the
+    /// current font (dashboard override / session zoom / live zoom / initial) so the config re-apply can't
+    /// reset the pane's font, including a sessionless scratch/overlay's live cmd-+/- zoom. A malformed hex
+    /// is rejected; the per-surface config is retained in `ownedConfigs`, freed on teardown.
     func applyOSCBackground(_ hex: String) {
         guard let surface, WatermarkConfig.isValidColorHex(hex) else { return }
         oscBackgroundColorHex = hex

--- a/agterm/Ghostty/GhosttySurfaceView+Config.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Config.swift
@@ -7,33 +7,25 @@ import GhosttyKit
 extension GhosttySurfaceView {
     // MARK: - Surface config
 
-    /// Applies a rebuilt ghostty config to this live surface (font/theme change from Settings).
-    /// `update_config` re-applies the whole config including font-size, so any runtime cmd-+/-
-    /// zoom resets to the config default — the caller clears the per-session overrides to match.
+    /// Applies a rebuilt ghostty config to this live surface (a font/theme change from Settings).
+    /// `update_config` re-applies everything including font-size, so a runtime cmd-+/- zoom resets to the
+    /// config default — the caller clears the per-session overrides to match.
     func applyConfig(_ config: ghostty_config_t) {
         guard let surface else { return }
         ghostty_surface_update_config(surface, config)
     }
 
     /// Builds this session's background-watermark config overlay (base files + `background-image*` lines +
-    /// the font from `currentEffectiveFontSize()`, via `WatermarkConfig`/`WatermarkRenderer`) and pushes
-    /// it to the surface, retaining the config for teardown. Scratch surfaces inherit their owner's visual
-    /// config through `watermarkSession` while staying operationally sessionless; overlay and
-    /// quick-terminal surfaces carry neither link. A nil watermark with no font override yields the plain
-    /// base config, CLEARING a previously-applied image; the `.text` PNG is (re)rendered here to match the
-    /// current string/color. Main-actor, reading the session imperatively.
-    ///
-    /// The font falls through to the LIVE size, not just `session.fontSize`: a split or scratch pane has
-    /// its `onFontSizeChange` unwired (see `ControlServer+SurfaceIO.font`), so its cmd-+/- zoom is never
-    /// persisted and is readable only from the surface — composing from `session.fontSize` alone snapped
-    /// those panes back to the session size (or the config default) on every re-apply (a
-    /// `session.background` set/clear, and now an OSC reset).
+    /// `currentEffectiveFontSize()`) and pushes it to the surface, retaining the config for teardown.
+    /// Scratch surfaces inherit their owner's visual config through `watermarkSession` while staying
+    /// operationally sessionless; overlay and quick-terminal surfaces carry neither link. A nil watermark
+    /// with no font override yields the plain base config, CLEARING a previously-applied image; the
+    /// `.text` PNG is (re)rendered here to match the current string/color.
     func applyWatermarkFromSession() {
         guard let surface, let session = session ?? watermarkSession else { return }
-        // this installs a config with NO OSC-11 overlay, so release the OSC latch: it is the dedupe key in
-        // the COLOR_CHANGE handler, and a stale value skips an identical follow-up OSC 11 (a re-`printf`
-        // right after `session background clear/set`) so it never renders. the reload / opacity / dashboard
-        // re-assert paths guard on the latch BEFORE calling this, so no live OSC is dropped here.
+        // this installs a config with NO OSC-11 overlay, so release the latch — it is the COLOR_CHANGE
+        // dedupe key, and a stale value would swallow an identical follow-up OSC 11. the reload / opacity
+        // / dashboard re-assert paths guard on the latch BEFORE calling this, so no live OSC is dropped.
         oscBackgroundColorHex = nil
         let resolvedImagePath = WatermarkRenderer.materialize(session.backgroundWatermark, sessionID: session.id)
         let overlay = WatermarkConfig.overlayText(watermark: session.backgroundWatermark,
@@ -44,22 +36,21 @@ extension GhosttySurfaceView {
             return
         }
         ghostty_surface_update_config(surface, config)
-        // free the PRIOR per-surface config(s), keeping only this one: after `update_config` the surface no
-        // longer references the old, so freeing is safe and caps the retain at one per surface. Without it,
-        // scriptable `config.reload` re-applies each watermarked surface and grows `ownedConfigs` unbounded.
+        // free the PRIOR per-surface configs: after `update_config` the surface no longer references them,
+        // so freeing is safe and caps the retain at one. otherwise a scripted `config.reload` re-applies
+        // every watermarked surface and grows `ownedConfigs` unbounded.
         ownedConfigs.forEach { ghostty_config_free($0) }
         ownedConfigs = [config]
     }
 
     /// Re-assert the session's per-surface config (watermark and/or font zoom) after a global reload
-    /// broadcast the shared config here via `applyConfig`, wiping both. No-op when the session carries
-    /// neither, so a plain surface isn't rebuilt. Called from `GhosttyApp.reloadConfig`; the zoom-CLEARING
-    /// paths nil `session.fontSize` before the broadcast, so only a watermark re-applies there, while the
-    /// appearance flip (which skips the reset) carries each session's zoom across. Also re-emits an active
-    /// `dashboardFontOverride`, so a reload with the dashboard open can't strand the transient font.
+    /// broadcast the shared config here, wiping both; a no-op when the session carries neither. The
+    /// zoom-CLEARING reload paths nil `session.fontSize` first, so only a watermark re-applies there, while
+    /// the appearance flip (which skips the reset) carries each session's zoom across. Also re-emits an
+    /// active `dashboardFontOverride`, so a reload with the dashboard open can't strand the transient font.
     func reapplySessionConfigIfNeeded() {
-        // a transient OSC-11 background wins over the persisted watermark and must survive a config reload
-        // that broadcast the shared config to this surface (which wiped it).
+        // a transient OSC-11 background wins over the persisted watermark and must survive the reload
+        // broadcast that wiped it.
         if let hex = oscBackgroundColorHex { applyOSCBackground(hex); return }
         let configSession = session ?? watermarkSession
         guard configSession?.backgroundWatermark != nil || configSession?.fontSize != nil || dashboardFontOverride != nil else {
@@ -69,27 +60,21 @@ extension GhosttySurfaceView {
     }
 
     /// Re-assert a SOLID-color session background after a window-opacity change: a `.color` background
-    /// bakes the window opacity into its per-surface `background-opacity` at apply time
-    /// (`WatermarkConfig.overlayText`), so a live change must re-emit to keep tracking the slider. No-op
-    /// otherwise — an image/text watermark has a fixed opacity and must NOT re-render (a `.text` PNG
-    /// rebuild) on every opacity tick.
+    /// bakes the window opacity into its per-surface `background-opacity` at apply time, so a live change
+    /// must re-emit to keep tracking the slider. No-op otherwise — an image/text watermark has a fixed
+    /// opacity and must NOT re-render its PNG on every opacity tick.
     func reapplyColorBackgroundIfNeeded() {
-        // an OSC-11 background bakes the window opacity like a `.color` watermark, so a live opacity change
-        // must re-emit it to keep the tint tracking the slider.
+        // an OSC-11 background bakes the opacity like a `.color` watermark, so it must re-emit too.
         if let hex = oscBackgroundColorHex { applyOSCBackground(hex); return }
         guard (session ?? watermarkSession)?.backgroundWatermark?.kind == .color else { return }
         applyWatermarkFromSession()
     }
 
     /// Applies a solid background color to a sessionless OVERLAY surface (`session.overlay.open
-    /// --background-color`). Mirrors `applyWatermarkFromSession`'s `.color` path but reads the overlay's
-    /// own `overlayBackgroundColorHex`, since an overlay carries no `session`. Bakes the window
-    /// translucency into `background-opacity` at open time — the ephemeral overlay gets no live updates,
-    /// so unlike a session `.color` it does not re-track a later opacity change. A no-op, or a malformed
-    /// hex rejected by the leading `isValidColorHex` guard, leaves the plain base config; the per-surface
-    /// config is retained in `ownedConfigs` and freed on teardown. The font comes from
-    /// `currentEffectiveFontSize()`, NOT the creation size: this also runs on the OSC reset path, where
-    /// restating the creation size would snap back an overlay cmd-+/- zoomed since it opened.
+    /// --background-color`), reading the overlay's own `overlayBackgroundColorHex` since it carries no
+    /// `session`. Bakes the window translucency into `background-opacity` at open time — the ephemeral
+    /// overlay gets no live updates, so unlike a session `.color` it does not re-track a later opacity
+    /// change. A rejected (malformed) hex leaves the plain base config.
     func applyOverlayBackgroundColor() {
         guard let surface, let hex = overlayBackgroundColorHex, WatermarkConfig.isValidColorHex(hex) else { return }
         let overlay = WatermarkConfig.overlayText(watermark: BackgroundWatermark(kind: .color, colorHex: hex),
@@ -106,9 +91,8 @@ extension GhosttySurfaceView {
 
     /// Route a dynamic background color libghostty reported for THIS surface (`GHOSTTY_ACTION_COLOR_CHANGE`,
     /// kind background). The action carries no set-vs-reset flag — OSC 111 just reports the terminal's
-    /// default background — so the surface's own baseline (the session's `.color` watermark, a sessionless
-    /// overlay's `--background-color`, else the theme) identifies a reset: it is what ghostty seeded the
-    /// `default` color layer from. `OSCBackgroundPolicy` owns the decision and the per-prompt dedupe.
+    /// default background — so the surface's own baseline identifies a reset. `OSCBackgroundPolicy` owns
+    /// the decision and the per-prompt dedupe.
     func handleOSCBackgroundChange(_ hex: String) {
         switch OSCBackgroundPolicy.decide(incoming: hex, themeBackground: baselineBackgroundHex(),
                                           current: oscBackgroundColorHex) {
@@ -120,8 +104,8 @@ extension GhosttySurfaceView {
 
     /// What ghostty seeded the terminal's `default` color layer from when it last took this surface's
     /// config — the color a reported change must equal to count as a reset. `OSCBackgroundPolicy.baseline`
-    /// owns the rule (including why an installed OSC overlay makes it the theme, not this surface's own
-    /// color); here we only gather the two inputs.
+    /// owns the rule, including why an installed OSC overlay makes it the theme rather than this surface's
+    /// own color; here we only gather its two inputs.
     private func baselineBackgroundHex() -> String? {
         OSCBackgroundPolicy.baseline(oscOverlayActive: oscBackgroundColorHex != nil,
                                      surfaceBackground: surfaceOwnBackgroundHex(),
@@ -141,17 +125,13 @@ extension GhosttySurfaceView {
     /// Apply the dynamic background color a program set on THIS surface via OSC 11. libghostty already
     /// stored it in the terminal's dynamic `override` layer and the renderer draws `override orelse
     /// default`, so the color needs no restating — but under window translucency the surface renders
-    /// `background-opacity = 0` (the AppKit window backing supplies the tint), which hides it. This gives
-    /// the surface its OWN overlay lifting the opacity back to the window's, so the pane renders its tint
-    /// per-pane, honoring the opacity slider, without touching the window backing, the chrome, or any
-    /// other surface.
+    /// `background-opacity = 0` (the AppKit window backing supplies the tint), which hides it. The overlay
+    /// here lifts the opacity back to the window's, so the pane tints itself honoring the slider, leaving
+    /// the window backing, the chrome and every other surface alone.
     ///
-    /// The overlay deliberately carries NO `background` key: that would re-seed the terminal's `default`
-    /// color layer with the OSC color, and since OSC 111 resets the override TO that default, the
-    /// program's own reset would restore its color and strand the pane recolored (issue #309). Reads the
-    /// current font (dashboard override / session zoom / live zoom / initial) so the config re-apply can't
-    /// reset the pane's font, including a sessionless scratch/overlay's live cmd-+/- zoom. A malformed hex
-    /// is rejected; the per-surface config is retained in `ownedConfigs`, freed on teardown.
+    /// It deliberately carries NO `background` key: that would re-seed the terminal's `default` color layer
+    /// with the OSC color, and since OSC 111 resets the override TO that default, the program's own reset
+    /// would restore its color and strand the pane recolored (issue #309).
     func applyOSCBackground(_ hex: String) {
         guard let surface, WatermarkConfig.isValidColorHex(hex) else { return }
         oscBackgroundColorHex = hex
@@ -166,10 +146,10 @@ extension GhosttySurfaceView {
         ownedConfigs = [config]
     }
 
-    /// Drop this surface's OSC-11 overlay after a program reset the dynamic background, falling back to
-    /// the surface's own baseline config: the session's watermark/zoom, a sessionless overlay's
+    /// Drop this surface's OSC-11 overlay after a program reset the dynamic background, falling back to the
+    /// surface's own baseline config — the session's watermark/zoom, a sessionless overlay's
     /// `--background-color`, else the plain config with the live font zoom preserved. libghostty has
-    /// already restored its own `override` to the default color, so this only takes the opacity lift away.
+    /// already restored its `override` to the default color, so this only takes the opacity lift away.
     func releaseOSCBackground() {
         oscBackgroundColorHex = nil
         if session != nil || watermarkSession != nil { applyWatermarkFromSession(); return }
@@ -186,9 +166,12 @@ extension GhosttySurfaceView {
         ownedConfigs = [config]
     }
 
-    /// The font size a per-surface config re-apply must restate so it doesn't reset the pane's zoom:
+    /// The font size every per-surface config re-apply must restate so it doesn't reset the pane's zoom:
     /// the dashboard's transient override, else the session's zoom, else a sessionless surface's live
-    /// cmd-+/- size, else its creation size.
+    /// cmd-+/- size, else its creation size. A split or scratch pane has its `onFontSizeChange` unwired
+    /// (see `ControlServer+SurfaceIO.font`), so its zoom is never persisted and is readable only from the
+    /// surface — restating `session.fontSize` or an overlay's creation size snaps such a pane back on
+    /// every re-apply (a `session.background` set/clear, an OSC reset).
     private func currentEffectiveFontSize() -> Double? {
         dashboardFontOverride ?? session?.fontSize ?? currentFontSize() ?? initialFontSize.map(Double.init)
     }

--- a/agterm/Ghostty/GhosttySurfaceView+IO.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+IO.swift
@@ -5,20 +5,18 @@ import AppKit
 import GhosttyKit
 
 /// `GhosttySurfaceView` surface I/O and binding-action operations: type/paste into the pty, read the
-/// selection / buffer / foreground pid, drive libghostty binding actions (font size, search), and read
-/// the live font size. Methods only (no stored properties), split out of `GhosttySurfaceView.swift` to
-/// keep it under the size limit.
+/// selection / buffer / foreground pid, drive libghostty binding actions (font size, search), read the live
+/// font size. Methods only (no stored properties), split out to keep `GhosttySurfaceView.swift` under size.
 extension GhosttySurfaceView {
     /// Types `text` into this surface's pty (the control channel's `session.type`) as literal keystrokes,
-    /// the same path the keyboard uses (`ghostty_surface_key` with `.text` set — see `insertText`). It does
-    /// NOT use `ghostty_surface_text`, which wraps writes in bracketed-paste escapes that both suppress
-    /// command execution and leak `\e[200~`/`\e[201~` markers when fired rapidly. Printable runs are sent as
-    /// key-with-text events; every line ending (`\n`, `\r`, or `\r\n`) is a real Return keypress, so a
-    /// trailing newline submits the command and a multi-line payload runs line by line. The bytes are
-    /// copied via `withCString`, so no buffer must outlive the call. Returns `false` (a no-op) when the
-    /// surface has not been created yet (a never-shown / just-shown session), so a caller injecting into a
-    /// pane with no realize/select path (`right`/`scratch`) can report `session not realized` instead of a
-    /// false ok; the main-pane path realizes it first via select+poll.
+    /// the keyboard's own path (`ghostty_surface_key` with `.text` set — see `insertText`), NOT
+    /// `ghostty_surface_text`, whose bracketed-paste wrapping both suppresses command execution and leaks
+    /// `\e[200~`/`\e[201~` markers when fired rapidly. Printable runs go as key-with-text events; every line
+    /// ending (`\n`, `\r`, `\r\n`) is a real Return keypress, so a trailing newline submits and a multi-line
+    /// payload runs line by line. Bytes are copied via `withCString`, so no buffer outlives the call. Returns
+    /// `false` (a no-op) when the surface is not created yet (a never-shown / just-shown session), so a caller
+    /// injecting into a pane with no realize/select path (`right`/`scratch`) reports `session not realized`
+    /// instead of a false ok; the main-pane path realizes it first via select+poll.
     @discardableResult
     func inject(text: String) -> Bool {
         guard let surface else { return false }
@@ -38,23 +36,22 @@ extension GhosttySurfaceView {
         return true
     }
 
-    /// Inserts `text` into this surface as a bracketed paste — the drag-drop path. Unlike `inject(text:)`,
-    /// which types keystrokes and turns each `\n`/`\r` into a Return, this routes through `ghostty_surface_text`,
-    /// whose bracketed-paste wrapping makes the running program treat the whole payload as literal text, so a
-    /// dropped multi-line selection lands at the cursor without auto-submitting — exactly like ⌘V paste. The
-    /// guarantee tracks the program's bracketed-paste mode (a raw prompt with mode 2004 off still submits, the
-    /// same caveat as ⌘V). A drop must behave like a paste, not like typing; `session.type` keeps `inject`
-    /// because automation DOES want newline→Return. The bytes are copied synchronously, so nothing must
-    /// outlive the call. A no-op when the surface has not been created yet (a never-shown session).
+    /// Inserts `text` as a bracketed paste — the drag-drop path. Unlike `inject(text:)`, which types
+    /// keystrokes and turns each `\n`/`\r` into a Return, this routes through `ghostty_surface_text`, whose
+    /// bracketed-paste wrapping makes the running program treat the whole payload as literal text, so a
+    /// dropped multi-line selection lands at the cursor without auto-submitting — like ⌘V, and with ⌘V's
+    /// caveat that a raw prompt with mode 2004 off still submits. A drop must behave like a paste, not like
+    /// typing; `session.type` keeps `inject` because automation DOES want newline→Return. Bytes are copied
+    /// synchronously, so nothing outlives the call. A no-op when the surface is not created yet.
     func insertPasted(text: String) {
         guard let surface, !text.isEmpty else { return }
         text.withCString { ghostty_surface_text(surface, $0, UInt(text.utf8.count)) }
     }
 
-    /// Returns this surface's current selection text (the control channel's `session.copy`), or nil when
-    /// there is no selection or the surface has not been created yet. The selection is a property of the
-    /// surface's terminal state, independent of focus, so any realized session can be read. The libghostty
-    /// buffer is copied into a Swift `String` and freed via `ghostty_surface_free_text` before returning.
+    /// This surface's current selection text (the control channel's `session.copy`), or nil with no selection
+    /// or an uncreated surface. Selection is surface terminal state, independent of focus, so any realized
+    /// session can be read. The libghostty buffer is copied into a Swift `String` and freed via
+    /// `ghostty_surface_free_text` before returning.
     func readSelection() -> String? {
         guard let surface, ghostty_surface_has_selection(surface) else { return nil }
         var t = ghostty_text_s()
@@ -64,14 +61,13 @@ extension GhosttySurfaceView {
         return String(decoding: UnsafeRawBufferPointer(start: ptr, count: Int(t.text_len)), as: UTF8.self)
     }
 
-    /// This surface's terminal buffer as plain text (the control channel's `session.text`). Returns nil only
-    /// on a FAILED read — the surface does not exist yet or `ghostty_surface_read_text` fails — so the caller
-    /// can distinguish that from a genuinely blank screen, which reads as an empty string. The region is the
-    /// visible screen by default, or the whole screen plus scrollback when `all` is true or `lines` is set;
-    /// `lines` keeps the last N CONTENT lines (trailing blank grid rows trimmed). Like `readSelection`, the
-    /// read ignores focus and the libghostty buffer is copied into a Swift `String` and freed before
-    /// returning. UTF-8 only: `ghostty_surface_read_text` carries no per-cell color or SGR. Covered by the
-    /// `session.text` XCUITest e2e rather than a unit test, since the call needs a live surface.
+    /// This surface's terminal buffer as plain text (the control channel's `session.text`). nil ONLY on a
+    /// FAILED read (no surface yet, or `ghostty_surface_read_text` fails), so a caller can tell that from a
+    /// genuinely blank screen, which reads as an empty string. The region is the visible screen by default,
+    /// the whole screen plus scrollback when `all` is true or `lines` is set; `lines` keeps the last N
+    /// CONTENT lines (trailing blank grid rows trimmed). Like `readSelection` it ignores focus and
+    /// copies-then-frees the libghostty buffer. UTF-8 only — `ghostty_surface_read_text` carries no per-cell
+    /// color or SGR. Covered by the `session.text` XCUITest e2e, since the call needs a live surface.
     func readScreenText(all: Bool, lines: Int?) -> String? {
         guard let surface else { return nil }
         // A zero-init ghostty_point_s is GHOSTTY_POINT_ACTIVE / GHOSTTY_POINT_COORD_EXACT (both enum 0),
@@ -124,11 +120,11 @@ extension GhosttySurfaceView {
     }
 
     /// Triggers a libghostty keybind action on this surface (e.g. `increase_font_size:1`,
-    /// `decrease_font_size:1`, `reset_font_size`), so a menu item can drive the same behavior
-    /// as the built-in keybind. A font change rides the usual CELL_SIZE → persist path. Returns
-    /// whether the action ran: `false` when the libghostty surface isn't realized yet (the view
-    /// exists but its inner `surface` is nil), so a control caller can report `session not realized`
-    /// instead of a false ok. `@discardableResult` keeps the GUI/menu callers unchanged.
+    /// `decrease_font_size:1`, `reset_font_size`), so a menu item drives the same behavior as the built-in
+    /// keybind; a font change rides the usual CELL_SIZE → persist path. Returns whether it ran — `false`
+    /// when the libghostty surface isn't realized yet (the view exists, its inner `surface` is nil), so a
+    /// control caller reports `session not realized` instead of a false ok. `@discardableResult` for the
+    /// GUI/menu callers.
     @discardableResult
     func performBindingAction(_ action: String) -> Bool {
         guard let surface else { return false }
@@ -136,9 +132,8 @@ extension GhosttySurfaceView {
         return true
     }
 
-    /// The direction `navigateSearch` steps the selection. The pure enum (with its libghostty mapping)
-    /// lives host-free in `agtermCore.SearchDirection`; this alias keeps the existing
-    /// `GhosttySurfaceView.SearchDirection` call sites unchanged.
+    /// The direction `navigateSearch` steps the selection. The pure enum (with its libghostty mapping) is
+    /// host-free in `agtermCore.SearchDirection`; this alias keeps the existing call sites unchanged.
     typealias SearchDirection = agtermCore.SearchDirection
 
     /// Enters search mode on this surface (the `start_search` binding action). libghostty replies with a
@@ -161,9 +156,8 @@ extension GhosttySurfaceView {
     func endSearch() { performBindingAction("end_search") }
 
     /// The surface's live font size in points (post cmd +/-), read from `inherited_config`; nil when the
-    /// libghostty surface isn't realized yet or hasn't resolved a size. The read side of `font.*` — the
-    /// control `tree` reads it per pane so a script can query what a font change set (the split/scratch
-    /// panes' sizes are otherwise unobservable, being live-only).
+    /// libghostty surface isn't realized or hasn't resolved a size. The read side of `font.*` — the control
+    /// `tree` reads it per pane, since the split/scratch panes' sizes are otherwise unobservable (live-only).
     func currentFontSize() -> Double? {
         guard let surface else { return nil }
         let size = Double(ghostty_surface_inherited_config(surface, GHOSTTY_SURFACE_CONTEXT_WINDOW).font_size)

--- a/agterm/Ghostty/GhosttySurfaceView+IO.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+IO.swift
@@ -4,19 +4,16 @@ import agtermCore
 import AppKit
 import GhosttyKit
 
-/// `GhosttySurfaceView` surface I/O and binding-action operations: type/paste into the pty, read the
-/// selection / buffer / foreground pid, drive libghostty binding actions (font size, search), read the live
-/// font size. Methods only (no stored properties), split out to keep `GhosttySurfaceView.swift` under size.
+/// `GhosttySurfaceView` I/O and binding actions — type/paste into the pty, read selection / buffer /
+/// foreground pid / font size, drive font-size and search binds. Methods only, split out for file size.
 extension GhosttySurfaceView {
-    /// Types `text` into this surface's pty (the control channel's `session.type`) as literal keystrokes,
-    /// the keyboard's own path (`ghostty_surface_key` with `.text` set — see `insertText`), NOT
-    /// `ghostty_surface_text`, whose bracketed-paste wrapping both suppresses command execution and leaks
-    /// `\e[200~`/`\e[201~` markers when fired rapidly. Printable runs go as key-with-text events; every line
-    /// ending (`\n`, `\r`, `\r\n`) is a real Return keypress, so a trailing newline submits and a multi-line
-    /// payload runs line by line. Bytes are copied via `withCString`, so no buffer outlives the call. Returns
-    /// `false` (a no-op) when the surface is not created yet (a never-shown / just-shown session), so a caller
-    /// injecting into a pane with no realize/select path (`right`/`scratch`) reports `session not realized`
-    /// instead of a false ok; the main-pane path realizes it first via select+poll.
+    /// Types `text` into this surface's pty (`session.type`) as literal keystrokes via the keyboard's own path
+    /// (`ghostty_surface_key` with `.text` set), NOT `ghostty_surface_text`, whose bracketed-paste wrapping
+    /// suppresses command execution and leaks `\e[200~`/`\e[201~` markers when fired rapidly. Every line ending
+    /// (`\n`, `\r`, `\r\n`) becomes a real Return keypress, so a trailing newline submits and a multi-line
+    /// payload runs line by line; `withCString` means no buffer outlives the call. Returns `false` when the
+    /// surface is not created yet, so a caller injecting into a pane with no realize/select path
+    /// (`right`/`scratch`) reports `session not realized`, not a false ok; the main pane realizes via select+poll.
     @discardableResult
     func inject(text: String) -> Bool {
         guard let surface else { return false }
@@ -36,22 +33,20 @@ extension GhosttySurfaceView {
         return true
     }
 
-    /// Inserts `text` as a bracketed paste — the drag-drop path. Unlike `inject(text:)`, which types
-    /// keystrokes and turns each `\n`/`\r` into a Return, this routes through `ghostty_surface_text`, whose
-    /// bracketed-paste wrapping makes the running program treat the whole payload as literal text, so a
-    /// dropped multi-line selection lands at the cursor without auto-submitting — like ⌘V, and with ⌘V's
-    /// caveat that a raw prompt with mode 2004 off still submits. A drop must behave like a paste, not like
-    /// typing; `session.type` keeps `inject` because automation DOES want newline→Return. Bytes are copied
-    /// synchronously, so nothing outlives the call. A no-op when the surface is not created yet.
+    /// Inserts `text` as a bracketed paste — the drag-drop path. Unlike `inject(text:)`, this routes through
+    /// `ghostty_surface_text`, whose bracketed-paste wrapping makes the program treat the whole payload as
+    /// literal text, so a dropped multi-line selection lands at the cursor without auto-submitting — like ⌘V,
+    /// with ⌘V's caveat that a raw prompt with mode 2004 off still submits. A drop must behave like a paste,
+    /// not like typing; `session.type` keeps `inject` because automation DOES want newline→Return. Bytes are
+    /// copied synchronously; a no-op when the surface is not created yet.
     func insertPasted(text: String) {
         guard let surface, !text.isEmpty else { return }
         text.withCString { ghostty_surface_text(surface, $0, UInt(text.utf8.count)) }
     }
 
-    /// This surface's current selection text (the control channel's `session.copy`), or nil with no selection
-    /// or an uncreated surface. Selection is surface terminal state, independent of focus, so any realized
-    /// session can be read. The libghostty buffer is copied into a Swift `String` and freed via
-    /// `ghostty_surface_free_text` before returning.
+    /// This surface's current selection text (`session.copy`), nil with no selection or an uncreated surface.
+    /// Selection is surface terminal state, independent of focus, so any realized session can be read. The
+    /// libghostty buffer is copied into a Swift `String` and freed with `ghostty_surface_free_text`.
     func readSelection() -> String? {
         guard let surface, ghostty_surface_has_selection(surface) else { return nil }
         var t = ghostty_text_s()
@@ -61,17 +56,16 @@ extension GhosttySurfaceView {
         return String(decoding: UnsafeRawBufferPointer(start: ptr, count: Int(t.text_len)), as: UTF8.self)
     }
 
-    /// This surface's terminal buffer as plain text (the control channel's `session.text`). nil ONLY on a
-    /// FAILED read (no surface yet, or `ghostty_surface_read_text` fails), so a caller can tell that from a
-    /// genuinely blank screen, which reads as an empty string. The region is the visible screen by default,
-    /// the whole screen plus scrollback when `all` is true or `lines` is set; `lines` keeps the last N
-    /// CONTENT lines (trailing blank grid rows trimmed). Like `readSelection` it ignores focus and
-    /// copies-then-frees the libghostty buffer. UTF-8 only — `ghostty_surface_read_text` carries no per-cell
-    /// color or SGR. Covered by the `session.text` XCUITest e2e, since the call needs a live surface.
+    /// This surface's terminal buffer as plain text (`session.text`). nil ONLY on a FAILED read (no surface
+    /// yet, or `ghostty_surface_read_text` fails), so a caller can tell that from a genuinely blank screen,
+    /// which reads as an empty string. Region: the visible screen by default, the whole screen plus scrollback
+    /// when `all` or `lines` is set; `lines` keeps the last N CONTENT lines (trailing blank grid rows trimmed).
+    /// Ignores focus and copies-then-frees the buffer like `readSelection`; UTF-8 only, no per-cell color or
+    /// SGR. Covered by the `session.text` XCUITest e2e, which needs a live surface.
     func readScreenText(all: Bool, lines: Int?) -> String? {
         guard let surface else { return nil }
-        // A zero-init ghostty_point_s is GHOSTTY_POINT_ACTIVE / GHOSTTY_POINT_COORD_EXACT (both enum 0),
-        // not viewport/top-left, so set tag and coord on both endpoints.
+        // a zero-init ghostty_point_s is GHOSTTY_POINT_ACTIVE / GHOSTTY_POINT_COORD_EXACT (both enum 0), not
+        // viewport/top-left, so set tag and coord on both endpoints.
         let tag = (all || lines != nil) ? GHOSTTY_POINT_SCREEN : GHOSTTY_POINT_VIEWPORT
         var sel = ghostty_selection_s()
         sel.top_left = ghostty_point_s(tag: tag, coord: GHOSTTY_POINT_COORD_TOP_LEFT, x: 0, y: 0)
@@ -80,13 +74,12 @@ extension GhosttySurfaceView {
         var t = ghostty_text_s()
         guard ghostty_surface_read_text(surface, sel, &t) else { return nil }
         defer { ghostty_surface_free_text(surface, &t) }
-        // A successful read of a blank screen yields no bytes — that is an empty string, NOT a failure
-        // (nil is reserved for the guards above so `readText` can report a real read failure as an error).
+        // a blank screen reads as no bytes — an empty string, NOT a failure; nil is reserved for the guards
+        // above so `readText` can report a real read failure as an error.
         guard let ptr = t.text, t.text_len > 0 else { return "" }
         let full = String(decoding: UnsafeRawBufferPointer(start: ptr, count: Int(t.text_len)), as: UTF8.self)
         guard let n = lines, n > 0 else { return full }
-        // Drop trailing blank/whitespace-only rows (the unused grid below a short screen) so `--lines N`
-        // returns the last N CONTENT lines instead of blank padding, then keep the last N.
+        // drop trailing whitespace-only grid rows so `--lines N` returns the last N CONTENT lines, not padding
         var rows = full.components(separatedBy: "\n")
         while let last = rows.last, last.trimmingCharacters(in: .whitespaces).isEmpty {
             rows.removeLast()
@@ -94,17 +87,16 @@ extension GhosttySurfaceView {
         return rows.suffix(n).joined(separator: "\n")
     }
 
-    /// This surface's foreground process pid (libghostty `ghostty_surface_foreground_pid`), or nil when
-    /// the surface has not been created or the call returns 0. Read at quit by the restore-running-command
-    /// capture (`ForegroundProcess.command(for:shellBasename:)`); not focus-dependent, like `readSelection`.
+    /// This surface's foreground process pid (`ghostty_surface_foreground_pid`), nil when the surface is not
+    /// created or the call returns 0. Read at quit by the restore-running-command capture; not focus-dependent.
     func foregroundPid() -> pid_t? {
         guard let surface else { return nil }
         let pid = ghostty_surface_foreground_pid(surface)
         return pid > 0 ? pid_t(pid) : nil
     }
 
-    /// Synthesizes a Return keypress (press + release) on `surface` via the same key path the keyboard
-    /// uses, so the shell treats it as Enter. Keycode 36 is the macOS virtual keycode for Return.
+    /// Synthesizes a Return keypress (press + release) via the keyboard's own key path, so the shell treats it
+    /// as Enter. Keycode 36 is the macOS virtual keycode for Return.
     private func sendReturn(to surface: ghostty_surface_t) {
         var ke = ghostty_input_key_s()
         ke.keycode = 36
@@ -119,12 +111,10 @@ extension GhosttySurfaceView {
         _ = ghostty_surface_key(surface, ke)
     }
 
-    /// Triggers a libghostty keybind action on this surface (e.g. `increase_font_size:1`,
-    /// `decrease_font_size:1`, `reset_font_size`), so a menu item drives the same behavior as the built-in
-    /// keybind; a font change rides the usual CELL_SIZE → persist path. Returns whether it ran — `false`
-    /// when the libghostty surface isn't realized yet (the view exists, its inner `surface` is nil), so a
-    /// control caller reports `session not realized` instead of a false ok. `@discardableResult` for the
-    /// GUI/menu callers.
+    /// Triggers a libghostty keybind action on this surface (`increase_font_size:1`, `reset_font_size`, …), so
+    /// a menu item drives the same behavior as the built-in keybind; a font change rides the usual CELL_SIZE →
+    /// persist path. `false` when the libghostty surface isn't realized (the view exists, its inner `surface`
+    /// is nil), so a control caller reports `session not realized` instead of a false ok.
     @discardableResult
     func performBindingAction(_ action: String) -> Bool {
         guard let surface else { return false }
@@ -132,32 +122,29 @@ extension GhosttySurfaceView {
         return true
     }
 
-    /// The direction `navigateSearch` steps the selection. The pure enum (with its libghostty mapping) is
-    /// host-free in `agtermCore.SearchDirection`; this alias keeps the existing call sites unchanged.
+    /// The direction `navigateSearch` steps the selection; the enum and its libghostty mapping are host-free
+    /// in `agtermCore`, and this alias keeps the existing call sites unchanged.
     typealias SearchDirection = agtermCore.SearchDirection
 
-    /// Enters search mode on this surface (the `start_search` binding action). libghostty replies with a
-    /// START_SEARCH action carrying the current needle; sending it again while search is active closes it.
+    /// Enters search mode; libghostty replies with a START_SEARCH action carrying the current needle, and a
+    /// repeat while search is active closes it.
     func startSearch() { performBindingAction("start_search") }
 
-    /// Sets the search query (the `search:<needle>` binding action). libghostty replies with SEARCH_TOTAL
-    /// and SEARCH_SELECTED actions for the new match set.
+    /// Sets the search query; libghostty replies with SEARCH_TOTAL and SEARCH_SELECTED for the new match set.
     func sendSearchQuery(_ needle: String) { performBindingAction("search:\(needle)") }
 
-    /// Steps the selection one match. The agterm direction is INVERTED to libghostty's `navigate_search`
-    /// string by `SearchDirection.ghosttyAction` (see `agtermCore.SearchDirection`), so the DOWN chevron /
-    /// Enter / `--next` move visually down and the UP chevron / Shift-Enter / `--prev` move visually up.
+    /// Steps the selection one match. `SearchDirection.ghosttyAction` INVERTS the agterm direction into
+    /// libghostty's `navigate_search`, so DOWN/Enter/`--next` move visually down and UP/Shift-Enter/`--prev` up.
     func navigateSearch(_ direction: SearchDirection) {
         performBindingAction(direction.ghosttyAction)
     }
 
-    /// Exits search mode on this surface (the `end_search` binding action). libghostty replies with an
-    /// END_SEARCH action.
+    /// Exits search mode; libghostty replies with an END_SEARCH action.
     func endSearch() { performBindingAction("end_search") }
 
-    /// The surface's live font size in points (post cmd +/-), read from `inherited_config`; nil when the
-    /// libghostty surface isn't realized or hasn't resolved a size. The read side of `font.*` — the control
-    /// `tree` reads it per pane, since the split/scratch panes' sizes are otherwise unobservable (live-only).
+    /// The surface's live font size in points (post cmd +/-) from `inherited_config`; nil when the libghostty
+    /// surface isn't realized or hasn't resolved a size. The read side of `font.*`: the control `tree` reads it
+    /// per pane, since split/scratch pane sizes are live-only and otherwise unobservable.
     func currentFontSize() -> Double? {
         guard let surface else { return nil }
         let size = Double(ghostty_surface_inherited_config(surface, GHOSTTY_SURFACE_CONTEXT_WINDOW).font_size)

--- a/agterm/Ghostty/GhosttySurfaceView+Input.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Input.swift
@@ -13,9 +13,8 @@ extension GhosttySurfaceView {
         dropText(from: sender) != nil ? .copy : []
     }
 
-    /// Insert the dropped file's path (shell-escaped, space-joined for multiple) or text at the cursor as a
-    /// bracketed paste — ⌘V's no-auto-submit behavior, so a multi-line drop lands as literal text instead
-    /// of executing each line. Deferred a runloop tick so the drag session unwinds before the buffer moves.
+    /// Insert the dropped path (shell-escaped, space-joined) or text at the cursor as a bracketed paste, so
+    /// a multi-line drop is literal text, not executed lines. Deferred a tick so the drag session unwinds.
     override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
         guard let text = dropText(from: sender) else { return false }
         DispatchQueue.main.async { [weak self] in self?.insertPasted(text: text) }
@@ -23,15 +22,14 @@ extension GhosttySurfaceView {
     }
 
     /// The text a drop would insert, via the shared `GhosttyCallbacks.pasteboardText` reader; nil when the
-    /// drag carries nothing usable (e.g. an internal sidebar row drag).
+    /// drag carries nothing usable.
     private func dropText(from sender: any NSDraggingInfo) -> String? {
         GhosttyCallbacks.pasteboardText(sender.draggingPasteboard)
     }
 
     // MARK: - Keyboard
 
-    /// Reduce an `NSEvent` to the host-free `InterruptKeystroke` classifier — Escape or a bare Ctrl-C
-    /// clears a stale `active` glyph. The classification (and its negatives) is unit-tested in `agtermCore`.
+    /// Reduce an `NSEvent` to the host-free `InterruptKeystroke` classifier — Escape or a bare Ctrl-C.
     private func isInterruptKeystroke(_ event: NSEvent) -> Bool {
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         var modifiers: KeyModifiers = []
@@ -49,19 +47,16 @@ extension GhosttySurfaceView {
             super.keyDown(with: event)
             return
         }
-        // every keystroke is user activity: reset the window's auto-follow idle timer UNCONDITIONALLY (not
-        // gated on the status-clear below), else typing in an idle session lets the timer lapse and yanks
-        // the user to a blocked session mid-type.
+        // every keystroke is user activity: reset the auto-follow idle timer UNCONDITIONALLY, not gated on
+        // the status-clear below, else typing in an idle session yanks the user to a blocked one mid-type.
         onUserInput?()
-        // a keystroke in a session flagged for attention clears the glyph to idle: blocked/completed on ANY
-        // key (you've engaged with the prompt / finished result), active ONLY on an interrupt — Escape or
-        // Ctrl-C — so typing while the agent works keeps the "working" glyph but cancelling a pending prompt
-        // drops it. Claude Code treats Ctrl-C like Esc for dismissing a prompt, yet neither fires a hook,
-        // and a cancelled prompt can still read active (its blocked notification lands seconds later), so
-        // this keystroke clear is the only signal that drops the stale glyph. fire it UNCONDITIONALLY with
-        // the isInterrupt flag: the factory's closure owns the pane-scoped decision (AgentIndicator.clearedBy),
-        // so the scratch (no view.session) self-clears too and a background pane's block survives foreground
-        // typing.
+        // a keystroke clears an attention glyph to idle: blocked/completed on ANY key, active ONLY on an
+        // interrupt (Escape or Ctrl-C), so typing while the agent works keeps the "working" glyph but
+        // cancelling a pending prompt drops it. Claude Code treats Ctrl-C like Esc for dismissing a prompt,
+        // yet neither fires a hook and a cancelled prompt can still read active (its blocked notification
+        // lands seconds later), so this is the only signal that drops the stale glyph. fire UNCONDITIONALLY
+        // with the isInterrupt flag: the pane-scoped decision belongs to AgentIndicator.clearedBy, so the
+        // scratch (no view.session) self-clears too and a background pane's block survives foreground typing.
         onUserInputClearsStatus?(isInterruptKeystroke(event))
         let action: ghostty_input_action_e = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
@@ -146,10 +141,8 @@ extension GhosttySurfaceView {
         return NSPoint(x: local.x, y: bounds.height - local.y)
     }
 
-    /// Push the pointer position from `event` to libghostty and remember it in `lastReportedMousePoint`.
-    /// Every position-reporting handler routes through here so `scrollWheel` can tell the position is
-    /// current and skip a redundant `mouse_pos`, which a mouse-reporting TUI would turn into a per-packet
-    /// synthetic motion report.
+    /// Push the pointer position to libghostty and remember it in `lastReportedMousePoint`. Every
+    /// position-reporting handler routes through here so `scrollWheel` can skip a redundant `mouse_pos`.
     private func reportMousePos(from event: NSEvent) {
         guard let surface else { return }
         let pt = mousePoint(from: event)
@@ -171,9 +164,9 @@ extension GhosttySurfaceView {
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, mods(event))
     }
 
-    // forward right-/middle-button press/release so libghostty's mouse bindings fire (right-click-action).
-    // same `mouse_pos`-then-`mouse_button` order as the left handlers, minus the focus grab — a right or
-    // middle click doesn't move first responder. no terminal context menu, so the return value is discarded.
+    // forward right-/middle-button press/release so libghostty's mouse bindings fire (right-click-action),
+    // in the left handlers' `mouse_pos`-then-`mouse_button` order minus the focus grab — these buttons
+    // don't move first responder. no terminal context menu, so the return value is discarded.
     override func rightMouseDown(with event: NSEvent) {
         guard let surface else { return }
         reportMousePos(from: event)
@@ -205,29 +198,26 @@ extension GhosttySurfaceView {
     override func otherMouseDragged(with event: NSEvent) { mouseMoved(with: event) }
 
     /// Re-assert the libghostty-requested cursor on every move: `cursorUpdate` fires only on tracking-area
-    /// entry, not per intra-area move, and SwiftUI (which owns the hosted view's cursor) can reset it on any
-    /// move, so without this the pointing hand reverts to the arrow along a link. Gated on `deckVisible` —
-    /// only the on-screen pane sets the process-global cursor, so a background deck surface never paints its
-    /// shape over the visible terminal (issue #225).
+    /// entry, and SwiftUI (which owns the hosted view's cursor) can reset it on any move, so without this
+    /// the pointing hand reverts to the arrow along a link. Gated on `deckVisible` so a background deck
+    /// surface never paints its shape over the visible terminal via the process-global cursor (issue #225).
     override func mouseMoved(with event: NSEvent) {
         reportMousePos(from: event)
         guard deckVisible else { return }
         Self.nsCursor(for: mouseShape).set()
     }
 
-    /// The pointer entered the surface: restore libghostty's mouse position from the current point, undoing
-    /// `mouseExited`'s `-1, -1` reset so hovered-link and cursor-shape state are correct on re-entry.
-    /// `scrollWheel` syncs a stale `mouse_pos` too, but the restore still matters for hover before any move.
+    /// Restore libghostty's mouse position on entry, undoing `mouseExited`'s `-1, -1` reset so hovered-link
+    /// and cursor-shape state are right on re-entry — `scrollWheel`'s sync misses hover before any move.
     override func mouseEntered(with event: NSEvent) {
         pointerInside = true
         reportMousePos(from: event)
     }
 
-    /// The pointer left the surface. Report negative coordinates so libghostty clears hovered-link state —
-    /// it drops `over_link`, reverts the mouse shape and re-renders without the underline (its
-    /// `cursorPosCallback`); without this a ⌘-hovered link stays highlighted after the mouse leaves the
-    /// terminal (sidebar, another window, off the edge) until ⌘ is released. Skipped mid-drag (a button
-    /// down) so a selection crossing the edge isn't reported at `-1, -1`.
+    /// Report negative coordinates on exit so libghostty's `cursorPosCallback` clears hovered-link state
+    /// (drops `over_link`, reverts the mouse shape, re-renders without the underline); without this a
+    /// ⌘-hovered link stays highlighted after the mouse leaves the terminal until ⌘ is released. Skipped
+    /// mid-drag (a button down) so a selection crossing the edge isn't reported at `-1, -1`.
     override func mouseExited(with event: NSEvent) {
         guard let surface, NSEvent.pressedMouseButtons == 0 else { return }
         pointerInside = false
@@ -237,14 +227,13 @@ extension GhosttySurfaceView {
 
     override func scrollWheel(with event: NSEvent) {
         guard let surface else { return }
-        // sync libghostty's mouse position before scrolling, but ONLY when stale: mouse_scroll reports at
-        // the last-known cell, and a no-move reactivation (cmd-tab/keyboard, or scrolling with the pointer
+        // sync the mouse position before scrolling, but ONLY when stale: mouse_scroll reports at the
+        // last-known cell, and a no-move reactivation (cmd-tab/keyboard, or scrolling with the pointer
         // already inside) delivers no mouseDown/mouseEntered, so the position stays stale or -1,-1 (from
-        // mouseExited) and the first scroll in a mouse-reporting TUI (Claude Code, vim, less) hits the wrong
-        // cell until you nudge the mouse. gating on lastReportedMousePoint keeps an already-synced scroll
-        // from re-pushing the same cell per packet, which an any-motion + sgr-pixel TUI would turn into a
-        // synthetic motion report per packet. a LEFT-click reactivation is already covered by mouseDown via
-        // acceptsFirstMouse; this handles the no-click paths.
+        // mouseExited) and the first scroll in a mouse-reporting TUI hits the wrong cell. gating on
+        // lastReportedMousePoint stops an already-synced scroll re-pushing the same cell per packet, which
+        // an any-motion + sgr-pixel TUI turns into a synthetic motion report per packet. a LEFT-click
+        // reactivation is already covered by mouseDown via acceptsFirstMouse.
         let pt = mousePoint(from: event)
         if pt != lastReportedMousePoint {
             ghostty_surface_mouse_pos(surface, pt.x, pt.y, mods(event))
@@ -317,8 +306,7 @@ extension GhosttySurfaceView {
     }
 
     /// Builds a synthetic NSEvent whose modifier flags reflect libghostty's translation policy — with
-    /// macos-option-as-alt on, Option is stripped so `characters(byApplyingModifiers:)` returns the
-    /// unshifted char.
+    /// macos-option-as-alt on, Option is stripped so `characters(byApplyingModifiers:)` gives the unshifted char.
     private func translatedEvent(for event: NSEvent) -> NSEvent {
         guard let surface else { return event }
         let originalMods = mods(event)
@@ -418,38 +406,34 @@ extension GhosttySurfaceView: @preconcurrency NSTextInputClient {
 
     // MARK: - Mouse cursor shape + link opening
 
-    /// Applies the cursor shape libghostty requested (`GHOSTTY_ACTION_MOUSE_SHAPE`) — pointing hand over a
-    /// link, I-beam over the grid, resize/crosshair/grab in the matching modes. No-ops when unchanged, else
-    /// sets the cursor at once, but only while this is the on-screen pane (`deckVisible`) and the pointer is
-    /// inside: a background deck surface must not paint its shape over the visible terminal (issue #225), and
-    /// a revert delivered after the pointer left (the I-beam libghostty emits once `mouseExited` reports
-    /// `-1, -1`) must not paint the terminal cursor onto the sidebar. Setting it here is what makes a
-    /// stationary shape change (⌘ over a link without moving) take effect immediately; `mouseMoved`
-    /// re-asserts it as the pointer moves and `cursorUpdate` on entry.
+    /// Applies the cursor shape libghostty requested (`GHOSTTY_ACTION_MOUSE_SHAPE`). No-ops when unchanged,
+    /// else sets the cursor at once, but only while this is the on-screen pane (`deckVisible`) and the
+    /// pointer is inside: a background deck surface must not paint its shape over the visible terminal
+    /// (issue #225), and a revert delivered after the pointer left (the I-beam libghostty emits once
+    /// `mouseExited` reports `-1, -1`) must not paint the terminal cursor onto the sidebar. Setting it here
+    /// is what makes a stationary shape change (⌘ over a link without moving) take effect immediately.
     func applyMouseShape(_ shape: ghostty_action_mouse_shape_e) {
         guard shape != mouseShape else { return }
         mouseShape = shape
         if deckVisible, pointerInside { Self.nsCursor(for: shape).set() }
     }
 
-    /// AppKit cursor hook (the `.cursorUpdate` tracking-area callback, NOT cursor rectangles): paint the whole
-    /// surface with the libghostty-requested cursor. SwiftUI (`TerminalView`) hosts the surface and owns the
-    /// cursor, resetting it as the mouse moves, so `addCursorRect`/`resetCursorRects` never take hold here (the
-    /// link still underlines — libghostty draws that — but the pointing hand is dropped); setting it here
-    /// re-asserts it on AppKit's cursor pass, the same reason upstream Ghostty.app drives the cursor through
-    /// SwiftUI. Gated on `deckVisible`: AppKit still delivers a `cursorUpdate` to a hidden deck surface on
-    /// window activation, so a background pane must not set the cursor here (issue #225 refocus).
+    /// AppKit's `.cursorUpdate` tracking-area callback (NOT cursor rectangles): paint the whole surface with
+    /// the libghostty-requested cursor. SwiftUI (`TerminalView`) hosts the surface and owns the cursor,
+    /// resetting it as the mouse moves, so `addCursorRect`/`resetCursorRects` never take hold here — the
+    /// link still underlines (libghostty draws it) but the pointing hand is dropped; upstream Ghostty.app
+    /// drives the cursor through SwiftUI for the same reason. Gated on `deckVisible`: AppKit still delivers
+    /// a `cursorUpdate` to a hidden deck surface on window activation (issue #225 refocus).
     override func cursorUpdate(with event: NSEvent) {
         guard deckVisible else { return }
         Self.nsCursor(for: mouseShape).set()
     }
 
-    /// Re-assert this pane's cursor when its window becomes key: AppKit does NOT re-issue a `cursorUpdate` to
-    /// the visible pane on bare activation, so a reactivating click leaves the OS arrow until the next move.
-    /// Gated on `deckVisible` (only the on-screen pane sets the cursor) + `isKeyWindow` + pointer-in-bounds
-    /// (read fresh from `mouseLocationOutsideOfEventStream`, since `pointerInside` can be stale on a no-move
-    /// activation), so it never paints over the sidebar/titlebar or a background window; hidden surfaces are
-    /// already muted, so it wins uncontested.
+    /// Re-assert this pane's cursor when its window becomes key: AppKit does NOT re-issue a `cursorUpdate`
+    /// on bare activation, so a reactivating click leaves the OS arrow until the next move. Gated on
+    /// `deckVisible` + `isKeyWindow` + pointer-in-bounds — read fresh from
+    /// `mouseLocationOutsideOfEventStream`, since `pointerInside` can be stale on a no-move activation — so
+    /// it never paints over the sidebar/titlebar or a background window.
     func reassertCursorOnActivation() {
         guard deckVisible, let window, window.isKeyWindow else { return }
         let pointInView = convert(window.mouseLocationOutsideOfEventStream, from: nil)
@@ -479,9 +463,8 @@ extension GhosttySurfaceView: @preconcurrency NSTextInputClient {
         }
     }
 
-    /// Acts on a clicked terminal link (`GHOSTTY_ACTION_OPEN_URL`). The scheme/host decision lives in the
-    /// host-free `LinkPolicy` (unit-tested); this is the AppKit glue for its three dispositions: OPEN a
-    /// web/mail URL, REVEAL a `file://` link in Finder (never opened — reveal executes nothing), or IGNORE.
+    /// Acts on a clicked terminal link (`GHOSTTY_ACTION_OPEN_URL`); the scheme/host decision lives in the
+    /// host-free `LinkPolicy`. A `file://` link is REVEALED in Finder, never opened — reveal executes nothing.
     func openLink(_ raw: String) {
         switch LinkPolicy.disposition(for: raw) {
         case let .open(url): NSWorkspace.shared.open(url)
@@ -495,12 +478,11 @@ extension GhosttySurfaceView: @preconcurrency NSTextInputClient {
 
 /// The stock Edit ▸ Copy/Paste/Select All actions, implemented on the surface so AppKit's automatic menu
 /// enabling routes them to the terminal when it holds first responder, while a focused text field (inline
-/// rename, palette search, Settings) keeps its own `copy:`/`paste:`/`selectAll:` — its field editor wins the
-/// responder chain. That is why agterm keeps the standard SwiftUI Edit menu instead of a custom Commands
-/// group. Each action runs the same libghostty binding ⌘C/⌘V/⌘A use. Cut is deliberately NOT implemented, so
-/// it stays disabled for the terminal (nothing to cut) yet works in text fields; it cannot be dropped on its
-/// own, sharing SwiftUI's `.pasteboard` group with the other three. Undo/Redo are removed entirely
-/// (`CommandGroup(replacing: .undoRedo)` in `agtermApp+Menus`).
+/// rename, palette search, Settings) keeps its own — its field editor wins the responder chain. That is why
+/// agterm keeps the standard SwiftUI Edit menu instead of a custom Commands group. Each action runs the same
+/// libghostty binding ⌘C/⌘V/⌘A use. Cut is deliberately NOT implemented, so it stays disabled for the
+/// terminal yet works in text fields; it cannot be dropped on its own, sharing SwiftUI's `.pasteboard`
+/// group. Undo/Redo are removed entirely (`CommandGroup(replacing: .undoRedo)` in `agtermApp+Menus`).
 extension GhosttySurfaceView: NSMenuItemValidation {
     @objc func copy(_ sender: Any?) { performBindingAction("copy_to_clipboard") }
 
@@ -510,17 +492,16 @@ extension GhosttySurfaceView: NSMenuItemValidation {
     override func selectAll(_ sender: Any?) { performBindingAction("select_all") }
 
     /// Gate the three items on real availability: Copy needs a selection, Paste something the paste path can
-    /// actually insert, Select All a realized surface — all three need one, since `performBindingAction`
-    /// no-ops without it. Items we don't own enable by default (AppKit consults this only on the responder
-    /// that implements the action, so `cut:` never reaches it).
+    /// insert, all three a realized surface (`performBindingAction` no-ops without one). Items we don't own
+    /// enable by default — AppKit consults this only on the responder implementing the action, so `cut:`
+    /// never reaches it.
     ///
-    /// Paste asks `GhosttyCallbacks.hasPasteboardText()`, which runs the same branches as `pasteboardText` —
-    /// the SAME reader `paste_from_clipboard` uses — rather than probing for a plain string: the clipboard
-    /// may hold a file/web URL with no string representation (a Finder copy) that the reader turns into a
-    /// shell-escaped path, so an `NSString` probe reports "nothing to paste" while ⌘V pastes it — exactly the
-    /// menu-vs-keyboard divergence these responders exist to remove. A bare `canReadObject([NSURL])` TYPE
-    /// probe is wrong the other way, enabling Paste for a pasteboard that only declares a URL type. The gate
-    /// short-circuits on the first usable URL, so it never escapes and joins a whole Finder copy to answer.
+    /// Paste asks `GhosttyCallbacks.hasPasteboardText()`, the SAME reader `paste_from_clipboard` uses,
+    /// rather than probing for a plain string: the clipboard may hold a file/web URL with no string
+    /// representation (a Finder copy) the reader turns into a shell-escaped path, so an `NSString` probe
+    /// reports "nothing to paste" while ⌘V pastes it. A bare `canReadObject([NSURL])` TYPE probe is wrong
+    /// the other way, enabling Paste for a URL-type-only pasteboard. The gate short-circuits on the first
+    /// usable URL, never escaping a whole Finder copy to answer.
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         switch menuItem.action {
         case #selector(copy(_:)):

--- a/agterm/Ghostty/GhosttySurfaceView+Input.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Input.swift
@@ -14,9 +14,8 @@ extension GhosttySurfaceView {
     }
 
     /// Insert the dropped file's path (shell-escaped, space-joined for multiple) or text at the cursor as a
-    /// bracketed paste — the same no-auto-submit behavior as ⌘V, so a multi-line drop lands as literal text
-    /// instead of executing each line. Deferred to the next runloop tick so the drag session fully unwinds
-    /// before the terminal buffer is mutated.
+    /// bracketed paste — ⌘V's no-auto-submit behavior, so a multi-line drop lands as literal text instead
+    /// of executing each line. Deferred a runloop tick so the drag session unwinds before the buffer moves.
     override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
         guard let text = dropText(from: sender) else { return false }
         DispatchQueue.main.async { [weak self] in self?.insertPasted(text: text) }
@@ -51,18 +50,17 @@ extension GhosttySurfaceView {
             return
         }
         // every keystroke is user activity: reset the window's auto-follow idle timer UNCONDITIONALLY (not
-        // gated on the status-clear below), else ordinary typing in an idle session wouldn't keep the idle
-        // timer alive and the user would be yanked to a blocked session mid-type.
+        // gated on the status-clear below), else typing in an idle session lets the timer lapse and yanks
+        // the user to a blocked session mid-type.
         onUserInput?()
-        // a keystroke in a session flagged for your attention clears the glyph to idle: blocked/completed
-        // on ANY key (you've engaged with the prompt / finished result), active ONLY on an interrupt
-        // keystroke — Escape or Ctrl-C — so ordinary typing while the agent works doesn't wipe the
-        // "working" glyph, but cancelling a pending prompt does. Claude Code treats Ctrl-C like Esc for
-        // dismissing a prompt, yet neither fires a hook, and a pending prompt can still read active when
-        // you cancel (the blocked notification lands seconds later), so this keystroke clear is the only
-        // signal that drops the stale glyph. fire it UNCONDITIONALLY with the isInterrupt flag — the
-        // factory's closure owns the pane-scoped decision (AgentIndicator.clearedBy), so the scratch
-        // (which has no view.session) self-clears too, and a background pane's block survives foreground
+        // a keystroke in a session flagged for attention clears the glyph to idle: blocked/completed on ANY
+        // key (you've engaged with the prompt / finished result), active ONLY on an interrupt — Escape or
+        // Ctrl-C — so typing while the agent works keeps the "working" glyph but cancelling a pending prompt
+        // drops it. Claude Code treats Ctrl-C like Esc for dismissing a prompt, yet neither fires a hook,
+        // and a cancelled prompt can still read active (its blocked notification lands seconds later), so
+        // this keystroke clear is the only signal that drops the stale glyph. fire it UNCONDITIONALLY with
+        // the isInterrupt flag: the factory's closure owns the pane-scoped decision (AgentIndicator.clearedBy),
+        // so the scratch (no view.session) self-clears too and a background pane's block survives foreground
         // typing.
         onUserInputClearsStatus?(isInterruptKeystroke(event))
         let action: ghostty_input_action_e = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS
@@ -149,9 +147,9 @@ extension GhosttySurfaceView {
     }
 
     /// Push the pointer position from `event` to libghostty and remember it in `lastReportedMousePoint`.
-    /// Every handler that reports a position routes through here so `scrollWheel` can tell when the position
-    /// is already current and skip a redundant `mouse_pos` (which a mouse-reporting TUI would otherwise turn
-    /// into a per-packet synthetic motion report).
+    /// Every position-reporting handler routes through here so `scrollWheel` can tell the position is
+    /// current and skip a redundant `mouse_pos`, which a mouse-reporting TUI would turn into a per-packet
+    /// synthetic motion report.
     private func reportMousePos(from event: NSEvent) {
         guard let surface else { return }
         let pt = mousePoint(from: event)
@@ -173,10 +171,9 @@ extension GhosttySurfaceView {
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, mods(event))
     }
 
-    // forward right- and middle-button press/release to libghostty so its mouse bindings fire (e.g.
-    // `right-click-action = paste`). mirrors the left handlers — `mouse_pos` before `mouse_button` — but
-    // does NOT grab focus (a right/middle click on macOS doesn't move first responder). agterm has no
-    // terminal context menu, so the return value is discarded like the left handler.
+    // forward right-/middle-button press/release so libghostty's mouse bindings fire (right-click-action).
+    // same `mouse_pos`-then-`mouse_button` order as the left handlers, minus the focus grab — a right or
+    // middle click doesn't move first responder. no terminal context menu, so the return value is discarded.
     override func rightMouseDown(with event: NSEvent) {
         guard let surface else { return }
         reportMousePos(from: event)
@@ -207,11 +204,11 @@ extension GhosttySurfaceView {
     override func rightMouseDragged(with event: NSEvent) { mouseMoved(with: event) }
     override func otherMouseDragged(with event: NSEvent) { mouseMoved(with: event) }
 
-    /// Re-assert the libghostty-requested cursor on every move. `cursorUpdate` only fires on tracking-area
-    /// entry (not per intra-area move), and SwiftUI — which owns the cursor for the hosted view — can reset
-    /// it on any move, so without this the pointing hand would revert to the arrow while moving along a link.
-    /// Gated on `deckVisible`: only the on-screen pane sets the process-global cursor, so a background deck
-    /// surface never paints its shape over the visible terminal (issue #225).
+    /// Re-assert the libghostty-requested cursor on every move: `cursorUpdate` fires only on tracking-area
+    /// entry, not per intra-area move, and SwiftUI (which owns the hosted view's cursor) can reset it on any
+    /// move, so without this the pointing hand reverts to the arrow along a link. Gated on `deckVisible` —
+    /// only the on-screen pane sets the process-global cursor, so a background deck surface never paints its
+    /// shape over the visible terminal (issue #225).
     override func mouseMoved(with event: NSEvent) {
         reportMousePos(from: event)
         guard deckVisible else { return }
@@ -220,18 +217,17 @@ extension GhosttySurfaceView {
 
     /// The pointer entered the surface: restore libghostty's mouse position from the current point, undoing
     /// `mouseExited`'s `-1, -1` reset so hovered-link and cursor-shape state are correct on re-entry.
-    /// (`scrollWheel` also syncs `mouse_pos` when stale, so the first post-re-entry scroll no longer depends
-    /// on this — but the restore still matters for hover/link state before any move.)
+    /// `scrollWheel` syncs a stale `mouse_pos` too, but the restore still matters for hover before any move.
     override func mouseEntered(with event: NSEvent) {
         pointerInside = true
         reportMousePos(from: event)
     }
 
-    /// The pointer left the surface. Report negative coordinates so libghostty clears any hovered-link
-    /// state — it drops `over_link`, reverts the mouse shape, and re-renders without the underline (see its
-    /// `cursorPosCallback`). Without this a ⌘-hovered link stays highlighted after the mouse leaves the
-    /// terminal (into the sidebar, another window, or off the edge) until ⌘ is released. Skipped mid-drag
-    /// (a button is down) so a selection/drag that crosses the edge isn't reported at `-1, -1`.
+    /// The pointer left the surface. Report negative coordinates so libghostty clears hovered-link state —
+    /// it drops `over_link`, reverts the mouse shape and re-renders without the underline (its
+    /// `cursorPosCallback`); without this a ⌘-hovered link stays highlighted after the mouse leaves the
+    /// terminal (sidebar, another window, off the edge) until ⌘ is released. Skipped mid-drag (a button
+    /// down) so a selection crossing the edge isn't reported at `-1, -1`.
     override func mouseExited(with event: NSEvent) {
         guard let surface, NSEvent.pressedMouseButtons == 0 else { return }
         pointerInside = false
@@ -241,15 +237,14 @@ extension GhosttySurfaceView {
 
     override func scrollWheel(with event: NSEvent) {
         guard let surface else { return }
-        // sync libghostty's mouse position before scrolling, but ONLY when it's stale: mouse_scroll reports
-        // at the last-known cell, and reactivating the window with no mouse move — cmd-tab/keyboard, or
-        // scrolling to reactivate with the pointer already inside — delivers no mouseDown/mouseEntered, so
-        // the position stays stale or -1,-1 (from mouseExited) and the first scroll inside a mouse-reporting
-        // TUI (Claude Code, vim, less) reports at the wrong cell until you nudge the mouse. gating on
-        // lastReportedMousePoint means an already-synced (normal) scroll doesn't re-push the same cell every
-        // packet — which in an any-motion + sgr-pixel TUI would emit a synthetic motion report per packet.
-        // (a LEFT click reactivation is already covered by mouseDown via acceptsFirstMouse; this handles the
-        // no-click paths.)
+        // sync libghostty's mouse position before scrolling, but ONLY when stale: mouse_scroll reports at
+        // the last-known cell, and a no-move reactivation (cmd-tab/keyboard, or scrolling with the pointer
+        // already inside) delivers no mouseDown/mouseEntered, so the position stays stale or -1,-1 (from
+        // mouseExited) and the first scroll in a mouse-reporting TUI (Claude Code, vim, less) hits the wrong
+        // cell until you nudge the mouse. gating on lastReportedMousePoint keeps an already-synced scroll
+        // from re-pushing the same cell per packet, which an any-motion + sgr-pixel TUI would turn into a
+        // synthetic motion report per packet. a LEFT-click reactivation is already covered by mouseDown via
+        // acceptsFirstMouse; this handles the no-click paths.
         let pt = mousePoint(from: event)
         if pt != lastReportedMousePoint {
             ghostty_surface_mouse_pos(surface, pt.x, pt.y, mods(event))
@@ -321,9 +316,9 @@ extension GhosttySurfaceView {
         return text
     }
 
-    /// Builds a synthetic NSEvent whose modifier flags reflect libghostty's
-    /// translation policy — with macos-option-as-alt on, Option is stripped so
-    /// `characters(byApplyingModifiers:)` returns the unshifted char.
+    /// Builds a synthetic NSEvent whose modifier flags reflect libghostty's translation policy — with
+    /// macos-option-as-alt on, Option is stripped so `characters(byApplyingModifiers:)` returns the
+    /// unshifted char.
     private func translatedEvent(for event: NSEvent) -> NSEvent {
         guard let surface else { return event }
         let originalMods = mods(event)
@@ -354,9 +349,8 @@ extension GhosttySurfaceView {
     }
 
     private func unshiftedCodepoint(from event: NSEvent) -> UInt32 {
-        // characters(byApplyingModifiers:) is valid only for key up/down events; on a FlagsChanged
-        // (bare modifier) event it raises an AppKit assertion. A modifier press carries no codepoint,
-        // so report 0 for any non-key event.
+        // characters(byApplyingModifiers:) is valid only for key up/down; on a FlagsChanged (bare modifier)
+        // event it raises an AppKit assertion. a modifier press carries no codepoint, so report 0 there.
         guard event.type == .keyDown || event.type == .keyUp,
               let chars = event.characters(byApplyingModifiers: []),
               let scalar = chars.unicodeScalars.first
@@ -424,14 +418,14 @@ extension GhosttySurfaceView: @preconcurrency NSTextInputClient {
 
     // MARK: - Mouse cursor shape + link opening
 
-    /// Applies the cursor shape libghostty requested (`GHOSTTY_ACTION_MOUSE_SHAPE`) — the pointing hand
-    /// over a link, the I-beam over the grid, resize/crosshair/grab in the matching modes. No-ops when
-    /// unchanged; otherwise sets the cursor at once — but only while this is the on-screen pane (`deckVisible`)
-    /// and the pointer is inside, so a background deck surface never paints its shape over the visible terminal
-    /// (issue #225), and a revert delivered after the pointer already left (the I-beam libghostty emits once
-    /// `mouseExited` reports `-1, -1`) can't paint the terminal cursor onto the sidebar. Setting it here is what
-    /// makes a stationary shape change (⌘ pressed over a link without moving) take effect immediately;
-    /// `mouseMoved` re-asserts it as the pointer moves and `cursorUpdate` on entry.
+    /// Applies the cursor shape libghostty requested (`GHOSTTY_ACTION_MOUSE_SHAPE`) — pointing hand over a
+    /// link, I-beam over the grid, resize/crosshair/grab in the matching modes. No-ops when unchanged, else
+    /// sets the cursor at once, but only while this is the on-screen pane (`deckVisible`) and the pointer is
+    /// inside: a background deck surface must not paint its shape over the visible terminal (issue #225), and
+    /// a revert delivered after the pointer left (the I-beam libghostty emits once `mouseExited` reports
+    /// `-1, -1`) must not paint the terminal cursor onto the sidebar. Setting it here is what makes a
+    /// stationary shape change (⌘ over a link without moving) take effect immediately; `mouseMoved`
+    /// re-asserts it as the pointer moves and `cursorUpdate` on entry.
     func applyMouseShape(_ shape: ghostty_action_mouse_shape_e) {
         guard shape != mouseShape else { return }
         mouseShape = shape
@@ -439,24 +433,23 @@ extension GhosttySurfaceView: @preconcurrency NSTextInputClient {
     }
 
     /// AppKit cursor hook (the `.cursorUpdate` tracking-area callback, NOT cursor rectangles): paint the whole
-    /// surface with the libghostty-requested cursor. The surface is hosted inside SwiftUI (`TerminalView`),
-    /// which owns the cursor and resets it as the mouse moves, so `addCursorRect`/`resetCursorRects` never take
-    /// hold here (the link still underlines because libghostty draws that, but the pointing hand is dropped).
-    /// Setting the cursor from `cursorUpdate` re-asserts it on AppKit's cursor pass — the same reason upstream
-    /// Ghostty.app drives the cursor through SwiftUI rather than cursor rectangles. Gated on `deckVisible`:
-    /// AppKit still delivers a `cursorUpdate` to a hidden deck surface on window activation, so a background
-    /// pane must not set the cursor here (issue #225 refocus).
+    /// surface with the libghostty-requested cursor. SwiftUI (`TerminalView`) hosts the surface and owns the
+    /// cursor, resetting it as the mouse moves, so `addCursorRect`/`resetCursorRects` never take hold here (the
+    /// link still underlines — libghostty draws that — but the pointing hand is dropped); setting it here
+    /// re-asserts it on AppKit's cursor pass, the same reason upstream Ghostty.app drives the cursor through
+    /// SwiftUI. Gated on `deckVisible`: AppKit still delivers a `cursorUpdate` to a hidden deck surface on
+    /// window activation, so a background pane must not set the cursor here (issue #225 refocus).
     override func cursorUpdate(with event: NSEvent) {
         guard deckVisible else { return }
         Self.nsCursor(for: mouseShape).set()
     }
 
-    /// Re-assert this pane's cursor when its window becomes key. AppKit does NOT re-issue a `cursorUpdate`
-    /// to the visible pane on bare window activation, so a reactivating click otherwise leaves the OS default
-    /// (arrow) cursor until the next mouse move. Gated on `deckVisible` (only the on-screen pane sets the
-    /// cursor) + `isKeyWindow` + pointer-in-bounds (checked fresh from `mouseLocationOutsideOfEventStream`,
-    /// since `pointerInside` can be stale on a no-move activation) — so it never paints the terminal cursor
-    /// over the sidebar/titlebar or a background window, and with hidden surfaces already muted it wins uncontested.
+    /// Re-assert this pane's cursor when its window becomes key: AppKit does NOT re-issue a `cursorUpdate` to
+    /// the visible pane on bare activation, so a reactivating click leaves the OS arrow until the next move.
+    /// Gated on `deckVisible` (only the on-screen pane sets the cursor) + `isKeyWindow` + pointer-in-bounds
+    /// (read fresh from `mouseLocationOutsideOfEventStream`, since `pointerInside` can be stale on a no-move
+    /// activation), so it never paints over the sidebar/titlebar or a background window; hidden surfaces are
+    /// already muted, so it wins uncontested.
     func reassertCursorOnActivation() {
         guard deckVisible, let window, window.isKeyWindow else { return }
         let pointInView = convert(window.mouseLocationOutsideOfEventStream, from: nil)
@@ -487,9 +480,8 @@ extension GhosttySurfaceView: @preconcurrency NSTextInputClient {
     }
 
     /// Acts on a clicked terminal link (`GHOSTTY_ACTION_OPEN_URL`). The scheme/host decision lives in the
-    /// host-free `LinkPolicy` (unit-tested); this is just the AppKit glue for the three dispositions: OPEN a
-    /// web/mail URL, REVEAL a `file://` link in Finder (never opened — reveal selects it, executing nothing),
-    /// or IGNORE anything else.
+    /// host-free `LinkPolicy` (unit-tested); this is the AppKit glue for its three dispositions: OPEN a
+    /// web/mail URL, REVEAL a `file://` link in Finder (never opened — reveal executes nothing), or IGNORE.
     func openLink(_ raw: String) {
         switch LinkPolicy.disposition(for: raw) {
         case let .open(url): NSWorkspace.shared.open(url)
@@ -502,13 +494,13 @@ extension GhosttySurfaceView: @preconcurrency NSTextInputClient {
 // MARK: - Standard Edit menu (responder chain)
 
 /// The stock Edit ▸ Copy/Paste/Select All actions, implemented on the surface so AppKit's automatic menu
-/// enabling routes them to the terminal when it holds first responder — while a focused text field (inline
-/// rename, palette search, Settings) keeps its own `copy:`/`paste:`/`selectAll:` because its field editor
-/// wins the responder chain. This is why agterm keeps the standard SwiftUI Edit menu instead of a custom
-/// Commands group. Each action runs the same libghostty binding ⌘C/⌘V/⌘A use. Cut is deliberately NOT
-/// implemented here, so it stays disabled for the terminal (nothing to cut) yet still works in text fields;
-/// it cannot be dropped on its own, sharing SwiftUI's `.pasteboard` group with Copy/Paste/Select All.
-/// Undo/Redo are removed from the menu entirely (`CommandGroup(replacing: .undoRedo)` in `agtermApp+Menus`).
+/// enabling routes them to the terminal when it holds first responder, while a focused text field (inline
+/// rename, palette search, Settings) keeps its own `copy:`/`paste:`/`selectAll:` — its field editor wins the
+/// responder chain. That is why agterm keeps the standard SwiftUI Edit menu instead of a custom Commands
+/// group. Each action runs the same libghostty binding ⌘C/⌘V/⌘A use. Cut is deliberately NOT implemented, so
+/// it stays disabled for the terminal (nothing to cut) yet works in text fields; it cannot be dropped on its
+/// own, sharing SwiftUI's `.pasteboard` group with the other three. Undo/Redo are removed entirely
+/// (`CommandGroup(replacing: .undoRedo)` in `agtermApp+Menus`).
 extension GhosttySurfaceView: NSMenuItemValidation {
     @objc func copy(_ sender: Any?) { performBindingAction("copy_to_clipboard") }
 
@@ -517,19 +509,18 @@ extension GhosttySurfaceView: NSMenuItemValidation {
     /// `override` because `selectAll(_:)` is declared on `NSResponder`, unlike `copy:`/`paste:`.
     override func selectAll(_ sender: Any?) { performBindingAction("select_all") }
 
-    /// Gate the three items on real availability: Copy needs a selection, Paste needs something the paste
-    /// path can actually insert, Select All needs a realized surface. All three require a realized surface,
-    /// since `performBindingAction` no-ops without one. Items we don't own enable by default (AppKit only
-    /// consults this on the responder that implements the action, so `cut:` never reaches it).
+    /// Gate the three items on real availability: Copy needs a selection, Paste something the paste path can
+    /// actually insert, Select All a realized surface — all three need one, since `performBindingAction`
+    /// no-ops without it. Items we don't own enable by default (AppKit consults this only on the responder
+    /// that implements the action, so `cut:` never reaches it).
     ///
     /// Paste asks `GhosttyCallbacks.hasPasteboardText()`, which runs the same branches as `pasteboardText` —
-    /// the SAME reader `paste_from_clipboard` ends up using — rather than probing for a plain string. The
-    /// clipboard may hold a file/web URL with no string representation (a Finder copy), which that reader
-    /// turns into a shell-escaped path: probing for `NSString` alone reports "nothing to paste" while ⌘V
-    /// happily pastes the path, which is exactly the menu-vs-keyboard divergence these responder methods
-    /// exist to remove. A bare `canReadObject([NSURL])` TYPE probe is wrong the other way, enabling Paste for a
-    /// pasteboard that only declares a URL type. The gate short-circuits on the first usable URL, so it never
-    /// escapes and joins a whole Finder copy just to answer yes/no.
+    /// the SAME reader `paste_from_clipboard` uses — rather than probing for a plain string: the clipboard
+    /// may hold a file/web URL with no string representation (a Finder copy) that the reader turns into a
+    /// shell-escaped path, so an `NSString` probe reports "nothing to paste" while ⌘V pastes it — exactly the
+    /// menu-vs-keyboard divergence these responders exist to remove. A bare `canReadObject([NSURL])` TYPE
+    /// probe is wrong the other way, enabling Paste for a pasteboard that only declares a URL type. The gate
+    /// short-circuits on the first usable URL, so it never escapes and joins a whole Finder copy to answer.
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         switch menuItem.action {
         case #selector(copy(_:)):

--- a/agterm/Ghostty/GhosttySurfaceView+Panes.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Panes.swift
@@ -1,10 +1,9 @@
 extension GhosttySurfaceView {
     // MARK: - Pane role
 
-    /// `TerminalSurface` conformance: the model calls this when the primary pane exits and this split
-    /// (right) pane is promoted to the session's sole pane. Clears `isSplitPane` so subsequent
-    /// `applyPwd`/`applyTitle` reports route to `session.currentCwd`/`oscTitle` (the main fields) rather
-    /// than `splitCwd`/`splitTitle`.
+    /// `TerminalSurface` conformance: the model calls this when the primary pane exits and this split (right)
+    /// pane is promoted to the session's sole pane. Clearing `isSplitPane` routes subsequent
+    /// `applyPwd`/`applyTitle` reports to the main `session.currentCwd`/`oscTitle`, not `splitCwd`/`splitTitle`.
     func promoteToPrimaryPane() {
         isSplitPane = false
     }

--- a/agterm/Ghostty/GhosttySurfaceView+Tracking.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Tracking.swift
@@ -3,15 +3,14 @@ import GhosttyKit
 
 extension GhosttySurfaceView {
     /// Only the on-screen deck pane tracks the pointer. Every session's surface is eagerly realized, and
-    /// AppKit tracking areas ignore SwiftUI's `.opacity(0)` and sibling overlap exactly like the
-    /// drag-destination resolution (`deckVisible`) — a hidden surface's `visibleRect` is NOT clipped by an
-    /// overlapping sibling, so with `.mouseMoved`/`.cursorUpdate` still armed it receives the SAME move as the
-    /// visible pane and races to set the one process-global `NSCursor`. A hidden session cached at a different
-    /// mouse shape (a mouse-reporting TUI, or an OSC 22 pointer shape) then flickers over the visible terminal
-    /// (issue #225). `setupTrackingArea` installs the area only while `deckVisible`, so a hidden surface's
-    /// `mouseMoved`/`cursorUpdate` never fire — which also silences `applyMouseShape`'s `.set()` (guarded on
-    /// `pointerInside`, only set from `mouseEntered`). On going off-screen, clear the hover/pointer state a
-    /// now-untracked surface would otherwise keep (like `mouseExited`).
+    /// AppKit tracking areas ignore SwiftUI's `.opacity(0)` and sibling overlap exactly like drag-destination
+    /// resolution (`deckVisible`) — a hidden surface's `visibleRect` is NOT clipped by the sibling over it,
+    /// so with `.mouseMoved`/`.cursorUpdate` armed it gets the SAME move as the visible pane and races it for
+    /// the one process-global `NSCursor`; a hidden session cached at another mouse shape (a mouse-reporting
+    /// TUI, an OSC 22 pointer shape) then flickers over the visible terminal (issue #225). `setupTrackingArea`
+    /// installs the area only while `deckVisible`, so a hidden surface never fires `mouseMoved`/`cursorUpdate`
+    /// — which also silences `applyMouseShape`'s `.set()` (guarded on `pointerInside`, only set from
+    /// `mouseEntered`). Going off-screen clears the state it would otherwise keep (like `mouseExited`).
     func updatePointerTracking() {
         setupTrackingArea()
         guard !deckVisible else { return }
@@ -22,9 +21,7 @@ extension GhosttySurfaceView {
 
     func setupTrackingArea() {
         if let existing = currentTrackingArea { removeTrackingArea(existing); currentTrackingArea = nil }
-        // only the on-screen pane owns the pointer (see `updatePointerTracking`): a hidden deck surface
-        // installs NO tracking area, so its `mouseMoved`/`cursorUpdate` never fire and it can't race to set
-        // the one process-global cursor — the multi-surface flicker of issue #225.
+        // only the on-screen pane owns the pointer — see `updatePointerTracking` (issue #225).
         guard deckVisible else { return }
         let area = NSTrackingArea(
             rect: bounds,

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -9,24 +9,23 @@ import QuartzCore
 /// host-free `Session` can own it without importing GhosttyKit/AppKit.
 ///
 /// `surface` and the `configCStrings` strdup buffers are `nonisolated(unsafe)`: mutated only on the main
-/// actor (create/destroy), and the C callbacks that read them are serialized by libghostty's tick model.
+/// actor (create/destroy), and the C callbacks reading them are serialized by libghostty's tick model.
 final class GhosttySurfaceView: NSView, TerminalSurface {
     nonisolated(unsafe) private(set) var surface: ghostty_surface_t?
 
     private let workingDirectory: String
 
-    /// The command run as the surface's process instead of the login shell, nil for the login shell. A
-    /// creation input read in `createSurface`. The overlay uses it to run one program (e.g. a TUI) whose
-    /// exit closes the overlay.
+    /// The command run as the surface's process instead of the login shell, nil for the login shell; read in
+    /// `createSurface`. The overlay uses it to run one program (e.g. a TUI) whose exit closes the overlay.
     private let command: String?
 
-    /// Text fed to the pty as if typed at startup (libghostty `initial_input`), or nil for none. Used by
-    /// the restore-running-command feature: the captured foreground command line + `\n`, so a restored
-    /// login shell re-runs it and returns to a prompt on exit (UNLIKE `command`, which replaces the shell).
+    /// Text fed to the pty as if typed at startup (libghostty `initial_input`), nil for none.
+    /// Restore-running-command uses it: the captured foreground command line + `\n`, so a restored login
+    /// shell re-runs it and returns to a prompt on exit — UNLIKE `command`, which replaces the shell.
     private let initialInput: String?
 
-    /// Whether, when a `command` exits, libghostty keeps the surface open with its "press any key to
-    /// close" prompt (`true`) instead of closing immediately (`false`). Only meaningful with `command`.
+    /// Whether a `command`'s exit leaves the surface open on libghostty's "press any key to close" prompt
+    /// instead of closing immediately. Only meaningful with `command`.
     private let waitAfterCommand: Bool
 
     /// Whether this surface grabs first responder as soon as it is created — the overlay's path: it mounts
@@ -34,110 +33,98 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     /// window at the first `updateNSView`, which the deferred overlay surface is not, with no later update.
     private let autoFocus: Bool
 
-    /// Initial font size in points, nil for the ghostty config default. A creation input read in
-    /// `createSurface`, which may run after construction, so it is fixed at init. Not `private`: the
-    /// `+Config` extension (owner of `applyOverlayBackgroundColor`) reads it.
+    /// Initial font size in points, nil for the ghostty config default. Read in `createSurface`, which may
+    /// run after construction, so it is fixed at init. Not `private`: the `+Config` extension reads it.
     let initialFontSize: Float?
 
-    /// Extra environment variables (the `AGTERM_*` vars) the spawned shell sees, set into the surface
-    /// config at creation. A creation input (like `workingDirectory`): read in `createSurface`.
+    /// Extra environment variables (the `AGTERM_*` vars) the spawned shell sees; read in `createSurface`.
     let env: [String: String]
 
-    /// The owning model session, `weak` to avoid a retain cycle since `Session.surface` strongly owns this
-    /// view. Set by the app's surface factory after construction.
+    /// The owning model session, `weak` to break the cycle with `Session.surface`. Set by the factory.
     weak var session: Session?
 
-    /// The session whose visual config this surface inherits when it deliberately has no `session`. The
-    /// scratch uses this separate weak link to render the owner's watermark without its OSC title/PWD
-    /// reports mutating the session model. Nil for overlays and quick terminals; main/split use `session`.
+    /// The session whose visual config this surface inherits when it deliberately has no `session`: the scratch
+    /// renders the owner's watermark without its OSC title/PWD reports mutating the session model. Nil for
+    /// overlays and quick terminals; main/split use `session`.
     weak var watermarkSession: Session?
 
-    /// Whether this is the session's split (right) pane rather than the primary. Set by the split factory;
-    /// routes `applyPwd`/`applyTitle` to `session.splitCwd`/`splitTitle` so they can't clobber the
-    /// primary's, and clears back to false when the pane is promoted to primary on collapse.
+    /// Whether this is the session's split (right) pane. Routes `applyPwd`/`applyTitle` to the session's
+    /// `splitCwd`/`splitTitle` so they can't clobber the primary's; cleared when promoted on collapse.
     var isSplitPane = false
 
-    /// Whether the search lifecycle callbacks are wired (the main/split AND scratch factories set it).
-    /// Only these drive a visible bar and the END close path, so `AppActions.toggleSearch` refuses search on
-    /// a quick-terminal/overlay surface, which would enter libghostty search mode with no bar and no close.
+    /// Whether the search lifecycle callbacks are wired (the main/split and scratch factories set it). Only
+    /// those drive a visible bar and the END close path, so `AppActions.toggleSearch` refuses a
+    /// quick-terminal/overlay surface, which would enter libghostty search mode with no bar and no close.
     var isSearchable = false
 
-    /// Called on the main actor when the shell process exits, so the app can close the owning session
-    /// (freeing the surface and dropping the sidebar row). Set by the app's surface factory.
+    /// Called on the main actor when the shell process exits, so the app can close the owning session.
     var onExit: (() -> Void)?
 
     /// For a capturing overlay surface: the temp file the command wrapper writes its exit status to
-    /// (`echo $? > file`), nil for non-capturing surfaces. libghostty's child-exited status reflects the
-    /// login-shell wrapper (always 0), so the real status comes from the wrapper. `destroySurface` (every
-    /// teardown path) reads then deletes it, so its lifetime tracks the surface — no registry or sweep.
+    /// (`echo $? > file`), nil otherwise — libghostty's child-exited status reflects the login-shell wrapper
+    /// (always 0). `destroySurface` reads then deletes it on every teardown path — no registry or sweep.
     var overlayCodeFile: String?
 
-    /// For an OVERLAY surface: its own solid `#rrggbb` background (`session.overlay.open
-    /// --background-color`), nil for the theme background. Set by the overlay factory from
-    /// `Session.overlayBackgroundColor`, applied in `createSurface` — the sessionless overlay is skipped by
-    /// the session-watermark path.
+    /// For an OVERLAY surface: its own solid `#rrggbb` background (`session.overlay.open --background-color`),
+    /// nil for the theme background. Applied in `createSurface`, which the session-watermark path skips
+    /// because the overlay is sessionless.
     var overlayBackgroundColorHex: String?
 
     /// The dynamic background color a program set on THIS surface via OSC 11 (`#rrggbb`), or nil for none.
     /// Rendered per-pane by `applyOSCBackground` (which carries the detail).
     var oscBackgroundColorHex: String?
 
-    /// For a capturing overlay surface: receives the exit status parsed from `overlayCodeFile` on teardown.
-    /// The overlay factory sets it to record onto the session for `session.overlay.result`. Called from
-    /// `destroySurface` (main actor) on every in-process teardown, so capture never depends on `onExit`
-    /// (e.g. an explicit `session.overlay.close`). On a session/window force-close it no-ops — the session
-    /// is already gone and the result unqueryable — while the temp file is deleted regardless.
+    /// For a capturing overlay surface: receives the exit status parsed from `overlayCodeFile`, recorded onto
+    /// the session for `session.overlay.result`. Called from `destroySurface` on every in-process teardown,
+    /// so capture never depends on `onExit` (e.g. an explicit `session.overlay.close`). On a session/window
+    /// force-close it no-ops — the session is gone, the result unqueryable — the file deleted regardless.
     var onExitCodeCaptured: ((Int) -> Void)?
 
     /// Called on the main actor when this surface gains (`true`) or loses (`false`) first responder, so the
-    /// app can track which split pane is active. Set by the factory.
+    /// app can track which split pane is active.
     var onFocusChange: ((Bool) -> Void)?
     /// Rehosting for terminal zoom must update libghostty focus without changing app model state such as
     /// the focused split pane. `TerminalView` flips this while the surface is hosted in the zoom layer.
     var suppressFocusChange = false
     /// Called on the main actor to clear the session's unseen badge + delivered banners WITHOUT the
-    /// `splitFocused` write riding `onFocusChange(true)` — the refocus-clear path for a zoom-hosted
-    /// surface, whose focus report is suppressed though the user is looking at it. Set by the main/split
-    /// factories.
+    /// `splitFocused` write riding `onFocusChange(true)` — the refocus-clear path for a zoom-hosted surface,
+    /// whose focus report is suppressed though the user is looking at it. Set by the main/split factories.
     var onClearUnseen: (() -> Void)?
 
-    /// Called on the main actor on EVERY keystroke into this surface, carrying whether the key interrupts
-    /// the agent (Escape or Ctrl-C). The factory closure decides per pane via
-    /// `AgentIndicator.clearedBy(pane:isInterrupt:)`: clear the glyph to idle only when THIS surface's pane
-    /// owns a clearable status — `blocked`/`completed` on any key, `active` only on an interrupt — so
-    /// foreground typing cannot wipe a background pane's block. Passing the pane rather than reading
-    /// `view.session` lets the scratch surface, which has none, self-clear its own block. Status is
-    /// otherwise control-driven; this is the one input-driven clear, covering the decline case Claude Code
-    /// fires no hook for.
+    /// Called on the main actor on EVERY keystroke into this surface, carrying whether the key interrupts the
+    /// agent (Escape or Ctrl-C). The factory decides per pane via `AgentIndicator.clearedBy(pane:isInterrupt:)`:
+    /// clear the glyph to idle only when THIS surface's pane owns a clearable status — `blocked`/`completed`
+    /// on any key, `active` only on an interrupt — so foreground typing cannot wipe a background pane's block.
+    /// Passing the pane rather than reading `view.session` lets the scratch, which has none, self-clear.
+    /// Status is otherwise control-driven; this is the one input-driven clear, for the decline case Claude
+    /// Code fires no hook for.
     var onUserInputClearsStatus: ((Bool) -> Void)?
 
-    /// Called on the main actor on EVERY keystroke, so the app can stamp user activity and reset the
-    /// window's auto-follow idle timer. Fires unconditionally, unlike `onUserInputClearsStatus` (only on a
-    /// status-clearing key): ordinary typing in an idle session must count as activity or the user is
-    /// yanked to a blocked session mid-type. Set by the factory to call `AppStore.noteUserActivity()`.
+    /// Called on the main actor on EVERY keystroke to stamp user activity and reset the window's auto-follow
+    /// idle timer. Fires unconditionally, unlike `onUserInputClearsStatus`: ordinary typing in an idle
+    /// session must count as activity or the user is yanked to a blocked session mid-type.
     var onUserInput: (() -> Void)?
 
     /// Called on the main actor with the current font size (points) when it changes (cmd +/-), so the app
-    /// can persist it. Factory-set on the primary surface only. libghostty has no font-size getter or
-    /// change event, so it rides the CELL_SIZE action and reads via `ghostty_surface_inherited_config`.
+    /// can persist it. Set on the primary surface only. libghostty has no font-size getter or change event,
+    /// so it rides the CELL_SIZE action and reads via `ghostty_surface_inherited_config`.
     var onFontSizeChange: ((Double) -> Void)?
 
-    /// Called on the main actor when libghostty enters search mode (START_SEARCH) with the current needle
-    /// (nil when none). The main/split factory wires it to toggle the session's search bar: already visible
-    /// → send `end_search` (the ⌘F-again close), else open the bar and seed the needle.
+    /// Called when libghostty enters search mode (START_SEARCH) with the current needle (nil when none). The
+    /// main/split factory toggles the session's search bar: visible → send `end_search` (the ⌘F-again close),
+    /// else open the bar and seed the needle.
     var onSearchStart: ((String?) -> Void)?
 
     /// Called on the main actor when libghostty exits search mode (END_SEARCH). The main/split factory
-    /// wires it to clear the session's search fields, hide the bar, and return first responder to the
-    /// terminal.
+    /// clears the session's search fields, hides the bar, and returns first responder to the terminal.
     var onSearchEnd: (() -> Void)?
 
     /// Called on the main actor with the total match count (SEARCH_TOTAL), nil when libghostty reports a
-    /// negative count (no query). The main/split factory wires it to the session's `searchTotal`.
+    /// negative count (no query). Wired to the session's `searchTotal`.
     var onSearchTotal: ((Int?) -> Void)?
 
     /// Called on the main actor with the 1-based index of the selected match (SEARCH_SELECTED), nil when
-    /// libghostty reports a negative index. The main/split factory wires it to `searchSelected`.
+    /// libghostty reports a negative index. Wired to `searchSelected`.
     var onSearchSelected: ((Int?) -> Void)?
 
     /// Heap buffers backing the surface config's `const char*` fields — notably `initial_input`, which
@@ -146,25 +133,22 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     nonisolated(unsafe) private var configCStrings: [UnsafeMutablePointer<CChar>] = []
 
     /// The `ghostty_env_var_s` structs handed to `config.env_vars`; their `key`/`value` point into the
-    /// `configCStrings` strdup buffers (same lifetime). The array must itself outlive `ghostty_surface_new`,
-    /// so it is a stored property rather than a local, cleared in `destroySurface`/`deinit` with the strdup
-    /// frees. `nonisolated(unsafe)`: mutated only on the main actor (create/destroy).
+    /// `configCStrings` buffers (same lifetime). The array must itself outlive `ghostty_surface_new`, so it is
+    /// stored rather than local, cleared in `destroySurface`/`deinit`. `nonisolated(unsafe)`: main actor only.
     nonisolated(unsafe) private var envVars: [ghostty_env_var_s] = []
 
-    /// Per-surface ghostty configs for this surface's background watermark (`configWithOverlay`), retained
-    /// so they outlive their `ghostty_surface_update_config`. Capped at ONE: each re-apply
-    /// (`set`/`clear`/`config.reload`) frees the prior, since after `update_config` the surface no longer
-    /// references it — so a scripted `config.reload` loop can't grow the array. The last is freed in
-    /// `destroySurface`/`deinit`, safe because the surface (its only consumer) is gone by then (unlike the
-    /// app-wide config `GhosttyApp` never frees). `nonisolated(unsafe)`: mutated only on the main actor. Not
-    /// `private`, so the `+Config` extension (`applyWatermarkFromSession`/`applyOverlayBackgroundColor`) can
-    /// read/write it.
+    /// Per-surface ghostty configs for this surface's background watermark (`configWithOverlay`), retained so
+    /// they outlive their `ghostty_surface_update_config`. Capped at ONE: each re-apply frees the prior, since
+    /// after `update_config` the surface no longer references it, so a scripted `config.reload` loop can't
+    /// grow the array. The last is freed in `destroySurface`/`deinit`, safe because the surface — their only
+    /// consumer — is gone (unlike the app-wide config `GhosttyApp` never frees). `nonisolated(unsafe)`: main
+    /// actor only; internal for `+Config`.
     nonisolated(unsafe) var ownedConfigs: [ghostty_config_t] = []
 
     /// Key-window observers (didBecomeKey/didResignKey). A surface in a background window must report an
     /// unfocused (hollow) cursor, but AppKit first responder is per-window and does NOT resign when a window
-    /// merely loses key, so key changes re-push `liveFocus`. Removed on teardown. `nonisolated(unsafe)`:
-    /// mutated only on the main actor (register/destroy), read in the nonisolated `deinit` safety net.
+    /// merely loses key, so key changes re-push `liveFocus`. Removed on teardown; `nonisolated(unsafe)`
+    /// because the nonisolated `deinit` safety net reads them.
     nonisolated(unsafe) private var focusObservers: [NSObjectProtocol] = []
     private var pendingSurfaceCreation = false
     /// After `destroySurface()` the view is retired: never recreate a surface (a stray viewDidMoveToWindow).
@@ -181,22 +165,19 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     private static let autoFocusMaxAttempts = 40
     private static let autoFocusRetryInterval: TimeInterval = 0.05
 
-    /// Whether this surface's deck slot is the active (selected) session. The overlay/scratch auto-focus
-    /// grabs first responder on attach, so without this gate one opened in a BACKGROUND, non-selected
-    /// session would steal the keyboard from the visible one. `TerminalView` sets it before `createSurface`,
-    /// so `requestAutoFocus` fires only for the active slot and going inactive mid-retry bails the loop.
-    /// Inert for main/split panes: they never auto-focus, taking focus via the active-gated `focusIfNeeded`.
+    /// Whether this surface's deck slot is the active (selected) session. The overlay/scratch auto-focus grabs
+    /// first responder on attach, so without this gate one opened in a BACKGROUND session would steal the
+    /// keyboard from the visible one; `TerminalView` sets it before `createSurface`, and going inactive
+    /// mid-retry bails the loop. Inert for main/split panes, which take focus via `focusIfNeeded`.
     var deckActive = true
 
-    /// Whether this surface's deck slot is on-screen (session selected, not hidden by a full
-    /// overlay/scratch). UNLIKE `deckActive` it is NOT focus-gated, so both panes of a visible split are
-    /// `deckVisible`; `TerminalView` sets it from the deck. Load-bearing for drag-and-drop: every surface is
-    /// eagerly realized, and SwiftUI's `.opacity(0)`/`.allowsHitTesting(false)` on inactive deck panes never
-    /// reach AppKit's drag machinery (the NSView keeps `alphaValue == 1`, and drag-destination resolution
-    /// does NOT consult `hitTest`), so with every surface registered a file drop would land on whichever is
-    /// topmost in z-order — an INVISIBLE background session — not the one under the cursor. `didSet`
-    /// (un)registers the drag types, and (dis)installs the mouse-tracking area for the same reason (see
-    /// `updatePointerTracking`).
+    /// Whether this surface's deck slot is on-screen (session selected, not hidden by a full overlay/scratch).
+    /// UNLIKE `deckActive` it is NOT focus-gated, so both panes of a visible split are `deckVisible`.
+    /// Load-bearing for drag-and-drop: every surface is eagerly realized, and SwiftUI's `.opacity(0)`/
+    /// `.allowsHitTesting(false)` never reach AppKit's drag machinery (the NSView keeps `alphaValue == 1`, and
+    /// drag-destination resolution does NOT consult `hitTest`), so with every surface registered a file drop
+    /// would land on whichever is topmost in z-order — an INVISIBLE background session — not the one under
+    /// the cursor. `didSet` (un)registers the drag types and the mouse-tracking area for the same reason.
     var deckVisible = true {
         didSet {
             // `TerminalView` assigns this on every SwiftUI update pass, so skip the tracking-area teardown/
@@ -208,25 +189,23 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     }
 
     /// View-only mode: rendered but taking NO mouse or keyboard input (the dashboard grid cell). SwiftUI's
-    /// `.allowsHitTesting(false)` does NOT stop AppKit routing a click to this real NSView (AppKit hit
-    /// resolution bypasses SwiftUI, the same reason `deckVisible` gates drag registration), so a click would
-    /// reach `mouseDown`, grab first responder, and steal the keyboard from the dashboard's key-catcher.
-    /// When set, `hitTest` returns nil (clicks fall through to the SwiftUI cell overlay) and the surface
-    /// refuses first responder. `TerminalView` sets it: the dashboard cell on, the deck slot back off, on
-    /// the same reparent.
+    /// `.allowsHitTesting(false)` does NOT stop AppKit routing a click to this real NSView (hit resolution
+    /// bypasses SwiftUI, the same reason `deckVisible` gates drag registration), so a click would reach
+    /// `mouseDown`, grab first responder, and steal the keyboard from the dashboard's key-catcher. When set,
+    /// `hitTest` returns nil and the surface refuses first responder; set on the cell, cleared on the slot.
     var viewOnly = false {
         didSet {
             guard viewOnly, !oldValue else { return }
             // acceptsFirstResponder=false blocks only NEW grabs: a surface carrying first responder in from
-            // the deck (the focused split pane at dashboard open) keeps it across the reparent-within-window
-            // and its keystrokes defeat the key-catcher. resign here; once view-only nothing can re-grab.
+            // the deck (the focused split pane at dashboard open) keeps it across the reparent and defeats
+            // the key-catcher. resign here; once view-only nothing can re-grab.
             if let window, window.firstResponder === self { window.makeFirstResponder(nil) }
         }
     }
 
     /// Register the file/text drag types only while this surface is the on-screen deck pane, so an eagerly
-    /// realized background surface is never a drop target. Called from `deckVisible`'s didSet and once from
-    /// `createSurface` (didSet does not fire for the initializer default).
+    /// realized background surface is never a drop target. Also called once from `createSurface` — `didSet`
+    /// does not fire for the initializer default.
     private func updateDropRegistration() {
         if deckVisible {
             registerForDraggedTypes([.fileURL, .string, .URL])
@@ -235,33 +214,31 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         }
     }
 
-    /// Transient dashboard font size in points overriding `session.fontSize` while this surface is hosted in
-    /// a dashboard grid cell; nil = not overriding. The composer prefers it, `reapplySessionConfigIfNeeded`
+    /// Transient dashboard font size in points overriding `session.fontSize` while this surface is hosted in a
+    /// dashboard grid cell; nil = not overriding. The composer prefers it, `reapplySessionConfigIfNeeded`
     /// re-emits it across a config reload, and `reportFontSize` won't persist it, so a CELL_SIZE round-trip
-    /// can't write the transient size into `session.fontSize`. Writing it re-composes the surface config: a
-    /// value shrinks the cell's font, nil rebuilds from the session model.
+    /// can't write the transient size into `session.fontSize`.
     var dashboardFontOverride: Double? {
         didSet {
-            // keep a live OSC 11 tint across dashboard open/close (applyOSCBackground re-emits it with the dashboard font); else rebuild from the session model.
+            // keep a live OSC 11 tint across dashboard open/close; else rebuild from the session model.
             if let hex = oscBackgroundColorHex { applyOSCBackground(hex) } else { applyWatermarkFromSession() }
             // a SET override can't strand a revert report — reportFontSize's `dashboardFontOverride == nil`
             // guard drops the CELL_SIZE report while the override is active — so drop any pending restore.
             guard dashboardFontOverride == nil, let cleared = oldValue else { pendingFontRestore = nil; return }
-            // CLEARING reverts to session.fontSize (the app default when nil), firing a CELL_SIZE report
-            // ~0.4s LATER (async) — long after any same-runloop latch would clear — and with a nil
-            // session.fontSize persisting it would PIN the session to the default instead of following a
-            // later Settings change. remember the reverted-to size so reportFontSize consumes that report
-            // without persisting, arming only on a real change: an override equal to the target emits no
-            // report and would leak the flag onto a later zoom.
+            // CLEARING reverts to session.fontSize (the app default when nil), firing a CELL_SIZE report ~0.4s
+            // LATER — long after any same-runloop latch would clear — and persisting that would PIN a
+            // nil-fontSize session to the default instead of following a later Settings change. remember the
+            // reverted-to size so reportFontSize consumes that report without persisting; arm only on a real
+            // change, since an override equal to the target emits no report and would leak onto a later zoom.
             let target = session?.fontSize ?? GhosttyApp.shared.baseFontSize
             pendingFontRestore = abs(cleared - target) > 0.5 ? target : nil
         }
     }
 
     /// The font size (points) the surface reverts to when `dashboardFontOverride` is CLEARED — what that
-    /// revert's async CELL_SIZE report carries. Set in the override's `didSet`; `reportFontSize` drops the
-    /// matching report WITHOUT persisting, so restoring the grid font never pins a default-following
-    /// session's `session.fontSize`. State, not a one-runloop latch, so it survives the ~0.4s report gap.
+    /// revert's async CELL_SIZE report carries; `reportFontSize` drops that report WITHOUT persisting, so
+    /// restoring the grid font never pins a default-following session. State, not a one-runloop latch, so it
+    /// survives the ~0.4s report gap.
     private var pendingFontRestore: Double?
 
     // IME composition state shared with GhosttySurfaceView+Input.swift (stored properties can't live in an extension).
@@ -274,10 +251,9 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     // can't live in an extension, so it stays here as internal rather than private).
     var currentTrackingArea: NSTrackingArea?
 
-    /// The mouse-cursor shape libghostty last requested (`GHOSTTY_ACTION_MOUSE_SHAPE`): I-beam over the
-    /// grid, pointing hand over a detected link / OSC-8 hyperlink, resize/crosshair in the matching modes.
-    /// `cursorUpdate` maps it to an `NSCursor`; it defaults to the terminal I-beam so the resting cursor is
-    /// right before the first event. Not `private`, so the `+Input` extension can read it.
+    /// The mouse-cursor shape libghostty last requested (`GHOSTTY_ACTION_MOUSE_SHAPE`): I-beam over the grid,
+    /// pointing hand over a detected link / OSC-8 hyperlink, resize/crosshair in the matching modes.
+    /// `cursorUpdate` maps it to an `NSCursor`; the I-beam default makes the resting cursor right from the start.
     var mouseShape: ghostty_action_mouse_shape_e = GHOSTTY_MOUSE_SHAPE_TEXT
 
     /// Whether the pointer is inside this surface (from `mouseEntered`/`mouseExited`), gating the immediate
@@ -285,9 +261,8 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     var pointerInside = false
 
     /// The last pointer position pushed via `ghostty_surface_mouse_pos` (view-flipped), nil before the first
-    /// report. `scrollWheel` syncs only when the current point differs, so an already-synced scroll doesn't
-    /// re-push the same cell per packet — which in an any-motion + sgr-pixel mouse-reporting TUI emits a
-    /// synthetic motion report per packet. Not `private`, so the `+Input` extension can read/write it.
+    /// report. `scrollWheel` syncs only when the current point differs: re-pushing the same cell per packet
+    /// makes an any-motion + sgr-pixel mouse-reporting TUI emit a synthetic motion report per packet.
     var lastReportedMousePoint: NSPoint?
 
     init(workingDirectory: String, fontSize: Float? = nil, command: String? = nil, initialInput: String? = nil,
@@ -305,10 +280,9 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         observeKeyWindowChanges()
     }
 
-    /// Watch every window's key transitions and re-evaluate focus on each. No need to filter to my own
-    /// window: `updateGhosttyFocus` reads `self.window.isKeyWindow`, so each surface reports its OWN state
-    /// (a background window's goes hollow, the new key window's active one solid) and this survives a
-    /// re-host into another window.
+    /// Watch every window's key transitions and re-evaluate focus on each. No filtering to my own window:
+    /// `updateGhosttyFocus` reads `self.window.isKeyWindow`, so each surface reports its OWN state (a
+    /// background window's goes hollow, the new key window's active one solid) and this survives a re-host.
     private func observeKeyWindowChanges() {
         let center = NotificationCenter.default
         for name in [NSWindow.didBecomeKeyNotification, NSWindow.didResignKeyNotification] {
@@ -317,10 +291,9 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
                 MainActor.assumeIsolated {
                     guard let self else { return }
                     self.updateGhosttyFocus()
-                    // returning focus to agterm (cmd-tab or a reactivating click) while this pane is on
-                    // screen counts as seeing the session, so clear its unseen badge. becomeFirstResponder
-                    // can't: AppKit's per-window first responder never resigned while agterm was
-                    // backgrounded, so no focus transition fires on return and the badge sticks.
+                    // returning focus to agterm while this pane is on screen counts as seeing the session, so
+                    // clear its unseen badge. becomeFirstResponder can't: AppKit's per-window first responder
+                    // never resigned while agterm was backgrounded, so no focus transition fires on return.
                     if becameKey {
                         self.reassertCursorOnActivation()
                         self.clearUnseenOnRefocus()
@@ -331,16 +304,14 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         }
     }
 
-    /// Clear the seen state (unseen badge + delivered banners) for this pane's session when agterm regains
-    /// key focus on it — the inverse of notification suppression, which drops a banner only when the firing
-    /// pane is the key window's first responder AND the app is active. `liveFocus` encodes both (a window is
-    /// key only while the app is active), so this fires solely for the focused pane of the now-key window,
-    /// never a background one. Reusing `onFocusChange` clears exactly for the main/split panes that already
-    /// clear on a focus transition (a scratch/overlay has neither), and no-ops after teardown once the
-    /// closure is nil'd. `suppressFocusChange` is honored as at the first-responder call sites: a zoom-hosted
-    /// surface is first responder of the key window, so `onFocusChange?(true)` would mutate `splitFocused` on
-    /// every key regain — the write the zoom host suppresses elsewhere. The badge must still clear (the user
-    /// is looking at exactly this surface), so that branch takes the focus-free `onClearUnseen`.
+    /// Clear the seen state (unseen badge + delivered banners) for this pane's session when agterm regains key
+    /// focus on it. `liveFocus` (first responder of a key window, and a window is key only while the app is
+    /// active) confines it to the focused pane of the now-key window, never a background one. Reusing
+    /// `onFocusChange` clears exactly for the main/split panes that already clear on a focus transition (a
+    /// scratch/overlay has neither), and no-ops after teardown once the closure is nil'd. Under
+    /// `suppressFocusChange` a zoom-hosted surface IS the key window's first responder, so `onFocusChange`
+    /// would mutate `splitFocused` on every key regain — take the focus-free `onClearUnseen`, since the badge
+    /// must still clear.
     private func clearUnseenOnRefocus() {
         guard liveFocus else { return }
         if suppressFocusChange {
@@ -350,19 +321,19 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         }
     }
 
-    /// The cursor-focus state to report to libghostty: solid only when this surface is the first responder
-    /// of its window AND that window is key. The key-window gate is what stops every window's active surface
-    /// from blinking at once. Reading the live responder (not a cached flag) also means a re-hosted pane
-    /// reports its true focus, so opening a split can't leave both panes solid.
+    /// The cursor-focus state to report to libghostty: solid only when this surface is its window's first
+    /// responder AND that window is key — the key gate stops every window's active surface blinking at once.
+    /// Reading the live responder rather than a cached flag keeps a re-hosted pane's focus true, so opening
+    /// a split can't leave both panes solid.
     private var liveFocus: Bool {
         guard let window else { return false }
         return window.isKeyWindow && window.firstResponder === self
     }
 
-    /// Push `liveFocus` to libghostty (no-op before the surface exists; `createSurface` calls this once the
-    /// surface is up). Used on window-key changes, surface (re)attach, and the auto-focus/reparent grabs.
-    /// First-responder transitions push directly, because the live `window.firstResponder` is not yet
-    /// updated to self inside `becomeFirstResponder`/`resignFirstResponder`.
+    /// Push `liveFocus` to libghostty (no-op before the surface exists; `createSurface` calls it once the
+    /// surface is up). Used on window-key changes, surface (re)attach, and the auto-focus/reparent grabs;
+    /// first-responder transitions push directly, since `window.firstResponder` is not yet self inside
+    /// `becomeFirstResponder`/`resignFirstResponder`.
     func updateGhosttyFocus() {
         guard let surface else { return }
         ghostty_surface_set_focus(surface, liveFocus)
@@ -374,14 +345,12 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     }
 
     deinit {
-        // free directly, not via destroySurface(): deinit is nonisolated and can't call the @MainActor
-        // method, while surface/configCStrings are nonisolated(unsafe) and freed with C calls. normal
-        // teardown goes through destroySurface() on the main actor; this is the net for a dropped view.
+        // free directly, not via destroySurface(): deinit is nonisolated and can't call the @MainActor method,
+        // while the nonisolated(unsafe) fields free with plain C calls. the net for a view dropped untorn.
         focusObservers.forEach { NotificationCenter.default.removeObserver($0) }
         if let surface { ghostty_surface_free(surface) }
         configCStrings.forEach { free($0) }
         envVars = []
-        // free the retained per-surface watermark configs (safe now the surface is gone — see ownedConfigs).
         ownedConfigs.forEach { ghostty_config_free($0) }
         ownedConfigs = []
         if let f = overlayCodeFile { try? FileManager.default.removeItem(atPath: f) }
@@ -390,16 +359,15 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     // MARK: - Callback entry points
 
     func applyPwd(_ rawPwd: String) {
-        // already on the main actor (the callback hops via DispatchQueue.main.async); `currentCwd` is
-        // observed, so the sidebar row refreshes live. strip control characters from the OSC 7 value: it
-        // flows unquoted into a /bin/sh -c line via {AGT_SESSION_PWD} and into every cwd-inheriting spawn
-        // (split/overlay/restore), so a newline (an sh -c separator) must never survive; a real path has none.
+        // already on the main actor (the callback hops via DispatchQueue.main.async); `currentCwd` is observed,
+        // so the sidebar row refreshes live. the OSC 7 value flows unquoted into a /bin/sh -c line via
+        // {AGT_SESSION_PWD} and into every cwd-inheriting spawn, so a newline (an sh -c separator) must never
+        // survive; a real path has none.
         let pwd = TerminalText.sanitized(rawPwd)
 
-        // deliberately no save(): OSC 7 fires on every cd/prompt redraw and would thrash the disk. live cwd
-        // is persisted on quit and on structural mutations (add/close/move/rename/select), so a
-        // crash/force-quit loses only cwd changes since the last save. the equality guard covers the same
-        // re-emit: an equal write would still notify @Observable observers and churn the sidebar reconcile.
+        // no save(): OSC 7 fires on every cd/prompt redraw and would thrash the disk. live cwd is persisted on
+        // quit and on structural mutations, so a crash loses only cwd changes since the last save. the
+        // equality guard matters likewise: an equal write still notifies observers and churns the reconcile.
         if isSplitPane {
             if session?.splitCwd != pwd { session?.splitCwd = pwd }
         } else {
@@ -408,14 +376,11 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     }
 
     func applyTitle(_ rawTitle: String) {
-        // already on the main actor (the callback hops via DispatchQueue.main.async). `oscTitle`/`splitTitle`
-        // are observed, so the sidebar row and window title refresh live; like applyPwd this does NOT save()
-        // — OSC set-title re-fires on every prompt redraw. strip control characters from the OSC 0/1/2
-        // title: it flows unquoted into a /bin/sh -c line via {AGT_SESSION_NAME}, so a newline (an sh -c
-        // separator) must never survive; a real title has none.
+        // already on the main actor; `oscTitle`/`splitTitle` are observed, so the sidebar row and window
+        // title refresh live. like applyPwd this does NOT save() — OSC set-title re-fires on every prompt
+        // redraw — and sanitizes: the title flows unquoted into a /bin/sh -c line via {AGT_SESSION_NAME}.
         let title = TerminalText.sanitized(rawTitle)
 
-        // guard on a real value change so an equal re-emit doesn't notify observers and churn the sidebar.
         if isSplitPane {
             if session?.splitTitle != title { session?.splitTitle = title }
         } else {
@@ -424,8 +389,7 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     }
 
     func handleProcessExit() {
-        // already on the main actor (the close callbacks hop via DispatchQueue.main.async). asks the app to
-        // close the owning session/overlay, tearing down this surface and its sidebar row. idempotent: the
+        // already on the main actor (the close callbacks hop via DispatchQueue.main.async). idempotent: the
         // SHOW_CHILD_EXITED action and close_surface_cb can both fire for one exit.
         guard !didHandleProcessExit else { return }
         didHandleProcessExit = true
@@ -434,19 +398,18 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
 
     /// Whether a child-exit should close this surface immediately, suppressing ghostty's "press any key"
     /// prompt. True only for a command surface (the overlay) that did NOT opt into the wait prompt, which
-    /// keeps the prompt and closes via `close_surface_cb` after the keypress. `nonisolated` so the C action
-    /// callback reads it with no main-actor hop — both backing fields are `let`s set in `init`.
+    /// instead closes via `close_surface_cb` after the keypress. `nonisolated` so the C action callback reads
+    /// it with no main-actor hop — both backing fields are `let`s.
     nonisolated var shouldCloseOnChildExitAction: Bool { command != nil && !waitAfterCommand }
 
     func reportFontSize() {
-        // already on the main actor (the CELL_SIZE callback hops via DispatchQueue.main.async). don't
-        // persist under a dashboard override — it would write the transient size into session.fontSize.
+        // already on the main actor (the CELL_SIZE callback hops). don't persist under a dashboard override —
+        // it would write the transient size into session.fontSize.
         guard dashboardFontOverride == nil else { return }
         // nil means libghostty hasn't resolved a font size yet.
         guard let size = currentFontSize() else { return }
-        // clearing the override reverts the font and fires its own CELL_SIZE report ~0.4s later (see
-        // dashboardFontOverride.didSet): drop the one matching the reverted-to value so a default-following
-        // session isn't pinned, then clear the flag so a later genuine zoom persists.
+        // clearing the override fires its own CELL_SIZE report ~0.4s later (see dashboardFontOverride.didSet):
+        // drop the one matching the reverted-to value, then clear the flag so a later genuine zoom persists.
         if let pending = pendingFontRestore {
             pendingFontRestore = nil
             if abs(size - pending) <= 0.5 { return }
@@ -465,8 +428,7 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     func createSurface() {
         guard !isDestroyed else { return }
         // register as a file drop target (issue #51) only while on-screen, so a background deck surface can't
-        // intercept it (see updateDropRegistration). idempotent across re-entry: createSurface re-runs when a
-        // deferred surface finally gets a backing size.
+        // intercept it. idempotent: createSurface re-runs when a deferred surface finally gets a size.
         updateDropRegistration()
         guard surface == nil, let app = GhosttyApp.shared.app else { return }
         let backingSize = convertToBacking(bounds).size
@@ -483,16 +445,16 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         config.scale_factor = Double(window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2.0)
 
         // the strdup'd working_directory buffer must outlive the call: retained on the instance, freed in
-        // destroySurface (the same contract initial_input needs later).
+        // destroySurface (the same contract initial_input needs below).
         configCStrings.forEach { free($0) }
         configCStrings = []
         if let p = strdup(workingDirectory) {
             configCStrings.append(p)
             config.working_directory = UnsafePointer(p)
         }
-        // a command runs as the surface's process (the overlay's one program) instead of the login shell;
-        // its strdup'd buffer joins the `configCStrings` lifetime. wait_after_command keeps the surface on
-        // the "press any key" prompt at exit; default false, so the overlay vanishes immediately (API opt-in).
+        // a command replaces the login shell (the overlay's one program); its strdup'd buffer joins the
+        // `configCStrings` lifetime. wait_after_command keeps the "press any key" prompt at exit, opt-in, so
+        // by default the overlay vanishes immediately.
         if let command, let p = strdup(command) {
             configCStrings.append(p)
             config.command = UnsafePointer(p)
@@ -500,20 +462,18 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         } else {
             config.command = nil // login shell
         }
-        // restore-running-command: feed the captured command line to the login shell as if typed, so it
-        // re-runs and exits back to a prompt. same strdup'd-buffer lifetime; mutually exclusive with
-        // `command` (which REPLACES the shell), enforced here rather than by caller discipline alone.
+        // restore-running-command: feed the captured command line to the login shell as if typed, so it re-runs
+        // and exits back to a prompt. same buffer lifetime; mutually exclusive with `command` (which REPLACES
+        // the shell), enforced here rather than by caller discipline alone.
         if command == nil, let initialInput, let p = strdup(initialInput) {
             configCStrings.append(p)
             config.initial_input = UnsafePointer(p)
         }
-        // a persisted/restored size overrides the config default; nil leaves
-        // config_new's default (the ghostty config font-size) in place.
+        // a persisted/restored size overrides config_new's default (the ghostty config font-size).
         if let initialFontSize { config.font_size = initialFontSize }
 
-        // extra environment for the spawned shell (the AGTERM_* vars). each key/value is strdup'd into the
-        // `configCStrings` lifetime; the `ghostty_env_var_s` structs pointing at them are retained in
-        // `envVars` (a value type, so it can't live in `configCStrings`).
+        // extra environment for the spawned shell. each key/value is strdup'd into the `configCStrings`
+        // lifetime; the structs pointing at them are retained in `envVars` — value types, so not strdup'able.
         envVars = []
         for (key, value) in env {
             guard let keyPtr = strdup(key), let valuePtr = strdup(value) else { continue }
@@ -521,17 +481,15 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
             configCStrings.append(valuePtr)
             envVars.append(ghostty_env_var_s(key: UnsafePointer(keyPtr), value: UnsafePointer(valuePtr)))
         }
-        // set the app color scheme BEFORE creating the surface: `ghostty_surface_new` derives the initial
-        // theme from the app's conditional state, so a dual `theme = light:,dark:` renders the right side
-        // from the FIRST frame instead of defaulting to light until a later reload. read the APP-level side
-        // (`currentIsDark()` = `NSApp.effectiveAppearance`, the single source the KVO observer feeds), not
-        // this view's own `effectiveAppearance`. `set_color_scheme` records it, early-returning if unchanged.
+        // set the app color scheme BEFORE creating the surface: `ghostty_surface_new` derives the initial theme
+        // from the app's conditional state, so a dual `theme = light:,dark:` renders the right side from the
+        // FIRST frame instead of defaulting to light until a later reload. read the APP-level `currentIsDark()`
+        // (`NSApp.effectiveAppearance`, the single source the KVO observer feeds), not this view's own.
         let isDark = GhosttyApp.currentIsDark()
         ghostty_app_set_color_scheme(app, isDark ? GHOSTTY_COLOR_SCHEME_DARK : GHOSTTY_COLOR_SCHEME_LIGHT)
 
-        // create with `config.env_vars` pointing at the retained `envVars`. the pointer is taken inside
-        // `withUnsafeMutableBufferPointer` and `ghostty_surface_new` runs in the same closure, so it never
-        // escapes the call (no UB); ghostty copies the env at creation. no-env surfaces take the plain path.
+        // the env pointer is taken inside `withUnsafeMutableBufferPointer` and `ghostty_surface_new` runs in
+        // the same closure, so it never escapes the call (no UB); ghostty copies the env at creation.
         if envVars.isEmpty {
             surface = ghostty_surface_new(app, &config)
         } else {
@@ -552,22 +510,20 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         }
         updateGhosttyFocus()
 
-        // a session carrying a background watermark (set on a never-shown session, or restored from a
-        // snapshot) applies it now the surface exists — covering deferred-size creation, the eager deck, and
-        // relaunch. the scratch inherits via `watermarkSession`; sessionless overlay/quick surfaces skip it.
-        // ALSO re-applies a standalone `dashboardFontOverride` (a member realizing AFTER the dashboard set
-        // the transient font), since `applyWatermarkFromSession` honors `dashboardFontOverride ??
-        // session.fontSize` — else the late cell renders at the default font. mirrors
-        // `reapplySessionConfigIfNeeded`.
+        // a session carrying a background watermark (never shown, or restored from a snapshot) applies it now
+        // the surface exists — deferred-size creation, the eager deck, relaunch; the scratch inherits via
+        // `watermarkSession`, sessionless overlay/quick skip it. ALSO re-applies a standalone
+        // `dashboardFontOverride` for a member realizing AFTER the dashboard set the transient font, since
+        // `applyWatermarkFromSession` honors `dashboardFontOverride ?? session.fontSize`.
         if (session ?? watermarkSession)?.backgroundWatermark != nil || dashboardFontOverride != nil {
             applyWatermarkFromSession()
         }
-        // an overlay surface with its own background color (session.overlay.open --background-color) applies
-        // it here too — the overlay is sessionless, so the watermark path above skips it.
+        // an overlay surface with its own background color applies it here too — the overlay is sessionless,
+        // so the watermark path above skips it.
         if overlayBackgroundColorHex != nil { applyOverlayBackgroundColor() }
 
-        // the overlay grabs first responder itself (TerminalView's once-on-attach grab misses the
-        // deferred overlay surface); a bounded run-loop retry beats the SwiftUI/AppKit responder race.
+        // the overlay grabs first responder itself (TerminalView's once-on-attach grab misses the deferred
+        // overlay surface); a bounded run-loop retry beats the SwiftUI/AppKit responder race.
         requestAutoFocus(in: window)
     }
 
@@ -585,9 +541,9 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         restoreAutoFocus(in: window, attempt: 0)
     }
 
-    /// Retries `makeFirstResponder` on the run loop until this view is in `window` with a surface and
-    /// actually holds first responder, then marks it focused. Bounded so it never spins forever; gives
-    /// up if the view is torn down or moved windows. macterm's FocusRestoration pattern.
+    /// Retries `makeFirstResponder` on the run loop until this view is in `window`, has a surface and holds
+    /// first responder, then marks it focused. Bounded; gives up if the view is torn down or moved windows
+    /// (macterm's FocusRestoration pattern).
     private func restoreAutoFocus(in window: NSWindow, attempt: Int) {
         guard autoFocus, deckActive, !didAutoFocus, !isDestroyed, !Self.pickOwnsFocus(in: window) else {
             autoFocusInFlight = false
@@ -611,11 +567,10 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
 
     private var reparentFocusInFlight = false
 
-    /// Grabs first responder with a bounded run-loop retry for the pane that became the maximized survivor
-    /// of a sibling close: the collapse re-hosts this view (HSplitView → standalone) and one
-    /// `makeFirstResponder` loses that race, so retry until it is in a window, has a surface, and holds first
-    /// responder. Unlike the overlay's auto-focus, no `autoFocus` gate and no `didAutoFocus` latch, so it can
-    /// run again on a later collapse.
+    /// Grabs first responder with a bounded run-loop retry for the pane left as the maximized survivor of a
+    /// sibling close: the collapse re-hosts this view (HSplitView → standalone) and one `makeFirstResponder`
+    /// loses that race. Unlike the overlay's auto-focus there is no `autoFocus` gate and no `didAutoFocus`
+    /// latch, so it runs again on a later collapse.
     func focusAfterReparent() {
         guard !isDestroyed, !reparentFocusInFlight else { return }
         reparentFocusInFlight = true
@@ -633,9 +588,8 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
             holds = window.firstResponder === self
             if holds { notifySurfaceFocused() }
         }
-        // the collapse re-hosts this view a tick or two AFTER focus is first requested, and that resigns
-        // the grab. So don't stop on the first success — keep re-grabbing until focus has STUCK for a few
-        // consecutive ticks (past the re-host), or the attempt budget runs out.
+        // the collapse re-hosts this view a tick or two AFTER focus is first requested, which resigns the grab
+        // — re-grab until focus STICKS for a few consecutive ticks (past the re-host) or the budget runs out.
         let nextHeld = holds ? heldFor + 1 : 0
         guard nextHeld < 3, attempt < Self.autoFocusMaxAttempts else { reparentFocusInFlight = false; return }
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.autoFocusRetryInterval) { [weak self] in
@@ -643,9 +597,9 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         }
     }
 
-    /// A picker is modal to terminal keyboard focus in its own window. This check deliberately lives inside
-    /// both retry loops (not just their callers): a picker can open after a retry starts, and the next tick
-    /// must stop before it steals first responder from the picker field.
+    /// A picker is modal to terminal keyboard focus in its own window. The check lives inside both retry loops,
+    /// not just their callers: a picker can open after a retry starts, and the next tick must stop before it
+    /// steals first responder from the picker field.
     static func pickOwnsFocus(in window: NSWindow?) -> Bool {
         guard let window, let windowID = WindowRegistry.shared.windowID(for: window) else { return false }
         return PickRegistry.shared.controller(for: windowID)?.pending != nil
@@ -664,8 +618,8 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         // free the retained per-surface watermark configs — the surface (their only consumer) is gone.
         ownedConfigs.forEach { ghostty_config_free($0) }
         ownedConfigs = []
-        // read the wrapper-captured exit status, hand it off, then delete the temp file so its lifetime
-        // tracks the surface. runs on every in-process teardown (natural exit, explicit close, force-close).
+        // read the wrapper-captured exit status, hand it off, then delete the temp file. runs on every
+        // in-process teardown: natural exit, explicit close, force-close.
         if let f = overlayCodeFile {
             if let text = try? String(contentsOfFile: f, encoding: .utf8),
                let code = OverlayCapture.parseExitCode(text) {
@@ -677,8 +631,8 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
             overlayCodeFile = nil
         }
         // nil the store-capturing callbacks last to break the store -> session -> surface -> closure -> store
-        // retain cycle on every close path. MUST stay after the onExitCodeCaptured?(code) call above; niling
-        // it earlier would silently drop the overlay exit status. no libghostty callback fires once freed.
+        // retain cycle. MUST stay after the onExitCodeCaptured?(code) call above, which niling earlier would
+        // silently drop. no libghostty callback fires once the surface is freed.
         onExit = nil
         onExitCodeCaptured = nil
         onFocusChange = nil
@@ -714,9 +668,8 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
             updateGhosttyFocus()
         }
         updateMetalLayerSize()
-        // Focus is driven by TerminalView.updateNSView when this surface becomes the active session's
-        // detail view, so it isn't grabbed here — except an auto-focus (overlay) surface, which drives
-        // its own bounded retry since the representable's once-on-attach grab misses the deferred surface.
+        // focus is driven by TerminalView.updateNSView when this surface becomes the active session's detail
+        // view; only an auto-focus (overlay) surface grabs here, since that grab misses a deferred surface.
         requestAutoFocus(in: window)
     }
 
@@ -731,13 +684,11 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         updateMetalLayerSize()
     }
 
-    /// Record this surface's light/dark scheme from the authoritative `isDark` (the app-level side the caller
-    /// resolved from `NSApp.effectiveAppearance`), so the NEXT `update_config` re-resolves a dual
-    /// `theme = light:,dark:` to the matching side. libghostty takes the active side from the surface's
-    /// RECORDED conditional state at `update_config` time, not from the config file alone, so a surface whose
-    /// state lagged (created before its window's appearance resolved) would re-derive the WRONG side. Cheap
-    /// to re-assert before each reload — `set_color_scheme` early-returns when unchanged. The caller
-    /// (`GhosttyApp.reloadConfig`) sets the APP-level scheme, so this touches only the surface.
+    /// Record this surface's light/dark scheme from the authoritative app-level `isDark`
+    /// (`NSApp.effectiveAppearance`), so the NEXT `update_config` re-resolves a dual `theme = light:,dark:` to
+    /// the matching side: libghostty takes the active side from the surface's RECORDED conditional state, not
+    /// the config file alone, so a surface created before its window's appearance resolved re-derives the
+    /// WRONG side. Cheap to re-assert (`set_color_scheme` early-returns unchanged); the caller sets the APP side.
     func syncColorScheme(isDark: Bool) {
         guard let surface else { return }
         ghostty_surface_set_color_scheme(surface, isDark ? GHOSTTY_COLOR_SCHEME_DARK : GHOSTTY_COLOR_SCHEME_LIGHT)
@@ -756,9 +707,8 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         }
         ghostty_surface_set_content_scale(surface, scale, scale)
         ghostty_surface_set_size(surface, UInt32(scaledSize.width), UInt32(scaledSize.height))
-        // the split-toggle re-parent invalidates the Metal drawable, and neither a same-grid set_size nor the
-        // `ghostty_app_tick` (which draws only dirty surfaces) repaints it — so force one, or the re-hosted
-        // pane stays blank over an intact buffer.
+        // the split re-parent invalidates the Metal drawable, and neither a same-grid set_size nor the tick
+        // (dirty surfaces only) repaints it — force one or the re-hosted pane stays blank over a live buffer.
         ghostty_surface_refresh(surface)
     }
 
@@ -766,20 +716,18 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
 
     override var acceptsFirstResponder: Bool { !viewOnly }
 
-    /// In view-only mode (a dashboard grid cell) refuse hit-testing, so a click passes THROUGH to the SwiftUI
-    /// cell overlay (highlight/enter) instead of reaching `mouseDown` and grabbing first responder. AppKit
-    /// routes clicks to this real NSView regardless of `.allowsHitTesting(false)`, so the block lives here.
+    /// In view-only mode refuse hit-testing, so a click passes THROUGH to the SwiftUI cell overlay instead of
+    /// reaching `mouseDown` — AppKit routes clicks here regardless of `.allowsHitTesting(false)`.
     override func hitTest(_ point: NSPoint) -> NSView? {
         viewOnly ? nil : super.hitTest(point)
     }
 
     /// Deliver the LEFT click that reactivates a background window straight to the surface (a "first mouse")
-    /// rather than letting AppKit swallow it to raise the window: without this, clicking a specific pane of a
-    /// two-pane split from another window raises it but never runs `mouseDown`, so the pane doesn't become
-    /// first responder and `splitFocused` stays on the previously-focused one. The click then behaves like
-    /// any in-window one — selects the pane AND is reported to the program — as in Terminal.app/iTerm2/Ghostty.
-    /// Gated to `.leftMouseDown`: a first-mouse right/middle click would reach
-    /// `rightMouseDown`/`otherMouseDown`, which forward to libghostty, and with the default
+    /// instead of letting AppKit swallow it to raise the window: otherwise clicking a pane of a two-pane split
+    /// from another window raises it but never runs `mouseDown`, leaving `splitFocused` on the previous pane.
+    /// The click then behaves like any in-window one — selects the pane AND is reported to the program — as in
+    /// Terminal.app/iTerm2/Ghostty. Gated to `.leftMouseDown`: a first-mouse right/middle click reaches
+    /// `rightMouseDown`/`otherMouseDown`, which forward to libghostty, where the default
     /// `right-click-action = paste` would paste into a window you only meant to raise.
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
         // with auto-hide-inactive-sidebars on, activating an inactive window expands its hidden sidebar and
@@ -792,9 +740,9 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     override func becomeFirstResponder() -> Bool {
         let result = super.becomeFirstResponder()
         if result, let surface {
-            // report focused, gated on the window being key (a background window's surface stays hollow).
-            // push directly: `window.firstResponder` is not yet self inside this call, so `liveFocus` reads
-            // stale. onFocusChange (split-pane tracking) is independent of key state.
+            // report focused, gated on the window being key (a background window's surface stays hollow). push
+            // directly: `window.firstResponder` is not yet self inside this call, so `liveFocus` reads stale.
+            // onFocusChange (split-pane tracking) is independent of key state.
             ghostty_surface_set_focus(surface, window?.isKeyWindow ?? false)
             if !suppressFocusChange { onFocusChange?(true) }
         }

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -5,21 +5,19 @@ import AppKit
 import GhosttyKit
 import QuartzCore
 
-/// A Metal-backed NSView hosting one libghostty surface (one shell). Conforms to
-/// `TerminalSurface` so the host-free `Session` can own it without importing
-/// GhosttyKit/AppKit.
+/// A Metal-backed NSView hosting one libghostty surface (one shell). Conforms to `TerminalSurface` so the
+/// host-free `Session` can own it without importing GhosttyKit/AppKit.
 ///
-/// `surface` and the `configCStrings` strdup buffers are `nonisolated(unsafe)`:
-/// they are mutated only on the main actor (create/destroy) and the C callbacks
-/// that read them are serialized by libghostty's tick model.
+/// `surface` and the `configCStrings` strdup buffers are `nonisolated(unsafe)`: mutated only on the main
+/// actor (create/destroy), and the C callbacks that read them are serialized by libghostty's tick model.
 final class GhosttySurfaceView: NSView, TerminalSurface {
     nonisolated(unsafe) private(set) var surface: ghostty_surface_t?
 
     private let workingDirectory: String
 
-    /// The command the surface runs as its process instead of the login shell, or nil for the login
-    /// shell. A creation input (like `workingDirectory`): read in `createSurface`. Used by the overlay
-    /// surface to run one program (e.g. a TUI) whose exit closes the overlay.
+    /// The command run as the surface's process instead of the login shell, nil for the login shell. A
+    /// creation input read in `createSurface`. The overlay uses it to run one program (e.g. a TUI) whose
+    /// exit closes the overlay.
     private let command: String?
 
     /// Text fed to the pty as if typed at startup (libghostty `initial_input`), or nil for none. Used by
@@ -31,164 +29,145 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     /// close" prompt (`true`) instead of closing immediately (`false`). Only meaningful with `command`.
     private let waitAfterCommand: Bool
 
-    /// Whether this surface grabs first responder as soon as it is created. The overlay needs it: it is
-    /// added on top of an already-focused session, and `TerminalView.focusIfNeeded` only grabs focus if
-    /// the view is in a window at the first `updateNSView` — which the deferred overlay surface is not,
-    /// and no later update fires. So the overlay focuses itself once its surface exists (in a window).
+    /// Whether this surface grabs first responder as soon as it is created — the overlay's path: it mounts
+    /// over an already-focused session, and `TerminalView.focusIfNeeded` grabs only when the view is in a
+    /// window at the first `updateNSView`, which the deferred overlay surface is not, with no later update.
     private let autoFocus: Bool
 
-    /// The initial font size in points to create the surface with, or nil to use the
-    /// ghostty config default. A creation input (like `workingDirectory`): read in
-    /// `createSurface`, which may run after construction, so it's fixed at init. Not `private` so the
-    /// `+Config` extension (which owns `applyOverlayBackgroundColor`) can read it.
+    /// Initial font size in points, nil for the ghostty config default. A creation input read in
+    /// `createSurface`, which may run after construction, so it is fixed at init. Not `private`: the
+    /// `+Config` extension (owner of `applyOverlayBackgroundColor`) reads it.
     let initialFontSize: Float?
 
     /// Extra environment variables (the `AGTERM_*` vars) the spawned shell sees, set into the surface
     /// config at creation. A creation input (like `workingDirectory`): read in `createSurface`.
     let env: [String: String]
 
-    /// The owning model session. `weak` to avoid a retain cycle: the `Session`
-    /// strongly owns this surface via `Session.surface`. Set by the app's surface
-    /// factory after construction.
+    /// The owning model session, `weak` to avoid a retain cycle since `Session.surface` strongly owns this
+    /// view. Set by the app's surface factory after construction.
     weak var session: Session?
 
-    /// The session whose per-session visual config this surface inherits when it deliberately has no
-    /// `session`. Scratch surfaces use this separate weak link so they can render the owning session's
-    /// watermark without letting their OSC title/PWD reports mutate the session model. Nil for overlays
-    /// and quick terminals; main/split surfaces use `session` directly.
+    /// The session whose visual config this surface inherits when it deliberately has no `session`. The
+    /// scratch uses this separate weak link to render the owner's watermark without its OSC title/PWD
+    /// reports mutating the session model. Nil for overlays and quick terminals; main/split use `session`.
     weak var watermarkSession: Session?
 
-    /// Whether this surface is the session's split (right) pane rather than the primary. Set by the
-    /// split factory; routes `applyPwd`/`applyTitle` to `session.splitCwd`/`splitTitle` so the split
-    /// pane's reports don't clobber the primary's, and clears back to false when the pane is promoted
-    /// to primary on collapse.
+    /// Whether this is the session's split (right) pane rather than the primary. Set by the split factory;
+    /// routes `applyPwd`/`applyTitle` to `session.splitCwd`/`splitTitle` so they can't clobber the
+    /// primary's, and clears back to false when the pane is promoted to primary on collapse.
     var isSplitPane = false
 
-    /// Whether this surface has the search lifecycle callbacks wired (the main/split AND scratch factories
-    /// set it). Only these surfaces drive a visible bar and the END close path, so `AppActions.toggleSearch`
-    /// refuses to start search on a quick-terminal/overlay surface that lacks them (which would otherwise
-    /// enter libghostty search mode with no bar and no way to close).
+    /// Whether the search lifecycle callbacks are wired (the main/split AND scratch factories set it).
+    /// Only these drive a visible bar and the END close path, so `AppActions.toggleSearch` refuses search on
+    /// a quick-terminal/overlay surface, which would enter libghostty search mode with no bar and no close.
     var isSearchable = false
 
-    /// Called on the main actor when the shell process exits, so the app can
-    /// close the owning session (free the surface and drop the sidebar row). Set
-    /// by the app's surface factory.
+    /// Called on the main actor when the shell process exits, so the app can close the owning session
+    /// (freeing the surface and dropping the sidebar row). Set by the app's surface factory.
     var onExit: (() -> Void)?
 
     /// For a capturing overlay surface: the temp file the command wrapper writes its exit status to
-    /// (`echo $? > file`). libghostty's child-exited status reflects the login-shell wrapper (always 0),
-    /// so the real command status is captured via the wrapper instead. Read in `destroySurface` (every
-    /// teardown path) and then deleted, so the file's lifetime tracks the surface — no registry or sweep.
-    /// nil for non-capturing surfaces.
+    /// (`echo $? > file`), nil for non-capturing surfaces. libghostty's child-exited status reflects the
+    /// login-shell wrapper (always 0), so the real status comes from the wrapper. `destroySurface` (every
+    /// teardown path) reads then deletes it, so its lifetime tracks the surface — no registry or sweep.
     var overlayCodeFile: String?
 
-    /// For an OVERLAY surface: its own solid background color as `#rrggbb` (`session.overlay.open
-    /// --background-color`), or nil for the default theme background. Applied in `createSurface` once the
-    /// surface exists — the overlay carries no `session`, so the session-watermark path skips it. Set by
-    /// the overlay factory from `Session.overlayBackgroundColor`.
+    /// For an OVERLAY surface: its own solid `#rrggbb` background (`session.overlay.open
+    /// --background-color`), nil for the theme background. Set by the overlay factory from
+    /// `Session.overlayBackgroundColor`, applied in `createSurface` — the sessionless overlay is skipped by
+    /// the session-watermark path.
     var overlayBackgroundColorHex: String?
 
     /// The dynamic background color a program set on THIS surface via OSC 11 (`#rrggbb`), or nil for none.
     /// Rendered per-pane by `applyOSCBackground` (which carries the detail).
     var oscBackgroundColorHex: String?
 
-    /// For a capturing overlay surface: receives the parsed exit status read from `overlayCodeFile` on
-    /// teardown. Set by the overlay factory to record it onto the session for `session.overlay.result`.
-    /// Called from `destroySurface` (main actor) on every in-process teardown, so the status is captured
-    /// without depending on `onExit` (e.g. an explicit `session.overlay.close`). For a session/window
-    /// force-close the recording no-ops (the session is already gone), but the result is then unqueryable
-    /// anyway; the temp file is deleted regardless.
+    /// For a capturing overlay surface: receives the exit status parsed from `overlayCodeFile` on teardown.
+    /// The overlay factory sets it to record onto the session for `session.overlay.result`. Called from
+    /// `destroySurface` (main actor) on every in-process teardown, so capture never depends on `onExit`
+    /// (e.g. an explicit `session.overlay.close`). On a session/window force-close it no-ops — the session
+    /// is already gone and the result unqueryable — while the temp file is deleted regardless.
     var onExitCodeCaptured: ((Int) -> Void)?
 
-    /// Called on the main actor when this surface gains (`true`) or loses (`false`) first
-    /// responder, so the app can track which split pane is active. Set by the factory.
+    /// Called on the main actor when this surface gains (`true`) or loses (`false`) first responder, so the
+    /// app can track which split pane is active. Set by the factory.
     var onFocusChange: ((Bool) -> Void)?
     /// Rehosting for terminal zoom must update libghostty focus without changing app model state such as
     /// the focused split pane. `TerminalView` flips this while the surface is hosted in the zoom layer.
     var suppressFocusChange = false
     /// Called on the main actor to clear the session's unseen badge + delivered banners WITHOUT the
-    /// `splitFocused` write that rides `onFocusChange(true)` — the refocus-clear path for a zoom-hosted
-    /// surface, where the focus report is suppressed but the user is demonstrably looking at the session.
-    /// Set by the main/split factories alongside `onFocusChange`.
+    /// `splitFocused` write riding `onFocusChange(true)` — the refocus-clear path for a zoom-hosted
+    /// surface, whose focus report is suppressed though the user is looking at it. Set by the main/split
+    /// factories.
     var onClearUnseen: (() -> Void)?
 
     /// Called on the main actor on EVERY keystroke into this surface, carrying whether the key interrupts
-    /// the agent (Escape or Ctrl-C). The factory's closure owns the pane-scoped decision (via
-    /// `AgentIndicator.clearedBy(pane:isInterrupt:)`): it clears the glyph to idle only when THIS surface's
-    /// pane owns a clearable status — `blocked`/`completed` on any key (you've engaged with the prompt /
-    /// finished result), `active` only on an interrupt keystroke. Typing in a foreground pane therefore no
-    /// longer wipes a background pane's block. Passing the pane in the closure (not reading `view.session`)
-    /// is what lets the scratch surface — which has no `view.session` — self-clear its own block. The status
-    /// is otherwise control-driven; this is the one input-driven clear, covering the decline case Claude
-    /// Code fires no hook for.
+    /// the agent (Escape or Ctrl-C). The factory closure decides per pane via
+    /// `AgentIndicator.clearedBy(pane:isInterrupt:)`: clear the glyph to idle only when THIS surface's pane
+    /// owns a clearable status — `blocked`/`completed` on any key, `active` only on an interrupt — so
+    /// foreground typing cannot wipe a background pane's block. Passing the pane rather than reading
+    /// `view.session` lets the scratch surface, which has none, self-clear its own block. Status is
+    /// otherwise control-driven; this is the one input-driven clear, covering the decline case Claude Code
+    /// fires no hook for.
     var onUserInputClearsStatus: ((Bool) -> Void)?
 
-    /// Called on the main actor on EVERY keystroke into this surface, so the app can stamp user activity
-    /// and reset the window's auto-follow idle timer. Unlike `onUserInputClearsStatus` (which fires only on
-    /// a status-clearing key), this fires unconditionally — ordinary typing in an idle session must count as
-    /// activity or the user would be yanked to a blocked session mid-type. Set by the factory to call the
-    /// owning window's `AppStore.noteUserActivity()`.
+    /// Called on the main actor on EVERY keystroke, so the app can stamp user activity and reset the
+    /// window's auto-follow idle timer. Fires unconditionally, unlike `onUserInputClearsStatus` (only on a
+    /// status-clearing key): ordinary typing in an idle session must count as activity or the user is
+    /// yanked to a blocked session mid-type. Set by the factory to call `AppStore.noteUserActivity()`.
     var onUserInput: (() -> Void)?
 
-    /// Called on the main actor with the surface's current font size (points) when it
-    /// changes (cmd +/-), so the app can persist it. Set by the factory on the primary
-    /// surface only. libghostty has no font-size getter or change event, so this is driven
-    /// off the CELL_SIZE action and reads the size via `ghostty_surface_inherited_config`.
+    /// Called on the main actor with the current font size (points) when it changes (cmd +/-), so the app
+    /// can persist it. Factory-set on the primary surface only. libghostty has no font-size getter or
+    /// change event, so it rides the CELL_SIZE action and reads via `ghostty_surface_inherited_config`.
     var onFontSizeChange: ((Double) -> Void)?
 
-    /// Called on the main actor when libghostty enters search mode (START_SEARCH), carrying the current
-    /// needle (nil when none). The factory wires this to toggle the session's search bar — if the bar is
-    /// already visible it sends `end_search` (the ⌘F-again close), else it opens the bar and seeds the
-    /// needle. Set by the main/split surface factory.
+    /// Called on the main actor when libghostty enters search mode (START_SEARCH) with the current needle
+    /// (nil when none). The main/split factory wires it to toggle the session's search bar: already visible
+    /// → send `end_search` (the ⌘F-again close), else open the bar and seed the needle.
     var onSearchStart: ((String?) -> Void)?
 
-    /// Called on the main actor when libghostty exits search mode (END_SEARCH). The factory wires this to
-    /// clear the session's search fields, hide the bar, and return first responder to the terminal. Set by
-    /// the main/split surface factory.
+    /// Called on the main actor when libghostty exits search mode (END_SEARCH). The main/split factory
+    /// wires it to clear the session's search fields, hide the bar, and return first responder to the
+    /// terminal.
     var onSearchEnd: (() -> Void)?
 
-    /// Called on the main actor with the total match count (SEARCH_TOTAL), or nil when libghostty reports a
-    /// negative count (no query). The factory wires this to the session's `searchTotal`. Set by the
-    /// main/split surface factory.
+    /// Called on the main actor with the total match count (SEARCH_TOTAL), nil when libghostty reports a
+    /// negative count (no query). The main/split factory wires it to the session's `searchTotal`.
     var onSearchTotal: ((Int?) -> Void)?
 
-    /// Called on the main actor with the 1-based index of the selected match (SEARCH_SELECTED), or nil when
-    /// libghostty reports a negative index. The factory wires this to the session's `searchSelected`. Set by
-    /// the main/split surface factory.
+    /// Called on the main actor with the 1-based index of the selected match (SEARCH_SELECTED), nil when
+    /// libghostty reports a negative index. The main/split factory wires it to `searchSelected`.
     var onSearchSelected: ((Int?) -> Void)?
 
-    /// Heap buffers backing the `const char*` fields of the surface config —
-    /// notably `initial_input`, which libghostty writes to the pty
-    /// asynchronously after the child spawns, so the buffer must outlive
-    /// `ghostty_surface_new`. Retained here and freed in `destroySurface`.
+    /// Heap buffers backing the surface config's `const char*` fields — notably `initial_input`, which
+    /// libghostty writes to the pty asynchronously after the child spawns, so the buffer must outlive
+    /// `ghostty_surface_new`. Freed in `destroySurface`.
     nonisolated(unsafe) private var configCStrings: [UnsafeMutablePointer<CChar>] = []
 
-    /// The `ghostty_env_var_s` structs handed to the surface config via `config.env_vars`. Each
-    /// struct's `key`/`value` point into the `configCStrings` strdup buffers (same lifetime). This
-    /// array must itself outlive `ghostty_surface_new`, so it's retained on the instance (a stored
-    /// property, not a local), and cleared in `destroySurface`/`deinit` alongside the strdup frees.
-    /// `nonisolated(unsafe)`: mutated only on the main actor (create/destroy), like `configCStrings`.
+    /// The `ghostty_env_var_s` structs handed to `config.env_vars`; their `key`/`value` point into the
+    /// `configCStrings` strdup buffers (same lifetime). The array must itself outlive `ghostty_surface_new`,
+    /// so it is a stored property rather than a local, cleared in `destroySurface`/`deinit` with the strdup
+    /// frees. `nonisolated(unsafe)`: mutated only on the main actor (create/destroy).
     nonisolated(unsafe) private var envVars: [ghostty_env_var_s] = []
 
-    /// Per-surface ghostty configs built for this surface's background watermark (`configWithOverlay`),
-    /// retained so they outlive their `ghostty_surface_update_config`. Capped at ONE: each re-apply
-    /// (`set`/`clear`/`config.reload`) frees the prior and keeps only the current, since after
-    /// `update_config` the surface no longer references the old config — so a scriptable `config.reload`
-    /// loop can't grow it. The remaining one is freed in `destroySurface`/`deinit`, when the surface (its
-    /// only consumer) is gone, so that free is safe too (unlike the app-wide config `GhosttyApp` never frees).
-    /// `nonisolated(unsafe)`: mutated only on the main actor, like `configCStrings`. Not `private` so the
-    /// `+Config` extension (which owns `applyWatermarkFromSession`/`applyOverlayBackgroundColor`) can read/write it.
+    /// Per-surface ghostty configs for this surface's background watermark (`configWithOverlay`), retained
+    /// so they outlive their `ghostty_surface_update_config`. Capped at ONE: each re-apply
+    /// (`set`/`clear`/`config.reload`) frees the prior, since after `update_config` the surface no longer
+    /// references it — so a scripted `config.reload` loop can't grow the array. The last is freed in
+    /// `destroySurface`/`deinit`, safe because the surface (its only consumer) is gone by then (unlike the
+    /// app-wide config `GhosttyApp` never frees). `nonisolated(unsafe)`: mutated only on the main actor. Not
+    /// `private`, so the `+Config` extension (`applyWatermarkFromSession`/`applyOverlayBackgroundColor`) can
+    /// read/write it.
     nonisolated(unsafe) var ownedConfigs: [ghostty_config_t] = []
 
     /// Key-window observers (didBecomeKey/didResignKey). A surface in a background window must report an
-    /// unfocused (hollow) cursor, but AppKit first responder is per-window and does NOT resign when a
-    /// window merely loses key, so we watch key changes and re-push `liveFocus`. Removed on teardown.
-    /// `nonisolated(unsafe)`: mutated only on the main actor (register/destroy), like `configCStrings`,
-    /// but read in the nonisolated `deinit` safety net.
+    /// unfocused (hollow) cursor, but AppKit first responder is per-window and does NOT resign when a window
+    /// merely loses key, so key changes re-push `liveFocus`. Removed on teardown. `nonisolated(unsafe)`:
+    /// mutated only on the main actor (register/destroy), read in the nonisolated `deinit` safety net.
     nonisolated(unsafe) private var focusObservers: [NSObjectProtocol] = []
     private var pendingSurfaceCreation = false
-    /// Once destroySurface() runs this view is "retired": it must never
-    /// recreate a surface (e.g. from a stray viewDidMoveToWindow).
+    /// After `destroySurface()` the view is retired: never recreate a surface (a stray viewDidMoveToWindow).
     private var isDestroyed = false
 
     /// Guards `handleProcessExit` so the close runs once. Both the `SHOW_CHILD_EXITED` action and the
@@ -203,22 +182,21 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     private static let autoFocusRetryInterval: TimeInterval = 0.05
 
     /// Whether this surface's deck slot is the active (selected) session. The overlay/scratch auto-focus
-    /// path grabs first responder when the surface attaches, so without this gate a full overlay (or scratch)
-    /// opened in a BACKGROUND, non-selected session would steal keyboard input from the visible session.
-    /// `TerminalView` sets it before `createSurface` so `requestAutoFocus` fires only for the active slot, and
-    /// a slot going inactive mid-retry makes the loop bail. Main/split panes never auto-focus, so it's inert
-    /// for them; they take focus through `TerminalView.focusIfNeeded`, which is already active-gated.
+    /// grabs first responder on attach, so without this gate one opened in a BACKGROUND, non-selected
+    /// session would steal the keyboard from the visible one. `TerminalView` sets it before `createSurface`,
+    /// so `requestAutoFocus` fires only for the active slot and going inactive mid-retry bails the loop.
+    /// Inert for main/split panes: they never auto-focus, taking focus via the active-gated `focusIfNeeded`.
     var deckActive = true
 
-    /// Whether this surface's deck slot is on-screen (its session is selected and not hidden by a full
-    /// overlay/scratch). UNLIKE `deckActive`, this is NOT focus-gated: both panes of a visible split are
-    /// `deckVisible`. `TerminalView` sets it from the deck. Load-bearing for drag-and-drop: every session's
-    /// surface is eagerly realized, and SwiftUI's `.opacity(0)`/`.allowsHitTesting(false)` on inactive deck
-    /// panes do NOT reach AppKit's drag machinery (the NSView keeps `alphaValue == 1`, and AppKit's
-    /// drag-destination resolution does NOT consult `hitTest`), so if every surface stayed a registered
-    /// drag target a file drop would land on whichever is topmost in z-order — an INVISIBLE background
-    /// session — instead of the one under the cursor. `didSet` (un)registers the drag types to fix that,
-    /// and (dis)installs the mouse-tracking area for the same reason (see `updatePointerTracking`).
+    /// Whether this surface's deck slot is on-screen (session selected, not hidden by a full
+    /// overlay/scratch). UNLIKE `deckActive` it is NOT focus-gated, so both panes of a visible split are
+    /// `deckVisible`; `TerminalView` sets it from the deck. Load-bearing for drag-and-drop: every surface is
+    /// eagerly realized, and SwiftUI's `.opacity(0)`/`.allowsHitTesting(false)` on inactive deck panes never
+    /// reach AppKit's drag machinery (the NSView keeps `alphaValue == 1`, and drag-destination resolution
+    /// does NOT consult `hitTest`), so with every surface registered a file drop would land on whichever is
+    /// topmost in z-order — an INVISIBLE background session — not the one under the cursor. `didSet`
+    /// (un)registers the drag types, and (dis)installs the mouse-tracking area for the same reason (see
+    /// `updatePointerTracking`).
     var deckVisible = true {
         didSet {
             // `TerminalView` assigns this on every SwiftUI update pass, so skip the tracking-area teardown/
@@ -229,29 +207,26 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         }
     }
 
-    /// View-only mode: the surface is rendered but takes NO mouse or keyboard input (the dashboard grid
-    /// cell). SwiftUI's `.allowsHitTesting(false)` does NOT stop AppKit routing a click to this real NSView
-    /// (the same reason `deckVisible` gates drag registration — AppKit's hit resolution bypasses SwiftUI),
-    /// so a click would reach `mouseDown` and grab first responder, defeating the view-only dashboard and
-    /// stealing the keyboard from its key-catcher. When set, `hitTest` returns nil (clicks fall through to
-    /// the SwiftUI cell overlay) and the surface refuses first responder, so keystrokes never reach it.
-    /// `TerminalView` sets it; the dashboard cell turns it on and the deck slot turns it back off on the
-    /// same reparent.
+    /// View-only mode: rendered but taking NO mouse or keyboard input (the dashboard grid cell). SwiftUI's
+    /// `.allowsHitTesting(false)` does NOT stop AppKit routing a click to this real NSView (AppKit hit
+    /// resolution bypasses SwiftUI, the same reason `deckVisible` gates drag registration), so a click would
+    /// reach `mouseDown`, grab first responder, and steal the keyboard from the dashboard's key-catcher.
+    /// When set, `hitTest` returns nil (clicks fall through to the SwiftUI cell overlay) and the surface
+    /// refuses first responder. `TerminalView` sets it: the dashboard cell on, the deck slot back off, on
+    /// the same reparent.
     var viewOnly = false {
         didSet {
             guard viewOnly, !oldValue else { return }
-            // acceptsFirstResponder=false only blocks NEW grabs — a surface that carried first responder in
-            // from the deck (the focused split pane when the dashboard opened) keeps it across the
-            // reparent-within-window, so keystrokes reach the cell and defeat the dashboard's key-catcher.
-            // Resign it here; once view-only, nothing can re-grab it, so the key-catcher owns the keyboard.
+            // acceptsFirstResponder=false blocks only NEW grabs: a surface carrying first responder in from
+            // the deck (the focused split pane at dashboard open) keeps it across the reparent-within-window
+            // and its keystrokes defeat the key-catcher. resign here; once view-only nothing can re-grab.
             if let window, window.firstResponder === self { window.makeFirstResponder(nil) }
         }
     }
 
-    /// Register the file/text drag types only while this surface is the on-screen deck pane; unregister
-    /// otherwise, so an eagerly-realized background surface is not a drag target and a drop can only reach
-    /// the visible pane. Called from `deckVisible`'s didSet and once from `createSurface` (didSet does not
-    /// fire for the initializer default).
+    /// Register the file/text drag types only while this surface is the on-screen deck pane, so an eagerly
+    /// realized background surface is never a drop target. Called from `deckVisible`'s didSet and once from
+    /// `createSurface` (didSet does not fire for the initializer default).
     private func updateDropRegistration() {
         if deckVisible {
             registerForDraggedTypes([.fileURL, .string, .URL])
@@ -260,35 +235,33 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         }
     }
 
-    /// Transient dashboard font size in points that overrides `session.fontSize` for this surface while it
-    /// is hosted in a dashboard grid cell; nil = not overriding. The composer prefers it,
-    /// `reapplySessionConfigIfNeeded` re-emits it across a config reload, and `reportFontSize` won't persist
-    /// it (so a CELL_SIZE round-trip can't write the transient size into `session.fontSize`). Writing it
-    /// re-composes the surface config — a value shrinks the cell's font, nil rebuilds from the session model.
+    /// Transient dashboard font size in points overriding `session.fontSize` while this surface is hosted in
+    /// a dashboard grid cell; nil = not overriding. The composer prefers it, `reapplySessionConfigIfNeeded`
+    /// re-emits it across a config reload, and `reportFontSize` won't persist it, so a CELL_SIZE round-trip
+    /// can't write the transient size into `session.fontSize`. Writing it re-composes the surface config: a
+    /// value shrinks the cell's font, nil rebuilds from the session model.
     var dashboardFontOverride: Double? {
         didSet {
             // keep a live OSC 11 tint across dashboard open/close (applyOSCBackground re-emits it with the dashboard font); else rebuild from the session model.
             if let hex = oscBackgroundColorHex { applyOSCBackground(hex) } else { applyWatermarkFromSession() }
-            // a SET override (-> value) can't strand a revert report — reportFontSize's
-            // `dashboardFontOverride == nil` guard drops its CELL_SIZE report while the override is active
-            // — so just drop any pending restore.
+            // a SET override can't strand a revert report — reportFontSize's `dashboardFontOverride == nil`
+            // guard drops the CELL_SIZE report while the override is active — so drop any pending restore.
             guard dashboardFontOverride == nil, let cleared = oldValue else { pendingFontRestore = nil; return }
-            // CLEARING the override reverts the surface to session.fontSize (the app default when nil). that
-            // fires a CELL_SIZE report ~0.4s LATER (async), long after any same-runloop latch would clear.
-            // when session.fontSize is nil, persisting that report would PIN the session to the default and
-            // stop it following a later Settings change. remember the size the surface reverts to so
-            // reportFontSize consumes THAT report without persisting. only arm when the font actually changes
-            // — an override equal to the target emits no report and would leak the flag onto a later zoom.
+            // CLEARING reverts to session.fontSize (the app default when nil), firing a CELL_SIZE report
+            // ~0.4s LATER (async) — long after any same-runloop latch would clear — and with a nil
+            // session.fontSize persisting it would PIN the session to the default instead of following a
+            // later Settings change. remember the reverted-to size so reportFontSize consumes that report
+            // without persisting, arming only on a real change: an override equal to the target emits no
+            // report and would leak the flag onto a later zoom.
             let target = session?.fontSize ?? GhosttyApp.shared.baseFontSize
             pendingFontRestore = abs(cleared - target) > 0.5 ? target : nil
         }
     }
 
-    /// The font size (points) the surface reverts to when `dashboardFontOverride` is CLEARED — the value
-    /// the async CELL_SIZE report for that revert will carry. Set in the override's `didSet`, consumed by
-    /// `reportFontSize`, which drops the matching report WITHOUT persisting so restoring the dashboard grid
-    /// font never pins a default-following session's `session.fontSize`. State (not a one-runloop latch), so
-    /// it survives the ~0.4s gap before the report arrives.
+    /// The font size (points) the surface reverts to when `dashboardFontOverride` is CLEARED — what that
+    /// revert's async CELL_SIZE report carries. Set in the override's `didSet`; `reportFontSize` drops the
+    /// matching report WITHOUT persisting, so restoring the grid font never pins a default-following
+    /// session's `session.fontSize`. State, not a one-runloop latch, so it survives the ~0.4s report gap.
     private var pendingFontRestore: Double?
 
     // IME composition state shared with GhosttySurfaceView+Input.swift (stored properties can't live in an extension).
@@ -301,22 +274,20 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     // can't live in an extension, so it stays here as internal rather than private).
     var currentTrackingArea: NSTrackingArea?
 
-    /// The mouse-cursor shape libghostty last requested for this surface (`GHOSTTY_ACTION_MOUSE_SHAPE`):
-    /// the I-beam over the grid, the pointing hand over a detected link / OSC-8 hyperlink, resize/crosshair
-    /// in the matching modes. `cursorUpdate` maps it to an `NSCursor`. Defaults to the terminal I-beam
-    /// so the resting cursor is right before the first event. Not `private` so the `+Input` extension (which
-    /// owns the `cursorUpdate` override and `applyMouseShape`) can read it.
+    /// The mouse-cursor shape libghostty last requested (`GHOSTTY_ACTION_MOUSE_SHAPE`): I-beam over the
+    /// grid, pointing hand over a detected link / OSC-8 hyperlink, resize/crosshair in the matching modes.
+    /// `cursorUpdate` maps it to an `NSCursor`; it defaults to the terminal I-beam so the resting cursor is
+    /// right before the first event. Not `private`, so the `+Input` extension can read it.
     var mouseShape: ghostty_action_mouse_shape_e = GHOSTTY_MOUSE_SHAPE_TEXT
 
     /// Whether the pointer is inside this surface (from `mouseEntered`/`mouseExited`), gating the immediate
     /// `.set()` in `applyMouseShape` so a revert delivered after the pointer left can't leak onto the sidebar.
     var pointerInside = false
 
-    /// The last pointer position pushed to libghostty via `ghostty_surface_mouse_pos` (view-flipped
-    /// coordinates), or nil before the first report. `scrollWheel` syncs the position only when the current
-    /// point differs from this, so a normal already-synced scroll doesn't re-push the same cell on every
-    /// packet — which in an any-motion + sgr-pixel mouse-reporting TUI would emit a synthetic motion report
-    /// per packet. Not `private` so the `+Input` extension (which owns the mouse handlers) can read/write it.
+    /// The last pointer position pushed via `ghostty_surface_mouse_pos` (view-flipped), nil before the first
+    /// report. `scrollWheel` syncs only when the current point differs, so an already-synced scroll doesn't
+    /// re-push the same cell per packet — which in an any-motion + sgr-pixel mouse-reporting TUI emits a
+    /// synthetic motion report per packet. Not `private`, so the `+Input` extension can read/write it.
     var lastReportedMousePoint: NSPoint?
 
     init(workingDirectory: String, fontSize: Float? = nil, command: String? = nil, initialInput: String? = nil,
@@ -334,10 +305,10 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         observeKeyWindowChanges()
     }
 
-    /// Watch every window's key transitions and re-evaluate this surface's focus on each. No need to
-    /// filter to my own window: `updateGhosttyFocus` reads `self.window.isKeyWindow`, so on any key change
-    /// each surface reports its OWN current state (a background window's surface goes hollow, the new key
-    /// window's active surface goes solid). Observing all windows also survives a re-host into another one.
+    /// Watch every window's key transitions and re-evaluate focus on each. No need to filter to my own
+    /// window: `updateGhosttyFocus` reads `self.window.isKeyWindow`, so each surface reports its OWN state
+    /// (a background window's goes hollow, the new key window's active one solid) and this survives a
+    /// re-host into another window.
     private func observeKeyWindowChanges() {
         let center = NotificationCenter.default
         for name in [NSWindow.didBecomeKeyNotification, NSWindow.didResignKeyNotification] {
@@ -346,11 +317,10 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
                 MainActor.assumeIsolated {
                     guard let self else { return }
                     self.updateGhosttyFocus()
-                    // returning focus to agterm (cmd-tab or a reactivating click) while this pane is the
-                    // one on screen counts as "seeing" the session — clear its unseen badge, the same as a
-                    // focus transition does. becomeFirstResponder can't cover this: AppKit's per-window
-                    // first responder never resigned while agterm was backgrounded, so no focus transition
-                    // fires on return, leaving the badge stuck until you switch sessions and back.
+                    // returning focus to agterm (cmd-tab or a reactivating click) while this pane is on
+                    // screen counts as seeing the session, so clear its unseen badge. becomeFirstResponder
+                    // can't: AppKit's per-window first responder never resigned while agterm was
+                    // backgrounded, so no focus transition fires on return and the badge sticks.
                     if becameKey {
                         self.reassertCursorOnActivation()
                         self.clearUnseenOnRefocus()
@@ -361,18 +331,16 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         }
     }
 
-    /// Clear the "you've seen it" state (unseen badge + delivered banners) for this pane's session when
-    /// agterm regains key focus on it — the inverse of notification suppression (which drops a banner only
-    /// when the firing pane is the key window's first responder AND the app is active). `liveFocus` already
-    /// encodes both: a window is key only while the app is active, so it fires solely for the focused pane of
-    /// the now-key window, never a background one. Reuses `onFocusChange`, so it clears exactly for the
-    /// main/split panes that already clear on a focus transition (a scratch/overlay has no `onFocusChange`
-    /// and doesn't clear on focus either), and no-ops after teardown (the closure is nil'd).
-    /// Honors `suppressFocusChange` like the first-responder call sites: a zoom-hosted surface is first
-    /// responder of the key window, so `onFocusChange?(true)` here would mutate `splitFocused` on every
-    /// window-key regain — the model change the zoom host suppresses on the other two paths. The unseen
-    /// badge must still clear, though (the user is looking at exactly this surface), so the suppressed
-    /// branch takes the focus-free `onClearUnseen` path instead of dropping the clear.
+    /// Clear the seen state (unseen badge + delivered banners) for this pane's session when agterm regains
+    /// key focus on it — the inverse of notification suppression, which drops a banner only when the firing
+    /// pane is the key window's first responder AND the app is active. `liveFocus` encodes both (a window is
+    /// key only while the app is active), so this fires solely for the focused pane of the now-key window,
+    /// never a background one. Reusing `onFocusChange` clears exactly for the main/split panes that already
+    /// clear on a focus transition (a scratch/overlay has neither), and no-ops after teardown once the
+    /// closure is nil'd. `suppressFocusChange` is honored as at the first-responder call sites: a zoom-hosted
+    /// surface is first responder of the key window, so `onFocusChange?(true)` would mutate `splitFocused` on
+    /// every key regain — the write the zoom host suppresses elsewhere. The badge must still clear (the user
+    /// is looking at exactly this surface), so that branch takes the focus-free `onClearUnseen`.
     private func clearUnseenOnRefocus() {
         guard liveFocus else { return }
         if suppressFocusChange {
@@ -406,11 +374,9 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     }
 
     deinit {
-        // free directly here, not via destroySurface(): deinit is nonisolated and
-        // can't call the @MainActor method. surface/configCStrings are
-        // nonisolated(unsafe) and freed with C calls, so this is safe. (Normal
-        // teardown goes through destroySurface() on the main actor; this is the
-        // safety net for a view dropped without an explicit close.)
+        // free directly, not via destroySurface(): deinit is nonisolated and can't call the @MainActor
+        // method, while surface/configCStrings are nonisolated(unsafe) and freed with C calls. normal
+        // teardown goes through destroySurface() on the main actor; this is the net for a dropped view.
         focusObservers.forEach { NotificationCenter.default.removeObserver($0) }
         if let surface { ghostty_surface_free(surface) }
         configCStrings.forEach { free($0) }
@@ -424,22 +390,16 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     // MARK: - Callback entry points
 
     func applyPwd(_ rawPwd: String) {
-        // Already on the main actor (the callback hops via DispatchQueue.main.async).
-        // `currentCwd` is observed, so the sidebar row refreshes live.
-        //
-        // Strip control characters from the OSC 7 value first: it flows unquoted into a /bin/sh -c
-        // line via {AGT_SESSION_PWD} and into every cwd-inheriting spawn (split/overlay/restore), so a
-        // newline (an sh -c command separator) must never survive; a real path has no control chars.
+        // already on the main actor (the callback hops via DispatchQueue.main.async); `currentCwd` is
+        // observed, so the sidebar row refreshes live. strip control characters from the OSC 7 value: it
+        // flows unquoted into a /bin/sh -c line via {AGT_SESSION_PWD} and into every cwd-inheriting spawn
+        // (split/overlay/restore), so a newline (an sh -c separator) must never survive; a real path has none.
         let pwd = TerminalText.sanitized(rawPwd)
 
-        // This deliberately does NOT save(): OSC 7 fires on every cd/prompt redraw,
-        // so persisting here would thrash the disk. Live cwd is persisted on quit
-        // and on structural mutations (add/close/move/rename/select), not on every
-        // cd, so a crash/force-quit loses only cwd changes since the last save.
-        //
-        // Guard on a real value change: OSC 7 re-emits the same pwd on every prompt
-        // redraw, so an equal write would still notify @Observable observers and churn
-        // the sidebar reconcile for nothing.
+        // deliberately no save(): OSC 7 fires on every cd/prompt redraw and would thrash the disk. live cwd
+        // is persisted on quit and on structural mutations (add/close/move/rename/select), so a
+        // crash/force-quit loses only cwd changes since the last save. the equality guard covers the same
+        // re-emit: an equal write would still notify @Observable observers and churn the sidebar reconcile.
         if isSplitPane {
             if session?.splitCwd != pwd { session?.splitCwd = pwd }
         } else {
@@ -448,16 +408,14 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     }
 
     func applyTitle(_ rawTitle: String) {
-        // Already on the main actor (the callback hops via DispatchQueue.main.async).
-        // `oscTitle`/`splitTitle` are observed, so the sidebar row and window title refresh live. Like
-        // applyPwd, this deliberately does NOT save(): OSC set-title re-fires on every prompt redraw.
-        //
-        // Strip control characters from the OSC 0/1/2 title first: it flows unquoted into a /bin/sh -c
-        // line via {AGT_SESSION_NAME}, so a newline (an sh -c command separator) must never survive; a
-        // real title has no control chars.
+        // already on the main actor (the callback hops via DispatchQueue.main.async). `oscTitle`/`splitTitle`
+        // are observed, so the sidebar row and window title refresh live; like applyPwd this does NOT save()
+        // — OSC set-title re-fires on every prompt redraw. strip control characters from the OSC 0/1/2
+        // title: it flows unquoted into a /bin/sh -c line via {AGT_SESSION_NAME}, so a newline (an sh -c
+        // separator) must never survive; a real title has none.
         let title = TerminalText.sanitized(rawTitle)
 
-        // Guard on a real value change so an equal re-emit doesn't notify observers and churn the sidebar.
+        // guard on a real value change so an equal re-emit doesn't notify observers and churn the sidebar.
         if isSplitPane {
             if session?.splitTitle != title { session?.splitTitle = title }
         } else {
@@ -466,31 +424,29 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     }
 
     func handleProcessExit() {
-        // Already on the main actor (the close callbacks hop via DispatchQueue.main.async). Ask the app
-        // to close the owning session/overlay, which tears down this surface and removes its sidebar row.
-        // Idempotent: the SHOW_CHILD_EXITED action and close_surface_cb can both fire for one exit.
+        // already on the main actor (the close callbacks hop via DispatchQueue.main.async). asks the app to
+        // close the owning session/overlay, tearing down this surface and its sidebar row. idempotent: the
+        // SHOW_CHILD_EXITED action and close_surface_cb can both fire for one exit.
         guard !didHandleProcessExit else { return }
         didHandleProcessExit = true
         onExit?()
     }
 
-    /// Whether a child-exit should close this surface immediately (suppressing ghostty's "press any key"
-    /// prompt). True only for a command surface (the overlay) that did NOT opt into the wait prompt; a
-    /// `waitAfterCommand` overlay keeps the prompt and closes via `close_surface_cb` after the keypress.
-    /// `nonisolated` so the C action callback can read it without a main-actor hop; both backing fields
-    /// are immutable `let`s set in `init`, so the read is data-race-free.
+    /// Whether a child-exit should close this surface immediately, suppressing ghostty's "press any key"
+    /// prompt. True only for a command surface (the overlay) that did NOT opt into the wait prompt, which
+    /// keeps the prompt and closes via `close_surface_cb` after the keypress. `nonisolated` so the C action
+    /// callback reads it with no main-actor hop — both backing fields are `let`s set in `init`.
     nonisolated var shouldCloseOnChildExitAction: Bool { command != nil && !waitAfterCommand }
 
     func reportFontSize() {
-        // already on the main actor (the CELL_SIZE callback hops via DispatchQueue.main.async).
-        // while a dashboard font override is active, don't persist: it would write the transient dashboard
-        // size into session.fontSize.
+        // already on the main actor (the CELL_SIZE callback hops via DispatchQueue.main.async). don't
+        // persist under a dashboard override — it would write the transient size into session.fontSize.
         guard dashboardFontOverride == nil else { return }
-        // currentFontSize reads the surface's live font size; nil means libghostty hasn't resolved one yet.
+        // nil means libghostty hasn't resolved a font size yet.
         guard let size = currentFontSize() else { return }
-        // clearing the override reverts the surface font and fires its own CELL_SIZE report ~0.4s later
-        // (see dashboardFontOverride.didSet): drop the one whose size matches the reverted-to value so a
-        // default-following session isn't pinned, then clear the flag so a later genuine zoom persists.
+        // clearing the override reverts the font and fires its own CELL_SIZE report ~0.4s later (see
+        // dashboardFontOverride.didSet): drop the one matching the reverted-to value so a default-following
+        // session isn't pinned, then clear the flag so a later genuine zoom persists.
         if let pending = pendingFontRestore {
             pendingFontRestore = nil
             if abs(size - pending) <= 0.5 { return }
@@ -508,9 +464,9 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
 
     func createSurface() {
         guard !isDestroyed else { return }
-        // register as a file drop target (issue #51) only while on-screen, so a background deck surface
-        // can't intercept the drop (see updateDropRegistration). idempotent across re-entry (createSurface
-        // re-runs when a deferred surface finally gets a backing size).
+        // register as a file drop target (issue #51) only while on-screen, so a background deck surface can't
+        // intercept it (see updateDropRegistration). idempotent across re-entry: createSurface re-runs when a
+        // deferred surface finally gets a backing size.
         updateDropRegistration()
         guard surface == nil, let app = GhosttyApp.shared.app else { return }
         let backingSize = convertToBacking(bounds).size
@@ -526,8 +482,7 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         config.userdata = Unmanaged.passUnretained(self).toOpaque()
         config.scale_factor = Double(window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2.0)
 
-        // The strdup'd working_directory buffer must stay valid for the
-        // duration of the call; retained on the instance and freed in
+        // the strdup'd working_directory buffer must outlive the call: retained on the instance, freed in
         // destroySurface (the same contract initial_input needs later).
         configCStrings.forEach { free($0) }
         configCStrings = []
@@ -535,10 +490,9 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
             configCStrings.append(p)
             config.working_directory = UnsafePointer(p)
         }
-        // a command runs as the surface's process (the overlay's one program) instead of the login
-        // shell; its strdup'd buffer joins the same `configCStrings` lifetime as working_directory.
-        // wait_after_command controls whether the surface lingers on the "press any key" prompt when
-        // the command exits; default false so the overlay vanishes immediately (opt-in via the API).
+        // a command runs as the surface's process (the overlay's one program) instead of the login shell;
+        // its strdup'd buffer joins the `configCStrings` lifetime. wait_after_command keeps the surface on
+        // the "press any key" prompt at exit; default false, so the overlay vanishes immediately (API opt-in).
         if let command, let p = strdup(command) {
             configCStrings.append(p)
             config.command = UnsafePointer(p)
@@ -547,9 +501,8 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
             config.command = nil // login shell
         }
         // restore-running-command: feed the captured command line to the login shell as if typed, so it
-        // re-runs and exits back to a prompt. Same strdup'd-buffer lifetime as working_directory. Mutually
-        // exclusive with `command` (which REPLACES the shell): a command surface ignores initialInput, so
-        // the invariant is enforced here, not just by caller discipline.
+        // re-runs and exits back to a prompt. same strdup'd-buffer lifetime; mutually exclusive with
+        // `command` (which REPLACES the shell), enforced here rather than by caller discipline alone.
         if command == nil, let initialInput, let p = strdup(initialInput) {
             configCStrings.append(p)
             config.initial_input = UnsafePointer(p)
@@ -558,10 +511,9 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         // config_new's default (the ghostty config font-size) in place.
         if let initialFontSize { config.font_size = initialFontSize }
 
-        // extra environment for the spawned shell (the AGTERM_* vars). Each key/value is strdup'd into
-        // the same `configCStrings` lifetime as working_directory; the `ghostty_env_var_s` structs
-        // pointing at those buffers are retained in `envVars` (a stored property, value-type, so it
-        // can't live in `configCStrings`).
+        // extra environment for the spawned shell (the AGTERM_* vars). each key/value is strdup'd into the
+        // `configCStrings` lifetime; the `ghostty_env_var_s` structs pointing at them are retained in
+        // `envVars` (a value type, so it can't live in `configCStrings`).
         envVars = []
         for (key, value) in env {
             guard let keyPtr = strdup(key), let valuePtr = strdup(value) else { continue }
@@ -569,19 +521,17 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
             configCStrings.append(valuePtr)
             envVars.append(ghostty_env_var_s(key: UnsafePointer(keyPtr), value: UnsafePointer(valuePtr)))
         }
-        // set the app color scheme to the current appearance BEFORE creating the surface: a new surface
-        // derives its initial theme from the app's conditional state (`ghostty_surface_new` reads it), so
-        // a dual `theme = light:,dark:` renders the correct side from the FIRST frame instead of defaulting
-        // to light and only correcting on a later reload. Read the APP-level side (`currentIsDark()`, i.e.
-        // `NSApp.effectiveAppearance`) — the single source the KVO observer also feeds, not this view's own
-        // `effectiveAppearance`. `set_color_scheme` records the state; it early-returns when unchanged.
+        // set the app color scheme BEFORE creating the surface: `ghostty_surface_new` derives the initial
+        // theme from the app's conditional state, so a dual `theme = light:,dark:` renders the right side
+        // from the FIRST frame instead of defaulting to light until a later reload. read the APP-level side
+        // (`currentIsDark()` = `NSApp.effectiveAppearance`, the single source the KVO observer feeds), not
+        // this view's own `effectiveAppearance`. `set_color_scheme` records it, early-returning if unchanged.
         let isDark = GhosttyApp.currentIsDark()
         ghostty_app_set_color_scheme(app, isDark ? GHOSTTY_COLOR_SCHEME_DARK : GHOSTTY_COLOR_SCHEME_LIGHT)
 
-        // create the surface with `config.env_vars` pointing at the retained `envVars` storage. The
-        // pointer is taken inside `withUnsafeMutableBufferPointer` AND `ghostty_surface_new` runs in
-        // the same closure, so it's never used past the call (no escaping-pointer UB); ghostty copies
-        // the env at creation. No-env surfaces take the plain path.
+        // create with `config.env_vars` pointing at the retained `envVars`. the pointer is taken inside
+        // `withUnsafeMutableBufferPointer` and `ghostty_surface_new` runs in the same closure, so it never
+        // escapes the call (no UB); ghostty copies the env at creation. no-env surfaces take the plain path.
         if envVars.isEmpty {
             surface = ghostty_surface_new(app, &config)
         } else {
@@ -602,13 +552,13 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         }
         updateGhosttyFocus()
 
-        // a session carrying a background watermark (set earlier on a never-shown session, or restored from
-        // a snapshot) applies it now that the surface exists — covering deferred-size creation, the eager
-        // deck, and relaunch. Scratch inherits through `watermarkSession`; overlay/quick surfaces remain
-        // sessionless and skip it. ALSO re-applies a
-        // standalone `dashboardFontOverride` (a dashboard member whose surface realizes AFTER the dashboard
-        // set the transient font): `applyWatermarkFromSession` honors `dashboardFontOverride ?? session.fontSize`,
-        // so without this the late-realized cell renders at the default font. Mirrors `reapplySessionConfigIfNeeded`.
+        // a session carrying a background watermark (set on a never-shown session, or restored from a
+        // snapshot) applies it now the surface exists — covering deferred-size creation, the eager deck, and
+        // relaunch. the scratch inherits via `watermarkSession`; sessionless overlay/quick surfaces skip it.
+        // ALSO re-applies a standalone `dashboardFontOverride` (a member realizing AFTER the dashboard set
+        // the transient font), since `applyWatermarkFromSession` honors `dashboardFontOverride ??
+        // session.fontSize` — else the late cell renders at the default font. mirrors
+        // `reapplySessionConfigIfNeeded`.
         if (session ?? watermarkSession)?.backgroundWatermark != nil || dashboardFontOverride != nil {
             applyWatermarkFromSession()
         }
@@ -661,11 +611,11 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
 
     private var reparentFocusInFlight = false
 
-    /// Grabs first responder with a bounded run-loop retry, for a pane that just became the maximized
-    /// survivor after its sibling pane closed. The collapse re-hosts this view (HSplitView → standalone)
-    /// and a single `makeFirstResponder` loses the re-parent race, so retry until it's in a window with a
-    /// surface and holds first responder. Distinct from the overlay's auto-focus: not gated on `autoFocus`
-    /// and no `didAutoFocus` latch, so it can run again on a later collapse.
+    /// Grabs first responder with a bounded run-loop retry for the pane that became the maximized survivor
+    /// of a sibling close: the collapse re-hosts this view (HSplitView → standalone) and one
+    /// `makeFirstResponder` loses that race, so retry until it is in a window, has a surface, and holds first
+    /// responder. Unlike the overlay's auto-focus, no `autoFocus` gate and no `didAutoFocus` latch, so it can
+    /// run again on a later collapse.
     func focusAfterReparent() {
         guard !isDestroyed, !reparentFocusInFlight else { return }
         reparentFocusInFlight = true
@@ -742,8 +692,7 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         onSearchSelected = nil
     }
 
-    /// `TerminalSurface` conformance: the model calls this when the owning
-    /// session is closed.
+    /// `TerminalSurface` conformance: the model calls this when the owning session is closed.
     func teardown() {
         destroySurface()
     }
@@ -782,14 +731,13 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         updateMetalLayerSize()
     }
 
-    /// Record this surface's light/dark scheme from the authoritative `isDark` (the app-level side the
-    /// caller resolved from `NSApp.effectiveAppearance`), so the NEXT `update_config` re-resolves a dual
-    /// `theme = light:,dark:` to the matching side. libghostty derives the active side from the surface's
-    /// RECORDED conditional state at `update_config` time — not from the config file alone — so a surface
-    /// whose recorded state lagged (e.g. created before its window's appearance resolved) would re-derive
-    /// the WRONG side. Re-asserting it before each reload keeps the terminal in sync; `set_color_scheme`
-    /// early-returns when unchanged, so it is cheap. The APP-level scheme is set once by the caller
-    /// (`GhosttyApp.reloadConfig`), so this only touches the surface.
+    /// Record this surface's light/dark scheme from the authoritative `isDark` (the app-level side the caller
+    /// resolved from `NSApp.effectiveAppearance`), so the NEXT `update_config` re-resolves a dual
+    /// `theme = light:,dark:` to the matching side. libghostty takes the active side from the surface's
+    /// RECORDED conditional state at `update_config` time, not from the config file alone, so a surface whose
+    /// state lagged (created before its window's appearance resolved) would re-derive the WRONG side. Cheap
+    /// to re-assert before each reload — `set_color_scheme` early-returns when unchanged. The caller
+    /// (`GhosttyApp.reloadConfig`) sets the APP-level scheme, so this touches only the surface.
     func syncColorScheme(isDark: Bool) {
         guard let surface else { return }
         ghostty_surface_set_color_scheme(surface, isDark ? GHOSTTY_COLOR_SCHEME_DARK : GHOSTTY_COLOR_SCHEME_LIGHT)
@@ -808,10 +756,9 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         }
         ghostty_surface_set_content_scale(surface, scale, scale)
         ghostty_surface_set_size(surface, UInt32(scaledSize.width), UInt32(scaledSize.height))
-        // force a repaint after any resize or re-attach. the split-toggle re-parent (HSplitView <-> a
-        // standalone host) detaches and re-attaches the view, invalidating the Metal drawable; set_size to
-        // an unchanged grid is a no-op and the 120Hz `ghostty_app_tick` only draws surfaces flagged dirty,
-        // so without this the re-hosted pane keeps a blank drawable even though its terminal buffer is intact.
+        // the split-toggle re-parent invalidates the Metal drawable, and neither a same-grid set_size nor the
+        // `ghostty_app_tick` (which draws only dirty surfaces) repaints it — so force one, or the re-hosted
+        // pane stays blank over an intact buffer.
         ghostty_surface_refresh(surface)
     }
 
@@ -819,29 +766,25 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
 
     override var acceptsFirstResponder: Bool { !viewOnly }
 
-    /// In view-only mode (a dashboard grid cell) refuse hit-testing so a click passes THROUGH to the SwiftUI
+    /// In view-only mode (a dashboard grid cell) refuse hit-testing, so a click passes THROUGH to the SwiftUI
     /// cell overlay (highlight/enter) instead of reaching `mouseDown` and grabbing first responder. AppKit
-    /// routes clicks to this real NSView regardless of SwiftUI `.allowsHitTesting(false)`, so the block must
-    /// live here.
+    /// routes clicks to this real NSView regardless of `.allowsHitTesting(false)`, so the block lives here.
     override func hitTest(_ point: NSPoint) -> NSView? {
         viewOnly ? nil : super.hitTest(point)
     }
 
-    /// Deliver the LEFT click that reactivates a background/inactive window straight to the surface (a
-    /// "first mouse") instead of AppKit swallowing it just to raise the window. Without this, clicking a
-    /// specific pane of a two-pane split from another window raises the window but never runs `mouseDown`,
-    /// so the clicked pane doesn't become first responder and `splitFocused` stays on the previously-focused
-    /// pane ("the mouse works but the pane isn't selected"). The left click then behaves like any normal
-    /// in-window click — it selects the pane AND is reported to the program — matching Terminal.app/iTerm2/Ghostty.
-    /// Gated to `.leftMouseDown` on purpose: a first-mouse right/middle click would otherwise reach
+    /// Deliver the LEFT click that reactivates a background window straight to the surface (a "first mouse")
+    /// rather than letting AppKit swallow it to raise the window: without this, clicking a specific pane of a
+    /// two-pane split from another window raises it but never runs `mouseDown`, so the pane doesn't become
+    /// first responder and `splitFocused` stays on the previously-focused one. The click then behaves like
+    /// any in-window one — selects the pane AND is reported to the program — as in Terminal.app/iTerm2/Ghostty.
+    /// Gated to `.leftMouseDown`: a first-mouse right/middle click would reach
     /// `rightMouseDown`/`otherMouseDown`, which forward to libghostty, and with the default
-    /// `right-click-action = paste` that would paste the clipboard into a window you only meant to raise —
-    /// so right/middle first clicks just raise the window.
+    /// `right-click-action = paste` would paste into a window you only meant to raise.
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
-        // with auto-hide-inactive-sidebars on, activating an inactive window expands its (currently hidden)
-        // sidebar and resizes THIS surface; if the activating click also pressed the terminal button, that
-        // mid-gesture resize would drag the still-held press into a phantom selection. Let the click only
-        // raise the window in that mode — a follow-up click selects normally once the window is key.
+        // with auto-hide-inactive-sidebars on, activating an inactive window expands its hidden sidebar and
+        // resizes THIS surface, so an activating click on the terminal would drag the still-held press into a
+        // phantom selection. in that mode the click only raises; a follow-up click selects once key.
         if GhosttyApp.shared.autoHideSidebarInactiveWindows { return false }
         return event?.type == .leftMouseDown
     }
@@ -849,10 +792,9 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
     override func becomeFirstResponder() -> Bool {
         let result = super.becomeFirstResponder()
         if result, let surface {
-            // becoming first responder: report focused, gated on the window being key (a background
-            // window's surface stays hollow). Push directly — `window.firstResponder` is not yet self
-            // inside this call, so `liveFocus` would read stale. onFocusChange (split-pane tracking) is
-            // independent of key state.
+            // report focused, gated on the window being key (a background window's surface stays hollow).
+            // push directly: `window.firstResponder` is not yet self inside this call, so `liveFocus` reads
+            // stale. onFocusChange (split-pane tracking) is independent of key state.
             ghostty_surface_set_focus(surface, window?.isKeyWindow ?? false)
             if !suppressFocusChange { onFocusChange?(true) }
         }

--- a/agterm/Ghostty/WatermarkRenderer.swift
+++ b/agterm/Ghostty/WatermarkRenderer.swift
@@ -4,11 +4,11 @@ import os
 
 private let logger = Logger(subsystem: "com.umputun.agterm", category: "WatermarkRenderer")
 
-/// Turns a `BackgroundWatermark` into a PNG file path for libghostty's `background-image`. For `.image`
-/// it validates and returns the user's file; for `.text` it rasterizes the string (via Core Text on a
-/// transparent canvas) to a per-session PNG in the state dir, which `background-image-fit` then scales
-/// to the surface. AppKit-only and `@MainActor` (it reads the live terminal foreground color for the
-/// default text tint), so it lives in the app target, not the host-free `agtermCore`.
+/// Turns a `BackgroundWatermark` into a PNG file path for libghostty's `background-image`: `.image`
+/// validates and returns the user's file, `.text` rasterizes the string (Core Text on a transparent canvas)
+/// to a per-session PNG in the state dir for `background-image-fit` to scale to the surface. AppKit-only and
+/// `@MainActor` (it reads the live terminal foreground for the default text tint), so it lives in the app
+/// target, not the host-free `agtermCore`.
 @MainActor
 enum WatermarkRenderer {
     /// The image formats libghostty reads (Config.zig: PNG or JPEG only).
@@ -43,10 +43,9 @@ enum WatermarkRenderer {
         }
     }
 
-    /// Rasterize `text` in `color` onto a transparent PNG sized to the glyphs (plus padding), at a large
-    /// fixed resolution so `background-image-fit = contain` scales it up crisply to fill the terminal.
-    /// Transparent background → only the glyphs composite over the terminal; the overall translucency is
-    /// applied by `background-image-opacity`, not baked into the pixels.
+    /// Rasterize `text` in `color` onto a transparent PNG sized to the glyphs plus padding, at a large fixed
+    /// resolution so `background-image-fit = contain` scales it up crisply to fill the terminal. Transparent,
+    /// so only the glyphs composite over it; translucency comes from `background-image-opacity`, not pixels.
     private static func renderText(_ text: String, color: NSColor, to url: URL) -> Bool {
         let fontSize: CGFloat = 256
         let attributes: [NSAttributedString.Key: Any] = [

--- a/agterm/Notifications/DockBadgeController.swift
+++ b/agterm/Notifications/DockBadgeController.swift
@@ -3,26 +3,25 @@ import Foundation
 import Observation
 import UserNotifications
 
-/// Drives the Dock icon's unseen-notification badge from the app-wide total of unseen terminal
-/// notifications — the same `Session.unseenCount` the sidebar's red pills show, summed across every open
-/// window by `WindowLibrary.totalUnseenCount`. Capped at 99 (mirrors the sidebar pill's `99+`), cleared at
-/// zero, gated by the SAME `GhosttyApp.notificationBadgeEnabled` ("Show notification badges") Settings
-/// toggle — one switch governs both surfaces.
+/// Drives the Dock icon's unseen-notification badge from the app-wide total — the same `Session.unseenCount`
+/// the sidebar's red pills show, summed across open windows by `WindowLibrary.totalUnseenCount`. Capped at 99
+/// (the sidebar pill's `99+`), cleared at zero, gated by the SAME `GhosttyApp.notificationBadgeEnabled`
+/// ("Show notification badges") toggle as the pills.
 ///
-/// **Uses the modern UserNotifications badge, NOT `NSApp.dockTile.badgeLabel`.** For agterm the legacy
-/// dock-tile label is silently suppressed — the value sets and persists on the tile, but the Dock never
-/// draws the pill — because it requires the `.badge` authorization option (which `NotificationManager` now
-/// requests alongside `.alert`). `UNUserNotificationCenter.setBadgeCount(_:)` renders the count correctly
-/// over the LIVE adaptive Icon Composer icon with no loss of light/dark/tint/clear adaptivity, so the badge
-/// is purely the number — no self-drawn icon, no `applicationIconImage` override.
+/// **Uses the modern UserNotifications badge, NOT `NSApp.dockTile.badgeLabel`.** The legacy dock-tile label
+/// is silently suppressed for agterm — the value sets and persists on the tile, but the Dock never draws the
+/// pill — because it requires the `.badge` authorization option (`NotificationManager` requests it alongside
+/// `.alert`). `UNUserNotificationCenter.setBadgeCount(_:)` renders the count over the LIVE adaptive Icon
+/// Composer icon with no loss of light/dark/tint/clear adaptivity, so the badge is purely the number — no
+/// self-drawn icon, no `applicationIconImage` override.
 ///
 /// `@MainActor` singleton like `NotificationManager`. Reactivity uses the Observation re-registration
-/// pattern: `apply()` reads the observable inputs inside `withObservationTracking` and re-arms itself on
-/// the next change, so a notification bump, a focus/select clear, and a session add/remove all refresh the
-/// badge. Changes that are NOT observable are poked explicitly: a window CLOSE drops, and a window REOPEN
-/// loads, an `@ObservationIgnored` store (`refresh()` on the `willClose` teardown / `window.close`, and on
-/// `ContentView.resolveStore`), and a badge-toggle flip lands in the non-`@Observable` `GhosttyApp` flag
-/// (it rides `.agtermAppearanceChanged`, the same channel the sidebar uses).
+/// pattern: `apply()` reads the observable inputs inside `withObservationTracking` and re-arms on the next
+/// change, so a notification bump, a focus/select clear, and a session add/remove all refresh. Non-observable
+/// changes are poked explicitly — a window CLOSE drops, and a REOPEN loads, an `@ObservationIgnored` store
+/// (`refresh()` from the `willClose` teardown / `window.close`, and from `ContentView.resolveStore`), and a
+/// badge-toggle flip lands in the non-`@Observable` `GhosttyApp` flag, riding `.agtermAppearanceChanged` like
+/// the sidebar.
 @MainActor
 final class DockBadgeController {
     static let shared = DockBadgeController()
@@ -50,17 +49,15 @@ final class DockBadgeController {
         apply()
     }
 
-    /// Recompute and set the badge now — the explicit poke for a change the Observation tracking can't see
-    /// (a window close drops, or a reopen loads, an `@ObservationIgnored` store, leaving the tracked inputs
-    /// unchanged).
+    /// Recompute and set the badge now — the explicit poke for a change Observation can't see (a window close
+    /// drops, or a reopen loads, an `@ObservationIgnored` store, leaving the tracked inputs unchanged).
     func refresh() { apply() }
 
-    /// Zero the Dock badge immediately — called from `applicationWillTerminate`. `setBadgeCount` writes an
-    /// OS-level badge that OUTLIVES the process, and `unseenCount` is ephemeral (never restored), so a quit
-    /// with unseen > 0 would otherwise leave a stale count pinned on the Dock icon until the next launch
-    /// recomputes it. The `willClose` `refresh()` poke can't cover this: the quit-flush sets
-    /// `library.isTerminating`, so `closeWindow` no-ops and the still-open stores recompute the same
-    /// positive total.
+    /// Zero the Dock badge immediately, from `applicationWillTerminate`. `setBadgeCount` writes an OS-level
+    /// badge that OUTLIVES the process while `unseenCount` is ephemeral (never restored), so a quit with
+    /// unseen > 0 would pin a stale count on the Dock icon until the next launch recomputes it. The
+    /// `willClose` `refresh()` poke can't cover it: the quit-flush sets `library.isTerminating`, so
+    /// `closeWindow` no-ops and the still-open stores recompute the same positive total.
     func clear() { UNUserNotificationCenter.current().setBadgeCount(0) }
 
     /// Defer a single re-apply to the next runloop turn. An observation `onChange` fires at willSet (before
@@ -85,9 +82,7 @@ final class DockBadgeController {
         } onChange: { [weak self] in
             DispatchQueue.main.async { MainActor.assumeIsolated { self?.scheduleRefresh() } }
         }
-        // setBadgeCount(0) clears the badge; a positive count shows the OS-rendered pill over the live
-        // adaptive icon (needs the `.badge` authorization `NotificationManager` requests). Capped at 99
-        // to mirror the sidebar pill's `99+` ceiling (the OS renders the raw Int, so this is the cap).
+        // capped at 99 to mirror the sidebar pill's `99+` ceiling — the OS renders the raw Int.
         UNUserNotificationCenter.current().setBadgeCount(min(count, 99))
     }
 }

--- a/agterm/Notifications/NotificationManager.swift
+++ b/agterm/Notifications/NotificationManager.swift
@@ -5,47 +5,41 @@ import os
 
 private let logger = Logger(subsystem: "com.umputun.agterm", category: "NotificationManager")
 
-/// Owns the macOS notification surface for terminal desktop notifications (OSC 9 / 777).
-///
-/// `@MainActor` and the `UNUserNotificationCenterDelegate`. `@preconcurrency` on the conformance keeps
-/// the delegate methods main-actor isolated against the pre-concurrency UserNotifications API (as
-/// macterm does).
+/// Owns the macOS notification surface for terminal desktop notifications (OSC 9 / 777). `@preconcurrency`
+/// on the `UNUserNotificationCenterDelegate` conformance keeps the delegate methods main-actor isolated
+/// against the pre-concurrency UserNotifications API (as macterm does).
 @MainActor
 final class NotificationManager: NSObject, @preconcurrency UNUserNotificationCenterDelegate {
     static let shared = NotificationManager()
 
-    /// The action hub used to navigate to a session/pane on a notification click. Set at launch by
-    /// `agtermApp`; weak since `AppActions` outlives the manager only by app lifetime.
+    /// The action hub used to navigate to a session/pane on a notification click. Set at launch by `agtermApp`;
+    /// weak since `AppActions` outlives the manager only by app lifetime.
     weak var actions: AppActions?
 
-    /// Resolves the firing surface's owning window id when building a notification identity, so a click
-    /// can reopen a since-closed window. Set at launch by `agtermApp`; weak for the same app-lifetime
-    /// reason as `actions`.
+    /// Resolves the firing surface's owning window id when building a notification identity, so a click can
+    /// reopen a since-closed window. Set at launch by `agtermApp`; weak like `actions`.
     weak var library: WindowLibrary?
 
-    /// Whether to post macOS banners (the General settings toggle, default on). When off, banners are
-    /// suppressed but the sidebar badge still tracks unseen notifications. Set by `SettingsModel`.
+    /// Whether to post macOS banners (the General settings toggle, default on, set by `SettingsModel`). When
+    /// off, the sidebar badge still tracks unseen notifications.
     var bannersEnabled = true
 
-    /// How a delivered notification bounces the Dock icon (the Notifications settings picker, default
-    /// `off`, set by `SettingsModel`). Independent of `bannersEnabled` — like the badge, a bounce fires
-    /// whether or not banners show. `.once` is a single `.informationalRequest`, `.untilFocused` a
-    /// `.criticalRequest` macOS auto-cancels on activation; both no-op while agterm is the active app, so
-    /// a bounce only fires for a notification arriving in the background.
+    /// How a delivered notification bounces the Dock icon (the Notifications settings picker, default `off`,
+    /// set by `SettingsModel`). Independent of `bannersEnabled`, like the badge. `.once` is a single
+    /// `.informationalRequest`, `.untilFocused` a `.criticalRequest` macOS auto-cancels on activation; both
+    /// no-op while agterm is the active app, so a bounce only fires for one arriving in the background.
     var dockBounce: DockBounce = .off
 
     /// Name of the system sound attached to a delivered notification (the Notifications settings picker,
-    /// default nil = silent, set by `SettingsModel`). Routed through the OS as `UNNotificationSound` on
-    /// the banner's content, NOT played directly, so it follows the banner: gated by `bannersEnabled` and
-    /// the macOS notification authorization, and silenced by Do Not Disturb / Focus, unlike the raw
-    /// `NSSound` agent-status sounds.
+    /// default nil = silent, set by `SettingsModel`). Attached as `UNNotificationSound` on the banner content,
+    /// NOT played directly, so it follows the banner: gated by `bannersEnabled` and the macOS notification
+    /// authorization, and silenced by Do Not Disturb / Focus — unlike the raw `NSSound` agent-status sounds.
     var notificationSoundName: String?
 
     /// Register as the notification delegate and request alert + badge + sound authorization. Idempotent
-    /// (the scene `.task` may re-run) and best-effort — a denial just means no banners. `.badge` is what
-    /// lets `DockBadgeController` render the Dock count via `UNUserNotificationCenter.setBadgeCount`;
-    /// without it the legacy `NSApp.dockTile.badgeLabel` is silently suppressed for agterm. `.sound` is
-    /// what lets the configured notification sound, attached to the banner's content, actually play.
+    /// (the scene `.task` may re-run) and best-effort — a denial just means no banners. `.badge` is what lets
+    /// `DockBadgeController` render the Dock count via `setBadgeCount`; without it the legacy
+    /// `NSApp.dockTile.badgeLabel` is silently suppressed for agterm. `.sound` lets the configured sound play.
     func start() {
         let center = UNUserNotificationCenter.current()
         center.delegate = self
@@ -54,10 +48,9 @@ final class NotificationManager: NSObject, @preconcurrency UNUserNotificationCen
         }
     }
 
-    /// Handle a terminal desktop notification fired by `surface` (OSC 9 / 777). Resolves the owning
-    /// session + pane, suppresses when that pane is focused and agterm is active, otherwise posts a
-    /// banner (coalescing by session/pane) and bumps the session's unseen badge. Title falls back to
-    /// the session name when the program sent an empty title (OSC 9 carries only a body).
+    /// Handle a terminal desktop notification fired by `surface` (OSC 9 / 777). Resolves the owning session
+    /// + pane, suppresses when that pane is focused and agterm is active, else posts a banner and bumps the
+    /// unseen badge. Title falls back to the session name when the program sent none (OSC 9 has only a body).
     func notify(surface: GhosttySurfaceView, title: String, body: String) {
         guard let session = surface.session else { return }
         let pane = paneRole(of: surface, in: session)
@@ -93,19 +86,18 @@ final class NotificationManager: NSObject, @preconcurrency UNUserNotificationCen
         content.title = effectiveTitle
         content.body = body
         content.sound = notificationSound
-        // the request identifier is the identity (`<windowID>:<sessionID>:<pane>`): it both coalesces
-        // repeats from the same pane and carries the target a click decodes via `TerminalNotification`.
+        // the request identifier is the identity (`<windowID>:<sessionID>:<pane>`): it coalesces repeats from
+        // the same pane and carries the target a click decodes.
         let identity = TerminalNotification.identity(windowID: windowID, sessionID: session.id, pane: pane)
         UNUserNotificationCenter.current().add(UNNotificationRequest(identifier: identity, content: content, trigger: nil)) { error in
             if let error { logger.error("add failed: \(error.localizedDescription, privacy: .public)") }
         }
     }
 
-    /// Post a desktop notification for a session via the control channel (the `notify` command) rather
-    /// than a terminal OSC. NO focus-suppression here — the caller asked for it, so it always bumps the
-    /// badge and posts a banner (gated only by `bannersEnabled`), attributed to the session's primary pane
-    /// so a click reveals it. False, and nothing sent, when no open window owns the session (there is then
-    /// no click-reveal identity to build).
+    /// Post a desktop notification for a session via the control `notify` command rather than a terminal OSC.
+    /// NO focus-suppression — the caller asked for it, so it always bumps the badge and posts a banner (gated
+    /// only by `bannersEnabled`), attributed to the session's primary pane so a click reveals it. False, and
+    /// nothing sent, when no open window owns the session (no click-reveal identity to build).
     @discardableResult
     func send(toSession session: Session, title: String, body: String) -> Bool {
         guard let windowID = library?.windowID(forSession: session.id) else { return false }
@@ -133,9 +125,8 @@ final class NotificationManager: NSObject, @preconcurrency UNUserNotificationCen
         return true
     }
 
-    /// Remove a session's delivered banners from Notification Center — called when you focus the session,
-    /// so one you've navigated to doesn't linger. Covers every pane by removing each possible
-    /// `<windowID>:<sessionID>:<paneRole>` identifier. No-op when the session's window isn't open.
+    /// Remove a session's delivered banners from Notification Center on focus, so one you navigated to doesn't
+    /// linger. Removes every pane's identifier. No-op when the session's window isn't open.
     func clearDelivered(sessionID: UUID) {
         guard let windowID = library?.windowID(forSession: sessionID) else {
             logger.debug("clearDelivered: no open window owns session \(sessionID, privacy: .public); nothing to clear")
@@ -145,9 +136,8 @@ final class NotificationManager: NSObject, @preconcurrency UNUserNotificationCen
         UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: identifiers)
     }
 
-    /// Post a failure banner for a custom command that exited non-zero or failed to spawn. Unlike a
-    /// terminal notification it isn't tied to a surface, so it always posts when banners are enabled
-    /// (no focus/window gating); a fixed identifier coalesces repeated failures of the same command.
+    /// Post a failure banner for a custom command that exited non-zero or failed to spawn. Not tied to a
+    /// surface, so no focus/window gating; a fixed identifier coalesces repeated failures of one command.
     func notifyCommandFailure(name: String, detail: String) {
         guard bannersEnabled else { return }
         let content = UNMutableNotificationContent()
@@ -159,9 +149,8 @@ final class NotificationManager: NSObject, @preconcurrency UNUserNotificationCen
         }
     }
 
-    /// Post a banner when the keymap parsed with problems (parse errors or cross-section conflicts), so
-    /// they're visible without opening Settings. Session-less and app-level, like `notifyCommandFailure`:
-    /// no focus/window gating; a fixed identifier coalesces repeated reloads to a single banner.
+    /// Post a banner when the keymap parsed with problems (parse errors or cross-section conflicts), visible
+    /// without opening Settings. App-level like `notifyCommandFailure`; a fixed identifier coalesces reloads.
     func notifyKeymapDiagnostics(count: Int) {
         guard bannersEnabled else { return }
         let content = UNMutableNotificationContent()
@@ -173,12 +162,11 @@ final class NotificationManager: NSObject, @preconcurrency UNUserNotificationCen
         }
     }
 
-    /// Post a banner when the ghostty config reloaded with problems (parse errors or invalid keys), so
-    /// they're visible without digging through the log. The count spans ALL config sources (bundled
-    /// defaults, the global `~/.config/ghostty/config`, the agterm-scoped `ghostty.conf`, the UI settings
-    /// conf) since libghostty diagnostics carry no source-file attribution, so the banner does NOT blame
-    /// `ghostty.conf`. Session-less and app-level like `notifyKeymapDiagnostics`: no focus/window gating,
-    /// and a fixed identifier coalesces repeated reloads to a single banner.
+    /// Post a banner when the ghostty config reloaded with problems (parse errors or invalid keys), visible
+    /// without digging through the log. The count spans ALL config sources (bundled defaults, global
+    /// `~/.config/ghostty/config`, agterm-scoped `ghostty.conf`, the UI settings conf) — libghostty
+    /// diagnostics carry no source-file attribution, so the banner does NOT blame `ghostty.conf`. App-level
+    /// like `notifyKeymapDiagnostics`, a fixed identifier coalescing reloads.
     func notifyConfigDiagnostics(count: Int) {
         guard bannersEnabled else { return }
         let content = UNMutableNotificationContent()
@@ -190,8 +178,8 @@ final class NotificationManager: NSObject, @preconcurrency UNUserNotificationCen
         }
     }
 
-    /// Bounce the Dock icon for a background notification per the configured `dockBounce` mode. macOS
-    /// auto-cancels `.untilFocused`'s `.criticalRequest` on activation, so there is no cancel bookkeeping.
+    /// Bounce the Dock icon per `dockBounce`; macOS auto-cancels `.untilFocused` on activation, so there is
+    /// no cancel bookkeeping.
     private func bounceDock() {
         switch dockBounce {
         case .off: return
@@ -200,11 +188,10 @@ final class NotificationManager: NSObject, @preconcurrency UNUserNotificationCen
         }
     }
 
-    /// The `UNNotificationSound` for the configured name, nil when unset (silent, the default).
-    /// `default`/`beep` map to the system alert sound; any other value names a sound file the OS resolves
-    /// against the standard locations (`~/Library/Sounds` through `/System/Library/Sounds`), with `.aiff`
-    /// assumed when the name carries no extension — the system sounds' format, and how the Settings
-    /// picker stores them.
+    /// The `UNNotificationSound` for the configured name, nil when unset (silent, the default). `default`/`beep`
+    /// map to the system alert sound; any other value names a file the OS resolves against the standard
+    /// locations (`~/Library/Sounds` through `/System/Library/Sounds`), with `.aiff` assumed when the name
+    /// carries no extension — the system sounds' format, and how the Settings picker stores them.
     private var notificationSound: UNNotificationSound? {
         guard let name = notificationSoundName, !name.isEmpty else { return nil }
         if name == "default" || name == "beep" { return .default }
@@ -218,16 +205,16 @@ final class NotificationManager: NSObject, @preconcurrency UNUserNotificationCen
         return .main
     }
 
-    /// Present banners, with their attached sound, even while agterm is the active app — the focused-pane
-    /// case is dropped before delivery, so anything reaching here should show. Without `.sound` a
-    /// foreground banner is silent, so a session you're NOT looking at would only ding while backgrounded.
+    /// Present banners, with their attached sound, even while agterm is active — the focused-pane case is
+    /// dropped before delivery. Without `.sound` a foreground banner is silent, so a session you are NOT
+    /// looking at would only ding while backgrounded.
     func userNotificationCenter(_: UNUserNotificationCenter, willPresent _: UNNotification,
                                 withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         completionHandler([.banner, .list, .sound])
     }
 
-    /// A banner was clicked: bring agterm forward and navigate to the firing session/pane (decoded from
-    /// the request identifier). A malformed identifier or closed session just leaves the app active.
+    /// A banner was clicked: bring agterm forward and navigate to the firing session/pane, decoded from the
+    /// request identifier. A malformed identifier or closed session just leaves the app active.
     func userNotificationCenter(_: UNUserNotificationCenter, didReceive response: UNNotificationResponse,
                                 withCompletionHandler completionHandler: @escaping () -> Void) {
         defer { completionHandler() }

--- a/agterm/Notifications/NotificationManager.swift
+++ b/agterm/Notifications/NotificationManager.swift
@@ -7,9 +7,9 @@ private let logger = Logger(subsystem: "com.umputun.agterm", category: "Notifica
 
 /// Owns the macOS notification surface for terminal desktop notifications (OSC 9 / 777).
 ///
-/// `@MainActor` and the `UNUserNotificationCenterDelegate`. `@preconcurrency` on the
-/// conformance lets the delegate methods stay main-actor isolated against the pre-concurrency
-/// UserNotifications API (matches macterm).
+/// `@MainActor` and the `UNUserNotificationCenterDelegate`. `@preconcurrency` on the conformance keeps
+/// the delegate methods main-actor isolated against the pre-concurrency UserNotifications API (as
+/// macterm does).
 @MainActor
 final class NotificationManager: NSObject, @preconcurrency UNUserNotificationCenterDelegate {
     static let shared = NotificationManager()
@@ -18,9 +18,9 @@ final class NotificationManager: NSObject, @preconcurrency UNUserNotificationCen
     /// `agtermApp`; weak since `AppActions` outlives the manager only by app lifetime.
     weak var actions: AppActions?
 
-    /// The window library, used to resolve the firing surface's owning window id when building a
-    /// notification identity (so a click can reopen that window if it has since closed). Set at
-    /// launch by `agtermApp`; weak for the same app-lifetime reason as `actions`.
+    /// Resolves the firing surface's owning window id when building a notification identity, so a click
+    /// can reopen a since-closed window. Set at launch by `agtermApp`; weak for the same app-lifetime
+    /// reason as `actions`.
     weak var library: WindowLibrary?
 
     /// Whether to post macOS banners (the General settings toggle, default on). When off, banners are
@@ -28,25 +28,24 @@ final class NotificationManager: NSObject, @preconcurrency UNUserNotificationCen
     var bannersEnabled = true
 
     /// How a delivered notification bounces the Dock icon (the Notifications settings picker, default
-    /// `off`). Independent of `bannersEnabled` — like the badge, a bounce can fire whether or not banners
-    /// show. Set by `SettingsModel`. `.once` requests a single `.informationalRequest`; `.untilFocused` a
-    /// `.criticalRequest` macOS auto-cancels when agterm becomes active — both no-op while agterm is the
-    /// active app, so a bounce only fires when a notification arrives in the background.
+    /// `off`, set by `SettingsModel`). Independent of `bannersEnabled` — like the badge, a bounce fires
+    /// whether or not banners show. `.once` is a single `.informationalRequest`, `.untilFocused` a
+    /// `.criticalRequest` macOS auto-cancels on activation; both no-op while agterm is the active app, so
+    /// a bounce only fires for a notification arriving in the background.
     var dockBounce: DockBounce = .off
 
-    /// Name of the system sound attached to a delivered notification (the Notifications settings
-    /// picker, default nil = silent). Routed through the OS (`UNNotificationSound` on the banner's
-    /// content), NOT played directly — so it follows the banner: gated by `bannersEnabled` and the
-    /// macOS notification authorization, and silenced by Do Not Disturb / Focus, unlike the raw
-    /// `NSSound` agent-status sounds. Set by `SettingsModel`.
+    /// Name of the system sound attached to a delivered notification (the Notifications settings picker,
+    /// default nil = silent, set by `SettingsModel`). Routed through the OS as `UNNotificationSound` on
+    /// the banner's content, NOT played directly, so it follows the banner: gated by `bannersEnabled` and
+    /// the macOS notification authorization, and silenced by Do Not Disturb / Focus, unlike the raw
+    /// `NSSound` agent-status sounds.
     var notificationSoundName: String?
 
-    /// Register as the notification delegate and request alert + badge + sound authorization.
-    /// Idempotent; the scene `.task` may re-run. Best-effort: a denial just means no banners. The
-    /// `.badge` option is what lets `DockBadgeController` render the Dock count via
-    /// `UNUserNotificationCenter.setBadgeCount` — the legacy `NSApp.dockTile.badgeLabel` is silently
-    /// suppressed for agterm without it. `.sound` is what lets the configured notification sound
-    /// (attached to the banner's content) actually play.
+    /// Register as the notification delegate and request alert + badge + sound authorization. Idempotent
+    /// (the scene `.task` may re-run) and best-effort — a denial just means no banners. `.badge` is what
+    /// lets `DockBadgeController` render the Dock count via `UNUserNotificationCenter.setBadgeCount`;
+    /// without it the legacy `NSApp.dockTile.badgeLabel` is silently suppressed for agterm. `.sound` is
+    /// what lets the configured notification sound, attached to the banner's content, actually play.
     func start() {
         let center = UNUserNotificationCenter.current()
         center.delegate = self
@@ -102,11 +101,11 @@ final class NotificationManager: NSObject, @preconcurrency UNUserNotificationCen
         }
     }
 
-    /// Post a desktop notification for a session via the control channel (the `notify` command), as
-    /// opposed to a terminal OSC. Unlike the OSC path there is NO focus-suppression — the caller asked
-    /// for it explicitly, so it always bumps the badge and posts a banner (gated only by
-    /// `bannersEnabled`). Attributed to the session's primary pane so a click reveals it. Returns false
-    /// when no open window owns the session (the click-reveal identity can't be built) → not sent.
+    /// Post a desktop notification for a session via the control channel (the `notify` command) rather
+    /// than a terminal OSC. NO focus-suppression here — the caller asked for it, so it always bumps the
+    /// badge and posts a banner (gated only by `bannersEnabled`), attributed to the session's primary pane
+    /// so a click reveals it. False, and nothing sent, when no open window owns the session (there is then
+    /// no click-reveal identity to build).
     @discardableResult
     func send(toSession session: Session, title: String, body: String) -> Bool {
         guard let windowID = library?.windowID(forSession: session.id) else { return false }
@@ -134,10 +133,9 @@ final class NotificationManager: NSObject, @preconcurrency UNUserNotificationCen
         return true
     }
 
-    /// Remove any delivered banners for a session from Notification Center — called when you focus
-    /// the session, so a notification you've navigated to doesn't linger. Covers all of the session's
-    /// panes by removing each possible `<windowID>:<sessionID>:<paneRole>` identifier. No-op when the
-    /// session's window isn't open (nothing it delivered could be lingering).
+    /// Remove a session's delivered banners from Notification Center — called when you focus the session,
+    /// so one you've navigated to doesn't linger. Covers every pane by removing each possible
+    /// `<windowID>:<sessionID>:<paneRole>` identifier. No-op when the session's window isn't open.
     func clearDelivered(sessionID: UUID) {
         guard let windowID = library?.windowID(forSession: sessionID) else {
             logger.debug("clearDelivered: no open window owns session \(sessionID, privacy: .public); nothing to clear")
@@ -177,10 +175,10 @@ final class NotificationManager: NSObject, @preconcurrency UNUserNotificationCen
 
     /// Post a banner when the ghostty config reloaded with problems (parse errors or invalid keys), so
     /// they're visible without digging through the log. The count spans ALL config sources (bundled
-    /// defaults, the global `~/.config/ghostty/config`, the agterm-scoped `ghostty.conf`, and the UI
-    /// settings conf) because libghostty diagnostics carry no source-file attribution, so the banner does
-    /// NOT blame `ghostty.conf` specifically. Session-less and app-level, like `notifyKeymapDiagnostics`:
-    /// no focus/window gating; a fixed identifier coalesces repeated reloads to a single banner.
+    /// defaults, the global `~/.config/ghostty/config`, the agterm-scoped `ghostty.conf`, the UI settings
+    /// conf) since libghostty diagnostics carry no source-file attribution, so the banner does NOT blame
+    /// `ghostty.conf`. Session-less and app-level like `notifyKeymapDiagnostics`: no focus/window gating,
+    /// and a fixed identifier coalesces repeated reloads to a single banner.
     func notifyConfigDiagnostics(count: Int) {
         guard bannersEnabled else { return }
         let content = UNMutableNotificationContent()
@@ -192,10 +190,8 @@ final class NotificationManager: NSObject, @preconcurrency UNUserNotificationCen
         }
     }
 
-    /// Bounce the Dock icon for a background notification per the configured mode. `.once` is a single
-    /// `.informationalRequest`; `.untilFocused` a `.criticalRequest` that bounces until agterm becomes active
-    /// (macOS auto-cancels it then, so there is no cancel bookkeeping). Both are automatically a no-op while
-    /// agterm is the active app, so a notification for a session you're already looking at never bounces.
+    /// Bounce the Dock icon for a background notification per the configured `dockBounce` mode. macOS
+    /// auto-cancels `.untilFocused`'s `.criticalRequest` on activation, so there is no cancel bookkeeping.
     private func bounceDock() {
         switch dockBounce {
         case .off: return
@@ -204,11 +200,11 @@ final class NotificationManager: NSObject, @preconcurrency UNUserNotificationCen
         }
     }
 
-    /// The `UNNotificationSound` for the configured name, or nil when unset (silent, the default).
-    /// `default`/`beep` map to the system alert sound; any other value names a sound file the OS
-    /// resolves against the standard sound locations (`~/Library/Sounds` through
-    /// `/System/Library/Sounds`), with `.aiff` assumed when the name carries no extension — the system
-    /// sounds' format, and how the Settings picker stores them.
+    /// The `UNNotificationSound` for the configured name, nil when unset (silent, the default).
+    /// `default`/`beep` map to the system alert sound; any other value names a sound file the OS resolves
+    /// against the standard locations (`~/Library/Sounds` through `/System/Library/Sounds`), with `.aiff`
+    /// assumed when the name carries no extension — the system sounds' format, and how the Settings
+    /// picker stores them.
     private var notificationSound: UNNotificationSound? {
         guard let name = notificationSoundName, !name.isEmpty else { return nil }
         if name == "default" || name == "beep" { return .default }
@@ -222,10 +218,9 @@ final class NotificationManager: NSObject, @preconcurrency UNUserNotificationCen
         return .main
     }
 
-    /// Present banners — with their attached sound — even while agterm is the active app (the
-    /// focused-pane case is dropped before delivery, so anything reaching here should show). Without
-    /// `.sound` a foreground banner would show silently, so a notification from a session you're NOT
-    /// looking at would only ding while agterm is backgrounded.
+    /// Present banners, with their attached sound, even while agterm is the active app — the focused-pane
+    /// case is dropped before delivery, so anything reaching here should show. Without `.sound` a
+    /// foreground banner is silent, so a session you're NOT looking at would only ding while backgrounded.
     func userNotificationCenter(_: UNUserNotificationCenter, willPresent _: UNNotification,
                                 withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         completionHandler([.banner, .list, .sound])

--- a/agterm/SettingsModel.swift
+++ b/agterm/SettingsModel.swift
@@ -4,12 +4,10 @@ import os
 
 private let logger = Logger(subsystem: "com.umputun.agterm", category: "SettingsModel")
 
-/// The observable settings state for the Settings window. Loads `AppSettings` from `SettingsStore`
-/// at init; each mutation persists AND applies live to the running terminals.
-///
-/// Applying writes the ghostty settings file, rebuilds + broadcasts the config to every live
-/// surface, and clears per-session font-size overrides (the shared `update_config` resets all
-/// surfaces to the new default, so the persisted overrides are cleared to match).
+/// The observable settings state for the Settings window. Loads `AppSettings` from `SettingsStore` at
+/// init; each mutation persists AND applies live: writes the ghostty settings file, rebuilds +
+/// broadcasts the config to every live surface, and clears the per-session font-size overrides to match
+/// (the shared `update_config` resets all surfaces to the new default).
 @Observable
 @MainActor
 final class SettingsModel {
@@ -25,31 +23,26 @@ final class SettingsModel {
     /// Problems found while parsing the keymap file, surfaced read-only in the Key Mapping settings tab.
     private(set) var keymapDiagnostics: [KeymapDiagnostic] = []
 
-    /// Coalesces rapid theme-picker navigation/typing previews so a burst of `previewTheme` calls
-    /// triggers a single `apply()` once the quiet window elapses, instead of rebuilding + reloading
-    /// every surface on each arrow keypress. Commit flushes it; cancel drops it (see `commitTheme`
-    /// and `revertThemePreview`).
+    /// Coalesces a burst of `previewTheme` calls into one `apply()` once the quiet window elapses,
+    /// instead of rebuilding + reloading every surface per arrow keypress. `commitTheme` flushes it;
+    /// `revertThemePreview` drops it.
     private let previewThemeDebouncer = Debouncer()
     private static let previewThemeDebounceInterval: TimeInterval = 0.07
 
-    /// Coalesces the opacity/blur slider's live drag into a single deferred `settings.json` write: the
-    /// preview methods apply each tick WITHOUT saving and reschedule this, so the disk write fires once
-    /// the slider settles. This persists KEYBOARD adjustments too (arrow keys don't fire the slider's
-    /// `onEditingChanged`), while a mouse release flushes it immediately via `commitBackgroundSettings`.
+    /// Coalesces the opacity/blur drag into one deferred `settings.json` write: the preview methods apply
+    /// each tick WITHOUT saving and reschedule this. Covers KEYBOARD adjustments too (arrows don't fire
+    /// the slider's `onEditingChanged`); a mouse release flushes it via `commitBackgroundSettings`.
     private let backgroundSaveDebouncer = Debouncer()
     private static let backgroundSaveInterval: TimeInterval = 0.3
 
-    /// Coalesces `.agtermSystemAppearanceChanged` into a single re-apply when the macOS light/dark
-    /// appearance flips. Posted by the app-level KVO observer on `NSApplication.effectiveAppearance`
-    /// (`SystemAppearanceObserver`); the debounce absorbs any rapid repeat post during the transition.
+    /// Coalesces `.agtermSystemAppearanceChanged` (posted by the app-level KVO observer on
+    /// `NSApplication.effectiveAppearance`, `SystemAppearanceObserver`) into one re-apply per flip.
     private let appearanceDebouncer = Debouncer()
     private static let appearanceDebounceInterval: TimeInterval = 0.05
 
     /// The theme slots as of the last real persist (`persistAndApply`/`commitTheme`), NOT updated by the
-    /// live theme preview. The opacity/blur background-save debounce persists a snapshot pinned to these
-    /// values instead of the in-flight `settings.theme`/`darkTheme`, so a slider write firing mid-preview
-    /// can't leak an uncommitted previewed theme to `settings.json` (the preview persists only on
-    /// commit; Esc reverts it in memory, and disk must never have seen it).
+    /// live preview. The background-save debounce pins its snapshot to these, so a slider write firing
+    /// mid-preview can't leak an uncommitted previewed theme to `settings.json`.
     private var committedTheme: String?
     private var committedDarkTheme: String?
 
@@ -59,15 +52,13 @@ final class SettingsModel {
         self.settings = settingsStore.load()
         self.committedTheme = settings.theme
         self.committedDarkTheme = settings.darkTheme
-        // write the ghostty config from the loaded settings NOW — before GhosttyApp boots and reads it
-        // (its loadConfig runs in applicationDidFinishLaunching, AFTER this App.init). The SEEDED default
-        // theme (agterm) lives only in memory (load() seeds it; it isn't in settings.json), so without
-        // this the launch config carries no theme line and the terminal renders ghostty's built-in until
-        // the first settings change rewrites the conf. Idempotent: writeGhosttyConfig no-ops when the file
-        // already matches (e.g. a user with an explicit theme already has it on disk).
+        // write the ghostty config NOW — GhosttyApp's loadConfig runs in applicationDidFinishLaunching,
+        // AFTER this App.init. The SEEDED default theme (agterm) is memory-only (load() seeds it; it
+        // isn't in settings.json), so without this the launch config carries no theme line and the
+        // terminal renders ghostty's built-in until the next settings change. Idempotent: no-ops when
+        // the file already matches.
         _ = writeGhosttyConfig()
-        // mirror the persisted window translucency + notification toggle + toolbar mode + badge
-        // toggle into their shared channels at launch, before any settings change fires.
+        // mirror the persisted settings into their shared channels before any settings change fires.
         applyWindowTranslucency()
         applyNotificationsEnabled()
         applyDockBounce()
@@ -84,18 +75,14 @@ final class SettingsModel {
         applyAttentionButtonEnabled()
         applyInterfaceElements()
         applyAutoHideSidebarInactiveWindows()
-        // create the commented starter keymap on first launch, then load + parse it.
         ensureStarterKeymap()
         loadKeymap()
-        // create the commented starter ghostty.conf on first launch (all comments, a no-op until edited).
         ensureStarterGhosttyConfig()
-        // seed the restore-denylist.conf (multiplexers) on first launch, then parse it into GhosttyApp.
         ensureStarterRestoreDenylist()
         loadRestoreDenylist()
-        // follow the macOS light/dark appearance: `SystemAppearanceObserver` (app-level KVO on
-        // NSApp.effectiveAppearance) posts this with the resolved `isDark`; we re-feed the config so
-        // libghostty re-resolves the dual `theme = light:,dark:` conditional to the new side. The side
-        // rides the notification (the KVO-delivered value) and is threaded straight into the reload.
+        // follow the macOS appearance: `SystemAppearanceObserver` (app-level KVO on
+        // NSApp.effectiveAppearance) posts the resolved `isDark`, threaded straight into the reload,
+        // which re-feeds the config so libghostty re-resolves the dual `theme = light:,dark:` conditional.
         NotificationCenter.default.addObserver(forName: .agtermSystemAppearanceChanged, object: nil,
                                                queue: .main) { [weak self] note in
             guard let isDark = note.userInfo?["isDark"] as? Bool else { return }
@@ -107,29 +94,24 @@ final class SettingsModel {
     /// user's current work. Settings views still mutate through this model; they don't need library access.
     var activeSessionCwd: String? { library.activeStore?.activeSession?.focusedCwd }
 
-    /// The appearance side the last config feed applied, used to suppress redundant re-posts of
-    /// `.agtermSystemAppearanceChanged` on the same side (KVO `[.initial]` seeds one at launch, and the
-    /// debounce can coalesce a burst). Starts `false` because a host-loaded config is always resolved to
-    /// the LIGHT side: a light launch then skips the seeding reload entirely, while a dark launch takes
-    /// exactly one (which re-sides the chrome colors via the CONFIG_CHANGE clone). Read-only outside: the
-    /// UI-test-only `debug.appearance` probe (bare form) reports it so a test can assert a flip drove the reload.
+    /// The appearance side the last config feed applied, suppressing same-side reloads (KVO `[.initial]`
+    /// seeds one at launch, and the debounce can coalesce a burst). Starts `false` because a host-loaded
+    /// config always resolves LIGHT: a light launch skips the seeding reload, a dark launch takes exactly
+    /// one (re-siding the chrome colors via the CONFIG_CHANGE clone). Read outside only by the
+    /// UI-test-only `debug.appearance` probe (bare form), so a test can assert a flip drove the reload.
     private(set) var lastAppliedIsDark = false
 
-    /// Re-feed the config on a macOS appearance flip so libghostty re-resolves the dual theme to the new
-    /// side — the system→settings half of light/dark sync. A no-op unless following with both slots set,
-    /// and a no-op when the appearance side hasn't actually changed since the last feed (see
-    /// `lastAppliedIsDark`). The config file holds the RAW `theme = light:,dark:` value and is IDENTICAL
-    /// across flips, so `writeGhosttyConfig()` would no-op and `apply()` would skip the reload; reload
-    /// DIRECTLY instead. ghostty already recorded the new scheme (`set_color_scheme`) and re-resolves
-    /// when we re-feed the config via `update_config`. Debounced because a burst can arrive (KVO
-    /// `[.initial]` at launch, plus the seam); the latest posted side wins. Unlike an explicit File ▸
-    /// Reload / `config.reload`, an automatic flip PRESERVES each session's ⌘+/⌘− zoom — silently wiping
-    /// it on an OS schedule would be a surprise.
-    ///
-    /// `isDark` is the KVO-delivered side (from `SystemAppearanceObserver`), threaded straight into the
-    /// reload so libghostty is set to exactly this side — never re-read from a view, whose
-    /// `effectiveAppearance` can lag around sleep/wake. This makes `lastAppliedIsDark` equal the applied
-    /// side by construction. A zero-surface reload is safe (the app-scheme set re-sides the chrome clone).
+    /// Re-feed the config on a macOS appearance flip so libghostty re-resolves the dual theme — the
+    /// system→settings half of light/dark sync. No-op unless following with both slots set, or when the
+    /// side is unchanged since the last feed (`lastAppliedIsDark`). The file's RAW `theme = light:,dark:`
+    /// text is IDENTICAL across flips, so `writeGhosttyConfig()`/`apply()` would skip the reload — reload
+    /// DIRECTLY instead; ghostty already recorded the scheme (`set_color_scheme`) and re-resolves on
+    /// `update_config`. Debounced against bursts (KVO `[.initial]` at launch, plus the seam); the latest
+    /// posted side wins. An automatic flip PRESERVES each session's ⌘+/⌘− zoom (unlike File ▸ Reload /
+    /// `config.reload`) — wiping it on an OS schedule would surprise. A zero-surface reload is safe: the
+    /// app-scheme set re-sides the chrome clone. `isDark` is the KVO-delivered side, threaded straight in
+    /// and never re-read from a view (whose `effectiveAppearance` lags around sleep/wake), so
+    /// `lastAppliedIsDark` equals the applied side by construction.
     private func appearanceChanged(isDark: Bool) {
         guard settings.followSystemAppearance == true, settings.theme != nil, settings.darkTheme != nil else { return }
         appearanceDebouncer.schedule(after: Self.appearanceDebounceInterval) { [weak self] in
@@ -148,8 +130,7 @@ final class SettingsModel {
     private var rendersDarkSlot: Bool { settings.followSystemAppearance == true && GhosttyApp.currentIsDark() }
 
     /// Set the light/single slot — the control channel's `theme set <name>`. A name keeps the dark side
-    /// (syncing stays on); nil ("default ghostty") clears everything, since a nil side can't be a dual
-    /// slot.
+    /// (syncing stays on); nil ("default ghostty") clears everything, since a nil side can't be a dual slot.
     func setLightTheme(_ value: String?) {
         settings.theme = value
         if value == nil { settings.darkTheme = nil; settings.followSystemAppearance = nil }
@@ -187,9 +168,8 @@ final class SettingsModel {
     }
 
     /// Settings alternate picker (shown only while following): the theme for the OTHER appearance.
-    /// Clearing the dark slot (nil while the alternate IS the dark slot) routes through `setDarkTheme(nil)`
-    /// so following can never be left ON with `darkTheme == nil` — the picker has no such row today, but the
-    /// setter stays consistent regardless of what a future caller passes.
+    /// Clearing the dark slot routes through `setDarkTheme(nil)` so following can never be left ON with
+    /// `darkTheme == nil` — no picker row does that today, but the setter holds for any caller.
     func setAlternateTheme(_ value: String?) {
         if rendersDarkSlot {
             settings.theme = value          // the alternate is the LIGHT slot while rendering dark
@@ -218,9 +198,8 @@ final class SettingsModel {
         persistAndApply()
     }
 
-    /// The light side seeded when a dark theme is chosen while the theme is nil/empty (ghostty
-    /// built-in, which cannot be a dual side) — a bundled light theme so the pick composes a
-    /// well-formed dual value.
+    /// The light side seeded when a dark theme is chosen while `theme` is nil/empty (ghostty's built-in,
+    /// which cannot be a dual side) — a bundled light theme, so the pick composes a well-formed dual value.
     static let defaultLightTheme = "Builtin Light"
 
     func setNotificationsEnabled(_ value: Bool?) { settings.notificationsEnabled = value; persistAndApply() }
@@ -244,21 +223,19 @@ final class SettingsModel {
     func setAttentionButtonEnabled(_ value: Bool?) { settings.attentionButtonEnabled = value; persistAndApply() }
 
     /// Persist whether only the frontmost window shows its sidebar. A behavior flag, not a ghostty key, so
-    /// `persistAndApply()` no-ops the config; it pushes the `GhosttyApp` mirror the frontmost-change driver
-    /// reads. Turning it ON collapses every inactive window's sidebar immediately, rather than waiting for
-    /// the next window-focus change.
+    /// `persistAndApply()` no-ops the config and just pushes the `GhosttyApp` mirror the frontmost-change
+    /// driver reads. Turning it ON collapses every inactive sidebar at once, not at the next focus change.
     func setAutoHideSidebarInactiveWindows(_ value: Bool?) {
         settings.autoHideSidebarInactiveWindows = value
         persistAndApply()
         if value == true { library.applyInactiveWindowSidebarHiding() }
     }
 
-    /// Show or hide a single title-bar / sidebar-footer chrome element, then persist. Toggling `visible`
-    /// off adds the element to `hiddenInterfaceElements`, on removes it; an empty result maps back to nil so
-    /// `settings.json` stays minimal. A GUI-only chrome flag, not a ghostty key — `persistAndApply()`
-    /// no-ops the config text but rides `.agtermAppearanceChanged` so every window re-gates the element live.
-    /// Mutates the RAW string set (not `resolvedHiddenInterfaceElements`, which drops unknown names) so a
-    /// future element hidden by a newer build survives a toggle here instead of being erased.
+    /// Show or hide one title-bar / sidebar-footer chrome element, then persist; an empty result maps back
+    /// to nil so `settings.json` stays minimal. Not a ghostty key — `persistAndApply()` no-ops the config
+    /// text but rides `.agtermAppearanceChanged`, so every window re-gates the element live. Mutates the
+    /// RAW string set: `resolvedHiddenInterfaceElements` drops unknown names, erasing an element a newer
+    /// build hid.
     func setInterfaceElementVisible(_ element: InterfaceElement, visible: Bool) {
         var hidden = Set(settings.hiddenInterfaceElements ?? [])
         if visible { hidden.remove(element.rawValue) } else { hidden.insert(element.rawValue) }
@@ -266,11 +243,11 @@ final class SettingsModel {
         persistAndApply()
     }
 
-    /// Persist whether agterm inherits the user's global `~/.config/ghostty/config` and FULLY reload the
-    /// ghostty config so the change takes effect live. NOT a `ghosttyConfigLines()` key, so
-    /// `persistAndApply`'s text-diff guard would skip the reload — but it changes WHICH files `loadConfig`
-    /// reads, so it takes the unconditional reload path (like `setConfigDirectory`). nil/false = off (the
-    /// default): agterm stays self-contained; the scoped `ghostty.conf` is the place for customizations.
+    /// Persist whether agterm inherits the user's global `~/.config/ghostty/config`, then FULLY reload so
+    /// it takes effect live. NOT a `ghosttyConfigLines()` key, so `persistAndApply`'s text-diff guard
+    /// would skip the reload — but it changes WHICH files `loadConfig` reads, so it takes the
+    /// unconditional path (like `setConfigDirectory`). nil/false = off: agterm stays self-contained, and
+    /// the scoped `ghostty.conf` is the place for customizations.
     func setInheritGlobalGhosttyConfig(_ value: Bool?) {
         settings.inheritGlobalGhosttyConfig = value
         try? settingsStore.save(settings)
@@ -288,9 +265,8 @@ final class SettingsModel {
     /// Persist the system sound played when a session enters `blocked` (nil/empty = none). Not a ghostty
     /// key and nothing renders it continuously, so it only saves — `ControlServer` reads it on demand.
     func setBlockedStatusSoundName(_ name: String?) { settings.blockedStatusSoundName = name; try? settingsStore.save(settings) }
-    /// Persist where a new (⌘T) session opens (nil = the home default). Not a ghostty key and nothing
-    /// renders it continuously — it only affects the NEXT new session, read then by `AppActions.newSession()`
-    /// — so it just saves (no config rewrite / surface reload).
+    /// Persist where a new (⌘T) session opens (nil = home). Not a ghostty key and read only at the NEXT
+    /// new session (`AppActions.newSession()`), so it just saves — no config rewrite or surface reload.
     func setNewSessionDirectory(_ value: String?) { settings.newSessionDirectory = value; try? settingsStore.save(settings) }
     /// Persist the fixed directory used when `newSessionDirectory` is `custom` (nil/empty falls back to home).
     func setNewSessionCustomDirectory(_ value: String?) { settings.newSessionCustomDirectory = value; try? settingsStore.save(settings) }
@@ -314,11 +290,9 @@ final class SettingsModel {
         applyAutoFollowToAllWindows()
     }
 
-    /// Apply a new background opacity live WITHOUT an immediate save — the live-drag half of the opacity
-    /// slider. Updates translucency on every drag tick (apply-without-save) and schedules a debounced
-    /// write, so the window updates continuously while the disk write coalesces to one once the slider
-    /// settles (covering keyboard arrow adjustments, which never fire `onEditingChanged`). A mouse
-    /// release flushes it immediately via `commitBackgroundSettings`. Mirrors the theme apply/save split.
+    /// Apply a new background opacity live WITHOUT saving — the live-drag half of the slider: each tick
+    /// applies and reschedules `backgroundSaveDebouncer`, so the disk write coalesces to one on settle.
+    /// Mirrors the theme apply/save split.
     func previewBackgroundOpacity(_ value: Double?) {
         settings.backgroundOpacity = value
         apply()
@@ -333,17 +307,15 @@ final class SettingsModel {
         scheduleBackgroundSave()
     }
 
-    /// Persist the current opacity/blur NOW — the slider's `onEditingChanged` drag-end commit. Flushes
-    /// the pending debounced write so a mouse release saves immediately (save-only; the value is already
-    /// live from the preview applies, so no redundant re-apply).
+    /// Persist the current opacity/blur NOW — the slider's `onEditingChanged` drag-end commit. Save-only:
+    /// the value is already live from the preview applies, so it just flushes the pending debounced write.
     func commitBackgroundSettings() { backgroundSaveDebouncer.flush() }
 
     private func scheduleBackgroundSave() {
         backgroundSaveDebouncer.schedule(after: Self.backgroundSaveInterval) { [weak self] in
             guard let self else { return }
-            // pin the theme to the last committed value: a theme preview mutates settings.theme in
-            // place WITHOUT persisting, so saving the live settings here would leak an uncommitted
-            // preview to disk. Opacity/blur (what this save is for) keep their live values.
+            // pin the theme to the last committed value — a live preview mutates `settings.theme` in
+            // place without persisting. Opacity/blur (what this save is for) keep their live values.
             var snapshot = settings
             snapshot.theme = committedTheme
             snapshot.darkTheme = committedDarkTheme
@@ -351,25 +323,23 @@ final class SettingsModel {
         }
     }
 
-    /// Apply a theme live WITHOUT persisting it — the live-preview half of the action-palette theme
-    /// picker (navigation/typing). Sets `settings.theme` immediately (so a commit captures the latest
-    /// even if the apply hasn't fired yet) but DEBOUNCES the expensive `apply()` (config rewrite +
-    /// surface reload + chrome refresh), so a burst of arrow/typing previews coalesces to one reload
-    /// once the quiet window elapses. Skips `settingsStore.save`, so navigating themes doesn't touch
-    /// `settings.json`; the picker commits with `commitTheme()` on Enter (which flushes the pending
-    /// apply) or reverts with `revertThemePreview(theme:darkTheme:)` on Esc (restoring both captured
-    /// slots). Writes the CURRENT-appearance slot (the dark slot while following in dark mode, else
-    /// `theme`) so the preview renders on screen.
+    /// Apply a theme live WITHOUT persisting — the action-palette picker's preview half. Sets the slot
+    /// immediately (so a commit captures the latest even if the apply hasn't fired) but DEBOUNCES the
+    /// expensive `apply()` (config rewrite + surface reload + chrome refresh) and skips
+    /// `settingsStore.save`, so browsing never touches `settings.json`. Writes the CURRENT-appearance
+    /// slot (the dark one while following in dark mode, else `theme`) so the preview renders on screen.
+    /// Enter commits via `commitTheme()` (flushing the pending apply), Esc reverts via
+    /// `revertThemePreview(theme:darkTheme:)` (restoring both captured slots).
     func previewTheme(_ value: String?) {
         if rendersDarkSlot { settings.darkTheme = value } else { settings.theme = value }
         previewThemeDebouncer.schedule(after: Self.previewThemeDebounceInterval) { [weak self] in self?.apply() }
     }
 
-    /// Restore BOTH theme slots IMMEDIATELY (no debounce), cancelling any pending debounced preview — the
-    /// revert half of the picker (Esc / scrim / mode switch / unmount). Synchronous so the captured pair
-    /// is restored with no debounce lag and no queued preview fires afterwards. Writes both slots (not
-    /// the on-screen one) so an appearance flip mid-preview can't leave a previewed value in the wrong
-    /// slot — `AppActions` snapshots the pair on open and passes it straight back.
+    /// Restore BOTH theme slots IMMEDIATELY, cancelling any pending debounced preview — the revert half
+    /// of the picker (Esc / scrim / mode switch / unmount). Synchronous, so nothing lags and no queued
+    /// preview fires after. Both slots, not just the on-screen one, so an appearance flip mid-preview
+    /// can't strand a previewed value in the other — `AppActions` snapshots the pair on open and passes
+    /// it straight back.
     func revertThemePreview(theme: String?, darkTheme: String?) {
         previewThemeDebouncer.cancel()
         settings.theme = theme
@@ -377,15 +347,13 @@ final class SettingsModel {
         apply()
     }
 
-    /// Persist the picker's final theme — the commit half, called on Enter after one or more
-    /// `previewTheme` applies. Only the slot rendering AT ENTER-TIME (the active slot) keeps its browsed
-    /// value; the OTHER slot is restored to `nonActiveOriginal` (its value when the picker opened). Without
-    /// that, a mid-preview appearance flip that browsed a value into the off-screen slot would persist it
-    /// even though it was never confirmed, and it would resurface on the next flip — the commit-side twin
-    /// of the `revertThemePreview` bug. Flushes any pending debounced preview first (so the active slot's
-    /// latest value is live), restores the off-screen slot, re-applies ONLY if that changed the config
-    /// (the flip case — so the dual line on disk matches, and the reverted slot won't resurface), then
-    /// writes `settings.json`. The common no-flip commit stays save-only (nothing to restore, no reload).
+    /// Persist the picker's final theme — the commit half, on Enter after one or more `previewTheme`
+    /// applies. Only the slot rendering AT ENTER-TIME keeps its browsed value; the OTHER is restored to
+    /// `nonActiveOriginal` (its value when the picker opened), or a mid-preview appearance flip would
+    /// persist a value into the off-screen slot that was never confirmed and would resurface on the next
+    /// flip. Flushes the pending preview first (so the active slot is live), restores the off-screen
+    /// slot, re-applies ONLY if that changed the config (the flip case, so the dual line on disk
+    /// matches), then saves; a no-flip commit stays save-only.
     func commitTheme(nonActiveOriginal: (theme: String?, dark: String?)) {
         previewThemeDebouncer.flush()
         let restored: Bool
@@ -402,18 +370,16 @@ final class SettingsModel {
         committedDarkTheme = settings.darkTheme
     }
 
-    /// Flush any pending debounced settings writes synchronously — the quit path. The opacity/blur
-    /// slider's debounced `settings.json` write (and the theme preview, for symmetry) holds a pending
-    /// save for ~0.3 s after a KEYBOARD adjustment, which never fires the slider's drag-end commit;
-    /// quitting within that window would otherwise lose it. Called from `applicationWillTerminate`.
+    /// Flush any pending debounced settings writes synchronously, from `applicationWillTerminate`. A
+    /// KEYBOARD opacity/blur adjustment never fires the slider's drag-end commit, so its ~0.3 s pending
+    /// write (and the theme preview's, for symmetry) would be lost by quitting inside that window.
     func flushPendingSaves() {
         backgroundSaveDebouncer.flush()
         previewThemeDebouncer.flush()
     }
 
-    /// Reset the whole Agent Status section to defaults (the "Reset to defaults" button): the three glyph
-    /// colors back to the system defaults, the three glyph shapes back to the default plain circle,
-    /// AND the blocked sound back to none.
+    /// Reset the whole Agent Status section (the "Reset to defaults" button): the three glyph colors to
+    /// the system defaults, the three glyph shapes to the default plain circle, the blocked sound to none.
     func resetAgentStatus() {
         settings.activeStatusColorHex = nil
         settings.blockedStatusColorHex = nil
@@ -426,9 +392,8 @@ final class SettingsModel {
     }
 
     /// Persist a new config directory (where `keymap.conf` and `ghostty.conf` live) and reload BOTH
-    /// co-located files from it, so neither lags behind a directory change (each reload posts its own
-    /// diagnostics banner). A nil value falls back to the default location resolved by
-    /// `ConfigPaths.configDirectory`.
+    /// co-located files so neither lags the change (each reload posts its own diagnostics banner). nil
+    /// falls back to the default location `ConfigPaths.configDirectory` resolves.
     func setConfigDirectory(_ value: String?) {
         settings.configDirectory = value
         try? settingsStore.save(settings)
@@ -436,11 +401,11 @@ final class SettingsModel {
         reloadGhosttyConfig()
     }
 
-    /// Re-read and re-parse `keymap.conf`, then post `.agtermKeymapChanged` so the custom-command
-    /// runner rebuilds and the action palette re-reads the custom commands. The data-driven menu
-    /// shortcuts re-render on their own (they read the `@Observable` `keymap`). Surfaces any parse
-    /// errors or conflicts as a banner — this runtime reload path runs after notification registration,
-    /// so it's safe to post here (the startup path posts from the scene `.task` instead).
+    /// Re-read and re-parse `keymap.conf`, then post `.agtermKeymapChanged` so the custom-command runner
+    /// rebuilds and the action palette re-reads them; the data-driven menu shortcuts re-render on their
+    /// own off the `@Observable` `keymap`. Parse errors/conflicts surface as a banner — safe to post here
+    /// since this runtime path runs after notification registration (the startup path posts from the
+    /// scene `.task` instead).
     func reloadKeymap() {
         loadKeymap()
         NotificationCenter.default.post(name: .agtermKeymapChanged, object: nil)
@@ -466,8 +431,7 @@ final class SettingsModel {
     /// The resolved `keymap.conf` path, exposed for the Edit Keymap action (the overlay command).
     var keymapPath: String { keymapURL().path }
 
-    /// The resolved agterm-scoped `ghostty.conf` path: `<config dir>/ghostty.conf`, co-located with
-    /// `keymap.conf`.
+    /// The resolved agterm-scoped `ghostty.conf` path: `<config dir>/ghostty.conf`, beside `keymap.conf`.
     private func ghosttyConfigURL() -> URL {
         ConfigPaths.ghosttyConfigPath(configDirectory: configDirectoryURL())
     }
@@ -524,16 +488,14 @@ final class SettingsModel {
         """
     }
 
-    /// Rebuild the ghostty config from all sources (re-reading the agterm-scoped `ghostty.conf` the user
-    /// just edited) and broadcast it to every live surface, clearing per-session font overrides like a
-    /// settings change. Unconditional — unlike `apply()`, which skips the reload when the generated
-    /// settings text is unchanged; `ghostty.conf` is edited externally, so there is always something to
-    /// re-read. Posts `.agtermAppearanceChanged` so the chrome picks up any color change, and a warning
-    /// banner on diagnostics (mirroring `reloadKeymap`, so every caller surfaces them — this runtime path
-    /// runs after notification registration, so posting here is safe). Returns the rebuilt config's
-    /// diagnostic count (0 = clean), counted across ALL config sources (libghostty diagnostics carry no
-    /// source-file attribution, so it is not specific to `ghostty.conf`). Drives File ▸ Reload Config, the
-    /// Edit-ghostty overlay close, a Key Mapping directory change, and the `config.reload` control command.
+    /// Rebuild the ghostty config from all sources (re-reading the externally edited agterm-scoped
+    /// `ghostty.conf`) and broadcast it to every live surface, clearing per-session font overrides like a
+    /// settings change. UNCONDITIONAL, unlike `apply()`'s unchanged-text skip — an external edit always
+    /// has something to re-read. Posts `.agtermAppearanceChanged` for the chrome, and a warning banner on
+    /// diagnostics (safe here, like `reloadKeymap`: a runtime path, after notification registration).
+    /// Returns the diagnostic count (0 = clean) across ALL config sources, since libghostty diagnostics
+    /// carry no source-file attribution. Drives File ▸ Reload Config, the Edit-ghostty overlay close, a
+    /// Key Mapping directory change, and the `config.reload` control command.
     @discardableResult
     func reloadGhosttyConfig() -> Int {
         let count = reloadConfigClearingSessionZoom()
@@ -542,21 +504,20 @@ final class SettingsModel {
         return count
     }
 
-    /// Clears every session's per-session ⌘+/⌘− zoom BEFORE rebuilding + rebroadcasting the ghostty
-    /// config to the live surfaces, returning the rebuilt config's diagnostic count. The ORDER is
-    /// load-bearing: `reloadConfig` re-asserts each surface's per-session overlay (`reapplySessionConfigIfNeeded`),
-    /// which re-emits `font-size` from `session.fontSize`. Clearing the override FIRST makes that re-emit
-    /// read nil — so a watermarked pane drops its zoom on screen and the snapshot persists `fontSize == nil`
-    /// in agreement, matching the documented "reload clears per-session zoom" contract (resetting AFTER would
-    /// leave the surface zoomed while the model said nil). The EXPLICIT reload callers — `reloadGhosttyConfig`
-    /// and `apply()` — funnel through here so neither can drift back to reload-then-reset; the automatic
-    /// appearance flip is the one deliberate exception (`reloadConfigPreservingSessionZoom`).
+    /// Clears every session's ⌘+/⌘− zoom BEFORE rebuilding + rebroadcasting the config to the live
+    /// surfaces, returning the rebuilt config's diagnostic count. The ORDER is load-bearing: the reload
+    /// re-asserts each surface's per-session overlay (`reapplySessionConfigIfNeeded`), re-emitting
+    /// `font-size` from `session.fontSize` — clearing first makes that read nil, so a watermarked pane
+    /// drops its zoom on screen and the snapshot persists `fontSize == nil` in agreement, matching the
+    /// documented "reload clears per-session zoom" contract (resetting AFTER leaves the surface zoomed
+    /// while the model says nil). Both EXPLICIT callers (`reloadGhosttyConfig`, `apply()`) funnel here;
+    /// the automatic appearance flip is the one exception (`reloadConfigPreservingSessionZoom`).
     @discardableResult
     private func reloadConfigClearingSessionZoom() -> Int {
         // every reload re-sides the config (surface schemes + the CONFIG_CHANGE chrome clone) to the
-        // CURRENT appearance, so record the side here — for ALL reload paths, not just the appearance
-        // flip — to keep `appearanceChanged()`'s same-side suppression from firing one spurious reload
-        // later. The app-level `NSApp.effectiveAppearance` (via `currentIsDark()`) is the single source.
+        // CURRENT appearance, from the single source `NSApp.effectiveAppearance` (via `currentIsDark()`).
+        // Record it on ALL reload paths, not just the flip, or `appearanceChanged()`'s same-side
+        // suppression fires one spurious reload later.
         let isDark = GhosttyApp.currentIsDark()
         lastAppliedIsDark = isDark
         // open windows reset live, closed ones by rewriting their snapshot file (the shared config reset
@@ -565,23 +526,20 @@ final class SettingsModel {
         return GhosttyApp.shared.reloadConfig(surfaces: liveSurfaces(), isDark: isDark)
     }
 
-    /// The appearance-flip variant of the reload above: re-feeds the config so libghostty re-resolves
-    /// the dual theme, but KEEPS every session's ⌘+/⌘− zoom — after the shared-config broadcast,
-    /// `reapplySessionConfigIfNeeded` re-emits the session's `fontSize` per surface (the same
-    /// round-trip that re-asserts watermarks). An automatic OS flip (or the launch seeding reload of a
-    /// dark launch) must not silently wipe zoom; only the explicit reloads carry the documented
-    /// zoom-clearing contract. The latch records the `isDark` we actually applied (the KVO-delivered
-    /// side threaded through the reload), so "latch == applied side" holds for ALL reload paths — there
-    /// is one source now, so the poster-vs-rendered divergence the old two-source design feared is gone.
+    /// The appearance-flip variant of the reload above: re-feeds the config so libghostty re-resolves the
+    /// dual theme, but KEEPS every session's ⌘+/⌘− zoom — after the broadcast `reapplySessionConfigIfNeeded`
+    /// re-emits each session's `fontSize` per surface (the same round-trip that re-asserts watermarks).
+    /// An automatic OS flip (or a dark launch's seeding reload) must not silently wipe zoom; only the
+    /// explicit reloads carry that contract. The latch records the `isDark` actually applied (the
+    /// KVO-delivered side threaded through the reload), so "latch == applied side" holds on every path.
     private func reloadConfigPreservingSessionZoom(isDark: Bool) {
         GhosttyApp.shared.reloadConfig(surfaces: liveSurfaces(), isDark: isDark)
         lastAppliedIsDark = isDark
     }
 
-    /// Read `keymap.conf` and parse it into `keymap` + `keymapDiagnostics`. A MISSING file is not an
-    /// error: it yields an empty keymap with no diagnostics (the starter file is created at init). A
-    /// file that EXISTS but can't be read (permissions, invalid UTF-8) is surfaced as a single line-0
-    /// diagnostic so the warning banner fires, rather than being silently treated as missing.
+    /// Read `keymap.conf` into `keymap` + `keymapDiagnostics`. A MISSING file is not an error — empty
+    /// keymap, no diagnostics (the starter is written at init). One that EXISTS but can't be read
+    /// (permissions, invalid UTF-8) becomes a single line-0 diagnostic so the warning banner fires.
     private func loadKeymap() {
         let loaded = KeymapStore(configDirectory: configDirectoryURL()).load()
         keymap = loaded.keymap
@@ -604,9 +562,8 @@ final class SettingsModel {
     }
 
     /// On first launch, if `ghostty.conf` does not exist, create the config directory and write a
-    /// commented starter file pointing at ghostty's config docs with an example override. Never
-    /// overwrites an existing file. (Seeded after GhosttyApp's first `loadConfig` runs, but harmless:
-    /// the starter is all comments — a no-op — exactly like the starter keymap.)
+    /// commented starter pointing at ghostty's config docs with an example override. Never overwrites.
+    /// Seeded AFTER GhosttyApp's first `loadConfig`, but harmless: the starter is all comments, a no-op.
     private func ensureStarterGhosttyConfig() {
         let url = ghosttyConfigURL()
         if FileManager.default.fileExists(atPath: url.path) { return }
@@ -619,9 +576,8 @@ final class SettingsModel {
         }
     }
 
-    /// The commented starter `ghostty.conf`: a header linking ghostty's config docs, a commented
-    /// example override, and a note that agterm's UI-managed keys win over this file. Every line is a
-    /// comment so a fresh file changes nothing.
+    /// The commented starter `ghostty.conf`: a header linking ghostty's config docs, an example override,
+    /// and a note that agterm's UI-managed keys win. Every line is a comment, so a fresh file is a no-op.
     private func starterGhosttyConfigText() -> String {
         """
         # agterm-scoped ghostty config — applies ONLY to agterm, not the standalone Ghostty.app.
@@ -649,26 +605,23 @@ final class SettingsModel {
         apply()
     }
 
-    /// Apply the current `settings` to the running app WITHOUT persisting: rewrite the ghostty config
-    /// and rebroadcast it to every live surface (only when the generated text changed), then refresh
-    /// the window translucency, toggles, and chrome. Split out of `persistAndApply` so the theme
-    /// picker can preview-apply without writing `settings.json`.
+    /// Apply the current `settings` to the running app WITHOUT persisting: rewrite the ghostty config and
+    /// rebroadcast it to every live surface (only when the generated text changed), then refresh the
+    /// window translucency, toggles, and chrome. Split out so the theme picker can preview-apply.
     private func apply() {
-        // only rebuild + rebroadcast the ghostty config (which resets every surface to the default
-        // font size) when the generated config TEXT actually changed. A window-opacity drag within
-        // the translucent range, or a blur change, leaves the config identical — re-syncing the
-        // window alone is enough and avoids hammering surface rebuilds on every slider tick.
+        // rebuild + rebroadcast (which resets every surface to the default font size) only when the
+        // generated config TEXT changed: an opacity drag within the translucent range, or a blur change,
+        // leaves it identical, and re-syncing the window alone avoids a rebuild per slider tick.
         let opacityBefore = GhosttyApp.shared.windowOpacity
         if writeGhosttyConfig() {
             reloadConfigClearingSessionZoom()
         }
         applyWindowTranslucency()
-        // a `.color` session background bakes the window opacity into its per-surface `background-opacity`
-        // at apply time, so re-assert those surfaces whenever the opacity changed — reloadConfig's own
-        // re-assert (when the config text changed) runs BEFORE `applyWindowTranslucency` updates the
-        // opacity, and a within-range slider drag doesn't reload at all, so neither path alone keeps a
-        // color session tracking the slider. Guarded to `.color` surfaces so a plain/image/text session
-        // isn't rebuilt on every opacity tick (blur composites at the AppKit level and needs no re-emit).
+        // a `.color` background bakes the window opacity into its per-surface `background-opacity` at
+        // apply time, so re-assert on any opacity change: reloadConfig's own re-assert runs BEFORE
+        // `applyWindowTranslucency` updates the opacity, and a within-range drag doesn't reload at all.
+        // Guarded to `.color` so a plain/image/text session isn't rebuilt per tick (blur composites in
+        // AppKit and needs no re-emit).
         if GhosttyApp.shared.windowOpacity != opacityBefore {
             for surface in liveSurfaces() { surface.reapplyColorBackgroundIfNeeded() }
         }
@@ -687,9 +640,9 @@ final class SettingsModel {
         applyAttentionButtonEnabled()
         applyInterfaceElements()
         applyAutoHideSidebarInactiveWindows()
-        // refresh the app chrome (title bar + sidebar + quick terminal) with the new terminal color,
-        // window translucency, and toolbar style immediately, rather than only when the window next
-        // re-keys. The title-bar re-sync and the cwd-subtitle drop both ride this notification.
+        // refresh the chrome (title bar + sidebar + quick terminal) for the new terminal color,
+        // translucency and toolbar style now, not at the next window re-key; the title-bar re-sync and
+        // the cwd-subtitle drop both ride this.
         NotificationCenter.default.post(name: .agtermAppearanceChanged, object: nil)
     }
 
@@ -735,19 +688,17 @@ final class SettingsModel {
         GhosttyApp.shared.setAutoHideSidebarInactiveWindows(settings.autoHideSidebarInactiveWindows ?? false)
     }
 
-    /// Push the current auto-follow configuration into a single window's store. Called when a window's
-    /// store is first resolved (`ContentView.resolveStore`) so a newly opened window honors the setting:
-    /// the store is built host-free in `WindowLibrary` and can't read these settings itself, so — unlike
-    /// the chrome flags that ride a `GhosttyApp` mirror — the value is pushed straight into the store.
+    /// Push the current auto-follow configuration into one window's store, from `ContentView.resolveStore`
+    /// so a newly opened window honors the setting. The store is built host-free in `WindowLibrary` and
+    /// can't read settings itself, so the value is pushed in rather than riding a `GhosttyApp` mirror.
     func applyAutoFollow(to store: AppStore) {
         let timeout = AppSettings.AutoFollowAttention(tolerant: settings.autoFollowAttention).timeout
         store.setAutoFollow(timeout: timeout, stayOnActive: settings.autoFollowStayOnActive ?? false)
     }
 
     /// Fan the current auto-follow configuration out to every open window's store — the settings-change
-    /// broadcast (and the launch seed, called from the scene `.task` once the model is wired). Idempotent:
-    /// re-pushing the same values is a no-op in `AppStore.setAutoFollow`. Distinct name from the single-window
-    /// `applyAutoFollow(to:)` so the fan-out and the one-store push don't read as arity-overloaded twins.
+    /// broadcast, and the launch seed from the scene `.task` once the model is wired. Idempotent:
+    /// re-pushing the same values is a no-op in `AppStore.setAutoFollow`.
     func applyAutoFollowToAllWindows() {
         for store in library.openIDs().compactMap({ library.store(for: $0) }) {
             applyAutoFollow(to: store)
@@ -798,9 +749,8 @@ final class SettingsModel {
         return true
     }
 
-    /// All live ghostty surfaces across every open window: each session's primary + split + scratch
-    /// surfaces in every open window's store, plus every open window's quick terminal. A config reload
-    /// therefore broadcasts to all windows, not just the frontmost one.
+    /// All live ghostty surfaces: every open window's sessions (primary + split + scratch) plus its quick
+    /// terminal — so a config reload broadcasts to all windows, not just the frontmost.
     private func liveSurfaces() -> [GhosttySurfaceView] {
         var views = library.openIDs()
             .compactMap { library.store(for: $0) }

--- a/agterm/SettingsModel.swift
+++ b/agterm/SettingsModel.swift
@@ -4,45 +4,40 @@ import os
 
 private let logger = Logger(subsystem: "com.umputun.agterm", category: "SettingsModel")
 
-/// The observable settings state for the Settings window. Loads `AppSettings` from `SettingsStore` at
-/// init; each mutation persists AND applies live: writes the ghostty settings file, rebuilds +
-/// broadcasts the config to every live surface, and clears the per-session font-size overrides to match
-/// (the shared `update_config` resets all surfaces to the new default).
+/// Observable settings state for the Settings window, loaded from `SettingsStore` at init. Each mutation
+/// persists AND applies live: rewrites the ghostty settings file, rebroadcasts the config to every live
+/// surface, and clears per-session font-size overrides (the shared `update_config` resets all surfaces).
 @Observable
 @MainActor
 final class SettingsModel {
-    /// The window library; a config reload broadcasts to the surfaces of EVERY open window (and
-    /// every window's quick terminal), so a settings change updates all windows live.
+    /// A config reload broadcasts to every open window's surfaces and quick terminal, so settings apply live.
     private let library: WindowLibrary
     private let settingsStore: SettingsStore
     private(set) var settings: AppSettings
 
-    /// The parsed keymap (built-in overrides + custom commands). Driven `@Observable` so the
-    /// data-driven menu shortcuts re-render on reload.
+    /// The parsed keymap (built-in overrides + custom commands); `@Observable` so menu shortcuts re-render.
     private(set) var keymap: Keymap = Keymap(builtinOverrides: [:], commands: [])
     /// Problems found while parsing the keymap file, surfaced read-only in the Key Mapping settings tab.
     private(set) var keymapDiagnostics: [KeymapDiagnostic] = []
 
-    /// Coalesces a burst of `previewTheme` calls into one `apply()` once the quiet window elapses,
-    /// instead of rebuilding + reloading every surface per arrow keypress. `commitTheme` flushes it;
-    /// `revertThemePreview` drops it.
+    /// Coalesces a burst of `previewTheme` calls into one `apply()` instead of rebuilding + reloading every
+    /// surface per arrow keypress. `commitTheme` flushes it; `revertThemePreview` drops it.
     private let previewThemeDebouncer = Debouncer()
     private static let previewThemeDebounceInterval: TimeInterval = 0.07
 
-    /// Coalesces the opacity/blur drag into one deferred `settings.json` write: the preview methods apply
-    /// each tick WITHOUT saving and reschedule this. Covers KEYBOARD adjustments too (arrows don't fire
-    /// the slider's `onEditingChanged`); a mouse release flushes it via `commitBackgroundSettings`.
+    /// Coalesces the opacity/blur drag into one deferred `settings.json` write (previews apply per tick
+    /// without saving). Covers KEYBOARD adjustment too — arrows don't fire the slider's `onEditingChanged`;
+    /// a mouse release flushes it.
     private let backgroundSaveDebouncer = Debouncer()
     private static let backgroundSaveInterval: TimeInterval = 0.3
 
-    /// Coalesces `.agtermSystemAppearanceChanged` (posted by the app-level KVO observer on
-    /// `NSApplication.effectiveAppearance`, `SystemAppearanceObserver`) into one re-apply per flip.
+    /// Coalesces `.agtermSystemAppearanceChanged` (`SystemAppearanceObserver`'s app-level KVO on
+    /// `NSApplication.effectiveAppearance`) into one re-apply per flip.
     private let appearanceDebouncer = Debouncer()
     private static let appearanceDebounceInterval: TimeInterval = 0.05
 
-    /// The theme slots as of the last real persist (`persistAndApply`/`commitTheme`), NOT updated by the
-    /// live preview. The background-save debounce pins its snapshot to these, so a slider write firing
-    /// mid-preview can't leak an uncommitted previewed theme to `settings.json`.
+    /// The theme slots as of the last real persist, NOT updated by the live preview: the background-save
+    /// debounce pins its snapshot to these, so a slider write mid-preview can't leak an uncommitted theme.
     private var committedTheme: String?
     private var committedDarkTheme: String?
 
@@ -52,11 +47,10 @@ final class SettingsModel {
         self.settings = settingsStore.load()
         self.committedTheme = settings.theme
         self.committedDarkTheme = settings.darkTheme
-        // write the ghostty config NOW — GhosttyApp's loadConfig runs in applicationDidFinishLaunching,
-        // AFTER this App.init. The SEEDED default theme (agterm) is memory-only (load() seeds it; it
-        // isn't in settings.json), so without this the launch config carries no theme line and the
-        // terminal renders ghostty's built-in until the next settings change. Idempotent: no-ops when
-        // the file already matches.
+        // write NOW: GhosttyApp's loadConfig runs in applicationDidFinishLaunching, AFTER this App.init,
+        // and the SEEDED default theme (agterm) is memory-only, never in settings.json — without this the
+        // launch config carries no theme line and the terminal renders ghostty's built-in until the next
+        // settings change. Idempotent: no-ops when the file already matches.
         _ = writeGhosttyConfig()
         // mirror the persisted settings into their shared channels before any settings change fires.
         applyWindowTranslucency()
@@ -80,9 +74,8 @@ final class SettingsModel {
         ensureStarterGhosttyConfig()
         ensureStarterRestoreDenylist()
         loadRestoreDenylist()
-        // follow the macOS appearance: `SystemAppearanceObserver` (app-level KVO on
-        // NSApp.effectiveAppearance) posts the resolved `isDark`, threaded straight into the reload,
-        // which re-feeds the config so libghostty re-resolves the dual `theme = light:,dark:` conditional.
+        // follow the macOS appearance: `SystemAppearanceObserver` posts the resolved `isDark`, threaded
+        // straight into `appearanceChanged`.
         NotificationCenter.default.addObserver(forName: .agtermSystemAppearanceChanged, object: nil,
                                                queue: .main) { [weak self] note in
             guard let isDark = note.userInfo?["isDark"] as? Bool else { return }
@@ -90,28 +83,25 @@ final class SettingsModel {
         }
     }
 
-    /// The frontmost session's focused-pane cwd, used only to seed directory-picking panels near the
-    /// user's current work. Settings views still mutate through this model; they don't need library access.
+    /// The frontmost session's focused-pane cwd, used only to seed directory-picking panels near the user's
+    /// current work — Settings views need no library access of their own.
     var activeSessionCwd: String? { library.activeStore?.activeSession?.focusedCwd }
 
-    /// The appearance side the last config feed applied, suppressing same-side reloads (KVO `[.initial]`
-    /// seeds one at launch, and the debounce can coalesce a burst). Starts `false` because a host-loaded
-    /// config always resolves LIGHT: a light launch skips the seeding reload, a dark launch takes exactly
-    /// one (re-siding the chrome colors via the CONFIG_CHANGE clone). Read outside only by the
-    /// UI-test-only `debug.appearance` probe (bare form), so a test can assert a flip drove the reload.
+    /// The appearance side the last config feed applied, suppressing same-side reloads (KVO `[.initial]` at
+    /// launch, plus coalesced bursts). Starts `false` because a host-loaded config always resolves LIGHT: a
+    /// light launch skips the seeding reload, a dark launch takes exactly one (re-siding the chrome colors
+    /// via the CONFIG_CHANGE clone). Read outside only by the UI-test `debug.appearance` probe (bare form).
     private(set) var lastAppliedIsDark = false
 
     /// Re-feed the config on a macOS appearance flip so libghostty re-resolves the dual theme — the
     /// system→settings half of light/dark sync. No-op unless following with both slots set, or when the
-    /// side is unchanged since the last feed (`lastAppliedIsDark`). The file's RAW `theme = light:,dark:`
-    /// text is IDENTICAL across flips, so `writeGhosttyConfig()`/`apply()` would skip the reload — reload
-    /// DIRECTLY instead; ghostty already recorded the scheme (`set_color_scheme`) and re-resolves on
-    /// `update_config`. Debounced against bursts (KVO `[.initial]` at launch, plus the seam); the latest
-    /// posted side wins. An automatic flip PRESERVES each session's ⌘+/⌘− zoom (unlike File ▸ Reload /
-    /// `config.reload`) — wiping it on an OS schedule would surprise. A zero-surface reload is safe: the
-    /// app-scheme set re-sides the chrome clone. `isDark` is the KVO-delivered side, threaded straight in
-    /// and never re-read from a view (whose `effectiveAppearance` lags around sleep/wake), so
-    /// `lastAppliedIsDark` equals the applied side by construction.
+    /// side is unchanged (`lastAppliedIsDark`). The RAW `theme = light:,dark:` text is IDENTICAL across
+    /// flips, so `writeGhosttyConfig()`/`apply()` would skip the reload — reload DIRECTLY instead; ghostty
+    /// already recorded the scheme (`set_color_scheme`) and re-resolves on `update_config`. Debounced, the
+    /// latest posted side wins. An automatic flip PRESERVES each session's ⌘+/⌘− zoom (unlike File ▸
+    /// Reload / `config.reload`) — wiping it on an OS schedule would surprise. A zero-surface reload is
+    /// safe: the app-scheme set re-sides the chrome clone. `isDark` is the KVO-delivered side, never
+    /// re-read from a view (whose `effectiveAppearance` lags around sleep/wake).
     private func appearanceChanged(isDark: Bool) {
         guard settings.followSystemAppearance == true, settings.theme != nil, settings.darkTheme != nil else { return }
         appearanceDebouncer.schedule(after: Self.appearanceDebounceInterval) { [weak self] in
@@ -125,8 +115,8 @@ final class SettingsModel {
     func setFontFamily(_ value: String?) { settings.fontFamily = value; persistAndApply() }
     func setFontSize(_ value: Double?) { settings.fontSize = value; persistAndApply() }
 
-    /// Whether the slot rendering RIGHT NOW is the dark one: following AND the app is in dark mode. The
-    /// current-appearance picker and the theme preview target this slot so on-screen edits stick.
+    /// Whether the slot rendering RIGHT NOW is the dark one. The current-appearance picker and the theme
+    /// preview target this slot so on-screen edits stick.
     private var rendersDarkSlot: Bool { settings.followSystemAppearance == true && GhosttyApp.currentIsDark() }
 
     /// Set the light/single slot — the control channel's `theme set <name>`. A name keeps the dark side
@@ -137,9 +127,9 @@ final class SettingsModel {
         persistAndApply()
     }
 
-    /// Set the dark slot — the control channel's `theme set --dark`. A name turns syncing on (the light
-    /// side seeds from the current theme, else `defaultLightTheme`, since ghostty's built-in can't be a
-    /// dual slot); `none`/nil turns syncing off and drops the dark slot.
+    /// Set the dark slot — the control channel's `theme set --dark`. A name turns syncing on, seeding the
+    /// light side from the current theme else `defaultLightTheme` (ghostty's built-in can't be a dual
+    /// slot); `none`/nil turns syncing off.
     func setDarkTheme(_ value: String?) {
         if let value {
             if settings.theme?.isEmpty ?? true { settings.theme = Self.defaultLightTheme }
@@ -160,16 +150,14 @@ final class SettingsModel {
         persistAndApply()
     }
 
-    /// Settings picker 1: the theme for the CURRENT appearance (no relabel). While following in dark mode
-    /// this edits the dark slot; otherwise the light/single `theme`.
+    /// Settings picker 1: the theme for the CURRENT appearance (`rendersDarkSlot`), with no relabel.
     func setThemeForCurrentAppearance(_ value: String?) {
         if rendersDarkSlot { settings.darkTheme = value } else { settings.theme = value }
         persistAndApply()
     }
 
-    /// Settings alternate picker (shown only while following): the theme for the OTHER appearance.
-    /// Clearing the dark slot routes through `setDarkTheme(nil)` so following can never be left ON with
-    /// `darkTheme == nil` — no picker row does that today, but the setter holds for any caller.
+    /// Settings alternate picker (shown only while following): the theme for the OTHER appearance. Clearing
+    /// the dark slot routes through `setDarkTheme(nil)` so following is never left ON with a nil dark slot.
     func setAlternateTheme(_ value: String?) {
         if rendersDarkSlot {
             settings.theme = value          // the alternate is the LIGHT slot while rendering dark
@@ -182,9 +170,8 @@ final class SettingsModel {
         persistAndApply()
     }
 
-    /// Settings "Follow system appearance" toggle. ON seeds the other slot from the current theme (both
-    /// start equal — a well-formed dual with no visual change; the user then picks the alternative). OFF
-    /// collapses to the on-screen theme so there is no flip and `theme` always holds one meaningful value.
+    /// Settings "Follow system appearance" toggle. ON seeds the other slot from the current theme (a
+    /// well-formed dual with no visual change). OFF collapses to the on-screen theme so there is no flip.
     func setFollowSystemAppearance(_ on: Bool) {
         if on {
             if settings.theme?.isEmpty ?? true { settings.theme = Self.defaultLightTheme }
@@ -198,13 +185,13 @@ final class SettingsModel {
         persistAndApply()
     }
 
-    /// The light side seeded when a dark theme is chosen while `theme` is nil/empty (ghostty's built-in,
-    /// which cannot be a dual side) — a bundled light theme, so the pick composes a well-formed dual value.
+    /// The light side seeded when a dark theme is chosen while `theme` is nil/empty (ghostty's built-in
+    /// cannot be a dual side); a bundled theme, so the pick composes a well-formed dual value.
     static let defaultLightTheme = "Builtin Light"
 
     func setNotificationsEnabled(_ value: Bool?) { settings.notificationsEnabled = value; persistAndApply() }
-    /// Set the toolbar row mode (nil = the default = compact). Nils the legacy `compactToolbar` shim so
-    /// it evaporates from `settings.json` on the next save; the Settings Picker maps `.compact` back to nil.
+    /// Set the toolbar row mode (nil = compact). Nils the legacy `compactToolbar` shim so it evaporates
+    /// from `settings.json` on the next save; the Settings picker maps `.compact` back to nil.
     func setToolbarMode(_ mode: ToolbarMode?) { settings.toolbarMode = mode?.rawValue; settings.compactToolbar = nil; persistAndApply() }
     func setNotificationBadgeEnabled(_ value: Bool?) { settings.notificationBadgeEnabled = value; persistAndApply() }
     func setDockBounce(_ mode: DockBounce?) { settings.dockBounce = mode?.rawValue; persistAndApply() }
@@ -222,20 +209,19 @@ final class SettingsModel {
     // chrome flag, not a ghostty key: persistAndApply() no-ops the config but rides .agtermAppearanceChanged.
     func setAttentionButtonEnabled(_ value: Bool?) { settings.attentionButtonEnabled = value; persistAndApply() }
 
-    /// Persist whether only the frontmost window shows its sidebar. A behavior flag, not a ghostty key, so
-    /// `persistAndApply()` no-ops the config and just pushes the `GhosttyApp` mirror the frontmost-change
-    /// driver reads. Turning it ON collapses every inactive sidebar at once, not at the next focus change.
+    /// Persist whether only the frontmost window shows its sidebar. Not a ghostty key, so `persistAndApply()`
+    /// only pushes the `GhosttyApp` mirror; turning it ON collapses every inactive sidebar at once, not at
+    /// the next focus change.
     func setAutoHideSidebarInactiveWindows(_ value: Bool?) {
         settings.autoHideSidebarInactiveWindows = value
         persistAndApply()
         if value == true { library.applyInactiveWindowSidebarHiding() }
     }
 
-    /// Show or hide one title-bar / sidebar-footer chrome element, then persist; an empty result maps back
-    /// to nil so `settings.json` stays minimal. Not a ghostty key — `persistAndApply()` no-ops the config
-    /// text but rides `.agtermAppearanceChanged`, so every window re-gates the element live. Mutates the
-    /// RAW string set: `resolvedHiddenInterfaceElements` drops unknown names, erasing an element a newer
-    /// build hid.
+    /// Show or hide one title-bar / sidebar-footer chrome element (an empty result maps back to nil so
+    /// `settings.json` stays minimal). Not a ghostty key — it rides `.agtermAppearanceChanged`, so every
+    /// window re-gates live. Mutates the RAW string set: `resolvedHiddenInterfaceElements` drops unknown
+    /// names, which would erase an element a newer build hid.
     func setInterfaceElementVisible(_ element: InterfaceElement, visible: Bool) {
         var hidden = Set(settings.hiddenInterfaceElements ?? [])
         if visible { hidden.remove(element.rawValue) } else { hidden.insert(element.rawValue) }
@@ -243,11 +229,10 @@ final class SettingsModel {
         persistAndApply()
     }
 
-    /// Persist whether agterm inherits the user's global `~/.config/ghostty/config`, then FULLY reload so
-    /// it takes effect live. NOT a `ghosttyConfigLines()` key, so `persistAndApply`'s text-diff guard
-    /// would skip the reload — but it changes WHICH files `loadConfig` reads, so it takes the
-    /// unconditional path (like `setConfigDirectory`). nil/false = off: agterm stays self-contained, and
-    /// the scoped `ghostty.conf` is the place for customizations.
+    /// Persist whether agterm inherits the user's global `~/.config/ghostty/config`, then FULLY reload. NOT
+    /// a `ghosttyConfigLines()` key, so `persistAndApply`'s text-diff guard would skip the reload — but it
+    /// changes WHICH files `loadConfig` reads, hence the unconditional path (like `setConfigDirectory`).
+    /// nil/false = off: agterm stays self-contained, with the scoped `ghostty.conf` for customizations.
     func setInheritGlobalGhosttyConfig(_ value: Bool?) {
         settings.inheritGlobalGhosttyConfig = value
         try? settingsStore.save(settings)
@@ -256,28 +241,26 @@ final class SettingsModel {
     func setActiveStatusColorHex(_ hex: String?) { settings.activeStatusColorHex = hex; persistAndApply() }
     func setBlockedStatusColorHex(_ hex: String?) { settings.blockedStatusColorHex = hex; persistAndApply() }
     func setCompletedStatusColorHex(_ hex: String?) { settings.completedStatusColorHex = hex; persistAndApply() }
-    /// Persist an agent-status glyph silhouette, stored as the `StatusShape` raw string (nil keeps that
-    /// status on the default plain circle, so `settings.json` stays minimal). `persistAndApply` pushes
-    /// the mirror and posts `.agtermAppearanceChanged`, which repaints the visible glyphs live.
+    /// Persist an agent-status glyph silhouette as the `StatusShape` raw string (nil = the default plain
+    /// circle, keeping `settings.json` minimal). `persistAndApply` repaints the visible glyphs live.
     func setActiveStatusShape(_ shape: StatusShape?) { settings.activeStatusShape = shape?.rawValue; persistAndApply() }
     func setBlockedStatusShape(_ shape: StatusShape?) { settings.blockedStatusShape = shape?.rawValue; persistAndApply() }
     func setCompletedStatusShape(_ shape: StatusShape?) { settings.completedStatusShape = shape?.rawValue; persistAndApply() }
     /// Persist the system sound played when a session enters `blocked` (nil/empty = none). Not a ghostty
     /// key and nothing renders it continuously, so it only saves — `ControlServer` reads it on demand.
     func setBlockedStatusSoundName(_ name: String?) { settings.blockedStatusSoundName = name; try? settingsStore.save(settings) }
-    /// Persist where a new (⌘T) session opens (nil = home). Not a ghostty key and read only at the NEXT
-    /// new session (`AppActions.newSession()`), so it just saves — no config rewrite or surface reload.
+    /// Persist where a new (⌘T) session opens (nil = home). Read only at the next `AppActions.newSession()`,
+    /// so it just saves — no config rewrite or surface reload.
     func setNewSessionDirectory(_ value: String?) { settings.newSessionDirectory = value; try? settingsStore.save(settings) }
     /// Persist the fixed directory used when `newSessionDirectory` is `custom` (nil/empty falls back to home).
     func setNewSessionCustomDirectory(_ value: String?) { settings.newSessionCustomDirectory = value; try? settingsStore.save(settings) }
-    /// Persist whether closing a session from the GUI first asks for confirmation (nil = off). Not a ghostty
-    /// key and nothing renders it continuously — `AppActions` reads it on demand at close time — so it just saves.
+    /// Persist whether a GUI session close first asks for confirmation (nil = off). `AppActions` reads it on
+    /// demand at close time, so it just saves.
     func setConfirmCloseSession(_ value: Bool?) { settings.confirmCloseSession = value; try? settingsStore.save(settings) }
     /// Persist whether GUI closes use the short undo grace period. nil = on; false = close immediately.
     func setCloseGraceUndoEnabled(_ value: Bool?) { settings.closeGraceUndoEnabled = value; try? settingsStore.save(settings) }
-    /// Persist the user-idle auto-follow timeout (nil = off) and fan it out to every open window's store.
-    /// Not a ghostty key — a per-window `AppStore` behavior — so it just saves, then pushes the resolved
-    /// timeout into the live stores (a newly opened window seeds itself via `applyAutoFollow(to:)`).
+    /// Persist the user-idle auto-follow timeout (nil = off) and push it into every open window's `AppStore`
+    /// (a newly opened window seeds itself via `applyAutoFollow(to:)`).
     func setAutoFollowAttention(_ value: String?) {
         settings.autoFollowAttention = value
         try? settingsStore.save(settings)
@@ -290,17 +273,15 @@ final class SettingsModel {
         applyAutoFollowToAllWindows()
     }
 
-    /// Apply a new background opacity live WITHOUT saving — the live-drag half of the slider: each tick
-    /// applies and reschedules `backgroundSaveDebouncer`, so the disk write coalesces to one on settle.
-    /// Mirrors the theme apply/save split.
+    /// Apply a new background opacity live WITHOUT saving — the live-drag half of the slider; each tick
+    /// reschedules `backgroundSaveDebouncer`, so the disk write coalesces to one on settle.
     func previewBackgroundOpacity(_ value: Double?) {
         settings.backgroundOpacity = value
         apply()
         scheduleBackgroundSave()
     }
 
-    /// Apply a new background blur live, the counterpart of `previewBackgroundOpacity`: apply-without-save
-    /// plus a debounced write flushed on drag-end.
+    /// Apply a new background blur live — the blur counterpart of `previewBackgroundOpacity`.
     func previewBackgroundBlur(_ value: Int?) {
         settings.backgroundBlur = value
         apply()
@@ -308,14 +289,14 @@ final class SettingsModel {
     }
 
     /// Persist the current opacity/blur NOW — the slider's `onEditingChanged` drag-end commit. Save-only:
-    /// the value is already live from the preview applies, so it just flushes the pending debounced write.
+    /// the value is already live from the preview applies.
     func commitBackgroundSettings() { backgroundSaveDebouncer.flush() }
 
     private func scheduleBackgroundSave() {
         backgroundSaveDebouncer.schedule(after: Self.backgroundSaveInterval) { [weak self] in
             guard let self else { return }
-            // pin the theme to the last committed value — a live preview mutates `settings.theme` in
-            // place without persisting. Opacity/blur (what this save is for) keep their live values.
+            // pin the theme to the last committed value — a live preview mutates it in place without
+            // persisting. opacity/blur, what this save is for, keep their live values.
             var snapshot = settings
             snapshot.theme = committedTheme
             snapshot.darkTheme = committedDarkTheme
@@ -323,23 +304,19 @@ final class SettingsModel {
         }
     }
 
-    /// Apply a theme live WITHOUT persisting — the action-palette picker's preview half. Sets the slot
-    /// immediately (so a commit captures the latest even if the apply hasn't fired) but DEBOUNCES the
-    /// expensive `apply()` (config rewrite + surface reload + chrome refresh) and skips
-    /// `settingsStore.save`, so browsing never touches `settings.json`. Writes the CURRENT-appearance
-    /// slot (the dark one while following in dark mode, else `theme`) so the preview renders on screen.
-    /// Enter commits via `commitTheme()` (flushing the pending apply), Esc reverts via
-    /// `revertThemePreview(theme:darkTheme:)` (restoring both captured slots).
+    /// Apply a theme live WITHOUT persisting — the action-palette picker's preview half. Sets the
+    /// CURRENT-appearance slot immediately (so a commit captures the latest even if the apply hasn't fired)
+    /// but DEBOUNCES the expensive `apply()` and skips `settingsStore.save`, so browsing never touches
+    /// `settings.json`. Enter commits via `commitTheme()`, Esc reverts via `revertThemePreview(theme:darkTheme:)`.
     func previewTheme(_ value: String?) {
         if rendersDarkSlot { settings.darkTheme = value } else { settings.theme = value }
         previewThemeDebouncer.schedule(after: Self.previewThemeDebounceInterval) { [weak self] in self?.apply() }
     }
 
-    /// Restore BOTH theme slots IMMEDIATELY, cancelling any pending debounced preview — the revert half
-    /// of the picker (Esc / scrim / mode switch / unmount). Synchronous, so nothing lags and no queued
-    /// preview fires after. Both slots, not just the on-screen one, so an appearance flip mid-preview
-    /// can't strand a previewed value in the other — `AppActions` snapshots the pair on open and passes
-    /// it straight back.
+    /// Restore BOTH theme slots IMMEDIATELY, cancelling any pending debounced preview — the picker's revert
+    /// half (Esc / scrim / mode switch / unmount). Synchronous, so no queued preview fires after. Both
+    /// slots, not just the on-screen one, or an appearance flip mid-preview strands a previewed value in
+    /// the other; `AppActions` snapshots the pair on open and passes it straight back.
     func revertThemePreview(theme: String?, darkTheme: String?) {
         previewThemeDebouncer.cancel()
         settings.theme = theme
@@ -347,13 +324,11 @@ final class SettingsModel {
         apply()
     }
 
-    /// Persist the picker's final theme — the commit half, on Enter after one or more `previewTheme`
-    /// applies. Only the slot rendering AT ENTER-TIME keeps its browsed value; the OTHER is restored to
-    /// `nonActiveOriginal` (its value when the picker opened), or a mid-preview appearance flip would
-    /// persist a value into the off-screen slot that was never confirmed and would resurface on the next
-    /// flip. Flushes the pending preview first (so the active slot is live), restores the off-screen
-    /// slot, re-applies ONLY if that changed the config (the flip case, so the dual line on disk
-    /// matches), then saves; a no-flip commit stays save-only.
+    /// Persist the picker's final theme — the commit half, on Enter. Only the slot rendering AT ENTER-TIME
+    /// keeps its browsed value; the OTHER is restored to `nonActiveOriginal` (its value when the picker
+    /// opened), or a mid-preview appearance flip persists an unconfirmed value into the off-screen slot
+    /// that resurfaces on the next flip. Flushes the pending preview first, restores the off-screen slot,
+    /// re-applies ONLY if that changed the config (the flip case), then saves; a no-flip commit is save-only.
     func commitTheme(nonActiveOriginal: (theme: String?, dark: String?)) {
         previewThemeDebouncer.flush()
         let restored: Bool
@@ -370,16 +345,15 @@ final class SettingsModel {
         committedDarkTheme = settings.darkTheme
     }
 
-    /// Flush any pending debounced settings writes synchronously, from `applicationWillTerminate`. A
-    /// KEYBOARD opacity/blur adjustment never fires the slider's drag-end commit, so its ~0.3 s pending
-    /// write (and the theme preview's, for symmetry) would be lost by quitting inside that window.
+    /// Flush pending debounced settings writes synchronously, from `applicationWillTerminate`: a KEYBOARD
+    /// opacity/blur adjustment never fires the slider's drag-end commit, so quitting inside its ~0.3 s
+    /// window would lose the write (the theme preview flushes alongside, for symmetry).
     func flushPendingSaves() {
         backgroundSaveDebouncer.flush()
         previewThemeDebouncer.flush()
     }
 
-    /// Reset the whole Agent Status section (the "Reset to defaults" button): the three glyph colors to
-    /// the system defaults, the three glyph shapes to the default plain circle, the blocked sound to none.
+    /// Reset the whole Agent Status section (the "Reset to defaults" button): glyph colors, shapes, sound.
     func resetAgentStatus() {
         settings.activeStatusColorHex = nil
         settings.blockedStatusColorHex = nil
@@ -391,9 +365,8 @@ final class SettingsModel {
         persistAndApply()
     }
 
-    /// Persist a new config directory (where `keymap.conf` and `ghostty.conf` live) and reload BOTH
-    /// co-located files so neither lags the change (each reload posts its own diagnostics banner). nil
-    /// falls back to the default location `ConfigPaths.configDirectory` resolves.
+    /// Persist a new config directory and reload BOTH co-located files so neither lags the change (each
+    /// posts its own diagnostics banner). nil falls back to what `ConfigPaths.configDirectory` resolves.
     func setConfigDirectory(_ value: String?) {
         settings.configDirectory = value
         try? settingsStore.save(settings)
@@ -401,11 +374,10 @@ final class SettingsModel {
         reloadGhosttyConfig()
     }
 
-    /// Re-read and re-parse `keymap.conf`, then post `.agtermKeymapChanged` so the custom-command runner
-    /// rebuilds and the action palette re-reads them; the data-driven menu shortcuts re-render on their
-    /// own off the `@Observable` `keymap`. Parse errors/conflicts surface as a banner — safe to post here
-    /// since this runtime path runs after notification registration (the startup path posts from the
-    /// scene `.task` instead).
+    /// Re-read `keymap.conf` and post `.agtermKeymapChanged` so the custom-command runner and action palette
+    /// rebuild (menu shortcuts re-render off the `@Observable` `keymap`). Parse errors/conflicts surface as
+    /// a banner, safe here because this runtime path runs after notification registration — the startup
+    /// path posts from the scene `.task` instead.
     func reloadKeymap() {
         loadKeymap()
         NotificationCenter.default.post(name: .agtermKeymapChanged, object: nil)
@@ -444,17 +416,15 @@ final class SettingsModel {
         ConfigPaths.restoreDenylistPath(configDirectory: configDirectoryURL())
     }
 
-    /// Read + parse `restore-denylist.conf` and mirror it into `GhosttyApp.shared.restoreDenylist` (the
-    /// set the restore factories consult). A missing/unreadable file yields an empty denylist (restore
-    /// everything). Read at launch; an edit takes effect on the next launch (restore is launch-time).
+    /// Read `restore-denylist.conf` into `GhosttyApp.shared.restoreDenylist`; a missing/unreadable file
+    /// yields an empty denylist (restore everything). Read at launch, so an edit takes effect on the next.
     private func loadRestoreDenylist() {
         let text = (try? String(contentsOf: restoreDenylistURL(), encoding: .utf8)) ?? ""
         GhosttyApp.shared.setRestoreDenylist(CommandRestore.parseDenylist(text))
     }
 
-    /// On first launch, if `restore-denylist.conf` does not exist, create the config directory and write
-    /// a commented starter listing the terminal multiplexers (the one class of program that just starts a
-    /// fresh empty session on re-run). Never overwrites an existing file.
+    /// Write a commented starter `restore-denylist.conf` (and its directory) when none exists, listing the
+    /// terminal multiplexers — the one class of program that just starts a fresh empty session on re-run.
     private func ensureStarterRestoreDenylist() {
         let url = restoreDenylistURL()
         if FileManager.default.fileExists(atPath: url.path) { return }
@@ -467,8 +437,7 @@ final class SettingsModel {
         }
     }
 
-    /// The commented starter `restore-denylist.conf`: a header explaining the format, the terminal
-    /// multiplexers as active default entries, and commented examples the user can uncomment.
+    /// The commented starter `restore-denylist.conf` text.
     private func starterRestoreDenylistText() -> String {
         """
         # restore-denylist.conf — programs NOT to re-run when "Restore running commands on restart"
@@ -489,10 +458,9 @@ final class SettingsModel {
     }
 
     /// Rebuild the ghostty config from all sources (re-reading the externally edited agterm-scoped
-    /// `ghostty.conf`) and broadcast it to every live surface, clearing per-session font overrides like a
-    /// settings change. UNCONDITIONAL, unlike `apply()`'s unchanged-text skip — an external edit always
-    /// has something to re-read. Posts `.agtermAppearanceChanged` for the chrome, and a warning banner on
-    /// diagnostics (safe here, like `reloadKeymap`: a runtime path, after notification registration).
+    /// `ghostty.conf`) and broadcast it to every live surface, clearing per-session font overrides.
+    /// UNCONDITIONAL, unlike `apply()`'s unchanged-text skip — an external edit always has something to
+    /// re-read. Posts `.agtermAppearanceChanged` for the chrome, and a warning banner on diagnostics.
     /// Returns the diagnostic count (0 = clean) across ALL config sources, since libghostty diagnostics
     /// carry no source-file attribution. Drives File ▸ Reload Config, the Edit-ghostty overlay close, a
     /// Key Mapping directory change, and the `config.reload` control command.
@@ -504,20 +472,17 @@ final class SettingsModel {
         return count
     }
 
-    /// Clears every session's ⌘+/⌘− zoom BEFORE rebuilding + rebroadcasting the config to the live
-    /// surfaces, returning the rebuilt config's diagnostic count. The ORDER is load-bearing: the reload
-    /// re-asserts each surface's per-session overlay (`reapplySessionConfigIfNeeded`), re-emitting
-    /// `font-size` from `session.fontSize` — clearing first makes that read nil, so a watermarked pane
-    /// drops its zoom on screen and the snapshot persists `fontSize == nil` in agreement, matching the
-    /// documented "reload clears per-session zoom" contract (resetting AFTER leaves the surface zoomed
-    /// while the model says nil). Both EXPLICIT callers (`reloadGhosttyConfig`, `apply()`) funnel here;
-    /// the automatic appearance flip is the one exception (`reloadConfigPreservingSessionZoom`).
+    /// Clear every session's ⌘+/⌘− zoom BEFORE rebuilding + rebroadcasting the config, returning the
+    /// rebuilt config's diagnostic count. The ORDER is load-bearing: the reload re-asserts each surface's
+    /// per-session overlay (`reapplySessionConfigIfNeeded`), re-emitting `font-size` from
+    /// `session.fontSize` — clearing first makes that read nil, so a watermarked pane drops its zoom on
+    /// screen and the snapshot persists `fontSize == nil` in agreement (resetting AFTER leaves the surface
+    /// zoomed while the model says nil). Both EXPLICIT callers funnel here; the automatic appearance flip
+    /// is the one exception (`reloadConfigPreservingSessionZoom`).
     @discardableResult
     private func reloadConfigClearingSessionZoom() -> Int {
-        // every reload re-sides the config (surface schemes + the CONFIG_CHANGE chrome clone) to the
-        // CURRENT appearance, from the single source `NSApp.effectiveAppearance` (via `currentIsDark()`).
-        // Record it on ALL reload paths, not just the flip, or `appearanceChanged()`'s same-side
-        // suppression fires one spurious reload later.
+        // every reload re-sides the config to the CURRENT appearance, so record it on ALL reload paths,
+        // not just the flip, or `appearanceChanged()`'s same-side suppression fires one spurious reload.
         let isDark = GhosttyApp.currentIsDark()
         lastAppliedIsDark = isDark
         // open windows reset live, closed ones by rewriting their snapshot file (the shared config reset
@@ -526,29 +491,27 @@ final class SettingsModel {
         return GhosttyApp.shared.reloadConfig(surfaces: liveSurfaces(), isDark: isDark)
     }
 
-    /// The appearance-flip variant of the reload above: re-feeds the config so libghostty re-resolves the
-    /// dual theme, but KEEPS every session's ⌘+/⌘− zoom — after the broadcast `reapplySessionConfigIfNeeded`
-    /// re-emits each session's `fontSize` per surface (the same round-trip that re-asserts watermarks).
-    /// An automatic OS flip (or a dark launch's seeding reload) must not silently wipe zoom; only the
-    /// explicit reloads carry that contract. The latch records the `isDark` actually applied (the
-    /// KVO-delivered side threaded through the reload), so "latch == applied side" holds on every path.
+    /// The appearance-flip variant: re-feeds the config so libghostty re-resolves the dual theme but KEEPS
+    /// every session's ⌘+/⌘− zoom — after the broadcast `reapplySessionConfigIfNeeded` re-emits each
+    /// session's `fontSize` per surface. An automatic OS flip (or a dark launch's seeding reload) must not
+    /// silently wipe zoom; only explicit reloads carry that contract. The latch records the `isDark`
+    /// actually applied.
     private func reloadConfigPreservingSessionZoom(isDark: Bool) {
         GhosttyApp.shared.reloadConfig(surfaces: liveSurfaces(), isDark: isDark)
         lastAppliedIsDark = isDark
     }
 
-    /// Read `keymap.conf` into `keymap` + `keymapDiagnostics`. A MISSING file is not an error — empty
-    /// keymap, no diagnostics (the starter is written at init). One that EXISTS but can't be read
-    /// (permissions, invalid UTF-8) becomes a single line-0 diagnostic so the warning banner fires.
+    /// Read `keymap.conf` into `keymap` + `keymapDiagnostics`. A MISSING file is not an error (empty keymap,
+    /// no diagnostics); one that EXISTS but can't be read (permissions, invalid UTF-8) becomes a single
+    /// line-0 diagnostic so the warning banner fires.
     private func loadKeymap() {
         let loaded = KeymapStore(configDirectory: configDirectoryURL()).load()
         keymap = loaded.keymap
         keymapDiagnostics = loaded.diagnostics
     }
 
-    /// On first launch, if `keymap.conf` does not exist, create the config directory and write a
-    /// commented starter file documenting every built-in action name + default, the `map`/`command`
-    /// syntax, and the `{AGT_X}` tokens. Never overwrites an existing file.
+    /// Write a commented starter `keymap.conf` (and its directory) when none exists, documenting every
+    /// built-in action name + default, the `map`/`command` syntax, and the `{AGT_X}` tokens.
     private func ensureStarterKeymap() {
         let url = keymapURL()
         if FileManager.default.fileExists(atPath: url.path) { return }
@@ -561,9 +524,8 @@ final class SettingsModel {
         }
     }
 
-    /// On first launch, if `ghostty.conf` does not exist, create the config directory and write a
-    /// commented starter pointing at ghostty's config docs with an example override. Never overwrites.
-    /// Seeded AFTER GhosttyApp's first `loadConfig`, but harmless: the starter is all comments, a no-op.
+    /// Write a commented starter `ghostty.conf` (and its directory) when none exists. Seeded AFTER
+    /// GhosttyApp's first `loadConfig`, but harmless: the starter is all comments, a no-op.
     private func ensureStarterGhosttyConfig() {
         let url = ghosttyConfigURL()
         if FileManager.default.fileExists(atPath: url.path) { return }
@@ -576,8 +538,7 @@ final class SettingsModel {
         }
     }
 
-    /// The commented starter `ghostty.conf`: a header linking ghostty's config docs, an example override,
-    /// and a note that agterm's UI-managed keys win. Every line is a comment, so a fresh file is a no-op.
+    /// The commented starter `ghostty.conf` text; every line is a comment, so a fresh file is a no-op.
     private func starterGhosttyConfigText() -> String {
         """
         # agterm-scoped ghostty config — applies ONLY to agterm, not the standalone Ghostty.app.
@@ -606,12 +567,11 @@ final class SettingsModel {
     }
 
     /// Apply the current `settings` to the running app WITHOUT persisting: rewrite the ghostty config and
-    /// rebroadcast it to every live surface (only when the generated text changed), then refresh the
-    /// window translucency, toggles, and chrome. Split out so the theme picker can preview-apply.
+    /// rebroadcast (only when the generated text changed), then refresh translucency, toggles and chrome.
     private func apply() {
-        // rebuild + rebroadcast (which resets every surface to the default font size) only when the
-        // generated config TEXT changed: an opacity drag within the translucent range, or a blur change,
-        // leaves it identical, and re-syncing the window alone avoids a rebuild per slider tick.
+        // rebuild only when the generated config TEXT changed: an opacity drag within the translucent
+        // range, or a blur change, leaves it identical, and re-syncing the window alone avoids a rebuild
+        // (which resets every surface to the default font size) per slider tick.
         let opacityBefore = GhosttyApp.shared.windowOpacity
         if writeGhosttyConfig() {
             reloadConfigClearingSessionZoom()
@@ -620,8 +580,7 @@ final class SettingsModel {
         // a `.color` background bakes the window opacity into its per-surface `background-opacity` at
         // apply time, so re-assert on any opacity change: reloadConfig's own re-assert runs BEFORE
         // `applyWindowTranslucency` updates the opacity, and a within-range drag doesn't reload at all.
-        // Guarded to `.color` so a plain/image/text session isn't rebuilt per tick (blur composites in
-        // AppKit and needs no re-emit).
+        // Guarded to `.color` so other sessions aren't rebuilt per tick (blur composites in AppKit).
         if GhosttyApp.shared.windowOpacity != opacityBefore {
             for surface in liveSurfaces() { surface.reapplyColorBackgroundIfNeeded() }
         }
@@ -641,8 +600,7 @@ final class SettingsModel {
         applyInterfaceElements()
         applyAutoHideSidebarInactiveWindows()
         // refresh the chrome (title bar + sidebar + quick terminal) for the new terminal color,
-        // translucency and toolbar style now, not at the next window re-key; the title-bar re-sync and
-        // the cwd-subtitle drop both ride this.
+        // translucency and toolbar style now, not at the next window re-key.
         NotificationCenter.default.post(name: .agtermAppearanceChanged, object: nil)
     }
 
@@ -664,7 +622,6 @@ final class SettingsModel {
     }
 
     private func applyToolbarMode() {
-        // effectiveToolbarMode resolves nil (and the legacy compactToolbar shim) to the concrete mode.
         GhosttyApp.shared.setToolbarMode(settings.effectiveToolbarMode)
     }
 
@@ -689,16 +646,14 @@ final class SettingsModel {
     }
 
     /// Push the current auto-follow configuration into one window's store, from `ContentView.resolveStore`
-    /// so a newly opened window honors the setting. The store is built host-free in `WindowLibrary` and
-    /// can't read settings itself, so the value is pushed in rather than riding a `GhosttyApp` mirror.
+    /// so a newly opened window honors the setting. The store is host-free and can't read settings itself.
     func applyAutoFollow(to store: AppStore) {
         let timeout = AppSettings.AutoFollowAttention(tolerant: settings.autoFollowAttention).timeout
         store.setAutoFollow(timeout: timeout, stayOnActive: settings.autoFollowStayOnActive ?? false)
     }
 
-    /// Fan the current auto-follow configuration out to every open window's store — the settings-change
-    /// broadcast, and the launch seed from the scene `.task` once the model is wired. Idempotent:
-    /// re-pushing the same values is a no-op in `AppStore.setAutoFollow`.
+    /// Fan auto-follow out to every open window's store — the settings-change broadcast and the launch seed
+    /// from the scene `.task`. Idempotent: re-pushing the same values no-ops in `AppStore.setAutoFollow`.
     func applyAutoFollowToAllWindows() {
         for store in library.openIDs().compactMap({ library.store(for: $0) }) {
             applyAutoFollow(to: store)
@@ -736,12 +691,11 @@ final class SettingsModel {
     }
 
     /// Write the ghostty config lines (font/size/theme + the translucency pins) to the file
-    /// `GhosttyApp.loadConfig` reads. Returns true if the file content changed, so the caller can
-    /// skip the expensive reload when it didn't.
+    /// `GhosttyApp.loadConfig` reads. Returns true when the content changed, so the caller can skip the reload.
     private func writeGhosttyConfig() -> Bool {
         let url = GhosttyApp.settingsConfigURL
-        // emit the raw single/dual theme — no appearance resolution here. A dual value is stable across
-        // flips, so `appearanceChanged` reloads directly (this file's text doesn't change on a flip).
+        // emit the raw single/dual theme, no appearance resolution: a dual value is stable across flips,
+        // so `appearanceChanged` reloads directly rather than diffing this text.
         let text = settings.ghosttyConfigLines().joined(separator: "\n") + "\n"
         if (try? String(contentsOf: url, encoding: .utf8)) == text { return false }
         try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
@@ -749,8 +703,7 @@ final class SettingsModel {
         return true
     }
 
-    /// All live ghostty surfaces: every open window's sessions (primary + split + scratch) plus its quick
-    /// terminal — so a config reload broadcasts to all windows, not just the frontmost.
+    /// Every live ghostty surface: all open windows' sessions (primary + split + scratch) and quick terminals.
     private func liveSurfaces() -> [GhosttySurfaceView] {
         var views = library.openIDs()
             .compactMap { library.store(for: $0) }

--- a/agterm/SkillInstaller.swift
+++ b/agterm/SkillInstaller.swift
@@ -1,12 +1,11 @@
 import AppKit
 import agtermCore
 
-/// Installs the bundled agent skill into the skills directories of the coding agents present on the
-/// machine: Claude Code (`~/.claude/skills/agterm/`) and Codex (`~/.codex/skills/agterm/`) — both use
-/// the same SKILL.md Agent-Skill format. So an agent running INSIDE an agterm session learns how to
-/// drive the app via `agtermctl`. The host-free path/target/ownership logic lives in
-/// `agtermCore.SkillInstall`; this type owns the AppKit filesystem glue. Idempotent: re-running
-/// refreshes the skill. It refuses to overwrite a same-named skill the user authored themselves.
+/// Installs the bundled agent skill into the skills directories of the coding agents present on the machine:
+/// Claude Code (`~/.claude/skills/agterm/`) and Codex (`~/.codex/skills/agterm/`), both using the same
+/// SKILL.md Agent-Skill format, so an agent running INSIDE an agterm session learns to drive the app via
+/// `agtermctl`. The host-free path/target/ownership logic is `agtermCore.SkillInstall`; this type owns the
+/// AppKit filesystem glue. Idempotent, and it refuses to overwrite a same-named skill the user authored.
 @MainActor
 enum SkillInstaller {
     private struct InstallError: Error { let message: String }
@@ -51,11 +50,11 @@ enum SkillInstaller {
         var report = Report()
         for target in targets {
             let destination = URL(fileURLWithPath: target.skillDirectory)
-            // refuse to clobber a same-named skill the user authored themselves (a present dir whose
-            // SKILL.md is absent, unreadable, or lacks the agterm marker). `attributesOfItem` uses lstat
-            // semantics (does NOT follow the final symlink), so a dangling/any symlink at the destination
-            // counts as present too — unlike `fileExists(atPath:)`, which follows the link and would read a
-            // dangling symlink as absent, letting the wipe path delete the user's own symlink.
+            // refuse to clobber a same-named skill the user authored (a present dir whose SKILL.md is
+            // absent, unreadable, or lacks the agterm marker). `attributesOfItem` uses lstat semantics (does
+            // NOT follow the final symlink), so any symlink at the destination counts as present —
+            // `fileExists(atPath:)` follows it and reads a dangling one as absent, letting the wipe path
+            // delete the user's own symlink.
             let directoryExists = (try? fm.attributesOfItem(atPath: destination.path)) != nil
             let existingSKILL = try? String(contentsOf: destination.appendingPathComponent("SKILL.md"), encoding: .utf8)
             guard SkillInstall.mayOverwrite(directoryExists: directoryExists, existingSKILL: existingSKILL) else {

--- a/agterm/SystemAccessibilityObserver.swift
+++ b/agterm/SystemAccessibilityObserver.swift
@@ -1,20 +1,19 @@
 import AppKit
 import Foundation
 
-/// Bridges macOS accessibility display-option changes into agterm's app-local notification center.
-/// AppKit posts this notification on `NSWorkspace.notificationCenter` (not the default center), while
-/// agterm's window and sidebar consumers use lifecycle-scoped tokens on the default center.
-///
-/// Consumers read the settled values directly from `NSWorkspace` when handling the bridged event:
-/// `WindowAppearance` handles Reduce Transparency and `StatusIconView` handles Reduce Motion. Native
-/// SwiftUI consumers use the matching accessibility environment values and update independently.
+/// Bridges macOS accessibility display-option changes into agterm's app-local notification center: AppKit
+/// posts them on `NSWorkspace.notificationCenter`, not the default center that agterm's window and sidebar
+/// consumers observe with lifecycle-scoped tokens. Consumers read the settled values directly from
+/// `NSWorkspace` when handling the bridged event — `WindowAppearance` for Reduce Transparency,
+/// `StatusIconView` for Reduce Motion; native SwiftUI consumers use the matching accessibility environment
+/// values and update independently.
 @MainActor
 final class SystemAccessibilityObserver {
     private var displayOptionsObserver: NSObjectProtocol?
 
-    /// Register once for the process. The scene `.task` runs for every window, so this must be
-    /// idempotent like `SystemAppearanceObserver.start()`. No initial post is needed because consumers
-    /// read the current preference during their normal first render or window attachment.
+    /// Register once for the process — the scene `.task` runs for every window, so this must be idempotent
+    /// like `SystemAppearanceObserver.start()`. No initial post: consumers read the current preference
+    /// during their normal first render or window attachment.
     func start() {
         guard displayOptionsObserver == nil else { return }
         let workspace = NSWorkspace.shared

--- a/agterm/SystemAppearanceObserver.swift
+++ b/agterm/SystemAppearanceObserver.swift
@@ -4,21 +4,18 @@ import Foundation
 /// Follows the macOS light/dark appearance for the dual `theme = light:,dark:` conditional.
 ///
 /// The single source of truth is the APP-level `NSApplication.effectiveAppearance`, observed via KVO —
-/// the same mechanism Ghostty and the AppKit community use (Apple exposes no notification API for
-/// appearance; KVO is it). Two properties make it survive sleep/wake, where the old per-view
-/// `viewDidChangeEffectiveAppearance` hook wedged:
-///
-/// - KVO fires when the property actually SETTLES, including the belated update after wake, so there is
-///   no dead callback to route around (the wedge that stuck the theme on the old side).
-/// - The change delivers the new value directly (`change.newValue`), so the side is never re-read at
-///   receive time — no stale read. This is why we take the value from the change, not from a property
-///   read inside the handler.
+/// what Ghostty and the AppKit community use, since Apple exposes no notification API for appearance.
+/// Two properties make it survive sleep/wake, where the old per-view `viewDidChangeEffectiveAppearance`
+/// hook wedged and stuck the theme on the old side: KVO fires when the property actually SETTLES,
+/// including the belated update after wake, so there is no dead callback to route around; and the change
+/// carries the new value (`change.newValue`), so the side is never re-read at receive time — take it from
+/// the change, never from a property read inside the handler.
 ///
 /// Deliberately NOT `AppleInterfaceStyle` (wrong under macOS "Auto" scheduled switching, and cached
-/// per-process) and NOT the distributed `AppleInterfaceThemeChangedNotification` (undocumented, fires
-/// before `effectiveAppearance` settles). The observer feeds the resolved side into the same
-/// `.agtermSystemAppearanceChanged` channel a real flip uses, so `SettingsModel.appearanceChanged`
-/// applies the follow guard, debounce, latch suppression, and zoom-preserving reload unchanged.
+/// per-process) nor the distributed `AppleInterfaceThemeChangedNotification` (undocumented, fires before
+/// `effectiveAppearance` settles). The resolved side goes into the same `.agtermSystemAppearanceChanged`
+/// channel a real flip uses, so `SettingsModel.appearanceChanged` applies the follow guard, debounce,
+/// latch suppression, and zoom-preserving reload unchanged.
 @MainActor
 final class SystemAppearanceObserver {
     private var observation: NSKeyValueObservation?
@@ -29,17 +26,16 @@ final class SystemAppearanceObserver {
     func start() {
         guard observation == nil else { return }
         observation = NSApplication.shared.observe(\.effectiveAppearance, options: [.new, .initial]) { [weak self] _, change in
-            // Resolve the Bool in the non-isolated KVO closure so the non-Sendable NSAppearance never
-            // crosses the hop. The change carries the SETTLED value — never re-read here. KVO's handler is
-            // @Sendable (no main-thread guarantee), so HOP to main rather than assert isolation — matches
-            // the GhosttyCallbacks convention (`DispatchQueue.main.async`, never `assumeIsolated`).
+            // resolve the Bool inside the non-isolated KVO closure so the non-Sendable NSAppearance never
+            // crosses the hop; the change carries the SETTLED value, never re-read here. The @Sendable
+            // handler has no main-thread guarantee, so HOP to main rather than assert isolation — the
+            // GhosttyCallbacks convention (`DispatchQueue.main.async`, never `assumeIsolated`).
             let isDark = change.newValue?.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
             DispatchQueue.main.async { self?.post(isDark: isDark) }
         }
     }
 
-    /// Feed the resolved side into the flip pipeline — the same channel as a real appearance flip, so
-    /// the follow guard, debounce, latch suppression, and zoom-preserving reload all apply unchanged.
+    /// Feed the resolved side into the same `.agtermSystemAppearanceChanged` channel a real flip uses.
     private func post(isDark: Bool) {
         NotificationCenter.default.post(name: .agtermSystemAppearanceChanged, object: nil,
                                         userInfo: ["isDark": isDark])

--- a/agterm/Views/DashboardView.swift
+++ b/agterm/Views/DashboardView.swift
@@ -2,18 +2,17 @@ import agtermCore
 import AppKit
 import SwiftUI
 
-/// The dashboard grid overlay: a per-window modal that hosts up to `DashboardLayout.maxCells` live pane
-/// cells in a `ceil(sqrt(n))`-wide grid, view-only. The cell unit is a session+pane (a `DashboardMember`),
-/// so a split session shows as TWO cells (its primary + split panes). No pane SURFACE takes keyboard or
-/// mouse input — each is `.allowsHitTesting(false)` and never becomes first responder, so its cursor draws
-/// hollow. An AppKit key-catcher owns first responder while open and swallows every key, walking a
-/// keyboard highlight between cells; Enter jumps into the highlighted session AND focuses that exact pane,
-/// Esc closes. A transparent hit target over each cell handles a mouse click: it flashes the active frame on
-/// the cell, then enters that session+pane after a brief delay (an instant jump with no flash is confusing).
+/// The dashboard grid overlay: a per-window, view-only modal hosting up to `DashboardLayout.maxCells` live
+/// pane cells in a `ceil(sqrt(n))`-wide grid. The cell unit is a session+pane (a `DashboardMember`), so a
+/// split session shows as TWO cells (its primary + split panes). No pane SURFACE takes input — each is
+/// `.allowsHitTesting(false)` and never becomes first responder, so its cursor draws hollow; an AppKit
+/// key-catcher owns first responder while open and swallows every key, walking a highlight between cells
+/// (Enter enters the highlighted session AND focuses that exact pane, Esc closes). A transparent hit target
+/// over each cell flashes the active frame before entering, since an instant jump with no flash is confusing.
 ///
-/// The view is purely presentational and closure-driven: `WindowContentView` mounts it in
-/// `windowOverlayLayer` while `controller.isOpen`, generalizes its deck to yield each member's surface into
-/// a cell, and supplies the session lookup, surface factories, and enter/close side effects.
+/// Purely presentational and closure-driven: `WindowContentView` mounts it in `windowOverlayLayer` while
+/// `controller.isOpen`, generalizes its deck to yield each member's surface into a cell, and supplies the
+/// session lookup, surface factories, and enter/close side effects.
 struct DashboardView: View {
     let controller: DashboardController
     /// Resolves a member's session UUID to its live `Session` (the window's `AppStore`), mirroring `SessionSwitcherOverlay`.
@@ -73,16 +72,12 @@ struct DashboardView: View {
         }
         .padding(Self.gridSpacing)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        // an OPAQUE themed backdrop (the terminal theme's background, the SAME color the cells use), so the
-        // grid reads as a SOLID modal instead of letting the layer beneath it bleed through the margins around
-        // the cells — the sidebar, its bottom add-buttons, and the session deck showing through the
-        // transparent margin looked odd. This deliberately drops the window translucency/blur in the dashboard
-        // area: a clean theme-colored panel beats a see-through margin over the regular layer. Not a black
-        // scrim (which composited over the translucent backing and read as near-black) — the theme background.
+        // an OPAQUE themed backdrop so the grid reads as a SOLID modal instead of letting the layer beneath
+        // (sidebar, add-buttons, deck) bleed through the margins — deliberately dropping window
+        // translucency/blur here. Not a black scrim: over the translucent backing that read as near-black.
         .background(captionBackground)
-        // restore the title-bar/content hairline the opaque backdrop would otherwise cover: the SAME 1px
-        // themed line `detailColumn` draws under the title bar (`highlightColor` is the chrome foreground), so
-        // the boundary under the (stripped) title bar stays visible while the dashboard is open.
+        // restores the hairline the opaque backdrop would cover — the SAME 1px themed line `detailColumn`
+        // draws under the title bar (`highlightColor` is the chrome foreground).
         .overlay(alignment: .top) { Rectangle().fill(highlightColor.opacity(0.1)).frame(height: 1) }
         // the key-catcher sits behind the cells so it never intercepts their click hit targets; it owns
         // first responder and swallows every key while open.
@@ -115,15 +110,12 @@ struct DashboardView: View {
     private func cell(for member: DashboardMember, session: Session) -> some View {
         let isHighlighted = controller.highlighted == member
         return ZStack {
-            // an opaque theme-background backing so a translucent terminal surface (window
-            // background-opacity < 1) reads as an OPAQUE cell in the grid, not a see-through one.
             captionBackground
             memberTerminal(for: member, session: session)
                 .allowsHitTesting(false)
-            // transparent hit target above the terminal: a single click flashes the frame then enters (see
-            // onClick). A lone count:1 tap has no double-click interval to wait out, so the click registers
-            // immediately — a count:2 + count:1 pair delayed every single click by the system double-click timeout.
-            // it carries the per-cell accessibility id (the Metal-backed surface is not in the a11y tree).
+            // transparent hit target above the terminal: a lone count:1 tap has no double-click interval to
+            // wait out, so the click registers immediately — a count:2 + count:1 pair delayed every click by
+            // the system timeout. Carries the per-cell a11y id (the Metal-backed surface is not in the tree).
             Color.clear
                 .contentShape(Rectangle())
                 .onTapGesture { onClick(member) }
@@ -141,17 +133,15 @@ struct DashboardView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .clipShape(RoundedRectangle(cornerRadius: Self.cellCornerRadius))
         .overlay {
-            // a thin, theme-tracking ring: the themed chrome foreground on the highlighted cell, the same
-            // color at low opacity on the rest, so the border matches the active terminal theme (not the OS
-            // accent) in both light and dark.
+            // a thin ring tracking the terminal theme, not the OS accent, in both light and dark: the chrome
+            // foreground on the highlighted cell, the same color at low opacity on the rest.
             RoundedRectangle(cornerRadius: Self.cellCornerRadius)
                 .strokeBorder(isHighlighted ? highlightColor : highlightColor.opacity(0.12),
                               lineWidth: isHighlighted ? Self.highlightLineWidth : 1)
         }
-        // the caption rides the cell's BOTTOM frame line: an overlay OUTSIDE the clip (so its lower half is
-        // not clipped away) is bottom-aligned and nudged down, so the chip straddles the border stroke
-        // instead of covering the terminal's last row. it is layered AFTER the border ring so the chip draws
-        // ON TOP of the frame line (the line never crosses over the name), keeping it legible.
+        // the caption rides the cell's BOTTOM frame line: an overlay OUTSIDE the clip (so its lower half
+        // survives), bottom-aligned and nudged down, so the chip straddles the stroke instead of covering
+        // the terminal's last row. Layered AFTER the ring so the frame line never crosses the name.
         .overlay(alignment: .bottom) {
             caption(for: member, session: session, isHighlighted: isHighlighted)
                 .offset(y: Self.captionBottomOffset)
@@ -160,11 +150,10 @@ struct DashboardView: View {
 
     /// Hosts the member's OWN pane surface as a view-only `TerminalView`: `.primary` → `\.surface` via
     /// `makeSurface`, `.split` → `\.splitSurface` via `makeSplitSurface`. The `.id` carries the hosted slot
-    /// (`-dashboard-primary`/`-dashboard-split`) so a cell keyed to one pane never reuses the other pane's
-    /// representable, PLUS the resolved surface's per-instance identity (`surfaceToken`) so a surface
-    /// REPLACEMENT re-mounts the cell — see `surfaceToken`. `isActive`/`deckVisible`/`reportsFocusChange` are
-    /// all off and `viewOnly` is on, so the cell auto-focuses nothing, is not a drop target, refuses first
-    /// responder, and never mutates session focus state.
+    /// (`-dashboard-primary`/`-dashboard-split`), so a cell keyed to one pane never reuses the other's
+    /// representable, plus the surface's per-instance `surfaceToken` so a REPLACEMENT re-mounts the cell.
+    /// `isActive`/`deckVisible`/`reportsFocusChange` off and `viewOnly` on: the cell auto-focuses nothing,
+    /// is not a drop target, refuses first responder, and never mutates session focus state.
     @ViewBuilder
     private func memberTerminal(for member: DashboardMember, session: Session) -> some View {
         if member.surface == .split {
@@ -181,30 +170,26 @@ struct DashboardView: View {
     /// A per-instance identity token for the member's currently-resolved slot surface (`.split` →
     /// `session.splitSurface`, else `session.surface`), folded into the cell `.id`. When a shown session's
     /// PRIMARY shell exits, `AppStore.closePrimaryPane` PROMOTES the split survivor into `session.surface`
-    /// (a DIFFERENT surface instance) and nils `splitSurface`; reconcile then drops the `.split` cell but
-    /// keeps the `.primary` one. `TerminalView.updateNSView` never re-resolves `session[keyPath:]`, so without
-    /// the surface identity in the id SwiftUI would keep hosting the torn-down old primary surface (a blank
-    /// cell) while the live survivor stays unhosted. Folding `ObjectIdentifier` into the id changes it on a
-    /// swap, forcing a re-mount → `makeNSView` re-resolves the slot → hosts the survivor. The token is STABLE
-    /// across ordinary re-renders (same instance → same token → no spurious re-host, which would invalidate
-    /// the Metal drawable and flicker), and changes ONLY on a genuine surface swap. `session.surface`/
-    /// `splitSurface` are `@ObservationIgnored`, so the swap alone does not re-render — the reconcile-driven
-    /// `controller.members` change is what re-renders the grid and re-reads the new slot surface. A nil slot
-    /// keeps a stable `"none"` suffix.
+    /// (a DIFFERENT instance) and nils `splitSurface`, and reconcile drops the `.split` cell but keeps
+    /// `.primary`; `TerminalView.updateNSView` never re-resolves `session[keyPath:]`, so without the surface
+    /// identity in the id SwiftUI keeps hosting the torn-down old primary (a blank cell) while the live
+    /// survivor stays unhosted. `ObjectIdentifier` changes the id ONLY on a genuine swap, forcing a re-mount
+    /// → `makeNSView` re-resolves the slot → hosts the survivor; it is STABLE across ordinary re-renders, so
+    /// no spurious re-host invalidates the Metal drawable and flickers. `session.surface`/`splitSurface` are
+    /// `@ObservationIgnored`, so the swap alone does not re-render — the reconcile-driven `controller.members`
+    /// change re-renders the grid and re-reads the new slot surface. A nil slot keeps a stable `"none"` suffix.
     private func surfaceToken(for member: DashboardMember, session: Session) -> String {
         let surface = member.surface == .split ? session.splitSurface : session.surface
         guard let surface else { return "none" }
         return "\(ObjectIdentifier(surface as AnyObject))"
     }
 
-    /// A small name chip riding the cell's bottom-RIGHT frame line. For a split session's two cells a subtle
-    /// pane marker (`◀` primary / `▶` split) is appended so they read as the left/right pane of the same
-    /// session; a non-split session's single cell shows just the name. The chip's fill DOUBLES as the session's
-    /// agent-status light: a non-idle `agentIndicator` fills it with that status color (pulsing while `--blink`
-    /// is set), an idle session keeps the muted theme-selection pill. `DashboardCaptionPill` owns the fill,
-    /// contrast, and blink; this method only right-aligns it via the leading `Spacer` (which also fixes the
-    /// chip's width so a long name middle-truncates instead of overflowing) and makes it non-interactive so it
-    /// never blocks the hit target above it.
+    /// A small name chip riding the cell's bottom-RIGHT frame line, with a pane marker (`◀` primary / `▶`
+    /// split) appended for a split session's two cells so they read as its left/right panes. The fill DOUBLES
+    /// as the agent-status light: a non-idle `agentIndicator` colors it (pulsing while `--blink` is set), an
+    /// idle session keeps the muted theme-selection pill. `DashboardCaptionPill` owns fill, contrast and
+    /// blink; this only right-aligns it via the leading `Spacer` (which also fixes the width, so a long name
+    /// middle-truncates instead of overflowing) and makes it non-interactive so it never blocks the hit target.
     private func caption(for member: DashboardMember, session: Session, isHighlighted: Bool) -> some View {
         HStack(spacing: 0) {
             Spacer(minLength: 0)
@@ -217,9 +202,8 @@ struct DashboardView: View {
         .allowsHitTesting(false)
     }
 
-    /// The pane marker suffix for the caption: `▶` for a split (right) pane cell, `◀` for the primary (left)
-    /// pane cell of a SPLIT session (both cells present, so they need distinguishing), and nothing for a
-    /// non-split session's single primary cell.
+    /// The caption's pane marker: `▶` for a split (right) pane cell, `◀` for the primary (left) cell of a
+    /// SPLIT session (both cells present, so they need distinguishing), nothing for a non-split session.
     private func paneIndicator(for member: DashboardMember, session: Session) -> String {
         if member.surface == .split { return " ▶" }
         return session.hasSplit ? " ◀" : ""
@@ -237,16 +221,15 @@ struct DashboardView: View {
     }
 }
 
-/// The dashboard cell's name chip, which also carries the session's agent status. An IDLE session draws the
-/// muted theme-selection pill — `idleText` (selection-foreground) over an `idleFill` (selection-background)
-/// capsule, with the label muted (`unselectedTextOpacity`) on an unselected cell so the highlighted cell's
-/// name stands out. A NON-IDLE session fills the capsule with its agent-status color
-/// (`GhosttyApp.statusColor(for:override:)`, honoring a `session.status --color` override) and draws the name
-/// in the luminance-contrasting black/white (`GhosttyApp.contrastingText`), so the name stays readable over ANY
-/// status color — including an arbitrary override. When the status is blinking the capsule stays fully OPAQUE
-/// and a color WASH pulses on top for attention (brighten a light fill / darken a dark one). It is NOT an
-/// opacity fade: fading the pill let the highlighted cell's bright frame ring bleed through the chip and read
-/// as broken, while an opaque capsule always covers the ring.
+/// The dashboard cell's name chip, which also carries the session's agent status. IDLE draws the muted
+/// theme-selection pill — `idleText` (selection-foreground) over an `idleFill` (selection-background)
+/// capsule, the label muted (`unselectedTextOpacity`) on an unselected cell so the highlighted cell's name
+/// stands out. NON-IDLE fills the capsule with the agent-status color
+/// (`GhosttyApp.statusColor(for:override:)`, honoring a `session.status --color` override) and draws the
+/// name in luminance-contrasting black/white (`GhosttyApp.contrastingText`), readable over ANY status color
+/// including an arbitrary override. Blinking keeps the capsule fully OPAQUE and pulses a color WASH on top
+/// (brighten a light fill / darken a dark one), NOT an opacity fade — fading let the highlighted cell's
+/// bright frame ring bleed through the chip and read as broken.
 private struct DashboardCaptionPill: View {
     let text: String
     let indicator: AgentIndicator
@@ -255,9 +238,8 @@ private struct DashboardCaptionPill: View {
     let idleText: Color
     let unselectedTextOpacity: Double
 
-    /// peak opacity of the pulsing color wash — how far the fill brightens/darkens at the top of each blink.
-    /// Deep on purpose: the wash rides a large opaque capsule, so a shallow value reads as a faint dimming
-    /// rather than a blink (the small sidebar glyph gets away with a lighter pulse; this chip needs more).
+    /// peak opacity of the pulsing color wash. Deep on purpose: the wash rides a large opaque capsule, so a
+    /// shallow value reads as faint dimming rather than a blink (the small sidebar glyph needs less).
     private static let washPeakOpacity: Double = 0.75
     private static let pulseDuration: Double = 0.45
 
@@ -273,8 +255,7 @@ private struct DashboardCaptionPill: View {
     private var fill: Color { isStatus ? Color(nsColor: statusColor) : idleFill }
     private var textColor: Color { isStatus ? Color(nsColor: textNSColor) : idleText }
     /// wash toward the OPPOSITE of the text — white over a black-text (light) fill, black over a white-text
-    /// (dark) fill — so the pulse pushes the fill further from the contrast crossover and the name stays
-    /// readable at the wash peak.
+    /// (dark) one — so the pulse pushes the fill away from the contrast crossover, readable at the peak.
     private var washColor: Color { textNSColor == .black ? .white : .black }
     /// full-opacity text on a status pill and on the highlighted cell; muted only for an idle, unselected cell
     /// so the highlighted name reads as the focused one.
@@ -322,11 +303,10 @@ private enum DashboardKey {
 }
 
 /// A zero-content AppKit view that owns first responder while the dashboard is open and consumes EVERY
-/// keyDown, so no keystroke reaches a background terminal surface (the cells are view-only). Arrows drive a
-/// highlight move, Return/Enter selects, Escape closes, and all other keys are swallowed (never passed to
-/// the next responder). Placed as a `.background` so it never intercepts the cells' click hit targets. Menu
-/// key-equivalents (⌘Q, ⌘W, …) still reach the menu bar — those go through `performKeyEquivalent` before
-/// keyDown, so the user is never trapped; only plain keystrokes to the terminal are blocked.
+/// keyDown, so no keystroke reaches a background terminal surface. Arrows move the highlight, Return/Enter
+/// selects, Escape closes, everything else is swallowed (never passed to the next responder). Placed as a
+/// `.background` so it never intercepts the cells' click hit targets. Menu key-equivalents (⌘Q, ⌘W, …) still
+/// reach the menu bar via `performKeyEquivalent`, which runs before keyDown, so the user is never trapped.
 private struct DashboardKeyCatcher: NSViewRepresentable {
     let focusRevision: Int
     let focusAllowed: Bool

--- a/agterm/Views/DashboardView.swift
+++ b/agterm/Views/DashboardView.swift
@@ -6,9 +6,7 @@ import SwiftUI
 /// pane cells in a `ceil(sqrt(n))`-wide grid. The cell unit is a session+pane (a `DashboardMember`), so a
 /// split session shows as TWO cells (its primary + split panes). No pane SURFACE takes input — each is
 /// `.allowsHitTesting(false)` and never becomes first responder, so its cursor draws hollow; an AppKit
-/// key-catcher owns first responder while open and swallows every key, walking a highlight between cells
-/// (Enter enters the highlighted session AND focuses that exact pane, Esc closes). A transparent hit target
-/// over each cell flashes the active frame before entering, since an instant jump with no flash is confusing.
+/// key-catcher owns first responder while open, walking a highlight between cells.
 ///
 /// Purely presentational and closure-driven: `WindowContentView` mounts it in `windowOverlayLayer` while
 /// `controller.isOpen`, generalizes its deck to yield each member's surface into a cell, and supplies the
@@ -21,41 +19,35 @@ struct DashboardView: View {
     let makeSurface: (Session) -> GhosttySurfaceView
     /// The split surface factory — used for a `.split` pane cell (`session.splitSurface`).
     let makeSplitSurface: (Session) -> GhosttySurfaceView
-    /// The themed chrome foreground (the terminal theme's foreground), used for the highlight ring so it
-    /// tracks the active terminal theme rather than the OS accent.
+    /// The themed chrome foreground for the highlight ring, so it tracks the terminal theme, not the OS accent.
     let highlightColor: Color
     /// The themed terminal background — the OPAQUE backing for BOTH the whole grid and each cell, so a
-    /// translucent terminal surface (window background-opacity < 1) still reads as a solid grid, and the
-    /// regular layer beneath the overlay (sidebar, add-buttons, deck) doesn't bleed through the margins.
+    /// translucent terminal surface (window background-opacity < 1) still reads as a solid grid.
     let captionBackground: Color
-    /// The IDLE caption pill's FILL — the theme's muted selection-background highlight (the same color the
-    /// selected sidebar row draws), so an idle chip is a themed, muted accent rather than the loud foreground.
-    /// A non-idle session overrides this with its agent-status color (see `DashboardCaptionPill`).
+    /// The IDLE caption pill's FILL — the theme's muted selection-background (the selected sidebar row's
+    /// color), so an idle chip is a muted themed accent rather than the loud foreground.
     let pillColor: Color
-    /// The IDLE caption pill's TEXT — the theme's selection-foreground, readable over `pillColor`. A non-idle
-    /// pill uses a luminance-contrasting black/white instead.
+    /// The IDLE caption pill's TEXT — the theme's selection-foreground, readable over `pillColor`.
     let pillTextColor: Color
     /// False while a control picker is above the dashboard, so its key catcher cannot steal focus.
     let focusAllowed: Bool
-    /// A single mouse click on a cell: the wiring flashes the active frame on it, then enters it after a brief
-    /// delay, so the click is visibly acknowledged before the grid closes.
+    /// A single click on a cell: the wiring flashes the active frame, then enters after a brief delay, so the
+    /// click is visibly acknowledged before the grid closes.
     let onClick: (DashboardMember) -> Void
-    /// Enter on the keyboard highlight jumps into that session+pane immediately (the wiring selects + closes +
-    /// focuses). No click-flash delay on this path — the keyboard highlight is already visible.
+    /// Enter jumps into the highlighted session+pane immediately (select + close + focus). No click-flash
+    /// delay — the keyboard highlight is already visible.
     let onSelect: (DashboardMember) -> Void
     /// Esc, or the wiring's close path, dismisses the dashboard.
     let onClose: () -> Void
 
     private static let cellCornerRadius: CGFloat = 6
-    /// inter-cell (and outer) gap. Kept a few points WIDER than `captionBottomOffset` so the caption chip,
-    /// which overhangs the cell's bottom edge by that offset, clears the cell below instead of touching it.
+    /// inter-cell (and outer) gap, kept WIDER than `captionBottomOffset` so the overhanging chip clears the
+    /// cell below.
     private static let gridSpacing: CGFloat = 12
     private static let highlightLineWidth: CGFloat = 1.5
-    /// how far the caption chip is nudged below the cell's bottom edge so it straddles the frame line
-    /// instead of covering the terminal's last row.
+    /// nudge below the cell's bottom edge so the chip straddles the frame line instead of the last row.
     private static let captionBottomOffset: CGFloat = 8
-    /// caption text opacity on an UNSELECTED (non-highlighted) cell — the label font reads muted there so
-    /// the highlighted cell's name stands out; the highlighted cell keeps full-opacity text.
+    /// caption text opacity on an UNSELECTED cell, so the highlighted cell's name stands out.
     private static let unselectedCaptionTextOpacity: Double = 0.55
 
     var body: some View {
@@ -72,15 +64,14 @@ struct DashboardView: View {
         }
         .padding(Self.gridSpacing)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        // an OPAQUE themed backdrop so the grid reads as a SOLID modal instead of letting the layer beneath
-        // (sidebar, add-buttons, deck) bleed through the margins — deliberately dropping window
-        // translucency/blur here. Not a black scrim: over the translucent backing that read as near-black.
+        // an OPAQUE themed backdrop: the layer beneath (sidebar, add-buttons, deck) must not bleed through
+        // the margins, deliberately dropping window translucency/blur. Not a black scrim — over the
+        // translucent backing that read as near-black.
         .background(captionBackground)
-        // restores the hairline the opaque backdrop would cover — the SAME 1px themed line `detailColumn`
-        // draws under the title bar (`highlightColor` is the chrome foreground).
+        // restores the hairline the opaque backdrop covers — the same 1px themed line `detailColumn` draws
+        // under the title bar.
         .overlay(alignment: .top) { Rectangle().fill(highlightColor.opacity(0.1)).frame(height: 1) }
-        // the key-catcher sits behind the cells so it never intercepts their click hit targets; it owns
-        // first responder and swallows every key while open.
+        // behind the cells so it never intercepts their click hit targets.
         .background {
             DashboardKeyCatcher(
                 focusRevision: controller.focusRevision,
@@ -90,14 +81,13 @@ struct DashboardView: View {
         }
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("dashboard")
-        // no implicit animation on the grid geometry / highlight — a modal reparent overlay applies its
-        // @Observable-driven changes instantly, never as an animated transition.
+        // no implicit animation on grid geometry or highlight — a modal reparent overlay applies its
+        // @Observable-driven changes instantly, never as a transition.
         .transaction { $0.animation = nil }
     }
 
-    /// One grid position: the member pane cell when `index` is in range and its session/pane still resolves,
-    /// else a clear filler that keeps every real cell the same size as the full rows above it (the ragged
-    /// last-row case, and the stale-member guard for a session/pane that vanished mid-frame).
+    /// One grid position: the member pane cell when `index` resolves, else a clear filler keeping every real
+    /// cell the size of the full rows above (the ragged last row, and a session/pane that vanished mid-frame).
     @ViewBuilder
     private func cellSlot(index: Int, members: [DashboardMember]) -> some View {
         if index < members.count, let session = store.session(withID: members[index].session) {
@@ -113,17 +103,16 @@ struct DashboardView: View {
             captionBackground
             memberTerminal(for: member, session: session)
                 .allowsHitTesting(false)
-            // transparent hit target above the terminal: a lone count:1 tap has no double-click interval to
-            // wait out, so the click registers immediately — a count:2 + count:1 pair delayed every click by
-            // the system timeout. Carries the per-cell a11y id (the Metal-backed surface is not in the tree).
+            // transparent hit target above the terminal: a lone count:1 tap registers immediately, while a
+            // count:2 + count:1 pair delayed every click by the double-click timeout. Carries the per-cell
+            // a11y id — the Metal-backed surface is not in the tree.
             Color.clear
                 .contentShape(Rectangle())
                 .onTapGesture { onClick(member) }
                 .accessibilityElement()
                 .accessibilityIdentifier("dashboard-cell")
             if isHighlighted {
-                // a zero-content marker the e2e queries to locate the highlighted cell; it fills the cell,
-                // so its frame identifies which cell holds the highlight.
+                // a zero-content marker the e2e queries: it fills the cell, so its frame locates the highlight.
                 Color.clear
                     .allowsHitTesting(false)
                     .accessibilityElement()
@@ -133,25 +122,22 @@ struct DashboardView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .clipShape(RoundedRectangle(cornerRadius: Self.cellCornerRadius))
         .overlay {
-            // a thin ring tracking the terminal theme, not the OS accent, in both light and dark: the chrome
-            // foreground on the highlighted cell, the same color at low opacity on the rest.
+            // the chrome foreground on the highlighted cell, the same color at low opacity on the rest.
             RoundedRectangle(cornerRadius: Self.cellCornerRadius)
                 .strokeBorder(isHighlighted ? highlightColor : highlightColor.opacity(0.12),
                               lineWidth: isHighlighted ? Self.highlightLineWidth : 1)
         }
-        // the caption rides the cell's BOTTOM frame line: an overlay OUTSIDE the clip (so its lower half
-        // survives), bottom-aligned and nudged down, so the chip straddles the stroke instead of covering
-        // the terminal's last row. Layered AFTER the ring so the frame line never crosses the name.
+        // the caption rides the cell's BOTTOM frame line: an overlay OUTSIDE the clip, so its lower half
+        // survives. Layered AFTER the ring so the frame line never crosses the name.
         .overlay(alignment: .bottom) {
             caption(for: member, session: session, isHighlighted: isHighlighted)
                 .offset(y: Self.captionBottomOffset)
         }
     }
 
-    /// Hosts the member's OWN pane surface as a view-only `TerminalView`: `.primary` → `\.surface` via
-    /// `makeSurface`, `.split` → `\.splitSurface` via `makeSplitSurface`. The `.id` carries the hosted slot
+    /// Hosts the member's OWN pane surface as a view-only `TerminalView`. The `.id` carries the hosted slot
     /// (`-dashboard-primary`/`-dashboard-split`), so a cell keyed to one pane never reuses the other's
-    /// representable, plus the surface's per-instance `surfaceToken` so a REPLACEMENT re-mounts the cell.
+    /// representable, plus `surfaceToken` so a REPLACEMENT re-mounts the cell.
     /// `isActive`/`deckVisible`/`reportsFocusChange` off and `viewOnly` on: the cell auto-focuses nothing,
     /// is not a drop target, refuses first responder, and never mutates session focus state.
     @ViewBuilder
@@ -167,29 +153,25 @@ struct DashboardView: View {
         }
     }
 
-    /// A per-instance identity token for the member's currently-resolved slot surface (`.split` →
-    /// `session.splitSurface`, else `session.surface`), folded into the cell `.id`. When a shown session's
-    /// PRIMARY shell exits, `AppStore.closePrimaryPane` PROMOTES the split survivor into `session.surface`
-    /// (a DIFFERENT instance) and nils `splitSurface`, and reconcile drops the `.split` cell but keeps
-    /// `.primary`; `TerminalView.updateNSView` never re-resolves `session[keyPath:]`, so without the surface
-    /// identity in the id SwiftUI keeps hosting the torn-down old primary (a blank cell) while the live
-    /// survivor stays unhosted. `ObjectIdentifier` changes the id ONLY on a genuine swap, forcing a re-mount
-    /// → `makeNSView` re-resolves the slot → hosts the survivor; it is STABLE across ordinary re-renders, so
-    /// no spurious re-host invalidates the Metal drawable and flickers. `session.surface`/`splitSurface` are
-    /// `@ObservationIgnored`, so the swap alone does not re-render — the reconcile-driven `controller.members`
-    /// change re-renders the grid and re-reads the new slot surface. A nil slot keeps a stable `"none"` suffix.
+    /// A per-instance identity token for the member's resolved slot surface, folded into the cell `.id`; a
+    /// nil slot keeps a stable `"none"` suffix. When a shown session's PRIMARY shell exits,
+    /// `AppStore.closePrimaryPane` PROMOTES the split survivor into `session.surface` (a DIFFERENT instance)
+    /// and nils `splitSurface`, and reconcile drops the `.split` cell but keeps `.primary`;
+    /// `TerminalView.updateNSView` never re-resolves `session[keyPath:]`, so without the surface identity in
+    /// the id SwiftUI keeps hosting the torn-down old primary (a blank cell) while the live survivor stays
+    /// unhosted. `ObjectIdentifier` changes ONLY on a genuine swap, forcing a re-mount whose `makeNSView`
+    /// re-resolves the slot; it is STABLE across ordinary re-renders, so no spurious re-host invalidates the
+    /// Metal drawable and flickers. The slots are `@ObservationIgnored`, so the swap alone does not
+    /// re-render — the reconcile-driven `controller.members` change does.
     private func surfaceToken(for member: DashboardMember, session: Session) -> String {
         let surface = member.surface == .split ? session.splitSurface : session.surface
         guard let surface else { return "none" }
         return "\(ObjectIdentifier(surface as AnyObject))"
     }
 
-    /// A small name chip riding the cell's bottom-RIGHT frame line, with a pane marker (`◀` primary / `▶`
-    /// split) appended for a split session's two cells so they read as its left/right panes. The fill DOUBLES
-    /// as the agent-status light: a non-idle `agentIndicator` colors it (pulsing while `--blink` is set), an
-    /// idle session keeps the muted theme-selection pill. `DashboardCaptionPill` owns fill, contrast and
-    /// blink; this only right-aligns it via the leading `Spacer` (which also fixes the width, so a long name
-    /// middle-truncates instead of overflowing) and makes it non-interactive so it never blocks the hit target.
+    /// A small name chip on the cell's bottom-RIGHT frame line, with a pane marker for a split session's two
+    /// cells. `DashboardCaptionPill` owns fill, contrast and blink; this only right-aligns it via the leading
+    /// `Spacer` (which also fixes the width, so a long name middle-truncates) and blocks no hit target.
     private func caption(for member: DashboardMember, session: Session, isHighlighted: Bool) -> some View {
         HStack(spacing: 0) {
             Spacer(minLength: 0)
@@ -202,8 +184,8 @@ struct DashboardView: View {
         .allowsHitTesting(false)
     }
 
-    /// The caption's pane marker: `▶` for a split (right) pane cell, `◀` for the primary (left) cell of a
-    /// SPLIT session (both cells present, so they need distinguishing), nothing for a non-split session.
+    /// The caption's pane marker: `▶` for a split (right) cell, `◀` for the primary (left) cell of a SPLIT
+    /// session (both cells present, so they need distinguishing), nothing for a non-split session.
     private func paneIndicator(for member: DashboardMember, session: Session) -> String {
         if member.surface == .split { return " ▶" }
         return session.hasSplit ? " ◀" : ""
@@ -222,14 +204,10 @@ struct DashboardView: View {
 }
 
 /// The dashboard cell's name chip, which also carries the session's agent status. IDLE draws the muted
-/// theme-selection pill — `idleText` (selection-foreground) over an `idleFill` (selection-background)
-/// capsule, the label muted (`unselectedTextOpacity`) on an unselected cell so the highlighted cell's name
-/// stands out. NON-IDLE fills the capsule with the agent-status color
-/// (`GhosttyApp.statusColor(for:override:)`, honoring a `session.status --color` override) and draws the
-/// name in luminance-contrasting black/white (`GhosttyApp.contrastingText`), readable over ANY status color
-/// including an arbitrary override. Blinking keeps the capsule fully OPAQUE and pulses a color WASH on top
-/// (brighten a light fill / darken a dark one), NOT an opacity fade — fading let the highlighted cell's
-/// bright frame ring bleed through the chip and read as broken.
+/// theme-selection pill (`idleText` over an `idleFill` capsule); NON-IDLE fills it with the agent-status
+/// color and draws the name in luminance-contrasting black/white, readable over ANY color including an
+/// arbitrary `session.status --color` override. Blinking keeps the capsule fully OPAQUE and pulses a color
+/// WASH on top, NOT an opacity fade — fading let the cell's bright frame ring bleed through and read broken.
 private struct DashboardCaptionPill: View {
     let text: String
     let indicator: AgentIndicator
@@ -238,8 +216,8 @@ private struct DashboardCaptionPill: View {
     let idleText: Color
     let unselectedTextOpacity: Double
 
-    /// peak opacity of the pulsing color wash. Deep on purpose: the wash rides a large opaque capsule, so a
-    /// shallow value reads as faint dimming rather than a blink (the small sidebar glyph needs less).
+    /// peak opacity of the pulsing wash. Deep on purpose: on a large opaque capsule a shallow value reads as
+    /// faint dimming rather than a blink (the small sidebar glyph needs less).
     private static let washPeakOpacity: Double = 0.75
     private static let pulseDuration: Double = 0.45
 
@@ -247,8 +225,7 @@ private struct DashboardCaptionPill: View {
     @State private var pulsed = false
 
     private var isStatus: Bool { indicator.status != .idle }
-    /// the resolved status tint (per-call `--color` override else the Settings color); computed once so the
-    /// fill and its contrasting text agree.
+    /// the resolved status tint (per-call `--color` override else Settings), computed once so fill and text agree.
     private var statusColor: NSColor { GhosttyApp.shared.statusColor(for: indicator.status, override: indicator.color) }
     /// black/white by the fill's luminance so the name is readable over any status color.
     private var textNSColor: NSColor { GhosttyApp.contrastingText(for: statusColor) }
@@ -257,12 +234,11 @@ private struct DashboardCaptionPill: View {
     /// wash toward the OPPOSITE of the text — white over a black-text (light) fill, black over a white-text
     /// (dark) one — so the pulse pushes the fill away from the contrast crossover, readable at the peak.
     private var washColor: Color { textNSColor == .black ? .white : .black }
-    /// full-opacity text on a status pill and on the highlighted cell; muted only for an idle, unselected cell
-    /// so the highlighted name reads as the focused one.
+    /// full opacity on a status pill and on the highlighted cell; muted only for an idle, unselected cell.
     private var textOpacity: Double { isStatus || isHighlighted ? 1 : unselectedTextOpacity }
     private var shouldPulse: Bool { isStatus && indicator.blink }
-    /// Keep status color/text as the durable signal, but suppress the indefinite wash animation when
-    /// macOS Reduce Motion is enabled. SwiftUI refreshes this environment value live.
+    /// Status color/text stay the durable signal, but the indefinite wash animation is suppressed under
+    /// macOS Reduce Motion (SwiftUI refreshes the environment value live).
     private var shouldAnimatePulse: Bool { shouldPulse && !reduceMotion }
 
     var body: some View {
@@ -276,16 +252,13 @@ private struct DashboardCaptionPill: View {
             .background {
                 Capsule()
                     .fill(fill)
-                    // the blink: the opaque fill keeps covering the cell's frame ring while this wash capsule
-                    // pulses its opacity on top, so nothing behind the chip ever shows through.
                     .overlay {
                         Capsule().fill(washColor)
                             .opacity(shouldAnimatePulse && pulsed ? Self.washPeakOpacity : 0)
                     }
             }
-            // a pill-level implicit animation on `pulsed` — deeper in the tree than the grid's
-            // `.transaction { animation = nil }`, so it re-enables the pulse for this pill WITHOUT re-animating
-            // the grid's reparent (later-in-tree wins). Only the wash opacity keys off `pulsed`.
+            // deeper in the tree than the grid's `.transaction { animation = nil }` (later-in-tree wins), so
+            // the pulse returns for this pill without re-animating the grid reparent; only the wash keys off it.
             .animation(shouldAnimatePulse
                 ? .easeInOut(duration: Self.pulseDuration).repeatForever(autoreverses: true)
                 : nil,
@@ -303,9 +276,7 @@ private enum DashboardKey {
 }
 
 /// A zero-content AppKit view that owns first responder while the dashboard is open and consumes EVERY
-/// keyDown, so no keystroke reaches a background terminal surface. Arrows move the highlight, Return/Enter
-/// selects, Escape closes, everything else is swallowed (never passed to the next responder). Placed as a
-/// `.background` so it never intercepts the cells' click hit targets. Menu key-equivalents (⌘Q, ⌘W, …) still
+/// keyDown, so no keystroke reaches a background terminal surface. Menu key-equivalents (⌘Q, ⌘W, …) still
 /// reach the menu bar via `performKeyEquivalent`, which runs before keyDown, so the user is never trapped.
 private struct DashboardKeyCatcher: NSViewRepresentable {
     let focusRevision: Int
@@ -323,8 +294,7 @@ private struct DashboardKeyCatcher: NSViewRepresentable {
         _ = focusRevision
         nsView.focusAllowed = focusAllowed
         nsView.onKey = onKey
-        // re-assert first responder on every render so a cell click (or any focus reshuffle) can't leave the
-        // overlay without the keyboard while it is open.
+        // re-assert first responder each render so a click or focus reshuffle can't leave the overlay keyless.
         if focusAllowed { nsView.grabFocus() }
     }
 
@@ -346,8 +316,7 @@ private struct DashboardKeyCatcher: NSViewRepresentable {
         }
 
         override func keyDown(with event: NSEvent) {
-            // consume EVERY key: recognized keys drive the dashboard, the rest are swallowed by NOT calling
-            // super, so nothing (and no beep) leaks to a terminal behind the overlay.
+            // the rest are swallowed by NOT calling super, so nothing (and no beep) leaks to the terminal behind.
             switch event.keyCode {
             case 123: onKey?(.move(.left)) // left arrow
             case 124: onKey?(.move(.right)) // right arrow

--- a/agterm/Views/Palette.swift
+++ b/agterm/Views/Palette.swift
@@ -2,30 +2,27 @@ import agtermCore
 import AppKit
 import SwiftUI
 
-/// One selectable palette entry: a title (and optional subtitle, e.g. a session's cwd), an optional
-/// keyboard-shortcut hint shown right-aligned, plus the closure to run when chosen.
+/// One selectable palette entry: a title, an optional subtitle (e.g. a session's cwd), and the closure to
+/// run when chosen.
 struct PaletteItem: Identifiable {
     let id: String
     let title: String
     let subtitle: String?
-    /// The right-aligned keyboard-shortcut hint, nil for items with no shortcut. Rebindable built-ins read
-    /// the live keymap (`AppActions.shortcutGlyph`), so it tracks rebinds, and render as macOS menu glyphs
-    /// (e.g. `⌘⇧E`); custom commands show their raw kitty shortcut string (e.g. `cmd+shift+e`).
+    /// The right-aligned shortcut hint, nil for items with no shortcut. Rebindable built-ins render the
+    /// live keymap (`AppActions.shortcutGlyph`) as macOS menu glyphs (`⌘⇧E`), so they track rebinds; a
+    /// custom command shows its raw kitty string (`cmd+shift+e`).
     let shortcut: String?
     /// A small trailing badge label (e.g. `custom` for user-defined keymap commands), nil for none.
     let badge: String?
-    /// A leading agent-status glyph, nil for items with no status — only the `.attention` palette sets it,
-    /// so the other palettes render no glyph.
+    /// A leading agent-status glyph, nil for none — only the `.attention` palette sets it.
     let status: AgentStatus?
-    /// Per-call `#rrggbb` glyph-tint override for the leading status glyph (the session's
-    /// `AgentIndicator.color`), so the attention row matches the sidebar; nil = the default status color.
+    /// Per-call `#rrggbb` tint for the status glyph (the session's `AgentIndicator.color`), so the
+    /// attention row matches the sidebar; nil = the default status color.
     let statusColor: String?
-    /// Per-call silhouette override for the leading status glyph (the session's `AgentIndicator.shape`),
-    /// so the attention row matches the sidebar; nil = the Settings shape for that status.
+    /// Per-call silhouette for the status glyph (`AgentIndicator.shape`); nil = the Settings shape.
     let statusShape: StatusShape?
     /// Fired when this item BECOMES the selection (keyboard navigation), distinct from `run` (Enter/click).
-    /// Only `.themes` sets it, to drive the live theme preview; nil elsewhere, so the other palettes have no
-    /// selection side effect.
+    /// Only `.themes` sets it, driving the live theme preview.
     let onSelect: (() -> Void)?
     let run: () -> Void
 
@@ -45,10 +42,9 @@ struct PaletteItem: Identifiable {
     }
 }
 
-/// Which palette is open. `actions` fuzzy-searches the app's commands; `sessions` fuzzy-searches
-/// the open sessions to jump between them; `themes` fuzzy-searches the bundled themes with a live
-/// preview on navigation (Enter commits, Esc reverts); `customCommands` fuzzy-searches only the
-/// user-defined keymap commands (the `custom` subset of `actions`, shown without the badge).
+/// Which palette is open. Each fuzzy-searches its own source: `actions` the app's commands, `sessions` the
+/// open sessions to jump between, `themes` the bundled themes with a live preview on navigation (Enter
+/// commits, Esc reverts), `customCommands` the `custom` subset of `actions` shown without the badge.
 enum PaletteMode {
     case actions
     case sessions
@@ -69,16 +65,16 @@ final class PaletteController {
         self.mode = (self.mode == mode) ? nil : mode
     }
 
-    /// Open a specific palette unconditionally (used by the theme picker's launcher/menu item, which
-    /// must open `.themes` rather than toggle it closed if it happened to already be the mode).
+    /// Open a palette unconditionally — the theme picker's launcher/menu item must not toggle `.themes`
+    /// closed when it already happens to be the mode.
     func open(_ mode: PaletteMode) { self.mode = mode }
 
     func close() { mode = nil }
 }
 
-/// The palette overlay: a dimmed scrim (click to dismiss) with a top-centered search field and a
+/// The palette overlay: a dimmed scrim (click to dismiss) over a top-centered search field and a
 /// fuzzy-filtered result list. Type to filter, ↑/↓ to move, Enter to run, Esc to close. Mounted by
-/// `ContentView` only while a palette is open; the item source switches on `controller.mode`.
+/// `ContentView` only while a palette is open.
 struct CommandPalette: View {
     let controller: PaletteController
     let actions: AppActions
@@ -96,9 +92,8 @@ struct CommandPalette: View {
 
     @State private var query = ""
     @State private var selection = 0
-    /// The visible, filtered result list. Held in `@State` (recomputed on query/mode change) so the rendered
-    /// rows and the Enter target are guaranteed to be the same array — a computed property could be
-    /// evaluated out of sync between the list and the run handler.
+    /// The visible, filtered result list. Held in `@State` so the rendered rows and the Enter target are
+    /// one array — a computed property could be evaluated out of sync between the list and the handler.
     @State private var filtered: [PaletteItem] = []
     @FocusState private var fieldFocused: Bool
 
@@ -126,15 +121,13 @@ struct CommandPalette: View {
         }
     }
 
-    /// Recomputes `filtered` for the current query: keep items whose title (or subtitle) matches,
-    /// best score first, then alphabetically by title (so an empty query lists everything A→Z and
-    /// equal-scoring matches are ordered predictably).
+    /// Recomputes `filtered`: items whose title or subtitle matches, best score first then alphabetically
+    /// by title, so an empty query lists everything A→Z and equal scores are ordered predictably.
     private func updateFiltered() {
         let q = query.trimmingCharacters(in: .whitespaces)
-        // the attention palette's empty-query order is the paletteAttention()/attentionSessions ranking
-        // (blocked→active→completed, newest change first), preserved verbatim: every row scores 0 for an
-        // empty query, so the alphabetical tie-break below would re-sort them A→Z and Return would jump to
-        // the alphabetically-first session, not the blocked one. fuzzy filtering applies once the user types.
+        // the attention palette's empty-query order is `paletteAttention()`'s ranking
+        // (blocked→active→completed, newest change first), preserved verbatim: every row scores 0, so the
+        // tie-break below would re-sort A→Z and Return would jump to the alphabetically-first session.
         if explicitItems == nil, controller.mode == .attention, q.isEmpty {
             filtered = allItems
             selection = filtered.isEmpty ? 0 : min(selection, filtered.count - 1)
@@ -163,8 +156,8 @@ struct CommandPalette: View {
     }
 
     /// Enter/leave the live-preview theme session as the palette opens, switches mode, or closes: entering
-    /// `.themes` captures the current theme (so Esc can revert) and starts the selection on its row; leaving
-    /// it reverts any uncommitted preview. Idempotent — `AppActions` guards begin/cancel on its active flag.
+    /// `.themes` captures the current theme (so Esc can revert) and starts the selection on its row,
+    /// leaving reverts any uncommitted preview. Idempotent — `AppActions` guards on its active flag.
     private func syncThemeSession() {
         guard explicitItems == nil, controller.mode == .themes else {
             actions.cancelThemePreview()
@@ -216,9 +209,8 @@ struct CommandPalette: View {
             updateFiltered()
             if explicitItems == nil { syncThemeSession() }
             // a palette opened from a title-bar button (the attention bell) mounts while that button still
-            // holds first responder, so the synchronous focus above loses the race and the field never takes
-            // the keyboard. re-assert on the next runloop tick, after the click settles, so the field wins;
-            // a no-op for the menu/hotkey/⌃P paths, where the field is already focused by then.
+            // holds first responder, so the synchronous focus above loses the race. re-assert on the next
+            // runloop tick, once the click settles; a no-op for the menu/hotkey/⌃P paths.
             DispatchQueue.main.async { fieldFocused = true }
         }
         .onChange(of: controller.mode) {
@@ -247,9 +239,9 @@ struct CommandPalette: View {
             .onChange(of: selection) { _, sel in
                 guard filtered.indices.contains(sel) else { return }
                 filtered[sel].onSelect?()
-                // with no anchor, scrollTo no-ops while the row is already visible and does the minimum
-                // reveal at an edge. animating a center-anchored scroll on every key-repeat event
-                // continually interrupted layout/compositing and made the material-backed palette flash.
+                // with no anchor, scrollTo no-ops while the row is visible and does the minimum reveal at
+                // an edge. an animated center-anchored scroll on every key-repeat kept interrupting
+                // layout/compositing and made the material-backed palette flash.
                 proxy.scrollTo(filtered[sel].id)
             }
         }
@@ -260,9 +252,8 @@ struct CommandPalette: View {
         selection = max(0, min(selection + delta, filtered.count - 1))
     }
 
-    /// Preview the currently-selected item (fires its `onSelect`). Called after a filter re-orders the
-    /// list so the new top match previews even when `selection` stayed 0 (no `onChange(of: selection)`).
-    /// A no-op for non-theme palettes — only theme rows carry an `onSelect`.
+    /// Fires the selected item's `onSelect`. Called after a filter re-orders the list, so the new top match
+    /// previews even when `selection` stayed 0 and `onChange(of: selection)` never fires.
     private func previewSelected() {
         guard filtered.indices.contains(selection) else { return }
         filtered[selection].onSelect?()
@@ -284,8 +275,7 @@ struct CommandPalette: View {
     }
 }
 
-/// The panel's live material is deliberately a separate view type so selection state changes in
-/// `CommandPalette` do not invalidate and re-resolve the entire backdrop.
+/// A separate view type so a selection change in `CommandPalette` doesn't re-resolve the whole backdrop.
 private struct PalettePanelBackground: View {
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
 
@@ -300,8 +290,8 @@ private struct PalettePanelBackground: View {
     }
 }
 
-/// A real row view gives SwiftUI a narrow diffing boundary: selection changes update the previous
-/// and next rows instead of rebuilding every row helper in the lazy stack.
+/// A real row view narrows SwiftUI's diffing boundary: a selection change updates the previous and next
+/// rows instead of rebuilding every row helper in the lazy stack.
 private struct PaletteRow: View {
     let item: PaletteItem
     let isSelected: Bool

--- a/agterm/Views/Palette.swift
+++ b/agterm/Views/Palette.swift
@@ -8,15 +8,14 @@ struct PaletteItem: Identifiable {
     let id: String
     let title: String
     let subtitle: String?
-    /// The action's keyboard shortcut hint shown right-aligned, nil for items with no shortcut.
-    /// Rebindable built-ins read the live keymap (`AppActions.shortcutGlyph`) so it tracks rebinds and
-    /// render as macOS menu glyphs (e.g. `⌘⇧E`); custom commands show their raw kitty shortcut string
-    /// (e.g. `cmd+shift+e`).
+    /// The right-aligned keyboard-shortcut hint, nil for items with no shortcut. Rebindable built-ins read
+    /// the live keymap (`AppActions.shortcutGlyph`), so it tracks rebinds, and render as macOS menu glyphs
+    /// (e.g. `⌘⇧E`); custom commands show their raw kitty shortcut string (e.g. `cmd+shift+e`).
     let shortcut: String?
     /// A small trailing badge label (e.g. `custom` for user-defined keymap commands), nil for none.
     let badge: String?
-    /// A leading agent-status glyph (the attention palette's rows carry it), nil for items with no
-    /// status — only the `.attention` palette sets it, so the other palettes render no glyph.
+    /// A leading agent-status glyph, nil for items with no status — only the `.attention` palette sets it,
+    /// so the other palettes render no glyph.
     let status: AgentStatus?
     /// Per-call `#rrggbb` glyph-tint override for the leading status glyph (the session's
     /// `AgentIndicator.color`), so the attention row matches the sidebar; nil = the default status color.
@@ -24,9 +23,9 @@ struct PaletteItem: Identifiable {
     /// Per-call silhouette override for the leading status glyph (the session's `AgentIndicator.shape`),
     /// so the attention row matches the sidebar; nil = the Settings shape for that status.
     let statusShape: StatusShape?
-    /// Fired when this item BECOMES the selection (keyboard navigation), distinct from `run` (Enter/
-    /// click). Only the `.themes` palette sets it — it drives the live theme preview; nil everywhere
-    /// else, so the other palettes have no selection side effect.
+    /// Fired when this item BECOMES the selection (keyboard navigation), distinct from `run` (Enter/click).
+    /// Only `.themes` sets it, to drive the live theme preview; nil elsewhere, so the other palettes have no
+    /// selection side effect.
     let onSelect: (() -> Void)?
     let run: () -> Void
 
@@ -97,9 +96,9 @@ struct CommandPalette: View {
 
     @State private var query = ""
     @State private var selection = 0
-    /// The visible, filtered result list. Held in `@State` (recomputed on query/mode change) so
-    /// the rendered rows and the Enter target are guaranteed to be the same array — a recomputed
-    /// property could otherwise be evaluated out of sync between the list and the run handler.
+    /// The visible, filtered result list. Held in `@State` (recomputed on query/mode change) so the rendered
+    /// rows and the Enter target are guaranteed to be the same array — a computed property could be
+    /// evaluated out of sync between the list and the run handler.
     @State private var filtered: [PaletteItem] = []
     @FocusState private var fieldFocused: Bool
 
@@ -133,10 +132,9 @@ struct CommandPalette: View {
     private func updateFiltered() {
         let q = query.trimmingCharacters(in: .whitespaces)
         // the attention palette's empty-query order is the paletteAttention()/attentionSessions ranking
-        // (blocked→active→completed, newest change first). preserve it verbatim instead of falling through
-        // to the alphabetical tie-break below — every row scores 0 for an empty query, so that tie-break
-        // would re-sort them A→Z and Return would jump to the alphabetically-first session, not the blocked
-        // one. fuzzy filtering still applies once the user types.
+        // (blocked→active→completed, newest change first), preserved verbatim: every row scores 0 for an
+        // empty query, so the alphabetical tie-break below would re-sort them A→Z and Return would jump to
+        // the alphabetically-first session, not the blocked one. fuzzy filtering applies once the user types.
         if explicitItems == nil, controller.mode == .attention, q.isEmpty {
             filtered = allItems
             selection = filtered.isEmpty ? 0 : min(selection, filtered.count - 1)
@@ -164,10 +162,9 @@ struct CommandPalette: View {
         }
     }
 
-    /// Enter/leave the live-preview theme session as the palette opens, switches mode, or closes:
-    /// entering `.themes` captures the current theme (so Esc can revert) and starts the selection on
-    /// the current theme's row; leaving it (to another mode or closed) reverts any uncommitted preview.
-    /// Idempotent — `AppActions` guards begin/cancel on its active flag.
+    /// Enter/leave the live-preview theme session as the palette opens, switches mode, or closes: entering
+    /// `.themes` captures the current theme (so Esc can revert) and starts the selection on its row; leaving
+    /// it reverts any uncommitted preview. Idempotent — `AppActions` guards begin/cancel on its active flag.
     private func syncThemeSession() {
         guard explicitItems == nil, controller.mode == .themes else {
             actions.cancelThemePreview()
@@ -210,8 +207,6 @@ struct CommandPalette: View {
             Divider()
             results
         }
-        // Keep the live material in its own invalidation boundary: arrow-key selection changes
-        // rebuild the palette content, but must not recreate/re-resolve the whole panel backdrop.
         .background { PalettePanelBackground() }
         .overlay(RoundedRectangle(cornerRadius: 12).strokeBorder(.white.opacity(0.1)))
         .shadow(radius: 24)
@@ -220,11 +215,10 @@ struct CommandPalette: View {
             fieldFocused = true
             updateFiltered()
             if explicitItems == nil { syncThemeSession() }
-            // a palette opened from a title-bar button (the attention bell) mounts while that button
-            // still holds first responder, so the synchronous focus above loses the race and the field
-            // never takes the keyboard. re-assert on the next runloop tick — after the click settles —
-            // so the field wins. for the menu/hotkey/⌃P paths the field is already focused by then, so
-            // this is a no-op (see swiftui focus-pattern: onAppear focus may need a main-async kick).
+            // a palette opened from a title-bar button (the attention bell) mounts while that button still
+            // holds first responder, so the synchronous focus above loses the race and the field never takes
+            // the keyboard. re-assert on the next runloop tick, after the click settles, so the field wins;
+            // a no-op for the menu/hotkey/⌃P paths, where the field is already focused by then.
             DispatchQueue.main.async { fieldFocused = true }
         }
         .onChange(of: controller.mode) {
@@ -252,13 +246,10 @@ struct CommandPalette: View {
             .frame(maxHeight: 320)
             .onChange(of: selection) { _, sel in
                 guard filtered.indices.contains(sel) else { return }
-                // live theme preview: navigating a row applies it (no-op for non-theme palettes,
-                // whose items carry no onSelect).
                 filtered[sel].onSelect?()
-                // With no anchor, scrollTo is a no-op while the row is already visible and performs
-                // only the minimum reveal at an edge. Animating a center-anchored scroll on every
-                // key-repeat event continually interrupted layout/compositing and made the whole
-                // material-backed palette flash.
+                // with no anchor, scrollTo no-ops while the row is already visible and does the minimum
+                // reveal at an edge. animating a center-anchored scroll on every key-repeat event
+                // continually interrupted layout/compositing and made the material-backed palette flash.
                 proxy.scrollTo(filtered[sel].id)
             }
         }

--- a/agterm/Views/PaneShortcuts.swift
+++ b/agterm/Views/PaneShortcuts.swift
@@ -1,11 +1,10 @@
 import agtermCore
 import AppKit
 
-/// App-wide Ctrl-1 / Ctrl-2 to focus the active session's left (primary) / right (split) pane
-/// directly — a faster alias for the ⌘⌥←/→ menu nav. Caught by an `NSEvent` local monitor rather
-/// than a SwiftUI shortcut so it isn't a duplicate menu item, matching the Ctrl-Tab switcher. The
-/// keys are always consumed (reserved app shortcuts), so they never leak to the shell — on a
-/// non-split session `focusPane` is simply a no-op rather than the terminal printing a literal "1".
+/// App-wide Ctrl-1 / Ctrl-2 focus the active session's left (primary) / right (split) pane directly, a
+/// faster alias for the ⌘⌥←/→ menu nav. Caught by an `NSEvent` local monitor rather than a SwiftUI shortcut
+/// so it isn't a duplicate menu item, like the Ctrl-Tab switcher. Always consumed (reserved app shortcuts),
+/// so they never leak to the shell — on a non-split session `focusPane` no-ops instead of printing "1".
 @MainActor
 final class PaneShortcuts {
     private let library: WindowLibrary
@@ -33,7 +32,6 @@ final class PaneShortcuts {
     private func handleKeyDown(_ event: NSEvent) -> Bool {
         let mods = event.modifierFlags.intersection([.command, .option, .control, .shift])
         guard mods == .control else { return false }
-        // always consume ⌃1/⌃2 so they never reach the shell; `focusPane` no-ops when not split.
         switch event.keyCode {
         case Self.oneKey: actions.focusPane(.main); return true
         case Self.twoKey: actions.focusPane(.split); return true

--- a/agterm/Views/QuickTerminal.swift
+++ b/agterm/Views/QuickTerminal.swift
@@ -2,40 +2,39 @@ import agtermCore
 import AppKit
 import SwiftUI
 
-/// The in-app quick terminal: a single scratch terminal shown as a centered overlay at 90% of
-/// the window, on top of the sidebar and terminal. A toolbar button toggles it; clicking the
-/// dimmed margin also hides it. Hiding keeps the shell alive — the surface is owned here, not by
-/// the overlay view, so it survives the view being removed. Not persisted (fresh each launch).
+/// The in-app quick terminal: a single scratch terminal shown as a centered overlay at 90% of the window,
+/// over the sidebar and terminal. A toolbar button toggles it, and clicking the dimmed margin hides it;
+/// hiding keeps the shell alive, since the surface is owned here rather than by the overlay view, so it
+/// survives the view being removed. Not persisted (fresh each launch).
 ///
-/// Per window: each `WindowContentView` owns one and registers it in `QuickTerminalRegistry`
-/// keyed by its window id, so the frontmost-window call sites (the menu/keybind, `AppActions`,
-/// `ControlServer`) can reach the controller of the window the user is looking at. The owning view
-/// binds `cwdProvider` so a freshly-spawned quick terminal opens in that window's active session's
-/// directory (home when nothing is selected).
+/// Per window: each `WindowContentView` owns one and registers it in `QuickTerminalRegistry` under its window
+/// id, so the frontmost-window call sites (menu/keybind, `AppActions`, `ControlServer`) reach the controller
+/// of the window the user is looking at. The owner binds `cwdProvider`, so a freshly-spawned quick terminal
+/// opens in that window's active session's directory (home when nothing is selected).
 @MainActor @Observable
 final class QuickTerminalController {
     /// Whether the overlay is shown. Observed, so `WindowContentView` shows/hides the overlay.
     private(set) var isVisible = false
 
-    /// The long-lived quick-terminal surface, created lazily on first show and kept across
-    /// hide/show so the shell survives. `@ObservationIgnored`: the overlay pulls it imperatively
-    /// (like a session owns its surface), nothing in SwiftUI observes the view itself.
+    /// The long-lived quick-terminal surface, created lazily on first show and kept across hide/show so the
+    /// shell survives. The overlay pulls it imperatively, like a session owns its surface; nothing in
+    /// SwiftUI observes the view itself.
     @ObservationIgnored private var surfaceView: GhosttySurfaceView?
 
-    /// The directory a freshly-created quick terminal spawns its shell in. Read once, when the
-    /// surface is created, so the quick terminal keeps its own working directory afterwards.
+    /// The directory a freshly-created quick terminal spawns its shell in. Read once, at surface creation,
+    /// so the quick terminal keeps its own working directory afterwards.
     @ObservationIgnored var cwdProvider: () -> String = { FileManager.default.homeDirectoryForCurrentUser.path }
 
-    /// The `AGTERM_*` environment a freshly-created quick terminal exposes to its shell (ENABLED +
-    /// WINDOW_ID + SOCKET — scratch, so no workspace/session ids). Read once, when the surface is
-    /// created. Set by the owning `WindowContentView` so the var carries this window's id.
+    /// The `AGTERM_*` environment a freshly-created quick terminal exposes to its shell (ENABLED + WINDOW_ID
+    /// + SOCKET — scratch, so no workspace/session ids). Read once, at surface creation. Set by the owning
+    /// `WindowContentView`, so the var carries this window's id.
     @ObservationIgnored var envProvider: () -> [String: String] = { [:] }
 
-    /// Notes a keystroke in the quick terminal as user activity on the owning window's `AppStore`, so
-    /// typing here resets that window's auto-follow idle timer (an idle fire must NOT change the selection
-    /// behind the overlay while the user types). The controller is store-less, so `WindowContentView`
-    /// supplies this; `surface()` forwards it to the surface's `onUserInput` (mirroring the overlay/scratch
-    /// factories), which `destroySurface` nils on teardown.
+    /// Notes a keystroke as user activity on the owning window's `AppStore`, so typing here resets that
+    /// window's auto-follow idle timer (an idle fire must NOT change the selection behind the overlay while
+    /// the user types). The controller is store-less, so `WindowContentView` supplies this; `surface()`
+    /// forwards it to the surface's `onUserInput`, as the overlay/scratch factories do, and `destroySurface`
+    /// nils it on teardown.
     @ObservationIgnored var onUserInput: (() -> Void)?
 
     /// Whether this cover may claim keyboard focus. The owning window disables it while a control picker
@@ -49,23 +48,23 @@ final class QuickTerminalController {
 
     func hide() { isVisible = false }
 
-    /// The existing quick-terminal surface, or nil — does NOT create one (unlike `surface()`), so
-    /// a settings broadcast can reach it without spawning a shell.
+    /// The existing quick-terminal surface, or nil — does NOT create one (unlike `surface()`), so a settings
+    /// broadcast can reach it without spawning a shell.
     func currentSurface() -> GhosttySurfaceView? { surfaceView }
 
-    /// The surface to render in the overlay, created on first use in the active cwd and reused
-    /// afterwards. Recreated after the shell exits.
+    /// The surface to render in the overlay, created on first use in the active cwd and reused afterwards.
+    /// Recreated after the shell exits.
     func surface() -> GhosttySurfaceView {
         if let surfaceView { return surfaceView }
         let view = GhosttySurfaceView(workingDirectory: cwdProvider(), env: envProvider())
         view.onExit = { [weak self] in self?.handleShellExit() }
-        view.onUserInput = onUserInput // note activity so typing here resets the window's auto-follow timer
+        view.onUserInput = onUserInput
         surfaceView = view
         return view
     }
 
-    /// Re-assert first responder on the surface for a short window so focus lands once the
-    /// overlay is on-window (a one-shot would race the overlay's layout).
+    /// Re-assert first responder on the surface for a short window so focus lands once the overlay is
+    /// on-window (a one-shot would race the overlay's layout).
     func focus(attempt: Int = 0) {
         guard focusAllowed() else { return }
         if let surfaceView, let window = surfaceView.window {
@@ -77,8 +76,8 @@ final class QuickTerminalController {
         }
     }
 
-    /// The quick-terminal shell exited: hide the overlay and tear down the surface so the next
-    /// show spawns a fresh shell (the surface, not the overlay, owns the shell).
+    /// The quick-terminal shell exited: hide the overlay and tear down the surface so the next show spawns a
+    /// fresh shell (the surface, not the overlay, owns the shell).
     private func handleShellExit() {
         isVisible = false
         surfaceView?.teardown()
@@ -86,9 +85,9 @@ final class QuickTerminalController {
     }
 }
 
-/// Hosts the quick-terminal surface in the overlay. Like `TerminalView`, it pulls the
-/// long-lived surface from its owner (the per-window controller) rather than creating one, and
-/// never frees it on dismantle — hiding the overlay must keep the shell alive.
+/// Hosts the quick-terminal surface in the overlay. Like `TerminalView`, it pulls the long-lived surface
+/// from its owner (the per-window controller) rather than creating one, and never frees it on dismantle —
+/// hiding the overlay must keep the shell alive.
 struct QuickTerminalPane: NSViewRepresentable {
     let controller: QuickTerminalController
 
@@ -105,10 +104,9 @@ struct QuickTerminalPane: NSViewRepresentable {
     }
 }
 
-/// App-side bridge mapping a `WindowInfo.ID` to its window's `QuickTerminalController`. The
-/// controller is a per-window instance owned by `WindowContentView` (which registers/unregisters
-/// it on appear/close); the frontmost-window call sites resolve the controller to act on through
-/// `controller(for: library.activeWindowID)`.
+/// App-side bridge mapping a `WindowInfo.ID` to its window's `QuickTerminalController`, a per-window instance
+/// owned by `WindowContentView` (which registers/unregisters on appear/close). Frontmost-window call sites
+/// resolve the controller to act on through `controller(for: library.activeWindowID)`.
 @MainActor
 final class QuickTerminalRegistry {
     static let shared = QuickTerminalRegistry()
@@ -130,8 +128,8 @@ final class QuickTerminalRegistry {
         return controllers[id]
     }
 
-    /// Every registered (open-window) controller — used by the settings broadcast to reach each
-    /// window's quick-terminal surface.
+    /// Every registered (open-window) controller — used by the settings broadcast to reach each window's
+    /// quick-terminal surface.
     func allControllers() -> [QuickTerminalController] {
         Array(controllers.values)
     }

--- a/agterm/Views/SessionSwitcher.swift
+++ b/agterm/Views/SessionSwitcher.swift
@@ -2,19 +2,16 @@ import agtermCore
 import AppKit
 import SwiftUI
 
-/// The Ctrl-Tab "previously visited session" switcher (macOS app-switcher style). Hold Ctrl and
-/// press Tab to walk a frozen most-recently-used list (Shift+Tab reverses); releasing Ctrl commits
-/// the highlighted session. The order comes from `AppStore.sessionRecency`; the candidate list is
-/// snapshotted on `begin()` so cycling never reorders it — only the commit does (via selection).
-///
-/// Keys are caught by app-wide `NSEvent` local monitors rather than SwiftUI shortcuts, because the
-/// interaction needs Tab while a modifier is held plus the modifier-release ("commit") signal.
+/// The Ctrl-Tab "previously visited session" switcher (macOS app-switcher style): hold Ctrl and press Tab to
+/// walk a frozen most-recently-used list (Shift+Tab reverses), release Ctrl to commit the highlighted
+/// session. The order comes from `AppStore.sessionRecency`, snapshotted on `begin()` so cycling never
+/// reorders it — only the commit does, via selection. Keys come from app-wide `NSEvent` local monitors, not
+/// SwiftUI shortcuts, because the interaction needs Tab-while-held plus the modifier-release commit signal.
 @Observable
 @MainActor
 final class SessionSwitcher {
-    /// The window library; the switcher cycles the frontmost window's session recency. (A
-    /// per-window switcher tracking each window's own MRU is a later concern — for now it follows
-    /// the frontmost window, matching the single-window behavior.)
+    /// The window library; the switcher cycles the FRONTMOST window's session recency (a per-window
+    /// switcher tracking each window's own MRU is a later concern).
     private let library: WindowLibrary
     private let canSwitch: () -> Bool
     private var store: AppStore? { library.activeStore }
@@ -27,9 +24,9 @@ final class SessionSwitcher {
 
     private static let tabKey: UInt16 = 48
     private static let escapeKey: UInt16 = 53
-    /// Cap on rows the Ctrl-Tab switcher shows: it's a quick most-recent jump, not a full session list
-    /// (the ⌃P fuzzy palette covers everything). The recency STORE keeps its full 100-item history.
-    /// Shared with the mouse-driven recent-sessions popover so the two list the same sessions.
+    /// Cap on rows shown: a quick most-recent jump, not a full session list (the ⌃P fuzzy palette covers
+    /// everything); the recency STORE keeps its full 100-item history. Shared with the mouse-driven
+    /// recent-sessions popover so the two list the same sessions.
     static let maxCandidates = 10
 
     init(library: WindowLibrary, canSwitch: @escaping () -> Bool) {
@@ -77,10 +74,9 @@ final class SessionSwitcher {
     }
 
     /// Snapshot the MRU order (live sessions only, capped at `maxCandidates`) and pre-select the previous
-    /// session. No-op when there's nothing to switch to (fewer than two sessions). The candidate set is
-    /// scoped to the VISIBLE/FILTERED sessions (`navigableSessions` — the flagged set in flagged mode, the
-    /// sessions of the workspaces MARKED in the focus set while the filter applies, else all), so clearing
-    /// the flag or suspending the filter restores the full MRU.
+    /// session; no-op with fewer than two sessions. Scoped to the VISIBLE/FILTERED set (`navigableSessions`
+    /// — the flagged set in flagged mode, the MARKED workspaces' sessions while the filter applies, else
+    /// all), so clearing the flag or suspending the filter restores the full MRU.
     private func begin() {
         guard let store else { return }
         let valid = Set(store.navigableSessions.map(\.id))
@@ -117,9 +113,9 @@ final class SessionSwitcher {
     }
 }
 
-/// The switcher overlay: a top-centered list of the frozen candidate sessions (name + workspace ·
-/// cwd) with the current pick highlighted. Keyboard-driven (no controls to focus), so the terminal
-/// keeps first responder and the global monitors drive selection.
+/// The switcher overlay: a top-centered list of the frozen candidates (name + workspace · cwd), current pick
+/// highlighted. Keyboard-driven with no focusable control, so the terminal keeps first responder and the
+/// global monitors drive selection.
 struct SessionSwitcherOverlay: View {
     let switcher: SessionSwitcher
     let store: AppStore
@@ -166,10 +162,10 @@ struct SessionSwitcherOverlay: View {
     }
 }
 
-/// One session row for the switcher surfaces — the display name over a `workspace · cwd` subtitle.
-/// Shared by the keyboard Ctrl-Tab overlay (`SessionSwitcherOverlay`) and the mouse-driven recent-sessions
-/// popover (`WindowContentView.recentSessionsPopover`) so the two rows never drift; the caller supplies the
-/// row's background (the overlay's keyboard highlight, the popover's button hover).
+/// One session row for the switcher surfaces — the display name over a `workspace · cwd` subtitle. Shared by
+/// the Ctrl-Tab overlay (`SessionSwitcherOverlay`) and the recent-sessions popover
+/// (`WindowContentView.recentSessionsPopover`) so the two never drift; the caller supplies the row's
+/// background (the overlay's keyboard highlight, the popover's button hover).
 struct SessionSwitcherRow: View {
     let title: String
     let subtitle: String

--- a/agterm/Views/SettingsView.swift
+++ b/agterm/Views/SettingsView.swift
@@ -9,6 +9,7 @@ private let logger = Logger(subsystem: "com.umputun.agterm", category: "Settings
 /// (font/theme + window translucency + pane dimming), Interface (per-element title-bar and sidebar chrome
 /// visibility), Notifications (banner / badge / attention toggles), Agent Status (sidebar glyph colors and
 /// shapes + blocked sound + auto-follow), and Key Mapping (config directory + keymap diagnostics + Reload).
+/// Throughout, a control's binding maps its DEFAULT value back to nil so `settings.json` stays minimal.
 struct SettingsView: View {
     let model: SettingsModel
 
@@ -60,8 +61,7 @@ private struct NonRestorableWindow: NSViewRepresentable {
     }
 }
 
-/// A terse one-line caption under a control. Only non-obvious controls carry one, so the tabs stay short
-/// enough to fit without scrolling.
+/// A terse one-line caption under a control; only non-obvious controls carry one, so tabs fit unscrolled.
 private struct SettingHint: View {
     let text: String
     init(_ text: String) { self.text = text }
@@ -72,9 +72,8 @@ private struct SettingHint: View {
     }
 }
 
-/// General tab: a Mouse section (scroll speed + right-click-pastes toggle), a Sessions section (the
-/// new-session directory picker + restore-running-commands toggle), and the inherit-global-ghostty-config
-/// toggle. The visual and notification settings live on their own tabs.
+/// General tab: Mouse (scroll speed, right-click-pastes), Sessions (new-session directory, restore running
+/// commands) and the inherit-global-ghostty-config toggle; visual and notification settings have own tabs.
 private struct GeneralSettingsView: View {
     let model: SettingsModel
 
@@ -132,39 +131,34 @@ private struct GeneralSettingsView: View {
         .padding()
     }
 
-    /// nil (the default) reads as OFF, so on → true / off → nil keeps settings.json minimal.
     private var restoreRunningCommand: Binding<Bool> {
         Binding(get: { model.settings.restoreRunningCommand ?? false },
                 set: { model.setRestoreRunningCommand($0 ? true : nil) })
     }
 
-    /// nil (the default) reads as OFF, so on → true / off → nil keeps settings.json minimal.
     private var confirmCloseSession: Binding<Bool> {
         Binding(get: { model.settings.confirmCloseSession ?? false },
                 set: { model.setConfirmCloseSession($0 ? true : nil) })
     }
 
-    /// nil (the default) reads as ON; turning it off stores false and makes GUI closes immediate.
+    /// Default ON; turning it off stores false and makes GUI closes immediate.
     private var closeGraceUndoEnabled: Binding<Bool> {
         Binding(get: { model.settings.closeGraceUndoEnabled ?? true },
                 set: { model.setCloseGraceUndoEnabled($0 ? nil : false) })
     }
 
-    /// nil (the default) reads as OFF, so on → true / off → nil keeps settings.json minimal.
     private var inheritGlobalGhosttyConfig: Binding<Bool> {
         Binding(get: { model.settings.inheritGlobalGhosttyConfig ?? false },
                 set: { model.setInheritGlobalGhosttyConfig($0 ? true : nil) })
     }
 
-    /// nil (the default) reads as ON, so off → false / on → nil keeps settings.json minimal. Drives the
-    /// ghostty `right-click-action` key (paste when on, ignore when off).
+    /// Default ON. Drives the ghostty `right-click-action` key (paste when on, ignore when off).
     private var rightClickPaste: Binding<Bool> {
         Binding(get: { model.settings.rightClickPaste ?? true },
                 set: { model.setRightClickPaste($0 ? nil : false) })
     }
 
-    /// nil (the default) reads as 3; stepping back to 3 stores nil so settings.json stays minimal. The
-    /// config always emits 3 either way, so the default speed is effective regardless.
+    /// Default 3. The config emits 3 either way, so the default speed is effective regardless.
     private var mouseScrollMultiplier: Binding<Double> {
         Binding(get: { model.settings.mouseScrollMultiplier ?? 3 },
                 set: { model.setMouseScrollMultiplier($0 == 3 ? nil : $0) })
@@ -177,8 +171,7 @@ private struct GeneralSettingsView: View {
         return dir?.isEmpty == false ? dir : nil
     }
 
-    /// The new-session directory mode; nil (the default) reads as `.home`, and picking `.home` stores nil
-    /// so settings.json stays minimal. An unknown stored value also resolves to `.home`.
+    /// The new-session directory mode; nil (the default) or an unknown stored value resolves to `.home`.
     private var newSessionDirectory: Binding<AppSettings.NewSessionDirectory> {
         Binding(get: { AppSettings.NewSessionDirectory(rawValue: model.settings.newSessionDirectory ?? "") ?? .home },
                 set: { model.setNewSessionDirectory($0 == .home ? nil : $0.rawValue) })
@@ -198,9 +191,8 @@ private struct GeneralSettingsView: View {
     }
 }
 
-/// Appearance tab: a Terminal section (font family, default font size, theme) and a Window section
-/// (toolbar mode — Normal/Compact/Hidden, background opacity + blur, sidebar tint, sidebar font size,
-/// inactive-pane dimming). Each control persists and live-applies through `SettingsModel`.
+/// Appearance tab: Terminal (font family, size, theme) and Window (toolbar mode, background opacity + blur,
+/// sidebar tint + font size, inactive-pane dimming), each persisting and live-applying via `SettingsModel`.
 private struct AppearanceSettingsView: View {
     let model: SettingsModel
     private let themes = SettingsCatalog.themeNames()
@@ -221,8 +213,8 @@ private struct AppearanceSettingsView: View {
                 }
                 .accessibilityIdentifier("settings-font-size")
 
-                // the CURRENT appearance's theme; while following that is the on-screen side. The "default
-                // ghostty" row shows only when NOT following — a dual conditional needs two named themes.
+                // the CURRENT appearance's theme; while following, the on-screen side. The "default ghostty"
+                // row shows only when NOT following — a dual conditional needs two named themes.
                 Picker("Theme", selection: themeForCurrentAppearance) {
                     if !following { Text("default ghostty").tag(String?.none) }
                     ForEach(themes, id: \.self) { Text($0).tag(String?.some($0)) }
@@ -232,8 +224,8 @@ private struct AppearanceSettingsView: View {
                 Toggle("Follow system appearance", isOn: followSystemAppearance)
                     .accessibilityIdentifier("settings-follow-appearance")
 
-                // revealed only when following: the theme for the OTHER appearance. ghostty resolves the
-                // active side at runtime, so no config rewrite happens on a light/dark flip.
+                // only while following: the OTHER appearance's theme. ghostty resolves the active side at
+                // runtime, so a light/dark flip rewrites no config.
                 if following {
                     Picker(GhosttyApp.currentIsDark() ? "Light theme" : "Dark theme", selection: alternateTheme) {
                         ForEach(themes, id: \.self) { Text($0).tag(String?.some($0)) }
@@ -313,7 +305,7 @@ private struct AppearanceSettingsView: View {
         Binding(get: { model.settings.fontSize ?? 13 }, set: { model.setFontSize($0) })
     }
 
-    /// The sidebar row-text size; the default maps back to nil so `settings.json` stays minimal.
+    /// The sidebar row-text size.
     private var sidebarFontSize: Binding<Double> {
         Binding(get: { model.settings.sidebarFontSize ?? AppSettings.defaultSidebarFontSize },
                 set: { model.setSidebarFontSize($0 == AppSettings.defaultSidebarFontSize ? nil : $0) })
@@ -322,15 +314,13 @@ private struct AppearanceSettingsView: View {
     /// Whether the terminal follows the macOS appearance — reveals the alternate picker.
     private var following: Bool { model.settings.followSystemAppearance == true }
 
-    /// Picker 1: the theme for the CURRENT appearance (dark slot while following in dark mode, else
-    /// `theme`). Drives `SettingsModel.setThemeForCurrentAppearance`.
+    /// Picker 1: the CURRENT appearance's theme — the dark slot while following in dark mode, else `theme`.
     private var themeForCurrentAppearance: Binding<String?> {
         Binding(get: { model.settings.activeTheme(isDark: GhosttyApp.currentIsDark()) },
                 set: { model.setThemeForCurrentAppearance($0) })
     }
 
-    /// Picker 2 (shown only while following): the OTHER appearance's theme — the light slot in dark mode,
-    /// the dark slot in light mode. Drives `SettingsModel.setAlternateTheme`.
+    /// Picker 2, only while following: the OTHER appearance's theme — light slot in dark mode, dark in light.
     private var alternateTheme: Binding<String?> {
         Binding(get: { GhosttyApp.currentIsDark() ? model.settings.theme : model.settings.darkTheme },
                 set: { model.setAlternateTheme($0) })
@@ -342,20 +332,19 @@ private struct AppearanceSettingsView: View {
                 set: { model.setFollowSystemAppearance($0) })
     }
 
-    /// 1.0 maps to nil (the opaque default) so settings.json stays minimal, like the font/theme controls.
     /// PREVIEWS live (apply without save) per drag tick and debounces; `onEditingChanged` flushes on release.
     private var backgroundOpacity: Binding<Double> {
         Binding(get: { model.settings.backgroundOpacity ?? 1 },
                 set: { model.previewBackgroundOpacity($0 >= 1 ? nil : $0) })
     }
 
-    /// PREVIEWS live (apply without save) per drag tick and debounces; `onEditingChanged` flushes on release.
+    /// Previews and flushes like `backgroundOpacity`.
     private var backgroundBlur: Binding<Double> {
         Binding(get: { Double(model.settings.backgroundBlur ?? 0) },
                 set: { model.previewBackgroundBlur($0 <= 0 ? nil : Int($0.rounded())) })
     }
 
-    /// neutral (5) maps to nil so settings.json stays minimal, like the other appearance controls.
+    /// Neutral is 5.
     private var sidebarBackgroundShift: Binding<Double> {
         Binding(get: { Double(model.settings.sidebarBackgroundShift ?? AppSettings.defaultSidebarBackgroundShift) },
                 set: { value in
@@ -372,26 +361,23 @@ private struct AppearanceSettingsView: View {
         return offset < 0 ? "Lighter \(-offset)" : "Darker \(offset)"
     }
 
-    /// `.compact` (the default) maps back to nil so settings.json stays minimal, like the other appearance
-    /// controls; `.normal`/`.hidden` write an explicit mode.
+    /// `.compact` is the default; `.normal`/`.hidden` write an explicit mode.
     private var toolbarMode: Binding<ToolbarMode> {
         Binding(get: { model.settings.effectiveToolbarMode },
                 set: { model.setToolbarMode($0 == .compact ? nil : $0) })
     }
 
-    /// nil (the default) reads as `defaultInactivePaneMuteStrength`; sliding back to it stores nil so
-    /// settings.json stays minimal. The slider is integer-stepped, so the Double is rounded to an Int.
+    /// nil (the default) reads as `defaultInactivePaneMuteStrength`.
     private var inactivePaneMuteStrength: Binding<Double> {
         Binding(get: { Double(model.settings.inactivePaneMuteStrength ?? AppSettings.defaultInactivePaneMuteStrength) },
                 set: { let v = Int($0.rounded()); model.setInactivePaneMuteStrength(v == AppSettings.defaultInactivePaneMuteStrength ? nil : v) })
     }
 }
 
-/// Interface tab: per-element title-bar and sidebar chrome visibility, grouped by surface (Title Bar /
-/// Sidebar), two toggles per row so the tab keeps fitting the fixed 540×590 Settings window without
-/// scrolling as the element set grows. Everything shows by default; a toggle off adds it to
-/// `AppSettings.hiddenInterfaceElements` and live-applies through `SettingsModel` — title-bar and footer
-/// elements re-gate in open windows on `.agtermAppearanceChanged`, the workspace add-session "+" on hover.
+/// Interface tab: per-element title-bar and sidebar chrome visibility, grouped by surface, two toggles per
+/// row so the tab keeps fitting the fixed 540×590 window as the element set grows. Everything shows by
+/// default; a toggle off adds it to `AppSettings.hiddenInterfaceElements` and live-applies — title-bar and
+/// footer elements re-gate in open windows on `.agtermAppearanceChanged`, the add-session "+" on hover.
 private struct InterfaceSettingsView: View {
     let model: SettingsModel
 
@@ -408,16 +394,14 @@ private struct InterfaceSettingsView: View {
         .padding()
     }
 
-    /// Default-OFF binding: ON hides the sidebar on every non-frontmost window (writes true), OFF maps back
-    /// to nil to keep `settings.json` minimal — the default-off idiom shared with the other opt-in toggles.
+    /// Default OFF; ON hides the sidebar on every non-frontmost window.
     private var autoHideSidebarInactiveWindows: Binding<Bool> {
         Binding(get: { model.settings.autoHideSidebarInactiveWindows ?? false },
                 set: { model.setAutoHideSidebarInactiveWindows($0 ? true : nil) })
     }
 
-    /// A section whose toggles lay out TWO per row. Each fills half the row around a centered `Divider`, so
-    /// the columns read as EVEN and visibly separated (each column's switch trails at its own right edge);
-    /// an odd final element pairs with an empty half.
+    /// A section whose toggles lay out TWO per row, each filling half the row around a centered `Divider` so
+    /// the columns read as EVEN and visibly separated; an odd final element pairs with an empty half.
     @ViewBuilder
     private func twoColumnSection(_ title: String, elements: [InterfaceElement]) -> some View {
         Section(title) {
@@ -447,9 +431,8 @@ private struct InterfaceSettingsView: View {
     }
 }
 
-/// Notifications tab: the banner / badge / attention-indicator toggles plus the Dock-bounce mode and
-/// notification-sound pickers, all default-driven through `SettingsModel`. The controls are independent —
-/// the badge count keeps tracking, and a Dock bounce or a sound can fire, whether or not banners are shown.
+/// Notifications tab: the banner / badge / attention-indicator toggles plus the Dock-bounce and sound
+/// pickers. All independent — the badge count keeps tracking and a bounce or sound can fire with banners off.
 private struct NotificationsSettingsView: View {
     let model: SettingsModel
 
@@ -485,27 +468,25 @@ private struct NotificationsSettingsView: View {
         .padding()
     }
 
-    /// nil (the default) reads as on, so settings.json stays minimal until banners are turned off.
+    /// Default ON.
     private var notificationsEnabled: Binding<Bool> {
         Binding(get: { model.settings.notificationsEnabled ?? true },
                 set: { model.setNotificationsEnabled($0 ? nil : false) })
     }
 
-    /// nil (the default) reads as on, so settings.json stays minimal until the count badges are hidden.
+    /// Default ON.
     private var notificationBadgeEnabled: Binding<Bool> {
         Binding(get: { model.settings.notificationBadgeEnabled ?? true },
                 set: { model.setNotificationBadgeEnabled($0 ? nil : false) })
     }
 
-    /// Resolves nil (the default) to `.off`; None maps back to nil so settings.json stays minimal. Mirrors
-    /// the toolbar-mode picker binding.
+    /// Resolves nil (the default) to `.off`.
     private var dockBounce: Binding<DockBounce> {
         Binding(get: { model.settings.effectiveDockBounce },
                 set: { model.setDockBounce($0 == .off ? nil : $0) })
     }
 
-    // the system sound played when a notification is delivered; "None" maps to nil. Selecting a sound
-    // previews it so you hear the choice, the way macOS sound settings do.
+    // the sound played when a notification is delivered; selecting one previews it, like macOS sound settings
     private var notificationSound: Binding<String> {
         Binding(get: { model.settings.notificationSoundName ?? "None" },
                 set: { name in
@@ -515,22 +496,20 @@ private struct NotificationsSettingsView: View {
                 })
     }
 
-    /// nil (the default) reads as OFF, so on → true / off → nil keeps settings.json minimal.
     private var attentionButtonEnabled: Binding<Bool> {
         Binding(get: { model.settings.attentionButtonEnabled ?? false },
                 set: { model.setAttentionButtonEnabled($0 ? true : nil) })
     }
 }
 
-/// Agent Status tab: Colors and Shapes (one row per state — active / blocked / completed — with that sidebar
-/// glyph's color well and silhouette picker side by side), Sound (the blocked sound), Auto-follow (the
-/// idle-timeout picker + stay-on-active toggle), and a trailing Reset clearing colors, shapes and sound.
+/// Agent Status tab: Colors and Shapes (a row per state — active/blocked/completed — with that glyph's color
+/// well and shape picker), Sound, Auto-follow (idle timeout + stay-on-active), and a Reset clearing all three.
 private struct AgentStatusSettingsView: View {
     /// Gap between a glyph row's color well and its shape picker.
     private static let controlSpacing: CGFloat = 8
-    /// Column width every shape picker reserves. A menu button sizes to the glyph it shows and the six
+    /// Column width every shape picker reserves: a menu button sizes to the glyph it shows and the six
     /// silhouettes differ by a few points, so without a fixed column the color wells jog between rows. Snug
-    /// enough to read as spacing rather than a hole, with room above the widest silhouette's button.
+    /// enough to read as spacing, not a hole, with room above the widest silhouette's button.
     private static let shapePickerWidth: CGFloat = 80
 
     let model: SettingsModel
@@ -578,12 +557,11 @@ private struct AgentStatusSettingsView: View {
         .padding()
     }
 
-    /// One state's glyph row: the state name labels it, with the color well and shape picker on the trailing
-    /// side, both label-hidden so the state name is the row's only visible label. The shape picker draws its
-    /// button at the TRAILING edge of its fixed-width column so the row ends flush with the tab's right
-    /// margin (the column's default center alignment left it floating inboard). Both bindings and both
-    /// accessibility ids derive from the state argument, so a row cannot label one status while driving
-    /// another's setting.
+    /// One state's glyph row: the state name labels it, with the color well and shape picker trailing, both
+    /// label-hidden so the state name is the row's only visible label. The shape picker draws at the TRAILING
+    /// edge of its fixed-width column so the row ends flush with the tab's right margin — the column's default
+    /// center alignment left it floating inboard. Both bindings and both accessibility ids derive from the
+    /// state argument, so a row cannot label one status while driving another's setting.
     private func glyphRow(_ status: AgentStatus) -> some View {
         let color = statusColor(for: status)
         let shape = statusShape(for: status)
@@ -601,8 +579,8 @@ private struct AgentStatusSettingsView: View {
         }
     }
 
-    // the ColorPicker binds to the resolved color (the user's hex or the system default); a pick stores
-    // the sRGB hex, and "Reset to defaults" clears the hex back to nil (the system color).
+    // binds to the resolved color (the user's hex or the system default); a pick stores the sRGB hex, and
+    // "Reset to defaults" clears it back to nil, the system color.
     private func statusColor(for status: AgentStatus) -> Binding<Color> {
         Binding(get: { Color(nsColor: NSColor(agtermHex: storedColorHex(for: status)) ?? Self.defaultColor(for: status)) },
                 set: { setColorHex(NSColor($0).agtermHexString, for: status) })
@@ -635,10 +613,9 @@ private struct AgentStatusSettingsView: View {
         }
     }
 
-    /// The option list one shape picker shows: one entry per `StatusShape` from `allCases`, so the picker
-    /// cannot drift from the enum. Each entry is the symbol ALONE (a name beside it only crowds the row),
-    /// with the shape's name kept as its accessibility label so VoiceOver still announces the choice. `tint`
-    /// is the status's current glyph color, from the row's binding, so a new color redraws the options in it.
+    /// The options one shape picker shows: one per `StatusShape` from `allCases`, so it cannot drift from the
+    /// enum. Each entry is the symbol ALONE (a name beside it crowds the row), with the shape name kept as its
+    /// accessibility label for VoiceOver; `tint` is the row's live glyph color, so a color change redraws them.
     @ViewBuilder
     private func shapeOptions(tint: NSColor) -> some View {
         ForEach(StatusShape.allCases, id: \.self) { shape in
@@ -648,9 +625,9 @@ private struct AgentStatusSettingsView: View {
         }
     }
 
-    /// One picker option's glyph, drawn as the sidebar draws it: the shape's symbol at the sidebar glyph's
-    /// own point size, tinted with that status's current color. A NON-template `NSImage`, because a menu
-    /// recolors a template symbol to its own text color and would wash out the tint being previewed.
+    /// One picker option's glyph, drawn like the sidebar's: the symbol at the sidebar glyph point size, tinted
+    /// with the status's current color. NON-template — a menu recolors a template symbol to its own text color
+    /// and would wash out the previewed tint.
     private static func shapeImage(_ shape: StatusShape, tint: NSColor) -> NSImage {
         let config = NSImage.SymbolConfiguration(pointSize: StatusIconView.glyphPointSize, weight: .regular)
             .applying(NSImage.SymbolConfiguration(paletteColors: [tint]))
@@ -664,8 +641,7 @@ private struct AgentStatusSettingsView: View {
         return image
     }
 
-    // the shape picker reads the resolved setting and writes the typed shape; the default plain circle
-    // maps back to nil so settings.json stays minimal (nil and `circle` render identically).
+    // the default plain circle maps back to nil; nil and `circle` render identically
     private func statusShape(for status: AgentStatus) -> Binding<StatusShape> {
         Binding(get: { model.settings.effectiveStatusShape(for: status) ?? .circle },
                 set: { setShape($0 == .circle ? nil : $0, for: status) })
@@ -680,8 +656,7 @@ private struct AgentStatusSettingsView: View {
         }
     }
 
-    // the system sound played when a session enters `blocked`; "None" maps to nil. Selecting a sound
-    // previews it so you hear the choice, the way macOS sound settings do.
+    // the sound played when a session enters `blocked`; selecting one previews it, like the notification sound
     private var blockedStatusSound: Binding<String> {
         Binding(get: { model.settings.blockedStatusSoundName ?? "None" },
                 set: { name in
@@ -691,26 +666,23 @@ private struct AgentStatusSettingsView: View {
                 })
     }
 
-    /// The auto-follow idle timeout; nil (the default) reads as `.off`, and picking `.off` stores nil so
-    /// settings.json stays minimal. An unknown stored value also resolves to `.off`.
+    /// The auto-follow idle timeout; nil (the default) or an unknown stored value resolves to `.off`.
     private var autoFollowAttention: Binding<AppSettings.AutoFollowAttention> {
         Binding(get: { AppSettings.AutoFollowAttention(tolerant: model.settings.autoFollowAttention) },
                 set: { model.setAutoFollowAttention($0 == .off ? nil : $0.rawValue) })
     }
 
-    /// Inverted view of the stored `autoFollowStayOnActive` so the toggle reads forward ("auto-follow away"
-    /// ON = do leave a running session) instead of a double negative. The stored nil default means "follow
-    /// away", so it shows ON; opting to STAY (toggle OFF) stores `true`, and toggling back stores nil.
+    /// Inverted view of the stored `autoFollowStayOnActive` so the toggle reads forward — ON = do leave a
+    /// running session — instead of a double negative. The nil default means "follow away", so it shows ON.
     private var autoFollowAwayFromRunning: Binding<Bool> {
         Binding(get: { !(model.settings.autoFollowStayOnActive ?? false) },
                 set: { model.setAutoFollowStayOnActive($0 ? nil : true) })
     }
 }
 
-/// Key Mapping tab: the config directory holding `keymap.conf` (directory picker + "Use Default"), a
-/// read-only parse-diagnostics list, and a Reload button. Both route through `SettingsModel`, which re-reads
-/// + re-parses the keymap and posts the change, updating the data-driven menu shortcuts, the custom-command
-/// runner and the action palette.
+/// Key Mapping tab: the config directory holding `keymap.conf` (picker + "Use Default"), a read-only
+/// parse-diagnostics list, and Reload. Both route through `SettingsModel`, which re-reads and re-parses the
+/// keymap and posts the change, updating the menu shortcuts, custom-command runner and action palette.
 private struct KeyMappingSettingsView: View {
     let model: SettingsModel
 
@@ -774,8 +746,7 @@ private struct KeyMappingSettingsView: View {
         .padding()
     }
 
-    /// A diagnostic as one line: "line N: message". A whole-file/cross-section diagnostic (line 0)
-    /// drops the line number, showing just the message.
+    /// A diagnostic as one line, "line N: message"; a whole-file/cross-section one (line 0) shows the message.
     private func diagnosticLine(_ diagnostic: KeymapDiagnostic) -> String {
         diagnostic.line > 0 ? "line \(diagnostic.line): \(diagnostic.message)" : diagnostic.message
     }

--- a/agterm/Views/SettingsView.swift
+++ b/agterm/Views/SettingsView.swift
@@ -5,17 +5,15 @@ import SwiftUI
 
 private let logger = Logger(subsystem: "com.umputun.agterm", category: "SettingsView")
 
-/// The Settings window (Cmd+,): six tabs — General (mouse, sessions, ghostty config),
-/// Appearance (font/theme + window translucency + pane dimming), Interface (per-element title-bar and
-/// sidebar chrome visibility), Notifications (banner / badge / attention toggles), Agent Status
-/// (the sidebar glyph colors and shapes + blocked sound + auto-follow), and Key Mapping (the config
-/// directory + keymap diagnostics + Reload).
+/// The Settings window (Cmd+,): six tabs — General (mouse, sessions, ghostty config), Appearance
+/// (font/theme + window translucency + pane dimming), Interface (per-element title-bar and sidebar chrome
+/// visibility), Notifications (banner / badge / attention toggles), Agent Status (sidebar glyph colors and
+/// shapes + blocked sound + auto-follow), and Key Mapping (config directory + keymap diagnostics + Reload).
 struct SettingsView: View {
     let model: SettingsModel
 
-    /// Identifies each tab. An explicit selection binding is what keeps the window opening on General:
-    /// without it, SwiftUI's Settings scene auto-persists the last tab to `selectedTabIndex` in user
-    /// defaults and restores it next launch, which we don't want for a settings window.
+    /// Identifies each tab. The explicit selection binding keeps the window opening on General: without it
+    /// SwiftUI's Settings scene persists the last tab to `selectedTabIndex` in defaults and restores it.
     private enum Tab: Hashable { case general, appearance, interface, notifications, agentStatus, keyMapping }
     @State private var selection: Tab = .general
 
@@ -41,9 +39,8 @@ struct SettingsView: View {
                 .tag(Tab.keyMapping)
         }
         .frame(width: 540, height: 590)
-        // keep macOS from saving/restoring the Settings window across launches. Otherwise a
-        // process-launch reopen (see agtermApp's FB11763863 workaround) resurrects a stale Settings
-        // window on whatever tab it was last on, which steals key focus from the real launch window.
+        // without this a process-launch reopen (see agtermApp's FB11763863 workaround) resurrects a stale
+        // Settings window on its last tab, stealing key focus from the real launch window.
         .background(NonRestorableWindow())
     }
 }
@@ -63,8 +60,8 @@ private struct NonRestorableWindow: NSViewRepresentable {
     }
 }
 
-/// A terse one-line caption shown under a control. Kept short on purpose: only non-obvious controls
-/// carry one, so the tabs stay short enough to fit without scrolling.
+/// A terse one-line caption under a control. Only non-obvious controls carry one, so the tabs stay short
+/// enough to fit without scrolling.
 private struct SettingHint: View {
     let text: String
     init(_ text: String) { self.text = text }
@@ -135,15 +132,13 @@ private struct GeneralSettingsView: View {
         .padding()
     }
 
-    /// 1:1 with the toggle; nil (the default) reads as OFF, so on → true / off → nil keeps settings.json
-    /// minimal until the user opts in.
+    /// nil (the default) reads as OFF, so on → true / off → nil keeps settings.json minimal.
     private var restoreRunningCommand: Binding<Bool> {
         Binding(get: { model.settings.restoreRunningCommand ?? false },
                 set: { model.setRestoreRunningCommand($0 ? true : nil) })
     }
 
-    /// 1:1 with the toggle; nil (the default) reads as OFF, so on → true / off → nil keeps settings.json
-    /// minimal until the user opts into the close confirmation.
+    /// nil (the default) reads as OFF, so on → true / off → nil keeps settings.json minimal.
     private var confirmCloseSession: Binding<Bool> {
         Binding(get: { model.settings.confirmCloseSession ?? false },
                 set: { model.setConfirmCloseSession($0 ? true : nil) })
@@ -155,15 +150,14 @@ private struct GeneralSettingsView: View {
                 set: { model.setCloseGraceUndoEnabled($0 ? nil : false) })
     }
 
-    /// 1:1 with the toggle; nil (the default) reads as OFF, so on → true / off → nil keeps settings.json
-    /// minimal until the user opts into inheriting the global ghostty config.
+    /// nil (the default) reads as OFF, so on → true / off → nil keeps settings.json minimal.
     private var inheritGlobalGhosttyConfig: Binding<Bool> {
         Binding(get: { model.settings.inheritGlobalGhosttyConfig ?? false },
                 set: { model.setInheritGlobalGhosttyConfig($0 ? true : nil) })
     }
 
-    /// 1:1 with the toggle; nil (the default) reads as ON, so off → false / on → nil keeps settings.json
-    /// minimal. Drives the ghostty `right-click-action` key (paste when on, ignore when off).
+    /// nil (the default) reads as ON, so off → false / on → nil keeps settings.json minimal. Drives the
+    /// ghostty `right-click-action` key (paste when on, ignore when off).
     private var rightClickPaste: Binding<Bool> {
         Binding(get: { model.settings.rightClickPaste ?? true },
                 set: { model.setRightClickPaste($0 ? nil : false) })
@@ -176,9 +170,8 @@ private struct GeneralSettingsView: View {
                 set: { model.setMouseScrollMultiplier($0 == 3 ? nil : $0) })
     }
 
-    /// The custom directory to display, treating nil OR empty as "unset" (nil) to match
-    /// `resolveNewSessionCwd`, which falls back to home for both. So a blank value from a hand-edited
-    /// `settings.json` renders as "Not set" rather than a blank primary-styled path.
+    /// The directory to display, treating nil OR empty as "unset" to match `resolveNewSessionCwd` (home for
+    /// both), so a blank hand-edited `settings.json` value renders as "Not set", not a blank styled path.
     private var customDirectory: String? {
         let dir = model.settings.newSessionCustomDirectory
         return dir?.isEmpty == false ? dir : nil
@@ -191,8 +184,7 @@ private struct GeneralSettingsView: View {
                 set: { model.setNewSessionDirectory($0 == .home ? nil : $0.rawValue) })
     }
 
-    /// Pick the fixed directory for the `custom` new-session mode with the standard open panel
-    /// (directories only), then persist it.
+    /// Pick the `custom` new-session mode's fixed directory with the standard open panel (dirs only), persist.
     private func chooseCustomDirectory() {
         let panel = NSOpenPanel()
         panel.canChooseDirectories = true
@@ -229,9 +221,8 @@ private struct AppearanceSettingsView: View {
                 }
                 .accessibilityIdentifier("settings-font-size")
 
-                // the theme for the CURRENT appearance. While following, this edits the on-screen side
-                // (dark in dark mode, light in light mode); the "default ghostty" row is offered only
-                // when NOT following, since a dual conditional needs two named themes.
+                // the CURRENT appearance's theme; while following that is the on-screen side. The "default
+                // ghostty" row shows only when NOT following — a dual conditional needs two named themes.
                 Picker("Theme", selection: themeForCurrentAppearance) {
                     if !following { Text("default ghostty").tag(String?.none) }
                     ForEach(themes, id: \.self) { Text($0).tag(String?.some($0)) }
@@ -345,30 +336,26 @@ private struct AppearanceSettingsView: View {
                 set: { model.setAlternateTheme($0) })
     }
 
-    /// The "Follow system appearance" toggle — seeds/collapses the two slots via
-    /// `SettingsModel.setFollowSystemAppearance`.
+    /// The "Follow system appearance" toggle — `setFollowSystemAppearance` seeds/collapses the two slots.
     private var followSystemAppearance: Binding<Bool> {
         Binding(get: { model.settings.followSystemAppearance == true },
                 set: { model.setFollowSystemAppearance($0) })
     }
 
-    /// 1.0 maps to nil (the opaque default) so settings.json stays minimal and the "unset = default"
-    /// convention matches the font/theme controls. The setter PREVIEWS live (apply without save) on
-    /// every drag tick and debounces the write; the slider's `onEditingChanged` flushes it on release.
+    /// 1.0 maps to nil (the opaque default) so settings.json stays minimal, like the font/theme controls.
+    /// PREVIEWS live (apply without save) per drag tick and debounces; `onEditingChanged` flushes on release.
     private var backgroundOpacity: Binding<Double> {
         Binding(get: { model.settings.backgroundOpacity ?? 1 },
                 set: { model.previewBackgroundOpacity($0 >= 1 ? nil : $0) })
     }
 
-    /// PREVIEWS live (apply without save) on every drag tick and debounces the write; the slider's
-    /// `onEditingChanged` flushes it on release.
+    /// PREVIEWS live (apply without save) per drag tick and debounces; `onEditingChanged` flushes on release.
     private var backgroundBlur: Binding<Double> {
         Binding(get: { Double(model.settings.backgroundBlur ?? 0) },
                 set: { model.previewBackgroundBlur($0 <= 0 ? nil : Int($0.rounded())) })
     }
 
-    /// neutral (5) maps to nil so settings.json stays minimal, matching the other appearance controls'
-    /// "unset = default" convention.
+    /// neutral (5) maps to nil so settings.json stays minimal, like the other appearance controls.
     private var sidebarBackgroundShift: Binding<Double> {
         Binding(get: { Double(model.settings.sidebarBackgroundShift ?? AppSettings.defaultSidebarBackgroundShift) },
                 set: { value in
@@ -385,8 +372,8 @@ private struct AppearanceSettingsView: View {
         return offset < 0 ? "Lighter \(-offset)" : "Darker \(offset)"
     }
 
-    /// `.compact` (the default) maps back to nil so settings.json stays minimal, matching the other
-    /// appearance controls' "unset = default" convention; `.normal`/`.hidden` write an explicit mode.
+    /// `.compact` (the default) maps back to nil so settings.json stays minimal, like the other appearance
+    /// controls; `.normal`/`.hidden` write an explicit mode.
     private var toolbarMode: Binding<ToolbarMode> {
         Binding(get: { model.settings.effectiveToolbarMode },
                 set: { model.setToolbarMode($0 == .compact ? nil : $0) })
@@ -400,12 +387,11 @@ private struct AppearanceSettingsView: View {
     }
 }
 
-/// Interface tab: per-element visibility of the window's title-bar and sidebar chrome, grouped by
-/// surface (Title Bar / Sidebar) and laid out two toggles per row so the tab keeps fitting the fixed
-/// 540×590 Settings window without scrolling as the element set grows. Every element is shown by default;
-/// a toggle off adds it to `AppSettings.hiddenInterfaceElements`. Each toggle live-applies through
-/// `SettingsModel`; the title-bar and footer elements re-gate in every open window via
-/// `.agtermAppearanceChanged`, while the hover-only workspace add-session "+" re-gates on its next hover.
+/// Interface tab: per-element title-bar and sidebar chrome visibility, grouped by surface (Title Bar /
+/// Sidebar), two toggles per row so the tab keeps fitting the fixed 540×590 Settings window without
+/// scrolling as the element set grows. Everything shows by default; a toggle off adds it to
+/// `AppSettings.hiddenInterfaceElements` and live-applies through `SettingsModel` — title-bar and footer
+/// elements re-gate in open windows on `.agtermAppearanceChanged`, the workspace add-session "+" on hover.
 private struct InterfaceSettingsView: View {
     let model: SettingsModel
 
@@ -429,10 +415,9 @@ private struct InterfaceSettingsView: View {
                 set: { model.setAutoHideSidebarInactiveWindows($0 ? true : nil) })
     }
 
-    /// A section whose toggles lay out TWO per row, so the tab keeps fitting the fixed Settings window
-    /// without scrolling as the `InterfaceElement` set grows. Each toggle fills half the row around a
-    /// centered `Divider`, so the two columns read as EVEN and visibly separated (each column's switch
-    /// trails at its own right edge); an odd final element pairs with an empty half.
+    /// A section whose toggles lay out TWO per row. Each fills half the row around a centered `Divider`, so
+    /// the columns read as EVEN and visibly separated (each column's switch trails at its own right edge);
+    /// an odd final element pairs with an empty half.
     @ViewBuilder
     private func twoColumnSection(_ title: String, elements: [InterfaceElement]) -> some View {
         Section(title) {
@@ -450,8 +435,7 @@ private struct InterfaceSettingsView: View {
         }
     }
 
-    /// A show/hide toggle for one element: ON = visible (the default), so hiding it is the opt-in that
-    /// writes to `hiddenInterfaceElements`.
+    /// One element's show/hide toggle: ON = visible (the default), so hiding is the opt-in that writes.
     private func toggle(for element: InterfaceElement) -> some View {
         Toggle(element.displayName, isOn: binding(for: element))
             .accessibilityIdentifier("settings-interface-\(element.rawValue)")
@@ -465,8 +449,7 @@ private struct InterfaceSettingsView: View {
 
 /// Notifications tab: the banner / badge / attention-indicator toggles plus the Dock-bounce mode and
 /// notification-sound pickers, all default-driven through `SettingsModel`. The controls are independent —
-/// the badge count keeps tracking whether or not banners are shown, and a Dock bounce or a sound can
-/// fire whether or not banners are shown.
+/// the badge count keeps tracking, and a Dock bounce or a sound can fire, whether or not banners are shown.
 private struct NotificationsSettingsView: View {
     let model: SettingsModel
 
@@ -502,22 +485,20 @@ private struct NotificationsSettingsView: View {
         .padding()
     }
 
-    /// 1:1 with the toggle; nil (the default) reads as on, so settings.json stays minimal until the
-    /// user turns banners off.
+    /// nil (the default) reads as on, so settings.json stays minimal until banners are turned off.
     private var notificationsEnabled: Binding<Bool> {
         Binding(get: { model.settings.notificationsEnabled ?? true },
                 set: { model.setNotificationsEnabled($0 ? nil : false) })
     }
 
-    /// 1:1 with the toggle; nil (the default) reads as on, so settings.json stays minimal until the
-    /// user hides the count badges.
+    /// nil (the default) reads as on, so settings.json stays minimal until the count badges are hidden.
     private var notificationBadgeEnabled: Binding<Bool> {
         Binding(get: { model.settings.notificationBadgeEnabled ?? true },
                 set: { model.setNotificationBadgeEnabled($0 ? nil : false) })
     }
 
-    /// Resolves nil (the default) to `.off`; selecting None maps back to nil so settings.json stays
-    /// minimal until the user picks a bounce mode. Mirrors the toolbar-mode picker binding.
+    /// Resolves nil (the default) to `.off`; None maps back to nil so settings.json stays minimal. Mirrors
+    /// the toolbar-mode picker binding.
     private var dockBounce: Binding<DockBounce> {
         Binding(get: { model.settings.effectiveDockBounce },
                 set: { model.setDockBounce($0 == .off ? nil : $0) })
@@ -534,25 +515,22 @@ private struct NotificationsSettingsView: View {
                 })
     }
 
-    /// 1:1 with the toggle; nil (the default) reads as OFF, so on → true / off → nil keeps settings.json
-    /// minimal until the user opts into the title-bar attention bell.
+    /// nil (the default) reads as OFF, so on → true / off → nil keeps settings.json minimal.
     private var attentionButtonEnabled: Binding<Bool> {
         Binding(get: { model.settings.attentionButtonEnabled ?? false },
                 set: { model.setAttentionButtonEnabled($0 ? true : nil) })
     }
 }
 
-/// Agent Status tab: a Colors and Shapes section (one row per state — active / blocked / completed —
-/// carrying that sidebar glyph's color well and silhouette picker side by side), a Sound section (the
-/// blocked sound), an Auto-follow section (the idle-timeout picker + stay-on-active toggle), and a
-/// trailing Reset that clears the colors, shapes and sound back to their defaults.
+/// Agent Status tab: Colors and Shapes (one row per state — active / blocked / completed — with that sidebar
+/// glyph's color well and silhouette picker side by side), Sound (the blocked sound), Auto-follow (the
+/// idle-timeout picker + stay-on-active toggle), and a trailing Reset clearing colors, shapes and sound.
 private struct AgentStatusSettingsView: View {
     /// Gap between a glyph row's color well and its shape picker.
     private static let controlSpacing: CGFloat = 8
-    /// Column width every shape picker reserves. A menu button sizes to the glyph it currently shows and
-    /// the six silhouettes differ by a few points, so without a fixed column the color wells would jog
-    /// between rows. Snug enough that the reserved column reads as spacing rather than a hole, with room
-    /// above the widest silhouette's button.
+    /// Column width every shape picker reserves. A menu button sizes to the glyph it shows and the six
+    /// silhouettes differ by a few points, so without a fixed column the color wells jog between rows. Snug
+    /// enough to read as spacing rather than a hole, with room above the widest silhouette's button.
     private static let shapePickerWidth: CGFloat = 80
 
     let model: SettingsModel
@@ -600,13 +578,12 @@ private struct AgentStatusSettingsView: View {
         .padding()
     }
 
-    /// One state's glyph row: the state name labels the row, and its color well and shape picker sit
-    /// together on the trailing side. Both controls hide their own labels so the state name is the row's
-    /// only visible label. The shape picker takes a fixed-width column so the three rows line up, and
-    /// draws its button at that column's TRAILING edge so the row ends flush with the tab's right margin
-    /// like every other section's control (the column's default center alignment left it floating
-    /// inboard). Both bindings and both accessibility identifiers are derived from the state argument, so
-    /// a row can never label one status while driving another's setting.
+    /// One state's glyph row: the state name labels it, with the color well and shape picker on the trailing
+    /// side, both label-hidden so the state name is the row's only visible label. The shape picker draws its
+    /// button at the TRAILING edge of its fixed-width column so the row ends flush with the tab's right
+    /// margin (the column's default center alignment left it floating inboard). Both bindings and both
+    /// accessibility ids derive from the state argument, so a row cannot label one status while driving
+    /// another's setting.
     private func glyphRow(_ status: AgentStatus) -> some View {
         let color = statusColor(for: status)
         let shape = statusShape(for: status)
@@ -658,12 +635,10 @@ private struct AgentStatusSettingsView: View {
         }
     }
 
-    /// The option list one shape picker shows: one entry per `StatusShape`, built from `allCases` so the
-    /// picker can never drift from the enum. Each entry is the symbol ALONE — the silhouette is what is
-    /// being picked, and a name beside it only crowds the row — with the shape's name kept as its
-    /// accessibility label so VoiceOver still announces the choice. `tint` is that status's current glyph
-    /// color, so every option previews the real sidebar glyph; it comes from the row's color binding, so
-    /// picking a new color redraws the options in it.
+    /// The option list one shape picker shows: one entry per `StatusShape` from `allCases`, so the picker
+    /// cannot drift from the enum. Each entry is the symbol ALONE (a name beside it only crowds the row),
+    /// with the shape's name kept as its accessibility label so VoiceOver still announces the choice. `tint`
+    /// is the status's current glyph color, from the row's binding, so a new color redraws the options in it.
     @ViewBuilder
     private func shapeOptions(tint: NSColor) -> some View {
         ForEach(StatusShape.allCases, id: \.self) { shape in
@@ -673,10 +648,9 @@ private struct AgentStatusSettingsView: View {
         }
     }
 
-    /// One picker option's glyph, drawn the way the sidebar draws it: the shape's symbol at the sidebar
-    /// glyph's own point size, tinted with that status's current color. It is a NON-template `NSImage`
-    /// because a menu recolors a template symbol to its own text color, which would wash out the tint the
-    /// option is previewing.
+    /// One picker option's glyph, drawn as the sidebar draws it: the shape's symbol at the sidebar glyph's
+    /// own point size, tinted with that status's current color. A NON-template `NSImage`, because a menu
+    /// recolors a template symbol to its own text color and would wash out the tint being previewed.
     private static func shapeImage(_ shape: StatusShape, tint: NSColor) -> NSImage {
         let config = NSImage.SymbolConfiguration(pointSize: StatusIconView.glyphPointSize, weight: .regular)
             .applying(NSImage.SymbolConfiguration(paletteColors: [tint]))
@@ -725,25 +699,23 @@ private struct AgentStatusSettingsView: View {
     }
 
     /// Inverted view of the stored `autoFollowStayOnActive` so the toggle reads forward ("auto-follow away"
-    /// ON = do leave a running session) instead of a double negative. The stored default nil means "follow
-    /// away", so the toggle shows ON by default; opting to STAY (toggle OFF) stores `true`, and toggling back
-    /// to the follow-away default stores nil to keep settings.json minimal.
+    /// ON = do leave a running session) instead of a double negative. The stored nil default means "follow
+    /// away", so it shows ON; opting to STAY (toggle OFF) stores `true`, and toggling back stores nil.
     private var autoFollowAwayFromRunning: Binding<Bool> {
         Binding(get: { !(model.settings.autoFollowStayOnActive ?? false) },
                 set: { model.setAutoFollowStayOnActive($0 ? nil : true) })
     }
 }
 
-/// Key Mapping tab: the config directory holding `keymap.conf` (with a directory picker + "Use
-/// Default"), a read-only list of parse diagnostics, and a Reload button. The directory and Reload
-/// route through `SettingsModel`, which re-reads + re-parses the keymap and posts the change so the
-/// data-driven menu shortcuts, the custom-command runner, and the action palette all update.
+/// Key Mapping tab: the config directory holding `keymap.conf` (directory picker + "Use Default"), a
+/// read-only parse-diagnostics list, and a Reload button. Both route through `SettingsModel`, which re-reads
+/// + re-parses the keymap and posts the change, updating the data-driven menu shortcuts, the custom-command
+/// runner and the action palette.
 private struct KeyMappingSettingsView: View {
     let model: SettingsModel
 
-    /// The resolved config directory shown in the field: the explicit setting when set, else the
-    /// default location (`AGTERM_STATE_DIR/config` under test isolation, else `~/.config/agterm`),
-    /// matching `SettingsModel`'s own resolution.
+    /// The resolved config directory shown in the field: the explicit setting, else `AGTERM_STATE_DIR/config`
+    /// under test isolation, else `~/.config/agterm` — matching `SettingsModel`'s own resolution.
     private var configDirectoryPath: String {
         ConfigPaths.configDirectory(
             setting: model.settings.configDirectory,
@@ -808,8 +780,8 @@ private struct KeyMappingSettingsView: View {
         diagnostic.line > 0 ? "line \(diagnostic.line): \(diagnostic.message)" : diagnostic.message
     }
 
-    /// The diagnostics exposed as one accessibility value (each line joined), so a UI test can read
-    /// the full content from the container without scrolling each row into view. "No issues." when empty.
+    /// The diagnostics joined into one accessibility value, so a UI test reads the full content from the
+    /// container without scrolling each row into view. "No issues." when empty.
     private var diagnosticsSummary: String {
         model.keymapDiagnostics.isEmpty ? "No issues." : model.keymapDiagnostics.map(diagnosticLine).joined(separator: " | ")
     }

--- a/agterm/Views/SidebarRenameController.swift
+++ b/agterm/Views/SidebarRenameController.swift
@@ -1,11 +1,10 @@
 import agtermCore
 import AppKit
 
-/// Owns the sidebar's inline-rename interaction: it is the `NSTextFieldDelegate` for the outline's
-/// editable name fields and holds the rename reentrancy flags. The `WorkspaceSidebar.Coordinator`
-/// creates one, points it at the outline, and starts an edit via `beginEditing(node:)`; it reads
-/// `isEditing`/`isCommitting` to gate its own row reloads and focus hand-back, and supplies
-/// `onRenameEnded` to return keyboard focus to the terminal once an edit finishes.
+/// Owns the sidebar's inline-rename interaction: the `NSTextFieldDelegate` for the outline's editable name
+/// fields, plus the rename reentrancy flags. `WorkspaceSidebar.Coordinator` creates one, points it at the
+/// outline, starts an edit via `beginEditing(node:)`, reads `isEditing`/`isCommitting` to gate its own row
+/// reloads and focus hand-back, and supplies `onRenameEnded` to return keyboard focus to the terminal.
 @MainActor
 final class SidebarRenameController: NSObject, NSTextFieldDelegate {
     private let store: AppStore
@@ -16,27 +15,26 @@ final class SidebarRenameController: NSObject, NSTextFieldDelegate {
     /// field editor's resign settles first.
     var onRenameEnded: (() -> Void)?
 
-    /// Set while an end-editing notification is being processed, to ignore the
-    /// re-entrant end-editing the cancel/commit path can trigger.
+    /// Set while an end-editing notification is being processed, to ignore the re-entrant end-editing the
+    /// cancel/commit path can trigger.
     private var committing = false
-    /// Set while a rename field is the active first responder (between
-    /// `beginEditing` and `restore`), so a badge tick can't reload the row out
-    /// from under the in-progress edit. `committing` covers only the end-editing
-    /// instant; this covers the whole typing window.
+    /// Set while a rename field is the active first responder (between `beginEditing` and `restore`), so a
+    /// badge tick can't reload the row out from under the in-progress edit. `committing` covers only the
+    /// end-editing instant; this covers the whole typing window.
     private var editing = false
     /// Set by the Esc handler (`doCommandBy` cancelOperation) so the end-editing that the
     /// manual resign triggers is treated as a cancel — the typed value is discarded.
     private var cancellingRename = false
-    /// The row's pre-edit label, captured in `beginEditing` so an Esc-cancel can restore the
-    /// displayed text (a manual resign keeps the edited stringValue, and a cancel makes no model
-    /// change so no reload refreshes the row).
+    /// The row's pre-edit label, captured in `beginEditing` so an Esc-cancel can restore the displayed text
+    /// (a manual resign keeps the edited stringValue, and a cancel makes no model change, so no reload
+    /// refreshes the row).
     private var renameOriginalValue: String?
 
-    /// Whether a rename field is currently being edited (first responder between `beginEditing` and
-    /// `restore`). Read by the Coordinator to skip row reloads and focus hand-back mid-edit.
+    /// Whether a rename field is being edited (first responder between `beginEditing` and `restore`). Read by
+    /// the Coordinator to skip row reloads and focus hand-back mid-edit.
     var isEditing: Bool { editing }
-    /// Whether an end-editing notification is currently being processed. Read by the Coordinator to
-    /// skip a row reload during the commit instant.
+    /// Whether an end-editing notification is being processed. Read by the Coordinator to skip a row reload
+    /// during the commit instant.
     var isCommitting: Bool { committing }
 
     init(store: AppStore) {
@@ -44,27 +42,26 @@ final class SidebarRenameController: NSObject, NSTextFieldDelegate {
         super.init()
     }
 
-    /// Puts the row's text field into editing mode and focuses it. Called from
-    /// the "Rename" menu item and from double-click.
+    /// Puts the row's text field into editing mode and focuses it. Called from the "Rename" menu item and
+    /// from double-click.
     func beginEditing(node: SidebarNode) {
         guard let outline = outlineView else { return }
         let row = outline.row(forItem: node)
         guard row >= 0, let cell = outline.view(atColumn: 0, row: row, makeIfNecessary: true) as? NSTableCellView,
               let field = cell.textField else { return }
         renameOriginalValue = field.stringValue
-        // the flagged view shows a decorated `name : workspace` row label; seed the editable field with
-        // the bare session name so an edit that keeps the ` : workspace` tail never bakes it into the
-        // custom name. tree mode already shows the bare name, so this is a no-op there.
+        // the flagged view shows a decorated `name : workspace` label; seed the field with the bare session
+        // name so an edit never bakes the ` : workspace` tail into the custom name. no-op in tree mode.
         if node.kind == .session, let session = store.session(withID: node.id) {
             field.stringValue = session.displayName
         }
         field.isEditable = true
         field.isBordered = true
         field.drawsBackground = true
-        // the editable field draws its own background, and the label color was set to the row's
-        // (often dark) selection-foreground — leaving those makes the edit text unreadable (dark-on-
-        // dark) on every theme. paint the field with the terminal theme's foreground-on-background so
-        // it reads everywhere; setColors restores the row's color when it reloads after the commit.
+        // the editable field draws its own background while the label color is the row's (often dark)
+        // selection-foreground, so leaving both makes the edit text dark-on-dark on every theme. paint the
+        // field with the theme's foreground-on-background; setColors restores the row color on the
+        // post-commit reload.
         let theme = GhosttyApp.shared
         field.textColor = theme.terminalForegroundColor ?? .labelColor
         field.backgroundColor = theme.terminalBackgroundColor ?? .textBackgroundColor
@@ -77,11 +74,10 @@ final class SidebarRenameController: NSObject, NSTextFieldDelegate {
         store.suppressAutoFollow()
     }
 
-    /// Intercepts Esc during an inline rename. The field is focused via `makeFirstResponder`
-    /// (not the outline's edit session), so AppKit never delivers the cancel text-movement for
-    /// Esc — `cancelOperation:` would otherwise do nothing and leave the field stuck in edit
-    /// mode. Flag the cancel, resign so `controlTextDidEndEditing` fires, and consume the
-    /// command so the default (no-op) handling doesn't run.
+    /// Intercepts Esc during an inline rename. The field is focused via `makeFirstResponder`, not the
+    /// outline's edit session, so AppKit never delivers the cancel text-movement and `cancelOperation:`
+    /// would leave the field stuck in edit mode. Flag the cancel, resign so `controlTextDidEndEditing` fires,
+    /// and consume the command so the no-op default handling doesn't run.
     func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
         guard editing, commandSelector == #selector(NSResponder.cancelOperation(_:)),
               let field = control as? NSTextField else { return false }
@@ -95,7 +91,6 @@ final class SidebarRenameController: NSObject, NSTextFieldDelegate {
         committing = true
         defer { committing = false }
 
-        // resolve which node this field belongs to via the row of its cell view
         let row = outline.row(for: field)
         let node = row >= 0 ? outline.item(atRow: row) as? SidebarNode : nil
 
@@ -122,8 +117,8 @@ final class SidebarRenameController: NSObject, NSTextFieldDelegate {
         }
     }
 
-    /// Returns a renamed/edited field to its non-editable label state and resets
-    /// its accessibility identifier to the row identifier for its kind.
+    /// Returns a renamed/edited field to its non-editable label state and resets its accessibility
+    /// identifier to the row identifier for its kind.
     private func restore(field: NSTextField, kind: SidebarNode.Kind?) {
         editing = false
         // rename ended (commit or cancel) — lift the suppression `beginEditing` took so auto-follow resumes.
@@ -132,12 +127,11 @@ final class SidebarRenameController: NSObject, NSTextFieldDelegate {
         field.isBordered = false
         field.drawsBackground = false
         field.setAccessibilityIdentifier(kind == .workspace ? "workspace-row" : "session-row")
-        // beginEditing painted the field with the theme fg-on-bg for the edit box; restore the row's
-        // selection-aware themed color so a commit that didn't change the name (no reload) doesn't
-        // leave the edit color stuck on the row. read the hosting row view's live isSelected (the
-        // state the selection pill draws from) rather than recomputing via row(for:), which can miss
-        // if the row was reloaded during the edit — a stale tint here is invisible text on themes
-        // where foreground == selection-background.
+        // restore the row's selection-aware themed color so a commit that didn't change the name (no
+        // reload) doesn't leave beginEditing's edit-box color stuck on the row. read the hosting row view's
+        // live isSelected — the state the selection pill draws from — rather than recomputing via
+        // row(for:), which can miss if the row was reloaded during the edit; a stale tint here is invisible
+        // text on themes where foreground == selection-background.
         if let cell = field.superview as? SidebarCellView {
             cell.setColors(selected: (cell.superview as? NSTableRowView)?.isSelected ?? false)
         }

--- a/agterm/Views/SidebarRowViews.swift
+++ b/agterm/Views/SidebarRowViews.swift
@@ -2,33 +2,29 @@ import agtermCore
 import AppKit
 
 /// An `NSTableCellView` with a leading icon, the name field, and a trailing badge. The icon is the inherited
-/// `cell.imageView` (2x2 grid glyph for a workspace, outlined terminal for a session), so AppKit re-tints it
-/// white on a selected row; the name is `cell.textField`, which the rename and selection wiring operates on.
+/// `cell.imageView` (2x2 grid for a workspace, outlined terminal for a session), so AppKit re-tints it white on
+/// a selected row; the name is `cell.textField`, which the rename and selection wiring drives.
 final class SidebarCellView: NSTableCellView {
-    /// Trailing unseen-notification count for the row (a session's `unseenCount`, or a collapsed
-    /// workspace's roll-up), drawn as a small accent capsule. Hidden when 0.
+    /// Trailing unseen-notification count — a session's `unseenCount` or a collapsed workspace's roll-up; 0 hides.
     let badge = BadgeView()
 
-    /// Agent-status glyph drawn just left of the count badge, fed from the session's `agentIndicator`.
-    /// Hidden on `.idle` (workspace rows always idle for now).
+    /// Agent-status glyph fed from the session's `agentIndicator`; hidden on `.idle` (workspace rows always idle).
     let statusIcon = StatusIconView()
 
-    /// Inline "+" button between the name and the status icon, present only on workspace cells (nil for
-    /// session cells). Set by the cell builder; `handleSingleClick` reads it to avoid toggling expansion when
-    /// the click lands on the button.
+    /// Inline "+" button between the name and the status icon, workspace cells only (nil for session cells).
+    /// Set by the cell builder; `handleSingleClick` reads it to avoid toggling expansion on a click on it.
     var addButton: NSButton?
 
-    /// Width of `addButton`, toggled between 0 (hidden) and the glyph width by `setAddButtonVisible` — the
-    /// collapse-the-slot convention of `StatusIconView.widthConstraint`, so an idle row's name reclaims the
-    /// space. Set by the cell builder alongside `addButton`.
+    /// Width of `addButton`, toggled between 0 and the glyph width by `setAddButtonVisible` — the
+    /// collapse-the-slot convention of `StatusIconView.widthConstraint`, so an idle row's name reclaims it.
     var addButtonWidthConstraint: NSLayoutConstraint?
 
     private static let addButtonWidth: CGFloat = 16
     private var hoverTrackingArea: NSTrackingArea?
 
     /// Reveals or collapses the inline "+": the Finder/Xcode hover convention, so an idle row shows no button
-    /// and the roll-up badge keeps its slot. Driven by `mouseEntered`/`mouseExited`, reset hidden when a
-    /// reused cell is reconfigured in the row provider. No-op for session cells.
+    /// and the roll-up badge keeps its slot. Driven by `mouseEntered`/`mouseExited`, reset hidden when a reused
+    /// cell is reconfigured. No-op for session cells.
     func setAddButtonVisible(_ visible: Bool) {
         guard let addButton, let addButtonWidthConstraint else { return }
         addButton.isHidden = !visible
@@ -51,11 +47,9 @@ final class SidebarCellView: NSTableCellView {
 
     override func mouseEntered(with event: NSEvent) {
         super.mouseEntered(with: event)
-        // the workspace-row "+" is a toggleable Interface element, gated here so a hover reveals it only
-        // when the element is shown. hover-time only: a live Settings flip takes effect on the next hover,
-        // and a "+" already on screen when the element is hidden lingers until the next mouse exit/enter
-        // (e.g. a keyboard-driven toggle while the pointer sits on the row) — accepted, since it is a
-        // hover-only affordance and any stale "+" clears on the next mouse move.
+        // the "+" is a toggleable Interface element, gated at hover time only: a live Settings flip takes
+        // effect on the next hover, and a "+" already on screen lingers until the next mouse exit/enter —
+        // accepted for a hover-only affordance that clears on the next mouse move.
         guard !GhosttyApp.shared.hiddenInterfaceElements.contains(.workspaceAddSession) else { return }
         setAddButtonVisible(true)
     }
@@ -65,12 +59,11 @@ final class SidebarCellView: NSTableCellView {
         setAddButtonVisible(false)
     }
 
-    /// Color the row text/icon from the terminal theme: a selected row takes the selection foreground (over
-    /// the selection-background pill the row draws), or white over the soft wash when the theme exposes no
+    /// Colors row text/icon from the terminal theme: a selected row takes the selection foreground (over the
+    /// selection-background pill the row draws), or white over the soft wash when the theme exposes no
     /// selection color; an unselected row takes the theme foreground, icons dimmed. Driven from the real
     /// selection state, not `backgroundStyle` (AppKit flips that only while the table is first responder) —
-    /// the hosting `SidebarRowView` re-asserts it from its live `isSelected` on attach and on every selection
-    /// flip, and the coordinator re-runs it on theme changes.
+    /// `SidebarRowView` re-asserts it on attach and on every selection flip, the coordinator on theme changes.
     func setColors(selected: Bool) {
         let app = GhosttyApp.shared
         let color = selected
@@ -83,9 +76,9 @@ final class SidebarCellView: NSTableCellView {
     }
 }
 
-/// A small filled accent capsule showing an unseen-notification count, custom-drawn (not an
-/// `NSTextField`) so the capsule and text center cleanly at row size. A single digit reads as a
-/// circle (min width = height). Exposed to accessibility as a `notify-badge` static text.
+/// A small filled accent capsule showing an unseen-notification count, custom-drawn (not an `NSTextField`) so
+/// capsule and text center cleanly at row size. A single digit reads as a circle (min width = height). Exposed
+/// to accessibility as a `notify-badge` static text.
 final class BadgeView: NSView {
     /// The count to show, capped at `99+`. Drives `intrinsicContentSize` and redraw.
     var count = 0 {
@@ -109,17 +102,16 @@ final class BadgeView: NSView {
     required init?(coder _: NSCoder) { fatalError("init(coder:) is not supported") }
 
     private static let font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize, weight: .bold)
-    // space reserved at the badge's LEADING edge only while the badge shows, so the capsule keeps air from
-    // the status glyph to its left; a count-0 badge collapses fully and lets that glyph sit flush.
+    // leading-edge gap so the capsule keeps air from the status glyph to its left; a count-0 badge collapses
+    // fully and lets that glyph sit flush.
     private static let leadingGap: CGFloat = 4
     private var textAttributes: [NSAttributedString.Key: Any] { [.font: Self.font, .foregroundColor: NSColor.white] }
     private var label: String { count > 99 ? "99+" : String(count) }
 
     override var intrinsicContentSize: NSSize {
         let height: CGFloat = 16
-        // `isHidden` alone does NOT collapse a view in Auto Layout, so a count-0 badge would reserve a
-        // trailing slot and push the status glyph in from the right edge; zero width lets the name reclaim
-        // it and the glyph sit flush.
+        // `isHidden` alone does NOT collapse a view in Auto Layout, so a count-0 badge would reserve a trailing
+        // slot and push the status glyph in from the right edge; zero width lets the name reclaim it.
         guard count > 0 else { return NSSize(width: 0, height: height) }
         let capsule = max((label as NSString).size(withAttributes: textAttributes).width + 9, height)
         return NSSize(width: capsule + Self.leadingGap, height: height)
@@ -128,8 +120,8 @@ final class BadgeView: NSView {
     override func draw(_: NSRect) {
         let capsule = NSRect(x: Self.leadingGap, y: 0, width: bounds.width - Self.leadingGap, height: bounds.height)
         let radius = capsule.height / 2
-        // systemRed (the conventional unread/notification color) reads on both the dark rows and the
-        // accent-colored selected row — an accent capsule would blend into a selected row.
+        // systemRed (the conventional unread color) reads on dark rows and on the accent-colored selected row,
+        // where an accent capsule would blend in.
         NSColor.systemRed.setFill()
         NSBezierPath(roundedRect: capsule, xRadius: radius, yRadius: radius).fill()
         let text = label as NSString
@@ -139,21 +131,21 @@ final class BadgeView: NSView {
     }
 }
 
-/// A small SF-Symbol agent-status glyph drawn just left of the count badge: by default a `circle.fill` tinted
+/// A small SF-Symbol agent-status glyph left of the count badge: by default a `circle.fill` tinted
 /// lavender-grey for `active`, amber for `blocked`, green for `completed`; a Settings shape or a per-call
 /// `session.status --shape` swaps the silhouette, so shape carries the state alongside the tint. Hidden on
-/// `.idle`. Exposed to accessibility as an `agent-status` static text whose value is the state name (XCUITest
-/// matches `app.staticTexts["agent-status"]`; neither tint nor silhouette is accessibility-observable).
-/// Blink is a layer `opacity` `CABasicAnimation` (autoreverse/repeat), added only while visible AND blinking.
+/// `.idle`. Accessibility: an `agent-status` static text whose value is the state name (XCUITest matches
+/// `app.staticTexts["agent-status"]`; neither tint nor silhouette is observable there). Blink is a layer
+/// `opacity` `CABasicAnimation` (autoreverse/repeat), added only while visible AND blinking.
 final class StatusIconView: NSImageView {
     private static let blinkKey = "agent-status-blink"
     private static let glyphWidth: CGFloat = 16
-    /// Symbol point size of the drawn glyph. The Settings shape picker previews its options at the same
-    /// size, so an option looks like the glyph it will install.
+    /// Symbol point size of the glyph; the Settings shape picker previews options at the same size, so an
+    /// option looks like the glyph it installs.
     static let glyphPointSize: CGFloat = 13
 
-    /// The view's width, collapsed to 0 on `.idle` so a status-less row reclaims the slot (and its
-    /// label truncates full-width); `glyphWidth` when a glyph shows. Activated in init, toggled in `apply`.
+    /// The view's width, collapsed to 0 on `.idle` so a status-less row reclaims the slot (its label truncates
+    /// full-width); `glyphWidth` when a glyph shows. Activated in init, toggled in `apply`.
     private lazy var widthConstraint = widthAnchor.constraint(equalToConstant: 0)
 
     override init(frame frameRect: NSRect) {
@@ -169,8 +161,8 @@ final class StatusIconView: NSImageView {
     @available(*, unavailable)
     required init?(coder _: NSCoder) { fatalError("init(coder:) is not supported") }
 
-    /// apply renders the indicator's tinted glyph (hiding the view and stopping any blink on `.idle`),
-    /// updates the tooltip and accessibility value to the state name, and starts/stops the blink animation.
+    /// apply renders the indicator's tinted glyph and updates tooltip + accessibility value to the state name;
+    /// `.idle` hides the view and stops the blink.
     func apply(_ indicator: AgentIndicator) {
         toolTip = indicator.status.tooltipText
         guard indicator.status != .idle else {
@@ -206,8 +198,8 @@ final class StatusIconView: NSImageView {
 
     private static func icon(for status: AgentStatus, override colorHex: String?, shape: StatusShape?) -> NSImage? {
         guard status != .idle else { return nil } // unreachable: `apply` returns early on `.idle` before drawing
-        // symbol + color come from the shared resolvers (GhosttyApp.statusSymbolName + .statusColor) so this
-        // glyph and the SwiftUI StatusGlyph stay identical, per-call `--shape`/`--color` overrides included.
+        // symbol + color come from the shared resolvers, so this glyph and the SwiftUI StatusGlyph stay
+        // identical, per-call `--shape`/`--color` overrides included.
         let config = NSImage.SymbolConfiguration(pointSize: Self.glyphPointSize, weight: .regular)
             .applying(NSImage.SymbolConfiguration(paletteColors: [GhosttyApp.shared.statusColor(for: status, override: colorHex)]))
         let symbol = GhosttyApp.shared.statusSymbolName(for: status, override: shape)
@@ -216,21 +208,18 @@ final class StatusIconView: NSImageView {
     }
 }
 
-/// Row view that draws its own selection pill in `drawBackground`, so the selection is the terminal's
-/// `selection-background` color in every state. The table's `selectionHighlightStyle` is `.none` (set in
-/// `makeNSView`), so AppKit draws nothing of its own — otherwise it paints a gray unemphasized fill whenever
-/// the sidebar isn't first responder (the normal case, since focus lives in the terminal), overriding a
-/// custom `drawSelection`. `isEmphasized` is overridden so the row redraws on a window key-state change (the
-/// brightness dims for a background window).
+/// Row view drawing its own selection pill in `drawBackground`, so the selection is the terminal's
+/// `selection-background` color in every state. The table's `selectionHighlightStyle` is `.none` (`makeNSView`),
+/// or AppKit paints a gray unemphasized fill whenever the sidebar isn't first responder (the normal case, since
+/// focus lives in the terminal), overriding a custom `drawSelection`. `isEmphasized` is overridden so the row
+/// redraws on a window key-state change (dimmer for a background window).
 ///
-/// The row view is the single source of truth for the cell's selection tint: `isSelected` (the state the pill
-/// draws from) re-tints the hosted `SidebarCellView` whenever AppKit updates it, and `didAddSubview` tints a
-/// cell the moment it attaches. Otherwise the live pill and the imperatively-applied text color desync — and
-/// on the many themes where `foreground == selection-background` (the inverted-selection idiom), a stale tint
-/// renders the row text fully invisible.
+/// It is also the single source of truth for the cell's selection tint: `isSelected` (the state the pill draws
+/// from) re-tints the hosted `SidebarCellView` whenever AppKit updates it, and `didAddSubview` tints a cell the
+/// moment it attaches. Otherwise pill and text color desync — and on the many themes where
+/// `foreground == selection-background` (the inverted-selection idiom), a stale tint renders the text invisible.
 final class SidebarRowView: NSTableRowView {
-    /// White-wash fallback opacity (themes with no selection color): brighter for the key window,
-    /// dimmer for a background one.
+    /// White-wash fallback opacity for themes with no selection color: brighter key, dimmer background.
     private static let keyAlpha: CGFloat = 0.13
     private static let inactiveAlpha: CGFloat = 0.07
 
@@ -244,8 +233,7 @@ final class SidebarRowView: NSTableRowView {
     override var isSelected: Bool {
         didSet {
             guard isSelected != oldValue else { return }
-            // AppKit won't redraw on its own with selectionHighlightStyle == .none; re-tint the cell
-            // from the same state the pill draws from.
+            // AppKit won't redraw with selectionHighlightStyle == .none; re-tint the cell from the pill's state.
             needsDisplay = true
             retintCellViews()
         }
@@ -253,8 +241,8 @@ final class SidebarRowView: NSTableRowView {
 
     override func didAddSubview(_ subview: NSView) {
         super.didAddSubview(subview)
-        // a cell materialized into an already-selected row (reload/expand row-map flux can make the
-        // cell builder's own selection lookup miss) picks up the row's live state on attach.
+        // a cell materialized into an already-selected row (reload/expand row-map flux can make the cell
+        // builder's own selection lookup miss) picks up the row's live state on attach.
         (subview as? SidebarCellView)?.setColors(selected: isSelected)
     }
 
@@ -274,9 +262,9 @@ final class SidebarRowView: NSTableRowView {
     }
 }
 
-/// A stable reference-type node fed to `NSOutlineView`, which keys item identity and expansion state by
-/// object identity (`===`) — so nodes must be the SAME instances across reloads, never freshly-allocated
-/// structs. The coordinator caches one per workspace/session id and rebuilds only the child lists per reload.
+/// A stable reference-type node fed to `NSOutlineView`, which keys item identity and expansion state by object
+/// identity (`===`) — nodes must be the SAME instances across reloads, never fresh structs. The coordinator
+/// caches one per workspace/session id and rebuilds only the child lists.
 final class SidebarNode {
     enum Kind { case workspace, session }
 

--- a/agterm/Views/SidebarRowViews.swift
+++ b/agterm/Views/SidebarRowViews.swift
@@ -1,10 +1,9 @@
 import agtermCore
 import AppKit
 
-/// An `NSTableCellView` with a leading icon, the name field, and a trailing badge.
-/// The icon is the inherited `cell.imageView` (a 2x2 grid glyph for a workspace, an outlined
-/// terminal for a session), so AppKit re-tints it white on a selected row. The name field is `cell.textField`
-/// (rename and selection wiring operate on it).
+/// An `NSTableCellView` with a leading icon, the name field, and a trailing badge. The icon is the inherited
+/// `cell.imageView` (2x2 grid glyph for a workspace, outlined terminal for a session), so AppKit re-tints it
+/// white on a selected row; the name is `cell.textField`, which the rename and selection wiring operates on.
 final class SidebarCellView: NSTableCellView {
     /// Trailing unseen-notification count for the row (a session's `unseenCount`, or a collapsed
     /// workspace's roll-up), drawn as a small accent capsule. Hidden when 0.
@@ -14,22 +13,22 @@ final class SidebarCellView: NSTableCellView {
     /// Hidden on `.idle` (workspace rows always idle for now).
     let statusIcon = StatusIconView()
 
-    /// Inline "+" button between the name and the status icon, present only on workspace cells.
-    /// Nil for session cells. Set by the cell builder and used by `handleSingleClick` to guard
-    /// against toggling expansion when the click lands on this button.
+    /// Inline "+" button between the name and the status icon, present only on workspace cells (nil for
+    /// session cells). Set by the cell builder; `handleSingleClick` reads it to avoid toggling expansion when
+    /// the click lands on the button.
     var addButton: NSButton?
 
-    /// Width of `addButton`, toggled between 0 (hidden) and the glyph width by `setAddButtonVisible`
-    /// — the same collapse-the-slot convention as `StatusIconView.widthConstraint`, so an idle row's
-    /// name reclaims the space. Set by the cell builder alongside `addButton`.
+    /// Width of `addButton`, toggled between 0 (hidden) and the glyph width by `setAddButtonVisible` — the
+    /// collapse-the-slot convention of `StatusIconView.widthConstraint`, so an idle row's name reclaims the
+    /// space. Set by the cell builder alongside `addButton`.
     var addButtonWidthConstraint: NSLayoutConstraint?
 
     private static let addButtonWidth: CGFloat = 16
     private var hoverTrackingArea: NSTrackingArea?
 
-    /// Reveals or collapses the inline "+": the Finder/Xcode hover convention, so an idle row shows
-    /// no button and the roll-up badge keeps its slot. Driven by `mouseEntered`/`mouseExited` and
-    /// reset hidden when a reused cell is reconfigured in the row provider. No-op for session cells.
+    /// Reveals or collapses the inline "+": the Finder/Xcode hover convention, so an idle row shows no button
+    /// and the roll-up badge keeps its slot. Driven by `mouseEntered`/`mouseExited`, reset hidden when a
+    /// reused cell is reconfigured in the row provider. No-op for session cells.
     func setAddButtonVisible(_ visible: Bool) {
         guard let addButton, let addButtonWidthConstraint else { return }
         addButton.isHidden = !visible
@@ -52,11 +51,11 @@ final class SidebarCellView: NSTableCellView {
 
     override func mouseEntered(with event: NSEvent) {
         super.mouseEntered(with: event)
-        // the workspace-row "+" is a toggleable Interface element; gate it here so a hover only reveals
-        // it when the element is shown. this is hover-time only: a live Settings flip takes effect on the
-        // next hover, and a "+" already on screen when the element is hidden lingers until the next mouse
-        // exit/enter (e.g. a keyboard-driven toggle while the pointer sits on the row). accepted — it's a
-        // hover-only affordance, so any stale "+" clears on the next mouse move.
+        // the workspace-row "+" is a toggleable Interface element, gated here so a hover reveals it only
+        // when the element is shown. hover-time only: a live Settings flip takes effect on the next hover,
+        // and a "+" already on screen when the element is hidden lingers until the next mouse exit/enter
+        // (e.g. a keyboard-driven toggle while the pointer sits on the row) — accepted, since it is a
+        // hover-only affordance and any stale "+" clears on the next mouse move.
         guard !GhosttyApp.shared.hiddenInterfaceElements.contains(.workspaceAddSession) else { return }
         setAddButtonVisible(true)
     }
@@ -66,12 +65,12 @@ final class SidebarCellView: NSTableCellView {
         setAddButtonVisible(false)
     }
 
-    /// Color the row text/icon from the terminal theme: a selected row pairs with the selection
-    /// foreground (over the selection-background pill the row draws), or white over the soft wash when
-    /// the theme exposes no selection color; an unselected row uses the theme foreground, icons dimmed.
-    /// Driven from the real selection state (not `backgroundStyle`, which AppKit only flips while the
-    /// table is first responder): the hosting `SidebarRowView` re-asserts it from its live `isSelected`
-    /// on attach and on every selection flip, and the coordinator re-runs it on theme changes.
+    /// Color the row text/icon from the terminal theme: a selected row takes the selection foreground (over
+    /// the selection-background pill the row draws), or white over the soft wash when the theme exposes no
+    /// selection color; an unselected row takes the theme foreground, icons dimmed. Driven from the real
+    /// selection state, not `backgroundStyle` (AppKit flips that only while the table is first responder) —
+    /// the hosting `SidebarRowView` re-asserts it from its live `isSelected` on attach and on every selection
+    /// flip, and the coordinator re-runs it on theme changes.
     func setColors(selected: Bool) {
         let app = GhosttyApp.shared
         let color = selected
@@ -110,25 +109,23 @@ final class BadgeView: NSView {
     required init?(coder _: NSCoder) { fatalError("init(coder:) is not supported") }
 
     private static let font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize, weight: .bold)
-    // empty space reserved at the badge's LEADING edge, present only when the badge is shown, so the
-    // capsule keeps air from the status glyph to its left — while a count-0 badge collapses fully and
-    // lets that glyph sit flush at the trailing margin.
+    // space reserved at the badge's LEADING edge only while the badge shows, so the capsule keeps air from
+    // the status glyph to its left; a count-0 badge collapses fully and lets that glyph sit flush.
     private static let leadingGap: CGFloat = 4
     private var textAttributes: [NSAttributedString.Key: Any] { [.font: Self.font, .foregroundColor: NSColor.white] }
     private var label: String { count > 99 ? "99+" : String(count) }
 
     override var intrinsicContentSize: NSSize {
         let height: CGFloat = 16
-        // collapse to zero width when there's nothing to show: `isHidden` alone does NOT collapse a
-        // view in Auto Layout, so a count-0 badge would otherwise reserve a trailing slot and push the
-        // status glyph in from the right edge. zero width lets the name reclaim it and the glyph sit flush.
+        // `isHidden` alone does NOT collapse a view in Auto Layout, so a count-0 badge would reserve a
+        // trailing slot and push the status glyph in from the right edge; zero width lets the name reclaim
+        // it and the glyph sit flush.
         guard count > 0 else { return NSSize(width: 0, height: height) }
         let capsule = max((label as NSString).size(withAttributes: textAttributes).width + 9, height)
         return NSSize(width: capsule + Self.leadingGap, height: height)
     }
 
     override func draw(_: NSRect) {
-        // the capsule occupies bounds minus the reserved leading gap; the status glyph to its left keeps air
         let capsule = NSRect(x: Self.leadingGap, y: 0, width: bounds.width - Self.leadingGap, height: bounds.height)
         let radius = capsule.height / 2
         // systemRed (the conventional unread/notification color) reads on both the dark rows and the
@@ -142,12 +139,11 @@ final class BadgeView: NSView {
     }
 }
 
-/// A small SF-Symbol agent-status glyph drawn just left of the count badge: by default a `circle.fill`
-/// tinted lavender-grey for `active`, amber for `blocked`, green for `completed`. A Settings shape or a
-/// per-call `session.status --shape` swaps in another silhouette, so the shape carries the state
-/// alongside the tint. Hidden on `.idle`. Exposed to accessibility as an
-/// `agent-status` static text whose value is the state name (so XCUITest matches
-/// `app.staticTexts["agent-status"]`; neither the tint nor the silhouette is accessibility-observable).
+/// A small SF-Symbol agent-status glyph drawn just left of the count badge: by default a `circle.fill` tinted
+/// lavender-grey for `active`, amber for `blocked`, green for `completed`; a Settings shape or a per-call
+/// `session.status --shape` swaps the silhouette, so shape carries the state alongside the tint. Hidden on
+/// `.idle`. Exposed to accessibility as an `agent-status` static text whose value is the state name (XCUITest
+/// matches `app.staticTexts["agent-status"]`; neither tint nor silhouette is accessibility-observable).
 /// Blink is a layer `opacity` `CABasicAnimation` (autoreverse/repeat), added only while visible AND blinking.
 final class StatusIconView: NSImageView {
     private static let blinkKey = "agent-status-blink"
@@ -180,7 +176,7 @@ final class StatusIconView: NSImageView {
         guard indicator.status != .idle else {
             isHidden = true
             image = nil
-            widthConstraint.constant = 0 // collapse the slot so the name reads full-width
+            widthConstraint.constant = 0
             setAccessibilityValue(AgentStatus.idle.rawValue)
             stopBlink()
             return
@@ -221,18 +217,17 @@ final class StatusIconView: NSImageView {
 }
 
 /// Row view that draws its own selection pill in `drawBackground`, so the selection is the terminal's
-/// `selection-background` color in every state. The table's `selectionHighlightStyle` is `.none` (set
-/// in `makeNSView`), so AppKit draws nothing of its own — otherwise it paints a gray unemphasized fill
-/// whenever the sidebar isn't first responder (the normal case, since focus lives in the terminal),
-/// which would override a custom `drawSelection`. `isEmphasized` is overridden so the row redraws when
-/// the window's key state changes (the brightness dims for a background window).
+/// `selection-background` color in every state. The table's `selectionHighlightStyle` is `.none` (set in
+/// `makeNSView`), so AppKit draws nothing of its own — otherwise it paints a gray unemphasized fill whenever
+/// the sidebar isn't first responder (the normal case, since focus lives in the terminal), overriding a
+/// custom `drawSelection`. `isEmphasized` is overridden so the row redraws on a window key-state change (the
+/// brightness dims for a background window).
 ///
-/// The row view is the single source of truth for the cell's selection tint: `isSelected` (the same
-/// live state the pill draws from) re-tints the hosted `SidebarCellView` whenever AppKit updates it,
-/// and `didAddSubview` tints a cell the moment it attaches. Without this, the pill (drawn live) and
-/// the text color (applied imperatively at cell build) can desync — and on the many themes where
-/// `foreground == selection-background` (the inverted-selection idiom), a stale tint renders the row
-/// text fully invisible.
+/// The row view is the single source of truth for the cell's selection tint: `isSelected` (the state the pill
+/// draws from) re-tints the hosted `SidebarCellView` whenever AppKit updates it, and `didAddSubview` tints a
+/// cell the moment it attaches. Otherwise the live pill and the imperatively-applied text color desync — and
+/// on the many themes where `foreground == selection-background` (the inverted-selection idiom), a stale tint
+/// renders the row text fully invisible.
 final class SidebarRowView: NSTableRowView {
     /// White-wash fallback opacity (themes with no selection color): brighter for the key window,
     /// dimmer for a background one.
@@ -249,9 +244,8 @@ final class SidebarRowView: NSTableRowView {
     override var isSelected: Bool {
         didSet {
             guard isSelected != oldValue else { return }
-            // the pill follows isSelected at draw time; re-tint the cell from the same state so the
-            // text/icon can never keep the other state's color (white-on-white on inverted-selection
-            // themes). AppKit won't redraw on its own with selectionHighlightStyle == .none.
+            // AppKit won't redraw on its own with selectionHighlightStyle == .none; re-tint the cell
+            // from the same state the pill draws from.
             needsDisplay = true
             retintCellViews()
         }
@@ -272,28 +266,23 @@ final class SidebarRowView: NSTableRowView {
         super.drawBackground(in: dirtyRect)
         guard isSelected else { return }
         if let selection = GhosttyApp.shared.terminalSelectionBackgroundColor {
-            // the terminal's own selection color; dim it for a background (non-key) window.
             selection.withAlphaComponent(isEmphasized ? 1 : 0.55).setFill()
         } else {
-            // no theme selection color: a soft white wash, brighter for the key window.
             NSColor(white: 1, alpha: isEmphasized ? Self.keyAlpha : Self.inactiveAlpha).setFill()
         }
         NSBezierPath(roundedRect: bounds.insetBy(dx: 8, dy: 1.5), xRadius: 7, yRadius: 7).fill()
     }
 }
 
-/// A stable reference-type node fed to `NSOutlineView`. NSOutlineView keys item
-/// identity and expansion state by object identity (`===`), so the nodes must be
-/// the SAME instances across reloads — never freshly-allocated structs. The
-/// coordinator caches one node per workspace/session id and reuses it, rebuilding
-/// only the child lists from the store on each reload.
+/// A stable reference-type node fed to `NSOutlineView`, which keys item identity and expansion state by
+/// object identity (`===`) — so nodes must be the SAME instances across reloads, never freshly-allocated
+/// structs. The coordinator caches one per workspace/session id and rebuilds only the child lists per reload.
 final class SidebarNode {
     enum Kind { case workspace, session }
 
     let kind: Kind
     let id: UUID
-    /// Workspace child nodes, repopulated from the store on each rebuild. Empty
-    /// for session nodes.
+    /// Workspace child nodes, repopulated from the store on each rebuild. Empty for session nodes.
     var children: [SidebarNode] = []
 
     init(kind: Kind, id: UUID) {

--- a/agterm/Views/SplitRatioAccessor.swift
+++ b/agterm/Views/SplitRatioAccessor.swift
@@ -3,9 +3,9 @@ import AppKit
 import SwiftUI
 
 /// Bridges to the AppKit `NSSplitView` under SwiftUI's `HSplitView` to (1) persist and restore the split
-/// divider ratio — no public SwiftUI API exposes the divider position — and (2) clip the split's divider out
-/// of the titlebar strip. Attached as a `.background` on the primary pane so its `NSView` lives inside the
-/// split's view tree without becoming a third arranged pane.
+/// divider ratio — no public SwiftUI API exposes the divider position — and (2) clip the split's divider
+/// out of the titlebar strip. Attached as a `.background` on the primary pane so its `NSView` lives inside
+/// the split's view tree without becoming a third arranged pane.
 ///
 /// (1) Once the split has a real width it restores `session.splitRatio` via `setPosition`; on each divider
 /// resize it writes the current left-pane fraction back to the session, which the next `save()` (or the
@@ -13,13 +13,13 @@ import SwiftUI
 ///
 /// (2) In COMPACT mode the SwiftUI `.padding(.top, titlebarHeight)` (30px) lands inside the window's
 /// safe-area band, so the AppKit `NSSplitView` ignores it and grows to the FULL window height (verified:
-/// its frame + both arranged panes span pt 0..windowHeight). The panes' top strip is empty terminal-bg
-/// (invisible against the window bg), but the divider draws BLACK through it — a streak up through the
-/// transparent titlebar. A 48px inset clears the band so normal mode is already bounded. The fix is a
-/// CALayer mask on the split that hides its top `titlebarHeight` strip: a layer mask clips without
-/// reflowing the terminal grid (a SwiftUI `.mask`/`.clipped()` here scrolled the top row away), the panes'
-/// empty top strip is harmless to clip, and it composes with translucency (it reveals the window backing,
-/// never an opaque color over the titlebar).
+/// its frame + both arranged panes span pt 0..windowHeight); the panes' top strip is then empty
+/// terminal-bg (invisible against the window bg), but the divider draws BLACK through it — a streak up
+/// through the transparent titlebar. The 48px inset clears the band, so normal mode is already bounded.
+/// The fix is a CALayer mask hiding the split's top `titlebarHeight` strip: a layer mask clips without
+/// reflowing the terminal grid (a SwiftUI `.mask`/`.clipped()` here scrolled the top row away), the empty
+/// strip is harmless to clip, and it composes with translucency (revealing the window backing, never an
+/// opaque color over the titlebar).
 struct SplitRatioAccessor: NSViewRepresentable {
     let session: Session
     let titlebarHeight: CGFloat
@@ -92,8 +92,8 @@ struct SplitRatioAccessor: NSViewRepresentable {
                 MainActor.assumeIsolated { self?.capture() }
             }
             // `session.resize` stores a new fraction on the session and posts this (object-scoped to the
-            // session) to move the LIVE divider — the programmatic analogue of a user drag. Unlike the
-            // one-shot restore in `layout()`, it fires on every resize command.
+            // session) to move the LIVE divider — the programmatic analogue of a user drag, firing on
+            // every resize command unlike the one-shot restore in `layout()`.
             applyObserver = NotificationCenter.default.addObserver(
                 forName: .agtermApplySplitRatio, object: session, queue: .main) { [weak self] _ in
                 MainActor.assumeIsolated { self?.applyRatio() }
@@ -102,7 +102,7 @@ struct SplitRatioAccessor: NSViewRepresentable {
 
         /// Move the live divider to the session's stored `splitRatio` (set by `session.resize` just before
         /// it posts `.agtermApplySplitRatio`). The follow-on `didResizeSubviews` → `capture()` is a no-op:
-        /// the captured fraction equals the value we just set, so `capture()`'s near-equal guard skips it.
+        /// the captured fraction equals what was just set, so `capture()`'s near-equal guard skips it.
         private func applyRatio() {
             guard !suspended else { restored = false; return }
             guard let split = splitView, let ratio = session.splitRatio else { return }
@@ -113,12 +113,11 @@ struct SplitRatioAccessor: NSViewRepresentable {
             split.setPosition(total * CGFloat(ratio), ofDividerAt: 0)
         }
 
-        /// Mask the split's divider out of the titlebar zone — the strip ABOVE the window's titlebar boundary
-        /// (`titlebarHeight` points from the content top) that the NSSplitView overruns into in compact mode.
-        /// The clip amount is the split's overrun ABOVE that boundary, computed live: ~`titlebarHeight` in
-        /// compact (the split spans the full window) and 0 in normal (the split is already bounded at the
-        /// content top, so clipping a fixed strip would eat real terminal rows). A layer mask, not a frame
-        /// change, so the panes never reflow.
+        /// Mask the split's divider out of the titlebar zone — the strip ABOVE the window's titlebar
+        /// boundary (`titlebarHeight` points from the content top) that the NSSplitView overruns into in
+        /// compact mode. The clip amount is that overrun, computed live: ~`titlebarHeight` in compact (the
+        /// split spans the full window) and 0 in normal (already bounded at the content top, where clipping
+        /// a fixed strip would eat real terminal rows). A layer mask, not a frame change, so panes never reflow.
         private func updateDividerClip() {
             guard let split = splitView, let contentH = split.window?.contentView?.bounds.height else { return }
             split.wantsLayer = true
@@ -150,8 +149,8 @@ struct SplitRatioAccessor: NSViewRepresentable {
             split.layer?.mask = mask // re-assert (SwiftUI may rebuild the split's layer)
         }
 
-        /// Record the current left-pane fraction onto the session, skipping no-op and degenerate values so a
-        /// window resize that keeps the ratio doesn't churn it.
+        /// Record the current left-pane fraction onto the session, skipping no-op and degenerate values so
+        /// a window resize that keeps the ratio doesn't churn it.
         private func capture() {
             guard !suspended else { return }
             guard restored, let split = splitView, let first = split.arrangedSubviews.first else { return }

--- a/agterm/Views/TerminalSearchBar.swift
+++ b/agterm/Views/TerminalSearchBar.swift
@@ -1,9 +1,8 @@
 import SwiftUI
 
-/// A compact search bar shown over the focused terminal pane: a magnifier glyph, a query field, an
-/// "N of M" counter, previous/next chevrons, and a close button. It is decoupled from `Session` — the
-/// caller binds the needle, passes the display string, and the three navigation/close callbacks — so the
-/// bar can be hosted at the `detailPane` level (like the floating overlay) without reaching into the model.
+/// A compact search bar over the focused terminal pane: magnifier glyph, query field, "N of M" counter,
+/// previous/next chevrons, close button. Decoupled from `Session` — the caller binds the needle and passes
+/// the display string plus the three callbacks — so it hosts at `detailPane` level, like the floating overlay.
 struct TerminalSearchBar: View {
     @Binding var needle: String
     let displayText: String
@@ -25,8 +24,7 @@ struct TerminalSearchBar: View {
             TextField("Find", text: $needle)
                 .textFieldStyle(.plain)
                 .foregroundStyle(chromeText)
-                // a fixed, compact field width so the bar stays a narrow right-aligned panel
-                // instead of stretching across the top of the terminal.
+                // fixed compact width, so the bar stays a narrow right-aligned panel, not a full-width strip
                 .frame(width: 150)
                 .focused($fieldFocused)
                 .onSubmit { onNext() }

--- a/agterm/Views/TerminalView.swift
+++ b/agterm/Views/TerminalView.swift
@@ -4,16 +4,14 @@ import SwiftUI
 
 /// Bridges one session's libghostty surface (a `GhosttySurfaceView`) into SwiftUI.
 ///
-/// The surface is owned by the `Session` (`session.surface`), not the
-/// representable. `makeNSView` returns the session's cached surface view,
-/// creating it through the app-supplied `makeSurface` factory on first display;
-/// `dismantleNSView` is a no-op so the surface (and its shell) survives view
-/// churn when switching sessions. Only an explicit `teardown()` frees it.
+/// The surface is owned by the `Session` (`session.surface`), not the representable: `makeNSView` returns
+/// the cached view, creating it through the app-supplied `makeSurface` factory on first display, and
+/// `dismantleNSView` is a no-op so the surface (and its shell) survives view churn across session switches.
+/// Only an explicit `teardown()` frees it.
 ///
-/// The detail pane keeps every session's `TerminalView` mounted (a deck) and toggles visibility +
-/// `isActive` on selection rather than swapping by `.id`, so switching sessions does NOT dismantle/
-/// re-host the surface NSView (a re-host invalidates the Metal drawable and flickers). Surfaces stay
-/// alive regardless.
+/// The detail pane keeps every session's `TerminalView` mounted (a deck), toggling visibility + `isActive`
+/// on selection rather than swapping by `.id`, so a switch never dismantles/re-hosts the surface NSView —
+/// a re-host invalidates the Metal drawable and flickers.
 struct TerminalView: NSViewRepresentable {
     let session: Session
     /// Which surface slot this view binds to: the primary `\.surface` or the split
@@ -25,18 +23,16 @@ struct TerminalView: NSViewRepresentable {
     /// Whether this is the active (visible) pane in the deck. Every session's surface stays mounted, so
     /// a view only auto-grabs focus when active — otherwise every mounted pane would fight for it.
     var isActive = true
-    /// Whether this pane is on-screen (its session is selected and not hidden by a full overlay/scratch).
-    /// UNLIKE `isActive` this is NOT split-focus-gated: both panes of a visible split are `deckVisible`.
-    /// Drives `GhosttySurfaceView`'s drag-type (un)registration so a file drop can't land on an invisible
-    /// background surface.
+    /// Whether this pane is on-screen (its session selected and not hidden by a full overlay/scratch). UNLIKE
+    /// `isActive` it is NOT split-focus-gated — both panes of a visible split are `deckVisible`. Drives the
+    /// drag-type (un)registration, so a file drop can't land on an invisible background surface.
     var deckVisible = true
     /// False for the terminal-zoom host: zoom reparenting/focus must not mutate session state such as
     /// `splitFocused`, but libghostty should still receive normal focus updates.
     var reportsFocusChange = true
     /// True for the view-only dashboard grid cell: the surface renders but takes NO mouse or keyboard input,
     /// so it never grabs first responder from the dashboard's key-catcher. `.allowsHitTesting(false)` alone
-    /// doesn't stop AppKit routing a click to the real NSView, so the surface itself refuses hits + first
-    /// responder (`GhosttySurfaceView.viewOnly`).
+    /// doesn't stop AppKit routing a click to the NSView, so the surface itself refuses hits + first responder.
     var viewOnly = false
 
     func makeCoordinator() -> Coordinator { Coordinator() }
@@ -60,14 +56,14 @@ struct TerminalView: NSViewRepresentable {
         nsView.deckVisible = deckVisible
         nsView.suppressFocusChange = !reportsFocusChange
         nsView.viewOnly = viewOnly
-        // makeNSView may have run before the view had a sized window; createSurface is idempotent
-        // (guards surface == nil and a non-zero backing size), so calling it here is safe. Synchronous
-        // on purpose: a deferred next-tick create races the layout and gives the surface a stale size.
+        // makeNSView may have run before the view had a sized window; createSurface is idempotent (guards
+        // surface == nil and a non-zero backing size). synchronous on purpose: a deferred next-tick create
+        // races the layout and gives the surface a stale size.
         nsView.createSurface()
         guard isActive else {
-            // hidden deck pane: drop the focus latch so it re-grabs when it next becomes active, and
-            // never keep first responder while hidden — the active pane needs it, and a background pane
-            // that still looks "focused" wrongly suppresses its own OSC 9 desktop notification.
+            // hidden deck pane: drop the focus latch so it re-grabs when next active, and never hold first
+            // responder while hidden — the active pane needs it, and a background pane that still looks
+            // "focused" wrongly suppresses its own OSC 9 desktop notification.
             context.coordinator.didFocus = false
             if let window = nsView.window, window.firstResponder === nsView { window.makeFirstResponder(nil) }
             return
@@ -75,21 +71,17 @@ struct TerminalView: NSViewRepresentable {
         focusIfNeeded(nsView, coordinator: context.coordinator)
     }
 
-    /// Grabs first responder for this session's surface only when it is the
-    /// natural focus target, so unrelated detail-pane re-renders (window resize,
-    /// observable invalidations) don't steal focus.
+    /// Grabs first responder for this session's surface only when it is the natural focus target, so
+    /// unrelated detail-pane re-renders (window resize, observable invalidations) don't steal focus.
     ///
-    /// Focus is taken once, when this representable first attaches to a window
-    /// (each terminal host carries stable session + surface identity, so replacing
-    /// the hosted surface creates a fresh representable). On later updates focus is left
-    /// alone unless the surface already holds it — and never grabbed while a text
-    /// field editor is first responder, so editing a sidebar rename survives a
-    /// re-render. Mouse clicks (`mouseDown`) cover focus for the rest.
+    /// Focus is taken once, when the representable first attaches to a window (each terminal host carries
+    /// stable session + surface identity, so replacing the hosted surface makes a fresh representable). Later
+    /// updates leave it alone unless the surface already holds it, and never grab it while a text field editor
+    /// is first responder, so editing a sidebar rename survives a re-render. `mouseDown` covers the rest.
     private func focusIfNeeded(_ nsView: GhosttySurfaceView, coordinator: Coordinator) {
         guard let window = nsView.window else { return }
         if window.firstResponder === nsView { return }
-        // don't steal focus from an active text field editor (e.g. a sidebar
-        // rename TextField); its field editor is an NSText serving the window.
+        // don't steal focus from an active text field editor (a sidebar rename); its editor is an NSText.
         if window.firstResponder is NSText { return }
         guard !coordinator.didFocus else { return }
         coordinator.didFocus = true
@@ -97,12 +89,11 @@ struct TerminalView: NSViewRepresentable {
     }
 
     static func dismantleNSView(_: GhosttySurfaceView, coordinator _: Coordinator) {
-        // No-op: the surface outlives the representable and is owned by the
-        // session. Only an explicit teardown() may free it.
+        // no-op: the surface outlives the representable; only an explicit teardown() may free it.
     }
 
-    /// Tracks whether this representable has already claimed first responder, so
-    /// focus is grabbed only on first attach, not on every `updateNSView`.
+    /// Tracks whether this representable already claimed first responder, so focus is grabbed on first
+    /// attach only, not on every `updateNSView`.
     final class Coordinator {
         var didFocus = false
     }

--- a/agterm/Views/UndoCloseShortcut.swift
+++ b/agterm/Views/UndoCloseShortcut.swift
@@ -38,12 +38,11 @@ final class UndoCloseShortcut {
         if flags.contains(.option) { mods.insert(.option) }
         if flags.contains(.shift) { mods.insert(.shift) }
 
-        // a layout that cannot type ASCII resolves to the Latin key at the same physical position, so ⌘Z
-        // still reopens a closed item on a Cyrillic layout (where that key types `я`). Unlike
-        // `CustomCommandRunner.chord(from:)` the produced character here KEEPS shift (`shift+/` reports
-        // `?`), so a shifted-symbol chord does not match on a Latin layout — pre-existing, and the reason
-        // this monitor's `NSEvent` seam is the testable one (a synthesized event reports this accessor
-        // verbatim).
+        // a layout that cannot type ASCII resolves to the Latin key at the same physical position, so ⌘Z still
+        // reopens a closed item on a Cyrillic layout (where that key types `я`). unlike
+        // `CustomCommandRunner.chord(from:)` the produced character here KEEPS shift (`shift+/` reports `?`),
+        // so a shifted-symbol chord does not match on a Latin layout — pre-existing, and why this monitor's
+        // `NSEvent` seam is the testable one (a synthesized event reports this accessor verbatim).
         let key = namedKey(forKeyCode: event.keyCode)
             ?? chordKey(forKeyCode: event.keyCode, produced: event.charactersIgnoringModifiers,
                         layoutIsASCIICapable: KeyboardLayout.isASCIICapable)

--- a/agterm/Views/WindowAccessor.swift
+++ b/agterm/Views/WindowAccessor.swift
@@ -2,14 +2,12 @@ import agtermCore
 import AppKit
 import SwiftUI
 
-/// Blends the window title bar with the terminal (the title text itself comes from SwiftUI's
-/// `.navigationTitle`/`.navigationSubtitle`). The probe's `window` is nil at make time, so the blend is
-/// applied from `viewDidMoveToWindow` (window attachment) and re-applied on every `titleToken` change
-/// (session switch) and on the window key/fullscreen transitions where AppKit rebuilds the titlebar subviews.
-///
-/// It also carries the per-window plumbing: persisting/restoring the frame, reporting frontmost (key/main)
-/// and close (`willClose`) to the `WindowLibrary`, and registering the `NSWindow` in `WindowRegistry` for
-/// dedup/raise.
+/// Blends the window title bar with the terminal (the title text comes from SwiftUI's
+/// `.navigationTitle`/`.navigationSubtitle`): the probe's `window` is nil at make time, so the blend is
+/// applied from `viewDidMoveToWindow` and re-applied on every `titleToken` change (session switch) and the
+/// key/fullscreen transitions where AppKit rebuilds the titlebar subviews. It also carries the per-window
+/// plumbing: persisting/restoring the frame, reporting frontmost (key/main) and close (`willClose`) to the
+/// `WindowLibrary`, and registering the `NSWindow` in `WindowRegistry`.
 struct WindowAccessor: NSViewRepresentable {
     /// Changes when the active session changes, so `updateNSView` re-runs the blend.
     let titleToken: String
@@ -30,8 +28,7 @@ struct WindowAccessor: NSViewRepresentable {
         private let library: WindowLibrary
         private let store: AppStore
 
-        /// Observer tokens for window key/fullscreen transitions, after which AppKit
-        /// rebuilds the titlebar subviews and the blend must be re-applied.
+        /// Observer tokens: AppKit rebuilds the titlebar subviews on key/fullscreen, so the blend re-applies.
         nonisolated(unsafe) private var titlebarObservers: [NSObjectProtocol] = []
 
         /// One-shot guard so the saved frame is applied exactly once per window attach.
@@ -50,12 +47,10 @@ struct WindowAccessor: NSViewRepresentable {
         @available(*, unavailable)
         required init?(coder _: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
-        /// The current window title ("session — window"). Set on the OS window (for the window menu and
-        /// XCUITest title-matching) but hidden via titleVisibility, since our custom header draws the
-        /// visible one.
+        /// The current window title ("session — window"). Set on the OS window for the window menu and
+        /// XCUITest title-matching, but hidden via titleVisibility — the custom header draws the visible one.
         private var latestTitle = ""
 
-        /// Re-apply the blend with the latest title (called from `updateNSView` on a session switch).
         func reapplyBlend(title: String) {
             latestTitle = title
             if let window { applyTitlebarBlend(window) }
@@ -67,19 +62,18 @@ struct WindowAccessor: NSViewRepresentable {
             titlebarObservers.removeAll()
             guard let window else { return }
             // the app owns its window set (WindowLibrary + windows.json reopen-all); SwiftUI's WindowGroup
-            // restoration only fights it, re-creating empty stray windows from the remembered count (shared
-            // by bundle id, not isolated). Opt every real window fully out so that set never grows.
+            // restoration re-creates empty strays from its remembered count (shared by bundle id, not
+            // isolated), so opt every real window fully out.
             window.isRestorable = false
             window.restorationClass = nil
             window.disableSnapshotRestoration()
             window.invalidateRestorableState()
             frameRestored = false
-            // per-window geometry keyed by OUR window id. SwiftUI's WindowGroup autosaves frames under its
-            // own index-based name ("terminal-AppWindow-N"), OVERRIDES any setFrameAutosaveName, and that
-            // index loses a window's identity across an in-session close/reopen, landing the reopened window
-            // on the wrong/default slot. So the frame is persisted on close under the stable window UUID in
-            // UserDefaults and re-applied here AFTER SwiftUI's initial .defaultSize pass — on window-key
-            // plus a short delayed fallback, one-shot via `frameRestored`.
+            // per-window geometry keyed by OUR window id: SwiftUI's WindowGroup autosaves under its own
+            // index-based name ("terminal-AppWindow-N"), OVERRIDES any setFrameAutosaveName, and that index
+            // loses a window's identity across an in-session close/reopen, landing it on the wrong slot. so
+            // the frame is persisted on close under the stable window UUID and re-applied here, one-shot,
+            // AFTER SwiftUI's initial .defaultSize pass.
             let frameKeyToken = NotificationCenter.default.addObserver(
                 forName: NSWindow.didBecomeKeyNotification, object: window, queue: .main) { [weak self, weak window] _ in
                 DispatchQueue.main.async {
@@ -88,15 +82,14 @@ struct WindowAccessor: NSViewRepresentable {
                 }
             }
             titlebarObservers.append(frameKeyToken)
-            // fallback on the next run-loop tick (not a fixed delay) so the saved frame snaps in as soon
-            // as SwiftUI's initial sizing pass is done, minimizing the visible default-then-resize.
+            // fallback on the next run-loop tick, not a fixed delay, so the saved frame snaps in as soon as
+            // SwiftUI's initial sizing pass ends, minimizing the visible default-then-resize.
             DispatchQueue.main.async { [weak self, weak window] in
                 guard let self, let window, self.window === window else { return }
                 self.restoreSavedFrame(window)
             }
             // attach-race guard: a window.close that dropped this store mid-attach (window.new immediately
-            // followed by window.close) leaves a zombie — close it rather than register an orphaned
-            // on-screen window for a now-closed id.
+            // followed by window.close) leaves a zombie — close it rather than register it for a closed id.
             guard library.isOpen(windowID) else {
                 DispatchQueue.main.async { [weak window] in
                     window?.orderOut(nil)
@@ -104,8 +97,7 @@ struct WindowAccessor: NSViewRepresentable {
                 }
                 return
             }
-            // register the NSWindow so the app can raise an already-open window for this id (dedup)
-            // instead of spawning a second; install the confirm-before-close delegate proxy.
+            // register the NSWindow so the app raises this id's window (dedup) instead of spawning a second.
             WindowRegistry.shared.register(windowID, window: window)
             ensureCloseProxy(on: window)
             applyTitlebarBlend(window)
@@ -117,15 +109,14 @@ struct WindowAccessor: NSViewRepresentable {
                 self.applyTitlebarBlend(window)
             }
             // AppKit rebuilds the titlebar subviews and re-renders the sidebar Liquid Glass on
-            // key/main/fullscreen transitions (becomeKey fires right at launch), undoing the cleared titlebar
-            // layer and the glass tint — so re-apply on every transition, resign included, or a background
-            // window falls back to the lighter default glass. Only becomeKey/becomeMain mean frontmost.
+            // key/main/fullscreen transitions (becomeKey fires at launch), undoing the cleared titlebar layer
+            // and glass tint — re-apply on every transition, resign included, or a background window falls
+            // back to the lighter default glass.
             let frontmostNames: Set<NSNotification.Name> = [NSWindow.didBecomeKeyNotification, NSWindow.didBecomeMainNotification]
             for name in [NSWindow.didBecomeKeyNotification, NSWindow.didBecomeMainNotification,
                          NSWindow.didResignKeyNotification, NSWindow.didResignMainNotification,
                          NSWindow.didEnterFullScreenNotification, NSWindow.didExitFullScreenNotification] {
-                // the @Sendable observer block must not touch main-actor state directly; hop through
-                // DispatchQueue.main like the re-applies above.
+                // the @Sendable observer block can't touch main-actor state directly; hop through the main queue.
                 let token = NotificationCenter.default.addObserver(forName: name, object: window, queue: .main) { [windowID] notification in
                     let becameFrontmost = frontmostNames.contains(notification.name)
                     DispatchQueue.main.async { [weak self] in
@@ -136,26 +127,23 @@ struct WindowAccessor: NSViewRepresentable {
                 }
                 titlebarObservers.append(token)
             }
-            // report close: tear down this window's surfaces, then mark it closed in the library.
-            // capture library/store/id directly (NOT through `self`) — the view is being deallocated
-            // as the window closes, so a `[weak self]` hop would no-op and the index would never update.
+            // report close: tear down surfaces, then mark closed. captures library/store/id directly, NOT
+            // `self` — the view deallocates as the window closes, so a `[weak self]` hop would no-op.
             let closeToken = NotificationCenter.default.addObserver(forName: NSWindow.willCloseNotification, object: window, queue: .main) { [library, store, windowID, weak window] _ in
                 MainActor.assumeIsolated {
-                    // persist this window's final frame (keyed by its id) so an in-session reopen — or
-                    // a restart — restores its size/position. SwiftUI's own index-based autosave can't.
+                    // persist the final frame (keyed by its id) so an in-session reopen or a restart restores
+                    // size/position; SwiftUI's own index-based autosave can't.
                     if let window {
                         UserDefaults.standard.set(NSStringFromRect(window.frame), forKey: TitleProbeView.frameKey(windowID))
                     }
                     WindowRegistry.shared.unregister(windowID)
-                    // unregister synchronously on the real AppKit close edge: the registry cancels any
-                    // pending pick and retains its result for a poll arriving after this window and its
-                    // store have disappeared.
+                    // unregister synchronously on the real AppKit close edge: the registry cancels any pending
+                    // pick and retains its result for a poll arriving after the window and store are gone.
                     PickRegistry.shared.unregister(windowID)
                     store.finalizeAllPendingCloses()
-                    // flush cwd drift since the last structural mutation before dropping the store —
-                    // AppStore doesn't save on a live `cd`, so a closed-then-reopened window would load a
-                    // stale snapshot. Skipped when the window is no longer open in the library: a delete
-                    // already dropped the store + removed the per-window file, so this would resurrect it.
+                    // flush cwd drift before dropping the store — AppStore doesn't save on a live `cd`, so a
+                    // reopened window would load a stale snapshot. skipped once the window is no longer open:
+                    // a delete already dropped the store and removed the per-window file, so this resurrects it.
                     if library.isOpen(windowID) { store.save() }
                     for session in store.workspaces.flatMap(\.sessions) {
                         session.surface?.teardown()
@@ -164,16 +152,16 @@ struct WindowAccessor: NSViewRepresentable {
                         session.scratchSurface?.teardown()
                     }
                     library.closeWindow(windowID)
-                    // closing a window drops its (unobserved) store, so the Dock badge's observation
-                    // tracking won't fire — refresh explicitly to drop this window's unseen total. Guarded
-                    // on isTerminating: on quit willClose fires after applicationWillTerminate's clear() and
-                    // closeWindow no-ops (stores stay loaded), so a refresh would re-pin the zeroed badge.
+                    // closing a window drops its (unobserved) store, so the Dock badge's observation won't
+                    // fire — refresh explicitly. guarded on isTerminating: at quit willClose fires after
+                    // applicationWillTerminate's clear() and closeWindow no-ops (stores stay loaded), so the
+                    // refresh would re-pin the zeroed badge.
                     if !library.isTerminating { DockBadgeController.shared.refresh() }
                 }
             }
             titlebarObservers.append(closeToken)
-            // a settings theme change updates GhosttyApp.terminalBackgroundColor; re-apply the blend so the
-            // title bar and the transparent sidebar pick up the new window color live, not on the next re-key.
+            // a settings theme change updates GhosttyApp.terminalBackgroundColor; re-apply so the title bar
+            // and transparent sidebar pick up the new window color live, not on the next re-key.
             let appearanceToken = NotificationCenter.default.addObserver(forName: .agtermAppearanceChanged, object: nil, queue: .main) { _ in
                 DispatchQueue.main.async { [weak self] in
                     guard let self, let window = self.window else { return }
@@ -192,14 +180,13 @@ struct WindowAccessor: NSViewRepresentable {
             }
             titlebarObservers.append(accessibilityToken)
             // a window restored miniaturized isn't on-screen, so a fresh launch shows nothing and UI-test
-            // automation has nothing to hit. Bring it forward un-minimized, re-asserting next tick because
+            // automation has nothing to hit. bring it forward un-minimized, re-asserted next tick because
             // state restoration can re-apply the miniaturized state right after the view attaches.
             bringForward(window)
             DispatchQueue.main.async { [weak self] in self?.bringForward(window) }
             scheduleUITestWindowForward(window)
-            // the window may already be key: a reopened/raised window can become key DURING creation, before
-            // these observers exist, so that initial didBecomeKey was missed (and bringForward above is a
-            // no-op). Report frontmost explicitly so the palette/session switcher route to THIS window.
+            // a reopened/raised window can become key DURING creation, before these observers exist, missing
+            // that initial didBecomeKey. report frontmost so the palette/session switcher route to THIS window.
             if window.isKeyWindow || window.isMainWindow { reportFrontmost(windowID) }
         }
 
@@ -209,24 +196,23 @@ struct WindowAccessor: NSViewRepresentable {
 
         /// Record this window as frontmost in the library and persist the index. The persist and the
         /// frontmost-changed post are gated on an ACTUAL change, so the paired `didBecomeKey`/`didBecomeMain`
-        /// (and a re-key of the same window) collapse to one write instead of a per-focus-change storm.
+        /// (and a re-key) collapse to one write instead of a per-focus-change storm.
         @MainActor private func reportFrontmost(_ id: WindowInfo.ID) {
             let changed = library.frontmostWindowID != id
             if changed {
                 library.frontmostWindowID = id
                 library.saveIndex()
             }
-            // auto-hide-inactive-sidebars: reconcile on EVERY activation report, even when the frontmost id
-            // is unchanged — `newWindow()` pre-sets `frontmostWindowID` before the window keys and launch
+            // auto-hide-inactive-sidebars: reconcile on EVERY activation report, even when the id is
+            // unchanged — `newWindow()` pre-sets `frontmostWindowID` before the window keys and launch
             // restores it, so a changed-only gate would leave the prior window's sidebar showing (or the
-            // restored frontmost collapsed). Runs AFTER `frontmostWindowID` is set so `activeWindowID`
-            // resolves to this window, and is idempotent, so an unchanged re-key is cheap. Only fires on
-            // becomeKey/becomeMain, never resign, so switching to another app leaves every sidebar untouched.
+            // restored frontmost collapsed). runs AFTER `frontmostWindowID` is set so `activeWindowID`
+            // resolves here; never on resign, so switching apps leaves every sidebar untouched.
             if GhosttyApp.shared.autoHideSidebarInactiveWindows {
                 library.applyInactiveWindowSidebarHiding()
             }
-            // the active-window change is async; let the control server refresh its cached window list
-            // so a `window.list` poll sees the new `active` flag without waiting for the next command.
+            // the active-window change is async; let the control server refresh its cached window list so a
+            // `window.list` poll sees the new `active` flag without waiting for the next command.
             if changed {
                 NotificationCenter.default.post(name: .agtermWindowFrontmostChanged, object: nil)
             }
@@ -237,12 +223,11 @@ struct WindowAccessor: NSViewRepresentable {
             window.makeKeyAndOrderFront(nil)
         }
 
-        /// UserDefaults key for this window's saved frame, keyed by the stable window UUID (NOT
-        /// SwiftUI's index-based autosave name, which it overrides and which doesn't track identity).
+        /// UserDefaults key for this window's saved frame, keyed by the stable window UUID.
         static func frameKey(_ id: WindowInfo.ID) -> String { "agterm-frame-\(id.uuidString)" }
 
-        /// Applies the saved frame for this window id, once. Deferred (window-key / next tick) so
-        /// SwiftUI's initial `.defaultSize` pass has run and won't clobber the restored geometry.
+        /// Applies the saved frame for this window id, once. Deferred (window-key / next tick) so SwiftUI's
+        /// initial `.defaultSize` pass has run and won't clobber the restored geometry.
         private func restoreSavedFrame(_ window: NSWindow) {
             guard !frameRestored else { return }
             frameRestored = true
@@ -252,9 +237,9 @@ struct WindowAccessor: NSViewRepresentable {
             window.setFrame(Self.constrainedRestoredFrame(frame, for: window), display: true)
         }
 
-        /// Normalize a persisted frame before restore. A saved `NSRect` may come from a display that is
-        /// no longer attached; applying it directly can put the relaunched window entirely off-screen.
-        /// Keep the saved size/position when possible, but fully contain it on a current screen.
+        /// Normalize a persisted frame before restore: a saved `NSRect` may come from a display no longer
+        /// attached, which would put the relaunched window entirely off-screen. Keeps the saved size/position
+        /// where possible, fully contained on a current screen.
         private static func constrainedRestoredFrame(_ frame: NSRect, for window: NSWindow) -> NSRect {
             let screens = NSScreen.screens
             guard !screens.isEmpty, let fallback = window.screen ?? NSScreen.main ?? screens.first else { return frame }
@@ -269,7 +254,7 @@ struct WindowAccessor: NSViewRepresentable {
         }
 
         /// Installs (or re-asserts) the confirm-before-close proxy as the window's delegate, chaining to
-        /// whatever delegate SwiftUI set. No-op when it's already the delegate.
+        /// whatever delegate SwiftUI set.
         private func ensureCloseProxy(on window: NSWindow) {
             if closeProxy == nil {
                 closeProxy = WindowCloseDelegateProxy(windowID: windowID, library: library, store: store)
@@ -281,8 +266,8 @@ struct WindowAccessor: NSViewRepresentable {
             }
         }
 
-        /// Re-assert the window forward under XCUITest: the FB11763863 reopen can present it slightly
-        /// after the view attaches, so keep ordering it front for a short schedule.
+        /// Re-assert the window forward under XCUITest: the FB11763863 reopen can present it slightly after
+        /// the view attaches, so keep ordering it front for a short schedule.
         private func scheduleUITestWindowForward(_ window: NSWindow) {
             guard ContentView.isUITestLaunch else { return }
             let delays: [TimeInterval] = [0, 0.05, 0.15, 0.35, 0.7, 0.95]
@@ -297,12 +282,12 @@ struct WindowAccessor: NSViewRepresentable {
         /// One-shot latch so the per-window retry presents this window at most once.
         private var didPresentForUITests = false
         private func bringForwardForUITests(_ window: NSWindow) {
-            // present a window that isn't on screen yet (FB11763863: created minimized/background), then
-            // latch off — re-fronting on later ticks (or a momentary !isVisible during a re-render) would
-            // fight a deliberate window.select and oscillate the key window, flapping the "active" flag.
+            // present a window that isn't on screen yet (FB11763863: created minimized/background), then latch
+            // off — re-fronting on a later tick (or a momentary !isVisible during a re-render) would fight a
+            // deliberate window.select and oscillate the key window.
             guard !didPresentForUITests else { return }
-            // already on screen: it presented itself, so latch NOW — leaving the remaining ticks armed is
-            // the same hazard one step later, dragging a window.minimize-parked window back out of the Dock.
+            // already on screen: it presented itself, so latch NOW — leaving the remaining ticks armed is the
+            // same hazard one step later, dragging a window.minimize-parked window back out of the Dock.
             guard window.isMiniaturized || !window.isVisible else {
                 didPresentForUITests = true
                 return
@@ -327,8 +312,8 @@ struct WindowAccessor: NSViewRepresentable {
     }
 }
 
-// CoreGraphics <-> host-free WindowGeometry conversions for restore-frame clamping. The arithmetic lives
-// in agtermCore so display-selection and off-screen restore edge cases stay unit-testable.
+// CoreGraphics <-> host-free WindowGeometry conversions for restore-frame clamping. the arithmetic lives in
+// agtermCore so display-selection and off-screen restore edge cases stay unit-testable.
 private extension WindowGeometry.Size {
     init(_ cg: CGSize) { self.init(width: Double(cg.width), height: Double(cg.height)) }
 }
@@ -345,11 +330,10 @@ private extension WindowGeometry.Rect {
     }
 }
 
-/// Forwarding `NSWindowDelegate` that adds a confirm-before-close for a window with running sessions,
-/// forwarding every other delegate call to whatever delegate SwiftUI installed. Owned strongly by
-/// `TitleProbeView` (`NSWindow.delegate` is weak). Intercepts USER-driven closes (red button, File ▸
-/// Close); the programmatic `WindowRegistry.close` uses `window.close()` and skips `windowShouldClose`,
-/// so Delete Window / agtermctl don't double-prompt.
+/// Forwarding `NSWindowDelegate` adding a confirm-before-close for a window with running sessions, passing
+/// every other call to whatever delegate SwiftUI installed. Owned strongly by `TitleProbeView`
+/// (`NSWindow.delegate` is weak). Intercepts USER closes (red button, File ▸ Close); `WindowRegistry.close`
+/// uses `window.close()`, which skips `windowShouldClose`, so Delete Window / agtermctl don't double-prompt.
 @MainActor
 private final class WindowCloseDelegateProxy: NSObject, NSWindowDelegate {
     nonisolated(unsafe) weak var forwardingDelegate: NSObjectProtocol?
@@ -381,8 +365,8 @@ private final class WindowCloseDelegateProxy: NSObject, NSWindowDelegate {
             MainActor.assumeIsolated {
                 self.sheetOpen = false
                 guard response == .alertFirstButtonReturn else { return }
-                // force-close: close() doesn't re-enter windowShouldClose (no re-prompt) but still runs
-                // the willClose teardown + library mark-closed. The user already confirmed.
+                // close() doesn't re-enter windowShouldClose (no re-prompt) but still runs the willClose
+                // teardown + library mark-closed.
                 sender.close()
             }
         }
@@ -394,7 +378,7 @@ private final class WindowCloseDelegateProxy: NSObject, NSWindowDelegate {
     }
 
     // forward every other NSWindowDelegate selector to SwiftUI's delegate so its window bookkeeping
-    // (willClose, didResize, …) still runs. Called by the ObjC runtime; reads the weak forward target.
+    // (willClose, didResize, …) still runs. called by the ObjC runtime; reads the weak forward target.
     nonisolated override func responds(to selector: Selector!) -> Bool {
         super.responds(to: selector) || (forwardingDelegate?.responds(to: selector) ?? false)
     }

--- a/agterm/Views/WindowAccessor.swift
+++ b/agterm/Views/WindowAccessor.swift
@@ -2,15 +2,14 @@ import agtermCore
 import AppKit
 import SwiftUI
 
-/// Blends the window title bar with the terminal (the title text itself is set by
-/// SwiftUI's `.navigationTitle`/`.navigationSubtitle`). The probe's `window` is nil at
-/// make time, so the blend is applied from `viewDidMoveToWindow` (window attachment) and
-/// re-applied on every `titleToken` change (session switch) and on the window key/
-/// fullscreen transitions where AppKit rebuilds the titlebar subviews.
+/// Blends the window title bar with the terminal (the title text itself comes from SwiftUI's
+/// `.navigationTitle`/`.navigationSubtitle`). The probe's `window` is nil at make time, so the blend is
+/// applied from `viewDidMoveToWindow` (window attachment) and re-applied on every `titleToken` change
+/// (session switch) and on the window key/fullscreen transitions where AppKit rebuilds the titlebar subviews.
 ///
-/// It also carries the per-window plumbing: it sets the frame autosave name, reports
-/// frontmost (key/main) and close (`willClose`) to the `WindowLibrary`, and registers the
-/// `NSWindow` in `WindowRegistry` for dedup/raise.
+/// It also carries the per-window plumbing: persisting/restoring the frame, reporting frontmost (key/main)
+/// and close (`willClose`) to the `WindowLibrary`, and registering the `NSWindow` in `WindowRegistry` for
+/// dedup/raise.
 struct WindowAccessor: NSViewRepresentable {
     /// Changes when the active session changes, so `updateNSView` re-runs the blend.
     let titleToken: String
@@ -51,9 +50,9 @@ struct WindowAccessor: NSViewRepresentable {
         @available(*, unavailable)
         required init?(coder _: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
-        /// The current window title ("session — window"). Set on the OS window (for the window menu
-        /// and XCUITest title-matching) but kept visually hidden via titleVisibility, since our custom
-        /// header renders the visible title.
+        /// The current window title ("session — window"). Set on the OS window (for the window menu and
+        /// XCUITest title-matching) but hidden via titleVisibility, since our custom header draws the
+        /// visible one.
         private var latestTitle = ""
 
         /// Re-apply the blend with the latest title (called from `updateNSView` on a session switch).
@@ -67,22 +66,20 @@ struct WindowAccessor: NSViewRepresentable {
             titlebarObservers.forEach(NotificationCenter.default.removeObserver)
             titlebarObservers.removeAll()
             guard let window else { return }
-            // the app owns its window set (WindowLibrary + windows.json reopen-all); SwiftUI's own
-            // WindowGroup restoration only fights that by re-creating empty stray windows from the
-            // remembered window count (shared by bundle id, not isolated). Opt every real window fully
-            // out of AppKit/SwiftUI restoration so that remembered set never grows.
+            // the app owns its window set (WindowLibrary + windows.json reopen-all); SwiftUI's WindowGroup
+            // restoration only fights it, re-creating empty stray windows from the remembered count (shared
+            // by bundle id, not isolated). Opt every real window fully out so that set never grows.
             window.isRestorable = false
             window.restorationClass = nil
             window.disableSnapshotRestoration()
             window.invalidateRestorableState()
             frameRestored = false
-            // per-window geometry keyed by OUR window id. SwiftUI's WindowGroup autosaves frames under
-            // its own index-based name ("terminal-AppWindow-N") and OVERRIDES any setFrameAutosaveName
-            // we set — and that index doesn't track a window's identity across an in-session
-            // close/reopen, so the reopened window lands on the wrong/default slot. Instead we persist
-            // the frame ourselves on close (keyed by the stable window UUID, in UserDefaults) and
-            // re-apply it here AFTER SwiftUI's initial .defaultSize pass — on window-key plus a short
-            // delayed fallback — one-shot via `frameRestored`.
+            // per-window geometry keyed by OUR window id. SwiftUI's WindowGroup autosaves frames under its
+            // own index-based name ("terminal-AppWindow-N"), OVERRIDES any setFrameAutosaveName, and that
+            // index loses a window's identity across an in-session close/reopen, landing the reopened window
+            // on the wrong/default slot. So the frame is persisted on close under the stable window UUID in
+            // UserDefaults and re-applied here AFTER SwiftUI's initial .defaultSize pass — on window-key
+            // plus a short delayed fallback, one-shot via `frameRestored`.
             let frameKeyToken = NotificationCenter.default.addObserver(
                 forName: NSWindow.didBecomeKeyNotification, object: window, queue: .main) { [weak self, weak window] _ in
                 DispatchQueue.main.async {
@@ -97,9 +94,9 @@ struct WindowAccessor: NSViewRepresentable {
                 guard let self, let window, self.window === window else { return }
                 self.restoreSavedFrame(window)
             }
-            // attach-race guard: if a window.close dropped this window's store while it was still
-            // attaching (window.new immediately followed by window.close), it's a zombie — close it
-            // rather than register and leave an orphaned on-screen window for a now-closed id.
+            // attach-race guard: a window.close that dropped this store mid-attach (window.new immediately
+            // followed by window.close) leaves a zombie — close it rather than register an orphaned
+            // on-screen window for a now-closed id.
             guard library.isOpen(windowID) else {
                 DispatchQueue.main.async { [weak window] in
                     window?.orderOut(nil)
@@ -120,16 +117,15 @@ struct WindowAccessor: NSViewRepresentable {
                 self.applyTitlebarBlend(window)
             }
             // AppKit rebuilds the titlebar subviews and re-renders the sidebar Liquid Glass on
-            // key/main/fullscreen transitions (becomeKey fires right at launch), undoing the cleared
-            // titlebar layer and the glass tint — re-apply on every transition, including resign so a
-            // background window keeps the terminal tint instead of the lighter default glass. Only
-            // becomeKey/becomeMain mean this window became frontmost; resign/fullscreen do not.
+            // key/main/fullscreen transitions (becomeKey fires right at launch), undoing the cleared titlebar
+            // layer and the glass tint — so re-apply on every transition, resign included, or a background
+            // window falls back to the lighter default glass. Only becomeKey/becomeMain mean frontmost.
             let frontmostNames: Set<NSNotification.Name> = [NSWindow.didBecomeKeyNotification, NSWindow.didBecomeMainNotification]
             for name in [NSWindow.didBecomeKeyNotification, NSWindow.didBecomeMainNotification,
                          NSWindow.didResignKeyNotification, NSWindow.didResignMainNotification,
                          NSWindow.didEnterFullScreenNotification, NSWindow.didExitFullScreenNotification] {
-                // the observer block is @Sendable, so it must not touch main-actor state
-                // directly; hop through DispatchQueue.main like the re-applies above.
+                // the @Sendable observer block must not touch main-actor state directly; hop through
+                // DispatchQueue.main like the re-applies above.
                 let token = NotificationCenter.default.addObserver(forName: name, object: window, queue: .main) { [windowID] notification in
                     let becameFrontmost = frontmostNames.contains(notification.name)
                     DispatchQueue.main.async { [weak self] in
@@ -151,16 +147,15 @@ struct WindowAccessor: NSViewRepresentable {
                         UserDefaults.standard.set(NSStringFromRect(window.frame), forKey: TitleProbeView.frameKey(windowID))
                     }
                     WindowRegistry.shared.unregister(windowID)
-                    // Unregister synchronously on the real AppKit close edge. The registry cancels any
-                    // pending pick and retains its result for a poll that arrives after this window and
-                    // its store have disappeared.
+                    // unregister synchronously on the real AppKit close edge: the registry cancels any
+                    // pending pick and retains its result for a poll arriving after this window and its
+                    // store have disappeared.
                     PickRegistry.shared.unregister(windowID)
                     store.finalizeAllPendingCloses()
                     // flush cwd drift since the last structural mutation before dropping the store —
-                    // AppStore doesn't save on a live `cd`, so a closed-then-reopened window would
-                    // otherwise load a stale snapshot. Skip it when the window is no longer open in the
-                    // library (a delete already dropped the store + removed the per-window file, so a
-                    // save here would resurrect an orphan file).
+                    // AppStore doesn't save on a live `cd`, so a closed-then-reopened window would load a
+                    // stale snapshot. Skipped when the window is no longer open in the library: a delete
+                    // already dropped the store + removed the per-window file, so this would resurrect it.
                     if library.isOpen(windowID) { store.save() }
                     for session in store.workspaces.flatMap(\.sessions) {
                         session.surface?.teardown()
@@ -170,17 +165,15 @@ struct WindowAccessor: NSViewRepresentable {
                     }
                     library.closeWindow(windowID)
                     // closing a window drops its (unobserved) store, so the Dock badge's observation
-                    // tracking won't fire — refresh it explicitly so the unseen total drops this window's.
-                    // guard on isTerminating: on quit the willClose fires after applicationWillTerminate's
-                    // clear(), and closeWindow no-ops (stores stay loaded), so an unguarded refresh would
-                    // recompute the still-positive total and re-pin the badge clear() just zeroed.
+                    // tracking won't fire — refresh explicitly to drop this window's unseen total. Guarded
+                    // on isTerminating: on quit willClose fires after applicationWillTerminate's clear() and
+                    // closeWindow no-ops (stores stay loaded), so a refresh would re-pin the zeroed badge.
                     if !library.isTerminating { DockBadgeController.shared.refresh() }
                 }
             }
             titlebarObservers.append(closeToken)
-            // a settings theme change updates GhosttyApp.terminalBackgroundColor; re-apply the
-            // blend so the title bar and the (transparent) sidebar pick up the new window color
-            // live, not just when the window next re-keys.
+            // a settings theme change updates GhosttyApp.terminalBackgroundColor; re-apply the blend so the
+            // title bar and the transparent sidebar pick up the new window color live, not on the next re-key.
             let appearanceToken = NotificationCenter.default.addObserver(forName: .agtermAppearanceChanged, object: nil, queue: .main) { _ in
                 DispatchQueue.main.async { [weak self] in
                     guard let self, let window = self.window else { return }
@@ -198,17 +191,15 @@ struct WindowAccessor: NSViewRepresentable {
                 }
             }
             titlebarObservers.append(accessibilityToken)
-            // a window restored in a miniaturized state isn't on-screen, so a fresh
-            // launch shows nothing and UI-test automation has nothing to hit. bring it
-            // forward un-minimized; re-assert next tick because state restoration can
-            // re-apply the miniaturized state right after the view attaches.
+            // a window restored miniaturized isn't on-screen, so a fresh launch shows nothing and UI-test
+            // automation has nothing to hit. Bring it forward un-minimized, re-asserting next tick because
+            // state restoration can re-apply the miniaturized state right after the view attaches.
             bringForward(window)
             DispatchQueue.main.async { [weak self] in self?.bringForward(window) }
             scheduleUITestWindowForward(window)
-            // the window may already be key here: a reopened/raised window can become key DURING
-            // creation, before these observers were installed, so that initial didBecomeKey was missed
-            // (and bringForward above is then a no-op). Report frontmost explicitly so the palette /
-            // session switcher route to THIS window immediately, not the previously-frontmost one.
+            // the window may already be key: a reopened/raised window can become key DURING creation, before
+            // these observers exist, so that initial didBecomeKey was missed (and bringForward above is a
+            // no-op). Report frontmost explicitly so the palette/session switcher route to THIS window.
             if window.isKeyWindow || window.isMainWindow { reportFrontmost(windowID) }
         }
 
@@ -216,23 +207,21 @@ struct WindowAccessor: NSViewRepresentable {
             titlebarObservers.forEach(NotificationCenter.default.removeObserver)
         }
 
-        /// Record this window as the frontmost in the library and persist the index. The persist + the
-        /// frontmost-changed post are gated to an ACTUAL frontmost change, so the paired
-        /// `didBecomeKey`/`didBecomeMain` (and a re-key of the same window) collapse to a single write
-        /// instead of a per-focus-change write-storm.
+        /// Record this window as frontmost in the library and persist the index. The persist and the
+        /// frontmost-changed post are gated on an ACTUAL change, so the paired `didBecomeKey`/`didBecomeMain`
+        /// (and a re-key of the same window) collapse to one write instead of a per-focus-change storm.
         @MainActor private func reportFrontmost(_ id: WindowInfo.ID) {
             let changed = library.frontmostWindowID != id
             if changed {
                 library.frontmostWindowID = id
                 library.saveIndex()
             }
-            // auto-hide-inactive-sidebars: reconcile on EVERY activation report, even when the logical
-            // frontmost id is unchanged. `newWindow()` pre-sets `frontmostWindowID` before the window keys
-            // and launch restores it, so a changed-only gate would skip those paths and leave the prior
-            // window's sidebar showing (or the restored frontmost collapsed). Runs AFTER `frontmostWindowID`
-            // is set so `activeWindowID` resolves to this window; idempotent (`setSidebarVisible` no-ops
-            // when unchanged), so an unchanged re-key is cheap. Only fires on becomeKey/becomeMain, never
-            // on resign, so switching to another app leaves every sidebar untouched.
+            // auto-hide-inactive-sidebars: reconcile on EVERY activation report, even when the frontmost id
+            // is unchanged — `newWindow()` pre-sets `frontmostWindowID` before the window keys and launch
+            // restores it, so a changed-only gate would leave the prior window's sidebar showing (or the
+            // restored frontmost collapsed). Runs AFTER `frontmostWindowID` is set so `activeWindowID`
+            // resolves to this window, and is idempotent, so an unchanged re-key is cheap. Only fires on
+            // becomeKey/becomeMain, never resign, so switching to another app leaves every sidebar untouched.
             if GhosttyApp.shared.autoHideSidebarInactiveWindows {
                 library.applyInactiveWindowSidebarHiding()
             }
@@ -309,12 +298,11 @@ struct WindowAccessor: NSViewRepresentable {
         private var didPresentForUITests = false
         private func bringForwardForUITests(_ window: NSWindow) {
             // present a window that isn't on screen yet (FB11763863: created minimized/background), then
-            // latch off. Re-fronting on later ticks (or a momentary !isVisible during a re-render) would
+            // latch off — re-fronting on later ticks (or a momentary !isVisible during a re-render) would
             // fight a deliberate window.select and oscillate the key window, flapping the "active" flag.
             guard !didPresentForUITests else { return }
-            // already on screen: it presented on its own, so latch NOW instead of leaving the remaining
-            // ticks armed. Staying armed is the same hazard the comment above warns about, one step later:
-            // a window parked by window.minimize within the schedule would be dragged back out of the Dock.
+            // already on screen: it presented itself, so latch NOW — leaving the remaining ticks armed is
+            // the same hazard one step later, dragging a window.minimize-parked window back out of the Dock.
             guard window.isMiniaturized || !window.isVisible else {
                 didPresentForUITests = true
                 return
@@ -328,8 +316,6 @@ struct WindowAccessor: NSViewRepresentable {
         }
 
         private func applyTitlebarBlend(_ window: NSWindow) {
-            // set the OS window title (kept hidden via titleVisibility in the sync) so the window menu
-            // and XCUITest title-matching see it, even though our custom header shows the visible title.
             window.title = latestTitle
             let background = GhosttyApp.shared.terminalBackgroundColor
                 ?? NSColor(srgbRed: 0.157, green: 0.173, blue: 0.204, alpha: 1)

--- a/agterm/Views/WindowAppearance.swift
+++ b/agterm/Views/WindowAppearance.swift
@@ -1,12 +1,11 @@
 import agtermCore
 import AppKit
 
-/// Blends the window title bar with the terminal, mirroring macterm's `WindowAppearance`
-/// (which in turn mirrors Ghostty's transparent-titlebar path). The trick that makes it
-/// seamless: besides a transparent titlebar + `fullSizeContentView` + a window background
-/// matching the terminal, AppKit's private `NSTitlebarView` paints its own material layer
-/// that draws a visible band/seam at the titlebar height. Clearing that layer lets the
-/// window background (and the full-size content below it) show through continuously.
+/// Blends the window title bar with the terminal, mirroring macterm's `WindowAppearance` (itself mirroring
+/// Ghostty's transparent-titlebar path). Besides a transparent titlebar + `fullSizeContentView` + a window
+/// background matching the terminal, AppKit's private `NSTitlebarView` paints its own material layer that
+/// draws a visible band/seam at the titlebar height; clearing that layer lets the window background (and
+/// the full-size content below it) show through continuously.
 @MainActor
 enum WindowAppearance {
     /// The window-chrome inputs composited at the AppKit level, read from the shared `GhosttyApp`
@@ -17,18 +16,16 @@ enum WindowAppearance {
         var toolbarMode: ToolbarMode = .compact
     }
 
-    /// Apply the blend to `window` using `background` (the terminal background color) and the given
-    /// `chrome` inputs. Idempotent; safe to re-apply on attach and on every window/title/appearance
-    /// update — AppKit rebuilds the titlebar subviews (and re-asserts a default toolbar style) on
-    /// key/main/fullscreen transitions, so re-applying is required to keep the seam gone and the
-    /// chosen toolbar style stuck.
+    /// Apply the blend to `window` using `background` (the terminal background color) and the `chrome`
+    /// inputs. Idempotent, and re-applying on attach and on every window/title/appearance update is
+    /// REQUIRED: AppKit rebuilds the titlebar subviews and re-asserts a default toolbar style on
+    /// key/main/fullscreen transitions, bringing the seam back and unsticking the chosen toolbar style.
     ///
-    /// At full opacity the window is opaque with a solid background (the original behavior). Below
-    /// full opacity the window goes non-opaque and its background carries the alpha: the renderer is
-    /// pinned transparent (see `AppSettings.ghosttyConfigLines`) and the chrome paints nothing, so
-    /// the whole interior reads as one continuous translucent surface, optionally blurred. When macOS
-    /// Reduce Transparency is enabled, the saved chrome inputs stay unchanged but the effective
-    /// presentation is temporarily opaque and unblurred; disabling it restores those inputs.
+    /// At full opacity the window is opaque with a solid background. Below it the window goes non-opaque
+    /// and its background carries the alpha — the renderer is pinned transparent (see
+    /// `AppSettings.ghosttyConfigLines`) and the chrome paints nothing, so the interior reads as one
+    /// continuous translucent, optionally blurred surface. macOS Reduce Transparency leaves the saved
+    /// chrome inputs unchanged and presents opaque and unblurred until it is turned off.
     static func sync(window: NSWindow, background: NSColor, chrome: Chrome) {
         window.titlebarAppearsTransparent = true
         window.titlebarSeparatorStyle = .none
@@ -45,10 +42,9 @@ enum WindowAppearance {
             window.standardWindowButton(button)?.isHidden = hideButtons
         }
 
-        // Native fullscreen draws its own opaque background and the chrome shows through any
-        // transparency, so force opaque while fullscreened. Reduce Transparency is an effective
-        // runtime override: preserve the requested opacity/blur, but present an opaque, unblurred
-        // window until the system setting is turned off.
+        // native fullscreen draws its own opaque background and the chrome shows through any transparency,
+        // so force opaque there. Reduce Transparency is an effective runtime override: keep the requested
+        // opacity/blur, but present opaque and unblurred until the system setting is turned off.
         let reduceTransparency = NSWorkspace.shared.accessibilityDisplayShouldReduceTransparency
         let transparent = chrome.opacity < 1
             && !window.styleMask.contains(.fullScreen)
@@ -63,15 +59,13 @@ enum WindowAppearance {
             setWindowBackgroundBlur(window, radius: 0) // clear any blur applied while translucent
         }
 
-        // keep the sidebar see-through so the window background shows through it (the lighter/darker
-        // tint is layered in SwiftUI, not here). on macOS 26 the NavigationSplitView sidebar is a Liquid
-        // Glass container wrapping the sidebar content: `NSGlassEffectView.tintColor` is an INPUT to the
-        // glass material, not an
-        // opaque fill — so AppKit re-cooks it markedly lighter/frostier when the window resigns key,
-        // and there is no `NSVisualEffectView.state = .active` equivalent on `NSGlassEffectView` to
-        // pin it. To keep the sidebar a constant color across key/non-key (only visible once there are
-        // multiple windows), stop letting the glass be the background: clear it so the window background
-        // shows through (the sidebar tint is layered in SwiftUI — see `syncSidebarBackground`).
+        // keep the sidebar see-through (the lighter/darker tint is layered in SwiftUI, not here). on macOS
+        // 26 the NavigationSplitView sidebar is a Liquid Glass container wrapping the sidebar content:
+        // `NSGlassEffectView.tintColor` is an INPUT to the material, not an opaque fill, so AppKit re-cooks
+        // it markedly lighter/frostier when the window resigns key, and `NSGlassEffectView` has no
+        // `NSVisualEffectView.state = .active` equivalent to pin it. Clearing the glass (see
+        // `syncSidebarBackground`) keeps the color constant across key/non-key — visible only with multiple
+        // windows.
         syncSidebarBackground(in: window)
 
         // the title/terminal separator is drawn in the detail pane (ContentView), so it
@@ -81,24 +75,21 @@ enum WindowAppearance {
             titlebarView.wantsLayer = true
             titlebarView.layer?.backgroundColor = NSColor.clear.cgColor
         }
-        // always hide the OS titlebar background: our custom titlebar row is the chrome. At full
-        // opacity, or when .hiddenTitleBar doesn't hold (the XCUITest reopen path), it would otherwise
-        // paint a dark strip above the header.
+        // always hide the OS titlebar background — our custom row is the chrome. At full opacity, or when
+        // .hiddenTitleBar doesn't hold (the XCUITest reopen path), it paints a dark strip above the header.
         container.firstDescendant(withClassName: "NSTitlebarBackgroundView")?.isHidden = true
-        // hidden toolbar mode also has to suppress `_NSTitlebarDecorationView` — a separate full-width
-        // titlebar-height sibling of NSTitlebarView that paints a vibrancy material band (macOS 26).
-        // In tall/compact modes the custom row covers it; in hidden mode (traffic lights gone, row
-        // collapsed to the 3px drag strip) it is left exposed as a textured band over the full-bleed
-        // terminal. Hidden only in hidden mode so tall/compact keep AppKit's normal titlebar rendering.
+        // hidden mode must also suppress `_NSTitlebarDecorationView` — a full-width titlebar-height sibling
+        // of NSTitlebarView painting a vibrancy material band (macOS 26). tall/compact cover it with the
+        // custom row; hidden mode (traffic lights gone, row collapsed to the 3px drag strip) leaves it
+        // exposed over the full-bleed terminal. Hidden only there, so tall/compact keep AppKit's rendering.
         container.firstDescendant(withClassName: "_NSTitlebarDecorationView")?.isHidden = hideButtons
     }
 
-    /// Keeps the sidebar see-through so the window background shows through it — the opaque terminal
-    /// color at full opacity, or the translucent tinted background + blur below it. The user's
-    /// lighter/darker sidebar shift is layered in SwiftUI (a wash behind the transparent outline, see
-    /// `WindowContentView.sidebarTintWash`) so it composes with the translucency instead of fighting it
-    /// and covers the whole column (tree + bottom bar) uniformly. On macOS 26 the Liquid Glass container
-    /// that could wrap the sidebar is cleared too (defensive — the custom split no longer creates one).
+    /// Keeps the sidebar see-through — the opaque terminal color at full opacity, the translucent tinted
+    /// background + blur below it. The user's lighter/darker shift is layered in SwiftUI (a wash behind the
+    /// transparent outline, `WindowContentView.sidebarTintWash`) so it composes with the translucency and
+    /// covers the whole column (tree + bottom bar) uniformly. The macOS 26 Liquid Glass container is
+    /// cleared too (defensive — the custom split no longer creates one).
     private static func syncSidebarBackground(in window: NSWindow) {
         guard let scroll = sidebarScroll(in: window) else { return }
         if #available(macOS 26.0, *), let glass = sidebarGlass(containing: scroll) {
@@ -124,8 +115,7 @@ enum WindowAppearance {
     }
 
     /// The first `NSGlassEffectView` ancestor of the sidebar scroll view (the
-    /// `NSContainerConcentricGlassEffectView` that `NavigationSplitView` wraps the sidebar in on
-    /// macOS 26).
+    /// `NSContainerConcentricGlassEffectView` `NavigationSplitView` wraps the sidebar in on macOS 26).
     @available(macOS 26.0, *)
     private static func sidebarGlass(containing scroll: NSScrollView) -> NSGlassEffectView? {
         var node: NSView? = scroll.superview
@@ -136,8 +126,8 @@ enum WindowAppearance {
         return nil
     }
 
-    /// Forces any nested legacy `NSVisualEffectView` to render its active material regardless of
-    /// window key state — defensive insurance for the sidebar subtree.
+    /// Forces any nested legacy `NSVisualEffectView` to render its active material regardless of window key
+    /// state — defensive insurance for the sidebar subtree.
     private static func forceVisualEffectsActive(in view: NSView) {
         if let effect = view as? NSVisualEffectView { effect.state = .active }
         for subview in view.subviews { forceVisualEffectsActive(in: subview) }

--- a/agterm/Views/WindowAppearance.swift
+++ b/agterm/Views/WindowAppearance.swift
@@ -2,10 +2,9 @@ import agtermCore
 import AppKit
 
 /// Blends the window title bar with the terminal, mirroring macterm's `WindowAppearance` (itself mirroring
-/// Ghostty's transparent-titlebar path). Besides a transparent titlebar + `fullSizeContentView` + a window
-/// background matching the terminal, AppKit's private `NSTitlebarView` paints its own material layer that
-/// draws a visible band/seam at the titlebar height; clearing that layer lets the window background (and
-/// the full-size content below it) show through continuously.
+/// Ghostty's transparent-titlebar path). Besides a transparent titlebar + `fullSizeContentView` + a
+/// terminal-matching window background, AppKit's private `NSTitlebarView` paints its own material layer
+/// drawing a visible band at the titlebar height; clearing it lets the window background show through.
 @MainActor
 enum WindowAppearance {
     /// The window-chrome inputs composited at the AppKit level, read from the shared `GhosttyApp`
@@ -21,9 +20,9 @@ enum WindowAppearance {
     /// REQUIRED: AppKit rebuilds the titlebar subviews and re-asserts a default toolbar style on
     /// key/main/fullscreen transitions, bringing the seam back and unsticking the chosen toolbar style.
     ///
-    /// At full opacity the window is opaque with a solid background. Below it the window goes non-opaque
-    /// and its background carries the alpha — the renderer is pinned transparent (see
-    /// `AppSettings.ghosttyConfigLines`) and the chrome paints nothing, so the interior reads as one
+    /// At full opacity the window is opaque with a solid background; below it the window goes non-opaque
+    /// and its background carries the alpha — the renderer is pinned transparent
+    /// (`AppSettings.ghosttyConfigLines`) and the chrome paints nothing, so the interior reads as one
     /// continuous translucent, optionally blurred surface. macOS Reduce Transparency leaves the saved
     /// chrome inputs unchanged and presents opaque and unblurred until it is turned off.
     static func sync(window: NSWindow, background: NSColor, chrome: Chrome) {
@@ -34,17 +33,15 @@ enum WindowAppearance {
         window.titleVisibility = .hidden
         window.styleMask.insert(.fullSizeContentView)
 
-        // hidden toolbar mode drops the three traffic-light buttons for a full-bleed terminal; every
-        // other mode restores them. Skipped in fullscreen so entering/exiting fullscreen (which re-runs
-        // this sync) leaves AppKit's own auto-showing title bar buttons intact, like the translucency below.
+        // hidden toolbar mode drops the three traffic-light buttons for a full-bleed terminal, every other
+        // mode restores them. skipped in fullscreen so AppKit's own auto-showing buttons stay intact.
         let hideButtons = chrome.toolbarMode == .hidden && !window.styleMask.contains(.fullScreen)
         for button in [NSWindow.ButtonType.closeButton, .miniaturizeButton, .zoomButton] {
             window.standardWindowButton(button)?.isHidden = hideButtons
         }
 
         // native fullscreen draws its own opaque background and the chrome shows through any transparency,
-        // so force opaque there. Reduce Transparency is an effective runtime override: keep the requested
-        // opacity/blur, but present opaque and unblurred until the system setting is turned off.
+        // so force opaque there; Reduce Transparency forces the same without touching the saved inputs.
         let reduceTransparency = NSWorkspace.shared.accessibilityDisplayShouldReduceTransparency
         let transparent = chrome.opacity < 1
             && !window.styleMask.contains(.fullScreen)
@@ -60,16 +57,13 @@ enum WindowAppearance {
         }
 
         // keep the sidebar see-through (the lighter/darker tint is layered in SwiftUI, not here). on macOS
-        // 26 the NavigationSplitView sidebar is a Liquid Glass container wrapping the sidebar content:
-        // `NSGlassEffectView.tintColor` is an INPUT to the material, not an opaque fill, so AppKit re-cooks
-        // it markedly lighter/frostier when the window resigns key, and `NSGlassEffectView` has no
-        // `NSVisualEffectView.state = .active` equivalent to pin it. Clearing the glass (see
-        // `syncSidebarBackground`) keeps the color constant across key/non-key — visible only with multiple
-        // windows.
+        // 26 the NavigationSplitView sidebar is a Liquid Glass container: `NSGlassEffectView.tintColor` is
+        // an INPUT to the material, not an opaque fill, so AppKit re-cooks it markedly lighter/frostier when
+        // the window resigns key, and there is no `NSVisualEffectView.state = .active` equivalent to pin it.
+        // clearing the glass keeps the color constant across key/non-key — visible only with multiple windows.
         syncSidebarBackground(in: window)
 
-        // the title/terminal separator is drawn in the detail pane (ContentView), so it
-        // ends at the sidebar edge rather than spanning the full titlebar width.
+        // the title/terminal separator is drawn in the detail pane, so it ends at the sidebar edge.
         guard let container = titlebarContainer(in: window) else { return }
         if let titlebarView = container.firstDescendant(withClassName: "NSTitlebarView") {
             titlebarView.wantsLayer = true
@@ -80,16 +74,15 @@ enum WindowAppearance {
         container.firstDescendant(withClassName: "NSTitlebarBackgroundView")?.isHidden = true
         // hidden mode must also suppress `_NSTitlebarDecorationView` — a full-width titlebar-height sibling
         // of NSTitlebarView painting a vibrancy material band (macOS 26). tall/compact cover it with the
-        // custom row; hidden mode (traffic lights gone, row collapsed to the 3px drag strip) leaves it
-        // exposed over the full-bleed terminal. Hidden only there, so tall/compact keep AppKit's rendering.
+        // custom row; hidden mode (traffic lights gone, row collapsed to the 3px drag strip) leaves it bare.
         container.firstDescendant(withClassName: "_NSTitlebarDecorationView")?.isHidden = hideButtons
     }
 
-    /// Keeps the sidebar see-through — the opaque terminal color at full opacity, the translucent tinted
-    /// background + blur below it. The user's lighter/darker shift is layered in SwiftUI (a wash behind the
-    /// transparent outline, `WindowContentView.sidebarTintWash`) so it composes with the translucency and
-    /// covers the whole column (tree + bottom bar) uniformly. The macOS 26 Liquid Glass container is
-    /// cleared too (defensive — the custom split no longer creates one).
+    /// Keeps the sidebar see-through — opaque terminal color at full opacity, translucent tinted background
+    /// + blur below it. The user's lighter/darker shift is layered in SwiftUI (a wash behind the transparent
+    /// outline, `WindowContentView.sidebarTintWash`) so it composes with the translucency and covers tree +
+    /// bottom bar uniformly. The macOS 26 Liquid Glass container is cleared too (defensive — the custom
+    /// split no longer creates one).
     private static func syncSidebarBackground(in window: NSWindow) {
         guard let scroll = sidebarScroll(in: window) else { return }
         if #available(macOS 26.0, *), let glass = sidebarGlass(containing: scroll) {
@@ -126,15 +119,13 @@ enum WindowAppearance {
         return nil
     }
 
-    /// Forces any nested legacy `NSVisualEffectView` to render its active material regardless of window key
-    /// state — defensive insurance for the sidebar subtree.
+    /// Forces any nested legacy `NSVisualEffectView` to its active material regardless of window key state.
     private static func forceVisualEffectsActive(in view: NSView) {
         if let effect = view as? NSVisualEffectView { effect.state = .active }
         for subview in view.subviews { forceVisualEffectsActive(in: subview) }
     }
 
-    /// The `NSTitlebarContainerView` for `window` — a descendant of the window's root
-    /// theme frame (the superview chain above the content view).
+    /// The `NSTitlebarContainerView` for `window`, found from the window's root theme frame.
     private static func titlebarContainer(in window: NSWindow) -> NSView? {
         guard let contentView = window.contentView else { return nil }
         var root: NSView = contentView
@@ -146,10 +137,10 @@ enum WindowAppearance {
 
 // MARK: - Private CGS background-blur SPI
 
-// `CGSSetWindowBackgroundBlurRadius` is the private CoreGraphics call every macOS terminal
-// (Terminal.app, iTerm, Ghostty) uses to blur the content behind a translucent window. Undocumented
-// but long-stable; libghostty calls the same symbol. Resolved once via dlsym; a missing symbol
-// degrades to a no-op (no blur) rather than crashing. Adapted from thdxg/macterm (MIT).
+// `CGSSetWindowBackgroundBlurRadius` is the private CoreGraphics call every macOS terminal (Terminal.app,
+// iTerm, Ghostty, libghostty) uses to blur the content behind a translucent window — undocumented but
+// long-stable. resolved once via dlsym; a missing symbol degrades to a no-op (no blur), not a crash.
+// Adapted from thdxg/macterm (MIT).
 private let cgsDefaultConnection: (@convention(c) () -> Int32)? = {
     guard let sym = dlsym(dlopen(nil, RTLD_NOW), "CGSDefaultConnectionForThread") else { return nil }
     return unsafeBitCast(sym, to: (@convention(c) () -> Int32).self)
@@ -167,8 +158,8 @@ private func setWindowBackgroundBlur(_ window: NSWindow, radius: Int) {
 }
 
 extension NSView {
-    /// Depth-first search for the first descendant whose runtime class name matches.
-    /// Used to reach AppKit's private titlebar views by class name.
+    /// Depth-first search for the first descendant whose runtime class name matches — the only way to reach
+    /// AppKit's private titlebar views.
     func firstDescendant(withClassName className: String) -> NSView? {
         for subview in subviews {
             if String(describing: type(of: subview)) == className { return subview }
@@ -178,7 +169,6 @@ extension NSView {
     }
 
     /// Depth-first search for the first descendant (or self) carrying the given identifier.
-    /// Used to locate the tagged sidebar scroll view so its enclosing glass can be reached.
     func firstDescendant(withIdentifier identifier: String) -> NSView? {
         if self.identifier?.rawValue == identifier { return self }
         for subview in subviews {

--- a/agterm/Views/WindowContentView+Dashboard.swift
+++ b/agterm/Views/WindowContentView+Dashboard.swift
@@ -2,11 +2,9 @@ import agtermCore
 import AppKit
 import SwiftUI
 
-/// The font-relevant dashboard state: the pane-cell member set AND the font mode — a change to either
-/// re-applies the per-cell override. Members alone would miss a same-members re-open with a DIFFERENT mode
-/// (`dashboard A B` then `dashboard A B --font-size 20`), since SwiftUI suppresses `.onChange` when the
-/// whole key is Equatable-equal. Members are explicit `(session, pane)` cells, so a slot change is already
-/// a member-set change and no separate `kinds` term is needed.
+/// The font-relevant dashboard state: the pane-cell member set AND the font mode, since SwiftUI suppresses
+/// `.onChange` on an Equatable-equal key and members alone would miss a same-members re-open in a DIFFERENT
+/// mode. Members are explicit `(session, pane)` cells, so a slot change already changes the set.
 struct DashboardFontKey: Equatable {
     let members: [DashboardMember]
     let mode: DashboardFontMode
@@ -18,10 +16,9 @@ extension WindowContentView {
         DashboardFontKey(members: dashboard.members, mode: dashboard.fontMode)
     }
 
-    /// Every valid pane cell in this window's store, in tree order — each session's `.primary`, plus a
-    /// `.split` when it `hasSplit`. The reconcile key: closing a member session or a split pane while the
-    /// dashboard is open (e.g. over the control socket) changes this array, and
-    /// `reconcileDashboardMembers` prunes the gone cell(s).
+    /// Every valid pane cell in this window's store, in tree order. The reconcile key: closing a member
+    /// session or a split pane while the dashboard is open changes it, and `reconcileDashboardMembers`
+    /// prunes the gone cells.
     var dashboardValidMembers: [DashboardMember] {
         store.workspaces.flatMap(\.sessions).flatMap { session -> [DashboardMember] in
             var members = [DashboardMember(session: session.id, surface: .primary)]
@@ -31,9 +28,7 @@ extension WindowContentView {
     }
 
     /// The caption pill's FILL — the theme's muted selection background (what the selected sidebar row
-    /// draws), or a soft wash of the chrome foreground when the theme exposes none. Read live from
-    /// `GhosttyApp` so a theme flip (which re-renders the body via `chromeText`/`terminalColor`) re-resolves
-    /// it; muted and themed like the sidebar pill, never the loud foreground.
+    /// draws), or a soft wash of the chrome foreground when none. Read live so a theme flip re-resolves it.
     private var dashboardPillColor: Color {
         if let selection = GhosttyApp.shared.terminalSelectionBackgroundColor { return Color(nsColor: selection) }
         return chromeText.opacity(0.22)
@@ -46,9 +41,8 @@ extension WindowContentView {
         return chromeText
     }
 
-    /// "Dashboard", plus "— <window name>" when the window carries a custom name (auto "window N" names
-    /// omitted, exactly like the normal `windowTitle`). No cwd subtitle — the grid has no single active
-    /// session to source one from.
+    /// "Dashboard", plus "— <window name>" for a custom window name (auto "window N" omitted, like the
+    /// normal `windowTitle`). No cwd subtitle — the grid has no single active session to source one from.
     private var dashboardWindowTitle: String {
         guard let info = library.windows.first(where: { $0.id == windowID }), info.hasCustomName else {
             return "Dashboard"
@@ -57,11 +51,10 @@ extension WindowContentView {
     }
 
     /// The stripped chrome above the OPEN grid, the counterpart of `zoomTitlebar`: in hidden-toolbar mode
-    /// the same invisible ~3px drag strip, else a bare bar with the title and an exit button — none of the
-    /// sidebar/split/scratch/quick-terminal/attention controls `customTitlebar` renders, which behind the
-    /// view-only grid would steal the key-catcher's first responder (stranding Esc) and drive actions that
-    /// make no sense. Window drag / double-click / traffic lights stay via `WindowControlArea`; the exit
-    /// button runs the same close-and-refocus path as Esc.
+    /// the same invisible ~3px drag strip, else a bare bar with the title and an exit button. None of
+    /// `customTitlebar`'s controls: behind the view-only grid they would steal the key-catcher's first
+    /// responder (stranding Esc) and drive actions that make no sense. Window drag / double-click / traffic
+    /// lights stay via `WindowControlArea`.
     @ViewBuilder var dashboardTitlebar: some View {
         if toolbarMode == .hidden {
             Color.clear
@@ -102,10 +95,9 @@ extension WindowContentView {
 
     /// The grid overlay, mounted in `windowOverlayLayer` while this window's `DashboardController` is open
     /// (inset by `titlebarHeight`, below `customTitlebar`, like the other window overlays). View-only cells
-    /// reparent each member's OWN pane surface (`.primary` → `\.surface`, `.split` → `\.splitSurface`) via
-    /// the generalized deck yield. `highlightColor` is the themed chrome foreground, so the highlight ring
-    /// tracks the terminal theme rather than the OS accent, and `captionBackground` the themed terminal
-    /// background, so the caption chip matches the active theme too.
+    /// reparent each member's OWN pane surface via the generalized deck yield.
+    /// `highlightColor`/`captionBackground` are themed, so the ring and caption chip track the terminal
+    /// theme rather than the OS accent.
     @ViewBuilder var dashboardOverlay: some View {
         if dashboard.isOpen {
             DashboardView(
@@ -127,9 +119,8 @@ extension WindowContentView {
 
     /// Title-bar opener for the view-only grid — the frontmost window's most-recently-used sessions,
     /// auto-sized (the `AppActions.toggleDashboard` / ⌘⇧D / Navigate ▸ Dashboard path). A single glyph,
-    /// never a 2-state toggle: an open dashboard swaps the whole titlebar for the stripped
-    /// `dashboardTitlebar`, so this renders only while closed. Disabled with no sessions, like the
-    /// split/scratch buttons. Non-private so `titlebarRow` can place it, like the `+RecentSessions` buttons.
+    /// never a 2-state toggle: an open dashboard swaps the whole titlebar for `dashboardTitlebar`, so this
+    /// renders only while closed. Disabled with no sessions; non-private so `titlebarRow` can place it.
     var dashboardButton: some View {
         Button {
             actions.toggleDashboard()
@@ -141,11 +132,10 @@ extension WindowContentView {
         .accessibilityIdentifier("dashboard-toggle-button")
     }
 
-    /// Whether an OPEN dashboard hosts this session-pane slot in a grid cell. A member is a `(session,
-    /// pane)` cell, so BOTH panes of a split member are claimed and the deck must yield its `Color.clear`
-    /// placeholder for each — an NSView lives in one host at a time, the zoom exclusion generalized to N
-    /// panes. False for a non-member slot, for a member's scratch/overlay surfaces (never hosted here), and
-    /// while the dashboard is closed.
+    /// Whether an OPEN dashboard hosts this session-pane slot in a grid cell. BOTH panes of a split member
+    /// are claimed and the deck must yield its `Color.clear` placeholder for each — an NSView lives in one
+    /// host at a time, the zoom exclusion generalized to N panes. False for a non-member slot, for a
+    /// member's scratch/overlay surfaces, and while closed.
     func dashboardHostsSurface(session: Session, surface: TerminalZoomSurface) -> Bool {
         guard dashboard.isOpen else { return false }
         return dashboard.members.contains(DashboardMember(session: session.id, surface: surface))
@@ -165,8 +155,7 @@ extension WindowContentView {
 
     /// The `.onChange(of: dashboard.isOpen)` transition: entering closes this window's transient chrome and
     /// pauses auto-follow (mirroring `handleZoomTargetChange`), exiting resumes it. The per-member font
-    /// override rides `dashboardFontKey` instead, so a retarget (re-open with a new set) OR a same-members
-    /// re-open with a new font mode re-applies it.
+    /// override rides `dashboardFontKey` instead.
     func handleDashboardOpenChange(_ isOpen: Bool) {
         if isOpen {
             // the palette is app-global and renders in the FRONTMOST window, so only that window's dashboard
@@ -177,8 +166,7 @@ extension WindowContentView {
                 (session.searchSurface as? GhosttySurfaceView)?.endSearch()
             }
             if quickTerminal.isVisible { quickTerminal.hide() }
-            // the switcher is app-global and frontmost-rendered like the palette, so a control-driven
-            // dashboard of a background window must not abort an in-progress Ctrl-Tab in the frontmost one.
+            // the switcher is app-global and frontmost-rendered like the palette, same background-window guard.
             if library.activeWindowID == windowID, sessionSwitcher.isActive { sessionSwitcher.cancel() }
             // pause this window's idle auto-follow so an armed jump can't reshuffle the selection under the modal.
             store.suppressAutoFollow()
@@ -187,11 +175,9 @@ extension WindowContentView {
         }
     }
 
-    /// The `.onChange(of: dashboardFontKey)` apply: clear every prior override, re-apply the mode to the
-    /// current pane cells (each cell's OWN surface — `.primary` → `\.surface`, `.split` →
-    /// `\.splitSurface`), and record the applied size on the controller. Fires on open, retarget, a
-    /// same-members mode change, a member add/remove and close, so a de-membered surface never keeps a
-    /// stale shrunk font and a re-open always re-sizes.
+    /// The `.onChange(of: dashboardFontKey)` apply: clear every prior override, re-apply the mode to each
+    /// current pane cell's OWN surface, and record the applied size on the controller. Fires on open,
+    /// retarget, mode change, member add/remove and close, so no de-membered surface keeps a stale font.
     func handleDashboardFontChange() {
         clearDashboardFontOverrides()
         guard dashboard.isOpen else {
@@ -207,17 +193,15 @@ extension WindowContentView {
     }
 
     /// The `.onChange(of: dashboardValidMembers)` hook: drops any pane cell whose session or split pane
-    /// closed while the dashboard is open (e.g. over the control socket), so the grid recomputes to the
-    /// smaller count and the highlight never points at a gone pane. A no-op while closed or when nothing
-    /// vanished; `DashboardController.reconcile` closes the dashboard once the last member is gone.
+    /// closed, so the grid recomputes to the smaller count and the highlight never points at a gone pane.
+    /// `DashboardController.reconcile` closes the dashboard once the last member is gone.
     func reconcileDashboardMembers() {
         guard dashboard.isOpen else { return }
         dashboard.reconcile(existing: Set(dashboardValidMembers))
-        // reconcile may have CLOSED the dashboard (its last member vanished), unmounting the key-catcher
-        // that held first responder with nothing to re-grab it. Restore focus like Esc/Enter — but ONLY for
-        // the frontmost window: this fires per-window (a background window on a control-driven close too)
-        // while `focusActiveSession` targets the frontmost store, so an unguarded call would grab first
-        // responder in the WRONG window (the hazard the zoom-exit refocus guards against).
+        // a reconcile-driven close unmounts the key-catcher that held first responder with nothing to
+        // re-grab it, so restore focus like Esc/Enter — but ONLY for the frontmost window: this fires
+        // per-window while `focusActiveSession` targets the frontmost store, so an unguarded call would
+        // grab first responder in the WRONG window.
         if !dashboard.isOpen, library.activeWindowID == windowID { actions.focusActiveSession() }
     }
 
@@ -228,15 +212,14 @@ extension WindowContentView {
         dashboard.close()
     }
 
-    /// How long the active frame flashes on a clicked cell before the click enters it — a brief, visible
-    /// acknowledgement so a mouse jump doesn't feel like an instant, unexplained close.
+    /// How long the active frame flashes on a clicked cell before the click enters it, so a mouse jump
+    /// doesn't read as an instant, unexplained close.
     static let dashboardClickEnterDelay: TimeInterval = 0.18
 
-    /// A click flashes the active frame on the cell (`dashboard.highlight`), then enters after a brief delay
-    /// — an instant jump with no flash reads as confusing (keyboard Enter needs none, its highlight is
-    /// already visible). The delayed enter fires only while this cell is STILL highlighted, so a superseding
-    /// click or arrow wins (last-click, not first-scheduled) and a close/reconcile in the gap, which clears
-    /// or moves the highlight, cancels it.
+    /// A click flashes the active frame on the cell, then enters after a brief delay — an instant jump with
+    /// no flash reads as confusing (keyboard Enter needs none, its highlight is already visible). The
+    /// delayed enter fires only while this cell is STILL highlighted, so a superseding click or arrow wins
+    /// (last-click, not first-scheduled) and a close/reconcile in the gap cancels it.
     func clickDashboardMember(_ member: DashboardMember) {
         dashboard.highlight(member)
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.dashboardClickEnterDelay) {
@@ -246,10 +229,9 @@ extension WindowContentView {
     }
 
     /// Entering a cell (Enter immediately, a click after its flash delay): select that session, close the
-    /// dashboard, then land first responder in the cell's EXACT pane — for `.split`, flip `splitFocused`
-    /// then `focusSplitPane(wantSplit: true)`, mirroring `revealActiveBlockedPane`'s `.right` branch; else
-    /// the main pane. Close BEFORE focusing or the `focusSplitPane`/`focusActiveSession` `dashboardActive`
-    /// guards (the window's controller `isOpen`) block it.
+    /// dashboard, then land first responder in the cell's EXACT pane, the `.split` leg mirroring
+    /// `revealActiveBlockedPane`'s `.right` branch. Close BEFORE focusing or the
+    /// `focusSplitPane`/`focusActiveSession` `dashboardActive` guards block it.
     func selectDashboardMember(_ member: DashboardMember) {
         store.selectSession(member.session)
         dashboard.close()
@@ -274,19 +256,16 @@ extension WindowContentView {
 
     /// The absolute size for every member surface in the current mode, or nil for `.untouched` (each keeps
     /// its own `session.fontSize`). Resolves through the SAME host-free `DashboardFontMode.appliedFontSize`
-    /// seam `ControlServer.setDashboard` uses, so the surface overrides and the controller's synchronous
-    /// read-back land on the identical value (the onChange re-apply is a no-op re-write). `.auto` derives it
-    /// from the grid and the Settings font size (nil → the ghostty default).
+    /// seam `ControlServer.setDashboard` uses, so the surface overrides and the controller's read-back land
+    /// on the identical value. `.auto` derives it from the grid and the Settings font size (nil → ghostty's).
     private func dashboardTargetFontSize(memberCount: Int) -> Double? {
         let base = actions.settingsModel?.settings.fontSize ?? DashboardLayout.ghosttyDefaultFontSize
         return dashboard.fontMode.appliedFontSize(memberCount: memberCount, base: base)
     }
 
     /// Clear the transient dashboard font override wherever one is set, restoring each surface's real
-    /// (session-model) font. Sweeps BOTH `\.surface` AND `\.splitSurface` of every session, since a split
-    /// member carries one per pane, and sweeps store-wide rather than over `dashboard.members` so it stays
-    /// correct on close (members already emptied) and on window teardown; an override-less surface is not
-    /// needlessly re-configured.
+    /// (session-model) font. Sweeps store-wide rather than over `dashboard.members`, so it stays correct on
+    /// close (members already emptied) and on window teardown.
     private func clearDashboardFontOverrides() {
         for session in store.workspaces.flatMap(\.sessions) {
             for surface in [session.surface, session.splitSurface] {
@@ -296,8 +275,8 @@ extension WindowContentView {
         }
     }
 
-    /// The cell's OWN pane surface as a `GhosttySurfaceView`, for the font override: `.split` → the session's
-    /// `splitSurface`, else its `surface` — the SAME slot the dashboard cell reparents.
+    /// The cell's OWN pane surface as a `GhosttySurfaceView`, for the font override — the SAME slot the
+    /// dashboard cell reparents.
     private func dashboardMemberSurface(_ member: DashboardMember) -> GhosttySurfaceView? {
         guard let session = store.session(withID: member.session) else { return nil }
         let surface = member.surface == .split ? session.splitSurface : session.surface

--- a/agterm/Views/WindowContentView+Dashboard.swift
+++ b/agterm/Views/WindowContentView+Dashboard.swift
@@ -2,28 +2,26 @@ import agtermCore
 import AppKit
 import SwiftUI
 
-/// The font-relevant dashboard state — the pane-cell member set AND the font mode. A change to either
-/// re-applies the per-cell font override. The members-only key would miss (SwiftUI suppresses `.onChange`
-/// when the whole key is Equatable-equal) a same-members re-open with a DIFFERENT font mode
-/// (`dashboard A B` then `dashboard A B --font-size 20`), so the mode rides the key too. Each member is now
-/// an explicit `(session, pane)` cell, so a member-set change already captures any slot change — no separate
-/// `kinds` term is needed.
+/// The font-relevant dashboard state: the pane-cell member set AND the font mode — a change to either
+/// re-applies the per-cell override. Members alone would miss a same-members re-open with a DIFFERENT mode
+/// (`dashboard A B` then `dashboard A B --font-size 20`), since SwiftUI suppresses `.onChange` when the
+/// whole key is Equatable-equal. Members are explicit `(session, pane)` cells, so a slot change is already
+/// a member-set change and no separate `kinds` term is needed.
 struct DashboardFontKey: Equatable {
     let members: [DashboardMember]
     let mode: DashboardFontMode
 }
 
 extension WindowContentView {
-    /// The composite key the font apply reacts to (see `DashboardFontKey`): the pane-cell member set plus the
-    /// font mode, so a retarget, a same-members mode change, or a member add/remove re-applies the override.
+    /// The composite key the font apply reacts to (see `DashboardFontKey`).
     var dashboardFontKey: DashboardFontKey {
         DashboardFontKey(members: dashboard.members, mode: dashboard.fontMode)
     }
 
-    /// Every VALID pane cell currently in this window's store, in tree order — each session contributes its
-    /// `.primary` cell plus a `.split` cell when it `hasSplit`. The reconcile key: when a member session is
-    /// closed OR a split pane closes while the dashboard is open (e.g. over the control socket), this array
-    /// changes and `reconcileDashboardMembers` prunes the gone cell(s).
+    /// Every valid pane cell in this window's store, in tree order — each session's `.primary`, plus a
+    /// `.split` when it `hasSplit`. The reconcile key: closing a member session or a split pane while the
+    /// dashboard is open (e.g. over the control socket) changes this array, and
+    /// `reconcileDashboardMembers` prunes the gone cell(s).
     var dashboardValidMembers: [DashboardMember] {
         store.workspaces.flatMap(\.sessions).flatMap { session -> [DashboardMember] in
             var members = [DashboardMember(session: session.id, surface: .primary)]
@@ -32,11 +30,10 @@ extension WindowContentView {
         }
     }
 
-    /// The dashboard caption pill's FILL — the theme's muted selection-background highlight (the same color
-    /// the selected sidebar row draws), or a soft wash of the chrome foreground when the theme exposes no
-    /// selection color. Read live from `GhosttyApp` so a theme flip (which re-renders the body via
-    /// `chromeText`/`terminalColor`) re-resolves it, matching the sidebar pill — muted and themed, never the
-    /// loud foreground.
+    /// The caption pill's FILL — the theme's muted selection background (what the selected sidebar row
+    /// draws), or a soft wash of the chrome foreground when the theme exposes none. Read live from
+    /// `GhosttyApp` so a theme flip (which re-renders the body via `chromeText`/`terminalColor`) re-resolves
+    /// it; muted and themed like the sidebar pill, never the loud foreground.
     private var dashboardPillColor: Color {
         if let selection = GhosttyApp.shared.terminalSelectionBackgroundColor { return Color(nsColor: selection) }
         return chromeText.opacity(0.22)
@@ -49,9 +46,9 @@ extension WindowContentView {
         return chromeText
     }
 
-    /// The dashboard's title, following the normal `windowTitle` logic: just "Dashboard", plus "— <window
-    /// name>" when the window carries a custom name (auto "window N" names omitted, exactly like the normal
-    /// title). No cwd subtitle — the grid has no single active session to source one from.
+    /// "Dashboard", plus "— <window name>" when the window carries a custom name (auto "window N" names
+    /// omitted, exactly like the normal `windowTitle`). No cwd subtitle — the grid has no single active
+    /// session to source one from.
     private var dashboardWindowTitle: String {
         guard let info = library.windows.first(where: { $0.id == windowID }), info.hasCustomName else {
             return "Dashboard"
@@ -59,13 +56,12 @@ extension WindowContentView {
         return "Dashboard — \(info.name)"
     }
 
-    /// The stripped chrome above the OPEN dashboard grid, the exact counterpart of `zoomTitlebar`: in
-    /// hidden-toolbar mode the same invisible ~3px drag strip, otherwise a bare bar carrying the dashboard
-    /// title and an exit button — none of the sidebar/split/scratch/quick-terminal/attention controls the full `customTitlebar`
-    /// renders. Dropping them is the fix: while the view-only grid is up those buttons would steal the
-    /// key-catcher's first responder (stranding Esc) and drive actions that make no sense behind the modal.
-    /// Window drag / double-click / traffic lights stay via `WindowControlArea`; the exit button runs the
-    /// same close-and-refocus path as Esc.
+    /// The stripped chrome above the OPEN grid, the counterpart of `zoomTitlebar`: in hidden-toolbar mode
+    /// the same invisible ~3px drag strip, else a bare bar with the title and an exit button — none of the
+    /// sidebar/split/scratch/quick-terminal/attention controls `customTitlebar` renders, which behind the
+    /// view-only grid would steal the key-catcher's first responder (stranding Esc) and drive actions that
+    /// make no sense. Window drag / double-click / traffic lights stay via `WindowControlArea`; the exit
+    /// button runs the same close-and-refocus path as Esc.
     @ViewBuilder var dashboardTitlebar: some View {
         if toolbarMode == .hidden {
             Color.clear
@@ -104,13 +100,12 @@ extension WindowContentView {
         }
     }
 
-    /// The dashboard grid overlay, mounted in `windowOverlayLayer` while this window's `DashboardController`
-    /// is open (inset by `titlebarHeight`, below `customTitlebar`, like the other window overlays). Closed
-    /// over its `onSelect`/`onClose` closures + the control socket; view-only cells reparent each member's
-    /// OWN pane surface (`.primary` → `\.surface`, `.split` → `\.splitSurface`) via the generalized deck
-    /// yield. `highlightColor` is the themed chrome foreground (the highlight ring tracks the terminal theme
-    /// rather than the OS accent), and `captionBackground` is the themed terminal background (the caption
-    /// chip fill), so the name chip matches the active theme too.
+    /// The grid overlay, mounted in `windowOverlayLayer` while this window's `DashboardController` is open
+    /// (inset by `titlebarHeight`, below `customTitlebar`, like the other window overlays). View-only cells
+    /// reparent each member's OWN pane surface (`.primary` → `\.surface`, `.split` → `\.splitSurface`) via
+    /// the generalized deck yield. `highlightColor` is the themed chrome foreground, so the highlight ring
+    /// tracks the terminal theme rather than the OS accent, and `captionBackground` the themed terminal
+    /// background, so the caption chip matches the active theme too.
     @ViewBuilder var dashboardOverlay: some View {
         if dashboard.isOpen {
             DashboardView(
@@ -130,12 +125,11 @@ extension WindowContentView {
         }
     }
 
-    /// Title-bar button that opens the dashboard grid — the frontmost window's most-recently-used sessions in
-    /// a view-only grid, auto-sized (the `AppActions.toggleDashboard` / ⌘⇧D / Navigate ▸ Dashboard opener). A
-    /// single glyph, never a 2-state toggle: while the dashboard is open the whole titlebar is swapped for the
-    /// stripped `dashboardTitlebar`, so this button only ever renders while the dashboard is closed. Disabled
-    /// with no sessions (nothing to show), like the split/scratch buttons. Non-private so `titlebarRow`
-    /// (in `WindowContentView`) can place it, mirroring the `+RecentSessions` buttons.
+    /// Title-bar opener for the view-only grid — the frontmost window's most-recently-used sessions,
+    /// auto-sized (the `AppActions.toggleDashboard` / ⌘⇧D / Navigate ▸ Dashboard path). A single glyph,
+    /// never a 2-state toggle: an open dashboard swaps the whole titlebar for the stripped
+    /// `dashboardTitlebar`, so this renders only while closed. Disabled with no sessions, like the
+    /// split/scratch buttons. Non-private so `titlebarRow` can place it, like the `+RecentSessions` buttons.
     var dashboardButton: some View {
         Button {
             actions.toggleDashboard()
@@ -147,12 +141,11 @@ extension WindowContentView {
         .accessibilityIdentifier("dashboard-toggle-button")
     }
 
-    /// Whether an OPEN dashboard hosts this session-pane slot in a grid cell. A member is now an explicit
-    /// `(session, pane)` cell, so BOTH panes of a split member are claimed (each hosts its own surface) — the
-    /// deck must yield the `Color.clear` placeholder for every claimed slot (an NSView lives in one host at a
-    /// time), exactly like the zoom exclusion, but generalized to N panes. False for every non-member slot,
-    /// for a member's scratch/overlay surfaces (the dashboard never hosts those), and while the dashboard is
-    /// closed.
+    /// Whether an OPEN dashboard hosts this session-pane slot in a grid cell. A member is a `(session,
+    /// pane)` cell, so BOTH panes of a split member are claimed and the deck must yield its `Color.clear`
+    /// placeholder for each — an NSView lives in one host at a time, the zoom exclusion generalized to N
+    /// panes. False for a non-member slot, for a member's scratch/overlay surfaces (never hosted here), and
+    /// while the dashboard is closed.
     func dashboardHostsSurface(session: Session, surface: TerminalZoomSurface) -> Bool {
         guard dashboard.isOpen else { return false }
         return dashboard.members.contains(DashboardMember(session: session.id, surface: surface))
@@ -170,10 +163,10 @@ extension WindowContentView {
         DashboardControllerRegistry.shared.unregister(windowID)
     }
 
-    /// The dashboard-open transition (the body's `.onChange(of: dashboard.isOpen)`): entering closes this
-    /// window's transient chrome and pauses auto-follow (mirrors `handleZoomTargetChange`); exiting resumes
-    /// auto-follow. The per-member font override is driven separately off `dashboardFontKey` so a retarget
-    /// (re-open with a new set) OR a same-members re-open with a new font mode re-applies it.
+    /// The `.onChange(of: dashboard.isOpen)` transition: entering closes this window's transient chrome and
+    /// pauses auto-follow (mirroring `handleZoomTargetChange`), exiting resumes it. The per-member font
+    /// override rides `dashboardFontKey` instead, so a retarget (re-open with a new set) OR a same-members
+    /// re-open with a new font mode re-applies it.
     func handleDashboardOpenChange(_ isOpen: Bool) {
         if isOpen {
             // the palette is app-global and renders in the FRONTMOST window, so only that window's dashboard
@@ -184,9 +177,8 @@ extension WindowContentView {
                 (session.searchSurface as? GhosttySurfaceView)?.endSearch()
             }
             if quickTerminal.isVisible { quickTerminal.hide() }
-            // the session switcher is app-global and renders in the FRONTMOST window (like the palette above),
-            // so only that window's dashboard may cancel it — a control-driven dashboard of a background window
-            // must not abort an in-progress Ctrl-Tab in the frontmost window.
+            // the switcher is app-global and frontmost-rendered like the palette, so a control-driven
+            // dashboard of a background window must not abort an in-progress Ctrl-Tab in the frontmost one.
             if library.activeWindowID == windowID, sessionSwitcher.isActive { sessionSwitcher.cancel() }
             // pause this window's idle auto-follow so an armed jump can't reshuffle the selection under the modal.
             store.suppressAutoFollow()
@@ -195,12 +187,11 @@ extension WindowContentView {
         }
     }
 
-    /// The font-key change (the body's `.onChange(of: dashboardFontKey)`): clears every prior override, then
-    /// re-applies the font mode to the current pane cells and records the applied size on the controller.
-    /// Fires on open ([] → members), retarget (members → new set), a same-members font-mode change, a
-    /// member add/remove, and close (members → []), so a de-membered surface never keeps a stale shrunk font
-    /// and a re-open always re-sizes. Each cell's OWN pane surface (`.primary` → `\.surface`, `.split` →
-    /// `\.splitSurface`) gets the override.
+    /// The `.onChange(of: dashboardFontKey)` apply: clear every prior override, re-apply the mode to the
+    /// current pane cells (each cell's OWN surface — `.primary` → `\.surface`, `.split` →
+    /// `\.splitSurface`), and record the applied size on the controller. Fires on open, retarget, a
+    /// same-members mode change, a member add/remove and close, so a de-membered surface never keeps a
+    /// stale shrunk font and a re-open always re-sizes.
     func handleDashboardFontChange() {
         clearDashboardFontOverrides()
         guard dashboard.isOpen else {
@@ -215,26 +206,23 @@ extension WindowContentView {
         }
     }
 
-    /// The reconcile hook (the body's `.onChange(of: dashboardValidMembers)`): drops any pane cell whose
-    /// session was closed OR whose split pane closed while the dashboard is open (e.g. over the control
-    /// socket), so the grid recomputes to the smaller count and the highlight never points at a gone pane. A
-    /// no-op while closed or when no member vanished; `DashboardController.reconcile` closes the dashboard
-    /// when the last member is gone.
+    /// The `.onChange(of: dashboardValidMembers)` hook: drops any pane cell whose session or split pane
+    /// closed while the dashboard is open (e.g. over the control socket), so the grid recomputes to the
+    /// smaller count and the highlight never points at a gone pane. A no-op while closed or when nothing
+    /// vanished; `DashboardController.reconcile` closes the dashboard once the last member is gone.
     func reconcileDashboardMembers() {
         guard dashboard.isOpen else { return }
         dashboard.reconcile(existing: Set(dashboardValidMembers))
-        // reconcile may have CLOSED the dashboard (its last member's session/pane vanished); the key-catcher
-        // that held first responder then unmounts with nothing to re-grab it, stranding the window without
-        // focus. Restore it like the Esc/Enter paths do — but ONLY for the frontmost window: this fires
-        // per-window (incl. a background window on a control-driven session close) and `focusActiveSession`
-        // targets the frontmost store, so an unguarded call would grab first responder in the WRONG window
-        // (the same hazard the zoom-exit refocus guards against).
+        // reconcile may have CLOSED the dashboard (its last member vanished), unmounting the key-catcher
+        // that held first responder with nothing to re-grab it. Restore focus like Esc/Enter — but ONLY for
+        // the frontmost window: this fires per-window (a background window on a control-driven close too)
+        // while `focusActiveSession` targets the frontmost store, so an unguarded call would grab first
+        // responder in the WRONG window (the hazard the zoom-exit refocus guards against).
         if !dashboard.isOpen, library.activeWindowID == windowID { actions.focusActiveSession() }
     }
 
-    /// Reciprocal exclusivity (folded into the body's `.onChange(of: terminalZoom.target)`): a zoom becoming
-    /// active while the dashboard is open closes the dashboard — the mirror of `ControlServer.setDashboard`
-    /// clearing an active zoom on open.
+    /// Reciprocal exclusivity (in the body's `.onChange(of: terminalZoom.target)`): a zoom becoming active
+    /// closes an open dashboard — the mirror of `ControlServer.setDashboard` clearing a zoom on open.
     func closeDashboardIfZoomActive(_ target: TerminalZoomTarget?) {
         guard target != nil, dashboard.isOpen else { return }
         dashboard.close()
@@ -244,11 +232,11 @@ extension WindowContentView {
     /// acknowledgement so a mouse jump doesn't feel like an instant, unexplained close.
     static let dashboardClickEnterDelay: TimeInterval = 0.18
 
-    /// A mouse click on a cell: flash the active frame on it (`dashboard.highlight`), then enter after a brief
-    /// delay — an instant jump with no frame flash reads as confusing. Keyboard Enter has no delay (its
-    /// highlight is already visible). The delayed enter only fires while this cell is STILL the highlighted
-    /// one, so a superseding click (or an arrow) on another cell wins — last-click, not first-scheduled — and
-    /// a close/reconcile in the gap (which clears or moves the highlight) cancels the pending enter.
+    /// A click flashes the active frame on the cell (`dashboard.highlight`), then enters after a brief delay
+    /// — an instant jump with no flash reads as confusing (keyboard Enter needs none, its highlight is
+    /// already visible). The delayed enter fires only while this cell is STILL highlighted, so a superseding
+    /// click or arrow wins (last-click, not first-scheduled) and a close/reconcile in the gap, which clears
+    /// or moves the highlight, cancels it.
     func clickDashboardMember(_ member: DashboardMember) {
         dashboard.highlight(member)
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.dashboardClickEnterDelay) {
@@ -257,11 +245,11 @@ extension WindowContentView {
         }
     }
 
-    /// Enter (immediately), or a mouse click (after its flash delay), enters a cell: select that session,
-    /// close the dashboard, then land first responder in the cell's EXACT pane — the split (right) pane for a `.split` cell (mirroring
-    /// `revealActiveBlockedPane`'s `.right` branch: flip `splitFocused`, then `focusSplitPane(wantSplit:true)`),
-    /// else the main pane. Close BEFORE focusing so the `focusSplitPane`/`focusActiveSession` `dashboardActive`
-    /// guards (the window's controller `isOpen`) don't block the focus.
+    /// Entering a cell (Enter immediately, a click after its flash delay): select that session, close the
+    /// dashboard, then land first responder in the cell's EXACT pane — for `.split`, flip `splitFocused`
+    /// then `focusSplitPane(wantSplit: true)`, mirroring `revealActiveBlockedPane`'s `.right` branch; else
+    /// the main pane. Close BEFORE focusing or the `focusSplitPane`/`focusActiveSession` `dashboardActive`
+    /// guards (the window's controller `isOpen`) block it.
     func selectDashboardMember(_ member: DashboardMember) {
         store.selectSession(member.session)
         dashboard.close()
@@ -284,23 +272,21 @@ extension WindowContentView {
         actions.focusActiveSession()
     }
 
-    /// The absolute font size to apply to every member surface for the current mode, or nil for `.untouched`
-    /// (leave each surface at its own `session.fontSize`). Resolves through the SAME host-free
-    /// `DashboardFontMode.appliedFontSize` seam `ControlServer.setDashboard` uses, so the surface overrides
-    /// and the controller's synchronous read-back land on the identical value (the onChange re-apply is a
-    /// no-op re-write). `.auto` derives it from the grid, based on the Settings font size (nil → the ghostty
-    /// default).
+    /// The absolute size for every member surface in the current mode, or nil for `.untouched` (each keeps
+    /// its own `session.fontSize`). Resolves through the SAME host-free `DashboardFontMode.appliedFontSize`
+    /// seam `ControlServer.setDashboard` uses, so the surface overrides and the controller's synchronous
+    /// read-back land on the identical value (the onChange re-apply is a no-op re-write). `.auto` derives it
+    /// from the grid and the Settings font size (nil → the ghostty default).
     private func dashboardTargetFontSize(memberCount: Int) -> Double? {
         let base = actions.settingsModel?.settings.fontSize ?? DashboardLayout.ghosttyDefaultFontSize
         return dashboard.fontMode.appliedFontSize(memberCount: memberCount, base: base)
     }
 
-    /// Clear the transient dashboard font override on every surface that currently carries one, restoring its
-    /// real (session-model) font. Sweeps BOTH `\.surface` AND `\.splitSurface` of every session, since a split
-    /// member now carries the override on its OWN pane surface (both panes can carry one). A store-wide sweep
-    /// rather than iterating `dashboard.members`, so it stays correct on close (members already emptied) and
-    /// on window teardown; only touches surfaces with an active override, so a plain surface isn't needlessly
-    /// re-configured.
+    /// Clear the transient dashboard font override wherever one is set, restoring each surface's real
+    /// (session-model) font. Sweeps BOTH `\.surface` AND `\.splitSurface` of every session, since a split
+    /// member carries one per pane, and sweeps store-wide rather than over `dashboard.members` so it stays
+    /// correct on close (members already emptied) and on window teardown; an override-less surface is not
+    /// needlessly re-configured.
     private func clearDashboardFontOverrides() {
         for session in store.workspaces.flatMap(\.sessions) {
             for surface in [session.surface, session.splitSurface] {

--- a/agterm/Views/WindowContentView+RecentSessions.swift
+++ b/agterm/Views/WindowContentView+RecentSessions.swift
@@ -7,20 +7,19 @@ import SwiftUI
 /// equivalent of the Ctrl-Tab switcher — and the attention bell. Both open a session picker over the
 /// frontmost window and are referenced from `WindowContentView.titlebarRow`.
 extension WindowContentView {
-    /// The frontmost window's most-recently-used sessions, EXCLUDING the current one (it's not a jump target —
-    /// you're already there), scoped to the visible/filtered set and capped like the Ctrl-Tab switcher.
-    /// The live refresh rides the OBSERVED `activeSession`/`navigableSessions` reads — every `sessionRecency`
-    /// mutation co-occurs with one of them (a push on select changes `activeSession`, a prune on close changes
-    /// `navigableSessions`); `sessionRecency` itself is `@ObservationIgnored`, read for its value, not for
-    /// observation, so it registers none on its own.
+    /// The frontmost window's most-recently-used sessions, EXCLUDING the current one (not a jump target —
+    /// you're already there), scoped to the visible/filtered set and capped like the Ctrl-Tab switcher. The
+    /// live refresh rides the OBSERVED `activeSession`/`navigableSessions` reads — every `sessionRecency`
+    /// mutation co-occurs with one (a push on select changes `activeSession`, a prune on close changes
+    /// `navigableSessions`); `sessionRecency` itself is `@ObservationIgnored` and registers no observation.
     private var recentSessions: [UUID] {
         store.navigableRecentSessions(limit: SessionSwitcher.maxCandidates)
     }
 
-    /// Title-bar button that opens the recent-sessions popover — the mouse equivalent of the Ctrl-Tab
-    /// switcher. Lists the window's most-recently-used OTHER sessions; disabled/dimmed when there's nothing
-    /// to switch to (only the current session). Opening a popover is interactive-only, so it's control-API
-    /// keep-in-sync exempt (like the bell opening the attention palette).
+    /// Title-bar button opening the recent-sessions popover — the mouse equivalent of the Ctrl-Tab switcher.
+    /// Lists the window's most-recently-used OTHER sessions; disabled/dimmed when there is nothing to switch to
+    /// (only the current session). Opening a popover is interactive-only, so it is control-API keep-in-sync
+    /// exempt, like the bell opening the attention palette.
     var recentSessionsButton: some View {
         let enabled = !recentSessions.isEmpty && pick.pending == nil
         return Button {
@@ -30,9 +29,9 @@ extension WindowContentView {
             Label("Recent sessions", systemImage: "clock.arrow.circlepath")
         }
         .help("Recent sessions (⌃Tab)")
-        // pin the tint to chromeText like the attention bell: without it a disabled plain button resolves
-        // the SF Symbol to the system disabled color, which is near-invisible on the themed titlebar (the
-        // dimmed clock would vanish instead of graying out like the bell).
+        // pin the tint to chromeText like the attention bell: a disabled plain button otherwise resolves the SF
+        // Symbol to the system disabled color, near-invisible on the themed titlebar — the dimmed clock would
+        // vanish instead of graying out like the bell.
         .foregroundStyle(chromeText)
         .disabled(!enabled)
         .opacity(enabled ? 1 : 0.35)
@@ -41,9 +40,9 @@ extension WindowContentView {
             recentSessionsPopover
         }
         .onChange(of: recentSessionsShown) { _, shown in
-            // suppress this window's auto-follow while the popover is open so an armed idle jump can't
-            // reshuffle the MRU rows under the pointer (the command palette + dashboard bracket the same way);
-            // the counted suppression stays balanced across open/close and with the attention popover.
+            // suppress this window's auto-follow while the popover is open so an armed idle jump can't reshuffle
+            // the MRU rows under the pointer (the palette + dashboard bracket the same way); the counted
+            // suppression stays balanced across open/close and with the attention popover.
             if shown { store.suppressAutoFollow() } else { store.resumeAutoFollow() }
         }
         .onChange(of: recentSessions.isEmpty) { _, empty in
@@ -53,16 +52,14 @@ extension WindowContentView {
         }
     }
 
-    /// The recent-sessions popover body: the MRU OTHER sessions as full-row `RecentSessionRow`s (the shared
-    /// two-line `SessionSwitcherRow`) — the current session is omitted since it isn't a jump target. Each row
-    /// highlights on hover and, on click anywhere in the row, commits the switch (`noteUserActivity` +
-    /// `selectSession` + focus, like the Ctrl-Tab release) then closes the popover — the palette-row feel.
-    /// Tinted to the terminal theme (`terminalColor` panel, `chromeText` text, selection-color hover) so it
-    /// matches the themed sidebar/titlebar chrome rather than the system popover look.
+    /// The recent-sessions popover body: the MRU OTHER sessions as full rows (the shared two-line
+    /// `SessionSwitcherRow`). Each row highlights on hover and, on a click anywhere in the row, commits the
+    /// switch (`noteUserActivity` + `selectSession` + focus, like the Ctrl-Tab release) then closes the popover
+    /// — the palette-row feel. Tinted to the terminal theme (`terminalColor` panel, `chromeText` text,
+    /// selection-color hover) so it matches the themed chrome rather than the system popover look.
     private var recentSessionsPopover: some View {
-        // no `.accessibilityIdentifier` on this container: a SwiftUI accessibility identifier on a parent
-        // propagates to and OVERRIDES its descendants' identifiers, which would clobber the per-row
-        // `recent-session-row` ids the tests read. The rows carry their own ids.
+        // no `.accessibilityIdentifier` on this container: a SwiftUI identifier on a parent propagates to and
+        // OVERRIDES its descendants', clobbering the per-row `recent-session-row` ids the tests read.
         VStack(spacing: 2) {
             ForEach(recentSessions, id: \.self) { id in
                 recentSessionRow(id)
@@ -108,14 +105,14 @@ extension WindowContentView {
         recentSessionsShown = false
     }
 
-    /// Title-bar bell reflecting the window's attention state at a glance (opt-in, gated by the
-    /// `attentionButtonEnabled` mirror). Three states from `store.attentionSessions`: empty → a dimmed
-    /// disabled outline bell; non-empty with nothing blocked → a plain enabled bell in `chromeText`; any
-    /// blocked session → a filled bell tinted the blocked-status color. No count, no pulse. Click opens the
-    /// attention popover (the mouse form; ⌃⇧I / the Navigate menu keep the searchable `.attention` palette).
-    /// Reading `store.attentionSessions` in the body registers the per-session `agentIndicator` observation,
-    /// so the glyph re-renders live as a status changes. `.accessibilityValue` (none|attention|blocked)
-    /// exposes the otherwise-unobservable bell↔bell.fill state to XCUITest, mirroring `StatusIconView`.
+    /// Title-bar bell reflecting the window's attention state (opt-in, gated by the `attentionButtonEnabled`
+    /// mirror). Three states from `store.attentionSessions`: empty → a dimmed disabled outline bell; non-empty
+    /// with nothing blocked → a plain enabled bell in `chromeText`; any blocked session → a filled bell tinted
+    /// the blocked-status color. No count, no pulse. Click opens the attention popover (the mouse form; ⌃⇧I /
+    /// the Navigate menu keep the searchable `.attention` palette). Reading `store.attentionSessions` in the
+    /// body registers the per-session `agentIndicator` observation, so the glyph re-renders live;
+    /// `.accessibilityValue` (none|attention|blocked) exposes the otherwise-unobservable bell↔bell.fill state
+    /// to XCUITest, mirroring `StatusIconView`.
     var attentionButton: some View {
         let sessions = store.attentionSessions
         let blocked = sessions.contains { $0.agentIndicator.status == .blocked }
@@ -137,8 +134,7 @@ extension WindowContentView {
             attentionPopover
         }
         .onChange(of: attentionPopoverShown) { _, shown in
-            // same as the recent popover: suppress auto-follow while open so an armed idle jump can't
-            // reshuffle the listed attention sessions under the pointer; counted, so it stays balanced.
+            // same as the recent popover: suppress auto-follow while open (counted, so it stays balanced).
             if shown { store.suppressAutoFollow() } else { store.resumeAutoFollow() }
         }
         .onChange(of: empty) { _, isEmpty in
@@ -150,8 +146,8 @@ extension WindowContentView {
 
     /// The attention popover body: the window's sessions needing attention (`store.attentionSessions`, sorted
     /// blocked→active→completed) as full-row `SessionPopoverRow`s with a leading status glyph — the mouse form
-    /// of the ⌃⇧I attention palette, themed and hover-highlighted like the recent-sessions popover. Clicking a
-    /// row selects the session and reveals its blocked pane. Same tint (`terminalColor`/`chromeText`/selection).
+    /// of the ⌃⇧I attention palette, tinted and hover-highlighted like the recent-sessions popover. Clicking a
+    /// row selects the session and reveals its blocked pane.
     private var attentionPopover: some View {
         VStack(spacing: 2) {
             ForEach(store.attentionSessions) { session in
@@ -187,10 +183,9 @@ extension WindowContentView {
 /// One clickable session row for the title-bar popovers (recent-sessions and attention) — the shared two-line
 /// `SessionSwitcherRow` tinted with the terminal theme (`foreground`), with an optional leading status glyph
 /// (`status` plus its per-call `statusColorHex`/`statusShape` overrides, set only by the attention popover so
-/// the row matches the sidebar glyph), a pointer-hover highlight (`hoverColor`) and a full-row hit
-/// area (`.contentShape`), so the WHOLE row selects on click, not just the text (the command-palette-row
-/// feel). Kept a `Button` so it reads as an actionable control to VoiceOver; `accessibilityID` distinguishes
-/// the two popovers' rows for the tests.
+/// the row matches the sidebar glyph), a pointer-hover highlight (`hoverColor`) and a full-row hit area
+/// (`.contentShape`), so the WHOLE row selects on click, not just the text. Kept a `Button` so it reads as an
+/// actionable control to VoiceOver; `accessibilityID` distinguishes the two popovers' rows for the tests.
 private struct SessionPopoverRow: View {
     let title: String
     let subtitle: String

--- a/agterm/Views/WindowContentView+Titlebar.swift
+++ b/agterm/Views/WindowContentView+Titlebar.swift
@@ -2,25 +2,22 @@ import agtermCore
 import AppKit
 import SwiftUI
 
-/// The custom title-bar row and its label/buttons, split out of `WindowContentView` to keep that file
-/// under the size limit (like `+Dashboard` / `+RecentSessions` / `+Zoom`). Owns the title text (session /
-/// window name, gated by the Interface toggles), the toolbar row layout, and the per-session chrome
-/// buttons; the recent-sessions / attention / dashboard buttons live in their own extensions.
+/// The custom title-bar row and its label/buttons, split out of `WindowContentView` for the file size limit.
+/// Owns the title text (session / window name, gated by the Interface toggles), the row layout, and the
+/// per-session chrome buttons; recent-sessions / attention / dashboard buttons live in their own extensions.
 extension WindowContentView {
-    /// The titlebar title (first line): the active session's display name, suffixed with the window
-    /// name as "session — window" when the window has a custom (user-set) name, so a renamed window
-    /// is identifiable at a glance. Auto "window N" names are omitted. "Agterm" when nothing is selected.
-    /// Non-private so the body's `WindowAccessor` uses it as the OS window title — always the real name,
-    /// regardless of the Interface toggles that gate only the on-screen `titleText`.
+    /// The titlebar title (first line): the active session's display name, suffixed as "session — window" for
+    /// a custom (user-set) window name; auto "window N" names are omitted, and "Agterm" when nothing is
+    /// selected. Non-private: the body's `WindowAccessor` uses it as the OS window title, always the real
+    /// name, regardless of the Interface toggles that gate only the on-screen `titleText`.
     var windowTitle: String {
         let session = store.activeSession?.displayName ?? "Agterm"
         guard let name = customWindowName else { return session }
         return "\(session) — \(name)"
     }
 
-    /// The titlebar subtitle (second line): the focused pane's `subtitleDetail` — its terminal title for
-    /// a remote (SSH) session whose local cwd is stale, else its working directory (the split pane's while
-    /// it's focused, else the primary's). Shown only in normal mode; compact/hidden drop it.
+    /// The titlebar subtitle (second line): the focused pane's `subtitleDetail` — the terminal title for a
+    /// remote (SSH) session whose local cwd is stale, else its cwd. Normal mode only; compact/hidden drop it.
     private var windowSubtitle: String {
         toolbarMode == .normal ? (store.activeSession?.subtitleDetail ?? "") : ""
     }
@@ -32,10 +29,9 @@ extension WindowContentView {
         return info.name
     }
 
-    /// The VISIBLE title-bar label, honoring the Interface toggles: the session name (hidden by
-    /// `.sessionName`), the custom window name (hidden by `.windowName`), or both joined as
-    /// "session — window". Empty when both parts are hidden or absent — distinct from `windowTitle`, which
-    /// always feeds the OS window title so Mission Control / the Window menu stay labelled regardless.
+    /// The VISIBLE title-bar label, honoring the Interface toggles: the session name (hidden by `.sessionName`),
+    /// the custom window name (hidden by `.windowName`), or both as "session — window"; empty when both are
+    /// hidden or absent. `windowTitle` still feeds the OS title, so Mission Control / Window stay labelled.
     private var titleText: String {
         let sessionPart = shows(.sessionName) ? (store.activeSession?.displayName ?? "Agterm") : nil
         let windowPart = shows(.windowName) ? customWindowName : nil
@@ -47,10 +43,9 @@ extension WindowContentView {
         }
     }
 
-    /// The window title at the terminal's leading edge: the session/window name (gated by the Interface
-    /// toggles), plus the cwd subtitle on a second line only in normal mode (compact drops it for a single
-    /// short row). Non-private so the zoom titlebar reuses it — a zoomed terminal shows the same title as
-    /// the normal window.
+    /// The window title at the terminal's leading edge: the gated session/window name, plus the cwd subtitle
+    /// on a second line in normal mode only (compact drops it for one short row). Non-private so the zoom
+    /// titlebar reuses it — a zoomed terminal shows the same title as the normal window.
     var titleLabel: some View {
         VStack(alignment: .leading, spacing: 1) {
             if !titleText.isEmpty {
@@ -64,21 +59,19 @@ extension WindowContentView {
         }
     }
 
-    /// The window chrome above the terminal: the full custom titlebar row, or — in hidden mode — an
-    /// invisible ~3px top drag strip and nothing else (no row, and `WindowAppearance.sync` also drops the
-    /// traffic lights) so the terminal runs full-bleed while the window stays movable + double-click-zoomable.
-    /// Non-private so the body renders it above the window overlays.
+    /// The window chrome above the terminal: the full custom titlebar row, or in hidden mode an invisible ~3px
+    /// top drag strip alone (no row; `WindowAppearance.sync` also drops the traffic lights), so the terminal
+    /// runs full-bleed while staying movable + double-click-zoomable. Non-private, rendered above the overlays.
     @ViewBuilder var customTitlebar: some View {
         if toolbarMode == .hidden {
-            // only the top ~3px loses click-through (the accepted cost) — kept thin so it doesn't cover the
-            // terminal's first row (window-padding-y = 6), which would otherwise swallow clicks meant to
-            // select it; it still keeps the standard title-bar gestures via the same `WindowControlArea`.
+            // only the top ~3px loses click-through (the accepted cost), kept thin so it stays clear of the
+            // terminal's first row (window-padding-y = 6) whose clicks it would swallow; `WindowControlArea`
+            // still supplies the standard title-bar gestures.
             Color.clear
                 .frame(height: 3)
                 .frame(maxWidth: .infinity)
-                // Color.clear is hit-testable in SwiftUI, so it would swallow the mouseDown before it
-                // reaches the WindowControlArea behind it — opt out (like the titlebarRow spacers) so the
-                // strip's drag/double-click-zoom gestures fall through to the AppKit view.
+                // Color.clear is hit-testable in SwiftUI and would swallow the mouseDown before the
+                // WindowControlArea behind it, so opt out and let drag/double-click-zoom reach the AppKit view.
                 .allowsHitTesting(false)
                 .background { WindowControlArea() }
         } else {
@@ -86,11 +79,10 @@ extension WindowContentView {
         }
     }
 
-    /// Custom titlebar row replacing the system toolbar: the sidebar toggle pinned to the sidebar's
-    /// trailing edge (by the divider), the title at the terminal's start, and the trailing action cluster
-    /// (recent-sessions / attention popovers, a divider, the scratch / split view controls, a divider, then
-    /// the dashboard / quick-terminal group). Positions track `sidebarWidth`; the left inset clears the
-    /// system traffic lights.
+    /// Custom titlebar row replacing the system toolbar: the sidebar toggle pinned to the sidebar's trailing
+    /// edge (by the divider), the title at the terminal's start, and the trailing cluster (recent-sessions /
+    /// attention popovers, divider, scratch / split controls, divider, dashboard / quick terminal). Positions
+    /// track `sidebarWidth`; the left inset clears the system traffic lights.
     private var titlebarRow: some View {
         HStack(spacing: 0) {
             Color.clear.frame(width: 78).allowsHitTesting(false) // system traffic lights
@@ -112,9 +104,8 @@ extension WindowContentView {
                 Spacer().frame(width: 12)
             }
             titleLabel
-                // the title text falls through to the drag/zoom layer behind it (see `.background` below),
-                // so double-clicking it zooms and dragging it moves the window — the rest of the row is
-                // empty spacers (already non-hittable) and the buttons, which keep their own clicks.
+                // the title text falls through to the drag/zoom layer behind it, so double-click zooms and
+                // drag moves the window; the rest of the row is non-hittable spacers plus the buttons.
                 .allowsHitTesting(false)
             Spacer(minLength: 12)
             titlebarTrailingActions
@@ -123,24 +114,21 @@ extension WindowContentView {
         // tint the title text and the toolbar buttons with the terminal theme's foreground so the
         // chrome tracks the theme (the cwd subtitle dims itself to 0.6 over this).
         .foregroundStyle(chromeText)
-        // larger icons in the normal row, smaller in compact (the row isn't drawn in hidden mode; imageScale hits the
-        // SF Symbols, not the title text).
+        // the row isn't drawn in hidden mode; imageScale hits the SF Symbols, not the title text.
         .imageScale(toolbarMode == .normal ? .large : .medium)
         .frame(height: titlebarHeight)
         .frame(maxWidth: .infinity)
         // make the header behave like a standard title bar: single-click drag moves the window, double-click
-        // runs the user's configured title-bar action (zoom/minimize/none). The layer sits BEHIND the row,
-        // so the buttons render in front and keep their clicks; the empty spacers + the title text opt out of
-        // hit-testing (above) so their region falls through to it. Custom titlebar = no native title-bar
-        // double-click handling, hence this.
+        // runs the user's configured title-bar action (zoom/minimize/none) — a custom titlebar gets no native
+        // double-click handling. the layer sits BEHIND the row, so the buttons keep their clicks while the
+        // spacers + title text opt out of hit-testing (above) and fall through to it.
         .background { WindowControlArea() }
     }
 
-    /// The title bar's trailing action cluster, each button gated by its Interface toggle: the
-    /// recent-sessions / attention popovers, the per-session scratch / split controls, and the
-    /// window-overlay dashboard / quick-terminal group. A separator sits ONLY where two groups that each
-    /// still show 2+ buttons meet, so a group reduced to a single button flows in without a bracketing
-    /// separator (and an empty group lets its two neighbors meet directly).
+    /// The title bar's trailing action cluster, each button gated by its Interface toggle: recent-sessions /
+    /// attention popovers, per-session scratch / split controls, window-overlay dashboard / quick terminal.
+    /// A separator sits ONLY where two groups that each still show 2+ buttons meet, so a group reduced to one
+    /// button flows in unbracketed and an empty group lets its neighbors meet directly.
     private var titlebarTrailingActions: some View {
         let showRecent = shows(.recentSessions)
         let showAttention = attentionButtonEnabled // the bell keeps its own separate Notifications setting
@@ -148,9 +136,9 @@ extension WindowContentView {
         let showSplit = shows(.split)
         let showDashboard = shows(.dashboard)
         let showQuick = shows(.quickTerminal)
-        let countA = (showRecent ? 1 : 0) + (showAttention ? 1 : 0)  // recent-sessions + attention popovers
-        let countB = (showScratch ? 1 : 0) + (showSplit ? 1 : 0)     // per-session scratch + split controls
-        let countC = (showDashboard ? 1 : 0) + (showQuick ? 1 : 0)   // window-overlay dashboard + quick terminal
+        let countA = (showRecent ? 1 : 0) + (showAttention ? 1 : 0)
+        let countB = (showScratch ? 1 : 0) + (showSplit ? 1 : 0)
+        let countC = (showDashboard ? 1 : 0) + (showQuick ? 1 : 0)
         // a separator only between two 2+-button groups (the host-free rule, unit-tested in agtermCore).
         let dividers = InterfaceElement.titlebarGroupDividers(countA: countA, countB: countB, countC: countC)
         return HStack(spacing: 14) {
@@ -186,11 +174,10 @@ extension WindowContentView {
         let isSplit = store.activeSession?.isSplit ?? false
         let hasSplit = store.activeSession?.hasSplit ?? false
         let splitFocused = store.activeSession?.splitFocused ?? false
-        // filled = pane visible, outline = hidden. no split: an empty two-pane outline. split shown: both
-        // panes filled. collapsed to a single pane (hasSplit but not shown): only the VISIBLE pane's half
-        // is filled — left for the primary, right for the split pane (`splitFocused` is the shown one when
-        // hidden) — so the glyph tells you which pane is up and that the other is parked. `a11y` mirrors the
-        // four states for XCUITest, which can't read the symbol name (like the attention bell's value).
+        // filled = pane visible, outline = hidden: no split is an empty two-pane outline, a shown split fills
+        // both, a collapsed one (hasSplit, not shown) fills only the visible half — left for the primary, right
+        // for the split (`splitFocused` is the shown pane when hidden) — naming the pane up and the one parked.
+        // `a11y` mirrors the four states for XCUITest, which can't read the symbol name.
         let symbol: String
         let a11y: String
         if !hasSplit {
@@ -205,8 +192,7 @@ extension WindowContentView {
         return Button {
             actions.toggleSplit()
         } label: {
-            // a Label (icon + title) so the toolbar's "Icon and Text" mode has text to show; the title
-            // is hidden in the default icon-only mode.
+            // a Label (icon + title) so the toolbar's "Icon and Text" mode has text; hidden in icon-only mode.
             Label("Split", systemImage: symbol)
         }
         .help(helpHint(isSplit ? "Hide split" : (hasSplit ? "Show split" : "Split right"), .toggleSplit))
@@ -215,9 +201,8 @@ extension WindowContentView {
         .accessibilityIdentifier("split-toggle")
     }
 
-    /// Toolbar button that toggles the active session's scratch terminal — a third, full-overlay login
-    /// shell, kept alive when hidden. 2-state glyph (filled while shown): unlike the split there is no
-    /// "hidden but exists" indicator, since the shell's own `exit` clears it and the next show is fresh.
+    /// Toggles the active session's scratch terminal — a third, full-overlay login shell kept alive when
+    /// hidden. 2-state glyph (filled while shown): no "hidden but exists" state, since its `exit` clears it.
     private var scratchButton: some View {
         let active = store.activeSession?.scratchActive ?? false
         return Button {
@@ -230,9 +215,8 @@ extension WindowContentView {
         .accessibilityIdentifier("scratch-toggle")
     }
 
-    /// Toolbar button (next to the split toggle) that toggles the quick terminal: a single
-    /// scratch terminal overlaid at 90% of the window, on top of the sidebar and terminal.
-    /// Click the button again or the surrounding margin to hide; the shell stays alive until quit.
+    /// Toggles the quick terminal: one scratch terminal overlaid at 90% of the window, above the sidebar and
+    /// terminal. Clicking it again or the surrounding margin hides it; the shell stays alive until quit.
     private var quickTerminalButton: some View {
         Button {
             actions.toggleQuickTerminal()

--- a/agterm/Views/WindowContentView+Zoom.swift
+++ b/agterm/Views/WindowContentView+Zoom.swift
@@ -70,13 +70,12 @@ extension WindowContentView {
     /// closes the window's transient chrome and focuses the zoomed surface; exiting returns focus.
     func handleZoomTargetChange(old: TerminalZoomTarget?, new: TerminalZoomTarget?) {
         if let new {
-            // zoom closes this window's transient chrome, uniformly: the palette, an open ⌘F search
-            // (otherwise libghostty stays in search mode with stale full-window highlights and no
-            // visible bar), and — for a session-surface zoom — a visible quick terminal (the zoom
-            // layer replaces its host, which would strand `isVisible` true with nothing on screen).
-            // A `.quick` zoom keeps the quick terminal: the zoom layer hosts it. The palette is
-            // app-global and renders in the FRONTMOST window, so only that window's zoom may close
-            // it — a control-driven zoom of a background window must not kill the user's palette.
+            // zoom closes this window's transient chrome: the palette, an open ⌘F search (else libghostty
+            // stays in search mode with stale full-window highlights and no visible bar), and — for a
+            // session-surface zoom — a visible quick terminal (the zoom layer replaces its host, stranding
+            // `isVisible` true with nothing on screen); a `.quick` zoom keeps it, the zoom layer hosting it.
+            // The palette is app-global and renders in the FRONTMOST window, so only that window's zoom may
+            // close it — a control-driven zoom of a background window must not kill the user's palette.
             if library.activeWindowID == windowID { palette.close() }
             if let session = store.activeSession, session.searchActive {
                 (session.searchSurface as? GhosttySurfaceView)?.endSearch()
@@ -100,26 +99,23 @@ extension WindowContentView {
         if let old, new == nil {
             switch old {
             case .quick:
-                // the un-zoomed quick terminal may have been hidden in the same step (`quick hide`
-                // un-zooms then hides): only refocus it while it is still on screen — its own
+                // `quick hide` un-zooms then hides, so refocus only while it is still on screen — its own
                 // isVisible onChange handles the focus return otherwise.
                 if quickTerminal.isVisible { quickTerminal.focus() }
             case .session:
                 // scoped to THIS window, like the palette close above: `focusActiveSession` targets the
-                // FRONTMOST window, so a background window's zoom exit (its zoomed overlay/scratch
-                // exiting on its own, or a control-driven `surface zoom hide --window`) must not grab
-                // first responder there — e.g. out of an open ⌘F search field the user is typing into.
+                // FRONTMOST window, so a background window's zoom exit must not grab first responder there
+                // — e.g. out of an open ⌘F search field the user is typing into.
                 if library.activeWindowID == windowID { actions.focusActiveSession() }
             }
         }
     }
 
-    /// Whether the eager deck (not the zoom layer OR a dashboard cell) hosts this session-surface slot.
-    /// False for the one surface terminal zoom currently owns AND for any surface an open dashboard has
-    /// reparented into a grid cell — either renders the `Color.clear` placeholder in `sessionDetail` (an
-    /// NSView can live in one host at a time) while every other slot stays mounted, keeping the deck entry's
-    /// shape constant and its surfaces realizing behind the modal layer. The dashboard exclusion is the
-    /// union partner of the zoom exclusion (both are mutually exclusive, so at most one is ever active).
+    /// Whether the eager deck (not the zoom layer or a dashboard cell) hosts this session-surface slot. False
+    /// for the one surface zoom owns AND for any surface an open dashboard reparented into a grid cell —
+    /// either renders the `Color.clear` placeholder in `sessionDetail` (an NSView lives in one host at a
+    /// time) while every other slot stays mounted, keeping the deck entry's shape constant and its surfaces
+    /// realizing behind the modal layer. The two exclusions are mutually exclusive, so at most one is active.
     func deckHostsSurface(session: Session, surface: TerminalZoomSurface) -> Bool {
         if dashboardHostsSurface(session: session, surface: surface) { return false }
         guard case let .session(sessionID, zoomSurface) = terminalZoom.target else { return true }
@@ -134,9 +130,8 @@ extension WindowContentView {
                     QuickTerminalPane(controller: quickTerminal)
                 }
             case let .session(sessionID, surface):
-                // focus is driven by the body's `.onChange(of: terminalZoom.target)`, not an
-                // `.onAppear` here: a retarget while already zoomed keeps this branch's structural
-                // identity, so `.onAppear` would fire only for the first target.
+                // focus is driven by the body's `.onChange(of: terminalZoom.target)` — see
+                // `handleZoomTargetChange` for why no `.onAppear` here.
                 if let session = store.session(withID: sessionID) {
                     zoomTerminalHost {
                         zoomedSessionTerminal(session: session, surface: surface)
@@ -159,9 +154,8 @@ extension WindowContentView {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        // no opaque backing: the deck behind is already at opacity 0, so the window backing shows
-        // through and zoom keeps the un-zoomed terminal's translucency (an opaque color here flipped
-        // a translucent window solid on zoom and back).
+        // no opaque backing: the deck behind is already at opacity 0, so the window backing shows through
+        // and zoom keeps the terminal's translucency (an opaque color flipped a translucent window solid).
         .accessibilityIdentifier("terminal-zoom")
     }
 
@@ -186,11 +180,10 @@ extension WindowContentView {
         }
     }
 
-    /// Focus the zoomed surface once it exists, then hand off to `focusAfterReparent()` — the shared
-    /// bounded reparent-focus retry (conditional grab, stops once focus has stuck) — so zoom doesn't
-    /// grow its own copy of that machinery. The outer retry here only waits for a surface the zoom
-    /// layer's `TerminalView` hasn't realized yet (e.g. zooming a scratch that was never shown); it
-    /// dies as soon as the zoom target changes.
+    /// Focus the zoomed surface once it exists, then hand off to `focusAfterReparent()` — the shared bounded
+    /// reparent-focus retry (conditional grab, stops once focus sticks) — so zoom grows no copy of that
+    /// machinery. The outer retry here only waits for a surface the zoom layer's `TerminalView` hasn't
+    /// realized yet (e.g. zooming a never-shown scratch), and dies as soon as the zoom target changes.
     func focusZoomedSessionSurface(session: Session, surface: TerminalZoomSurface, attempt: Int = 0) {
         guard pick.pending == nil else { return }
         let expectedTarget = TerminalZoomTarget.session(session.id, surface)
@@ -202,11 +195,10 @@ extension WindowContentView {
         case .overlay: session.overlaySurface
         }
         if let view = target as? GhosttySurfaceView {
-            // suppress the focus report BEFORE the first grab: this runs from the target onChange, which
-            // can land before the zoom layer's TerminalView has mounted and flipped the flag — an
-            // unsuppressed makeFirstResponder on the still-deck-hosted surface would fire
-            // onFocusChange(true) and mutate splitFocused, the exact write zoom must not make. The deck
-            // TerminalView resets the flag when it remounts the surface on zoom exit.
+            // suppress the focus report BEFORE the first grab: this runs from the target onChange, which can
+            // land before the zoom layer's TerminalView has mounted and flipped the flag, and an unsuppressed
+            // makeFirstResponder on the still-deck-hosted surface fires onFocusChange(true) and mutates
+            // splitFocused — the exact write zoom must not make. The deck TerminalView resets it on exit.
             view.suppressFocusChange = true
             view.focusAfterReparent()
             return

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -2,8 +2,8 @@ import agtermCore
 import AppKit
 import SwiftUI
 
-/// Window-local handoff between picker dismissal and the owning window becoming frontmost: a background
-/// window must not claim first responder, yet its removed picker field cannot stay the responder later.
+/// Window-local handoff from picker dismissal to the window becoming frontmost: a background window must
+/// not claim first responder, yet its removed picker field cannot remain the responder.
 struct PickFocusRestorationState {
     private(set) var isDeferred = false
 
@@ -19,9 +19,8 @@ struct PickFocusRestorationState {
     }
 }
 
-/// The per-window UI: the workspace/session sidebar + the active session's terminal, plus the
-/// quick-terminal / palette / switcher overlays. `ContentView` resolves the store and hands in the
-/// non-optional `AppStore` the binding-based wiring needs.
+/// The per-window UI: sidebar + active session terminal, plus the quick-terminal / palette / switcher
+/// overlays. `ContentView` resolves the store and hands in the non-optional `AppStore` the bindings need.
 struct WindowContentView: View {
     let windowID: WindowInfo.ID
     @Bindable var store: AppStore
@@ -34,18 +33,17 @@ struct WindowContentView: View {
     let actions: AppActions
     let palette: PaletteController
     let sessionSwitcher: SessionSwitcher
-    /// This window's own quick terminal (one per window). Registered in `QuickTerminalRegistry` on appear
-    /// so the frontmost-window call sites reach it; its `cwdProvider` binds to this window's active session.
+    /// One quick terminal per window, registered in `QuickTerminalRegistry` on appear so the
+    /// frontmost-window call sites reach it; its `cwdProvider` binds to this window's active session.
     @State var quickTerminal = QuickTerminalController()
-    /// Window-level terminal zoom: rehosts the currently visible terminal surface above the sidebar,
-    /// titlebar, quick terminal frame, palettes, and switcher until the toggle is invoked again.
+    /// Window-level zoom: rehosts the visible terminal surface above the sidebar, titlebar, quick terminal
+    /// frame, palettes and switcher until toggled off.
     @State var terminalZoom = TerminalZoomController()
-    /// Window-level dashboard grid overlay: reparents a control-picked set of member session surfaces into a
-    /// view-only grid. Registered in `DashboardControllerRegistry` on appear so the socket can drive it; the
-    /// `+Dashboard` extension owns the overlay branch, deck yield, font override, and modal lifecycle.
+    /// View-only grid of reparented member surfaces, registered in `DashboardControllerRegistry` on appear so
+    /// the socket drives it; `+Dashboard` owns the overlay branch, deck yield, font override and lifecycle.
     @State var dashboard = DashboardController()
-    /// Per-window native picker presented through the shared palette view. Registered for control-socket
-    /// lookup while this window is mounted; unlike `palette`, its pending state is window-scoped.
+    /// Per-window native picker on the shared palette view, registered for control-socket lookup while this
+    /// window is mounted; unlike `palette`, its pending state is window-scoped.
     @State var pick = PickController()
     /// Tracks this view's balanced auto-follow suppression so window teardown can release it even when
     /// SwiftUI removes the observer before the pick controller publishes its cancellation.
@@ -53,27 +51,23 @@ struct WindowContentView: View {
     /// Defers picker focus restoration when a control request resolves in a background window. The
     /// always-mounted frontmost observer consumes it without activating or ordering that window.
     @State private var pickFocusRestoration = PickFocusRestorationState()
-    /// The terminal background color, mirrored from the non-observable `GhosttyApp` and used as the quick
-    /// terminal's opaque backing; `.agtermAppearanceChanged` re-renders it live on a settings theme change.
+    /// The terminal background color, the quick terminal's opaque backing. This and every mirror below track
+    /// the non-observable `GhosttyApp`, refreshed on `.agtermAppearanceChanged` so Settings applies live.
     @State var terminalColor: Color = WindowContentView.resolvedTerminalColor()
-    /// Mirror of `GhosttyApp.toolbarMode`: `normal` shows the cwd subtitle, `compact` collapses the title bar
-    /// to a single line, `hidden` drops the row (and the traffic lights) for a full-bleed terminal. Refreshed
-    /// on `.agtermAppearanceChanged`, like every mirror below.
+    /// `normal` shows the cwd subtitle, `compact` collapses the title bar to a single line, `hidden` drops
+    /// the row (and the traffic lights) for a full-bleed terminal.
     @State var toolbarMode: ToolbarMode = WindowContentView.resolvedToolbarMode()
-    /// Mirror of `GhosttyApp.inactivePaneMuteStrength` (0...10): how strongly `paneDim` mutes the inactive
-    /// split pane's text.
+    /// How strongly `paneDim` mutes the inactive split pane's text (0...10).
     @State private var inactivePaneMute: Int = WindowContentView.resolvedInactivePaneMute()
-    /// Mirror of `GhosttyApp.sidebarBackgroundShift` (0...10, 5 = neutral): how much lighter/darker the
-    /// sidebar background is than the terminal. Drives `sidebarTintWash`.
+    /// How much lighter/darker the sidebar background is than the terminal (0...10, 5 = neutral). Drives
+    /// `sidebarTintWash`.
     @State var sidebarShift: Int = WindowContentView.resolvedSidebarShift()
-    /// The terminal theme's foreground, mirrored from `GhosttyApp` for the chrome text (title bar text +
-    /// buttons, sidebar bottom bar) so non-terminal text tracks the theme.
+    /// The terminal theme's foreground, used for the chrome text (title bar text + buttons, sidebar bottom
+    /// bar) so non-terminal text tracks the theme.
     @State var chromeText: Color = WindowContentView.resolvedChromeText()
-    /// Mirror of `GhosttyApp.attentionButtonEnabled`: when true the title bar shows the attention bell, so
-    /// flipping the Settings toggle shows/hides it live without a relaunch.
+    /// When true the title bar shows the attention bell.
     @State var attentionButtonEnabled: Bool = WindowContentView.resolvedAttentionButtonEnabled()
-    /// Mirror of `GhosttyApp.hiddenInterfaceElements`: the title-bar / sidebar-footer chrome the user hid in
-    /// Settings ▸ Interface, read by `shows(_:)`; a toggle flip applies live without a relaunch.
+    /// The title-bar / sidebar-footer chrome the user hid in Settings ▸ Interface, read by `shows(_:)`.
     @State var hiddenInterfaceElements: Set<InterfaceElement> = WindowContentView.resolvedHiddenInterfaceElements()
     /// Whether the recent-sessions popover (the mouse form of the Ctrl-Tab switcher) is shown, anchored on
     /// the title-bar clock button. Non-private so `+RecentSessions`'s button/rows can toggle it.
@@ -81,11 +75,10 @@ struct WindowContentView: View {
     /// Whether the attention popover (the mouse equivalent of the ⌃⇧I attention palette) is shown, anchored
     /// on the title-bar bell. Non-private so the `+RecentSessions` extension's bell/rows can toggle it.
     @State var attentionPopoverShown = false
-    /// Custom sidebar width and show/hide live on the per-window `AppStore` (`sidebarWidth` /
-    /// `sidebarVisible`), persisted in `Snapshot`; the toolbar button, View menu, palette, and the
-    /// `sidebar` control command share `sidebarVisible`.
-    /// Height of the custom titlebar row: two lines (title + cwd) normal, one short line compact, zero
-    /// hidden (an invisible drag strip, terminal full-bleed). The split content is inset by this.
+    /// Sidebar width and visibility live on the per-window `AppStore`, persisted in `Snapshot` and shared
+    /// with the toolbar button, View menu, palette and the `sidebar` control command.
+    /// Height of the custom titlebar row: title + cwd normal, one short line compact, zero hidden (an
+    /// invisible drag strip, terminal full-bleed). The split content is inset by this.
     var titlebarHeight: CGFloat {
         switch toolbarMode {
         case .normal: return 48
@@ -96,9 +89,8 @@ struct WindowContentView: View {
 
     var body: some View {
         ZStack(alignment: .top) {
-            // the AppKit HSplitView can overrun into the titlebar zone and steal header clicks, so the deck
-            // stays inset below it. Kept mounted while zoomed (the zoom layer owns the visible window) so
-            // background sessions and control-opened overlays still realize their surfaces and run.
+            // the AppKit HSplitView overruns into the titlebar and steals header clicks, so the deck stays
+            // inset below it; kept mounted while zoomed so background sessions and overlays still realize.
             alwaysMountedSplitLayer
             if let zoomTarget = terminalZoom.target {
                 terminalZoomLayer(zoomTarget)
@@ -106,18 +98,14 @@ struct WindowContentView: View {
                 zoomTitlebar
                     .zIndex(11)
             } else {
-                // the window overlays (quick terminal / palettes / switcher) sit BELOW the titlebar, inset by
-                // its height — NOT a body-level `.overlay` above everything: a full-window overlay's dim scrim
-                // would composite over the transparent custom titlebar (backing deliberately hidden for
-                // translucency, WindowAppearance) and darken + seam the non-compact one. Keeping the titlebar
-                // at the highest zIndex means a scrim can never cover it.
+                // overlays sit BELOW the titlebar, inset by its height: a body-level `.overlay`'s scrim
+                // composites over the titlebar (backing hidden for translucency) and seams the non-compact one.
                 windowOverlayLayer
                     .padding(.top, titlebarHeight)
                     .zIndex(1)
                 if dashboard.isOpen {
-                    // the open dashboard is a view-only modal like zoom: a stripped bar (mirroring
-                    // zoomTitlebar) so titlebar buttons can't steal the key-catcher's first responder — which
-                    // strands Esc — or drive actions meaningless behind the grid. The two modes are exclusive.
+                    // view-only modal like zoom: a stripped bar so titlebar buttons can't steal the key
+                    // catcher's first responder (stranding Esc) or drive actions behind the grid.
                     dashboardTitlebar
                         .zIndex(2)
                 } else {
@@ -125,8 +113,8 @@ struct WindowContentView: View {
                         .zIndex(2)
                 }
             }
-            // A control picker is the window's topmost modal. It must stay visible and interactive even
-            // when terminal zoom or the dashboard was already active when the request arrived.
+            // the picker is the window's topmost modal: it stays visible and interactive even when terminal
+            // zoom or the dashboard was already active when the request arrived.
             pickPaletteOverlay
                 .padding(.top, titlebarHeight)
                 .zIndex(20)
@@ -141,9 +129,8 @@ struct WindowContentView: View {
                 DispatchQueue.main.async { NotificationCenter.default.post(name: .agtermAppearanceChanged, object: nil) }
             }
         }
-        // when the quick terminal hides, return focus to the active session's terminal — unless THIS
-        // window's zoom owns focus (zoom-enter hides the quick terminal itself, and `actions` targets
-        // the FRONTMOST window, so a background window's zoom-driven hide must not move focus there).
+        // on quick-terminal hide refocus the active session, unless this window's zoom owns focus: zoom-enter
+        // hides it, and `actions` targets the FRONTMOST window, so a background hide must not move focus.
         .onChange(of: quickTerminal.isVisible) { _, visible in
             if !visible, terminalZoom.target == .quick { terminalZoom.clear() }
             if !visible, terminalZoom.target == nil { actions.focusActiveSession() }
@@ -152,9 +139,8 @@ struct WindowContentView: View {
             handleZoomTargetChange(old: old, new: new)
             closeDashboardIfZoomActive(new)
         }
-        // dashboard open/close drives the modal lifecycle + auto-follow pause; the font key (members + font
-        // mode) drives the per-member transient font override, so a retarget OR a same-members re-open with a
-        // new font mode re-sizes; the session-id set drives member reconcile (prune a closed member).
+        // open/close drives the modal lifecycle + auto-follow pause; the font key (members + mode) drives the
+        // transient font override, so a re-open with a new mode re-sizes too; the id set prunes closed members.
         .onChange(of: dashboard.isOpen) { _, isOpen in
             handleDashboardOpenChange(isOpen)
         }
@@ -164,13 +150,12 @@ struct WindowContentView: View {
         .onChange(of: dashboardValidMembers) { _, _ in
             reconcileDashboardMembers()
         }
-        // Editor-overlay reload hooks must stay mounted while terminal zoom replaces the normal deck.
+        // editor-overlay reload hooks must stay mounted while terminal zoom replaces the normal deck.
         .onChange(of: openOverlaySessionIDs) { old, new in
             handleClosedEditorOverlays(previousOpenOverlaySessionIDs: old, currentOpenOverlaySessionIDs: new)
         }
-        // a palette is a transient overlay that owns the keyboard: suppress this window's auto-follow while
-        // it is open so an armed idle jump can't reshuffle the selection under it (an action-palette run
-        // would then hit the wrong session), and resume + return focus to the terminal when it closes.
+        // a palette owns the keyboard: suppress auto-follow while it is open so an armed idle jump can't
+        // reshuffle the selection under it and an action-palette run hit the wrong session.
         .onChange(of: palette.mode == nil) { _, closed in
             if closed {
                 store.resumeAutoFollow()
@@ -179,12 +164,12 @@ struct WindowContentView: View {
                 store.suppressAutoFollow()
             }
         }
-        // A native picker owns keyboard focus just like a built-in palette. Pair auto-follow suppression
-        // per window, then return first responder to this window's terminal after every resolution path.
+        // a native picker owns keyboard focus like a palette: pair auto-follow suppression per window, then
+        // return first responder to this window's terminal after every resolution path.
         .onChange(of: pick.pending?.id) { old, new in
             if old == nil, new != nil, !pickSuppressesAutoFollow {
-                // A socket-driven picker may arrive while either title-bar popover is already open.
-                // Dismiss both immediately so no second interactive surface remains above the modal picker.
+                // a socket-driven picker may arrive with either title-bar popover already open; dismiss
+                // both so no second interactive surface remains above the modal picker.
                 recentSessionsShown = false
                 attentionPopoverShown = false
                 store.suppressAutoFollow()
@@ -197,8 +182,7 @@ struct WindowContentView: View {
                 }
             }
         }
-        // a settings appearance change isn't observable through GhosttyApp, so re-render on the
-        // notification to pick up the new terminal color in the quick terminal backing.
+        // `GhosttyApp` isn't observable, so re-read every mirror when a settings appearance change posts.
         .onReceive(NotificationCenter.default.publisher(for: .agtermAppearanceChanged)) { _ in
             terminalColor = WindowContentView.resolvedTerminalColor()
             toolbarMode = WindowContentView.resolvedToolbarMode()
@@ -211,16 +195,14 @@ struct WindowContentView: View {
         // blend the title bar with the terminal; report frontmost/close to the library; surface the window
         // un-minimized on launch. the title token re-runs the blend in updateNSView on a session switch.
         .background(WindowAccessor(titleToken: windowTitle, windowID: windowID, library: library, store: store))
-        // own a per-window quick terminal: register it so the frontmost-window call sites resolve it,
-        // and spawn its shell in THIS window's active session's directory.
         .onAppear {
             quickTerminal.cwdProvider = { [store] in
                 store.activeSession?.effectiveCwd ?? FileManager.default.homeDirectoryForCurrentUser.path
             }
             // the quick terminal's shell sees this window's AGTERM_* env (scratch: ENABLED + WINDOW_ID + SOCKET).
             quickTerminal.envProvider = { [quickTerminalEnv, windowID] in quickTerminalEnv(windowID) }
-            // typing in the quick terminal counts as activity, so an idle auto-follow fire can't change this
-            // window's selected session behind the overlay while the user types (mirrors the overlay/scratch).
+            // typing counts as activity, so an idle auto-follow fire can't change this window's selected
+            // session behind the overlay while the user types (mirrors the overlay/scratch).
             quickTerminal.onUserInput = { [store] in store.noteUserActivity() }
             quickTerminal.focusAllowed = { [pick] in pick.pending == nil }
             QuickTerminalRegistry.shared.register(windowID, controller: quickTerminal)
@@ -263,9 +245,8 @@ struct WindowContentView: View {
         }
     }
 
-    /// Our own split instead of `NavigationSplitView`, so macOS 26 cannot impose the Liquid-Glass sidebar
-    /// chrome (inset panel, toggle capsule) or couple it to the toolbar style: a plain `HStack` of the
-    /// sidebar tree + a themed draggable divider + the terminal.
+    /// A plain `HStack` (sidebar + themed draggable divider + terminal) instead of `NavigationSplitView`, so
+    /// macOS 26 can't impose Liquid-Glass sidebar chrome (inset panel, toggle capsule) or the toolbar style.
     @ViewBuilder private var splitRoot: some View {
         HStack(spacing: 0) {
             if store.sidebarVisible {
@@ -279,18 +260,15 @@ struct WindowContentView: View {
             detailColumn
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        // DO NOT animate visibility: the width animation interpolates the detail column's frame every
-        // display frame, and detailPane is the EAGER deck (every session's surface mounted), so each frame
-        // reflows the grid (set_size) AND force-repaints (refresh) EVERY surface, hidden opacity-0 panes
-        // included — a cost scaling with session count that janks a many-session window. An instant toggle
-        // reflows each surface once. The mode switch below is safe: it swaps sidebar CONTENT, not the split
-        // width, so the detail column (and the deck) never resize.
+        // DO NOT animate visibility: interpolating the detail column's frame reflows (set_size) and
+        // force-repaints (refresh) EVERY eager-deck surface each display frame, hidden opacity-0 panes
+        // included, and janks a many-session window. The mode switch is safe — it swaps sidebar CONTENT,
+        // not the split width, so the detail column (and the deck) never resize.
         .animation(.easeInOut(duration: 0.15), value: store.sidebarMode)
     }
 
-    /// The eager split/deck stays mounted behind every modal presentation, zoom included. Frontmost-driven
-    /// cleanup belongs here, not on `windowOverlayLayer` (absent while zoomed): otherwise a palette owned by
-    /// the old front window survives the handoff and remounts after the picker and zoom both close.
+    /// Stays mounted behind every modal, zoom included, so frontmost-driven cleanup belongs here, not on
+    /// `windowOverlayLayer` (absent while zoomed): else the old front window's palette survives the handoff.
     private var alwaysMountedSplitLayer: some View {
         splitRoot
             .padding(.top, titlebarHeight)
@@ -306,8 +284,7 @@ struct WindowContentView: View {
 
     private var sidebarColumn: some View {
         VStack(spacing: 0) {
-            // matches the detail pane's hairline so the line runs the full width under the title bar (the
-            // vertical divider hangs from it at the junction); themed so it stays visible on light themes.
+            // matches the detail pane's hairline so the line runs full width under the title bar.
             Rectangle()
                 .fill(chromeText.opacity(0.1))
                 .frame(height: 1)
@@ -315,9 +292,8 @@ struct WindowContentView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         }
         .safeAreaInset(edge: .bottom) { bottomBar }
-        // the sidebar tint wash sits behind the transparent outline + bottom bar so the column reads as one
-        // surface, behind the content (never tints row text) and over the window background (composes with
-        // translucency/blur). Neutral paints nothing.
+        // sits behind the transparent outline + bottom bar so the column reads as one surface, behind the
+        // content (never tints row text) and over the window background (composes with translucency/blur).
         .background(sidebarTintWash)
     }
 
@@ -331,9 +307,7 @@ struct WindowContentView: View {
         }
     }
 
-    /// A 1px themed vertical separator with a wider invisible drag handle to resize the sidebar. The divider
-    /// carries `.zIndex(1)` at the call site so the full grab strip is reachable from both sides (the
-    /// terminal column would otherwise shadow its right half).
+    /// A 1px themed vertical separator with a wider invisible drag handle to resize the sidebar.
     private var sidebarDivider: some View {
         Rectangle()
             .fill(chromeText.opacity(0.1))
@@ -373,10 +347,9 @@ struct WindowContentView: View {
         }
     }
 
-    /// The terminal area: a DECK of EVERY session's terminal, all mounted so each spawns its shell at
-    /// startup, only the selected one visible + hit-testable. Switching is a visibility flip, never a
-    /// re-host (re-hosting invalidates the Metal drawable and flickers). A placeholder shows when nothing
-    /// is selected.
+    /// A DECK of EVERY session's terminal, all mounted so each spawns its shell at startup, only the selected
+    /// one visible + hit-testable. Switching is a visibility flip; a re-host would invalidate the Metal
+    /// drawable and flicker.
     @ViewBuilder private var detailPane: some View {
         let sessions = store.workspaces.flatMap(\.sessions)
         ZStack {
@@ -394,55 +367,43 @@ struct WindowContentView: View {
     }
 
     /// One session's terminal content: the primary pane, a side-by-side split (`HSplitView`), or the
-    /// maximized hidden-split pane, plus any overlay. `isActive` gates which pane auto-grabs focus — only
-    /// the visible deck entry, and within a split only the focused pane.
+    /// maximized hidden-split pane, plus any overlay. `isActive` gates which pane auto-grabs focus — the
+    /// visible deck entry, and within a split the focused pane.
     ///
-    /// While zoom hosts one of these surfaces the deck entry stays MOUNTED at the SAME shape, only the
-    /// zoom-owned slot swapping to its `deckHostsSurface` placeholder (an NSView lives in one host at a
-    /// time), so a control-opened split/scratch/overlay still spawns and runs behind the zoom layer —
-    /// swapping the whole entry out would re-host the NSSplitView (the titlebar-overrun rule) and orphan
-    /// those surfaces until zoom exits. The arranged panes are stable ZStack wrappers (content swaps
-    /// INSIDE), so the NSSplitView never re-layouts on a zoom toggle and the divider stays put;
-    /// `SplitRatioAccessor` rides the primary wrapper as one persistent instance, suspended while zoomed.
+    /// While zoom hosts one of these surfaces the entry stays MOUNTED at the SAME shape, only the zoom-owned
+    /// slot swapping to a placeholder (an NSView lives in one host at a time), so a control-opened
+    /// split/scratch/overlay still runs behind it; swapping the entry out would re-host the NSSplitView
+    /// (the titlebar-overrun rule) and orphan those surfaces until zoom exits.
     @ViewBuilder private func sessionDetail(_ session: Session, isActive: Bool) -> some View {
-        // a FULL overlay (no size) hides the session beneath it (opacity 0) and draws translucent; a
-        // FLOATING overlay (overlaySizePercent set) leaves the session VISIBLE and draws a smaller
-        // opaque framed panel on top. Either way the pane(s) stay non-interactive while an overlay is up.
+        // a FULL overlay (no size) hides the panes and draws translucent; a FLOATING one leaves them VISIBLE
+        // under a smaller opaque framed panel. Either way the pane(s) stay non-interactive while one is up.
         let fullOverlay = session.fullOverlayActive
-        // While zoomed OR while the dashboard is open, the normal deck stays mounted only to realize
-        // surfaces; it must not focus, register drag targets, or show focusable controls behind the
-        // full-window modal layer (both are mutually exclusive, so at most one gate is ever active).
+        // while zoomed OR the dashboard is open (mutually exclusive) the deck stays mounted only to realize
+        // surfaces: no focus, no drag targets, no focusable controls behind the full-window modal layer.
         let deckInteractive = terminalZoom.target == nil && !dashboard.isOpen
-        // the scratch is full-coverage too, so `hideForOverlay` hides the pane(s) like a FULL overlay
-        // (opacity + hit-testing); `overlaid` (any overlay OR scratch) owns focus, so it gates the panes'
-        // `isActive`. `hideForOverlay` stays false for a FLOATING overlay — this subtree's shape and
-        // hit-testing must not change when one opens (NSSplitView overrun).
+        // the scratch is full-coverage too, so `hideForOverlay` hides the panes like a FULL overlay and
+        // `overlaid` (any overlay OR scratch) gates their `isActive`. It stays false for a FLOATING overlay:
+        // this subtree's shape and hit-testing must not change when one opens (NSSplitView overrun).
         let hideForOverlay = fullOverlay || session.scratchActive
         let overlaid = session.overlayActive || session.scratchActive
         // on-screen = selected, not hidden by a full overlay/scratch, not covered by the quick terminal.
-        // Shared by BOTH split panes (unlike the focus-gated `isActive`), it gates each surface's drag-type
-        // (un)registration AND its mouse-cursor tracking (the `deckVisible` note in libghostty.md), so no
-        // file drop or cursor write lands off-screen. Without `!quickTerminal.isVisible` the covered pane
-        // keeps deckVisible=true, races the quick-terminal surface for the cursor, and fans mouse-motion
-        // into the covered TUI (issue #225 quick-terminal path).
+        // Shared by BOTH split panes (unlike focus-gated `isActive`), it gates drag-type (un)registration and
+        // mouse-cursor tracking (the `deckVisible` note in libghostty.md). Without the quick-terminal term a
+        // covered pane races it for the cursor and fans mouse-motion into the covered TUI (issue #225).
         let visible = deckInteractive && isActive && !hideForOverlay && !quickTerminal.isVisible
         // focus gate: a visible quick terminal OWNS first responder, so no deck surface may be `isActive`
-        // behind it — `TerminalView.updateNSView` would grab focus and send keystrokes to a covered session.
-        // Every automatic reselection (`reselectIfSelectionHidden`, auto-follow) reaches this, not just a
-        // click; the quick terminal's own hide flips it back.
+        // behind it — `updateNSView` would grab focus and send keystrokes to a covered session. Every
+        // automatic reselection (`reselectIfSelectionHidden`, auto-follow) reaches this, not just a click.
         let focusable = deckInteractive && isActive && !quickTerminal.isVisible
         ZStack {
-            // the session's pane(s), kept MOUNTED while an overlay is up — shells stay alive, like the deck
-            // does for inactive sessions. a FULL overlay hides them (opacity 0) so its translucency reveals the
-            // window backing, not the session; a FLOATING overlay leaves them visible behind its opaque panel.
+            // the pane(s) stay MOUNTED while an overlay is up so their shells stay alive; a FULL overlay
+            // hides them (opacity 0) so its translucency reveals the window backing, not the session.
             Group {
                 if session.isSplit {
                     HSplitView {
-                        // each arranged pane is a STABLE ZStack wrapper whose CONTENT swaps between the live
-                        // TerminalView and the zoom placeholder: swapping the arranged subview itself makes
-                        // NSSplitView re-layout and normalize the divider on every zoom enter/exit, and with
-                        // no stored ratio there is nothing to restore. The wrapper keeps both arranged
-                        // NSViews' identity, so the divider never moves.
+                        // a STABLE ZStack wrapper whose CONTENT swaps between the live TerminalView and the
+                        // zoom placeholder: swapping the arranged subview itself makes NSSplitView re-layout
+                        // and normalize the divider on every zoom toggle, with no stored ratio to restore.
                         ZStack {
                             if deckHostsSurface(session: session, surface: .primary) {
                                 TerminalView(session: session, surfaceKeyPath: \.surface, makeSurface: makeSurface,
@@ -455,10 +416,9 @@ struct WindowContentView: View {
                                     .id("\(session.id.uuidString)-primary-placeholder")
                             }
                         }
-                        // introspects the AppKit NSSplitView to persist/restore the divider ratio and clip it
-                        // out of the titlebar strip (see SplitRatioAccessor); a background on the stable
-                        // wrapper (not a third pane, not inside the swapped content), so ONE probe survives
-                        // zoom and its suspend/resume flips in place.
+                        // persists/restores the divider ratio and clips the NSSplitView out of the titlebar
+                        // strip; a background on the stable wrapper (not a third pane, not inside the swapped
+                        // content), so ONE probe survives zoom and suspend/resume flips in place.
                         .background { SplitRatioAccessor(session: session, titlebarHeight: titlebarHeight, suspended: !deckInteractive, onPersist: { store.save() }) }
                         ZStack {
                             if deckHostsSurface(session: session, surface: .split) {
@@ -498,22 +458,18 @@ struct WindowContentView: View {
                 }
             }
             .opacity(hideForOverlay ? 0 : 1)
-            // gate on `hideForOverlay` (full overlay OR scratch), NOT `session.overlayActive`: this modifier
-            // must not change when a floating overlay opens, or the NSSplitView re-lays-out and overruns up
-            // into the titlebar (same perturbation class as adding a sibling). A floating overlay leaves the
-            // panes hit-testable; `overlayPanel`'s transparent catcher absorbs the clicks around it.
+            // gate on `hideForOverlay`, NOT `session.overlayActive`: this modifier must not change when a
+            // floating overlay opens, or the NSSplitView re-lays-out and overruns into the titlebar (same
+            // perturbation class as adding a sibling). Floating leaves the panes hit-testable;
+            // `overlayPanel`'s transparent catcher absorbs the clicks around it.
             .allowsHitTesting(deckInteractive && !hideForOverlay)
-            // the scratch renders in-deck above the (hidden) pane(s) — a full-coverage sibling is safe (the
-            // panes go opacity 0, the split's frame is hidden). It sits BELOW the ephemeral overlay (zIndex 1
-            // vs `overlayPanel`'s 3) and hides under a FULL overlay like the panes: under window translucency
-            // every surface background renders fully transparent, so a scratch left visible would show THROUGH
-            // it (reading as "the overlay opened under the scratch"); a FLOATING panel's opaque backing needs
-            // no such hiding. `overlayPanel` hosts BOTH variants, always present at a constant shape (content
-            // gated internally), so opening or resizing an overlay never re-hosts the NSSplitView.
+            // the scratch renders in-deck above the hidden pane(s), BELOW the ephemeral overlay (zIndex 1 vs
+            // `overlayPanel`'s 3), and hides under a FULL overlay like they do: under window translucency
+            // every surface background renders fully transparent, so a visible scratch would show THROUGH it.
+            // A FLOATING panel's opaque backing needs no such hiding.
             if session.scratchActive, deckHostsSurface(session: session, surface: .scratch) {
-                // a full overlay renders above the scratch (`overlayPanel`, zIndex 3), so it gates focus on
-                // top of `focusable` (matching makeScratchSurface's autoFocus suppression); `deckVisible`
-                // mirrors the panes' rule so only an on-screen scratch is a file-drop target.
+                // a full overlay renders above the scratch, so it gates focus on top of `focusable` (matching
+                // makeScratchSurface's autoFocus suppression); `deckVisible` keeps drops to an on-screen one.
                 TerminalView(session: session, surfaceKeyPath: \.scratchSurface, makeSurface: makeScratchSurface,
                              isActive: focusable && !session.overlayActive,
                              deckVisible: deckInteractive && isActive && !fullOverlay && !quickTerminal.isVisible)
@@ -522,61 +478,51 @@ struct WindowContentView: View {
                     .id("\(session.id.uuidString)-scratch")
                     .zIndex(1)
             }
-            // the overlay renders IN-DECK per session, so its program runs even when the session isn't
-            // active; see `overlayPanel` for the constant-shape rule that keeps open/close/resize from
-            // re-hosting the NSSplitView or re-parenting the surface.
+            // renders IN-DECK per session, so its program runs even when the session isn't active;
+            // `overlayPanel` owns the constant-shape rule.
             overlayPanel(session: session, isActive: focusable)
                 .zIndex(3)
         }
-        // on overlay close, refocus the topmost remaining surface (scratch if still shown, else the pane)
-        // via the shared `topmostSurface` precedence — never a pane hidden under the scratch. A single
-        // makeFirstResponder loses the race with the overlay view's teardown/re-host, so drive the bounded
-        // retry the split-collapse survivor uses. Gated on isActive so only the visible session reclaims
-        // focus, and skipped while the quick terminal covers the window (it owns focus; its own hide
-        // restores the session).
+        // on overlay close refocus the topmost remaining surface via `topmostSurface` — never a pane hidden
+        // under the scratch. One makeFirstResponder loses the race with the overlay's teardown/re-host, so
+        // drive the bounded retry the split-collapse survivor uses; only the visible session reclaims focus.
         .onChange(of: session.overlayActive) { _, isOpen in
             if !isOpen, deckInteractive, isActive, !quickTerminal.isVisible {
                 (session.topmostSurface as? GhosttySurfaceView)?.focusAfterReparent()
             }
         }
-        // scratch show AND hide both need the bounded focus retry: the surface is kept alive across hides,
-        // so a re-show remounts it and `autoFocus`'s one-shot latch won't re-fire (same remount race as the
-        // split-collapse survivor). `topmostSurface` routes focus correctly either way — on show it is the
-        // scratch (or a still-open overlay above it), on hide the overlay-if-up else the pane.
+        // show AND hide both need the bounded focus retry: the surface is kept alive across hides, so a
+        // re-show remounts it and `autoFocus`'s one-shot latch won't re-fire (same remount race as the
+        // split-collapse survivor). `topmostSurface` routes either way — the scratch (or a still-open overlay
+        // above it) on show, the overlay-if-up else the pane on hide.
         .onChange(of: session.scratchActive) { _, _ in
-            // skip while the quick terminal covers the window — it owns focus above the session layers
-            // (mirrors focusActiveSession); the deck re-grabs the scratch when the quick terminal hides.
+            // the quick terminal owns focus while it covers the window; its own hide re-grabs the scratch.
             guard deckInteractive, isActive, !quickTerminal.isVisible else { return }
             (session.topmostSurface as? GhosttySurfaceView)?.focusAfterReparent()
         }
     }
 
-    /// The overlay — FULL or FLOATING — rendered IN-DECK inside each session's `sessionDetail` ZStack as ONE
-    /// ALWAYS-PRESENT sibling, its content gated INSIDE the GeometryReader so the ZStack's child count never
-    /// changes (constant shape = no NSSplitView re-host = no titlebar overrun). Both variants share this one
-    /// surface host, so `session.overlay.resize` switching full<->% only re-flows the frame and never
-    /// re-parents the NSView (which would blank its Metal drawable). A nil `overlaySizePercent` fills the
-    /// detail area translucent (no backing/frame), panes hidden by `hideForOverlay`; a percent draws an
-    /// opaque framed panel at that size, centered, panes visible around it. Per-session in the eager deck,
-    /// so the surface mounts and its program runs while the session is inactive.
+    /// The overlay — FULL or FLOATING — rendered IN-DECK as ONE ALWAYS-PRESENT sibling of each session's
+    /// `sessionDetail` ZStack, its content gated INSIDE the GeometryReader so the child count never changes
+    /// (constant shape = no NSSplitView re-host = no titlebar overrun). Both variants share this one surface
+    /// host, so `session.overlay.resize` switching full<->% only re-flows the frame and never re-parents the
+    /// NSView (which would blank its Metal drawable).
     @ViewBuilder private func overlayPanel(session: Session, isActive: Bool) -> some View {
         GeometryReader { geo in
             ZStack {
                 if session.overlayActive, deckHostsSurface(session: session, surface: .overlay) {
                     let floating = session.overlaySizePercent != nil
                     let fraction = session.overlaySizePercent.map { CGFloat($0) / 100 } ?? 1
-                    // transparent click-catcher: absorbs clicks AROUND a floating panel so they can't reach
-                    // the still-hit-testable panes and steal the overlay's first responder (the full variant
-                    // hides the panes anyway).
+                    // absorbs clicks AROUND a floating panel so they can't reach the hit-testable panes and
+                    // steal the overlay's first responder (the full variant hides the panes anyway).
                     Color.clear.contentShape(Rectangle())
                     TerminalView(session: session, surfaceKeyPath: \.overlaySurface,
                                  makeSurface: makeOverlaySurface, isActive: isActive, deckVisible: isActive)
                         .frame(width: geo.size.width * fraction, height: geo.size.height * fraction)
-                        // floating = opaque backing + hairline frame + shadow so it reads as a distinct window
-                        // over the still-visible session; full = translucent, no chrome (libghostty draws only
-                        // the terminal, so the window backing shows through). The modifier CHAIN is constant
-                        // across both — only the parameters go inert for full — so a full<->% resize keeps
-                        // the same view tree and never re-hosts the surface NSView.
+                        // floating = opaque backing + frame + shadow so it reads as a distinct window over the
+                        // still-visible session; full = translucent and chromeless (libghostty draws only the
+                        // terminal, so the window backing shows through). The CHAIN is constant across both,
+                        // only the parameters going inert for full.
                         .background(floating ? terminalColor : Color.clear)
                         .clipShape(RoundedRectangle(cornerRadius: floating ? 12 : 0))
                         .overlay(
@@ -589,15 +535,14 @@ struct WindowContentView: View {
             }
             .frame(width: geo.size.width, height: geo.size.height)
         }
-        // when no overlay is up the panel is an empty full-frame GeometryReader — make it inert so it never
+        // with no overlay up this is an empty full-frame GeometryReader; keep it inert so it never
         // intercepts clicks meant for the pane(s).
         .allowsHitTesting(isActive && session.overlayActive && deckHostsSurface(session: session, surface: .overlay))
     }
 
-    /// The terminal search bar, a top-aligned `.overlay` on `detailPane` — NOT inside any session's
-    /// `sessionDetail`/HSplitView ZStack, so toggling it can't perturb the split and overrun the NSSplitView
-    /// into the titlebar. Shown while zoom is off and the active session's `searchActive` is set; the needle
-    /// binding drives the query through `actions.updateSearchNeedle`.
+    /// A top-aligned `.overlay` on `detailPane` — NOT inside any session's `sessionDetail`/HSplitView ZStack,
+    /// so toggling it can't perturb the split and overrun the NSSplitView into the titlebar. Shown while zoom
+    /// is off and the active session's `searchActive` is set.
     @ViewBuilder private var searchBarLayer: some View {
         if terminalZoom.target == nil, let session = store.activeSession, session.searchActive {
             TerminalSearchBar(
@@ -618,19 +563,16 @@ struct WindowContentView: View {
         }
     }
 
-    /// Keeps a primary host stable through lazy surface creation and ordinary updates, but remounts it when
-    /// one live surface replaces another (split-survivor promotion): `TerminalView.updateNSView` cannot
-    /// replace the view `makeNSView` returned, so session identity alone would keep hosting the torn-down
-    /// prior primary.
+    /// Keeps the primary host stable through lazy surface creation, but remounts it when one live surface
+    /// replaces another (split-survivor promotion): `updateNSView` cannot replace the view `makeNSView`
+    /// returned, so session identity alone would keep hosting the torn-down prior primary.
     func primarySurfaceID(_ session: Session) -> String {
         "\(session.id.uuidString)-primary-\(session.primarySurfaceHostRevision)"
     }
 
     /// Mutes the inactive split pane's TEXT without darkening the background: a translucent wash of the
-    /// terminal background over the pane, so background pixels blend bg→bg (unchanged) and text pixels
-    /// text→bg (less bright). Opacity comes from the Settings mute-strength slider via
-    /// `AppSettings.muteOpacity` (0...10, strength 0 renders nothing); clicks pass through so the muted
-    /// pane can still be focused.
+    /// terminal background, so background pixels blend bg→bg and text pixels text→bg. Opacity comes from
+    /// `AppSettings.muteOpacity` (strength 0 renders nothing); clicks pass through, so it stays focusable.
     @ViewBuilder private func paneDim(_ dimmed: Bool) -> some View {
         let opacity = AppSettings.muteOpacity(strength: inactivePaneMute)
         if dimmed, opacity > 0 {
@@ -644,17 +586,14 @@ struct WindowContentView: View {
             ?? NSColor(srgbRed: 0.157, green: 0.173, blue: 0.204, alpha: 1))
     }
 
-    /// The toolbar mode from the (non-observable) `GhosttyApp`; see the `toolbarMode` mirror.
     private static func resolvedToolbarMode() -> ToolbarMode {
         GhosttyApp.shared.toolbarMode
     }
 
-    /// The attention-button flag from the non-observable `GhosttyApp`; see the `attentionButtonEnabled` mirror.
     private static func resolvedAttentionButtonEnabled() -> Bool {
         GhosttyApp.shared.attentionButtonEnabled
     }
 
-    /// The hidden-chrome-element set from the non-observable `GhosttyApp`; see the mirror above.
     private static func resolvedHiddenInterfaceElements() -> Set<InterfaceElement> {
         GhosttyApp.shared.hiddenInterfaceElements
     }
@@ -665,12 +604,10 @@ struct WindowContentView: View {
         !hiddenInterfaceElements.contains(element)
     }
 
-    /// The inactive-pane mute strength from the non-observable `GhosttyApp`; see the `inactivePaneMute` mirror.
     private static func resolvedInactivePaneMute() -> Int {
         GhosttyApp.shared.inactivePaneMuteStrength
     }
 
-    /// The sidebar background shift from the (non-observable) `GhosttyApp`; see the `sidebarShift` mirror.
     private static func resolvedSidebarShift() -> Int {
         GhosttyApp.shared.sidebarBackgroundShift
     }
@@ -680,39 +617,34 @@ struct WindowContentView: View {
         Color(nsColor: GhosttyApp.shared.terminalForegroundColor ?? .labelColor)
     }
 
-    /// The base text with the action's current shortcut appended in parentheses (`Toggle Sidebar (⌃⌘S)`),
-    /// or bare when the action has none — via the SAME `AppActions.shortcutGlyph` resolver the action
-    /// palette uses, so a rebind shows the new chord. Non-private so the `+RecentSessions` extension's
-    /// attention button can build its tooltip.
+    /// The base text with the action's current shortcut appended (`Toggle Sidebar (⌃⌘S)`), or bare when it
+    /// has none — via the SAME `AppActions.shortcutGlyph` the palette uses, so a rebind shows the new chord.
+    /// Non-private so the `+RecentSessions` attention button can build its tooltip.
     func helpHint(_ base: String, _ action: BuiltinAction) -> String {
         guard let glyph = actions.shortcutGlyph(for: action) else { return base }
         return "\(base) (\(glyph))"
     }
 
-    /// The quick-terminal overlay: the scratch terminal centered at 90% of the window, framed by a hairline
-    /// border and shadow so it reads as a distinct floating window over the (undimmed) content — libghostty
-    /// renders only the terminal, so the frame is drawn here. The margin is a transparent tap-catcher that
-    /// dismisses on click; no dim, because the overlay cannot cover the AppKit title bar and would shade the
-    /// body but not the chrome. Rendered only while visible; the controller owns the surface, so hiding
-    /// keeps the shell alive.
-    /// The window-level overlays (quick terminal, command palettes, Ctrl-Tab switcher) as one layer: a ZStack
-    /// sibling INSIDE the body's root ZStack, not body-level `.overlay`s, so it can be inset below the
-    /// titlebar and ordered BELOW `customTitlebar` (which a body-level `.overlay` cannot). Every child is
-    /// conditional, so with none showing this is an empty frame — not hit-testable, so the terminal below
-    /// stays interactive; each overlay's own `GeometryReader` fills the inset area. Order here = z-order
-    /// (switcher over palette over quick terminal).
+    /// The window-level overlays (quick terminal, palettes, Ctrl-Tab switcher) as one ZStack sibling INSIDE
+    /// the body's root ZStack, not body-level `.overlay`s, so it can be inset below the titlebar and ordered
+    /// BELOW `customTitlebar`. Every child is conditional, so an empty layer is not hit-testable and the
+    /// terminal below stays interactive. Order here = z-order (switcher over palette over quick terminal).
     private var windowOverlayLayer: some View {
         ZStack {
             quickTerminalOverlay
             commandPaletteOverlay
             sessionSwitcherOverlay
-            // the dashboard is the topmost window overlay: opening it closes the three above (mirrors the
-            // zoom lifecycle), so ordering only settles the empty case, but it renders last for clarity.
+            // opening the dashboard closes the three above, so ordering only settles the empty case.
             dashboardOverlay
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
+    /// The scratch terminal centered at 90% of the window, framed by a hairline border and shadow so it reads
+    /// as a distinct floating window over the (undimmed) content — libghostty renders only the terminal, so
+    /// the frame is drawn here. The margin is a transparent tap-catcher that dismisses on click; no dim,
+    /// because the overlay cannot cover the AppKit title bar and would shade the body but not the chrome.
+    /// The controller owns the surface, so hiding keeps the shell alive.
     @ViewBuilder private var quickTerminalOverlay: some View {
         if quickTerminal.isVisible {
             GeometryReader { geo in
@@ -741,26 +673,25 @@ struct WindowContentView: View {
         }
     }
 
-    /// True only for the frontmost window. The palette and session switcher are app-global singles acting on
-    /// the frontmost store, so only that window mounts their overlays — otherwise every open window renders
-    /// a duplicate, contending for focus and showing the wrong window's candidates. `activeWindowID`
-    /// (frontmost-or-first-open, the accessor the palette/actions resolve through) matches exactly one
-    /// window even before the first `didBecomeKey` sets `frontmostWindowID`, and is observed, so this reacts.
+    /// True only for the frontmost window: the palette and switcher are app-global singles on the frontmost
+    /// store, so only that window mounts their overlays — else every open window renders a duplicate,
+    /// contending for focus and showing the wrong window's candidates. `activeWindowID`
+    /// (frontmost-or-first-open) matches exactly one window even before the first `didBecomeKey` sets
+    /// `frontmostWindowID`, and is observed, so this reacts.
     private var isFrontmost: Bool { library.activeWindowID == windowID }
 
-    /// The command-palette overlay, mounted only while a palette is open in the frontmost window. Its
-    /// content (search field + result list) is rebuilt from `palette.mode`.
+    /// Mounted only while a palette is open in the frontmost window; its content (search field + result
+    /// list) is rebuilt from `palette.mode`.
     @ViewBuilder private var commandPaletteOverlay: some View {
         if isFrontmost, pick.pending == nil, palette.mode != nil {
             CommandPalette(controller: palette, actions: actions)
         }
     }
 
-    /// A control picker is per-window rather than frontmost-global, so a caller can present one in a
-    /// background window without duplicating it elsewhere. Selection preserves the caller's original item
-    /// index even though fuzzy filtering reorders the visible rows. Keyed by the pending id so a picker
-    /// replacing another in the same view update gets fresh palette state instead of the previous picker's
-    /// rows, whose select closures capture the previous picker's items.
+    /// Per-window rather than frontmost-global, so a caller can present one in a background window without
+    /// duplicating it elsewhere. Selection reports the caller's original item index even though fuzzy
+    /// filtering reorders the visible rows. Keyed by the pending id so a picker replacing another in the same
+    /// view update gets fresh palette state, not the previous picker's rows and their captured items.
     @ViewBuilder private var pickPaletteOverlay: some View {
         if let pending = pick.pending {
             CommandPalette(
@@ -795,9 +726,8 @@ struct WindowContentView: View {
     }
 
     /// The sidebar footer, source-list style: two add controls on the left (a workspace; a menu adding a
-    /// session to the current workspace at the default cwd or at a picked directory) and two view toggles on
-    /// the right (the workspace focus filter, the flagged working-set view). Each of the four is
-    /// individually hideable via Settings ▸ Interface (`shows(_:)`).
+    /// session at the default cwd or a picked directory) and two view toggles on the right (the workspace
+    /// focus filter, the flagged working-set view). Each is hideable via Settings ▸ Interface (`shows(_:)`).
     private var bottomBar: some View {
         HStack(spacing: 2) {
             if shows(.newWorkspace) {
@@ -852,7 +782,7 @@ struct WindowContentView: View {
                 .help(helpHint(store.focusEnabled ? "Show all workspaces" : "Show only focused workspaces",
                                .toggleWorkspaceFilter))
                 .accessibilityLabel("Toggle Workspace Filter")
-                // the only accessibility-observable read of the filter state now that the pill is gone.
+                // the only accessibility-observable read of the filter state.
                 .accessibilityValue(store.focusEnabled ? "on" : "off")
                 .accessibilityIdentifier("focus-filter-toggle")
             }

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -2,9 +2,8 @@ import agtermCore
 import AppKit
 import SwiftUI
 
-/// Window-local handoff between picker dismissal and the owning window becoming frontmost.
-/// A background window must not claim first responder, but its removed picker field cannot remain
-/// the responder when that window is activated later.
+/// Window-local handoff between picker dismissal and the owning window becoming frontmost: a background
+/// window must not claim first responder, yet its removed picker field cannot stay the responder later.
 struct PickFocusRestorationState {
     private(set) var isDeferred = false
 
@@ -20,10 +19,9 @@ struct PickFocusRestorationState {
     }
 }
 
-/// The actual per-window UI: the workspace/session sidebar + the active session's terminal, plus
-/// the quick-terminal / palette / switcher overlays. Holds the resolved non-optional `AppStore` so
-/// the binding-based wiring is unchanged from the single-window version; `ContentView` resolves the
-/// store and hands it in.
+/// The per-window UI: the workspace/session sidebar + the active session's terminal, plus the
+/// quick-terminal / palette / switcher overlays. `ContentView` resolves the store and hands in the
+/// non-optional `AppStore` the binding-based wiring needs.
 struct WindowContentView: View {
     let windowID: WindowInfo.ID
     @Bindable var store: AppStore
@@ -36,9 +34,8 @@ struct WindowContentView: View {
     let actions: AppActions
     let palette: PaletteController
     let sessionSwitcher: SessionSwitcher
-    /// This window's own quick terminal, owned here (one per window). Registered in
-    /// `QuickTerminalRegistry` on appear so the frontmost-window call sites can reach it, and its
-    /// `cwdProvider` binds to this window's active session.
+    /// This window's own quick terminal (one per window). Registered in `QuickTerminalRegistry` on appear
+    /// so the frontmost-window call sites reach it; its `cwdProvider` binds to this window's active session.
     @State var quickTerminal = QuickTerminalController()
     /// Window-level terminal zoom: rehosts the currently visible terminal surface above the sidebar,
     /// titlebar, quick terminal frame, palettes, and switcher until the toggle is invoked again.
@@ -56,46 +53,39 @@ struct WindowContentView: View {
     /// Defers picker focus restoration when a control request resolves in a background window. The
     /// always-mounted frontmost observer consumes it without activating or ordering that window.
     @State private var pickFocusRestoration = PickFocusRestorationState()
-    /// The terminal background color, mirrored from the (non-observable) `GhosttyApp` into view
-    /// state and used as the quick terminal's opaque backing, so a settings theme change (posting
-    /// `.agtermAppearanceChanged`) re-renders it live.
+    /// The terminal background color, mirrored from the non-observable `GhosttyApp` and used as the quick
+    /// terminal's opaque backing; `.agtermAppearanceChanged` re-renders it live on a settings theme change.
     @State var terminalColor: Color = WindowContentView.resolvedTerminalColor()
-    /// Mirror of `GhosttyApp.toolbarMode`: `normal` shows the cwd subtitle, `compact` collapses the title
-    /// bar to a single line, `hidden` drops the row (and the traffic lights) for a full-bleed terminal.
-    /// Refreshed on `.agtermAppearanceChanged`, like `terminalColor`.
+    /// Mirror of `GhosttyApp.toolbarMode`: `normal` shows the cwd subtitle, `compact` collapses the title bar
+    /// to a single line, `hidden` drops the row (and the traffic lights) for a full-bleed terminal. Refreshed
+    /// on `.agtermAppearanceChanged`, like every mirror below.
     @State var toolbarMode: ToolbarMode = WindowContentView.resolvedToolbarMode()
-    /// Mirror of `GhosttyApp.inactivePaneMuteStrength` (0...10): how strongly `paneDim` mutes the
-    /// inactive split pane's text. Refreshed on `.agtermAppearanceChanged`, like `toolbarMode`.
+    /// Mirror of `GhosttyApp.inactivePaneMuteStrength` (0...10): how strongly `paneDim` mutes the inactive
+    /// split pane's text.
     @State private var inactivePaneMute: Int = WindowContentView.resolvedInactivePaneMute()
     /// Mirror of `GhosttyApp.sidebarBackgroundShift` (0...10, 5 = neutral): how much lighter/darker the
-    /// sidebar background is than the terminal. Drives `sidebarTintWash`; refreshed on
-    /// `.agtermAppearanceChanged`, like `inactivePaneMute`.
+    /// sidebar background is than the terminal. Drives `sidebarTintWash`.
     @State var sidebarShift: Int = WindowContentView.resolvedSidebarShift()
-    /// The terminal theme's foreground color, mirrored from `GhosttyApp` and used for the chrome text
-    /// (title bar text + buttons, sidebar bottom bar) so non-terminal text tracks the theme. Refreshed
-    /// on `.agtermAppearanceChanged`, like `terminalColor`.
+    /// The terminal theme's foreground, mirrored from `GhosttyApp` for the chrome text (title bar text +
+    /// buttons, sidebar bottom bar) so non-terminal text tracks the theme.
     @State var chromeText: Color = WindowContentView.resolvedChromeText()
-    /// Mirror of `GhosttyApp.attentionButtonEnabled`: when true the title bar shows the attention bell.
-    /// Refreshed on `.agtermAppearanceChanged`, like `toolbarMode`, so flipping the Settings toggle
-    /// shows/hides the bell live without a relaunch.
+    /// Mirror of `GhosttyApp.attentionButtonEnabled`: when true the title bar shows the attention bell, so
+    /// flipping the Settings toggle shows/hides it live without a relaunch.
     @State var attentionButtonEnabled: Bool = WindowContentView.resolvedAttentionButtonEnabled()
-    /// Mirror of `GhosttyApp.hiddenInterfaceElements`: the title-bar / sidebar-footer chrome elements the
-    /// user has hidden in Settings ▸ Interface. Refreshed on `.agtermAppearanceChanged`, like `toolbarMode`,
-    /// so flipping a toggle shows/hides the element live without a relaunch. `shows(_:)` reads it.
+    /// Mirror of `GhosttyApp.hiddenInterfaceElements`: the title-bar / sidebar-footer chrome the user hid in
+    /// Settings ▸ Interface, read by `shows(_:)`; a toggle flip applies live without a relaunch.
     @State var hiddenInterfaceElements: Set<InterfaceElement> = WindowContentView.resolvedHiddenInterfaceElements()
-    /// Whether the recent-sessions popover (the mouse equivalent of the Ctrl-Tab switcher) is shown,
-    /// anchored on the title-bar clock button. Non-private so the `+RecentSessions` extension's button/rows
-    /// can toggle it.
+    /// Whether the recent-sessions popover (the mouse form of the Ctrl-Tab switcher) is shown, anchored on
+    /// the title-bar clock button. Non-private so `+RecentSessions`'s button/rows can toggle it.
     @State var recentSessionsShown = false
     /// Whether the attention popover (the mouse equivalent of the ⌃⇧I attention palette) is shown, anchored
     /// on the title-bar bell. Non-private so the `+RecentSessions` extension's bell/rows can toggle it.
     @State var attentionPopoverShown = false
-    /// Custom sidebar width and show/hide both live on the per-window `AppStore` (`sidebarWidth` /
-    /// `sidebarVisible`), persisted in `Snapshot` so they restore on relaunch. The toolbar button, the View
-    /// menu, the palette, and the `sidebar` control command share `sidebarVisible`.
-    /// Height of the custom titlebar row: two lines (title + cwd) when normal, one short line when
-    /// compact, and zero when hidden (the row collapses to an invisible drag strip and the terminal
-    /// runs full-bleed). The split content is inset by this so it sits below the row.
+    /// Custom sidebar width and show/hide live on the per-window `AppStore` (`sidebarWidth` /
+    /// `sidebarVisible`), persisted in `Snapshot`; the toolbar button, View menu, palette, and the
+    /// `sidebar` control command share `sidebarVisible`.
+    /// Height of the custom titlebar row: two lines (title + cwd) normal, one short line compact, zero
+    /// hidden (an invisible drag strip, terminal full-bleed). The split content is inset by this.
     var titlebarHeight: CGFloat {
         switch toolbarMode {
         case .normal: return 48
@@ -106,10 +96,9 @@ struct WindowContentView: View {
 
     var body: some View {
         ZStack(alignment: .top) {
-            // The split's AppKit HSplitView can overrun into the titlebar zone and steal header clicks, so
-            // the deck stays inset below the titlebar. While zoomed, keep that eager deck mounted so
-            // background sessions and control-opened overlays still realize their terminal surfaces and run;
-            // the zoom layer owns the visible window.
+            // the AppKit HSplitView can overrun into the titlebar zone and steal header clicks, so the deck
+            // stays inset below it. Kept mounted while zoomed (the zoom layer owns the visible window) so
+            // background sessions and control-opened overlays still realize their surfaces and run.
             alwaysMountedSplitLayer
             if let zoomTarget = terminalZoom.target {
                 terminalZoomLayer(zoomTarget)
@@ -118,18 +107,17 @@ struct WindowContentView: View {
                     .zIndex(11)
             } else {
                 // the window overlays (quick terminal / palettes / switcher) sit BELOW the titlebar, inset by
-                // its height — NOT as a body-level `.overlay` above EVERYTHING. A full-window overlay's dim
-                // scrim composites OVER the transparent custom titlebar (whose AppKit backing is deliberately
-                // hidden for translucency, WindowAppearance), darkening + seaming the normal non-compact titlebar
-                // (the corruption). Keeping the titlebar at the highest zIndex means a scrim can never cover it.
+                // its height — NOT a body-level `.overlay` above everything: a full-window overlay's dim scrim
+                // would composite over the transparent custom titlebar (backing deliberately hidden for
+                // translucency, WindowAppearance) and darken + seam the non-compact one. Keeping the titlebar
+                // at the highest zIndex means a scrim can never cover it.
                 windowOverlayLayer
                     .padding(.top, titlebarHeight)
                     .zIndex(1)
                 if dashboard.isOpen {
-                    // the open dashboard is a view-only modal, like terminal zoom: swap the full titlebar for
-                    // a stripped bar (mirroring zoomTitlebar) so its interactive buttons can't steal the
-                    // key-catcher's first responder — which strands Esc — or drive actions that make no sense
-                    // behind the grid. The two modes are mutually exclusive, so only one titlebar is ever up.
+                    // the open dashboard is a view-only modal like zoom: a stripped bar (mirroring
+                    // zoomTitlebar) so titlebar buttons can't steal the key-catcher's first responder — which
+                    // strands Esc — or drive actions meaningless behind the grid. The two modes are exclusive.
                     dashboardTitlebar
                         .zIndex(2)
                 } else {
@@ -162,7 +150,6 @@ struct WindowContentView: View {
         }
         .onChange(of: terminalZoom.target) { old, new in
             handleZoomTargetChange(old: old, new: new)
-            // reciprocal exclusivity: a zoom becoming active while the dashboard is open closes the dashboard.
             closeDashboardIfZoomActive(new)
         }
         // dashboard open/close drives the modal lifecycle + auto-follow pause; the font key (members + font
@@ -221,9 +208,8 @@ struct WindowContentView: View {
             inactivePaneMute = WindowContentView.resolvedInactivePaneMute()
             sidebarShift = WindowContentView.resolvedSidebarShift()
         }
-        // blend the title bar with the terminal; report frontmost/close to the library; surface the
-        // window un-minimized on launch. the title token makes updateNSView re-run the blend on a
-        // session switch.
+        // blend the title bar with the terminal; report frontmost/close to the library; surface the window
+        // un-minimized on launch. the title token re-runs the blend in updateNSView on a session switch.
         .background(WindowAccessor(titleToken: windowTitle, windowID: windowID, library: library, store: store))
         // own a per-window quick terminal: register it so the frontmost-window call sites resolve it,
         // and spawn its shell in THIS window's active session's directory.
@@ -267,50 +253,44 @@ struct WindowContentView: View {
                                             currentOpenOverlaySessionIDs new: [UUID]) {
         let closed = Set(old).subtracting(new)
         if let id = actions.keymapEditOverlaySession, closed.contains(id) {
-            // a keymap-edit overlay just closed -> reapply the edited keymap.
             actions.keymapEditOverlaySession = nil
             actions.reloadKeymap()
         }
         if let id = actions.ghosttyEditOverlaySession, closed.contains(id) {
-            // a ghostty.conf-edit overlay just closed -> reload the edited ghostty config (skipped when the
-            // file is unchanged, so a no-op editor session keeps per-session font zoom).
+            // the reload is skipped when the file is unchanged, so a no-op editor session keeps its font zoom.
             actions.ghosttyEditOverlaySession = nil
             actions.reloadGhosttyConfigIfEdited()
         }
     }
 
-    /// EXPERIMENT (custom-sidebar branch): our own split instead of `NavigationSplitView`, so macOS 26
-    /// doesn't impose the Liquid-Glass sidebar chrome (inset panel, toggle capsule) or couple it to the
-    /// toolbar style. A plain `HStack` gives the sidebar tree + a themed draggable divider + the terminal.
+    /// Our own split instead of `NavigationSplitView`, so macOS 26 cannot impose the Liquid-Glass sidebar
+    /// chrome (inset panel, toggle capsule) or couple it to the toolbar style: a plain `HStack` of the
+    /// sidebar tree + a themed draggable divider + the terminal.
     @ViewBuilder private var splitRoot: some View {
         HStack(spacing: 0) {
             if store.sidebarVisible {
                 sidebarColumn
                     .frame(width: CGFloat(store.sidebarWidth))
                 sidebarDivider
-                    // draw/hit above the terminal: the divider is the middle HStack child, so without this
-                    // the detail column (drawn last) shadows the right half of the grab handle, leaving only
-                    // a few points grabbable. zIndex lifts the whole handle on top so the full strip works.
+                    // the divider is the middle HStack child, so without this the detail column (drawn last)
+                    // shadows the right half of the grab handle and only a few points stay grabbable.
                     .zIndex(1)
             }
             detailColumn
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        // deliberately NOT animated on visibility: animating the split width interpolates the detail
-        // column's frame every display frame, and detailPane is the EAGER deck (a ZStack over EVERY
-        // session's surface, all mounted). so an animated collapse/expand resizes every ghostty surface
-        // each frame — each resize reflows the grid (set_size) AND force-repaints (refresh), even hidden
-        // opacity-0 panes — a cost that scales with total session count and janks on a window with many
-        // sessions. an instant toggle reflows each surface exactly once. DO NOT re-add the width animation.
-        // the mode switch below is safe to animate — it swaps sidebar CONTENT, not the split width, so
-        // the detail column (and the deck) never resize.
+        // DO NOT animate visibility: the width animation interpolates the detail column's frame every
+        // display frame, and detailPane is the EAGER deck (every session's surface mounted), so each frame
+        // reflows the grid (set_size) AND force-repaints (refresh) EVERY surface, hidden opacity-0 panes
+        // included — a cost scaling with session count that janks a many-session window. An instant toggle
+        // reflows each surface once. The mode switch below is safe: it swaps sidebar CONTENT, not the split
+        // width, so the detail column (and the deck) never resize.
         .animation(.easeInOut(duration: 0.15), value: store.sidebarMode)
     }
 
-    /// The eager split/deck remains mounted behind every modal presentation, including terminal zoom.
-    /// Keep frontmost-driven cleanup here rather than on `windowOverlayLayer`, which is absent while
-    /// zoomed: otherwise a palette owned by the old front window can survive the handoff and remount
-    /// after the picker and zoom both close.
+    /// The eager split/deck stays mounted behind every modal presentation, zoom included. Frontmost-driven
+    /// cleanup belongs here, not on `windowOverlayLayer` (absent while zoomed): otherwise a palette owned by
+    /// the old front window survives the handoff and remounts after the picker and zoom both close.
     private var alwaysMountedSplitLayer: some View {
         splitRoot
             .padding(.top, titlebarHeight)
@@ -326,10 +306,8 @@ struct WindowContentView: View {
 
     private var sidebarColumn: some View {
         VStack(spacing: 0) {
-            // matches the detail pane's hairline so the line continues across the full width under
-            // the title bar (the vertical divider hangs from it at the sidebar/terminal junction).
-            // themed (chromeText at low opacity), same as the detail-pane half, so it stays visible on
-            // light themes too.
+            // matches the detail pane's hairline so the line runs the full width under the title bar (the
+            // vertical divider hangs from it at the junction); themed so it stays visible on light themes.
             Rectangle()
                 .fill(chromeText.opacity(0.1))
                 .frame(height: 1)
@@ -337,17 +315,15 @@ struct WindowContentView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         }
         .safeAreaInset(edge: .bottom) { bottomBar }
-        // the lighter/darker sidebar tint: a wash behind the transparent outline + bottom bar, so the
-        // whole column reads as one surface a touch darker/lighter than the terminal. Behind the column
-        // content (so it never tints row text) and over the window background (so it composes with
+        // the sidebar tint wash sits behind the transparent outline + bottom bar so the column reads as one
+        // surface, behind the content (never tints row text) and over the window background (composes with
         // translucency/blur). Neutral paints nothing.
         .background(sidebarTintWash)
     }
 
-    /// The sidebar lighter/darker wash for the current `sidebarShift`: black (darker) or white (lighter)
-    /// at the shift's magnitude, composited over the window background. Compositing this over the window
-    /// background equals blending the terminal color toward black/white, and works the same over an
-    /// opaque or a translucent+blurred backdrop. Neutral (`amount == 0`) renders nothing.
+    /// The wash for the current `sidebarShift`: black (darker) or white (lighter) at the shift's magnitude
+    /// over the window background — equivalent to blending the terminal color toward black/white, and the
+    /// same over an opaque or a translucent+blurred backdrop. Neutral (`amount == 0`) renders nothing.
     @ViewBuilder private var sidebarTintWash: some View {
         let amount = AppSettings.sidebarShiftAmount(strength: sidebarShift)
         if amount != 0 {
@@ -355,9 +331,9 @@ struct WindowContentView: View {
         }
     }
 
-    /// A 1px themed vertical separator with a wider invisible drag handle to resize the sidebar. The
-    /// handle is wider than the line and the divider carries `.zIndex(1)` at the call site so the full
-    /// grab strip is reachable from both sides (the terminal column would otherwise shadow its right half).
+    /// A 1px themed vertical separator with a wider invisible drag handle to resize the sidebar. The divider
+    /// carries `.zIndex(1)` at the call site so the full grab strip is reachable from both sides (the
+    /// terminal column would otherwise shadow its right half).
     private var sidebarDivider: some View {
         Rectangle()
             .fill(chromeText.opacity(0.1))
@@ -371,9 +347,8 @@ struct WindowContentView: View {
                         if inside { NSCursor.resizeLeftRight.set() } else { NSCursor.arrow.set() }
                     }
                     .gesture(
-                        // drive width from the absolute cursor X (window coords), NOT accumulated
-                        // translation: the divider moves with the width, so translation-based resize
-                        // feeds back on itself and the line flickers. Absolute position is stable.
+                        // width comes from the absolute cursor X, NOT accumulated translation: the divider
+                        // moves with the width, so translation feeds back on itself and the line flickers.
                         DragGesture(minimumDistance: 1, coordinateSpace: .global)
                             .onChanged { value in
                                 store.sidebarWidth = min(AppStore.sidebarWidthMax, max(AppStore.sidebarWidthMin, Double(value.location.x)))
@@ -386,27 +361,22 @@ struct WindowContentView: View {
 
     @ViewBuilder private var detailColumn: some View {
         VStack(spacing: 0) {
-            // a subtle hairline between the title bar and the terminal; lives in the
-            // detail pane so it starts at the sidebar's right edge, not the full width.
-            // themed (chromeText at low opacity) so it stays visible on light themes too.
+            // hairline between the title bar and the terminal; in the detail pane so it starts at the
+            // sidebar's right edge, themed (chromeText, low opacity) so it stays visible on light themes.
             Rectangle()
                 .fill(chromeText.opacity(0.1))
                 .frame(height: 1)
             detailPane
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                // the overlay renders in-deck inside `sessionDetail` (`overlayPanel`), not at this
-                // `detailPane` level.
-                // the search bar, anchored at the `detailPane` level (never inside `sessionDetail`'s
-                // HSplitView ZStack) so toggling it can't overrun the NSSplitView up into the titlebar.
-                // Sits at the top-right of the detail area, like a standard find bar.
+                // the overlay renders in-deck inside `sessionDetail` (`overlayPanel`), not at this level.
                 .overlay(alignment: .topTrailing) { searchBarLayer }
         }
     }
 
-    /// The terminal area: a DECK of EVERY session's terminal, all mounted so each is realized (its
-    /// shell spawned) at startup, with only the selected one visible + hit-testable. Switching is a
-    /// visibility flip, not a re-host, so the surface NSView is never detached/re-attached (re-hosting
-    /// invalidates the Metal drawable and flickers). A placeholder shows behind when nothing is selected.
+    /// The terminal area: a DECK of EVERY session's terminal, all mounted so each spawns its shell at
+    /// startup, only the selected one visible + hit-testable. Switching is a visibility flip, never a
+    /// re-host (re-hosting invalidates the Metal drawable and flickers). A placeholder shows when nothing
+    /// is selected.
     @ViewBuilder private var detailPane: some View {
         let sessions = store.workspaces.flatMap(\.sessions)
         ZStack {
@@ -424,16 +394,15 @@ struct WindowContentView: View {
     }
 
     /// One session's terminal content: the primary pane, a side-by-side split (`HSplitView`), or the
-    /// maximized hidden-split pane, plus any overlay. `isActive` gates which pane auto-grabs focus —
-    /// only the visible deck entry, and within a split only the focused pane.
+    /// maximized hidden-split pane, plus any overlay. `isActive` gates which pane auto-grabs focus — only
+    /// the visible deck entry, and within a split only the focused pane.
     ///
-    /// While terminal zoom hosts one of this session's surfaces, the deck entry stays MOUNTED with the
-    /// SAME shape — only the zoom-owned slot swaps to its `deckHostsSurface` placeholder (an NSView can
-    /// live in one host at a time). Everything else keeps realizing surfaces, so a control-opened
-    /// split/scratch/overlay on the zoomed session still spawns and runs behind the zoom layer; swapping
-    /// the whole entry out would re-host the NSSplitView (the titlebar-overrun rule) and orphan those
-    /// surfaces until zoom exits. The split's arranged panes are stable ZStack wrappers (content swaps
-    /// INSIDE them), so the NSSplitView never re-layouts on a zoom toggle and the divider stays put;
+    /// While zoom hosts one of these surfaces the deck entry stays MOUNTED at the SAME shape, only the
+    /// zoom-owned slot swapping to its `deckHostsSurface` placeholder (an NSView lives in one host at a
+    /// time), so a control-opened split/scratch/overlay still spawns and runs behind the zoom layer —
+    /// swapping the whole entry out would re-host the NSSplitView (the titlebar-overrun rule) and orphan
+    /// those surfaces until zoom exits. The arranged panes are stable ZStack wrappers (content swaps
+    /// INSIDE), so the NSSplitView never re-layouts on a zoom toggle and the divider stays put;
     /// `SplitRatioAccessor` rides the primary wrapper as one persistent instance, suspended while zoomed.
     @ViewBuilder private func sessionDetail(_ session: Session, isActive: Bool) -> some View {
         // a FULL overlay (no size) hides the session beneath it (opacity 0) and draws translucent; a
@@ -444,25 +413,23 @@ struct WindowContentView: View {
         // surfaces; it must not focus, register drag targets, or show focusable controls behind the
         // full-window modal layer (both are mutually exclusive, so at most one gate is ever active).
         let deckInteractive = terminalZoom.target == nil && !dashboard.isOpen
-        // the scratch terminal is a full-coverage overlay too, so it hides the pane(s) exactly like a
-        // FULL overlay; `hideForOverlay` drives opacity + hit-testing. `overlaid` (any overlay OR scratch)
-        // is what owns focus, so it gates the pane(s)' `isActive` (focus goes to the overlay/scratch, not
-        // the pane). NOTE `hideForOverlay` stays false for a FLOATING overlay — preserving the rule that
-        // this subtree's shape/hit-testing must not change when a floating overlay opens (NSSplitView overrun).
+        // the scratch is full-coverage too, so `hideForOverlay` hides the pane(s) like a FULL overlay
+        // (opacity + hit-testing); `overlaid` (any overlay OR scratch) owns focus, so it gates the panes'
+        // `isActive`. `hideForOverlay` stays false for a FLOATING overlay — this subtree's shape and
+        // hit-testing must not change when one opens (NSSplitView overrun).
         let hideForOverlay = fullOverlay || session.scratchActive
         let overlaid = session.overlayActive || session.scratchActive
-        // on-screen = selected session, not hidden by a full overlay/scratch, and not covered by the
-        // window-level quick terminal. Shared by BOTH split panes (unlike the focus-gated `isActive`), it
-        // gates each surface's drag-type (un)registration AND its mouse-cursor tracking (the `deckVisible`
-        // note in libghostty.md) so neither a file drop nor a cursor write lands on an off-screen surface.
-        // `!quickTerminal.isVisible` mutes the covered pane while the quick terminal is up — otherwise the
-        // covered pane keeps deckVisible=true and races the quick-terminal surface for the cursor and fans
-        // mouse-motion into the covered TUI (issue #225 quick-terminal path).
+        // on-screen = selected, not hidden by a full overlay/scratch, not covered by the quick terminal.
+        // Shared by BOTH split panes (unlike the focus-gated `isActive`), it gates each surface's drag-type
+        // (un)registration AND its mouse-cursor tracking (the `deckVisible` note in libghostty.md), so no
+        // file drop or cursor write lands off-screen. Without `!quickTerminal.isVisible` the covered pane
+        // keeps deckVisible=true, races the quick-terminal surface for the cursor, and fans mouse-motion
+        // into the covered TUI (issue #225 quick-terminal path).
         let visible = deckInteractive && isActive && !hideForOverlay && !quickTerminal.isVisible
-        // focus gate: while the window-level quick terminal is up it OWNS first responder, so no deck
-        // surface may be `isActive` behind it — `TerminalView.updateNSView` would grab focus and send
-        // keystrokes to a covered session. Every automatic reselection (`reselectIfSelectionHidden`,
-        // auto-follow) reaches this, not just a click. The quick terminal's own hide flips it back.
+        // focus gate: a visible quick terminal OWNS first responder, so no deck surface may be `isActive`
+        // behind it — `TerminalView.updateNSView` would grab focus and send keystrokes to a covered session.
+        // Every automatic reselection (`reselectIfSelectionHidden`, auto-follow) reaches this, not just a
+        // click; the quick terminal's own hide flips it back.
         let focusable = deckInteractive && isActive && !quickTerminal.isVisible
         ZStack {
             // the session's pane(s), kept MOUNTED while an overlay is up — shells stay alive, like the deck
@@ -472,11 +439,10 @@ struct WindowContentView: View {
                 if session.isSplit {
                     HSplitView {
                         // each arranged pane is a STABLE ZStack wrapper whose CONTENT swaps between the live
-                        // TerminalView and the zoom placeholder. Swapping the arranged subview itself (the
-                        // pre-wrapper design) made NSSplitView re-layout and normalize the divider on every
-                        // zoom enter/exit — with no stored ratio there was nothing to restore, so the
-                        // proportions broke. With the wrapper, the split's two arranged NSViews never change
-                        // identity and the divider never moves.
+                        // TerminalView and the zoom placeholder: swapping the arranged subview itself makes
+                        // NSSplitView re-layout and normalize the divider on every zoom enter/exit, and with
+                        // no stored ratio there is nothing to restore. The wrapper keeps both arranged
+                        // NSViews' identity, so the divider never moves.
                         ZStack {
                             if deckHostsSurface(session: session, surface: .primary) {
                                 TerminalView(session: session, surfaceKeyPath: \.surface, makeSurface: makeSurface,
@@ -489,10 +455,10 @@ struct WindowContentView: View {
                                     .id("\(session.id.uuidString)-primary-placeholder")
                             }
                         }
-                        // introspects the AppKit NSSplitView to persist/restore the divider ratio AND to
-                        // clip its divider out of the titlebar strip (see SplitRatioAccessor); a background
-                        // on the stable wrapper (not a third pane, not inside the swapped content), so ONE
-                        // probe instance survives zoom and its suspend/resume actually flips in place.
+                        // introspects the AppKit NSSplitView to persist/restore the divider ratio and clip it
+                        // out of the titlebar strip (see SplitRatioAccessor); a background on the stable
+                        // wrapper (not a third pane, not inside the swapped content), so ONE probe survives
+                        // zoom and its suspend/resume flips in place.
                         .background { SplitRatioAccessor(session: session, titlebarHeight: titlebarHeight, suspended: !deckInteractive, onPersist: { store.save() }) }
                         ZStack {
                             if deckHostsSurface(session: session, surface: .split) {
@@ -532,26 +498,22 @@ struct WindowContentView: View {
                 }
             }
             .opacity(hideForOverlay ? 0 : 1)
-            // gate hit-testing on `hideForOverlay` (full overlay OR scratch), NOT `session.overlayActive`:
-            // this modifier must NOT change when a floating overlay opens, or the AppKit NSSplitView
-            // re-lays-out and overruns up into the titlebar (same class of perturbation as adding a sibling).
-            // a floating overlay therefore leaves the panes hit-testable here; `overlayPanel`'s transparent
-            // catcher absorbs clicks around the panel so they can't reach the panes.
+            // gate on `hideForOverlay` (full overlay OR scratch), NOT `session.overlayActive`: this modifier
+            // must not change when a floating overlay opens, or the NSSplitView re-lays-out and overruns up
+            // into the titlebar (same perturbation class as adding a sibling). A floating overlay leaves the
+            // panes hit-testable; `overlayPanel`'s transparent catcher absorbs the clicks around it.
             .allowsHitTesting(deckInteractive && !hideForOverlay)
-            // the scratch terminal renders here, in-deck, above the (hidden) pane(s) — a full-coverage sibling
-            // is safe (the panes go opacity 0, the split's frame is hidden). It sits BELOW the ephemeral overlay
-            // (zIndex 1 vs `overlayPanel`'s 3) AND goes hidden while a full overlay is up, exactly like the
-            // pane(s): under window translucency every surface's background renders fully transparent, so a
-            // scratch left visible below would show through the overlay (reading as "the overlay opened under
-            // the scratch"). BOTH overlay variants are the `overlayPanel` sibling below (zIndex 3): it is ALWAYS
-            // present with a constant shape (its content is gated internally), so opening/resizing an overlay
-            // never re-hosts the NSSplitView — and the floating panel's opaque backing needs no hiding of the
-            // scratch behind it.
+            // the scratch renders in-deck above the (hidden) pane(s) — a full-coverage sibling is safe (the
+            // panes go opacity 0, the split's frame is hidden). It sits BELOW the ephemeral overlay (zIndex 1
+            // vs `overlayPanel`'s 3) and hides under a FULL overlay like the panes: under window translucency
+            // every surface background renders fully transparent, so a scratch left visible would show THROUGH
+            // it (reading as "the overlay opened under the scratch"); a FLOATING panel's opaque backing needs
+            // no such hiding. `overlayPanel` hosts BOTH variants, always present at a constant shape (content
+            // gated internally), so opening or resizing an overlay never re-hosts the NSSplitView.
             if session.scratchActive, deckHostsSurface(session: session, surface: .scratch) {
-                // a full overlay renders above the scratch (`overlayPanel`, zIndex 3), so it gates focus here
-                // on top of what `focusable` already covers. (matches the autoFocus suppression in
-                // makeScratchSurface.) `deckVisible` mirrors the panes' rule so only an on-screen scratch is
-                // a file-drop target.
+                // a full overlay renders above the scratch (`overlayPanel`, zIndex 3), so it gates focus on
+                // top of `focusable` (matching makeScratchSurface's autoFocus suppression); `deckVisible`
+                // mirrors the panes' rule so only an on-screen scratch is a file-drop target.
                 TerminalView(session: session, surfaceKeyPath: \.scratchSurface, makeSurface: makeScratchSurface,
                              isActive: focusable && !session.overlayActive,
                              deckVisible: deckInteractive && isActive && !fullOverlay && !quickTerminal.isVisible)
@@ -560,23 +522,18 @@ struct WindowContentView: View {
                     .id("\(session.id.uuidString)-scratch")
                     .zIndex(1)
             }
-            // the overlay — FULL or FLOATING — renders IN-DECK (per session) so its surface mounts + program
-            // runs even when the session isn't active. ONE ALWAYS-PRESENT host (constant ZStack shape): the
-            // content is gated INSIDE `overlayPanel`, the sibling itself never appears/disappears, so opening,
-            // closing, OR resizing an overlay never re-hosts the NSSplitView (the titlebar-overrun trigger)
-            // and never re-parents the surface (which would blank its Metal drawable). Full fills the area
-            // translucent with the pane(s) hidden by `hideForOverlay`; floating draws an opaque framed panel
-            // over the still-visible pane(s). Switching full<->% (session.overlay.resize) only re-flows the frame.
+            // the overlay renders IN-DECK per session, so its program runs even when the session isn't
+            // active; see `overlayPanel` for the constant-shape rule that keeps open/close/resize from
+            // re-hosting the NSSplitView or re-parenting the surface.
             overlayPanel(session: session, isActive: focusable)
                 .zIndex(3)
         }
-        // when the overlay closes, the underlying pane must reclaim first responder. the pane re-activating
-        // only does a single makeFirstResponder, which loses the race with the overlay view's teardown/
-        // re-host — so drive the bounded retry the split-collapse survivor uses. gated on isActive so only
-        // the visible session reclaims focus.
         // on overlay close, refocus the topmost remaining surface (scratch if still shown, else the pane)
-        // via the shared `topmostSurface` precedence — never a pane hidden under the scratch, and not at all
-        // while the quick terminal covers the window (it owns focus; its own hide restores the session).
+        // via the shared `topmostSurface` precedence — never a pane hidden under the scratch. A single
+        // makeFirstResponder loses the race with the overlay view's teardown/re-host, so drive the bounded
+        // retry the split-collapse survivor uses. Gated on isActive so only the visible session reclaims
+        // focus, and skipped while the quick terminal covers the window (it owns focus; its own hide
+        // restores the session).
         .onChange(of: session.overlayActive) { _, isOpen in
             if !isOpen, deckInteractive, isActive, !quickTerminal.isVisible {
                 (session.topmostSurface as? GhosttySurfaceView)?.focusAfterReparent()
@@ -595,32 +552,31 @@ struct WindowContentView: View {
     }
 
     /// The overlay — FULL or FLOATING — rendered IN-DECK inside each session's `sessionDetail` ZStack as ONE
-    /// ALWAYS-PRESENT sibling. The content is gated INSIDE the GeometryReader, so the ZStack's child count
-    /// never changes when an overlay opens/closes (constant shape = no NSSplitView re-host = no titlebar
-    /// overrun), and BOTH variants share this single surface host, so `session.overlay.resize` switching
-    /// full<->% only re-flows the frame — it never re-parents the NSView (which would blank its Metal drawable).
-    /// A nil `overlaySizePercent` fills the detail area translucent (no opaque backing/frame) with the pane(s)
-    /// hidden by `hideForOverlay`; a percent draws an opaque, framed panel at that size, centered, with the
-    /// pane(s) visible around it. Per-session in the eager deck, so the surface mounts + program runs even when
-    /// the session isn't active.
+    /// ALWAYS-PRESENT sibling, its content gated INSIDE the GeometryReader so the ZStack's child count never
+    /// changes (constant shape = no NSSplitView re-host = no titlebar overrun). Both variants share this one
+    /// surface host, so `session.overlay.resize` switching full<->% only re-flows the frame and never
+    /// re-parents the NSView (which would blank its Metal drawable). A nil `overlaySizePercent` fills the
+    /// detail area translucent (no backing/frame), panes hidden by `hideForOverlay`; a percent draws an
+    /// opaque framed panel at that size, centered, panes visible around it. Per-session in the eager deck,
+    /// so the surface mounts and its program runs while the session is inactive.
     @ViewBuilder private func overlayPanel(session: Session, isActive: Bool) -> some View {
         GeometryReader { geo in
             ZStack {
                 if session.overlayActive, deckHostsSurface(session: session, surface: .overlay) {
                     let floating = session.overlaySizePercent != nil
                     let fraction = session.overlaySizePercent.map { CGFloat($0) / 100 } ?? 1
-                    // transparent click-catcher over the whole detail area: absorbs clicks AROUND a floating
-                    // panel so they can't reach the still-hit-testable panes and steal the overlay's first
-                    // responder (the full variant hides the panes, so it's covered either way).
+                    // transparent click-catcher: absorbs clicks AROUND a floating panel so they can't reach
+                    // the still-hit-testable panes and steal the overlay's first responder (the full variant
+                    // hides the panes anyway).
                     Color.clear.contentShape(Rectangle())
                     TerminalView(session: session, surfaceKeyPath: \.overlaySurface,
                                  makeSurface: makeOverlaySurface, isActive: isActive, deckVisible: isActive)
                         .frame(width: geo.size.width * fraction, height: geo.size.height * fraction)
                         // floating = opaque backing + hairline frame + shadow so it reads as a distinct window
                         // over the still-visible session; full = translucent, no chrome (libghostty draws only
-                        // the terminal, so the window backing shows through). The modifier CHAIN stays constant
-                        // across both variants — only the parameters go inert for full — so a full<->% resize
-                        // keeps the same view tree and never re-hosts the surface NSView.
+                        // the terminal, so the window backing shows through). The modifier CHAIN is constant
+                        // across both — only the parameters go inert for full — so a full<->% resize keeps
+                        // the same view tree and never re-hosts the surface NSView.
                         .background(floating ? terminalColor : Color.clear)
                         .clipShape(RoundedRectangle(cornerRadius: floating ? 12 : 0))
                         .overlay(
@@ -638,10 +594,10 @@ struct WindowContentView: View {
         .allowsHitTesting(isActive && session.overlayActive && deckHostsSurface(session: session, surface: .overlay))
     }
 
-    /// The terminal search bar, attached as a top-aligned `.overlay` on `detailPane` — NOT inside any
-    /// session's `sessionDetail`/HSplitView ZStack, so toggling it never perturbs the split and overruns the
-    /// NSSplitView into the titlebar. Shown only while zoom is off and the active session's `searchActive`
-    /// is set; the needle binding drives the query through `actions.updateSearchNeedle`.
+    /// The terminal search bar, a top-aligned `.overlay` on `detailPane` — NOT inside any session's
+    /// `sessionDetail`/HSplitView ZStack, so toggling it can't perturb the split and overrun the NSSplitView
+    /// into the titlebar. Shown while zoom is off and the active session's `searchActive` is set; the needle
+    /// binding drives the query through `actions.updateSearchNeedle`.
     @ViewBuilder private var searchBarLayer: some View {
         if terminalZoom.target == nil, let session = store.activeSession, session.searchActive {
             TerminalSearchBar(
@@ -662,20 +618,19 @@ struct WindowContentView: View {
         }
     }
 
-    /// Keeps a primary host stable through lazy surface creation and ordinary updates, but remounts it
-    /// when one live surface replaces another (split-survivor promotion). `TerminalView.updateNSView`
-    /// cannot replace the AppKit view that `makeNSView` returned, so session identity alone would keep
-    /// hosting the torn-down prior primary.
+    /// Keeps a primary host stable through lazy surface creation and ordinary updates, but remounts it when
+    /// one live surface replaces another (split-survivor promotion): `TerminalView.updateNSView` cannot
+    /// replace the view `makeNSView` returned, so session identity alone would keep hosting the torn-down
+    /// prior primary.
     func primarySurfaceID(_ session: Session) -> String {
         "\(session.id.uuidString)-primary-\(session.primarySurfaceHostRevision)"
     }
 
-    /// Mutes the inactive split pane's TEXT so the active pane stands out, WITHOUT darkening the
-    /// background: a translucent wash of the terminal background color over the pane. Background pixels
-    /// blend bg→bg (unchanged), text pixels blend text→bg (less bright) — the way other terminals dim an
-    /// inactive pane. The opacity comes from the Settings mute-strength slider (0...10) via
-    /// `AppSettings.muteOpacity`, so strength 0 renders nothing. Clicks pass through
-    /// (`allowsHitTesting(false)`) so the muted pane can still be focused; `dimmed == false` renders nothing.
+    /// Mutes the inactive split pane's TEXT without darkening the background: a translucent wash of the
+    /// terminal background over the pane, so background pixels blend bg→bg (unchanged) and text pixels
+    /// text→bg (less bright). Opacity comes from the Settings mute-strength slider via
+    /// `AppSettings.muteOpacity` (0...10, strength 0 renders nothing); clicks pass through so the muted
+    /// pane can still be focused.
     @ViewBuilder private func paneDim(_ dimmed: Bool) -> some View {
         let opacity = AppSettings.muteOpacity(strength: inactivePaneMute)
         if dimmed, opacity > 0 {
@@ -683,28 +638,23 @@ struct WindowContentView: View {
         }
     }
 
-    /// The terminal background color from the ghostty config (a dark fallback if libghostty hasn't
-    /// reported one), used as the quick terminal's opaque backing. Read into the `terminalColor`
-    /// view state so it re-renders when the theme changes.
+    /// The terminal background color from the ghostty config, with a dark fallback if libghostty has none.
     private static func resolvedTerminalColor() -> Color {
         Color(nsColor: GhosttyApp.shared.terminalBackgroundColor
             ?? NSColor(srgbRed: 0.157, green: 0.173, blue: 0.204, alpha: 1))
     }
 
-    /// The toolbar mode from the (non-observable) `GhosttyApp`, mirrored into view state so a settings
-    /// change (posting `.agtermAppearanceChanged`) re-renders the title bar (subtitle / hidden) live.
+    /// The toolbar mode from the (non-observable) `GhosttyApp`; see the `toolbarMode` mirror.
     private static func resolvedToolbarMode() -> ToolbarMode {
         GhosttyApp.shared.toolbarMode
     }
 
-    /// The attention-button flag from the (non-observable) `GhosttyApp`, mirrored into view state so a
-    /// settings change (posting `.agtermAppearanceChanged`) shows/hides the title bar bell live.
+    /// The attention-button flag from the non-observable `GhosttyApp`; see the `attentionButtonEnabled` mirror.
     private static func resolvedAttentionButtonEnabled() -> Bool {
         GhosttyApp.shared.attentionButtonEnabled
     }
 
-    /// The hidden-chrome-element set from the (non-observable) `GhosttyApp`, mirrored into view state so a
-    /// settings change (posting `.agtermAppearanceChanged`) shows/hides the gated chrome live.
+    /// The hidden-chrome-element set from the non-observable `GhosttyApp`; see the mirror above.
     private static func resolvedHiddenInterfaceElements() -> Set<InterfaceElement> {
         GhosttyApp.shared.hiddenInterfaceElements
     }
@@ -715,48 +665,42 @@ struct WindowContentView: View {
         !hiddenInterfaceElements.contains(element)
     }
 
-    /// The inactive-pane mute strength from the (non-observable) `GhosttyApp`, mirrored into view state
-    /// so a settings change (posting `.agtermAppearanceChanged`) re-renders the inactive pane live.
+    /// The inactive-pane mute strength from the non-observable `GhosttyApp`; see the `inactivePaneMute` mirror.
     private static func resolvedInactivePaneMute() -> Int {
         GhosttyApp.shared.inactivePaneMuteStrength
     }
 
-    /// The sidebar background shift from the (non-observable) `GhosttyApp`, mirrored into view state so a
-    /// settings change (posting `.agtermAppearanceChanged`) re-tints the sidebar wash live.
+    /// The sidebar background shift from the (non-observable) `GhosttyApp`; see the `sidebarShift` mirror.
     private static func resolvedSidebarShift() -> Int {
         GhosttyApp.shared.sidebarBackgroundShift
     }
 
-    /// The terminal theme's foreground color (a light fallback if libghostty hasn't reported one),
-    /// mirrored into view state so a theme change re-tints the chrome text live.
+    /// The terminal theme's foreground color, with a light fallback if libghostty hasn't reported one.
     private static func resolvedChromeText() -> Color {
         Color(nsColor: GhosttyApp.shared.terminalForegroundColor ?? .labelColor)
     }
 
-    /// A tooltip string with the action's current shortcut appended in parentheses (e.g. `Toggle
-    /// Sidebar (⌃⌘S)`), or just the base text when the action has no configured shortcut. Keeps the
-    /// toolbar/sidebar hints in lockstep with the keymap — a rebind shows the new chord, an unbound
-    /// action shows none — via the SAME `AppActions.shortcutGlyph` resolver the action palette uses.
-    /// Non-private so the `+RecentSessions` extension's attention button can build its tooltip.
+    /// The base text with the action's current shortcut appended in parentheses (`Toggle Sidebar (⌃⌘S)`),
+    /// or bare when the action has none — via the SAME `AppActions.shortcutGlyph` resolver the action
+    /// palette uses, so a rebind shows the new chord. Non-private so the `+RecentSessions` extension's
+    /// attention button can build its tooltip.
     func helpHint(_ base: String, _ action: BuiltinAction) -> String {
         guard let glyph = actions.shortcutGlyph(for: action) else { return base }
         return "\(base) (\(glyph))"
     }
 
-    /// The quick-terminal overlay: the scratch terminal centered at 90% of the window, framed by a
-    /// hairline border and shadow so it reads as a distinct floating window over the (undimmed)
-    /// content. libghostty renders only the terminal content, so the frame is drawn here. The margin
-    /// is a transparent tap-catcher that dismisses on click — no darkening, because the overlay
-    /// can't cover the AppKit title bar, so a dim would shade the body but not the chrome. Rendered
-    /// only while visible; the surface it hosts is owned by the controller, so hiding keeps the
-    /// shell alive.
-    /// The window-level overlays (quick terminal, command palettes, Ctrl-Tab switcher) as one layer,
-    /// rendered as a ZStack sibling INSIDE the body's root ZStack rather than as body-level `.overlay`s —
-    /// so it can be inset below the titlebar and ordered BELOW `customTitlebar` (which a body-level
-    /// `.overlay` cannot). Each child is conditional, so when none is showing this is empty (an empty
-    /// frame is not hit-testable, so the terminal below stays interactive); each overlay's own
-    /// `GeometryReader` fills the inset area. Order here = z-order (switcher on top of palette on top of
-    /// quick terminal), matching the previous `.overlay` stacking.
+    /// The quick-terminal overlay: the scratch terminal centered at 90% of the window, framed by a hairline
+    /// border and shadow so it reads as a distinct floating window over the (undimmed) content — libghostty
+    /// renders only the terminal, so the frame is drawn here. The margin is a transparent tap-catcher that
+    /// dismisses on click; no dim, because the overlay cannot cover the AppKit title bar and would shade the
+    /// body but not the chrome. Rendered only while visible; the controller owns the surface, so hiding
+    /// keeps the shell alive.
+    /// The window-level overlays (quick terminal, command palettes, Ctrl-Tab switcher) as one layer: a ZStack
+    /// sibling INSIDE the body's root ZStack, not body-level `.overlay`s, so it can be inset below the
+    /// titlebar and ordered BELOW `customTitlebar` (which a body-level `.overlay` cannot). Every child is
+    /// conditional, so with none showing this is an empty frame — not hit-testable, so the terminal below
+    /// stays interactive; each overlay's own `GeometryReader` fills the inset area. Order here = z-order
+    /// (switcher over palette over quick terminal).
     private var windowOverlayLayer: some View {
         ZStack {
             quickTerminalOverlay
@@ -773,9 +717,8 @@ struct WindowContentView: View {
         if quickTerminal.isVisible {
             GeometryReader { geo in
                 ZStack {
-                    // the transparent tap-catcher also carries the `quick-terminal` accessibility id:
-                    // a SwiftUI view is exposed in the accessibility tree (the Metal-backed
-                    // `QuickTerminalPane` is not), so this is the element control-API tests query for.
+                    // the tap-catcher carries the `quick-terminal` accessibility id: a SwiftUI view is in
+                    // the a11y tree (the Metal-backed `QuickTerminalPane` is not), so tests query this one.
                     Color.clear
                         .contentShape(Rectangle())
                         .onTapGesture { quickTerminal.hide() }
@@ -798,12 +741,11 @@ struct WindowContentView: View {
         }
     }
 
-    /// True only for the frontmost window. The palette and session switcher are app-global single
-    /// instances (they act on the frontmost store), so only the frontmost window mounts their
-    /// overlays — otherwise every open window would render a duplicate overlay, contending for focus
-    /// and showing the wrong window's candidates. Uses `activeWindowID` (frontmost-or-first-open, the
-    /// same accessor the palette/actions resolve through), so exactly one window matches even before
-    /// the first `didBecomeKey` sets `frontmostWindowID`. Reactive: `frontmostWindowID` is observed.
+    /// True only for the frontmost window. The palette and session switcher are app-global singles acting on
+    /// the frontmost store, so only that window mounts their overlays — otherwise every open window renders
+    /// a duplicate, contending for focus and showing the wrong window's candidates. `activeWindowID`
+    /// (frontmost-or-first-open, the accessor the palette/actions resolve through) matches exactly one
+    /// window even before the first `didBecomeKey` sets `frontmostWindowID`, and is observed, so this reacts.
     private var isFrontmost: Bool { library.activeWindowID == windowID }
 
     /// The command-palette overlay, mounted only while a palette is open in the frontmost window. Its
@@ -814,11 +756,11 @@ struct WindowContentView: View {
         }
     }
 
-    /// A control picker is per-window rather than frontmost-global, so a caller may present one in a
-    /// background window without duplicating it elsewhere. Selection preserves the caller's original
-    /// item index even though fuzzy filtering reorders the visible rows. Keyed by the pending id so one
-    /// picker replacing another in the same view update gets fresh palette state rather than keeping the
-    /// previous picker's rows, whose select closures capture the previous picker's items.
+    /// A control picker is per-window rather than frontmost-global, so a caller can present one in a
+    /// background window without duplicating it elsewhere. Selection preserves the caller's original item
+    /// index even though fuzzy filtering reorders the visible rows. Keyed by the pending id so a picker
+    /// replacing another in the same view update gets fresh palette state instead of the previous picker's
+    /// rows, whose select closures capture the previous picker's items.
     @ViewBuilder private var pickPaletteOverlay: some View {
         if let pending = pick.pending {
             CommandPalette(
@@ -852,10 +794,10 @@ struct WindowContentView: View {
         }
     }
 
-    /// The sidebar footer, source-list style: two add controls on the left — add a workspace, and a menu
-    /// to add a session to the current workspace (default cwd) or a picked directory — and two view
-    /// toggles on the right, the workspace focus filter and the flagged working-set view. Each of the four
-    /// is individually hideable via Settings ▸ Interface (`shows(_:)`).
+    /// The sidebar footer, source-list style: two add controls on the left (a workspace; a menu adding a
+    /// session to the current workspace at the default cwd or at a picked directory) and two view toggles on
+    /// the right (the workspace focus filter, the flagged working-set view). Each of the four is
+    /// individually hideable via Settings ▸ Interface (`shows(_:)`).
     private var bottomBar: some View {
         HStack(spacing: 2) {
             if shows(.newWorkspace) {
@@ -893,8 +835,7 @@ struct WindowContentView: View {
             Spacer()
 
             // apply or suspend the marked-workspace filter WITHOUT losing the set, so peeking at the whole
-            // tree costs one click each way. 2-state glyph (filled while the filter applies); it is both
-            // the indicator and the control for the filter state.
+            // tree costs one click each way. 2-state glyph (filled while applied): indicator and control.
             if shows(.focusFilter) {
                 Button {
                     actions.toggleFocusFilter()
@@ -904,9 +845,8 @@ struct WindowContentView: View {
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.borderless)
-                // nothing marked means nothing to filter to, and the store refuses to enable an empty set
-                // anyway. The explicit chromeText foregroundStyle defeats SwiftUI's default disabled
-                // dimming, so mute it by hand — the flagged toggle's rule.
+                // nothing marked = nothing to filter to, and the store refuses an empty set anyway. The
+                // explicit chromeText foregroundStyle defeats SwiftUI's disabled dimming, so mute by hand.
                 .disabled(store.focusedWorkspaceIDs.isEmpty)
                 .opacity(store.focusedWorkspaceIDs.isEmpty ? 0.35 : 1)
                 .help(helpHint(store.focusEnabled ? "Show all workspaces" : "Show only focused workspaces",
@@ -929,9 +869,8 @@ struct WindowContentView: View {
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.borderless)
-                // nothing to show: disable entering an empty flagged view (tree mode + no flags). Stays
-                // enabled in flagged mode so the button can always switch back to the tree. The explicit
-                // chromeText foregroundStyle defeats SwiftUI's default disabled dimming, so mute it by hand.
+                // disable entering an empty flagged view (tree mode + no flags); stays enabled in flagged
+                // mode so the button can always switch back to the tree. Hand-muted, like the filter above.
                 .disabled(store.sidebarMode == .tree && store.flaggedSessions.isEmpty)
                 .opacity(store.sidebarMode == .tree && store.flaggedSessions.isEmpty ? 0.35 : 1)
                 .help(helpHint(store.sidebarMode == .flagged ? "Show all sessions" : "Show flagged sessions", .toggleFlaggedView))
@@ -943,8 +882,8 @@ struct WindowContentView: View {
         .padding(.vertical, 4)
         // the add buttons track the terminal theme's foreground, matching the sidebar rows above.
         .foregroundStyle(chromeText)
-        // no explicit background: the sidebar is transparent (the window's terminal color shows
-        // through), so a `.bar` material here would paint a mismatched darker strip.
+        // no explicit background: the sidebar is transparent (the window's terminal color shows through),
+        // so a `.bar` material here would paint a mismatched darker strip.
     }
 
 }

--- a/agterm/Views/WindowControlArea.swift
+++ b/agterm/Views/WindowControlArea.swift
@@ -1,13 +1,13 @@
 import AppKit
 import SwiftUI
 
-/// A transparent AppKit layer placed behind the custom titlebar's decorative regions (the title text and
-/// the empty spacers, which opt out of SwiftUI hit-testing) so the header behaves like a real title bar:
-/// a single-click drag moves the window (`performDrag`) and a double-click runs the user's configured
-/// title-bar double-click action. The custom titlebar is a SwiftUI view, not AppKit's native title bar,
-/// so the OS double-click handling never reaches it; this restores it. The interactive header buttons
-/// render in front and keep their own clicks. `mouseDownCanMoveWindow` is off so our `mouseDown` — not
-/// AppKit's automatic move — sees the event and can tell a double-click apart from a drag.
+/// A transparent AppKit layer behind the custom titlebar's decorative regions (the title text and the
+/// empty spacers, which opt out of SwiftUI hit-testing) so the header behaves like a real title bar: a
+/// single-click drag moves the window (`performDrag`), a double-click runs the user's configured
+/// title-bar action. The custom titlebar is SwiftUI, not AppKit's native title bar, so the OS
+/// double-click handling never reaches it; the interactive header buttons render in front and keep their
+/// own clicks. `mouseDownCanMoveWindow` is off so our `mouseDown`, not AppKit's automatic move, sees the
+/// event and can tell a double-click apart from a drag.
 struct WindowControlArea: NSViewRepresentable {
     func makeNSView(context _: Context) -> TitlebarControlView { TitlebarControlView() }
     func updateNSView(_: TitlebarControlView, context _: Context) {}
@@ -24,20 +24,17 @@ struct WindowControlArea: NSViewRepresentable {
             window?.performDrag(with: event)
         }
 
-        /// Mirror AppKit's native title-bar double-click by honoring the system setting at
-        /// Desktop & Dock ▸ "Double-click a window's title bar to" (`AppleActionOnDoubleClick`
-        /// in `NSGlobalDomain`): Zoom/Fill → zoom, Minimize → miniaturize, "Do Nothing" → no-op.
-        /// The key is absent until the user changes it from the macOS default (Zoom), so an
-        /// untouched system reads as `nil` here and still zooms — preserving the prior behavior.
-        /// Read live on each double-click so a setting change takes effect without an app relaunch.
-        /// "Fill" maps to `zoom` (the closest standard NSWindow action; true Fill uses the newer
-        /// window-tiling APIs). Zoom matches the `window.zoom` control command (the plain green button does
-        /// native full screen, not zoom).
-        ///
-        /// A UITest env override (`AGTERM_UITEST_DOUBLECLICK_ACTION`) takes precedence so the gesture
-        /// tests are hermetic regardless of the host machine's setting; it rides the environment
-        /// because launch arguments trip the macOS 15+ no-window-at-launch bug (FB11763863, see
-        /// `ui-tests.md`). Production never sets it and falls through to the live system default.
+        /// Mirror AppKit's native title-bar double-click by honoring Desktop & Dock ▸ "Double-click a
+        /// window's title bar to" (`AppleActionOnDoubleClick` in `NSGlobalDomain`): Zoom/Fill → zoom,
+        /// Minimize → miniaturize, "Do Nothing" → no-op. The key is absent until the user changes it from
+        /// the macOS default (Zoom), so an untouched system reads `nil` here and still zooms. Read live on
+        /// each double-click, so a setting change needs no relaunch. "Fill" maps to `zoom`, the closest
+        /// standard NSWindow action (true Fill uses the newer window-tiling APIs); zoom matches the
+        /// `window.zoom` control command, while the plain green button does native full screen. The UITest
+        /// env override `AGTERM_UITEST_DOUBLECLICK_ACTION` takes precedence so the gesture tests are
+        /// hermetic regardless of the host's setting; it rides the environment because launch arguments
+        /// trip the macOS 15+ no-window-at-launch bug (FB11763863, see `ui-tests.md`). Production never
+        /// sets it and falls through to the live system default.
         private func performTitlebarDoubleClickAction() {
             guard let window else { return }
             let action = ProcessInfo.processInfo.environment["AGTERM_UITEST_DOUBLECLICK_ACTION"]

--- a/agterm/Views/WorkspaceSidebar+ContextMenu.swift
+++ b/agterm/Views/WorkspaceSidebar+ContextMenu.swift
@@ -1,18 +1,16 @@
 import agtermCore
 import AppKit
 
-/// `WorkspaceSidebar.Coordinator` per-row context menu and its actions — the double-click rename
-/// trigger, the menu builder, and the `@objc` handlers that drive the store/`AppActions`. Split out of
-/// `WorkspaceSidebar.swift` to keep that file under the swiftlint size limit. Selector dispatch from an
-/// extension works, so the handlers stay private.
+/// `WorkspaceSidebar.Coordinator`'s per-row context menu and actions — the double-click rename trigger, the
+/// menu builder, and the `@objc` handlers driving the store/`AppActions`. Split from `WorkspaceSidebar.swift`
+/// for the swiftlint size limit; selector dispatch from an extension works, so the handlers stay private.
 extension WorkspaceSidebar.Coordinator {
     // MARK: - Context menu
 
-    /// Single click on a workspace row toggles its expansion, so the whole row is a hit target for
-    /// expand/collapse (not just the disclosure triangle). The toggle is DEFERRED by the double-click
-    /// interval: a double-click (`handleDoubleClick`) cancels it, so renaming a workspace no longer flips
-    /// it open/closed on the way into edit mode. `action` fires on a genuine click, never during a drag,
-    /// so workspace drag-reorder is unaffected.
+    /// Single click anywhere on a workspace row toggles its expansion, so the whole row is the hit target,
+    /// not just the disclosure triangle. The toggle is DEFERRED by the double-click interval and cancelled
+    /// by `handleDoubleClick`, so renaming does not flip the row open/closed on the way into edit mode.
+    /// `action` fires on a genuine click, never during a drag, so workspace drag-reorder is unaffected.
     @objc func handleSingleClick(_ sender: NSOutlineView) {
         let row = sender.clickedRow
         guard row >= 0, let node = sender.item(atRow: row) as? SidebarNode, node.kind == .workspace else { return }
@@ -47,19 +45,16 @@ extension WorkspaceSidebar.Coordinator {
         if outline.isItemExpanded(node) { outline.collapseItem(node) } else { outline.expandItem(node) }
     }
 
-    /// Builds the per-row context menu. Resolves the clicked row lazily so the
-    /// same menu serves every row.
+    /// Builds the per-row context menu, resolving the clicked row lazily so one menu serves every row.
     func menu(forRow row: Int) -> NSMenu? {
         guard let outline = outlineView, row >= 0, let node = outline.item(atRow: row) as? SidebarNode else { return nil }
         let menu = NSMenu()
-        // manage enabled state explicitly (the Delete item is disabled at the last workspace)
-        // rather than via the responder-chain auto-enabling.
+        // explicit enabled state (Delete is disabled at the last workspace), not responder-chain auto-enabling.
         menu.autoenablesItems = false
         let sessionTargets = node.kind == .session ? store.sidebarSelectionTargets(forContextSession: node.id) : []
         let sessionCount = sessionTargets.count
 
-        // "Clear Status" sits first for a session row that has a status to clear (same effect as
-        // `agtermctl session status idle`).
+        // "Clear Status" sits first for a session row with a status, the `agtermctl session status idle` effect.
         if node.kind == .session, sessionTargets.contains(where: { store.session(withID: $0)?.agentIndicator.status != .idle }) {
             let clearStatus = NSMenuItem(title: sessionCount == 1 ? "Clear Status" : "Clear Statuses",
                                          action: #selector(menuClearStatus(_:)), keyEquivalent: "")
@@ -78,9 +73,9 @@ extension WorkspaceSidebar.Coordinator {
 
         switch node.kind {
         case .session:
-            // "Duplicate Session" opens a fresh shell in this session's directory, right after it —
-            // single-selection only (like Rename/Reveal in Finder), and sitting next to Rename mirrors
-            // Finder's ordering. The title matches the New Session / Close Session naming on the same menu.
+            // "Duplicate Session" opens a fresh shell in this session's directory, right after it.
+            // Single-selection only and next to Rename, mirroring Finder; the title matches the New
+            // Session / Close Session naming on this menu.
             if sessionCount == 1 {
                 let duplicate = NSMenuItem(title: "Duplicate Session", action: #selector(menuDuplicate(_:)), keyEquivalent: "")
                 duplicate.target = self
@@ -102,8 +97,7 @@ extension WorkspaceSidebar.Coordinator {
                 moveTo.submenu = submenu
                 menu.addItem(moveTo)
             }
-            // "Flag"/"Unflag" toggles the session's flagged working-set membership; the label
-            // reflects the current state.
+            // "Flag"/"Unflag" toggles flagged working-set membership; the label reflects the current state.
             let allFlagged = !sessionTargets.isEmpty && sessionTargets.allSatisfy { store.session(withID: $0)?.flagged == true }
             let flagTitle: String
             if sessionCount == 1 {
@@ -136,8 +130,8 @@ extension WorkspaceSidebar.Coordinator {
             openSession.target = self
             openSession.representedObject = node
             menu.addItem(openSession)
-            // the two focus items are their own group: they filter what the tree shows, unlike the
-            // create items above and the destructive one below.
+            // the focus items are their own group: they filter what the tree shows, unlike the create items
+            // above and the destructive one below.
             menu.addItem(.separator())
             // "Focus"/"Unfocus" REPLACES the marked set with this workspace (or clears it when this is
             // already the only marked one, with the filter on); the label reflects the current state.
@@ -207,8 +201,7 @@ extension WorkspaceSidebar.Coordinator {
 
     @objc private func menuDuplicate(_ sender: NSMenuItem) {
         guard let node = sender.representedObject as? SidebarNode else { return }
-        // pass THIS sidebar's window-local store, like Close/Flag: a background window's Duplicate must
-        // act on its own row, not the frontmost window's session.
+        // this sidebar's window-local store, like Close/Flag — a background window acts on its own row.
         actions.duplicateSession(node.id, in: store)
     }
 
@@ -224,9 +217,8 @@ extension WorkspaceSidebar.Coordinator {
         addSession(toWorkspace: node.id, cwd: actions.resolvedNewSessionCwd())
     }
 
-    /// Inline "+" button on a workspace row — same action as the right-click "New Session" menu item.
-    /// The button carries no workspace id; we derive it from the outline row at click time so reused
-    /// cells always target the correct workspace.
+    /// Inline "+" button on a workspace row, the right-click "New Session" action. The button carries no
+    /// workspace id, so it is derived from the outline row at click time — reused cells target the right one.
     @objc func addSessionButtonClicked(_ sender: NSButton) {
         // cancel any pending single-click workspace toggle so clicking "+" doesn't also flip expansion.
         pendingRowToggle?.cancel()
@@ -239,17 +231,15 @@ extension WorkspaceSidebar.Coordinator {
 
     @objc private func menuDeleteWorkspace(_ sender: NSMenuItem) {
         guard let node = sender.representedObject as? SidebarNode else { return }
-        // pass THIS sidebar's window-local store, like Close/Flag/Duplicate/Focus: the item's enabled state
-        // came from `store.canRemoveWorkspace`, so a background window's row must delete its own workspace —
-        // routing through the frontmost store would not find the id there and would silently do nothing.
+        // this sidebar's window-local store, like Close/Flag/Duplicate/Focus: the enabled state came from
+        // `store.canRemoveWorkspace`, and the frontmost store would not find the id — a silent no-op.
         actions.deleteWorkspace(node.id, in: store)
     }
 
     @objc private func menuFocusWorkspace(_ sender: NSMenuItem) {
         guard let node = sender.representedObject as? SidebarNode else { return }
-        // pass THIS sidebar's window-local store, like Close/Flag/Duplicate: the "Focus"/"Unfocus" label
-        // was computed from it, so a background window's row must toggle its own tree — routing through
-        // the frontmost store would read one window and write another.
+        // this sidebar's window-local store, like Close/Flag/Duplicate: the "Focus"/"Unfocus" label was
+        // computed from it, and the frontmost store would read one window and write another.
         actions.focusWorkspace(node.id, in: store)
     }
 

--- a/agterm/Views/WorkspaceSidebar+DragDrop.swift
+++ b/agterm/Views/WorkspaceSidebar+DragDrop.swift
@@ -1,10 +1,10 @@
 import agtermCore
 import AppKit
 
-/// `WorkspaceSidebar.Coordinator` native drag-and-drop — the pasteboard writer plus validate/accept and
-/// the resolve helpers that glue AppKit's proposed drop to the host-free `SidebarDrop` index math. Split
-/// out of `WorkspaceSidebar.swift` to keep that file under the swiftlint size limit. `workspaceNode(forID:)`
-/// stays in the main file (it reads the private `roots` cache); the pasteboard type constants are file-level.
+/// `WorkspaceSidebar.Coordinator` native drag-and-drop: the pasteboard writer, validate/accept, and the
+/// resolve helpers gluing AppKit's proposed drop to the host-free `SidebarDrop` index math. Split out of
+/// `WorkspaceSidebar.swift` for its size limit; `workspaceNode(forID:)` stays there (it reads the private
+/// `roots` cache) and the pasteboard type constants are file-level.
 extension WorkspaceSidebar.Coordinator {
     // MARK: - Drag and drop
 
@@ -42,7 +42,6 @@ extension WorkspaceSidebar.Coordinator {
                 cancelSpringLoadedExpansion()
                 return []
             }
-            // redraw the drop highlight on the target workspace row at the resolved insert slot.
             outlineView.setDropItem(workspaceNode(forID: move.workspace), dropChildIndex: move.dropChildIndex)
             scheduleSpringLoadedExpansion(of: move.workspace, in: outlineView)
             return .move
@@ -118,11 +117,10 @@ extension WorkspaceSidebar.Coordinator {
         let destination: Int
     }
 
-    /// Resolves a proposed session drop into the move it would perform, or nil when the drop is
-    /// invalid or a no-op (so both `validateDrop` and `acceptDrop` agree exactly). Reads the pasteboard
-    /// + store to map the dragged sessions and drop-target row to indices, then defers the index
-    /// arithmetic (drop-on-row redirect, post-removal insertion slot, no-op detection) to the host-free
-    /// `SidebarDrop.resolveSessions`.
+    /// Resolves a proposed session drop into the move it would perform, nil when the drop is invalid or a
+    /// no-op, so `validateDrop` and `acceptDrop` agree exactly. Reads the pasteboard + store to map dragged
+    /// sessions and the drop-target row to indices, then defers the index arithmetic (drop-on-row redirect,
+    /// post-removal insertion slot, no-op detection) to the host-free `SidebarDrop.resolveSessions`.
     private func resolveSessionMove(from info: NSDraggingInfo, item: Any?, childIndex index: Int) -> SessionMove? {
         let sessionIDs = draggedSessionIDs(from: info)
         guard !sessionIDs.isEmpty, let node = item as? SidebarNode else { return nil }
@@ -148,10 +146,9 @@ extension WorkspaceSidebar.Coordinator {
                            dropChildIndex: move.dropChildIndex, destination: move.destination)
     }
 
-    /// Resolves a Finder drop to existing directory URLs and a destination workspace. Dropping on a
-    /// workspace row adds there; dropping on a session row adds to that session's workspace; dropping into
-    /// empty sidebar space uses the store's `soleFocusedWorkspaceID` (the workspace the tree is zoomed to),
-    /// otherwise the current workspace.
+    /// Resolves a Finder drop to existing directory URLs and a destination workspace: a workspace row adds
+    /// there, a session row adds to that session's workspace, and empty sidebar space uses the store's
+    /// `soleFocusedWorkspaceID` (the workspace the tree is zoomed to), otherwise the current workspace.
     private func resolveDirectoryDrop(from info: NSDraggingInfo, item: Any?) -> DirectoryDrop? {
         let resolved = directoryURLs(from: info)
         guard !resolved.urls.isEmpty,
@@ -238,10 +235,9 @@ extension WorkspaceSidebar.Coordinator {
         suppressExpansionPersist = false
     }
 
-    /// Drops the pending spring-load work item and the opened-row tracking WITHOUT collapsing. Used on a
-    /// successful drop so a workspace the drag spring-opened stays open to reveal the dropped/moved
-    /// session — a `moveSessions` accept never changes the selection, so `syncSelection`'s reveal can't
-    /// re-expand it, and collapsing here would hide the moved row until a manual expand.
+    /// Drops the pending spring-load work item and the opened-row tracking WITHOUT collapsing, so a workspace
+    /// the drag spring-opened stays open on a successful drop: a `moveSessions` accept never changes the
+    /// selection, so `syncSelection`'s reveal can't re-expand it and collapsing would hide the moved row.
     private func clearSpringLoadedTracking() {
         pendingSpringLoadedExpansion?.workItem.cancel()
         pendingSpringLoadedExpansion = nil
@@ -273,18 +269,17 @@ extension WorkspaceSidebar.Coordinator {
         }
     }
 
-    /// Resolves a workspace drop into the top-level reorder it would perform, or nil when it is a no-op
-    /// (so `validateDrop` and `acceptDrop` agree exactly). A workspace reorder is a TOP-LEVEL move, but
-    /// with workspaces expanded their sessions fill the gaps between workspace rows, so `NSOutlineView`
-    /// only ever proposes drops INTO a workspace's children (`item != nil`) — never the clean root
-    /// between-rows slot — making the reorder impossible from the proposed `item`/`childIndex` alone.
-    /// Derive the insert slot from the cursor Y against the workspace ROWS' midpoints instead (sessions
-    /// ignored): the slot is the count of RENDERED workspace rows whose midpoint sits above the cursor, so
-    /// the top half of a row drops before it and the bottom half after it. The focus filter can render a
-    /// non-contiguous subset of the workspaces, so that slot is a VISIBLE-row count, not a full-array
-    /// index; `SidebarDrop.workspaceInsertIndex` maps it back onto the full array (landing adjacent to the
-    /// aimed-at row rather than jumping across the hidden workspaces between them), and the index
-    /// arithmetic (post-removal off-by-one, no-op detection) defers to `SidebarDrop.resolveWorkspace`.
+    /// Resolves a workspace drop into the TOP-LEVEL reorder it would perform, nil when it is a no-op, so
+    /// `validateDrop` and `acceptDrop` agree exactly. With workspaces expanded their sessions fill the gaps
+    /// between workspace rows, so `NSOutlineView` only ever proposes drops INTO a workspace's children
+    /// (`item != nil`), never the clean root between-rows slot — the reorder is impossible from the proposed
+    /// `item`/`childIndex` alone. The insert slot instead comes from the cursor Y against the workspace ROWS'
+    /// midpoints (sessions ignored): the count of RENDERED rows whose midpoint sits above the cursor, so a
+    /// row's top half drops before it and its bottom half after. The focus filter can render a non-contiguous
+    /// subset, so that is a VISIBLE-row count, not a full-array index; `SidebarDrop.workspaceInsertIndex` maps
+    /// it back onto the full array (landing adjacent to the aimed-at row rather than jumping across the hidden
+    /// workspaces between them), and the arithmetic (post-removal off-by-one, no-op detection) defers to
+    /// `SidebarDrop.resolveWorkspace`.
     private func resolveWorkspaceMove(from info: NSDraggingInfo, in outlineView: NSOutlineView)
         -> (workspaceID: UUID, dropChildIndex: Int, destination: Int)? {
         guard let workspaceID = draggedWorkspaceID(from: info),

--- a/agterm/Views/WorkspaceSidebar+RowRendering.swift
+++ b/agterm/Views/WorkspaceSidebar+RowRendering.swift
@@ -1,10 +1,9 @@
 import agtermCore
 import AppKit
 
-/// `WorkspaceSidebar.Coordinator` row rendering — the `NSOutlineViewDelegate` cell/row builders and
-/// their helpers (cell construction, badge/icon application, row labels). Split out of
-/// `WorkspaceSidebar.swift` to keep that file under the swiftlint size limit. The lazy icon caches and
-/// `rowIcon`/`rowLabel(for:workspaceName:)` stay in the main file (lazy stored properties can't live in
+/// `WorkspaceSidebar.Coordinator` row rendering — the `NSOutlineViewDelegate` cell/row builders and their
+/// helpers, split out to keep `WorkspaceSidebar.swift` under the swiftlint size limit. The lazy icon caches
+/// and `rowIcon`/`rowLabel(for:workspaceName:)` stay in the main file (lazy stored properties can't live in
 /// an extension, and those two are shared with the reconcile path).
 extension WorkspaceSidebar.Coordinator {
     // MARK: - NSOutlineViewDelegate
@@ -52,10 +51,9 @@ extension WorkspaceSidebar.Coordinator {
             // roll-up badge so an unseen notification stays visible when the workspace is collapsed
             // (gated by the Settings badge toggle, like the session badge below)
             applyBadge(toCell: cell, count: effectiveUnseen(workspace?.unseenCount ?? 0))
-            // a workspace in the focus set draws the SAME grid glyph at BLACK weight. keyed on
-            // MEMBERSHIP alone, not on `focusEnabled`: a marked workspace reads black while the filter
-            // is off too, which is the point — the marked set stays legible while looking at the whole
-            // tree.
+            // a workspace in the focus set draws the SAME grid glyph at BLACK weight, keyed on MEMBERSHIP
+            // alone and NOT on `focusEnabled` — so the marked set stays legible with the filter off, while
+            // looking at the whole tree.
             cell.imageView?.image = store.focusedWorkspaceIDs.contains(node.id) ? focusedWorkspaceIcon : workspaceIcon
             cell.imageView?.setAccessibilityIdentifier("workspace-icon")
         case .session:
@@ -67,10 +65,10 @@ extension WorkspaceSidebar.Coordinator {
             applyBadge(toCell: cell, count: effectiveUnseen(session?.unseenCount ?? 0))
             // gate the agent-status glyph: hidden for the frontmost window's selected session.
             cell.statusIcon.apply(effectiveIndicator(forSession: node.id))
-            // a session with a split shows the split-rectangle icon (matching the toolbar split
-            // button) in BOTH modes so it stays distinguishable at a glance; `hasSplit` keeps it while
-            // merely hidden. only the filled `flagged` variant is tree-mode only — in the flat flagged
-            // view every row is flagged, so the fill marker would be noise.
+            // the split-rectangle icon (matching the toolbar split button) shows in BOTH modes so a split
+            // stays distinguishable at a glance, and `hasSplit` keeps it while merely hidden. Only the
+            // filled `flagged` variant is tree-mode only — every row in the flat flagged view is flagged,
+            // so the fill would be noise.
             let showSplitIcon = session?.hasSplit == true
             let flagged = store.sidebarMode == .tree && session?.flagged == true
             cell.imageView?.image = iconForSession(split: showSplitIcon, flagged: flagged)
@@ -93,9 +91,8 @@ extension WorkspaceSidebar.Coordinator {
         cell.badge.count = count
     }
 
-    /// The leading icon for a session row: the split-rectangle when split, the plain terminal
-    /// otherwise, each swapped to its filled variant when `flagged`. The filled variant is
-    /// tree-mode only (the caller passes `flagged: false` in the flat flagged view).
+    /// The leading session-row icon: split-rectangle when split, else plain terminal, each swapped to its
+    /// filled variant when `flagged` — tree mode only, the flat flagged view passes `flagged: false`.
     private func iconForSession(split: Bool, flagged: Bool) -> NSImage? {
         switch (split, flagged) {
         case (true, true): return flaggedSplitSessionIcon
@@ -105,17 +102,14 @@ extension WorkspaceSidebar.Coordinator {
         }
     }
 
-    /// Builds a view-based outline cell: an `SidebarCellView` with a leading icon
-    /// (`cell.imageView`), the name `NSTextField` (`cell.textField`, editable on demand by
-    /// `beginEditing`), and a trailing notification badge. The name hugs and resists compression
-    /// weakly while the icon and badge hug and resist strongly, so the name truncates first and
-    /// the icon and badge stay whole.
+    /// Builds a view-based outline cell: a `SidebarCellView` with a leading icon (`cell.imageView`), the
+    /// name `NSTextField` (`cell.textField`, made editable on demand by `beginEditing`), and a trailing
+    /// notification badge. The name hugs and resists compression weakly while the icon and badge do so
+    /// strongly, so the name truncates first and both stay whole.
     ///
-    /// Workspace cells additionally get an inline "+" button (`cell.addButton`) between the name
-    /// and the status icon, revealed only while the pointer hovers the row (the Finder/Xcode
-    /// convention; see `SidebarCellView.setAddButtonVisible`) — clicking it adds a new session to
-    /// that workspace via `addSessionButtonClicked`, the same path as the right-click "New Session"
-    /// menu item.
+    /// Workspace cells also get an inline "+" (`cell.addButton`) between the name and the status icon,
+    /// revealed only on hover (the Finder/Xcode convention; `SidebarCellView.setAddButtonVisible`); it runs
+    /// `addSessionButtonClicked`, the same path as the right-click "New Session" item.
     private func makeCell(identifier: NSUserInterfaceItemIdentifier) -> SidebarCellView {
         let cell = SidebarCellView()
         cell.identifier = identifier

--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -2,21 +2,18 @@ import agtermCore
 import AppKit
 import SwiftUI
 
-/// Local-only (within-outline) pasteboard type carrying a dragged session's UUID, identifying the
-/// session being moved.
+/// Local-only (within-outline) pasteboard type carrying a dragged session's UUID.
 let sessionPasteboardType = NSPasteboard.PasteboardType("com.umputun.agterm.session")
 
-/// Local-only pasteboard type carrying a dragged workspace's UUID, identifying the workspace being
-/// reordered.
+/// Local-only pasteboard type carrying a dragged workspace's UUID.
 let workspacePasteboardType = NSPasteboard.PasteboardType("com.umputun.agterm.workspace")
 
-/// AppKit `NSOutlineView` sidebar (`.plain` style + a custom row height and top/left content insets that
-/// match the terminal's ghostty padding) hosted in SwiftUI via `NSViewRepresentable`. Replaces the
-/// SwiftUI `List` sidebar so cross-workspace drag-and-drop works natively: a session row dragged onto
-/// another workspace moves in the model, preserving the same `Session` instance.
+/// AppKit `NSOutlineView` sidebar hosted in SwiftUI via `NSViewRepresentable`, chosen over a SwiftUI
+/// `List` so cross-workspace drag-and-drop works natively: a session row dragged onto another workspace
+/// moves in the model, preserving the same `Session` instance.
 ///
 /// Two-level tree: workspaces (expandable parents, bold) → sessions (children). Only session rows are
-/// selectable detail targets. Inline rename via double-click or the "Rename" context menu; per-row
+/// selectable detail targets; inline rename via double-click or the "Rename" context menu, and per-row
 /// context menus drive the store API.
 struct WorkspaceSidebar: NSViewRepresentable {
     @Bindable var store: AppStore
@@ -32,8 +29,8 @@ struct WorkspaceSidebar: NSViewRepresentable {
         outline.delegate = context.coordinator
         outline.headerView = nil
         // .plain (not .sourceList) drops the built-in ~10px top inset above the first row, so the tree runs
-        // flush below the titlebar in every toolbar mode; a custom row height restores the roomy
-        // source-list-like size .plain's .default would shrink to ~17px.
+        // flush below the titlebar; a custom row height restores the roomy size .plain's .default shrinks
+        // to ~17px.
         outline.rowSizeStyle = .custom
         outline.rowHeight = AppSettings.sidebarRowHeight(fontSize: GhosttyApp.shared.sidebarFontSize)
         outline.floatsGroupRows = false
@@ -44,12 +41,11 @@ struct WorkspaceSidebar: NSViewRepresentable {
         outline.doubleAction = #selector(Coordinator.handleDoubleClick(_:))
         if #available(macOS 11.0, *) { outline.style = .plain }
         // .plain reverts backgroundColor to an OPAQUE controlBackgroundColor (unlike .sourceList's
-        // translucent material), painting over the sidebar tint wash and the terminal-colored/translucent
-        // window backing — clear it, matching scroll.drawsBackground = false below.
+        // translucent material), painting over the tint wash and the terminal-colored window backing —
+        // clear it, matching scroll.drawsBackground = false below.
         outline.backgroundColor = .clear
-        // AppKit's own selection drawing would paint a gray unemphasized capsule whenever the sidebar isn't
-        // first responder (focus normally lives in the terminal); SidebarRowView draws the themed selection
-        // pill in drawBackground for every state.
+        // AppKit would paint a gray unemphasized capsule whenever the sidebar isn't first responder (focus
+        // lives in the terminal); SidebarRowView draws the themed pill in drawBackground for every state.
         outline.selectionHighlightStyle = .none
         outline.allowsMultipleSelection = true
         outline.allowsEmptySelection = true
@@ -60,65 +56,55 @@ struct WorkspaceSidebar: NSViewRepresentable {
         outline.outlineTableColumn = column
 
         // native drag-and-drop: session rows reorder within / move across workspaces; workspace rows
-        // reorder among themselves; Finder folder drops create sessions rooted at those folders. Both
-        // private types are load-bearing — without the workspace type AppKit never delivers
-        // validate/accept for a workspace drag.
+        // reorder among themselves; Finder folder drops create sessions rooted at those folders. Without
+        // the workspace type registered AppKit never delivers validate/accept for a workspace drag.
         outline.registerForDraggedTypes([sessionPasteboardType, workspacePasteboardType, .fileURL])
-        // sidebar rows are app-private move sources exporting no public representation; Finder folder
-        // import is independent — Finder owns that external source and supplies `.fileURL`.
+        // sidebar rows are app-private move sources with no public representation; the Finder import is
+        // independent — Finder owns that external source and supplies `.fileURL`.
         outline.setDraggingSourceOperationMask(.move, forLocal: true)
         outline.setDraggingSourceOperationMask([], forLocal: false)
 
         context.coordinator.outlineView = outline
         context.coordinator.renameController.outlineView = outline
-        // pin the appearance to the theme brightness up front so the disclosure triangle reads on launch (a
-        // light theme under macOS dark mode would draw an invisible light triangle).
+        // pin the appearance up front so the disclosure triangle reads on launch.
         context.coordinator.applyThemeAppearance()
-        // seed tracked expansion from the persisted per-workspace state BEFORE the reload, so
-        // rebuildAndReload restores each workspace's saved open/collapsed state (a collapsed workspace stays
-        // collapsed across relaunch) instead of force-expanding every row.
+        // seed tracked expansion BEFORE the reload, so rebuildAndReload restores each workspace's saved
+        // open/collapsed state instead of force-expanding every row.
         context.coordinator.seedExpansionFromModel()
         context.coordinator.rebuildAndReload()
         context.coordinator.syncSelection()
-        // on launch AppKit makes the sidebar the window's initial first responder; hand focus to the
-        // terminal once the window + surface are attached (retries internally).
+        // on launch AppKit makes the sidebar the window's initial first responder; hand focus to the terminal.
         context.coordinator.focusActiveTerminal()
 
         let scroll = NSScrollView()
         scroll.identifier = NSUserInterfaceItemIdentifier("agterm-sidebar-scroll")
         scroll.documentView = outline
         scroll.hasVerticalScroller = true
-        // hide the scroller when the tree fits (the common case): otherwise macOS set to "Show scroll bars:
-        // Always" paints a permanent track over the short, non-overflowing tree.
+        // otherwise macOS set to "Show scroll bars: Always" paints a permanent track over a tree that fits.
         scroll.autohidesScrollers = true
         // transparent so the window's backgroundColor (the terminal color, set by WindowAppearance) shows
-        // through the sidebar's translucent material and the whole column — including the strip behind the
-        // titlebar — reads as one dark surface.
+        // through and the whole column — including the strip behind the titlebar — reads as one surface.
         scroll.drawsBackground = false
         scroll.borderType = .noBorder
         context.coordinator.installEmptyState(in: scroll)
-        // inset the tree to match the terminal's ghostty padding so they line up in every toolbar mode.
+        // inset the tree to match the terminal's ghostty padding.
         context.coordinator.applySidebarContentInset(scroll)
         return scroll
     }
 
     func updateNSView(_ nsView: NSScrollView, context: Context) {
         // touching the observed store properties HERE registers this representable as an observer, so
-        // SwiftUI re-invokes updateNSView on a change to the tree shape, selection, any session's
-        // name/displayName, split state, unseen count or agent status — which is what lets reconcile do a
-        // targeted per-row reload for a content change; a touch inside viewFor wouldn't register it.
-        // agentIndicator feeds the status-icon reconcile (it renders on every session). The
-        // badge-visibility toggle (GhosttyApp.notificationBadgeEnabled) is NOT observable, so it drives a
-        // re-reconcile via .agtermAppearanceChanged (appearanceChanged), like toolbarMode.
+        // SwiftUI re-invokes updateNSView on any tracked change and reconcile can do a targeted per-row
+        // reload; a touch inside viewFor wouldn't register it. The badge-visibility toggle
+        // (GhosttyApp.notificationBadgeEnabled) is NOT observable and drives a re-reconcile via
+        // .agtermAppearanceChanged, like toolbarMode.
         _ = store.workspaces.map { ($0.id, $0.name, $0.unseenCount, $0.sessions.map { ($0.id, $0.displayName, $0.hasSplit, $0.unseenCount, $0.agentIndicator, $0.flagged) }) }
         _ = store.selectedSessionID
         _ = store.sidebarSelectionIDs
-        // sidebarMode flips the whole data source between the tree and the flat flagged list, so reading it
-        // makes a mode change re-invoke updateNSView and reconcile rebuild.
+        // sidebarMode flips the whole data source (tree ↔ flat flagged list), so a mode change must rebuild.
         _ = store.sidebarMode
-        // the marked set restricts the tree to its members (via visibleWorkspaces) while the filter is on;
-        // BOTH fields are read so either a membership change or a filter flip re-invokes updateNSView and
-        // reconcile takes the rebuild branch.
+        // the marked set restricts the tree to its members while the filter is on; BOTH fields are read so
+        // a membership change or a filter flip takes the rebuild branch.
         _ = store.focusedWorkspaceIDs
         _ = store.focusEnabled
         context.coordinator.reconcile()
@@ -134,38 +120,31 @@ struct WorkspaceSidebar: NSViewRepresentable {
         let renameController: SidebarRenameController
         weak var outlineView: NSOutlineView?
 
-        /// Root workspace nodes in store order, rebuilt in place from the store on each reload, reusing
-        /// cached node instances.
+        /// Root workspace nodes in store order, rebuilt from the store on each reload from cached instances.
         private var roots: [SidebarNode] = []
         /// Cache of node instances keyed by id, so identity is stable across reloads.
         private var nodeCache: [UUID: SidebarNode] = [:]
-        /// Guards `syncSelection` against the selection-change delegate callback it itself triggers, which
-        /// would re-enter the store.
+        /// Guards `syncSelection` against re-entering the store via the selection-change callback it fires.
         private var applyingSelection = false
         /// Last session id whose row was revealed (expanded owner + scrolled into view). Gates the intrusive
-        /// reveal so unrelated observable updates (cwd/title/badge) to the already-selected session don't
-        /// re-expand a collapsed workspace or yank the scroll position back.
+        /// reveal so unrelated updates (cwd/title/badge) to the already-selected session don't re-expand a
+        /// collapsed workspace or yank the scroll position back.
         private var lastRevealedSelection: UUID?
         /// Last-seen `TreeShape`; a change is structural and forces a full rebuild.
         private var lastShape: [TreeShape] = []
-        /// Last-seen sidebar mode. A flip (tree ↔ flagged) swaps which data source the outline renders, so
-        /// it forces a full `rebuildAndReload` independent of the shape diff.
+        /// Last-seen sidebar mode; a flip forces a full `rebuildAndReload` independent of the shape diff.
         private var lastMode: SidebarMode = .tree
-        /// Workspace ids the user has expanded, tracked via the expand/collapse delegate callbacks. The
-        /// source of truth for restoring expansion on rebuild, because it survives the flagged-mode reload:
-        /// that reload drops the workspace nodes from the data source and NSOutlineView discards its own
-        /// expansion state for items it no longer renders, so this set is the only surviving record.
+        /// Workspace ids the user has expanded, tracked via the expand/collapse callbacks. The source of
+        /// truth for restoring expansion on rebuild: NSOutlineView discards its own expansion state for
+        /// items it no longer renders, and the flagged-mode reload drops every workspace node.
         private var expandedWorkspaceIDs = Set<UUID>()
         /// Set true around PROGRAMMATIC `expandItem`/`collapseItem` (the launch/rebuild re-apply, the
         /// `syncSelection` reveal, the focus force-expand): the didExpand/DidCollapse callbacks still update
-        /// the visual `expandedWorkspaceIDs` but SKIP the persist write-back, so a view-only reveal or focus
-        /// zoom-in never burns a deliberately-persisted collapse. Only a genuine user toggle (row click /
-        /// disclosure triangle), which fires the callback with this false, persists; `expandAll`/
-        /// `collapseOthers` set it too and persist once explicitly at the end.
+        /// the visual `expandedWorkspaceIDs` but SKIP the persist write-back, so a view-only reveal never
+        /// burns a persisted collapse. `expandAll`/`collapseOthers` set it too and persist once at the end.
         var suppressExpansionPersist = false
-        /// Scheduled single-click workspace expand/collapse, deferred by the double-click interval so a
-        /// double-click (rename) can cancel it — else the first click of a rename double-click flips the
-        /// workspace open/closed on its way into edit mode. See `handleSingleClick`.
+        /// Scheduled single-click workspace toggle, deferred by the double-click interval so a rename
+        /// double-click can cancel it — else its first click flips the workspace open on the way into edit.
         var pendingRowToggle: DispatchWorkItem?
         /// Scheduled spring-loaded workspace expand while a drag hovers over a collapsed workspace row.
         /// View-only like the selection reveal: opens the target for this drag without persisting expansion.
@@ -177,18 +156,16 @@ struct WorkspaceSidebar: NSViewRepresentable {
         /// mouse move, so caching keeps network-volume metadata checks out of the hot path.
         var cachedDirectoryDrop: (sequenceNumber: Int, urls: [URL], exceedsLimit: Bool)?
 
-        /// Stable pseudo-workspace id for the flat flagged group's `TreeShape`, so within flagged mode only
-        /// a change to the flagged session list (not a per-call fresh id) triggers a rebuild.
+        /// Stable pseudo-workspace id for the flat flagged group's `TreeShape`, so only a change to the
+        /// flagged session list — not a per-call fresh id — triggers a rebuild.
         private static let flaggedShapeID = UUID()
 
         /// The `userInfo` key AppKit uses for the item in `outlineViewItemDidExpand`/`DidCollapse`
         /// notifications (documented as the literal string `"NSObject"`).
         private static let outlineItemUserInfoKey = "NSObject"
 
-        /// `userInfo` keys for the `.agtermSetWorkspaceExpanded` per-workspace poke (the
-        /// `workspace.collapse`/`workspace.expand` control path): the target workspace `UUID` and the
-        /// desired `Bool` expansion state. Read by `setWorkspaceExpandedNotified`, written by
-        /// `AppActions.setWorkspaceExpanded(_:expanded:in:)`.
+        /// `userInfo` keys for the `.agtermSetWorkspaceExpanded` per-workspace poke: the target workspace
+        /// `UUID` and the desired `Bool` state, written by `AppActions.setWorkspaceExpanded(_:expanded:in:)`.
         static let workspaceIDUserInfoKey = "agterm.workspaceID"
         static let expandedUserInfoKey = "agterm.expanded"
 
@@ -197,12 +174,10 @@ struct WorkspaceSidebar: NSViewRepresentable {
         private var lastRowContent: [UUID: RowContent] = [:]
 
         /// The sidebar font size last applied (row height + row fonts). `.agtermAppearanceChanged` fires for
-        /// every settings change (theme, colors, toggles) and the font size is not part of the per-row
-        /// content diff, so `appearanceChanged` compares against this and rebuilds only on a real change.
+        /// every settings change, so `appearanceChanged` compares against this and rebuilds only on a change.
         private var lastSidebarFontSize: CGFloat = CGFloat(AppSettings.defaultSidebarFontSize)
 
-        /// Centered hint shown over the empty outline in flagged mode when nothing is flagged. Floats in the
-        /// scroll view above the document, hidden otherwise.
+        /// Centered hint floating over the empty outline in flagged mode; hidden otherwise.
         private weak var emptyStateLabel: NSTextField?
 
         init(store: AppStore, actions: AppActions) {
@@ -210,23 +185,20 @@ struct WorkspaceSidebar: NSViewRepresentable {
             self.actions = actions
             self.renameController = SidebarRenameController(store: store)
             super.init()
-            // seed from the live mirror (SettingsModel applied the persisted size at launch, before any
-            // window's sidebar is built) so the first appearanceChanged doesn't rebuild for no change.
+            // seed from the live mirror (SettingsModel applies the persisted size before any sidebar is
+            // built) so the first appearanceChanged doesn't rebuild for no change.
             lastSidebarFontSize = GhosttyApp.shared.sidebarFontSize
             renameController.onRenameEnded = { [weak self] in self?.focusActiveTerminal() }
-            // the menu/palette can't reach the inline editor directly, so they post a notification and this
-            // coordinator starts the edit on the selected row. Scoped by `object: store` like
-            // expand/collapse below: the handlers' selected-session guard is NOT a per-window scope (every
-            // open window has one), so an `object: nil` pairing starts an inline edit in EVERY window — each
-            // leaving an unopened editor plus an unbalanced `suppressAutoFollow` that wedges that window's
-            // idle auto-follow off for good.
+            // the menu/palette can't reach the inline editor directly, so they post a notification. Scoped
+            // by `object: store`: the handlers' selected-session guard is NOT a per-window scope, so an
+            // `object: nil` pairing starts an inline edit in EVERY window — each leaving an unopened editor
+            // plus an unbalanced `suppressAutoFollow` that wedges that window's idle auto-follow off for good.
             NotificationCenter.default.addObserver(self, selector: #selector(beginRenameSessionNotified),
                                                    name: .agtermBeginRenameSession, object: store)
             NotificationCenter.default.addObserver(self, selector: #selector(beginRenameWorkspaceNotified),
                                                    name: .agtermBeginRenameWorkspace, object: store)
-            // expand/collapse target ONLY the frontmost window's sidebar: AppActions posts them with the
-            // frontmost store as the object, and `object: store` makes NotificationCenter deliver only to
-            // the Coordinator whose store matches, leaving other windows' sidebars put.
+            // expand/collapse target ONLY the frontmost window's sidebar: AppActions posts with the
+            // frontmost store as the object, so `object: store` delivers to that Coordinator alone.
             NotificationCenter.default.addObserver(self, selector: #selector(expandWorkspacesNotified),
                                                    name: .agtermExpandWorkspaces, object: store)
             NotificationCenter.default.addObserver(self, selector: #selector(collapseWorkspacesNotified),
@@ -247,9 +219,8 @@ struct WorkspaceSidebar: NSViewRepresentable {
             NotificationCenter.default.removeObserver(self)
         }
 
-        /// Re-tint the visible rows' text/icon for the current selection and redraw the selection pills
-        /// without a `reloadData` — needed on a selection change (AppKit doesn't redraw by itself with
-        /// `selectionHighlightStyle == .none`) and on a live theme change.
+        /// Re-tint the visible rows and redraw the selection pills without a `reloadData` — needed on a
+        /// selection change (with `selectionHighlightStyle == .none` AppKit won't) and on a theme change.
         func refreshSelectionAppearance() {
             guard let outline = outlineView else { return }
             for row in 0 ..< outline.numberOfRows {
@@ -261,18 +232,17 @@ struct WorkspaceSidebar: NSViewRepresentable {
 
         /// Pin the outline's appearance to the terminal theme's brightness so AppKit-drawn chrome — the
         /// disclosure triangle — tracks the theme, not the macOS light/dark setting: a light theme under
-        /// macOS dark mode otherwise draws a light-gray triangle invisible on the light sidebar (row
-        /// text/icons survive only because they are set explicitly to the theme color).
+        /// macOS dark mode otherwise draws a light-gray triangle invisible on it (row text/icons survive
+        /// only because they are set explicitly to the theme color).
         func applyThemeAppearance() {
             outlineView?.appearance = NSAppearance(named: GhosttyApp.shared.terminalThemeIsDark ? .darkAqua : .aqua)
         }
 
         /// Inset the tree to line up with the terminal's DEFAULT ghostty padding
         /// (agterm/Resources/ghostty-defaults.conf; a user window-padding override in ghostty.conf is not
-        /// tracked): window-padding-x = 8 matches the left margin, plus a 2px top nudge putting the first
-        /// row's text on the terminal's first line — most of the ~window-padding-y = 6 gap already comes from
-        /// the row centering its content (`centerYAnchor`) in a ~28px row, so a full 6px would double it.
-        /// `.plain` adds no insets of its own, so we own them (auto-adjust off). Same in every toolbar mode.
+        /// tracked): window-padding-x = 8 is the left margin; the top is a 2px nudge, not the full
+        /// window-padding-y = 6, because the row already centers its content in a ~28px row. `.plain` adds
+        /// no insets of its own, so we own them (auto-adjust off). Same in every toolbar mode.
         func applySidebarContentInset(_ scroll: NSScrollView?) {
             guard let scroll else { return }
             scroll.automaticallyAdjustsContentInsets = false
@@ -283,15 +253,12 @@ struct WorkspaceSidebar: NSViewRepresentable {
             applySidebarFontSizeIfChanged()
             refreshSelectionAppearance()
             applyThemeAppearance()
-            // a settings change may have flipped the badge-visibility toggle; reconcile so the gated unseen
-            // count (0 when off, the real count when on) reloads the affected badge rows.
+            // a settings change may have flipped the badge-visibility toggle; reconcile reloads those rows.
             reconcile()
-            // agent-status colors are global, not per-row, so reconcile's content diff can't see a color
-            // change — re-apply every visible glyph so a Settings color edit takes effect live.
+            // agent-status colors are global, so the content diff can't see a color change — re-apply all.
             reapplyStatusGlyphs()
             updateEmptyState()
-            // cheap re-assert in case a settings change requires recomputing the inset; it is
-            // mode-independent, so this is not a per-mode recalculation.
+            // cheap re-assert in case a settings change requires recomputing the inset.
             applySidebarContentInset(outlineView?.enclosingScrollView)
         }
 
@@ -299,10 +266,9 @@ struct WorkspaceSidebar: NSViewRepresentable {
             reapplyStatusGlyphs()
         }
 
-        /// Re-apply the row height + fonts when the sidebar font-size setting changed. The font size is not
-        /// part of `reconcile`'s per-row content diff, so a change needs an explicit row-height update and a
-        /// full `rebuildAndReload` (which re-runs the cell builder, re-setting each row's font). Guarded on
-        /// the tracked value so an unrelated appearance change (theme/color/toggle) doesn't force a reload.
+        /// Re-apply the row height + fonts when the sidebar font-size setting changed. The size is not part
+        /// of `reconcile`'s per-row content diff, so it needs an explicit row-height update plus a full
+        /// `rebuildAndReload` to re-run the cell builder, guarded on the tracked value.
         private func applySidebarFontSizeIfChanged() {
             let size = GhosttyApp.shared.sidebarFontSize
             guard size != lastSidebarFontSize else { return }
@@ -340,19 +306,16 @@ struct WorkspaceSidebar: NSViewRepresentable {
             expandAll()
         }
 
-        /// Collapse every workspace except the active one in this window's sidebar. `collapseOthers` gates
-        /// on tree mode itself, so flagged mode is a clean no-op.
+        /// Collapse every workspace except the active one; `collapseOthers` gates on tree mode itself.
         @objc private func collapseWorkspacesNotified() {
             collapseOthers()
         }
 
-        /// Sync the sidebar to a SINGLE workspace's collapse/expand (the
-        /// `workspace.collapse`/`workspace.expand` control path). `AppActions.setWorkspaceExpanded` has
-        /// ALREADY persisted `Workspace.isExpanded` — the source of truth, independent of this Coordinator
-        /// being alive — so this handler only keeps the tracked `expandedWorkspaceIDs` in step (letting the
-        /// intent survive a collapsed flagged-mode / focused-away row and a transient focus force-reveal)
-        /// and drives the live outline row when it is on screen (tree mode, row resolved), suppressing the
-        /// callback's re-persist.
+        /// Sync the sidebar to a SINGLE workspace's collapse/expand (`workspace.collapse`/`.expand`).
+        /// `AppActions.setWorkspaceExpanded` has ALREADY persisted `Workspace.isExpanded` — the source of
+        /// truth, independent of this Coordinator — so this handler only keeps the tracked
+        /// `expandedWorkspaceIDs` in step (letting the intent survive a flagged-mode or focused-away row and
+        /// a focus force-reveal) and drives the live outline row when on screen, suppressing its re-persist.
         @objc private func setWorkspaceExpandedNotified(_ notification: Notification) {
             guard let id = notification.userInfo?[Self.workspaceIDUserInfoKey] as? UUID,
                   let expanded = notification.userInfo?[Self.expandedUserInfoKey] as? Bool else { return }
@@ -367,18 +330,16 @@ struct WorkspaceSidebar: NSViewRepresentable {
         // MARK: - Model rebuild
 
         /// The tree SHAPE: a workspace's id and its ordered session ids. Equal shapes mean no
-        /// add/remove/move/reorder, so a content change (name/icon/badge) takes a targeted per-row reload
-        /// instead of a full rebuild. Row TEXT is deliberately NOT here: a cwd-driven `displayName` change
-        /// must not trigger a `reloadData` + re-expand, which re-lays-out every row and jitters the labels.
+        /// add/remove/move/reorder, so a content change takes a targeted per-row reload. Row TEXT is NOT
+        /// here: a cwd-driven `displayName` change must not `reloadData` + re-expand, which jitters labels.
         private struct TreeShape: Equatable {
             let workspaceID: UUID
             let sessionIDs: [UUID]
         }
 
-        /// A row's visible content: its label (workspace name or session `displayName`), whether the session
-        /// has a split (the split-rectangle icon), the unseen-badge count, and the GATED agent-status
-        /// indicator (after the frontmost-selected hide). A delta reloads just that row. Uses `hasSplit`
-        /// (not `isSplit`) so the icon persists while a split is hidden.
+        /// A row's visible content: label (workspace name or session `displayName`), split-rectangle icon,
+        /// the gated unseen-badge count and the agent-status indicator. A delta reloads just that row. Uses
+        /// `hasSplit` (not `isSplit`) so the icon persists while a split is hidden.
         private struct RowContent: Equatable {
             let label: String
             let hasSplit: Bool
@@ -387,34 +348,31 @@ struct WorkspaceSidebar: NSViewRepresentable {
             /// Whether the session is flagged (tree-mode filled-icon variant). A change re-badges just this
             /// row via `reloadItem`. Always false for workspace rows.
             let flagged: Bool
-            /// Whether the workspace is a member of the focus set (the black-weight grid icon). MEMBERSHIP
-            /// only, independent of `focusEnabled`, so marking re-renders just that row via `reloadItem`
-            /// even while the filter is off (with it on, the shape changes too and the rebuild branch takes
-            /// over). Always false for session rows.
+            /// Whether the workspace is in the focus set (the black-weight grid icon). MEMBERSHIP only,
+            /// independent of `focusEnabled`, so marking re-renders just that row even while the filter is
+            /// off (with it on the shape changes too and the rebuild branch takes over). False for sessions.
             let focusMember: Bool
         }
 
-        /// The session's own agent-status indicator (or `.idle` for an unknown id / workspace row). Shown on
-        /// every session regardless of selection — `completed --auto-reset` clears itself on `selectSession`,
-        /// so a visited session drops its glyph without a render-time gate.
+        /// The session's own agent-status indicator (`.idle` for an unknown id / workspace row). Shown
+        /// regardless of selection — `completed --auto-reset` clears itself on `selectSession`, so a
+        /// visited session drops its glyph without a render-time gate.
         func effectiveIndicator(forSession id: UUID) -> AgentIndicator {
             store.session(withID: id)?.agentIndicator ?? AgentIndicator()
         }
 
-        /// The unseen count after the badge-visibility gate: 0 when the Settings badge toggle is off, else
-        /// the raw count. Render-only — `unseenCount` keeps tracking, so re-enabling instantly shows current
-        /// counts. The agent-status glyph is NOT gated by this.
+        /// The unseen count after the badge-visibility gate: 0 when the Settings toggle is off. Render-only
+        /// — `unseenCount` keeps tracking, so re-enabling instantly shows current counts. The agent-status
+        /// glyph is NOT gated by this.
         func effectiveUnseen(_ count: Int) -> Int {
             GhosttyApp.shared.notificationBadgeEnabled ? count : 0
         }
 
         /// Decides between a full rebuild (a SHAPE change: add/move/close/reorder) and a targeted per-row
-        /// reload (a content change: rename, cwd-driven name, split open/close, badge). Content changes
-        /// never rebuild — a `reloadData` + re-expand re-lays-out every row and jitters the labels. A reload
-        /// during an in-progress rename is skipped so a tick can't drop the edit.
+        /// reload (a content change: rename, cwd-driven name, split open/close, badge). A reload during an
+        /// in-progress rename is skipped so a tick can't drop the edit.
         func reconcile() {
-            // a mode flip swaps the whole data source (tree ↔ flat flagged list), so rebuild regardless of
-            // the shape diff; otherwise compare the mode-appropriate shape.
+            // a mode flip swaps the whole data source, so rebuild regardless of the shape diff.
             let shape = currentShape()
             if store.sidebarMode != lastMode || shape != lastShape {
                 lastMode = store.sidebarMode
@@ -426,12 +384,10 @@ struct WorkspaceSidebar: NSViewRepresentable {
             reloadChangedContentRows()
         }
 
-        /// The structural shape for the current mode: the workspace tree (workspace id + ordered session
-        /// ids) in `.tree`, or one flat group of the flagged session ids in `.flagged`. A change means an
-        /// add/remove/move/reorder (or a flag/unflag in flagged mode) and forces a full rebuild. The tree
-        /// case derives from `visibleWorkspaces` (the marked set with the focus filter on, else all), so
-        /// marking a workspace or flipping the filter — both of which change the rendered root set —
-        /// registers as a shape change.
+        /// The structural shape for the current mode: the workspace tree, or one flat group of the flagged
+        /// session ids. A change means an add/remove/move/reorder (or a flag/unflag in flagged mode) and
+        /// forces a full rebuild. The tree case derives from `visibleWorkspaces`, so marking a workspace or
+        /// flipping the focus filter counts as a shape change too.
         private func currentShape() -> [TreeShape] {
             switch store.sidebarMode {
             case .tree:
@@ -441,10 +397,9 @@ struct WorkspaceSidebar: NSViewRepresentable {
             }
         }
 
-        /// Reloads only the rows whose visible content (label, split icon, badge) changed — the session row
-        /// and, for a badge roll-up, its workspace row. A per-row `reloadItem` re-renders at the row's
-        /// stable frame, so a name/cwd update never re-lays-out the tree. Skipped mid-rename so it can't
-        /// drop an in-progress edit.
+        /// Reloads only the rows whose visible content changed — the session row and, for a badge roll-up,
+        /// its workspace row. A per-row `reloadItem` re-renders at the row's stable frame, so a name/cwd
+        /// update never re-lays-out the tree. Skipped mid-rename so it can't drop an in-progress edit.
         private func reloadChangedContentRows() {
             guard let outline = outlineView, !renameController.isCommitting, !renameController.isEditing else { return }
             func reloadIfChanged(_ id: UUID, _ content: RowContent) {
@@ -460,8 +415,7 @@ struct WorkspaceSidebar: NSViewRepresentable {
             }
         }
 
-        /// Records every row's current visible content (label, split icon, badge), keyed by id, so the next
-        /// reconcile can detect a per-row delta.
+        /// Records every row's current visible content, keyed by id, so the next reconcile can diff it.
         private func snapshotRowContent() {
             var snapshot: [UUID: RowContent] = [:]
             for workspace in store.workspaces {
@@ -482,9 +436,8 @@ struct WorkspaceSidebar: NSViewRepresentable {
         }
 
         /// The visible content of a session row. One builder shared by `reloadChangedContentRows` and
-        /// `snapshotRowContent` so the snapshot and the diff can't drift. Both callers iterate the
-        /// `workspace … session` tree and pass the owning `workspaceName` in, so the label needs no
-        /// `session(withID:)`/`workspace(forSession:)` lookup and the reconcile stays linear.
+        /// `snapshotRowContent` so the snapshot and the diff can't drift. Both callers pass the owning
+        /// `workspaceName` in, so the label needs no per-session lookup and the reconcile stays linear.
         private func rowContent(forSession session: Session, workspaceName: String) -> RowContent {
             RowContent(label: rowLabel(for: session, workspaceName: workspaceName), hasSplit: session.hasSplit,
                        unseen: effectiveUnseen(session.unseenCount),
@@ -497,8 +450,7 @@ struct WorkspaceSidebar: NSViewRepresentable {
         func rebuildAndReload() {
             guard let outline = outlineView else { return }
 
-            // flagged mode: the root's children are the flagged sessions as flat, non-expandable rows; no
-            // workspace nodes participate, so they fall out of the cache below.
+            // flagged mode: flat, non-expandable session rows; no workspace nodes, so they leave the cache.
             if store.sidebarMode == .flagged {
                 var seen = Set<UUID>()
                 roots = store.flaggedSessions.map { session in
@@ -511,8 +463,7 @@ struct WorkspaceSidebar: NSViewRepresentable {
                 return
             }
 
-            // render only the visible workspaces: the marked set's subtrees when the focus filter is on,
-            // else the full tree.
+            // render only the visible workspaces: the marked set when the focus filter is on, else all.
             var seen = Set<UUID>()
             var newRoots: [SidebarNode] = []
             for workspace in store.visibleWorkspaces {
@@ -528,22 +479,19 @@ struct WorkspaceSidebar: NSViewRepresentable {
             roots = newRoots
 
             // keep the tracked set in step with the model: drop ids for workspaces that no longer exist,
-            // then pick up any the model reports expanded but that aren't tracked yet — a workspace added
-            // at runtime defaults `isExpanded == true`, so this renders it open. A user-collapsed workspace
-            // has `isExpanded == false` (excluded) and a programmatic reveal keeps its already-present id
-            // (formUnion only adds), so neither is disturbed.
+            // then pick up any the model reports expanded — a runtime-added workspace defaults
+            // `isExpanded == true`, so it renders open, while a user-collapsed one and a reveal's
+            // already-present id are undisturbed (formUnion only adds).
             expandedWorkspaceIDs.formIntersection(Set(store.workspaces.map(\.id)))
             expandedWorkspaceIDs.formUnion(store.workspaces.filter(\.isExpanded).map(\.id))
 
-            // restore expansion from the tracked set, not the live outline state: a flagged-mode reload
-            // drops the workspace nodes so the outline forgets they were expanded, while the tracked set
-            // remembers across the interlude. A filter applied to a SINGLE marked workspace also
-            // force-expands it — a "zoom in", so its sessions must show even from a collapsed row. The force
-            // stops at one member on purpose: with a working SET the tree is a list of workspaces, not a
-            // zoom, and re-expanding every member on each rebuild (any session add/close/move re-shapes the
-            // tree) would repeatedly undo the user's collapse while `tree` still reported it `collapsed` — a
-            // visible read-back divergence. The re-apply is a VIEW restore, not a user action, so suppress
-            // the persist: a marked-but-collapsed workspace keeps its persisted collapse.
+            // restore expansion from the tracked set, not the live outline state, which forgets across a
+            // flagged-mode reload. A filter applied to a SINGLE marked workspace also force-expands it — a
+            // "zoom in", so its sessions show even from a collapsed row. The force stops at one member on
+            // purpose: with a working SET the tree is a list of workspaces, not a zoom, and re-expanding
+            // every member on each rebuild (any session add/close/move re-shapes it) would undo the user's
+            // collapse while `tree` still reported it `collapsed`. The re-apply is a VIEW restore, so
+            // suppress the persist: a marked-but-collapsed workspace keeps its persisted collapse.
             outline.reloadData()
             suppressExpansionPersist = true
             let forceExpanded = store.soleFocusedWorkspaceID
@@ -554,9 +502,8 @@ struct WorkspaceSidebar: NSViewRepresentable {
             updateEmptyState()
         }
 
-        /// Adds the flagged-mode empty-state hint near the top of the scroll view, below the safe-area inset
-        /// so it clears the titlebar, as a non-scrolling overlay — a sibling of the clip view, so it floats
-        /// above the document and stays put. Hidden until the flagged view is empty.
+        /// Adds the flagged-mode empty-state hint below the safe-area inset so it clears the titlebar, as a
+        /// non-scrolling sibling of the clip view floating above the document. Hidden until it applies.
         func installEmptyState(in scroll: NSScrollView) {
             let label = NSTextField(wrappingLabelWithString: "No flagged sessions.\nRight-click a session → Flag.")
             label.translatesAutoresizingMaskIntoConstraints = false
@@ -578,26 +525,23 @@ struct WorkspaceSidebar: NSViewRepresentable {
             updateEmptyState()
         }
 
-        /// Shows the empty-state hint only in flagged mode with no flagged sessions; re-tints it to the
-        /// current theme foreground (dimmed, like a placeholder).
+        /// Shows the hint only in flagged mode with nothing flagged; re-tints it to the dimmed theme color.
         func updateEmptyState() {
             guard let label = emptyStateLabel else { return }
             label.isHidden = !(store.sidebarMode == .flagged && store.flaggedSessions.isEmpty)
             label.textColor = (GhosttyApp.shared.terminalForegroundColor ?? .secondaryLabelColor).withAlphaComponent(0.6)
         }
 
-        /// Seeds the tracked expansion set from the persisted `Workspace.isExpanded`, so the launch reload
-        /// restores each workspace's saved open/collapsed state. Sets only the tracked set —
-        /// `rebuildAndReload` applies it to the outline. Called once from `makeNSView`.
+        /// Seeds the tracked expansion set from the persisted `Workspace.isExpanded`. Sets only the tracked
+        /// set — `rebuildAndReload` applies it to the outline. Called once from `makeNSView`.
         func seedExpansionFromModel() {
             expandedWorkspaceIDs = Set(store.workspaces.filter(\.isExpanded).map(\.id))
         }
 
         /// Expands every workspace row — the "Expand Workspaces" user action. Seeds the tracked expansion
-        /// from the live `store.workspaces`, NOT the current `roots` (only the marked set's subtrees while
-        /// the focus filter is on), so turning the filter off remembers every workspace as expanded.
-        /// Per-item callbacks are suppressed; being a deliberate all-workspace command, the whole-tree state
-        /// is persisted once via `setWorkspacesExpanded`.
+        /// from the live `store.workspaces`, NOT `roots` (only the marked subtrees while the focus filter is
+        /// on), so turning the filter off remembers every workspace as expanded. Per-item callbacks are
+        /// suppressed; the whole-tree state is persisted once via `setWorkspacesExpanded`.
         func expandAll() {
             guard let outline = outlineView else { return }
             for workspace in store.workspaces { expandedWorkspaceIDs.insert(workspace.id) }
@@ -608,15 +552,13 @@ struct WorkspaceSidebar: NSViewRepresentable {
         }
 
         /// Collapses every workspace except the active session's (`store.currentWorkspaceID`), keeping that
-        /// one expanded and scrolled into view. Tree-mode only — flagged mode has no workspace rows, so it
-        /// is a graceful no-op there.
+        /// one expanded and scrolled into view. Tree-mode only — flagged mode has no workspace rows.
         func collapseOthers() {
             guard let outline = outlineView, store.sidebarMode == .tree else { return }
             let keepID = store.currentWorkspaceID
             // this command targets ALL workspaces, not just the visible `roots`: reduce the tracked set to
-            // exactly the active workspace so a focus filter hiding some workspaces can't leave them in the
-            // set and have the batch write below persist them expanded. The outline expand/collapse only
-            // touches the rows currently on screen.
+            // exactly the active workspace, so a focus filter hiding some can't leave them in the set for
+            // the batch write below to persist as expanded. The outline only touches on-screen rows.
             if let keepID { expandedWorkspaceIDs = [keepID] } else { expandedWorkspaceIDs = [] }
             suppressExpansionPersist = true
             for node in roots where node.kind == .workspace {
@@ -627,8 +569,7 @@ struct WorkspaceSidebar: NSViewRepresentable {
                 }
             }
             suppressExpansionPersist = false
-            // a deliberate command, so persist the whole-tree state once — every workspace, only the active
-            // one expanded — unlike the per-toggle callback path.
+            // a deliberate command, so persist the whole-tree state once, unlike the per-toggle callback.
             store.setWorkspacesExpanded(expandedWorkspaceIDs)
             // keep the active workspace's row on screen (mirrors syncSelection's scroll-into-view).
             guard let keepID, let node = nodeCache[keepID] else { return }
@@ -640,9 +581,8 @@ struct WorkspaceSidebar: NSViewRepresentable {
             guard let node = notification.userInfo?[Self.outlineItemUserInfoKey] as? SidebarNode,
                   node.kind == .workspace else { return }
             expandedWorkspaceIDs.insert(node.id)
-            // persist ONLY a genuine user expand (row click / disclosure triangle): a programmatic reveal or
-            // rebuild re-apply sets suppressExpansionPersist, updating the visual set above without burning
-            // the persisted collapse intent.
+            // persist ONLY a genuine user expand: a programmatic reveal or rebuild re-apply sets
+            // suppressExpansionPersist, updating the visual set above without burning the persisted intent.
             if !suppressExpansionPersist { store.setWorkspaceExpanded(node.id, expanded: true) }
         }
 
@@ -674,15 +614,14 @@ struct WorkspaceSidebar: NSViewRepresentable {
                 lastRevealedSelection = nil
                 return
             }
-            // the row-selection sync runs every call (keeps the highlight correct), but the intrusive reveal
-            // — expanding a collapsed owner and scrolling into view — only fires on a real selection change,
-            // so unrelated cwd/title/badge updates to the already-selected session leave a user-collapsed
-            // workspace and a user-moved scroll position alone.
+            // the row-selection sync runs every call, but the intrusive reveal — expanding a collapsed owner
+            // and scrolling into view — only fires on a real selection change, so unrelated cwd/title/badge
+            // updates leave a user-collapsed workspace and a user-moved scroll position alone.
             let selectionChanged = selectedID != lastRevealedSelection
             // a session selected by keyboard nav may live in a collapsed workspace, whose row is -1 until
-            // expanded; expand its owner first so the row resolves. A VIEW action, not a user expand, so
-            // suppress the persist: navigating into (or launching with the selection inside) a deliberately
-            // collapsed workspace shows the session without un-collapsing it on disk.
+            // expanded; expand its owner first so the row resolves. A VIEW action, so suppress the persist:
+            // navigating into a deliberately collapsed workspace shows the session without un-collapsing it
+            // on disk.
             if selectionChanged, let owner = ownerWorkspaceNode(ofSession: selectedID), !outline.isItemExpanded(owner) {
                 suppressExpansionPersist = true
                 outline.expandItem(owner)
@@ -707,15 +646,13 @@ struct WorkspaceSidebar: NSViewRepresentable {
             lastRevealedSelection = selectedID
         }
 
-        /// The workspace node whose `children` hold `sessionID`, or nil — used to expand a collapsed owner
-        /// before resolving a keyboard-navigated session's row.
+        /// The workspace node whose `children` hold `sessionID` — used to expand a collapsed owner first.
         private func ownerWorkspaceNode(ofSession sessionID: UUID) -> SidebarNode? {
             roots.first { $0.children.contains { $0.id == sessionID } }
         }
 
         func outlineViewSelectionDidChange(_ notification: Notification) {
-            // repaint the selection pill + row text colors for the new selection — with the .none highlight
-            // style AppKit won't redraw rows itself.
+            // repaint the selection pill + row text — with the .none highlight style AppKit won't redraw.
             refreshSelectionAppearance()
             guard !applyingSelection, let outline = outlineView else { return }
             let selectedIDs = outline.selectedRowIndexes.compactMap { row -> UUID? in
@@ -734,27 +671,25 @@ struct WorkspaceSidebar: NSViewRepresentable {
                 store.setSidebarSelection(selectedIDs)
                 return
             }
-            // a genuine user row click (the applyingSelection guard above skips programmatic sync, so
-            // auto-follow's own jump never reaches here) counts as activity, buying the full idle grace
-            // before auto-follow can pull the selection back.
+            // a genuine user row click (the applyingSelection guard skips programmatic sync, so auto-follow's
+            // own jump never reaches here) counts as activity, buying the full idle grace before it pulls back.
             store.noteUserActivity()
             let indicator = store.selectSession(activeID, sidebarSelection: selectedIDs)
             // land on the selected session's blocked pane when it carries a pane-tagged block (else a
-            // no-op), async so it runs after the selection + the sidebar's own focus-restore settle.
+            // no-op), async so it runs after the selection + the sidebar's focus-restore settle.
             DispatchQueue.main.async { [weak self] in
                 self?.actions.revealActiveBlockedPane(captured: indicator)
             }
         }
 
-        /// Returns keyboard focus to the active session's terminal after a sidebar interaction, so the
-        /// sidebar never keeps focus. Mirrors macterm's `FocusRestoration`: the target surface may not be
-        /// attached to the window yet (a just-selected session's view is still materializing), so retry on
-        /// the run loop until it is, with a bounded cap. Skipped while a rename field is first responder or
-        /// an edit is in progress.
+        /// Returns keyboard focus to the active session's terminal after a sidebar interaction, mirroring
+        /// macterm's `FocusRestoration`: the target surface may not be attached to the window yet (a
+        /// just-selected session's view is still materializing), so retry on the run loop with a bounded
+        /// cap. Skipped while a rename field is first responder or an edit is in progress.
         ///
-        /// Targets `topmostSurface` (overlay, else scratch, else the active pane), not the main `surface`:
-        /// a cover owns the keyboard, so focusing a pane would starve the overlay/scratch program of input —
-        /// and a full overlay or scratch hides the pane, sending keystrokes to a surface the user can't see.
+        /// Targets `topmostSurface` (overlay, else scratch, else the active pane), not the main `surface`: a
+        /// cover owns the keyboard and hides the pane, so focusing a pane would starve the overlay/scratch
+        /// program of input and send keystrokes to a surface the user can't see.
         func focusActiveTerminal(attempt: Int = 0) {
             if renameController.isEditing { return }
             let window = outlineView?.window
@@ -763,7 +698,6 @@ struct WorkspaceSidebar: NSViewRepresentable {
                 window.makeFirstResponder(surface)
                 return
             }
-            // not attached yet — at launch, or a just-selected session still materializing.
             guard attempt < 20 else { return }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.03) { [weak self] in
                 self?.focusActiveTerminal(attempt: attempt + 1)
@@ -787,16 +721,12 @@ struct WorkspaceSidebar: NSViewRepresentable {
             return node.kind == .workspace
         }
 
-        /// Leading row icons as monochrome template symbols: a 2x2 grid for a workspace, an outlined
-        /// terminal for a single session, a split-rectangle for a split one. A flagged SESSION swaps to its
-        /// base glyph's `.fill` variant (`terminal.fill` / `rectangle.split.2x1.fill` — the solid-interior
-        /// idiom the scratch-active toolbar glyph uses). A workspace in the focus SET keeps the same
-        /// `square.grid.2x2` outline at `.black` weight, so a workspace row holds one identity and
-        /// membership costs stroke weight alone, keeping the two markers distinct (fill = flagged session,
-        /// black = marked workspace) instead of both reading as "filled". Never a composited corner badge,
-        /// so each stays a single template `setColors` tints; the weight variant renders 1pt larger (16x15
-        /// vs 15x14) but the icon view is pinned to a fixed 16x16 box, so neither swap moves the row.
-        /// Cached because few distinct symbols exist and every row reuses them.
+        /// Leading row icons as monochrome template symbols. A flagged SESSION swaps to its base glyph's
+        /// `.fill` variant (the solid-interior idiom the scratch-active toolbar glyph uses); a workspace in
+        /// the focus SET keeps the same `square.grid.2x2` outline at `.black` weight, so the two markers
+        /// stay distinct (fill = flagged session, black = marked workspace). Never a composited corner
+        /// badge, so each stays a single template `setColors` tints; the weight variant renders 1pt larger
+        /// (16x15 vs 15x14) but the icon view is pinned to 16x16, so neither swap moves the row. Cached.
         lazy var workspaceIcon = Self.rowIcon("square.grid.2x2")
         lazy var focusedWorkspaceIcon = Self.rowIcon("square.grid.2x2", weight: .black)
         lazy var splitSessionIcon = Self.rowIcon("rectangle.split.2x1")
@@ -812,8 +742,7 @@ struct WorkspaceSidebar: NSViewRepresentable {
             return image
         }
 
-        /// The row label from an already-resolved session + its owning workspace name, with no store lookup —
-        /// the form the reconcile loops use, since they iterate the `workspace … session` tree.
+        /// The row label from an already-resolved session + its owning workspace name, with no store lookup.
         func rowLabel(for session: Session, workspaceName: String) -> String {
             guard store.sidebarMode == .flagged else { return session.displayName }
             return "\(session.displayName) : \(workspaceName)"
@@ -825,14 +754,12 @@ struct WorkspaceSidebar: NSViewRepresentable {
     }
 }
 
-/// An `NSOutlineView` subclass serving a per-row context menu and starting inline rename on double-click,
-/// both routed to the coordinator.
+/// `NSOutlineView` subclass routing the per-row context menu and double-click rename to the coordinator.
 final class SidebarOutlineView: NSOutlineView {
-    // never become first responder: focus lives in the terminal. A mouse click still selects the row
-    // (selection is independent of first responder); otherwise the click steals first responder and the
-    // responder bounce (terminal → outline → terminal, via mouseDown's focusActiveTerminal) makes AppKit
-    // re-set `isEmphasized` on the rows — an extra repaint that flicks the selection pill on every click.
-    // Programmatic selection (palette/Ctrl-Tab) never bounces, so it is already smooth.
+    // never become first responder: focus lives in the terminal, and a mouse click still selects the row
+    // (selection is independent of first responder). Otherwise the responder bounce (terminal → outline →
+    // terminal, via mouseDown's focusActiveTerminal) makes AppKit re-set `isEmphasized` on the rows — an
+    // extra repaint that flicks the selection pill on every click. Programmatic selection never bounces.
     override var acceptsFirstResponder: Bool { false }
 
     override func draggingExited(_ sender: NSDraggingInfo?) {
@@ -854,29 +781,25 @@ final class SidebarOutlineView: NSOutlineView {
 
     override func mouseDown(with event: NSEvent) {
         super.mouseDown(with: event)
-        // after the click is handled (selection, expand/collapse, drag), hand keyboard focus back to the
-        // terminal so the sidebar never keeps it. row selection persists (model state); only first responder
-        // moves. skipped mid-rename by the coordinator.
+        // after the click is handled, hand keyboard focus back to the terminal; row selection persists
+        // (model state), only first responder moves. Skipped mid-rename by the coordinator.
         (delegate as? WorkspaceSidebar.Coordinator)?.focusActiveTerminal()
     }
 }
 
 extension Notification.Name {
-    /// Posted by the menu/palette to start an inline rename of the active session or its workspace;
-    /// `WorkspaceSidebar.Coordinator` observes these and begins editing the row.
+    /// Posted by the menu/palette to start an inline rename of the active session or its workspace.
     static let agtermBeginRenameSession = Notification.Name("agterm.beginRenameSession")
     static let agtermBeginRenameWorkspace = Notification.Name("agterm.beginRenameWorkspace")
-    /// Posted by the menu/palette/control channel to expand every workspace, or collapse every workspace
-    /// except the active one, with the frontmost window's `AppStore` as the object so
-    /// `WorkspaceSidebar.Coordinator` observes them scoped to that one window's sidebar.
+    /// Posted by the menu/palette/control channel to expand every workspace, or collapse all but the active
+    /// one, with the frontmost window's `AppStore` as the object so only that window's sidebar reacts.
     static let agtermExpandWorkspaces = Notification.Name("agterm.expandWorkspaces")
     static let agtermCollapseWorkspaces = Notification.Name("agterm.collapseWorkspaces")
     /// Posted by the `workspace.collapse`/`workspace.expand` control arm for a SINGLE workspace, with the
     /// target window's `AppStore` as the object and the workspace id + desired state in `userInfo`.
-    /// Object-scoped like the all-workspace pokes, so only the matching window's sidebar reacts.
     static let agtermSetWorkspaceExpanded = Notification.Name("agterm.setWorkspaceExpanded")
     /// Posted by the `session.resize` control arm after storing a new split-divider fraction, with the
-    /// target `Session` as the object so the matching `SplitProbeView` (in `ContentView`) moves the live
-    /// divider to `Session.splitRatio`. Object-scoped, so only that one session's pane view reacts.
+    /// target `Session` as the object so only that session's `SplitProbeView` (in `ContentView`) moves its
+    /// live divider to `Session.splitRatio`.
     static let agtermApplySplitRatio = Notification.Name("agterm.applySplitRatio")
 }

--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -2,22 +2,22 @@ import agtermCore
 import AppKit
 import SwiftUI
 
-/// Custom pasteboard type carrying a dragged session's UUID string. Local-only
-/// drags (within the outline) use this to identify the session being moved.
+/// Local-only (within-outline) pasteboard type carrying a dragged session's UUID, identifying the
+/// session being moved.
 let sessionPasteboardType = NSPasteboard.PasteboardType("com.umputun.agterm.session")
 
-/// Custom pasteboard type carrying a dragged workspace's UUID string. Local-only
-/// drags (within the outline) use this to identify the workspace being reordered.
+/// Local-only pasteboard type carrying a dragged workspace's UUID, identifying the workspace being
+/// reordered.
 let workspacePasteboardType = NSPasteboard.PasteboardType("com.umputun.agterm.workspace")
 
 /// AppKit `NSOutlineView` sidebar (`.plain` style + a custom row height and top/left content insets that
 /// match the terminal's ghostty padding) hosted in SwiftUI via `NSViewRepresentable`. Replaces the
-/// SwiftUI `List` sidebar so cross-workspace drag-and-drop works natively: a session row can be dragged
-/// onto a different workspace and the model moves it (same `Session` instance preserved).
+/// SwiftUI `List` sidebar so cross-workspace drag-and-drop works natively: a session row dragged onto
+/// another workspace moves in the model, preserving the same `Session` instance.
 ///
-/// Two-level tree: workspaces (expandable parents, bold) → sessions (children).
-/// Only session rows are selectable detail targets. Inline rename via double-click
-/// or the "Rename" context menu. Context menus per row drive the store API.
+/// Two-level tree: workspaces (expandable parents, bold) → sessions (children). Only session rows are
+/// selectable detail targets. Inline rename via double-click or the "Rename" context menu; per-row
+/// context menus drive the store API.
 struct WorkspaceSidebar: NSViewRepresentable {
     @Bindable var store: AppStore
     let actions: AppActions
@@ -31,9 +31,9 @@ struct WorkspaceSidebar: NSViewRepresentable {
         outline.dataSource = context.coordinator
         outline.delegate = context.coordinator
         outline.headerView = nil
-        // .plain style (not .sourceList) so there is no built-in ~10px top inset above the first row (the
-        // sidebar tree runs flush below the titlebar in every toolbar mode); a custom row height restores
-        // the roomy source-list-like row size that .plain's .default would otherwise shrink to ~17px.
+        // .plain (not .sourceList) drops the built-in ~10px top inset above the first row, so the tree runs
+        // flush below the titlebar in every toolbar mode; a custom row height restores the roomy
+        // source-list-like size .plain's .default would shrink to ~17px.
         outline.rowSizeStyle = .custom
         outline.rowHeight = AppSettings.sidebarRowHeight(fontSize: GhosttyApp.shared.sidebarFontSize)
         outline.floatsGroupRows = false
@@ -43,14 +43,13 @@ struct WorkspaceSidebar: NSViewRepresentable {
         outline.action = #selector(Coordinator.handleSingleClick(_:))
         outline.doubleAction = #selector(Coordinator.handleDoubleClick(_:))
         if #available(macOS 11.0, *) { outline.style = .plain }
-        // .plain reverts the outline's backgroundColor to an OPAQUE controlBackgroundColor (unlike
-        // .sourceList's translucent source-list material), which would paint over the sidebar tint wash and
-        // the terminal-colored/translucent window backing. Clear it so the transparent column shows through,
-        // matching scroll.drawsBackground = false below.
+        // .plain reverts backgroundColor to an OPAQUE controlBackgroundColor (unlike .sourceList's
+        // translucent material), painting over the sidebar tint wash and the terminal-colored/translucent
+        // window backing — clear it, matching scroll.drawsBackground = false below.
         outline.backgroundColor = .clear
-        // disable AppKit's own selection drawing: it would paint a gray unemphasized capsule whenever
-        // the sidebar isn't first responder (focus normally lives in the terminal). SidebarRowView
-        // draws the themed selection pill itself in drawBackground for every state.
+        // AppKit's own selection drawing would paint a gray unemphasized capsule whenever the sidebar isn't
+        // first responder (focus normally lives in the terminal); SidebarRowView draws the themed selection
+        // pill in drawBackground for every state.
         outline.selectionHighlightStyle = .none
         outline.allowsMultipleSelection = true
         outline.allowsEmptySelection = true
@@ -60,41 +59,41 @@ struct WorkspaceSidebar: NSViewRepresentable {
         outline.addTableColumn(column)
         outline.outlineTableColumn = column
 
-        // native drag-and-drop: session rows reorder within / move across workspaces; workspace
-        // rows reorder among themselves; Finder folder drops create sessions rooted at those folders.
-        // Registering BOTH private types is load-bearing — without the workspace type AppKit never
-        // delivers validate/accept for a workspace drag.
+        // native drag-and-drop: session rows reorder within / move across workspaces; workspace rows
+        // reorder among themselves; Finder folder drops create sessions rooted at those folders. Both
+        // private types are load-bearing — without the workspace type AppKit never delivers
+        // validate/accept for a workspace drag.
         outline.registerForDraggedTypes([sessionPasteboardType, workspacePasteboardType, .fileURL])
-        // Sidebar rows are app-private move sources. Finder folder import is independent: Finder owns
-        // that external source and supplies `.fileURL`, while agterm rows export no public representation.
+        // sidebar rows are app-private move sources exporting no public representation; Finder folder
+        // import is independent — Finder owns that external source and supplies `.fileURL`.
         outline.setDraggingSourceOperationMask(.move, forLocal: true)
         outline.setDraggingSourceOperationMask([], forLocal: false)
 
         context.coordinator.outlineView = outline
         context.coordinator.renameController.outlineView = outline
-        // pin the outline appearance to the theme brightness up front so the disclosure triangle reads on
-        // launch (a light theme under macOS dark mode would otherwise draw an invisible light triangle).
+        // pin the appearance to the theme brightness up front so the disclosure triangle reads on launch (a
+        // light theme under macOS dark mode would draw an invisible light triangle).
         context.coordinator.applyThemeAppearance()
-        // seed the tracked expansion from the persisted per-workspace state BEFORE the reload, so
-        // rebuildAndReload restores each workspace's saved open/collapsed state (a collapsed workspace
-        // stays collapsed across relaunch) instead of force-expanding every row.
+        // seed tracked expansion from the persisted per-workspace state BEFORE the reload, so
+        // rebuildAndReload restores each workspace's saved open/collapsed state (a collapsed workspace stays
+        // collapsed across relaunch) instead of force-expanding every row.
         context.coordinator.seedExpansionFromModel()
         context.coordinator.rebuildAndReload()
         context.coordinator.syncSelection()
-        // on launch AppKit makes the sidebar the window's initial first responder; hand
-        // focus to the terminal once the window + surface are attached (retries internally).
+        // on launch AppKit makes the sidebar the window's initial first responder; hand focus to the
+        // terminal once the window + surface are attached (retries internally).
         context.coordinator.focusActiveTerminal()
 
         let scroll = NSScrollView()
         scroll.identifier = NSUserInterfaceItemIdentifier("agterm-sidebar-scroll")
         scroll.documentView = outline
         scroll.hasVerticalScroller = true
-        // hide the scroller when the tree fits (the common case): without this, macOS set to
-        // "Show scroll bars: Always" paints a permanent track over the short, non-overflowing tree.
+        // hide the scroller when the tree fits (the common case): otherwise macOS set to "Show scroll bars:
+        // Always" paints a permanent track over the short, non-overflowing tree.
         scroll.autohidesScrollers = true
-        // transparent: the window's backgroundColor (the terminal color, set by
-        // WindowAppearance) shows through the sidebar's translucent material so the whole
-        // column — including the strip behind the titlebar — reads as one dark surface.
+        // transparent so the window's backgroundColor (the terminal color, set by WindowAppearance) shows
+        // through the sidebar's translucent material and the whole column — including the strip behind the
+        // titlebar — reads as one dark surface.
         scroll.drawsBackground = false
         scroll.borderType = .noBorder
         context.coordinator.installEmptyState(in: scroll)
@@ -104,18 +103,18 @@ struct WorkspaceSidebar: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: NSScrollView, context: Context) {
-        // touching the observed store properties here registers this representable as an observer, so
-        // SwiftUI re-invokes updateNSView when the tree shape, selection, any session's name/displayName,
-        // split state, unseen count, or agent status changes. folding all of those into the read is what
-        // lets reconcile do a targeted per-row reload for a content change; a touch inside viewFor wouldn't
-        // register it. agentIndicator feeds the status-icon reconcile (it renders on every session). the
+        // touching the observed store properties HERE registers this representable as an observer, so
+        // SwiftUI re-invokes updateNSView on a change to the tree shape, selection, any session's
+        // name/displayName, split state, unseen count or agent status — which is what lets reconcile do a
+        // targeted per-row reload for a content change; a touch inside viewFor wouldn't register it.
+        // agentIndicator feeds the status-icon reconcile (it renders on every session). The
         // badge-visibility toggle (GhosttyApp.notificationBadgeEnabled) is NOT observable, so it drives a
-        // re-reconcile via the .agtermAppearanceChanged notification (appearanceChanged), like toolbarMode.
+        // re-reconcile via .agtermAppearanceChanged (appearanceChanged), like toolbarMode.
         _ = store.workspaces.map { ($0.id, $0.name, $0.unseenCount, $0.sessions.map { ($0.id, $0.displayName, $0.hasSplit, $0.unseenCount, $0.agentIndicator, $0.flagged) }) }
         _ = store.selectedSessionID
         _ = store.sidebarSelectionIDs
-        // sidebarMode flips the whole data source between the tree and the flat flagged list; reading it
-        // here registers the observer so a mode change re-invokes updateNSView and reconcile rebuilds.
+        // sidebarMode flips the whole data source between the tree and the flat flagged list, so reading it
+        // makes a mode change re-invoke updateNSView and reconcile rebuild.
         _ = store.sidebarMode
         // the marked set restricts the tree to its members (via visibleWorkspaces) while the filter is on;
         // BOTH fields are read so either a membership change or a filter flip re-invokes updateNSView and
@@ -126,9 +125,8 @@ struct WorkspaceSidebar: NSViewRepresentable {
         context.coordinator.syncSelection()
     }
 
-    /// Backs the outline as both data source and delegate. `@MainActor` so the
-    /// AppKit delegate callbacks (all main-thread) satisfy the store's main-actor
-    /// isolation under strict concurrency.
+    /// Backs the outline as data source and delegate. `@MainActor` so the AppKit delegate callbacks (all
+    /// main-thread) satisfy the store's main-actor isolation under strict concurrency.
     @MainActor
     final class Coordinator: NSObject, NSOutlineViewDataSource, NSOutlineViewDelegate {
         let store: AppStore
@@ -136,49 +134,44 @@ struct WorkspaceSidebar: NSViewRepresentable {
         let renameController: SidebarRenameController
         weak var outlineView: NSOutlineView?
 
-        /// Root workspace nodes in store order. Rebuilt (in place, reusing cached
-        /// node instances) from the store on each reload.
+        /// Root workspace nodes in store order, rebuilt in place from the store on each reload, reusing
+        /// cached node instances.
         private var roots: [SidebarNode] = []
         /// Cache of node instances keyed by id, so identity is stable across reloads.
         private var nodeCache: [UUID: SidebarNode] = [:]
-        /// Guards `syncSelection` against the selection-change delegate callback it
-        /// itself triggers (which would otherwise re-enter the store).
+        /// Guards `syncSelection` against the selection-change delegate callback it itself triggers, which
+        /// would re-enter the store.
         private var applyingSelection = false
-        /// Last session id whose row was revealed (expanded owner + scrolled into view).
-        /// Gates the intrusive reveal so unrelated observable updates (cwd/title/badge) to
-        /// the already-selected session don't re-expand a collapsed workspace or yank the
-        /// scroll position back — only an actual selection change reveals.
+        /// Last session id whose row was revealed (expanded owner + scrolled into view). Gates the intrusive
+        /// reveal so unrelated observable updates (cwd/title/badge) to the already-selected session don't
+        /// re-expand a collapsed workspace or yank the scroll position back.
         private var lastRevealedSelection: UUID?
-        /// Last-seen tree SHAPE (ordered workspace ids, each with its ordered session ids). A change
-        /// here is structural (add/remove/move/reorder) and needs a full rebuild; a row's name/icon/
-        /// badge changing is NOT structural — it reloads just that row, so a cwd-driven name change
-        /// can't force a full `reloadData` + re-expand that re-lays-out (and jitters) every row.
+        /// Last-seen `TreeShape`; a change is structural and forces a full rebuild.
         private var lastShape: [TreeShape] = []
         /// Last-seen sidebar mode. A flip (tree ↔ flagged) swaps which data source the outline renders, so
         /// it forces a full `rebuildAndReload` independent of the shape diff.
         private var lastMode: SidebarMode = .tree
-        /// Workspace ids the user has expanded, tracked via the expand/collapse delegate callbacks. It is
-        /// the source of truth for restoring expansion on rebuild because it survives the flagged-mode
-        /// reload: that reload drops the workspace nodes from the data source entirely, and NSOutlineView
-        /// discards its own expansion state for items it no longer renders, so on the way back to the tree
-        /// this set is the only record of which workspaces were open.
+        /// Workspace ids the user has expanded, tracked via the expand/collapse delegate callbacks. The
+        /// source of truth for restoring expansion on rebuild, because it survives the flagged-mode reload:
+        /// that reload drops the workspace nodes from the data source and NSOutlineView discards its own
+        /// expansion state for items it no longer renders, so this set is the only surviving record.
         private var expandedWorkspaceIDs = Set<UUID>()
         /// Set true around PROGRAMMATIC `expandItem`/`collapseItem` (the launch/rebuild re-apply, the
-        /// `syncSelection` reveal, the focus force-expand). While set, the didExpand/DidCollapse callbacks
-        /// still update the visual `expandedWorkspaceIDs` but SKIP the persist write-back, so a view-only
-        /// reveal or focus zoom-in never burns a workspace's deliberately-persisted collapse. Only a genuine
-        /// user toggle (row click / disclosure triangle) — which fires the callback with this false —
-        /// persists. `expandAll`/`collapseOthers` set it too and persist once explicitly at the end.
+        /// `syncSelection` reveal, the focus force-expand): the didExpand/DidCollapse callbacks still update
+        /// the visual `expandedWorkspaceIDs` but SKIP the persist write-back, so a view-only reveal or focus
+        /// zoom-in never burns a deliberately-persisted collapse. Only a genuine user toggle (row click /
+        /// disclosure triangle), which fires the callback with this false, persists; `expandAll`/
+        /// `collapseOthers` set it too and persist once explicitly at the end.
         var suppressExpansionPersist = false
         /// Scheduled single-click workspace expand/collapse, deferred by the double-click interval so a
-        /// double-click (rename) can cancel it — otherwise the first click of a rename double-click would
-        /// flip the workspace open/closed on its way into edit mode. See `handleSingleClick`.
+        /// double-click (rename) can cancel it — else the first click of a rename double-click flips the
+        /// workspace open/closed on its way into edit mode. See `handleSingleClick`.
         var pendingRowToggle: DispatchWorkItem?
         /// Scheduled spring-loaded workspace expand while a drag hovers over a collapsed workspace row.
-        /// View-only like selection reveal: it opens the target for this drag without persisting expansion.
+        /// View-only like the selection reveal: opens the target for this drag without persisting expansion.
         var pendingSpringLoadedExpansion: (workspaceID: UUID, workItem: DispatchWorkItem)?
-        /// A workspace actually opened by spring-loading during the current drag. Finder-style spring
-        /// navigation is transient: leaving/cancelling collapses this row back to its pre-drag state.
+        /// A workspace opened by spring-loading during the current drag. Finder-style spring navigation is
+        /// transient: leaving/cancelling collapses this row back to its pre-drag state.
         var springLoadedWorkspaceID: UUID?
         /// Finder file URLs resolved for the current AppKit dragging sequence. Validation runs on every
         /// mouse move, so caching keeps network-volume metadata checks out of the hot path.
@@ -189,12 +182,13 @@ struct WorkspaceSidebar: NSViewRepresentable {
         private static let flaggedShapeID = UUID()
 
         /// The `userInfo` key AppKit uses for the item in `outlineViewItemDidExpand`/`DidCollapse`
-        /// notifications (the documented value is the literal string `"NSObject"`).
+        /// notifications (documented as the literal string `"NSObject"`).
         private static let outlineItemUserInfoKey = "NSObject"
 
-        /// `userInfo` keys for the `.agtermSetWorkspaceExpanded` per-workspace poke (the `workspace.collapse`/`workspace.expand`
-        /// control path): the target workspace `UUID` and the desired `Bool` expansion state. Read by
-        /// `setWorkspaceExpandedNotified`, written by `AppActions.setWorkspaceExpanded(_:expanded:in:)`.
+        /// `userInfo` keys for the `.agtermSetWorkspaceExpanded` per-workspace poke (the
+        /// `workspace.collapse`/`workspace.expand` control path): the target workspace `UUID` and the
+        /// desired `Bool` expansion state. Read by `setWorkspaceExpandedNotified`, written by
+        /// `AppActions.setWorkspaceExpanded(_:expanded:in:)`.
         static let workspaceIDUserInfoKey = "agterm.workspaceID"
         static let expandedUserInfoKey = "agterm.expanded"
 
@@ -202,14 +196,13 @@ struct WorkspaceSidebar: NSViewRepresentable {
         /// reconcile reloads only the rows whose content changed. An absent key ≠ any real content.
         private var lastRowContent: [UUID: RowContent] = [:]
 
-        /// The sidebar font size last applied to the outline (row height + row fonts). `.agtermAppearanceChanged`
-        /// fires for every settings change (theme, colors, toggles), but the font size isn't part of the
-        /// per-row content diff, so `appearanceChanged` compares against this and only rebuilds when it
-        /// actually changed — avoiding a full reload on every unrelated appearance change.
+        /// The sidebar font size last applied (row height + row fonts). `.agtermAppearanceChanged` fires for
+        /// every settings change (theme, colors, toggles) and the font size is not part of the per-row
+        /// content diff, so `appearanceChanged` compares against this and rebuilds only on a real change.
         private var lastSidebarFontSize: CGFloat = CGFloat(AppSettings.defaultSidebarFontSize)
 
-        /// Centered hint shown over the (empty) outline in flagged mode when nothing is flagged. Floats in
-        /// the scroll view above the document, hidden otherwise.
+        /// Centered hint shown over the empty outline in flagged mode when nothing is flagged. Floats in the
+        /// scroll view above the document, hidden otherwise.
         private weak var emptyStateLabel: NSTextField?
 
         init(store: AppStore, actions: AppActions) {
@@ -221,20 +214,19 @@ struct WorkspaceSidebar: NSViewRepresentable {
             // window's sidebar is built) so the first appearanceChanged doesn't rebuild for no change.
             lastSidebarFontSize = GhosttyApp.shared.sidebarFontSize
             renameController.onRenameEnded = { [weak self] in self?.focusActiveTerminal() }
-            // the menu/palette can't reach the inline editor directly, so they post a
-            // notification and this coordinator starts the edit on the selected row.
-            // Scoped by `object: store` like expand/collapse below: the selected-session guard in the
-            // handlers is NOT a per-window scope (every open window has a selected session), so an
-            // object: nil pairing started an inline edit in EVERY window — each leaving an editor the
-            // user never opened, plus an unbalanced `suppressAutoFollow` that wedged that window's idle
-            // auto-follow off for good.
+            // the menu/palette can't reach the inline editor directly, so they post a notification and this
+            // coordinator starts the edit on the selected row. Scoped by `object: store` like
+            // expand/collapse below: the handlers' selected-session guard is NOT a per-window scope (every
+            // open window has one), so an `object: nil` pairing starts an inline edit in EVERY window — each
+            // leaving an unopened editor plus an unbalanced `suppressAutoFollow` that wedges that window's
+            // idle auto-follow off for good.
             NotificationCenter.default.addObserver(self, selector: #selector(beginRenameSessionNotified),
                                                    name: .agtermBeginRenameSession, object: store)
             NotificationCenter.default.addObserver(self, selector: #selector(beginRenameWorkspaceNotified),
                                                    name: .agtermBeginRenameWorkspace, object: store)
-            // expand/collapse target ONLY the frontmost window's sidebar: AppActions posts these with the
-            // frontmost store as the object, and registering with `object: store` lets NotificationCenter
-            // deliver only to the Coordinator whose store matches — so other windows' sidebars stay put.
+            // expand/collapse target ONLY the frontmost window's sidebar: AppActions posts them with the
+            // frontmost store as the object, and `object: store` makes NotificationCenter deliver only to
+            // the Coordinator whose store matches, leaving other windows' sidebars put.
             NotificationCenter.default.addObserver(self, selector: #selector(expandWorkspacesNotified),
                                                    name: .agtermExpandWorkspaces, object: store)
             NotificationCenter.default.addObserver(self, selector: #selector(collapseWorkspacesNotified),
@@ -255,9 +247,9 @@ struct WorkspaceSidebar: NSViewRepresentable {
             NotificationCenter.default.removeObserver(self)
         }
 
-        /// Re-tint the visible rows' text/icon to the current selection state and redraw the selection
-        /// pills, without a reloadData — used both when the selection changes (AppKit doesn't redraw on
-        /// its own with selectionHighlightStyle == .none) and on a live theme change.
+        /// Re-tint the visible rows' text/icon for the current selection and redraw the selection pills
+        /// without a `reloadData` — needed on a selection change (AppKit doesn't redraw by itself with
+        /// `selectionHighlightStyle == .none`) and on a live theme change.
         func refreshSelectionAppearance() {
             guard let outline = outlineView else { return }
             for row in 0 ..< outline.numberOfRows {
@@ -268,20 +260,19 @@ struct WorkspaceSidebar: NSViewRepresentable {
         }
 
         /// Pin the outline's appearance to the terminal theme's brightness so AppKit-drawn chrome — the
-        /// disclosure triangle — tracks the theme, not the macOS system light/dark setting. Without this a
-        /// light theme under macOS dark mode draws a light-gray triangle that's invisible on the light
-        /// sidebar (the row text/icons stay visible only because they're set explicitly to the theme color).
+        /// disclosure triangle — tracks the theme, not the macOS light/dark setting: a light theme under
+        /// macOS dark mode otherwise draws a light-gray triangle invisible on the light sidebar (row
+        /// text/icons survive only because they are set explicitly to the theme color).
         func applyThemeAppearance() {
             outlineView?.appearance = NSAppearance(named: GhosttyApp.shared.terminalThemeIsDark ? .darkAqua : .aqua)
         }
 
-        /// Inset the sidebar tree to line up with the terminal's DEFAULT ghostty padding (agterm/Resources/ghostty-defaults.conf;
-        /// a user window-padding override in ghostty.conf is not tracked here): window-padding-x = 8 matches
-        /// the terminal's left margin, plus a small 2px top nudge so the first
-        /// row's text sits on the terminal's first line. Most of the ~window-padding-y = 6 gap above the text
-        /// comes from the row centering its content (`centerYAnchor`) in a ~28px row; the 2px fine-tunes it (a
-        /// full 6px top inset would double it). The `.plain` outline style adds no insets of its own, so we own
-        /// them (auto-adjust off). Mode-independent — same offset in every toolbar mode.
+        /// Inset the tree to line up with the terminal's DEFAULT ghostty padding
+        /// (agterm/Resources/ghostty-defaults.conf; a user window-padding override in ghostty.conf is not
+        /// tracked): window-padding-x = 8 matches the left margin, plus a 2px top nudge putting the first
+        /// row's text on the terminal's first line — most of the ~window-padding-y = 6 gap already comes from
+        /// the row centering its content (`centerYAnchor`) in a ~28px row, so a full 6px would double it.
+        /// `.plain` adds no insets of its own, so we own them (auto-adjust off). Same in every toolbar mode.
         func applySidebarContentInset(_ scroll: NSScrollView?) {
             guard let scroll else { return }
             scroll.automaticallyAdjustsContentInsets = false
@@ -292,15 +283,15 @@ struct WorkspaceSidebar: NSViewRepresentable {
             applySidebarFontSizeIfChanged()
             refreshSelectionAppearance()
             applyThemeAppearance()
-            // a settings change may have flipped the badge-visibility toggle; reconcile so the gated
-            // unseen count (0 when off, the real count when on) reloads the affected badge rows.
+            // a settings change may have flipped the badge-visibility toggle; reconcile so the gated unseen
+            // count (0 when off, the real count when on) reloads the affected badge rows.
             reconcile()
-            // the agent-status colors are global (not per-row), so reconcile's content diff can't see a
-            // color change — re-apply every visible glyph so a Settings color edit takes effect live.
+            // agent-status colors are global, not per-row, so reconcile's content diff can't see a color
+            // change — re-apply every visible glyph so a Settings color edit takes effect live.
             reapplyStatusGlyphs()
             updateEmptyState()
-            // re-apply the sidebar content inset in case a settings change requires recomputing it (the
-            // inset itself is mode-independent, so this is a cheap re-assert, not a per-mode recalculation).
+            // cheap re-assert in case a settings change requires recomputing the inset; it is
+            // mode-independent, so this is not a per-mode recalculation.
             applySidebarContentInset(outlineView?.enclosingScrollView)
         }
 
@@ -308,11 +299,10 @@ struct WorkspaceSidebar: NSViewRepresentable {
             reapplyStatusGlyphs()
         }
 
-        /// Re-apply the sidebar row height + fonts when the sidebar font-size setting changed. The font size
-        /// isn't part of the per-row content diff `reconcile` uses, so a change needs an explicit row-height
-        /// update and a full `rebuildAndReload` (which re-runs the cell builder, re-setting each row's font).
-        /// Guarded on the tracked value so an unrelated appearance change (theme/color/toggle) doesn't force
-        /// a needless full reload.
+        /// Re-apply the row height + fonts when the sidebar font-size setting changed. The font size is not
+        /// part of `reconcile`'s per-row content diff, so a change needs an explicit row-height update and a
+        /// full `rebuildAndReload` (which re-runs the cell builder, re-setting each row's font). Guarded on
+        /// the tracked value so an unrelated appearance change (theme/color/toggle) doesn't force a reload.
         private func applySidebarFontSizeIfChanged() {
             let size = GhosttyApp.shared.sidebarFontSize
             guard size != lastSidebarFontSize else { return }
@@ -322,8 +312,7 @@ struct WorkspaceSidebar: NSViewRepresentable {
         }
 
         /// Re-apply the status glyph on every visible session row so a global agent-status color change
-        /// (from Settings) re-renders the existing glyphs. Appearance changes are rare, so the full sweep
-        /// is cheap.
+        /// (from Settings) re-renders it. Appearance changes are rare, so the full sweep is cheap.
         private func reapplyStatusGlyphs() {
             guard let outline = outlineView else { return }
             for row in 0 ..< outline.numberOfRows {
@@ -344,8 +333,8 @@ struct WorkspaceSidebar: NSViewRepresentable {
             DispatchQueue.main.async { [weak self] in self?.renameController.beginEditing(node: node) }
         }
 
-        /// Expand every workspace in this window's sidebar. A graceful no-op in flagged mode (no workspace
-        /// rows), gated here so `expandAll`'s tracked-expansion seeding can't fire in flagged mode.
+        /// Expand every workspace in this window's sidebar. Gated on tree mode here so `expandAll`'s
+        /// tracked-expansion seeding can't fire in flagged mode, where there are no workspace rows.
         @objc private func expandWorkspacesNotified() {
             guard store.sidebarMode == .tree else { return }
             expandAll()
@@ -357,14 +346,13 @@ struct WorkspaceSidebar: NSViewRepresentable {
             collapseOthers()
         }
 
-        /// Sync the sidebar to a SINGLE workspace's collapse/expand (the `workspace.collapse`/`workspace.expand`
-        /// control path). The persisted `Workspace.isExpanded` is ALREADY written by
-        /// `AppActions.setWorkspaceExpanded` before this notification is posted (that write is the source of
-        /// truth and does not depend on this Coordinator being alive), so this handler only keeps the tracked
-        /// `expandedWorkspaceIDs` in step — so the intent survives a collapsed (flagged-mode / focused-away)
-        /// row and a transient focus force-reveal — and drives the LIVE outline row when it is on screen
-        /// (tree mode, row resolved), suppressing the expand/collapse callback's re-persist since the store
-        /// already holds the truth.
+        /// Sync the sidebar to a SINGLE workspace's collapse/expand (the
+        /// `workspace.collapse`/`workspace.expand` control path). `AppActions.setWorkspaceExpanded` has
+        /// ALREADY persisted `Workspace.isExpanded` — the source of truth, independent of this Coordinator
+        /// being alive — so this handler only keeps the tracked `expandedWorkspaceIDs` in step (letting the
+        /// intent survive a collapsed flagged-mode / focused-away row and a transient focus force-reveal)
+        /// and drives the live outline row when it is on screen (tree mode, row resolved), suppressing the
+        /// callback's re-persist.
         @objc private func setWorkspaceExpandedNotified(_ notification: Notification) {
             guard let id = notification.userInfo?[Self.workspaceIDUserInfoKey] as? UUID,
                   let expanded = notification.userInfo?[Self.expandedUserInfoKey] as? Bool else { return }
@@ -378,53 +366,52 @@ struct WorkspaceSidebar: NSViewRepresentable {
 
         // MARK: - Model rebuild
 
-        /// The tree SHAPE: a workspace's id and its ordered session ids. Equal shapes across an update
-        /// mean no add/remove/move/reorder, so a row's content change (name/icon/badge) is handled by a
-        /// targeted per-row reload instead of a full rebuild. Row TEXT is deliberately NOT here: a
-        /// cwd-driven `displayName` change must not trigger a full `reloadData` + re-expand (which
-        /// re-lays-out every sidebar row and jitters their labels horizontally).
+        /// The tree SHAPE: a workspace's id and its ordered session ids. Equal shapes mean no
+        /// add/remove/move/reorder, so a content change (name/icon/badge) takes a targeted per-row reload
+        /// instead of a full rebuild. Row TEXT is deliberately NOT here: a cwd-driven `displayName` change
+        /// must not trigger a `reloadData` + re-expand, which re-lays-out every row and jitters the labels.
         private struct TreeShape: Equatable {
             let workspaceID: UUID
             let sessionIDs: [UUID]
         }
 
-        /// A row's visible content: its label (workspace name or session `displayName`), whether the
-        /// session has a split (the split-rectangle icon), the unseen-badge count, and the GATED
-        /// agent-status indicator (after the frontmost-selected hide). A delta reloads just that one row.
-        /// Uses `hasSplit` (not `isSplit`) so the icon persists while a split is hidden.
+        /// A row's visible content: its label (workspace name or session `displayName`), whether the session
+        /// has a split (the split-rectangle icon), the unseen-badge count, and the GATED agent-status
+        /// indicator (after the frontmost-selected hide). A delta reloads just that row. Uses `hasSplit`
+        /// (not `isSplit`) so the icon persists while a split is hidden.
         private struct RowContent: Equatable {
             let label: String
             let hasSplit: Bool
             let unseen: Int
             let indicator: AgentIndicator
-            /// Whether the session is flagged (tree-mode filled-icon variant). A change re-badges
-            /// just this row via `reloadItem`. Always false for workspace rows.
+            /// Whether the session is flagged (tree-mode filled-icon variant). A change re-badges just this
+            /// row via `reloadItem`. Always false for workspace rows.
             let flagged: Bool
-            /// Whether the workspace is a member of the focus set (the black-weight grid icon). Tracks
-            /// MEMBERSHIP only, independent of `focusEnabled`, so marking a workspace re-renders just
-            /// that row via `reloadItem` even while the filter is off (with the filter on, the shape
-            /// changes too and the rebuild branch takes over). Always false for session rows.
+            /// Whether the workspace is a member of the focus set (the black-weight grid icon). MEMBERSHIP
+            /// only, independent of `focusEnabled`, so marking re-renders just that row via `reloadItem`
+            /// even while the filter is off (with it on, the shape changes too and the rebuild branch takes
+            /// over). Always false for session rows.
             let focusMember: Bool
         }
 
-        /// The session's own agent-status indicator (or `.idle` for an unknown id / workspace row). Shown
-        /// on every session regardless of selection — `completed --auto-reset` clears itself on
-        /// `selectSession`, so a visited session drops its glyph without a render-time gate.
+        /// The session's own agent-status indicator (or `.idle` for an unknown id / workspace row). Shown on
+        /// every session regardless of selection — `completed --auto-reset` clears itself on `selectSession`,
+        /// so a visited session drops its glyph without a render-time gate.
         func effectiveIndicator(forSession id: UUID) -> AgentIndicator {
             store.session(withID: id)?.agentIndicator ?? AgentIndicator()
         }
 
-        /// The unseen-count after the badge-visibility gate: 0 (hidden) when the Settings badge toggle
-        /// is off, else the raw count. Render-only — `unseenCount` keeps tracking, so re-enabling the
-        /// toggle instantly shows the current counts. The agent-status glyph is NOT gated by this.
+        /// The unseen count after the badge-visibility gate: 0 when the Settings badge toggle is off, else
+        /// the raw count. Render-only — `unseenCount` keeps tracking, so re-enabling instantly shows current
+        /// counts. The agent-status glyph is NOT gated by this.
         func effectiveUnseen(_ count: Int) -> Int {
             GhosttyApp.shared.notificationBadgeEnabled ? count : 0
         }
 
-        /// Decides between a full rebuild (a SHAPE change: add/move/close/reorder) and a targeted
-        /// per-row reload (a content change: rename, cwd-driven name, split open/close, badge). Content
-        /// changes never rebuild — that full `reloadData` + re-expand re-lays-out every row and jitters
-        /// their labels. A reload during an in-progress rename is skipped so a tick can't drop the edit.
+        /// Decides between a full rebuild (a SHAPE change: add/move/close/reorder) and a targeted per-row
+        /// reload (a content change: rename, cwd-driven name, split open/close, badge). Content changes
+        /// never rebuild — a `reloadData` + re-expand re-lays-out every row and jitters the labels. A reload
+        /// during an in-progress rename is skipped so a tick can't drop the edit.
         func reconcile() {
             // a mode flip swaps the whole data source (tree ↔ flat flagged list), so rebuild regardless of
             // the shape diff; otherwise compare the mode-appropriate shape.
@@ -440,11 +427,11 @@ struct WorkspaceSidebar: NSViewRepresentable {
         }
 
         /// The structural shape for the current mode: the workspace tree (workspace id + ordered session
-        /// ids) in `.tree`, or a single flat group of the flagged session ids in `.flagged`. A change here
-        /// means an add/remove/move/reorder (or a flag/unflag in flagged mode) and forces a full rebuild.
-        /// The tree case derives from `visibleWorkspaces` (the marked set when the focus filter is on,
-        /// else all), so marking a workspace or flipping the filter — either of which changes the
-        /// rendered root set — registers as a shape change.
+        /// ids) in `.tree`, or one flat group of the flagged session ids in `.flagged`. A change means an
+        /// add/remove/move/reorder (or a flag/unflag in flagged mode) and forces a full rebuild. The tree
+        /// case derives from `visibleWorkspaces` (the marked set with the focus filter on, else all), so
+        /// marking a workspace or flipping the filter — both of which change the rendered root set —
+        /// registers as a shape change.
         private func currentShape() -> [TreeShape] {
             switch store.sidebarMode {
             case .tree:
@@ -454,10 +441,10 @@ struct WorkspaceSidebar: NSViewRepresentable {
             }
         }
 
-        /// Reloads only the rows whose visible content (label, split icon, or badge) changed — the
-        /// session row and, for a badge roll-up, its workspace row. A per-row `reloadItem` re-renders
-        /// just that row at its stable frame, so a name/cwd update never re-lays-out the whole tree.
-        /// Skipped mid-rename so it can't drop an in-progress edit.
+        /// Reloads only the rows whose visible content (label, split icon, badge) changed — the session row
+        /// and, for a badge roll-up, its workspace row. A per-row `reloadItem` re-renders at the row's
+        /// stable frame, so a name/cwd update never re-lays-out the tree. Skipped mid-rename so it can't
+        /// drop an in-progress edit.
         private func reloadChangedContentRows() {
             guard let outline = outlineView, !renameController.isCommitting, !renameController.isEditing else { return }
             func reloadIfChanged(_ id: UUID, _ content: RowContent) {
@@ -473,8 +460,8 @@ struct WorkspaceSidebar: NSViewRepresentable {
             }
         }
 
-        /// Records the current visible content (label, split icon, badge) of every row (keyed by their
-        /// distinct ids) so the next reconcile can detect a per-row content delta.
+        /// Records every row's current visible content (label, split icon, badge), keyed by id, so the next
+        /// reconcile can detect a per-row delta.
         private func snapshotRowContent() {
             var snapshot: [UUID: RowContent] = [:]
             for workspace in store.workspaces {
@@ -486,18 +473,18 @@ struct WorkspaceSidebar: NSViewRepresentable {
             lastRowContent = snapshot
         }
 
-        /// The visible content of a workspace row. The single builder shared by `reloadChangedContentRows`
-        /// and `snapshotRowContent` so the change-detection snapshot and the diff can't drift.
+        /// The visible content of a workspace row. One builder shared by `reloadChangedContentRows` and
+        /// `snapshotRowContent` so the snapshot and the diff can't drift.
         private func rowContent(forWorkspace workspace: Workspace) -> RowContent {
             RowContent(label: workspace.name, hasSplit: false, unseen: effectiveUnseen(workspace.unseenCount),
                        indicator: AgentIndicator(), flagged: false,
                        focusMember: store.focusedWorkspaceIDs.contains(workspace.id))
         }
 
-        /// The visible content of a session row. The single builder shared by `reloadChangedContentRows`
-        /// and `snapshotRowContent` so the change-detection snapshot and the diff can't drift. Both callers
-        /// iterate the `workspace … session` tree, so they pass the owning `workspaceName` in — the label
-        /// then needs no `session(withID:)`/`workspace(forSession:)` lookup, keeping the reconcile linear.
+        /// The visible content of a session row. One builder shared by `reloadChangedContentRows` and
+        /// `snapshotRowContent` so the snapshot and the diff can't drift. Both callers iterate the
+        /// `workspace … session` tree and pass the owning `workspaceName` in, so the label needs no
+        /// `session(withID:)`/`workspace(forSession:)` lookup and the reconcile stays linear.
         private func rowContent(forSession session: Session, workspaceName: String) -> RowContent {
             RowContent(label: rowLabel(for: session, workspaceName: workspaceName), hasSplit: session.hasSplit,
                        unseen: effectiveUnseen(session.unseenCount),
@@ -505,9 +492,8 @@ struct WorkspaceSidebar: NSViewRepresentable {
                        focusMember: false)
         }
 
-        /// Rebuilds `roots` from the store, reusing cached node instances by id so
-        /// NSOutlineView item identity and expansion state stay stable, then reloads
-        /// the outline preserving expansion.
+        /// Rebuilds `roots` from the store, reusing cached node instances by id so NSOutlineView item
+        /// identity and expansion state stay stable, then reloads the outline preserving expansion.
         func rebuildAndReload() {
             guard let outline = outlineView else { return }
 
@@ -538,29 +524,26 @@ struct WorkspaceSidebar: NSViewRepresentable {
                 }
                 newRoots.append(wsNode)
             }
-            // drop cached nodes for ids no longer present
             nodeCache = nodeCache.filter { seen.contains($0.key) }
             roots = newRoots
 
             // keep the tracked set in step with the model: drop ids for workspaces that no longer exist,
             // then pick up any the model reports expanded but that aren't tracked yet — a workspace added
-            // at runtime defaults `isExpanded == true`, so this renders it open rather than collapsed. A
-            // user-collapsed workspace has `isExpanded == false` (so it's excluded) and a programmatic
-            // reveal keeps its already-present id (formUnion only adds), so neither is disturbed.
+            // at runtime defaults `isExpanded == true`, so this renders it open. A user-collapsed workspace
+            // has `isExpanded == false` (excluded) and a programmatic reveal keeps its already-present id
+            // (formUnion only adds), so neither is disturbed.
             expandedWorkspaceIDs.formIntersection(Set(store.workspaces.map(\.id)))
             expandedWorkspaceIDs.formUnion(store.workspaces.filter(\.isExpanded).map(\.id))
 
-            // restore expansion from the tracked set rather than the live outline state: a flagged-mode
-            // reload drops the workspace nodes, so the outline forgets they were expanded, but the tracked
-            // set remembers across the interlude. A filter applied to a SINGLE marked workspace also
-            // force-expands it — that case is a "zoom in" on one workspace, so its sessions must show even
-            // if the row was collapsed. The force stops at one member on purpose: with a working SET the
-            // tree is a list of workspaces, not a zoom, and re-expanding every member on each rebuild
-            // (any session add/close/move re-shapes the tree) would undo the user's collapse of a member
-            // over and over while `tree` still reported it `collapsed` — a visible read-back divergence.
-            // This re-apply is a VIEW restore, not a user action, so suppress the persist: a
-            // marked-but-collapsed workspace must keep its persisted collapse (the zoom-in shows it, but
-            // doesn't un-collapse it).
+            // restore expansion from the tracked set, not the live outline state: a flagged-mode reload
+            // drops the workspace nodes so the outline forgets they were expanded, while the tracked set
+            // remembers across the interlude. A filter applied to a SINGLE marked workspace also
+            // force-expands it — a "zoom in", so its sessions must show even from a collapsed row. The force
+            // stops at one member on purpose: with a working SET the tree is a list of workspaces, not a
+            // zoom, and re-expanding every member on each rebuild (any session add/close/move re-shapes the
+            // tree) would repeatedly undo the user's collapse while `tree` still reported it `collapsed` — a
+            // visible read-back divergence. The re-apply is a VIEW restore, not a user action, so suppress
+            // the persist: a marked-but-collapsed workspace keeps its persisted collapse.
             outline.reloadData()
             suppressExpansionPersist = true
             let forceExpanded = store.soleFocusedWorkspaceID
@@ -571,9 +554,9 @@ struct WorkspaceSidebar: NSViewRepresentable {
             updateEmptyState()
         }
 
-        /// Adds the flagged-mode empty-state hint near the top of the scroll view (below the safe-area
-        /// inset, so it clears the titlebar) as a non-scrolling overlay (a sibling of the clip view, so it
-        /// floats above the document and stays put). Hidden until the flagged view is empty.
+        /// Adds the flagged-mode empty-state hint near the top of the scroll view, below the safe-area inset
+        /// so it clears the titlebar, as a non-scrolling overlay — a sibling of the clip view, so it floats
+        /// above the document and stays put. Hidden until the flagged view is empty.
         func installEmptyState(in scroll: NSScrollView) {
             let label = NSTextField(wrappingLabelWithString: "No flagged sessions.\nRight-click a session → Flag.")
             label.translatesAutoresizingMaskIntoConstraints = false
@@ -603,18 +586,18 @@ struct WorkspaceSidebar: NSViewRepresentable {
             label.textColor = (GhosttyApp.shared.terminalForegroundColor ?? .secondaryLabelColor).withAlphaComponent(0.6)
         }
 
-        /// Seeds the tracked expansion set from the persisted per-workspace state (`Workspace.isExpanded`),
-        /// so the launch reload restores each workspace's saved open/collapsed state. Sets only the tracked
-        /// set — `rebuildAndReload` applies it to the outline. Called once from `makeNSView`.
+        /// Seeds the tracked expansion set from the persisted `Workspace.isExpanded`, so the launch reload
+        /// restores each workspace's saved open/collapsed state. Sets only the tracked set —
+        /// `rebuildAndReload` applies it to the outline. Called once from `makeNSView`.
         func seedExpansionFromModel() {
             expandedWorkspaceIDs = Set(store.workspaces.filter(\.isExpanded).map(\.id))
         }
 
         /// Expands every workspace row — the "Expand Workspaces" user action. Seeds the tracked expansion
         /// from the live `store.workspaces`, NOT the current `roots` (only the marked set's subtrees while
-        /// the focus filter is on), so turning the filter off remembers every workspace as expanded. The
-        /// per-item callbacks are suppressed; the whole-tree state is persisted once via
-        /// `setWorkspacesExpanded` since this is a deliberate all-workspace command.
+        /// the focus filter is on), so turning the filter off remembers every workspace as expanded.
+        /// Per-item callbacks are suppressed; being a deliberate all-workspace command, the whole-tree state
+        /// is persisted once via `setWorkspacesExpanded`.
         func expandAll() {
             guard let outline = outlineView else { return }
             for workspace in store.workspaces { expandedWorkspaceIDs.insert(workspace.id) }
@@ -624,17 +607,16 @@ struct WorkspaceSidebar: NSViewRepresentable {
             store.setWorkspacesExpanded(expandedWorkspaceIDs)
         }
 
-        /// Collapses every workspace except the active one (the workspace of the active session,
-        /// `store.currentWorkspaceID`), keeping that one expanded and scrolling its row into view so it
-        /// stays visible. Tree-mode only — no workspace rows exist in flagged mode, so it is a graceful
-        /// no-op there.
+        /// Collapses every workspace except the active session's (`store.currentWorkspaceID`), keeping that
+        /// one expanded and scrolled into view. Tree-mode only — flagged mode has no workspace rows, so it
+        /// is a graceful no-op there.
         func collapseOthers() {
             guard let outline = outlineView, store.sidebarMode == .tree else { return }
             let keepID = store.currentWorkspaceID
             // this command targets ALL workspaces, not just the visible `roots`: reduce the tracked set to
-            // exactly the active workspace so a focus filter that hides some workspaces can't leave them in
-            // the set and get them persisted expanded by the batch write below. The outline expand/collapse
-            // only touches the rows currently on screen.
+            // exactly the active workspace so a focus filter hiding some workspaces can't leave them in the
+            // set and have the batch write below persist them expanded. The outline expand/collapse only
+            // touches the rows currently on screen.
             if let keepID { expandedWorkspaceIDs = [keepID] } else { expandedWorkspaceIDs = [] }
             suppressExpansionPersist = true
             for node in roots where node.kind == .workspace {
@@ -645,8 +627,8 @@ struct WorkspaceSidebar: NSViewRepresentable {
                 }
             }
             suppressExpansionPersist = false
-            // persist the whole-tree collapse state once — this is a deliberate command, so it writes every
-            // workspace (only the active one expanded), unlike the per-toggle callback path.
+            // a deliberate command, so persist the whole-tree state once — every workspace, only the active
+            // one expanded — unlike the per-toggle callback path.
             store.setWorkspacesExpanded(expandedWorkspaceIDs)
             // keep the active workspace's row on screen (mirrors syncSelection's scroll-into-view).
             guard let keepID, let node = nodeCache[keepID] else { return }
@@ -658,9 +640,9 @@ struct WorkspaceSidebar: NSViewRepresentable {
             guard let node = notification.userInfo?[Self.outlineItemUserInfoKey] as? SidebarNode,
                   node.kind == .workspace else { return }
             expandedWorkspaceIDs.insert(node.id)
-            // persist ONLY a genuine user expand (row click / disclosure triangle). A programmatic reveal or
-            // rebuild re-apply sets suppressExpansionPersist, so it updates the visual set above without
-            // burning the persisted collapse intent.
+            // persist ONLY a genuine user expand (row click / disclosure triangle): a programmatic reveal or
+            // rebuild re-apply sets suppressExpansionPersist, updating the visual set above without burning
+            // the persisted collapse intent.
             if !suppressExpansionPersist { store.setWorkspaceExpanded(node.id, expanded: true) }
         }
 
@@ -681,8 +663,8 @@ struct WorkspaceSidebar: NSViewRepresentable {
 
         // MARK: - Selection
 
-        /// Reflects `store.selectedSessionID` into the outline selection without
-        /// re-entering the store. Workspace rows are never auto-selected.
+        /// Reflects `store.selectedSessionID` into the outline selection without re-entering the store.
+        /// Workspace rows are never auto-selected.
         func syncSelection() {
             guard let outline = outlineView else { return }
             applyingSelection = true
@@ -692,15 +674,15 @@ struct WorkspaceSidebar: NSViewRepresentable {
                 lastRevealedSelection = nil
                 return
             }
-            // the row-selection sync runs every call (keeps the highlight correct), but the intrusive
-            // reveal — expanding a collapsed owner and scrolling into view — only fires when the
-            // selection actually changed, so unrelated cwd/title/badge updates to the already-selected
-            // session leave a user-collapsed workspace and a user-moved scroll position alone.
+            // the row-selection sync runs every call (keeps the highlight correct), but the intrusive reveal
+            // — expanding a collapsed owner and scrolling into view — only fires on a real selection change,
+            // so unrelated cwd/title/badge updates to the already-selected session leave a user-collapsed
+            // workspace and a user-moved scroll position alone.
             let selectionChanged = selectedID != lastRevealedSelection
-            // a session selected by keyboard nav may live in a collapsed workspace, whose row is -1
-            // until expanded; expand its owner first so the row resolves. This reveal is a VIEW action,
-            // not a user expand, so suppress the persist: navigating into (or launching with the selection
-            // inside) a deliberately-collapsed workspace shows the session without un-collapsing it on disk.
+            // a session selected by keyboard nav may live in a collapsed workspace, whose row is -1 until
+            // expanded; expand its owner first so the row resolves. A VIEW action, not a user expand, so
+            // suppress the persist: navigating into (or launching with the selection inside) a deliberately
+            // collapsed workspace shows the session without un-collapsing it on disk.
             if selectionChanged, let owner = ownerWorkspaceNode(ofSession: selectedID), !outline.isItemExpanded(owner) {
                 suppressExpansionPersist = true
                 outline.expandItem(owner)
@@ -725,15 +707,15 @@ struct WorkspaceSidebar: NSViewRepresentable {
             lastRevealedSelection = selectedID
         }
 
-        /// The workspace node containing `sessionID` (its `children`), or nil if not found — used to
-        /// expand a collapsed owner before resolving a keyboard-navigated session's row.
+        /// The workspace node whose `children` hold `sessionID`, or nil — used to expand a collapsed owner
+        /// before resolving a keyboard-navigated session's row.
         private func ownerWorkspaceNode(ofSession sessionID: UUID) -> SidebarNode? {
             roots.first { $0.children.contains { $0.id == sessionID } }
         }
 
         func outlineViewSelectionDidChange(_ notification: Notification) {
-            // repaint the selection pill + row text colors for the new selection (with .none highlight
-            // style AppKit won't redraw rows on its own).
+            // repaint the selection pill + row text colors for the new selection — with the .none highlight
+            // style AppKit won't redraw rows itself.
             refreshSelectionAppearance()
             guard !applyingSelection, let outline = outlineView else { return }
             let selectedIDs = outline.selectedRowIndexes.compactMap { row -> UUID? in
@@ -753,30 +735,27 @@ struct WorkspaceSidebar: NSViewRepresentable {
                 return
             }
             // a genuine user row click (the applyingSelection guard above skips programmatic sync, so
-            // auto-follow's own jump never reaches here) counts as activity: it buys the full idle grace
+            // auto-follow's own jump never reaches here) counts as activity, buying the full idle grace
             // before auto-follow can pull the selection back.
             store.noteUserActivity()
             let indicator = store.selectSession(activeID, sidebarSelection: selectedIDs)
-            // land on the selected session's blocked pane when it carries a pane-tagged block (a no-op
-            // otherwise), async so it runs after the selection + the sidebar's own focus-restore settle.
+            // land on the selected session's blocked pane when it carries a pane-tagged block (else a
+            // no-op), async so it runs after the selection + the sidebar's own focus-restore settle.
             DispatchQueue.main.async { [weak self] in
                 self?.actions.revealActiveBlockedPane(captured: indicator)
             }
         }
 
-        /// Returns keyboard focus to the active session's terminal after a sidebar
-        /// interaction, so the sidebar never keeps focus (typing always reaches the
-        /// terminal). Mirrors macterm's `FocusRestoration`: the target surface may not be
-        /// attached to the window yet (a just-selected session's view is still
-        /// materializing), so retry on the run loop until it is, with a bounded cap.
-        /// Skipped while a rename field is the first responder or an edit is in progress.
+        /// Returns keyboard focus to the active session's terminal after a sidebar interaction, so the
+        /// sidebar never keeps focus. Mirrors macterm's `FocusRestoration`: the target surface may not be
+        /// attached to the window yet (a just-selected session's view is still materializing), so retry on
+        /// the run loop until it is, with a bounded cap. Skipped while a rename field is first responder or
+        /// an edit is in progress.
         ///
-        /// Targets `topmostSurface` (overlay, else scratch, else the active pane) rather than the main
-        /// `surface`: while a cover is up it owns the keyboard, so focusing a pane instead would starve the
-        /// overlay/scratch program of input — and a full overlay or scratch also hides the pane, so the
-        /// keystrokes would land on a surface the user cannot see.
+        /// Targets `topmostSurface` (overlay, else scratch, else the active pane), not the main `surface`:
+        /// a cover owns the keyboard, so focusing a pane would starve the overlay/scratch program of input —
+        /// and a full overlay or scratch hides the pane, sending keystrokes to a surface the user can't see.
         func focusActiveTerminal(attempt: Int = 0) {
-            // never steal focus from an in-progress rename.
             if renameController.isEditing { return }
             let window = outlineView?.window
             if let window, window.firstResponder is NSText { return }
@@ -784,8 +763,7 @@ struct WorkspaceSidebar: NSViewRepresentable {
                 window.makeFirstResponder(surface)
                 return
             }
-            // window or surface not attached yet (launch, or a just-selected session still
-            // materializing) — retry on the run loop until ready, with a bounded cap.
+            // not attached yet — at launch, or a just-selected session still materializing.
             guard attempt < 20 else { return }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.03) { [weak self] in
                 self?.focusActiveTerminal(attempt: attempt + 1)
@@ -809,18 +787,16 @@ struct WorkspaceSidebar: NSViewRepresentable {
             return node.kind == .workspace
         }
 
-        /// Leading row icons: a 2x2 grid glyph for a workspace, an outlined terminal for a single
-        /// session, and a split-rectangle for a split session, rendered as monochrome template symbols.
-        /// A flagged SESSION swaps to the `.fill` variant of its base glyph (a solid interior — the same
-        /// "small filled area" idiom the scratch-active toolbar glyph uses): `terminal.fill` /
-        /// `rectangle.split.2x1.fill`. A workspace in the focus SET keeps the very same
-        /// `square.grid.2x2` outline and only draws it at `.black` weight, so every workspace row holds
-        /// one identity and membership costs stroke weight alone — the two markers stay distinct
-        /// (fill = flagged session, black = marked workspace) instead of both reading as "filled".
-        /// Never a composited corner badge, so each stays a single template `setColors` tints; the
-        /// weight variant renders 1pt larger (16x15 vs 15x14) but the icon view is pinned to a fixed
-        /// 16x16 box, so neither swap moves the row.
-        /// Cached because only a few distinct symbols exist and every row reuses them.
+        /// Leading row icons as monochrome template symbols: a 2x2 grid for a workspace, an outlined
+        /// terminal for a single session, a split-rectangle for a split one. A flagged SESSION swaps to its
+        /// base glyph's `.fill` variant (`terminal.fill` / `rectangle.split.2x1.fill` — the solid-interior
+        /// idiom the scratch-active toolbar glyph uses). A workspace in the focus SET keeps the same
+        /// `square.grid.2x2` outline at `.black` weight, so a workspace row holds one identity and
+        /// membership costs stroke weight alone, keeping the two markers distinct (fill = flagged session,
+        /// black = marked workspace) instead of both reading as "filled". Never a composited corner badge,
+        /// so each stays a single template `setColors` tints; the weight variant renders 1pt larger (16x15
+        /// vs 15x14) but the icon view is pinned to a fixed 16x16 box, so neither swap moves the row.
+        /// Cached because few distinct symbols exist and every row reuses them.
         lazy var workspaceIcon = Self.rowIcon("square.grid.2x2")
         lazy var focusedWorkspaceIcon = Self.rowIcon("square.grid.2x2", weight: .black)
         lazy var splitSessionIcon = Self.rowIcon("rectangle.split.2x1")
@@ -837,7 +813,7 @@ struct WorkspaceSidebar: NSViewRepresentable {
         }
 
         /// The row label from an already-resolved session + its owning workspace name, with no store lookup —
-        /// the form the reconcile loops use (they iterate the `workspace … session` tree).
+        /// the form the reconcile loops use, since they iterate the `workspace … session` tree.
         func rowLabel(for session: Session, workspaceName: String) -> String {
             guard store.sidebarMode == .flagged else { return session.displayName }
             return "\(session.displayName) : \(workspaceName)"
@@ -849,14 +825,14 @@ struct WorkspaceSidebar: NSViewRepresentable {
     }
 }
 
-/// An `NSOutlineView` subclass that serves a per-row context menu and starts
-/// inline rename on double-click, both routed to the coordinator.
+/// An `NSOutlineView` subclass serving a per-row context menu and starting inline rename on double-click,
+/// both routed to the coordinator.
 final class SidebarOutlineView: NSOutlineView {
     // never become first responder: focus lives in the terminal. A mouse click still selects the row
-    // (selection is independent of first responder), but without this the click steals first responder,
-    // and the responder bounce (terminal → outline → terminal, via mouseDown's focusActiveTerminal) makes
-    // AppKit re-set `isEmphasized` on the rows — an extra repaint that flicks the selection pill on every
-    // click. Programmatic selection (palette/Ctrl-Tab) never bounces, so it's already smooth.
+    // (selection is independent of first responder); otherwise the click steals first responder and the
+    // responder bounce (terminal → outline → terminal, via mouseDown's focusActiveTerminal) makes AppKit
+    // re-set `isEmphasized` on the rows — an extra repaint that flicks the selection pill on every click.
+    // Programmatic selection (palette/Ctrl-Tab) never bounces, so it is already smooth.
     override var acceptsFirstResponder: Bool { false }
 
     override func draggingExited(_ sender: NSDraggingInfo?) {
@@ -867,8 +843,8 @@ final class SidebarOutlineView: NSOutlineView {
     override func menu(for event: NSEvent) -> NSMenu? {
         let point = convert(event.locationInWindow, from: nil)
         let row = self.row(at: point)
-        // Keep a multi-selection when right-clicking one of its selected rows; narrow to the clicked
-        // session when right-clicking outside the selection, matching standard Mac list behavior.
+        // standard Mac list behavior: keep a multi-selection when right-clicking one of its selected rows,
+        // narrow to the clicked session when right-clicking outside it.
         if row >= 0, let node = item(atRow: row) as? SidebarNode, node.kind == .session,
            !selectedRowIndexes.contains(row) {
             selectRowIndexes(IndexSet(integer: row), byExtendingSelection: false)
@@ -878,30 +854,29 @@ final class SidebarOutlineView: NSOutlineView {
 
     override func mouseDown(with event: NSEvent) {
         super.mouseDown(with: event)
-        // after the click is handled (selection, expand/collapse, drag), hand keyboard
-        // focus back to the terminal so the sidebar never keeps it. row selection persists
-        // (model state); only first responder moves. skipped mid-rename by the coordinator.
+        // after the click is handled (selection, expand/collapse, drag), hand keyboard focus back to the
+        // terminal so the sidebar never keeps it. row selection persists (model state); only first responder
+        // moves. skipped mid-rename by the coordinator.
         (delegate as? WorkspaceSidebar.Coordinator)?.focusActiveTerminal()
     }
 }
 
 extension Notification.Name {
-    /// Posted by the menu/palette to start an inline rename of the active session or its
-    /// workspace; `WorkspaceSidebar.Coordinator` observes these and begins editing the row.
+    /// Posted by the menu/palette to start an inline rename of the active session or its workspace;
+    /// `WorkspaceSidebar.Coordinator` observes these and begins editing the row.
     static let agtermBeginRenameSession = Notification.Name("agterm.beginRenameSession")
     static let agtermBeginRenameWorkspace = Notification.Name("agterm.beginRenameWorkspace")
-    /// Posted by the menu/palette/control channel to expand every workspace, or to collapse every
-    /// workspace except the active one. Posted with the frontmost window's `AppStore` as the object so
+    /// Posted by the menu/palette/control channel to expand every workspace, or collapse every workspace
+    /// except the active one, with the frontmost window's `AppStore` as the object so
     /// `WorkspaceSidebar.Coordinator` observes them scoped to that one window's sidebar.
     static let agtermExpandWorkspaces = Notification.Name("agterm.expandWorkspaces")
     static let agtermCollapseWorkspaces = Notification.Name("agterm.collapseWorkspaces")
-    /// Posted by the `workspace.collapse`/`workspace.expand` control arm to collapse or expand a SINGLE
-    /// workspace, with the target window's `AppStore` as the object and the workspace id + desired state in
-    /// `userInfo`. Object-scoped like the all-workspace pokes, so only the matching window's sidebar reacts.
+    /// Posted by the `workspace.collapse`/`workspace.expand` control arm for a SINGLE workspace, with the
+    /// target window's `AppStore` as the object and the workspace id + desired state in `userInfo`.
+    /// Object-scoped like the all-workspace pokes, so only the matching window's sidebar reacts.
     static let agtermSetWorkspaceExpanded = Notification.Name("agterm.setWorkspaceExpanded")
-    /// Posted by the `session.resize` control arm after it stores a new split-divider fraction, with the
+    /// Posted by the `session.resize` control arm after storing a new split-divider fraction, with the
     /// target `Session` as the object so the matching `SplitProbeView` (in `ContentView`) moves the live
-    /// divider to `Session.splitRatio`. Object-scoped like the expand/collapse pokes, so only the one
-    /// session's pane view reacts.
+    /// divider to `Session.splitRatio`. Object-scoped, so only that one session's pane view reacts.
     static let agtermApplySplitRatio = Notification.Name("agterm.applySplitRatio")
 }

--- a/agterm/WindowRegistry.swift
+++ b/agterm/WindowRegistry.swift
@@ -1,10 +1,9 @@
 import agtermCore
 import AppKit
 
-/// App-side bridge mapping a `WindowInfo.ID` to its live `NSWindow`. `WindowLibrary` is host-free
-/// (no AppKit), so the NSWindow handles live here. `TitleProbeView` registers/unregisters on window
-/// attach/close; `raise(_:)` brings an already-open window forward (the dedup-by-id raise path) and
-/// `close(_:)` runs `performClose` (the `window.close` teardown path).
+/// App-side bridge mapping a `WindowInfo.ID` to its live `NSWindow` — `WindowLibrary` is host-free (no
+/// AppKit), so the NSWindow handles live here. `TitleProbeView` registers/unregisters on window attach/close;
+/// `raise(_:)` brings an already-open window forward (the dedup-by-id raise path), `close(_:)` tears it down.
 @MainActor
 final class WindowRegistry {
     static let shared = WindowRegistry()
@@ -22,9 +21,9 @@ final class WindowRegistry {
     /// Whether an on-screen window is registered for `id` (i.e. its NSWindow has attached).
     func isRegistered(_ id: WindowInfo.ID) -> Bool { windows[id] != nil }
 
-    /// Whether the on-screen window for `id` is currently the key window. False when none is registered.
-    /// The auto-follow focus bridge gates on this so only a key window pulls first responder into the
-    /// auto-followed session; a background window changes only its selection.
+    /// Whether the on-screen window for `id` is currently the key window; false when none is registered. The
+    /// auto-follow focus bridge gates on it, so only a key window pulls first responder into the followed
+    /// session and a background window changes only its selection.
     func isKeyWindow(_ id: WindowInfo.ID) -> Bool { windows[id]?.isKeyWindow ?? false }
 
     func unregister(_ id: WindowInfo.ID) {
@@ -51,10 +50,10 @@ final class WindowRegistry {
         return true
     }
 
-    /// Closes the on-screen window for `id` if one is live. Uses `window.close()` (NOT `performClose`)
-    /// so it bypasses the confirm-before-close proxy — this is the programmatic path (Delete Window,
-    /// which already confirms, and the control socket, which must stay headless). `close()` still runs
-    /// the `willClose` teardown + library mark-closed. Returns whether a window was closed.
+    /// Closes the on-screen window for `id` if one is live, returning whether one was. `window.close()` NOT
+    /// `performClose`, to bypass the confirm-before-close proxy — this is the programmatic path (Delete
+    /// Window already confirms; the control socket must stay headless). `close()` still runs the `willClose`
+    /// teardown + library mark-closed.
     @discardableResult
     func close(_ id: WindowInfo.ID) -> Bool {
         guard let window = windows[id] else { return false }
@@ -62,10 +61,9 @@ final class WindowRegistry {
         return true
     }
 
-    /// Resizes the on-screen window for `id` to `width` x `height` points (frame size), keeping its top
-    /// edge fixed and clamping into `[window.minSize, screen.visibleFrame]` via `WindowGeometry.clampSize`
-    /// (the single clamp path). Returns false if no window is registered for `id` (not open). The
-    /// control-channel `window.resize` path.
+    /// Resizes the on-screen window for `id` to `width` x `height` points (frame size), top edge fixed,
+    /// clamped into `[window.minSize, screen.visibleFrame]` via `WindowGeometry.clampSize` (the single clamp
+    /// path). False if no window is registered for `id` (not open). The control-channel `window.resize` path.
     @discardableResult
     func resize(_ id: WindowInfo.ID, width: Int, height: Int) -> Bool {
         guard let window = windows[id] else { return false }
@@ -81,11 +79,10 @@ final class WindowRegistry {
         return true
     }
 
-    /// Moves the on-screen window for `id` so its top-left corner is at (`x`, `y`) points relative to the
-    /// top-left of `display` (an index into the screen list; nil = the window's current display), y down.
-    /// The origin is clamped via `WindowGeometry.clampOrigin` so an off-screen request keeps a grabbable
-    /// strip on the target display. Returns false if no window is registered for `id` (not open) or
-    /// `display` is out of range. The control-channel `window.move` path.
+    /// Moves the on-screen window for `id` so its top-left is at (`x`, `y`) points from the top-left of
+    /// `display` (a screen-list index; nil = the window's current display), y down, clamped via
+    /// `WindowGeometry.clampOrigin` so an off-screen request keeps a grabbable strip on the target display.
+    /// False if no window is registered (not open) or `display` is out of range. The `window.move` path.
     @discardableResult
     func move(_ id: WindowInfo.ID, x: Int, y: Int, display: Int?) -> Bool {
         guard let window = windows[id] else { return false }
@@ -101,7 +98,6 @@ final class WindowRegistry {
         // (x, y) is the top-left relative to the screen's top-left (y down) → AppKit screen point (y up).
         let size = window.frame.size
         let topLeft = NSPoint(x: screen.frame.minX + CGFloat(x), y: screen.frame.maxY - CGFloat(y))
-        // convert top-left to the frame's bottom-left origin, then clamp so a strip stays on the display.
         let requested = WindowGeometry.Point(x: Double(topLeft.x), y: Double(topLeft.y - size.height))
         let origin = WindowGeometry.clampOrigin(requested, windowSize: WindowGeometry.Size(size),
                                                 displayFrame: WindowGeometry.Rect(screen.frame)).cgPoint
@@ -109,11 +105,10 @@ final class WindowRegistry {
         return true
     }
 
-    /// Zooms (the maximize-to-screen toggle) the on-screen window for `id` if one is live, driving the
-    /// standard `NSWindow.zoom` — the same action as the double-click-header gesture (a plain green-button
-    /// click does native full screen instead; Option-click zooms). A second call restores the prior frame.
-    /// Returns false if no window is registered for `id`
-    /// (not open). The control-channel `window.zoom` path.
+    /// Zooms (maximize-to-screen) the on-screen window for `id` if one is live, driving the standard
+    /// `NSWindow.zoom` — the double-click-header gesture's action (a plain green-button click does native
+    /// full screen instead; Option-click zooms). A second call restores the prior frame. False if no window
+    /// is registered for `id` (not open). The control-channel `window.zoom` path.
     @discardableResult
     func zoom(_ id: WindowInfo.ID) -> Bool {
         guard let window = windows[id] else { return false }
@@ -121,10 +116,10 @@ final class WindowRegistry {
         return true
     }
 
-    /// Toggles native macOS full screen for the on-screen window for `id` if one is live, driving the
-    /// standard `NSWindow.toggleFullScreen` — the same action as the green traffic-light button. A second
-    /// call exits full screen. Returns false if no window is registered for `id` (not open). The
-    /// control-channel `window.fullscreen` path; the GUI half toggles the key window directly.
+    /// Toggles native macOS full screen for `id`'s window if one is live, driving the standard
+    /// `NSWindow.toggleFullScreen` — the green traffic-light button's action; a second call exits. False if
+    /// no window is registered (not open). The control-channel `window.fullscreen` path; the GUI half
+    /// toggles the key window directly.
     @discardableResult
     func fullscreen(_ id: WindowInfo.ID) -> Bool {
         guard let window = windows[id] else { return false }
@@ -143,14 +138,13 @@ final class WindowRegistry {
         case fullScreen
     }
 
-    /// Minimizes the on-screen window for `id` to the Dock, or restores it, driving the standard
-    /// `NSWindow.miniaturize`/`deminiaturize` — the same action as ⌘M, the yellow traffic-light button, and
-    /// the Minimize title-bar double-click action. The mode resolves against the window's CURRENT state, so
-    /// `on`/`off` are idempotent and only `toggle` flips. Restoring puts the window back on screen without
-    /// making it key; `window.select` (`raise`) is the raise-it-too path.
-    ///
-    /// A window in native full screen is rejected rather than silently ignored: AppKit no-ops
-    /// `miniaturize` there, so applying it would report success having done nothing.
+    /// Minimizes `id`'s on-screen window to the Dock, or restores it, via the standard
+    /// `NSWindow.miniaturize`/`deminiaturize` — the action of ⌘M, the yellow traffic-light button, and the
+    /// Minimize title-bar double-click. The mode resolves against the window's CURRENT state, so `on`/`off`
+    /// are idempotent and only `toggle` flips. Restoring puts the window back on screen without making it
+    /// key; `window.select` (`raise`) is the raise-it-too path. A window in native full screen is REJECTED
+    /// rather than silently ignored: AppKit no-ops `miniaturize` there, so applying it would report success
+    /// having done nothing.
     func minimize(_ id: WindowInfo.ID, mode: ControlToggleMode) -> MinimizeOutcome {
         guard let window = windows[id] else { return .notOpen }
         let desired = mode.desiredValue(current: window.isMiniaturized)
@@ -162,12 +156,11 @@ final class WindowRegistry {
 
     /// The screen a window's frame belongs to. `NSWindow.screen` is nil whenever the window is off-screen —
     /// notably while MINIMIZED to the Dock, and while the app is hidden — so fall back to the display its
-    /// frame overlaps most (`WindowGeometry.bestDisplayIndex`, the same resolution the frame-restore path
-    /// uses), then the main screen for a frame overlapping nothing (a disconnected display).
-    ///
-    /// Shared by `geometry`, `move`, and `resize` on purpose: a read resolved by overlap and a write
-    /// resolved against `NSScreen.main` would disagree on the display index, so a minimized window's
-    /// reported frame would stop round-tripping back through `window.move`.
+    /// frame overlaps most (`WindowGeometry.bestDisplayIndex`, the frame-restore path's resolution), then
+    /// the main screen for a frame overlapping nothing (a disconnected display). Shared by `geometry`,
+    /// `move`, and `resize` on purpose: a read resolved by overlap and a write resolved against
+    /// `NSScreen.main` would disagree on the display index, so a minimized window's reported frame would
+    /// stop round-tripping back through `window.move`.
     private func resolvedScreen(for window: NSWindow) -> NSScreen? {
         if let screen = window.screen { return screen }
         let screens = NSScreen.screens
@@ -179,12 +172,11 @@ final class WindowRegistry {
     }
 
     /// The window's current frame in the SAME coordinate system `move`/`resize` accept, so `window.list`'s
-    /// read-back round-trips back through `window.move`/`window.resize`: `x`/`y` are the top-left relative to
-    /// the window's display top-left (y down), `width`/`height` the frame size, `display` the screen index.
-    /// This is the inverse of `move`'s forward math (`x = minX - screen.minX`, `y = screen.maxY - maxY`) to
-    /// integer-point precision: the values round to `Int` since `window.move`/`window.resize` take `Int`, so a
-    /// user-dragged fractional frame restores to the nearest point (which is all those commands accept).
-    /// Nil when no window is registered for `id` (closed). The `window.list` frame source.
+    /// read-back round-trips back through them: `x`/`y` are the top-left relative to the window's display
+    /// top-left (y down), `width`/`height` the frame size, `display` the screen index. The inverse of
+    /// `move`'s forward math (`x = minX - screen.minX`, `y = screen.maxY - maxY`) to integer-point precision
+    /// — the values round to `Int` because those commands take `Int`, so a user-dragged fractional frame
+    /// restores to the nearest point. Nil when no window is registered (closed). The `window.list` source.
     func geometry(for id: WindowInfo.ID) -> ControlWindowFrame? {
         guard let window = windows[id], let screen = resolvedScreen(for: window) else { return nil }
         let frame = window.frame
@@ -197,9 +189,8 @@ final class WindowRegistry {
     }
 
     /// Whether the window for `id` is in native full screen, zoomed (maximized-to-screen, NOT full screen),
-    /// and/or minimized to the Dock, or nil when no window is registered (closed). The read side of
-    /// `window.fullscreen`/`window.zoom`/`window.minimize` on `window.list`, so a script can make those
-    /// toggles idempotent.
+    /// and/or minimized to the Dock; nil when no window is registered (closed). The read side of
+    /// `window.fullscreen`/`window.zoom`/`window.minimize` on `window.list`, for idempotent toggles.
     func windowFlags(for id: WindowInfo.ID) -> (fullscreen: Bool, zoomed: Bool, minimized: Bool)? {
         guard let window = windows[id] else { return nil }
         return (fullscreen: window.styleMask.contains(.fullScreen), zoomed: window.isZoomed,

--- a/agterm/agtermApp+Menus.swift
+++ b/agterm/agtermApp+Menus.swift
@@ -3,18 +3,16 @@ import AppKit
 import SwiftUI
 
 extension agtermApp {
-    /// The active SwiftUI shortcut for a built-in action, driven by the keymap: the user override when one
-    /// is `map`ped, else the shipped default; `nil` only for a keyless action, until the user maps a chord.
-    /// `keymap` is `@Observable`, but SwiftUI defers its menu rebuild to the next app activation, so a reload
-    /// leaves the live key equivalents stale until then. ⌘W is asserted from AppKit instead, by
-    /// `AppDelegate.applyCloseSessionChord`.
+    /// The active SwiftUI shortcut for a built-in action: the user's `map` override, else the shipped
+    /// default; nil only for a keyless action. `keymap` is `@Observable`, but SwiftUI defers its menu
+    /// rebuild to the next app activation, so a reload leaves live key equivalents stale until then — ⌘W is
+    /// asserted from AppKit instead, by `AppDelegate.applyCloseSessionChord`.
     private func shortcut(for action: BuiltinAction) -> KeyboardShortcut? {
         settingsModel.keymap.equivalent(for: action).map(Self.toShortcut)
     }
 
     /// Map a host-free `Chord` to a SwiftUI `KeyboardShortcut` — the menu-side mirror of the runner's
-    /// `NSEvent`→`Chord` mapping. The base key is a single printable `Character` or a named key the grammar
-    /// allows (`tab`/`space`/`return`/`delete` and the four arrows); the modifiers map one-for-one.
+    /// `NSEvent`→`Chord` mapping. The base key is a printable `Character` or a named key; modifiers map 1:1.
     private static func toShortcut(_ chord: Chord) -> KeyboardShortcut {
         let key: KeyEquivalent
         switch chord.key {
@@ -46,25 +44,23 @@ extension agtermApp {
             CommandGroup(replacing: .appInfo) {
                 Button("About Agterm") { showAboutPanel() }
             }
-            // drop SwiftUI's stock Undo/Redo: agterm registers no NSUndoManager, and the ⌘Z they advertise is
-            // owned by File ▸ Reopen Closed Item (`BuiltinAction.undoClose`), whose menu precedes Edit and
-            // wins the key-equivalent search — so Undo could only ever be CLICKED. AppKit enabled it only in
-            // the sidebar's inline rename field (its field editor supplies an undo manager), too narrow to
-            // keep a permanently-greyed duplicate. The rest stays stock: Cut/Copy/Paste/Delete/Select All
-            // share the `.pasteboard` group, and replacing it takes ⌘C/⌘V/⌘A from the text fields needing them.
+            // drop SwiftUI's stock Undo/Redo: agterm registers no NSUndoManager, and the ⌘Z they advertise
+            // is owned by File ▸ Reopen Closed Item (`BuiltinAction.undoClose`), whose menu precedes Edit
+            // and wins the key-equivalent search — so Undo could only ever be CLICKED, and AppKit enabled it
+            // only in the sidebar's inline rename field (whose field editor supplies an undo manager). The
+            // rest stays stock: replacing the shared `.pasteboard` group takes ⌘C/⌘V/⌘A from text fields.
             CommandGroup(replacing: .undoRedo) {}
             // File: replace the default "New" group with agterm's creation/management actions, grouped by
             // entity into Window, Workspace, Session. System Close / Close All stay below in their own group.
             CommandGroup(replacing: .newItem) {
-                // While terminal zoom, the dashboard grid, OR the topmost native picker is up, the UI is modal
-                // (the AppActions gate already no-ops these). `.disabled` mirrors that gate so items read as
-                // unavailable instead of dead and key equivalents cannot mutate the covered deck.
+                // zoom, the dashboard grid, or a topmost native picker makes the UI modal (the AppActions
+                // gate already no-ops these); `.disabled` mirrors it so items read as unavailable instead
+                // of dead and key equivalents cannot mutate the covered deck.
                 let zoomed = actions.terminalZoomActive
                 let pickActive = actions.pickActive(for: library.activeWindowID)
                 let modalActive = zoomed || (actions.frontmostDashboard?.isOpen ?? false) || pickActive
-                // Window: create/open/rename/delete the top-level window bundles. Open Window lists
-                // the library with a checkmark on already-open ones (picking a closed one opens it,
-                // an open one raises it). Delete is disabled with one window left (keep-at-least-one).
+                // Window: Open Window lists the library with a checkmark on already-open ones (picking a
+                // closed one opens it, an open one raises it). Delete is disabled with one window left.
                 Button("New Window") { actions.newWindow() }
                     .keyboardShortcut(shortcut(for: .newWindow))
                     .disabled(modalActive)
@@ -157,26 +153,23 @@ extension agtermApp {
                     .keyboardShortcut(shortcut(for: .clearStatus))
                     .disabled(library.activeStore?.activeSession == nil || modalActive)
                 Divider()
-                // open keymap.conf in $EDITOR in a 95% overlay over the active session; it reloads on the
-                // editor exiting. Keyless, like Reload Keymap.
+                // open keymap.conf in $EDITOR in a 95% overlay over the active session; reloads when the
+                // editor exits. keyless, like Reload Keymap.
                 Button { actions.editKeymap() } label: { Label("Edit Keymap…", systemImage: "pencil") }
                     .disabled(modalActive)
-                // re-read keymap.conf and apply (menu shortcuts re-render, the runner + palette rebuild).
-                // Keyless — a future BuiltinAction could give it a default chord.
+                // re-read keymap.conf and apply — menu shortcuts, runner and palette rebuild. keyless.
                 Button { actions.reloadKeymap() } label: { Label("Reload Keymap", systemImage: "keyboard") }
-                // open the agterm-scoped ghostty.conf in $EDITOR in a 95% overlay; it reloads the config on
-                // the editor exiting. Keyless, like Edit Keymap.
+                // open the agterm-scoped ghostty.conf in $EDITOR in a 95% overlay; reloads on editor exit.
                 Button { actions.editGhosttyConfig() } label: { Label("Edit ghostty.conf…", systemImage: "slider.horizontal.3") }
                     .disabled(modalActive)
-                // re-read ghostty.conf and rebroadcast to every surface; warns with a banner on a
-                // malformed file. Keyless, like Reload Keymap.
+                // re-read ghostty.conf and rebroadcast to every surface; banner-warns on a malformed file.
                 Button { actions.reloadGhosttyConfig() } label: { Label("Reload Config", systemImage: "arrow.clockwise") }
             }
-            // View: font zoom (on the focused terminal), the status-bar toggle, and split / quick terminal /
-            // palettes. Every custom item carries an SF Symbol because the system "Enter Full Screen" item
-            // has one and reserves an icon column — without it they render as blank, indented slots.
+            // View: font zoom (on the focused terminal), the status-bar toggle, split / quick terminal /
+            // palettes. Every custom item needs an SF Symbol — the system "Enter Full Screen" item reserves
+            // an icon column, so an iconless one renders as a blank, indented slot.
             CommandGroup(after: .toolbar) {
-                // Mirror the File group's modal gate: zoom, dashboard, or the topmost native picker.
+                // the File group's modal gate, mirrored.
                 let zoomed = actions.terminalZoomActive
                 let pickActive = actions.pickActive(for: library.activeWindowID)
                 let modalActive = zoomed || (actions.frontmostDashboard?.isOpen ?? false) || pickActive
@@ -186,8 +179,8 @@ extension agtermApp {
                     .keyboardShortcut(shortcut(for: .decreaseFontSize))
                 Button { actions.resetFontSize() } label: { Label("Actual Size", systemImage: "textformat.size") }
                     .keyboardShortcut(shortcut(for: .resetFontSize))
-                // open the live-preview theme picker (the .themes palette). Keyless by default like Edit
-                // Keymap; rebindable via select_theme. The control half is theme.set / theme.list.
+                // open the live-preview theme picker (the .themes palette). keyless by default, rebindable
+                // via select_theme; the control half is theme.set / theme.list.
                 Button { actions.openThemePalette() } label: { Label("Select Theme…", systemImage: "paintpalette") }
                     .keyboardShortcut(shortcut(for: .selectTheme))
                     .disabled(modalActive)
@@ -198,17 +191,15 @@ extension agtermApp {
                 }
                 .keyboardShortcut(shortcut(for: .toggleSidebar))
                 .disabled(modalActive)
-                // expand every workspace / collapse all but the active one. plain (non-BuiltinAction)
-                // keyless items like Reload Keymap; disabled with no active store or in flagged mode
-                // (no workspace rows to expand/collapse). The control half is sidebar.expand/collapse.
+                // expand every workspace / collapse all but the active one. plain keyless items, disabled
+                // with no active store or in flagged mode (no workspace rows); control sidebar.expand/collapse.
                 let treeMode = library.activeStore?.sidebarMode == .tree
                 Button { actions.expandAllWorkspaces() } label: { Label("Expand Workspaces", systemImage: "chevron.down") }
                     .disabled(library.activeStore == nil || !treeMode || modalActive)
                 Button { actions.collapseOtherWorkspaces() } label: { Label("Collapse Workspaces", systemImage: "chevron.right") }
                     .disabled(library.activeStore == nil || !treeMode || modalActive)
-                // flip the sidebar between the workspace tree and the flat flagged working-set list. One
-                // 2-state item like the sidebar/scratch toggles, keyless by default (rebindable via
-                // toggle_flagged_view); the control half is sidebar.mode.
+                // flip the sidebar between the workspace tree and the flat flagged working-set list. one
+                // 2-state item, keyless by default (rebindable via toggle_flagged_view); control sidebar.mode.
                 let flaggedMode = library.activeStore?.sidebarMode == .flagged
                 // disabled (along with its shortcut) when there's nothing to show: tree mode + no flags.
                 // Enabled in flagged mode so it can always switch back to the tree.
@@ -227,8 +218,7 @@ extension agtermApp {
                 Button { actions.clearFlags() } label: { Label("Clear Flagged", systemImage: "flag.slash") }
                     .disabled(library.activeStore?.flaggedSessions.isEmpty ?? true || modalActive)
                 // collapse the tree to the current workspace's subtree (or unfocus when already focused).
-                // keyless by default (rebindable via focus_workspace). The control half is workspace.focus.
-                // the label tracks the toggle (Focus/Unfocus) like the workspace row's context-menu item.
+                // keyless, rebindable via focus_workspace; control workspace.focus. the label tracks the toggle.
                 let focusStore = library.activeStore
                 Button { actions.focusActiveWorkspace() } label: {
                     Label(focusStore?.isCurrentWorkspaceSoleFocus == true ? "Unfocus Workspace" : "Focus Workspace",
@@ -237,19 +227,17 @@ extension agtermApp {
                 .keyboardShortcut(shortcut(for: .focusWorkspace))
                 .disabled(focusStore?.currentWorkspaceID == nil || modalActive)
                 // the ADDITIVE sibling of Focus Workspace: mark the current workspace without dropping the
-                // other members, so a working set can be built from the menu. Plain (non-BuiltinAction)
-                // keyless item like Clear Focus below; control half workspace.focus add. Disabled once the
-                // workspace is already marked, where it would be a silent no-op (the row menu flips to
-                // "Remove from Focus" instead, having a clicked row). Membership is NOT gated on the sidebar
-                // mode here or in the palette (unlike Expand/Collapse above), matching the focus siblings.
+                // other members, so a working set can be built from the menu. plain keyless item; control
+                // workspace.focus add. disabled once the workspace is marked, where it would be a silent
+                // no-op (the row menu flips to "Remove from Focus", having a clicked row). membership is
+                // NOT gated on sidebar mode here or in the palette, matching its focus siblings.
                 Button { actions.addActiveWorkspaceToFocus() } label: {
                     Label("Add Workspace to Focus", systemImage: "square.grid.2x2")
                 }
                 .disabled(focusStore?.currentWorkspaceID == nil
                     || focusStore?.isCurrentWorkspaceFocusMember == true || modalActive)
-                // apply or suspend the filter without losing the marked set — the menu twin of the
-                // bottom-bar grid toggle, disabled in the same empty-set state (the store refuses to
-                // enable an empty set, so the item would be a no-op). The control half is workspace.filter.
+                // apply or suspend the filter without losing the marked set — the menu twin of the bottom-bar
+                // grid toggle, disabled on an empty set (the store refuses one); control workspace.filter.
                 Button { actions.toggleFocusFilter() } label: {
                     Label("Toggle Workspace Filter", systemImage: "square.grid.2x2")
                 }
@@ -270,8 +258,8 @@ extension agtermApp {
                 }
                 .keyboardShortcut(shortcut(for: .toggleScratch))
                 .disabled(library.activeStore?.activeSession == nil || modalActive)
-                // search the focused terminal's scrollback. data-driven shortcut (⌘F default) like the
-                // toggles above — no hardcoded literal; the bar's open/close toggle lives in onSearchStart.
+                // search the focused terminal's scrollback. data-driven shortcut (⌘F default), no hardcoded
+                // literal; the bar's open/close toggle lives in onSearchStart.
                 Button { actions.toggleSearch() } label: { Label("Find…", systemImage: "magnifyingglass") }
                     .keyboardShortcut(shortcut(for: .toggleSearch))
                     .disabled(library.activeStore?.activeSession == nil || modalActive)
@@ -281,18 +269,18 @@ extension agtermApp {
                 Button { actions.toggleTerminalZoom() } label: { Label("Toggle Terminal Zoom", systemImage: "arrow.up.left.and.arrow.down.right") }
                     .keyboardShortcut(shortcut(for: .toggleTerminalZoom))
                 Divider()
-                // native macOS full screen for the key window (⌃⌘F default, rebindable). Toggles: a second
-                // invocation exits. The green traffic-light button drives the same NSWindow.toggleFullScreen.
+                // native macOS full screen for the key window (⌃⌘F default, rebindable); a second invocation
+                // exits. the green traffic-light button drives the same NSWindow.toggleFullScreen.
                 Button { actions.toggleFullscreen() } label: {
                     Label("Toggle Full Screen", systemImage: "arrow.up.left.and.arrow.down.right")
                 }
                 .keyboardShortcut(shortcut(for: .toggleFullscreen))
             }
-            // a dedicated Navigate menu keeps the View menu scannable: moving the selection/focus between
+            // a dedicated Navigate menu keeps the View menu scannable: selection/focus movement between
             // sessions and split panes lives here, driving the SAME AppActions the View menu does, with the
             // control API / palette / keymap surfaces untouched.
             CommandMenu("Navigate") {
-                // Mirror the File/View modal gate: zoom, dashboard, or the topmost native picker.
+                // the File/View modal gate, mirrored.
                 let zoomed = actions.terminalZoomActive
                 let pickActive = actions.pickActive(for: library.activeWindowID)
                 let modalActive = zoomed || (actions.frontmostDashboard?.isOpen ?? false) || pickActive
@@ -310,15 +298,14 @@ extension agtermApp {
                     .disabled(modalActive)
                 Button { actions.toggleDashboard() } label: { Label("Dashboard", systemImage: "rectangle.split.2x2") }
                     .keyboardShortcut(shortcut(for: .dashboard))
-                    // Do not disable merely because the dashboard itself is open: ⌘⇧D remains its close
-                    // escape hatch. Zoom and a topmost native picker still block the toggle.
+                    // not disabled when the dashboard itself is open: ⌘⇧D remains its close escape hatch.
+                    // zoom and a topmost native picker still block the toggle.
                     .disabled(zoomed || pickActive)
                 Divider()
-                // step between sessions in the sidebar's flattened order. Prev/Next ride ⌥⌘↑/↓, NOT bare
-                // ⌘+arrows (which shadow text-field caret nav in the rename/palette/settings fields), and
-                // complement the ⌥⌘←/→ pane focus below (left/right = panes, up/down = sessions). First/Last
-                // get no key (menu + palette + control only). Real menu items, so AppKit menu dispatch
-                // swallows the shortcut before libghostty and nothing leaks to the shell.
+                // step between sessions in the sidebar's flattened order. prev/next ride ⌥⌘↑/↓, NOT bare
+                // ⌘+arrows (which shadow text-field caret nav in rename/palette/settings fields), and
+                // complement the ⌥⌘←/→ pane focus below. first/last get no key. real menu items, so AppKit
+                // menu dispatch swallows the shortcut before libghostty and nothing leaks to the shell.
                 Button { actions.selectPreviousSession() } label: { Label("Previous Session", systemImage: "chevron.up") }
                     .keyboardShortcut(shortcut(for: .previousSession))
                     .disabled(library.activeStore?.activeSession == nil || modalActive)
@@ -363,9 +350,8 @@ extension agtermApp {
             }
     }
 
-    /// Opens the standard About panel, enriched with a clickable agterm.com link and — on release
-    /// builds, where `GIT_COMMIT` is baked into the bundle — the short build commit shown in the
-    /// version's parenthetical. Dev builds (no baked commit) fall back to the plain version.
+    /// Opens the standard About panel with a clickable agterm.com link and, on release builds where
+    /// `GIT_COMMIT` is baked into the bundle, the short commit in the version's parenthetical.
     private func showAboutPanel() {
         var options: [NSApplication.AboutPanelOptionKey: Any] = [:]
         let website = "https://agterm.com"

--- a/agterm/agtermApp+Menus.swift
+++ b/agterm/agtermApp+Menus.swift
@@ -3,20 +3,18 @@ import AppKit
 import SwiftUI
 
 extension agtermApp {
-    /// The active SwiftUI shortcut for a built-in action, driven by the keymap: the user override when
-    /// one is `map`ped, else the action's shipped default. `nil` only for a keyless action, which stays
-    /// keyless until the user maps a chord.
-    /// `keymap` is `@Observable`, but SwiftUI does not rebuild the menu when it changes — it defers to the
-    /// next app activation, so a reload leaves the live key equivalents stale until then.
-    /// ⌘W is asserted from AppKit instead, by `AppDelegate.applyCloseSessionChord`.
+    /// The active SwiftUI shortcut for a built-in action, driven by the keymap: the user override when one
+    /// is `map`ped, else the shipped default; `nil` only for a keyless action, until the user maps a chord.
+    /// `keymap` is `@Observable`, but SwiftUI defers its menu rebuild to the next app activation, so a reload
+    /// leaves the live key equivalents stale until then. ⌘W is asserted from AppKit instead, by
+    /// `AppDelegate.applyCloseSessionChord`.
     private func shortcut(for action: BuiltinAction) -> KeyboardShortcut? {
         settingsModel.keymap.equivalent(for: action).map(Self.toShortcut)
     }
 
-    /// Map a host-free `Chord` to a SwiftUI `KeyboardShortcut`. The base key is a single printable
-    /// character (`Character`) or one of the named keys the grammar allows (`tab`/`space`/`return`/
-    /// `delete` and the four arrows); the modifiers map one-for-one. This is the menu-side mirror of the
-    /// runner's `NSEvent`→`Chord` mapping.
+    /// Map a host-free `Chord` to a SwiftUI `KeyboardShortcut` — the menu-side mirror of the runner's
+    /// `NSEvent`→`Chord` mapping. The base key is a single printable `Character` or a named key the grammar
+    /// allows (`tab`/`space`/`return`/`delete` and the four arrows); the modifiers map one-for-one.
     private static func toShortcut(_ chord: Chord) -> KeyboardShortcut {
         let key: KeyEquivalent
         switch chord.key {
@@ -45,23 +43,18 @@ extension agtermApp {
 
     @CommandsBuilder
     var appCommands: some Commands {
-            // App menu: replace the default "About Agterm" with one that opens the standard
-            // panel enriched with a clickable repo link and, on release builds, the build commit.
             CommandGroup(replacing: .appInfo) {
                 Button("About Agterm") { showAboutPanel() }
             }
-            // Edit: drop SwiftUI's stock Undo/Redo. agterm registers no NSUndoManager, so they are dead for
-            // the terminal, and the ⌘Z they advertise is already owned by File ▸ Reopen Closed Item
-            // (`BuiltinAction.undoClose`), whose menu precedes Edit and wins the key-equivalent search — the
-            // Undo item could only ever be CLICKED, never invoked by its own shortcut. The one place AppKit
-            // enabled it was the sidebar's inline rename field (its field editor supplies an undo manager),
-            // too narrow to justify a permanently-greyed item that duplicates another menu's shortcut.
-            // The rest of the Edit menu stays stock: Cut/Copy/Paste/Delete/Select All share the `.pasteboard`
-            // group, and replacing that would take ⌘C/⌘V/⌘A away from the text fields that need them.
+            // drop SwiftUI's stock Undo/Redo: agterm registers no NSUndoManager, and the ⌘Z they advertise is
+            // owned by File ▸ Reopen Closed Item (`BuiltinAction.undoClose`), whose menu precedes Edit and
+            // wins the key-equivalent search — so Undo could only ever be CLICKED. AppKit enabled it only in
+            // the sidebar's inline rename field (its field editor supplies an undo manager), too narrow to
+            // keep a permanently-greyed duplicate. The rest stays stock: Cut/Copy/Paste/Delete/Select All
+            // share the `.pasteboard` group, and replacing it takes ⌘C/⌘V/⌘A from the text fields needing them.
             CommandGroup(replacing: .undoRedo) {}
-            // File: replace the default "New" group with all of agterm's creation/management actions,
-            // grouped by entity into three sections — Window, then Workspace, then Session. The
-            // system Close / Close All commands stay below in their own group.
+            // File: replace the default "New" group with agterm's creation/management actions, grouped by
+            // entity into Window, Workspace, Session. System Close / Close All stay below in their own group.
             CommandGroup(replacing: .newItem) {
                 // While terminal zoom, the dashboard grid, OR the topmost native picker is up, the UI is modal
                 // (the AppActions gate already no-ops these). `.disabled` mirrors that gate so items read as
@@ -109,8 +102,7 @@ extension agtermApp {
                     .disabled(library.activeStore?.canRemoveWorkspace != true || modalActive)
 
                 Divider()
-                // Session. Open Directory… opens a new session rooted at a chosen folder; Close
-                // Session is terminal-style ⌘W (closes the active session, or the window when none).
+                // Session.
                 Button("New Session") { actions.newSession() }
                     .keyboardShortcut(shortcut(for: .newSession))
                     .disabled(modalActive)
@@ -180,10 +172,9 @@ extension agtermApp {
                 // malformed file. Keyless, like Reload Keymap.
                 Button { actions.reloadGhosttyConfig() } label: { Label("Reload Config", systemImage: "arrow.clockwise") }
             }
-            // View: font zoom (drives ghostty on the focused terminal), the status-bar toggle, and
-            // split / quick terminal / palettes. The menu reserves an icon column because the system
-            // "Enter Full Screen" item has an icon, so every custom item carries an SF Symbol too —
-            // otherwise they render as blank, indented slots.
+            // View: font zoom (on the focused terminal), the status-bar toggle, and split / quick terminal /
+            // palettes. Every custom item carries an SF Symbol because the system "Enter Full Screen" item
+            // has one and reserves an icon column — without it they render as blank, indented slots.
             CommandGroup(after: .toolbar) {
                 // Mirror the File group's modal gate: zoom, dashboard, or the topmost native picker.
                 let zoomed = actions.terminalZoomActive
@@ -215,9 +206,9 @@ extension agtermApp {
                     .disabled(library.activeStore == nil || !treeMode || modalActive)
                 Button { actions.collapseOtherWorkspaces() } label: { Label("Collapse Workspaces", systemImage: "chevron.right") }
                     .disabled(library.activeStore == nil || !treeMode || modalActive)
-                // flip the sidebar between the workspace tree and the flat flagged working-set list.
-                // single 2-state item like the sidebar/scratch toggles; keyless by default (rebindable
-                // via toggle_flagged_view). The control half is sidebar.mode.
+                // flip the sidebar between the workspace tree and the flat flagged working-set list. One
+                // 2-state item like the sidebar/scratch toggles, keyless by default (rebindable via
+                // toggle_flagged_view); the control half is sidebar.mode.
                 let flaggedMode = library.activeStore?.sidebarMode == .flagged
                 // disabled (along with its shortcut) when there's nothing to show: tree mode + no flags.
                 // Enabled in flagged mode so it can always switch back to the tree.
@@ -247,11 +238,10 @@ extension agtermApp {
                 .disabled(focusStore?.currentWorkspaceID == nil || modalActive)
                 // the ADDITIVE sibling of Focus Workspace: mark the current workspace without dropping the
                 // other members, so a working set can be built from the menu. Plain (non-BuiltinAction)
-                // keyless item like Clear Focus below. The control half is workspace.focus add. Disabled
-                // once the current workspace is already marked — it would be a silent no-op (the row menu
-                // flips to "Remove from Focus" instead, which it can do because it has a clicked row).
-                // Membership is NOT gated on the sidebar mode here or in the palette (unlike Expand/Collapse
-                // Workspaces above), matching the focus siblings and the control modes.
+                // keyless item like Clear Focus below; control half workspace.focus add. Disabled once the
+                // workspace is already marked, where it would be a silent no-op (the row menu flips to
+                // "Remove from Focus" instead, having a clicked row). Membership is NOT gated on the sidebar
+                // mode here or in the palette (unlike Expand/Collapse above), matching the focus siblings.
                 Button { actions.addActiveWorkspaceToFocus() } label: {
                     Label("Add Workspace to Focus", systemImage: "square.grid.2x2")
                 }
@@ -299,9 +289,8 @@ extension agtermApp {
                 .keyboardShortcut(shortcut(for: .toggleFullscreen))
             }
             // a dedicated Navigate menu keeps the View menu scannable: moving the selection/focus between
-            // existing sessions and split panes lives here — the palettes that jump to a session/command,
-            // the spatial session stepping, and the pane focus. all drive the SAME AppActions the View items
-            // did; only their menu home changed (the control API / palette / keymap surfaces are untouched).
+            // sessions and split panes lives here, driving the SAME AppActions the View menu does, with the
+            // control API / palette / keymap surfaces untouched.
             CommandMenu("Navigate") {
                 // Mirror the File/View modal gate: zoom, dashboard, or the topmost native picker.
                 let zoomed = actions.terminalZoomActive
@@ -325,11 +314,11 @@ extension agtermApp {
                     // escape hatch. Zoom and a topmost native picker still block the toggle.
                     .disabled(zoomed || pickActive)
                 Divider()
-                // step between sessions in the sidebar's flattened order. Prev/Next ride ⌥⌘↑/↓ (NOT bare
-                // ⌘+arrows, which shadow text-field caret nav in the rename/palette/settings fields); ⌥⌘↑/↓
-                // sessions complements the ⌥⌘←/→ pane focus below (left/right = panes, up/down = sessions).
-                // First/Last get no key (menu + palette + control only). Real menu items so AppKit menu
-                // dispatch swallows the shortcut before libghostty — never leaked to the shell.
+                // step between sessions in the sidebar's flattened order. Prev/Next ride ⌥⌘↑/↓, NOT bare
+                // ⌘+arrows (which shadow text-field caret nav in the rename/palette/settings fields), and
+                // complement the ⌥⌘←/→ pane focus below (left/right = panes, up/down = sessions). First/Last
+                // get no key (menu + palette + control only). Real menu items, so AppKit menu dispatch
+                // swallows the shortcut before libghostty and nothing leaks to the shell.
                 Button { actions.selectPreviousSession() } label: { Label("Previous Session", systemImage: "chevron.up") }
                     .keyboardShortcut(shortcut(for: .previousSession))
                     .disabled(library.activeStore?.activeSession == nil || modalActive)

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -29,7 +29,7 @@ struct agtermApp: App {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
 
     /// Hosted XCTest loads the real executable before `setUp`, so its scheme sets isolated state/socket paths
-    /// plus this sentinel pre-`init()`; the scene then mounts a shell-free placeholder — no surfaces, no server.
+    /// plus this sentinel pre-`init()`; the scene then mounts a placeholder — no surfaces, no server.
     static var isHostedUnitTest: Bool {
         ProcessInfo.processInfo.environment["AGTERM_HOSTED_TESTS"] == "1"
     }
@@ -39,8 +39,8 @@ struct agtermApp: App {
         _library = State(initialValue: library)
         let actions = AppActions(library: library)
         _actions = State(initialValue: actions)
-        // settings persist alongside the workspace snapshot (same AGTERM_STATE_DIR override), built before
-        // the control server so it can drive `keymap.reload` — both depend only on the library, so safe.
+        // settings persist alongside the workspace snapshot (same AGTERM_STATE_DIR override); built before the
+        // control server so it can drive `keymap.reload`, safe since both need only the library.
         let settingsStore = ProcessInfo.processInfo.environment["AGTERM_STATE_DIR"]
             .map { SettingsStore(directory: URL(fileURLWithPath: $0, isDirectory: true)) } ?? SettingsStore()
         let settingsModel = SettingsModel(library: library, settingsStore: settingsStore)
@@ -50,24 +50,21 @@ struct agtermApp: App {
         _sessionSwitcher = State(initialValue: SessionSwitcher(library: library, canSwitch: { actions.uiActionsEnabled }))
         _paneShortcuts = State(initialValue: PaneShortcuts(library: library, actions: actions))
         _undoCloseShortcut = State(initialValue: UndoCloseShortcut(actions: actions))
-        // the custom-command runner needs the keymap (settings) and the bound socket path (control
-        // server) for the `{AGT_SOCKET}` token; built last so both are available.
+        // built last: needs the keymap (settings) and the control server's bound socket path for `{AGT_SOCKET}`.
         _customCommandRunner = State(initialValue: CustomCommandRunner(
             library: library, settings: settingsModel,
             socketProvider: { controlServer.resolvedSocketPath }))
-        // follows the macOS light/dark appearance via an app-level KVO observer on NSApp.effectiveAppearance;
-        // no dependencies, started in `.task`.
+        // follows macOS light/dark via KVO on NSApp.effectiveAppearance; dependency-free, started in `.task`.
         _appearanceObserver = State(initialValue: SystemAppearanceObserver())
-        // follows Reduce Motion / Reduce Transparency through NSWorkspace's accessibility display
-        // notification and fans live changes out to AppKit consumers. SwiftUI consumers use Environment.
+        // follows Reduce Motion / Reduce Transparency via NSWorkspace's accessibility-display notification,
+        // fanning live changes to AppKit consumers; SwiftUI ones use Environment.
         _accessibilityObserver = State(initialValue: SystemAccessibilityObserver())
     }
 
     var body: some Scene {
-        // a plain WindowGroup auto-opens one window at launch plus one per `openWindow(id:)`; a value-based
-        // `WindowGroup(for:)` does NOT auto-open at launch with SwiftUI restoration off, so it can't
-        // bootstrap the first window. `WindowLibrary` owns the open-set: each appearing window claims the
-        // next open id from its claim queue (dedup-by-id), and a window beyond the open set dismisses itself.
+        // a plain WindowGroup auto-opens one window at launch plus one per `openWindow(id:)`; value-based
+        // `WindowGroup(for:)` can't bootstrap the first (no auto-open with SwiftUI restoration off). windows
+        // claim the next open id off `WindowLibrary`'s claim queue (dedup-by-id); one past the set dismisses itself.
         WindowGroup(id: Self.windowGroupID) {
             if Self.isHostedUnitTest {
                 Color.clear
@@ -84,8 +81,8 @@ struct agtermApp: App {
                     },
                     makeOverlaySurface: { Self.makeOverlaySurface(for: $0, store: $1, env: surfaceEnv(for: $0)) },
                     makeScratchSurface: { session, store in
-                        // suppress the scratch's creation autoFocus when a full overlay OR this window's quick
-                        // terminal is already up — each renders above the scratch and owns focus.
+                        // suppress the scratch's creation autoFocus when a full overlay or this window's quick
+                        // terminal is up — each renders above it and owns focus.
                         let qtVisible = library.windowID(forSession: session.id)
                             .flatMap { QuickTerminalRegistry.shared.controller(for: $0) }?.isVisible ?? false
                         return Self.makeScratchSurface(for: session, store: store,
@@ -101,77 +98,73 @@ struct agtermApp: App {
                     .frame(minWidth: 640, minHeight: 400)
                     .task {
                         appDelegate.library = library
-                        // the scene's `openWindow` is reachable only here, so hand it to the action hub — a
-                        // cross-window reveal reopens a banner-clicked closed window, `window.new`/`window.select`
-                        // open one (raise if on-screen, else claim the id + spawn). Installed BEFORE the control
-                        // server starts, or an early socket command finds it nil and returns ok with no window.
+                        // `openWindow` lives only in the scene: hand it to the action hub for cross-window
+                        // reveal and `window.new`/`window.select` (raise if on-screen, else claim + spawn).
+                        // MUST precede `controlServer.start()`, or an early command finds it nil: ok, no window.
                         actions.openWindow = { id in
                             if WindowRegistry.shared.raise(id) { return }
                             library.enqueueClaim(id)
                             openWindow(id: Self.windowGroupID)
                         }
-                        // start the control channel (idempotent); the delegate reference lets it stop + unlink
-                        // the socket on terminate.
+                        // start the control channel (idempotent); the delegate reference stops it + unlinks the
+                        // socket on terminate.
                         appDelegate.controlServer = controlServer
                         controlServer.start()
-                        // install the Ctrl-Tab session-switcher key monitors (idempotent).
+                        // Ctrl-Tab session-switcher key monitors (idempotent).
                         sessionSwitcher.start()
-                        // install the Ctrl-1/Ctrl-2 direct pane-focus key monitor (idempotent).
+                        // Ctrl-1/Ctrl-2 direct pane-focus key monitor (idempotent).
                         paneShortcuts.start()
-                        // install the undo-close shortcut (idempotent); it passes through text fields so
-                        // native edit undo still wins there.
+                        // undo-close shortcut (idempotent); passes through text fields so native undo wins there.
                         undoCloseShortcut.start()
-                        // install the custom-command key monitor (idempotent); it rebuilds its matcher from the
-                        // keymap on `.agtermKeymapChanged`, and the delegate reference removes it on terminate.
+                        // custom-command key monitor (idempotent): rebuilds its matcher from the keymap on
+                        // `.agtermKeymapChanged`, removed on terminate via the delegate reference.
                         appDelegate.customCommandRunner = customCommandRunner
                         appDelegate.settingsModel = settingsModel
-                        // hand the delegate the action hub and drain any folders an `open -a agterm /path`
-                        // queued before the window store resolved.
+                        // hand the delegate the action hub and drain folders `open -a agterm /path` queued
+                        // before the window store resolved.
                         appDelegate.actions = actions
                         appDelegate.drainPendingOpenDirectories()
                         customCommandRunner.start()
-                        // wire the keymap + runner into the action hub so the command palette can list and run
-                        // custom commands; both are built after `actions`, so they're set here, not in `init`.
+                        // wire the keymap + runner into the action hub for the command palette's custom
+                        // commands; both are built after `actions`, so not in `init`.
                         actions.settingsModel = settingsModel
-                        // seed auto-follow into every open window's store now the model is wired: idempotent and
-                        // order-independent of resolveStore/onAppear (windows opened later seed in resolveStore).
+                        // seed auto-follow into every open store now the model is wired: idempotent and
+                        // order-independent of resolveStore/onAppear (later windows seed in resolveStore).
                         settingsModel.applyAutoFollowToAllWindows()
                         actions.customCommandRunner = customCommandRunner
                         // the action hub opens the .themes palette for the "Select Theme…" launcher + menu.
                         actions.palette = palette
                         // register the notification delegate + request authorization (idempotent); the hub +
-                        // library let a banner click reach the firing pane and stamp its window id into the identity.
+                        // library let a banner click reach the firing pane and stamp its window id in.
                         NotificationManager.shared.actions = actions
                         NotificationManager.shared.library = library
                         NotificationManager.shared.start()
-                        // drive the Dock icon's count badge (via UNUserNotifications) from the app-wide unseen
-                        // total (the same Session.unseenCount the sidebar pills track, summed across windows).
+                        // drive the Dock badge (via UNUserNotifications) from the app-wide unseen total — the
+                        // sidebar pills' Session.unseenCount summed across windows.
                         DockBadgeController.shared.library = library
                         DockBadgeController.shared.start()
-                        // surface keymap parse errors / conflicts loaded at SettingsModel init — too early to post
-                        // then, before the notification registration above. Launch window only: `hasReopened` is
-                        // still false in the first window's `.task` (`reopenWindows()` flips it), so no reposts.
+                        // keymap parse errors / conflicts from SettingsModel init — too early to post then,
+                        // before registration. launch window only: `hasReopened` is false until `reopenWindows()`.
                         if !library.hasReopened, !settingsModel.keymapDiagnostics.isEmpty {
                             NotificationManager.shared.notifyKeymapDiagnostics(count: settingsModel.keymapDiagnostics.count)
                         }
-                        // same for ghostty config diagnostics, recorded by GhosttyApp.loadConfig at boot
-                        // (applicationDidFinishLaunching, before notification registration): same `hasReopened` gate.
+                        // same for ghostty config diagnostics, recorded at boot by GhosttyApp.loadConfig
+                        // (applicationDidFinishLaunching, before registration): same `hasReopened` gate.
                         if !library.hasReopened, GhosttyApp.shared.lastConfigDiagnosticsCount > 0 {
                             NotificationManager.shared.notifyConfigDiagnostics(count: GhosttyApp.shared.lastConfigDiagnosticsCount)
                         }
                         // runs once via the library latch — the .task fires per window.
                         reopenWindows()
                         appDelegate.scheduleRestoredWindowReconciliation(reason: "scene-task")
-                        // start following the macOS appearance last: `[.initial]` seeds the launch side once
-                        // the eager-deck surfaces exist (idempotent, so per-window `.task` re-entry is safe).
+                        // start appearance following last: `[.initial]` seeds the launch side once the
+                        // eager-deck surfaces exist; idempotent, so per-window `.task` re-entry is safe.
                         appearanceObserver.start()
                         // consumers read current accessibility values at first render; this handles live flips.
                         accessibilityObserver.start()
                     }
             }
         }
-        // chromeless: no system title bar (the traffic lights float over our custom titlebar row in
-        // ContentView), so there's no empty title-bar strip above our header.
+        // chromeless: traffic lights float over ContentView's custom titlebar row, so no empty strip above it.
         .windowStyle(.hiddenTitleBar)
         .defaultSize(width: 900, height: 600)
         .windowResizability(.contentMinSize)
@@ -182,9 +175,8 @@ struct agtermApp: App {
         }
     }
 
-    /// Builds the app-global window library rooted at the state directory. Its bootstrap runs
-    /// migration/recovery (legacy `workspaces.json` → one window, else seed), so the window set is always
-    /// valid and non-empty. UI tests set `AGTERM_STATE_DIR` to a temp dir, never touching the real state.
+    /// Builds the app-global window library at the state directory — `AGTERM_STATE_DIR`, a temp dir under UI test.
+    /// Bootstrap migrates/recovers (legacy `workspaces.json` → one window, else seed): always valid, non-empty.
     @MainActor
     private static func restoredLibrary() -> WindowLibrary {
         ProcessInfo.processInfo.environment["AGTERM_STATE_DIR"]
@@ -200,21 +192,19 @@ struct agtermApp: App {
         for _ in 0..<extra { openWindow(id: Self.windowGroupID) }
     }
 
-    /// Surface factory: a libghostty-backed view for the session, spawning a login shell in its initial
-    /// working directory. On shell exit the view calls back to close the owning session in the store.
+    /// Surface factory: a libghostty-backed view for the session, spawning a login shell in its initial working
+    /// directory. On shell exit the view calls back to close the owning session in the store.
     @MainActor
     private static func makeSurface(for session: Session, store: AppStore, env: [String: String],
                                     library: WindowLibrary) -> GhosttySurfaceView {
-        // `initialCommand` (`session.new --command`) runs as the surface's process instead of the login shell;
-        // `onExit` below then closes the single session on its exit, like kitty. It is the durable creation
-        // identity, re-emitted by every `snapshot()`, while `foregroundCommand` — a distinct child captured at
-        // quit — is consumed run-once here. A command that exec-replaces the shell is invisible to libghostty's
-        // foreground pid (nil), so it is never captured and restores via the exec `command` path, keeping
-        // close-on-exit. Precedence (fresh always runs, restored honors the toggle, a captured foreground
-        // preempts `initialCommand` even when denylist-suppressed) is the host-free `CommandRestore.restorePlan`.
-        // A `session.restore` override beats both: taken from the TRANSIENT pending slot (seeded only by an
-        // app-bootstrap restore), never the sticky persisted field, and taking it clears it so a second surface
-        // for this pane runs a plain shell.
+        // `initialCommand` (`session.new --command`) replaces the login shell and closes the session on its exit
+        // (like kitty); it is the durable creation identity, re-emitted by every `snapshot()`. `foregroundCommand`,
+        // a distinct child captured at quit, is consumed run-once; an exec-replacing command has a nil libghostty
+        // foreground pid, so it is never captured and restores via the exec `command` path, keeping close-on-exit.
+        // Precedence is host-free `CommandRestore.restorePlan`: fresh always runs, restored honors the toggle, a
+        // captured foreground preempts `initialCommand` even when denylist-suppressed. A `session.restore` override
+        // beats both, from the TRANSIENT pending slot (only an app-bootstrap restore seeds it) not the sticky
+        // persisted field; taking it clears it, so this pane's next surface is a plain shell.
         let hadForeground = session.foregroundCommand != nil
         let restoreInput = Self.restoreInitialInput(session.foregroundCommand)
         session.foregroundCommand = nil
@@ -240,8 +230,8 @@ struct agtermApp: App {
             store.clearUnseen(sessionID)
             NotificationManager.shared.clearDelivered(sessionID: sessionID)
         }
-        // the focus-free half of the clear above, for the zoom-hosted case where the focus report is
-        // suppressed but the refocused user is looking at exactly this surface.
+        // focus-free half of the clear above: zoom hosting suppresses the focus report though the refocused
+        // user is looking right at this surface.
         view.onClearUnseen = {
             store.clearUnseen(sessionID)
             NotificationManager.shared.clearDelivered(sessionID: sessionID)
@@ -253,26 +243,24 @@ struct agtermApp: App {
         return view
     }
 
-    /// Shell-exit handler for BOTH pane factories, dispatched on the surface's CURRENT role rather than the
-    /// factory that built it: a promoted split survivor (built by `makeSplitSurface`, moved into the main slot
-    /// with `isSplitPane` cleared) must run `closePrimaryPane` on its own exit, or a re-split then a main-pane
-    /// exit fires the stale `closeSplitPane`, whose guard now passes (both slots live), tearing down the fresh
-    /// right pane and stranding the session on the dead left one. Role-aware like `onFocusChange`.
+    /// Shell-exit handler for BOTH pane factories, dispatched on the surface's CURRENT role, not the factory that
+    /// built it (role-aware like `onFocusChange`): a promoted split survivor (main slot, `isSplitPane` cleared) must
+    /// run `closePrimaryPane`, or a re-split then a main-pane exit fires the stale `closeSplitPane` — its guard now
+    /// passes with both slots live — tearing down the fresh right pane, stranding the session on the dead left.
     @MainActor
     private static func handlePaneExit(_ view: GhosttySurfaceView, store: AppStore, sessionID: UUID) {
         if view.isSplitPane {
             store.closeSplitPane(sessionID)
         } else {
             store.closePrimaryPane(sessionID)
-            // makeSplitSurface omits onFontSizeChange, but a promoted survivor is now the sole pane and must
-            // persist its own cmd +/- like a primary. no-op when the session closed instead (`surface` nil).
+            // makeSplitSurface omits onFontSizeChange, but a promoted survivor is the sole pane and must persist
+            // its own cmd +/-. no-op when the session closed instead (`surface` nil).
             if let promoted = store.session(withID: sessionID)?.surface as? GhosttySurfaceView {
                 promoted.onFontSizeChange = { store.setFontSize(sessionID, $0) }
             }
         }
-        // focus the surviving (now maximized) pane, else the session reselected to when the whole session
-        // closed; the collapse/switch re-hosts the target, hence the retry. `topmostSurface` hands focus to
-        // an overlay/scratch cover rather than to the pane it hides.
+        // focus the surviving (now maximized) pane, else the session reselected to; the collapse/switch re-hosts
+        // the target, hence the retry. `topmostSurface` prefers an overlay/scratch cover over the pane it hides.
         let target = store.session(withID: sessionID)?.topmostSurface ?? store.activeSession?.topmostSurface
         (target as? GhosttySurfaceView)?.focusAfterReparent()
     }
@@ -287,13 +275,12 @@ struct agtermApp: App {
         return CommandRestore.shellQuotedLine(argv) + "\n"
     }
 
-    /// Wires the four `onSearch*` callbacks to the owning session's search fields, resolved live via
-    /// `sessionID`. START toggles: with the bar already open it sends `end_search` (the ⌘F-again close) and
-    /// lets the resulting END clear; else it opens the bar (`searchActive = true`, seeding any returned needle)
-    /// and pins THIS surface as `searchSurface`, the owner the bar's needle/navigate/close drive. END is the
-    /// single clear point — fields, owner, bar, and first responder back to the session's visible terminal.
-    /// TOTAL/SELECTED carry the match count/index. Shared by both factories, so the GUI and control channel
-    /// pin the owner identically.
+    /// Wires the four `onSearch*` callbacks to the owning session's search fields, resolved live via `sessionID`.
+    /// START toggles: with the bar open it sends `end_search` (the ⌘F-again close), letting the resulting END
+    /// clear; else it opens the bar (seeding any returned needle) and pins THIS surface as `searchSurface`, the
+    /// owner the bar's needle/navigate/close drive. END is the single clear point — fields, owner, bar, and first
+    /// responder back to the visible terminal. TOTAL/SELECTED carry the count/index; both factories share it, so
+    /// GUI and control pin the owner alike.
     @MainActor
     private static func wireSearchCallbacks(_ view: GhosttySurfaceView, store: AppStore, sessionID: UUID,
                                             library: WindowLibrary) {
@@ -301,9 +288,8 @@ struct agtermApp: App {
         view.onSearchStart = { [weak view] needle in
             guard let session = store.session(withID: sessionID) else { return }
             if session.searchActive {
-                // ⌘F-again close: end search on the PINNED owner (the surface START first fired on), not the
-                // just-fired `view`, so a second ⌘F on the OTHER split pane closes the original owner instead
-                // of stranding it in libghostty search mode. the resulting END clears the fields and refocuses.
+                // ⌘F-again close: end search on the PINNED owner, not the just-fired `view`, so a second ⌘F on
+                // the OTHER split pane closes the original owner instead of stranding it in libghostty search.
                 (session.searchSurface as? GhosttySurfaceView)?.endSearch()
                 return
             }
@@ -318,22 +304,21 @@ struct agtermApp: App {
             session.searchTotal = nil
             session.searchSelected = nil
             session.searchSurface = nil
-            // refocus the terminal ONLY while this is still the selected session and no cover is up: a
-            // `session.search --close --target <background>` closes a hidden, opacity-0 surface whose first
-            // responder would steal input from the visible session (hidden views CAN become first responder),
-            // and a cover owns focus itself. `topmostSurface` catches the in-deck overlay/scratch (overlay >
-            // scratch > active pane); the window-level quick terminal does not, so bail while it is up — it
-            // restores the session on its own hide. the bounded retry re-asserts past the SwiftUI teardown.
+            // refocus ONLY while this is still the selected session and no cover is up: `session.search --close
+            // --target <background>` would otherwise make a hidden, opacity-0 surface first responder and steal
+            // input from the visible session (hidden views CAN), and a cover owns focus. `topmostSurface` catches
+            // the in-deck overlay/scratch (overlay > scratch > active pane) but not the window-level quick
+            // terminal, so bail while that is up — it refocuses on hide; the retry outlasts the SwiftUI teardown.
             guard store.selectedSessionID == sessionID else { return }
             let windowID = library.windowID(forSession: sessionID)
             let quickTerminalVisible = windowID
                 .flatMap { QuickTerminalRegistry.shared.controller(for: $0) }?.isVisible ?? false
             guard !quickTerminalVisible else { return }
-            // terminal zoom owns focus above the deck, and zoom-enter itself ends an open search — this END
-            // lands a tick later, so refocusing here would steal first responder back from the zoomed terminal.
+            // terminal zoom owns focus above the deck and zoom-enter ends an open search; this END lands a tick
+            // later, so refocusing would steal first responder back from the zoomed terminal.
             guard windowID.flatMap({ TerminalZoomRegistry.shared.controller(for: $0) })?.target == nil else { return }
             // a control picker is the topmost modal: `session.search --to close` stays valid cleanup while one
-            // is pending, but its asynchronous END must not return focus behind the picker.
+            // is pending, but its async END must not return focus behind it.
             guard PickRegistry.shared.controller(for: windowID)?.pending == nil else { return }
             (session.topmostSurface as? GhosttySurfaceView)?.focusAfterReparent()
         }
@@ -341,13 +326,12 @@ struct agtermApp: App {
         view.onSearchSelected = { selected in store.session(withID: sessionID)?.searchSelected = selected }
     }
 
-    /// Wires the pane-scoped keystroke-clear: `keyDown` fires `onUserInputClearsStatus` unconditionally, and
-    /// this closure resets the status to idle only when the host-free `AgentIndicator.clearedBy(pane:isInterrupt:)`
-    /// says the keystroke's OWN pane owns it, so a block set from a background pane survives typing elsewhere.
-    /// Main/split resolve the pane from the surface's LIVE `isSplitPane` at keystroke time, not statically: a
-    /// promoted split survivor then clears as `.left`, matching its migrated status identity and `tree`
-    /// addressing, where a captured `.right` would clear the wrong pane and a re-split would leave both panes
-    /// `.right`-wired. The scratch passes `fixedPane: .scratch` — never promoted, and it has no `view.session`.
+    /// Wires the pane-scoped keystroke-clear: `keyDown` fires `onUserInputClearsStatus` unconditionally, and this
+    /// closure clears to idle only when host-free `AgentIndicator.clearedBy(pane:isInterrupt:)` says the keystroke's
+    /// OWN pane owns the status, so a block set from a background pane survives typing elsewhere. Main/split read
+    /// the LIVE `isSplitPane` at keystroke time, so a promoted survivor clears as `.left`, matching its migrated
+    /// status identity and `tree` addressing; a captured `.right` would clear the wrong pane and leave both panes
+    /// `.right`-wired after a re-split. The scratch passes `fixedPane: .scratch`: never promoted, no `view.session`.
     @MainActor
     private static func wireStatusClear(_ view: GhosttySurfaceView, store: AppStore, sessionID: UUID,
                                         fixedPane: StatusPane? = nil) {
@@ -359,20 +343,19 @@ struct agtermApp: App {
         }
     }
 
-    /// Split-pane surface factory: a second independent login shell in the session's current directory. Wired
-    /// as `isSplitPane`, so its PWD/title reports go to `session.splitCwd`/`splitTitle` instead of the
-    /// primary's, and on shell exit it closes just the split (hide + teardown), not the whole session.
+    /// Split-pane surface factory: a second independent login shell in the session's current directory, wired as
+    /// `isSplitPane` so its PWD/title reports go to `session.splitCwd`/`splitTitle` and its shell exit closes
+    /// just the split (hide + teardown), not the session.
     @MainActor
     private static func makeSplitSurface(for session: Session, store: AppStore, env: [String: String],
                                          library: WindowLibrary) -> GhosttySurfaceView {
-        // cwd from the persisted `initialSplitCwd`, so a restored split keeps its own directory, else the
-        // session's effectiveCwd for a fresh one. Font size matches the primary; its own cmd +/- is not
-        // persisted. Env inherits the parent's window/workspace/session ids. The captured foreground command
-        // re-runs via initial_input (consumed run-once); splits never carry an `initialCommand`, so there is
-        // no mutual-exclusion guard and no `restorePlan` — `restoreInput` alone decides. A `session.restore`
-        // override wins over the capture, taken from the TRANSIENT pending slot (seeded only by an
-        // app-bootstrap restore whose split was shown) not the sticky persisted field, and taking it clears
-        // it: this factory runs again for a fresh ⌘D split after a split shell exits, which must be a shell.
+        // cwd is the persisted `initialSplitCwd` (a restored split keeps its own directory), else the session's
+        // effectiveCwd. Font size matches the primary; the split's own cmd +/- is not persisted. Env inherits the
+        // parent's window/workspace/session ids. The captured foreground command re-runs via initial_input
+        // (run-once); splits never carry an `initialCommand`, so there is no mutual-exclusion guard and no
+        // `restorePlan` — `restoreInput` alone decides. A `session.restore` override wins over the capture, from
+        // the TRANSIENT pending slot (seeded only by an app-bootstrap restore whose split was shown) not the
+        // sticky persisted field; taking it clears it, so a fresh ⌘D split after a split shell exits is a shell.
         let capturedInput = Self.restoreInitialInput(session.splitForegroundCommand)
         session.splitForegroundCommand = nil
         let restoreInput = CommandRestore.restoreInput(restoreEnabled: GhosttyApp.shared.restoreRunningCommand,
@@ -406,14 +389,13 @@ struct agtermApp: App {
         return view
     }
 
-    /// The fixed wrapper that runs the overlay command and records its exit status to a temp file.
-    /// stdout/stderr are NOT redirected (so a TUI renders normally); only the status is captured.
+    /// The fixed wrapper running the overlay command and recording its exit status to a temp file. stdout/stderr
+    /// are NOT redirected (so a TUI renders normally); only the status is captured.
     private static let overlayExitWrapper = "sh -c '\(OverlayCapture.shellLine)'"
 
-    /// Overlay-terminal surface factory: an ephemeral surface running the session's `overlayCommand` as its
-    /// process in `overlayCwd` (default the session's current dir). NOT wired to the session (no
-    /// `view.session`), so its PWD reports don't clobber the session's cwd. On the command's exit the
-    /// process-exit fires `onExit` → `closeOverlay`, tearing the surface down and hiding the overlay.
+    /// Overlay-terminal surface factory: an ephemeral surface running the session's `overlayCommand` in
+    /// `overlayCwd` (default the session's current dir). NOT wired to the session (no `view.session`), so its
+    /// PWD reports don't clobber the session cwd; on exit `onExit` → `closeOverlay` tears it down and hides it.
     @MainActor
     private static func makeOverlaySurface(for session: Session, store: AppStore, env: [String: String]) -> GhosttySurfaceView {
         let sessionID = session.id
@@ -425,28 +407,25 @@ struct agtermApp: App {
                                       fontSize: session.fontSize.map(Float.init), command: overlayExitWrapper,
                                       waitAfterCommand: session.overlayWait, autoFocus: true, env: overlayEnv)
         view.overlayCodeFile = codeFile
-        // the overlay's own background color (session.overlay.open --background-color), applied to the
-        // surface in createSurface — the overlay is sessionless, so it can't read it off the session there.
+        // the overlay's own background color (`session.overlay.open --background-color`), applied in
+        // createSurface — the overlay is sessionless, so it can't read it off the session there.
         view.overlayBackgroundColorHex = session.overlayBackgroundColor
-        // record the exit status on teardown (always through destroySurface), so it survives an explicit
-        // session.overlay.close that bypasses onExit; a force-close removes the session first and no-ops here,
-        // where the result is unqueryable anyway.
+        // record the exit status on teardown (always via destroySurface), so it survives a `session.overlay.close`
+        // that bypasses onExit; a force-close removes the session first and no-ops here, where it is unqueryable.
         view.onExitCodeCaptured = { store.recordOverlayExit(sessionID, code: $0) }
         view.onExit = { store.closeOverlay(sessionID) }
-        // typing in the cover is user activity: reset the auto-follow idle timer so an idle fire can't change
-        // the selection (vanishing the overlay) mid-typing. destroySurface nils this, breaking the
-        // store -> surface -> closure retain cycle.
+        // typing is user activity: resets the auto-follow idle timer so an idle fire can't change the selection
+        // (vanishing the overlay) mid-typing. destroySurface nils this, breaking the store->surface->closure cycle.
         view.onUserInput = { store.noteUserActivity() }
         return view
     }
 
-    /// Scratch-terminal surface factory: a third per-session shell, full-overlay rendered. Like the overlay it
-    /// is NOT operationally wired to the session (no `view.session`/`isSplitPane`), so its PWD/title never
-    /// clobber the sidebar name, but it keeps a weak visual-config link for the session watermark and — unlike
-    /// the overlay — stays alive when hidden. Runs a login shell, or `session.scratchCommand`
-    /// (`session.scratch --command`) RUN-ONCE, consumed here so a respawn after its exit is a plain shell.
-    /// `autoFocus` grabs first responder on show (winning the SwiftUI/AppKit responder race); the shell's
-    /// `exit` runs `closeScratch`, hiding + tearing down so the next show is fresh. Seeds from the cwd + env ids.
+    /// Scratch-terminal surface factory: a third per-session shell, full-overlay rendered. Like the overlay it is
+    /// NOT operationally wired to the session (no `view.session`/`isSplitPane`), so its PWD/title never clobber
+    /// the sidebar name, but it keeps a weak visual-config link for the watermark and — unlike the overlay —
+    /// stays alive when hidden. Runs a login shell, or `session.scratchCommand` (`session.scratch --command`)
+    /// RUN-ONCE. `autoFocus` grabs first responder on show (winning the SwiftUI/AppKit responder race); the
+    /// shell's `exit` runs `closeScratch`, hiding + tearing down so the next show is fresh.
     @MainActor
     private static func makeScratchSurface(for session: Session, store: AppStore, env: [String: String],
                                            suppressAutoFocus: Bool, library: WindowLibrary) -> GhosttySurfaceView {
@@ -462,23 +441,21 @@ struct agtermApp: App {
         let sessionID = session.id
         view.onExit = { store.closeScratch(sessionID) }
         Self.wireStatusClear(view, store: store, sessionID: sessionID, fixedPane: .scratch)
-        // typing in the scratch is user activity: reset the auto-follow idle timer so an idle fire can't
-        // change the selection (hiding the scratch) mid-typing. destroySurface nils this, breaking the
-        // store -> surface -> closure retain cycle.
+        // same idle-timer reset as the overlay: an idle auto-follow fire must not hide the scratch mid-typing.
         view.onUserInput = { store.noteUserActivity() }
-        // the scratch is searchable (⌘F), pinned to the same session like the main/split panes; unlike the
-        // overlay/quick terminal it behaves as a real pane (kept alive across hides), so a bar over it is safe.
+        // the scratch is searchable (⌘F), pinned to the same session as the panes: unlike the overlay/quick
+        // terminal it stays alive across hides, so a bar over it is safe.
         Self.wireSearchCallbacks(view, store: store, sessionID: sessionID, library: library)
         return view
     }
 
     /// The environment a tree surface (main / split / overlay / scratch) exposes to its shell: the `AGTERM_*`
-    /// session facts plus agterm's identity (`TERM_PROGRAM`/`TERM_PROGRAM_VERSION`). The window id comes from
-    /// the open store owning the session (split/overlay/scratch inherit it), the workspace from the session's
-    /// owner, and `AGTERM_SOCKET` is the path `ControlServer` will bind — resolved at init, so a launch-window
-    /// shell materializing before `start()` binds still sees it — honoring a test's `AGTERM_CONTROL_SOCKET`
-    /// override. `pane` injects `AGTERM_PANE` (`left`=main, `right`=split, `scratch`) so the hook wrapper
-    /// forwards `--pane` and a background-pane status records which surface blocked; the overlay passes nil.
+    /// session facts plus agterm's identity (`TERM_PROGRAM`/`TERM_PROGRAM_VERSION`). The window id comes from the
+    /// open store owning the session (split/overlay/scratch inherit it), the workspace from the session's owner.
+    /// `AGTERM_SOCKET` is the path `ControlServer` will bind, resolved at init so a launch-window shell
+    /// materializing before `start()` still sees it, honoring a test's `AGTERM_CONTROL_SOCKET` override. `pane`
+    /// injects `AGTERM_PANE` (`left`=main, `right`=split, `scratch`) so the hook wrapper forwards `--pane` and a
+    /// background-pane status records which surface blocked; the overlay passes nil.
     @MainActor
     private func surfaceEnv(for session: Session, pane: StatusPane? = nil) -> [String: String] {
         var windowID: WindowInfo.ID?

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -28,9 +28,8 @@ struct agtermApp: App {
     private static let terminalProgramVersion =
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
 
-    /// Application-hosted XCTest loads the real app executable before test `setUp`. Its scheme supplies
-    /// isolated state/socket paths plus this sentinel before `init()` runs; the scene uses a shell-free
-    /// placeholder so hosted model/AppKit tests never mount terminal surfaces or start the control server.
+    /// Hosted XCTest loads the real executable before `setUp`, so its scheme sets isolated state/socket paths
+    /// plus this sentinel pre-`init()`; the scene then mounts a shell-free placeholder — no surfaces, no server.
     static var isHostedUnitTest: Bool {
         ProcessInfo.processInfo.environment["AGTERM_HOSTED_TESTS"] == "1"
     }
@@ -40,9 +39,8 @@ struct agtermApp: App {
         _library = State(initialValue: library)
         let actions = AppActions(library: library)
         _actions = State(initialValue: actions)
-        // settings persist alongside the workspace snapshot (same AGTERM_STATE_DIR override). Built
-        // before the control server so the server can drive `keymap.reload` on it (both depend only on
-        // the library, so this reorder is safe).
+        // settings persist alongside the workspace snapshot (same AGTERM_STATE_DIR override), built before
+        // the control server so it can drive `keymap.reload` — both depend only on the library, so safe.
         let settingsStore = ProcessInfo.processInfo.environment["AGTERM_STATE_DIR"]
             .map { SettingsStore(directory: URL(fileURLWithPath: $0, isDirectory: true)) } ?? SettingsStore()
         let settingsModel = SettingsModel(library: library, settingsStore: settingsStore)
@@ -57,8 +55,8 @@ struct agtermApp: App {
         _customCommandRunner = State(initialValue: CustomCommandRunner(
             library: library, settings: settingsModel,
             socketProvider: { controlServer.resolvedSocketPath }))
-        // follows the macOS light/dark appearance via an app-level KVO observer on
-        // NSApp.effectiveAppearance (see SystemAppearanceObserver). No dependencies; started in `.task`.
+        // follows the macOS light/dark appearance via an app-level KVO observer on NSApp.effectiveAppearance;
+        // no dependencies, started in `.task`.
         _appearanceObserver = State(initialValue: SystemAppearanceObserver())
         // follows Reduce Motion / Reduce Transparency through NSWorkspace's accessibility display
         // notification and fans live changes out to AppKit consumers. SwiftUI consumers use Environment.
@@ -66,11 +64,10 @@ struct agtermApp: App {
     }
 
     var body: some Scene {
-        // a plain WindowGroup: it auto-opens one window at launch and one per `openWindow(id:)`.
-        // (A value-based `WindowGroup(for:)` does NOT auto-open at launch when SwiftUI window
-        // restoration is off, so it can't bootstrap the first window.) `WindowLibrary` is the single
-        // source of truth for the open-set: each appearing window claims the next open id from the
-        // library's claim queue (Task 0 dedup-by-id); a window beyond the open set dismisses itself.
+        // a plain WindowGroup auto-opens one window at launch plus one per `openWindow(id:)`; a value-based
+        // `WindowGroup(for:)` does NOT auto-open at launch with SwiftUI restoration off, so it can't
+        // bootstrap the first window. `WindowLibrary` owns the open-set: each appearing window claims the
+        // next open id from its claim queue (dedup-by-id), and a window beyond the open set dismisses itself.
         WindowGroup(id: Self.windowGroupID) {
             if Self.isHostedUnitTest {
                 Color.clear
@@ -104,23 +101,19 @@ struct agtermApp: App {
                     .frame(minWidth: 640, minHeight: 400)
                     .task {
                         appDelegate.library = library
-                        // give the action hub a window opener (the scene's `openWindow` is only reachable
-                        // here) so the cross-window reveal can reopen a banner-clicked closed window, and a
-                        // control-socket window.new/window.select can open one: raise it if it's already
-                        // on-screen, else claim its id + spawn a new window. Installed BEFORE the control
-                        // server starts so an early socket command never finds it nil (returns ok with no
-                        // window opened).
+                        // the scene's `openWindow` is reachable only here, so hand it to the action hub — a
+                        // cross-window reveal reopens a banner-clicked closed window, `window.new`/`window.select`
+                        // open one (raise if on-screen, else claim the id + spawn). Installed BEFORE the control
+                        // server starts, or an early socket command finds it nil and returns ok with no window.
                         actions.openWindow = { id in
                             if WindowRegistry.shared.raise(id) { return }
                             library.enqueueClaim(id)
                             openWindow(id: Self.windowGroupID)
                         }
-                        // start the control channel (idempotent) and hand the delegate a
-                        // reference so it can stop + unlink the socket on terminate.
+                        // start the control channel (idempotent); the delegate reference lets it stop + unlink
+                        // the socket on terminate.
                         appDelegate.controlServer = controlServer
                         controlServer.start()
-                        // the quick terminal is per-window now: each WindowContentView owns its own
-                        // controller and binds its own cwdProvider to that window's active session.
                         // install the Ctrl-Tab session-switcher key monitors (idempotent).
                         sessionSwitcher.start()
                         // install the Ctrl-1/Ctrl-2 direct pane-focus key monitor (idempotent).
@@ -128,9 +121,8 @@ struct agtermApp: App {
                         // install the undo-close shortcut (idempotent); it passes through text fields so
                         // native edit undo still wins there.
                         undoCloseShortcut.start()
-                        // install the custom-command key monitor (idempotent); rebuilds its matcher from
-                        // the keymap on `.agtermKeymapChanged`. Hand the delegate a reference so it can
-                        // remove the monitor on terminate.
+                        // install the custom-command key monitor (idempotent); it rebuilds its matcher from the
+                        // keymap on `.agtermKeymapChanged`, and the delegate reference removes it on terminate.
                         appDelegate.customCommandRunner = customCommandRunner
                         appDelegate.settingsModel = settingsModel
                         // hand the delegate the action hub and drain any folders an `open -a agterm /path`
@@ -138,20 +130,17 @@ struct agtermApp: App {
                         appDelegate.actions = actions
                         appDelegate.drainPendingOpenDirectories()
                         customCommandRunner.start()
-                        // wire the keymap + runner into the action hub so the command palette can list the
-                        // custom commands and run them (both are built after `actions`, so they're set here
-                        // rather than in the init, mirroring the NotificationManager wiring below).
+                        // wire the keymap + runner into the action hub so the command palette can list and run
+                        // custom commands; both are built after `actions`, so they're set here, not in `init`.
                         actions.settingsModel = settingsModel
-                        // seed the auto-follow setting into every open window's store now that the model is
-                        // wired — deterministic regardless of the per-window resolveStore/onAppear ordering
-                        // (the resolveStore seed handles windows opened later). Idempotent.
+                        // seed auto-follow into every open window's store now the model is wired: idempotent and
+                        // order-independent of resolveStore/onAppear (windows opened later seed in resolveStore).
                         settingsModel.applyAutoFollowToAllWindows()
                         actions.customCommandRunner = customCommandRunner
                         // the action hub opens the .themes palette for the "Select Theme…" launcher + menu.
                         actions.palette = palette
-                        // register the notification delegate + request authorization (idempotent), and
-                        // hand it the action hub + library so a banner click can navigate to the firing
-                        // pane and the capture side can stamp the firing window id into the identity.
+                        // register the notification delegate + request authorization (idempotent); the hub +
+                        // library let a banner click reach the firing pane and stamp its window id into the identity.
                         NotificationManager.shared.actions = actions
                         NotificationManager.shared.library = library
                         NotificationManager.shared.start()
@@ -159,28 +148,24 @@ struct agtermApp: App {
                         // total (the same Session.unseenCount the sidebar pills track, summed across windows).
                         DockBadgeController.shared.library = library
                         DockBadgeController.shared.start()
-                        // surface keymap parse errors / conflicts loaded at SettingsModel init (too early to
-                        // post then — before notification registration above). Only on the launch window:
-                        // `hasReopened` is still false here for the first window's `.task` (reopenWindows()
-                        // below flips it), so subsequent windows don't repost the same banner.
+                        // surface keymap parse errors / conflicts loaded at SettingsModel init — too early to post
+                        // then, before the notification registration above. Launch window only: `hasReopened` is
+                        // still false in the first window's `.task` (`reopenWindows()` flips it), so no reposts.
                         if !library.hasReopened, !settingsModel.keymapDiagnostics.isEmpty {
                             NotificationManager.shared.notifyKeymapDiagnostics(count: settingsModel.keymapDiagnostics.count)
                         }
-                        // same for ghostty config diagnostics: GhosttyApp.loadConfig records them at boot
-                        // (applicationDidFinishLaunching, before notification registration), so surface them
-                        // here on the launch window only, the same `hasReopened` gate as the keymap banner.
+                        // same for ghostty config diagnostics, recorded by GhosttyApp.loadConfig at boot
+                        // (applicationDidFinishLaunching, before notification registration): same `hasReopened` gate.
                         if !library.hasReopened, GhosttyApp.shared.lastConfigDiagnosticsCount > 0 {
                             NotificationManager.shared.notifyConfigDiagnostics(count: GhosttyApp.shared.lastConfigDiagnosticsCount)
                         }
-                        // reopen every window that was open at quit. SwiftUI auto-opened one window
-                        // (this one) at launch, which claimed the launch id; open one more per remaining
-                        // open id. runs once (the .task fires per window) via the library latch.
+                        // runs once via the library latch — the .task fires per window.
                         reopenWindows()
                         appDelegate.scheduleRestoredWindowReconciliation(reason: "scene-task")
                         // start following the macOS appearance last: `[.initial]` seeds the launch side once
                         // the eager-deck surfaces exist (idempotent, so per-window `.task` re-entry is safe).
                         appearanceObserver.start()
-                        // Consumers read current accessibility values at first render; this handles live flips.
+                        // consumers read current accessibility values at first render; this handles live flips.
                         accessibilityObserver.start()
                     }
             }
@@ -197,10 +182,9 @@ struct agtermApp: App {
         }
     }
 
-    /// Builds the app-global window library rooted at the state directory. The library's bootstrap
-    /// runs migration/recovery (legacy `workspaces.json` → one window, else seed) so the resulting
-    /// window set is always valid and non-empty. UI tests pass `AGTERM_STATE_DIR` to isolate persistence
-    /// in a temp dir so a run never touches the user's real state.
+    /// Builds the app-global window library rooted at the state directory. Its bootstrap runs
+    /// migration/recovery (legacy `workspaces.json` → one window, else seed), so the window set is always
+    /// valid and non-empty. UI tests set `AGTERM_STATE_DIR` to a temp dir, never touching the real state.
     @MainActor
     private static func restoredLibrary() -> WindowLibrary {
         ProcessInfo.processInfo.environment["AGTERM_STATE_DIR"]
@@ -208,32 +192,29 @@ struct agtermApp: App {
             ?? WindowLibrary()
     }
 
-    /// Opens the additional windows that were open at quit. SwiftUI auto-opened one window at launch
-    /// (it claimed the launch id), so this opens one more per remaining open id. Runs once via the
-    /// library latch (`consumeReopen` seeds the claim queue and returns the extra-window count).
+    /// Opens the windows open at quit beyond the one SwiftUI auto-opened at launch (which claimed the launch
+    /// id). Runs once via the library latch: `consumeReopen` seeds the claim queue, returning the extra count.
     @MainActor
     private func reopenWindows() {
         let extra = library.consumeReopen()
         for _ in 0..<extra { openWindow(id: Self.windowGroupID) }
     }
 
-    /// Surface factory: creates a libghostty-backed view for the session, spawning
-    /// a login shell in the session's initial working directory. On shell exit the
-    /// view calls back to close the owning session in the store.
+    /// Surface factory: a libghostty-backed view for the session, spawning a login shell in its initial
+    /// working directory. On shell exit the view calls back to close the owning session in the store.
     @MainActor
     private static func makeSurface(for session: Session, store: AppStore, env: [String: String],
                                     library: WindowLibrary) -> GhosttySurfaceView {
-        // `initialCommand` (from `session.new --command`) runs as the surface's process instead of the
-        // login shell; on its exit the surface's onExit (below) closes the single session, like kitty.
-        // restore-running-command: `foregroundCommand` (a distinct child captured at quit) is consumed
-        // run-once here; the persisted `initialCommand` is the durable creation identity (re-emitted by every
-        // `snapshot()`). A command that exec-replaces the shell is invisible to libghostty's foreground pid
-        // (nil), so it is never captured and restores via the exec `command` path (preserving close-on-exit).
-        // The gate + precedence (fresh-always-runs, restored-honors-toggle, a captured foreground preempts
-        // `initialCommand` even when denylist-suppressed) is the host-free `CommandRestore.restorePlan`.
-        // A pinned override (`session.restore`) wins over BOTH the capture and `initialCommand`; it is read
-        // from the TRANSIENT pending slot (seeded only by an app-bootstrap restore), never from the sticky
-        // persisted field, and taking it clears it so a second surface for this pane runs a plain shell.
+        // `initialCommand` (`session.new --command`) runs as the surface's process instead of the login shell;
+        // `onExit` below then closes the single session on its exit, like kitty. It is the durable creation
+        // identity, re-emitted by every `snapshot()`, while `foregroundCommand` — a distinct child captured at
+        // quit — is consumed run-once here. A command that exec-replaces the shell is invisible to libghostty's
+        // foreground pid (nil), so it is never captured and restores via the exec `command` path, keeping
+        // close-on-exit. Precedence (fresh always runs, restored honors the toggle, a captured foreground
+        // preempts `initialCommand` even when denylist-suppressed) is the host-free `CommandRestore.restorePlan`.
+        // A `session.restore` override beats both: taken from the TRANSIENT pending slot (seeded only by an
+        // app-bootstrap restore), never the sticky persisted field, and taking it clears it so a second surface
+        // for this pane runs a plain shell.
         let hadForeground = session.foregroundCommand != nil
         let restoreInput = Self.restoreInitialInput(session.foregroundCommand)
         session.foregroundCommand = nil
@@ -272,37 +253,33 @@ struct agtermApp: App {
         return view
     }
 
-    /// Shell-exit handler shared by BOTH pane factories, dispatched on the surface's CURRENT role rather
-    /// than the factory that built it: a promoted split survivor (built by `makeSplitSurface`, then moved
-    /// into the main slot with `isSplitPane` cleared) must run `closePrimaryPane` on its own exit — else
-    /// a re-split followed by exiting the main pane fires the stale `closeSplitPane`, whose guard now
-    /// passes (both slots live) and tears down the fresh right pane, stranding the session on the dead
-    /// left one. Mirrors the role-aware `onFocusChange` so fresh and promoted panes route the same way.
+    /// Shell-exit handler for BOTH pane factories, dispatched on the surface's CURRENT role rather than the
+    /// factory that built it: a promoted split survivor (built by `makeSplitSurface`, moved into the main slot
+    /// with `isSplitPane` cleared) must run `closePrimaryPane` on its own exit, or a re-split then a main-pane
+    /// exit fires the stale `closeSplitPane`, whose guard now passes (both slots live), tearing down the fresh
+    /// right pane and stranding the session on the dead left one. Role-aware like `onFocusChange`.
     @MainActor
     private static func handlePaneExit(_ view: GhosttySurfaceView, store: AppStore, sessionID: UUID) {
         if view.isSplitPane {
             store.closeSplitPane(sessionID)
         } else {
             store.closePrimaryPane(sessionID)
-            // a promoted survivor was built by makeSplitSurface (which omits onFontSizeChange); as the
-            // session's now-sole pane it should persist its own cmd +/- like a real primary, so adopt that
-            // wiring. no-op when the session closed instead (single pane) — `surface` is then nil.
+            // makeSplitSurface omits onFontSizeChange, but a promoted survivor is now the sole pane and must
+            // persist its own cmd +/- like a primary. no-op when the session closed instead (`surface` nil).
             if let promoted = store.session(withID: sessionID)?.surface as? GhosttySurfaceView {
                 promoted.onFontSizeChange = { store.setFontSize(sessionID, $0) }
             }
         }
-        // focus the surviving (now maximized) pane; if the whole session closed instead, focus the session
-        // it reselected to. the collapse/switch re-hosts the target, so use the retry.
-        // resolve through `topmostSurface`, so a pane exiting under an overlay or scratch hands focus to
-        // the cover on top rather than to the pane it hides.
+        // focus the surviving (now maximized) pane, else the session reselected to when the whole session
+        // closed; the collapse/switch re-hosts the target, hence the retry. `topmostSurface` hands focus to
+        // an overlay/scratch cover rather than to the pane it hides.
         let target = store.session(withID: sessionID)?.topmostSurface ?? store.activeSession?.topmostSurface
         (target as? GhosttySurfaceView)?.focusAfterReparent()
     }
 
-    /// The `initial_input` for a restored pane: the captured foreground argv re-rendered as a shell
-    /// command line + newline, or nil when the restore-running-command flag is off or the command's
-    /// basename is in the user's `restore-denylist.conf` (→ plain shell). Host-free decisions live in
-    /// `CommandRestore`; the denylist is parsed at launch into `GhosttyApp.shared.restoreDenylist`.
+    /// The `initial_input` for a restored pane: the captured foreground argv re-rendered as a shell command
+    /// line + newline, or nil when the restore-running-command flag is off or the basename is in the user's
+    /// `restore-denylist.conf` (→ plain shell), parsed at launch into `GhosttyApp.shared.restoreDenylist`.
     @MainActor
     private static func restoreInitialInput(_ argv: [String]?) -> String? {
         guard GhosttyApp.shared.restoreRunningCommand, let argv,
@@ -310,14 +287,13 @@ struct agtermApp: App {
         return CommandRestore.shellQuotedLine(argv) + "\n"
     }
 
-    /// Wire the four `onSearch*` surface callbacks to the owning session's search fields, resolving the
-    /// session live via `sessionID`. START toggles: if the session's bar is already open it sends
-    /// `end_search` (the ⌘F-again close) and lets the resulting END do the clear; else it opens the bar
-    /// (`searchActive = true`, seeding any returned needle) and pins THIS surface as `searchSurface` (the
-    /// owner the bar's needle/navigate/close drive). END is the single clear point — it resets the fields,
-    /// clears the owner, hides the bar, and returns first responder to the session's visible terminal.
-    /// TOTAL/SELECTED carry the match count/index. Shared by both surface factories — so the GUI and the
-    /// control channel pin the owner the same way and can't drift.
+    /// Wires the four `onSearch*` callbacks to the owning session's search fields, resolved live via
+    /// `sessionID`. START toggles: with the bar already open it sends `end_search` (the ⌘F-again close) and
+    /// lets the resulting END clear; else it opens the bar (`searchActive = true`, seeding any returned needle)
+    /// and pins THIS surface as `searchSurface`, the owner the bar's needle/navigate/close drive. END is the
+    /// single clear point — fields, owner, bar, and first responder back to the session's visible terminal.
+    /// TOTAL/SELECTED carry the match count/index. Shared by both factories, so the GUI and control channel
+    /// pin the owner identically.
     @MainActor
     private static func wireSearchCallbacks(_ view: GhosttySurfaceView, store: AppStore, sessionID: UUID,
                                             library: WindowLibrary) {
@@ -325,10 +301,9 @@ struct agtermApp: App {
         view.onSearchStart = { [weak view] needle in
             guard let session = store.session(withID: sessionID) else { return }
             if session.searchActive {
-                // bar already open: ⌘F-again close — end search on the PINNED owner (the surface START
-                // first fired on), not the just-fired `view`, so a second ⌘F on the OTHER split pane closes
-                // the original owner rather than stranding it in libghostty search mode. the resulting END
-                // callback clears the fields and refocuses.
+                // ⌘F-again close: end search on the PINNED owner (the surface START first fired on), not the
+                // just-fired `view`, so a second ⌘F on the OTHER split pane closes the original owner instead
+                // of stranding it in libghostty search mode. the resulting END clears the fields and refocuses.
                 (session.searchSurface as? GhosttySurfaceView)?.endSearch()
                 return
             }
@@ -343,25 +318,22 @@ struct agtermApp: App {
             session.searchTotal = nil
             session.searchSelected = nil
             session.searchSurface = nil
-            // return first responder to the terminal ONLY when this is still the selected session AND no
-            // covering surface is up: a `session.search --close --target <background>` closes a hidden,
-            // opacity-0 surface whose first responder would steal input from the visible session (hidden
-            // views CAN become first responder), and a cover owns focus itself. besides the in-deck
-            // overlay/scratch (caught by `topmostSurface`), the window-level quick terminal also covers the
-            // session — refocusing the hidden pane behind it would steal focus, so bail while it's up
-            // (it restores the session on its own hide). target the visible `topmostSurface` (overlay >
-            // scratch > active pane) and re-assert past the SwiftUI teardown via the bounded retry.
+            // refocus the terminal ONLY while this is still the selected session and no cover is up: a
+            // `session.search --close --target <background>` closes a hidden, opacity-0 surface whose first
+            // responder would steal input from the visible session (hidden views CAN become first responder),
+            // and a cover owns focus itself. `topmostSurface` catches the in-deck overlay/scratch (overlay >
+            // scratch > active pane); the window-level quick terminal does not, so bail while it is up — it
+            // restores the session on its own hide. the bounded retry re-asserts past the SwiftUI teardown.
             guard store.selectedSessionID == sessionID else { return }
             let windowID = library.windowID(forSession: sessionID)
             let quickTerminalVisible = windowID
                 .flatMap { QuickTerminalRegistry.shared.controller(for: $0) }?.isVisible ?? false
             guard !quickTerminalVisible else { return }
-            // terminal zoom owns focus above the whole deck, and zoom-enter itself ends an open search —
-            // this END lands a tick later, so refocusing the deck's topmost surface here would steal
-            // first responder back from the zoomed terminal (the zoom cover bails like the quick one).
+            // terminal zoom owns focus above the deck, and zoom-enter itself ends an open search — this END
+            // lands a tick later, so refocusing here would steal first responder back from the zoomed terminal.
             guard windowID.flatMap({ TerminalZoomRegistry.shared.controller(for: $0) })?.target == nil else { return }
-            // A control picker is the topmost modal. `session.search --to close` remains valid cleanup while
-            // one is pending, but its asynchronous END callback must not return focus behind the picker.
+            // a control picker is the topmost modal: `session.search --to close` stays valid cleanup while one
+            // is pending, but its asynchronous END must not return focus behind the picker.
             guard PickRegistry.shared.controller(for: windowID)?.pending == nil else { return }
             (session.topmostSurface as? GhosttySurfaceView)?.focusAfterReparent()
         }
@@ -369,15 +341,13 @@ struct agtermApp: App {
         view.onSearchSelected = { selected in store.session(withID: sessionID)?.searchSelected = selected }
     }
 
-    /// Wire the pane-scoped keystroke-clear: `keyDown` fires `onUserInputClearsStatus` unconditionally, and
-    /// this closure clears the status back to idle ONLY when the host-free `AgentIndicator.clearedBy(pane:isInterrupt:)`
-    /// says the keystroke's OWN pane owns the current status — so a block set from a background pane survives
-    /// foreground typing in another pane. The main/split panes resolve their pane from the surface's LIVE role
-    /// (`isSplitPane`) at keystroke time, NOT statically: a promoted split survivor (a split surface whose
-    /// `isSplitPane` was cleared) then clears as `.left`, matching its migrated status identity and `tree`
-    /// addressing — a statically-captured `.right` would keep clearing the wrong pane after promotion, and a
-    /// re-split would leave both panes `.right`-wired (mirrors the role-aware `onFocusChange`). The scratch pane
-    /// passes `fixedPane: .scratch` (never promoted, and it has no `view.session` to read a role from).
+    /// Wires the pane-scoped keystroke-clear: `keyDown` fires `onUserInputClearsStatus` unconditionally, and
+    /// this closure resets the status to idle only when the host-free `AgentIndicator.clearedBy(pane:isInterrupt:)`
+    /// says the keystroke's OWN pane owns it, so a block set from a background pane survives typing elsewhere.
+    /// Main/split resolve the pane from the surface's LIVE `isSplitPane` at keystroke time, not statically: a
+    /// promoted split survivor then clears as `.left`, matching its migrated status identity and `tree`
+    /// addressing, where a captured `.right` would clear the wrong pane and a re-split would leave both panes
+    /// `.right`-wired. The scratch passes `fixedPane: .scratch` — never promoted, and it has no `view.session`.
     @MainActor
     private static func wireStatusClear(_ view: GhosttySurfaceView, store: AppStore, sessionID: UUID,
                                         fixedPane: StatusPane? = nil) {
@@ -389,23 +359,20 @@ struct agtermApp: App {
         }
     }
 
-    /// Split-pane surface factory: a second independent login shell in the session's current
-    /// directory. Wired to the session as `isSplitPane`, so its PWD/title reports go to
-    /// `session.splitCwd`/`splitTitle` (never clobbering the primary's), and on shell exit it closes
-    /// just the split (hide + teardown), not the whole session.
+    /// Split-pane surface factory: a second independent login shell in the session's current directory. Wired
+    /// as `isSplitPane`, so its PWD/title reports go to `session.splitCwd`/`splitTitle` instead of the
+    /// primary's, and on shell exit it closes just the split (hide + teardown), not the whole session.
     @MainActor
     private static func makeSplitSurface(for session: Session, store: AppStore, env: [String: String],
                                          library: WindowLibrary) -> GhosttySurfaceView {
-        // seed the split's cwd from its persisted `initialSplitCwd` (so a restored split keeps its
-        // own directory, not the primary's), falling back to the session's effectiveCwd for a fresh
-        // split. Font size matches the primary; its own cmd +/- changes aren't persisted. It inherits
-        // the parent session's window/workspace/session ids in the env.
-        // restore-running-command: re-run the split pane's captured foreground command via initial_input
-        // (consumed run-once). Splits never carry an `initialCommand`, so no mutual-exclusion guard and no
-        // `restorePlan` — `restoreInput` alone decides. A pinned override (`session.restore`) wins over the
-        // capture; it comes from the TRANSIENT pending slot (seeded only by an app-bootstrap restore whose
-        // split was shown), never the sticky persisted field, and taking it clears it — this factory runs
-        // again when a split shell exits and the user opens a fresh ⌘D split, which must be a plain shell.
+        // cwd from the persisted `initialSplitCwd`, so a restored split keeps its own directory, else the
+        // session's effectiveCwd for a fresh one. Font size matches the primary; its own cmd +/- is not
+        // persisted. Env inherits the parent's window/workspace/session ids. The captured foreground command
+        // re-runs via initial_input (consumed run-once); splits never carry an `initialCommand`, so there is
+        // no mutual-exclusion guard and no `restorePlan` — `restoreInput` alone decides. A `session.restore`
+        // override wins over the capture, taken from the TRANSIENT pending slot (seeded only by an
+        // app-bootstrap restore whose split was shown) not the sticky persisted field, and taking it clears
+        // it: this factory runs again for a fresh ⌘D split after a split shell exits, which must be a shell.
         let capturedInput = Self.restoreInitialInput(session.splitForegroundCommand)
         session.splitForegroundCommand = nil
         let restoreInput = CommandRestore.restoreInput(restoreEnabled: GhosttyApp.shared.restoreRunningCommand,
@@ -422,9 +389,8 @@ struct agtermApp: App {
         }
         view.onFocusChange = { [weak view] focused in
             guard focused else { return }
-            // a promoted survivor keeps this split-factory closure but has had `isSplitPane` cleared, so
-            // honor the view's CURRENT role: once it is the main pane it must NOT re-raise `splitFocused`
-            // (which would mask its migrated title and mis-route focus after a later re-split).
+            // a promoted survivor keeps this closure with `isSplitPane` cleared: as the main pane it must not
+            // re-raise `splitFocused`, which masks its migrated title and mis-routes focus after a re-split.
             store.session(withID: sessionID)?.splitFocused = view?.isSplitPane ?? false
             store.clearUnseen(sessionID)
             NotificationManager.shared.clearDelivered(sessionID: sessionID)
@@ -444,16 +410,13 @@ struct agtermApp: App {
     /// stdout/stderr are NOT redirected (so a TUI renders normally); only the status is captured.
     private static let overlayExitWrapper = "sh -c '\(OverlayCapture.shellLine)'"
 
-    /// Overlay-terminal surface factory: an ephemeral surface running the session's `overlayCommand`
-    /// as its process in `overlayCwd` (default the session's current dir). Like the split, it is NOT
-    /// wired to the session (no `view.session`), so its PWD reports don't clobber the session's
-    /// cwd. When the command exits, the surface's process-exit fires `onExit` → `closeOverlay`,
-    /// which tears the surface down and hides the overlay — so the program's exit makes it vanish.
+    /// Overlay-terminal surface factory: an ephemeral surface running the session's `overlayCommand` as its
+    /// process in `overlayCwd` (default the session's current dir). NOT wired to the session (no
+    /// `view.session`), so its PWD reports don't clobber the session's cwd. On the command's exit the
+    /// process-exit fires `onExit` → `closeOverlay`, tearing the surface down and hiding the overlay.
     @MainActor
     private static func makeOverlaySurface(for session: Session, store: AppStore, env: [String: String]) -> GhosttySurfaceView {
         let sessionID = session.id
-        // wrap the command so its exit status lands in a per-surface temp file. No stdout/stderr
-        // redirect — the program renders in the overlay as usual.
         let codeFile = (NSTemporaryDirectory() as NSString).appendingPathComponent("agterm-ovl-\(UUID().uuidString).code")
         var overlayEnv = env
         overlayEnv[OverlayCapture.cmdEnvKey] = session.overlayCommand ?? ""
@@ -465,33 +428,29 @@ struct agtermApp: App {
         // the overlay's own background color (session.overlay.open --background-color), applied to the
         // surface in createSurface — the overlay is sessionless, so it can't read it off the session there.
         view.overlayBackgroundColorHex = session.overlayBackgroundColor
-        // record the exit status on teardown (the surface always tears down through destroySurface), so
-        // it survives an explicit session.overlay.close that bypasses onExit. a session/window force-close
-        // removes the session first, so this no-ops there — but the result is unqueryable after that anyway.
+        // record the exit status on teardown (always through destroySurface), so it survives an explicit
+        // session.overlay.close that bypasses onExit; a force-close removes the session first and no-ops here,
+        // where the result is unqueryable anyway.
         view.onExitCodeCaptured = { store.recordOverlayExit(sessionID, code: $0) }
         view.onExit = { store.closeOverlay(sessionID) }
-        // typing in the cover counts as user activity: reset the window's auto-follow idle timer so an
-        // idle fire can't change the underlying selection (vanishing the overlay) while you type in it.
-        // destroySurface nils this, breaking the store -> surface -> closure retain cycle.
+        // typing in the cover is user activity: reset the auto-follow idle timer so an idle fire can't change
+        // the selection (vanishing the overlay) mid-typing. destroySurface nils this, breaking the
+        // store -> surface -> closure retain cycle.
         view.onUserInput = { store.noteUserActivity() }
         return view
     }
 
-    /// Scratch-terminal surface factory: a third per-session shell, full-overlay rendered. Like the
-    /// overlay it is NOT operationally wired to the session (no `view.session`/`isSplitPane`), so its
-    /// PWD/title never clobber the session's sidebar name. It does retain a weak visual-config link so the
-    /// session watermark renders on it; unlike the overlay it is kept alive when hidden. Runs a plain
-    /// login shell, or `session.scratchCommand` when set (`session.scratch --command`) — RUN-ONCE: the
-    /// command is consumed here so a respawn after it exits is a plain shell. `autoFocus` grabs first
-    /// responder on show (winning the SwiftUI/AppKit responder race); on the shell's `exit`, `closeScratch`
-    /// hides + tears it down so the next show spawns fresh. Seeds from the session's current dir + env ids.
+    /// Scratch-terminal surface factory: a third per-session shell, full-overlay rendered. Like the overlay it
+    /// is NOT operationally wired to the session (no `view.session`/`isSplitPane`), so its PWD/title never
+    /// clobber the sidebar name, but it keeps a weak visual-config link for the session watermark and — unlike
+    /// the overlay — stays alive when hidden. Runs a login shell, or `session.scratchCommand`
+    /// (`session.scratch --command`) RUN-ONCE, consumed here so a respawn after its exit is a plain shell.
+    /// `autoFocus` grabs first responder on show (winning the SwiftUI/AppKit responder race); the shell's
+    /// `exit` runs `closeScratch`, hiding + tearing down so the next show is fresh. Seeds from the cwd + env ids.
     @MainActor
     private static func makeScratchSurface(for session: Session, store: AppStore, env: [String: String],
                                            suppressAutoFocus: Bool, library: WindowLibrary) -> GhosttySurfaceView {
-        // autoFocus on creation gives the first show reliable focus — but suppress it when another
-        // surface already owns focus above the scratch (a full overlay, or the window-level quick
-        // terminal), so a scratch created under one can't steal first responder. Re-shows are focused
-        // via the `scratchActive` onChange (which also defers to those covers).
+        // re-shows are focused via the `scratchActive` onChange (which also defers to those covers).
         // scratchCommand is run-once: read it for this spawn, then clear so a post-exit respawn is a shell.
         let command = session.scratchCommand
         session.scratchCommand = nil
@@ -503,25 +462,23 @@ struct agtermApp: App {
         let sessionID = session.id
         view.onExit = { store.closeScratch(sessionID) }
         Self.wireStatusClear(view, store: store, sessionID: sessionID, fixedPane: .scratch)
-        // typing in the scratch counts as user activity: reset the window's auto-follow idle timer so an
-        // idle fire can't change the underlying selection (hiding the per-session scratch) while you type
-        // in it. destroySurface nils this, breaking the store -> surface -> closure retain cycle.
+        // typing in the scratch is user activity: reset the auto-follow idle timer so an idle fire can't
+        // change the selection (hiding the scratch) mid-typing. destroySurface nils this, breaking the
+        // store -> surface -> closure retain cycle.
         view.onUserInput = { store.noteUserActivity() }
-        // the scratch supports in-terminal search (⌘F), so wire the four onSearch* callbacks and mark it
-        // searchable — pinned to the same session, like the main/split panes. Unlike the overlay/quick
-        // terminal, the scratch behaves like a real pane (kept alive across hides), so a bar over it is safe.
+        // the scratch is searchable (⌘F), pinned to the same session like the main/split panes; unlike the
+        // overlay/quick terminal it behaves as a real pane (kept alive across hides), so a bar over it is safe.
         Self.wireSearchCallbacks(view, store: store, sessionID: sessionID, library: library)
         return view
     }
 
-    /// The environment a tree surface (main / split / overlay / scratch) exposes to its spawned shell: the
-    /// `AGTERM_*` session facts plus agterm's app identity (`TERM_PROGRAM`/`TERM_PROGRAM_VERSION`). The window
-    /// id comes from the open store that owns the session (split/overlay/scratch inherit it
-    /// via the same session); the workspace from the session's owning workspace; `AGTERM_SOCKET` is the path
-    /// `ControlServer` will bind (resolved at init, so a launch-window shell that materializes before
-    /// `start()` binds still sees it), honoring a test's `AGTERM_CONTROL_SOCKET` override. `pane` injects the
-    /// matching `AGTERM_PANE` (`left`=main, `right`=split, `scratch`) so the hook wrapper forwards `--pane`
-    /// and a status set from a background pane records which surface blocked; the overlay passes nil (no pane).
+    /// The environment a tree surface (main / split / overlay / scratch) exposes to its shell: the `AGTERM_*`
+    /// session facts plus agterm's identity (`TERM_PROGRAM`/`TERM_PROGRAM_VERSION`). The window id comes from
+    /// the open store owning the session (split/overlay/scratch inherit it), the workspace from the session's
+    /// owner, and `AGTERM_SOCKET` is the path `ControlServer` will bind — resolved at init, so a launch-window
+    /// shell materializing before `start()` binds still sees it — honoring a test's `AGTERM_CONTROL_SOCKET`
+    /// override. `pane` injects `AGTERM_PANE` (`left`=main, `right`=split, `scratch`) so the hook wrapper
+    /// forwards `--pane` and a background-pane status records which surface blocked; the overlay passes nil.
     @MainActor
     private func surfaceEnv(for session: Session, pane: StatusPane? = nil) -> [String: String] {
         var windowID: WindowInfo.ID?
@@ -532,9 +489,8 @@ struct agtermApp: App {
                 workspaceID = workspace.id
             }
         }
-        // a session-owned pane (main/split/scratch) gets a fresh stable token baked as AGTERM_PANE_ID so the
-        // agent-status hook can forward it as --pane-id and the status handler resolves the surface's LIVE
-        // slot rather than the baked role (#199); the overlay (pane == nil) needs none.
+        // a session-owned pane bakes a fresh stable AGTERM_PANE_ID, so the hook forwards --pane-id and the
+        // status handler resolves the surface's LIVE slot, not the baked role (#199); the overlay needs none.
         return SurfaceEnvironment.session(sessionID: session.id, windowID: windowID,
                                           workspaceID: workspaceID, socketPath: controlServer.resolvedSocketPath,
                                           programVersion: Self.terminalProgramVersion,

--- a/agtermCore/Sources/agtermCore/AgentHooksInstall.swift
+++ b/agtermCore/Sources/agtermCore/AgentHooksInstall.swift
@@ -1,58 +1,50 @@
 import Foundation
 import TOMLDecoder
 
-/// Host-free helpers for installing the agent-status hooks package. Most are testable string/JSON/TOML
-/// transforms: given the current file contents and the installed script directory they return the new contents
-/// plus a `changed` flag, all idempotent. Plus a mode-preserving write (`writeFile`/`posixMode`) so rewriting a
-/// restrictive-mode file (e.g. a chmod-600 `settings.json`) keeps its permissions instead of an atomic rename
-/// widening it to 0644. The app side still owns copying the bundled scripts and resolving symlinks.
+/// Host-free helpers for installing the agent-status hooks package: idempotent string/JSON/TOML transforms
+/// returning the new contents plus a `changed` flag. Plus a mode-preserving write (`writeFile`/`posixMode`) so
+/// rewriting a restrictive-mode file (e.g. a chmod-600 `settings.json`) keeps its permissions instead of an
+/// atomic rename widening it to 0644. The app side owns copying the bundled scripts and resolving symlinks.
 public enum AgentHooksInstall {
     /// The wrapper script the hooks invoke, installed into the script directory.
     public static let wrapperName = "agterm-agent-status.sh"
 
-    /// Codex-specific lifecycle adapter installed beside the generic status wrapper. Agent-specific
-    /// event and terminal-output knowledge stays in this hook resource, outside agterm's runtime.
+    /// Codex-specific lifecycle adapter installed beside the generic status wrapper; agent-specific event and
+    /// terminal-output knowledge stays in this hook resource, outside agterm's runtime.
     public static let codexWrapperName = "agterm-codex-status.sh"
 
-    /// The bundled Pi extension's path relative to the agent-status package.
+    /// The bundled Pi extension's path relative to the agent-status package, and its destination filename.
     public static let piExtensionRelativePath = "pi/agterm-status.ts"
-
-    /// The Pi extension's destination filename under `~/.pi/agent/extensions/`.
     public static let piExtensionName = "agterm-status.ts"
 
-    /// Ownership sentinel in the bundled Pi extension. A reinstall refuses to overwrite an unmarked
-    /// same-named extension, preserving a user-authored integration.
+    /// Ownership sentinel in the bundled Pi extension: a reinstall refuses to overwrite an unmarked same-named
+    /// extension, preserving a user-authored integration.
     public static let piExtensionMarker = "// agterm-pi-status-extension"
 
-    /// The bundled OpenCode plugin's path relative to the agent-status package.
+    /// The bundled OpenCode plugin's path relative to the agent-status package, and its destination filename.
     public static let opencodePluginRelativePath = "opencode/agterm-status.js"
-
-    /// The OpenCode plugin's destination filename under `~/.config/opencode/plugins/`.
     public static let opencodePluginName = "agterm-status.js"
 
-    /// Ownership sentinel in the bundled OpenCode plugin. A reinstall refuses to overwrite an unmarked
-    /// same-named plugin, preserving a user-authored integration. Named `*Plugin*` (not `*Extension*`)
-    /// because OpenCode's host term is plugin — intentional divergence from Pi's `piExtension*`.
+    /// Ownership sentinel in the bundled OpenCode plugin, same policy as `piExtensionMarker`. Named `*Plugin*`
+    /// (not `*Extension*`) because OpenCode's host term is plugin — a deliberate divergence from `piExtension*`.
     public static let opencodePluginMarker = "// agterm-opencode-status-plugin"
 
-    /// The shell integration script sourced from the user's rc files, relative to the script directory.
+    /// The shell integration scripts sourced from the user's rc files / config.fish, relative to the script
+    /// directory.
     public static let integrationRelativePath = "shell/integration.sh"
-
-    /// The fish shell integration script sourced from the user's config.fish, relative to the script directory.
     public static let fishIntegrationRelativePath = "shell/integration.fish"
 
-    /// Marker lines bracketing the agterm-managed block in a shell rc file. The opening marker is also
-    /// the idempotency probe (present → already installed).
+    /// Marker lines bracketing the agterm-managed block in a shell rc file; the opening marker is also the
+    /// idempotency probe (present → already installed).
     public static let rcMarkerBegin = "# >>> agterm agent-status >>>"
     public static let rcMarkerEnd = "# <<< agterm agent-status <<<"
 
-    /// The Claude Code hook events the merge installs, paired with the agent state (plus any flags) each maps
-    /// to. `UserPromptSubmit` and `PostToolUse` both set `active`: the former on a new prompt, the latter after
-    /// every tool run so the status returns to `active` when work RESUMES after a `blocked` permission prompt
-    /// — Claude Code has no "permission answered" event, and the gated tool's own `PreToolUse` fired BEFORE
-    /// `blocked` was set, so the approved tool's `PostToolUse` is the first hook afterwards. `Notification`
-    /// alone carries the `permission_prompt` matcher. Only `Stop`→`completed` passes `--auto-reset` (it clears
-    /// on visit); `active` and `blocked` stay keep-state.
+    /// The Claude Code hook events the merge installs, paired with the state (plus flags) each maps to.
+    /// `UserPromptSubmit` and `PostToolUse` both set `active` — the latter after every tool run, so the status
+    /// returns to `active` when work RESUMES after a `blocked` permission prompt: Claude Code has no
+    /// "permission answered" event, and the gated tool's `PreToolUse` fired BEFORE `blocked` was set, so its
+    /// `PostToolUse` is the first hook afterwards. `Notification` alone carries the `permission_prompt` matcher,
+    /// and only `Stop`→`completed` passes `--auto-reset` (it clears on visit); the rest stay keep-state.
     static let claudeHooks: [(event: String, matcher: String?, state: String)] = [
         ("UserPromptSubmit", nil, "active --blink"),
         ("PostToolUse", nil, "active --blink"),
@@ -60,8 +52,8 @@ public enum AgentHooksInstall {
         ("Notification", "permission_prompt", "blocked"),
     ]
 
-    /// Codex lifecycle events paired with actions understood by the installed Codex hook. The adapter,
-    /// rather than agterm's runtime, owns the event-to-status behavior and Auto Review workaround.
+    /// Codex lifecycle events paired with actions the installed Codex hook understands; the adapter, not
+    /// agterm's runtime, owns the event-to-status behavior and the Auto Review workaround.
     static let codexHooks: [(event: String, action: String)] = [
         ("SessionStart", "session-start"),
         ("UserPromptSubmit", "user-prompt-submit"),
@@ -76,13 +68,12 @@ public enum AgentHooksInstall {
         home + "/.pi/agent/extensions"
     }
 
-    /// The destination path for agterm's Pi status extension.
     public static func piExtensionPath(home: String) -> String {
         piExtensionDirectory(home: home) + "/" + piExtensionName
     }
 
-    /// Whether the Pi extension destination is safe to replace. An absent destination is safe; an
-    /// existing file must carry the agterm ownership marker. An unreadable file is treated as user-owned.
+    /// Whether the Pi extension destination is safe to replace: absent is safe, an existing file must carry the
+    /// agterm ownership marker, and an unreadable one counts as user-owned.
     public static func mayOverwritePiExtension(fileExists: Bool, existingContents: String?) -> Bool {
         guard fileExists else { return true }
         guard let existingContents else { return false }
@@ -94,31 +85,26 @@ public enum AgentHooksInstall {
         home + "/.config/opencode/plugins"
     }
 
-    /// The destination path for agterm's OpenCode status plugin.
     public static func opencodePluginPath(home: String) -> String {
         opencodePluginDirectory(home: home) + "/" + opencodePluginName
     }
 
-    /// Whether the OpenCode plugin destination is safe to replace. Same ownership policy as Pi:
-    /// absent is safe; an existing file must carry the agterm marker; unreadable counts as user-owned.
+    /// Whether the OpenCode plugin destination is safe to replace; same ownership policy as Pi.
     public static func mayOverwriteOpenCodePlugin(fileExists: Bool, existingContents: String?) -> Bool {
         guard fileExists else { return true }
         guard let existingContents else { return false }
         return existingContents.contains(opencodePluginMarker)
     }
 
-    /// Thrown by `mergeClaudeSettings` when the existing `settings.json` is non-empty but not a valid
-    /// JSON object: the installer refuses to overwrite a hand-maintained file it cannot safely parse.
+    /// Thrown by `mergeClaudeSettings` when the existing `settings.json` is non-empty but not a valid JSON
+    /// object: the installer refuses to overwrite a hand-maintained file it cannot safely parse.
     public enum MergeError: Error { case malformedExistingSettings }
 
     /// merge the four agent-status hooks into an existing Claude Code `settings.json`.
     ///
-    /// `existing` is the current file contents (nil or empty = no file yet); `scriptDir` is the directory the
-    /// wrapper script was installed into. Returns the new JSON text and whether it differs from `existing`.
-    /// Idempotent: with the agterm hooks (detected by the wrapper command) already present it returns the input
-    /// unchanged with `changed == false`. Unrelated hooks and keys are preserved; an absent/empty file starts
-    /// from a fresh object, but a non-empty one that is not valid JSON throws
-    /// `MergeError.malformedExistingSettings` so the caller can leave a hand-maintained file untouched.
+    /// `existing` is the current contents (nil/empty = start from a fresh object). Returns the new JSON and
+    /// whether it differs; idempotent — hooks already present (detected by the wrapper command) return the
+    /// input with `changed == false`. Unrelated hooks and keys are preserved; invalid JSON throws.
     public static func mergeClaudeSettings(existing: String?, scriptDir: String) throws -> (json: String, changed: Bool) {
         let command = wrapperCommand(scriptDir: scriptDir)
         var root = try parsedObject(existing)
@@ -143,9 +129,8 @@ public enum AgentHooksInstall {
 
     /// append the marker-guarded `source` line for the shell integration to a shell rc file.
     ///
-    /// `existing` is the rc file's current contents, `scriptDir` the installed script directory. Returns the
-    /// new contents and whether anything was appended; idempotent — a begin marker already present returns the
-    /// input unchanged with `changed == false`.
+    /// Returns the new contents and whether anything was appended; idempotent — a begin marker already present
+    /// returns `existing` with `changed == false`.
     public static func appendShellRC(existing: String, scriptDir: String, scriptName: String = integrationRelativePath) -> (contents: String, changed: Bool) {
         if existing.contains(rcMarkerBegin) {
             return (existing, false)
@@ -164,8 +149,8 @@ public enum AgentHooksInstall {
         return (prefix + block, true)
     }
 
-    /// The result of merging the Codex hooks into `~/.codex/config.toml`, decided by parsing the existing
-    /// file with `TOMLDecoder` before touching it.
+    /// The result of merging the Codex hooks into `~/.codex/config.toml`, decided by parsing the file with
+    /// `TOMLDecoder` before touching it.
     public enum CodexMergeOutcome: Equatable {
         /// The hooks block was added (and any stale `codex-notify.sh` notify line removed) — write `contents`.
         case merged(contents: String)
@@ -178,20 +163,15 @@ public enum AgentHooksInstall {
         case unparseable
     }
 
-    /// merge the Codex lifecycle-status hooks into an existing `~/.codex/config.toml`.
-    ///
-    /// `existing` is the file's current contents (empty = no file yet), `scriptDir` the installed script
-    /// directory. The decision is made by PARSING `existing` with `TOMLDecoder` (a pure-Swift, spec-compliant
-    /// parser) rather than string-matching, which is what keeps the merge safe:
-    /// - marker already present → upgrade an older managed block to the current installed Codex adapter,
-    ///   preserving Codex's trailing hook trust-state tables; otherwise `.unchanged`;
-    /// - does not parse as TOML → `.unparseable` (never rewrite a file we can't understand);
-    /// - already defines `hooks` → `.hooksExist` (appending ours would duplicate or break them);
-    /// - otherwise → `.merged`, appending the marker-guarded `[[hooks.*]]` block (a new array-of-tables at
-    ///   end-of-file, valid because the file was verified to have no existing `hooks`) and removing a stale
-    ///   top-level `notify` ONLY when its PARSED value points at the retired `codex-notify.sh`, so a comment
-    ///   merely naming the file, or the user's own notifier, is never touched. The surgical append/removal
-    ///   preserves the user's comments and layout.
+    /// merge the Codex lifecycle-status hooks into an existing `~/.codex/config.toml` (`existing` empty = no
+    /// file yet). The decision is made by PARSING with `TOMLDecoder` rather than string-matching, which is what
+    /// keeps the merge safe: marker present → upgrade an older managed block to the currently installed Codex
+    /// adapter, preserving Codex's trailing hook trust-state tables, else `.unchanged`; not valid TOML →
+    /// `.unparseable`; already defines `hooks` → `.hooksExist`; otherwise `.merged`, appending the
+    /// marker-guarded `[[hooks.*]]` array-of-tables at end-of-file (valid because no existing `hooks` was
+    /// found) and removing a stale top-level `notify` ONLY when its PARSED value points at the retired
+    /// `codex-notify.sh`, so a comment merely naming the file, or the user's own notifier, is never touched.
+    /// The surgical append/removal preserves the user's comments and layout.
     public static func mergeCodexConfig(existing: String, scriptDir: String) -> CodexMergeOutcome {
         // marker present → refresh only our managed hook definitions. Codex may append hook trust-state
         // tables before our end marker; the refresh preserves that suffix byte-for-byte.
@@ -213,7 +193,6 @@ public enum AgentHooksInstall {
             return .hooksExist
         }
 
-        // strip a stale top-level `notify` ONLY when its PARSED value points at the retired codex-notify.sh.
         var text = existing
         if probe.notify.contains(where: { $0.contains("codex-notify.sh") }) {
             text = removeLegacyCodexNotify(from: text)
@@ -221,10 +200,9 @@ public enum AgentHooksInstall {
         return .merged(contents: appendCodexBlock(to: text, scriptDir: scriptDir))
     }
 
-    // the two top-level keys the merge cares about, decoded from an arbitrary config (Codable ignores every
-    // other key). `hooksPresent` is a pure presence check across any hooks shape; `notify` is the top-level
-    // notify program (array-of-argv or a bare string), so the retired codex-notify.sh entry is recognized by
-    // its PARSED value, not a fragile line match.
+    // the two top-level keys the merge cares about (Codable ignores every other). `hooksPresent` is a presence
+    // check across any hooks shape; `notify` is the top-level notify program (array-of-argv or a bare string),
+    // so the retired codex-notify.sh is recognized by its PARSED value, not a fragile line match.
     private struct CodexConfigProbe: Decodable {
         let hooksPresent: Bool
         let notify: [String]
@@ -255,7 +233,7 @@ public enum AgentHooksInstall {
 
     // replace only the generated definitions inside an existing managed block. Codex writes its
     // `[hooks.state...]` trust records at the end of config.toml, landing inside our EOF marker, so retain that
-    // whole suffix. A coincidental marker block without one of our hook scripts is foreign and left untouched.
+    // suffix. A coincidental marker block without one of our hook scripts is foreign and left untouched.
     private static func refreshManagedCodexBlock(in text: String, scriptDir: String) -> String {
         var lines = text.components(separatedBy: "\n")
         guard let begin = lines.firstIndex(where: { $0.trimmingCharacters(in: .whitespaces) == rcMarkerBegin }),
@@ -286,10 +264,10 @@ public enum AgentHooksInstall {
         return lines.joined(separator: "\n")
     }
 
-    // remove the retired single-line `notify = [...codex-notify.sh...]` assignment — only ever written by the
-    // old installer in that form, and the caller already confirmed via the parsed value that it exists.
-    // Restricted to the TOP-LEVEL region (above the first table header) so a table-scoped notify is untouched,
-    // and to a line carrying codex-notify.sh in its VALUE so a hand-authored multi-line array isn't half-removed.
+    // remove the retired single-line `notify = [...codex-notify.sh...]` — only the old installer wrote that
+    // form, and the caller already confirmed the parsed value. Restricted to the TOP-LEVEL region (above the
+    // first table header), so a table-scoped notify is untouched, and to codex-notify.sh in the VALUE, so a
+    // hand-authored multi-line array isn't half-removed.
     private static func removeLegacyCodexNotify(from text: String) -> String {
         var lines = text.components(separatedBy: "\n")
         let limit = lines.firstIndex { $0.trimmingCharacters(in: .whitespaces).hasPrefix("[") } ?? lines.count
@@ -301,28 +279,25 @@ public enum AgentHooksInstall {
         return lines.joined(separator: "\n")
     }
 
-    /// derive a backup path by appending `.bak` to the full path, extension intact:
-    /// `settings.json` → `settings.json.bak`.
+    /// derive a backup path by appending `.bak` to the full path, extension intact (`settings.json.bak`).
     public static func backupPath(for path: String) -> String {
         path + ".bak"
     }
 
-    /// the absolute wrapper-script path the installed hooks invoke, with state appended by the caller's
-    /// hook entry. e.g. `<scriptDir>/agterm-agent-status.sh`.
+    /// the absolute wrapper-script path the installed hooks invoke (`<scriptDir>/agterm-agent-status.sh`); the
+    /// caller's hook entry appends the state.
     public static func wrapperPath(scriptDir: String) -> String {
         scriptDir + "/" + wrapperName
     }
 
-    /// The absolute installed Codex lifecycle-adapter path.
     public static func codexWrapperPath(scriptDir: String) -> String {
         scriptDir + "/" + codexWrapperName
     }
 
-    /// render the `~/.codex/config.toml` `[[hooks.*]]` block the installer merges into the user's config
-    /// (or surfaces for a manual add when the file already has hooks or doesn't parse), wiring Codex's
-    /// lifecycle events to the indicator. `scriptDir` is the installed script directory; the wrapper's
-    /// absolute path is baked into each command — shell-quoted (so a path with spaces is one token)
-    /// inside a TOML basic string — so the hook fires without the CLI on PATH.
+    /// render the `~/.codex/config.toml` `[[hooks.*]]` block the installer merges in (or surfaces for a manual
+    /// add when the file already has hooks or doesn't parse), wiring Codex's lifecycle events to the indicator.
+    /// The wrapper's absolute path is baked into each command — shell-quoted (so a path with spaces stays one
+    /// token) inside a TOML basic string — so the hook fires without the CLI on PATH.
     public static func codexHooksBlock(scriptDir: String) -> String {
         let wrapper = shellQuote(codexWrapperPath(scriptDir: scriptDir))
         return codexHooks.map { hook in
@@ -335,17 +310,16 @@ public enum AgentHooksInstall {
         }.joined(separator: "\n\n")
     }
 
-    /// the POSIX permission bits of the file at `path`, or nil when the file is absent or its
-    /// attributes can't be read. Used to capture a file's mode before a mode-preserving rewrite.
+    /// the POSIX permission bits of the file at `path`, or nil when it is absent or unreadable — captured
+    /// before a mode-preserving rewrite.
     public static func posixMode(ofFile path: String) -> NSNumber? {
         guard let attrs = try? FileManager.default.attributesOfItem(atPath: path) else { return nil }
         return attrs[.posixPermissions] as? NSNumber
     }
 
-    /// write `text` to `path` atomically, then re-apply `posixMode` when non-nil so the rewrite keeps the
-    /// original file's permissions: an atomic write renames a fresh 0644 temp over the target, which would
-    /// otherwise widen a restrictive mode (e.g. a chmod-600 secret). A nil `posixMode` leaves the new file's
-    /// default permissions untouched.
+    /// write `text` to `path` atomically, then re-apply `posixMode` when non-nil: the atomic write renames a
+    /// fresh 0644 temp over the target, which would otherwise widen a restrictive mode (e.g. a chmod-600
+    /// secret). A nil `posixMode` leaves the new file's default permissions.
     public static func writeFile(_ text: String, toPath path: String, posixMode: NSNumber?) throws {
         try text.write(toFile: path, atomically: true, encoding: .utf8)
         if let posixMode {
@@ -376,8 +350,8 @@ public enum AgentHooksInstall {
         return commands.contains { ($0["command"] as? String)?.contains(probe) == true }
     }
 
-    // parse existing JSON into a dictionary. absent/empty/whitespace-only → fresh empty object; a
-    // non-empty file that is not a valid JSON object → throw rather than silently discard the user's file.
+    // absent/empty/whitespace-only → fresh empty object; a non-empty file that is not a valid JSON object →
+    // throw rather than silently discard the user's file.
     private static func parsedObject(_ text: String?) throws -> [String: Any] {
         guard let text, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return [:] }
         guard let data = text.data(using: .utf8),

--- a/agtermCore/Sources/agtermCore/AgentHooksInstall.swift
+++ b/agtermCore/Sources/agtermCore/AgentHooksInstall.swift
@@ -2,11 +2,10 @@ import Foundation
 import TOMLDecoder
 
 /// Host-free helpers for installing the agent-status hooks package. Most are testable string/JSON/TOML
-/// transforms — given the current file contents and the installed script directory they return the new
-/// contents plus a `changed` flag, all idempotent. It also provides a small mode-preserving file write
-/// (`writeFile`/`posixMode`) so rewriting a restrictive-mode file (e.g. a chmod-600 `settings.json`)
-/// keeps its permissions instead of an atomic rename widening it to 0644. The app side still owns
-/// copying the bundled scripts and resolving symlinks.
+/// transforms: given the current file contents and the installed script directory they return the new contents
+/// plus a `changed` flag, all idempotent. Plus a mode-preserving write (`writeFile`/`posixMode`) so rewriting a
+/// restrictive-mode file (e.g. a chmod-600 `settings.json`) keeps its permissions instead of an atomic rename
+/// widening it to 0644. The app side still owns copying the bundled scripts and resolving symlinks.
 public enum AgentHooksInstall {
     /// The wrapper script the hooks invoke, installed into the script directory.
     public static let wrapperName = "agterm-agent-status.sh"
@@ -47,14 +46,13 @@ public enum AgentHooksInstall {
     public static let rcMarkerBegin = "# >>> agterm agent-status >>>"
     public static let rcMarkerEnd = "# <<< agterm agent-status <<<"
 
-    /// The Claude Code hook events the merge installs, paired with the agent state (plus any flags)
-    /// each maps to. `UserPromptSubmit` and `PostToolUse` both set `active`: the former on a new prompt,
-    /// the latter after every tool runs so the status returns to `active` when work RESUMES after a
-    /// `blocked` permission prompt (Claude Code has no "permission answered" event, and the gated tool's
-    /// own `PreToolUse` already fired BEFORE `blocked` was set — so the approved tool's `PostToolUse` is
-    /// the first hook to fire afterwards). `Notification` additionally carries the `permission_prompt`
-    /// matcher (the others are unmatched). Only the `Stop`→`completed` hook passes `--auto-reset` (it
-    /// clears on visit); `active` and `blocked` stay keep-state.
+    /// The Claude Code hook events the merge installs, paired with the agent state (plus any flags) each maps
+    /// to. `UserPromptSubmit` and `PostToolUse` both set `active`: the former on a new prompt, the latter after
+    /// every tool run so the status returns to `active` when work RESUMES after a `blocked` permission prompt
+    /// — Claude Code has no "permission answered" event, and the gated tool's own `PreToolUse` fired BEFORE
+    /// `blocked` was set, so the approved tool's `PostToolUse` is the first hook afterwards. `Notification`
+    /// alone carries the `permission_prompt` matcher. Only `Stop`→`completed` passes `--auto-reset` (it clears
+    /// on visit); `active` and `blocked` stay keep-state.
     static let claudeHooks: [(event: String, matcher: String?, state: String)] = [
         ("UserPromptSubmit", nil, "active --blink"),
         ("PostToolUse", nil, "active --blink"),
@@ -115,13 +113,12 @@ public enum AgentHooksInstall {
 
     /// merge the four agent-status hooks into an existing Claude Code `settings.json`.
     ///
-    /// `existing` is the current file contents (nil or empty = no file yet); `scriptDir` is the
-    /// directory the wrapper script was installed into. Returns the new JSON text and whether it
-    /// differs from `existing`. Idempotent: when the agterm hooks (detected by the wrapper command)
-    /// are already present, returns the input unchanged with `changed == false`. Unrelated hooks and
-    /// keys are preserved; an absent/empty existing file starts from a fresh object, but a non-empty
-    /// file that is not valid JSON throws `MergeError.malformedExistingSettings` so the caller can leave
-    /// the user's hand-maintained file untouched rather than overwrite it.
+    /// `existing` is the current file contents (nil or empty = no file yet); `scriptDir` is the directory the
+    /// wrapper script was installed into. Returns the new JSON text and whether it differs from `existing`.
+    /// Idempotent: with the agterm hooks (detected by the wrapper command) already present it returns the input
+    /// unchanged with `changed == false`. Unrelated hooks and keys are preserved; an absent/empty file starts
+    /// from a fresh object, but a non-empty one that is not valid JSON throws
+    /// `MergeError.malformedExistingSettings` so the caller can leave a hand-maintained file untouched.
     public static func mergeClaudeSettings(existing: String?, scriptDir: String) throws -> (json: String, changed: Bool) {
         let command = wrapperCommand(scriptDir: scriptDir)
         var root = try parsedObject(existing)
@@ -131,7 +128,7 @@ public enum AgentHooksInstall {
         for hook in claudeHooks {
             var entries = hooks[hook.event] as? [[String: Any]] ?? []
             if entries.contains(where: { entryUsesWrapper($0, scriptDir: scriptDir) }) {
-                continue // already installed for this event
+                continue
             }
             entries.append(hookEntry(command: command, state: hook.state, matcher: hook.matcher))
             hooks[hook.event] = entries
@@ -146,12 +143,12 @@ public enum AgentHooksInstall {
 
     /// append the marker-guarded `source` line for the shell integration to a shell rc file.
     ///
-    /// `existing` is the rc file's current contents; `scriptDir` is the installed script directory.
-    /// Returns the new contents and whether anything was appended. Idempotent: if the begin marker is
-    /// already present the input is returned unchanged with `changed == false`.
+    /// `existing` is the rc file's current contents, `scriptDir` the installed script directory. Returns the
+    /// new contents and whether anything was appended; idempotent — a begin marker already present returns the
+    /// input unchanged with `changed == false`.
     public static func appendShellRC(existing: String, scriptDir: String, scriptName: String = integrationRelativePath) -> (contents: String, changed: Bool) {
         if existing.contains(rcMarkerBegin) {
-            return (existing, false) // already installed
+            return (existing, false)
         }
         let source = "source \(shellQuote(scriptDir + "/" + scriptName))"
         var block = rcMarkerBegin + "\n" + source + "\n" + rcMarkerEnd + "\n"
@@ -174,9 +171,8 @@ public enum AgentHooksInstall {
         case merged(contents: String)
         /// The file already carries the current agterm hooks block — nothing to do.
         case unchanged
-        /// The file already defines its OWN `hooks` — auto-appending ours would duplicate (array-of-tables
-        /// form) or break (compact form) them, so the merge is skipped; surface `codexHooksBlock` for a
-        /// manual merge.
+        /// The file already defines its OWN `hooks` — appending ours would duplicate (array-of-tables form) or
+        /// break (compact form) them, so the merge is skipped; surface `codexHooksBlock` for a manual merge.
         case hooksExist
         /// The existing file is not valid TOML — leave it untouched and surface the block for a manual add.
         case unparseable
@@ -184,18 +180,18 @@ public enum AgentHooksInstall {
 
     /// merge the Codex lifecycle-status hooks into an existing `~/.codex/config.toml`.
     ///
-    /// `existing` is the file's current contents (empty = no file yet); `scriptDir` is the installed
-    /// script directory. The decision is made by PARSING `existing` with `TOMLDecoder` (a pure-Swift,
-    /// spec-compliant parser) rather than string-matching, which is what keeps the merge safe:
+    /// `existing` is the file's current contents (empty = no file yet), `scriptDir` the installed script
+    /// directory. The decision is made by PARSING `existing` with `TOMLDecoder` (a pure-Swift, spec-compliant
+    /// parser) rather than string-matching, which is what keeps the merge safe:
     /// - marker already present → upgrade an older managed block to the current installed Codex adapter,
     ///   preserving Codex's trailing hook trust-state tables; otherwise `.unchanged`;
-    /// - the file does not parse as TOML → `.unparseable` (never rewrite a file we can't understand);
-    /// - the file already defines `hooks` → `.hooksExist` (appending ours would duplicate or break them);
+    /// - does not parse as TOML → `.unparseable` (never rewrite a file we can't understand);
+    /// - already defines `hooks` → `.hooksExist` (appending ours would duplicate or break them);
     /// - otherwise → `.merged`, appending the marker-guarded `[[hooks.*]]` block (a new array-of-tables at
-    ///   end-of-file, valid because we verified the file has no existing `hooks`) and removing a stale
-    ///   top-level `notify` ONLY when its PARSED value points at the retired `codex-notify.sh` (so a
-    ///   comment merely naming the file, or the user's own notifier, is never touched). The surgical
-    ///   append/removal preserves the user's comments and layout.
+    ///   end-of-file, valid because the file was verified to have no existing `hooks`) and removing a stale
+    ///   top-level `notify` ONLY when its PARSED value points at the retired `codex-notify.sh`, so a comment
+    ///   merely naming the file, or the user's own notifier, is never touched. The surgical append/removal
+    ///   preserves the user's comments and layout.
     public static func mergeCodexConfig(existing: String, scriptDir: String) -> CodexMergeOutcome {
         // marker present → refresh only our managed hook definitions. Codex may append hook trust-state
         // tables before our end marker; the refresh preserves that suffix byte-for-byte.
@@ -225,10 +221,10 @@ public enum AgentHooksInstall {
         return .merged(contents: appendCodexBlock(to: text, scriptDir: scriptDir))
     }
 
-    // the two top-level keys the merge cares about, decoded from an arbitrary config (Codable ignores
-    // every other key). `hooksPresent` is a pure presence check across any hooks shape; `notify` is the
-    // top-level notify program (array-of-argv, or a bare string) so the retired codex-notify.sh entry is
-    // recognized by its PARSED value, not a fragile line match.
+    // the two top-level keys the merge cares about, decoded from an arbitrary config (Codable ignores every
+    // other key). `hooksPresent` is a pure presence check across any hooks shape; `notify` is the top-level
+    // notify program (array-of-argv or a bare string), so the retired codex-notify.sh entry is recognized by
+    // its PARSED value, not a fragile line match.
     private struct CodexConfigProbe: Decodable {
         let hooksPresent: Bool
         let notify: [String]
@@ -257,10 +253,9 @@ public enum AgentHooksInstall {
         return prefix + "\n" + block
     }
 
-    // Replace only the generated definitions inside an existing managed block. Codex writes its
-    // `[hooks.state...]` trust records at the end of config.toml, which lands inside our EOF marker;
-    // retain that entire suffix. A coincidental marker block without one of our hook scripts is foreign
-    // and remains untouched.
+    // replace only the generated definitions inside an existing managed block. Codex writes its
+    // `[hooks.state...]` trust records at the end of config.toml, landing inside our EOF marker, so retain that
+    // whole suffix. A coincidental marker block without one of our hook scripts is foreign and left untouched.
     private static func refreshManagedCodexBlock(in text: String, scriptDir: String) -> String {
         var lines = text.components(separatedBy: "\n")
         guard let begin = lines.firstIndex(where: { $0.trimmingCharacters(in: .whitespaces) == rcMarkerBegin }),
@@ -291,11 +286,10 @@ public enum AgentHooksInstall {
         return lines.joined(separator: "\n")
     }
 
-    // remove the retired single-line `notify = [...codex-notify.sh...]` assignment (only ever written by
-    // the old installer in the single-line form). Restricted to the TOP-LEVEL region (above the first
-    // table header) so a table-scoped notify is never touched, and to a line carrying codex-notify.sh in
-    // its VALUE so a hand-authored multi-line array is left intact rather than half-removed (the caller
-    // already confirmed via the parsed value that the stale entry exists).
+    // remove the retired single-line `notify = [...codex-notify.sh...]` assignment — only ever written by the
+    // old installer in that form, and the caller already confirmed via the parsed value that it exists.
+    // Restricted to the TOP-LEVEL region (above the first table header) so a table-scoped notify is untouched,
+    // and to a line carrying codex-notify.sh in its VALUE so a hand-authored multi-line array isn't half-removed.
     private static func removeLegacyCodexNotify(from text: String) -> String {
         var lines = text.components(separatedBy: "\n")
         let limit = lines.firstIndex { $0.trimmingCharacters(in: .whitespaces).hasPrefix("[") } ?? lines.count
@@ -307,8 +301,8 @@ public enum AgentHooksInstall {
         return lines.joined(separator: "\n")
     }
 
-    /// derive a backup path for a file by appending `.bak` to its full path. `settings.json` →
-    /// `settings.json.bak`; the extension is left intact (the `.bak` is appended to the whole name).
+    /// derive a backup path by appending `.bak` to the full path, extension intact:
+    /// `settings.json` → `settings.json.bak`.
     public static func backupPath(for path: String) -> String {
         path + ".bak"
     }
@@ -348,10 +342,10 @@ public enum AgentHooksInstall {
         return attrs[.posixPermissions] as? NSNumber
     }
 
-    /// write `text` to `path` atomically, then re-apply `posixMode` when non-nil so the rewrite keeps
-    /// the original file's permissions. An atomic write renames a fresh 0644 temp over the target, which
-    /// would otherwise widen a restrictive mode (e.g. a chmod-600 secret) to 0644; re-applying the
-    /// captured mode restores it. A nil `posixMode` leaves the new file's default permissions untouched.
+    /// write `text` to `path` atomically, then re-apply `posixMode` when non-nil so the rewrite keeps the
+    /// original file's permissions: an atomic write renames a fresh 0644 temp over the target, which would
+    /// otherwise widen a restrictive mode (e.g. a chmod-600 secret). A nil `posixMode` leaves the new file's
+    /// default permissions untouched.
     public static func writeFile(_ text: String, toPath path: String, posixMode: NSNumber?) throws {
         try text.write(toFile: path, atomically: true, encoding: .utf8)
         if let posixMode {

--- a/agtermCore/Sources/agtermCore/AgentStatus.swift
+++ b/agtermCore/Sources/agtermCore/AgentStatus.swift
@@ -5,19 +5,16 @@ import Foundation
 public enum AgentStatus: String, Codable, Sendable, CaseIterable {
     case idle, active, completed, blocked
 
-    /// True for the states that need user attention (a `blocked` prompt or a `completed` run) — the set
-    /// the attention navigation (⌃⌥↑/↓, `session.go next-attention|prev-attention`) steps through,
-    /// excluding `idle` (no glyph) and `active` (the agent is still working).
+    /// True for the states attention navigation (⌃⌥↑/↓, `session.go next-attention|prev-attention`) steps
+    /// through: a `blocked` prompt or a `completed` run, not `active` (still working) or `idle` (no glyph).
     public var needsAttention: Bool { self == .blocked || self == .completed }
 
     /// Whether a keystroke in the session's terminal should clear this glyph back to idle. `blocked` and
-    /// `completed` clear on ANY key (you've engaged with the prompt / the finished result); `active` clears
-    /// ONLY on an interrupt keystroke — Escape or Ctrl-C, which Claude Code (like most TUIs) treats alike
-    /// for dismissing a pending prompt — so ordinary typing while the agent works does NOT wipe the
-    /// "working" glyph, but cancelling a prompt does. That covers the quick-cancel case: a pending question
-    /// can still read `active` when you cancel it (Claude Code's `blocked` notification lands seconds
-    /// later) and the interrupt fires no hook, so this is the only signal that drops the stale `active`.
-    /// `idle` has no glyph to clear.
+    /// `completed` clear on ANY key (you've engaged with the prompt / the finished result); `active` clears ONLY
+    /// on an interrupt (Escape or Ctrl-C), so typing while the agent works keeps the "working" glyph. That
+    /// covers the quick-cancel case: a pending question can still read `active` when you cancel it (Claude
+    /// Code's `blocked` notification lands seconds later) and the interrupt fires no hook, so nothing else
+    /// drops the stale value.
     func clearedByKeystroke(isInterrupt: Bool) -> Bool {
         switch self {
         case .blocked, .completed: return true
@@ -26,9 +23,8 @@ public enum AgentStatus: String, Codable, Sendable, CaseIterable {
         }
     }
 
-    /// Sort priority for the attention list, lower first: `blocked` (0) is most urgent, then `active` (1),
-    /// then `completed` (2). `idle` (3) is never sorted — idle sessions are filtered out before the list is
-    /// built — but ranks last so any accidental inclusion sorts after the rest.
+    /// Sort priority for the attention list, lower first. `idle` is never sorted — idle sessions are filtered
+    /// out before the list is built — but ranks last so an accidental inclusion sorts after the rest.
     public var attentionRank: Int {
         switch self {
         case .blocked: return 0
@@ -38,10 +34,9 @@ public enum AgentStatus: String, Codable, Sendable, CaseIterable {
         }
     }
 
-    /// The sound to play for a `session.status` call, or nil for none. An explicit per-call sound
-    /// (`session.status --sound`) always wins, else the caller-configured `blockedDefault` plays but ONLY
-    /// for `blocked` (the Settings "Blocked sound"); empty strings count as unset. The app resolves the
-    /// returned name with `NSSound(named:)` — this is just the host-free precedence decision.
+    /// The sound to play for a `session.status` call, or nil for none: an explicit per-call sound
+    /// (`session.status --sound`) wins, else the configured `blockedDefault` (Settings "Blocked sound") plays
+    /// ONLY for `blocked`; empty strings count as unset. The app resolves the name with `NSSound(named:)`.
     public func effectiveSound(perCall: String?, blockedDefault: String?) -> String? {
         if let perCall, !perCall.isEmpty { return perCall }
         if self == .blocked, let blockedDefault, !blockedDefault.isEmpty { return blockedDefault }
@@ -49,10 +44,8 @@ public enum AgentStatus: String, Codable, Sendable, CaseIterable {
     }
 
     /// symbolName resolves the SF Symbol for the status glyph, shared by the AppKit sidebar and the SwiftUI
-    /// attention list. Two-level precedence: the per-call `override` (the ephemeral `AgentIndicator.shape`
-    /// from `session.status --shape`) wins, else the `configured` Settings shape for this status, else
-    /// `StatusShape.circle` — the built-in default for every non-idle state. `idle` returns the empty
-    /// string in every combination; it never renders a glyph, so the value is filtered out before use.
+    /// attention list: the per-call `override` (from `session.status --shape`) wins, else the `configured`
+    /// Settings shape, else `StatusShape.circle`. `idle` renders no glyph, so its "" is filtered out before use.
     public func symbolName(override: StatusShape?, configured: StatusShape?) -> String {
         guard self != .idle else { return "" }
         return (override ?? configured ?? .circle).symbolName
@@ -64,62 +57,52 @@ public enum AgentStatus: String, Codable, Sendable, CaseIterable {
     }
 }
 
-/// StatusPane records which pane of a session set the current agent status, in the same
-/// `left|right|scratch` vocabulary as the `--pane` control argument (`left`=main, `right`=split). It rides
-/// on `AgentIndicator` so pane-scoped keystroke-clear and pane-aware navigation know which surface
-/// blocked; raw values serialize to JSON as `"left"|"right"|"scratch"`.
+/// StatusPane records which pane set the current agent status, in the `--pane` control vocabulary it also
+/// serializes as (`left`=main, `right`=split, `scratch`). Pane-scoped keystroke-clear and pane-aware
+/// navigation read it off `AgentIndicator` to know which surface blocked.
 public enum StatusPane: String, Codable, Sendable, CaseIterable {
     case left, right, scratch
 }
 
-/// StatusShape is the silhouette a status glyph draws, so the shape carries the state alongside the tint.
-/// Every shape is a plain silhouette with no interior mark, selectable per status in Settings or per call
-/// via `session.status --shape`; `circle` is what an unset status draws. The raw value is the SF Symbol
-/// base name and serializes to JSON as `"circle"|"square"|…`.
+/// StatusShape is the silhouette a status glyph draws, so shape carries the state alongside the tint. Every
+/// shape is plain, with no interior mark, selectable per status in Settings or per call via
+/// `session.status --shape`; `circle` is what an unset status draws. The raw value is the SF Symbol base name.
 public enum StatusShape: String, Codable, Sendable, CaseIterable {
     case circle, square, triangle, diamond, capsule, star
 
-    /// SF Symbol name for the shape — the `.fill` variant, so every glyph is a solid silhouette rather
-    /// than an outline.
+    /// SF Symbol name for the shape — the `.fill` variant, so every glyph is a solid silhouette, not an outline.
     public var symbolName: String { "\(rawValue).fill" }
 
-    /// The human-facing name for the shape ("Triangle"): the Settings picker uses it as an option's
-    /// accessibility label and as the picker's own accessibility value.
+    /// The human-facing name ("Triangle"): the Settings picker's per-option accessibility label and its value.
     public var displayName: String { rawValue.capitalized }
 
-    /// The accepted names pipe-joined (`circle|square|…`) — the compact form the control server's rejection
-    /// message uses. Derived from `allCases`, like `WatermarkConfig.validFits`, so no message can go stale.
+    /// The accepted names pipe-joined — the compact form the control server's rejection message uses. Derived
+    /// from `allCases`, like `WatermarkConfig.validFits`, so no message can go stale.
     public static var validNamesList: String { validNames.joined(separator: "|") }
 
-    /// The accepted names comma-joined (`circle, square, …`) — the prose form the `agtermctl --shape`
-    /// help text and its local rejection message use.
+    /// The accepted names comma-joined — the prose form for `agtermctl --shape` help and its local rejection.
     public static var validNamesPhrase: String { validNames.joined(separator: ", ") }
 
     private static var validNames: [String] { allCases.map(\.rawValue) }
 }
 
-/// AgentIndicator is the per-session agent status value: the state plus an optional blink flag (pulse the
-/// glyph for attention), an optional autoReset flag (clear back to idle once the session is visited),
-/// optional per-call color and shape overrides for the glyph, and the pane that set the status. Ephemeral
-/// (never persisted) and set only via the control API.
+/// AgentIndicator is the per-session agent status value: state, blink, autoReset, per-call color and shape
+/// overrides, and the pane that set it. Ephemeral (never persisted) and set only via the control API.
 public struct AgentIndicator: Equatable, Sendable {
-    /// status is the current agent state; `.idle` renders no glyph.
     public var status: AgentStatus = .idle
     /// blink makes the visible glyph pulse for attention.
     public var blink: Bool = false
-    /// autoReset, when true, the indicator resets to idle once the session is visited (selected) — a
-    /// caller-set, status-agnostic flag, like blink.
+    /// autoReset resets the indicator to idle once the session is visited (selected) — caller-set and
+    /// status-agnostic, like blink.
     public var autoReset: Bool = false
-    /// color, when set, is a `#rrggbb` hex overriding the Settings-configured tint for this glyph only — a
-    /// caller-set, per-call value riding the ephemeral indicator, so the next `session.status` without a
-    /// color naturally discards it. nil renders the default status color.
+    /// color, when set, is a `#rrggbb` hex overriding the Settings tint for this glyph only; it rides the
+    /// ephemeral indicator, so the next `session.status` without a color discards it. nil = the default tint.
     public var color: String?
-    /// shape, when set, overrides the Settings-configured silhouette for this glyph only — a caller-set,
-    /// per-call value riding the ephemeral indicator, so the next `session.status` without a shape
-    /// naturally discards it. nil falls back to the Settings shape, else the default plain circle.
+    /// shape, when set, overrides the Settings-configured silhouette for this glyph only, discarded like
+    /// `color`. nil falls back to the Settings shape, else the default plain circle.
     public var shape: StatusShape?
-    /// statusPane records which pane set this status; nil means unspecified and is treated as `.left`
-    /// (main) by the clear logic.
+    /// statusPane records which pane set this status; nil is unspecified and treated as `.left` (main) by the
+    /// clear logic.
     public var statusPane: StatusPane?
 
     public init(status: AgentStatus = .idle, blink: Bool = false, autoReset: Bool = false,
@@ -132,10 +115,8 @@ public struct AgentIndicator: Equatable, Sendable {
         self.statusPane = statusPane
     }
 
-    /// clearedBy reports whether a keystroke from `pane` should clear this indicator back to idle: only
-    /// when the keystroke's own pane owns the current status (a nil `statusPane` counts as `.left`) AND the
-    /// status is clearable by that keystroke (`AgentStatus.clearedByKeystroke`). Keeps foreground typing
-    /// from wiping a status set by a background pane.
+    /// clearedBy: a keystroke from `pane` clears this indicator only when that pane owns the current status and
+    /// `clearedByKeystroke` allows it, so foreground typing can't wipe a background pane's status.
     public func clearedBy(pane: StatusPane, isInterrupt: Bool) -> Bool {
         (statusPane ?? .left) == pane && status.clearedByKeystroke(isInterrupt: isInterrupt)
     }

--- a/agtermCore/Sources/agtermCore/AgentStatus.swift
+++ b/agtermCore/Sources/agtermCore/AgentStatus.swift
@@ -11,13 +11,13 @@ public enum AgentStatus: String, Codable, Sendable, CaseIterable {
     public var needsAttention: Bool { self == .blocked || self == .completed }
 
     /// Whether a keystroke in the session's terminal should clear this glyph back to idle. `blocked` and
-    /// `completed` clear on ANY key (you've engaged with the prompt / the finished result); `active`
-    /// clears ONLY on an interrupt keystroke (Escape or Ctrl-C) — so ordinary typing while the agent works
-    /// does NOT wipe the "working" glyph, but cancelling a prompt the agent is showing does. Both keys
-    /// interrupt: Claude Code (like most TUIs) treats Ctrl-C as Esc for dismissing a pending prompt. This
-    /// covers the quick-cancel case: a pending question can still read `active` when you cancel it (Claude
-    /// Code's `blocked` notification lands seconds later), and the interrupt itself fires no hook, so this
-    /// keystroke clear is the only signal that drops the stale `active`. `idle` has no glyph to clear.
+    /// `completed` clear on ANY key (you've engaged with the prompt / the finished result); `active` clears
+    /// ONLY on an interrupt keystroke — Escape or Ctrl-C, which Claude Code (like most TUIs) treats alike
+    /// for dismissing a pending prompt — so ordinary typing while the agent works does NOT wipe the
+    /// "working" glyph, but cancelling a prompt does. That covers the quick-cancel case: a pending question
+    /// can still read `active` when you cancel it (Claude Code's `blocked` notification lands seconds
+    /// later) and the interrupt fires no hook, so this is the only signal that drops the stale `active`.
+    /// `idle` has no glyph to clear.
     func clearedByKeystroke(isInterrupt: Bool) -> Bool {
         switch self {
         case .blocked, .completed: return true
@@ -26,9 +26,9 @@ public enum AgentStatus: String, Codable, Sendable, CaseIterable {
         }
     }
 
-    /// Sort priority for the attention list: lower comes first. `blocked` (0) is most urgent, then
-    /// `active` (1), then `completed` (2). `idle` (3) is never sorted — idle sessions are filtered out
-    /// before the list is built — but it ranks last so any accidental inclusion sorts after the rest.
+    /// Sort priority for the attention list, lower first: `blocked` (0) is most urgent, then `active` (1),
+    /// then `completed` (2). `idle` (3) is never sorted — idle sessions are filtered out before the list is
+    /// built — but ranks last so any accidental inclusion sorts after the rest.
     public var attentionRank: Int {
         switch self {
         case .blocked: return 0
@@ -39,21 +39,20 @@ public enum AgentStatus: String, Codable, Sendable, CaseIterable {
     }
 
     /// The sound to play for a `session.status` call, or nil for none. An explicit per-call sound
-    /// (`session.status --sound`) always wins; otherwise the caller-configured `blockedDefault` plays, but
-    /// ONLY for the `blocked` state (the Settings "Blocked sound"). Empty strings count as unset. The app
-    /// resolves the returned name with `NSSound(named:)`; this is just the host-free precedence decision.
+    /// (`session.status --sound`) always wins, else the caller-configured `blockedDefault` plays but ONLY
+    /// for `blocked` (the Settings "Blocked sound"); empty strings count as unset. The app resolves the
+    /// returned name with `NSSound(named:)` — this is just the host-free precedence decision.
     public func effectiveSound(perCall: String?, blockedDefault: String?) -> String? {
         if let perCall, !perCall.isEmpty { return perCall }
         if self == .blocked, let blockedDefault, !blockedDefault.isEmpty { return blockedDefault }
         return nil
     }
 
-    /// symbolName resolves the SF Symbol for the status glyph, shared by the AppKit sidebar and the
-    /// SwiftUI attention list. Precedence is two-level: the per-call `override` (the ephemeral
-    /// `AgentIndicator.shape` from `session.status --shape`) wins, else the `configured` Settings shape
-    /// for this status, else `StatusShape.circle` — the built-in default for every non-idle state. `idle`
-    /// returns the empty string in every combination — idle never renders a glyph, so it is filtered out
-    /// before any glyph is built and this value is never used.
+    /// symbolName resolves the SF Symbol for the status glyph, shared by the AppKit sidebar and the SwiftUI
+    /// attention list. Two-level precedence: the per-call `override` (the ephemeral `AgentIndicator.shape`
+    /// from `session.status --shape`) wins, else the `configured` Settings shape for this status, else
+    /// `StatusShape.circle` — the built-in default for every non-idle state. `idle` returns the empty
+    /// string in every combination; it never renders a glyph, so the value is filtered out before use.
     public func symbolName(override: StatusShape?, configured: StatusShape?) -> String {
         guard self != .idle else { return "" }
         return (override ?? configured ?? .circle).symbolName
@@ -65,18 +64,18 @@ public enum AgentStatus: String, Codable, Sendable, CaseIterable {
     }
 }
 
-/// StatusPane records which pane of a session set the current agent status, using the same
-/// `left|right|scratch` vocabulary as the `--pane` control argument (`left`=main, `right`=split).
-/// It rides on `AgentIndicator` so pane-scoped keystroke-clear and pane-aware navigation know which
-/// surface blocked. Raw values serialize to JSON as `"left"|"right"|"scratch"`.
+/// StatusPane records which pane of a session set the current agent status, in the same
+/// `left|right|scratch` vocabulary as the `--pane` control argument (`left`=main, `right`=split). It rides
+/// on `AgentIndicator` so pane-scoped keystroke-clear and pane-aware navigation know which surface
+/// blocked; raw values serialize to JSON as `"left"|"right"|"scratch"`.
 public enum StatusPane: String, Codable, Sendable, CaseIterable {
     case left, right, scratch
 }
 
 /// StatusShape is the silhouette a status glyph draws, so the shape carries the state alongside the tint.
-/// Every shape is a plain silhouette with no interior mark, and one is selectable per status in Settings
-/// or per call via `session.status --shape`; `circle` is what an unset status draws. The raw value is the
-/// SF Symbol base name and serializes to JSON as `"circle"|"square"|…`.
+/// Every shape is a plain silhouette with no interior mark, selectable per status in Settings or per call
+/// via `session.status --shape`; `circle` is what an unset status draws. The raw value is the SF Symbol
+/// base name and serializes to JSON as `"circle"|"square"|…`.
 public enum StatusShape: String, Codable, Sendable, CaseIterable {
     case circle, square, triangle, diamond, capsule, star
 
@@ -88,9 +87,8 @@ public enum StatusShape: String, Codable, Sendable, CaseIterable {
     /// accessibility label and as the picker's own accessibility value.
     public var displayName: String { rawValue.capitalized }
 
-    /// The accepted names pipe-joined (`circle|square|…`) — the compact form the control server's
-    /// rejection message uses. Derived from `allCases`, like `WatermarkConfig.validFits`, so no message
-    /// can go stale when the set changes.
+    /// The accepted names pipe-joined (`circle|square|…`) — the compact form the control server's rejection
+    /// message uses. Derived from `allCases`, like `WatermarkConfig.validFits`, so no message can go stale.
     public static var validNamesList: String { validNames.joined(separator: "|") }
 
     /// The accepted names comma-joined (`circle, square, …`) — the prose form the `agtermctl --shape`
@@ -100,10 +98,10 @@ public enum StatusShape: String, Codable, Sendable, CaseIterable {
     private static var validNames: [String] { allCases.map(\.rawValue) }
 }
 
-/// AgentIndicator is the per-session agent status value: the state plus an optional blink flag (pulse
-/// the glyph for attention), an optional autoReset flag (clear back to idle once the session is
-/// visited), optional per-call color and shape overrides for the glyph, and the pane that set the status.
-/// It is ephemeral (never persisted) and set only via the control API.
+/// AgentIndicator is the per-session agent status value: the state plus an optional blink flag (pulse the
+/// glyph for attention), an optional autoReset flag (clear back to idle once the session is visited),
+/// optional per-call color and shape overrides for the glyph, and the pane that set the status. Ephemeral
+/// (never persisted) and set only via the control API.
 public struct AgentIndicator: Equatable, Sendable {
     /// status is the current agent state; `.idle` renders no glyph.
     public var status: AgentStatus = .idle
@@ -112,12 +110,12 @@ public struct AgentIndicator: Equatable, Sendable {
     /// autoReset, when true, the indicator resets to idle once the session is visited (selected) — a
     /// caller-set, status-agnostic flag, like blink.
     public var autoReset: Bool = false
-    /// color, when set, is a `#rrggbb` hex that overrides the Settings-configured glyph tint for this
-    /// glyph only — a caller-set, per-call value that rides the ephemeral indicator, so the next
-    /// `session.status` call without a color naturally discards it. nil renders the default status color.
+    /// color, when set, is a `#rrggbb` hex overriding the Settings-configured tint for this glyph only — a
+    /// caller-set, per-call value riding the ephemeral indicator, so the next `session.status` without a
+    /// color naturally discards it. nil renders the default status color.
     public var color: String?
     /// shape, when set, overrides the Settings-configured silhouette for this glyph only — a caller-set,
-    /// per-call value that rides the ephemeral indicator, so the next `session.status` without a shape
+    /// per-call value riding the ephemeral indicator, so the next `session.status` without a shape
     /// naturally discards it. nil falls back to the Settings shape, else the default plain circle.
     public var shape: StatusShape?
     /// statusPane records which pane set this status; nil means unspecified and is treated as `.left`
@@ -134,10 +132,10 @@ public struct AgentIndicator: Equatable, Sendable {
         self.statusPane = statusPane
     }
 
-    /// clearedBy reports whether a keystroke from `pane` should clear this indicator back to idle. It
-    /// clears only when the keystroke's own pane owns the current status (a nil `statusPane` is treated
-    /// as `.left`) AND the status itself is clearable by that keystroke (`AgentStatus.clearedByKeystroke`).
-    /// This keeps foreground typing from wiping a status set by a background pane.
+    /// clearedBy reports whether a keystroke from `pane` should clear this indicator back to idle: only
+    /// when the keystroke's own pane owns the current status (a nil `statusPane` counts as `.left`) AND the
+    /// status is clearable by that keystroke (`AgentStatus.clearedByKeystroke`). Keeps foreground typing
+    /// from wiping a status set by a background pane.
     public func clearedBy(pane: StatusPane, isInterrupt: Bool) -> Bool {
         (statusPane ?? .left) == pane && status.clearedByKeystroke(isInterrupt: isInterrupt)
     }

--- a/agtermCore/Sources/agtermCore/AppSettings.swift
+++ b/agtermCore/Sources/agtermCore/AppSettings.swift
@@ -2,21 +2,20 @@ import Foundation
 
 /// The window's custom titlebar row state: `normal` stacks the session name over the cwd subtitle,
 /// `compact` is a single short row, `hidden` drops the row and the traffic lights for a full-bleed
-/// terminal. Stored raw so an unknown future value decodes tolerantly (via `effectiveToolbarMode`)
-/// rather than failing the whole decode.
-///
-/// Top-level (unlike the nested sibling mode enums) because the app target references it as a bare `ToolbarMode`.
+/// terminal. Stored raw so an unknown future value decodes tolerantly via `effectiveToolbarMode` instead
+/// of failing the whole decode. Top-level, unlike the nested sibling mode enums, because the app target
+/// references it as a bare `ToolbarMode`.
 public enum ToolbarMode: String, Codable, Sendable, CaseIterable {
     case normal
     case compact
     case hidden
 }
 
-/// How a delivered notification bounces the Dock icon (macOS `requestUserAttention`): `off` (no bounce),
-/// `once` (a single `.informationalRequest`), or `untilFocused` (a `.criticalRequest` that bounces until
-/// agterm becomes active). Stored raw on `AppSettings` so an unknown future value decodes tolerantly (via
-/// `effectiveDockBounce`). The default `off` case is named `off` (not `none`) to avoid the `Optional.none`
-/// collision at the `effectiveDockBounce` call site, matching the `AutoFollowAttention.off` precedent.
+/// How a delivered notification bounces the Dock icon (macOS `requestUserAttention`): `off`, `once` (a
+/// single `.informationalRequest`), or `untilFocused` (a `.criticalRequest` bouncing until agterm becomes
+/// active). Stored raw so an unknown future value decodes tolerantly via `effectiveDockBounce`. The
+/// default case is named `off`, not `none`, to dodge the `Optional.none` collision at that call site
+/// (the `AutoFollowAttention.off` precedent).
 public enum DockBounce: String, Codable, Sendable, CaseIterable {
     case off
     case once
@@ -24,9 +23,8 @@ public enum DockBounce: String, Codable, Sendable, CaseIterable {
 }
 
 /// A toggleable window-chrome element in the title bar or the sidebar. Persisted by raw name in
-/// `AppSettings.hiddenInterfaceElements`, so an unknown future case in a stored list decodes tolerantly
-/// (it is simply dropped) rather than failing the whole decode — the AppSettings forward-compat rule.
-/// Every element is shown by default; hiding one adds its raw name to the persisted list.
+/// `AppSettings.hiddenInterfaceElements`: an unknown future case in a stored list is dropped rather than
+/// failing the whole decode (the forward-compat rule). Shown by default; hiding adds its raw name.
 public enum InterfaceElement: String, Codable, Sendable, CaseIterable {
     // title bar
     case sidebarToggle
@@ -75,12 +73,11 @@ public enum InterfaceElement: String, Codable, Sendable, CaseIterable {
         }
     }
 
-    /// Which of the two separators in the title bar's trailing button cluster to draw, given how many
-    /// visible buttons each of the three groups has (A = recent-sessions + attention, B = scratch + split,
-    /// C = dashboard + quick-terminal). A separator sits ONLY where two groups that each still show 2+
-    /// buttons meet: `afterA` between A and B, `afterB` between B and C, or — when B is empty — directly
-    /// between a full A and a full C. A group reduced to one button flows in without a bracketing separator.
-    /// Host-free so the rule is unit-tested without an app host; the view supplies the three counts.
+    /// Which of the two title-bar trailing-cluster separators to draw, given each group's visible button
+    /// count (A = recent-sessions + attention, B = scratch + split, C = dashboard + quick-terminal). A
+    /// separator sits ONLY where two groups that each show 2+ buttons meet — `afterA` between A and B,
+    /// `afterB` between B and C or, when B is empty, between a full A and a full C; a group reduced to one
+    /// button needs none. Host-free so the rule is unit-tested with no app host; the view supplies the counts.
     public static func titlebarGroupDividers(countA: Int, countB: Int, countC: Int) -> (afterA: Bool, afterB: Bool) {
         let afterA = countA >= 2 && countB >= 2
         let afterB = (countB >= 2 && countC >= 2) || (countA >= 2 && countC >= 2 && countB == 0)
@@ -90,27 +87,23 @@ public enum InterfaceElement: String, Codable, Sendable, CaseIterable {
 
 /// User-facing appearance settings, persisted independently of the workspace tree.
 ///
-/// Every field is optional: nil means "use the ghostty default", and a settings file written
-/// before a field existed still decodes — that optionality IS the forward-compat mechanism, so
-/// there is no version field (a version bump would only add a discard-on-mismatch path that wipes
-/// the user's settings).
+/// Every field is optional: nil means "use the ghostty default", and a file written before a field
+/// existed still decodes. That optionality IS the forward-compat mechanism, so there is no version field
+/// — a version bump would only add a discard-on-mismatch path that wipes the user's settings.
 public struct AppSettings: Codable, Equatable, Sendable {
-    /// Where a new (⌘T) session opens. Stored as the `newSessionDirectory` raw string so an unknown
-    /// future value decodes tolerantly to `home` (the AppSettings forward-compat rule) instead of
-    /// failing the whole decode. `home` is also the nil case (the default), so picking it clears the
-    /// field and keeps `settings.json` minimal.
+    /// Where a new (⌘T) session opens. Stored as the `newSessionDirectory` raw string so an unknown future
+    /// value decodes tolerantly to `home` instead of failing the whole decode. `home` is also the nil case
+    /// (the default), so picking it clears the field and keeps `settings.json` minimal.
     public enum NewSessionDirectory: String, CaseIterable, Sendable {
         case home
         case currentSession
         case custom
     }
 
-    /// The user-idle timeout after which the window's selection auto-follows to the oldest blocked
-    /// session, stored as the `autoFollowAttention` raw string so an unknown future value decodes
-    /// tolerantly to `off` (the AppSettings forward-compat rule) instead of failing the whole decode.
-    /// `off` is also the nil case (the default), so picking it clears the field and keeps
-    /// `settings.json` minimal. Each case's `timeout` is the idle grace in seconds (`off` = nil = the
-    /// feature is disabled).
+    /// The user-idle timeout after which the window's selection auto-follows to the oldest blocked session,
+    /// stored as the `autoFollowAttention` raw string so an unknown future value decodes tolerantly to `off`
+    /// instead of failing the whole decode. `off` is also the nil case (the default), so picking it clears
+    /// the field and keeps `settings.json` minimal. Each case's `timeout` is the idle grace in seconds.
     public enum AutoFollowAttention: String, CaseIterable, Sendable {
         case off
         case s5
@@ -120,8 +113,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         case m5
 
         /// Tolerant lookup shared by the Settings binding and the store fan-out: an unknown or nil raw
-        /// value resolves to `off` (the AppSettings forward-compat default) instead of failing, so a
-        /// future-written value never breaks the read.
+        /// value resolves to `off`, so a future-written value never breaks the read.
         public init(tolerant raw: String?) {
             self = AutoFollowAttention(rawValue: raw ?? "") ?? .off
         }
@@ -148,14 +140,12 @@ public struct AppSettings: Codable, Equatable, Sendable {
     /// extreme), used when `inactivePaneMuteStrength` is nil. 5 maps to the historical 0.4 opacity.
     public static let defaultInactivePaneMuteStrength = 5
 
-    /// The out-of-the-box sidebar background shift on the 0...10 scale, used when
-    /// `sidebarBackgroundShift` is nil. 5 is the neutral center (sidebar matches the terminal
-    /// background); below 5 lightens it, above 5 darkens it.
+    /// The out-of-the-box sidebar background shift on the 0...10 scale, used when `sidebarBackgroundShift`
+    /// is nil. 5 is the neutral center (sidebar matches the terminal background); below lightens, above darkens.
     public static let defaultSidebarBackgroundShift = 5
 
     /// The out-of-the-box sidebar row-text point size, used when `sidebarFontSize` is nil. Matches the
-    /// macOS `.body` text style (13pt) the sidebar rows used before the size became configurable, so a
-    /// fresh install renders exactly as it always did.
+    /// macOS `.body` text style (13pt), so a fresh install renders exactly as it always did.
     public static let defaultSidebarFontSize: Double = 13
 
     /// The allowed sidebar row-text point-size range (the Settings stepper bounds). Kept modest so the
@@ -166,165 +156,140 @@ public struct AppSettings: Codable, Equatable, Sendable {
     public var fontFamily: String?
     /// Default terminal font size in points, or nil for the ghostty default.
     public var fontSize: Double?
-    /// The ghostty `theme` value: a plain bundled name (e.g. `Adwaita Dark`), or nil for the ghostty
-    /// default. When `followSystemAppearance` is on this is the LIGHT-appearance slot; otherwise it is
-    /// the single theme, applied in both appearances.
+    /// The ghostty `theme` value: a plain bundled name (e.g. `Adwaita Dark`), or nil for the ghostty default.
+    /// With `followSystemAppearance` on this is the LIGHT slot, else the single theme used in both appearances.
     public var theme: String?
-    /// The DARK-appearance theme, used only when `followSystemAppearance` is on. nil = unset. Together
-    /// with `theme` it is emitted as ghostty's dual `theme = light:NAME,dark:NAME` conditional, which
-    /// libghostty resolves at runtime on a color-scheme change (agterm no longer picks the side).
+    /// The DARK-appearance theme, used only when `followSystemAppearance` is on. nil = unset. With `theme`
+    /// it is emitted as ghostty's dual `theme = light:NAME,dark:NAME` conditional, which libghostty
+    /// resolves at runtime on a color-scheme change.
     public var darkTheme: String?
     /// Whether the terminal follows the macOS Light/Dark appearance. nil/false = off (the default): a
     /// single `theme` is emitted. On: `theme`/`darkTheme` are emitted as the raw dual conditional.
     public var followSystemAppearance: Bool?
-    /// Window background opacity in 0...1 (1 = fully opaque), or nil for opaque. Composited at the
-    /// AppKit window level, NOT by the ghostty renderer: when < 1, `ghosttyConfigLines()` pins the
-    /// renderer fully transparent so the window's tinted background is the single translucent layer
-    /// (otherwise the surface and the window would stack two tints).
+    /// Window background opacity in 0...1 (1 = fully opaque), or nil for opaque. Composited at the AppKit
+    /// window level, NOT by the ghostty renderer: below 1, `ghosttyConfigLines()` pins the renderer fully
+    /// transparent so the window's tint is the single translucent layer instead of two stacked tints.
     public var backgroundOpacity: Double?
-    /// Background blur radius (private CGS window blur, 0...100), or nil for no blur. Only has a
-    /// visible effect when `backgroundOpacity` < 1. Applied in the app target, NOT a ghostty key.
+    /// Background blur radius (private CGS window blur, 0...100), or nil for no blur. Only visible when
+    /// `backgroundOpacity` < 1. Applied in the app target, NOT a ghostty key.
     public var backgroundBlur: Int?
-    /// Whether to post macOS notification banners for terminal desktop notifications. nil means the
-    /// default (on). Only gates the OS banner — the sidebar unseen-count badge tracks notifications
-    /// either way.
+    /// Whether to post macOS notification banners for terminal desktop notifications. nil = on. Gates only
+    /// the OS banner — the sidebar unseen-count badge tracks notifications either way.
     public var notificationsEnabled: Bool?
-    /// Whether the sidebar shows the red unseen-notification count badge (the count pill on session
-    /// rows and the collapsed-workspace roll-up). nil means the default (on). Render-only: the
-    /// unseen count keeps tracking, so turning it back on instantly shows the current counts.
-    /// Distinct from `notificationsEnabled`, which gates the OS banner.
+    /// Whether the sidebar shows the red unseen-notification count badge (the pill on session rows and the
+    /// collapsed-workspace roll-up). nil = on. Render-only: the count keeps tracking, so re-enabling shows
+    /// current counts at once. Distinct from `notificationsEnabled`, which gates the OS banner.
     public var notificationBadgeEnabled: Bool?
-    /// The custom titlebar row state, stored as a `ToolbarMode` RAW STRING (`normal`/`compact`/`hidden`) so an
-    /// unknown future value decodes tolerantly to the default (the AppSettings forward-compat rule) instead
-    /// of failing the whole decode and discarding every other setting; nil means the default (compact).
-    /// Resolved through `effectiveToolbarMode`, which also maps a legacy `compactToolbar`. Applied at the
-    /// AppKit window level, NOT a ghostty key. Writing a mode nils `compactToolbar`, so the legacy key evaporates.
+    /// The custom titlebar row state, a `ToolbarMode` RAW STRING (`normal`/`compact`/`hidden`) so an unknown
+    /// future value decodes tolerantly to the default instead of failing the whole decode and discarding
+    /// every other setting; nil = compact. Resolved through `effectiveToolbarMode`, which also maps the
+    /// legacy `compactToolbar` — writing a mode nils that key, so it evaporates. Applied at the AppKit
+    /// window level, NOT a ghostty key.
     public var toolbarMode: String?
-    /// Legacy decode shim for the pre-`toolbarMode` two-state toggle: false = the normal bar, true/nil = the
-    /// compact bar. Read only by `effectiveToolbarMode` when `toolbarMode` is unset; nilled on the next
-    /// mode write. Applied at the AppKit window level, NOT a ghostty key.
+    /// Legacy decode shim for the pre-`toolbarMode` two-state toggle: false = normal bar, true/nil = compact.
+    /// Read only by `effectiveToolbarMode` when `toolbarMode` is unset; nilled on the next mode write.
     public var compactToolbar: Bool?
-    /// Hex colors (`#RRGGBB`) for the agent-status glyph's three states; nil for each means the built-in
-    /// default (active = a muted lavender-grey `#DBD9E6`, blocked = system amber, completed = system
-    /// green). Applied at the AppKit level when the glyph is drawn, NOT ghostty keys, so they never appear
-    /// in `ghosttyConfigLines()`.
+    /// Hex colors (`#RRGGBB`) for the agent-status glyph's three states; nil each means the built-in
+    /// default (active a muted lavender-grey `#DBD9E6`, blocked system amber, completed system green).
+    /// Applied at the AppKit level when the glyph is drawn, NOT ghostty keys.
     public var activeStatusColorHex: String?
     public var blockedStatusColorHex: String?
     public var completedStatusColorHex: String?
-    /// Silhouettes for the agent-status glyph's three states, stored as `StatusShape` RAW STRINGS so an
-    /// unknown future value decodes tolerantly to nil via `effectiveStatusShape(for:)` (the AppSettings
-    /// forward-compat rule). nil for each means the default plain circle, and the Settings picker stores
-    /// nil when Circle is picked, so `settings.json` stays minimal. A per-call `session.status --shape`
-    /// overrides these. Applied at the AppKit level when the glyph is drawn, NOT ghostty keys, so they
-    /// never appear in `ghosttyConfigLines()`.
+    /// Silhouettes for the agent-status glyph's three states, as `StatusShape` RAW STRINGS so an unknown
+    /// future value decodes tolerantly to nil via `effectiveStatusShape(for:)`. nil each means the default
+    /// plain circle, and the Settings picker stores nil when Circle is picked, so `settings.json` stays
+    /// minimal. A per-call `session.status --shape` overrides these. Applied at the AppKit level when the
+    /// glyph is drawn, NOT ghostty keys.
     public var activeStatusShape: String?
     public var blockedStatusShape: String?
     public var completedStatusShape: String?
-    /// Directory holding the user-editable keymap config (`keymap.conf`), or nil for the default
-    /// (`~/.config/agterm`). Resolved by `ConfigPaths.configDirectory(setting:stateDir:home:)`; an
-    /// app-level path, never a ghostty key.
+    /// Directory holding the user-editable keymap config (`keymap.conf`), nil for `~/.config/agterm`.
+    /// Resolved by `ConfigPaths.configDirectory(setting:stateDir:home:)`; a path, never a ghostty key.
     public var configDirectory: String?
-    /// Mouse scroll speed multiplier (ghostty `mouse-scroll-multiplier`), applied as a bare value to
-    /// both the notched wheel and the trackpad. nil means agterm's default of 3. UNLIKE the other
-    /// fields, this key is ALWAYS emitted (nil emits `= 3`), so the default is effective rather than
-    /// deferring to ghostty's per-device defaults (discrete 3 / precision 1) — a fresh install scrolls
-    /// at 3, which speeds the trackpad up out of the box. Consequence: it overrides any
-    /// `mouse-scroll-multiplier` set in the user's own `~/.config/ghostty/config`.
+    /// Mouse scroll speed multiplier (ghostty `mouse-scroll-multiplier`), a bare value applied to both the
+    /// notched wheel and the trackpad. nil means agterm's default of 3, and UNLIKE the other fields this
+    /// key is ALWAYS emitted (nil emits `= 3`), so the default is effective rather than ghostty's
+    /// per-device defaults (discrete 3 / precision 1) — which also means it overrides any
+    /// `mouse-scroll-multiplier` in the user's own `~/.config/ghostty/config`.
     public var mouseScrollMultiplier: Double?
-    /// How strongly the inactive split pane's text is muted, on a 0...10 scale (0 = no mute, 10 =
-    /// extreme); nil means the default (`defaultInactivePaneMuteStrength`). Applied as a SwiftUI
-    /// overlay opacity in the app target (see `muteOpacity(strength:)`), NOT a ghostty key — it never
-    /// appears in `ghosttyConfigLines()`.
+    /// How strongly the inactive split pane's text is muted, 0...10 (0 = no mute, 10 = extreme); nil means
+    /// `defaultInactivePaneMuteStrength`. Applied as a SwiftUI overlay opacity in the app target (see
+    /// `muteOpacity(strength:)`), NOT a ghostty key.
     public var inactivePaneMuteStrength: Int?
-    /// How much darker or lighter the sidebar background is than the terminal background, on a 0...10
-    /// scale where 5 is neutral (identical to the terminal); below 5 lightens, above 5 darkens. nil
-    /// means the default (`defaultSidebarBackgroundShift`, neutral). Applied in the app target as a
-    /// SwiftUI wash behind the sidebar (see `sidebarShiftAmount`), NOT a ghostty key — it never appears
-    /// in `ghosttyConfigLines()`.
+    /// How much darker or lighter the sidebar background is than the terminal background, 0...10 with 5
+    /// neutral (below lightens, above darkens); nil means `defaultSidebarBackgroundShift` (neutral).
+    /// Applied as a SwiftUI wash behind the sidebar (see `sidebarShiftAmount`), NOT a ghostty key.
     public var sidebarBackgroundShift: Int?
     /// Whether, on app restart, each pane re-runs the command it was running at the last clean quit: a
     /// captured foreground command (`SessionSnapshot.foregroundCommand`) and a `session.new --command`
-    /// session's persisted `initialCommand`. nil means the default (off). An app-level behavior flag, NOT a
-    /// ghostty key — it never appears in `ghosttyConfigLines()`.
+    /// session's persisted `initialCommand`. nil = off. A behavior flag, NOT a ghostty key.
     public var restoreRunningCommand: Bool?
     /// Whether agterm also loads the user's GLOBAL ghostty config (`~/.config/ghostty/config`) on top of
-    /// its bundled defaults. nil means the default (off): agterm is self-contained, so a config written
-    /// for the standalone Ghostty.app does NOT silently change agterm. Opt in to share one config across
-    /// both. The agterm-scoped `~/.config/agterm/ghostty.conf` is ALWAYS loaded regardless and is the
-    /// place for agterm overrides/customizations. An app-level flag read at config-load time (NOT a
-    /// ghostty key, so it never appears in `ghosttyConfigLines()`), gating which files `loadConfig` reads.
+    /// its bundled defaults. nil = off, so agterm is self-contained and a config written for the standalone
+    /// Ghostty.app does NOT silently change it; opt in to share one config across both. The agterm-scoped
+    /// `~/.config/agterm/ghostty.conf` is ALWAYS loaded regardless and is the place for overrides. Read at
+    /// config-load time to gate which files `loadConfig` reads, NOT a ghostty key.
     public var inheritGlobalGhosttyConfig: Bool?
-    /// Whether the window title bar shows the attention bell icon (window-wide non-idle session status at
-    /// a glance). nil means the default (off). An app-level chrome flag, NOT a ghostty key — it never
-    /// appears in `ghosttyConfigLines()`; it only gates whether the titlebar builds the icon.
+    /// Whether the window title bar shows the attention bell icon (window-wide non-idle session status at a
+    /// glance). nil = off. A chrome flag gating only whether the titlebar builds the icon, NOT a ghostty key.
     public var attentionButtonEnabled: Bool?
-    /// How a delivered notification bounces the Dock icon (`off`/`once`/`untilFocused`), stored as a
-    /// `DockBounce` RAW STRING so an unknown future value decodes tolerantly to the default via
-    /// `effectiveDockBounce` (the AppSettings forward-compat rule). nil means the default (`off`). An
-    /// app-level attention setting, NOT a ghostty key — it never appears in `ghosttyConfigLines()`;
-    /// `NotificationManager` reads its mirror and issues the matching `requestUserAttention`, a no-op while
-    /// agterm is the frontmost app.
+    /// How a delivered notification bounces the Dock icon (`off`/`once`/`untilFocused`), a `DockBounce` RAW
+    /// STRING so an unknown future value decodes tolerantly to the default via `effectiveDockBounce`; nil =
+    /// `off`. NOT a ghostty key — `NotificationManager` reads its mirror and issues the matching
+    /// `requestUserAttention`, a no-op while agterm is the frontmost app.
     public var dockBounce: String?
-    /// Name of the system sound attached to a delivered desktop notification (e.g. `Glass`), or
-    /// nil/empty for no sound (the default). Delivered as `UNNotificationSound(named:)` on the banner's
-    /// content (the `.aiff` suffix is added when the name has none), so it RIDES the banner: gated by
-    /// `notificationsEnabled` and the macOS notification authorization, and silenced by Do Not Disturb —
-    /// unlike the badge and the Dock bounce, which fire whether or not banners show (only the Settings
-    /// picker's preview uses `NSSound`). An app-level value, NOT a ghostty key — it never appears in
-    /// `ghosttyConfigLines()`.
+    /// Name of the system sound attached to a delivered desktop notification (e.g. `Glass`), nil/empty for
+    /// no sound (the default). Delivered as `UNNotificationSound(named:)` on the banner's content (`.aiff`
+    /// appended when the name has no suffix), so it RIDES the banner: gated by `notificationsEnabled` and
+    /// the macOS notification authorization, silenced by Do Not Disturb — unlike the badge and the Dock
+    /// bounce, which fire whether or not banners show. Only the Settings preview uses `NSSound`. NOT a
+    /// ghostty key.
     public var notificationSoundName: String?
-    /// Name of the system sound played when a session enters the `blocked` status (e.g. `Glass`, resolved by
-    /// `NSSound(named:)`), or nil/empty for no sound (the default). A per-call `session.status --sound`
-    /// overrides this. An app-level value played at the AppKit level, NOT a ghostty key — it never appears
-    /// in `ghosttyConfigLines()`.
+    /// Name of the system sound played when a session enters the `blocked` status (e.g. `Glass`, resolved
+    /// by `NSSound(named:)`), nil/empty for no sound (the default). A per-call `session.status --sound`
+    /// overrides this. Played at the AppKit level, NOT a ghostty key.
     public var blockedStatusSoundName: String?
-    /// Whether a right-click pastes the clipboard (ghostty `right-click-action`). nil means the default
-    /// (on): agterm forwards right-/middle-click to libghostty, so a right-click pastes out of the box.
-    /// UNLIKE most flags this IS a ghostty key — `ghosttyConfigLines()` emits `right-click-action = paste`
-    /// when on and `= ignore` when off, so the UI owns the key (the settings conf loads last and wins over
-    /// a `right-click-action` in the user's own `ghostty.conf`). agterm has no terminal context menu, so
-    /// paste-or-off is the whole meaningful choice.
+    /// Whether a right-click pastes the clipboard (ghostty `right-click-action`). nil = on: agterm forwards
+    /// right-/middle-click to libghostty, so a right-click pastes out of the box. UNLIKE most flags this IS
+    /// a ghostty key — emitted as `= paste` when on and `= ignore` when off, and the settings conf loads
+    /// last, so the UI owns the key over a `right-click-action` in the user's own `ghostty.conf`. agterm
+    /// has no terminal context menu, so paste-or-off is the whole meaningful choice.
     public var rightClickPaste: Bool?
-    /// Which directory a new (⌘T) session opens in, as a `NewSessionDirectory` raw value; nil means the
-    /// default (`home`). `currentSession` inherits the active session's focused-pane cwd, `custom` uses
-    /// `newSessionCustomDirectory`. An app-level behavior value read by `AppActions.newSession()`, NOT a
-    /// ghostty key — it never appears in `ghosttyConfigLines()`. Resolved by `resolveNewSessionCwd(...)`.
+    /// Which directory a new (⌘T) session opens in, a `NewSessionDirectory` raw value; nil = `home`.
+    /// `currentSession` inherits the active session's focused-pane cwd, `custom` uses
+    /// `newSessionCustomDirectory`. Read by `AppActions.newSession()` through `resolveNewSessionCwd`, NOT
+    /// a ghostty key.
     public var newSessionDirectory: String?
     /// The fixed directory a new session opens in when `newSessionDirectory` is `custom`; nil/empty falls
     /// back to home. Ignored for the `home`/`currentSession` modes. Set by the Settings directory picker.
     public var newSessionCustomDirectory: String?
     /// Whether closing a session from the GUI (⌘W, the File/palette Close Session, the sidebar row's Close)
-    /// first asks for confirmation. nil means the default (off — the session closes immediately). An
-    /// app-level behavior flag read on demand by `AppActions`, NOT a ghostty key — it never appears in
-    /// `ghosttyConfigLines()`; the control channel's `session.close` closes without a prompt.
+    /// first asks for confirmation. nil = off (it closes immediately). Read on demand by `AppActions`, NOT
+    /// a ghostty key; the control channel's `session.close` closes without a prompt.
     public var confirmCloseSession: Bool?
     /// Whether GUI closes keep a short undo grace period before final teardown. nil means the default
     /// (on). When off, GUI closes are immediate but still enter File > Open Recent.
     public var closeGraceUndoEnabled: Bool?
-    /// The user-idle timeout that auto-follows the window's selection to the oldest blocked session, as an
-    /// `AutoFollowAttention` raw value; nil means the default (`off` — disabled). An app-level per-window
-    /// behavior value driving `AppStore`'s idle controller, NOT a ghostty key — it never appears in
-    /// `ghosttyConfigLines()`.
+    /// The user-idle timeout that auto-follows the window's selection to the oldest blocked session, an
+    /// `AutoFollowAttention` raw value; nil = `off` (disabled). Per-window, drives `AppStore`'s idle
+    /// controller, NOT a ghostty key.
     public var autoFollowAttention: String?
     /// Whether the auto-follow stays put on a currently running (`active`) session instead of pulling to a
-    /// blocked one. nil/false means the default (off — auto-follow always pulls to blocked). Only meaningful
-    /// when `autoFollowAttention` is set. An app-level flag, NOT a ghostty key.
+    /// blocked one. nil/false = off (it always pulls to blocked). Only meaningful when
+    /// `autoFollowAttention` is set. NOT a ghostty key.
     public var autoFollowStayOnActive: Bool?
-    /// The sidebar row-text point size, or nil for the default (`defaultSidebarFontSize`). The row height
-    /// scales with it (`sidebarRowHeight(fontSize:)`); the row icons and status glyphs keep their fixed
-    /// sizes. Applied at the AppKit level when the sidebar draws, NOT a ghostty key — it never appears in
-    /// `ghosttyConfigLines()`.
+    /// The sidebar row-text point size, nil for `defaultSidebarFontSize`. The row height scales with it
+    /// (`sidebarRowHeight(fontSize:)`); the row icons and status glyphs keep their fixed sizes. Applied at
+    /// the AppKit level when the sidebar draws, NOT a ghostty key.
     public var sidebarFontSize: Double?
-    /// Raw names of title-bar / sidebar chrome elements the user has HIDDEN (see `InterfaceElement`).
-    /// nil/empty means every element is shown (the default). Stored as raw strings so an unknown future
-    /// element name decodes tolerantly (it is dropped by `resolvedHiddenInterfaceElements`) instead of
-    /// failing the whole decode — the AppSettings forward-compat rule. A GUI-only chrome value applied at
-    /// the AppKit/SwiftUI level, NOT a ghostty key — it never appears in `ghosttyConfigLines()`.
+    /// Raw names of title-bar / sidebar chrome elements the user has HIDDEN (see `InterfaceElement`);
+    /// nil/empty means every element is shown. Raw strings so an unknown future element name is dropped by
+    /// `resolvedHiddenInterfaceElements` instead of failing the whole decode. GUI-only, applied at the
+    /// AppKit/SwiftUI level, NOT a ghostty key.
     public var hiddenInterfaceElements: [String]?
     /// Whether, with more than one window open, only the frontmost window shows its sidebar and every other
-    /// window collapses its own. nil means the default (off). While on, sidebar visibility is driven by
-    /// window focus, so a manual per-window hide is transient (the frontmost window re-shows its sidebar on
-    /// refocus). An app-level behavior flag, NOT a ghostty key — it never appears in `ghosttyConfigLines()`.
+    /// collapses its own. nil = off. While on, sidebar visibility is driven by window focus, so a manual
+    /// per-window hide is transient — the frontmost window re-shows its sidebar on refocus. NOT a ghostty key.
     public var autoHideSidebarInactiveWindows: Bool?
 
     public init(fontFamily: String? = nil, fontSize: Double? = nil, theme: String? = nil,
@@ -385,9 +350,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.autoHideSidebarInactiveWindows = autoHideSidebarInactiveWindows
     }
 
-    /// The resolved set of hidden chrome elements: the known raw names from `hiddenInterfaceElements`,
-    /// with any unknown (future-written) names dropped. The single read point the app target and the
-    /// Settings UI use, so callers never touch the raw string list.
+    /// The resolved set of hidden chrome elements — the known raw names from `hiddenInterfaceElements`,
+    /// unknown (future-written) ones dropped. The single read point, so callers never touch the raw list.
     public var resolvedHiddenInterfaceElements: Set<InterfaceElement> {
         Set((hiddenInterfaceElements ?? []).compactMap(InterfaceElement.init(rawValue:)))
     }
@@ -398,25 +362,22 @@ public struct AppSettings: Codable, Equatable, Sendable {
         resolvedHiddenInterfaceElements.contains(element)
     }
 
-    /// The resolved titlebar row state: the explicit `toolbarMode` when set to a KNOWN raw value, else the
-    /// legacy `compactToolbar` mapping (`false` = `.normal`, `true`/nil = `.compact`). An unknown/nil raw value
-    /// falls through to that default the same way, so a future-written mode never fails the read. The single
-    /// read point the app target uses, so callers never touch the raw shim.
+    /// The resolved titlebar row state: the explicit `toolbarMode` when a KNOWN raw value, else the legacy
+    /// `compactToolbar` mapping (`false` = `.normal`, `true`/nil = `.compact`), so an unknown/nil value
+    /// never fails the read. The single read point, so callers never touch the raw shim.
     public var effectiveToolbarMode: ToolbarMode {
         toolbarMode.flatMap(ToolbarMode.init(rawValue:)) ?? (compactToolbar == false ? .normal : .compact)
     }
 
-    /// The resolved Dock-bounce mode: the explicit `dockBounce` when set to a KNOWN raw value, else `off`.
-    /// An unknown/nil raw value falls through to `off` the same way, so a future-written mode never fails
-    /// the read. The single read point the app target uses, so callers never touch the raw string.
+    /// The resolved Dock-bounce mode: the explicit `dockBounce` when a KNOWN raw value, else `off`, so an
+    /// unknown/nil value never fails the read. The single read point, so callers never touch the raw string.
     public var effectiveDockBounce: DockBounce {
         dockBounce.flatMap(DockBounce.init(rawValue:)) ?? .off
     }
 
-    /// The resolved glyph silhouette for one agent status: the configured raw name when it is a KNOWN
-    /// `StatusShape`, else nil, which means the default plain circle. An unknown/nil raw value falls
-    /// through to nil the same way, so a hand-edited or future-written value never fails the read. `idle`
-    /// renders no glyph and so has no shape. The single read point the app target uses, so callers never
+    /// The resolved glyph silhouette for one agent status: the configured raw name when a KNOWN
+    /// `StatusShape`, else nil (the default plain circle), so a hand-edited or future-written value never
+    /// fails the read. `idle` renders no glyph and has no shape. The single read point, so callers never
     /// touch the raw strings.
     public func effectiveStatusShape(for status: AgentStatus) -> StatusShape? {
         let raw: String?
@@ -429,11 +390,11 @@ public struct AppSettings: Codable, Equatable, Sendable {
         return raw.flatMap(StatusShape.init(rawValue:))
     }
 
-    /// The working directory a new session should open in, resolving the `newSessionDirectory` mode
-    /// against the active session's focused-pane cwd and the home directory. An unknown/nil mode, a
-    /// nil/blank `currentSessionCwd`, or a nil/blank custom path all fall back to `home`: `home` → home;
-    /// `currentSession` → `currentSessionCwd` (else home); `custom` → `newSessionCustomDirectory` (else
-    /// home). Host-free so `AppActions.newSession()` and the tests share one resolution.
+    /// The working directory a new session opens in, resolving `newSessionDirectory` against the active
+    /// session's focused-pane cwd and the home directory: `home` → home; `currentSession` →
+    /// `currentSessionCwd`; `custom` → `newSessionCustomDirectory`. An unknown/nil mode, a nil/blank
+    /// `currentSessionCwd`, or a nil/blank custom path all fall back to home. Host-free so
+    /// `AppActions.newSession()` and the tests share one resolution.
     public func resolveNewSessionCwd(currentSessionCwd: String?, home: String) -> String {
         switch NewSessionDirectory(rawValue: newSessionDirectory ?? "") ?? .home {
         case .home:
@@ -447,19 +408,18 @@ public struct AppSettings: Codable, Equatable, Sendable {
         }
     }
 
-    /// The SwiftUI overlay opacity for a given inactive-pane mute strength: the strength is clamped to
-    /// 0...10 and scaled by 0.08, so 0 → 0 (no mute), 5 → 0.4 (the historical default), 10 → 0.8
-    /// (extreme). The overlay is the terminal background color, so a higher opacity blends the pane's
-    /// text further toward the background (less bright) while leaving background pixels unchanged.
+    /// The SwiftUI overlay opacity for an inactive-pane mute strength: clamped to 0...10 and scaled by
+    /// 0.08, so 0 → 0 (no mute), 5 → 0.4 (the default), 10 → 0.8 (extreme). The overlay is the terminal
+    /// background color, so a higher opacity blends the pane's text further toward the background (less
+    /// bright) while leaving background pixels unchanged.
     public static func muteOpacity(strength: Int) -> Double {
         Double(min(10, max(0, strength))) * 0.08
     }
 
-    /// The signed sidebar background shift for a given strength: the strength is clamped to 0...10 and
-    /// measured from the neutral center (5), so 5 → 0 (no shift), 0 → -0.30 (full lighten), 10 → +0.30
-    /// (full darken). A positive amount darkens (a black wash over the sidebar), a negative one lightens
-    /// (a white wash); the magnitude is the wash opacity. Compositing that wash over the window
-    /// background is what the app target's sidebar tint does (`WindowContentView.sidebarTintWash`).
+    /// The signed sidebar background shift for a strength: clamped to 0...10 and measured from the neutral
+    /// center 5, so 5 → 0 (no shift), 0 → -0.30 (full lighten), 10 → +0.30 (full darken). Positive darkens
+    /// (a black wash over the sidebar), negative lightens (a white wash); the magnitude is the wash
+    /// opacity, composited over the window background by `WindowContentView.sidebarTintWash`.
     public static func sidebarShiftAmount(strength: Int) -> Double {
         Double(min(10, max(0, strength)) - 5) * 0.06
     }
@@ -470,9 +430,9 @@ public struct AppSettings: Codable, Equatable, Sendable {
         min(sidebarFontSizeRange.upperBound, max(sidebarFontSizeRange.lowerBound, size))
     }
 
-    /// The outline row height for a given sidebar font size: the clamped point size plus a fixed 15pt of
-    /// vertical padding, so the default 13pt maps to the historical 28pt row and larger text gets a
-    /// proportionally taller row. The row icon and status glyph keep their fixed sizes.
+    /// The outline row height for a sidebar font size: the clamped point size plus a fixed 15pt of vertical
+    /// padding, so the default 13pt maps to a 28pt row and larger text gets a proportionally taller one.
+    /// The row icon and status glyph keep their fixed sizes.
     public static func sidebarRowHeight(fontSize: Double) -> Double {
         clampSidebarFontSize(fontSize).rounded() + 15
     }
@@ -485,18 +445,18 @@ public struct AppSettings: Codable, Equatable, Sendable {
         return isDark ? (darkTheme ?? theme) : theme
     }
 
-    /// The ghostty config lines for the set fields, one `key = value` per line, suitable for a
-    /// file loaded via `ghostty_config_load_file`. Unset (or blank) fields are omitted. Values are
-    /// written raw — ghostty takes the whole line remainder as the value, so names with spaces
-    /// (`3024 Night`, `SF Mono`) are NOT quoted (quoting would become part of the value).
+    /// The ghostty config lines for the set fields, one `key = value` per line, for a file loaded via
+    /// `ghostty_config_load_file`. Unset or blank fields are omitted. Values are written raw — ghostty
+    /// takes the whole line remainder as the value, so names with spaces (`3024 Night`, `SF Mono`) are
+    /// NOT quoted; quoting would become part of the value.
     public func ghosttyConfigLines() -> [String] {
         var lines: [String] = []
         if let fontFamily, !fontFamily.isEmpty { lines.append("font-family = \(fontFamily)") }
         if let fontSize { lines.append("font-size = \(Self.format(fontSize))") }
-        // theme: when following the macOS appearance, emit ghostty's dual conditional RAW and let
-        // libghostty resolve the active side on a color-scheme change (it records the new state and asks
-        // the host to re-feed the config, which the reload path does). Otherwise emit the single theme.
-        // No appearance input here — ghostty owns the switch.
+        // when following the macOS appearance, emit ghostty's dual conditional RAW and let libghostty
+        // resolve the active side on a color-scheme change (it records the new state and asks the host to
+        // re-feed the config, which the reload path does); else the single theme. no appearance input
+        // here — ghostty owns the switch.
         let light = theme.flatMap { $0.isEmpty ? nil : $0 }
         let dark = darkTheme.flatMap { $0.isEmpty ? nil : $0 }
         if followSystemAppearance == true, let light, let dark {
@@ -504,9 +464,9 @@ public struct AppSettings: Codable, Equatable, Sendable {
         } else if let single = light ?? dark {
             lines.append("theme = \(single)")
         }
-        // a translucent window composites its tint at the AppKit level, so the renderer must draw a
-        // fully transparent terminal — else the surface and the window stack two tints. At full
-        // opacity (or unset) ghostty paints its own background as usual and these are omitted.
+        // a translucent window composites its tint at the AppKit level, so the renderer must draw a fully
+        // transparent terminal — else the surface and the window stack two tints. at full opacity (or
+        // unset) these are omitted and ghostty paints its own background.
         if let backgroundOpacity, backgroundOpacity < 1 {
             lines.append("background-opacity = 0")
             lines.append("background-blur = 0")
@@ -514,9 +474,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
         // always emitted (nil = agterm's default of 3), so the default speed is effective rather than
         // ghostty's per-device defaults. a bare value sets both the wheel and the trackpad.
         lines.append("mouse-scroll-multiplier = \(Self.format(mouseScrollMultiplier ?? 3))")
-        // always emitted (nil = on): agterm forwards right-/middle-click to libghostty, so a right-click
-        // pastes by default. off emits `ignore` so the toggle hard-disables it (the settings conf loads
-        // last, so the UI owns the key over any `right-click-action` in the user's own ghostty.conf).
+        // always emitted (nil = on): a right-click pastes by default, off emits `ignore` to hard-disable
+        // it. the settings conf loads last, so this wins over the user's own ghostty.conf.
         lines.append("right-click-action = \((rightClickPaste ?? true) ? "paste" : "ignore")")
         return lines
     }

--- a/agtermCore/Sources/agtermCore/AppSettings.swift
+++ b/agtermCore/Sources/agtermCore/AppSettings.swift
@@ -1,30 +1,28 @@
 import Foundation
 
 /// The window's custom titlebar row state: `normal` stacks the session name over the cwd subtitle,
-/// `compact` is a single short row, `hidden` drops the row and the traffic lights for a full-bleed
-/// terminal. Stored raw so an unknown future value decodes tolerantly via `effectiveToolbarMode` instead
-/// of failing the whole decode. Top-level, unlike the nested sibling mode enums, because the app target
-/// references it as a bare `ToolbarMode`.
+/// `compact` is one short row, `hidden` drops the row and the traffic lights for a full-bleed terminal.
+/// Raw-stored, resolved by `effectiveToolbarMode`. Top-level, unlike the nested sibling mode enums,
+/// because the app target uses a bare `ToolbarMode`.
 public enum ToolbarMode: String, Codable, Sendable, CaseIterable {
     case normal
     case compact
     case hidden
 }
 
-/// How a delivered notification bounces the Dock icon (macOS `requestUserAttention`): `off`, `once` (a
-/// single `.informationalRequest`), or `untilFocused` (a `.criticalRequest` bouncing until agterm becomes
-/// active). Stored raw so an unknown future value decodes tolerantly via `effectiveDockBounce`. The
-/// default case is named `off`, not `none`, to dodge the `Optional.none` collision at that call site
-/// (the `AutoFollowAttention.off` precedent).
+/// How a delivered notification bounces the Dock icon (`requestUserAttention`): `off`, `once` (one
+/// `.informationalRequest`), or `untilFocused` (a `.criticalRequest` bouncing until agterm activates).
+/// Raw-stored, resolved by `effectiveDockBounce`. Named `off`, not `none`, to dodge the `Optional.none`
+/// collision at that call site (as `AutoFollowAttention.off`).
 public enum DockBounce: String, Codable, Sendable, CaseIterable {
     case off
     case once
     case untilFocused
 }
 
-/// A toggleable window-chrome element in the title bar or the sidebar. Persisted by raw name in
-/// `AppSettings.hiddenInterfaceElements`: an unknown future case in a stored list is dropped rather than
-/// failing the whole decode (the forward-compat rule). Shown by default; hiding adds its raw name.
+/// A toggleable title-bar or sidebar chrome element, persisted by raw name in
+/// `AppSettings.hiddenInterfaceElements` (an unknown stored name is dropped, not fatal). Shown by
+/// default; hiding adds its raw name.
 public enum InterfaceElement: String, Codable, Sendable, CaseIterable {
     // title bar
     case sidebarToggle
@@ -45,8 +43,7 @@ public enum InterfaceElement: String, Codable, Sendable, CaseIterable {
     /// Which chrome surface the element belongs to — the Settings tab groups the toggles by this.
     public enum Section: Sendable { case titleBar, sidebar }
 
-    /// The surface this element lives on: the sidebar for the add/flag/filter controls (the footer
-    /// buttons plus the workspace-row add-session "+"), the title bar for everything else.
+    /// The surface this element lives on; the title bar for everything not listed as sidebar.
     public var section: Section {
         switch self {
         case .newWorkspace, .newSession, .flaggedView, .focusFilter, .workspaceAddSession: return .sidebar
@@ -73,11 +70,9 @@ public enum InterfaceElement: String, Codable, Sendable, CaseIterable {
         }
     }
 
-    /// Which of the two title-bar trailing-cluster separators to draw, given each group's visible button
-    /// count (A = recent-sessions + attention, B = scratch + split, C = dashboard + quick-terminal). A
-    /// separator sits ONLY where two groups that each show 2+ buttons meet — `afterA` between A and B,
-    /// `afterB` between B and C or, when B is empty, between a full A and a full C; a group reduced to one
-    /// button needs none. Host-free so the rule is unit-tested with no app host; the view supplies the counts.
+    /// Which of the two title-bar trailing-cluster separators to draw, from each group's visible button
+    /// count (A = recent-sessions + attention, B = scratch + split, C = dashboard + quick-terminal): one
+    /// sits ONLY where two groups that each still show 2+ buttons meet. Host-free so it is unit-testable.
     public static func titlebarGroupDividers(countA: Int, countB: Int, countC: Int) -> (afterA: Bool, afterB: Bool) {
         let afterA = countA >= 2 && countB >= 2
         let afterB = (countB >= 2 && countC >= 2) || (countA >= 2 && countC >= 2 && countB == 0)
@@ -87,23 +82,23 @@ public enum InterfaceElement: String, Codable, Sendable, CaseIterable {
 
 /// User-facing appearance settings, persisted independently of the workspace tree.
 ///
-/// Every field is optional: nil means "use the ghostty default", and a file written before a field
-/// existed still decodes. That optionality IS the forward-compat mechanism, so there is no version field
-/// — a version bump would only add a discard-on-mismatch path that wipes the user's settings.
+/// Every field is optional: nil means "use the default", and a file written before a field existed still
+/// decodes. That optionality IS the forward-compat mechanism, so there is no version field — a bump would
+/// only add a discard-on-mismatch path that wipes the user's settings. Enum-valued fields are raw strings
+/// for the same reason, read back through an `effective…` accessor resolving an unknown (future-written)
+/// value to the default rather than failing the whole decode. Only what `ghosttyConfigLines()` emits is a
+/// ghostty key; every other field drives AppKit/SwiftUI chrome or app behavior.
 public struct AppSettings: Codable, Equatable, Sendable {
-    /// Where a new (⌘T) session opens. Stored as the `newSessionDirectory` raw string so an unknown future
-    /// value decodes tolerantly to `home` instead of failing the whole decode. `home` is also the nil case
-    /// (the default), so picking it clears the field and keeps `settings.json` minimal.
+    /// Where a new (⌘T) session opens. `home` is both the default and the nil case, so picking it clears
+    /// the stored field and keeps `settings.json` minimal.
     public enum NewSessionDirectory: String, CaseIterable, Sendable {
         case home
         case currentSession
         case custom
     }
 
-    /// The user-idle timeout after which the window's selection auto-follows to the oldest blocked session,
-    /// stored as the `autoFollowAttention` raw string so an unknown future value decodes tolerantly to `off`
-    /// instead of failing the whole decode. `off` is also the nil case (the default), so picking it clears
-    /// the field and keeps `settings.json` minimal. Each case's `timeout` is the idle grace in seconds.
+    /// The user-idle timeout after which the window's selection auto-follows to the oldest blocked
+    /// session. `off` is both the default and the nil case, so picking it clears the stored field.
     public enum AutoFollowAttention: String, CaseIterable, Sendable {
         case off
         case s5
@@ -112,8 +107,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         case s60
         case m5
 
-        /// Tolerant lookup shared by the Settings binding and the store fan-out: an unknown or nil raw
-        /// value resolves to `off`, so a future-written value never breaks the read.
+        /// Tolerant lookup shared by the Settings binding and the store fan-out: unknown or nil is `off`.
         public init(tolerant raw: String?) {
             self = AutoFollowAttention(rawValue: raw ?? "") ?? .off
         }
@@ -131,165 +125,129 @@ public struct AppSettings: Codable, Equatable, Sendable {
         }
     }
 
-    /// The app's out-of-the-box theme — a bundled theme applied on a fresh install (no saved
-    /// settings), seeded by `SettingsStore.load()`. Distinct from `theme == nil`, which means
-    /// ghostty's built-in default (the "default ghostty" entry in the theme picker).
+    /// The out-of-the-box bundled theme, seeded by `SettingsStore.load()` on a fresh install. Distinct
+    /// from `theme == nil`, which means ghostty's own built-in default (the picker's "default ghostty").
     public static let defaultTheme = "agterm"
 
-    /// The out-of-the-box inactive-split-pane mute strength on the 0...10 scale (0 = no mute, 10 =
-    /// extreme), used when `inactivePaneMuteStrength` is nil. 5 maps to the historical 0.4 opacity.
+    /// The inactive-split-pane mute strength (0...10, 0 = no mute) used when `inactivePaneMuteStrength` is nil.
     public static let defaultInactivePaneMuteStrength = 5
 
-    /// The out-of-the-box sidebar background shift on the 0...10 scale, used when `sidebarBackgroundShift`
-    /// is nil. 5 is the neutral center (sidebar matches the terminal background); below lightens, above darkens.
+    /// The sidebar background shift used when `sidebarBackgroundShift` is nil; 5 is the neutral center,
+    /// where the sidebar matches the terminal background.
     public static let defaultSidebarBackgroundShift = 5
 
-    /// The out-of-the-box sidebar row-text point size, used when `sidebarFontSize` is nil. Matches the
-    /// macOS `.body` text style (13pt), so a fresh install renders exactly as it always did.
+    /// The sidebar row-text point size used when `sidebarFontSize` is nil; matches macOS `.body` (13pt).
     public static let defaultSidebarFontSize: Double = 13
 
-    /// The allowed sidebar row-text point-size range (the Settings stepper bounds). Kept modest so the
-    /// fixed-size row icons and status glyphs stay visually balanced against the text at either end.
+    /// The Settings stepper bounds, kept modest so the fixed-size row icons and status glyphs stay
+    /// visually balanced against the text at either end.
     public static let sidebarFontSizeRange: ClosedRange<Double> = 9 ... 20
 
     /// Terminal font family name (e.g. `SF Mono`), or nil for the ghostty default.
     public var fontFamily: String?
     /// Default terminal font size in points, or nil for the ghostty default.
     public var fontSize: Double?
-    /// The ghostty `theme` value: a plain bundled name (e.g. `Adwaita Dark`), or nil for the ghostty default.
-    /// With `followSystemAppearance` on this is the LIGHT slot, else the single theme used in both appearances.
+    /// The ghostty `theme` value: a bundled name (e.g. `Adwaita Dark`), or nil for the ghostty default.
+    /// With `followSystemAppearance` on this is the LIGHT slot, else the single theme for both appearances.
     public var theme: String?
-    /// The DARK-appearance theme, used only when `followSystemAppearance` is on. nil = unset. With `theme`
-    /// it is emitted as ghostty's dual `theme = light:NAME,dark:NAME` conditional, which libghostty
-    /// resolves at runtime on a color-scheme change.
+    /// The DARK-appearance slot, used only when `followSystemAppearance` is on. With `theme` it emits
+    /// ghostty's dual `theme = light:NAME,dark:NAME`, which libghostty resolves on a color-scheme change.
     public var darkTheme: String?
-    /// Whether the terminal follows the macOS Light/Dark appearance. nil/false = off (the default): a
-    /// single `theme` is emitted. On: `theme`/`darkTheme` are emitted as the raw dual conditional.
+    /// Whether the terminal follows the macOS Light/Dark appearance; nil/false = off, emitting one `theme`.
     public var followSystemAppearance: Bool?
-    /// Window background opacity in 0...1 (1 = fully opaque), or nil for opaque. Composited at the AppKit
-    /// window level, NOT by the ghostty renderer: below 1, `ghosttyConfigLines()` pins the renderer fully
-    /// transparent so the window's tint is the single translucent layer instead of two stacked tints.
+    /// Window background opacity in 0...1, nil = opaque. Composited at the AppKit window level, NOT by the
+    /// ghostty renderer, which `ghosttyConfigLines()` pins fully transparent below 1.
     public var backgroundOpacity: Double?
-    /// Background blur radius (private CGS window blur, 0...100), or nil for no blur. Only visible when
-    /// `backgroundOpacity` < 1. Applied in the app target, NOT a ghostty key.
+    /// Background blur radius (private CGS window blur, 0...100), nil = none; visible only when
+    /// `backgroundOpacity` < 1. Applied in the app target.
     public var backgroundBlur: Int?
-    /// Whether to post macOS notification banners for terminal desktop notifications. nil = on. Gates only
+    /// Whether to post macOS notification banners for terminal desktop notifications; nil = on. Gates only
     /// the OS banner — the sidebar unseen-count badge tracks notifications either way.
     public var notificationsEnabled: Bool?
-    /// Whether the sidebar shows the red unseen-notification count badge (the pill on session rows and the
-    /// collapsed-workspace roll-up). nil = on. Render-only: the count keeps tracking, so re-enabling shows
-    /// current counts at once. Distinct from `notificationsEnabled`, which gates the OS banner.
+    /// Whether the sidebar shows the red unseen-count badge (the session-row pill and the
+    /// collapsed-workspace roll-up); nil = on. Render-only — the count keeps tracking while hidden.
     public var notificationBadgeEnabled: Bool?
-    /// The custom titlebar row state, a `ToolbarMode` RAW STRING (`normal`/`compact`/`hidden`) so an unknown
-    /// future value decodes tolerantly to the default instead of failing the whole decode and discarding
-    /// every other setting; nil = compact. Resolved through `effectiveToolbarMode`, which also maps the
-    /// legacy `compactToolbar` — writing a mode nils that key, so it evaporates. Applied at the AppKit
-    /// window level, NOT a ghostty key.
+    /// The custom titlebar row state, a `ToolbarMode` raw string; nil = compact. Resolved through
+    /// `effectiveToolbarMode`, which also maps the legacy `compactToolbar` — writing a mode nils that key.
     public var toolbarMode: String?
-    /// Legacy decode shim for the pre-`toolbarMode` two-state toggle: false = normal bar, true/nil = compact.
-    /// Read only by `effectiveToolbarMode` when `toolbarMode` is unset; nilled on the next mode write.
+    /// Legacy decode shim for the pre-`toolbarMode` two-state toggle: false = normal bar, true/nil =
+    /// compact. Read only by `effectiveToolbarMode` when `toolbarMode` is unset.
     public var compactToolbar: Bool?
     /// Hex colors (`#RRGGBB`) for the agent-status glyph's three states; nil each means the built-in
     /// default (active a muted lavender-grey `#DBD9E6`, blocked system amber, completed system green).
-    /// Applied at the AppKit level when the glyph is drawn, NOT ghostty keys.
     public var activeStatusColorHex: String?
     public var blockedStatusColorHex: String?
     public var completedStatusColorHex: String?
-    /// Silhouettes for the agent-status glyph's three states, as `StatusShape` RAW STRINGS so an unknown
-    /// future value decodes tolerantly to nil via `effectiveStatusShape(for:)`. nil each means the default
-    /// plain circle, and the Settings picker stores nil when Circle is picked, so `settings.json` stays
-    /// minimal. A per-call `session.status --shape` overrides these. Applied at the AppKit level when the
-    /// glyph is drawn, NOT ghostty keys.
+    /// Silhouettes for the agent-status glyph's three states, `StatusShape` raw strings resolved by
+    /// `effectiveStatusShape(for:)`; nil each means the default plain circle, which is also what the
+    /// Settings picker stores for Circle. A per-call `session.status --shape` overrides these.
     public var activeStatusShape: String?
     public var blockedStatusShape: String?
     public var completedStatusShape: String?
-    /// Directory holding the user-editable keymap config (`keymap.conf`), nil for `~/.config/agterm`.
-    /// Resolved by `ConfigPaths.configDirectory(setting:stateDir:home:)`; a path, never a ghostty key.
+    /// Directory holding the user-editable `keymap.conf`, nil for `~/.config/agterm`. Resolved by
+    /// `ConfigPaths.configDirectory(setting:stateDir:home:)`.
     public var configDirectory: String?
-    /// Mouse scroll speed multiplier (ghostty `mouse-scroll-multiplier`), a bare value applied to both the
-    /// notched wheel and the trackpad. nil means agterm's default of 3, and UNLIKE the other fields this
-    /// key is ALWAYS emitted (nil emits `= 3`), so the default is effective rather than ghostty's
-    /// per-device defaults (discrete 3 / precision 1) — which also means it overrides any
-    /// `mouse-scroll-multiplier` in the user's own `~/.config/ghostty/config`.
+    /// Ghostty `mouse-scroll-multiplier`; nil means agterm's default of 3, which is ALWAYS emitted, so it
+    /// also overrides a `mouse-scroll-multiplier` in the user's own `~/.config/ghostty/config`.
     public var mouseScrollMultiplier: Double?
-    /// How strongly the inactive split pane's text is muted, 0...10 (0 = no mute, 10 = extreme); nil means
-    /// `defaultInactivePaneMuteStrength`. Applied as a SwiftUI overlay opacity in the app target (see
-    /// `muteOpacity(strength:)`), NOT a ghostty key.
+    /// How strongly the inactive split pane's text is muted, 0...10; nil means
+    /// `defaultInactivePaneMuteStrength`. A SwiftUI overlay opacity (`muteOpacity(strength:)`).
     public var inactivePaneMuteStrength: Int?
     /// How much darker or lighter the sidebar background is than the terminal background, 0...10 with 5
-    /// neutral (below lightens, above darkens); nil means `defaultSidebarBackgroundShift` (neutral).
-    /// Applied as a SwiftUI wash behind the sidebar (see `sidebarShiftAmount`), NOT a ghostty key.
+    /// neutral; nil means `defaultSidebarBackgroundShift`. A SwiftUI wash (`sidebarShiftAmount`).
     public var sidebarBackgroundShift: Int?
-    /// Whether, on app restart, each pane re-runs the command it was running at the last clean quit: a
-    /// captured foreground command (`SessionSnapshot.foregroundCommand`) and a `session.new --command`
-    /// session's persisted `initialCommand`. nil = off. A behavior flag, NOT a ghostty key.
+    /// Whether, on restart, each pane re-runs what it ran at the last clean quit (nil = off) — a captured
+    /// `SessionSnapshot.foregroundCommand` plus a `session.new --command` session's `initialCommand`.
     public var restoreRunningCommand: Bool?
-    /// Whether agterm also loads the user's GLOBAL ghostty config (`~/.config/ghostty/config`) on top of
-    /// its bundled defaults. nil = off, so agterm is self-contained and a config written for the standalone
-    /// Ghostty.app does NOT silently change it; opt in to share one config across both. The agterm-scoped
-    /// `~/.config/agterm/ghostty.conf` is ALWAYS loaded regardless and is the place for overrides. Read at
-    /// config-load time to gate which files `loadConfig` reads, NOT a ghostty key.
+    /// Whether agterm also loads the user's GLOBAL `~/.config/ghostty/config` over its bundled defaults.
+    /// nil = off, so a config written for the standalone Ghostty.app does NOT silently change agterm; opt
+    /// in to share one config across both. The agterm-scoped `~/.config/agterm/ghostty.conf` is ALWAYS
+    /// loaded and is the place for overrides. Gates which files `loadConfig` reads.
     public var inheritGlobalGhosttyConfig: Bool?
-    /// Whether the window title bar shows the attention bell icon (window-wide non-idle session status at a
-    /// glance). nil = off. A chrome flag gating only whether the titlebar builds the icon, NOT a ghostty key.
+    /// Whether the title bar shows the attention bell (window-wide non-idle status at a glance); nil = off.
     public var attentionButtonEnabled: Bool?
-    /// How a delivered notification bounces the Dock icon (`off`/`once`/`untilFocused`), a `DockBounce` RAW
-    /// STRING so an unknown future value decodes tolerantly to the default via `effectiveDockBounce`; nil =
-    /// `off`. NOT a ghostty key — `NotificationManager` reads its mirror and issues the matching
-    /// `requestUserAttention`, a no-op while agterm is the frontmost app.
+    /// Dock-bounce mode for a delivered notification, a `DockBounce` raw value; nil = `off`.
+    /// `NotificationManager` reads its mirror and issues the matching `requestUserAttention`, a no-op
+    /// while agterm is frontmost.
     public var dockBounce: String?
-    /// Name of the system sound attached to a delivered desktop notification (e.g. `Glass`), nil/empty for
-    /// no sound (the default). Delivered as `UNNotificationSound(named:)` on the banner's content (`.aiff`
-    /// appended when the name has no suffix), so it RIDES the banner: gated by `notificationsEnabled` and
-    /// the macOS notification authorization, silenced by Do Not Disturb — unlike the badge and the Dock
-    /// bounce, which fire whether or not banners show. Only the Settings preview uses `NSSound`. NOT a
-    /// ghostty key.
+    /// System sound attached to a delivered desktop notification, nil/empty for silent. Delivered as
+    /// `UNNotificationSound(named:)` on the banner content (`.aiff` appended when the name has no suffix),
+    /// so it RIDES the banner: gated by `notificationsEnabled` and the macOS notification authorization,
+    /// silenced by Do Not Disturb, unlike the badge and the Dock bounce. Only Settings previews `NSSound`.
     public var notificationSoundName: String?
-    /// Name of the system sound played when a session enters the `blocked` status (e.g. `Glass`, resolved
-    /// by `NSSound(named:)`), nil/empty for no sound (the default). A per-call `session.status --sound`
-    /// overrides this. Played at the AppKit level, NOT a ghostty key.
+    /// System sound played when a session enters `blocked` (resolved by `NSSound(named:)`), nil/empty for
+    /// silent. A per-call `session.status --sound` overrides this.
     public var blockedStatusSoundName: String?
-    /// Whether a right-click pastes the clipboard (ghostty `right-click-action`). nil = on: agterm forwards
-    /// right-/middle-click to libghostty, so a right-click pastes out of the box. UNLIKE most flags this IS
-    /// a ghostty key — emitted as `= paste` when on and `= ignore` when off, and the settings conf loads
-    /// last, so the UI owns the key over a `right-click-action` in the user's own `ghostty.conf`. agterm
-    /// has no terminal context menu, so paste-or-off is the whole meaningful choice.
+    /// Whether a right-click pastes the clipboard (ghostty `right-click-action`); nil = on, since agterm
+    /// forwards right-/middle-click to libghostty. agterm has no terminal context menu, so paste-or-off is
+    /// the whole meaningful choice.
     public var rightClickPaste: Bool?
-    /// Which directory a new (⌘T) session opens in, a `NewSessionDirectory` raw value; nil = `home`.
-    /// `currentSession` inherits the active session's focused-pane cwd, `custom` uses
-    /// `newSessionCustomDirectory`. Read by `AppActions.newSession()` through `resolveNewSessionCwd`, NOT
-    /// a ghostty key.
+    /// Which directory a new (⌘T) session opens in, a `NewSessionDirectory` raw value; nil = `home`. Read
+    /// by `AppActions.newSession()` through `resolveNewSessionCwd`.
     public var newSessionDirectory: String?
-    /// The fixed directory a new session opens in when `newSessionDirectory` is `custom`; nil/empty falls
-    /// back to home. Ignored for the `home`/`currentSession` modes. Set by the Settings directory picker.
+    /// The fixed directory used when `newSessionDirectory` is `custom`; nil/empty falls back to home.
     public var newSessionCustomDirectory: String?
-    /// Whether closing a session from the GUI (⌘W, the File/palette Close Session, the sidebar row's Close)
-    /// first asks for confirmation. nil = off (it closes immediately). Read on demand by `AppActions`, NOT
-    /// a ghostty key; the control channel's `session.close` closes without a prompt.
+    /// Whether a GUI session close (⌘W, the File/palette Close Session, the sidebar row's Close) confirms
+    /// first; nil = off. Read on demand; the control channel's `session.close` never prompts.
     public var confirmCloseSession: Bool?
-    /// Whether GUI closes keep a short undo grace period before final teardown. nil means the default
-    /// (on). When off, GUI closes are immediate but still enter File > Open Recent.
+    /// Whether GUI closes keep a short undo grace period before final teardown; nil = on. When off they
+    /// are immediate but still enter File > Open Recent.
     public var closeGraceUndoEnabled: Bool?
-    /// The user-idle timeout that auto-follows the window's selection to the oldest blocked session, an
-    /// `AutoFollowAttention` raw value; nil = `off` (disabled). Per-window, drives `AppStore`'s idle
-    /// controller, NOT a ghostty key.
+    /// The idle timeout that auto-follows the window's selection to the oldest blocked session, an
+    /// `AutoFollowAttention` raw value; nil = `off`. Per-window, drives `AppStore`'s idle controller.
     public var autoFollowAttention: String?
-    /// Whether the auto-follow stays put on a currently running (`active`) session instead of pulling to a
-    /// blocked one. nil/false = off (it always pulls to blocked). Only meaningful when
-    /// `autoFollowAttention` is set. NOT a ghostty key.
+    /// Whether auto-follow stays put on a running (`active`) session instead of pulling to a blocked one;
+    /// nil/false = off. Only meaningful when `autoFollowAttention` is set.
     public var autoFollowStayOnActive: Bool?
-    /// The sidebar row-text point size, nil for `defaultSidebarFontSize`. The row height scales with it
-    /// (`sidebarRowHeight(fontSize:)`); the row icons and status glyphs keep their fixed sizes. Applied at
-    /// the AppKit level when the sidebar draws, NOT a ghostty key.
+    /// The sidebar row-text point size, nil for `defaultSidebarFontSize`; the row height scales with it
+    /// (`sidebarRowHeight(fontSize:)`).
     public var sidebarFontSize: Double?
-    /// Raw names of title-bar / sidebar chrome elements the user has HIDDEN (see `InterfaceElement`);
-    /// nil/empty means every element is shown. Raw strings so an unknown future element name is dropped by
-    /// `resolvedHiddenInterfaceElements` instead of failing the whole decode. GUI-only, applied at the
-    /// AppKit/SwiftUI level, NOT a ghostty key.
+    /// Raw names of the chrome elements the user has HIDDEN (see `InterfaceElement`); nil/empty shows
+    /// everything. Unknown names are dropped by `resolvedHiddenInterfaceElements`.
     public var hiddenInterfaceElements: [String]?
-    /// Whether, with more than one window open, only the frontmost window shows its sidebar and every other
-    /// collapses its own. nil = off. While on, sidebar visibility is driven by window focus, so a manual
-    /// per-window hide is transient — the frontmost window re-shows its sidebar on refocus. NOT a ghostty key.
+    /// Whether, with more than one window open, only the frontmost shows its sidebar and every other
+    /// collapses its own; nil = off. Visibility then follows window focus, so a manual per-window hide is
+    /// transient — the frontmost window re-shows its sidebar on refocus.
     public var autoHideSidebarInactiveWindows: Bool?
 
     public init(fontFamily: String? = nil, fontSize: Double? = nil, theme: String? = nil,
@@ -350,35 +308,31 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.autoHideSidebarInactiveWindows = autoHideSidebarInactiveWindows
     }
 
-    /// The resolved set of hidden chrome elements — the known raw names from `hiddenInterfaceElements`,
-    /// unknown (future-written) ones dropped. The single read point, so callers never touch the raw list.
+    /// The hidden chrome elements, unknown (future-written) raw names dropped. The single read point.
     public var resolvedHiddenInterfaceElements: Set<InterfaceElement> {
         Set((hiddenInterfaceElements ?? []).compactMap(InterfaceElement.init(rawValue:)))
     }
 
-    /// Whether a given chrome element is hidden. Everything is shown by default, so an element absent from
-    /// the persisted list reads as visible.
+    /// Whether a chrome element is hidden; anything absent from the persisted list reads as visible.
     public func isInterfaceElementHidden(_ element: InterfaceElement) -> Bool {
         resolvedHiddenInterfaceElements.contains(element)
     }
 
     /// The resolved titlebar row state: the explicit `toolbarMode` when a KNOWN raw value, else the legacy
-    /// `compactToolbar` mapping (`false` = `.normal`, `true`/nil = `.compact`), so an unknown/nil value
-    /// never fails the read. The single read point, so callers never touch the raw shim.
+    /// `compactToolbar` mapping. The single read point.
     public var effectiveToolbarMode: ToolbarMode {
         toolbarMode.flatMap(ToolbarMode.init(rawValue:)) ?? (compactToolbar == false ? .normal : .compact)
     }
 
-    /// The resolved Dock-bounce mode: the explicit `dockBounce` when a KNOWN raw value, else `off`, so an
-    /// unknown/nil value never fails the read. The single read point, so callers never touch the raw string.
+    /// The resolved Dock-bounce mode: the explicit `dockBounce` when a KNOWN raw value, else `off`. The
+    /// single read point.
     public var effectiveDockBounce: DockBounce {
         dockBounce.flatMap(DockBounce.init(rawValue:)) ?? .off
     }
 
     /// The resolved glyph silhouette for one agent status: the configured raw name when a KNOWN
-    /// `StatusShape`, else nil (the default plain circle), so a hand-edited or future-written value never
-    /// fails the read. `idle` renders no glyph and has no shape. The single read point, so callers never
-    /// touch the raw strings.
+    /// `StatusShape`, else nil (the default plain circle). `idle` renders no glyph and has no shape. The
+    /// single read point.
     public func effectiveStatusShape(for status: AgentStatus) -> StatusShape? {
         let raw: String?
         switch status {
@@ -391,10 +345,8 @@ public struct AppSettings: Codable, Equatable, Sendable {
     }
 
     /// The working directory a new session opens in, resolving `newSessionDirectory` against the active
-    /// session's focused-pane cwd and the home directory: `home` → home; `currentSession` →
-    /// `currentSessionCwd`; `custom` → `newSessionCustomDirectory`. An unknown/nil mode, a nil/blank
-    /// `currentSessionCwd`, or a nil/blank custom path all fall back to home. Host-free so
-    /// `AppActions.newSession()` and the tests share one resolution.
+    /// session's focused-pane cwd and home. An unknown/nil mode, a blank `currentSessionCwd`, or a blank
+    /// custom path all fall back to home. Host-free so `AppActions` and the tests share one resolution.
     public func resolveNewSessionCwd(currentSessionCwd: String?, home: String) -> String {
         switch NewSessionDirectory(rawValue: newSessionDirectory ?? "") ?? .home {
         case .home:
@@ -408,55 +360,52 @@ public struct AppSettings: Codable, Equatable, Sendable {
         }
     }
 
-    /// The SwiftUI overlay opacity for an inactive-pane mute strength: clamped to 0...10 and scaled by
-    /// 0.08, so 0 → 0 (no mute), 5 → 0.4 (the default), 10 → 0.8 (extreme). The overlay is the terminal
-    /// background color, so a higher opacity blends the pane's text further toward the background (less
-    /// bright) while leaving background pixels unchanged.
+    /// The SwiftUI overlay opacity for an inactive-pane mute strength, clamped and scaled by 0.08 (the
+    /// default 5 → 0.4). The overlay is the terminal background color, so a higher opacity blends the
+    /// pane's text further toward the background while leaving background pixels unchanged.
     public static func muteOpacity(strength: Int) -> Double {
         Double(min(10, max(0, strength))) * 0.08
     }
 
-    /// The signed sidebar background shift for a strength: clamped to 0...10 and measured from the neutral
-    /// center 5, so 5 → 0 (no shift), 0 → -0.30 (full lighten), 10 → +0.30 (full darken). Positive darkens
-    /// (a black wash over the sidebar), negative lightens (a white wash); the magnitude is the wash
-    /// opacity, composited over the window background by `WindowContentView.sidebarTintWash`.
+    /// The signed sidebar background shift, clamped and measured from the neutral center 5, so the
+    /// endpoints are -0.30 (full lighten) and +0.30 (full darken). Positive darkens with a black wash,
+    /// negative lightens with a white one; the magnitude is the wash opacity, composited over the window
+    /// background by `WindowContentView.sidebarTintWash`.
     public static func sidebarShiftAmount(strength: Int) -> Double {
         Double(min(10, max(0, strength)) - 5) * 0.06
     }
 
-    /// The clamped sidebar row-text point size for a raw value: bounded to `sidebarFontSizeRange` so a
-    /// stray persisted or out-of-range value can't produce a degenerate row.
+    /// Bounds a raw sidebar row-text point size to `sidebarFontSizeRange`, so a stray persisted or
+    /// out-of-range value can't produce a degenerate row.
     public static func clampSidebarFontSize(_ size: Double) -> Double {
         min(sidebarFontSizeRange.upperBound, max(sidebarFontSizeRange.lowerBound, size))
     }
 
-    /// The outline row height for a sidebar font size: the clamped point size plus a fixed 15pt of vertical
-    /// padding, so the default 13pt maps to a 28pt row and larger text gets a proportionally taller one.
-    /// The row icon and status glyph keep their fixed sizes.
+    /// The outline row height: the clamped point size plus a fixed 15pt of vertical padding, so the
+    /// default 13pt maps to a 28pt row. The row icon and status glyph keep their fixed sizes.
     public static func sidebarRowHeight(fontSize: Double) -> Double {
         clampSidebarFontSize(fontSize).rounded() + 15
     }
 
-    /// The theme name that renders for the given appearance: when following, the dark slot in dark mode
-    /// (falling back to `theme`) and `theme` in light mode; otherwise the plain `theme`. Used only by the
-    /// theme-palette badge/selection (emission composes the raw dual and lets ghostty pick the side).
+    /// The theme name that renders for the given appearance, the dark slot falling back to `theme`. Used
+    /// only by the theme-palette badge/selection — emission composes the raw dual and lets ghostty pick
+    /// the side.
     public func activeTheme(isDark: Bool) -> String? {
         guard followSystemAppearance == true else { return theme }
         return isDark ? (darkTheme ?? theme) : theme
     }
 
-    /// The ghostty config lines for the set fields, one `key = value` per line, for a file loaded via
-    /// `ghostty_config_load_file`. Unset or blank fields are omitted. Values are written raw — ghostty
-    /// takes the whole line remainder as the value, so names with spaces (`3024 Night`, `SF Mono`) are
-    /// NOT quoted; quoting would become part of the value.
+    /// The `key = value` lines for the set fields, for a file loaded via `ghostty_config_load_file`; unset
+    /// or blank fields are omitted. Values are written raw — ghostty takes the whole line remainder as the
+    /// value, so names with spaces (`3024 Night`, `SF Mono`) are NOT quoted; quotes would become part of
+    /// the value.
     public func ghosttyConfigLines() -> [String] {
         var lines: [String] = []
         if let fontFamily, !fontFamily.isEmpty { lines.append("font-family = \(fontFamily)") }
         if let fontSize { lines.append("font-size = \(Self.format(fontSize))") }
-        // when following the macOS appearance, emit ghostty's dual conditional RAW and let libghostty
-        // resolve the active side on a color-scheme change (it records the new state and asks the host to
-        // re-feed the config, which the reload path does); else the single theme. no appearance input
-        // here — ghostty owns the switch.
+        // when following, emit ghostty's dual conditional RAW and let libghostty resolve the active side
+        // on a color-scheme change (it records the new state and asks the host to re-feed the config,
+        // which the reload path does). no appearance input here — ghostty owns the switch.
         let light = theme.flatMap { $0.isEmpty ? nil : $0 }
         let dark = darkTheme.flatMap { $0.isEmpty ? nil : $0 }
         if followSystemAppearance == true, let light, let dark {
@@ -464,18 +413,18 @@ public struct AppSettings: Codable, Equatable, Sendable {
         } else if let single = light ?? dark {
             lines.append("theme = \(single)")
         }
-        // a translucent window composites its tint at the AppKit level, so the renderer must draw a fully
-        // transparent terminal — else the surface and the window stack two tints. at full opacity (or
-        // unset) these are omitted and ghostty paints its own background.
+        // a translucent window composites its tint at the AppKit level, so the renderer must draw fully
+        // transparent or the surface and the window stack two tints. at full opacity (or unset) these are
+        // omitted and ghostty paints its own background.
         if let backgroundOpacity, backgroundOpacity < 1 {
             lines.append("background-opacity = 0")
             lines.append("background-blur = 0")
         }
-        // always emitted (nil = agterm's default of 3), so the default speed is effective rather than
-        // ghostty's per-device defaults. a bare value sets both the wheel and the trackpad.
+        // always emitted (nil = agterm's 3), so the default speed wins over ghostty's per-device defaults
+        // (discrete 3 / precision 1). a bare value sets both the wheel and the trackpad.
         lines.append("mouse-scroll-multiplier = \(Self.format(mouseScrollMultiplier ?? 3))")
-        // always emitted (nil = on): a right-click pastes by default, off emits `ignore` to hard-disable
-        // it. the settings conf loads last, so this wins over the user's own ghostty.conf.
+        // always emitted (nil = on); off emits `ignore` to hard-disable it. the settings conf loads last,
+        // so this wins over a `right-click-action` in the user's own ghostty.conf.
         lines.append("right-click-action = \((rightClickPaste ?? true) ? "paste" : "ignore")")
         return lines
     }

--- a/agtermCore/Sources/agtermCore/AppStore+AutoFollow.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+AutoFollow.swift
@@ -2,41 +2,37 @@ import Foundation
 import Observation
 
 extension Notification.Name {
-    /// Posted by `AppStore.autoFollowFire` right after an idle auto-follow moves a window's selection to a
-    /// blocked session, carrying the target session id and its pre-selection indicator under
-    /// `AppStore.autoFollowSessionIDKey`/`autoFollowIndicatorKey`. Host-free agtermCore cannot call the
-    /// app-target's `focusActiveSession`, so the app-side observer resolves the owning window and — only when
-    /// that window is key — moves first responder into the newly selected session; selection alone does not,
-    /// since the eager deck keeps the prior surface as first responder.
+    /// Posted by `AppStore.autoFollowFire` after an idle auto-follow moves a window's selection to a blocked
+    /// session; `userInfo` carries the target id and its pre-selection indicator. Host-free agtermCore cannot
+    /// call the app-target's `focusActiveSession`, so the app-side observer resolves the owning window and,
+    /// only when it is key, moves first responder in — selection alone doesn't, per the eager deck.
     public static let agtermAutoFollowed = Notification.Name("agterm.autoFollowed")
 
-    /// Posted by `AppStore.setSidebarVisible` whenever a window's sidebar visibility actually changes.
-    /// `window.list` is served from a background-thread cache refreshed after every control command and on
-    /// frontmost changes, but a GUI-only toggle (⌃⌘S / toolbar / menu / palette) is neither — so the app-target
-    /// `ControlServer` observes this to refresh it. The live `tree` reads it directly and needs no refresh.
+    /// Posted by `AppStore.setSidebarVisible` whenever a window's sidebar visibility changes. `window.list`
+    /// is served from a cache refreshed after every control command and on frontmost changes, but a GUI-only
+    /// toggle (⌃⌘S / toolbar / menu / palette) is neither, so `ControlServer` observes this to refresh it.
+    /// The live `tree` reads it directly and needs no refresh.
     public static let agtermSidebarVisibilityChanged = Notification.Name("agterm.sidebarVisibilityChanged")
 }
 
 // MARK: - Auto-follow attention
 
 /// After `autoFollowTimeout` of input idleness the window jumps its selection to the oldest blocked session,
-/// pulling the user to whatever agent is waiting. The activity stamp, the pure target decision, the fire path
-/// and the idle metric live here; the stored state is on the main `AppStore` body (Observation can't add
-/// stored properties in an extension).
+/// pulling the user to whatever agent is waiting. The stored state lives on the main `AppStore` body —
+/// Observation can't add stored properties in an extension.
 extension AppStore {
-    /// The `userInfo` key carrying the auto-followed session's `UUID` in an `.agtermAutoFollowed` notification.
-    /// `nonisolated` so both the poster below and the app-target observer (reading it off the notification on
-    /// the main queue) reach it without actor hops.
+    /// The `userInfo` key carrying the auto-followed session's `UUID`. `nonisolated` so both the poster and
+    /// the app-target observer reach it without actor hops.
     public nonisolated static let autoFollowSessionIDKey = "sessionID"
 
     /// The `userInfo` key carrying the destination's pre-selection `AgentIndicator`, paired with
     /// `autoFollowSessionIDKey` so an `autoReset` status can still route focus after selection clears it.
     public nonisolated static let autoFollowIndicatorKey = "indicator"
 
-    /// Records user interaction with this window (a keystroke or a manual selection). Stamps `lastActivityAt`
-    /// UNCONDITIONALLY so the idle metric is independent of the feature being enabled, then arms the debouncer
-    /// for `autoFollowFire` when a timeout is configured, cancelling any pending fire when not. Only USER entry
-    /// points may call it — auto-follow's OWN `selectSession` would keep resetting its own idle timer.
+    /// Records user interaction (a keystroke or a manual selection). Stamps `lastActivityAt` UNCONDITIONALLY
+    /// so the idle metric is independent of the feature being enabled, then arms the `autoFollowFire`
+    /// debouncer when a timeout is configured, cancelling any pending fire when not. Only USER entry points
+    /// may call it — auto-follow's OWN `selectSession` would keep resetting its idle timer.
     public func noteUserActivity() {
         lastActivityAt = Date()
         guard let timeout = autoFollowTimeout else {
@@ -46,33 +42,28 @@ extension AppStore {
         armAutoFollow(after: timeout)
     }
 
-    /// Suppresses auto-follow for this window while a non-terminal editor or transient overlay owns first
-    /// responder (the sidebar inline-rename field, a command palette), balanced by `resumeAutoFollow` on close.
-    /// Counted rather than a bare bool so overlapping suppressors keep the jump suppressed until the LAST lifts.
+    /// Suppresses auto-follow while a non-terminal editor or overlay owns first responder (inline rename,
+    /// command palette), balanced by `resumeAutoFollow`. Counted, so overlapping suppressors hold to the LAST.
     public func suppressAutoFollow() { autoFollowSuppressionCount += 1 }
 
-    /// Lifts one auto-follow suppression, paired with `suppressAutoFollow`. Clamped at zero so an unbalanced
-    /// extra resume can't drive the count negative and wedge the gate. Does NOT re-arm the debouncer (matching
-    /// `autoFollowFire`'s no-reschedule contract); the next keystroke or attention change re-arms normally.
+    /// Lifts one suppression, clamped at zero so an unbalanced extra resume can't wedge the gate. Does NOT
+    /// re-arm the debouncer (`autoFollowFire`'s no-reschedule contract); the next keystroke or change does.
     public func resumeAutoFollow() { autoFollowSuppressionCount = max(0, autoFollowSuppressionCount - 1) }
 
-    /// The single debouncer-arming seam the activity stamp, the enable/grace-change path and the status-change
-    /// re-arm share: schedule `autoFollowFire` after `delay`. `[weak self]` so a pending fire never keeps the
-    /// store alive.
+    /// The single debouncer-arming seam: schedule `autoFollowFire` after `delay`, weakly so a pending fire
+    /// never keeps the store alive.
     private func armAutoFollow(after delay: TimeInterval) {
         autoFollowDebouncer.schedule(after: delay) { [weak self] in self?.autoFollowFire() }
     }
 
-    /// Enables or disables auto-follow for this window and reconciles the debouncer + status observation.
-    /// A nil `timeout` DISABLES: it drops any pending fire and lets the status observer tear itself down (its
-    /// coalesced re-arm returns without re-registering once the timeout is nil, so the live tracker dies on the
-    /// next change). A non-nil one ENABLES: the off→on transition starts observing the window's attention set
-    /// AND arms the debouncer from the CURRENT state, so a user already idle with a block waiting is pulled
-    /// after the grace window. A changed timeout OR `stayOnActive` while already enabled re-arms (the observer
-    /// stays registered) so the next fire re-evaluates from the new config — a changed grace uses the new
-    /// delay, a changed `stayOnActive` re-decides for a block already waiting (turning it OFF must stop an
-    /// `active` current from suppressing that block). `stayOnActive` is stored either way: it changes the fire
-    /// DECISION, never the delay. Called by the Settings fan-out; both values come from
+    /// Enables or disables auto-follow and reconciles the debouncer + status observation. A nil `timeout`
+    /// DISABLES: pending fire dropped, and the status observer tears itself down (its coalesced re-arm stops
+    /// re-registering once the timeout is nil, so the tracker dies on the next change). Off→on starts
+    /// observing the attention set AND arms from the CURRENT state, so a user already idle with a block
+    /// waiting is pulled after the grace. A changed timeout or `stayOnActive` while enabled re-arms (the
+    /// observer stays registered) so the next fire re-evaluates: a changed grace uses the new delay, and
+    /// `stayOnActive` turned OFF must stop an `active` current from suppressing a waiting block — it changes
+    /// the fire DECISION, never the delay. Called by the Settings fan-out from
     /// `AppSettings.AutoFollowAttention`.
     public func setAutoFollow(timeout: TimeInterval?, stayOnActive: Bool) {
         let previousTimeout = autoFollowTimeout
@@ -83,18 +74,15 @@ extension AppStore {
             autoFollowDebouncer.cancel()
             return
         }
-        // (re-)arm on the off->on enable, a changed grace, OR a changed stayOnActive: each can change the next
-        // fire's outcome for a block already waiting while the user is idle (a bare stayOnActive flip has no
-        // pending fire to piggyback on, so it must arm one itself).
+        // a bare stayOnActive flip has no pending fire to piggyback on, so it must arm one itself.
         if previousTimeout != timeout || previousStayOnActive != stayOnActive { armAutoFollow(after: timeout) }
         if previousTimeout == nil { observeAttentionForAutoFollow() }
     }
 
-    /// Re-arms the auto-follow debouncer whenever the window's attention set changes while enabled, so a block
-    /// that LANDS (or an `active` session that finishes) while the user is ALREADY idle gets the same idle
-    /// grace a keystroke would buy. Mirrors `DockBadgeController.apply`: reads the observable inputs inside
-    /// `withObservationTracking` and re-registers itself on the next change via a coalesced, deferred re-arm.
-    /// Self-tears-down when disabled — the re-arm returns without re-registering once the timeout is nil.
+    /// Re-arms whenever the window's attention set changes while enabled, so a block that LANDS (or an
+    /// `active` session that finishes) while the user is ALREADY idle gets the same grace a keystroke buys.
+    /// Mirrors `DockBadgeController.apply`: re-registers on each change via a coalesced, deferred re-arm that
+    /// self-tears-down when disabled.
     private func observeAttentionForAutoFollow() {
         withObservationTracking {
             _ = attentionSessions // the observable inputs: workspaces + each agentIndicator
@@ -103,10 +91,8 @@ extension AppStore {
         }
     }
 
-    /// Defers a single re-arm to the next runloop turn, coalescing the several trackers a status change can
-    /// fire into one (the `DockBadgeController.scheduleRefresh` pattern). Re-arms from the current state and
-    /// re-registers the observer, but only while still enabled — a nil timeout returns without re-registering,
-    /// so the observation chain ends and the tracker is not renewed.
+    /// Defers a single re-arm to the next runloop turn, coalescing the trackers one status change fires (the
+    /// `DockBadgeController.scheduleRefresh` pattern). A nil timeout returns without re-registering.
     private func scheduleAutoFollowRearm() {
         guard !autoFollowRearmScheduled else { return }
         autoFollowRearmScheduled = true
@@ -119,12 +105,11 @@ extension AppStore {
         }
     }
 
-    /// The pure auto-follow decision (host-free, unit-tested): which session the window should jump to, or nil
-    /// to stay put. Suppresses when the current session is already `blocked` (you're on it) or — under
-    /// `stayOnActive` — `active` (don't leave a running agent); skips any blocked session already
-    /// `autoFollowConsumed` (pulled to once and left, muted until it re-enters blocked); otherwise the oldest
-    /// remaining `blocked` by `statusChangedAt` ascending (FIFO), else nil. A missing stamp sorts last, so a
-    /// stamped session always wins. `blocked` is the window-wide blocked set the caller supplies.
+    /// The pure auto-follow decision: which session the window should jump to, or nil to stay put. Suppresses
+    /// when the current session is already `blocked` (you're on it) or, under `stayOnActive`, `active` (don't
+    /// leave a running agent); skips a blocked session already `autoFollowConsumed` (pulled to once and left,
+    /// muted until it re-enters blocked); else the oldest remaining `blocked` by `statusChangedAt` (FIFO), a
+    /// missing stamp sorting last. `blocked` is the caller-supplied window-wide blocked set.
     func autoFollowTarget(current: Session?, blocked: [Session], stayOnActive: Bool) -> UUID? {
         if current?.agentIndicator.status == .blocked { return nil }
         if stayOnActive, current?.agentIndicator.status == .active { return nil }
@@ -132,18 +117,14 @@ extension AppStore {
             .min { ($0.statusChangedAt ?? .distantFuture) < ($1.statusChangedAt ?? .distantFuture) }?.id
     }
 
-    /// Fires one auto-follow step: computes the window-wide blocked set (the non-idle `attentionSessions`
-    /// filtered to `.blocked`), consults `autoFollowTarget` and selects any target. No target = no-op and NO
-    /// reschedule — being parked on the blocked session is itself the suppressor until a keystroke clears it
-    /// and re-arms the timer. Selection here deliberately does NOT note activity (that would reset the idle
-    /// timer on the app's own jump). Marks the target `autoFollowConsumed` so a later idle fire won't pull back
-    /// to it until it re-enters blocked. `internal` so tests can drive it directly. Posts `.agtermAutoFollowed`
-    /// after the select so the app target can move first responder into the target when its window is key
-    /// (selection alone doesn't, per the eager deck).
+    /// Fires one auto-follow step: filters `attentionSessions` to `.blocked`, consults `autoFollowTarget` and
+    /// selects any target. No target = no-op and NO reschedule — being parked on the blocked session is the
+    /// suppressor until a keystroke re-arms the timer. The selection does NOT note activity, which would reset
+    /// the idle timer on the app's own jump. Marks the target `autoFollowConsumed` so a later idle fire won't
+    /// pull back until it re-enters blocked; `internal` for tests. Posts `.agtermAutoFollowed` after select.
     func autoFollowFire() {
-        // a non-terminal editor/overlay (sidebar inline rename, command palette) owns first responder: no-op,
-        // so the jump can't interrupt a rename or reshuffle a palette's target. no reschedule — the next
-        // keystroke or attention change re-arms once the editor closes and resumeAutoFollow lifts this.
+        // suppressed (a rename field or palette owns first responder): no-op so the jump can't interrupt a
+        // rename; no reschedule — the next keystroke or attention change re-arms once resumeAutoFollow lifts.
         guard autoFollowSuppressionCount == 0 else { return }
         let blocked = attentionSessions.filter { $0.agentIndicator.status == .blocked }
         guard let target = autoFollowTarget(current: activeSession, blocked: blocked,
@@ -156,16 +137,14 @@ extension AppStore {
         NotificationCenter.default.post(name: .agtermAutoFollowed, object: nil, userInfo: userInfo)
     }
 
-    /// Milliseconds since the last user activity (`lastActivityAt`), or nil before any; clamped to >= 0 so
-    /// clock skew can't yield a negative. The live idle metric the control `tree` exposes; `asOf` is injectable
-    /// for deterministic tests.
+    /// Milliseconds since `lastActivityAt`, or nil before any; clamped to >= 0 against clock skew. The idle
+    /// metric the control `tree` exposes; `asOf` is injectable for deterministic tests.
     func idleMs(asOf now: Date = Date()) -> Int? {
         guard let lastActivityAt else { return nil }
         return max(0, Int(now.timeIntervalSince(lastActivityAt) * 1000))
     }
 
-    /// The configured auto-follow timeout in milliseconds, or nil when disabled. The control projection of
-    /// `autoFollowTimeout` shared by `tree` (this store) and `window.list` (`WindowLibrary` per open store), so
-    /// the `* 1000` scaling lives in one place.
+    /// The auto-follow timeout in milliseconds, nil when disabled — the projection `tree` (this store) and
+    /// `window.list` (`WindowLibrary` per open store) share, so the `* 1000` scaling lives in one place.
     var autoFollowMs: Int? { autoFollowTimeout.map { Int($0 * 1000) } }
 }

--- a/agtermCore/Sources/agtermCore/AppStore+AutoFollow.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+AutoFollow.swift
@@ -4,42 +4,39 @@ import Observation
 extension Notification.Name {
     /// Posted by `AppStore.autoFollowFire` right after an idle auto-follow moves a window's selection to a
     /// blocked session, carrying the target session id and its pre-selection indicator under
-    /// `AppStore.autoFollowSessionIDKey` / `autoFollowIndicatorKey`. agtermCore is host-free and cannot
-    /// call the app-target's `focusActiveSession`, so it posts this instead; the app-side observer resolves
-    /// the owning window and — only when that window is key — moves first responder into the newly selected
-    /// session (selection alone does not move it, since the eager deck keeps the prior surface as first
-    /// responder).
+    /// `AppStore.autoFollowSessionIDKey`/`autoFollowIndicatorKey`. Host-free agtermCore cannot call the
+    /// app-target's `focusActiveSession`, so the app-side observer resolves the owning window and — only when
+    /// that window is key — moves first responder into the newly selected session; selection alone does not,
+    /// since the eager deck keeps the prior surface as first responder.
     public static let agtermAutoFollowed = Notification.Name("agterm.autoFollowed")
 
     /// Posted by `AppStore.setSidebarVisible` whenever a window's sidebar visibility actually changes.
     /// `window.list` is served from a background-thread cache refreshed after every control command and on
-    /// frontmost changes, but a GUI-only sidebar toggle (⌃⌘S / toolbar / menu / palette) is neither — so
-    /// the app-target `ControlServer` observes this to refresh the cache, keeping `window.list`'s
-    /// `sidebarVisible` honest (the live `tree` reads it directly and needs no refresh).
+    /// frontmost changes, but a GUI-only toggle (⌃⌘S / toolbar / menu / palette) is neither — so the app-target
+    /// `ControlServer` observes this to refresh it. The live `tree` reads it directly and needs no refresh.
     public static let agtermSidebarVisibilityChanged = Notification.Name("agterm.sidebarVisibilityChanged")
 }
 
 // MARK: - Auto-follow attention
 
-/// After the user has been idle from input for `autoFollowTimeout`, the window jumps its selection to the
-/// oldest blocked session, pulling the user to whatever agent is waiting for input. The activity stamp,
-/// the pure target decision, the fire path, and the idle metric live here; the stored state lives on the
-/// main `AppStore` body (Observation can't add stored properties in an extension).
+/// After `autoFollowTimeout` of input idleness the window jumps its selection to the oldest blocked session,
+/// pulling the user to whatever agent is waiting. The activity stamp, the pure target decision, the fire path
+/// and the idle metric live here; the stored state is on the main `AppStore` body (Observation can't add
+/// stored properties in an extension).
 extension AppStore {
-    /// The `userInfo` key carrying the auto-followed session's `UUID` in an `.agtermAutoFollowed`
-    /// notification. `nonisolated` so the app-target observer (reading it off the notification on the main
-    /// queue) and the poster below both reach it without actor hops.
+    /// The `userInfo` key carrying the auto-followed session's `UUID` in an `.agtermAutoFollowed` notification.
+    /// `nonisolated` so both the poster below and the app-target observer (reading it off the notification on
+    /// the main queue) reach it without actor hops.
     public nonisolated static let autoFollowSessionIDKey = "sessionID"
 
     /// The `userInfo` key carrying the destination's pre-selection `AgentIndicator`, paired with
     /// `autoFollowSessionIDKey` so an `autoReset` status can still route focus after selection clears it.
     public nonisolated static let autoFollowIndicatorKey = "indicator"
 
-    /// Records user interaction with this window (a keystroke or a manual selection). Stamps
-    /// `lastActivityAt` UNCONDITIONALLY so the idle metric is independent of the feature being enabled,
-    /// then — only when a timeout is configured — arms the debouncer to fire `autoFollowFire` after the
-    /// idle window; when disabled it cancels any pending fire. Auto-follow's OWN `selectSession` must NOT
-    /// call this (only user entry points do), else the jump would keep resetting its own idle timer.
+    /// Records user interaction with this window (a keystroke or a manual selection). Stamps `lastActivityAt`
+    /// UNCONDITIONALLY so the idle metric is independent of the feature being enabled, then arms the debouncer
+    /// for `autoFollowFire` when a timeout is configured, cancelling any pending fire when not. Only USER entry
+    /// points may call it — auto-follow's OWN `selectSession` would keep resetting its own idle timer.
     public func noteUserActivity() {
         lastActivityAt = Date()
         guard let timeout = autoFollowTimeout else {
@@ -50,70 +47,66 @@ extension AppStore {
     }
 
     /// Suppresses auto-follow for this window while a non-terminal editor or transient overlay owns first
-    /// responder — the app calls this when the sidebar inline-rename field opens or a command palette opens.
-    /// Balanced by `resumeAutoFollow` when it closes. Bracketing (rather than a bare bool) lets the several
-    /// suppressors overlap: a nested suppressor keeps the jump suppressed until the LAST one lifts.
+    /// responder (the sidebar inline-rename field, a command palette), balanced by `resumeAutoFollow` on close.
+    /// Counted rather than a bare bool so overlapping suppressors keep the jump suppressed until the LAST lifts.
     public func suppressAutoFollow() { autoFollowSuppressionCount += 1 }
 
-    /// Lifts one auto-follow suppression (the paired call to `suppressAutoFollow` when the editor/overlay
-    /// closes). Clamped at zero so an unbalanced extra resume can't drive the count negative and wedge the
-    /// gate. Does NOT re-arm the debouncer — matching `autoFollowFire`'s no-reschedule contract; the next
-    /// keystroke or attention change re-arms normally.
+    /// Lifts one auto-follow suppression, paired with `suppressAutoFollow`. Clamped at zero so an unbalanced
+    /// extra resume can't drive the count negative and wedge the gate. Does NOT re-arm the debouncer (matching
+    /// `autoFollowFire`'s no-reschedule contract); the next keystroke or attention change re-arms normally.
     public func resumeAutoFollow() { autoFollowSuppressionCount = max(0, autoFollowSuppressionCount - 1) }
 
-    /// The single debouncer-arming seam the activity stamp, the enable/grace-change path, and the
-    /// status-change re-arm all share: schedule `autoFollowFire` after `delay`. `[weak self]` so a pending
-    /// fire never keeps the store alive.
+    /// The single debouncer-arming seam the activity stamp, the enable/grace-change path and the status-change
+    /// re-arm share: schedule `autoFollowFire` after `delay`. `[weak self]` so a pending fire never keeps the
+    /// store alive.
     private func armAutoFollow(after delay: TimeInterval) {
         autoFollowDebouncer.schedule(after: delay) { [weak self] in self?.autoFollowFire() }
     }
 
     /// Enables or disables auto-follow for this window and reconciles the debouncer + status observation.
-    /// A nil `timeout` DISABLES: it drops any pending fire and lets the status observer tear itself down
-    /// (its coalesced re-arm returns without re-registering once the timeout is nil, so the live tracker
-    /// dies on the next change). A non-nil `timeout` ENABLES: on the off→on transition it starts observing
-    /// the window's attention set AND arms the debouncer from the CURRENT state, so a user already idle with
-    /// a block waiting is pulled after the grace window; a timeout OR stayOnActive CHANGE while already
-    /// enabled re-arms the debouncer (the observer stays registered) so the next fire re-evaluates from the
-    /// new config — a changed grace re-arms to the new delay, and a changed stayOnActive re-decides for a
-    /// block already waiting (turning the toggle OFF must stop an active current suppressing that block).
-    /// `stayOnActive` is stored either way (it affects the fire DECISION, and a change to it re-arms so the
-    /// decision is re-run — it never changes the delay). Called by the Settings fan-out (public); the
-    /// resolved `timeout`/`stayOnActive` come from `AppSettings.AutoFollowAttention`.
+    /// A nil `timeout` DISABLES: it drops any pending fire and lets the status observer tear itself down (its
+    /// coalesced re-arm returns without re-registering once the timeout is nil, so the live tracker dies on the
+    /// next change). A non-nil one ENABLES: the off→on transition starts observing the window's attention set
+    /// AND arms the debouncer from the CURRENT state, so a user already idle with a block waiting is pulled
+    /// after the grace window. A changed timeout OR `stayOnActive` while already enabled re-arms (the observer
+    /// stays registered) so the next fire re-evaluates from the new config — a changed grace uses the new
+    /// delay, a changed `stayOnActive` re-decides for a block already waiting (turning it OFF must stop an
+    /// `active` current from suppressing that block). `stayOnActive` is stored either way: it changes the fire
+    /// DECISION, never the delay. Called by the Settings fan-out; both values come from
+    /// `AppSettings.AutoFollowAttention`.
     public func setAutoFollow(timeout: TimeInterval?, stayOnActive: Bool) {
         let previousTimeout = autoFollowTimeout
         let previousStayOnActive = autoFollowStayOnActive
         autoFollowStayOnActive = stayOnActive
         autoFollowTimeout = timeout
         guard let timeout else {
-            autoFollowDebouncer.cancel() // disable: drop the pending fire; the observer self-tears-down
+            autoFollowDebouncer.cancel()
             return
         }
-        // (re-)arm on the off->on enable, a changed grace, OR a changed stayOnActive: each can change the
-        // outcome of the next fire for a block already waiting while the user is idle (a bare stayOnActive
-        // flip has no pending fire to piggyback on, so it must arm one itself).
+        // (re-)arm on the off->on enable, a changed grace, OR a changed stayOnActive: each can change the next
+        // fire's outcome for a block already waiting while the user is idle (a bare stayOnActive flip has no
+        // pending fire to piggyback on, so it must arm one itself).
         if previousTimeout != timeout || previousStayOnActive != stayOnActive { armAutoFollow(after: timeout) }
-        if previousTimeout == nil { observeAttentionForAutoFollow() } // start tracking on the off->on edge
+        if previousTimeout == nil { observeAttentionForAutoFollow() }
     }
 
-    /// Re-arms the auto-follow debouncer whenever the window's attention set changes while enabled, so a
-    /// block that LANDS (or an `active` session that finishes) while the user is ALREADY idle gets the same
-    /// idle grace a keystroke would buy. Mirrors `DockBadgeController.apply`: reads the observable inputs
-    /// inside `withObservationTracking` and re-registers itself on the next change via a coalesced, deferred
-    /// re-arm. Self-tears-down when disabled — the re-arm returns without re-registering once the timeout is
-    /// nil, so the live tracker dies on the next change.
+    /// Re-arms the auto-follow debouncer whenever the window's attention set changes while enabled, so a block
+    /// that LANDS (or an `active` session that finishes) while the user is ALREADY idle gets the same idle
+    /// grace a keystroke would buy. Mirrors `DockBadgeController.apply`: reads the observable inputs inside
+    /// `withObservationTracking` and re-registers itself on the next change via a coalesced, deferred re-arm.
+    /// Self-tears-down when disabled — the re-arm returns without re-registering once the timeout is nil.
     private func observeAttentionForAutoFollow() {
         withObservationTracking {
-            _ = attentionSessions // read the observable inputs (workspaces + each agentIndicator); value unused
+            _ = attentionSessions // the observable inputs: workspaces + each agentIndicator
         } onChange: { [weak self] in
             DispatchQueue.main.async { MainActor.assumeIsolated { self?.scheduleAutoFollowRearm() } }
         }
     }
 
     /// Defers a single re-arm to the next runloop turn, coalescing the several trackers a status change can
-    /// fire into one (the `DockBadgeController.scheduleRefresh` pattern). Re-arms the debouncer from the
-    /// current state and re-registers the observer — but only while still enabled; a nil timeout (disabled)
-    /// returns without re-registering, so the observation chain ends and the tracker is not renewed.
+    /// fire into one (the `DockBadgeController.scheduleRefresh` pattern). Re-arms from the current state and
+    /// re-registers the observer, but only while still enabled — a nil timeout returns without re-registering,
+    /// so the observation chain ends and the tracker is not renewed.
     private func scheduleAutoFollowRearm() {
         guard !autoFollowRearmScheduled else { return }
         autoFollowRearmScheduled = true
@@ -126,13 +119,12 @@ extension AppStore {
         }
     }
 
-    /// The pure auto-follow decision (host-free, unit-tested): which session the window should jump to, or
-    /// nil to stay put. Suppresses when the current session is already `blocked` (you're on it) or — when
-    /// `stayOnActive` is on — `active` (don't leave a running agent); skips any blocked session already
-    /// `autoFollowConsumed` (a block the user was pulled to once and left, muted until it re-enters blocked);
-    /// otherwise returns the oldest remaining `blocked` session by `statusChangedAt` ascending (FIFO), or nil
-    /// when none remain. A missing stamp sorts last, so a stamped session is always preferred. `blocked` is
-    /// the window-wide blocked set the caller supplies.
+    /// The pure auto-follow decision (host-free, unit-tested): which session the window should jump to, or nil
+    /// to stay put. Suppresses when the current session is already `blocked` (you're on it) or — under
+    /// `stayOnActive` — `active` (don't leave a running agent); skips any blocked session already
+    /// `autoFollowConsumed` (pulled to once and left, muted until it re-enters blocked); otherwise the oldest
+    /// remaining `blocked` by `statusChangedAt` ascending (FIFO), else nil. A missing stamp sorts last, so a
+    /// stamped session always wins. `blocked` is the window-wide blocked set the caller supplies.
     func autoFollowTarget(current: Session?, blocked: [Session], stayOnActive: Bool) -> UUID? {
         if current?.agentIndicator.status == .blocked { return nil }
         if stayOnActive, current?.agentIndicator.status == .active { return nil }
@@ -141,41 +133,39 @@ extension AppStore {
     }
 
     /// Fires one auto-follow step: computes the window-wide blocked set (the non-idle `attentionSessions`
-    /// filtered to `.blocked`), consults `autoFollowTarget`, and selects the target when there is one. A
-    /// no-op (no target) does nothing and does NOT reschedule — being parked on the blocked session is
-    /// itself the suppressor until a keystroke clears it and re-arms the timer. Selection here deliberately
-    /// does NOT note activity (that would reset the idle timer on the app's own jump). Marks the target
-    /// `autoFollowConsumed` so a later idle fire won't pull back to it until it re-enters blocked.
-    /// `internal` so tests can drive it directly. Posts `.agtermAutoFollowed` after the select so the app
-    /// target can move first responder into the target (selection alone doesn't, per the eager deck) when
-    /// its window is key.
+    /// filtered to `.blocked`), consults `autoFollowTarget` and selects any target. No target = no-op and NO
+    /// reschedule — being parked on the blocked session is itself the suppressor until a keystroke clears it
+    /// and re-arms the timer. Selection here deliberately does NOT note activity (that would reset the idle
+    /// timer on the app's own jump). Marks the target `autoFollowConsumed` so a later idle fire won't pull back
+    /// to it until it re-enters blocked. `internal` so tests can drive it directly. Posts `.agtermAutoFollowed`
+    /// after the select so the app target can move first responder into the target when its window is key
+    /// (selection alone doesn't, per the eager deck).
     func autoFollowFire() {
-        // a non-terminal editor/overlay (sidebar inline rename, command palette) owns first responder:
-        // no-op so the jump can't interrupt a rename or reshuffle a palette's target. no reschedule — the
-        // next keystroke or attention change re-arms once the editor closes and resumeAutoFollow lifts this.
+        // a non-terminal editor/overlay (sidebar inline rename, command palette) owns first responder: no-op,
+        // so the jump can't interrupt a rename or reshuffle a palette's target. no reschedule — the next
+        // keystroke or attention change re-arms once the editor closes and resumeAutoFollow lifts this.
         guard autoFollowSuppressionCount == 0 else { return }
         let blocked = attentionSessions.filter { $0.agentIndicator.status == .blocked }
         guard let target = autoFollowTarget(current: activeSession, blocked: blocked,
                                             stayOnActive: autoFollowStayOnActive) else { return }
         let indicator = selectSession(target)
-        // mute this block: a later idle fire won't yank the user back here after they leave, until the
-        // session re-enters blocked (setAgentIndicator resets the flag on that transition).
+        // setAgentIndicator clears this flag when the session re-enters blocked, un-muting it.
         session(withID: target)?.autoFollowConsumed = true
         var userInfo: [String: Any] = [Self.autoFollowSessionIDKey: target]
         if let indicator { userInfo[Self.autoFollowIndicatorKey] = indicator }
         NotificationCenter.default.post(name: .agtermAutoFollowed, object: nil, userInfo: userInfo)
     }
 
-    /// Milliseconds since the last user activity (`lastActivityAt`), or nil before any activity. Clamped to
-    /// >= 0 so a clock skew can't yield a negative idle. The live idle metric the control `tree` exposes;
-    /// `asOf` is injectable for deterministic tests.
+    /// Milliseconds since the last user activity (`lastActivityAt`), or nil before any; clamped to >= 0 so
+    /// clock skew can't yield a negative. The live idle metric the control `tree` exposes; `asOf` is injectable
+    /// for deterministic tests.
     func idleMs(asOf now: Date = Date()) -> Int? {
         guard let lastActivityAt else { return nil }
         return max(0, Int(now.timeIntervalSince(lastActivityAt) * 1000))
     }
 
     /// The configured auto-follow timeout in milliseconds, or nil when disabled. The control projection of
-    /// `autoFollowTimeout` shared by the `tree` (this store) and `window.list` (`WindowLibrary` per open
-    /// store), so the `* 1000` scaling lives in one place.
+    /// `autoFollowTimeout` shared by `tree` (this store) and `window.list` (`WindowLibrary` per open store), so
+    /// the `* 1000` scaling lives in one place.
     var autoFollowMs: Int? { autoFollowTimeout.map { Int($0 * 1000) } }
 }

--- a/agtermCore/Sources/agtermCore/AppStore+CloseReselection.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+CloseReselection.swift
@@ -3,18 +3,16 @@ import Foundation
 extension AppStore {
     /// Picks the next selection after CLOSING the active session at `location`: the most-recently-active
     /// surviving session, else a positional walk.
-    /// The MRU scope narrows to the closing session's own workspace ∩ the VISIBLE set
-    /// (`navigableSessions`, so both the flagged list and the focus filter apply) — an unscoped survivor
-    /// could yank the user into another workspace, and a pick the sidebar isn't rendering would strand the
-    /// selection.
-    /// Exhausting a scope widens through three levels: that workspace's visible sessions, everything
-    /// visible, then the whole tree.
-    /// Only when the widened scope carries no recency does a positional walk decide, and while any
-    /// narrowing is applied that is the flattened in-scope walk over the widened scope, not
-    /// `reselectionTarget` — `narrowed` keys on the MODE, so it stays true after the widening.
-    /// A pick outside the marked set meets each caller's `disableFocusIfSelectionOutsideSet`.
-    /// The scope is built from the TREE, so a session already removed cannot come back even while it
-    /// survives in `sessionRecency` (the soft-close paths keep it there for undo).
+    /// The MRU scope narrows to the closing session's own workspace ∩ the VISIBLE set (`navigableSessions`,
+    /// so both the flagged list and the focus filter apply) — an unscoped survivor could yank the user into
+    /// another workspace, and a pick the sidebar isn't rendering would strand the selection. Exhausting a
+    /// scope widens through three levels: that workspace's visible sessions, everything visible, the whole
+    /// tree. Only a widened scope with no recency falls to a positional walk, and while any narrowing is
+    /// applied that is the flattened in-scope walk over the widened scope, not `reselectionTarget` —
+    /// `narrowed` keys on the MODE, so it stays true after the widening.
+    /// A pick outside the marked set meets each caller's `disableFocusIfSelectionOutsideSet`. The scope is
+    /// built from the TREE, so a session already removed cannot come back even while it survives in
+    /// `sessionRecency` (the soft-close paths keep it there for undo).
     func closeReselectionTarget(after location: (workspaceIndex: Int, sessionIndex: Int)) -> UUID? {
         let visible = Set(navigableSessions.map(\.id))
         let everything = Set(workspaces.flatMap(\.sessions).map(\.id))
@@ -24,9 +22,7 @@ extension AppStore {
         // visible scope falls to a positional jump into the first workspace.
         let scope = sameWorkspace.isEmpty ? (visible.isEmpty ? everything : visible) : sameWorkspace
         if let recent = sessionRecency.top(1, in: scope).first { return recent }
-        // under a narrowing the positional fallback runs over `scope`, which the widening above may have
-        // grown to the whole tree — so it stays inside the visible set only while one survives there.
-        // Reachable with no recency at all, e.g. the first close after a restore.
+        // reachable with no recency at all, e.g. the first close after a restore.
         let narrowed = sidebarMode == .flagged || focusEnabled
         if narrowed, let inScope = nearestInScopeTarget(after: location, scope: scope) {
             return inScope
@@ -35,9 +31,9 @@ extension AppStore {
     }
 
     /// `reselectionTarget`'s walk restricted to `scope`, over the tree FLATTENED in sidebar order: the
-    /// in-scope session that shifted into the removed slot, else the nearest one before it.
-    /// It spans workspaces because the scope can — the flagged sidebar renders one flat cross-workspace
-    /// list, so the adjacent row there may live elsewhere; a same-workspace scope collapses it back.
+    /// in-scope session that shifted into the removed slot, else the nearest one before it. It spans
+    /// workspaces because the scope can — the flagged sidebar renders one flat cross-workspace list, so the
+    /// adjacent row there may live elsewhere; a same-workspace scope collapses it back.
     private func nearestInScopeTarget(after location: (workspaceIndex: Int, sessionIndex: Int),
                                       scope: Set<UUID>) -> UUID? {
         let sessions = workspaces[location.workspaceIndex].sessions

--- a/agtermCore/Sources/agtermCore/AppStore+Dashboard.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Dashboard.swift
@@ -1,11 +1,10 @@
 import Foundation
 
 extension AppStore {
-    /// Expand session ids into dashboard pane cells IN ORDER — each resolved id yields its `.primary` cell,
-    /// plus a `.split` cell when the session `hasSplit` (both shells alive, shown OR hidden) — so a split
-    /// session becomes two cells. Ids that don't resolve to a session are skipped. UNCAPPED: the caller applies
-    /// the cell cap and reports the dropped-pane count, so the expansion has exactly ONE implementation shared
-    /// by `ControlServer.setDashboard` and `AppActions.toggleDashboard`.
+    /// Expand session ids into dashboard pane cells IN ORDER: each resolved id yields its `.primary` cell,
+    /// plus a `.split` cell when the session `hasSplit` (both shells alive, shown OR hidden). Unresolvable
+    /// ids are skipped. UNCAPPED — the caller caps and reports the dropped-pane count, so the expansion has
+    /// exactly ONE implementation, shared by `ControlServer.setDashboard` and `AppActions.toggleDashboard`.
     public func dashboardPaneCells(for ids: [UUID]) -> [DashboardMember] {
         var members: [DashboardMember] = []
         for id in ids {
@@ -16,10 +15,10 @@ extension AppStore {
         return members
     }
 
-    /// Expand `ids` into dashboard pane cells (see `dashboardPaneCells(for:)`) and cap the result to `limit`
-    /// cells, returning the capped cells plus the number of panes dropped past the cap. The single expansion +
-    /// cap used by both the control `dashboard` command and the GUI `toggleDashboard`; `dropped` feeds the
-    /// control path's "dropped N pane(s) beyond the N-cell limit" note.
+    /// Expand `ids` into dashboard pane cells (see `dashboardPaneCells(for:)`) capped to `limit`, returning
+    /// them plus the number of panes dropped past the cap. The single expansion + cap used by both the
+    /// control `dashboard` command and the GUI `toggleDashboard`; `dropped` feeds the control path's
+    /// "dropped N pane(s) beyond the N-cell limit" note.
     public func dashboardMembers(for ids: [UUID], limit: Int) -> (members: [DashboardMember], dropped: Int) {
         let expanded = dashboardPaneCells(for: ids)
         let capped = Array(expanded.prefix(limit))

--- a/agtermCore/Sources/agtermCore/AppStore+Duplicate.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Duplicate.swift
@@ -2,14 +2,12 @@ import Foundation
 
 extension AppStore {
     /// Duplicates a session: a fresh shell in the SAME workspace, inserted directly after the source, rooted
-    /// at the source's focused-pane cwd (`focusedCwd` — the directory the sidebar row shows and the one
-    /// "Reveal in Finder" opens, so a duplicate lands where the row says it will).
+    /// at its focused-pane cwd (`focusedCwd` — the directory the sidebar row shows and "Reveal in Finder"
+    /// opens, so the duplicate lands where the row says it will).
     ///
-    /// ONLY the directory carries over. The duplicate is a plain new session — auto basename (no inherited
-    /// `customName`), no split, no scratch, no status, unflagged, no `initialCommand` — i.e. exactly `New
-    /// Session` seeded with the source's cwd, not a clone of its state. Returns nil if no session matches.
-    ///
-    /// Backs the sidebar row's "Duplicate" and the `session.duplicate` control command.
+    /// ONLY the directory carries over: auto basename (no inherited `customName`), no split, scratch, status,
+    /// flag or `initialCommand` — `New Session` seeded with the source's cwd, not a clone of its state.
+    /// Returns nil if no session matches. Backs the sidebar row's "Duplicate" and `session.duplicate`.
     @discardableResult
     public func duplicateSession(_ id: UUID) -> Session? {
         guard let session = session(withID: id), let location = sessionLocation(ofSession: id) else { return nil }

--- a/agtermCore/Sources/agtermCore/AppStore+Focus.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Focus.swift
@@ -1,19 +1,17 @@
 import Foundation
 
-/// The sidebar focus filter: which workspaces the tree renders, the session set navigation and the
-/// palettes derive from it, and the mutators/lifecycle guards keeping the filter in step with the
-/// selection. The stored filter state stays on the class — an extension cannot hold stored properties.
+/// The sidebar focus filter: which workspaces the tree renders, the session set navigation and the palettes
+/// derive from it, and the mutators/lifecycle guards keeping it in step with the selection. The stored filter
+/// state lives on the class — an extension cannot hold stored properties.
 extension AppStore {
-    /// Switches the focus filter OFF — KEEPING the marked set — when the newly selected session lives
-    /// outside it, so an explicit cross-set select (`session.select <id>` of a hidden session, a
-    /// notification reveal, a move/close that reselects elsewhere) reveals its target and the active
-    /// session is always inside the visible set. Navigation is scoped to the filtered set
-    /// (`navigableSessions`), so its targets never trip this. No-op when the filter is off, nothing is
-    /// selected, or the selection sits in a member workspace; persistence rides the caller's
-    /// `selectSession` save. Also a no-op in `.flagged` mode — that flat list is cross-workspace and
-    /// ignores the marked set, so a selection outside it has not navigated past the filter; without the
-    /// term, entering the flagged view with the only flagged session in an unmarked workspace silently
-    /// switches the filter off. Returning to `.tree` re-applies it.
+    /// Switches the filter OFF — KEEPING the marked set — when the newly selected session is outside it, so an
+    /// explicit cross-set select (a hidden `session.select`, a notification reveal, a reselect after move/close)
+    /// reveals its target and the active session is always inside the visible set. Navigation is scoped to
+    /// `navigableSessions`, so it never trips this. No-op when the filter is off, nothing is selected, or the
+    /// selection sits in a member workspace; persistence rides the caller's `selectSession` save. Also a no-op
+    /// in `.flagged` mode — that flat list is cross-workspace and ignores the marked set, so without the term,
+    /// entering flagged view with the only flagged session in an unmarked workspace would silently disable it.
+    /// Returning to `.tree` re-applies it.
     func disableFocusIfSelectionOutsideSet(_ sessionID: UUID?) {
         guard focusEnabled, sidebarMode != .flagged, let sessionID else { return }
         if let owner = workspace(forSession: sessionID)?.id, focusedWorkspaceIDs.contains(owner) { return }
@@ -21,63 +19,57 @@ extension AppStore {
     }
 
     /// Replaces the marked set with just `id` and ENABLES the filter — the single-workspace zoom every
-    /// row-menu/menu-bar/`workspace.focus on` caller drives. No-op for an id naming no workspace: a
-    /// phantom member no tree can render breaks the row-visibility read-back contract
-    /// (`ControlWorkspaceNode.focused`) until the next restore prunes it.
+    /// row-menu/menu-bar/`workspace.focus on` caller drives. No-op for an id naming no workspace: a phantom
+    /// member breaks the row-visibility read-back (`ControlWorkspaceNode.focused`) until a restore prunes it.
     func setFocusedWorkspace(_ id: UUID) {
         guard workspaces.contains(where: { $0.id == id }) else { return }
         commitFocus(ids: [id], enabled: true)
     }
 
-    /// Empties the marked set and switches the filter off, restoring the full tree — the menu/palette
-    /// "Clear Focus" and the clearing half of the replace-toggle. Clean no-op when nothing is marked.
-    /// Distinct from `setFocusEnabled(false)`, which keeps the set and only stops applying it.
+    /// Empties the marked set and switches the filter off — the menu/palette "Clear Focus" and the clearing half
+    /// of the replace-toggle; no-op when nothing is marked. Unlike `setFocusEnabled(false)`, which keeps the set.
     public func clearFocus() {
         commitFocus(ids: [], enabled: false)
     }
 
-    /// Replace-TOGGLE: clears the filter when `id` is the SOLE marked workspace and the filter applies,
-    /// else replaces the marked set with it (enabling). The row menu's Focus/Unfocus, the
-    /// `focus_workspace` keybind/menu item and `workspace.focus toggle` share this ONE definition, so a
-    /// "toggle" can never mean two things. No-op on an unknown id, like `setFocusedWorkspace`.
+    /// Replace-TOGGLE: clears the filter when `id` is the SOLE marked workspace and the filter applies, else
+    /// replaces the set with it (enabling), so the row menu's Focus/Unfocus, the `focus_workspace` keybind/menu
+    /// item and `workspace.focus toggle` cannot mean two things. No-op on an unknown id.
     public func toggleFocusedWorkspace(_ id: UUID) {
         if isSoleFocus(id) { clearFocus() } else { setFocusedWorkspace(id) }
     }
 
-    /// The ONE workspace the tree is zoomed to — the sole marked workspace while the filter APPLIES, else
-    /// nil. The single definition, read by `isSoleFocus(_:)`, the sidebar's force-expand of a zoomed-to
-    /// workspace, and the empty-space drop fallback (a Finder folder dropped below the rows lands where
-    /// the user is looking, so adding a session cannot silently leave the filtered view). The
-    /// `focusEnabled` term is load-bearing: marked but filter OFF means the WHOLE tree is on screen, so
-    /// nothing is zoomed to; two or more members have no unambiguous answer either.
+    /// The ONE workspace the tree is zoomed to — the sole marked workspace while the filter APPLIES, else nil.
+    /// The single definition, read by `isSoleFocus(_:)`, the sidebar's force-expand, and the empty-space drop
+    /// fallback (a Finder folder dropped below the rows lands where the user is looking, so adding a session
+    /// cannot silently leave the filtered view). The `focusEnabled` term is load-bearing: marked with the
+    /// filter OFF means the WHOLE tree is on screen, so nothing is zoomed to; two or more members are ambiguous.
     public var soleFocusedWorkspaceID: UUID? {
         guard focusEnabled, focusedWorkspaceIDs.count == 1 else { return nil }
         return focusedWorkspaceIDs.first
     }
 
-    /// Whether `id` is the workspace the tree is zoomed to — the "already focused on this one" state,
-    /// which is what makes Focus read Unfocus and what a `toggle` clears.
+    /// Whether `id` is the workspace the tree is zoomed to — the state that makes Focus read Unfocus and that
+    /// a `toggle` clears.
     public func isSoleFocus(_ id: UUID) -> Bool { soleFocusedWorkspaceID == id }
 
-    /// `isSoleFocus` for the CURRENT workspace (the one new sessions land in) — the fact the keyless View ▸
-    /// Focus/Unfocus Workspace item needs, since it has no clicked row and targets `currentWorkspaceID`
-    /// exactly as `AppActions.focusActiveWorkspace()` does.
+    /// `isSoleFocus` for the CURRENT workspace — what the keyless View ▸ Focus/Unfocus Workspace item needs,
+    /// having no clicked row and targeting `currentWorkspaceID` like `AppActions.focusActiveWorkspace()`.
     public var isCurrentWorkspaceSoleFocus: Bool {
         guard let id = currentWorkspaceID else { return false }
         return isSoleFocus(id)
     }
 
-    /// Whether the CURRENT workspace is already in the marked set — what View ▸ Add Workspace to Focus and
-    /// its palette twin read to avoid offering a silent no-op (the row menu instead flips to "Remove from
-    /// Focus", which it can do because it has a clicked row).
+    /// Whether the CURRENT workspace is already marked — read by View ▸ Add Workspace to Focus and its
+    /// palette twin to avoid a silent no-op (the row menu, having a clicked row, flips to "Remove from Focus").
     public var isCurrentWorkspaceFocusMember: Bool {
         guard let id = currentWorkspaceID else { return false }
         return focusedWorkspaceIDs.contains(id)
     }
 
-    /// Applies one `workspace.focus` mode to `id`. Host-free, so the mode-to-mutator mapping is unit
-    /// tested, the app-side control arm keeps only target resolution, and the GUI's replace-toggle can't
-    /// drift from the wire's `toggle`. Every arm is delta-guarded, so each mode is idempotent.
+    /// Applies one `workspace.focus` mode to `id`, host-free so the mode-to-mutator mapping is unit tested, the
+    /// control arm keeps only target resolution, and the GUI toggle can't drift from the wire's. Arms are
+    /// delta-guarded, so each mode is idempotent.
     public func applyFocusMode(_ mode: ControlWorkspaceFocusMode, to id: UUID) {
         switch mode {
         case .on: setFocusedWorkspace(id)
@@ -87,19 +79,17 @@ extension AppStore {
         }
     }
 
-    /// Applies one `workspace.filter` mode to this window's filter flag, leaving the marked set alone.
-    /// Host-free half of the control arm (which keeps only the window resolution), so the mode-to-flag
-    /// mapping — including the refusal to enable an empty set — is unit tested rather than re-spelled.
+    /// Applies one `workspace.filter` mode to this window's flag, leaving the marked set alone. Host-free half of
+    /// the control arm, so the mapping — including the refusal to enable an empty set — is unit tested.
     public func applyWorkspaceFilter(_ mode: ControlToggleMode) {
         setFocusEnabled(mode.desiredValue(current: focusEnabled))
     }
 
-    /// Adds or removes one workspace from the marked set, leaving the other members alone. Marking ONLY
-    /// marks — an add that enabled the filter would hide the very rows the next add needs — so a working
-    /// set is built row by row with the whole tree on screen; `setFocusedWorkspace(_:)` (the replacing
-    /// "Focus") is the one that enables immediately. Removing still disables the filter once the set
-    /// empties. Marking is refused for an id naming no workspace, so no phantom member is ever persisted;
-    /// un-marking is never gated on existence, so a stale id already in the set stays removable.
+    /// Adds or removes one workspace from the marked set, leaving the others alone. Marking ONLY marks — an add
+    /// that enabled the filter would hide the very rows the next add needs — so a working set is built row by
+    /// row with the whole tree on screen; `setFocusedWorkspace(_:)` is the one that enables immediately.
+    /// Removing still disables the filter once the set empties. Marking is refused for an id naming no
+    /// workspace (no phantom member is persisted); un-marking is ungated, so a stale id stays removable.
     public func setFocusMembership(_ id: UUID, member: Bool) {
         if member, !workspaces.contains(where: { $0.id == id }) { return }
         var wantIDs = focusedWorkspaceIDs
@@ -107,17 +97,15 @@ extension AppStore {
         commitFocus(ids: wantIDs, enabled: focusEnabled)
     }
 
-    /// Turns the focus filter on or off WITHOUT touching the marked set, so peeking at the whole tree
-    /// costs one flip. Enabling an empty set is refused (a no-op), matching the bottom-bar toggle, which
-    /// is disabled in exactly that state.
+    /// Turns the filter on or off WITHOUT touching the marked set, so peeking at the whole tree costs one flip.
+    /// Enabling an empty set is refused, matching the bottom-bar toggle, disabled in exactly that state.
     public func setFocusEnabled(_ on: Bool) {
         commitFocus(ids: focusedWorkspaceIDs, enabled: on)
     }
 
-    /// The single write point for the two filter fields: clamps `enabled` to false on an empty set (the
-    /// guard making `enabled + empty` unrepresentable), skips the write when nothing changes (so the
-    /// delta-computed control/menu callers stay idempotent and no-op writes never persist), then prunes
-    /// the sidebar selection and saves.
+    /// The single write point for the two filter fields: clamps `enabled` to false on an empty set (making
+    /// `enabled + empty` unrepresentable), skips an unchanged write (so delta-computed control/menu callers
+    /// stay idempotent and no-op writes never persist), then prunes the sidebar selection and saves.
     private func commitFocus(ids: Set<UUID>, enabled: Bool) {
         let wantEnabled = enabled && !ids.isEmpty
         guard focusedWorkspaceIDs != ids || focusEnabled != wantEnabled else { return }
@@ -129,78 +117,69 @@ extension AppStore {
     }
 
     /// Drops `id` from the marked set, disabling the filter once it empties — the LIFECYCLE half of the
-    /// `enabled + empty` invariant, for the paths that remove a workspace outright (`removeWorkspace`,
-    /// `softRemoveWorkspace`) rather than un-marking it, so a further removal path gets it for free.
-    /// Deliberately does NOT `save()` or prune the sidebar selection: its callers do both.
+    /// `enabled + empty` invariant, for paths that remove a workspace outright (`removeWorkspace`,
+    /// `softRemoveWorkspace`) rather than un-marking it. No `save()` or selection prune: its callers do both.
     func dropFocusMember(_ id: UUID) {
         focusedWorkspaceIDs.remove(id)
         if focusedWorkspaceIDs.isEmpty { focusEnabled = false }
     }
 
-    /// Marks a freshly created workspace so it is visible while the filter applies (the auto-reveal
-    /// contract of `addWorkspace`/`ensureWorkspace`); a no-op when the filter is off, where the whole tree
-    /// is on screen and the set must not widen behind the user's back. Save-free: `addWorkspace` saves.
+    /// Marks a freshly created workspace so it is visible while the filter applies (the auto-reveal contract of
+    /// `addWorkspace`/`ensureWorkspace`); no-op with the filter off, where the whole tree is on screen and the
+    /// set must not widen behind the user's back. Save-free: `addWorkspace` saves.
     func revealNewFocusMember(_ id: UUID) {
         guard focusEnabled else { return }
         focusedWorkspaceIDs.insert(id)
     }
 
-    /// Puts a workspace back into the marked set when its removal is REVERSED — both restore paths, the
-    /// pending-close undo and Reopen Closed Item. MARK-ONLY: membership belongs to the closed workspace
-    /// and is restored with it, but `focusEnabled` is CURRENT WINDOW STATE, so a restore must never
-    /// override a toggle made meanwhile; an insert-only path also honors the marking rule (an add never
-    /// applies the filter) and can never reach `enabled + empty`. Callers run it BEFORE their reselect (so
-    /// a restored member is in-set for `disableFocusIfSelectionOutsideSet`) and, in the undo, ahead of the
-    /// empty-workspace early return whose row would otherwise stay filtered out. Save-free; the restore
-    /// paths save.
+    /// Puts a workspace back into the marked set when its removal is REVERSED — the pending-close undo and Reopen
+    /// Closed Item. MARK-ONLY: membership belongs to the closed workspace, but `focusEnabled` is CURRENT WINDOW
+    /// STATE, so a restore must never override a toggle made meanwhile; insert-only also honors the marking rule
+    /// and can never reach `enabled + empty`. Callers run it BEFORE their reselect (so a restored member is
+    /// in-set for `disableFocusIfSelectionOutsideSet`) and, in the undo, ahead of the empty-workspace early
+    /// return whose row would otherwise stay filtered out. Save-free; the restore paths save.
     func markFocusMember(_ id: UUID) {
         focusedWorkspaceIDs.insert(id)
     }
 
-    /// Restores the focus filter from a snapshot, PRUNING member ids absent from the restored tree and
-    /// disabling the filter when the pruned set comes back empty — that prune keeps `enabled + empty`
-    /// unrepresentable across a restore, or an all-stale set (workspaces deleted by another window, or a
-    /// hand-edited file) restores as an enabled-but-invisible filter and the row-visibility read-back
-    /// lies. A partially stale set keeps its survivors and stays enabled. Called from `restore(from:)`
-    /// AFTER the tree is rebuilt; writes the fields directly, since the mutators would `save()` what was
-    /// just read.
+    /// Restores the filter from a snapshot, PRUNING member ids absent from the restored tree and disabling when
+    /// the pruned set comes back empty — without it an all-stale set (workspaces deleted by another window, or
+    /// a hand-edited file) restores as an enabled-but-invisible filter and the row-visibility read-back lies. A
+    /// partially stale set keeps its survivors and stays enabled. Called from `restore(from:)` AFTER the tree
+    /// is rebuilt; writes the fields directly, since the mutators would `save()` what was just read.
     func restoreFocus(from snapshot: Snapshot) {
         let present = Set(workspaces.map(\.id))
         focusedWorkspaceIDs = Set(snapshot.focusedWorkspaceIDs ?? []).intersection(present)
         focusEnabled = (snapshot.focusEnabled ?? false) && !focusedWorkspaceIDs.isEmpty
     }
 
-    /// The workspaces the sidebar TREE renders: the marked set when the filter is enabled, else all — the
-    /// `!workspaceFilter || focused` TERM of the published row-visibility contract
-    /// (`ControlWorkspaceNode.focused`). Only that term: sidebar mode and visibility gate the tree ABOVE
-    /// this (`.flagged` renders a flat session list and never calls here), so it is not the whole
-    /// predicate a script evaluates. The empty-result fallback guards an INVARIANT VIOLATION only — the
-    /// mutators keep `enabled + empty` out of reach, marking is gated on the id existing and
-    /// `restoreFocus` prunes stale ids, so reaching it takes writing the two stored fields directly,
-    /// which `internal(set)` limits to this module. Rendering the full tree there beats stranding the
-    /// user with no rows at all.
+    /// The workspaces the sidebar TREE renders: the marked set while the filter is enabled, else all — the
+    /// `!workspaceFilter || focused` TERM of the row-visibility contract (`ControlWorkspaceNode.focused`), not
+    /// the whole predicate a script evaluates: sidebar mode and visibility gate the tree ABOVE this (`.flagged`
+    /// renders a flat session list and never calls here). The empty-result fallback guards an INVARIANT
+    /// VIOLATION only — reaching it takes writing the two stored fields directly (`internal(set)`, so
+    /// in-module), since the mutators keep `enabled + empty` out of reach, marking is gated on the id existing
+    /// and `restoreFocus` prunes stale ids. Rendering the full tree beats stranding the user with no rows.
     public var visibleWorkspaces: [Workspace] {
         guard focusEnabled else { return workspaces }
         let visible = workspaces.filter { focusedWorkspaceIDs.contains($0.id) }
         return visible.isEmpty ? workspaces : visible
     }
 
-    /// The session set navigation operates over — the VISIBLE/FILTERED set, not the whole tree: the
-    /// flagged sessions in `.flagged` sidebar mode, the marked workspaces' sessions when the focus filter
-    /// is on, else all. Computed live, so clearing the flag/filter restores the full set.
-    /// `navigateSession` next/prev WRAP within it (an end lands on the opposite end, never leaking across
-    /// the filter). Backs `navigateSession` (and via it `session.go`, attention-nav), the Ctrl-Tab MRU
-    /// candidates, AND the ⌃P session palette (`AppActions.paletteSessions`) — all one filter.
+    /// The session set navigation operates over — the VISIBLE/FILTERED set, not the whole tree: flagged
+    /// sessions in `.flagged` mode, the marked workspaces' sessions while the filter is on, else all. Computed
+    /// live, so clearing the flag/filter restores the full set. `navigateSession` next/prev WRAP within it,
+    /// never leaking across the filter. Backs `navigateSession` (and via it `session.go`, attention-nav), the
+    /// Ctrl-Tab MRU candidates and the ⌃P session palette (`AppActions.paletteSessions`) — all one filter.
     public var navigableSessions: [Session] {
         sidebarMode == .flagged ? flaggedSessions : visibleWorkspaces.flatMap(\.sessions)
     }
 
-    /// Moves the selection back inside the visible set whenever the active session is outside it — a
-    /// narrowing that hid it, or a widening that filled a set which was empty; the counterpart of
-    /// `disableFocusIfSelectionOutsideSet`. Targets the most recent visible session, else the first (MRU
-    /// rather than positional keeps a filter-off-then-on round trip in place). No-op on a nil selection (a
-    /// restore clears a dangling one deliberately) or an empty visible set; keyboard focus needs nothing
-    /// here, `TerminalView.updateNSView` moves first responder on a selection change.
+    /// Moves the selection back inside the visible set whenever the active session is outside it — a narrowing
+    /// that hid it, or a widening that filled an empty set; counterpart of `disableFocusIfSelectionOutsideSet`.
+    /// Targets the most recent visible session, else the first (MRU rather than positional keeps a
+    /// filter-off-then-on round trip in place). No-op on a nil selection (a restore clears a dangling one
+    /// deliberately) or an empty visible set; `TerminalView.updateNSView` moves first responder on its own.
     func reselectIfSelectionHidden() {
         guard let selected = selectedSessionID else { return }
         let visible = navigableSessions
@@ -209,11 +188,10 @@ extension AppStore {
         selectSession(navigableRecentSessions(limit: 1).first ?? visible[0].id)
     }
 
-    /// The selection after the workspace holding the active session is removed: the most recent session
-    /// still VISIBLE, else the first visible one. Unlike `closeReselectionTarget` there is no "stay in the
-    /// current workspace" term (that workspace is what was removed), but the visible-set term holds or the
-    /// pick strands the selection on a row the sidebar cannot render. Falls back to the positional walk at
-    /// `index` only when nothing is visible at all.
+    /// The selection after the workspace holding the active session is removed: the most recent VISIBLE
+    /// session, else the first visible one. Unlike `closeReselectionTarget` there is no "stay in the current
+    /// workspace" term (that workspace is what was removed), but the visible-set term holds or the pick strands
+    /// the selection on a row the sidebar cannot render. Positional walk at `index` only when nothing is visible.
     func workspaceRemovalTarget(at index: Int) -> UUID? {
         let visible = navigableSessions
         if !visible.isEmpty { return navigableRecentSessions(limit: 1).first ?? visible[0].id }

--- a/agtermCore/Sources/agtermCore/AppStore+Focus.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Focus.swift
@@ -1,22 +1,19 @@
 import Foundation
 
 /// The sidebar focus filter: which workspaces the tree renders, the session set navigation and the
-/// palettes derive from it, and the mutators/lifecycle guards that keep the filter in step with the
-/// selection. Split out of the main `AppStore` declaration to keep each file focused; the stored
-/// filter state itself stays on the class, since an extension cannot hold stored properties.
+/// palettes derive from it, and the mutators/lifecycle guards keeping the filter in step with the
+/// selection. The stored filter state stays on the class — an extension cannot hold stored properties.
 extension AppStore {
     /// Switches the focus filter OFF — KEEPING the marked set — when the newly selected session lives
-    /// outside that set, so an explicit cross-set select (`session.select <id>` of a hidden session, a
-    /// notification reveal, a move/close that reselects elsewhere) reveals its target: the active session
-    /// is then always inside the visible set. Session navigation is scoped to the filtered set
-    /// (`navigableSessions`), so its targets are always in-set and never trip this. No-op when the filter
-    /// is off, when nothing is selected, or when the selection sits in a member workspace. Persistence
-    /// rides the caller's `selectSession` save.
-    ///
-    /// Also a no-op in `.flagged` mode: the flat flagged list is cross-workspace and ignores the marked
-    /// set, so a selection outside the set there has not navigated past the filter and there is nothing to
-    /// reveal. Without the term, entering the flagged view with the only flagged session in an unmarked
-    /// workspace silently switches the filter off. Returning to `.tree` re-applies it.
+    /// outside it, so an explicit cross-set select (`session.select <id>` of a hidden session, a
+    /// notification reveal, a move/close that reselects elsewhere) reveals its target and the active
+    /// session is always inside the visible set. Navigation is scoped to the filtered set
+    /// (`navigableSessions`), so its targets never trip this. No-op when the filter is off, nothing is
+    /// selected, or the selection sits in a member workspace; persistence rides the caller's
+    /// `selectSession` save. Also a no-op in `.flagged` mode — that flat list is cross-workspace and
+    /// ignores the marked set, so a selection outside it has not navigated past the filter; without the
+    /// term, entering the flagged view with the only flagged session in an unmarked workspace silently
+    /// switches the filter off. Returning to `.tree` re-applies it.
     func disableFocusIfSelectionOutsideSet(_ sessionID: UUID?) {
         guard focusEnabled, sidebarMode != .flagged, let sessionID else { return }
         if let owner = workspace(forSession: sessionID)?.id, focusedWorkspaceIDs.contains(owner) { return }
@@ -24,9 +21,9 @@ extension AppStore {
     }
 
     /// Replaces the marked set with just `id` and ENABLES the filter — the single-workspace zoom every
-    /// row-menu/menu-bar/`workspace.focus on` caller drives. Clean no-op for an id that names no workspace:
-    /// marking a phantom id would persist a member no tree can render and would break the row-visibility
-    /// read-back contract (`ControlWorkspaceNode.focused`) until the next restore pruned it.
+    /// row-menu/menu-bar/`workspace.focus on` caller drives. No-op for an id naming no workspace: a
+    /// phantom member no tree can render breaks the row-visibility read-back contract
+    /// (`ControlWorkspaceNode.focused`) until the next restore prunes it.
     func setFocusedWorkspace(_ id: UUID) {
         guard workspaces.contains(where: { $0.id == id }) else { return }
         commitFocus(ids: [id], enabled: true)
@@ -40,20 +37,19 @@ extension AppStore {
     }
 
     /// Replace-TOGGLE: clears the filter when `id` is the SOLE marked workspace and the filter applies,
-    /// else replaces the marked set with it (enabling). The semantic of the row menu's Focus/Unfocus, the
-    /// `focus_workspace` keybind/menu item, and `workspace.focus toggle` — one definition all three drive,
-    /// so a "toggle" can never mean two things. Clean no-op on an unknown id, like `setFocusedWorkspace`.
+    /// else replaces the marked set with it (enabling). The row menu's Focus/Unfocus, the
+    /// `focus_workspace` keybind/menu item and `workspace.focus toggle` share this ONE definition, so a
+    /// "toggle" can never mean two things. No-op on an unknown id, like `setFocusedWorkspace`.
     public func toggleFocusedWorkspace(_ id: UUID) {
         if isSoleFocus(id) { clearFocus() } else { setFocusedWorkspace(id) }
     }
 
     /// The ONE workspace the tree is zoomed to — the sole marked workspace while the filter APPLIES, else
-    /// nil. The single definition of that state, read by everything that needs it: `isSoleFocus(_:)`, the
-    /// sidebar's force-expand of a zoomed-to workspace, and the empty-space drop fallback (a Finder folder
-    /// dropped below the rows lands where the user is looking, so adding a session cannot silently leave
-    /// the filtered view). The `focusEnabled` term is load-bearing: with a workspace marked but the filter
-    /// OFF the WHOLE tree is on screen, so the mark names nothing to zoom to. Two or more members give no
-    /// unambiguous answer either.
+    /// nil. The single definition, read by `isSoleFocus(_:)`, the sidebar's force-expand of a zoomed-to
+    /// workspace, and the empty-space drop fallback (a Finder folder dropped below the rows lands where
+    /// the user is looking, so adding a session cannot silently leave the filtered view). The
+    /// `focusEnabled` term is load-bearing: marked but filter OFF means the WHOLE tree is on screen, so
+    /// nothing is zoomed to; two or more members have no unambiguous answer either.
     public var soleFocusedWorkspaceID: UUID? {
         guard focusEnabled, focusedWorkspaceIDs.count == 1 else { return nil }
         return focusedWorkspaceIDs.first
@@ -79,10 +75,9 @@ extension AppStore {
         return focusedWorkspaceIDs.contains(id)
     }
 
-    /// Applies one `workspace.focus` mode to `id`. Host-free, so the whole mode-to-mutator mapping is unit
-    /// tested and the app-side control arm is left with only target resolution — and so the GUI's
-    /// replace-toggle and the wire's `toggle` cannot drift apart. Every arm is delta-guarded, so each mode
-    /// is idempotent.
+    /// Applies one `workspace.focus` mode to `id`. Host-free, so the mode-to-mutator mapping is unit
+    /// tested, the app-side control arm keeps only target resolution, and the GUI's replace-toggle can't
+    /// drift from the wire's `toggle`. Every arm is delta-guarded, so each mode is idempotent.
     public func applyFocusMode(_ mode: ControlWorkspaceFocusMode, to id: UUID) {
         switch mode {
         case .on: setFocusedWorkspace(id)
@@ -93,20 +88,18 @@ extension AppStore {
     }
 
     /// Applies one `workspace.filter` mode to this window's filter flag, leaving the marked set alone.
-    /// Host-free half of the control arm (which is left with only the window resolution), so the
-    /// mode-to-flag mapping — including the refusal to enable an empty set — is exercised by a unit test
-    /// rather than re-spelled in a test double.
+    /// Host-free half of the control arm (which keeps only the window resolution), so the mode-to-flag
+    /// mapping — including the refusal to enable an empty set — is unit tested rather than re-spelled.
     public func applyWorkspaceFilter(_ mode: ControlToggleMode) {
         setFocusEnabled(mode.desiredValue(current: focusEnabled))
     }
 
     /// Adds or removes one workspace from the marked set, leaving the other members alone. Marking ONLY
-    /// marks: adding never switches the filter on, so a working set is built row by row with the whole
-    /// tree on screen — an add that enabled the filter would hide the very rows the next add needs.
-    /// Removing still disables the filter once the set empties. `setFocusedWorkspace(_:)` (the replacing
-    /// "Focus") is the one that enables immediately. Marking is refused for an id that names no workspace,
-    /// so a phantom member can never be persisted; un-marking is never gated on existence, because a stale
-    /// id already in the set must stay removable.
+    /// marks — an add that enabled the filter would hide the very rows the next add needs — so a working
+    /// set is built row by row with the whole tree on screen; `setFocusedWorkspace(_:)` (the replacing
+    /// "Focus") is the one that enables immediately. Removing still disables the filter once the set
+    /// empties. Marking is refused for an id naming no workspace, so no phantom member is ever persisted;
+    /// un-marking is never gated on existence, so a stale id already in the set stays removable.
     public func setFocusMembership(_ id: UUID, member: Bool) {
         if member, !workspaces.contains(where: { $0.id == id }) { return }
         var wantIDs = focusedWorkspaceIDs
@@ -121,10 +114,10 @@ extension AppStore {
         commitFocus(ids: focusedWorkspaceIDs, enabled: on)
     }
 
-    /// The single write point for the two filter fields. It clamps `enabled` to false on an empty set —
-    /// the guard that makes `enabled + empty` unrepresentable — skips the write entirely when nothing
-    /// changes (so the delta-computed control/menu callers stay idempotent and no-op writes never persist),
-    /// then prunes the sidebar selection and saves.
+    /// The single write point for the two filter fields: clamps `enabled` to false on an empty set (the
+    /// guard making `enabled + empty` unrepresentable), skips the write when nothing changes (so the
+    /// delta-computed control/menu callers stay idempotent and no-op writes never persist), then prunes
+    /// the sidebar selection and saves.
     private func commitFocus(ids: Set<UUID>, enabled: Bool) {
         let wantEnabled = enabled && !ids.isEmpty
         guard focusedWorkspaceIDs != ids || focusEnabled != wantEnabled else { return }
@@ -135,63 +128,57 @@ extension AppStore {
         save()
     }
 
-    /// Drops `id` from the marked set, disabling the filter once the set empties — the LIFECYCLE half of
-    /// the `enabled + empty` invariant, for the paths that remove a workspace outright
-    /// (`removeWorkspace`, `softRemoveWorkspace`) rather than un-marking it. It exists so the two-line
-    /// remove-then-disable pair lives in ONE place: a fourth removal path added elsewhere gets the
-    /// invariant for free. Deliberately does NOT `save()` or prune the sidebar selection — the callers do
-    /// both as part of the larger removal they are in the middle of.
+    /// Drops `id` from the marked set, disabling the filter once it empties — the LIFECYCLE half of the
+    /// `enabled + empty` invariant, for the paths that remove a workspace outright (`removeWorkspace`,
+    /// `softRemoveWorkspace`) rather than un-marking it, so a further removal path gets it for free.
+    /// Deliberately does NOT `save()` or prune the sidebar selection: its callers do both.
     func dropFocusMember(_ id: UUID) {
         focusedWorkspaceIDs.remove(id)
         if focusedWorkspaceIDs.isEmpty { focusEnabled = false }
     }
 
     /// Marks a freshly created workspace so it is visible while the filter applies (the auto-reveal
-    /// contract of `addWorkspace`/`ensureWorkspace`), and a no-op when the filter is off — the whole tree
-    /// is on screen then, so there is nothing to reveal and the set must not be widened behind the user's
-    /// back. Save-free: `addWorkspace` saves.
+    /// contract of `addWorkspace`/`ensureWorkspace`); a no-op when the filter is off, where the whole tree
+    /// is on screen and the set must not widen behind the user's back. Save-free: `addWorkspace` saves.
     func revealNewFocusMember(_ id: UUID) {
         guard focusEnabled else { return }
         focusedWorkspaceIDs.insert(id)
     }
 
     /// Puts a workspace back into the marked set when its removal is REVERSED — both restore paths, the
-    /// pending-close undo and Reopen Closed Item. MARK-ONLY, leaving `focusEnabled` exactly as the window
-    /// has it: membership belongs to the closed workspace and is restored with it, but the filter flag is
-    /// CURRENT WINDOW STATE, so a restore must never override a toggle the user made in the meantime.
-    /// That also honors the marking rule (an add never applies the filter) and keeps `enabled + empty`
-    /// unreachable, since an insert-only path can never enable. Callers run it BEFORE their reselect, so a
-    /// restored member is inside the set when `disableFocusIfSelectionOutsideSet` runs, and — in the undo —
-    /// ahead of the empty-workspace early return, whose row would otherwise stay filtered out. Save-free;
-    /// the restore paths save.
+    /// pending-close undo and Reopen Closed Item. MARK-ONLY: membership belongs to the closed workspace
+    /// and is restored with it, but `focusEnabled` is CURRENT WINDOW STATE, so a restore must never
+    /// override a toggle made meanwhile; an insert-only path also honors the marking rule (an add never
+    /// applies the filter) and can never reach `enabled + empty`. Callers run it BEFORE their reselect (so
+    /// a restored member is in-set for `disableFocusIfSelectionOutsideSet`) and, in the undo, ahead of the
+    /// empty-workspace early return whose row would otherwise stay filtered out. Save-free; the restore
+    /// paths save.
     func markFocusMember(_ id: UUID) {
         focusedWorkspaceIDs.insert(id)
     }
 
     /// Restores the focus filter from a snapshot, PRUNING member ids absent from the restored tree and
-    /// disabling the filter when the pruned set comes back empty. The prune is what keeps
-    /// `enabled + empty` unrepresentable across a restore: an all-stale set (its workspaces deleted by
-    /// another window, or a hand-edited file) would otherwise restore as an enabled-but-invisible filter,
-    /// making the row-visibility read-back contract lie. A partially stale set keeps its
-    /// survivors and stays enabled. Called from `restore(from:)` AFTER the tree is rebuilt, and
-    /// deliberately writes the fields directly rather than going through the mutators, which would
-    /// `save()` what was just read.
+    /// disabling the filter when the pruned set comes back empty — that prune keeps `enabled + empty`
+    /// unrepresentable across a restore, or an all-stale set (workspaces deleted by another window, or a
+    /// hand-edited file) restores as an enabled-but-invisible filter and the row-visibility read-back
+    /// lies. A partially stale set keeps its survivors and stays enabled. Called from `restore(from:)`
+    /// AFTER the tree is rebuilt; writes the fields directly, since the mutators would `save()` what was
+    /// just read.
     func restoreFocus(from snapshot: Snapshot) {
         let present = Set(workspaces.map(\.id))
         focusedWorkspaceIDs = Set(snapshot.focusedWorkspaceIDs ?? []).intersection(present)
         focusEnabled = (snapshot.focusEnabled ?? false) && !focusedWorkspaceIDs.isEmpty
     }
 
-    /// The workspaces the sidebar TREE should render: the marked set when the filter is enabled, else
-    /// all workspaces — the `!workspaceFilter || focused` TERM of the published row-visibility contract
-    /// (`ControlWorkspaceNode.focused`), spelled in code. Only that term: the sidebar's mode and
-    /// visibility gate the tree ABOVE this (`.flagged` mode renders a flat session list and never calls
-    /// here), so this is not the whole predicate a script evaluates.
-    /// The empty-result fallback guards an INVARIANT VIOLATION and nothing else, since
-    /// the mutators keep `enabled + empty` out of reach, marking is gated on the id existing, and
-    /// `restoreFocus` prunes stale ids — the only way to reach it is to write the two stored fields
-    /// directly, which `internal(set)` limits to inside this module. Rendering the full tree there is the
-    /// lesser evil: an empty sidebar strands the user with no rows at all.
+    /// The workspaces the sidebar TREE renders: the marked set when the filter is enabled, else all — the
+    /// `!workspaceFilter || focused` TERM of the published row-visibility contract
+    /// (`ControlWorkspaceNode.focused`). Only that term: sidebar mode and visibility gate the tree ABOVE
+    /// this (`.flagged` renders a flat session list and never calls here), so it is not the whole
+    /// predicate a script evaluates. The empty-result fallback guards an INVARIANT VIOLATION only — the
+    /// mutators keep `enabled + empty` out of reach, marking is gated on the id existing and
+    /// `restoreFocus` prunes stale ids, so reaching it takes writing the two stored fields directly,
+    /// which `internal(set)` limits to this module. Rendering the full tree there beats stranding the
+    /// user with no rows at all.
     public var visibleWorkspaces: [Workspace] {
         guard focusEnabled else { return workspaces }
         let visible = workspaces.filter { focusedWorkspaceIDs.contains($0.id) }
@@ -199,24 +186,21 @@ extension AppStore {
     }
 
     /// The session set navigation operates over — the VISIBLE/FILTERED set, not the whole tree: the
-    /// flagged sessions in `.flagged` sidebar mode, the marked workspaces' sessions when the focus
-    /// filter is on, else all sessions. Computed live, so clearing the flag/filter naturally restores the
-    /// full set. `navigateSession` next/prev WRAP within this set (an end lands on the opposite end, never
-    /// leaking across the filter). Backs `navigateSession` (and via it `session.go`, attention-nav), the
-    /// Ctrl-Tab MRU candidate set, AND the ⌃P session palette (`AppActions.paletteSessions`), so all
-    /// follow the same filter as the visible sidebar.
+    /// flagged sessions in `.flagged` sidebar mode, the marked workspaces' sessions when the focus filter
+    /// is on, else all. Computed live, so clearing the flag/filter restores the full set.
+    /// `navigateSession` next/prev WRAP within it (an end lands on the opposite end, never leaking across
+    /// the filter). Backs `navigateSession` (and via it `session.go`, attention-nav), the Ctrl-Tab MRU
+    /// candidates, AND the ⌃P session palette (`AppActions.paletteSessions`) — all one filter.
     public var navigableSessions: [Session] {
         sidebarMode == .flagged ? flaggedSessions : visibleWorkspaces.flatMap(\.sessions)
     }
 
     /// Moves the selection back inside the visible set whenever the active session is outside it — a
-    /// narrowing that hid it, or a widening that filled a set which was empty. The counterpart of
-    /// `disableFocusIfSelectionOutsideSet`, which handles the other direction.
-    /// Target is the most recent session within the visible set, else the first; MRU rather than
-    /// positional keeps a filter-off-then-on round trip in place.
-    /// No-op on a nil selection (a restore clears a dangling one deliberately) and on an empty visible
-    /// set. Keyboard focus needs nothing here: `TerminalView.updateNSView` moves first responder when the
-    /// selection changes.
+    /// narrowing that hid it, or a widening that filled a set which was empty; the counterpart of
+    /// `disableFocusIfSelectionOutsideSet`. Targets the most recent visible session, else the first (MRU
+    /// rather than positional keeps a filter-off-then-on round trip in place). No-op on a nil selection (a
+    /// restore clears a dangling one deliberately) or an empty visible set; keyboard focus needs nothing
+    /// here, `TerminalView.updateNSView` moves first responder on a selection change.
     func reselectIfSelectionHidden() {
         guard let selected = selectedSessionID else { return }
         let visible = navigableSessions
@@ -226,10 +210,10 @@ extension AppStore {
     }
 
     /// The selection after the workspace holding the active session is removed: the most recent session
-    /// still VISIBLE, else the first visible one. Unlike `closeReselectionTarget` there is no
-    /// "stay in the current workspace" term — that workspace is what was removed — but the visible-set
-    /// term still holds, or the pick strands the selection on a row the sidebar cannot render.
-    /// Falls back to the positional walk at `index` only when nothing is visible at all.
+    /// still VISIBLE, else the first visible one. Unlike `closeReselectionTarget` there is no "stay in the
+    /// current workspace" term (that workspace is what was removed), but the visible-set term holds or the
+    /// pick strands the selection on a row the sidebar cannot render. Falls back to the positional walk at
+    /// `index` only when nothing is visible at all.
     func workspaceRemovalTarget(at index: Int) -> UUID? {
         let visible = navigableSessions
         if !visible.isEmpty { return navigableRecentSessions(limit: 1).first ?? visible[0].id }

--- a/agtermCore/Sources/agtermCore/AppStore+Panes.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Panes.swift
@@ -3,17 +3,16 @@ import Foundation
 // MARK: - Split, overlay, and scratch panes
 
 extension AppStore {
-    /// Toggles the one-level split for a session. The second pane's surface is created
-    /// lazily by the detail pane on first show and kept alive when hidden, so this only
-    /// flips the flag. The flag is persisted, so the split is restored on relaunch.
+    /// Toggles the one-level split. The second pane's surface is created lazily by the detail pane on first
+    /// show and kept alive when hidden, so this only flips the flag, which is persisted and restored on
+    /// relaunch.
     public func toggleSplit(_ sessionID: UUID) {
         guard let session = session(withID: sessionID) else { return }
         session.isSplit.toggle()
-        // opening a NEW split marks the session as having one and moves focus to the new (right) pane;
-        // RE-showing a hidden split preserves whichever pane was focused before it was hidden (so a
-        // hide/show round-trip, e.g. the tmux-style zoom script, doesn't jerk focus to the right pane).
-        // hiding (toggling off) leaves `hasSplit` and `splitFocused` set so the split indicators persist
-        // and the focused pane is the one shown maximized. Only `closeSplit` clears them.
+        // opening a NEW split marks the session as having one and moves focus to the new (right) pane, while
+        // RE-showing a hidden one preserves the pane focused before hiding (so a hide/show round-trip, e.g.
+        // the tmux-style zoom script, doesn't jerk focus right). hiding leaves `hasSplit`/`splitFocused` set,
+        // so the indicators persist and the focused pane shows maximized; only `closeSplit` clears them.
         if session.isSplit {
             let isNewSplit = !session.hasSplit
             session.hasSplit = true
@@ -22,10 +21,10 @@ extension AppStore {
         save()
     }
 
-    /// Sets a session's split-divider left-pane fraction to `ratio`, clamped to the bounds, and persists.
-    /// Returns the applied (clamped) fraction, or nil when the id is unknown. Moving the LIVE divider is
-    /// driven separately by the caller (`session.resize` posts `.agtermApplySplitRatio` to the pane view) —
-    /// this is control-native, so there is no GUI surface that goes through `AppActions`.
+    /// Sets a session's split-divider left-pane fraction to `ratio`, clamped and persisted; returns the
+    /// applied (clamped) fraction, nil for an unknown id. Moving the LIVE divider is the caller's
+    /// (`session.resize` posts `.agtermApplySplitRatio` to the pane view): control-native, no GUI path
+    /// through `AppActions`.
     @discardableResult
     public func applySplitRatio(_ ratio: Double, forSession id: UUID) -> Double? {
         guard let session = session(withID: id) else { return nil }
@@ -35,20 +34,20 @@ extension AppStore {
         return applied
     }
 
-    /// Clear the agent-status indicator when the pane that OWNED it is being torn down, so a pane-tagged
-    /// block (`session.status --pane`) can't strand a glyph no surviving surface can keystroke-clear
-    /// (`AgentIndicator.clearedBy` requires the typing pane to match `statusPane`). `owner` is the pane
-    /// whose surface is going away; a nil tag counts as `.left` (main), matching the clear-decision default.
-    /// Mirrors the `clearSearch()` reconcile on these same teardown paths.
+    /// Clear the agent-status indicator when the pane that OWNED it is torn down, so a pane-tagged block
+    /// (`session.status --pane`) can't strand a glyph no surviving surface can keystroke-clear
+    /// (`AgentIndicator.clearedBy` requires the typing pane to match `statusPane`). `owner` is the departing
+    /// pane; a nil tag counts as `.left` (main), matching the clear-decision default. Mirrors `clearSearch()`
+    /// on these same teardown paths.
     private func clearIndicatorOwnedByPane(_ owner: StatusPane, of session: Session) {
         guard session.agentIndicator.status != .idle,
               (session.agentIndicator.statusPane ?? .left) == owner else { return }
         setAgentIndicator(AgentIndicator(), forSession: session.id)
     }
 
-    /// Closes the split pane: hides it AND tears down its surface, so a subsequent split
-    /// starts a fresh shell. Used when the split shell exits on its own; resets the focus flag so a
-    /// stale `splitFocused` doesn't point the collapsed view at the gone pane.
+    /// Closes the split pane: hides it AND tears down its surface, so a later split starts a fresh shell.
+    /// Used when the split shell exits on its own; resets the focus flag so a stale `splitFocused` can't
+    /// point the collapsed view at the gone pane.
     public func closeSplit(_ sessionID: UUID) {
         guard let session = session(withID: sessionID) else { return }
         session.isSplit = false
@@ -73,15 +72,15 @@ extension AppStore {
         save()
     }
 
-    /// The primary pane's shell exited. If a split pane is alive it is PROMOTED into the primary slot
-    /// and the session survives as a single (non-split) pane; otherwise the session is closed. The
-    /// survivor MOVES from `splitSurface` into `surface` (its surface, cwd, title, and foreground command
-    /// migrate to the main fields, and its split-role reporting is turned off via `promoteToPrimaryPane`),
-    /// so the session becomes indistinguishable from a fresh single pane: `surface != nil`,
-    /// `splitSurface == nil`, `hasSplit == false`, `splitFocused == false`. That is what makes the
-    /// promoted pane addressable as the MAIN/left pane everywhere — `session.type`/`session.text --pane
-    /// left` (and omitted) reach it, `{AGT_PANE}` reports `left`, and a later `session.split` opens a
-    /// fresh RIGHT pane instead of displacing the survivor. Called by the primary surface's `onExit`.
+    /// The primary pane's shell exited: a live split pane is PROMOTED into the primary slot and the session
+    /// survives as a single (non-split) pane, otherwise the session is closed. The survivor MOVES from
+    /// `splitSurface` into `surface` (surface, cwd, title, and foreground command migrate to the main fields,
+    /// and `promoteToPrimaryPane` turns off its split-role reporting), leaving the session indistinguishable
+    /// from a fresh single pane — `surface != nil`, `splitSurface == nil`, `hasSplit == false`,
+    /// `splitFocused == false` — so the promoted pane is addressable as the MAIN/left pane everywhere:
+    /// `session.type`/`session.text --pane left` (and omitted) reach it, `{AGT_PANE}` reports `left`, and a
+    /// later `session.split` opens a fresh RIGHT pane instead of displacing it. Called by the primary
+    /// surface's `onExit`.
     public func closePrimaryPane(_ sessionID: UUID) {
         guard let session = session(withID: sessionID) else { return }
         guard let survivor = session.splitSurface else {
@@ -90,8 +89,8 @@ extension AppStore {
         }
         let priorPrimary = session.surface // the exiting pane, torn down below; scopes the search reset
         priorPrimary?.teardown()
-        // promote the surviving split pane into the primary slot. `promoteToPrimaryPane` flips the
-        // surface's split-role flag so its future pwd/title reports write to the main fields.
+        // `promoteToPrimaryPane` flips the surface's split-role flag so its future pwd/title reports
+        // write to the main fields.
         survivor.promoteToPrimaryPane()
         session.surface = survivor
         session.splitSurface = nil
@@ -104,20 +103,18 @@ extension AppStore {
         // promoted shell, and a snapshot would persist commandWait with no initialCommand.
         session.initialCommand = nil
         session.commandWait = false
-        // migrate the split pane's live/persisted metadata up to the session (main) fields, then clear the
-        // now-meaningless split fields so nothing still describes a pane that no longer exists.
-        // cwd prefers the split's live PWD, then its restore-seed (`initialSplitCwd`, set for a restored
-        // split whose shell hasn't emitted OSC yet), and only falls back to the exited primary's cwd when
-        // the split has none at all (a fresh split seeds its cwd from the primary anyway). title is replaced
-        // OUTRIGHT from the split's (nil clears it) so the dead primary's title can never linger on the
-        // survivor — likewise foregroundCommand, so the exited primary's captured command can't either.
+        // migrate the split pane's live/persisted metadata up to the main fields, then clear the split ones
+        // so nothing still describes a pane that no longer exists. cwd prefers the split's live PWD, then its
+        // restore-seed (`initialSplitCwd`, for a restored split whose shell hasn't emitted OSC yet), falling
+        // back to the exited primary's only when the split has none (a fresh split seeds from the primary
+        // anyway). title is replaced OUTRIGHT from the split's (nil clears it), so the dead primary's title
+        // can never linger on the survivor — likewise foregroundCommand and its captured command.
         session.currentCwd = session.splitCwd ?? session.initialSplitCwd ?? session.currentCwd
         session.oscTitle = session.splitTitle
         session.foregroundCommand = session.splitForegroundCommand
-        // the restore-command override follows the survivor into the main slot the same way, BOTH halves:
-        // the persisted pin (so the next launch restores the promoted pane's command, not the dead
-        // primary's) and any payload still armed for this launch (so a surface built after promotion
-        // still runs it).
+        // the restore-command override follows the survivor into the main slot, BOTH halves: the persisted
+        // pin (so the next launch restores the promoted pane's command, not the dead primary's) and any
+        // payload still armed for this launch (so a surface built after promotion still runs it).
         session.restoreCommand = session.splitRestoreCommand
         session.pendingRestoreCommand = session.pendingSplitRestoreCommand
         session.splitCwd = nil
@@ -132,11 +129,11 @@ extension AppStore {
         if session.searchSurface == nil || session.searchSurface === priorPrimary {
             session.clearSearch()
         }
-        // migrate the agent-status identity like the cwd/title above: the exited primary owned any
-        // `.left`/nil-tagged block, which dies with it (clear); a `.right`-tagged block belonged to the
-        // promoted survivor and FOLLOWS it into the main slot — re-tag to `.left` so the `tree` (which now
-        // reports `split:false`) and the survivor's now-`.left`-role-aware keystroke-clear agree, instead of
-        // a self-contradictory `split:false` + `statusPane:"right"`. A `.scratch` block is untouched.
+        // migrate the agent-status identity like the cwd/title: the exited primary owned any `.left`/nil tag,
+        // which dies with it, while a `.right` tag belonged to the survivor and FOLLOWS it into the main slot
+        // — re-tagged to `.left` so `tree` (now reporting `split:false`) and the survivor's `.left`-role
+        // keystroke-clear agree, not a self-contradictory `split:false` + `statusPane:"right"`. `.scratch` is
+        // untouched.
         if session.agentIndicator.status != .idle {
             switch session.agentIndicator.statusPane ?? .left {
             case .left: setAgentIndicator(AgentIndicator(), forSession: session.id)
@@ -150,14 +147,13 @@ extension AppStore {
         save()
     }
 
-    /// The split pane's shell exited. It collapses to the primary (`closeSplit`) ONLY when a genuine
-    /// two-pane split is live — BOTH `surface` and `splitSurface` set. Otherwise this was the session's
-    /// last pane and the session is closed: the surface has been PROMOTED into the primary slot
-    /// (`splitSurface == nil`) — a promoted survivor keeps the split pane's `onExit`, so its own exit still
-    /// routes here, and closing (not collapsing a split that no longer exists) is what keeps it from
-    /// leaving a zombie session. (The `surface == nil` half of the guard is defensive: `closePrimaryPane`
-    /// now always promotes the survivor INTO `surface`, so a live `splitSurface` implies a live `surface`.)
-    /// Called by the split surface's `onExit`.
+    /// The split pane's shell exited: collapses to the primary (`closeSplit`) ONLY when a genuine two-pane
+    /// split is live, BOTH `surface` and `splitSurface` set. Otherwise this was the session's last pane —
+    /// the surface having been PROMOTED into the primary slot (`splitSurface == nil`) while keeping the split
+    /// pane's `onExit`, so its own exit routes here — and closing, rather than collapsing a split that no
+    /// longer exists, is what avoids a zombie session. The `surface == nil` half of the guard is defensive:
+    /// `closePrimaryPane` always promotes the survivor INTO `surface`, so a live `splitSurface` implies a
+    /// live `surface`. Called by the split surface's `onExit`.
     public func closeSplitPane(_ sessionID: UUID) {
         guard let session = session(withID: sessionID) else { return }
         guard session.surface != nil, session.splitSurface != nil else {
@@ -167,17 +163,14 @@ extension AppStore {
         closeSplit(sessionID)
     }
 
-    /// Opens an ephemeral overlay terminal on a session running `command` (e.g. a TUI). The overlay
-    /// surface is created lazily by the detail pane and runs the command as its process; when the
-    /// program exits, `closeOverlay` tears it down. No-op (returns false) when the session is unknown
-    /// or already has an overlay open. NOT persisted — the overlay never survives a relaunch.
-    ///
-    /// `sizePercent` (clamped to 1...100) requests a *floating* overlay: an opaque, framed panel sized
-    /// to that percent of the pane, with the session still visible behind it. nil gives the default
-    /// full-pane overlay that hides the session.
-    ///
-    /// `backgroundColor` (`#rrggbb`) gives the overlay pane its own solid background, independent of the
-    /// session's; nil leaves the default theme background. Read by the overlay surface factory at creation.
+    /// Opens an ephemeral overlay terminal on a session running `command` (e.g. a TUI). The surface is
+    /// created lazily by the detail pane and runs the command as its process; `closeOverlay` tears it down
+    /// when the program exits. No-op (returns false) for an unknown session or one already showing an
+    /// overlay. NOT persisted, so it never survives a relaunch.
+    /// - `sizePercent` (clamped to 1...100) requests a *floating* overlay: an opaque framed panel at that
+    ///   percent of the pane with the session visible behind it; nil gives the full-pane overlay that hides it.
+    /// - `backgroundColor` (`#rrggbb`) gives the overlay pane its own solid background, independent of the
+    ///   session's; nil leaves the default theme background. Read by the overlay factory at creation.
     @discardableResult public func openOverlay(_ sessionID: UUID, command: String, cwd: String? = nil,
                                                wait: Bool = false, sizePercent: Int? = nil,
                                                backgroundColor: String? = nil) -> Bool {
@@ -192,27 +185,24 @@ extension AppStore {
         return true
     }
 
-    /// Resizes an already-open overlay in place. `sizePercent` (clamped to 1...100) switches it to a
-    /// *floating* opaque framed panel at that percent of the pane with the session visible behind it;
-    /// nil switches it to the full-pane overlay that hides the session and draws translucent. The overlay
-    /// surface stays mounted (the detail pane hosts both variants in one place), so this only re-flows the
-    /// layout — the program keeps running, never re-spawns. No-op (returns false) with no overlay open.
+    /// Resizes an already-open overlay in place: `sizePercent` (clamped to 1...100) switches it to a *floating*
+    /// opaque framed panel at that percent of the pane with the session visible behind it, nil to the translucent
+    /// full-pane overlay that hides the session. The surface stays mounted (the detail pane hosts both variants),
+    /// so only the layout re-flows and the program never re-spawns. No-op (false) with no overlay open.
     @discardableResult public func resizeOverlay(_ sessionID: UUID, sizePercent: Int?) -> Bool {
         guard let session = session(withID: sessionID), session.overlayActive else { return false }
         session.overlaySizePercent = sizePercent.map { min(100, max(1, $0)) }
         return true
     }
 
-    /// Records the overlay program's exit status (parsed app-side from the wrapper's temp file on the
-    /// surface's teardown) so `session.overlay.result` can report it after the overlay closes. No-op
-    /// for an unknown session.
+    /// Records the overlay program's exit status (parsed app-side from the wrapper's temp file at surface
+    /// teardown) so `session.overlay.result` can report it after the overlay closes. No-op for an unknown id.
     public func recordOverlayExit(_ sessionID: UUID, code: Int) {
         session(withID: sessionID)?.overlayExitCode = code
     }
 
-    /// Closes the overlay terminal: hides it AND tears down its surface (unlike the split, the overlay
-    /// is never kept alive — it is ephemeral). Used both on explicit close and when the overlay's
-    /// program exits on its own. No-op (returns false) when there is no overlay.
+    /// Closes the overlay terminal: hides it AND tears down its surface — unlike the split it is ephemeral,
+    /// never kept alive. Used on explicit close and when the program exits. No-op (false) with no overlay.
     @discardableResult public func closeOverlay(_ sessionID: UUID) -> Bool {
         guard let session = session(withID: sessionID), session.overlayActive else { return false }
         session.overlayActive = false
@@ -226,25 +216,24 @@ extension AppStore {
         return true
     }
 
-    /// Toggles the scratch terminal for a session — a third, full-overlay login shell. The scratch
-    /// surface is created lazily by the detail pane on first show and, like the split, kept alive when
-    /// hidden (this only flips `scratchActive`), so a re-show reuses the same shell. Not persisted, so
-    /// no `save()`. No-op for an unknown session.
+    /// Toggles the scratch terminal — a third, full-overlay login shell. Its surface is created lazily by
+    /// the detail pane on first show and, like the split, kept alive when hidden (this only flips
+    /// `scratchActive`), so a re-show reuses the same shell. Not persisted, so no `save()`. No-op for an
+    /// unknown session.
     public func toggleScratch(_ sessionID: UUID) {
         guard let session = session(withID: sessionID) else { return }
         session.scratchActive.toggle()
     }
 
-    /// Closes the scratch terminal: hides it AND tears down its surface (so a subsequent show starts a
-    /// fresh shell). Used on the scratch shell's own `exit` and on session/workspace/window teardown.
-    /// No-op (returns false) when there is no scratch surface.
+    /// Closes the scratch terminal: hides it AND tears down its surface, so a later show starts a fresh
+    /// shell. Used on the scratch shell's own `exit` and on session/workspace/window teardown. No-op
+    /// (returns false) when there is no scratch surface.
     @discardableResult public func closeScratch(_ sessionID: UUID) -> Bool {
         guard let session = session(withID: sessionID), let scratch = session.scratchSurface else { return false }
         session.scratchActive = false
         // if the open search bar is pinned to the scratch being torn down, reset search rather than leave a
-        // stuck, no-op bar (the weak `searchSurface` zeroes but `searchActive` stays true) — mirrors the
-        // closeSplit/closePrimaryPane handling. Guarded on identity so a search owned by the main/split pane
-        // (the scratch can cover a session whose pane opened search) survives the scratch teardown.
+        // stuck no-op bar (the weak `searchSurface` zeroes but `searchActive` stays true), mirroring
+        // closeSplit/closePrimaryPane. guarded on identity so a search owned by the main/split pane survives.
         if session.searchSurface === scratch { session.clearSearch() }
         // a `.scratch`-tagged block loses its owning surface here; clear it so it can't strand a glyph the
         // surviving main/split panes can never keystroke-clear (a main/split tag survives — the helper guards).

--- a/agtermCore/Sources/agtermCore/AppStore+Panes.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Panes.swift
@@ -3,16 +3,15 @@ import Foundation
 // MARK: - Split, overlay, and scratch panes
 
 extension AppStore {
-    /// Toggles the one-level split. The second pane's surface is created lazily by the detail pane on first
-    /// show and kept alive when hidden, so this only flips the flag, which is persisted and restored on
-    /// relaunch.
+    /// Toggles the one-level split. The second pane's surface is created lazily by the detail pane and kept
+    /// alive when hidden, so this only flips the persisted flag.
     public func toggleSplit(_ sessionID: UUID) {
         guard let session = session(withID: sessionID) else { return }
         session.isSplit.toggle()
-        // opening a NEW split marks the session as having one and moves focus to the new (right) pane, while
-        // RE-showing a hidden one preserves the pane focused before hiding (so a hide/show round-trip, e.g.
-        // the tmux-style zoom script, doesn't jerk focus right). hiding leaves `hasSplit`/`splitFocused` set,
-        // so the indicators persist and the focused pane shows maximized; only `closeSplit` clears them.
+        // a NEW split focuses the new (right) pane; RE-showing a hidden one keeps the pane focused before
+        // hiding, so a hide/show round-trip (the tmux-style zoom script) doesn't jerk focus right. hiding
+        // leaves `hasSplit`/`splitFocused` set — indicators persist, the focused pane shows maximized — and
+        // only `closeSplit` clears them.
         if session.isSplit {
             let isNewSplit = !session.hasSplit
             session.hasSplit = true
@@ -21,10 +20,9 @@ extension AppStore {
         save()
     }
 
-    /// Sets a session's split-divider left-pane fraction to `ratio`, clamped and persisted; returns the
-    /// applied (clamped) fraction, nil for an unknown id. Moving the LIVE divider is the caller's
-    /// (`session.resize` posts `.agtermApplySplitRatio` to the pane view): control-native, no GUI path
-    /// through `AppActions`.
+    /// Sets a session's split-divider left-pane fraction, clamped and persisted; returns the applied
+    /// fraction, nil for an unknown id. Moving the LIVE divider is the caller's job (`session.resize` posts
+    /// `.agtermApplySplitRatio` to the pane view): control-native, no GUI path through `AppActions`.
     @discardableResult
     public func applySplitRatio(_ ratio: Double, forSession id: UUID) -> Double? {
         guard let session = session(withID: id) else { return nil }
@@ -35,10 +33,9 @@ extension AppStore {
     }
 
     /// Clear the agent-status indicator when the pane that OWNED it is torn down, so a pane-tagged block
-    /// (`session.status --pane`) can't strand a glyph no surviving surface can keystroke-clear
-    /// (`AgentIndicator.clearedBy` requires the typing pane to match `statusPane`). `owner` is the departing
-    /// pane; a nil tag counts as `.left` (main), matching the clear-decision default. Mirrors `clearSearch()`
-    /// on these same teardown paths.
+    /// can't strand a glyph no surviving surface can keystroke-clear (`AgentIndicator.clearedBy` requires the
+    /// typing pane to match `statusPane`). `owner` is the departing pane; a nil tag counts as `.left`,
+    /// matching the clear-decision default. Mirrors `clearSearch()` on these same teardown paths.
     private func clearIndicatorOwnedByPane(_ owner: StatusPane, of session: Session) {
         guard session.agentIndicator.status != .idle,
               (session.agentIndicator.statusPane ?? .left) == owner else { return }
@@ -46,8 +43,8 @@ extension AppStore {
     }
 
     /// Closes the split pane: hides it AND tears down its surface, so a later split starts a fresh shell.
-    /// Used when the split shell exits on its own; resets the focus flag so a stale `splitFocused` can't
-    /// point the collapsed view at the gone pane.
+    /// Used on the split shell's own exit; resets `splitFocused`, else it points the collapsed view at the
+    /// gone pane.
     public func closeSplit(_ sessionID: UUID) {
         guard let session = session(withID: sessionID) else { return }
         session.isSplit = false
@@ -58,29 +55,27 @@ extension AppStore {
         session.splitCwd = nil
         session.splitTitle = nil
         session.initialSplitCwd = nil
-        // the right pane is gone, so its restore-command override describes nothing: drop both the
-        // persisted pin and any payload still armed for this launch (a fresh split must be a plain shell).
+        // the right pane is gone: drop both the persisted pin and any payload still armed for this launch,
+        // so a fresh split is a plain shell.
         session.splitRestoreCommand = nil
         session.pendingSplitRestoreCommand = nil
         session.splitRatio = nil // tearing down the split clears its geometry too, so a fresh split opens even
-        // a search bar pinned to the torn-down split surface would otherwise stay stuck (the weak
-        // `searchSurface` zeroes but `searchActive` stays true), so reset search on the surviving session.
+        // a search bar pinned to the torn-down split surface would stay stuck (the weak `searchSurface`
+        // zeroes but `searchActive` stays true), so reset search on the surviving session.
         session.clearSearch()
-        // the split (right) pane owned any `.right`-tagged block; with it gone the surviving main pane can
-        // never keystroke-clear that tag, so clear it here (mirrors the search reset above).
+        // the departing right pane owned any `.right`-tagged block, which no survivor can keystroke-clear.
         clearIndicatorOwnedByPane(.right, of: session)
         save()
     }
 
-    /// The primary pane's shell exited: a live split pane is PROMOTED into the primary slot and the session
-    /// survives as a single (non-split) pane, otherwise the session is closed. The survivor MOVES from
-    /// `splitSurface` into `surface` (surface, cwd, title, and foreground command migrate to the main fields,
-    /// and `promoteToPrimaryPane` turns off its split-role reporting), leaving the session indistinguishable
-    /// from a fresh single pane — `surface != nil`, `splitSurface == nil`, `hasSplit == false`,
-    /// `splitFocused == false` — so the promoted pane is addressable as the MAIN/left pane everywhere:
-    /// `session.type`/`session.text --pane left` (and omitted) reach it, `{AGT_PANE}` reports `left`, and a
-    /// later `session.split` opens a fresh RIGHT pane instead of displacing it. Called by the primary
-    /// surface's `onExit`.
+    /// The primary pane's shell exited: a live split is PROMOTED into the primary slot and the session
+    /// survives as a single pane, otherwise the session closes. The survivor MOVES from `splitSurface` into
+    /// `surface` (cwd, title and foreground command migrate too, and `promoteToPrimaryPane` turns off its
+    /// split-role reporting so future pwd/title reports write to the main fields), leaving `surface != nil`,
+    /// `splitSurface == nil`, `hasSplit == false`, `splitFocused == false` — so the promoted pane is
+    /// addressable as the MAIN/left pane everywhere: `session.type`/`session.text --pane left` (and omitted)
+    /// reach it, `{AGT_PANE}` reports `left`, and a later `session.split` opens a fresh RIGHT pane instead of
+    /// displacing it. Called by the primary surface's `onExit`.
     public func closePrimaryPane(_ sessionID: UUID) {
         guard let session = session(withID: sessionID) else { return }
         guard let survivor = session.splitSurface else {
@@ -89,8 +84,6 @@ extension AppStore {
         }
         let priorPrimary = session.surface // the exiting pane, torn down below; scopes the search reset
         priorPrimary?.teardown()
-        // `promoteToPrimaryPane` flips the surface's split-role flag so its future pwd/title reports
-        // write to the main fields.
         survivor.promoteToPrimaryPane()
         session.surface = survivor
         session.splitSurface = nil
@@ -98,23 +91,20 @@ extension AppStore {
         session.hasSplit = false
         session.splitFocused = false
         session.splitRatio = nil // promoted to a single pane; a later split should open even, not stale
-        // the command pane is gone — the promoted survivor is a plain shell, so drop the creation command
-        // (and its held-open flag) together or a restart would resurrect the exited command instead of the
-        // promoted shell, and a snapshot would persist commandWait with no initialCommand.
+        // the promoted survivor is a plain shell: drop the creation command and its held-open flag together,
+        // or a restart resurrects the exited command and a snapshot persists commandWait with no initialCommand.
         session.initialCommand = nil
         session.commandWait = false
-        // migrate the split pane's live/persisted metadata up to the main fields, then clear the split ones
-        // so nothing still describes a pane that no longer exists. cwd prefers the split's live PWD, then its
-        // restore-seed (`initialSplitCwd`, for a restored split whose shell hasn't emitted OSC yet), falling
-        // back to the exited primary's only when the split has none (a fresh split seeds from the primary
-        // anyway). title is replaced OUTRIGHT from the split's (nil clears it), so the dead primary's title
-        // can never linger on the survivor — likewise foregroundCommand and its captured command.
+        // migrate the split's metadata up, then clear the split fields so nothing describes a gone pane. cwd
+        // prefers the split's live PWD, then `initialSplitCwd` (a restored split whose shell hasn't emitted
+        // OSC yet), falling back to the exited primary's only when the split has none. title is replaced
+        // OUTRIGHT (nil clears it) so the dead primary's can't linger, likewise foregroundCommand.
         session.currentCwd = session.splitCwd ?? session.initialSplitCwd ?? session.currentCwd
         session.oscTitle = session.splitTitle
         session.foregroundCommand = session.splitForegroundCommand
-        // the restore-command override follows the survivor into the main slot, BOTH halves: the persisted
-        // pin (so the next launch restores the promoted pane's command, not the dead primary's) and any
-        // payload still armed for this launch (so a surface built after promotion still runs it).
+        // the restore-command override follows the survivor, BOTH halves: the persisted pin (so the next
+        // launch restores the promoted pane's command, not the dead primary's) and the payload still armed
+        // for this launch (so a surface built after promotion still runs it).
         session.restoreCommand = session.splitRestoreCommand
         session.pendingRestoreCommand = session.pendingSplitRestoreCommand
         session.splitCwd = nil
@@ -124,16 +114,13 @@ extension AppStore {
         session.splitRestoreCommand = nil
         session.pendingSplitRestoreCommand = nil
         // reset search only if the torn-down primary owned the bar (or the weak ref already dangled), so a
-        // search owned by the SURVIVING pane stays valid across promotion — matching closeScratch's
-        // identity guard rather than clearing unconditionally and dropping a still-valid search.
+        // search owned by the SURVIVING pane stays valid across promotion — `closeScratch`'s identity guard.
         if session.searchSurface == nil || session.searchSurface === priorPrimary {
             session.clearSearch()
         }
-        // migrate the agent-status identity like the cwd/title: the exited primary owned any `.left`/nil tag,
-        // which dies with it, while a `.right` tag belonged to the survivor and FOLLOWS it into the main slot
-        // — re-tagged to `.left` so `tree` (now reporting `split:false`) and the survivor's `.left`-role
-        // keystroke-clear agree, not a self-contradictory `split:false` + `statusPane:"right"`. `.scratch` is
-        // untouched.
+        // the exited primary owned any `.left`/nil tag, which dies with it; a `.right` tag belonged to the
+        // survivor and FOLLOWS it, re-tagged `.left` so `tree` (now `split:false`) and the survivor's
+        // `.left`-role keystroke-clear agree instead of contradicting. `.scratch` is untouched.
         if session.agentIndicator.status != .idle {
             switch session.agentIndicator.statusPane ?? .left {
             case .left: setAgentIndicator(AgentIndicator(), forSession: session.id)
@@ -149,11 +136,10 @@ extension AppStore {
 
     /// The split pane's shell exited: collapses to the primary (`closeSplit`) ONLY when a genuine two-pane
     /// split is live, BOTH `surface` and `splitSurface` set. Otherwise this was the session's last pane —
-    /// the surface having been PROMOTED into the primary slot (`splitSurface == nil`) while keeping the split
-    /// pane's `onExit`, so its own exit routes here — and closing, rather than collapsing a split that no
-    /// longer exists, is what avoids a zombie session. The `surface == nil` half of the guard is defensive:
-    /// `closePrimaryPane` always promotes the survivor INTO `surface`, so a live `splitSurface` implies a
-    /// live `surface`. Called by the split surface's `onExit`.
+    /// promoted into the primary slot (`splitSurface == nil`) while keeping the split pane's `onExit`, so its
+    /// exit routes here — and closing rather than collapsing a gone split is what avoids a zombie session.
+    /// The `surface == nil` half of the guard is defensive: `closePrimaryPane` always promotes the survivor
+    /// INTO `surface`. Called by the split surface's `onExit`.
     public func closeSplitPane(_ sessionID: UUID) {
         guard let session = session(withID: sessionID) else { return }
         guard session.surface != nil, session.splitSurface != nil else {
@@ -165,8 +151,7 @@ extension AppStore {
 
     /// Opens an ephemeral overlay terminal on a session running `command` (e.g. a TUI). The surface is
     /// created lazily by the detail pane and runs the command as its process; `closeOverlay` tears it down
-    /// when the program exits. No-op (returns false) for an unknown session or one already showing an
-    /// overlay. NOT persisted, so it never survives a relaunch.
+    /// when the program exits. False for an unknown session or one already showing an overlay. NOT persisted.
     /// - `sizePercent` (clamped to 1...100) requests a *floating* overlay: an opaque framed panel at that
     ///   percent of the pane with the session visible behind it; nil gives the full-pane overlay that hides it.
     /// - `backgroundColor` (`#rrggbb`) gives the overlay pane its own solid background, independent of the
@@ -185,10 +170,10 @@ extension AppStore {
         return true
     }
 
-    /// Resizes an already-open overlay in place: `sizePercent` (clamped to 1...100) switches it to a *floating*
-    /// opaque framed panel at that percent of the pane with the session visible behind it, nil to the translucent
-    /// full-pane overlay that hides the session. The surface stays mounted (the detail pane hosts both variants),
-    /// so only the layout re-flows and the program never re-spawns. No-op (false) with no overlay open.
+    /// Resizes an already-open overlay in place: `sizePercent` (clamped to 1...100) switches it to floating,
+    /// nil to the translucent full-pane overlay, as in `openOverlay`. The surface stays mounted (the detail
+    /// pane hosts both variants), so only the layout re-flows and the program never re-spawns. False with no
+    /// open overlay.
     @discardableResult public func resizeOverlay(_ sessionID: UUID, sizePercent: Int?) -> Bool {
         guard let session = session(withID: sessionID), session.overlayActive else { return false }
         session.overlaySizePercent = sizePercent.map { min(100, max(1, $0)) }
@@ -216,27 +201,24 @@ extension AppStore {
         return true
     }
 
-    /// Toggles the scratch terminal — a third, full-overlay login shell. Its surface is created lazily by
-    /// the detail pane on first show and, like the split, kept alive when hidden (this only flips
-    /// `scratchActive`), so a re-show reuses the same shell. Not persisted, so no `save()`. No-op for an
-    /// unknown session.
+    /// Toggles the scratch terminal — a third, full-overlay login shell. Its surface is created lazily by the
+    /// detail pane and, like the split, kept alive when hidden, so a re-show reuses the same shell. Not
+    /// persisted, so no `save()`.
     public func toggleScratch(_ sessionID: UUID) {
         guard let session = session(withID: sessionID) else { return }
         session.scratchActive.toggle()
     }
 
     /// Closes the scratch terminal: hides it AND tears down its surface, so a later show starts a fresh
-    /// shell. Used on the scratch shell's own `exit` and on session/workspace/window teardown. No-op
-    /// (returns false) when there is no scratch surface.
+    /// shell. Used on the scratch shell's own `exit` and on session/workspace/window teardown; false with no
+    /// scratch surface.
     @discardableResult public func closeScratch(_ sessionID: UUID) -> Bool {
         guard let session = session(withID: sessionID), let scratch = session.scratchSurface else { return false }
         session.scratchActive = false
-        // if the open search bar is pinned to the scratch being torn down, reset search rather than leave a
-        // stuck no-op bar (the weak `searchSurface` zeroes but `searchActive` stays true), mirroring
-        // closeSplit/closePrimaryPane. guarded on identity so a search owned by the main/split pane survives.
+        // a search bar pinned to the scratch being torn down would stay stuck; guarded on identity so a
+        // search owned by the main/split pane survives.
         if session.searchSurface === scratch { session.clearSearch() }
-        // a `.scratch`-tagged block loses its owning surface here; clear it so it can't strand a glyph the
-        // surviving main/split panes can never keystroke-clear (a main/split tag survives — the helper guards).
+        // the `.scratch`-tagged block loses its owning surface here; a main/split tag survives (helper guards).
         clearIndicatorOwnedByPane(.scratch, of: session)
         scratch.teardown()
         session.scratchSurface = nil

--- a/agtermCore/Sources/agtermCore/AppStore+PendingClose.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+PendingClose.swift
@@ -43,9 +43,9 @@ struct PendingWorkspaceClose {
     let workspace: Workspace
     let workspaceIndex: Int
     let selectedSessionID: UUID?
-    /// Whether the closed workspace was in the sidebar focus set — captured so the undo can put it back
-    /// INTO the set. The filter FLAG is deliberately not captured: it is current window state, restored by
-    /// nothing (see `AppStore.markFocusMember`).
+    /// Whether the closed workspace was in the sidebar focus set, captured so the undo can put it back INTO
+    /// the set. The filter FLAG deliberately is not: it is current window state, restored by nothing (see
+    /// `AppStore.markFocusMember`).
     let focusMember: Bool
 }
 
@@ -61,9 +61,9 @@ extension AppStore {
         let wasActive = selectedSessionID == sessionID
         let session = workspaces[location.workspaceIndex].sessions.remove(at: location.sessionIndex)
         emitSessionClosed(session, workspace: workspace.id)
-        // undo reinserts THIS object, so an override payload armed at bootstrap and never consumed would
-        // survive the round trip and fire when the restored session's surface is built. Drop it here; the
-        // persisted pin is untouched and still fires on the next launch.
+        // undo reinserts THIS object, so an override armed at bootstrap and never consumed would survive the
+        // round trip and fire when the restored surface is built. drop it; the persisted pin is untouched
+        // and still fires on the next launch.
         session.clearPendingRestoreOverrides()
         let closeID = UUID()
         let close = PendingSessionClose(
@@ -177,9 +177,9 @@ extension AppStore {
         for session in workspace.sessions { session.clearPendingRestoreOverrides() } // same undo hazard
         let removingActive = selectedSessionID.map { id in workspace.sessions.contains { $0.id == id } } ?? false
         let restoringSelection = removingActive ? selectedSessionID : nil
-        // the live set has already lost the membership whenever a superseded record holds it: that record's
-        // own close dropped it, and the session undo that rebuilt this workspace as a shell does not
-        // re-mark. So the absorbed record's flag is the only surviving copy and must win here.
+        // a superseded record's membership is already gone from the live set — its own close dropped it and
+        // the session undo that rebuilt this workspace as a shell does not re-mark — so its flag is the only
+        // surviving copy and must win here.
         let focusMember = focusedWorkspaceIDs.contains(workspaceID) || folded.focusMember
         dropFocusMember(workspaceID)
         if removingActive {
@@ -283,14 +283,13 @@ extension AppStore {
 
     /// Absorb any pending close of the same workspace into the copy being closed now, dropping the
     /// superseded record. Undoing a session close rebuilds a missing workspace as a shell, so closing that
-    /// shell while the earlier record still waits out its grace would leave two pending records sharing a
-    /// workspace id. Both key one Open Recent entry by that id (`RecentClosedStore.record` dedupes on it),
-    /// so the newer snapshot would evict the older one and its sessions would survive nowhere once both
-    /// records finalize. The copy closed now is the newer state, so its name, expansion and session order
-    /// lead; the superseded record's sessions follow. Its focus MEMBERSHIP is reported back alongside, ORed
-    /// across every absorbed record, because the rebuilt shell carries none: the caller ORs it into its own
-    /// capture, so the newer record — and the Open Recent entry it overwrites — still knows the workspace
-    /// was a set member.
+    /// shell during the earlier record's grace would leave two pending records sharing a workspace id — and
+    /// both key one Open Recent entry by it (`RecentClosedStore.record` dedupes on it), so the newer
+    /// snapshot would evict the older and its sessions would survive nowhere once both finalize. The copy
+    /// closed now is the newer state, so its name, expansion and session order lead and the superseded
+    /// record's sessions follow. Focus MEMBERSHIP is reported back ORed across every absorbed record,
+    /// because the rebuilt shell carries none; the caller ORs it into its own capture, so the newer record —
+    /// and the Open Recent entry it overwrites — still knows the workspace was a set member.
     private func foldingPendingCloses(of workspace: Workspace) -> (workspace: Workspace, focusMember: Bool) {
         var folded = workspace
         var focusMember = false
@@ -323,9 +322,8 @@ extension AppStore {
     }
 
     /// A workspace to stand in for one a restore needs but the tree no longer holds. Prefer the newest
-    /// description of it: a pending close of that same workspace carries its live name and expansion state,
-    /// and once those finalize an Open Recent snapshot still does. `name` is the caller's older copy, used
-    /// only when neither describes the workspace.
+    /// description: a pending close of that same workspace carries its live name and expansion state, and
+    /// once those finalize an Open Recent snapshot still does. `name` is the caller's older copy, a last resort.
     func rebuiltWorkspaceShell(id: UUID, name: String) -> Workspace {
         for closeID in pendingCloseOrder.reversed() {
             guard case .workspace(let close)? = pendingCloseRecords[closeID], close.workspace.id == id else { continue }
@@ -372,13 +370,12 @@ extension AppStore {
     }
 
     private func restorePendingWorkspace(_ close: PendingWorkspaceClose) {
-        // an undone session close, or an Open Recent restore, rebuilds a missing workspace by id as a
-        // shell holding just that session. merge into the shell instead of inserting a second workspace
-        // sharing its id: every id-keyed lookup resolves the first match, so a duplicate would strand the
-        // other copy's sessions. the shell was seeded from this record, and anything the user changed on
-        // it since is newer, so its name and expansion state stand. the shell also keeps its slot, so
-        // `workspaceIndex` and this record's session order are not honored. the filter is defensive: a
-        // session held by this record cannot already be live elsewhere.
+        // an undone session close, or an Open Recent restore, rebuilds a missing workspace by id as a shell
+        // holding just that session. merge into the shell rather than inserting a second workspace sharing
+        // its id: every id-keyed lookup resolves the first match, so a duplicate strands the other copy's
+        // sessions. the shell was seeded from this record and anything changed on it since is newer, so its
+        // name and expansion state stand, and it keeps its slot — `workspaceIndex` and this record's session
+        // order are not honored. the filter is defensive: a session held here cannot already be live elsewhere.
         if let existing = workspaces.firstIndex(where: { $0.id == close.workspace.id }) {
             let live = Set(workspaces.flatMap(\.sessions).map(\.id))
             let restored = close.workspace.sessions.filter { !live.contains($0.id) }
@@ -390,10 +387,9 @@ extension AppStore {
             for session in close.workspace.sessions { emitSessionCreated(session, workspace: close.workspace.id) }
             if close.workspace.sessions.isEmpty { scheduleTreeChanged() }
         }
-        // put the workspace back into the focus set BEFORE the reselect below, so a restored member is
-        // already inside the set when `disableFocusIfSelectionOutsideSet` runs. It also has to happen
-        // ahead of the `guard` — an EMPTY workspace returns there, and skipping the re-mark would leave
-        // its row filtered out, making the undo look like a no-op.
+        // re-mark BEFORE the reselect below, so a restored member is inside the set when
+        // `disableFocusIfSelectionOutsideSet` runs, and ahead of the `guard` — an EMPTY workspace returns
+        // there, and skipping the re-mark would leave its row filtered out, making the undo look a no-op.
         if close.focusMember { markFocusMember(close.workspace.id) }
         guard let target = close.selectedSessionID ?? close.workspace.sessions.first?.id else { return }
         selectedSessionID = target

--- a/agtermCore/Sources/agtermCore/AppStore+Recency.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Recency.swift
@@ -2,15 +2,15 @@ import Foundation
 
 extension AppStore {
     /// Up to `limit` most-recently-used session ids across all workspaces, most-recent first, skipping
-    /// stale/closed ids (so it returns fewer than `limit` when fewer qualify). The `dashboard --mru` open
-    /// reads it to populate the grid from the window's recent sessions.
+    /// stale/closed ids (so fewer than `limit` when fewer qualify). Read by the `dashboard --mru` open to
+    /// populate the grid from the window's recent sessions.
     public func recentSessions(limit: Int) -> [UUID] {
         sessionRecency.top(limit, in: Set(workspaces.flatMap { $0.sessions.map(\.id) }))
     }
 
-    /// The recent-session navigation candidates shared by the title-bar popover and Dock menu:
-    /// most-recent first, limited to the visible navigation scope, with the current session removed
-    /// because selecting it would not navigate anywhere.
+    /// The recent-session navigation candidates shared by the title-bar popover and Dock menu: most-recent
+    /// first, limited to the visible navigation scope, with the current session removed (selecting it would
+    /// not navigate anywhere).
     public func navigableRecentSessions(limit: Int) -> [UUID] {
         var valid = Set(navigableSessions.map(\.id))
         if let activeID = activeSession?.id { valid.remove(activeID) }

--- a/agtermCore/Sources/agtermCore/AppStore+RecentClosed.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+RecentClosed.swift
@@ -33,15 +33,14 @@ extension AppStore {
             // a close. its original object is alive in that record, so rebuild everything except it.
             let taken = Set(workspaces.flatMap(\.sessions).map(\.id)).union(pendingHeldSessionIDs())
             workspace.sessions.removeAll { taken.contains($0.id) }
-            // Persistent Open Recent appends like most editors' recent-project flow:
-            // reopening brings the workspace back without reshuffling current workspaces.
+            // persistent Open Recent appends, like most editors' recent-project flow: a reopen brings the
+            // workspace back without reshuffling current workspaces.
             workspaces.append(workspace)
             for session in workspace.sessions { emitSessionCreated(session, workspace: workspace.id) }
             if workspace.sessions.isEmpty { scheduleTreeChanged() }
             // re-mark BEFORE the reselect below, so a restored member is inside the set when
-            // `disableFocusIfSelectionOutsideSet` runs; the workspace is already in the tree, so the
-            // unguarded insert cannot leave a phantom member behind. Entries written before the field
-            // existed carry nil and restore unmarked.
+            // `disableFocusIfSelectionOutsideSet` runs; the workspace is already in the tree, so the unguarded
+            // insert can't leave a phantom member. entries predating the field carry nil and restore unmarked.
             if recent.focusMember == true { markFocusMember(workspace.id) }
             selectedSessionID = recent.selectedSessionID.flatMap { sessionID in
                 workspace.sessions.contains { $0.id == sessionID } ? sessionID : nil
@@ -66,20 +65,19 @@ extension AppStore {
     private func restoreOrSelectExistingRecentWorkspace(_ recent: RecentClosedWorkspace) -> Bool {
         let sessionIDs = Set(recent.snapshot.sessions.map(\.id))
         // pending closes may hold this workspace, or any number of its sessions closed one at a time. undo
-        // every match, not only the newest: an undo returns live sessions to the tree, and the merge below
-        // skips rebuilding only what it can see there. a session left pending would be rebuilt from the
-        // snapshot beside its live original, two objects under one id, and the original's surfaces torn
-        // down once its grace expired. each undo drops its own record, so the loop drains them. falling
-        // through matters too: returning an undo's result would report success while the caller deletes
-        // the recent entry holding the sessions that undo did not restore.
+        // every match, not just the newest: an undo returns live sessions to the tree and the merge below only
+        // skips what it sees there, so a session left pending would be rebuilt from the snapshot beside its
+        // live original — two objects under one id, the original's surfaces torn down at grace expiry. each
+        // undo drops its own record, so the loop drains them; and falling through matters, since returning an
+        // undo's result would report success while the caller deletes the entry holding the unrestored sessions.
         while let pendingID = pendingCloseID(forWorkspaceID: recent.snapshot.id, sessionIDs: sessionIDs) {
             undoPendingClose(pendingID)
         }
         if let index = workspaces.firstIndex(where: { $0.id == recent.snapshot.id }) {
             // reopening a session first rebuilds this workspace as a shell holding only that session, so
-            // selecting without merging would drop the snapshot's other sessions while the caller deletes
-            // the recent entry on success — their only copy. rebuild the ones that exist nowhere: not in
-            // the tree, and not held by a pending close whose undo would reinsert the original.
+            // selecting without merging would drop the snapshot's other sessions — their only copy — while the
+            // caller deletes the recent entry on success. rebuild only the ones absent from the tree AND from
+            // a pending close whose undo would reinsert the original.
             let taken = Set(workspaces.flatMap(\.sessions).map(\.id)).union(pendingHeldSessionIDs())
             let missing = recent.snapshot.sessions.filter { !taken.contains($0.id) }.map { session(from: $0) }
             workspaces[index].sessions.append(contentsOf: missing)
@@ -103,8 +101,8 @@ extension AppStore {
         for id in pendingCloseOrder.reversed() {
             guard let record = pendingCloseRecords[id] else { continue }
             switch record {
-            // A grace-period reopen restores the grouped batch close as one undo record, matching
-            // workspace close behavior while the record is still pending.
+            // a grace-period reopen restores the grouped batch close as one undo record, matching workspace
+            // close behavior while the record is still pending.
             case .sessions(let close) where close.sessions.contains(where: { $0.session.id == sessionID }):
                 return id
             case .workspace(let close) where close.workspace.sessions.contains(where: { $0.id == sessionID }):
@@ -116,10 +114,10 @@ extension AppStore {
         return nil
     }
 
-    /// A pending close this workspace's restore should consume. Only records of the workspace itself: a
-    /// foreign workspace that merely holds one of the snapshot's sessions (moved there before it closed)
-    /// is a close the user meant, and undoing it would resurrect a workspace they deliberately dismissed.
-    /// The merge treats such a session as occupied instead, so it is never rebuilt beside the original.
+    /// A pending close this workspace's restore should consume — records of the workspace itself only: a
+    /// foreign workspace merely holding one of the snapshot's sessions (moved there before it closed) is a
+    /// close the user meant, and undoing it would resurrect a deliberately dismissed workspace. The merge
+    /// treats such a session as occupied instead, so it is never rebuilt beside the original.
     private func pendingCloseID(forWorkspaceID workspaceID: UUID, sessionIDs: Set<UUID>) -> UUID? {
         for id in pendingCloseOrder.reversed() {
             guard let record = pendingCloseRecords[id] else { continue }

--- a/agtermCore/Sources/agtermCore/AppStore+Restore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Restore.swift
@@ -2,29 +2,27 @@ import Foundation
 
 // MARK: - Per-session restore-command override
 
-/// The persisted per-pane restore-command override behind the control channel's `session.restore`. Split
-/// out of the main `AppStore` body to keep it under the file-size budget, mirroring the
-/// `AppStore+Status.swift` split. The stored state lives on `Session`; this operates over it.
+/// The persisted per-pane restore-command override behind the control channel's `session.restore`. Split out
+/// of the main `AppStore` body for the file-size budget, like `AppStore+Status.swift`; the stored state lives
+/// on `Session` and this operates over it.
 extension AppStore {
-    /// Sets a pane's PERSISTED restore-command override, the single mutation point for the control
-    /// channel's `session.restore`. Tri-state `value`: nil = no override (auto-capture), `""` = pinned to
-    /// nothing (a plain shell), `"cmd"` = run that shell line on the next launch. Persists immediately —
-    /// the override must survive a SIGKILL, or a hook's write is lost before the next launch reads it.
-    /// Idempotent like `setFlag`: an unchanged value writes nothing and skips the save. No-op for an
-    /// unknown id.
+    /// Sets a pane's PERSISTED restore-command override, the single mutation point for the control channel's
+    /// `session.restore`. Tri-state `value`: nil = no override (auto-capture), `""` = pinned to nothing (a
+    /// plain shell), `"cmd"` = run that shell line on the next launch. Persists immediately — the override
+    /// must survive a SIGKILL, or a hook's write is lost before the next launch reads it. Idempotent like
+    /// `setFlag`: an unchanged value writes nothing and skips the save. No-op for an unknown id.
     ///
     /// It deliberately does NOT touch the pending slots: a write during this run must not execute during
     /// this run. Only an app-bootstrap restore copies the persisted value into `pendingRestoreCommand`
     /// (see `session(from:launchRestore:)`), which is what the surface factories consume. `.scratch` is
     /// rejected at the command layer (the scratch terminal is never restored), so it is not handled here.
     ///
-    /// Returns whether the requested value is now on disk, so the caller can refuse to acknowledge a write
-    /// that never landed — unlike the rest of the store, which mutates and lets `save()` swallow its
-    /// error. This payload is an arbitrary shell line re-typed on every launch: a false "cleared" would
-    /// leave the OLD command running forever. A failed save is therefore ROLLED BACK in memory, both so
-    /// the value keeps matching disk and so the unchanged-value guard can't swallow the retry. `false`
-    /// also covers the two nothing-to-write cases the command layer already rejects (an unknown id, the
-    /// scratch pane).
+    /// Returns whether the requested value is now on disk, so a caller can refuse to acknowledge a write
+    /// that never landed — unlike the rest of the store, which mutates and lets `save()` swallow the error.
+    /// The payload is an arbitrary shell line re-typed on every launch, so a false "cleared" would leave the
+    /// OLD command running forever. A failed save is ROLLED BACK in memory, keeping the value matching disk
+    /// and stopping the unchanged-value guard from swallowing the retry. `false` also covers the two
+    /// nothing-to-write cases the command layer already rejects (an unknown id, the scratch pane).
     @discardableResult
     public func setRestoreCommand(_ value: String?, pane: StatusPane, forSession id: UUID) -> Bool {
         guard let session = session(withID: id) else { return false }

--- a/agtermCore/Sources/agtermCore/AppStore+Status.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Status.swift
@@ -2,42 +2,37 @@ import Foundation
 
 // MARK: - Agent status & attention
 
-/// The per-session agent-status indicator (the sidebar glyph driven by the control channel's
-/// `session.status`) and the window-wide attention list derived from it. Split out of the main `AppStore`
-/// body to keep it under the file-size budget, mirroring the `AppStore+AutoFollow`/`+Recency`/`+PendingClose`
-/// split. The stored state lives on the main body; these operate over it.
+/// The per-session agent-status indicator (the sidebar glyph driven by the control channel's `session.status`)
+/// and the window-wide attention list derived from it. Split out of the main `AppStore` body for the file-size
+/// budget, like `AppStore+AutoFollow`/`+Recency`/`+PendingClose`; the stored state lives on that main body.
 extension AppStore {
-    /// Sets a session's agent status indicator (the sidebar status glyph). The single mutation point
-    /// for the control channel's `session.status`. Stamps `statusChangedAt` with the current time on any
-    /// non-idle status (the attention list's newest-first sort key) and clears it on idle. Clears the
-    /// session's `autoFollowConsumed` on a transition INTO blocked, re-arming idle auto-follow for the
-    /// fresh episode. No-op for an unknown id. Not persisted (the indicator is ephemeral), so it never
-    /// triggers a `save()`.
+    /// Sets a session's agent status indicator (the sidebar status glyph) — the single mutation point for the
+    /// control channel's `session.status`. Stamps `statusChangedAt` on any non-idle status (the attention
+    /// list's newest-first sort key) and clears it on idle. Clears the session's `autoFollowConsumed` on a
+    /// transition INTO blocked, re-arming idle auto-follow for the fresh episode. No-op for an unknown id.
+    /// Not persisted (the indicator is ephemeral), so it never triggers a `save()`.
     public func setAgentIndicator(_ indicator: AgentIndicator, forSession id: UUID) {
         guard let session = session(withID: id) else { return }
         let previous = session.agentIndicator
         let wasBlocked = session.agentIndicator.status == .blocked
         var indicator = indicator
-        // normalize a `.right` tag to `.left` when the session has NO split. A promoted survivor's
-        // shell keeps its baked `AGTERM_PANE=right`, so the agent-status hook re-emits `--pane right` after
-        // promotion even though there is no right pane — left unnormalized that re-creates the
-        // `split:false` + `statusPane:"right"` contradiction the round-3 re-tag fixed, and the sole
-        // (`.left`-role-aware) pane could never keystroke-clear it. A hidden-but-LIVE split keeps
-        // `hasSplit`, so `.right` stays valid there. `.left`/`.scratch` are untouched.
-        // gated on `hasSplit`, NOT `splitSurface == nil`: `toggleSplit`/restore set `hasSplit`
-        // synchronously while the deck creates `splitSurface` a render pass later, so a scripted
-        // `session.split` + immediate `session.status --pane right` lands in that realization window —
-        // there `.right` is the correct forward tag and must NOT be rewritten. `splitSurface != nil`
-        // implies `hasSplit` (only `closeSplit`/`closePrimaryPane` clear it, tearing the surface down
-        // with it), so `!hasSplit` still covers every genuinely splitless session.
+        // normalize a `.right` tag to `.left` when the session has NO split. A promoted survivor's shell keeps
+        // its baked `AGTERM_PANE=right`, so the agent-status hook re-emits `--pane right` after promotion with
+        // no right pane — unnormalized that yields a `split:false` + `statusPane:"right"` contradiction the
+        // sole (`.left`-role-aware) pane could never keystroke-clear. A hidden-but-LIVE split keeps `hasSplit`,
+        // so `.right` stays valid there; `.left`/`.scratch` are untouched.
+        // gated on `hasSplit`, NOT `splitSurface == nil`: `toggleSplit`/restore set `hasSplit` synchronously
+        // while the deck creates `splitSurface` a render pass later, so a scripted `session.split` + immediate
+        // `session.status --pane right` lands in that realization window, where `.right` is the correct forward
+        // tag and must NOT be rewritten. `splitSurface != nil` implies `hasSplit` (only
+        // `closeSplit`/`closePrimaryPane` clear it, tearing the surface down with it), so `!hasSplit` still
+        // covers every genuinely splitless session.
         if indicator.statusPane == .right, !session.hasSplit {
             indicator.statusPane = .left
         }
         session.agentIndicator = indicator
         session.statusChangedAt = indicator.status == .idle ? nil : Date()
-        // a fresh block episode (entering blocked from a non-blocked status) re-arms idle auto-follow for
-        // this session, so it can pull the user here once more; a re-asserted blocked-over-blocked is not a
-        // new episode and stays muted (see Session.autoFollowConsumed).
+        // a re-asserted blocked-over-blocked is not a new episode and stays muted (Session.autoFollowConsumed).
         if !wasBlocked, indicator.status == .blocked { session.autoFollowConsumed = false }
         guard previous != indicator else { return }
         emitControlEvent(
@@ -55,12 +50,11 @@ extension AppStore {
         )
     }
 
-    /// The window-wide non-idle sessions, the single source of truth for the titlebar attention icon
-    /// and the `.attention` palette. Spans ALL workspaces (`workspaces.flatMap(\.sessions)`) and
-    /// deliberately IGNORES the focus/flagged sidebar filter (unlike `navigableSessions`) — the point
-    /// is window-wide visibility even when the sidebar is hidden. Sorted by `attentionRank` ascending
-    /// (blocked → active → completed) then `statusChangedAt` DESCENDING (newest change first; a nil
-    /// stamp sorts last within its rank group).
+    /// The window-wide non-idle sessions, the single source of truth for the titlebar attention icon and the
+    /// `.attention` palette. Spans ALL workspaces (`workspaces.flatMap(\.sessions)`) and deliberately IGNORES
+    /// the focus/flagged sidebar filter (unlike `navigableSessions`) — the point is window-wide visibility even
+    /// when the sidebar is hidden. Sorted by `attentionRank` ascending (blocked → active → completed) then
+    /// `statusChangedAt` DESCENDING (newest first; a nil stamp sorts last within its rank group).
     public var attentionSessions: [Session] {
         workspaces.flatMap(\.sessions)
             .filter { $0.agentIndicator.status != .idle }

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -2,13 +2,13 @@ import Foundation
 import Observation
 
 /// A relative step through the flattened session list for keyboard navigation. `next`/`previous` step one
-/// and wrap at the ends, `first`/`last` jump to a tree end, `nextAttention`/`previousAttention` step
-/// (wrapping) through only the sessions needing attention — status `blocked` or `completed`.
+/// and wrap, `first`/`last` jump to a tree end, `nextAttention`/`previousAttention` step (wrapping) through
+/// only the sessions needing attention — status `blocked` or `completed`.
 public enum SessionNavigation: Sendable { case next, previous, first, last, nextAttention, previousAttention }
 
 extension SessionNavigation {
-    /// Maps a control-channel direction string to a case. The CLI uses `prev`; the enum case is
-    /// `.previous`, so both spellings are accepted. Returns nil for an unknown string.
+    /// Maps a control-channel direction string to a case, nil for an unknown one. Both `prev` (the CLI's
+    /// spelling) and `previous` are accepted.
     public init?(wire: String) {
         switch wire {
         case "next": self = .next
@@ -22,67 +22,59 @@ extension SessionNavigation {
     }
 }
 
-/// The whole app state: the workspace tree and the current selection.
-///
-/// `@Observable @MainActor` so views observe mutations and all model access is main-actor isolated
-/// (implicitly `Sendable` via isolation). Selection is one `Session.ID?` — workspace rows are
-/// non-selectable disclosure headers, so the owning workspace is derived.
+/// The whole app state: the workspace tree and the current selection. `@Observable @MainActor` so views
+/// observe mutations and all model access is main-actor isolated (implicitly `Sendable` via isolation).
+/// Selection is one `Session.ID?` — workspace rows are non-selectable headers, so the workspace is derived.
 @Observable
 @MainActor
 public final class AppStore {
     public var workspaces: [Workspace]
     public var selectedSessionID: UUID?
 
-    /// Transient sidebar multi-selection. Not persisted: it is UI command state, while
-    /// `selectedSessionID` remains the durable active terminal target.
+    /// Transient sidebar multi-selection, not persisted — `selectedSessionID` stays the durable active target.
     var sidebarSelectionRaw: [UUID] = []
 
-    /// Whether this window's sidebar is shown. Per-window state persisted in `Snapshot`; the custom split
-    /// owns visibility, so the toolbar button, the View menu item, the action palette, and the `sidebar`
-    /// control command all flip this one flag.
+    /// Whether this window's sidebar is shown; per-window state persisted in `Snapshot`. The custom split
+    /// owns visibility, so toolbar, View menu, palette and the `sidebar` command all flip this one flag.
     public var sidebarVisible = true
 
-    /// Which view this window's sidebar renders: the workspace tree or a flat list of the flagged
-    /// working-set. Per-window state persisted in `Snapshot`; flipped via `setSidebarMode(_:)` by the
-    /// bottom-bar toggle, the View menu, the action palette, and the `sidebar.mode` control command.
+    /// Which view this window's sidebar renders: the tree or the flat flagged working set. Per-window state
+    /// in `Snapshot`, flipped via `setSidebarMode(_:)` (bottom bar, View menu, palette, `sidebar.mode`).
     public var sidebarMode: SidebarMode = .tree
 
     /// The workspaces marked for the sidebar focus filter — the working set the tree renders when
-    /// `focusEnabled` is on (see `visibleWorkspaces`). Per-window state persisted in `Snapshot`; orthogonal
-    /// to `sidebarMode` (flagged mode ignores focus). Mutated by the workspace row menu, the View menu, the
-    /// palette and `workspace.focus` via `setFocusedWorkspace(_:)`/`setFocusMembership(_:member:)`; a
-    /// member is pruned when its workspace is removed. `internal(set)`, so only code inside `agtermCore`
-    /// can break the invariant below, never an app-target line writing the field directly.
+    /// `focusEnabled` is on (see `visibleWorkspaces`). Per-window state in `Snapshot`; orthogonal to
+    /// `sidebarMode` (flagged mode ignores focus). Mutated via `setFocusedWorkspace(_:)`/
+    /// `setFocusMembership(_:member:)` by the row menu, View menu, palette and `workspace.focus`; a member is
+    /// pruned when its workspace is removed. `internal(set)`, so no app-target line breaks the invariant below.
     public internal(set) var focusedWorkspaceIDs: Set<UUID> = []
 
-    /// Whether the focus filter applies, so a hand-curated set survives being switched off. Per-window
-    /// state persisted in `Snapshot`, `internal(set)` like the set above. Enabled with an EMPTY set is
-    /// unrepresentable, which makes the FILTER-ON half of the control row-visibility read-back
-    /// (`ControlWorkspaceNode.focused`) exact: an applied filter always has at least one visible member.
-    /// (The filter-OFF half — `visibleWorkspaces` returning the whole tree — is outside this invariant.)
-    /// Three guards hold it: `setFocusEnabled(true)` no-ops on an empty set (matching the bottom-bar
-    /// toggle, disabled in exactly that state), `setFocusMembership`/`dropFocusMember` disable as the set
-    /// empties, and `restoreFocus(from:)` prunes ids absent from the restored tree, disabling when that
-    /// empties it. Driven by the bottom-bar `focus-filter-toggle`, View ▸ Toggle Workspace Filter,
+    /// Whether the focus filter applies, so a hand-curated set survives being switched off. Per-window state
+    /// in `Snapshot`, `internal(set)` like the set above. Enabled with an EMPTY set is unrepresentable, which
+    /// makes the FILTER-ON half of the control row-visibility read-back (`ControlWorkspaceNode.focused`)
+    /// exact — an applied filter always has at least one visible member; the filter-OFF half
+    /// (`visibleWorkspaces` returning the whole tree) is outside the invariant. Three guards hold it:
+    /// `setFocusEnabled(true)` no-ops on an empty set (matching the bottom-bar toggle, disabled in exactly
+    /// that state), `setFocusMembership`/`dropFocusMember` disable as the set empties, and
+    /// `restoreFocus(from:)` prunes ids absent from the restored tree, disabling when that empties it. Driven
+    /// by the bottom-bar `focus-filter-toggle`, View ▸ Toggle Workspace Filter,
     /// `BuiltinAction.toggleWorkspaceFilter`, and `workspace.filter`.
     public internal(set) var focusEnabled = false
 
-    /// This window's sidebar width in points, persisted in `Snapshot`. Driven by the sidebar divider drag,
-    /// clamped to `sidebarWidthMin...sidebarWidthMax`.
+    /// This window's sidebar width in points, persisted in `Snapshot`; drag-driven, clamped to the bounds below.
     public var sidebarWidth: Double = AppStore.sidebarWidthDefault
 
-    /// The sidebar width default and drag/restore bounds, shared by the view's divider drag and the
-    /// `restore()` clamp so the two can't drift (and a hand-edited snapshot can't drive an out-of-range frame).
+    /// Default + drag/restore bounds, shared by the divider drag and the `restore()` clamp so they can't drift.
     public static let sidebarWidthDefault: Double = 220
     public static let sidebarWidthMin: Double = 160
     public static let sidebarWidthMax: Double = 560
 
-    /// The persisted split-divider left-pane fraction bounds. The live capture skips degenerate extremes
-    /// outside this range and `restore()` clamps to it, so the on-disk ratio is always within bounds.
+    /// The persisted split-divider left-pane fraction bounds: live capture skips degenerate extremes outside
+    /// this range and `restore()` clamps to it, so the on-disk ratio is always within bounds.
     public static let splitRatioMin: Double = 0.05
     public static let splitRatioMax: Double = 0.95
-    /// The even split fraction a never-moved divider renders at (the `HSplitView` default); the base for a
-    /// relative `session.resize` when `Session.splitRatio` is still nil.
+    /// The even split a never-moved divider renders at (the `HSplitView` default); the base for a relative
+    /// `session.resize` while `Session.splitRatio` is nil.
     public static let splitRatioDefault: Double = 0.5
 
     /// Clamp a left-pane split fraction to `splitRatioMin...splitRatioMax`.
@@ -90,13 +82,12 @@ public final class AppStore {
         min(splitRatioMax, max(splitRatioMin, ratio))
     }
 
-    /// Most-recently-selected session ids, front = current; drives the Ctrl-Tab switcher (`items[1]` is
-    /// the previous session). `@ObservationIgnored`: read imperatively by the switcher, not by any view.
-    /// Persisted in the snapshot so the switcher's order survives a relaunch.
+    /// Most-recently-selected session ids, front = current; drives the Ctrl-Tab switcher (`items[1]` is the
+    /// previous). `@ObservationIgnored`, read imperatively; persisted so the order survives a relaunch.
     @ObservationIgnored public private(set) var sessionRecency = RecencyStack<UUID>()
 
-    /// The latest session/workspace close that can still be undone. The hidden sessions/workspaces live
-    /// in `pendingCloseRecords`; this observed summary is the host-free state the app target presents.
+    /// The latest undoable session/workspace close; the hidden items live in `pendingCloseRecords`, this
+    /// observed summary is the host-free state the app target presents.
     public var pendingCloseSummary: PendingCloseSummary?
 
     @ObservationIgnored var pendingCloseRecords: [UUID: PendingCloseRecord] = [:]
@@ -107,48 +98,42 @@ public final class AppStore {
     @ObservationIgnored let recentClosedStore: RecentClosedStore?
     @ObservationIgnored var recentClosedDidChange: (() -> Void)?
     @ObservationIgnored let controlEventSink: ((ControlEventDraft) -> Void)?
-    /// Coalesces the high-frequency selection/font saves: a click-storm or a font ramp schedules one
-    /// write ~0.3 s after the burst settles instead of hitting disk per event. `save()` cancels any
-    /// pending scheduled save, so the quit-flush (`saveAllOpen()` → `save()`) still captures the latest.
+    /// Coalesces the high-frequency selection/font saves: a click-storm or a font ramp writes once after the
+    /// burst settles instead of hitting disk per event.
     @ObservationIgnored private let saveDebouncer = Debouncer()
 
     /// The quiet window before a scheduled (selection/font) save writes to disk.
     private static let saveDebounceInterval: TimeInterval = 0.3
 
-    /// The idle timeout after which the window auto-jumps its selection to the oldest blocked session, or
-    /// nil when auto-follow is off (the default). Set by the Settings fan-out; read by `noteUserActivity`
-    /// (to arm the debouncer) and the control tree. `@ObservationIgnored`: read imperatively, no view reacts.
+    /// Idle timeout after which the window auto-jumps its selection to the oldest blocked session, nil when
+    /// auto-follow is off (the default). Set by the Settings fan-out; read imperatively by `noteUserActivity`
+    /// (arming the debouncer) and the control tree, so no view reacts.
     @ObservationIgnored var autoFollowTimeout: TimeInterval?
 
-    /// Whether auto-follow suppresses the jump while the current session is `active` (the opt-in "don't
-    /// auto-follow away from a running session" toggle). Default false. `@ObservationIgnored`.
+    /// Whether auto-follow suppresses the jump while the current session is `active` (opt-in, default false).
     @ObservationIgnored var autoFollowStayOnActive = false
 
-    /// The last time the user interacted with this window (a keystroke or a manual selection), nil until
-    /// the first interaction. Stamped unconditionally by `noteUserActivity` so the idle metric is
-    /// independent of the feature being on. `@ObservationIgnored`: read imperatively (`idleMs`, the
-    /// control tree) and stamped at high frequency, so no view should react to it.
+    /// The last user interaction with this window (a keystroke or a manual selection), nil until the first.
+    /// Stamped unconditionally by `noteUserActivity`, so the idle metric is independent of the feature being
+    /// on. Stamped at high frequency and read imperatively, so no view may react to it.
     @ObservationIgnored var lastActivityAt: Date?
 
-    /// Coalesces user activity into a single deferred `autoFollowFire`: each `noteUserActivity` reschedules,
-    /// so the fire runs only once the user has been idle for `autoFollowTimeout`. `internal` (NOT private)
-    /// so `@testable` tests can drive its `flush()` seam.
+    /// Coalesces user activity into one deferred `autoFollowFire`: each `noteUserActivity` reschedules, so it
+    /// fires only after `autoFollowTimeout` of idle. `internal`, not private, for the tests' `flush()` seam.
     @ObservationIgnored let autoFollowDebouncer = Debouncer()
 
-    /// Coalesces the auto-follow status observer's deferred re-arms into one re-arm (and one
-    /// re-registration) per runloop turn, mirroring `DockBadgeController.scheduleRefresh`: one
-    /// agent-status flip can fire several live observation trackers at once. `internal` only so the
-    /// `AppStore+AutoFollow` extension (a separate file) can reach it.
+    /// Coalesces the auto-follow status observer's deferred re-arms into one re-arm (and re-registration) per
+    /// runloop turn, mirroring `DockBadgeController.scheduleRefresh`: one agent-status flip can fire several
+    /// live observation trackers at once. `internal` only for the `AppStore+AutoFollow` extension.
     @ObservationIgnored var autoFollowRearmScheduled = false
 
-    /// Non-zero while a non-terminal editor or transient overlay in this window owns first responder — the
-    /// sidebar inline-rename field or an open command palette. `autoFollowFire` no-ops while positive, so
-    /// an armed idle jump can't yank the selection out of an in-progress rename or reshuffle a palette's
-    /// action target. A COUNT, not a bool, so independent suppressors overlap safely: each brackets itself
-    /// with `suppressAutoFollow`/`resumeAutoFollow`, and one lifting while another still holds keeps the
-    /// jump suppressed. The app owns the first-responder knowledge, the store only the count. `internal`
-    /// for the `AppStore+AutoFollow` extension, mutated only through the two public methods so the app
-    /// target (a separate module) can't desync it. `@ObservationIgnored`: read imperatively at fire time.
+    /// Non-zero while a non-terminal editor or transient overlay owns first responder (the sidebar rename
+    /// field, an open command palette): `autoFollowFire` no-ops while positive, so an armed idle jump can't
+    /// yank the selection out of an in-progress rename or reshuffle a palette's action target. A COUNT, not a
+    /// bool, so independent suppressors overlap safely — each brackets itself with `suppressAutoFollow`/
+    /// `resumeAutoFollow`, and one lifting while another holds keeps the jump suppressed. The app owns the
+    /// first-responder knowledge, the store only the count; `internal` for the `AppStore+AutoFollow` extension
+    /// and mutated only through the two public methods, so the app target cannot desync it.
     @ObservationIgnored var autoFollowSuppressionCount = 0
 
     public init(workspaces: [Workspace] = [], selectedSessionID: UUID? = nil,
@@ -170,9 +155,8 @@ public final class AppStore {
         return session(withID: selectedSessionID)
     }
 
-    /// The workspace a new session should land in: the selected session's workspace, else the last
-    /// workspace (nil when there are none). Drives the bottom bar's add actions and the File menu's
-    /// New Session / Open Directory.
+    /// The workspace a new session lands in: the selected session's, else the last (nil when there are none).
+    /// Drives the bottom bar's add actions and File ▸ New Session / Open Directory.
     public var currentWorkspaceID: UUID? {
         if let selectedSessionID, let workspace = workspace(forSession: selectedSessionID) {
             return workspace.id
@@ -225,8 +209,8 @@ public final class AppStore {
                                           commandWait: (session.initialCommand != nil && session.commandWait) ? true : nil,
                                           foreground: foreground(session),
                                           splitForeground: splitForeground(session),
-                                          // the PERSISTED overrides, never the transient pending payloads,
-                                          // so a read after one fired still reports what stays pinned.
+                                          // the PERSISTED overrides, not the transient pending payloads, so
+                                          // a read after one fired still reports what stays pinned.
                                           restoreCommand: session.restoreCommand,
                                           splitRestoreCommand: session.splitRestoreCommand, status: status,
                                           statusPane: statusPane,
@@ -257,14 +241,12 @@ public final class AppStore {
                            pickPending: pickPending())
     }
 
-    /// Creates a workspace and appends it. With `revealNewWorkspace` (the default) and the focus filter ON,
-    /// the new workspace JOINS the marked set so it is immediately visible — else `visibleWorkspaces` would
-    /// render only the existing members and silently hide it (the auto-reveal contract, like `addSession`).
-    /// Widening rather than clearing keeps the rest of the working set filtered; the user asked for this
-    /// workspace, so mutating the set is intentional. `revealNewWorkspace: false` leaves the filter
-    /// untouched — a background `session.new --no-select` create must not widen the view. `collapsed: true`
-    /// creates it already collapsed (backs `workspace.new --collapsed`; a runtime add otherwise defaults to
-    /// `isExpanded == true` and renders open), so it can be filled with `addSession(select: false)` unopened.
+    /// Creates a workspace and appends it. With `revealNewWorkspace` (the default) and the filter ON, the new
+    /// workspace JOINS the marked set so it is immediately visible — the auto-reveal contract, like
+    /// `addSession`; widening rather than clearing keeps the rest filtered. `false` leaves the filter
+    /// untouched: a background `session.new --no-select` create must not widen the view. `collapsed: true`
+    /// (backing `workspace.new --collapsed`) starts it collapsed against the runtime default of expanded, so
+    /// it can be filled with `addSession(select: false)` unopened.
     @discardableResult
     public func addWorkspace(name: String, collapsed: Bool = false, revealNewWorkspace: Bool = true) -> Workspace {
         let workspace = Workspace(name: name, isExpanded: !collapsed)
@@ -275,9 +257,8 @@ public final class AppStore {
         return workspace
     }
 
-    /// The first workspace whose name exactly equals `name` (case-sensitive, trimmed), or nil when none
-    /// matches or `name` is blank. Backs `session.new --workspace-name` (addressing by sidebar label,
-    /// not id).
+    /// The first workspace whose name exactly equals `name` (case-sensitive, trimmed); nil when none matches
+    /// or `name` is blank. Backs `session.new --workspace-name` (addressing by sidebar label, not id).
     public func workspace(named name: String) -> Workspace? {
         guard let needle = name.trimmedOrNil else { return nil }
         return workspaces.first { $0.name == needle }
@@ -292,10 +273,10 @@ public final class AppStore {
     }
 
     /// Creates a session in the given workspace and selects it when `select` (the default); `select: false`
-    /// appends it in the background, leaving selection/focus/recency untouched (backs `session.new
-    /// --no-select`). `name` seeds `customName` (trimmed; blank = the auto basename, matching
-    /// `renameSession`). `at` nil appends, else inserts at the clamped index (`0...count`), backing
-    /// `session.new --after`/`--before`. Returns nil if no workspace matches.
+    /// appends it in the background, leaving selection/focus/recency untouched (`session.new --no-select`).
+    /// `name` seeds `customName` (trimmed; blank = the auto basename, matching `renameSession`). `at` nil
+    /// appends, else inserts at the clamped index (`0...count`), backing `--after`/`--before`. Nil if no
+    /// workspace matches.
     @discardableResult
     public func addSession(toWorkspace workspaceID: UUID, cwd: String, command: String? = nil,
                            name: String? = nil, wait: Bool = false, at index: Int? = nil, select: Bool = true) -> Session? {
@@ -319,13 +300,12 @@ public final class AppStore {
         return session
     }
 
-    /// Selects a session (or clears the selection when passed nil) and persists. A non-nil id matching no
-    /// session is ignored, leaving the current selection untouched; nil always deselects. Backs the
-    /// sidebar's `List(selection:)` so a click persists (debounced ~0.3 s) rather than waiting for the next
-    /// structural mutation, and clears the visited session's unseen badge. An `autoReset` indicator (the
-    /// one-time `completed` flash) resets to idle on BOTH the session moved to and the one moved from (it
-    /// must not persist once you leave it); a non-`autoReset` one (active/blocked) is left untouched
-    /// (keep-state). Returns the destination's pre-reset indicator so GUI callers can reveal its tagged pane.
+    /// Selects a session (nil clears) and persists. A non-nil id matching no session is ignored, leaving the
+    /// current selection; nil always deselects. Backs the sidebar's `List(selection:)`, so a click persists
+    /// (debounced) rather than waiting for the next structural mutation, and clears the visited session's
+    /// unseen badge. An `autoReset` indicator (the one-time `completed` flash) must not persist once you leave
+    /// it, so it resets to idle on BOTH the session moved to and the one moved from; a non-`autoReset` one
+    /// (active/blocked) is untouched. Returns the destination's pre-reset indicator to reveal its tagged pane.
     @discardableResult
     public func selectSession(_ sessionID: UUID?, sidebarSelection selectionIDs: [UUID]? = nil) -> AgentIndicator? {
         if let sessionID, session(withID: sessionID) == nil { return nil }
@@ -346,21 +326,18 @@ public final class AppStore {
         return destinationIndicator
     }
 
-    /// Reset a session's agent indicator to idle when it is marked `autoReset` (the one-time `completed`
-    /// flash). No-op for nil / an unknown id / a non-autoReset indicator.
+    /// Reset a session's indicator to idle when marked `autoReset`; no-op for nil, unknown, or non-autoReset.
     private func clearAutoResetIndicator(_ id: UUID?) {
         guard let id, let session = session(withID: id), session.agentIndicator.autoReset else { return }
         setAgentIndicator(AgentIndicator(), forSession: id)
     }
 
-    /// Clears a session's unseen-notification badge — it's been looked at. No-op for an unknown id.
-    /// Not persisted (the count is ephemeral), so it never triggers a `save()`.
+    /// Clears a session's unseen-notification badge; no-op for an unknown id, and never saves (ephemeral).
     public func clearUnseen(_ sessionID: UUID) {
         session(withID: sessionID)?.unseenCount = 0
     }
 
-    /// Pushes the current selection to the front of the recency stack (the Ctrl-Tab order); no-op when
-    /// nothing is selected.
+    /// Pushes the current selection to the front of the recency stack (the Ctrl-Tab order); no-op when none.
     func recordRecency() {
         if let selectedSessionID { sessionRecency.push(selectedSessionID) }
     }
@@ -399,16 +376,15 @@ public final class AppStore {
     /// Whether a workspace may be removed: one is always kept, so only when more than one exists.
     public var canRemoveWorkspace: Bool { workspaces.count > 1 }
 
-    /// Removes a workspace and every session in it, tearing down their surfaces and pruning them from the
-    /// recency stack. No-ops unless more than one workspace exists (the last is kept). If the active
-    /// session lived there, reselects through `workspaceRemovalTarget(at:)` — the most recent still VISIBLE
-    /// session, falling back to the positional walk only when nothing is visible, nil when none remain.
+    /// Removes a workspace and every session in it, tearing down their surfaces and pruning the recency
+    /// stack. No-ops unless more than one workspace exists (the last is kept). If the active session lived
+    /// there, `workspaceRemovalTarget(at:)` reselects the most recent still VISIBLE session, falling back to
+    /// the positional walk only when nothing is visible, nil when none remain.
     public func removeWorkspace(_ workspaceID: UUID) {
         guard canRemoveWorkspace, let index = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return }
         let workspace = workspaces[index]
         let removingActive = selectedSessionID.map { id in workspace.sessions.contains { $0.id == id } } ?? false
-        // the membership goes into the record BEFORE `dropFocusMember` below prunes it, so Reopen Closed
-        // Item can mark the workspace again
+        // record the membership BEFORE `dropFocusMember` below prunes it, so Reopen Closed Item can re-mark it
         recordRecentClosedWorkspace(workspace, selectedSessionID: removingActive ? selectedSessionID : nil,
                                     focusMember: focusedWorkspaceIDs.contains(workspaceID))
         for session in workspace.sessions { emitSessionClosed(session, workspace: workspace.id) }
@@ -434,14 +410,13 @@ public final class AppStore {
         save()
     }
 
-    /// Moves a session to another workspace (or reorders within one), keeping the **same** `Session`
-    /// instance so its attached surface and live shell survive. `index` is the destination position in the
-    /// target's array **after** the move's removal (clamped to bounds); nil appends. `selectedSessionID`
-    /// is unaffected — the id is stable, so a moved active session stays selected. No-ops on an unknown
-    /// session or target workspace; a same-workspace move to the current slot leaves order unchanged.
-    /// Moving the **active** session out of the marked set suspends the focus filter while KEEPING the set
-    /// (`disableFocusIfSelectionOutsideSet`, the auto-reveal contract: the active session must stay inside
-    /// the visible set); moving a non-active session leaves the filter intact.
+    /// Moves a session to another workspace (or reorders within one), keeping the **same** `Session` instance
+    /// so its attached surface and live shell survive. `index` is the destination position **after** the
+    /// move's removal (clamped); nil appends. `selectedSessionID` is unaffected — the id is stable. No-ops on
+    /// an unknown session or target workspace, and a same-workspace move to the current slot leaves order
+    /// unchanged. Moving the **active** session out of the marked set suspends the focus filter while KEEPING
+    /// the set (the auto-reveal contract: the active session must stay inside the visible set); a non-active
+    /// session leaves the filter intact.
     public func moveSession(_ sessionID: UUID, toWorkspace targetID: UUID, at index: Int? = nil) {
         guard let source = location(ofSession: sessionID) else { return }
         guard let targetIndex = workspaces.firstIndex(where: { $0.id == targetID }) else { return }
@@ -456,18 +431,16 @@ public final class AppStore {
         save()
     }
 
-    /// Moves selected sessions in their current tree order. With `index == nil`, a multi-session context
-    /// move appends cross-workspace sessions and leaves sessions already in the target in place; a
-    /// one-session call matches `moveSession` and appends even within that workspace. With an explicit
-    /// `index` (a drag drop), every dragged session is removed first, then the block inserted at that
-    /// post-removal index. Returns the number of sessions actually moved.
+    /// Moves selected sessions in their current tree order. With `index == nil`, a multi-session move appends
+    /// cross-workspace sessions and leaves those already in the target in place; a one-session call matches
+    /// `moveSession` and appends even within that workspace. With an explicit `index` (a drag drop), every
+    /// dragged session is removed first, then the block inserted at that post-removal index. Returns the count.
     @discardableResult
     public func moveSessions(_ sessionIDs: [UUID], toWorkspace targetID: UUID, at index: Int? = nil) -> Int {
         guard workspaces.contains(where: { $0.id == targetID }) else { return 0 }
         let before = workspaces.map { $0.sessions.map(\.id) }
         var movingIDs = orderedSessionIDs(matching: Set(sessionIDs))
-        // A one-element batch is wire-equivalent to `moveSession`: even within the destination
-        // workspace it moves to the end. Multi-selection context moves leave existing members in place.
+        // a one-element batch stays wire-equivalent to `moveSession`, so only multi-selection filters
         if index == nil, movingIDs.count > 1 {
             movingIDs = movingIDs.filter { workspace(forSession: $0)?.id != targetID }
         }
@@ -492,9 +465,8 @@ public final class AppStore {
         return moving.count
     }
 
-    /// Reorders a session one relative step within its own workspace (`up`/`down`/`top`/`bottom`), reusing
-    /// `moveSession` with the same workspace id. No-op (no write) on an unknown id or when the move would
-    /// leave order unchanged (already at the end in that direction).
+    /// Reorders a session one step within its own workspace (`up`/`down`/`top`/`bottom`) via `moveSession`.
+    /// No-op (no write) on an unknown id or when the move would leave order unchanged (already at that end).
     public func reorderSession(_ id: UUID, _ direction: ReorderDirection) {
         guard let loc = location(ofSession: id) else { return }
         let count = workspaces[loc.workspaceIndex].sessions.count
@@ -503,8 +475,7 @@ public final class AppStore {
     }
 
     /// Moves a workspace to `index` among its siblings, mirroring `moveSession`'s remove/clamp/insert/save
-    /// shape. `index` is the destination position **after** the move's removal (clamped). No-op on an
-    /// unknown id.
+    /// shape; `index` is the destination position **after** the move's removal (clamped). No-op on unknown.
     public func moveWorkspace(_ id: UUID, at index: Int) {
         guard let current = workspaces.firstIndex(where: { $0.id == id }) else { return }
         let before = workspaces.map(\.id)
@@ -515,31 +486,28 @@ public final class AppStore {
         save()
     }
 
-    /// Reorders a workspace one relative step among its siblings (`up`/`down`/`top`/`bottom`), reusing
-    /// `moveWorkspace`. No-op (no write) on an unknown id or when the move would leave order unchanged
-    /// (already at the end in that direction).
+    /// Reorders a workspace one step among its siblings (`up`/`down`/`top`/`bottom`) via `moveWorkspace`.
+    /// No-op (no write) on an unknown id or when the move would leave order unchanged (already at that end).
     public func reorderWorkspace(_ id: UUID, _ direction: ReorderDirection) {
         guard let current = workspaces.firstIndex(where: { $0.id == id }) else { return }
         guard let dest = direction.destinationIndex(from: current, count: workspaces.count) else { return }
         moveWorkspace(id, at: dest)
     }
 
-    /// The owning workspace id, the session's index within it, and that workspace's session count, or nil
-    /// for an unknown id — one tree walk for the sidebar drag handler instead of re-deriving each piece,
-    /// feeding the host-free `SidebarDrop` resolver.
+    /// The owning workspace id, the session's index in it, and that workspace's session count; nil for an
+    /// unknown id. One tree walk for the sidebar drag handler, feeding the host-free `SidebarDrop` resolver.
     public func sessionLocation(ofSession id: UUID) -> (workspace: UUID, index: Int, count: Int)? {
         guard let loc = location(ofSession: id) else { return nil }
         let workspace = workspaces[loc.workspaceIndex]
         return (workspace.id, loc.sessionIndex, workspace.sessions.count)
     }
 
-    /// Steps the selection through the flattened VISIBLE/FILTERED session list in the sidebar's visual
-    /// order (`navigableSessions`: the flagged set in `.flagged` mode, the MARKED workspaces' sessions
-    /// while the focus filter is applied, else all). `next`/`previous` move one and WRAP at the ends WITHIN
-    /// the filtered set, never leaking across the filter (matching the cyclic attention-nav below);
-    /// `first`/`last` jump to its ends; with no/invalid selection `next`/`previous` land on the first
-    /// session. No-op on an empty filtered list. Routes through `selectSession`, inheriting recency, badge
-    /// clearing, persistence and workspace derivation. Targets are always in-set, so nav never triggers
+    /// Steps the selection through the flattened VISIBLE/FILTERED session list in the sidebar's visual order
+    /// (`navigableSessions`: the flagged set in `.flagged` mode, the MARKED workspaces' sessions while the
+    /// focus filter is applied, else all). `next`/`previous` move one and WRAP WITHIN that set, never leaking
+    /// across the filter; `first`/`last` jump to its ends; with no/invalid selection `next`/`previous` land
+    /// on the first session. No-op on an empty list. Routes through `selectSession`, inheriting recency,
+    /// badge clearing, persistence and workspace derivation. Targets are always in-set, so nav never triggers
     /// `disableFocusIfSelectionOutsideSet` — that stays the safety net for an explicit cross-set select.
     @discardableResult
     public func navigateSession(_ direction: SessionNavigation) -> AgentIndicator? {
@@ -565,8 +533,8 @@ public final class AppStore {
     }
 
     /// The next/previous session needing attention (`blocked`/`completed`) in the flattened order, scanning
-    /// from the current selection and WRAPPING around; the current session is excluded, so repeated steps
-    /// cycle through the others. With no/invalid selection the scan starts from the tree end opposite the
+    /// from the current selection and WRAPPING; the current session is excluded, so repeated steps cycle
+    /// through the others. With no/invalid selection the scan starts from the tree end opposite the
     /// direction. Nil (a no-op) when no other attention session exists.
     private func attentionTarget(in sessions: [Session], forward: Bool) -> UUID? {
         let ids = sessions.map(\.id)
@@ -583,18 +551,16 @@ public final class AppStore {
         return nil
     }
 
-    /// Records a session's terminal font size (points) and persists it. No-ops when unchanged, so the
-    /// cell-size event firing on a DPI change (not a font change) doesn't write. The save is debounced
-    /// (~0.3 s) so a font ramp (held ⌘+/⌘−) coalesces into one write instead of one per step.
+    /// Records a session's terminal font size (points) and persists it, debounced so a held ⌘+/⌘− ramp
+    /// coalesces into one write. No-ops when unchanged, so a DPI-change cell-size event doesn't write.
     public func setFontSize(_ sessionID: UUID, _ size: Double) {
         guard let session = session(withID: sessionID), session.fontSize != size else { return }
         session.fontSize = size
         scheduleSave()
     }
 
-    /// Clears every session's per-session font-size override (back to the app default). Called when an
-    /// appearance change is applied: the shared ghostty `update_config` resets all live surfaces to the
-    /// default size, so the persisted overrides are cleared to match. No-ops (no write) when none was set.
+    /// Clears every per-session font-size override (no write when none was set). Called on an appearance
+    /// change: the shared ghostty `update_config` resets live surfaces to the default, so the pins must match.
     public func resetSessionFontSizes() {
         var changed = false
         for workspace in workspaces {
@@ -606,15 +572,14 @@ public final class AppStore {
         if changed { save() }
     }
 
-    /// Sets this window's sidebar visibility and persists it. Clean no-op (no write) when unchanged, so
-    /// menu, toolbar, palette and control callers can delta-compute their desired state without duplicating
-    /// the persistence gate. `sidebarVisible` is per-window state saved in this store's snapshot.
+    /// Sets this window's sidebar visibility and persists it. Clean no-op (no write) when unchanged, so menu,
+    /// toolbar, palette and control callers need not duplicate the persistence gate.
     public func setSidebarVisible(_ visible: Bool) {
         guard sidebarVisible != visible else { return }
         sidebarVisible = visible
         save()
-        // refresh the app-target ControlServer's window.list cache: a GUI-only toggle isn't a control
-        // command, so without this the cached sidebarVisible would lag until the next command.
+        // refresh ControlServer's window.list cache: a GUI-only toggle is no control command, so the cached
+        // sidebarVisible would lag until the next one.
         NotificationCenter.default.post(name: .agtermSidebarVisibilityChanged, object: nil)
     }
 
@@ -623,9 +588,8 @@ public final class AppStore {
         setSidebarVisible(!sidebarVisible)
     }
 
-    /// Sets the sidebar mode and persists it. Clean no-op (no write) when the mode is unchanged, so the
-    /// delta-computed control/menu callers stay idempotent. BOTH flips reselect when they would hide the
-    /// active session (`reselectIfSelectionHidden`).
+    /// Sets the sidebar mode and persists it; clean no-op when unchanged, so delta-computed control/menu
+    /// callers stay idempotent. BOTH flips reselect when they would hide the active session.
     public func setSidebarMode(_ mode: SidebarMode) {
         guard sidebarMode != mode else { return }
         sidebarMode = mode
@@ -634,21 +598,19 @@ public final class AppStore {
         save()
     }
 
-    /// Sets one workspace's expand/collapse state and persists it. Clean no-op (no write) for an unknown id
-    /// or when unchanged. The sidebar calls this for a GENUINE per-row user toggle only (a row click or the
-    /// disclosure triangle), never for a programmatic reveal — so a deliberate collapse survives a later
-    /// reveal of a session inside it, and toggling one workspace never touches another's saved state
-    /// (unlike `setWorkspacesExpanded`, which rewrites the whole tree).
+    /// Sets one workspace's expand/collapse state and persists it; clean no-op for an unknown id or when
+    /// unchanged. The sidebar calls this for a GENUINE per-row user toggle only (a row click or the
+    /// disclosure triangle), never a programmatic reveal, so a deliberate collapse survives a later reveal of
+    /// a session inside it and never touches another workspace's state (unlike `setWorkspacesExpanded`).
     public func setWorkspaceExpanded(_ id: UUID, expanded: Bool) {
         guard let index = workspaces.firstIndex(where: { $0.id == id }), workspaces[index].isExpanded != expanded else { return }
         workspaces[index].isExpanded = expanded
         save()
     }
 
-    /// Marks each workspace expanded iff its id is in `expandedIDs` and persists the collapse state. One
-    /// `save()` for the whole diff; a clean no-op (no write) when nothing changed. Backs the deliberate
-    /// all-workspace commands (Expand / Collapse Workspaces), which set every workspace at once; per-row
-    /// toggles use `setWorkspaceExpanded` instead.
+    /// Marks each workspace expanded iff its id is in `expandedIDs`, one `save()` for the whole diff and no
+    /// write when nothing changed. Backs Expand / Collapse Workspaces, which set every workspace at once;
+    /// per-row toggles use `setWorkspaceExpanded` instead.
     public func setWorkspacesExpanded(_ expandedIDs: Set<UUID>) {
         var changed = false
         for index in workspaces.indices {
@@ -662,10 +624,9 @@ public final class AppStore {
     }
 
     /// Sets (or clears) a session's flag — the durable flagged working-set membership the flat sidebar view
-    /// projects — and persists. Clean no-op (no write) for an unknown id or an already-matching flag, so
-    /// delta-computed control/menu callers stay idempotent. Unflagging narrows in `.flagged` mode (it drops
-    /// the row rendering the active session), so it runs `reselectIfSelectionHidden`; the flag change
-    /// cannot trigger that in tree mode, though it still repairs a selection stranded there by something else.
+    /// projects — and persists. Clean no-op for an unknown id or a matching flag, so delta-computed callers
+    /// stay idempotent. Unflagging narrows in `.flagged` mode (dropping the row rendering the active session),
+    /// hence `reselectIfSelectionHidden`; in tree mode it only repairs a selection stranded by something else.
     public func setFlag(_ on: Bool, forSession id: UUID) {
         guard let session = session(withID: id), session.flagged != on else { return }
         session.flagged = on
@@ -692,20 +653,18 @@ public final class AppStore {
         }
     }
 
-    /// Sets (or clears) a session's background watermark and persists it. Clean no-op (no write) for an
-    /// unknown id or an unchanged spec, so a repeated `session.background` set is idempotent. Returns
-    /// whether the spec actually CHANGED, so the app target can gate the (retained, teardown-only-freed)
-    /// per-surface config apply on a real change — without it a scripted set-loop keeps appending owned
-    /// configs. The app target applies it to the session's surface(s) after this returns: the host-free
-    /// store owns only the spec, the C-boundary apply lives in `ControlServer`/`GhosttySurfaceView`.
+    /// Sets (or clears) a session's background watermark and persists it; clean no-op for an unknown id or an
+    /// unchanged spec, so a repeated `session.background` is idempotent. Returns whether the spec CHANGED, so
+    /// the app target can gate its (retained, teardown-only-freed) per-surface config apply on a real change
+    /// — without that a scripted set-loop keeps appending owned configs. The store owns only the spec; the
+    /// C-boundary apply lives app-side in `ControlServer`/`GhosttySurfaceView`.
     @discardableResult
     public func setBackgroundWatermark(_ watermark: BackgroundWatermark?, forSession id: UUID) -> Bool {
         guard let session = session(withID: id), session.backgroundWatermark != watermark else { return false }
         let previous = session.backgroundWatermark
         session.backgroundWatermark = watermark
-        // a `.text` watermark owns a rendered `<id>.png`; switching to anything else (an image, or nil)
-        // leaves it id-keyed but unreferenced, so drop it here. `clear`/teardown sweep the same file, so
-        // this is just the eager reclaim for the text→image/nil transition.
+        // a `.text` watermark owns a rendered `<id>.png`; switching away leaves it unreferenced. `clear` and
+        // teardown sweep the same file, so this is only the eager reclaim for text→image/nil.
         if previous?.kind == .text, watermark?.kind != .text {
             WatermarkStorage.removeRenderedText(sessionID: id)
         }
@@ -713,10 +672,9 @@ public final class AppStore {
         return true
     }
 
-    /// Unflags every session across all workspaces in one `save()`. No-ops (no write) when nothing is
-    /// flagged. Backs the Clear Flagged action and the `session.flag clear` control mode. No
-    /// `reselectIfSelectionHidden`, unlike the two `setFlag` mutators: clearing EVERY flag leaves the list
-    /// empty, so there is nowhere to move. A partial clear would need it.
+    /// Unflags every session in one `save()`; no write when nothing is flagged. Backs Clear Flagged and the
+    /// `session.flag clear` control mode. No `reselectIfSelectionHidden`, unlike the `setFlag` mutators:
+    /// clearing EVERY flag leaves the list empty, so there is nowhere to move — a partial clear would need it.
     public func clearFlags() {
         var changed = false
         for workspace in workspaces {
@@ -731,28 +689,24 @@ public final class AppStore {
         }
     }
 
-    /// The flagged sessions across all workspaces in tree order — a pure derived projection the flat
-    /// sidebar view renders directly.
+    /// The flagged sessions across all workspaces in tree order — the projection the flat sidebar renders.
     public var flaggedSessions: [Session] {
         workspaces.flatMap(\.sessions).filter(\.flagged)
     }
 
     // MARK: - Persistence
 
-    /// Builds a `Snapshot` value of the current tree; each session captures its live `currentCwd` (or
-    /// `initialCwd` if no PWD report has arrived). Runs on `@MainActor`; the result is `Sendable` and
-    /// safe to hand to a writer.
+    /// Builds a `Snapshot` of the current tree; each session captures its live `currentCwd` (or `initialCwd`
+    /// if no PWD report arrived). Runs on `@MainActor`; the result is `Sendable`, safe to hand to a writer.
     public func snapshot() -> Snapshot {
         let workspaceSnapshots = workspaces.map { workspace in
             let sessions = workspace.sessions.map(sessionSnapshot)
-            // only a collapsed workspace writes the flag; an expanded one omits it (nil) so an all-expanded
-            // tree serializes identically to a legacy snapshot.
+            // only a collapsed workspace writes the flag, so an all-expanded tree matches a legacy snapshot.
             return WorkspaceSnapshot(id: workspace.id, name: workspace.name, sessions: sessions,
                                      collapsed: workspace.isExpanded ? nil : true)
         }
-        // the marked set in TREE order, so the on-disk list is deterministic rather than the Set's hash
-        // order; an unmarked store omits both focus keys, keeping its file identical to one written before
-        // the set existed. The legacy `focusedWorkspaceID` is never populated.
+        // TREE order keeps the on-disk list deterministic (not the Set's hash order); an unmarked store omits
+        // both focus keys, matching a file written before the set existed. `focusedWorkspaceID` stays unused.
         let focusIDs = workspaces.map(\.id).filter(focusedWorkspaceIDs.contains)
         return Snapshot(selectedSessionID: selectedSessionID, workspaces: workspaceSnapshots,
                         sidebarWidth: sidebarWidth, sidebarVisible: sidebarVisible, sidebarMode: sidebarMode,
@@ -762,22 +716,16 @@ public final class AppStore {
     }
 
     /// Rebuilds the tree from a snapshot: fresh `Session`s (surfaces and shells spawn lazily on first
-    /// display) keyed by the persisted ids so the restored `selectedSessionID` still resolves, replacing
-    /// the current state wholesale. A persisted `selectedSessionID` pointing at a session that no longer
-    /// exists is cleared, keeping the selection valid.
-    ///
-    /// Deliberately does NOT call `save()` — it loads what was just read from disk. The closing
-    /// `reselectIfSelectionHidden` is the exception: when it repairs a stranded selection, `selectSession`
-    /// schedules a save, and that one is worth writing.
-    ///
-    /// `launchRestore` marks an APP-BOOTSTRAP restore and threads down to `session(from:launchRestore:)`,
-    /// the only thing that arms a persisted `session.restore` override for this launch. It defaults to
-    /// false because reopening a closed window mid-process reloads its store through here, and that
-    /// RUNTIME caller must not execute anything.
+    /// display) keyed by the persisted ids so the restored `selectedSessionID` still resolves, replacing the
+    /// current state wholesale. A persisted selection pointing at a session that no longer exists is cleared.
+    /// Deliberately does NOT call `save()` — it loads what was just read from disk; the closing
+    /// `reselectIfSelectionHidden` is the exception, since repairing a stranded selection is worth writing.
+    /// `launchRestore` marks an APP-BOOTSTRAP restore, the only thing that arms a persisted `session.restore`
+    /// override for this launch. It defaults to false because reopening a closed window mid-process reloads
+    /// its store through here, and that RUNTIME caller must not execute anything.
     public func restore(from snapshot: Snapshot, launchRestore: Bool = false) {
-        // fold workspaces sharing an id into the first occurrence, and keep only the first snapshot of any
-        // repeated session id, wherever it sits: a file written by a build that could duplicate either
-        // stays unreachable past the first match otherwise, and re-saves the corruption.
+        // fold duplicate workspace ids into the first occurrence and keep only the first snapshot of a
+        // repeated session id, else the rest stay unreachable past the first match and get re-saved.
         var seenSessionIDs: Set<UUID> = []
         workspaces = snapshot.workspaces.reduce(into: [Workspace]()) { restored, workspaceSnapshot in
             let sessions = workspaceSnapshot.sessions
@@ -803,9 +751,8 @@ public final class AppStore {
             selectedSessionID = snapshot.selectedSessionID
         }
         replaceSidebarSelection(with: selectedSessionID)
-        // re-seed the Ctrl-Tab order from the persisted list (dropping ids not in the restored tree) so the
-        // switcher works right after relaunch; the restored selection floats to the front, keeping the
-        // "previous session" slot truthful.
+        // re-seed the Ctrl-Tab order from the persisted list (dropping ids not in the restored tree); the
+        // restored selection floats to the front, keeping the "previous session" slot truthful.
         let restoredIDs = Set(workspaces.flatMap(\.sessions).map(\.id))
         sessionRecency = RecencyStack(items: (snapshot.sessionRecency ?? []).filter { restoredIDs.contains($0) })
         recordRecency()
@@ -813,18 +760,16 @@ public final class AppStore {
         reselectIfSelectionHidden()
     }
 
-    /// Persists the current state eagerly; called after every structural mutation and on terminate.
-    /// Cancels any pending debounced save first, so a `save()` (incl. the quit-flush) always writes the
-    /// latest snapshot and a stale scheduled write can't fire afterward. A write failure is logged and
-    /// swallowed — a transient disk error must not bring down the model.
+    /// Persists the current state eagerly, after every structural mutation and on terminate. Cancels any
+    /// pending debounced save first, so a `save()` (incl. the quit-flush) writes the latest snapshot and no
+    /// stale write fires afterward. A failure is logged and swallowed — a disk error must not kill the model.
     public func save() {
         saveChecked()
     }
 
-    /// `save()` that REPORTS whether the write landed instead of swallowing the failure, for a caller whose
-    /// acknowledgement must not outrun the disk. `setRestoreCommand` is the one today: its payload is an
-    /// arbitrary shell line re-typed on every launch, so a "cleared" ack that never reached disk would
-    /// leave the old command armed forever. `save()` is this with the result discarded, so the two can't drift.
+    /// `save()` that REPORTS whether the write landed, for a caller whose acknowledgement must not outrun the
+    /// disk. `setRestoreCommand` is the one today: a "cleared" ack that never reached disk would leave the
+    /// old shell line armed on every launch. `save()` is this with the result discarded, so they can't drift.
     @discardableResult
     func saveChecked() -> Bool {
         saveDebouncer.cancel()
@@ -837,19 +782,17 @@ public final class AppStore {
         }
     }
 
-    /// Debounces a `save()` ~0.3 s out, coalescing the rapid selection/font writes; used only by
-    /// `selectSession`/`setFontSize`, while structural mutations call `save()` immediately. A `save()` (or
-    /// the quit-flush) cancels the pending schedule, so the latest state is always captured.
+    /// Debounces a `save()`, coalescing the rapid selection/font writes; used only by
+    /// `selectSession`/`setFontSize`, while structural mutations call `save()` immediately.
     private func scheduleSave() {
         saveDebouncer.schedule(after: AppStore.saveDebounceInterval) { [weak self] in
             self?.save()
         }
     }
 
-    /// Drops any pending debounced save WITHOUT writing — unlike `save()`, which cancels then writes. Used
-    /// when the owning window is being deleted (`WindowLibrary.removeWindow`): the per-window file is about
-    /// to go, so a save scheduled by a just-before-delete selectSession/setFontSize must be dropped rather
-    /// than flushed, else it fires after the delete and re-creates the file as an orphan.
+    /// Drops any pending debounced save WITHOUT writing, unlike `save()`, which cancels then writes. Used when
+    /// the owning window is being deleted (`WindowLibrary.removeWindow`): a save scheduled just before the
+    /// delete must be dropped, else it fires afterward and re-creates the per-window file as an orphan.
     public func cancelPendingSave() {
         saveDebouncer.cancel()
     }
@@ -885,9 +828,8 @@ public final class AppStore {
         workspaces.flatMap(\.sessions).map(\.id).filter { ids.contains($0) }
     }
 
-    /// Picks the next selection after removing the session at `location`, preferring the session that
-    /// shifted into the removed slot, then the previous one in that workspace, then the first session of
-    /// any remaining workspace.
+    /// Picks the next selection after removing the session at `location`: the session that shifted into the
+    /// removed slot, else the previous one in that workspace, else the first session of any remaining one.
     func reselectionTarget(after location: (workspaceIndex: Int, sessionIndex: Int)) -> UUID? {
         let sessions = workspaces[location.workspaceIndex].sessions
         if location.sessionIndex < sessions.count { return sessions[location.sessionIndex].id }
@@ -918,16 +860,15 @@ public final class AppStore {
                           collapsed: workspace.isExpanded ? nil : true)
     }
 
-    /// Rebuilds one session from its snapshot. `launchRestore` marks an APP-BOOTSTRAP restore, the only
-    /// path allowed to arm a persisted `restoreCommand` for this launch by copying it into the transient
-    /// `pendingRestoreCommand` the surface factory consumes; it defaults to false so any other rebuild (a
-    /// mid-process window reload, Reopen Closed Item) comes back with nothing armed.
+    /// Rebuilds one session from its snapshot. `launchRestore` marks an APP-BOOTSTRAP restore, the only path
+    /// allowed to arm a persisted `restoreCommand` by copying it into the transient `pendingRestoreCommand`
+    /// the surface factory consumes; it defaults to false so any other rebuild (a mid-process window reload,
+    /// Reopen Closed Item) comes back with nothing armed.
     ///
-    /// A split hidden at the last quit is NOT rebuilt (`hasSplit` follows `isSplit`), so its pinned
-    /// override describes a pane that no longer exists and is DROPPED here — the rule `closeSplit` applies
-    /// when a pane goes away. Keeping it would leave a value `tree` reports but no write can clear
-    /// (`session.restore --pane right` is rejected without a split), and a fresh ⌘D split shown at the
-    /// next quit would inherit and run it.
+    /// A split hidden at the last quit is NOT rebuilt (`hasSplit` follows `isSplit`), so its pinned override
+    /// describes a pane that no longer exists and is DROPPED here, the rule `closeSplit` applies when a pane
+    /// goes away. Keeping it would leave a value `tree` reports but no write can clear (`session.restore
+    /// --pane right` is rejected without a split), and a fresh ⌘D split at the next quit would inherit it.
     func session(from snapshot: SessionSnapshot, launchRestore: Bool = false) -> Session {
         let session = Session(id: snapshot.id, initialCwd: snapshot.cwd, customName: snapshot.customName)
         session.isSplit = snapshot.isSplit ?? false

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -1,10 +1,9 @@
 import Foundation
 import Observation
 
-/// A relative step through the flattened session list for keyboard navigation.
-/// `next`/`previous` step one and wrap around at the ends, `first`/`last` jump to a tree end.
-/// `nextAttention`/`previousAttention` step through only the sessions needing attention
-/// (status `blocked` or `completed`), wrapping around.
+/// A relative step through the flattened session list for keyboard navigation. `next`/`previous` step one
+/// and wrap at the ends, `first`/`last` jump to a tree end, `nextAttention`/`previousAttention` step
+/// (wrapping) through only the sessions needing attention — status `blocked` or `completed`.
 public enum SessionNavigation: Sendable { case next, previous, first, last, nextAttention, previousAttention }
 
 extension SessionNavigation {
@@ -25,10 +24,9 @@ extension SessionNavigation {
 
 /// The whole app state: the workspace tree and the current selection.
 ///
-/// `@Observable @MainActor` so SwiftUI views observe mutations and all model
-/// access is main-actor isolated (implicitly `Sendable` via isolation). Selection
-/// is a single `Session.ID?` — workspace rows are non-selectable disclosure
-/// headers, so one id is enough; the owning workspace is derived.
+/// `@Observable @MainActor` so views observe mutations and all model access is main-actor isolated
+/// (implicitly `Sendable` via isolation). Selection is one `Session.ID?` — workspace rows are
+/// non-selectable disclosure headers, so the owning workspace is derived.
 @Observable
 @MainActor
 public final class AppStore {
@@ -39,41 +37,38 @@ public final class AppStore {
     /// `selectedSessionID` remains the durable active terminal target.
     var sidebarSelectionRaw: [UUID] = []
 
-    /// Whether this window's sidebar is shown. Per-window UI state, persisted in `Snapshot` (restored on
-    /// relaunch); the custom split owns visibility, so the toolbar button, the View menu item, the action
-    /// palette, and the `sidebar` control command all flip this one flag.
+    /// Whether this window's sidebar is shown. Per-window state persisted in `Snapshot`; the custom split
+    /// owns visibility, so the toolbar button, the View menu item, the action palette, and the `sidebar`
+    /// control command all flip this one flag.
     public var sidebarVisible = true
 
-    /// Which view this window's sidebar renders: the normal workspace tree or a flat list of the
-    /// flagged working-set. Per-window UI state, persisted in `Snapshot` (restored on relaunch);
-    /// flipped by the bottom-bar toggle, the View menu, the action palette, and the `sidebar.mode`
-    /// control command via `setSidebarMode(_:)`.
+    /// Which view this window's sidebar renders: the workspace tree or a flat list of the flagged
+    /// working-set. Per-window state persisted in `Snapshot`; flipped via `setSidebarMode(_:)` by the
+    /// bottom-bar toggle, the View menu, the action palette, and the `sidebar.mode` control command.
     public var sidebarMode: SidebarMode = .tree
 
     /// The workspaces marked for the sidebar focus filter — the working set the tree renders when
-    /// `focusEnabled` is on (see `visibleWorkspaces`). Per-window UI state, persisted in `Snapshot`
-    /// (restored on relaunch); orthogonal to `sidebarMode` (flagged mode ignores focus). Mutated by the
-    /// workspace row menu, the View menu, the palette, and the `workspace.focus` control command via
-    /// `setFocusedWorkspace(_:)` / `setFocusMembership(_:member:)`. A member is pruned when its
-    /// workspace is removed. Read-only outside the module (`internal(set)`) so the invariant below can
-    /// only be broken from inside `agtermCore`, never by an app-target line writing the field directly.
+    /// `focusEnabled` is on (see `visibleWorkspaces`). Per-window state persisted in `Snapshot`; orthogonal
+    /// to `sidebarMode` (flagged mode ignores focus). Mutated by the workspace row menu, the View menu, the
+    /// palette and `workspace.focus` via `setFocusedWorkspace(_:)`/`setFocusMembership(_:member:)`; a
+    /// member is pruned when its workspace is removed. `internal(set)`, so only code inside `agtermCore`
+    /// can break the invariant below, never an app-target line writing the field directly.
     public internal(set) var focusedWorkspaceIDs: Set<UUID> = []
 
     /// Whether the focus filter applies, so a hand-curated set survives being switched off. Per-window
-    /// UI state, persisted in `Snapshot` (restored on relaunch), and `internal(set)` for the same reason
-    /// as the set above. Enabled with an EMPTY set is unrepresentable, which is what makes the FILTER-ON
-    /// half of the control row-visibility read-back (`ControlWorkspaceNode.focused`) exact: an applied
-    /// filter always has at least one visible member. (The filter-OFF half is `visibleWorkspaces`
-    /// returning the whole tree, which this invariant says nothing about.) Three guards hold it:
-    /// `setFocusEnabled(true)` is a no-op on an empty set (matching the bottom-bar toggle, disabled in
-    /// exactly that state), every mutator disables as the set empties (`setFocusMembership`,
-    /// `dropFocusMember`), and `restoreFocus(from:)` prunes ids absent from the restored tree, disabling
-    /// when the prune empties the set. Driven by the bottom-bar `focus-filter-toggle`, View ▸ Toggle
-    /// Workspace Filter, `BuiltinAction.toggleWorkspaceFilter`, and `workspace.filter`.
+    /// state persisted in `Snapshot`, `internal(set)` like the set above. Enabled with an EMPTY set is
+    /// unrepresentable, which makes the FILTER-ON half of the control row-visibility read-back
+    /// (`ControlWorkspaceNode.focused`) exact: an applied filter always has at least one visible member.
+    /// (The filter-OFF half — `visibleWorkspaces` returning the whole tree — is outside this invariant.)
+    /// Three guards hold it: `setFocusEnabled(true)` no-ops on an empty set (matching the bottom-bar
+    /// toggle, disabled in exactly that state), `setFocusMembership`/`dropFocusMember` disable as the set
+    /// empties, and `restoreFocus(from:)` prunes ids absent from the restored tree, disabling when that
+    /// empties it. Driven by the bottom-bar `focus-filter-toggle`, View ▸ Toggle Workspace Filter,
+    /// `BuiltinAction.toggleWorkspaceFilter`, and `workspace.filter`.
     public internal(set) var focusEnabled = false
 
-    /// This window's sidebar width in points. Per-window UI state, persisted in `Snapshot`. Driven by the
-    /// sidebar divider drag (clamped to `sidebarWidthMin...sidebarWidthMax`); restored on relaunch.
+    /// This window's sidebar width in points, persisted in `Snapshot`. Driven by the sidebar divider drag,
+    /// clamped to `sidebarWidthMin...sidebarWidthMax`.
     public var sidebarWidth: Double = AppStore.sidebarWidthDefault
 
     /// The sidebar width default and drag/restore bounds, shared by the view's divider drag and the
@@ -95,10 +90,9 @@ public final class AppStore {
         min(splitRatioMax, max(splitRatioMin, ratio))
     }
 
-    /// Most-recently-selected session ids, front = current. Drives the Ctrl-Tab switcher
-    /// (`items[1]` is the previous session). `@ObservationIgnored`: read imperatively by the
-    /// switcher, not by any SwiftUI view. Persisted in the snapshot so the switcher's order
-    /// survives a relaunch.
+    /// Most-recently-selected session ids, front = current; drives the Ctrl-Tab switcher (`items[1]` is
+    /// the previous session). `@ObservationIgnored`: read imperatively by the switcher, not by any view.
+    /// Persisted in the snapshot so the switcher's order survives a relaunch.
     @ObservationIgnored public private(set) var sessionRecency = RecencyStack<UUID>()
 
     /// The latest session/workspace close that can still be undone. The hidden sessions/workspaces live
@@ -130,10 +124,10 @@ public final class AppStore {
     /// auto-follow away from a running session" toggle). Default false. `@ObservationIgnored`.
     @ObservationIgnored var autoFollowStayOnActive = false
 
-    /// The last time the user interacted with this window (a keystroke or a manual selection), stamped
-    /// unconditionally by `noteUserActivity` so the idle metric is independent of the feature being on.
-    /// nil until the first interaction. `@ObservationIgnored`: read imperatively (`idleMs`, the control
-    /// tree) and stamped at high frequency, so no view should react to it.
+    /// The last time the user interacted with this window (a keystroke or a manual selection), nil until
+    /// the first interaction. Stamped unconditionally by `noteUserActivity` so the idle metric is
+    /// independent of the feature being on. `@ObservationIgnored`: read imperatively (`idleMs`, the
+    /// control tree) and stamped at high frequency, so no view should react to it.
     @ObservationIgnored var lastActivityAt: Date?
 
     /// Coalesces user activity into a single deferred `autoFollowFire`: each `noteUserActivity` reschedules,
@@ -141,21 +135,20 @@ public final class AppStore {
     /// so `@testable` tests can drive its `flush()` seam.
     @ObservationIgnored let autoFollowDebouncer = Debouncer()
 
-    /// Coalesces the deferred re-arms the auto-follow status observer schedules into one per runloop turn,
-    /// mirroring `DockBadgeController.scheduleRefresh`: a single agent-status flip can fire several live
-    /// observation trackers at once, so this collapses them to one re-arm (and one re-registration).
-    /// `internal` only so the `AppStore+AutoFollow` extension (a separate file) can reach it.
+    /// Coalesces the auto-follow status observer's deferred re-arms into one re-arm (and one
+    /// re-registration) per runloop turn, mirroring `DockBadgeController.scheduleRefresh`: one
+    /// agent-status flip can fire several live observation trackers at once. `internal` only so the
+    /// `AppStore+AutoFollow` extension (a separate file) can reach it.
     @ObservationIgnored var autoFollowRearmScheduled = false
 
     /// Non-zero while a non-terminal editor or transient overlay in this window owns first responder — the
-    /// sidebar inline-rename field or an open command palette. `autoFollowFire` no-ops while this is
-    /// positive, so an armed idle jump can't yank the selection out from under an in-progress rename or
-    /// reshuffle a palette's action target. A COUNT (not a bool) so the several independent suppressors can
-    /// overlap safely: each brackets itself with `suppressAutoFollow`/`resumeAutoFollow`, and a suppressor
-    /// lifting while another still holds keeps the jump suppressed. The app owns the first-responder
-    /// knowledge; the store just gates on the count. `internal` so the `AppStore+AutoFollow` extension can
-    /// read it; mutated only through the two public methods so the app target (a separate module) can't
-    /// desync it. `@ObservationIgnored`: read imperatively at fire time, no view reacts.
+    /// sidebar inline-rename field or an open command palette. `autoFollowFire` no-ops while positive, so
+    /// an armed idle jump can't yank the selection out of an in-progress rename or reshuffle a palette's
+    /// action target. A COUNT, not a bool, so independent suppressors overlap safely: each brackets itself
+    /// with `suppressAutoFollow`/`resumeAutoFollow`, and one lifting while another still holds keeps the
+    /// jump suppressed. The app owns the first-responder knowledge, the store only the count. `internal`
+    /// for the `AppStore+AutoFollow` extension, mutated only through the two public methods so the app
+    /// target (a separate module) can't desync it. `@ObservationIgnored`: read imperatively at fire time.
     @ObservationIgnored var autoFollowSuppressionCount = 0
 
     public init(workspaces: [Workspace] = [], selectedSessionID: UUID? = nil,
@@ -177,9 +170,9 @@ public final class AppStore {
         return session(withID: selectedSessionID)
     }
 
-    /// The workspace a new session should land in: the selected session's workspace, else the
-    /// last workspace (nil when there are no workspaces). Drives both the bottom bar's add
-    /// actions and the File menu's New Session / Open Directory.
+    /// The workspace a new session should land in: the selected session's workspace, else the last
+    /// workspace (nil when there are none). Drives the bottom bar's add actions and the File menu's
+    /// New Session / Open Directory.
     public var currentWorkspaceID: UUID? {
         if let selectedSessionID, let workspace = workspace(forSession: selectedSessionID) {
             return workspace.id
@@ -264,16 +257,14 @@ public final class AppStore {
                            pickPending: pickPending())
     }
 
-    /// Creates a workspace and appends it. When `revealNewWorkspace` (the default) and the focus filter is
-    /// ON, the new workspace JOINS the marked set so it is immediately visible — else `visibleWorkspaces`
-    /// would render only the existing members and silently hide it (the auto-reveal contract, like
-    /// `addSession`). Widening the set rather than clearing it keeps the rest of the working set filtered;
-    /// the user asked for this workspace, so mutating the set here is intentional.
-    /// Pass `revealNewWorkspace: false` to leave the filter untouched — a background
-    /// `session.new --no-select` create, which must not widen the view.
-    /// Pass `collapsed: true` to create it already collapsed in the sidebar (backs `workspace.new --collapsed`):
-    /// a runtime add defaults `isExpanded == true` and renders open, so a collapsed workspace can be built
-    /// and filled with `addSession(select: false)` without opening.
+    /// Creates a workspace and appends it. With `revealNewWorkspace` (the default) and the focus filter ON,
+    /// the new workspace JOINS the marked set so it is immediately visible — else `visibleWorkspaces` would
+    /// render only the existing members and silently hide it (the auto-reveal contract, like `addSession`).
+    /// Widening rather than clearing keeps the rest of the working set filtered; the user asked for this
+    /// workspace, so mutating the set is intentional. `revealNewWorkspace: false` leaves the filter
+    /// untouched — a background `session.new --no-select` create must not widen the view. `collapsed: true`
+    /// creates it already collapsed (backs `workspace.new --collapsed`; a runtime add otherwise defaults to
+    /// `isExpanded == true` and renders open), so it can be filled with `addSession(select: false)` unopened.
     @discardableResult
     public func addWorkspace(name: String, collapsed: Bool = false, revealNewWorkspace: Bool = true) -> Workspace {
         let workspace = Workspace(name: name, isExpanded: !collapsed)
@@ -285,8 +276,8 @@ public final class AppStore {
     }
 
     /// The first workspace whose name exactly equals `name` (case-sensitive, trimmed), or nil when none
-    /// matches or `name` is blank. Backs `session.new --workspace-name` (addressing a workspace by its
-    /// sidebar label instead of an id).
+    /// matches or `name` is blank. Backs `session.new --workspace-name` (addressing by sidebar label,
+    /// not id).
     public func workspace(named name: String) -> Workspace? {
         guard let needle = name.trimmedOrNil else { return nil }
         return workspaces.first { $0.name == needle }
@@ -300,11 +291,11 @@ public final class AppStore {
         return workspace(named: needle) ?? addWorkspace(name: needle, revealNewWorkspace: revealNewWorkspace)
     }
 
-    /// Creates a session in the given workspace and, when `select` is true (the default), selects it;
-    /// `select: false` appends it in the background, leaving selection/focus/recency untouched (backs
-    /// `session.new --no-select`). An optional `name` seeds `customName` (trimmed; blank = the auto
-    /// basename, matching `renameSession`). `at` nil appends (default); `at` set inserts at the clamped
-    /// index (`0...count`), backing `session.new --after`/`--before`. Returns nil if no workspace matches.
+    /// Creates a session in the given workspace and selects it when `select` (the default); `select: false`
+    /// appends it in the background, leaving selection/focus/recency untouched (backs `session.new
+    /// --no-select`). `name` seeds `customName` (trimmed; blank = the auto basename, matching
+    /// `renameSession`). `at` nil appends, else inserts at the clamped index (`0...count`), backing
+    /// `session.new --after`/`--before`. Returns nil if no workspace matches.
     @discardableResult
     public func addSession(toWorkspace workspaceID: UUID, cwd: String, command: String? = nil,
                            name: String? = nil, wait: Bool = false, at index: Int? = nil, select: Bool = true) -> Session? {
@@ -318,7 +309,6 @@ public final class AppStore {
         } else {
             workspaces[wsIndex].sessions.append(session)
         }
-        // a background add (`session.new --no-select`) leaves selection/focus/recency untouched.
         if select {
             selectedSessionID = session.id
             disableFocusIfSelectionOutsideSet(session.id) // a control-driven add into another workspace must reveal it
@@ -329,15 +319,13 @@ public final class AppStore {
         return session
     }
 
-    /// Selects a session (or clears the selection when passed nil) and persists.
-    /// A non-nil id that matches no session is ignored, leaving the current
-    /// selection untouched; nil always deselects. Backs the sidebar's
-    /// `List(selection:)` so a click persists (debounced ~0.3 s) rather than waiting
-    /// for the next structural mutation. Visiting a session clears its unseen badge. An
-    /// `autoReset` agent indicator (the one-time `completed` flash) is reset to idle on
-    /// BOTH the session moved to (you've seen it) and the one moved from (it must not
-    /// persist once you leave it); a non-`autoReset` indicator (active/blocked) is left
-    /// untouched (keep-state). Returns the destination's pre-reset indicator so GUI callers can reveal its tagged pane consistently.
+    /// Selects a session (or clears the selection when passed nil) and persists. A non-nil id matching no
+    /// session is ignored, leaving the current selection untouched; nil always deselects. Backs the
+    /// sidebar's `List(selection:)` so a click persists (debounced ~0.3 s) rather than waiting for the next
+    /// structural mutation, and clears the visited session's unseen badge. An `autoReset` indicator (the
+    /// one-time `completed` flash) resets to idle on BOTH the session moved to and the one moved from (it
+    /// must not persist once you leave it); a non-`autoReset` one (active/blocked) is left untouched
+    /// (keep-state). Returns the destination's pre-reset indicator so GUI callers can reveal its tagged pane.
     @discardableResult
     public func selectSession(_ sessionID: UUID?, sidebarSelection selectionIDs: [UUID]? = nil) -> AgentIndicator? {
         if let sessionID, session(withID: sessionID) == nil { return nil }
@@ -351,10 +339,10 @@ public final class AppStore {
         }
         disableFocusIfSelectionOutsideSet(sessionID)
         if let sessionID { clearUnseen(sessionID) }
-        clearAutoResetIndicator(sessionID) // visit: you've seen it
-        clearAutoResetIndicator(previous)  // leave: a one-time status must not linger on the row you left
+        clearAutoResetIndicator(sessionID)
+        clearAutoResetIndicator(previous)
         recordRecency()
-        scheduleSave() // selection fires on every click/keystroke — coalesce the writes
+        scheduleSave()
         return destinationIndicator
     }
 
@@ -371,8 +359,8 @@ public final class AppStore {
         session(withID: sessionID)?.unseenCount = 0
     }
 
-    /// Pushes the current selection to the front of the recency stack (the Ctrl-Tab order).
-    /// No-op when nothing is selected.
+    /// Pushes the current selection to the front of the recency stack (the Ctrl-Tab order); no-op when
+    /// nothing is selected.
     func recordRecency() {
         if let selectedSessionID { sessionRecency.push(selectedSessionID) }
     }
@@ -381,9 +369,8 @@ public final class AppStore {
         sessionRecency.remove(id)
     }
 
-    /// Removes a session, tears down its surface, and — if it was the active
-    /// session — reselects the most-recently-active surviving session in scope
-    /// (see `closeReselectionTarget(after:)`), falling back to the positional neighbor.
+    /// Removes a session, tears down its surface, and — if it was active — reselects the most-recently-active
+    /// surviving session in scope (`closeReselectionTarget(after:)`), falling back to the positional neighbor.
     public func closeSession(_ sessionID: UUID) {
         guard let location = location(ofSession: sessionID) else { return }
         let wasActive = selectedSessionID == sessionID
@@ -409,16 +396,13 @@ public final class AppStore {
         save()
     }
 
-    /// Whether a workspace may be removed: one workspace is always kept, so removal is
-    /// allowed only when more than one exists.
+    /// Whether a workspace may be removed: one is always kept, so only when more than one exists.
     public var canRemoveWorkspace: Bool { workspaces.count > 1 }
 
-    /// Removes a workspace and every session in it, tearing down each session's surfaces
-    /// and pruning them from the recency stack. No-ops unless more than one workspace
-    /// exists (the last one is kept). If the active session lived in the removed
-    /// workspace, reselects through `workspaceRemovalTarget(at:)` — the most recent still
-    /// VISIBLE session, falling back to the positional walk only when nothing is visible,
-    /// and nil when no sessions remain.
+    /// Removes a workspace and every session in it, tearing down their surfaces and pruning them from the
+    /// recency stack. No-ops unless more than one workspace exists (the last is kept). If the active
+    /// session lived there, reselects through `workspaceRemovalTarget(at:)` — the most recent still VISIBLE
+    /// session, falling back to the positional walk only when nothing is visible, nil when none remain.
     public func removeWorkspace(_ workspaceID: UUID) {
         guard canRemoveWorkspace, let index = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return }
         let workspace = workspaces[index]
@@ -450,17 +434,14 @@ public final class AppStore {
         save()
     }
 
-    /// Moves a session to another workspace (or reorders within the same one),
-    /// keeping the **same** `Session` instance so its attached surface and live
-    /// shell survive. `index` is the destination position in the target's session
-    /// array **after** the move's removal (clamped to bounds); nil appends.
-    /// `selectedSessionID` is unaffected — the id is stable, so a moved active
-    /// session stays selected. No-ops if the session or target workspace is
-    /// unknown; a same-workspace move to the current slot leaves order unchanged.
-    /// Moving the **active** session out of the marked set suspends the focus
-    /// filter while KEEPING the set (`disableFocusIfSelectionOutsideSet`, the
-    /// auto-reveal contract — the active session must stay inside the visible
-    /// set); moving a non-active session leaves the filter intact.
+    /// Moves a session to another workspace (or reorders within one), keeping the **same** `Session`
+    /// instance so its attached surface and live shell survive. `index` is the destination position in the
+    /// target's array **after** the move's removal (clamped to bounds); nil appends. `selectedSessionID`
+    /// is unaffected — the id is stable, so a moved active session stays selected. No-ops on an unknown
+    /// session or target workspace; a same-workspace move to the current slot leaves order unchanged.
+    /// Moving the **active** session out of the marked set suspends the focus filter while KEEPING the set
+    /// (`disableFocusIfSelectionOutsideSet`, the auto-reveal contract: the active session must stay inside
+    /// the visible set); moving a non-active session leaves the filter intact.
     public func moveSession(_ sessionID: UUID, toWorkspace targetID: UUID, at index: Int? = nil) {
         guard let source = location(ofSession: sessionID) else { return }
         guard let targetIndex = workspaces.firstIndex(where: { $0.id == targetID }) else { return }
@@ -478,8 +459,8 @@ public final class AppStore {
     /// Moves selected sessions in their current tree order. With `index == nil`, a multi-session context
     /// move appends cross-workspace sessions and leaves sessions already in the target in place; a
     /// one-session call matches `moveSession` and appends even within that workspace. With an explicit
-    /// `index`, this is a drag drop: remove every dragged session first, then insert the dragged block at
-    /// that post-removal target index. Returns the number of sessions actually moved.
+    /// `index` (a drag drop), every dragged session is removed first, then the block inserted at that
+    /// post-removal index. Returns the number of sessions actually moved.
     @discardableResult
     public func moveSessions(_ sessionIDs: [UUID], toWorkspace targetID: UUID, at index: Int? = nil) -> Int {
         guard workspaces.contains(where: { $0.id == targetID }) else { return 0 }
@@ -511,9 +492,9 @@ public final class AppStore {
         return moving.count
     }
 
-    /// Reorders a session one relative step within its own workspace (`up`/`down`/`top`/`bottom`),
-    /// reusing `moveSession` with the same workspace id. No-op (no write) on an unknown id or when
-    /// the move would leave order unchanged (already at the end in that direction).
+    /// Reorders a session one relative step within its own workspace (`up`/`down`/`top`/`bottom`), reusing
+    /// `moveSession` with the same workspace id. No-op (no write) on an unknown id or when the move would
+    /// leave order unchanged (already at the end in that direction).
     public func reorderSession(_ id: UUID, _ direction: ReorderDirection) {
         guard let loc = location(ofSession: id) else { return }
         let count = workspaces[loc.workspaceIndex].sessions.count
@@ -521,9 +502,9 @@ public final class AppStore {
         moveSession(id, toWorkspace: workspaces[loc.workspaceIndex].id, at: dest)
     }
 
-    /// Moves a workspace to `index` among its siblings, mirroring `moveSession`'s
-    /// remove/clamp/insert/save shape. `index` is the destination position **after**
-    /// the move's removal (clamped to bounds). No-op on an unknown id.
+    /// Moves a workspace to `index` among its siblings, mirroring `moveSession`'s remove/clamp/insert/save
+    /// shape. `index` is the destination position **after** the move's removal (clamped). No-op on an
+    /// unknown id.
     public func moveWorkspace(_ id: UUID, at index: Int) {
         guard let current = workspaces.firstIndex(where: { $0.id == id }) else { return }
         let before = workspaces.map(\.id)
@@ -534,35 +515,32 @@ public final class AppStore {
         save()
     }
 
-    /// Reorders a workspace one relative step among its siblings (`up`/`down`/`top`/`bottom`),
-    /// reusing `moveWorkspace`. No-op (no write) on an unknown id or when the move would leave
-    /// order unchanged (already at the end in that direction).
+    /// Reorders a workspace one relative step among its siblings (`up`/`down`/`top`/`bottom`), reusing
+    /// `moveWorkspace`. No-op (no write) on an unknown id or when the move would leave order unchanged
+    /// (already at the end in that direction).
     public func reorderWorkspace(_ id: UUID, _ direction: ReorderDirection) {
         guard let current = workspaces.firstIndex(where: { $0.id == id }) else { return }
         guard let dest = direction.destinationIndex(from: current, count: workspaces.count) else { return }
         moveWorkspace(id, at: dest)
     }
 
-    /// The owning workspace id, the session's index within it, and that workspace's session count, or
-    /// nil for an unknown id. Lets the sidebar drag handler resolve owner + index in a single tree walk
-    /// instead of re-deriving each piece, while feeding the host-free `SidebarDrop` resolver.
+    /// The owning workspace id, the session's index within it, and that workspace's session count, or nil
+    /// for an unknown id — one tree walk for the sidebar drag handler instead of re-deriving each piece,
+    /// feeding the host-free `SidebarDrop` resolver.
     public func sessionLocation(ofSession id: UUID) -> (workspace: UUID, index: Int, count: Int)? {
         guard let loc = location(ofSession: id) else { return nil }
         let workspace = workspaces[loc.workspaceIndex]
         return (workspace.id, loc.sessionIndex, workspace.sessions.count)
     }
 
-    /// Steps the selection through the flattened VISIBLE/FILTERED session list (`navigableSessions`:
-    /// the flagged set in `.flagged` mode, the MARKED workspaces' sessions while the focus filter is
-    /// applied, else all), in the sidebar's visual order. `next`/`previous` move one and WRAP at the ends
-    /// WITHIN the filtered set (`next` on the last lands on the first, `previous` on the first lands on
-    /// the last, never leaking across the filter — matching the cyclic attention-nav below);
-    /// `first`/`last` jump to the ends of the filtered list.
-    /// With no/invalid current selection, `next`/`previous` land on its first
-    /// session. No-op when the filtered list is empty. Routes through `selectSession`, inheriting recency,
-    /// badge clearing, persistence, and workspace derivation. Because the targets are always in-set, nav
-    /// never triggers `disableFocusIfSelectionOutsideSet` — that stays the safety net for an explicit cross-set
-    /// select.
+    /// Steps the selection through the flattened VISIBLE/FILTERED session list in the sidebar's visual
+    /// order (`navigableSessions`: the flagged set in `.flagged` mode, the MARKED workspaces' sessions
+    /// while the focus filter is applied, else all). `next`/`previous` move one and WRAP at the ends WITHIN
+    /// the filtered set, never leaking across the filter (matching the cyclic attention-nav below);
+    /// `first`/`last` jump to its ends; with no/invalid selection `next`/`previous` land on the first
+    /// session. No-op on an empty filtered list. Routes through `selectSession`, inheriting recency, badge
+    /// clearing, persistence and workspace derivation. Targets are always in-set, so nav never triggers
+    /// `disableFocusIfSelectionOutsideSet` — that stays the safety net for an explicit cross-set select.
     @discardableResult
     public func navigateSession(_ direction: SessionNavigation) -> AgentIndicator? {
         let sessions = navigableSessions
@@ -577,7 +555,7 @@ public final class AppStore {
                 let step = direction == .next ? 1 : -1
                 target = ids[((i + step) % ids.count + ids.count) % ids.count] // cycle within the filtered set
             } else {
-                target = first // no/invalid selection -> first
+                target = first
             }
         case .nextAttention, .previousAttention:
             guard let found = attentionTarget(in: sessions, forward: direction == .nextAttention) else { return nil }
@@ -586,10 +564,10 @@ public final class AppStore {
         return selectSession(target)
     }
 
-    /// The next/previous session needing attention (status `blocked` or `completed`) in the flattened
-    /// order, scanning from the current selection and WRAPPING around. The current session is excluded,
-    /// so repeated steps cycle through the others. With no/invalid selection the scan starts from the
-    /// tree end opposite the direction. Returns nil when no other attention session exists (a no-op).
+    /// The next/previous session needing attention (`blocked`/`completed`) in the flattened order, scanning
+    /// from the current selection and WRAPPING around; the current session is excluded, so repeated steps
+    /// cycle through the others. With no/invalid selection the scan starts from the tree end opposite the
+    /// direction. Nil (a no-op) when no other attention session exists.
     private func attentionTarget(in sessions: [Session], forward: Bool) -> UUID? {
         let ids = sessions.map(\.id)
         let count = ids.count
@@ -605,20 +583,18 @@ public final class AppStore {
         return nil
     }
 
-    /// Records a session's terminal font size (points) and persists it. No-ops when
-    /// unchanged so the cell-size event firing on a DPI change (not a font change)
-    /// doesn't write. The save is debounced (~0.3 s) so a font ramp (held ⌘+/⌘−)
-    /// coalesces into one write instead of hitting disk per step.
+    /// Records a session's terminal font size (points) and persists it. No-ops when unchanged, so the
+    /// cell-size event firing on a DPI change (not a font change) doesn't write. The save is debounced
+    /// (~0.3 s) so a font ramp (held ⌘+/⌘−) coalesces into one write instead of one per step.
     public func setFontSize(_ sessionID: UUID, _ size: Double) {
         guard let session = session(withID: sessionID), session.fontSize != size else { return }
         session.fontSize = size
         scheduleSave()
     }
 
-    /// Clears every session's per-session font-size override (back to the app default). Called
-    /// when an appearance change is applied: the shared ghostty `update_config` resets all live
-    /// surfaces to the default size, so the persisted overrides are cleared to match. No-ops (no
-    /// write) when nothing was overridden.
+    /// Clears every session's per-session font-size override (back to the app default). Called when an
+    /// appearance change is applied: the shared ghostty `update_config` resets all live surfaces to the
+    /// default size, so the persisted overrides are cleared to match. No-ops (no write) when none was set.
     public func resetSessionFontSizes() {
         var changed = false
         for workspace in workspaces {
@@ -631,9 +607,8 @@ public final class AppStore {
     }
 
     /// Sets this window's sidebar visibility and persists it. Clean no-op (no write) when unchanged, so
-    /// menu, toolbar, palette, and control callers can delta-compute their desired state without
-    /// duplicating the persistence gate. `sidebarVisible` is per-window state saved in this store's
-    /// snapshot.
+    /// menu, toolbar, palette and control callers can delta-compute their desired state without duplicating
+    /// the persistence gate. `sidebarVisible` is per-window state saved in this store's snapshot.
     public func setSidebarVisible(_ visible: Bool) {
         guard sidebarVisible != visible else { return }
         sidebarVisible = visible
@@ -662,18 +637,18 @@ public final class AppStore {
     /// Sets one workspace's expand/collapse state and persists it. Clean no-op (no write) for an unknown id
     /// or when unchanged. The sidebar calls this for a GENUINE per-row user toggle only (a row click or the
     /// disclosure triangle), never for a programmatic reveal — so a deliberate collapse survives a later
-    /// reveal of a session inside the workspace, and toggling one workspace never touches another's saved
-    /// state (unlike `setWorkspacesExpanded`, which rewrites the whole tree).
+    /// reveal of a session inside it, and toggling one workspace never touches another's saved state
+    /// (unlike `setWorkspacesExpanded`, which rewrites the whole tree).
     public func setWorkspaceExpanded(_ id: UUID, expanded: Bool) {
         guard let index = workspaces.firstIndex(where: { $0.id == id }), workspaces[index].isExpanded != expanded else { return }
         workspaces[index].isExpanded = expanded
         save()
     }
 
-    /// Marks each workspace expanded iff its id is in `expandedIDs` and persists the collapse state so it
-    /// survives a relaunch. One `save()` for the whole diff; a clean no-op (no write) when nothing changed.
-    /// Backs the deliberate all-workspace commands (Expand Workspaces / Collapse Workspaces), which set
-    /// every workspace at once; per-row toggles use `setWorkspaceExpanded` instead.
+    /// Marks each workspace expanded iff its id is in `expandedIDs` and persists the collapse state. One
+    /// `save()` for the whole diff; a clean no-op (no write) when nothing changed. Backs the deliberate
+    /// all-workspace commands (Expand / Collapse Workspaces), which set every workspace at once; per-row
+    /// toggles use `setWorkspaceExpanded` instead.
     public func setWorkspacesExpanded(_ expandedIDs: Set<UUID>) {
         var changed = false
         for index in workspaces.indices {
@@ -686,13 +661,11 @@ public final class AppStore {
         if changed { save() }
     }
 
-    /// Sets (or clears) a session's flag — the durable flagged working-set membership the flat sidebar
-    /// view projects. Persists the change. Clean no-op (no write) for an unknown id or when the flag is
-    /// already in the requested state, so the delta-computed control/menu callers stay idempotent.
-    ///
-    /// Unflagging is a narrowing in `.flagged` mode — it drops the row rendering the active session — so
-    /// it runs the same reselect (`reselectIfSelectionHidden`), which the flag change itself cannot
-    /// trigger in tree mode — though it still repairs a selection stranded there by something else.
+    /// Sets (or clears) a session's flag — the durable flagged working-set membership the flat sidebar view
+    /// projects — and persists. Clean no-op (no write) for an unknown id or an already-matching flag, so
+    /// delta-computed control/menu callers stay idempotent. Unflagging narrows in `.flagged` mode (it drops
+    /// the row rendering the active session), so it runs `reselectIfSelectionHidden`; the flag change
+    /// cannot trigger that in tree mode, though it still repairs a selection stranded there by something else.
     public func setFlag(_ on: Bool, forSession id: UUID) {
         guard let session = session(withID: id), session.flagged != on else { return }
         session.flagged = on
@@ -720,19 +693,19 @@ public final class AppStore {
     }
 
     /// Sets (or clears) a session's background watermark and persists it. Clean no-op (no write) for an
-    /// unknown id or when the spec is unchanged, so a repeated `session.background` set is idempotent.
-    /// Returns whether the spec actually CHANGED, so the app target can gate the (retained, teardown-only-
-    /// freed) per-surface config apply on a real change — without it, a scripted set-loop keeps appending
-    /// owned configs. The app target applies it to the session's surface(s) after this returns (the
-    /// host-free store owns only the spec; the C-boundary apply lives in `ControlServer`/`GhosttySurfaceView`).
+    /// unknown id or an unchanged spec, so a repeated `session.background` set is idempotent. Returns
+    /// whether the spec actually CHANGED, so the app target can gate the (retained, teardown-only-freed)
+    /// per-surface config apply on a real change — without it a scripted set-loop keeps appending owned
+    /// configs. The app target applies it to the session's surface(s) after this returns: the host-free
+    /// store owns only the spec, the C-boundary apply lives in `ControlServer`/`GhosttySurfaceView`.
     @discardableResult
     public func setBackgroundWatermark(_ watermark: BackgroundWatermark?, forSession id: UUID) -> Bool {
         guard let session = session(withID: id), session.backgroundWatermark != watermark else { return false }
         let previous = session.backgroundWatermark
         session.backgroundWatermark = watermark
-        // a `.text` watermark owns a rendered `<id>.png`; switching to anything that isn't `.text` (an
-        // image, or nil) leaves it id-keyed but unreferenced, so drop it here. `clear`/teardown also sweep
-        // the same id-keyed file, so this is just the eager reclaim for the text→image/nil transition.
+        // a `.text` watermark owns a rendered `<id>.png`; switching to anything else (an image, or nil)
+        // leaves it id-keyed but unreferenced, so drop it here. `clear`/teardown sweep the same file, so
+        // this is just the eager reclaim for the text→image/nil transition.
         if previous?.kind == .text, watermark?.kind != .text {
             WatermarkStorage.removeRenderedText(sessionID: id)
         }
@@ -741,10 +714,9 @@ public final class AppStore {
     }
 
     /// Unflags every session across all workspaces in one `save()`. No-ops (no write) when nothing is
-    /// flagged. Backs the Clear Flagged action and the `session.flag clear` control mode.
-    ///
-    /// No `reselectIfSelectionHidden`, unlike the two `setFlag` mutators: clearing EVERY flag leaves the
-    /// list empty, so there is nowhere to move. A partial clear would need it.
+    /// flagged. Backs the Clear Flagged action and the `session.flag clear` control mode. No
+    /// `reselectIfSelectionHidden`, unlike the two `setFlag` mutators: clearing EVERY flag leaves the list
+    /// empty, so there is nowhere to move. A partial clear would need it.
     public func clearFlags() {
         var changed = false
         for workspace in workspaces {
@@ -759,17 +731,17 @@ public final class AppStore {
         }
     }
 
-    /// The flagged sessions across all workspaces in tree order (`workspaces.flatMap(\.sessions)` filtered
-    /// by `flagged`). A pure derived projection — the flat sidebar view renders this directly.
+    /// The flagged sessions across all workspaces in tree order — a pure derived projection the flat
+    /// sidebar view renders directly.
     public var flaggedSessions: [Session] {
         workspaces.flatMap(\.sessions).filter(\.flagged)
     }
 
     // MARK: - Persistence
 
-    /// Builds a `Snapshot` value of the current tree. Each session captures its
-    /// live `currentCwd` (or `initialCwd` if no PWD report has arrived). Runs on
-    /// `@MainActor`; the resulting value is `Sendable` and safe to hand to a writer.
+    /// Builds a `Snapshot` value of the current tree; each session captures its live `currentCwd` (or
+    /// `initialCwd` if no PWD report has arrived). Runs on `@MainActor`; the result is `Sendable` and
+    /// safe to hand to a writer.
     public func snapshot() -> Snapshot {
         let workspaceSnapshots = workspaces.map { workspace in
             let sessions = workspace.sessions.map(sessionSnapshot)
@@ -778,9 +750,9 @@ public final class AppStore {
             return WorkspaceSnapshot(id: workspace.id, name: workspace.name, sessions: sessions,
                                      collapsed: workspace.isExpanded ? nil : true)
         }
-        // the marked set in TREE order, so the on-disk list is deterministic rather than following the
-        // Set's hash order; an unmarked store omits both focus keys, keeping its file identical to one
-        // written before the set existed. The legacy `focusedWorkspaceID` is never populated.
+        // the marked set in TREE order, so the on-disk list is deterministic rather than the Set's hash
+        // order; an unmarked store omits both focus keys, keeping its file identical to one written before
+        // the set existed. The legacy `focusedWorkspaceID` is never populated.
         let focusIDs = workspaces.map(\.id).filter(focusedWorkspaceIDs.contains)
         return Snapshot(selectedSessionID: selectedSessionID, workspaces: workspaceSnapshots,
                         sidebarWidth: sidebarWidth, sidebarVisible: sidebarVisible, sidebarMode: sidebarMode,
@@ -789,21 +761,19 @@ public final class AppStore {
                         sessionRecency: sessionRecency.items)
     }
 
-    /// Rebuilds the tree from a snapshot: fresh `Session`s (surfaces and shells
-    /// spawn lazily on first display) keyed by the persisted ids so the restored
-    /// `selectedSessionID` still resolves. Replaces the current state wholesale.
+    /// Rebuilds the tree from a snapshot: fresh `Session`s (surfaces and shells spawn lazily on first
+    /// display) keyed by the persisted ids so the restored `selectedSessionID` still resolves, replacing
+    /// the current state wholesale. A persisted `selectedSessionID` pointing at a session that no longer
+    /// exists is cleared, keeping the selection valid.
     ///
-    /// Deliberately does NOT call `save()`: it loads what was just read from disk,
-    /// so re-persisting it would be a pointless write. The closing
-    /// `reselectIfSelectionHidden` is the exception — when it repairs a stranded
-    /// selection, `selectSession` schedules a save, and that one is worth writing.
-    /// If the persisted `selectedSessionID` points at a session that no longer
-    /// exists, it is cleared to keep selection valid.
+    /// Deliberately does NOT call `save()` — it loads what was just read from disk. The closing
+    /// `reselectIfSelectionHidden` is the exception: when it repairs a stranded selection, `selectSession`
+    /// schedules a save, and that one is worth writing.
     ///
-    /// `launchRestore` marks an APP-BOOTSTRAP restore and is threaded down to `session(from:launchRestore:)`,
-    /// where it is the only thing that arms a persisted `session.restore` override for this launch. It
-    /// defaults to false because this method has a RUNTIME caller too: reopening a closed window
-    /// mid-process reloads its store through here, and that must not execute anything.
+    /// `launchRestore` marks an APP-BOOTSTRAP restore and threads down to `session(from:launchRestore:)`,
+    /// the only thing that arms a persisted `session.restore` override for this launch. It defaults to
+    /// false because reopening a closed window mid-process reloads its store through here, and that
+    /// RUNTIME caller must not execute anything.
     public func restore(from snapshot: Snapshot, launchRestore: Bool = false) {
         // fold workspaces sharing an id into the first occurrence, and keep only the first snapshot of any
         // repeated session id, wherever it sits: a file written by a build that could duplicate either
@@ -833,9 +803,9 @@ public final class AppStore {
             selectedSessionID = snapshot.selectedSessionID
         }
         replaceSidebarSelection(with: selectedSessionID)
-        // re-seed the Ctrl-Tab order from the persisted list (dropping ids not in the restored
-        // tree) so the switcher works right after relaunch; the restored selection floats to the
-        // front, keeping the "previous session" slot truthful.
+        // re-seed the Ctrl-Tab order from the persisted list (dropping ids not in the restored tree) so the
+        // switcher works right after relaunch; the restored selection floats to the front, keeping the
+        // "previous session" slot truthful.
         let restoredIDs = Set(workspaces.flatMap(\.sessions).map(\.id))
         sessionRecency = RecencyStack(items: (snapshot.sessionRecency ?? []).filter { restoredIDs.contains($0) })
         recordRecency()
@@ -843,20 +813,18 @@ public final class AppStore {
         reselectIfSelectionHidden()
     }
 
-    /// Persists the current state eagerly. Called after every structural mutation and on
-    /// terminate. Cancels any pending debounced save first, so a `save()` (incl. the
-    /// quit-flush) always writes the latest snapshot and a stale scheduled write can't
-    /// fire afterward. A write failure is logged and swallowed — a transient disk error
-    /// must not bring down the model.
+    /// Persists the current state eagerly; called after every structural mutation and on terminate.
+    /// Cancels any pending debounced save first, so a `save()` (incl. the quit-flush) always writes the
+    /// latest snapshot and a stale scheduled write can't fire afterward. A write failure is logged and
+    /// swallowed — a transient disk error must not bring down the model.
     public func save() {
         saveChecked()
     }
 
-    /// `save()` that REPORTS whether the write landed instead of swallowing the failure, for a caller
-    /// whose acknowledgement must not outrun the disk. `setRestoreCommand` is the one today: its payload
-    /// is an arbitrary shell line re-typed on every launch, so a "cleared" ack that never reached disk
-    /// would leave the old command armed forever. `save()` is this with the result discarded, so the two
-    /// can't drift.
+    /// `save()` that REPORTS whether the write landed instead of swallowing the failure, for a caller whose
+    /// acknowledgement must not outrun the disk. `setRestoreCommand` is the one today: its payload is an
+    /// arbitrary shell line re-typed on every launch, so a "cleared" ack that never reached disk would
+    /// leave the old command armed forever. `save()` is this with the result discarded, so the two can't drift.
     @discardableResult
     func saveChecked() -> Bool {
         saveDebouncer.cancel()
@@ -869,20 +837,19 @@ public final class AppStore {
         }
     }
 
-    /// Debounces a `save()` ~0.3 s out, coalescing the rapid selection/font writes. Used only by
-    /// `selectSession`/`setFontSize`; structural mutations call `save()` immediately. A `save()`
-    /// (or the quit-flush) cancels the pending schedule, so the latest state is always captured.
+    /// Debounces a `save()` ~0.3 s out, coalescing the rapid selection/font writes; used only by
+    /// `selectSession`/`setFontSize`, while structural mutations call `save()` immediately. A `save()` (or
+    /// the quit-flush) cancels the pending schedule, so the latest state is always captured.
     private func scheduleSave() {
         saveDebouncer.schedule(after: AppStore.saveDebounceInterval) { [weak self] in
             self?.save()
         }
     }
 
-    /// Drops any pending debounced save WITHOUT writing — unlike `save()`, which cancels then writes.
-    /// Used when the owning window is being deleted (`WindowLibrary.removeWindow`): the per-window file
-    /// is about to be removed, so a save scheduled by a just-before-delete selectSession/setFontSize
-    /// must be dropped rather than flushed, else it would fire after the file is deleted and re-create
-    /// it as an orphan.
+    /// Drops any pending debounced save WITHOUT writing — unlike `save()`, which cancels then writes. Used
+    /// when the owning window is being deleted (`WindowLibrary.removeWindow`): the per-window file is about
+    /// to go, so a save scheduled by a just-before-delete selectSession/setFontSize must be dropped rather
+    /// than flushed, else it fires after the delete and re-creates the file as an orphan.
     public func cancelPendingSave() {
         saveDebouncer.cancel()
     }
@@ -918,9 +885,9 @@ public final class AppStore {
         workspaces.flatMap(\.sessions).map(\.id).filter { ids.contains($0) }
     }
 
-    /// Picks the next selection after removing the session at `location`. Prefers
-    /// the session that shifted into the removed slot, then the previous one in
-    /// that workspace, then the first session of any remaining workspace.
+    /// Picks the next selection after removing the session at `location`, preferring the session that
+    /// shifted into the removed slot, then the previous one in that workspace, then the first session of
+    /// any remaining workspace.
     func reselectionTarget(after location: (workspaceIndex: Int, sessionIndex: Int)) -> UUID? {
         let sessions = workspaces[location.workspaceIndex].sessions
         if location.sessionIndex < sessions.count { return sessions[location.sessionIndex].id }
@@ -952,15 +919,15 @@ public final class AppStore {
     }
 
     /// Rebuilds one session from its snapshot. `launchRestore` marks an APP-BOOTSTRAP restore, the only
-    /// path allowed to arm a persisted `restoreCommand` override for this launch by copying it into the
-    /// transient `pendingRestoreCommand` the surface factory consumes; it defaults to false so any other
-    /// rebuild (a mid-process window reload, Reopen Closed Item) comes back with nothing armed.
+    /// path allowed to arm a persisted `restoreCommand` for this launch by copying it into the transient
+    /// `pendingRestoreCommand` the surface factory consumes; it defaults to false so any other rebuild (a
+    /// mid-process window reload, Reopen Closed Item) comes back with nothing armed.
     ///
     /// A split hidden at the last quit is NOT rebuilt (`hasSplit` follows `isSplit`), so its pinned
-    /// override describes a pane that no longer exists: it is DROPPED here, the same rule `closeSplit`
-    /// applies when the pane goes away. Keeping it would leave a value `tree` reports but no write can
-    /// clear (`session.restore --pane right` is rejected without a split), and a fresh ⌘D split shown at
-    /// the next quit would inherit and run it.
+    /// override describes a pane that no longer exists and is DROPPED here — the rule `closeSplit` applies
+    /// when a pane goes away. Keeping it would leave a value `tree` reports but no write can clear
+    /// (`session.restore --pane right` is rejected without a split), and a fresh ⌘D split shown at the
+    /// next quit would inherit and run it.
     func session(from snapshot: SessionSnapshot, launchRestore: Bool = false) -> Session {
         let session = Session(id: snapshot.id, initialCwd: snapshot.cwd, customName: snapshot.customName)
         session.isSplit = snapshot.isSplit ?? false

--- a/agtermCore/Sources/agtermCore/BackgroundWatermark.swift
+++ b/agtermCore/Sources/agtermCore/BackgroundWatermark.swift
@@ -1,14 +1,12 @@
 import Foundation
 
-/// A per-session background composited behind the terminal grid: a user-supplied image file (`.image`)
-/// or a string agterm rasterizes to a PNG (`.text`), both via libghostty's `background-image*` keys, or
-/// a solid `#rrggbb` background color (`.color`) via the `background` key. Stored on `Session`, persisted
-/// in `SessionSnapshot`, and carried on the control wire. Host-free + `Codable`: the app target turns it
-/// into a per-surface ghostty config overlay (see `WatermarkConfig`) and, for `.text`, renders the PNG
-/// (the only step that needs AppKit).
-///
-/// libghostty re-fits the image to the surface on every resize (`background-image-fit`), so the
-/// "auto-resize to the window" behavior needs no app-side resize handling.
+/// A per-session background composited behind the terminal grid: a user-supplied image file (`.image`) or
+/// a string agterm rasterizes to a PNG (`.text`), both via libghostty's `background-image*` keys, or a
+/// solid `#rrggbb` background color (`.color`) via the `background` key. Stored on `Session`, persisted in
+/// `SessionSnapshot`, carried on the control wire. Host-free + `Codable`: the app target turns it into a
+/// per-surface ghostty config overlay (see `WatermarkConfig`) and renders the `.text` PNG (the only step
+/// needing AppKit). libghostty re-fits the image on every resize (`background-image-fit`), so the
+/// auto-resize-to-the-window behavior needs no app-side resize handling.
 public struct BackgroundWatermark: Codable, Sendable, Equatable {
     public enum Kind: String, Codable, Sendable {
         /// `imagePath` points at a user-supplied PNG/JPEG (the only formats libghostty reads).
@@ -21,9 +19,8 @@ public struct BackgroundWatermark: Codable, Sendable, Equatable {
         case color
     }
 
-    /// libghostty `background-image-fit` (Config.zig `BackgroundImageFit`). A typed enum (like `Kind`)
-    /// so an invalid value can't reach a config line and the raw `validFits` array is unneeded — the raw
-    /// values match ghostty's keys exactly, so it serializes identically to the former `String`.
+    /// libghostty `background-image-fit` (Config.zig `BackgroundImageFit`). Typed like `Kind` so an invalid
+    /// value can't reach a config line; the raw values are ghostty's keys, so it serializes as that string.
     public enum Fit: String, Codable, Sendable, CaseIterable {
         case contain, cover, stretch, none
     }

--- a/agtermCore/Sources/agtermCore/BuiltinAction.swift
+++ b/agtermCore/Sources/agtermCore/BuiltinAction.swift
@@ -1,11 +1,9 @@
 import Foundation
 
-/// A rebindable, menu-backed built-in action. Each case has a canonical kitty-style raw name (the
-/// token the user writes after `map` in `keymap.conf`) and a `defaultChord` — the shortcut the menu
-/// ships with today, or `nil` for an action that has no default key.
-///
-/// The raw names mirror the menu items in `agtermApp`'s `.commands`; `defaultChord` is the single
-/// source of truth for those default shortcuts once the menu reads `equivalent(for:)`.
+/// A rebindable, menu-backed built-in action. Each case has a canonical kitty-style raw name (the token the
+/// user writes after `map` in `keymap.conf`) and a `defaultChord` — the shortcut the menu ships with, or
+/// `nil` for an action with no default key. The raw names mirror the menu items in `agtermApp`'s
+/// `.commands`; `defaultChord` is the single source of truth for those shortcuts, read via `equivalent(for:)`.
 public enum BuiltinAction: String, CaseIterable, Sendable {
     case newWindow = "new_window", renameWindow = "rename_window", deleteWindow = "delete_window"
     case newWorkspace = "new_workspace", renameWorkspace = "rename_workspace", deleteWorkspace = "delete_workspace"
@@ -26,14 +24,10 @@ public enum BuiltinAction: String, CaseIterable, Sendable {
     case customCommandPalette = "custom_command_palette", showAttention = "show_attention"
     case dashboard = "dashboard"
 
-    /// The shipped default chord for this action, or `nil` when it has no default key today.
-    ///
-    /// `nil` covers only the keyless actions (`rename_*`/`delete_*`/`duplicate_session`/`clear_status`/
-    /// `first_session`/`last_session`/`select_theme`/`toggle_flagged_view`/`focus_workspace`/
-    /// `toggle_workspace_filter`), which gain
-    /// a key only when the user `map`s one. Every action that ships with a key returns it here, including
-    /// the six arrow-bound ones — the arrows are part of the chord grammar, so their defaults round-trip
-    /// through `keymap.conf` like any other and the menu needs no hardcoded fallback.
+    /// The shipped default chord, or `nil` for a keyless action, which gains a key only when the user
+    /// `map`s one. Every action that ships with a key returns it here, including the six arrow-bound ones —
+    /// arrows are part of the chord grammar, so their defaults round-trip through `keymap.conf` like any
+    /// other and the menu needs no hardcoded fallback.
     public var defaultChord: Chord? {
         switch self {
         case .newWindow: return Chord(mods: [.command, .option], key: "n")

--- a/agtermCore/Sources/agtermCore/CLIInstall.swift
+++ b/agtermCore/Sources/agtermCore/CLIInstall.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-/// Pure, host-free helpers for installing the bundled `agtermctl` CLI into the user's PATH. The app
-/// side does the actual filesystem work (a symlink, with an `osascript` admin fallback when the
-/// target dir isn't user-writable); this type owns only the testable string/path logic.
+/// Pure, host-free helpers for installing the bundled `agtermctl` CLI into the user's PATH — only the
+/// testable string/path logic. The app side does the filesystem work: a symlink, with an `osascript` admin
+/// fallback when the target dir isn't user-writable.
 public enum CLIInstall {
     /// The CLI tool's executable name.
     public static let toolName = "agtermctl"
@@ -14,10 +14,9 @@ public enum CLIInstall {
     /// The full symlink path an install creates.
     public static var installPath: String { installDirectory + "/" + toolName }
 
-    /// The shell command that creates the symlink with elevated privileges, run via
-    /// `osascript … with administrator privileges` when `installDirectory` isn't user-writable. It
-    /// creates the directory first (a clean Apple Silicon Mac may lack it) and overwrites any
-    /// existing link.
+    /// The shell command creating the symlink with elevated privileges, run via `osascript … with
+    /// administrator privileges` when `installDirectory` isn't user-writable. Creates the directory first
+    /// (a clean Apple Silicon Mac may lack it) and overwrites any existing link.
     public static func privilegedInstallCommand(source: String) -> String {
         "mkdir -p \(shellQuote(installDirectory)) && ln -sf \(shellQuote(source)) \(shellQuote(installPath))"
     }

--- a/agtermCore/Sources/agtermCore/ClipboardPromptPolicy.swift
+++ b/agtermCore/Sources/agtermCore/ClipboardPromptPolicy.swift
@@ -16,11 +16,10 @@ public enum ClipboardDecision: Sendable {
     case prompt
 }
 
-/// ClipboardPromptPolicy remembers, per direction, whether the user has chosen to allow or deny OSC 52
-/// clipboard access for the rest of the app session (the "don't ask again this session" choice). With no
-/// remembered choice a direction defaults to `.prompt`. Read and write are independent so allowing writes
-/// never silently allows reads. Pure value logic: the app owns an instance, shows the dialog on `.prompt`,
-/// and records the outcome via `remember`.
+/// ClipboardPromptPolicy remembers, per direction, whether the user allowed or denied OSC 52 clipboard
+/// access for the rest of the app session (the "don't ask again this session" choice), defaulting to
+/// `.prompt` with no remembered choice. Read and write are independent, so allowing writes never silently
+/// allows reads. Pure value logic: the app owns an instance, prompts on `.prompt`, records via `remember`.
 public struct ClipboardPromptPolicy: Sendable {
     private var readChoice: Bool?
     private var writeChoice: Bool?

--- a/agtermCore/Sources/agtermCore/CommandRestore.swift
+++ b/agtermCore/Sources/agtermCore/CommandRestore.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-/// Pure, host-free logic for the restore-running-command feature: parsing a macOS `KERN_PROCARGS2`
-/// blob into argv, deciding whether a captured foreground command should be re-run, and rendering an
-/// argv back into a shell command line. The app target owns the `sysctl`/libghostty calls; every
+/// Pure, host-free logic for the restore-running-command feature: parsing a macOS `KERN_PROCARGS2` blob
+/// into argv, deciding whether a captured foreground command should be re-run, and rendering an argv
+/// back into a shell command line. The app target owns only the `sysctl`/libghostty calls; every
 /// judgement defers here so it stays unit-tested and off the C boundary.
 public enum CommandRestore {
     /// The login shells treated as "no program to restore" (the pane was at its prompt).
@@ -16,10 +16,10 @@ public enum CommandRestore {
         path.split(separator: "/").last.map(String.init) ?? path
     }
 
-    /// Whether `basename` is a login shell to skip, optionally also matching the user's `$SHELL`
-    /// basename passed as `extra` (so a non-standard login shell is recognized too). A leading `-` is
-    /// stripped first: macOS marks a login shell with a dash in argv[0], which for a bare-name argv0
-    /// (`-zsh`) survives `basename` (a path form like `-/bin/zsh` already loses it on the `/` split).
+    /// Whether `basename` is a login shell to skip, also matching the user's `$SHELL` basename passed as
+    /// `extra` (so a non-standard login shell counts). A leading `-` is stripped first: macOS dash-marks a
+    /// login shell's argv[0], which survives `basename` for a bare name (`-zsh`) but not a path
+    /// (`-/bin/zsh`, which loses it on the `/` split).
     public static func isKnownShell(_ basename: String, extra: String? = nil) -> Bool {
         let name = basename.hasPrefix("-") ? String(basename.dropFirst()) : basename
         if knownShells.contains(name) { return true }
@@ -27,12 +27,11 @@ public enum CommandRestore {
         return false
     }
 
-    /// Whether `argv` is an interactive shell sitting at its prompt — the "idle pane, nothing to restore"
-    /// case: `argv[0]` is a known shell (or `$SHELL`, passed as `extra`) AND there is no payload argument
-    /// after it, only option flags. A shell RUNNING something is NOT idle and IS captured: a script path
-    /// (`/bin/sh /usr/local/bin/cld`, the foreground of any `#!/bin/sh` wrapper) or a `-c` command leaves a
-    /// non-flag argument after `argv[0]`. Without this, every shell-script wrapper was wrongly skipped as a
-    /// prompt while a plain binary (`htop`) restored.
+    /// Whether `argv` is an interactive shell at its prompt — the "idle pane, nothing to restore" case:
+    /// `argv[0]` is a known shell (or `$SHELL`, passed as `extra`) AND only option flags follow it. A
+    /// shell RUNNING something is NOT idle and IS captured — a script path (`/bin/sh /usr/local/bin/cld`,
+    /// the foreground of any `#!/bin/sh` wrapper) or a `-c` command leaves a non-flag argument after
+    /// `argv[0]`.
     public static func isIdleShell(argv: [String], extra: String? = nil) -> Bool {
         guard let first = argv.first, isKnownShell(basename(first), extra: extra) else { return false }
         return !argv.dropFirst().contains { !$0.hasPrefix("-") }
@@ -58,13 +57,13 @@ public enum CommandRestore {
         }
     }
 
-    /// The inputs `restorePlan` decides from — everything about a pane that bears on what it seeds with.
-    /// - `wasRestored`: the session came from a restore (a FRESH command session always runs its command; a
+    /// The inputs `restorePlan` decides from.
+    /// - `wasRestored`: the session came from a restore (a FRESH command session always runs its command, a
     ///   RESTORED one only when the opt-in is on).
     /// - `restoreEnabled`: the `restoreRunningCommand` opt-in.
-    /// - `hadForeground`: a foreground command was CAPTURED at the last quit. A captured foreground PREEMPTS
-    ///   `initialCommand` even when suppressed (denylisted/off → `foregroundInput` nil), yielding a plain
-    ///   shell rather than the stale creation command — so gate on capture, not on whether the input survived.
+    /// - `hadForeground`: a foreground command was CAPTURED at the last quit. It PREEMPTS `initialCommand`
+    ///   even when suppressed (denylisted/off → `foregroundInput` nil), yielding a plain shell rather than
+    ///   the stale creation command — so gate on capture, not on the input surviving.
     /// - `foregroundInput`: the rendered foreground command line to type, or nil (none / suppressed).
     /// - `initialCommand`: the session's persisted `--command`.
     /// - `restoreOverride`: the pane's pinned restore command (`session.restore`), tri-state — nil = no
@@ -88,10 +87,10 @@ public enum CommandRestore {
     }
 
     /// The `initial_input` for a pane: a pinned override (empty → nil, a plain shell) when one exists, else
-    /// the captured foreground input. The override is gated on `restoreEnabled` — the toggle stays the single
-    /// master switch, matching `initialCommand`, the other explicit user-set seed. It is typed VERBATIM (never
-    /// run through `shellQuotedLine`), so `cd x && claude --resume y` works as written; the captured input
-    /// arrives already gated + denylist-filtered from the app side.
+    /// the captured foreground input. The override is gated on `restoreEnabled`, keeping the toggle the
+    /// single master switch (like `initialCommand`, the other explicit user-set seed), and is typed
+    /// VERBATIM — never through `shellQuotedLine` — so `cd x && claude --resume y` works as written; the
+    /// captured input arrives already gated + denylist-filtered from the app side.
     public static func restoreInput(restoreEnabled: Bool, restoreOverride: String?,
                                     capturedInput: String?) -> String? {
         guard let restoreOverride else { return capturedInput }
@@ -99,14 +98,12 @@ public enum CommandRestore {
         return restoreOverride + "\n"
     }
 
-    /// Decide a pane's seed on create/restore. Pure so the gate + precedence is unit-tested off the C
-    /// boundary; the app target owns only the libghostty seeding.
-    ///
-    /// A present `restoreOverride` short-circuits everything: it wins over both the captured foreground and
-    /// `initialCommand`, `command` is always nil (an override never takes the exec path), and the input comes
-    /// from `restoreInput` — so it obeys the `restoreEnabled` toggle while bypassing the denylist structurally
-    /// (that heuristic guards BLIND capture; an override names its command deliberately). With no override
-    /// this reproduces the capture/`initialCommand` precedence unchanged.
+    /// Decide a pane's seed on create/restore. Pure, so the gate + precedence is unit-tested off the C
+    /// boundary; the app target owns only the libghostty seeding. A present `restoreOverride`
+    /// short-circuits everything: it wins over the captured foreground and `initialCommand`, `command` is
+    /// always nil (an override never takes the exec path), and the input comes from `restoreInput` — so it
+    /// obeys the `restoreEnabled` toggle while bypassing the denylist, which guards BLIND capture, not a
+    /// deliberately named command. With no override the capture/`initialCommand` precedence applies.
     public static func restorePlan(_ inputs: RestoreInputs) -> RestorePlan {
         if inputs.restoreOverride != nil {
             let input = restoreInput(restoreEnabled: inputs.restoreEnabled, restoreOverride: inputs.restoreOverride,
@@ -131,9 +128,9 @@ public enum CommandRestore {
         return result
     }
 
-    /// Render an argv into a single POSIX shell command line by single-quoting each argument (so spaces,
-    /// `$`, globs, and quotes survive intact), space-joined. The inverse of capture; fed to a restored
-    /// login shell via `initial_input`.
+    /// Render an argv into one POSIX shell command line, single-quoting each argument (so spaces, `$`,
+    /// globs and quotes survive intact) and space-joining. The inverse of capture; fed to a restored login
+    /// shell via `initial_input`.
     public static func shellQuotedLine(_ argv: [String]) -> String {
         argv.map(shellQuote).joined(separator: " ")
     }

--- a/agtermCore/Sources/agtermCore/ConfigPaths.swift
+++ b/agtermCore/Sources/agtermCore/ConfigPaths.swift
@@ -29,9 +29,8 @@ public enum ConfigPaths {
         // longer than any current one can never silently truncate.
         let nameColumnWidth = (BuiltinAction.allCases.map { $0.rawValue.count }.max() ?? 0) + 2
         let actionLines = BuiltinAction.allCases.map { action -> String in
-            // a default whose key can't round-trip through the keymap grammar (e.g. increase_font_size's
-            // `+`, which clashes with the `+` separator) is documented as not file-expressible rather
-            // than printed as an unparseable token like `cmd++`.
+            // a default whose key can't round-trip through the keymap grammar (increase_font_size's `+`
+            // clashes with the `+` separator) documents as not-expressible, not an unparseable `cmd++`.
             let chord = action.defaultChord.map(starterChordSyntax) ?? "(no default)"
             return "#   \(action.rawValue.padding(toLength: nameColumnWidth, withPad: " ", startingAt: 0))\(chord)"
         }.joined(separator: "\n")
@@ -104,32 +103,28 @@ public enum ConfigPaths {
         configDirectory.appendingPathComponent("restore-denylist.conf")
     }
 
-    /// The shell command that opens `path` in the user's editor (`$VISUAL` else `$EDITOR` else `vi`),
-    /// working under POSIX login shells (zsh/bash/dash) AND fish. Shared by the keymap and ghostty-config
-    /// editor overlays.
+    /// The shell command that opens `path` in the user's editor (`$VISUAL` else `$EDITOR` else `vi`), under
+    /// POSIX login shells (zsh/bash/dash) AND fish. Shared by the keymap and ghostty-config editor overlays.
     ///
-    /// The user's INTERACTIVE login shell (`$SHELL -ilc`) is run first so it sources its rc and EXPORTS
-    /// `$EDITOR`/`$VISUAL` — the overlay's own process is a bare non-interactive `/bin/sh` that sources
-    /// none of the user's shell config, and a GUI-launched app inherits no shell env, so without this the
-    /// editor resolution always fell back to `vi`. The login shell then `exec`s a POSIX `/bin/sh` that does
-    /// the actual `${VISUAL:-${EDITOR:-vi}} "$1"` resolution + launch. Doing the resolution in the inner
-    /// `/bin/sh` (not in `$SHELL` directly) is what makes this work for fish: it can't parse POSIX
-    /// `${VAR:-default}` parameter-expansion, so the previous `$SHELL -ilc '${VISUAL:-${EDITOR:-vi}} …'`
-    /// died with `${ is not a valid variable` (exit 127) and the overlay just flashed. Here that POSIX text
-    /// rides inside single quotes that fish (and POSIX shells) pass through verbatim to the inner `/bin/sh`.
-    /// The path is embedded single-quoted as the inner `/bin/sh`'s positional `$1` (NOT passed positionally
-    /// to `$SHELL`, since fish has no `$1`), so spaces and embedded quotes survive.
+    /// The user's INTERACTIVE login shell (`$SHELL -ilc`) runs first so it sources its rc and EXPORTS
+    /// `$EDITOR`/`$VISUAL`: the overlay's own process is a bare non-interactive `/bin/sh` sourcing none of
+    /// the user's shell config, and a GUI-launched app inherits no shell env, so without this the editor
+    /// resolution always fell back to `vi`. It then `exec`s a POSIX `/bin/sh` doing the actual
+    /// `${VISUAL:-${EDITOR:-vi}} "$1"` resolution + launch — resolving there rather than in `$SHELL` is what
+    /// makes fish work, since fish cannot parse POSIX `${VAR:-default}` and the previous
+    /// `$SHELL -ilc '${VISUAL:-${EDITOR:-vi}} …'` died with `${ is not a valid variable` (exit 127), leaving
+    /// the overlay to flash. That POSIX text rides in single quotes fish and POSIX shells pass through
+    /// verbatim, and the path is embedded single-quoted as the inner shell's positional `$1` (NOT passed
+    /// positionally to `$SHELL`, since fish has no `$1`), so spaces and embedded quotes survive.
     ///
-    /// Two known limits: it assumes `$SHELL` accepts the `-ilc` flags and passes single-quoted text
-    /// verbatim — true for sh/bash/zsh/fish, NOT csh/tcsh (which reject `-ilc`); and it resolves
-    /// `$EDITOR`/`$VISUAL` only when EXPORTED (their universal convention — `export EDITOR=…` /
-    /// fish `set -gx EDITOR …`), since a non-exported, shell-local value does not survive the `exec`.
+    /// Two known limits: `$SHELL` must accept `-ilc` and pass single-quoted text verbatim — true for
+    /// sh/bash/zsh/fish, NOT csh/tcsh, which reject `-ilc`; and `$EDITOR`/`$VISUAL` resolve only when
+    /// EXPORTED (their universal convention — `export EDITOR=…` / fish `set -gx EDITOR …`), since a
+    /// non-exported, shell-local value does not survive the `exec`.
     public static func editorCommand(forPath path: String) -> String {
         // POSIX single-quote: wrap in '…' and escape any embedded ' as '\'' (works in fish + POSIX shells).
         func singleQuoted(_ s: String) -> String { "'\(s.replacingOccurrences(of: "'", with: "'\\''"))'" }
-        // the POSIX resolution + launch, run by the inner /bin/sh regardless of the login shell.
         let inner = "${VISUAL:-${EDITOR:-vi}} \"$1\""
-        // what the login shell runs: source its rc (above), then hand off to /bin/sh with the path as $1.
         let viaPosix = "exec /bin/sh -c \(singleQuoted(inner)) agterm-config-edit \(singleQuoted(path))"
         return "${SHELL:-/bin/zsh} -ilc \(singleQuoted(viaPosix))"
     }

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -266,7 +266,6 @@ public struct ControlDispatcher {
         case .sessionSelect:
             return actions.selectSession(request.target, window: request.args?.window)
         case .sessionGo:
-            // unknown/missing `to` is a structured error.
             guard let dir = (request.args?.to).flatMap(SessionNavigation.init(wire:)) else {
                 return ControlResponse(ok: false, error: "session.go requires --to next|prev|first|last|next-attention|prev-attention")
             }
@@ -365,9 +364,8 @@ public struct ControlDispatcher {
     /// `session.restore`: parse the `set`|`none`|`clear` mode into a `ControlRestoreOverride` and the pane
     /// selector into a `StatusPane`, then hand both to the host. A pinned command is validated but NEVER
     /// rewritten — it is a shell line, so metacharacters are the point; it is rejected only for being
-    /// absent, carrying control characters, or exceeding the storage cap. An EMPTY command is the same
-    /// pinned-to-nothing state as `none`. `paneID` rides through opaquely (the dispatcher has no session
-    /// to resolve it against).
+    /// absent, carrying control characters, or exceeding the storage cap. An EMPTY command means the same
+    /// pinned-to-nothing state as `none`. `paneID` rides through opaquely (no session here to resolve it).
     private func dispatchSessionRestore(_ request: ControlRequest) -> ControlResponse {
         let args = request.args
         let pin: ControlRestoreOverride
@@ -616,8 +614,8 @@ public struct ControlDispatcher {
     }
 
     /// The quick-terminal input/read commands, `async` because the app side polls briefly for the surface
-    /// to mount + realize after `quick show` (the twin of `session.type`/`session.text`, which are async
-    /// for the same realize-wait reason).
+    /// to mount + realize after `quick show` — the same realize-wait that makes `session.type`/`session.text`
+    /// async.
     private func dispatchQuickCommand(_ request: ControlRequest) async -> ControlResponse {
         switch request.cmd {
         case .quickType:
@@ -757,14 +755,14 @@ public struct ControlDispatcher {
         }
     }
 
-    /// The dashboard overlay is host-free-validated here. The open path needs at least one id (or `--mru`)
-    /// and at most one font flag; `--close` takes no id, `--mru`, or font flag; a `--font-size` must be
-    /// finite and positive; `--mru` cannot be combined with explicit ids (but composes with the font flags).
-    /// The 9-cell cap is NOT applied here: the cell unit is a session+pane, so a split session expands to two
-    /// cells and the cap counts PANES — that expansion needs the store, so it lives app-side in
-    /// `ControlServer.setDashboard`, which also reports any dropped panes. Target resolution (incl. the
-    /// `--mru` recency lookup), the pane expansion + cap, the surface reparent, and the per-window controller
-    /// all stay app-side behind `ControlActions.setDashboard`; this only forwards the raw ids.
+    /// The dashboard overlay is host-free-validated here: an open needs at least one id (or `--mru`) and at
+    /// most one font flag, `--close` takes no id/`--mru`/font flag, a `--font-size` must be finite and
+    /// positive, and `--mru` cannot be combined with explicit ids (but composes with the font flags).
+    /// The 9-cell cap is NOT applied here — the cell unit is a session+pane, so a split session expands to
+    /// two cells and the cap counts PANES, which needs the store. That expansion + cap, the dropped-pane
+    /// report, target resolution (incl. the `--mru` recency lookup), the surface reparent, and the
+    /// per-window controller all live app-side behind `ControlActions.setDashboard`
+    /// (`ControlServer.setDashboard`); this only forwards the raw ids.
     private func dispatchDashboard(_ request: ControlRequest) -> ControlResponse {
         let args = request.args
         let targets = args?.targets ?? []
@@ -787,8 +785,6 @@ public struct ControlDispatcher {
         }
         let fontMode: DashboardFontMode = autoSize ? .auto : (fontSize.map(DashboardFontMode.fixed) ?? .untouched)
         if mru {
-            // --mru supplies the members app-side from the window's recency, so it takes no explicit ids; the
-            // font flags still apply.
             guard targets.isEmpty else {
                 return ControlResponse(ok: false, error: "dashboard --mru cannot be combined with explicit session ids")
             }

--- a/agtermCore/Sources/agtermCore/ControlEvents.swift
+++ b/agtermCore/Sources/agtermCore/ControlEvents.swift
@@ -17,9 +17,8 @@ public struct ControlEventPayload: Codable, Sendable, Equatable {
     public var pane: String?
     public var blink: Bool?
     public var color: String?
-    /// The `status` event's per-call glyph silhouette (a `StatusShape` raw value), or nil when the glyph
-    /// uses the Settings shape / the default plain circle. A shape-only change is a real indicator change,
-    /// so it DOES emit a `status` event — without this field a consumer could not explain it.
+    /// The `status` event's per-call glyph silhouette (a `StatusShape` raw value), nil when the glyph uses the
+    /// Settings shape / default plain circle. A shape-only change emits a `status` event, unexplainable without it.
     public var shape: String?
     public var title: String?
     public var body: String?

--- a/agtermCore/Sources/agtermCore/ControlKeymap.swift
+++ b/agtermCore/Sources/agtermCore/ControlKeymap.swift
@@ -6,16 +6,16 @@ public struct ControlKeymapAction: Codable, Sendable, Equatable {
     public var action: String
     /// The resolved chord in kitty syntax (`cmd+shift+e`), omitted when the action is keyless.
     ///
-    /// One shipped default cannot be typed back into `keymap.conf`: `increase_font_size` is ⌘+, which
-    /// renders `cmd++` and does not re-parse (`+` is the chord joiner). It is reported verbatim anyway,
-    /// because the live `menu` half renders that item identically — substituting a placeholder here would
-    /// turn the one row that compares correctly into a false mismatch, which costs more than the wart.
+    /// One shipped default cannot be typed back into `keymap.conf`: `increase_font_size` is ⌘+, rendering
+    /// `cmd++`, which does not re-parse (`+` is the chord joiner). Reported verbatim anyway — the live `menu`
+    /// half renders that item identically, so a placeholder would turn the one row that compares correctly
+    /// into a false mismatch.
     public var chord: String?
     /// `true` when the action's resolved chord DIFFERS from its shipped default; omitted otherwise.
     ///
-    /// Deliberately a comparison of chords rather than "a `map` line exists for this action": a
-    /// redundant `map cmd+w close_session` parses fine and leaves the action on its default, and marking
-    /// that as overridden would report a difference a caller cannot see anywhere else.
+    /// Deliberately a chord comparison rather than "a `map` line exists for this action": a redundant
+    /// `map cmd+w close_session` parses fine and leaves the action on its default, and marking that overridden
+    /// would report a difference a caller cannot see anywhere else.
     public var overridden: Bool?
 
     public init(action: String, chord: String? = nil, overridden: Bool? = nil) {
@@ -53,10 +53,9 @@ public struct ControlKeymapDiagnostic: Codable, Sendable, Equatable {
 
 /// A live menu item that carries a key equivalent.
 ///
-/// This is the half that makes `keymap.list` diagnostic rather than merely descriptive. The `actions`
-/// list says what the keymap RESOLVED; this says what the menu bar is actually dispatching, and the two
-/// can disagree — SwiftUI defers its menu rebuild to the next app activation, so a chord can be correct
-/// in the model and stale in the menu.
+/// The half that makes `keymap.list` diagnostic rather than merely descriptive: `actions` says what the keymap
+/// RESOLVED, this says what the menu bar is actually dispatching, and the two can disagree — SwiftUI defers its
+/// menu rebuild to the next app activation, so a chord can be correct in the model and stale in the menu.
 public struct ControlKeymapMenuItem: Codable, Sendable, Equatable {
     /// The owning top-level menu's title, e.g. `File`.
     public var menu: String
@@ -67,14 +66,12 @@ public struct ControlKeymapMenuItem: Codable, Sendable, Equatable {
     /// anything else is an AppKit-supplied item (`performClose:`, `closeAll:`, …), which is what a
     /// stock item competing for an agterm chord looks like.
     public var selector: String?
-    /// `false` when the item is disabled and its chord therefore INERT — AppKit consumes the key
-    /// equivalent and fires nothing, so a same-chord enabled sibling does not run either. Omitted when
-    /// the item is enabled, which is the ordinary case.
+    /// `false` when the item is disabled and its chord therefore INERT — AppKit consumes the key equivalent
+    /// and fires nothing, so a same-chord enabled sibling does not run either. Omitted when enabled.
     ///
-    /// Worth reporting because disabled items are routine here rather than exotic: most File/View/Navigate
-    /// items carry a `modalActive` gate, so with the dashboard open the menu is largely inert while still
-    /// holding every chord. A caller comparing `actions` against `menu` would otherwise see the binding
-    /// present and conclude the menu is fine.
+    /// Reported because disabled items are routine here rather than exotic: most File/View/Navigate items carry
+    /// a `modalActive` gate, so with the dashboard open the menu is largely inert while still holding every
+    /// chord, and a caller comparing `actions` against `menu` would see the binding present and think it fine.
     public var enabled: Bool?
 
     public init(menu: String, title: String, chord: String, selector: String? = nil, enabled: Bool? = nil) {
@@ -107,12 +104,12 @@ public struct ControlKeymap: Codable, Sendable, Equatable {
 }
 
 public extension ControlKeymap {
-    /// Project a parsed keymap into the `keymap.list` payload. Host-free: the caller supplies the live
-    /// `menu` separately, since only the app target can read `NSApp.mainMenu`.
+    /// Project a parsed keymap into the `keymap.list` payload. Host-free: the caller supplies the live `menu`
+    /// separately, since only the app target can read `NSApp.mainMenu`.
     ///
-    /// Actions come out in `BuiltinAction.allCases` order rather than sorted, so the listing groups the
-    /// way the file's own reference comment does (window, workspace, session, …) instead of scattering
-    /// related actions alphabetically.
+    /// Actions come out in `BuiltinAction.allCases` order rather than sorted, so the listing groups the way the
+    /// file's own reference comment does (window, workspace, session, …) instead of scattering them
+    /// alphabetically.
     static func project(keymap: Keymap, diagnostics: [KeymapDiagnostic], path: String,
                         menu: [ControlKeymapMenuItem]? = nil) -> ControlKeymap {
         let actions = BuiltinAction.allCases.map { action in

--- a/agtermCore/Sources/agtermCore/ControlModes.swift
+++ b/agtermCore/Sources/agtermCore/ControlModes.swift
@@ -19,8 +19,7 @@ public enum ControlToggleMode: Equatable, Sendable {
     case off
     case toggle
 
-    /// Parse a mode string, nil defaulting to `toggle`. Callers keep their command-specific tokens and
-    /// error strings by choosing the true/false spellings they already expose on the wire.
+    /// Parse a mode string (nil = `toggle`); `onToken`/`offToken` keep each command's own wire spellings.
     public static func parse(_ mode: String?, on onToken: String = "on", off offToken: String = "off") -> ControlToggleMode? {
         let value = mode ?? "toggle"
         if value == onToken { return .on }
@@ -78,28 +77,23 @@ public enum ControlSidebarViewMode: Equatable, Sendable {
     }
 }
 
-/// The four modes `workspace.focus` accepts, raw values being the wire tokens: `on` replaces the marked set
-/// with the target and enables the filter; `off` removes the target, disabling once the set empties;
-/// `toggle` replace-toggles (clears when the set is exactly the target and enabled, else replaces and
-/// enables); `add` inserts the target WITHOUT touching the filter flag — marking alone, so a set is built
-/// member by member with the whole tree on screen, where an add that enabled the filter would hide the rows
-/// the next add needs. There is deliberately no membership-TOGGLE mode: the row menu's membership item
-/// computes its own direction from what it just read and maps to `add` or `off`.
+/// The four modes `workspace.focus` accepts; raw values are the wire tokens and `helpSummary` states each
+/// one's effect. `add` leaves the filter flag alone so a set is built member by member with the whole tree on
+/// screen — an add that enabled the filter would hide the rows the next add needs. There is no
+/// membership-TOGGLE mode: the row menu's membership item computes its own direction from what it just read
+/// and maps to `add` or `off`.
 public enum ControlWorkspaceFocusMode: String, CaseIterable, Equatable, Sendable {
     case on, off, toggle, add
 
-    /// The accepted names pipe-joined (`on|off|toggle|add`) — the compact form the dispatcher's rejection
-    /// message uses. Derived from `allCases`, like `StatusShape.validNamesList`, so it cannot go stale.
+    /// Pipe-joined (`on|off|toggle|add`) for the dispatcher's rejection message; derived from `allCases`.
     public static var validNamesList: String { validNames.joined(separator: "|") }
 
-    /// The accepted names comma-joined (`on, off, toggle, add`) — the prose form the `agtermctl workspace
-    /// focus` local rejection message uses.
+    /// Comma-joined (`on, off, toggle, add`) for the `agtermctl workspace focus` local rejection message.
     public static var validNamesPhrase: String { validNames.joined(separator: ", ") }
 
-    /// What this mode does to the marked set AND the filter flag in one clause — the building block of the
-    /// `agtermctl workspace focus` argument help, so that help cannot go stale when a case is added (the
-    /// `StatusShape.validNamesPhrase` precedent). Every clause names the filter effect, since `add`'s
-    /// "leaves the flag alone" reads as the exception unless the others say so too.
+    /// One clause per mode for the `agtermctl workspace focus` argument help (the
+    /// `StatusShape.validNamesPhrase` precedent), so that help cannot go stale when a case is added. Every
+    /// clause names the filter effect, else `add`'s "leaves the flag alone" reads as the exception.
     public var helpSummary: String {
         switch self {
         case .on: return "on (mark it alone and apply the filter)"
@@ -119,9 +113,8 @@ public enum ControlWorkspaceFocusMode: String, CaseIterable, Equatable, Sendable
 public enum ControlSessionMove: Equatable, Sendable {
     case reorder(ReorderDirection)
     case workspace(String)
-    /// Relocate + position relative to an anchor session (id / prefix / `active`); `after == false` places
-    /// before it. The anchor carries its own workspace, so this form self-identifies the destination and
-    /// never reads the workspace parameter.
+    /// Relocate relative to an anchor session (id / prefix / `active`); `after == false` places before it.
+    /// The anchor carries its own workspace, so this form never reads the workspace parameter.
     case place(anchor: String, after: Bool)
 }
 
@@ -139,17 +132,15 @@ public struct ControlSessionCreateOptions: Equatable, Sendable {
     public let workspaceName: String?
     public let createWorkspace: Bool?
     public let command: String?
-    /// Whether a `--command` session HOLDS its surface after the command exits (`--wait`) instead of
-    /// closing. Meaningful only with `command`; the dispatcher rejects `--wait` without a `--command`.
+    /// Hold the surface after `--command` exits; the dispatcher rejects `--wait` without a `--command`.
     public let wait: Bool?
     public let name: String?
-    /// Anchor session to place the new session right AFTER (id / prefix / `active`); the anchor carries its
-    /// own workspace, so this bypasses `workspace`/`workspaceName`. Mutually exclusive with `before`.
+    /// Anchor to place the new session right AFTER (id / prefix / `active`); it carries its own workspace,
+    /// so this bypasses `workspace`/`workspaceName`. Mutually exclusive with `before`.
     public let after: String?
     /// Anchor session to place the new session right BEFORE, the mirror of `after`.
     public let before: String?
-    /// Create in the background: skip selecting and focusing, leaving the current selection untouched (the
-    /// CLI's `--no-select`). Defaults to false, the normal select-and-focus behavior.
+    /// Create in the background (`--no-select`): skip select+focus, leaving the current selection untouched.
     public let noSelect: Bool
 
     public init(window: String?, cwd: String?, workspace: String?, workspaceName: String?,
@@ -169,25 +160,24 @@ public struct ControlSessionCreateOptions: Equatable, Sendable {
     }
 }
 
-/// Parsed `session.status` payload. Sound validation and playback stay host-side; `color` is the per-call
-/// `#rrggbb` glyph-tint override (hex-validated in the dispatcher) and `shape` the per-call silhouette
-/// override (parsed to `StatusShape` there), both threaded onto the ephemeral `AgentIndicator`.
+/// Parsed `session.status` payload. Sound validation and playback stay host-side; the dispatcher
+/// hex-validates the per-call `#rrggbb` `color`, and both overrides thread onto the ephemeral
+/// `AgentIndicator`.
 public struct ControlSessionStatusUpdate: Equatable, Sendable {
     public let status: AgentStatus
     public let blink: Bool?
     public let autoReset: Bool?
     public let sound: String?
     public let color: String?
-    /// The per-call glyph silhouette; nil falls back to the Settings shape / the built-in plain circle.
-    /// Already validated — the dispatcher rejects an unknown raw value before any mutation.
+    /// Per-call glyph silhouette; nil falls back to the Settings shape / the built-in plain circle. The
+    /// dispatcher rejects an unknown raw value before any mutation.
     public let shape: StatusShape?
     /// Which pane set the status (`left`=main, `right`=split, `scratch`), nil when unspecified. Stamped onto
     /// the indicator so pane-scoped keystroke-clear and pane-aware navigation know which surface blocked.
     public let pane: StatusPane?
-    /// The surface's STABLE spawn token (the shell's baked `AGTERM_PANE_ID`, forwarded by the hook as
-    /// `--pane-id`), carried through only — resolution stays app-side against the session's live surfaces
-    /// (`Session.paneRole(forToken:)`) because the dispatcher has no session. When it resolves it OVERRIDES
-    /// the stale role `pane`, fixing a status set from a promoted-then-re-split pane (#199);
+    /// The surface's STABLE spawn token (the shell's baked `AGTERM_PANE_ID`, forwarded as `--pane-id`),
+    /// carried through only: the dispatcher has no session, so `Session.paneRole(forToken:)` resolves it
+    /// app-side. A resolved token OVERRIDES the stale role `pane` (a promoted-then-re-split pane, #199);
     /// nil/empty/unknown falls back to `pane`.
     public let paneID: String?
 
@@ -205,10 +195,9 @@ public struct ControlSessionStatusUpdate: Equatable, Sendable {
     }
 }
 
-/// The three forms of the `session.restore` per-pane restore-command override, parsed from the wire tokens
-/// `set` / `none` / `clear`. `pinNone` is deliberately NOT spelled `none`: a bare `case none` makes the
-/// compiler warn "assuming you mean Optional<T>.none" wherever the enum appears in an Optional context,
-/// which the dispatcher's parse step does.
+/// The three forms of the `session.restore` per-pane restore-command override, from the wire tokens
+/// `set` / `none` / `clear`. `pinNone` is not spelled `none`: a bare `case none` makes the compiler warn
+/// "assuming you mean Optional<T>.none" in an Optional context, which the dispatcher's parse step is.
 public enum ControlRestoreOverride: Equatable, Sendable {
     /// wire `set` — pin this shell line, run verbatim on the next launch.
     case pin(String)
@@ -217,19 +206,17 @@ public enum ControlRestoreOverride: Equatable, Sendable {
     /// wire `clear` — drop the pin, back to the captured-foreground auto-restore.
     case unpin
 
-    /// The storage bound on a pinned command, in UTF-8 BYTES (not graphemes): the value persists in
-    /// `windows/<id>.json`, so the cap guards the snapshot, not the display width.
+    /// Storage bound in UTF-8 BYTES, not graphemes: the pin persists in `windows/<id>.json`, so the cap
+    /// guards the snapshot, not the display width.
     public static let maxCommandBytes = 1024
 }
 
-/// Parsed `session.restore` payload. Pane resolution stays host-side: `paneID` is carried opaquely and
-/// resolved app-side against the session's LIVE surfaces (`Session.paneRole(forToken:)`), falling back to
-/// the baked role `pane` — and, unlike `session.status`, an unresolvable token with no explicit `pane` is an
-/// error rather than a silent main-pane default.
+/// Parsed `session.restore` payload. `paneID` is carried opaquely and resolved app-side against the LIVE
+/// surfaces (`Session.paneRole(forToken:)`), falling back to the baked role `pane` — but unlike
+/// `session.status`, an unresolvable token with no explicit `pane` errors instead of defaulting to main.
 public struct ControlSessionRestoreUpdate: Equatable, Sendable {
     public let pin: ControlRestoreOverride
-    /// Which pane to pin (`left`=main, `right`=split; `scratch` is rejected app-side — the scratch terminal
-    /// is never restored); nil = the main pane.
+    /// Which pane to pin (`left`=main, `right`=split, nil=main); `scratch` is rejected app-side, never restored.
     public let pane: StatusPane?
     /// The surface's STABLE spawn token (the shell's baked `AGTERM_PANE_ID`), forwarded as `--pane-id`.
     public let paneID: String?

--- a/agtermCore/Sources/agtermCore/ControlModes.swift
+++ b/agtermCore/Sources/agtermCore/ControlModes.swift
@@ -19,7 +19,7 @@ public enum ControlToggleMode: Equatable, Sendable {
     case off
     case toggle
 
-    /// Parse a mode string, defaulting nil to `toggle`. Callers keep their command-specific tokens and
+    /// Parse a mode string, nil defaulting to `toggle`. Callers keep their command-specific tokens and
     /// error strings by choosing the true/false spellings they already expose on the wire.
     public static func parse(_ mode: String?, on onToken: String = "on", off offToken: String = "off") -> ControlToggleMode? {
         let value = mode ?? "toggle"
@@ -78,30 +78,28 @@ public enum ControlSidebarViewMode: Equatable, Sendable {
     }
 }
 
-/// The four modes `workspace.focus` accepts: `on` replaces the marked set with the target and enables
-/// the filter, `off` removes the target (disabling once the set empties), `toggle` replace-toggles
-/// (clears when the set is exactly the target and enabled, else replaces with the target and enables),
-/// and `add` inserts the target WITHOUT touching the filter flag — marking alone, so a set can be built
-/// member by member with the whole tree still on screen (an add that enabled the filter would hide the
-/// rows the next add needs). There is deliberately no membership-TOGGLE mode — the row menu's membership
-/// item computes its own direction from what it just read and maps to `add` or `off`. Raw values are the
-/// wire tokens.
+/// The four modes `workspace.focus` accepts, raw values being the wire tokens: `on` replaces the marked set
+/// with the target and enables the filter; `off` removes the target, disabling once the set empties;
+/// `toggle` replace-toggles (clears when the set is exactly the target and enabled, else replaces and
+/// enables); `add` inserts the target WITHOUT touching the filter flag — marking alone, so a set is built
+/// member by member with the whole tree on screen, where an add that enabled the filter would hide the rows
+/// the next add needs. There is deliberately no membership-TOGGLE mode: the row menu's membership item
+/// computes its own direction from what it just read and maps to `add` or `off`.
 public enum ControlWorkspaceFocusMode: String, CaseIterable, Equatable, Sendable {
     case on, off, toggle, add
 
     /// The accepted names pipe-joined (`on|off|toggle|add`) — the compact form the dispatcher's rejection
-    /// message uses. Derived from `allCases`, like `StatusShape.validNamesList`, so no message can go
-    /// stale when the set changes.
+    /// message uses. Derived from `allCases`, like `StatusShape.validNamesList`, so it cannot go stale.
     public static var validNamesList: String { validNames.joined(separator: "|") }
 
     /// The accepted names comma-joined (`on, off, toggle, add`) — the prose form the `agtermctl workspace
     /// focus` local rejection message uses.
     public static var validNamesPhrase: String { validNames.joined(separator: ", ") }
 
-    /// What this mode does to the marked set AND to the filter flag, in one clause — the building block of
-    /// the `agtermctl workspace focus` argument help, so that help cannot go stale when a case is added
-    /// (the `StatusShape.validNamesPhrase`-builds-its-own-help precedent). Every clause names the filter
-    /// effect, since `add`'s "leaves the flag alone" reads as the exception unless the others say so too.
+    /// What this mode does to the marked set AND the filter flag in one clause — the building block of the
+    /// `agtermctl workspace focus` argument help, so that help cannot go stale when a case is added (the
+    /// `StatusShape.validNamesPhrase` precedent). Every clause names the filter effect, since `add`'s
+    /// "leaves the flag alone" reads as the exception unless the others say so too.
     public var helpSummary: String {
         switch self {
         case .on: return "on (mark it alone and apply the filter)"
@@ -121,9 +119,9 @@ public enum ControlWorkspaceFocusMode: String, CaseIterable, Equatable, Sendable
 public enum ControlSessionMove: Equatable, Sendable {
     case reorder(ReorderDirection)
     case workspace(String)
-    /// Relocate + position relative to an anchor session (id / prefix / `active`). `after == false`
-    /// places before the anchor. The anchor carries its own workspace, so this form self-identifies the
-    /// destination and never reads the workspace parameter.
+    /// Relocate + position relative to an anchor session (id / prefix / `active`); `after == false` places
+    /// before it. The anchor carries its own workspace, so this form self-identifies the destination and
+    /// never reads the workspace parameter.
     case place(anchor: String, after: Bool)
 }
 
@@ -142,17 +140,16 @@ public struct ControlSessionCreateOptions: Equatable, Sendable {
     public let createWorkspace: Bool?
     public let command: String?
     /// Whether a `--command` session HOLDS its surface after the command exits (`--wait`) instead of
-    /// closing immediately. Meaningful only with `command`; the dispatcher rejects `--wait` without a
-    /// `--command`.
+    /// closing. Meaningful only with `command`; the dispatcher rejects `--wait` without a `--command`.
     public let wait: Bool?
     public let name: String?
-    /// Anchor session to place the new session right AFTER (id / prefix / `active`); the anchor carries
-    /// its own workspace, so this bypasses `workspace`/`workspaceName`. Mutually exclusive with `before`.
+    /// Anchor session to place the new session right AFTER (id / prefix / `active`); the anchor carries its
+    /// own workspace, so this bypasses `workspace`/`workspaceName`. Mutually exclusive with `before`.
     public let after: String?
     /// Anchor session to place the new session right BEFORE, the mirror of `after`.
     public let before: String?
-    /// Create the session in the background: skip selecting and focusing it, leaving the current selection
-    /// untouched (the CLI's `--no-select`). Defaults to false — the normal select-and-focus behavior.
+    /// Create in the background: skip selecting and focusing, leaving the current selection untouched (the
+    /// CLI's `--no-select`). Defaults to false, the normal select-and-focus behavior.
     public let noSelect: Bool
 
     public init(window: String?, cwd: String?, workspace: String?, workspaceName: String?,
@@ -172,27 +169,26 @@ public struct ControlSessionCreateOptions: Equatable, Sendable {
     }
 }
 
-/// Parsed `session.status` payload. Sound validation and playback stay host-side; `color` is the
-/// per-call `#rrggbb` glyph-tint override (validated for hex in the dispatcher) and `shape` the per-call
-/// silhouette override (parsed to `StatusShape` in the dispatcher), both threaded onto the ephemeral
-/// `AgentIndicator`.
+/// Parsed `session.status` payload. Sound validation and playback stay host-side; `color` is the per-call
+/// `#rrggbb` glyph-tint override (hex-validated in the dispatcher) and `shape` the per-call silhouette
+/// override (parsed to `StatusShape` there), both threaded onto the ephemeral `AgentIndicator`.
 public struct ControlSessionStatusUpdate: Equatable, Sendable {
     public let status: AgentStatus
     public let blink: Bool?
     public let autoReset: Bool?
     public let sound: String?
     public let color: String?
-    /// The per-call glyph silhouette, or nil to fall back to the Settings shape / the built-in plain
-    /// circle. Already validated — the dispatcher rejects an unknown raw value before any mutation.
+    /// The per-call glyph silhouette; nil falls back to the Settings shape / the built-in plain circle.
+    /// Already validated — the dispatcher rejects an unknown raw value before any mutation.
     public let shape: StatusShape?
-    /// Which pane set the status (`left`=main, `right`=split, `scratch`), or nil when unspecified. Stamped
-    /// onto the indicator so pane-scoped keystroke-clear and pane-aware navigation know which surface blocked.
+    /// Which pane set the status (`left`=main, `right`=split, `scratch`), nil when unspecified. Stamped onto
+    /// the indicator so pane-scoped keystroke-clear and pane-aware navigation know which surface blocked.
     public let pane: StatusPane?
     /// The surface's STABLE spawn token (the shell's baked `AGTERM_PANE_ID`, forwarded by the hook as
-    /// `--pane-id`). Resolved app-side against the session's live surfaces (`Session.paneRole(forToken:)`);
-    /// when it resolves it OVERRIDES the stale role `pane`, fixing a status set from a promoted-then-re-split
-    /// pane (#199). nil/empty/unknown falls back to `pane`. The resolution stays app-side because the
-    /// dispatcher has no session — this only carries the token through.
+    /// `--pane-id`), carried through only — resolution stays app-side against the session's live surfaces
+    /// (`Session.paneRole(forToken:)`) because the dispatcher has no session. When it resolves it OVERRIDES
+    /// the stale role `pane`, fixing a status set from a promoted-then-re-split pane (#199);
+    /// nil/empty/unknown falls back to `pane`.
     public let paneID: String?
 
     public init(status: AgentStatus, blink: Bool?, autoReset: Bool?, sound: String?,
@@ -209,10 +205,10 @@ public struct ControlSessionStatusUpdate: Equatable, Sendable {
     }
 }
 
-/// The three forms of the `session.restore` per-pane restore-command override, parsed from the wire
-/// tokens `set` / `none` / `clear`. `pinNone` is deliberately NOT spelled `none`: a bare `case none`
-/// makes the compiler warn "assuming you mean Optional<T>.none" wherever the enum appears in an
-/// Optional context, which the dispatcher's parse step does.
+/// The three forms of the `session.restore` per-pane restore-command override, parsed from the wire tokens
+/// `set` / `none` / `clear`. `pinNone` is deliberately NOT spelled `none`: a bare `case none` makes the
+/// compiler warn "assuming you mean Optional<T>.none" wherever the enum appears in an Optional context,
+/// which the dispatcher's parse step does.
 public enum ControlRestoreOverride: Equatable, Sendable {
     /// wire `set` — pin this shell line, run verbatim on the next launch.
     case pin(String)
@@ -221,19 +217,19 @@ public enum ControlRestoreOverride: Equatable, Sendable {
     /// wire `clear` — drop the pin, back to the captured-foreground auto-restore.
     case unpin
 
-    /// The storage bound on a pinned command, in UTF-8 BYTES (not graphemes) — the value persists in
+    /// The storage bound on a pinned command, in UTF-8 BYTES (not graphemes): the value persists in
     /// `windows/<id>.json`, so the cap guards the snapshot, not the display width.
     public static let maxCommandBytes = 1024
 }
 
-/// Parsed `session.restore` payload. The pane resolution stays host-side: `paneID` is carried through
-/// opaquely and resolved app-side against the session's LIVE surfaces (`Session.paneRole(forToken:)`),
-/// falling back to the baked role `pane` — and, unlike `session.status`, an unresolvable token with no
-/// explicit `pane` is an error rather than a silent main-pane default.
+/// Parsed `session.restore` payload. Pane resolution stays host-side: `paneID` is carried opaquely and
+/// resolved app-side against the session's LIVE surfaces (`Session.paneRole(forToken:)`), falling back to
+/// the baked role `pane` — and, unlike `session.status`, an unresolvable token with no explicit `pane` is an
+/// error rather than a silent main-pane default.
 public struct ControlSessionRestoreUpdate: Equatable, Sendable {
     public let pin: ControlRestoreOverride
-    /// Which pane to pin (`left`=main, `right`=split; `scratch` is rejected app-side — the scratch
-    /// terminal is never restored), or nil for the main pane.
+    /// Which pane to pin (`left`=main, `right`=split; `scratch` is rejected app-side — the scratch terminal
+    /// is never restored); nil = the main pane.
     public let pane: StatusPane?
     /// The surface's STABLE spawn token (the shell's baked `AGTERM_PANE_ID`), forwarded as `--pane-id`.
     public let paneID: String?

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -1,8 +1,7 @@
 import Foundation
 
-/// A control command name, the `cmd` field of a `ControlRequest`. Raw values are the wire strings
-/// the CLI and the socket server agree on; an unknown string fails to decode, which the server
-/// turns into an "unknown command" error rather than a crash.
+/// A control command name, the `cmd` field of a `ControlRequest`. Raw values are the wire strings the CLI
+/// and the socket server share; an unknown one fails to decode into an "unknown command" error, not a crash.
 public enum Command: String, Codable, Sendable {
     case tree
     case eventsRead = "events.read"
@@ -75,21 +74,19 @@ public enum Command: String, Codable, Sendable {
     case pickResult = "pick.result"
     case pickCancel = "pick.cancel"
     case restoreClear = "restore.clear"
-    /// UI-TEST-ONLY: force the app-level appearance (`light`|`dark` via `args.name`) so an XCUITest can
-    /// simulate a macOS light/dark flip; with NO name it READS the side the last config feed applied,
-    /// so a test can assert the flip actually drove the reload. The server refuses it outside an
-    /// XCUITest launch; deliberately EXEMPT from the four-point keep-in-sync (no CLI subcommand, absent
-    /// from the catalog/skill).
+    /// UI-TEST-ONLY: forces the app-level appearance (`light`|`dark` via `args.name`) so an XCUITest can
+    /// simulate a macOS light/dark flip; with NO name it READS the side the last config feed applied, so a
+    /// test can assert the flip drove the reload. Refused outside an XCUITest launch, and EXEMPT from the
+    /// four-point keep-in-sync: no CLI subcommand, absent from the catalog/skill.
     case debugAppearance = "debug.appearance"
 }
 
 /// A bag of optional command parameters. Each command reads only the fields it needs; the rest stay
 /// nil and are omitted from the JSON, keeping the wire form compact.
 public struct ControlArgs: Codable, Sendable, Equatable {
-    /// New name for `workspace.new`, `workspace.rename`, `session.rename`; the initial session name
-    /// for `session.new` (optional; blank/omitted leaves the auto basename); the theme name for
-    /// `theme.set` (omitted/empty selects ghostty's built-in colors / "default ghostty", NOT the
-    /// seeded `agterm` app default).
+    /// New name for `workspace.new`/`workspace.rename`/`session.rename`; the initial `session.new` name
+    /// (blank/omitted leaves the auto basename); the `theme.set` theme (omitted/empty = ghostty's built-in
+    /// colors / "default ghostty", NOT the seeded `agterm` app default).
     public var name: String?
     /// Working directory for `session.new`.
     public var cwd: String?
@@ -105,48 +102,40 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     /// For `session.new` with `workspaceName`: create the named workspace when none exists (idempotent
     /// reuse-or-create). An error without `workspaceName` — there is nothing to create by id.
     public var createWorkspace: Bool?
-    /// For `workspace.new`: create the workspace already COLLAPSED in the sidebar (the CLI's `--collapsed`)
-    /// instead of the default expanded state, so a script can build a workspace and fill it with
-    /// `session.new --no-select` without it opening. Omitted/`false` = expanded. The read-back is the
-    /// `tree` workspace node's `collapsed` field.
+    /// For `workspace.new`: create the workspace already COLLAPSED (the CLI's `--collapsed`), so a script
+    /// can build one and fill it with `session.new --no-select` without it opening. Omitted/`false` =
+    /// expanded. Read back as the `tree` workspace node's `collapsed`.
     public var collapsed: Bool?
-    /// For `window.new`: create the window already MINIMIZED to the Dock (the CLI's `--minimized`) instead
-    /// of presenting it, so a script can build a set of project windows without each one flashing on screen
-    /// and stealing focus. Omitted/`false` presents it as usual. The read-back is the `window.list` node's
-    /// `minimized` field; the new window also hands frontmost back to a still-visible window, so untargeted
-    /// commands do not route into the Dock.
+    /// For `window.new`: create the window already MINIMIZED to the Dock (the CLI's `--minimized`), so a
+    /// script can build project windows without each flashing on screen and stealing focus; omitted/`false`
+    /// presents it. Read back as the `window.list` node's `minimized`. The new window also hands frontmost
+    /// to a still-visible one, so untargeted commands do not route into the Dock.
     public var minimized: Bool?
-    /// For `session.new`: create the session in the background without selecting or focusing it, leaving
-    /// the current selection untouched (the CLI's `--no-select`). Omitted/`false` keeps the default
-    /// select-and-focus behavior. The read-back is the existing `tree` `active` flag — the new node is not
-    /// `active`.
+    /// For `session.new`: create in the background without selecting or focusing, leaving the current
+    /// selection untouched (the CLI's `--no-select`); omitted/`false` keeps select-and-focus. Read back via
+    /// the existing `tree` `active` flag — the new node is not `active`.
     public var noSelect: Bool?
     /// Text to inject for `session.type` / `quick.type`; the search needle for `session.search`.
     public var text: String?
     /// Whether `session.type` may select a never-shown session to realize its surface.
     public var select: Bool?
-    /// Mode for `session.split` / `quick` / `surface.zoom` (`on|off|toggle`,
-    /// `show|hide|toggle` for quick/surface zoom),
+    /// Mode for `session.split` (`on|off|toggle`), `quick`/`surface.zoom` (`show|hide|toggle`),
     /// `session.flag` (`on|off|toggle|clear`), `sidebar.mode` (`tree|flagged|toggle`),
-    /// `workspace.focus` (`on|off|toggle|add`), `workspace.filter` (`on|off|toggle`),
-    /// `window.minimize` (`on|off|toggle`),
-    /// `session.background` (`image|text|color|clear`), and
-    /// `session.restore` (`set|none|clear` — pin `command`, pin nothing, or drop the pin).
+    /// `workspace.focus` (`on|off|toggle|add`), `workspace.filter`/`window.minimize` (`on|off|toggle`),
+    /// `session.background` (`image|text|color|clear`), and `session.restore` (`set|none|clear` — pin
+    /// `command`, pin nothing, or drop the pin).
     public var mode: String?
     /// The image file path for `session.background` mode `image` (PNG or JPEG).
     public var path: String?
-    /// The color (`#rrggbb`) for `session.background`: the text tint for mode `text` (nil = the terminal
-    /// foreground), or the solid background color for mode `color` (required). Mode `color` takes no
-    /// opacity — it honors the Settings window translucency. Also the optional solid background color for
-    /// `session.overlay.open` (the overlay pane's own color, independent of the session's); nil = the
-    /// default theme background, honoring the same window translucency. And the optional per-call glyph-tint
-    /// override for `session.status` (rides the ephemeral indicator, so it lasts only until the next
-    /// `session.status` without a color); nil = the Settings-configured status color.
+    /// The `#rrggbb` color for `session.background`: the mode-`text` tint (nil = terminal foreground) or the
+    /// mode-`color` solid background (required, no opacity — it honors the Settings window translucency).
+    /// Also `session.overlay.open`'s own background, independent of the session's (nil = the default theme
+    /// background, same translucency). And `session.status`'s per-call glyph tint, riding the ephemeral
+    /// indicator so it lasts only until the next `session.status` without a color (nil = the Settings color).
     public var color: String?
-    /// The per-call glyph-SILHOUETTE override for `session.status` (a `StatusShape` raw value —
-    /// `circle|square|triangle|diamond|capsule|star`, parsed and validated in the dispatcher). Rides the
-    /// ephemeral indicator like `color`, so it lasts only until the next `session.status` without a shape;
-    /// nil = the Settings-configured shape for that status, else the default plain circle.
+    /// The per-call glyph-SILHOUETTE override for `session.status`: a `StatusShape` raw value
+    /// (`circle|square|triangle|diamond|capsule|star`), dispatcher-validated. Rides the ephemeral indicator,
+    /// lasting until the next `session.status` without a shape; nil = the Settings shape, else a circle.
     public var shape: String?
     /// The `background-image-opacity` for `session.background` (image + text), 0...1; nil = ghostty's 1.0.
     public var opacity: Double?
@@ -156,20 +145,19 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     public var position: String?
     /// The `background-image-repeat` flag for `session.background`; nil = false.
     public var repeats: Bool?
-    /// Which split pane to focus for `session.focus` (`left`|`right`|`other`; `other` toggles); also
-    /// which pane to read for `session.text` (`left`|`right`; omitted = the focused pane, no `other`),
-    /// which pane `session.type` injects into (`left`|`right`; omitted = the left/main pane, the
-    /// pre-pane behavior), which pane set `session.status` (`left`|`right`|`scratch`; omitted =
-    /// `left`/main, parsed to `StatusPane`), and which pane `session.restore` pins (same `StatusPane`
-    /// spelling; omitted = `left`/main, `scratch` rejected app-side).
+    /// Which split pane to focus for `session.focus` (`left`|`right`|`other`, `other` toggles); to read for
+    /// `session.text` (`left`|`right`, omitted = the focused pane, no `other`); `session.type` injects into
+    /// (`left`|`right`, omitted = left/main, the pre-pane behavior); set `session.status`
+    /// (`left`|`right`|`scratch`, omitted = `left`/main, parsed to `StatusPane`); and `session.restore` pins
+    /// (same `StatusPane` spelling, omitted = `left`/main, `scratch` rejected app-side).
     public var pane: String?
-    /// A surface's STABLE spawn token for `session.status --pane-id` and `session.restore --pane-id` (the
-    /// shell's baked `AGTERM_PANE_ID`, forwarded by the agent-status hook). When it resolves against the
-    /// session's live surfaces it OVERRIDES the stale role `pane`, so a status set from a
-    /// promoted-then-re-split pane lands on the pane's CURRENT slot; an empty/unknown token falls back to
-    /// `pane`. Opaque — validated only by whether it resolves. `session.restore` diverges on the fallback:
-    /// an unresolvable token with NO explicit `pane` is an error there rather than a silent `left`, since
-    /// pinning the wrong pane's restore command persists. See `Session.paneRole(forToken:)` and the #199 fix.
+    /// A surface's STABLE spawn token for `session.status --pane-id`/`session.restore --pane-id` (the
+    /// shell's baked `AGTERM_PANE_ID`, forwarded by the agent-status hook). Resolving it against the
+    /// session's live surfaces OVERRIDES the stale role `pane`, so a status from a promoted-then-re-split
+    /// pane lands on the CURRENT slot; empty/unknown falls back to `pane`. Opaque — validated only by
+    /// resolving. `session.restore` diverges: an unresolvable token with NO explicit `pane` errors there
+    /// rather than silently using `left`, since a wrong restore pin persists. See
+    /// `Session.paneRole(forToken:)` and the #199 fix.
     public var paneID: String?
     /// Absolute left-pane split fraction (0...1) for `session.resize`, clamped server-side to
     /// `AppStore.splitRatioMin...splitRatioMax`. Mutually exclusive with `ratioDelta`.
@@ -186,10 +174,9 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     /// `session.move` / `workspace.move` (`up`|`down`|`top`|`bottom`), and for `session.search`
     /// (`next`|`prev`|`close`).
     public var to: String?
-    /// Anchor session (id / unique prefix / `active`) to place a session right AFTER, for the placement
-    /// form of `session.new` / `session.move`. The anchor carries its own workspace (resolved across the
-    /// whole store), so it self-identifies the destination — mutually exclusive with `to`, `before`, and
-    /// the workspace parameter.
+    /// Anchor session (id / unique prefix / `active`) to place a session right AFTER, for the placement form
+    /// of `session.new`/`session.move`. The anchor carries its own workspace (resolved across the whole
+    /// store), so it names the destination — mutually exclusive with `to`, `before`, and the workspace param.
     public var after: String?
     /// Anchor session to place a session right BEFORE, the mirror of `after` (mutually exclusive with it).
     public var before: String?
@@ -218,9 +205,8 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     /// For `session.overlay.resize`, requests the full-pane (translucent, session-hidden) overlay —
     /// the way to switch a floating overlay back to full. Mutually exclusive with `sizePercent`.
     public var full: Bool?
-    /// For `session.overlay.open`, whether to select/switch to the target after opening; omitted/false
-    /// opens in the background without changing the active session (the default for both full and
-    /// floating overlays).
+    /// For `session.overlay.open`, whether to select the target after opening; omitted/false opens in the
+    /// background without changing the active session (the default for both full and floating overlays).
     public var follow: Bool?
     /// The finished caller-provided choices for `pick.open`.
     public var items: [ControlPickItem]?
@@ -246,15 +232,13 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     public var blink: Bool?
     /// Whether the `session.status` indicator resets to idle once the session is visited (selected).
     public var autoReset: Bool?
-    /// One-shot sound to play when `session.status` is set (caller-driven, not stored on the indicator):
-    /// `default`/`beep` is the system alert sound, any other value is a named system sound
-    /// (`NSSound(named:)`, e.g. `Glass`, also resolving custom sounds in `~/Library/Sounds`). nil/empty means
-    /// no per-call sound — the app may still play the Settings "Blocked sound" default on a `blocked` status.
+    /// One-shot sound for `session.status` (caller-driven, not stored on the indicator): `default`/`beep`
+    /// = the system alert, anything else a named `NSSound(named:)` sound (e.g. `Glass`, also resolving
+    /// custom `~/Library/Sounds`). nil/empty = none; the Settings "Blocked sound" may still play on `blocked`.
     public var sound: String?
-    /// The per-slot theme names for `theme.set`: `light` is the light/single slot (an alias for the
-    /// positional `name`, so passing both is an error); `dark` sets the dark slot — its presence makes
-    /// the app track the macOS appearance (the stored value becomes ghostty's dual `light:,dark:`
-    /// form), and the reserved value `none` clears it. Names must be bundled themes.
+    /// Per-slot theme names for `theme.set`: `light` is the light/single slot (an alias for the positional
+    /// `name`, so passing both errors); `dark` sets the dark slot, whose presence makes the app track the
+    /// macOS appearance (stored as ghostty's dual `light:,dark:` form); `none` clears it. Bundled names only.
     public var light: String?
     public var dark: String?
     /// Whether `dashboard` CLOSES the open dashboard instead of opening one (the CLI's `--close`). Mutually
@@ -268,8 +252,7 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     public var autoSize: Bool?
     /// For `dashboard`, populate the grid from the target window's most-recently-used sessions (up to 9,
     /// fewer if the window has fewer) instead of explicit ids (the CLI's `--mru`). Mutually exclusive with
-    /// `targets` and `close`; composes with the font flags. The MRU resolution is app-side (it needs the
-    /// store's recency), so this only signals the intent.
+    /// `targets`/`close`, composes with the font flags; resolution is app-side (it needs the store's recency).
     public var mru: Bool?
 
     public init(name: String? = nil, cwd: String? = nil, targets: [String]? = nil,
@@ -366,12 +349,11 @@ public struct ControlRequest: Codable, Sendable, Equatable {
     }
 }
 
-/// A terminal surface as projected into the `tree` response. `id` is the stable control address to pass
-/// to `surface.zoom`; `kind` is the user-facing surface name (`left`, `right`, `scratch`, `overlay`).
-/// `active`/`visible` are derived from the session's own flags (overlay/scratch/splitFocused), NOT from
-/// terminal zoom — and `visible` reads false for a pane behind a FLOATING overlay even though that pane
-/// is visually on screen (the derivation treats any open overlay as covering). Address by `id`/`kind`,
-/// not by these flags; read the window's zoom state from the tree's top-level `zoomedSurface`.
+/// A terminal surface as projected into the `tree` response. `id` is the stable control address for
+/// `surface.zoom`; `kind` the user-facing name (`left`, `right`, `scratch`, `overlay`). `active`/`visible`
+/// derive from the session's own flags (overlay/scratch/splitFocused), NOT from terminal zoom, and `visible`
+/// reads false for a pane behind a FLOATING overlay though it is visually on screen (any open overlay counts
+/// as covering). Address by `id`/`kind`, not these flags; the zoom state is the top-level `zoomedSurface`.
 public struct ControlSurfaceNode: Codable, Sendable, Equatable {
     public let id: String
     public let kind: String
@@ -391,47 +373,41 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
     public let id: String
     public let name: String
     public let cwd: String
-    /// The raw terminal title from the latest OSC 0/1/2 (a remote host over SSH, a shell
-    /// `PROMPT_COMMAND`); nil when none has been reported (omitted from the JSON). This is the
-    /// unprocessed `Session.oscTitle`, distinct from `name` (the derived sidebar label, which uses the
-    /// title as one fallback) — useful to a script because a remote session's local `cwd` goes stale.
+    /// The raw terminal title from the latest OSC 0/1/2 (a remote host over SSH, a shell `PROMPT_COMMAND`);
+    /// nil/omitted when none reported. The unprocessed `Session.oscTitle`, distinct from `name` (the derived
+    /// sidebar label, which uses it as one fallback) — useful since a remote session's local `cwd` goes stale.
     public let title: String?
     public let active: Bool
     public let split: Bool
-    /// The left-pane fraction (0.05...0.95) of a session that HAS a split pane (shown or hidden), or nil
-    /// when the session has no split OR the ratio was never explicitly set (via `session.resize` or a
-    /// divider drag), in which case the divider sits at the default 0.5. The read side of `session.resize`
-    /// — record it before maximizing a pane so a script can restore the exact divider position (the applied
-    /// ratio is otherwise echoed only on the `session.resize` call itself).
+    /// The left-pane fraction (0.05...0.95) of a session that HAS a split (shown or hidden); nil with no
+    /// split OR when the ratio was never explicitly set (via `session.resize` or a divider drag), the
+    /// divider then sitting at the default 0.5. The read side of `session.resize` — record it before
+    /// maximizing a pane to restore the exact position (otherwise it is echoed only on the resize call).
     public let splitRatio: Double?
-    /// For a session that HAS a split pane (shown or hidden), which pane holds keyboard focus: `true` = the
-    /// split (right) pane, `false` = the main (left) pane; nil when the session has no split (omitted from
-    /// the JSON). The read side of `session.focus` — record which pane was focused so a script can restore
-    /// it via `session.focus --pane left|right`.
+    /// For a session that HAS a split (shown or hidden), which pane holds keyboard focus: `true` = split
+    /// (right), `false` = main (left); nil/omitted with no split. The read side of `session.focus` — record
+    /// the focused pane to restore it via `session.focus --pane left|right`.
     public let splitFocused: Bool?
     public let overlay: Bool
-    /// For an OPEN overlay (`overlay == true`), its size: nil/omitted = the FULL-pane overlay, else the
-    /// floating panel's percent of the pane (1...100). Absent when no overlay is open. The read side of
-    /// `session.overlay.resize` — record the current size before resizing so a script can restore it exactly.
+    /// An OPEN overlay's size (`overlay == true`): nil/omitted = FULL-pane, else the floating panel's percent
+    /// of the pane (1...100); absent with no overlay. The read side of `session.overlay.resize` — record it
+    /// before resizing to restore it exactly.
     public let overlaySizePercent: Int?
     public let scratch: Bool
     public let flagged: Bool
-    /// For a `--command` session, whether it was created to HOLD its surface after the command exits
-    /// (`session.new --command … --wait`) rather than closing immediately; nil/omitted for a plain session
-    /// or a non-holding command session. The read side of `session.new --wait`, so a script can record and
-    /// restore the flag (it persists across restart, unlike an overlay's live-only wait).
+    /// For a `--command` session, whether it HOLDS its surface after the command exits (`session.new
+    /// --command … --wait`) instead of closing; nil/omitted for a plain or non-holding session. The read
+    /// side of `session.new --wait`; it persists across restart, unlike an overlay's live-only wait.
     public let commandWait: Bool?
-    /// The LIVE foreground process command (full argv) in the main pane, or nil when the pane is at its
-    /// shell prompt (omitted from the JSON). The same capture the restore-running-command feature uses,
-    /// surfaced for introspection ("what is each pane running").
+    /// The LIVE foreground process command (full argv) in the main pane; nil/omitted at the shell prompt.
+    /// The same capture restore-running-command uses, surfaced for "what is each pane running".
     public let foreground: [String]?
     /// The split (right) pane's live foreground command (full argv), the split analogue of `foreground`.
     public let splitForeground: [String]?
     /// The main pane's PERSISTED restore-command override, the read side of `session.restore`. Tri-state:
-    /// omitted = no override (the auto-capture behavior), `""` = pinned to nothing (a plain shell), a
-    /// command = that shell line runs on the next launch. Reported from the persisted state, so a read
-    /// after the override already fired still reports what is pinned — record-then-restore works at any
-    /// point in the launch. Unrelated to `foreground`, which is the LIVE process the capture would take.
+    /// omitted = no override (auto-capture), `""` = pinned to nothing (a plain shell), a command = that
+    /// shell line runs on the next launch. Read from the persisted state, so it still reports the pin after
+    /// the override fired (record-then-restore works any time). Unrelated to `foreground`, the LIVE process.
     public let restoreCommand: String?
     /// The split (right) pane's persisted restore-command override, the split analogue of `restoreCommand`
     /// (the read side of `session.restore --pane right`).
@@ -448,34 +424,31 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
     /// The per-call `#rrggbb` glyph-tint override for the session's agent status, or nil when idle or using
     /// the Settings-configured status color (omitted from the JSON). The read side of `session.status --color`.
     public let statusColor: String?
-    /// The per-call glyph-silhouette override for the session's agent status (a `StatusShape` raw value),
-    /// or nil when idle or using the Settings-configured shape / the default plain circle (omitted from
-    /// the JSON). The read side of `session.status --shape` — the PER-CALL override only, exactly like
-    /// `statusColor`, so record-then-restore treats both alike.
+    /// The per-call glyph-silhouette override for the session's agent status (a `StatusShape` raw value);
+    /// nil/omitted when idle or drawing the Settings-configured shape / the default plain circle. The read
+    /// side of `session.status --shape` — the PER-CALL override only, exactly like `statusColor`.
     public let statusShape: String?
     /// The session's background watermark spec, or nil when none is set (omitted from the JSON). The read
     /// side of `session.background` — set/clear/query symmetry, so a script can inspect the current watermark.
     public let background: BackgroundWatermark?
-    /// The session's unseen-notification badge count, or nil when zero (omitted from the JSON). The read
-    /// side of the notification badge: `notify` (and terminal OSC 9/777) raise it, `session.seen` clears it.
-    /// Ephemeral like `status` — never persisted, so it resets to nil on restart.
+    /// The session's unseen-notification badge count; nil/omitted when zero. `notify` (and terminal OSC
+    /// 9/777) raise it, `session.seen` clears it. Ephemeral like `status` — never persisted, resets on restart.
     public let unseen: Int?
-    /// The default/left pane's live font size in points, resolved via `addressableSurface`: the main pane,
-    /// or the promoted split survivor once the primary has exited (the same pane `font --pane left`, and the
-    /// default, writes). Nil when that pane isn't realized (omitted from the JSON). Reflects the live cmd
-    /// +/- value; the main pane's size is persisted across relaunch, but a promoted survivor's is live-only.
+    /// The default/left pane's live font size in points via `addressableSurface`: the main pane, or the
+    /// promoted split survivor once the primary exited (the pane `font --pane left`, and the default, writes).
+    /// Nil/omitted when unrealized. The live cmd +/- value; persisted for the main pane, live-only for a
+    /// promoted survivor.
     public let fontSize: Double?
-    /// The split (right) pane's live font size in points, or nil when the session has no realized split pane
-    /// (omitted). The read side of `font --pane right` — the split's font is otherwise unobservable, being
-    /// live-only (not persisted), so record it here before changing it.
+    /// The split (right) pane's live font size in points; nil/omitted with no realized split pane. The read
+    /// side of `font --pane right` — otherwise unobservable, being live-only (not persisted), so record it
+    /// here before changing it.
     public let splitFontSize: Double?
     /// The scratch terminal's live font size in points, or nil when no scratch surface is realized (omitted).
     /// The read side of `font --pane scratch` (also live-only).
     public let scratchFontSize: Double?
-    /// Addressable terminal surfaces owned by this session, or nil when talking to a server that
-    /// predates `surface.zoom` (omitted from the JSON — the optional-field pattern every post-v1 tree
-    /// addition uses, keeping Codable synthesized). Hidden-but-alive surfaces are included so control
-    /// clients can zoom them without mutating split/scratch visibility first.
+    /// Addressable terminal surfaces owned by this session; nil/omitted against a server predating
+    /// `surface.zoom` (the optional-field pattern every post-v1 tree addition uses, keeping Codable
+    /// synthesized). Hidden-but-alive surfaces are included, so a client can zoom them without unhiding.
     public let surfaces: [ControlSurfaceNode]?
 
     public init(id: String, name: String, cwd: String, title: String? = nil, active: Bool, split: Bool,
@@ -525,30 +498,26 @@ public struct ControlWorkspaceNode: Codable, Sendable, Equatable {
     public let id: String
     public let name: String
     public let active: Bool
-    /// Whether this workspace is a MEMBER of the sidebar's focus set, or nil when it is not (omitted from
-    /// the JSON). Membership is reported INDEPENDENTLY of whether the filter is currently applied, so a
-    /// script can read a marked-but-not-filtering set back; the flag itself is the tree top-level
-    /// `workspaceFilter`. Distinct from `active` (the SELECTED workspace). The read side of the write-only
-    /// `workspace.focus`/`workspace.filter` — so a script can record the working set and restore it.
+    /// Whether this workspace is a MEMBER of the sidebar's focus set; nil/omitted when not. Reported
+    /// INDEPENDENTLY of whether the filter is applied (that flag is the tree top-level `workspaceFilter`),
+    /// so a marked-but-not-filtering set reads back. Distinct from `active` (the SELECTED workspace). The
+    /// read side of the write-only `workspace.focus`/`workspace.filter`: record the working set, restore it.
     ///
-    /// A workspace ROW is VISIBLE in the sidebar iff
-    /// `tree.sidebarVisible && tree.sidebarMode == "tree" && (!tree.workspaceFilter || focused)` — every
-    /// term is on the same `tree` response, so a script evaluates it without a second call. The states,
-    /// enumerated: `sidebarVisible == false` renders no sidebar at all; `sidebarMode == "flagged"` renders
-    /// a FLAT flagged-session list with NO workspace rows, whatever the filter and the membership say;
-    /// `"tree"` with the filter OFF renders EVERY workspace regardless of membership; `"tree"` with the
-    /// filter ON renders only the members. Neither shorter form works: `focused && workspaceFilter`
-    /// reports nothing visible whenever the filter is off, and `!workspaceFilter || focused` alone reports
-    /// rows in flagged mode and behind a hidden sidebar, where no workspace row renders at all. The
-    /// filter-ON term is exact rather than approximate, because `workspaceFilter == true` with an empty
-    /// member set is unrepresentable (enabling an empty set is refused, and restore prunes stale ids then
-    /// disables when the set comes back empty), so an applied filter always has at least one visible member.
+    /// A workspace ROW is VISIBLE iff `tree.sidebarVisible && tree.sidebarMode == "tree" &&
+    /// (!tree.workspaceFilter || focused)`, every term on the same `tree` response — no second call needed.
+    /// Enumerated: a hidden sidebar renders nothing; `"flagged"` renders a FLAT flagged-session list with NO
+    /// workspace rows whatever the filter and membership say; `"tree"` + filter OFF renders EVERY workspace
+    /// regardless of membership; `"tree"` + filter ON only the members. Both shorter forms are wrong —
+    /// `focused && workspaceFilter` reports nothing visible while the filter is off, and a bare
+    /// `!workspaceFilter || focused` reports rows in flagged mode and behind a hidden sidebar. The filter-ON
+    /// term is exact, not approximate, because enabled-with-an-empty-set is unrepresentable (enabling an
+    /// empty set is refused; restore prunes stale ids then disables when it empties), so an applied filter
+    /// always has at least one visible member.
     public let focused: Bool?
-    /// Whether this workspace is COLLAPSED in the sidebar tree (`true`), or nil when expanded — the
-    /// default — so an all-expanded tree omits the field (matching the persisted `WorkspaceSnapshot.collapsed`).
-    /// The read side of the write-only `workspace.collapse`/`workspace.expand` (and `workspace.new --collapsed`),
-    /// so a script can record a workspace's open/closed state and restore it, or toggle by reading it first.
-    /// Reports the persisted model state (`!isExpanded`), independent of a transient focus force-reveal.
+    /// Whether this workspace is COLLAPSED in the sidebar tree; nil when expanded (the default), so an
+    /// all-expanded tree omits it, matching the persisted `WorkspaceSnapshot.collapsed`. The read side of
+    /// `workspace.collapse`/`workspace.expand` and `workspace.new --collapsed` — record/restore, or toggle
+    /// by reading first. Reports the persisted `!isExpanded`, independent of a transient focus force-reveal.
     public let collapsed: Bool?
     public let sessions: [ControlSessionNode]
 
@@ -566,73 +535,59 @@ public struct ControlWorkspaceNode: Codable, Sendable, Equatable {
 /// The whole workspace tree, the payload of a `tree` response.
 public struct ControlTree: Codable, Sendable, Equatable {
     public let workspaces: [ControlWorkspaceNode]
-    /// Milliseconds since the last user input in the projected window, or nil before any activity (omitted
-    /// from the JSON). A LIVE, continuously-growing delta — `tree`-only because the tree is built fresh on
-    /// the main actor per request; it must NOT ride `window.list` (cache-served, so it would freeze between
-    /// commands). The read side of the auto-follow idle metric.
+    /// Milliseconds since the last user input in the projected window; nil/omitted before any activity. A
+    /// LIVE, continuously-growing delta — `tree`-only, since the tree is built fresh per request on the main
+    /// actor while cache-served `window.list` would freeze it between commands. The auto-follow idle metric.
     public let idleMs: Int?
     /// The window's auto-follow-blocked timeout in milliseconds, or nil when the feature is disabled
     /// (omitted from the JSON). The read side of the GUI-only Auto-follow setting.
     public let autoFollowMs: Int?
-    /// Whether the projected window's sidebar is currently visible. LIVE — built fresh from the window's
-    /// store per request — so a script can read the current state (the read side of the write-only
-    /// `sidebar` command; e.g. a tmux-style zoom that must restore the sidebar only when it was visible
-    /// before zooming). Always present on a `tree` response (the producer passes a non-optional `Bool`),
-    /// so unlike `idleMs`/`autoFollowMs` it never omits; the per-window `window.list` copy is nil/omitted
-    /// only for a closed window.
+    /// Whether the projected window's sidebar is visible. LIVE, built fresh from the window's store per
+    /// request — the read side of the write-only `sidebar` command (e.g. a tmux-style zoom restoring the
+    /// sidebar only when it was visible before). Always present on a `tree` response (the producer passes a
+    /// non-optional `Bool`), unlike `idleMs`/`autoFollowMs`; the `window.list` copy omits for a closed window.
     public let sidebarVisible: Bool?
     /// The projected window's sidebar VIEW mode — `SidebarMode.rawValue` (`tree` = the workspace tree,
-    /// `flagged` = the flat flagged working-set list). LIVE and always populated on an app-produced `tree`
-    /// response; the type stays optional at the protocol level (like the other `tree` fields) for
-    /// forward-compat with version skew. The read side of the write-only `sidebar.mode` command, so a script can record the
-    /// mode and restore it. `tree`-only (not on `window.list`), since a GUI-only flagged-view toggle would
-    /// leave a cached copy stale — read the live tree copy instead.
+    /// `flagged` = the flat flagged working-set list). LIVE and always populated on an app-produced `tree`;
+    /// optional at the protocol level (like the other `tree` fields) for version skew. The read side of the
+    /// write-only `sidebar.mode`, `tree`-only — a GUI flagged-view toggle would leave a cached copy stale.
     public let sidebarMode: String?
-    /// Whether the projected window's workspace focus FILTER is currently applied — the flag half of the
-    /// focus set, whose member half is each workspace node's `focused`. It is one term of the row-visibility
-    /// predicate, not the whole of it: a workspace row renders iff
-    /// `sidebarVisible && sidebarMode == "tree" && (!workspaceFilter || focused)` — see `focused` for the
-    /// enumerated states, including `flagged` mode, where no workspace row renders whatever this says.
-    /// LIVE and `tree`-only (not on `window.list`), like `sidebarMode`:
-    /// the bottom-bar toggle and the row menu flip it without going through the command path, so a cached
-    /// copy would go stale — read the live tree copy instead. The read side of the write-only
-    /// `workspace.filter` command, so a script can record the filter state and restore it, or make the
-    /// toggle idempotent. nil in a host-produced tree that does not project a window.
+    /// Whether the projected window's workspace focus FILTER is applied — the flag half of the focus set,
+    /// whose member half is each workspace node's `focused`. Only ONE term of the row-visibility predicate;
+    /// see `focused` for the predicate and its enumerated states, including `flagged` mode, where no
+    /// workspace row renders whatever this says. LIVE and `tree`-only like `sidebarMode` (the bottom-bar
+    /// toggle and the row menu flip it outside the command path, so a cached copy goes stale). The read side
+    /// of the write-only `workspace.filter` — record and restore it, or make the toggle idempotent. nil in a
+    /// host-produced tree that projects no window.
     public let workspaceFilter: Bool?
-    /// Whether the projected window's quick terminal is currently visible. LIVE — resolved app-side per
-    /// request from the window's `QuickTerminalController` — so a script can make the `quick` toggle
-    /// idempotent (show only when hidden). The read side of the write-only `quick` command. `tree`-only
-    /// (not on `window.list`), since a GUI-only ⌃` toggle bypasses the command path and would leave a
-    /// cached copy stale — read the live tree copy instead. nil in a host-produced tree with no app closure.
+    /// Whether the projected window's quick terminal is visible. LIVE, resolved app-side per request from
+    /// the window's `QuickTerminalController`, so the `quick` toggle can be made idempotent (show only when
+    /// hidden). The read side of the write-only `quick` command, `tree`-only — a GUI ⌃` toggle bypasses the
+    /// command path and would leave a cached copy stale. nil in a host-produced tree with no app closure.
     public let quickVisible: Bool?
-    /// The control id of the surface terminal zoom currently fills the projected window with —
-    /// `surface:<session-id>:<kind>` for a session surface, `quick` for the quick terminal — or
-    /// nil/omitted when nothing is zoomed. LIVE — resolved app-side per request from the window's
-    /// `TerminalZoomController` — the read side of the write-only `surface.zoom` command, so a script
-    /// can check "is it already zoomed" and record-then-restore. `tree`-only (not on `window.list`),
-    /// like `quickVisible`: the GUI toggle bypasses the command path and would leave a cached copy stale.
+    /// The control id of the surface terminal zoom fills the projected window with —
+    /// `surface:<session-id>:<kind>`, or `quick` for the quick terminal — nil/omitted when nothing is
+    /// zoomed. LIVE, resolved app-side per request from the window's `TerminalZoomController`: the read side
+    /// of the write-only `surface.zoom`, for "is it already zoomed" and record-then-restore. `tree`-only
+    /// like `quickVisible` (the GUI toggle bypasses the command path and would leave a cached copy stale).
     public let zoomedSurface: String?
-    /// The pane refs (`<session-uuid>:left` for a primary pane, `<session-uuid>:right` for a split pane, in
-    /// grid order) of the cells the open dashboard shows, or nil/omitted when no dashboard is open. Each cell
-    /// is a session+pane, so a split session appears as TWO refs (`:left` and `:right`). LIVE — resolved
-    /// app-side per request from the projected window's `DashboardController` — the read side of the
-    /// write-only `dashboard` command, so a script can see which panes are on the grid. `tree`-only (not on
-    /// `window.list`), like `zoomedSurface`: the keyboard-driven dashboard bypasses the command path and
-    /// would leave a cached copy stale. nil in a host-produced tree with no app closure.
+    /// The open dashboard's cells as pane refs in grid order (`<session-uuid>:left` primary,
+    /// `<session-uuid>:right` split), so a split session appears as TWO refs; nil/omitted with no dashboard.
+    /// LIVE, resolved app-side per request from the projected window's `DashboardController` — the read side
+    /// of the write-only `dashboard` command. `tree`-only like `zoomedSurface` (the keyboard-driven dashboard
+    /// bypasses the command path). nil in a host-produced tree with no app closure.
     public let dashboardMembers: [String]?
-    /// The pane ref (`<session-uuid>:left`/`:right`) of the dashboard's currently highlighted cell (the one
-    /// Enter jumps into, focusing that exact pane), or nil/omitted when no dashboard is open. LIVE — resolved
-    /// app-side per request from the window's `DashboardController` — the read side of the keyboard highlight
-    /// nav. `tree`-only, like `dashboardMembers`.
+    /// The pane ref (`<session-uuid>:left`/`:right`) of the dashboard's highlighted cell — the one Enter
+    /// jumps into, focusing that exact pane; nil/omitted with no dashboard. LIVE from the window's
+    /// `DashboardController`, the read side of the keyboard highlight nav. `tree`-only, like `dashboardMembers`.
     public let dashboardHighlighted: String?
-    /// The absolute font size in points applied to the dashboard cells, or nil/omitted when no dashboard is
-    /// open OR the font is untouched (the members keep their own size). LIVE — resolved app-side per request
-    /// from the window's `DashboardController` — the read side of `dashboard --font-size`/`--auto-size`.
-    /// `tree`-only, like `dashboardMembers`.
+    /// The absolute font size in points applied to the dashboard cells; nil/omitted with no dashboard OR an
+    /// untouched font (the members keep their own size). LIVE from the window's `DashboardController`, the
+    /// read side of `dashboard --font-size`/`--auto-size`. `tree`-only, like `dashboardMembers`.
     public let dashboardFontSize: Double?
-    /// The dashboard's font mode — `auto` (`--auto-size`), `fixed` (`--font-size`), or `untouched` — or
-    /// nil/omitted when no dashboard is open. LIVE — resolved app-side per request from the window's
-    /// `DashboardController` — the read side of the font flags. `tree`-only, like `dashboardMembers`.
+    /// The dashboard's font mode — `auto` (`--auto-size`), `fixed` (`--font-size`), `untouched`; nil/omitted
+    /// with no dashboard. LIVE from the window's `DashboardController`, the read side of the font flags.
+    /// `tree`-only, like `dashboardMembers`.
     public let dashboardFontMode: String?
     /// The id of the picker currently awaiting a choice, or nil when no picker is open.
     public let pickPending: String?
@@ -659,10 +614,9 @@ public struct ControlTree: Codable, Sendable, Equatable {
     }
 }
 
-/// An open window's on-screen frame, in the SAME coordinate system `window.move`/`window.resize` accept,
-/// so a read-then-restore round-trips: `x`/`y` are the top-left relative to `display`'s top-left (y down),
-/// `width`/`height` the frame size in points, `display` the index into the screen list. The read side of
-/// the write-only `window.move`/`window.resize`.
+/// An open window's on-screen frame — the read side of write-only `window.move`/`window.resize`, in the
+/// SAME coordinate system those accept so a read-then-restore round-trips: `x`/`y` the top-left relative to
+/// `display`'s top-left (y down), `width`/`height` the frame size in points, `display` a screen-list index.
 public struct ControlWindowFrame: Codable, Sendable, Equatable {
     public let x: Int
     public let y: Int
@@ -686,33 +640,30 @@ public struct ControlWindowNode: Codable, Sendable, Equatable {
     public let name: String
     public let open: Bool
     public let active: Bool
-    /// The window's auto-follow-blocked timeout in milliseconds, or nil when disabled (omitted from the
-    /// JSON), as of the last cache refresh — `window.list` is answered from a nonisolated fast path, so a
-    /// just-changed setting may lag until the next command. Acceptable because the config rarely changes;
-    /// the live `idleMs` is deliberately kept off `window.list` (tree-only) for exactly this reason.
+    /// The window's auto-follow-blocked timeout in milliseconds; nil/omitted when disabled. As of the last
+    /// cache refresh — `window.list` answers from a nonisolated fast path, so a just-changed setting lags
+    /// until the next command. Acceptable since the config rarely changes; the live `idleMs` is deliberately
+    /// kept off `window.list` (tree-only) for exactly this reason.
     public let autoFollowMs: Int?
-    /// Whether this window's sidebar is currently visible, or nil for a CLOSED window with no live store
-    /// (omitted from the JSON) — read from the open window's store, mirroring `autoFollowMs`. The read side
-    /// of the write-only `sidebar` command, per window.
+    /// Whether this window's sidebar is visible; nil/omitted for a CLOSED window with no live store. Read
+    /// from the open window's store, mirroring `autoFollowMs`. The read side of `sidebar`, per window.
     public let sidebarVisible: Bool?
-    /// The window's current on-screen frame (position + size + display), or nil for a CLOSED window with no
-    /// live NSWindow (omitted from the JSON). The read side of `window.move`/`window.resize` — record it,
-    /// resize/move the window, then restore the exact frame. Read live app-side; it rides the window cache,
-    /// which is refreshed on window move/resize/zoom/fullscreen (`ControlServer` observes the NSWindow
-    /// notifications), so a hand-drag or GUI toggle is reflected without needing another command.
+    /// The window's on-screen frame (position + size + display); nil/omitted for a CLOSED window with no
+    /// live NSWindow. The read side of `window.move`/`window.resize` — record, move/resize, restore exactly.
+    /// Read live app-side on the window cache, refreshed on move/resize/zoom/fullscreen (`ControlServer`
+    /// observes the NSWindow notifications), so a hand-drag or GUI toggle shows up without another command.
     public let geometry: ControlWindowFrame?
-    /// Whether the window is in native macOS full screen, or nil for a CLOSED window (omitted from the
-    /// JSON). The read side of the write-only `window.fullscreen` toggle, so a script can make the toggle
-    /// idempotent (only enter/exit when needed). Read live app-side; like `geometry` it rides the cache.
+    /// Whether the window is in native macOS full screen; nil/omitted for a CLOSED window. The read side of
+    /// the write-only `window.fullscreen` toggle, so it can be made idempotent (only enter/exit when
+    /// needed). Read live app-side; like `geometry` it rides the cache.
     public let fullscreen: Bool?
     /// Whether the window is zoomed (maximized-to-screen, NOT full screen), or nil for a CLOSED window
     /// (omitted from the JSON). The read side of the write-only `window.zoom` toggle. Read live app-side.
     public let zoomed: Bool?
-    /// Whether the window is minimized to the Dock, or nil for a CLOSED window (omitted from the JSON).
-    /// The read side of `window.minimize`, so a script can skip a redundant minimize or restore the set
-    /// of windows it put away. Read live app-side; like `geometry` it rides the cache, refreshed on the
-    /// NSWindow miniaturize/deminiaturize notifications so ⌘M or a Dock click is reflected too. A
-    /// minimized window still reports its `geometry` (the frame it will come back to).
+    /// Whether the window is minimized to the Dock; nil/omitted for a CLOSED window. The read side of
+    /// `window.minimize` — skip a redundant minimize, or restore the set of windows a script put away.
+    /// Live app-side on the cache, refreshed on the NSWindow miniaturize/deminiaturize notifications so ⌘M
+    /// or a Dock click shows too. A minimized window still reports its `geometry` (where it comes back to).
     public let minimized: Bool?
 
     public init(id: String, name: String, open: Bool, active: Bool, autoFollowMs: Int? = nil,
@@ -740,11 +691,10 @@ public struct ControlResult: Codable, Sendable, Equatable {
     public var windows: [ControlWindowNode]?
     /// The overlay program's exit status for `session.overlay.result` (nil until the program exits).
     public var exitCode: Int?
-    /// A count payload for commands whose result is a number, e.g. the keymap-diagnostic count for
-    /// `keymap.reload`, the ghostty config-diagnostic count for `config.reload` (counted across ALL config
-    /// sources, not just the agterm-scoped `ghostty.conf` — libghostty diagnostics carry no source-file
-    /// attribution), and the total match count for `session.search` (whose "N of M" display string rides
-    /// in `text`).
+    /// A count payload for commands whose result is a number: the keymap-diagnostic count for
+    /// `keymap.reload`; the ghostty config-diagnostic count for `config.reload` (across ALL config sources,
+    /// not just the agterm-scoped `ghostty.conf` — libghostty diagnostics carry no source-file attribution);
+    /// and `session.search`'s total match count (whose "N of M" display string rides in `text`).
     public var count: Int?
     /// Number of sessions actually changed by a batch mutation (`session.close` or `session.move`).
     /// Kept separate from `count`, whose CLI rendering is specific to diagnostics/search results.
@@ -757,10 +707,10 @@ public struct ControlResult: Codable, Sendable, Equatable {
     /// The applied (clamped) left-pane split fraction echoed by `session.resize`, so a script can see
     /// where the divider landed after clamping / a relative nudge.
     public var ratio: Double?
-    /// The light/dark theme syncing state for `theme.set`/`theme.list`, derived from the stored theme
-    /// value: `sync` = whether it is ghostty's dual `light:,dark:` form (the terminal tracks the macOS
-    /// appearance), `light`/`dark` = its sides. While syncing, `theme` is absent — the state rides
-    /// these three; otherwise `theme` is the plain single theme and `light`/`dark` are absent.
+    /// The light/dark syncing state for `theme.set`/`theme.list`, derived from the stored theme: `sync` =
+    /// whether it is ghostty's dual `light:,dark:` form (the terminal tracks the macOS appearance),
+    /// `light`/`dark` its sides. While syncing `theme` is absent and the state rides these three; otherwise
+    /// `theme` is the plain single theme and `light`/`dark` are absent.
     public var sync: Bool?
     public var light: String?
     public var dark: String?
@@ -804,10 +754,9 @@ public enum OverlayResultError {
     public static let noResult = "no overlay result"
 }
 
-/// Advisory text `notify` returns in `result.text` when the banner toggle is off. The command still
-/// succeeds — the unseen badge tracks either way — but nothing is handed to macOS, so a bare `ok`
-/// would look identical to a broken notification path (issue #286). Shared so the server's wording and
-/// any caller matching on it cannot drift.
+/// Advisory text `notify` returns in `result.text` when the banner toggle is off. The command still succeeds
+/// (the unseen badge tracks either way) but hands macOS nothing, so a bare `ok` would look identical to a
+/// broken notification path (issue #286). Shared so the server's wording and any matcher cannot drift.
 public enum ControlNotify {
     public static let bannersOffNote = "badge updated, but \"Show notification banners\" is off, so no banner was posted"
 }

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -81,8 +81,8 @@ public enum Command: String, Codable, Sendable {
     case debugAppearance = "debug.appearance"
 }
 
-/// A bag of optional command parameters. Each command reads only the fields it needs; the rest stay
-/// nil and are omitted from the JSON, keeping the wire form compact.
+/// A bag of optional command parameters. Each command reads only the fields it needs; the rest stay nil and
+/// are omitted from the JSON.
 public struct ControlArgs: Codable, Sendable, Equatable {
     /// New name for `workspace.new`/`workspace.rename`/`session.rename`; the initial `session.new` name
     /// (blank/omitted leaves the auto basename); the `theme.set` theme (omitted/empty = ghostty's built-in
@@ -102,18 +102,17 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     /// For `session.new` with `workspaceName`: create the named workspace when none exists (idempotent
     /// reuse-or-create). An error without `workspaceName` — there is nothing to create by id.
     public var createWorkspace: Bool?
-    /// For `workspace.new`: create the workspace already COLLAPSED (the CLI's `--collapsed`), so a script
-    /// can build one and fill it with `session.new --no-select` without it opening. Omitted/`false` =
-    /// expanded. Read back as the `tree` workspace node's `collapsed`.
+    /// For `workspace.new`: create the workspace already COLLAPSED (the CLI's `--collapsed`), so a script can
+    /// fill it with `session.new --no-select` without it opening. Omitted/`false` = expanded; read back as
+    /// the `tree` workspace node's `collapsed`.
     public var collapsed: Bool?
     /// For `window.new`: create the window already MINIMIZED to the Dock (the CLI's `--minimized`), so a
     /// script can build project windows without each flashing on screen and stealing focus; omitted/`false`
     /// presents it. Read back as the `window.list` node's `minimized`. The new window also hands frontmost
     /// to a still-visible one, so untargeted commands do not route into the Dock.
     public var minimized: Bool?
-    /// For `session.new`: create in the background without selecting or focusing, leaving the current
-    /// selection untouched (the CLI's `--no-select`); omitted/`false` keeps select-and-focus. Read back via
-    /// the existing `tree` `active` flag — the new node is not `active`.
+    /// For `session.new`: create in the background without selecting or focusing (the CLI's `--no-select`);
+    /// omitted/`false` keeps select-and-focus. Read back via the `tree` `active` flag — the new node is not it.
     public var noSelect: Bool?
     /// Text to inject for `session.type` / `quick.type`; the search needle for `session.search`.
     public var text: String?
@@ -130,8 +129,8 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     /// The `#rrggbb` color for `session.background`: the mode-`text` tint (nil = terminal foreground) or the
     /// mode-`color` solid background (required, no opacity — it honors the Settings window translucency).
     /// Also `session.overlay.open`'s own background, independent of the session's (nil = the default theme
-    /// background, same translucency). And `session.status`'s per-call glyph tint, riding the ephemeral
-    /// indicator so it lasts only until the next `session.status` without a color (nil = the Settings color).
+    /// background, same translucency), and `session.status`'s per-call glyph tint, riding the ephemeral
+    /// indicator so it lasts only to the next `session.status` without a color (nil = the Settings color).
     public var color: String?
     /// The per-call glyph-SILHOUETTE override for `session.status`: a `StatusShape` raw value
     /// (`circle|square|triangle|diamond|capsule|star`), dispatcher-validated. Rides the ephemeral indicator,
@@ -147,17 +146,16 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     public var repeats: Bool?
     /// Which split pane to focus for `session.focus` (`left`|`right`|`other`, `other` toggles); to read for
     /// `session.text` (`left`|`right`, omitted = the focused pane, no `other`); `session.type` injects into
-    /// (`left`|`right`, omitted = left/main, the pre-pane behavior); set `session.status`
-    /// (`left`|`right`|`scratch`, omitted = `left`/main, parsed to `StatusPane`); and `session.restore` pins
-    /// (same `StatusPane` spelling, omitted = `left`/main, `scratch` rejected app-side).
+    /// (`left`|`right`, omitted = left/main); set `session.status` (`left`|`right`|`scratch`, omitted =
+    /// `left`/main, parsed to `StatusPane`); and `session.restore` pins (same `StatusPane` spelling, omitted
+    /// = `left`/main, `scratch` rejected app-side).
     public var pane: String?
-    /// A surface's STABLE spawn token for `session.status --pane-id`/`session.restore --pane-id` (the
-    /// shell's baked `AGTERM_PANE_ID`, forwarded by the agent-status hook). Resolving it against the
-    /// session's live surfaces OVERRIDES the stale role `pane`, so a status from a promoted-then-re-split
-    /// pane lands on the CURRENT slot; empty/unknown falls back to `pane`. Opaque — validated only by
-    /// resolving. `session.restore` diverges: an unresolvable token with NO explicit `pane` errors there
-    /// rather than silently using `left`, since a wrong restore pin persists. See
-    /// `Session.paneRole(forToken:)` and the #199 fix.
+    /// A surface's STABLE spawn token for `session.status --pane-id`/`session.restore --pane-id` (the shell's
+    /// baked `AGTERM_PANE_ID`, forwarded by the agent-status hook). Resolving it against the session's live
+    /// surfaces OVERRIDES the stale role `pane`, so a status from a promoted-then-re-split pane lands on the
+    /// CURRENT slot; empty/unknown falls back to `pane`. Opaque — validated only by resolving.
+    /// `session.restore` diverges: an unresolvable token with NO explicit `pane` errors there rather than
+    /// silently using `left`, since a wrong restore pin persists. See `Session.paneRole(forToken:)`, #199.
     public var paneID: String?
     /// Absolute left-pane split fraction (0...1) for `session.resize`, clamped server-side to
     /// `AppStore.splitRatioMin...splitRatioMax`. Mutually exclusive with `ratioDelta`.
@@ -182,8 +180,8 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     public var before: String?
     /// App-run UUID paired with `after` for `events.read`. Both fields are omitted for a bootstrap read.
     public var run: String?
-    /// Raw event-kind filters for `events.read`. Validation deliberately happens in the dispatcher so
-    /// unknown future kinds produce a normal control error rather than making the request undecodable.
+    /// Raw event-kind filters for `events.read`. Validation happens in the dispatcher so unknown future
+    /// kinds produce a normal control error rather than making the request undecodable.
     public var kinds: [String]?
     /// Maximum matching events returned by `events.read`; omitted uses the dispatcher default.
     public var limit: Int?
@@ -194,19 +192,19 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     /// The program the overlay terminal runs for `session.overlay.open` (e.g. `revdiff`); also the shell
     /// line `session.restore` pins for the next launch (mode `set` only, typed verbatim — never re-quoted).
     public var command: String?
-    /// Whether a command surface keeps its "press any key to close" prompt after the command exits instead
-    /// of closing immediately: `session.overlay.open --wait` (the overlay) and `session.new --command …
-    /// --wait` (the primary session surface, held via `Session.commandWait`).
+    /// Whether a command surface keeps its "press any key to close" prompt after the command exits instead of
+    /// closing: `session.overlay.open --wait`, and `session.new --command … --wait` (the primary session
+    /// surface, held via `Session.commandWait`).
     public var wait: Bool?
-    /// For `session.overlay.open`, the percent of the pane (1...100) a *floating* overlay panel
-    /// occupies in both dimensions; omitted gives the default full-pane overlay. Also carries the new
-    /// size for `session.overlay.resize` (mutually exclusive with `full`).
+    /// For `session.overlay.open`, the percent of the pane (1...100) a *floating* overlay panel occupies in
+    /// both dimensions; omitted gives the default full-pane overlay. Also the new size for
+    /// `session.overlay.resize` (mutually exclusive with `full`).
     public var sizePercent: Int?
-    /// For `session.overlay.resize`, requests the full-pane (translucent, session-hidden) overlay —
-    /// the way to switch a floating overlay back to full. Mutually exclusive with `sizePercent`.
+    /// For `session.overlay.resize`, requests the full-pane (translucent, session-hidden) overlay — the way
+    /// to switch a floating overlay back to full. Mutually exclusive with `sizePercent`.
     public var full: Bool?
     /// For `session.overlay.open`, whether to select the target after opening; omitted/false opens in the
-    /// background without changing the active session (the default for both full and floating overlays).
+    /// background without changing the active session (the default for full and floating overlays alike).
     public var follow: Bool?
     /// The finished caller-provided choices for `pick.open`.
     public var items: [ControlPickItem]?
@@ -214,8 +212,8 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     public var prompt: String?
     /// Whether `pick.open` accepts the current query as a custom result.
     public var allowCustom: Bool?
-    /// Target window for session/workspace/tree/font commands: id / prefix / `active` (=frontmost).
-    /// Selects the window whose tree the command operates on.
+    /// Target window whose tree a session/workspace/tree/font command operates on: id / prefix / `active`
+    /// (= frontmost).
     public var window: String?
     /// New window frame width/height in points for `window.resize`.
     public var width: Int?
@@ -252,7 +250,7 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     public var autoSize: Bool?
     /// For `dashboard`, populate the grid from the target window's most-recently-used sessions (up to 9,
     /// fewer if the window has fewer) instead of explicit ids (the CLI's `--mru`). Mutually exclusive with
-    /// `targets`/`close`, composes with the font flags; resolution is app-side (it needs the store's recency).
+    /// `targets`/`close`, composes with the font flags; resolved app-side, which needs the store's recency.
     public var mru: Bool?
 
     public init(name: String? = nil, cwd: String? = nil, targets: [String]? = nil,
@@ -375,23 +373,20 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
     public let cwd: String
     /// The raw terminal title from the latest OSC 0/1/2 (a remote host over SSH, a shell `PROMPT_COMMAND`);
     /// nil/omitted when none reported. The unprocessed `Session.oscTitle`, distinct from `name` (the derived
-    /// sidebar label, which uses it as one fallback) — useful since a remote session's local `cwd` goes stale.
+    /// sidebar label, which uses it as one fallback); a remote session's local `cwd` goes stale, this does not.
     public let title: String?
     public let active: Bool
     public let split: Bool
     /// The left-pane fraction (0.05...0.95) of a session that HAS a split (shown or hidden); nil with no
-    /// split OR when the ratio was never explicitly set (via `session.resize` or a divider drag), the
-    /// divider then sitting at the default 0.5. The read side of `session.resize` — record it before
-    /// maximizing a pane to restore the exact position (otherwise it is echoed only on the resize call).
+    /// split OR when the ratio was never explicitly set (via `session.resize` or a divider drag), the divider
+    /// then sitting at the default 0.5. The read side of `session.resize`, otherwise echoed only on that call.
     public let splitRatio: Double?
     /// For a session that HAS a split (shown or hidden), which pane holds keyboard focus: `true` = split
-    /// (right), `false` = main (left); nil/omitted with no split. The read side of `session.focus` — record
-    /// the focused pane to restore it via `session.focus --pane left|right`.
+    /// (right), `false` = main (left); nil/omitted with no split. The read side of `session.focus`.
     public let splitFocused: Bool?
     public let overlay: Bool
     /// An OPEN overlay's size (`overlay == true`): nil/omitted = FULL-pane, else the floating panel's percent
-    /// of the pane (1...100); absent with no overlay. The read side of `session.overlay.resize` — record it
-    /// before resizing to restore it exactly.
+    /// of the pane (1...100); absent with no overlay. The read side of `session.overlay.resize`.
     public let overlaySizePercent: Int?
     public let scratch: Bool
     public let flagged: Bool
@@ -399,56 +394,54 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
     /// --command … --wait`) instead of closing; nil/omitted for a plain or non-holding session. The read
     /// side of `session.new --wait`; it persists across restart, unlike an overlay's live-only wait.
     public let commandWait: Bool?
-    /// The LIVE foreground process command (full argv) in the main pane; nil/omitted at the shell prompt.
-    /// The same capture restore-running-command uses, surfaced for "what is each pane running".
+    /// The LIVE foreground process command (full argv) in the main pane; nil/omitted at the shell prompt —
+    /// the same capture restore-running-command uses.
     public let foreground: [String]?
     /// The split (right) pane's live foreground command (full argv), the split analogue of `foreground`.
     public let splitForeground: [String]?
     /// The main pane's PERSISTED restore-command override, the read side of `session.restore`. Tri-state:
-    /// omitted = no override (auto-capture), `""` = pinned to nothing (a plain shell), a command = that
-    /// shell line runs on the next launch. Read from the persisted state, so it still reports the pin after
-    /// the override fired (record-then-restore works any time). Unrelated to `foreground`, the LIVE process.
+    /// omitted = no override (auto-capture), `""` = pinned to nothing (a plain shell), a command = that shell
+    /// line runs on the next launch. Read from persisted state, so it still reports the pin after the
+    /// override fired. Unrelated to `foreground`, the LIVE process.
     public let restoreCommand: String?
     /// The split (right) pane's persisted restore-command override, the split analogue of `restoreCommand`
     /// (the read side of `session.restore --pane right`).
     public let splitRestoreCommand: String?
-    /// The session's agent status (`active`/`completed`/`blocked`) as the `AgentStatus` raw value, or nil
-    /// when the session is idle (omitted from the JSON). The read side of `session.status`.
+    /// The session's agent status (`active`/`completed`/`blocked`) as the `AgentStatus` raw value;
+    /// nil/omitted when idle. The read side of `session.status`.
     public let status: String?
-    /// Which pane set the session's agent status (`"left"|"right"|"scratch"`, `left`=main, `right`=split),
-    /// or nil when idle or unspecified (omitted from the JSON). The read side of `session.status --pane`.
+    /// Which pane set the agent status (`"left"|"right"|"scratch"`, `left`=main, `right`=split); nil/omitted
+    /// when idle or unspecified. The read side of `session.status --pane`.
     public let statusPane: String?
-    /// Whether the session's agent status glyph is set to blink (pulse for attention), or nil when idle or
-    /// not blinking (omitted from the JSON). The read side of `session.status --blink`.
+    /// Whether the agent-status glyph blinks (pulses for attention); nil/omitted when idle or not blinking.
+    /// The read side of `session.status --blink`.
     public let statusBlink: Bool?
-    /// The per-call `#rrggbb` glyph-tint override for the session's agent status, or nil when idle or using
-    /// the Settings-configured status color (omitted from the JSON). The read side of `session.status --color`.
+    /// The per-call `#rrggbb` glyph-tint override; nil/omitted when idle or using the Settings status color.
+    /// The read side of `session.status --color`.
     public let statusColor: String?
-    /// The per-call glyph-silhouette override for the session's agent status (a `StatusShape` raw value);
-    /// nil/omitted when idle or drawing the Settings-configured shape / the default plain circle. The read
-    /// side of `session.status --shape` — the PER-CALL override only, exactly like `statusColor`.
+    /// The per-call glyph-silhouette override (a `StatusShape` raw value); nil/omitted when idle or drawing
+    /// the Settings shape / the default plain circle. The read side of `session.status --shape` — the
+    /// PER-CALL override only, exactly like `statusColor`.
     public let statusShape: String?
-    /// The session's background watermark spec, or nil when none is set (omitted from the JSON). The read
-    /// side of `session.background` — set/clear/query symmetry, so a script can inspect the current watermark.
+    /// The session's background watermark spec; nil/omitted when none is set. The read side of
+    /// `session.background`.
     public let background: BackgroundWatermark?
     /// The session's unseen-notification badge count; nil/omitted when zero. `notify` (and terminal OSC
     /// 9/777) raise it, `session.seen` clears it. Ephemeral like `status` — never persisted, resets on restart.
     public let unseen: Int?
     /// The default/left pane's live font size in points via `addressableSurface`: the main pane, or the
-    /// promoted split survivor once the primary exited (the pane `font --pane left`, and the default, writes).
-    /// Nil/omitted when unrealized. The live cmd +/- value; persisted for the main pane, live-only for a
+    /// promoted split survivor once the primary exited (the pane `font --pane left`, and the default, writes);
+    /// nil/omitted when unrealized. The live cmd +/- value, persisted for the main pane but live-only for a
     /// promoted survivor.
     public let fontSize: Double?
     /// The split (right) pane's live font size in points; nil/omitted with no realized split pane. The read
-    /// side of `font --pane right` — otherwise unobservable, being live-only (not persisted), so record it
-    /// here before changing it.
+    /// side of `font --pane right`, otherwise unobservable — live-only, not persisted.
     public let splitFontSize: Double?
     /// The scratch terminal's live font size in points, or nil when no scratch surface is realized (omitted).
     /// The read side of `font --pane scratch` (also live-only).
     public let scratchFontSize: Double?
     /// Addressable terminal surfaces owned by this session; nil/omitted against a server predating
-    /// `surface.zoom` (the optional-field pattern every post-v1 tree addition uses, keeping Codable
-    /// synthesized). Hidden-but-alive surfaces are included, so a client can zoom them without unhiding.
+    /// `surface.zoom`. Hidden-but-alive surfaces are included, so a client can zoom them without unhiding.
     public let surfaces: [ControlSurfaceNode]?
 
     public init(id: String, name: String, cwd: String, title: String? = nil, active: Bool, split: Bool,
@@ -499,25 +492,23 @@ public struct ControlWorkspaceNode: Codable, Sendable, Equatable {
     public let name: String
     public let active: Bool
     /// Whether this workspace is a MEMBER of the sidebar's focus set; nil/omitted when not. Reported
-    /// INDEPENDENTLY of whether the filter is applied (that flag is the tree top-level `workspaceFilter`),
-    /// so a marked-but-not-filtering set reads back. Distinct from `active` (the SELECTED workspace). The
-    /// read side of the write-only `workspace.focus`/`workspace.filter`: record the working set, restore it.
+    /// INDEPENDENTLY of whether the filter is applied (that flag is the tree top-level `workspaceFilter`), so
+    /// a marked-but-not-filtering set reads back. Distinct from `active` (the SELECTED workspace). The read
+    /// side of the write-only `workspace.focus`/`workspace.filter`.
     ///
     /// A workspace ROW is VISIBLE iff `tree.sidebarVisible && tree.sidebarMode == "tree" &&
     /// (!tree.workspaceFilter || focused)`, every term on the same `tree` response — no second call needed.
-    /// Enumerated: a hidden sidebar renders nothing; `"flagged"` renders a FLAT flagged-session list with NO
-    /// workspace rows whatever the filter and membership say; `"tree"` + filter OFF renders EVERY workspace
-    /// regardless of membership; `"tree"` + filter ON only the members. Both shorter forms are wrong —
-    /// `focused && workspaceFilter` reports nothing visible while the filter is off, and a bare
-    /// `!workspaceFilter || focused` reports rows in flagged mode and behind a hidden sidebar. The filter-ON
-    /// term is exact, not approximate, because enabled-with-an-empty-set is unrepresentable (enabling an
-    /// empty set is refused; restore prunes stale ids then disables when it empties), so an applied filter
-    /// always has at least one visible member.
+    /// Both shorter forms are wrong: `focused && workspaceFilter` reports nothing visible while the filter is
+    /// off, and a bare `!workspaceFilter || focused` reports rows behind a hidden sidebar and in `"flagged"`
+    /// mode, which renders a FLAT flagged-session list with NO workspace rows whatever membership says. The
+    /// filter-ON term is exact because enabled-with-an-empty-set is unrepresentable (enabling an empty set is
+    /// refused; restore prunes stale ids then disables when it empties), so an applied filter always has at
+    /// least one visible member.
     public let focused: Bool?
     /// Whether this workspace is COLLAPSED in the sidebar tree; nil when expanded (the default), so an
     /// all-expanded tree omits it, matching the persisted `WorkspaceSnapshot.collapsed`. The read side of
-    /// `workspace.collapse`/`workspace.expand` and `workspace.new --collapsed` — record/restore, or toggle
-    /// by reading first. Reports the persisted `!isExpanded`, independent of a transient focus force-reveal.
+    /// `workspace.collapse`/`workspace.expand` and `workspace.new --collapsed`. Reports the persisted
+    /// `!isExpanded`, independent of a transient focus force-reveal.
     public let collapsed: Bool?
     public let sessions: [ControlSessionNode]
 
@@ -543,51 +534,47 @@ public struct ControlTree: Codable, Sendable, Equatable {
     /// (omitted from the JSON). The read side of the GUI-only Auto-follow setting.
     public let autoFollowMs: Int?
     /// Whether the projected window's sidebar is visible. LIVE, built fresh from the window's store per
-    /// request — the read side of the write-only `sidebar` command (e.g. a tmux-style zoom restoring the
-    /// sidebar only when it was visible before). Always present on a `tree` response (the producer passes a
-    /// non-optional `Bool`), unlike `idleMs`/`autoFollowMs`; the `window.list` copy omits for a closed window.
+    /// request — the read side of the write-only `sidebar` command. Always present on a `tree` response (the
+    /// producer passes a non-optional `Bool`), unlike `idleMs`/`autoFollowMs`; the `window.list` copy omits
+    /// it for a closed window.
     public let sidebarVisible: Bool?
     /// The projected window's sidebar VIEW mode — `SidebarMode.rawValue` (`tree` = the workspace tree,
     /// `flagged` = the flat flagged working-set list). LIVE and always populated on an app-produced `tree`;
     /// optional at the protocol level (like the other `tree` fields) for version skew. The read side of the
-    /// write-only `sidebar.mode`, `tree`-only — a GUI flagged-view toggle would leave a cached copy stale.
+    /// write-only `sidebar.mode`. `tree`-only, as every field below is: a GUI toggle bypasses the command
+    /// path, so a cached `window.list` copy would go stale.
     public let sidebarMode: String?
     /// Whether the projected window's workspace focus FILTER is applied — the flag half of the focus set,
     /// whose member half is each workspace node's `focused`. Only ONE term of the row-visibility predicate;
-    /// see `focused` for the predicate and its enumerated states, including `flagged` mode, where no
-    /// workspace row renders whatever this says. LIVE and `tree`-only like `sidebarMode` (the bottom-bar
-    /// toggle and the row menu flip it outside the command path, so a cached copy goes stale). The read side
-    /// of the write-only `workspace.filter` — record and restore it, or make the toggle idempotent. nil in a
-    /// host-produced tree that projects no window.
+    /// see `focused`. LIVE and `tree`-only (the bottom-bar toggle and the row menu flip it outside the
+    /// command path). The read side of the write-only `workspace.filter`. nil in a host-produced tree that
+    /// projects no window.
     public let workspaceFilter: Bool?
-    /// Whether the projected window's quick terminal is visible. LIVE, resolved app-side per request from
-    /// the window's `QuickTerminalController`, so the `quick` toggle can be made idempotent (show only when
-    /// hidden). The read side of the write-only `quick` command, `tree`-only — a GUI ⌃` toggle bypasses the
-    /// command path and would leave a cached copy stale. nil in a host-produced tree with no app closure.
+    /// Whether the projected window's quick terminal is visible. LIVE, resolved app-side per request from the
+    /// window's `QuickTerminalController`, so the `quick` toggle can be made idempotent. The read side of the
+    /// write-only `quick` command; `tree`-only (the GUI ⌃` toggle). nil in a host-produced tree with no app
+    /// closure.
     public let quickVisible: Bool?
     /// The control id of the surface terminal zoom fills the projected window with —
-    /// `surface:<session-id>:<kind>`, or `quick` for the quick terminal — nil/omitted when nothing is
-    /// zoomed. LIVE, resolved app-side per request from the window's `TerminalZoomController`: the read side
-    /// of the write-only `surface.zoom`, for "is it already zoomed" and record-then-restore. `tree`-only
-    /// like `quickVisible` (the GUI toggle bypasses the command path and would leave a cached copy stale).
+    /// `surface:<session-id>:<kind>`, or `quick` for the quick terminal — nil/omitted when nothing is zoomed.
+    /// LIVE, resolved app-side per request from the window's `TerminalZoomController`: the read side of the
+    /// write-only `surface.zoom`; `tree`-only.
     public let zoomedSurface: String?
     /// The open dashboard's cells as pane refs in grid order (`<session-uuid>:left` primary,
     /// `<session-uuid>:right` split), so a split session appears as TWO refs; nil/omitted with no dashboard.
     /// LIVE, resolved app-side per request from the projected window's `DashboardController` — the read side
-    /// of the write-only `dashboard` command. `tree`-only like `zoomedSurface` (the keyboard-driven dashboard
-    /// bypasses the command path). nil in a host-produced tree with no app closure.
+    /// of the write-only `dashboard` command; `tree`-only. nil in a host-produced tree with no app closure.
     public let dashboardMembers: [String]?
-    /// The pane ref (`<session-uuid>:left`/`:right`) of the dashboard's highlighted cell — the one Enter
-    /// jumps into, focusing that exact pane; nil/omitted with no dashboard. LIVE from the window's
-    /// `DashboardController`, the read side of the keyboard highlight nav. `tree`-only, like `dashboardMembers`.
+    /// The pane ref (`<session-uuid>:left`/`:right`) of the dashboard's highlighted cell — the one Enter jumps
+    /// into, focusing that exact pane; nil/omitted with no dashboard. LIVE from the window's
+    /// `DashboardController`, the read side of the keyboard highlight nav.
     public let dashboardHighlighted: String?
     /// The absolute font size in points applied to the dashboard cells; nil/omitted with no dashboard OR an
     /// untouched font (the members keep their own size). LIVE from the window's `DashboardController`, the
-    /// read side of `dashboard --font-size`/`--auto-size`. `tree`-only, like `dashboardMembers`.
+    /// read side of `dashboard --font-size`/`--auto-size`.
     public let dashboardFontSize: Double?
     /// The dashboard's font mode — `auto` (`--auto-size`), `fixed` (`--font-size`), `untouched`; nil/omitted
     /// with no dashboard. LIVE from the window's `DashboardController`, the read side of the font flags.
-    /// `tree`-only, like `dashboardMembers`.
     public let dashboardFontMode: String?
     /// The id of the picker currently awaiting a choice, or nil when no picker is open.
     public let pickPending: String?
@@ -642,28 +629,27 @@ public struct ControlWindowNode: Codable, Sendable, Equatable {
     public let active: Bool
     /// The window's auto-follow-blocked timeout in milliseconds; nil/omitted when disabled. As of the last
     /// cache refresh — `window.list` answers from a nonisolated fast path, so a just-changed setting lags
-    /// until the next command. Acceptable since the config rarely changes; the live `idleMs` is deliberately
-    /// kept off `window.list` (tree-only) for exactly this reason.
+    /// until the next command; the live `idleMs` is kept off `window.list` (tree-only) for that reason.
     public let autoFollowMs: Int?
     /// Whether this window's sidebar is visible; nil/omitted for a CLOSED window with no live store. Read
     /// from the open window's store, mirroring `autoFollowMs`. The read side of `sidebar`, per window.
     public let sidebarVisible: Bool?
-    /// The window's on-screen frame (position + size + display); nil/omitted for a CLOSED window with no
-    /// live NSWindow. The read side of `window.move`/`window.resize` — record, move/resize, restore exactly.
-    /// Read live app-side on the window cache, refreshed on move/resize/zoom/fullscreen (`ControlServer`
-    /// observes the NSWindow notifications), so a hand-drag or GUI toggle shows up without another command.
+    /// The window's on-screen frame (position + size + display); nil/omitted for a CLOSED window with no live
+    /// NSWindow. The read side of `window.move`/`window.resize`. Read live app-side on the window cache,
+    /// refreshed on move/resize/zoom/fullscreen (`ControlServer` observes the NSWindow notifications), so a
+    /// hand-drag or GUI toggle shows up without another command.
     public let geometry: ControlWindowFrame?
     /// Whether the window is in native macOS full screen; nil/omitted for a CLOSED window. The read side of
-    /// the write-only `window.fullscreen` toggle, so it can be made idempotent (only enter/exit when
-    /// needed). Read live app-side; like `geometry` it rides the cache.
+    /// the write-only `window.fullscreen` toggle, so it can be made idempotent. Read live app-side; like
+    /// `geometry` it rides the cache.
     public let fullscreen: Bool?
     /// Whether the window is zoomed (maximized-to-screen, NOT full screen), or nil for a CLOSED window
     /// (omitted from the JSON). The read side of the write-only `window.zoom` toggle. Read live app-side.
     public let zoomed: Bool?
     /// Whether the window is minimized to the Dock; nil/omitted for a CLOSED window. The read side of
-    /// `window.minimize` — skip a redundant minimize, or restore the set of windows a script put away.
-    /// Live app-side on the cache, refreshed on the NSWindow miniaturize/deminiaturize notifications so ⌘M
-    /// or a Dock click shows too. A minimized window still reports its `geometry` (where it comes back to).
+    /// `window.minimize`. Live app-side on the cache, refreshed on the NSWindow miniaturize/deminiaturize
+    /// notifications so ⌘M or a Dock click shows too. A minimized window still reports its `geometry` (where
+    /// it comes back to).
     public let minimized: Bool?
 
     public init(id: String, name: String, open: Bool, active: Bool, autoFollowMs: Int? = nil,
@@ -696,21 +682,19 @@ public struct ControlResult: Codable, Sendable, Equatable {
     /// not just the agterm-scoped `ghostty.conf` — libghostty diagnostics carry no source-file attribution);
     /// and `session.search`'s total match count (whose "N of M" display string rides in `text`).
     public var count: Int?
-    /// Number of sessions actually changed by a batch mutation (`session.close` or `session.move`).
-    /// Kept separate from `count`, whose CLI rendering is specific to diagnostics/search results.
+    /// Number of sessions actually changed by a batch mutation (`session.close` or `session.move`); separate
+    /// from `count`, whose CLI rendering is specific to diagnostics/search results.
     public var affected: Int?
     /// The current/affected theme name for `theme.set` (echo) and `theme.list` (current); nil =
     /// ghostty's built-in colors ("default ghostty"), distinct from the seeded `agterm` app default.
     public var theme: String?
     /// The available bundled theme names for `theme.list`.
     public var themes: [String]?
-    /// The applied (clamped) left-pane split fraction echoed by `session.resize`, so a script can see
-    /// where the divider landed after clamping / a relative nudge.
+    /// The applied left-pane split fraction echoed by `session.resize`, after clamping / a relative nudge.
     public var ratio: Double?
-    /// The light/dark syncing state for `theme.set`/`theme.list`, derived from the stored theme: `sync` =
-    /// whether it is ghostty's dual `light:,dark:` form (the terminal tracks the macOS appearance),
-    /// `light`/`dark` its sides. While syncing `theme` is absent and the state rides these three; otherwise
-    /// `theme` is the plain single theme and `light`/`dark` are absent.
+    /// The light/dark syncing state for `theme.set`/`theme.list`, from the stored theme: `sync` = whether it
+    /// is ghostty's dual `light:,dark:` form (the terminal tracks the macOS appearance), `light`/`dark` its
+    /// sides. While syncing `theme` is absent; otherwise `theme` is the plain single theme, these absent.
     public var sync: Bool?
     public var light: String?
     public var dark: String?
@@ -756,7 +740,7 @@ public enum OverlayResultError {
 
 /// Advisory text `notify` returns in `result.text` when the banner toggle is off. The command still succeeds
 /// (the unseen badge tracks either way) but hands macOS nothing, so a bare `ok` would look identical to a
-/// broken notification path (issue #286). Shared so the server's wording and any matcher cannot drift.
+/// broken notification path (issue #286). Shared so wording and matchers cannot drift.
 public enum ControlNotify {
     public static let bannersOffNote = "badge updated, but \"Show notification banners\" is off, so no banner was posted"
 }

--- a/agtermCore/Sources/agtermCore/CustomCommand.swift
+++ b/agtermCore/Sources/agtermCore/CustomCommand.swift
@@ -1,11 +1,9 @@
 import Foundation
 
-/// A user-defined command: a shell line run via `/bin/sh -c`, optionally bound to a keyboard
-/// shortcut and always listed in the action palette.
-///
-/// The `command` body may contain `{AGT_X}` template tokens (see `CommandContext`), expanded at
-/// fire time; the same values are also exported as `$AGT_X` environment variables on the spawned
-/// process. An empty `shortcut` means palette-only (no keybind).
+/// A user-defined command: a shell line run via `/bin/sh -c`, optionally bound to a keyboard shortcut
+/// and always listed in the action palette. The body may carry `{AGT_X}` template tokens (see
+/// `CommandContext`), expanded at fire time and also exported as `$AGT_X` environment variables on the
+/// spawned process. An empty `shortcut` means palette-only (no keybind).
 public struct CustomCommand: Codable, Equatable, Sendable, Identifiable {
     public let id: UUID
     /// Display name, shown in the palette and used in the failure banner.
@@ -23,11 +21,10 @@ public struct CustomCommand: Codable, Equatable, Sendable, Identifiable {
     }
 }
 
-/// The already-resolved session context for a command fire: one field per `{AGT_X}` token.
-///
-/// The app target builds this from the active session at fire time; agtermCore only turns it into
-/// the token substitutions (`expand`) and the environment dictionary (`environment`). Both derive
-/// from the single `tokens` table, so the `{AGT_X}` set and the `$AGT_X` set can never drift.
+/// The already-resolved session context for a command fire: one field per `{AGT_X}` token. The app
+/// target builds it from the active session at fire time; agtermCore only derives the token
+/// substitutions (`expand`) and the environment dictionary (`environment`), both off the single `tokens`
+/// table, so the `{AGT_X}` set and the `$AGT_X` set can never drift.
 public struct CommandContext: Equatable, Sendable {
     /// Which pane a command fired from. The raw values are exactly the `--pane` argument strings, so
     /// `pane.rawValue` is always a valid `session.type`/`session.text --pane` value.
@@ -47,10 +44,10 @@ public struct CommandContext: Equatable, Sendable {
     /// The pane that had focus at fire time — `.left` (main), `.right` (split), or `.scratch` (the
     /// session's scratch terminal). `.left` for any single-pane session, including a promoted split
     /// survivor: when the primary pane exits, `closePrimaryPane` moves the surviving split pane into the
-    /// main slot, so it reports `.left` and `session.type --pane left` reaches it. Typed (not a raw
-    /// `String`) so `rawValue` can only be `left`/`right`/`scratch`; it is consumed as the `$AGT_PANE`
-    /// env var a script feeds back through `session type --pane` (re-validated CLI- AND server-side —
-    /// the enum pins the token this emits, not the shell round-trip).
+    /// main slot, so it reports `.left` and `session.type --pane left` reaches it. Typed, so `rawValue`
+    /// can only be `left`/`right`/`scratch`; it is consumed as the `$AGT_PANE` env var a script feeds
+    /// back through `session type --pane` (re-validated CLI- AND server-side — the enum pins the token
+    /// emitted here, not the shell round-trip).
     public var pane: Pane
     public var selection: String
     public var socket: String
@@ -86,9 +83,9 @@ public struct CommandContext: Equatable, Sendable {
          ("AGT_SOCKET", socket)]
     }
 
-    /// The `AGT_X` token names available in a command body, in declaration order. Derived from the
-    /// same `tokens` table that `expand`/`environment` use, so the Settings token reference (the UI
-    /// that lists them) can't drift from the expansion set.
+    /// The `AGT_X` token names available in a command body, in declaration order. Off the same `tokens`
+    /// table `expand`/`environment` use, so the Settings token reference (the UI listing them) can't
+    /// drift from the expansion set.
     public static var tokenNames: [String] {
         CommandContext().tokens.map(\.name)
     }
@@ -99,20 +96,18 @@ public struct CommandContext: Equatable, Sendable {
     /// with no session, which is what keeps a launcher command firable in an emptied window.
     public static let sessionScopedTokenBases = ["AGT_SESSION", "AGT_WORKSPACE", "AGT_SELECTION"]
 
-    /// Whether `commandBody` references any session-scoped token (in `{AGT_X}`, `$AGT_X`, or `${AGT_X}`
-    /// form — a plain substring match, since these base names are specific enough not to occur by
-    /// accident). The empty-window keybind uses this to keep such a command inert with no active session
-    /// (matching the palette's no-op) instead of firing it with silently-empty tokens.
+    /// Whether `commandBody` references any session-scoped token (`{AGT_X}`, `$AGT_X` or `${AGT_X}` — a
+    /// plain substring match, the base names being specific enough not to occur by accident). The
+    /// empty-window keybind keeps such a command inert with no active session (like the palette's no-op)
+    /// instead of firing it with silently-empty tokens.
     public static func referencesSessionScopedContext(_ commandBody: String) -> Bool {
         sessionScopedTokenBases.contains { commandBody.contains($0) }
     }
 
-    /// Substitutes each `{AGT_X}` occurrence in `template` with its resolved value from this context.
-    /// A token whose value is empty becomes an empty string; an unknown `{...}` is left untouched.
-    ///
-    /// Single-pass: the input is scanned once and each `{...}` is replaced from the token table, so a
-    /// replaced value that itself contains a `{AGT_X}` literal (e.g. a selection that reads
-    /// `{AGT_SOCKET}`) is NOT re-substituted.
+    /// Substitutes each `{AGT_X}` occurrence in `template` with its resolved value from this context; an
+    /// empty value becomes an empty string, an unknown `{...}` is left untouched. Single-pass, so a
+    /// replaced value that itself contains a `{AGT_X}` literal (e.g. a selection reading `{AGT_SOCKET}`)
+    /// is NOT re-substituted.
     public func expand(_ template: String) -> String {
         let table = Dictionary(uniqueKeysWithValues: tokens.map { ($0.name, $0.value) })
         var result = ""
@@ -129,7 +124,6 @@ public struct CommandContext: Equatable, Sendable {
             if let value = table[name] {
                 result += value
             } else {
-                // not a known token — keep the `{...}` literal untouched.
                 result += rest[open...close]
             }
             rest = rest[rest.index(after: close)...]

--- a/agtermCore/Sources/agtermCore/DashboardController.swift
+++ b/agtermCore/Sources/agtermCore/DashboardController.swift
@@ -1,21 +1,20 @@
 import Foundation
 import Observation
 
-/// How the dashboard overlay sizes the font of its member surfaces.
-/// `.untouched` leaves each surface at its own `session.fontSize`; `.fixed` applies one absolute size to
-/// every cell; `.auto` derives a per-grid size from `DashboardLayout.dashboardFontSize` so a denser grid
-/// shrinks to stay readable. The app-side wiring translates the mode into a transient surface override.
+/// How the dashboard overlay sizes its member surfaces' font: `.untouched` leaves each at its own
+/// `session.fontSize`, `.fixed` applies one absolute size to every cell, `.auto` derives a per-grid size
+/// from `DashboardLayout.dashboardFontSize` so a denser grid shrinks to stay readable. The app-side wiring
+/// translates the mode into a transient surface override.
 public enum DashboardFontMode: Equatable, Sendable {
     case untouched
     case fixed(Double)
     case auto
 
     /// appliedFontSize resolves the absolute font size (points) the wiring applies to every member surface
-    /// for this mode over `memberCount` cells, or nil for `.untouched` (each surface keeps its own
-    /// `session.fontSize`). `.auto` derives it from the grid via `DashboardLayout`; `.fixed` returns its
-    /// value. Shared by the app-side font wiring and `ControlServer.setDashboard`, so the controller's
-    /// `appliedFontSize` (the `dashboardFontSize` tree read-back) is authoritative at command return — not
-    /// only after SwiftUI's onChange applies the surface overrides a runloop turn later.
+    /// over `memberCount` cells: nil for `.untouched` (each surface keeps its own `session.fontSize`),
+    /// `.fixed`'s own value, or a grid-derived one via `DashboardLayout` for `.auto`. Shared by the app-side
+    /// font wiring and `ControlServer.setDashboard`, so the controller's `appliedFontSize` (the
+    /// `dashboardFontSize` tree read-back) is authoritative at command return, not a runloop turn later.
     public func appliedFontSize(memberCount: Int, base: Double) -> Double? {
         switch self {
         case .untouched:
@@ -29,10 +28,9 @@ public enum DashboardFontMode: Equatable, Sendable {
     }
 }
 
-/// One dashboard cell's identity: a session plus which of its panes the cell hosts. A non-split session
-/// yields a single `.primary` member; a split session yields both `.primary` and `.split`, so each pane
-/// gets its own cell. `surface` is always `.primary` or `.split` for the dashboard — the `.scratch`/
-/// `.overlay` cases of `TerminalZoomSurface` are never dashboard members.
+/// One dashboard cell's identity: a session plus which of its panes it hosts. A non-split session yields one
+/// `.primary` member, a split session both `.primary` and `.split`, so each pane gets its own cell. `surface`
+/// is always `.primary` or `.split` here — `TerminalZoomSurface`'s `.scratch`/`.overlay` are never members.
 public struct DashboardMember: Equatable, Hashable, Sendable {
     public let session: UUID
     public let surface: TerminalZoomSurface
@@ -49,12 +47,11 @@ public struct DashboardMember: Equatable, Hashable, Sendable {
     }
 }
 
-/// Per-window dashboard state — the picked pane cells, the keyboard highlight, and the font mode.
-/// Host-free (`agtermCore`, Foundation + Observation only) and `@MainActor`, mirroring
-/// `TerminalZoomController`: the app target owns one per window and drives it, and `ControlServer` reaches
-/// a specific window's controller through `DashboardControllerRegistry`. `members` are `DashboardMember`
-/// pane cells (a session + which pane; resolved app-side to their live surfaces); `isOpen` derives from a
-/// non-empty member set, so `close()` (which empties it) is the single source of truth for open/closed.
+/// Per-window dashboard state — the picked pane cells, the keyboard highlight, the font mode. Host-free
+/// (`agtermCore`, Foundation + Observation only) and `@MainActor`, mirroring `TerminalZoomController`: the
+/// app target owns one per window and drives it, `ControlServer` reaches a specific window's through
+/// `DashboardControllerRegistry`. `members` are `DashboardMember` pane cells resolved app-side to their live
+/// surfaces; `isOpen` derives from a non-empty member set, so `close()` is the open/closed source of truth.
 @Observable
 @MainActor
 public final class DashboardController {
@@ -77,7 +74,7 @@ public final class DashboardController {
 
     public init() {}
 
-    /// Whether the dashboard is open, i.e. it holds at least one member.
+    /// Whether the dashboard is open.
     public var isOpen: Bool { !members.isEmpty }
 
     /// open shows the dashboard over `members`. The highlight starts on `highlighted` when it is one of
@@ -101,9 +98,9 @@ public final class DashboardController {
         appliedFontSize = nil
     }
 
-    /// highlight moves the highlight directly to `member`, but only when `member` is one of the current
-    /// members — a stray one leaves it unchanged; a no-op when closed. Used by a mouse click to flash the
-    /// active frame on the clicked cell before entering it (the keyboard walks the highlight with `move`).
+    /// highlight moves the highlight to `member`, only when it is a current member (a stray one changes
+    /// nothing); a no-op when closed. A mouse click uses it to flash the active frame on the clicked cell
+    /// before entering it; the keyboard walks the highlight with `move`.
     public func highlight(_ member: DashboardMember) {
         guard members.contains(member) else { return }
         highlighted = member
@@ -118,25 +115,24 @@ public final class DashboardController {
         self.highlighted = members[to]
     }
 
-    /// setAppliedFontSize records the absolute font size the app-side wiring applied to the member surfaces,
-    /// for the `dashboardFontSize` tree read-back. The stored property stays `private(set)` so only this
-    /// method (never a stray external write) mutates it; the wiring calls it on every font (re)apply.
+    /// setAppliedFontSize records the size the app-side wiring applied to the member surfaces, for the
+    /// `dashboardFontSize` tree read-back. `private(set)` keeps this the only writer; the wiring calls it on
+    /// every font (re)apply.
     public func setAppliedFontSize(_ size: Double?) {
         appliedFontSize = size
     }
 
-    /// requestFocus bumps `focusRevision` so the dashboard's AppKit key catcher reclaims first responder
-    /// once an overlay above it (a control picker) resolves. Called by `restoreFocusAfterPick`; the value
-    /// itself carries no meaning beyond changing.
+    /// requestFocus bumps `focusRevision` so the dashboard's AppKit key catcher reclaims first responder once
+    /// an overlay above it (a control picker) resolves. Called by `restoreFocusAfterPick`; only the change
+    /// carries meaning, never the value.
     public func requestFocus() {
         focusRevision &+= 1
     }
 
-    /// reconcile drops any member pane no longer present in `existing` (a member session closed, OR a split
-    /// pane closed, while the dashboard is open — e.g. over the control socket), preserving order. It closes
-    /// the dashboard when no member survives, and moves the highlight to the first survivor when the
-    /// highlighted one vanished. A no-op when nothing was removed, so it is cheap to call on every
-    /// session/split add/remove.
+    /// reconcile drops any member pane absent from `existing` (a member session or split pane closed while
+    /// the dashboard is open — e.g. over the control socket), preserving order. Closes the dashboard when no
+    /// member survives, and moves the highlight to the first survivor when the highlighted one vanished. A
+    /// no-op when nothing was removed, so it is cheap to call on every session/split add/remove.
     public func reconcile(existing: Set<DashboardMember>) {
         let survivors = members.filter { existing.contains($0) }
         guard survivors.count != members.count else { return }

--- a/agtermCore/Sources/agtermCore/DashboardLayout.swift
+++ b/agtermCore/Sources/agtermCore/DashboardLayout.swift
@@ -1,10 +1,9 @@
 import Foundation
 
-/// Pure grid geometry, keyboard navigation, and auto-size font math for the dashboard overlay.
-/// Host-free (Foundation-only, `Int`/`Double` — no CoreGraphics/AppKit) so `swift test` covers it with
-/// no app host. The dashboard shows up to `maxCells` live session surfaces in a `ceil(sqrt(n))`-wide grid;
-/// a keyboard highlight walks the cells and the auto-size math shrinks the font as the grid grows so a
-/// dense grid stays readable.
+/// Pure grid geometry, keyboard navigation, and auto-size font math for the dashboard overlay. Host-free
+/// (Foundation-only, `Int`/`Double` — no CoreGraphics/AppKit) so `swift test` covers it with no app host.
+/// The dashboard shows up to `maxCells` live session surfaces in a `ceil(sqrt(n))`-wide grid; a keyboard
+/// highlight walks the cells and the auto-size math shrinks the font as the grid grows, to stay readable.
 public enum DashboardLayout {
     /// Largest number of cells the grid holds; the call site caps a bigger request to this.
     public static let maxCells = 9

--- a/agtermCore/Sources/agtermCore/Debouncer.swift
+++ b/agtermCore/Sources/agtermCore/Debouncer.swift
@@ -1,12 +1,11 @@
 import Foundation
 
-/// Coalesces rapid repeated calls into a single deferred action. `schedule(after:_:)`
-/// cancels any pending work and reschedules, so only the latest action runs once the
-/// quiet window elapses. `flush()` runs the pending work synchronously (used by a
-/// commit/quit path that must capture the latest state now); `cancel()` drops it.
+/// Coalesces rapid repeated calls into a single deferred action: `schedule(after:_:)` cancels any pending
+/// work and reschedules, so only the latest runs once the quiet window elapses; `flush()` runs it
+/// synchronously (for a commit/quit path that must capture the latest state now); `cancel()` drops it.
 ///
-/// `@MainActor` so the scheduled work runs on the main actor like its callers
-/// (AppStore saves, SettingsModel theme preview). Foundation-only — host-free.
+/// `@MainActor` so the work runs on the main actor like its callers (AppStore saves, SettingsModel theme
+/// preview). Foundation-only — host-free.
 @MainActor
 public final class Debouncer {
     private var work: DispatchWorkItem?

--- a/agtermCore/Sources/agtermCore/Fuzzy.swift
+++ b/agtermCore/Sources/agtermCore/Fuzzy.swift
@@ -1,14 +1,11 @@
 import Foundation
 
-/// Scores how well `query` matches `target` for the command palettes — lower is a better match,
-/// `nil` means no match. The query is split on whitespace into terms (`"cap dev"` is two terms);
-/// EVERY term must match `target` and the score is the sum of the per-term scores, so the order
-/// between terms doesn't matter — `"cap dev"` and `"dev cap"` both match `caprica-dev`. An empty or
-/// whitespace-only query matches everything at `0` (so the unfiltered list keeps its natural order).
-/// Case-insensitive.
-///
-/// Per term: an exact prefix is `0`; a substring is `5 +` the offset where it starts; a scattered
-/// subsequence is `40 +` the length gap.
+/// Scores how well `query` matches `target` for the command palettes — lower is better, `nil` is no match.
+/// The query splits on whitespace into terms (`"cap dev"` is two); EVERY term must match `target` and the
+/// score is their sum, so term order is irrelevant — `"cap dev"` and `"dev cap"` both match `caprica-dev`.
+/// An empty or whitespace-only query matches everything at `0`, keeping the unfiltered list's natural
+/// order. Case-insensitive. Per term: an exact prefix is `0`, a substring `5 +` its start offset, a
+/// scattered subsequence `40 +` the length gap.
 public func fuzzyScore(query: String, target: String) -> Int? {
     let terms = query.lowercased().split(whereSeparator: \.isWhitespace).map(String.init)
     guard !terms.isEmpty else { return 0 }
@@ -21,12 +18,12 @@ public func fuzzyScore(query: String, target: String) -> Int? {
     return total
 }
 
-/// Ranks `items` against `query` for the command palettes: an item matches when any of its `keys`
-/// (for example, a title and optional subtitle) matches, scored by the best/lower score of those keys.
-/// Matches are sorted best-first with ties broken by the first key, case-insensitively.
+/// Ranks `items` against `query` for the command palettes: an item matches when any of its `keys` (a title
+/// and optional subtitle, say) matches, scored by the best (lowest) of those keys. Sorted best-first, ties
+/// broken by the first key case-insensitively.
 ///
-/// Empty queries score every item at `0`, which makes this an alphabetical sort by first key. Callers
-/// that need an empty query to preserve natural input order should skip ranking for that case.
+/// An empty query scores every item `0`, making this an alphabetical sort by first key — a caller needing
+/// natural input order there should skip ranking.
 public func fuzzyRank<Item>(query: String, items: [Item], keys: (Item) -> [String]) -> [Item] {
     items.compactMap { item -> (item: Item, score: Int, label: String)? in
         let itemKeys = keys(item)
@@ -41,9 +38,8 @@ public func fuzzyRank<Item>(query: String, items: [Item], keys: (Item) -> [Strin
     .map(\.item)
 }
 
-/// Scores a single whitespace-free `term` against the already-lowercased `target`: an exact prefix
-/// is `0`, a substring is `5 +` its start offset, a scattered subsequence is `40 +` the length gap,
-/// and `nil` when the term doesn't appear at all.
+/// Scores a single whitespace-free `term` against the already-lowercased `target` (see `fuzzyScore` for
+/// the scale), `nil` when the term doesn't appear at all.
 private func termScore(_ term: String, in target: String) -> Int? {
     if target.hasPrefix(term) { return 0 }
     if let range = target.range(of: term) {

--- a/agtermCore/Sources/agtermCore/InterruptKeystroke.swift
+++ b/agtermCore/Sources/agtermCore/InterruptKeystroke.swift
@@ -1,8 +1,7 @@
 import Foundation
 
-/// Host-free keyboard modifiers, mirroring the subset of `NSEvent.ModifierFlags` the interrupt
-/// classifier needs. The app target maps an `NSEvent`'s flags onto this so the classification stays
-/// testable without AppKit.
+/// Host-free keyboard modifiers, the subset of `NSEvent.ModifierFlags` the interrupt classifier needs. The
+/// app target maps an `NSEvent`'s flags onto this so the classification stays testable without AppKit.
 public struct KeyModifiers: OptionSet, Sendable {
     public let rawValue: Int
     public init(rawValue: Int) { self.rawValue = rawValue }
@@ -13,10 +12,9 @@ public struct KeyModifiers: OptionSet, Sendable {
     public static let shift = KeyModifiers(rawValue: 1 << 3)
 }
 
-/// Classifies a keystroke as one that interrupts a working agent — Escape, or a bare Ctrl-C. Both
-/// dismiss a pending Claude Code / TUI prompt, which is what clears a stale `active` status glyph. Kept
-/// host-free so the full truth table (including the negatives ordinary-key / Cmd-C / Ctrl-Shift-C) is
-/// unit-testable; the app target reduces an `NSEvent` to these primitives.
+/// Classifies a keystroke as one that interrupts a working agent — Escape or a bare Ctrl-C, both of which
+/// dismiss a pending Claude Code / TUI prompt and so clear a stale `active` status glyph. Host-free so the
+/// full truth table (negatives included: ordinary key, Cmd-C, Ctrl-Shift-C) is unit-testable.
 public enum InterruptKeystroke {
     /// The physical C key position (macOS `kVK_ANSI_C`). Layout-independent, unlike the produced character.
     public static let cKeyCode: UInt16 = 8
@@ -24,14 +22,13 @@ public enum InterruptKeystroke {
     public static let escapeKeyCode: UInt16 = 53
 
     /// Whether the keystroke interrupts the agent. `character` is the layout's base letter for the key
-    /// (`NSEvent.charactersIgnoringModifiers`); matching it covers Latin layouts including Dvorak, where
-    /// the C letter sits at a non-`cKeyCode` physical key. The `cKeyCode` fallback covers non-Latin layouts
-    /// (Cyrillic, Greek) where that physical key produces a non-Latin character rather than "c" — the same
-    /// layout-independent fallback the built-in `super+key_c` binds use — but only when the produced base
-    /// is non-Latin or unavailable: a remapped Latin layout where `cKeyCode` yields a Latin letter other
-    /// than "c" (Dvorak's "j") is left alone, so Ctrl-J there is not a false interrupt. Escape interrupts
-    /// under any modifiers; Ctrl-C must be bare (control only, no command/option/shift) so a copy-style
-    /// chord like Ctrl-Shift-C does not clear a glyph while the agent is still working.
+    /// (`NSEvent.charactersIgnoringModifiers`); matching it covers Latin layouts including Dvorak, where the
+    /// C letter sits at a non-`cKeyCode` physical key. The `cKeyCode` fallback — the layout-independent one
+    /// the built-in `super+key_c` binds use — covers non-Latin layouts (Cyrillic, Greek) where that physical
+    /// key produces no "c", but fires only when the produced base is non-Latin or unavailable, so a remapped
+    /// Latin layout yielding another letter there (Dvorak's "j") is left alone and Ctrl-J is no false
+    /// interrupt. Escape interrupts under any modifiers; Ctrl-C must be bare (control only, no
+    /// command/option/shift) so a copy-style chord like Ctrl-Shift-C can't clear a glyph mid-work.
     public static func isInterrupt(keyCode: UInt16, character: String?, modifiers: KeyModifiers) -> Bool {
         if keyCode == escapeKeyCode { return true }
         guard modifiers.contains(.control),

--- a/agtermCore/Sources/agtermCore/Keybind.swift
+++ b/agtermCore/Sources/agtermCore/Keybind.swift
@@ -1,10 +1,8 @@
 import Foundation
 
-/// The keyboard modifier flags a chord may require, as a host-free `OptionSet`.
-///
-/// The app target maps `NSEvent.ModifierFlags` onto this so the parser and matcher stay AppKit-free.
-/// `parseKeybind` recognizes the modifier words `ctrl`/`control`, `cmd`/`command`, `opt`/`option`/`alt`,
-/// and `shift`.
+/// The keyboard modifier flags a chord may require, as a host-free `OptionSet`. The app target maps
+/// `NSEvent.ModifierFlags` onto this so the parser and matcher stay AppKit-free; `parseKeybind` spells them
+/// `ctrl`/`control`, `cmd`/`command`, `opt`/`option`/`alt`, `shift`.
 public struct Modifier: OptionSet, Hashable, Sendable {
     public let rawValue: Int
     public init(rawValue: Int) { self.rawValue = rawValue }
@@ -15,34 +13,29 @@ public struct Modifier: OptionSet, Hashable, Sendable {
     public static let shift = Modifier(rawValue: 1 << 3)
 }
 
-/// The base keys a chord may name beyond a single printable character — exactly the named keys the
-/// app-side runner can produce from an `NSEvent`, so `parseKeybind` rejects any other name (one the UI
-/// would accept but the runner could never fire). `esc` is reserved as the leader abort and is
-/// intentionally NOT bindable. The four arrows are here because the six arrow-bound built-ins ship their
-/// defaults on them, so the grammar must be able to spell what `BuiltinAction.defaultChord` returns.
+/// The base keys a chord may name beyond a single printable character — exactly the named keys the app-side
+/// runner can produce from an `NSEvent`, so `parseKeybind` rejects any name the runner could never fire.
+/// `esc` is reserved as the leader abort and is NOT bindable. The arrows are here because the six
+/// arrow-bound built-ins ship their defaults on them, so the grammar must spell `BuiltinAction.defaultChord`.
 ///
-/// Adding a name here means updating five sites, two inbound and three outbound:
-/// - `CustomCommandRunner` and `UndoCloseShortcut` resolve `NSEvent` → name via `namedKey(forKeyCode:)`,
-///   so a name with no keycode parses in the file yet never fires;
-/// - `namedKey(forKeyEquivalent:)` resolves a live `NSMenuItem`'s key-equivalent CHARACTER back to the
-///   name for `keymap.list`, so a name missing there renders every menu item carrying that key with the
-///   key absent and stops it comparing against the resolved chord (its own test pins the two sets equal);
-/// - `Chord.glyphString` renders the name in palette hints and tooltips, degrading to the raw name — a
-///   miss there is cosmetic;
-/// - `agtermApp.toShortcut` maps the name to a SwiftUI `KeyEquivalent`, and its `default` arm is
-///   `KeyEquivalent(Character(chord.key))`, which TRAPS on a multi-character string — a crash on the
-///   first menu render, not a degradation, so update it first.
+/// Adding a name means updating five sites, two inbound and three outbound:
+/// - `CustomCommandRunner` and `UndoCloseShortcut` resolve `NSEvent` → name via `namedKey(forKeyCode:)`, so
+///   a name with no keycode parses in the file yet never fires;
+/// - `namedKey(forKeyEquivalent:)` maps a live `NSMenuItem` key-equivalent CHARACTER back for `keymap.list`;
+///   a name missing there renders the key absent and breaks comparison with the resolved chord (a test pins the sets equal);
+/// - `Chord.glyphString` renders the name in palette hints and tooltips, degrading to the raw name — cosmetic;
+/// - `agtermApp.toShortcut`'s `default` arm `KeyEquivalent(Character(chord.key))` TRAPS on a multi-character
+///   string — a crash on the first menu render, not a degradation, so update it first.
 public let bindableNamedKeys: Set<String> = Set(["tab", "space", "return", "delete"]).union(bindableArrowKeys)
 
-/// The four arrow keys, a subset of `bindableNamedKeys`. Named separately for one extra rule: a built-in
-/// `map` may not bind a modifier-less arrow (`parseMapLine`), since an always-on menu key-equivalent on a
-/// bare arrow swallows the key in the terminal, the palettes, the dashboard grid, and every text field.
+/// The four arrow keys, a subset of `bindableNamedKeys`. Separate for one extra rule: a built-in `map` may
+/// not bind a modifier-less arrow (`parseMapLine`), since an always-on menu key-equivalent on a bare arrow
+/// swallows the key in the terminal, the palettes, the dashboard grid and every text field.
 let bindableArrowKeys: Set<String> = ["left", "right", "up", "down"]
 
 /// The named key for a macOS virtual key code, or `nil` for a key carrying a normal character (which the
-/// caller derives from the event itself). The single source of truth for the keyCode→name half of the
-/// `NSEvent`→`Chord` mapping, shared by every app-side monitor so a name added to `bindableNamedKeys`
-/// can't parse in the file yet fail to fire at runtime.
+/// caller derives from the event). The single source of truth for the keyCode→name half of `NSEvent`→`Chord`,
+/// shared by every app-side monitor so a name in `bindableNamedKeys` can't parse yet fail to fire.
 public func namedKey(forKeyCode keyCode: UInt16) -> String? {
     switch keyCode {
     case 36: return "return"
@@ -57,12 +50,11 @@ public func namedKey(forKeyCode keyCode: UInt16) -> String? {
     }
 }
 
-/// The Latin base character at a physical ANSI key position, or `nil` for a position carrying no Latin
-/// key (a named key, a function key, the keypad). The letters, digits and punctuation of the ANSI layout
-/// keyed by macOS virtual key code — exactly the single characters `parseKeybind` accepts as a base key,
-/// so every entry is spellable in `keymap.conf`. This is the layout-INDEPENDENT half of key resolution:
-/// a virtual key code names a physical position and never changes with the active input source, unlike
-/// the character that position produces.
+/// The Latin base character at a physical ANSI key position, or `nil` where there is none (a named key, a
+/// function key, the keypad). ANSI letters/digits/punctuation keyed by macOS virtual key code — exactly the
+/// single characters `parseKeybind` accepts as a base key, so every entry is spellable in `keymap.conf`. The
+/// layout-INDEPENDENT half of key resolution: a key code names a physical position and never changes with
+/// the active input source, unlike the character that position produces.
 func latinKey(forKeyCode keyCode: UInt16) -> String? {
     switch keyCode {
     case 0: return "a"
@@ -117,56 +109,51 @@ func latinKey(forKeyCode keyCode: UInt16) -> String? {
 }
 
 /// The base key for a key press. `produced` is the character the ACTIVE layout puts on that key with no
-/// modifiers applied (the app-side monitors pass what the `NSEvent` reports), and
-/// `layoutIsASCIICapable` says whether that layout can type ASCII at all.
+/// modifiers applied, `layoutIsASCIICapable` whether that layout can type ASCII at all.
 ///
-/// The choice is per LAYOUT, not per key. An ASCII-capable layout — US, Dvorak, Colemak, US-International,
-/// French, German — binds by the character it produces, so a chord follows the letter the user sees on the
-/// key and an alternative Latin layout keeps its own letter positions. A layout that cannot type ASCII —
-/// Russian, Greek, Hebrew, Arabic, Thai — can never produce a character a `keymap.conf` chord is spelled
-/// with, so every one of its keys binds by physical position via `latinKey(forKeyCode:)`.
+/// The choice is per LAYOUT, not per key. An ASCII-capable layout (US, Dvorak, Colemak, US-International,
+/// French, German) binds by the character it produces, so a chord follows the letter the user sees on the
+/// key and an alternative Latin layout keeps its own letter positions. A layout that cannot type ASCII
+/// (Russian, Greek, Hebrew, Arabic, Thai) can never produce a character a `keymap.conf` chord is spelled
+/// with, so all its keys bind by physical position via `latinKey(forKeyCode:)`.
 ///
-/// Deciding per key instead (keeping any produced character that happens to be ASCII) does not work:
-/// Greek types `;` on the Q position and Hebrew types `/` there, so a Latin-spelled letter chord would
-/// stay dead on exactly the layouts this exists to serve, and two physical keys could collapse onto one
-/// chord — on Hebrew the `'` key produces `,` while the `,` key falls back to `,`. Resolving the whole
-/// layout at once keeps `latinKey`'s one-key-per-position mapping intact, so no two TABLE positions can
-/// collapse. A key code outside the table keeps what it types, which still aliases the table for the
-/// keypad — keypad `5` and the number row both give `"5"` — as it always did, since the keypad's output
-/// does not vary by layout.
+/// Deciding per key (keeping any produced character that happens to be ASCII) does not work: Greek types
+/// `;` on the Q position and Hebrew `/`, so a Latin-spelled letter chord would stay dead on exactly the
+/// layouts this exists to serve, and two physical keys could collapse onto one chord (on Hebrew the `'` key
+/// produces `,` while the `,` key falls back to `,`). Whole-layout resolution keeps `latinKey`'s
+/// one-key-per-position mapping intact, so no two TABLE positions collapse; a key code outside the table
+/// keeps what it types and still aliases the table for the keypad (keypad `5` and the number row both give
+/// `"5"`), harmless because keypad output does not vary by layout.
 ///
-/// A different rule from `InterruptKeystroke.isInterrupt`, which tests the produced character itself (is
-/// it a Latin letter?) rather than the layout: that one classifies a single hardcoded key and needs no
-/// layout context, while a chord needs the whole ANSI vocabulary.
+/// A different rule from `InterruptKeystroke.isInterrupt`, which tests the produced character (is it a Latin
+/// letter?) rather than the layout: that one classifies a single hardcoded key and needs no layout context.
 ///
-/// Returns `nil` when the press carries no usable base key. On a non-ASCII-capable layout that means a
-/// position outside `latinKey`'s table that produced nothing, plus the ISO section key; a dead key at a
-/// TABLE position resolves to its Latin key instead. On an ASCII-capable layout it means anything that
-/// produced nothing at all, table position or not — that branch never consults the table.
+/// Returns `nil` when the press carries no usable base key: on a non-ASCII-capable layout a position outside
+/// `latinKey`'s table that produced nothing, plus the ISO section key (a dead key at a TABLE position
+/// resolves to its Latin key); on an ASCII-capable layout anything that produced nothing at all, table
+/// position or not — that branch never consults the table.
 public func chordKey(forKeyCode keyCode: UInt16, produced: String?, layoutIsASCIICapable: Bool) -> String? {
     // space is a named key (`namedKey(forKeyCode:)` claims keyCode 49); a produced space is not a base key.
     let base = produced?.first.map { String($0).lowercased() }.flatMap { $0 == " " ? nil : $0 }
     guard !layoutIsASCIICapable else { return base }
     if let latin = latinKey(forKeyCode: keyCode) { return latin }
-    // the ISO section key — the extra key an ISO keyboard carries and an ANSI one does not — has no
-    // position in the table AND types a layout-dependent character, so keeping it would alias whichever
-    // table position types the same thing: Ukrainian-PC types `\` there against the ANSI backslash key,
-    // Hebrew-PC `;` against the ANSI semicolon key. Both would fire one binding from two keys and swallow
-    // the keystroke, so it cannot spell a chord on a layout resolved by position.
+    // the ISO section key (an ISO keyboard carries it, an ANSI one does not) has no table position AND types
+    // a layout-dependent character, so keeping it would alias whichever table position types the same thing:
+    // Ukrainian-PC types `\` there against the ANSI backslash key, Hebrew-PC `;` against the semicolon key.
+    // both would fire one binding from two keys and swallow the keystroke.
     return keyCode == isoSectionKeyCode ? nil : base
 }
 
 /// The ISO-only key left of Z (macOS `kVK_ISO_Section`), absent from an ANSI keyboard and from `latinKey`.
 private let isoSectionKeyCode: UInt16 = 10
 
-/// The named key for a menu item's key-equivalent CHARACTER, or `nil` for an ordinary printable key.
-///
-/// The character counterpart of `namedKey(forKeyCode:)`, for projecting live `NSMenuItem` key equivalents
-/// back into keymap syntax: a menu item carries a character rather than a virtual key code, and AppKit
-/// spells the arrows with private-use function-key scalars and return/tab/space/delete with control
-/// characters. Without this a menu chord renders as `cmd+opt+` with the key missing, which cannot be
-/// compared against the `cmd+opt+up` the keymap resolved. Matching scalar values rather than the AppKit
-/// constants keeps `agtermCore` AppKit-free; the values are the documented `NSUpArrowFunctionKey` family.
+/// The named key for a menu item's key-equivalent CHARACTER, or `nil` for an ordinary printable key — the
+/// character counterpart of `namedKey(forKeyCode:)`, projecting live `NSMenuItem` key equivalents back into
+/// keymap syntax: a menu item carries a character, not a virtual key code, and AppKit spells the arrows with
+/// private-use function-key scalars and return/tab/space/delete with control characters. Without this a menu
+/// chord renders as `cmd+opt+` with the key missing, uncomparable against the resolved `cmd+opt+up`. Matching
+/// scalars rather than the AppKit constants keeps `agtermCore` AppKit-free; they are the documented
+/// `NSUpArrowFunctionKey` family.
 public func namedKey(forKeyEquivalent character: String) -> String? {
     let scalars = character.unicodeScalars
     guard scalars.count == 1, let scalar = scalars.first else { return nil }
@@ -186,11 +173,9 @@ public func namedKey(forKeyEquivalent character: String) -> String? {
 /// Whether a chord is owned by the app's always-on `NSEvent` monitors (NOT a menu key-equivalent), so a
 /// keybind starting with it would dead-race the monitor and must be rejected. MIRRORS the monitors' real
 /// predicates, not a fixed list:
-/// - the Ctrl-Tab session switcher (`SessionSwitcher`) consumes Tab whenever Control is held, with ANY
-///   other modifiers (`ctrl+tab`, `ctrl+shift+tab`, `ctrl+opt+tab`, `ctrl+cmd+tab`);
+/// - the Ctrl-Tab session switcher (`SessionSwitcher`) consumes Tab whenever Control is held, with ANY other modifiers;
 /// - the Ctrl-1/2 pane shortcuts (`PaneShortcuts`) consume 1/2 only when Control is the SOLE modifier.
-/// Used by both the built-in `map` check and the custom-command cross-section validation so neither can
-/// rebind a reserved chord. Host-free, next to the chord model so the rule is discoverable.
+/// Used by the built-in `map` check and the custom-command cross-section validation, so neither can rebind one.
 public func isReservedMonitorChord(_ chord: Chord) -> Bool {
     if chord.mods.contains(.control), chord.key == "tab" { return true }
     if chord.mods == [.control], chord.key == "1" || chord.key == "2" { return true }
@@ -208,9 +193,8 @@ public struct Chord: Equatable, Hashable, Sendable {
         self.key = key
     }
 
-    /// The chord rendered back to kitty syntax (e.g. `cmd+shift+e`), the form the user writes in
-    /// `keymap.conf`. Modifiers are emitted in a fixed `ctrl+cmd+opt+shift` order so the round-trip is
-    /// stable; shows a built-in's current binding the same way custom commands show their raw shortcut.
+    /// The chord in kitty syntax (e.g. `cmd+shift+e`), the form the user writes in `keymap.conf`. Modifiers
+    /// emit in a fixed `ctrl+cmd+opt+shift` order so the round-trip is stable.
     public var displayString: String {
         var parts: [String] = []
         if mods.contains(.control) { parts.append("ctrl") }
@@ -221,10 +205,9 @@ public struct Chord: Equatable, Hashable, Sendable {
         return parts.joined(separator: "+")
     }
 
-    /// The chord rendered as macOS menu glyphs (e.g. `⌘N`, `⌘⌥N`, `⌃P`): modifiers in the macOS order
-    /// `⌃⌥⇧⌘`, then the key (single letters uppercased, named keys as their symbols). Used for the
-    /// action-palette hints so a built-in reads like its menu equivalent; custom commands keep the raw
-    /// kitty `displayString`.
+    /// The chord as macOS menu glyphs (e.g. `⌘⌥N`): modifiers in the macOS order `⌃⌥⇧⌘`, then the key (single
+    /// letters uppercased, named keys as symbols) — action-palette hints, so a built-in reads like its menu equivalent;
+    /// custom commands keep the raw kitty `displayString`.
     public var glyphString: String {
         var s = ""
         if mods.contains(.control) { s += "⌃" }
@@ -246,19 +229,17 @@ public struct Chord: Equatable, Hashable, Sendable {
     }
 }
 
-/// A keybind: an ordered sequence of chords. Length 1 is a simple chord (e.g. `cmd+shift+e`),
-/// length > 1 is a leader sequence (e.g. `ctrl+a > b`).
+/// A keybind: an ordered sequence of chords. Length 1 is a simple chord, length > 1 a leader sequence
+/// (e.g. `ctrl+a > b`).
 public typealias Keybind = [Chord]
 
-/// Parse a keybind string into a `Keybind`, or `nil` when it is empty, malformed, or names an unknown
-/// modifier.
+/// Parse a keybind string into a `Keybind`, or `nil` when it is empty, malformed, or names an unknown modifier.
 ///
 /// The grammar is chords separated by `>`, each a `+`-joined list of modifier words and a final base key,
-/// case-insensitive: `cmd+shift+e`, `ctrl+a>b`, `ctrl + a > b`. The base key is a single printable
-/// character or one of `bindableNamedKeys` (`tab`/`space`/`return`/`delete`/`left`/`right`/`up`/`down`) —
-/// the keys the app-side runner can actually produce; any other multi-char word (`esc`, `f1`) is rejected.
-/// Returns `nil` for an empty input, an empty chord (a trailing `>` or `+`), a chord with no base key or
-/// more than one, an unrecognized modifier word, or an unproducible named key.
+/// case-insensitive: `cmd+shift+e`, `ctrl+a>b`, `ctrl + a > b`. The base key is a single printable character
+/// or one of `bindableNamedKeys`; any other multi-char word (`esc`, `f1`) is rejected. Returns `nil` for an
+/// empty input, an empty chord (a trailing `>` or `+`), a chord with no base key or more than one, an
+/// unrecognized modifier word, or an unproducible named key.
 public func parseKeybind(_ s: String) -> Keybind? {
     let chordStrings = s.split(separator: ">", omittingEmptySubsequences: false)
     guard !chordStrings.isEmpty else { return nil }
@@ -271,9 +252,8 @@ public func parseKeybind(_ s: String) -> Keybind? {
     return keybind
 }
 
-/// Parse a single chord (a `+`-joined list of modifier words plus one base key), or `nil` when it
-/// is empty, has no base key, has multiple base keys, names an unknown modifier, or names a base key
-/// the runner can't fire (a multi-char word that is not in `bindableNamedKeys`).
+/// Parse a single chord (a `+`-joined list of modifier words plus one base key), or `nil` when it is empty,
+/// has no or multiple base keys, names an unknown modifier, or a multi-char key outside `bindableNamedKeys`.
 private func parseChord(_ s: String) -> Chord? {
     let tokens = s.split(separator: "+", omittingEmptySubsequences: false)
         .map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
@@ -291,8 +271,7 @@ private func parseChord(_ s: String) -> Chord? {
         key = token
     }
 
-    // the base key must be a single character or a named key the runner can produce; reject any
-    // other multi-char word (e.g. `esc`/`f1`) so the UI never accepts a chord that can't fire.
+    // reject a multi-char word outside `bindableNamedKeys` so the UI never accepts a chord that can't fire.
     guard let key, key.count == 1 || bindableNamedKeys.contains(key) else { return nil }
     return Chord(mods: mods, key: key)
 }
@@ -320,12 +299,10 @@ public struct KeybindConflict: Equatable, Sendable {
     }
 }
 
-/// Find shortcut conflicts across a list of custom commands.
-///
-/// Two parseable, non-empty shortcuts conflict when one keybind is a prefix of the other (a duplicate is
-/// the degenerate equal-length case): the shorter bind would fire — or be forced to wait — ambiguously
-/// while the longer one is still being typed. Commands with an empty or unparseable shortcut are skipped
-/// (palette-only / surfaced separately).
+/// Find shortcut conflicts across a list of custom commands. Two parseable, non-empty shortcuts conflict when
+/// one keybind is a prefix of the other (a duplicate is the degenerate equal-length case): the shorter would
+/// fire — or be forced to wait — ambiguously while the longer is still being typed. Commands with an empty or
+/// unparseable shortcut are skipped (palette-only / surfaced separately).
 public func keybindConflicts(_ commands: [CustomCommand]) -> [KeybindConflict] {
     let parsed: [(id: UUID, keybind: Keybind)] = commands.compactMap { command in
         guard !command.shortcut.isEmpty, let keybind = parseKeybind(command.shortcut) else { return nil }
@@ -342,8 +319,7 @@ public func keybindConflicts(_ commands: [CustomCommand]) -> [KeybindConflict] {
 }
 
 /// Whether one keybind is a prefix of another (equal length counts — a duplicate is a prefix of itself).
-/// Order-independent: it sorts the two by length itself and checks the shorter-or-equal against the
-/// longer, so the caller need not pass them in both directions.
+/// Order-independent: it checks the shorter-or-equal against the longer, so callers pass one direction only.
 private func isPrefix(_ a: Keybind, of b: Keybind) -> Bool {
     let (shorter, longer) = a.count <= b.count ? (a, b) : (b, a)
     return Array(longer.prefix(shorter.count)) == shorter

--- a/agtermCore/Sources/agtermCore/Keybind.swift
+++ b/agtermCore/Sources/agtermCore/Keybind.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// The keyboard modifier flags a chord may require, as a host-free `OptionSet`.
 ///
-/// The app target maps `NSEvent.ModifierFlags` onto this so the parser and matcher stay free of
-/// AppKit. `parseKeybind` recognizes the modifier words `ctrl`/`control`, `cmd`/`command`,
-/// `opt`/`option`/`alt`, and `shift`.
+/// The app target maps `NSEvent.ModifierFlags` onto this so the parser and matcher stay AppKit-free.
+/// `parseKeybind` recognizes the modifier words `ctrl`/`control`, `cmd`/`command`, `opt`/`option`/`alt`,
+/// and `shift`.
 public struct Modifier: OptionSet, Hashable, Sendable {
     public let rawValue: Int
     public init(rawValue: Int) { self.rawValue = rawValue }
@@ -15,37 +15,34 @@ public struct Modifier: OptionSet, Hashable, Sendable {
     public static let shift = Modifier(rawValue: 1 << 3)
 }
 
-/// The base keys a chord may name beyond a single printable character. These are exactly the named
-/// keys the app-side runner can produce from an `NSEvent`, so `parseKeybind` rejects any other name
-/// (a key the UI would accept but the runner could never fire). `esc` is reserved as the leader
-/// abort and is intentionally NOT bindable.
-///
-/// The four arrows are here because the six arrow-bound built-ins ship their defaults on them, so the
-/// grammar must be able to spell what `BuiltinAction.defaultChord` returns.
+/// The base keys a chord may name beyond a single printable character — exactly the named keys the
+/// app-side runner can produce from an `NSEvent`, so `parseKeybind` rejects any other name (one the UI
+/// would accept but the runner could never fire). `esc` is reserved as the leader abort and is
+/// intentionally NOT bindable. The four arrows are here because the six arrow-bound built-ins ship their
+/// defaults on them, so the grammar must be able to spell what `BuiltinAction.defaultChord` returns.
 ///
 /// Adding a name here means updating five sites, two inbound and three outbound:
 /// - `CustomCommandRunner` and `UndoCloseShortcut` resolve `NSEvent` → name via `namedKey(forKeyCode:)`,
 ///   so a name with no keycode parses in the file yet never fires;
 /// - `namedKey(forKeyEquivalent:)` resolves a live `NSMenuItem`'s key-equivalent CHARACTER back to the
-///   name for `keymap.list`, so a name missing there makes every menu item carrying that key render with
-///   the key absent and stop comparing against the resolved chord (its own test pins the two sets equal);
-/// - `Chord.glyphString` renders the name in palette hints and tooltips — it degrades to the raw name,
-///   so a miss here is cosmetic;
+///   name for `keymap.list`, so a name missing there renders every menu item carrying that key with the
+///   key absent and stops it comparing against the resolved chord (its own test pins the two sets equal);
+/// - `Chord.glyphString` renders the name in palette hints and tooltips, degrading to the raw name — a
+///   miss there is cosmetic;
 /// - `agtermApp.toShortcut` maps the name to a SwiftUI `KeyEquivalent`, and its `default` arm is
-///   `KeyEquivalent(Character(chord.key))`, which TRAPS on a multi-character string. That one is a
-///   crash on the first menu render, not a degradation, so it is the site to update first.
+///   `KeyEquivalent(Character(chord.key))`, which TRAPS on a multi-character string — a crash on the
+///   first menu render, not a degradation, so update it first.
 public let bindableNamedKeys: Set<String> = Set(["tab", "space", "return", "delete"]).union(bindableArrowKeys)
 
-/// The four arrow keys, a subset of `bindableNamedKeys`. Named separately because they carry one extra
-/// rule: a built-in `map` may not bind a modifier-less arrow (`parseMapLine`), since an always-on menu
-/// key-equivalent on a bare arrow swallows the key in the terminal, the palettes, the dashboard grid,
-/// and every text field at once.
+/// The four arrow keys, a subset of `bindableNamedKeys`. Named separately for one extra rule: a built-in
+/// `map` may not bind a modifier-less arrow (`parseMapLine`), since an always-on menu key-equivalent on a
+/// bare arrow swallows the key in the terminal, the palettes, the dashboard grid, and every text field.
 let bindableArrowKeys: Set<String> = ["left", "right", "up", "down"]
 
-/// The named key for a macOS virtual key code, or `nil` for a key that carries a normal character
-/// (which the caller derives from the event itself). The single source of truth for the keyCode→name
-/// half of the `NSEvent`→`Chord` mapping, shared by every app-side monitor so a name added to
-/// `bindableNamedKeys` can't parse in the file yet fail to fire at runtime.
+/// The named key for a macOS virtual key code, or `nil` for a key carrying a normal character (which the
+/// caller derives from the event itself). The single source of truth for the keyCode→name half of the
+/// `NSEvent`→`Chord` mapping, shared by every app-side monitor so a name added to `bindableNamedKeys`
+/// can't parse in the file yet fail to fire at runtime.
 public func namedKey(forKeyCode keyCode: UInt16) -> String? {
     switch keyCode {
     case 36: return "return"
@@ -60,13 +57,12 @@ public func namedKey(forKeyCode keyCode: UInt16) -> String? {
     }
 }
 
-/// The Latin base character at a physical ANSI key position, or `nil` for a position that carries no
-/// Latin key (a named key, a function key, the keypad). The letters, digits, and punctuation of the ANSI
-/// layout, keyed by macOS virtual key code — the values are exactly the single characters `parseKeybind`
-/// accepts as a base key, so every entry is spellable in `keymap.conf`.
-///
-/// This is the layout-INDEPENDENT half of key resolution: a virtual key code names a physical position
-/// and never changes with the active input source, unlike the character that position produces.
+/// The Latin base character at a physical ANSI key position, or `nil` for a position carrying no Latin
+/// key (a named key, a function key, the keypad). The letters, digits and punctuation of the ANSI layout
+/// keyed by macOS virtual key code — exactly the single characters `parseKeybind` accepts as a base key,
+/// so every entry is spellable in `keymap.conf`. This is the layout-INDEPENDENT half of key resolution:
+/// a virtual key code names a physical position and never changes with the active input source, unlike
+/// the character that position produces.
 func latinKey(forKeyCode keyCode: UInt16) -> String? {
     switch keyCode {
     case 0: return "a"
@@ -124,12 +120,11 @@ func latinKey(forKeyCode keyCode: UInt16) -> String? {
 /// modifiers applied (the app-side monitors pass what the `NSEvent` reports), and
 /// `layoutIsASCIICapable` says whether that layout can type ASCII at all.
 ///
-/// The choice is made per LAYOUT, not per key. An ASCII-capable layout — US, Dvorak, Colemak,
-/// US-International, French, German — binds by the character it produces, so a chord follows the letter
-/// the user sees on the key and an alternative Latin layout keeps its own letter positions. A layout that
-/// cannot type ASCII — Russian, Greek, Hebrew, Arabic, Thai — can never produce a character a
-/// `keymap.conf` chord is spelled with, so every one of its keys binds by physical position via
-/// `latinKey(forKeyCode:)`.
+/// The choice is per LAYOUT, not per key. An ASCII-capable layout — US, Dvorak, Colemak, US-International,
+/// French, German — binds by the character it produces, so a chord follows the letter the user sees on the
+/// key and an alternative Latin layout keeps its own letter positions. A layout that cannot type ASCII —
+/// Russian, Greek, Hebrew, Arabic, Thai — can never produce a character a `keymap.conf` chord is spelled
+/// with, so every one of its keys binds by physical position via `latinKey(forKeyCode:)`.
 ///
 /// Deciding per key instead (keeping any produced character that happens to be ASCII) does not work:
 /// Greek types `;` on the Q position and Hebrew types `/` there, so a Latin-spelled letter chord would
@@ -137,17 +132,17 @@ func latinKey(forKeyCode keyCode: UInt16) -> String? {
 /// chord — on Hebrew the `'` key produces `,` while the `,` key falls back to `,`. Resolving the whole
 /// layout at once keeps `latinKey`'s one-key-per-position mapping intact, so no two TABLE positions can
 /// collapse. A key code outside the table keeps what it types, which still aliases the table for the
-/// keypad — keypad `5` and the number row both give `"5"` — exactly as it did before any of this, since
-/// the keypad's output does not vary by layout.
+/// keypad — keypad `5` and the number row both give `"5"` — as it always did, since the keypad's output
+/// does not vary by layout.
 ///
-/// This is a different rule from `InterruptKeystroke.isInterrupt`, which tests the produced character
-/// itself (is it a Latin letter?) rather than the layout. That one classifies a single hardcoded key, so
-/// it needs no layout context; a chord needs the whole ANSI vocabulary and does.
+/// A different rule from `InterruptKeystroke.isInterrupt`, which tests the produced character itself (is
+/// it a Latin letter?) rather than the layout: that one classifies a single hardcoded key and needs no
+/// layout context, while a chord needs the whole ANSI vocabulary.
 ///
 /// Returns `nil` when the press carries no usable base key. On a non-ASCII-capable layout that means a
 /// position outside `latinKey`'s table that produced nothing, plus the ISO section key; a dead key at a
-/// TABLE position resolves to its Latin key rather than to `nil`. On an ASCII-capable layout it means
-/// anything that produced nothing at all, table position or not — that branch never consults the table.
+/// TABLE position resolves to its Latin key instead. On an ASCII-capable layout it means anything that
+/// produced nothing at all, table position or not — that branch never consults the table.
 public func chordKey(forKeyCode keyCode: UInt16, produced: String?, layoutIsASCIICapable: Bool) -> String? {
     // space is a named key (`namedKey(forKeyCode:)` claims keyCode 49); a produced space is not a base key.
     let base = produced?.first.map { String($0).lowercased() }.flatMap { $0 == " " ? nil : $0 }
@@ -156,8 +151,8 @@ public func chordKey(forKeyCode keyCode: UInt16, produced: String?, layoutIsASCI
     // the ISO section key — the extra key an ISO keyboard carries and an ANSI one does not — has no
     // position in the table AND types a layout-dependent character, so keeping it would alias whichever
     // table position types the same thing: Ukrainian-PC types `\` there against the ANSI backslash key,
-    // Hebrew-PC types `;` there against the ANSI semicolon key. Both would fire one binding from two
-    // keys and swallow the keystroke. It cannot spell a chord on a layout resolved by position.
+    // Hebrew-PC `;` against the ANSI semicolon key. Both would fire one binding from two keys and swallow
+    // the keystroke, so it cannot spell a chord on a layout resolved by position.
     return keyCode == isoSectionKeyCode ? nil : base
 }
 
@@ -166,14 +161,12 @@ private let isoSectionKeyCode: UInt16 = 10
 
 /// The named key for a menu item's key-equivalent CHARACTER, or `nil` for an ordinary printable key.
 ///
-/// The character counterpart of `namedKey(forKeyCode:)`, for projecting live `NSMenuItem` key
-/// equivalents back into keymap syntax: a menu item carries a character rather than a virtual key code,
-/// and AppKit spells the arrows with private-use function-key scalars and return/tab/space/delete with
-/// control characters. Without this a menu chord renders as `cmd+opt+` with the key missing, which
-/// cannot be compared against the `cmd+opt+up` the keymap resolved.
-///
-/// Kept host-free by matching the scalar values rather than the AppKit constants, so `agtermCore` stays
-/// AppKit-free; the values are the documented `NSUpArrowFunctionKey` family.
+/// The character counterpart of `namedKey(forKeyCode:)`, for projecting live `NSMenuItem` key equivalents
+/// back into keymap syntax: a menu item carries a character rather than a virtual key code, and AppKit
+/// spells the arrows with private-use function-key scalars and return/tab/space/delete with control
+/// characters. Without this a menu chord renders as `cmd+opt+` with the key missing, which cannot be
+/// compared against the `cmd+opt+up` the keymap resolved. Matching scalar values rather than the AppKit
+/// constants keeps `agtermCore` AppKit-free; the values are the documented `NSUpArrowFunctionKey` family.
 public func namedKey(forKeyEquivalent character: String) -> String? {
     let scalars = character.unicodeScalars
     guard scalars.count == 1, let scalar = scalars.first else { return nil }
@@ -191,13 +184,13 @@ public func namedKey(forKeyEquivalent character: String) -> String? {
 }
 
 /// Whether a chord is owned by the app's always-on `NSEvent` monitors (NOT a menu key-equivalent), so a
-/// keybind that starts with it would dead-race the monitor and must be rejected. This MIRRORS the
-/// monitors' real predicates, not a fixed list:
+/// keybind starting with it would dead-race the monitor and must be rejected. MIRRORS the monitors' real
+/// predicates, not a fixed list:
 /// - the Ctrl-Tab session switcher (`SessionSwitcher`) consumes Tab whenever Control is held, with ANY
 ///   other modifiers (`ctrl+tab`, `ctrl+shift+tab`, `ctrl+opt+tab`, `ctrl+cmd+tab`);
 /// - the Ctrl-1/2 pane shortcuts (`PaneShortcuts`) consume 1/2 only when Control is the SOLE modifier.
 /// Used by both the built-in `map` check and the custom-command cross-section validation so neither can
-/// rebind a reserved chord. Host-free; kept next to the chord model so the rule is discoverable.
+/// rebind a reserved chord. Host-free, next to the chord model so the rule is discoverable.
 public func isReservedMonitorChord(_ chord: Chord) -> Bool {
     if chord.mods.contains(.control), chord.key == "tab" { return true }
     if chord.mods == [.control], chord.key == "1" || chord.key == "2" { return true }
@@ -215,10 +208,9 @@ public struct Chord: Equatable, Hashable, Sendable {
         self.key = key
     }
 
-    /// The chord rendered back to kitty syntax (e.g. `cmd+shift+e`), the same form the user writes in
+    /// The chord rendered back to kitty syntax (e.g. `cmd+shift+e`), the form the user writes in
     /// `keymap.conf`. Modifiers are emitted in a fixed `ctrl+cmd+opt+shift` order so the round-trip is
-    /// stable; used to show a built-in's current binding consistently with how custom commands display
-    /// their raw shortcut string.
+    /// stable; shows a built-in's current binding the same way custom commands show their raw shortcut.
     public var displayString: String {
         var parts: [String] = []
         if mods.contains(.control) { parts.append("ctrl") }
@@ -230,9 +222,9 @@ public struct Chord: Equatable, Hashable, Sendable {
     }
 
     /// The chord rendered as macOS menu glyphs (e.g. `⌘N`, `⌘⌥N`, `⌃P`): modifiers in the macOS order
-    /// `⌃⌥⇧⌘`, then the key (single letters uppercased, the named keys as their symbols). Used for the
-    /// action-palette shortcut hints so a built-in reads like its menu equivalent; custom commands keep
-    /// the raw kitty `displayString`.
+    /// `⌃⌥⇧⌘`, then the key (single letters uppercased, named keys as their symbols). Used for the
+    /// action-palette hints so a built-in reads like its menu equivalent; custom commands keep the raw
+    /// kitty `displayString`.
     public var glyphString: String {
         var s = ""
         if mods.contains(.control) { s += "⌃" }
@@ -258,16 +250,15 @@ public struct Chord: Equatable, Hashable, Sendable {
 /// length > 1 is a leader sequence (e.g. `ctrl+a > b`).
 public typealias Keybind = [Chord]
 
-/// Parse a keybind string into a `Keybind`, or `nil` when it is empty, malformed, or names an
-/// unknown modifier.
+/// Parse a keybind string into a `Keybind`, or `nil` when it is empty, malformed, or names an unknown
+/// modifier.
 ///
-/// The grammar is chords separated by `>`, each chord a `+`-joined list of modifier words and a
-/// final base key, case-insensitive. Examples: `cmd+shift+e`, `ctrl+a>b`, `ctrl + a > b`. The base
-/// key is a single printable character or one of `bindableNamedKeys` (`tab`/`space`/`return`/
-/// `delete`/`left`/`right`/`up`/`down`) — the keys the app-side runner can actually produce; any other
-/// multi-char word (e.g. `esc`, `f1`) is rejected. Returns `nil` for an empty input, an empty chord (e.g. a trailing `>`
-/// or `+`), a chord with no base key, more than one base key in a chord, an unrecognized modifier
-/// word, or an unproducible named key.
+/// The grammar is chords separated by `>`, each a `+`-joined list of modifier words and a final base key,
+/// case-insensitive: `cmd+shift+e`, `ctrl+a>b`, `ctrl + a > b`. The base key is a single printable
+/// character or one of `bindableNamedKeys` (`tab`/`space`/`return`/`delete`/`left`/`right`/`up`/`down`) —
+/// the keys the app-side runner can actually produce; any other multi-char word (`esc`, `f1`) is rejected.
+/// Returns `nil` for an empty input, an empty chord (a trailing `>` or `+`), a chord with no base key or
+/// more than one, an unrecognized modifier word, or an unproducible named key.
 public func parseKeybind(_ s: String) -> Keybind? {
     let chordStrings = s.split(separator: ">", omittingEmptySubsequences: false)
     guard !chordStrings.isEmpty else { return nil }
@@ -331,10 +322,10 @@ public struct KeybindConflict: Equatable, Sendable {
 
 /// Find shortcut conflicts across a list of custom commands.
 ///
-/// Two parseable, non-empty shortcuts conflict when one keybind is a prefix of the other (a
-/// duplicate is the degenerate equal-length case). A prefix conflict means the shorter bind would
-/// fire — or be forced to wait — ambiguously while the longer one is still being typed. Commands
-/// with an empty or unparseable shortcut are skipped (palette-only / surfaced separately).
+/// Two parseable, non-empty shortcuts conflict when one keybind is a prefix of the other (a duplicate is
+/// the degenerate equal-length case): the shorter bind would fire — or be forced to wait — ambiguously
+/// while the longer one is still being typed. Commands with an empty or unparseable shortcut are skipped
+/// (palette-only / surfaced separately).
 public func keybindConflicts(_ commands: [CustomCommand]) -> [KeybindConflict] {
     let parsed: [(id: UUID, keybind: Keybind)] = commands.compactMap { command in
         guard !command.shortcut.isEmpty, let keybind = parseKeybind(command.shortcut) else { return nil }
@@ -350,9 +341,9 @@ public func keybindConflicts(_ commands: [CustomCommand]) -> [KeybindConflict] {
     return conflicts
 }
 
-/// Whether one keybind is a prefix of another (equal length counts — a duplicate is a prefix of
-/// itself). Order-independent: it sorts the two binds by length itself and checks the shorter-or-equal
-/// against the longer, so the caller need not pass them in both directions.
+/// Whether one keybind is a prefix of another (equal length counts — a duplicate is a prefix of itself).
+/// Order-independent: it sorts the two by length itself and checks the shorter-or-equal against the
+/// longer, so the caller need not pass them in both directions.
 private func isPrefix(_ a: Keybind, of b: Keybind) -> Bool {
     let (shorter, longer) = a.count <= b.count ? (a, b) : (b, a)
     return Array(longer.prefix(shorter.count)) == shorter

--- a/agtermCore/Sources/agtermCore/KeybindMatcher.swift
+++ b/agtermCore/Sources/agtermCore/KeybindMatcher.swift
@@ -4,8 +4,8 @@ import Foundation
 public enum MatchResult: Equatable, Sendable {
     /// The pending prefix plus this chord exactly matches a bound keybind; the matcher has reset.
     case fired(UUID)
-    /// The pending prefix plus this chord is a strict prefix of some longer bind; the matcher is
-    /// now waiting for the next chord (the leader is armed).
+    /// The pending prefix plus this chord is a strict prefix of a longer bind; the matcher now awaits the
+    /// next chord (the leader is armed).
     case armed
     /// No bind starts with the pending prefix plus this chord; the matcher has reset.
     case unmatched
@@ -13,10 +13,9 @@ public enum MatchResult: Equatable, Sendable {
 
 /// The leader/sequence state machine that turns a stream of chords into command fires.
 ///
-/// Built from a list of `(Keybind, UUID)` pairs, it holds the chords typed so far as a pending
-/// prefix. `advance(_:)` consumes one chord and reports `.fired`/`.armed`/`.unmatched`. It is
-/// deadline-free: the leader timeout that abandons a half-typed sequence is driven app-side, which
-/// calls `reset()` (the same call Esc makes). Pure agtermCore logic — no AppKit, no timers.
+/// Built from `(Keybind, UUID)` pairs, it holds the chords typed so far as a pending prefix; `advance(_:)`
+/// consumes one chord and reports `.fired`/`.armed`/`.unmatched`. Deadline-free — the leader timeout that
+/// abandons a half-typed sequence is app-side and calls `reset()`, as Esc does. No AppKit, no timers.
 public struct KeybindMatcher: Sendable {
     private let binds: [(keybind: Keybind, id: UUID)]
     private var pending: [Chord] = []
@@ -25,15 +24,15 @@ public struct KeybindMatcher: Sendable {
         self.binds = binds.map { (keybind: $0.0, id: $0.1) }
     }
 
-    /// Whether a sequence is partway through (a leader is armed). The app uses this to gate the
-    /// timeout timer and the on-screen hint.
+    /// Whether a sequence is partway through (a leader is armed). The app uses this to gate the timeout
+    /// timer and the on-screen hint.
     public var isArmed: Bool { !pending.isEmpty }
 
-    /// Feed one chord. An exact match fires (and resets); a strict prefix arms (keeps the pending
-    /// prefix for the next chord); anything else is unmatched (and resets). When armed, a chord that
-    /// completes no bind resets, so the caller can pass that chord through to the terminal — UNLESS
-    /// that chord is itself a fresh leader, in which case the matcher re-arms on it (so re-pressing a
-    /// leader mid-sequence restarts the sequence rather than abandoning it).
+    /// Feed one chord: an exact match fires and resets, a strict prefix arms (keeping the pending prefix for
+    /// the next chord), anything else is unmatched and resets. When armed, a chord completing no bind resets
+    /// so the caller can pass it through to the terminal — UNLESS the chord is itself a fresh leader, in
+    /// which case the matcher re-arms on it, so re-pressing a leader restarts rather than abandons the
+    /// sequence.
     public mutating func advance(_ chord: Chord) -> MatchResult {
         let candidate = pending + [chord]
 

--- a/agtermCore/Sources/agtermCore/Keymap.swift
+++ b/agtermCore/Sources/agtermCore/Keymap.swift
@@ -1,8 +1,7 @@
 import Foundation
 
-/// The parsed `keymap.conf`: `builtinOverrides` maps a `BuiltinAction` to the single chord the user
-/// `map`ped to it (built-in overrides are single-chord only); `commands` are the custom commands, each
-/// with a `shortcut` that may be empty (palette-only) or a leader sequence.
+/// The parsed `keymap.conf`. A built-in override is single-chord only; a custom command's `shortcut` may
+/// be empty (palette-only) or a leader sequence.
 public struct Keymap: Equatable, Sendable {
     public let builtinOverrides: [BuiltinAction: Chord]
     public let commands: [CustomCommand]
@@ -12,23 +11,21 @@ public struct Keymap: Equatable, Sendable {
         self.commands = commands
     }
 
-    /// The active chord for a built-in action: the user override when one is present, else the
-    /// action's shipped `defaultChord` (which is `nil` only for the keyless actions).
+    /// The active chord for a built-in: the user override, else the shipped `defaultChord`, which is
+    /// `nil` only for the keyless actions.
     public func equivalent(for action: BuiltinAction) -> Chord? {
         builtinOverrides[action] ?? action.defaultChord
     }
 
-    /// The action's current shortcut as a macOS menu glyph string (`⌘N`, `⌃⌘S`): the effective chord
-    /// (`equivalent(for:)` — user override else shipped default) rendered via `Chord.glyphString`. `nil`
-    /// means "not configured" and the caller shows no shortcut. Drives both the action-palette hints and
-    /// the toolbar tooltips so the two surfaces can't drift.
+    /// The effective chord (`equivalent(for:)`) as a macOS menu glyph string (`⌘N`, `⌃⌘S`); `nil` means
+    /// "not configured", the caller showing no shortcut. Drives palette hints and toolbar tooltips alike.
     public func glyphHint(for action: BuiltinAction) -> String? {
         equivalent(for: action)?.glyphString
     }
 }
 
-/// A single problem found while parsing `keymap.conf`. `line` is 1-based; `0` is a whole-file or
-/// cross-section diagnostic belonging to no single line.
+/// A problem found while parsing `keymap.conf`. `line` is 1-based; `0` is a whole-file or cross-section
+/// diagnostic belonging to no single line.
 public struct KeymapDiagnostic: Equatable, Sendable {
     public let line: Int
     public let message: String
@@ -72,34 +69,27 @@ public struct KeymapStore: Sendable {
 /// Parse the text of a `keymap.conf` into a `Keymap` plus diagnostics. Never throws: a bad line becomes a
 /// diagnostic and is skipped, so one malformed line never discards the rest of the file.
 ///
-/// Grammar (kitty-flavored), line-based. Blank lines and lines whose first non-space character is `#` are
-/// ignored. A trailing inline comment is stripped when a `#` is preceded by whitespace AND sits outside any
-/// quoted span, single OR double — so a `#` inside a `command "name"`, a double-quoted shell arg, or a
-/// single-quoted one like `git commit -m 'fix #42'` is kept, which keeps `command "x" echo a#b` and
-/// `map cmd+a#` simple while allowing `map cmd+d toggle_split  # rebind`.
-///
-/// The first whitespace-token is the verb:
-/// - `map <chord> <action>`: `<chord>` goes through `parseKeybind` (a leader sequence, count > 1, is
-///   rejected — built-ins are single-chord); `<action>` must be a `BuiltinAction` raw value. Collisions are
-///   resolved order-INDEPENDENTLY against the final chord set, see `resolveBuiltinOverrides`.
+/// Grammar (kitty-flavored), line-based. Blank and `#`-comment lines are ignored; `stripComment` owns the
+/// inline-comment rule. The first whitespace-token is the verb:
+/// - `map <chord> <action>`: `<chord>` goes through `parseKeybind`, a leader sequence rejected since
+///   built-ins are single-chord; `<action>` must be a `BuiltinAction` raw value. Collisions are resolved
+///   order-INDEPENDENTLY against the final chord set, see `resolveBuiltinOverrides`.
 /// - `command "<name>" [chord] <shell...>`: `<name>` is a required double-quoted string (spaces allowed).
-///   The token right after the closing quote is the chord IFF `parseKeybind` accepts it; otherwise there is
-///   no chord and the whole remainder is the shell line (palette-only), keeping `{AGT_X}` tokens verbatim.
+///   The token right after the closing quote is the chord IFF `parseKeybind` accepts it; otherwise the
+///   whole remainder is the shell line (palette-only), keeping `{AGT_X}` tokens verbatim.
 /// - anything else is an unknown verb, skipped with a diagnostic.
 ///
-/// After every line is parsed, a SINGLE final cross-section pass (`validateCommands`) drops any custom
-/// keybind colliding with an active built-in chord or another custom keybind, one diagnostic each. The
-/// dropped command stays in the result, palette-only, with its `shortcut` cleared.
+/// A SINGLE final cross-section pass (`validateCommands`) then drops any custom keybind colliding with an
+/// active built-in or another custom keybind, one diagnostic each; the command stays, palette-only.
 public func parseKeymap(_ text: String) -> (keymap: Keymap, diagnostics: [KeymapDiagnostic]) {
-    // overrides are collected in file order, NOT folded into a dict yet, so the final cross-builtin
-    // duplicate pass can resolve them against the FULLY-resolved active chord set and skip the
-    // later-in-file member of a colliding pair.
+    // collected in file order, NOT folded into a dict yet, so the final duplicate pass resolves them
+    // against the FULLY-resolved chord set and can skip the later-in-file member of a colliding pair.
     var parsedOverrides: [ParsedOverride] = []
     var commands: [CustomCommand] = []
     var diagnostics: [KeymapDiagnostic] = []
 
-    // normalize line endings: a CRLF line otherwise leaves a trailing `\r` that .whitespaces won't strip
-    // (so `toggle_split\r` reads as an unknown action) and a lone-CR file collapses into one line.
+    // normalize line endings: a CRLF leaves a trailing `\r` that .whitespaces won't strip (so
+    // `toggle_split\r` reads as an unknown action) and a lone-CR file would collapse into one line.
     let normalized = text.replacingOccurrences(of: "\r\n", with: "\n").replacingOccurrences(of: "\r", with: "\n")
     let rawLines = normalized.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
     for (index, rawLine) in rawLines.enumerated() {
@@ -120,13 +110,11 @@ public func parseKeymap(_ text: String) -> (keymap: Keymap, diagnostics: [Keymap
         }
     }
 
-    // a final pass, not incremental — the custom-command validation below needs the same fully resolved
-    // chord set.
+    // a final pass, not incremental: the custom-command validation below needs the same resolved chord set.
     let builtinOverrides = resolveBuiltinOverrides(parsedOverrides, diagnostics: &diagnostics)
 
-    // likewise a SINGLE final pass over the fully-resolved built-in set: a custom line parsed before a
-    // later keyless-built-in `map` must still be validated against the override that `map` installs, so
-    // all `map`/`command` lines are collected first.
+    // likewise final: a custom line parsed before a later keyless-built-in `map` must still be validated
+    // against the override that `map` installs.
     let keymap = Keymap(builtinOverrides: builtinOverrides, commands: commands)
     let validated = validateCommands(keymap.commands, against: keymap, diagnostics: &diagnostics)
 
@@ -142,21 +130,17 @@ private struct ParsedOverride {
 
 /// Fold the file-order overrides into the final `[BuiltinAction: Chord]`, rejecting only a TRUE
 /// final-state collision: two DISTINCT actions resolving to the same chord. Order-independent — NOT
-/// decided against a partially-built map, so `map cmd+d new_session` and `map cmd+shift+d toggle_split`
-/// succeed in EITHER order (final state: new_session=cmd+d, toggle_split moved off cmd+d). Re-mapping the
-/// SAME action is last-wins; it can't collide with itself.
+/// decided against a partially-built map — so moving a built-in off a chord and another claiming it
+/// succeed in EITHER line order. Re-mapping the SAME action is last-wins and can't collide with itself.
 ///
-/// Algorithm: (1) fold overrides last-wins per action into a candidate map; (2) iterate to a FIXPOINT —
-/// each pass resolves every action's chord (candidate override, else its default), finds one claimed by
-/// two distinct actions, and drops a loser, which REVERTS to its own default and may collide afresh, so
-/// the loop re-checks until clean. Per collision: an override colliding with another action's UNMOVED
-/// default loses (the default owner keeps it); two colliding OVERRIDES → the later-in-file one loses. Each
-/// drop is diagnosed. The shipped defaults are all distinct (pinned by `BuiltinActionTests`), so every
-/// collision involves ≥1 override and each iteration removes one → the loop terminates.
+/// Fold last-wins per action, then iterate to a FIXPOINT, since a dropped loser REVERTS to its own default
+/// and may collide afresh. An override colliding with another action's UNMOVED default loses; two
+/// colliding OVERRIDES drop the later-in-file one; each drop is diagnosed. The shipped defaults are all
+/// distinct (pinned by `BuiltinActionTests`), so every collision involves ≥1 override and each iteration
+/// removes one — the loop terminates.
 private func resolveBuiltinOverrides(_ overrides: [ParsedOverride],
                                      diagnostics: inout [KeymapDiagnostic]) -> [BuiltinAction: Chord] {
-    // (1) fold last-wins, remembering the winning override's file line per action so a two-override
-    // collision can name the later one.
+    // fold last-wins, remembering each winner's file line so a two-override collision can name the later.
     var candidates: [BuiltinAction: Chord] = [:]
     var overrideLine: [BuiltinAction: Int] = [:]
     for override in overrides {
@@ -164,8 +148,7 @@ private func resolveBuiltinOverrides(_ overrides: [ParsedOverride],
         overrideLine[override.action] = override.line
     }
 
-    // (2) iterate to a fixpoint, one loser per pass. drops are remembered and line-sorted at the end so
-    // the diagnostics are deterministic regardless of dictionary iteration order.
+    // one loser per pass. drops are line-sorted at the end so diagnostics don't depend on dictionary order.
     var pending: [(loser: BuiltinAction, keeper: BuiltinAction, line: Int)] = []
     while let drop = firstBuiltinCollision(candidates: candidates, overrideLine: overrideLine) {
         candidates.removeValue(forKey: drop.loser)
@@ -181,9 +164,8 @@ private func resolveBuiltinOverrides(_ overrides: [ParsedOverride],
     return candidates
 }
 
-/// One fixpoint iteration: find the first chord two distinct actions resolve to (an override against a
-/// default, or two overrides) and return the loser to drop, the keeper, and the loser's file line. nil
-/// when the candidate set is collision-free.
+/// One fixpoint iteration: the first chord two distinct actions resolve to, returned as the loser to drop,
+/// the keeper, and the loser's file line. nil when the candidate set is collision-free.
 private func firstBuiltinCollision(candidates: [BuiltinAction: Chord],
                                    overrideLine: [BuiltinAction: Int])
     -> (loser: BuiltinAction, keeper: BuiltinAction, line: Int)? {
@@ -202,10 +184,8 @@ private func firstBuiltinCollision(candidates: [BuiltinAction: Chord],
         let defaultOwners = owners.filter { candidates[$0] == nil }
         let decision: (loser: BuiltinAction, keeper: BuiltinAction)?
         if let defaultOwner = defaultOwners.first, let loser = overriddenOwners.first {
-            // an unmoved default keeps the chord; an override that collided with it loses.
             decision = (loser, defaultOwner)
         } else if overriddenOwners.count > 1 {
-            // two (or more) overrides claim the same chord: keep the earliest, drop the latest.
             let sorted = overriddenOwners.sorted { (overrideLine[$0] ?? 0) < (overrideLine[$1] ?? 0) }
             decision = (sorted[sorted.count - 1], sorted[0])
         } else {
@@ -220,29 +200,26 @@ private func firstBuiltinCollision(candidates: [BuiltinAction: Chord],
     return best
 }
 
-/// Cross-section validation: drop a custom keybind whose FIRST chord equals any active built-in chord OR a
-/// reserved monitor chord (Ctrl-Tab / Ctrl-1/2), and drop both keybinds of any custom-vs-custom
+/// Cross-section validation: drop a custom keybind whose FIRST chord equals any active built-in chord or
+/// that uses a reserved monitor chord (Ctrl-Tab / Ctrl-1/2), and drop BOTH keybinds of any custom-vs-custom
 /// duplicate/prefix conflict. A dropped keybind clears the command's `shortcut` to `""` — the command stays
 /// in the palette, unkeyed — and adds a diagnostic.
 ///
 /// Built-ins are single-chord, so any custom bind STARTING with that chord, single or leader, is shadowed
-/// by the menu. The reserved monitor chords (`isReservedMonitorChord`) belong to the app's always-on
-/// NSEvent monitors rather than the menu and are equally un-rebindable. The active built-in set already has
-/// every override applied (`Keymap.equivalent(for:)`), so a custom command may freely reuse a default chord
-/// the user moved a built-in off of.
+/// by the menu. The reserved chords (`isReservedMonitorChord`) belong to the app's always-on NSEvent
+/// monitors rather than the menu and are equally un-rebindable. The active built-in set already has every
+/// override applied, so a custom command may freely reuse a default chord the user moved a built-in off of.
 private func validateCommands(_ commands: [CustomCommand], against keymap: Keymap,
                               diagnostics: inout [KeymapDiagnostic]) -> [CustomCommand] {
-    // active built-in chords: the override when present, else the shipped default. keyless actions
-    // (defaultChord == nil) contribute only when the user mapped one; every shipped default, arrows
-    // included, is in the set, so a custom command can't shadow one.
+    // keyless actions (defaultChord == nil) contribute only when the user mapped one; every shipped
+    // default, arrows included, is in the set, so a custom command can't shadow one.
     let builtinChords = Set(BuiltinAction.allCases.compactMap { keymap.equivalent(for: $0) })
 
     var result = commands
 
-    // pass 1: drop a custom keybind colliding with a built-in on its FIRST chord, or with a reserved
-    // monitor chord at ANY position — the monitor consumes its chord wherever it lands in a leader, so
-    // `ctrl+a>ctrl+1` is just as dead as a leading one. line 0 because the command's source line isn't
-    // tracked, so cross-section diagnostics use the whole-file line.
+    // pass 1: a built-in collides on the FIRST chord only, a reserved monitor chord at ANY position — the
+    // monitor consumes its chord wherever it lands in a leader, so `ctrl+a>ctrl+1` is just as dead as a
+    // leading one. line 0 because the command's source line isn't tracked.
     for index in result.indices {
         let command = result[index]
         guard !command.shortcut.isEmpty, let keybind = parseKeybind(command.shortcut),
@@ -262,9 +239,8 @@ private func validateCommands(_ commands: [CustomCommand], against keymap: Keyma
         result[index].shortcut = ""
     }
 
-    // pass 2: drop BOTH keybinds of any custom-vs-custom duplicate/prefix conflict, computed over the
-    // post-pass-1 set so a keybind dropped there can't re-trigger. One diagnostic per command names the
-    // OTHER offender (the conflict carries both ids) so the user can find the pair.
+    // pass 2: computed over the post-pass-1 set so a keybind dropped there can't re-trigger. each
+    // diagnostic names the OTHER offender (the conflict carries both ids) so the user can find the pair.
     let conflicts = keybindConflicts(result)
     let nameByID = Dictionary(uniqueKeysWithValues: result.map { ($0.id, $0.name) })
     var otherOffender: [UUID: String] = [:]
@@ -283,11 +259,10 @@ private func validateCommands(_ commands: [CustomCommand], against keymap: Keyma
     return result
 }
 
-/// Strip a trailing inline comment: a `#` is a comment when preceded by whitespace AND outside a quoted
-/// span, single OR double. A whole-line `#` comment also falls out here, and the caller trims and
-/// re-checks emptiness, so a `# ...` line becomes empty. Single quotes matter because a shell line like
-/// `git commit -m 'fix #42'` must keep its `#`; the two quote states are mutually exclusive (a `"` inside
-/// `'...'` is literal, and vice versa).
+/// Strip a trailing inline comment: a `#` counts only when preceded by whitespace AND outside a quoted
+/// span, single OR double. A whole-line `#` comment falls out here too, leaving an empty line for the
+/// caller. Single quotes matter so a shell line like `git commit -m 'fix #42'` keeps its `#`; the two
+/// quote states are mutually exclusive (a `"` inside `'...'` is literal, and vice versa).
 private func stripComment(_ line: String) -> String {
     var inSingleQuotes = false
     var inDoubleQuotes = false
@@ -315,9 +290,9 @@ private func stripComment(_ line: String) -> String {
     return result
 }
 
-/// Parse the remainder of a `map` line (after the verb): `<chord> <action>`. On success it appends a
-/// `ParsedOverride` in file order; on any failure it appends a diagnostic and leaves `overrides` untouched.
-/// Cross-builtin duplicate detection is deferred to `resolveBuiltinOverrides`.
+/// Parse a `map` line's remainder, `<chord> <action>`: on success appends a `ParsedOverride` in file
+/// order, on any failure a diagnostic, leaving `overrides` untouched. Cross-builtin duplicate detection is
+/// deferred to `resolveBuiltinOverrides`.
 private func parseMapLine(_ rest: String, line: Int, overrides: inout [ParsedOverride],
                           diagnostics: inout [KeymapDiagnostic]) {
     // split on the first run of general whitespace (space OR tab) so a tab-separated `map` line works.
@@ -336,16 +311,15 @@ private func parseMapLine(_ rest: String, line: Int, overrides: inout [ParsedOve
         diagnostics.append(KeymapDiagnostic(line: line, message: "built-in shortcut cannot be a leader sequence"))
         return
     }
-    // a chord owned by an always-on NSEvent monitor (Ctrl-Tab / Ctrl-1/2) can't be a menu key-equivalent
-    // without dead-racing the monitor, so reject it for built-ins as for custom commands.
+    // a chord owned by an always-on NSEvent monitor can't be a menu key-equivalent without dead-racing
+    // the monitor, so reject it for built-ins as for custom commands.
     guard !isReservedMonitorChord(chord) else {
         diagnostics.append(KeymapDiagnostic(line: line, message: "chord '\(chordText)' is a reserved shortcut; map skipped"))
         return
     }
     // a modifier-less arrow would install an always-on menu key-equivalent swallowing the key everywhere
-    // at once — the terminal, the palettes, the dashboard grid, every text field — and the menu path,
-    // unlike the custom-command monitor, has no text-field pass-through. `parseCommandLine` requires a
-    // modifier for the same reason.
+    // — terminal, palettes, dashboard grid, every text field — and the menu path, unlike the
+    // custom-command monitor, has no text-field pass-through. `parseCommandLine` requires one likewise.
     guard !(bindableArrowKeys.contains(chord.key) && chord.mods.isEmpty) else {
         diagnostics.append(KeymapDiagnostic(line: line,
                                             message: "bare arrow chord '\(chordText)' needs a modifier; map skipped"))
@@ -369,10 +343,9 @@ private func parseCommandLine(_ rest: String, line: Int, commands: inout [Custom
     let name = String(rest[rest.index(after: rest.startIndex)..<closeQuote])
     let afterName = String(rest[rest.index(after: closeQuote)...]).trimmingCharacters(in: .whitespaces)
 
-    // the token right after the closing quote is the chord iff parseKeybind accepts it AND it carries a
-    // modifier; otherwise the whole remainder is the shell line (palette-only). the modifier is required so
-    // a custom shortcut can't be a bare key shadowing that key in the terminal, and so a palette-only shell
-    // line starting with a single-char token (`[`, `:`, a one-letter alias) isn't swallowed as a binding.
+    // the chord must also carry a modifier: a bare key would shadow that key in the terminal, and a
+    // palette-only shell line starting with a single-char token (`[`, `:`, a one-letter alias) would be
+    // swallowed as a binding.
     let firstToken = String(afterName.prefix(while: { !$0.isWhitespace }))
     var shortcut = ""
     var shellLine = afterName

--- a/agtermCore/Sources/agtermCore/Keymap.swift
+++ b/agtermCore/Sources/agtermCore/Keymap.swift
@@ -1,11 +1,8 @@
 import Foundation
 
-/// The parsed keymap: the built-in actions the user rebound, plus the custom commands defined in
-/// `keymap.conf`.
-///
-/// `builtinOverrides` maps a `BuiltinAction` to the single chord the user `map`ped to it (built-in
-/// overrides are single-chord only). `commands` are the custom commands, each with a `shortcut` that
-/// may be empty (palette-only) or a leader sequence.
+/// The parsed `keymap.conf`: `builtinOverrides` maps a `BuiltinAction` to the single chord the user
+/// `map`ped to it (built-in overrides are single-chord only); `commands` are the custom commands, each
+/// with a `shortcut` that may be empty (palette-only) or a leader sequence.
 public struct Keymap: Equatable, Sendable {
     public let builtinOverrides: [BuiltinAction: Chord]
     public let commands: [CustomCommand]
@@ -21,18 +18,17 @@ public struct Keymap: Equatable, Sendable {
         builtinOverrides[action] ?? action.defaultChord
     }
 
-    /// The action's current shortcut as a macOS menu glyph string (e.g. `⌘N`, `⌃⌘S`), or `nil` when
-    /// the action has no shortcut at all. Resolves the effective chord (`equivalent(for:)` — user
-    /// override else shipped default) and renders it via `Chord.glyphString`. `nil` means "not
-    /// configured" — the caller shows no shortcut. Drives both the action-palette hints and the toolbar
-    /// tooltips so the two surfaces can't drift.
+    /// The action's current shortcut as a macOS menu glyph string (`⌘N`, `⌃⌘S`): the effective chord
+    /// (`equivalent(for:)` — user override else shipped default) rendered via `Chord.glyphString`. `nil`
+    /// means "not configured" and the caller shows no shortcut. Drives both the action-palette hints and
+    /// the toolbar tooltips so the two surfaces can't drift.
     public func glyphHint(for action: BuiltinAction) -> String? {
         equivalent(for: action)?.glyphString
     }
 }
 
-/// A single problem found while parsing `keymap.conf`. `line` is 1-based; `0` is reserved for a
-/// whole-file or cross-section diagnostic that doesn't belong to a single line.
+/// A single problem found while parsing `keymap.conf`. `line` is 1-based; `0` is a whole-file or
+/// cross-section diagnostic belonging to no single line.
 public struct KeymapDiagnostic: Equatable, Sendable {
     public let line: Int
     public let message: String
@@ -73,47 +69,37 @@ public struct KeymapStore: Sendable {
     }
 }
 
-/// Parse the text of a `keymap.conf` into a `Keymap` plus a list of diagnostics. Never throws: a bad
-/// line becomes a diagnostic and is skipped, so a single malformed line never discards the rest of
-/// the file.
+/// Parse the text of a `keymap.conf` into a `Keymap` plus diagnostics. Never throws: a bad line becomes a
+/// diagnostic and is skipped, so one malformed line never discards the rest of the file.
 ///
-/// Grammar (kitty-flavored): the file is line-based. Blank lines and lines whose first non-space
-/// character is `#` are ignored. A trailing inline comment is stripped when a `#` is preceded by
-/// whitespace AND lies outside any quoted span, single OR double (so a `#` inside a `command "name"`,
-/// inside a double-quoted shell arg, or inside a single-quoted one like `git commit -m 'fix #42'` is
-/// kept) — this keeps `command "x" echo a#b` and `map cmd+a#` handling simple while allowing
-/// `map cmd+d toggle_split  # rebind`.
+/// Grammar (kitty-flavored), line-based. Blank lines and lines whose first non-space character is `#` are
+/// ignored. A trailing inline comment is stripped when a `#` is preceded by whitespace AND sits outside any
+/// quoted span, single OR double — so a `#` inside a `command "name"`, a double-quoted shell arg, or a
+/// single-quoted one like `git commit -m 'fix #42'` is kept, which keeps `command "x" echo a#b` and
+/// `map cmd+a#` simple while allowing `map cmd+d toggle_split  # rebind`.
 ///
 /// The first whitespace-token is the verb:
-/// - `map <chord> <action>`: `<chord>` is parsed via `parseKeybind` (a leader sequence, count > 1, is
-///   rejected — built-ins are single-chord); `<action>` must be a `BuiltinAction` raw value. Resolution
-///   is order-INDEPENDENT and decided against the FINAL resolved built-in set: only a chord that two
-///   DISTINCT actions resolve to in the final state is a duplicate. When that happens an override
-///   colliding with another action's unmoved default loses (the default owner keeps the chord); two
-///   colliding overrides → the later one (in file order) loses, each with a diagnostic. So
-///   `map cmd+d new_session` and `map cmd+shift+d toggle_split` both succeed in either order (the final
-///   state is conflict-free — toggle_split has moved off cmd+d).
-/// - `command "<name>" [chord] <shell...>`: `<name>` is a required double-quoted string (may contain
-///   spaces). The token right after the closing quote is the chord IFF `parseKeybind` accepts it;
-///   otherwise there is no chord and the whole remainder is the shell line (palette-only). The shell
-///   line keeps `{AGT_X}` tokens verbatim.
-/// - anything else is an unknown verb and is skipped with a diagnostic.
+/// - `map <chord> <action>`: `<chord>` goes through `parseKeybind` (a leader sequence, count > 1, is
+///   rejected — built-ins are single-chord); `<action>` must be a `BuiltinAction` raw value. Collisions are
+///   resolved order-INDEPENDENTLY against the final chord set, see `resolveBuiltinOverrides`.
+/// - `command "<name>" [chord] <shell...>`: `<name>` is a required double-quoted string (spaces allowed).
+///   The token right after the closing quote is the chord IFF `parseKeybind` accepts it; otherwise there is
+///   no chord and the whole remainder is the shell line (palette-only), keeping `{AGT_X}` tokens verbatim.
+/// - anything else is an unknown verb, skipped with a diagnostic.
 ///
-/// After every line is parsed, a SINGLE final cross-section validation pass runs (see
-/// `validateCommands`): it drops any custom keybind that collides with an active built-in chord or with
-/// another custom keybind, appending a diagnostic for each. The dropped command stays in the result
-/// (palette-only) with its `shortcut` cleared.
+/// After every line is parsed, a SINGLE final cross-section pass (`validateCommands`) drops any custom
+/// keybind colliding with an active built-in chord or another custom keybind, one diagnostic each. The
+/// dropped command stays in the result, palette-only, with its `shortcut` cleared.
 public func parseKeymap(_ text: String) -> (keymap: Keymap, diagnostics: [KeymapDiagnostic]) {
-    // overrides are collected in file order (NOT folded into a dict yet), so the final cross-builtin
+    // overrides are collected in file order, NOT folded into a dict yet, so the final cross-builtin
     // duplicate pass can resolve them against the FULLY-resolved active chord set and skip the
     // later-in-file member of a colliding pair.
     var parsedOverrides: [ParsedOverride] = []
     var commands: [CustomCommand] = []
     var diagnostics: [KeymapDiagnostic] = []
 
-    // normalize line endings so CRLF (`\r\n`) and lone-CR (`\r`) files split into lines correctly:
-    // without this a CRLF line leaves a trailing `\r` that .whitespaces won't strip (so `toggle_split\r`
-    // reads as an unknown action) and a lone-CR file collapses into one line.
+    // normalize line endings: a CRLF line otherwise leaves a trailing `\r` that .whitespaces won't strip
+    // (so `toggle_split\r` reads as an unknown action) and a lone-CR file collapses into one line.
     let normalized = text.replacingOccurrences(of: "\r\n", with: "\n").replacingOccurrences(of: "\r", with: "\n")
     let rawLines = normalized.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
     for (index, rawLine) in rawLines.enumerated() {
@@ -134,17 +120,13 @@ public func parseKeymap(_ text: String) -> (keymap: Keymap, diagnostics: [Keymap
         }
     }
 
-    // resolve the overrides against the final active chord set (a built-in's unmoved default OR an
-    // already-accepted override), skipping any `map` whose chord is already owned by a DIFFERENT
-    // action and diagnosing it. This must be a final pass, not incremental: `map cmd+shift+d
-    // toggle_split` then `map cmd+d new_session` succeeds (toggle_split moved off cmd+d frees it),
-    // and the freed-default case for custom commands below relies on the same final resolution.
+    // a final pass, not incremental — the custom-command validation below needs the same fully resolved
+    // chord set.
     let builtinOverrides = resolveBuiltinOverrides(parsedOverrides, diagnostics: &diagnostics)
 
-    // cross-section validation is a SINGLE final pass over the fully-resolved built-in set, NOT run
-    // incrementally during line parsing: a custom line parsed before a later keyless-built-in `map`
-    // must still be validated against the override that `map` installs, so all `map`/`command` lines
-    // are collected first.
+    // likewise a SINGLE final pass over the fully-resolved built-in set: a custom line parsed before a
+    // later keyless-built-in `map` must still be validated against the override that `map` installs, so
+    // all `map`/`command` lines are collected first.
     let keymap = Keymap(builtinOverrides: builtinOverrides, commands: commands)
     let validated = validateCommands(keymap.commands, against: keymap, diagnostics: &diagnostics)
 
@@ -158,26 +140,23 @@ private struct ParsedOverride {
     let line: Int
 }
 
-/// Fold the file-order overrides into the final `[BuiltinAction: Chord]`, rejecting only those that
-/// produce a TRUE final-state collision: two DISTINCT actions resolving to the same chord. Resolution
-/// is order-independent — it is NOT decided against a partially-built map, so `map cmd+d new_session`
-/// and `map cmd+shift+d toggle_split` succeed in EITHER order (the final state is conflict-free:
-/// new_session=cmd+d, toggle_split moved off cmd+d).
+/// Fold the file-order overrides into the final `[BuiltinAction: Chord]`, rejecting only a TRUE
+/// final-state collision: two DISTINCT actions resolving to the same chord. Order-independent — NOT
+/// decided against a partially-built map, so `map cmd+d new_session` and `map cmd+shift+d toggle_split`
+/// succeed in EITHER order (final state: new_session=cmd+d, toggle_split moved off cmd+d). Re-mapping the
+/// SAME action is last-wins; it can't collide with itself.
 ///
 /// Algorithm: (1) fold overrides last-wins per action into a candidate map; (2) iterate to a FIXPOINT —
-/// each pass computes every action's resolved chord (candidate override, else its default), finds a
-/// chord claimed by two distinct actions, and drops one loser. Dropping a loser REVERTS it to its own
-/// default, which may collide afresh with another action; the loop re-checks until no collision remains.
-/// Loser rule per collision: an override colliding with another action's UNMOVED default loses (keep the
-/// default owner); two colliding OVERRIDES → the later-in-file one loses. Each dropped override is
-/// diagnosed. The shipped defaults are all distinct (pinned by `BuiltinActionTests`), so every collision
-/// involves at least one override and each iteration removes ≥1 override → the loop terminates.
-/// Re-mapping the SAME action is last-wins
-/// (it can't collide with itself).
+/// each pass resolves every action's chord (candidate override, else its default), finds one claimed by
+/// two distinct actions, and drops a loser, which REVERTS to its own default and may collide afresh, so
+/// the loop re-checks until clean. Per collision: an override colliding with another action's UNMOVED
+/// default loses (the default owner keeps it); two colliding OVERRIDES → the later-in-file one loses. Each
+/// drop is diagnosed. The shipped defaults are all distinct (pinned by `BuiltinActionTests`), so every
+/// collision involves ≥1 override and each iteration removes one → the loop terminates.
 private func resolveBuiltinOverrides(_ overrides: [ParsedOverride],
                                      diagnostics: inout [KeymapDiagnostic]) -> [BuiltinAction: Chord] {
-    // (1) candidate overrides folded last-wins; remember the file line of the winning override per
-    // action so a two-override collision can name the later one.
+    // (1) fold last-wins, remembering the winning override's file line per action so a two-override
+    // collision can name the later one.
     var candidates: [BuiltinAction: Chord] = [:]
     var overrideLine: [BuiltinAction: Int] = [:]
     for override in overrides {
@@ -185,9 +164,8 @@ private func resolveBuiltinOverrides(_ overrides: [ParsedOverride],
         overrideLine[override.action] = override.line
     }
 
-    // (2) iterate to a fixpoint. each pass drops one collision's loser; dropping reverts it to its
-    // default, which the next pass re-checks. drops are remembered (line-sorted at the end) so the
-    // emitted diagnostics are deterministic regardless of dictionary iteration order.
+    // (2) iterate to a fixpoint, one loser per pass. drops are remembered and line-sorted at the end so
+    // the diagnostics are deterministic regardless of dictionary iteration order.
     var pending: [(loser: BuiltinAction, keeper: BuiltinAction, line: Int)] = []
     while let drop = firstBuiltinCollision(candidates: candidates, overrideLine: overrideLine) {
         candidates.removeValue(forKey: drop.loser)
@@ -203,9 +181,9 @@ private func resolveBuiltinOverrides(_ overrides: [ParsedOverride],
     return candidates
 }
 
-/// One iteration of the fixpoint: find the first chord that two distinct actions resolve to (an
-/// override colliding with a default, or two overrides), and return the loser to drop, the keeper it
-/// collided with, and the loser's file line. Returns nil when the candidate set is collision-free.
+/// One fixpoint iteration: find the first chord two distinct actions resolve to (an override against a
+/// default, or two overrides) and return the loser to drop, the keeper, and the loser's file line. nil
+/// when the candidate set is collision-free.
 private func firstBuiltinCollision(candidates: [BuiltinAction: Chord],
                                    overrideLine: [BuiltinAction: Int])
     -> (loser: BuiltinAction, keeper: BuiltinAction, line: Int)? {
@@ -242,30 +220,29 @@ private func firstBuiltinCollision(candidates: [BuiltinAction: Chord],
     return best
 }
 
-/// Cross-section validation: drop a custom keybind whose FIRST chord equals any active built-in chord
-/// OR a reserved monitor chord (Ctrl-Tab / Ctrl-1/2), and drop both keybinds of any custom-vs-custom
-/// duplicate/prefix conflict. A dropped keybind clears the command's `shortcut` to `""` (the command
-/// stays in the palette, unkeyed) and adds a diagnostic.
+/// Cross-section validation: drop a custom keybind whose FIRST chord equals any active built-in chord OR a
+/// reserved monitor chord (Ctrl-Tab / Ctrl-1/2), and drop both keybinds of any custom-vs-custom
+/// duplicate/prefix conflict. A dropped keybind clears the command's `shortcut` to `""` — the command stays
+/// in the palette, unkeyed — and adds a diagnostic.
 ///
-/// Built-ins are single-chord, so any custom bind STARTING with that chord — single or leader — is
-/// shadowed by the menu and is dropped. The reserved monitor chords (`isReservedMonitorChord`) are owned
-/// by the app's always-on NSEvent monitors, not the menu, and are equally un-rebindable. The active
-/// built-in chord set already has every override applied (via `Keymap.equivalent(for:)`), so a custom
-/// command may freely reuse a default chord the user moved a built-in off of.
+/// Built-ins are single-chord, so any custom bind STARTING with that chord, single or leader, is shadowed
+/// by the menu. The reserved monitor chords (`isReservedMonitorChord`) belong to the app's always-on
+/// NSEvent monitors rather than the menu and are equally un-rebindable. The active built-in set already has
+/// every override applied (`Keymap.equivalent(for:)`), so a custom command may freely reuse a default chord
+/// the user moved a built-in off of.
 private func validateCommands(_ commands: [CustomCommand], against keymap: Keymap,
                               diagnostics: inout [KeymapDiagnostic]) -> [CustomCommand] {
-    // active built-in chords: the override when present, else the shipped default. The keyless actions
-    // contribute a chord only when the user mapped one (defaultChord == nil); every shipped default,
-    // arrows included, is in the set, so a custom command can't shadow one.
+    // active built-in chords: the override when present, else the shipped default. keyless actions
+    // (defaultChord == nil) contribute only when the user mapped one; every shipped default, arrows
+    // included, is in the set, so a custom command can't shadow one.
     let builtinChords = Set(BuiltinAction.allCases.compactMap { keymap.equivalent(for: $0) })
 
     var result = commands
 
-    // pass 1: drop a custom keybind that collides with a built-in (its FIRST chord — built-ins are
-    // single-chord and shadow anything starting with that chord) OR with a reserved monitor chord at
-    // ANY position (the monitor consumes its chord wherever it lands in a leader, so a later reserved
-    // chord like `ctrl+a>ctrl+1` is just as dead as a leading one). line 0 — the command's source line
-    // isn't tracked, so cross-section diagnostics use the whole-file line.
+    // pass 1: drop a custom keybind colliding with a built-in on its FIRST chord, or with a reserved
+    // monitor chord at ANY position — the monitor consumes its chord wherever it lands in a leader, so
+    // `ctrl+a>ctrl+1` is just as dead as a leading one. line 0 because the command's source line isn't
+    // tracked, so cross-section diagnostics use the whole-file line.
     for index in result.indices {
         let command = result[index]
         guard !command.shortcut.isEmpty, let keybind = parseKeybind(command.shortcut),
@@ -285,9 +262,9 @@ private func validateCommands(_ commands: [CustomCommand], against keymap: Keyma
         result[index].shortcut = ""
     }
 
-    // pass 2: drop BOTH keybinds of any custom-vs-custom duplicate/prefix conflict (computed over the
-    // post-pass-1 set so a keybind already dropped in pass 1 can't re-trigger here). One diagnostic per
-    // command names the OTHER offender (the conflict carries both ids) so the user can find the pair.
+    // pass 2: drop BOTH keybinds of any custom-vs-custom duplicate/prefix conflict, computed over the
+    // post-pass-1 set so a keybind dropped there can't re-trigger. One diagnostic per command names the
+    // OTHER offender (the conflict carries both ids) so the user can find the pair.
     let conflicts = keybindConflicts(result)
     let nameByID = Dictionary(uniqueKeysWithValues: result.map { ($0.id, $0.name) })
     var otherOffender: [UUID: String] = [:]
@@ -306,12 +283,11 @@ private func validateCommands(_ commands: [CustomCommand], against keymap: Keyma
     return result
 }
 
-/// Strip a trailing inline comment: a `#` is a comment when it is preceded by whitespace AND sits
-/// outside a quoted span (single OR double). A leading `#` (the whole-line comment) is handled by the
-/// caller, but it also falls out here since position 0 has no preceding whitespace only when the line
-/// starts with `#` after trimming — the caller trims and re-checks emptiness, so a `# ...` line becomes
-/// empty. Single quotes matter because a shell line like `git commit -m 'fix #42'` must keep its `#`;
-/// the two quote states are mutually exclusive (a `"` inside `'...'` is literal, and vice versa).
+/// Strip a trailing inline comment: a `#` is a comment when preceded by whitespace AND outside a quoted
+/// span, single OR double. A whole-line `#` comment also falls out here, and the caller trims and
+/// re-checks emptiness, so a `# ...` line becomes empty. Single quotes matter because a shell line like
+/// `git commit -m 'fix #42'` must keep its `#`; the two quote states are mutually exclusive (a `"` inside
+/// `'...'` is literal, and vice versa).
 private func stripComment(_ line: String) -> String {
     var inSingleQuotes = false
     var inDoubleQuotes = false
@@ -339,10 +315,9 @@ private func stripComment(_ line: String) -> String {
     return result
 }
 
-/// Parse the remainder of a `map` line (everything after the `map` verb): `<chord> <action>`. On
-/// success it appends a `ParsedOverride` (in file order); on any failure it appends a diagnostic and
-/// leaves `overrides` untouched. Cross-builtin duplicate detection is deferred to
-/// `resolveBuiltinOverrides` (a final pass over the resolved active chord set).
+/// Parse the remainder of a `map` line (after the verb): `<chord> <action>`. On success it appends a
+/// `ParsedOverride` in file order; on any failure it appends a diagnostic and leaves `overrides` untouched.
+/// Cross-builtin duplicate detection is deferred to `resolveBuiltinOverrides`.
 private func parseMapLine(_ rest: String, line: Int, overrides: inout [ParsedOverride],
                           diagnostics: inout [KeymapDiagnostic]) {
     // split on the first run of general whitespace (space OR tab) so a tab-separated `map` line works.
@@ -362,15 +337,15 @@ private func parseMapLine(_ rest: String, line: Int, overrides: inout [ParsedOve
         return
     }
     // a chord owned by an always-on NSEvent monitor (Ctrl-Tab / Ctrl-1/2) can't be a menu key-equivalent
-    // without dead-racing the monitor, so reject it for built-ins exactly as for custom commands.
+    // without dead-racing the monitor, so reject it for built-ins as for custom commands.
     guard !isReservedMonitorChord(chord) else {
         diagnostics.append(KeymapDiagnostic(line: line, message: "chord '\(chordText)' is a reserved shortcut; map skipped"))
         return
     }
-    // a modifier-less arrow would install an always-on menu key-equivalent that swallows the key
-    // everywhere at once — the terminal, the palettes, the dashboard grid, and every text field — and
-    // the menu path (unlike the custom-command monitor) has no text-field pass-through to soften it.
-    // `parseCommandLine` requires a modifier for the same reason.
+    // a modifier-less arrow would install an always-on menu key-equivalent swallowing the key everywhere
+    // at once — the terminal, the palettes, the dashboard grid, every text field — and the menu path,
+    // unlike the custom-command monitor, has no text-field pass-through. `parseCommandLine` requires a
+    // modifier for the same reason.
     guard !(bindableArrowKeys.contains(chord.key) && chord.mods.isEmpty) else {
         diagnostics.append(KeymapDiagnostic(line: line,
                                             message: "bare arrow chord '\(chordText)' needs a modifier; map skipped"))
@@ -383,9 +358,8 @@ private func parseMapLine(_ rest: String, line: Int, overrides: inout [ParsedOve
     overrides.append(ParsedOverride(action: action, chord: chord, line: line))
 }
 
-/// Parse the remainder of a `command` line (everything after the `command` verb):
-/// `"<name>" [chord] <shell...>`. On any failure it appends a diagnostic and leaves `commands`
-/// untouched.
+/// Parse the remainder of a `command` line (after the verb): `"<name>" [chord] <shell...>`. On any failure
+/// it appends a diagnostic and leaves `commands` untouched.
 private func parseCommandLine(_ rest: String, line: Int, commands: inout [CustomCommand],
                               diagnostics: inout [KeymapDiagnostic]) {
     guard rest.first == "\"", let closeQuote = rest.dropFirst().firstIndex(of: "\"") else {
@@ -395,11 +369,10 @@ private func parseCommandLine(_ rest: String, line: Int, commands: inout [Custom
     let name = String(rest[rest.index(after: rest.startIndex)..<closeQuote])
     let afterName = String(rest[rest.index(after: closeQuote)...]).trimmingCharacters(in: .whitespaces)
 
-    // the token right after the closing quote is the chord iff parseKeybind accepts it AND it carries
-    // a modifier; otherwise the whole remainder is the shell line (palette-only). a modifier is
-    // required so a custom shortcut can't be a bare key that shadows that key in the terminal — and so
-    // a palette-only shell line that happens to start with a single-char token (`[`, `:`, a one-letter
-    // alias) isn't silently swallowed as a binding.
+    // the token right after the closing quote is the chord iff parseKeybind accepts it AND it carries a
+    // modifier; otherwise the whole remainder is the shell line (palette-only). the modifier is required so
+    // a custom shortcut can't be a bare key shadowing that key in the terminal, and so a palette-only shell
+    // line starting with a single-char token (`[`, `:`, a one-letter alias) isn't swallowed as a binding.
     let firstToken = String(afterName.prefix(while: { !$0.isWhitespace }))
     var shortcut = ""
     var shellLine = afterName

--- a/agtermCore/Sources/agtermCore/LinkPolicy.swift
+++ b/agtermCore/Sources/agtermCore/LinkPolicy.swift
@@ -2,14 +2,13 @@ import Foundation
 
 /// Decides what agterm does when a terminal hyperlink is clicked (`GHOSTTY_ACTION_OPEN_URL`). A terminal
 /// renders UNTRUSTED program output, so an escape-sequence link can carry any scheme. `disposition(for:)`
-/// maps a raw link to one of three actions: OPEN a web/mail URL (`NSWorkspace.open`), REVEAL a LOCAL
-/// `file://` link in Finder (`NSWorkspace.activateFileViewerSelecting`), or IGNORE anything else. `file://`
-/// is revealed, never opened: opening it goes through LaunchServices (the Finder double-click path), so a
-/// click on `file:///…/X.app` or `.command` would LAUNCH it — reveal only selects it, executing nothing. A
-/// `file://` whose host is NOT this machine is ignored: `activateFileViewerSelecting` on a remote host can
-/// trigger a Finder network/SMB mount. Host-free (Foundation-only) so it is unit-tested — the local host
-/// names are injected into the decision; the app-side glue just calls the two `NSWorkspace` methods (same
-/// split as `ShellEscape`).
+/// maps a raw link to OPEN a web/mail URL (`NSWorkspace.open`), REVEAL a LOCAL `file://` link in Finder
+/// (`NSWorkspace.activateFileViewerSelecting`), or IGNORE anything else. `file://` is revealed, never
+/// opened: opening goes through LaunchServices (the Finder double-click path), so a click on
+/// `file:///…/X.app` or `.command` would LAUNCH it, while reveal only selects it. A `file://` whose host is
+/// NOT this machine is ignored, since `activateFileViewerSelecting` on a remote host can trigger a Finder
+/// network/SMB mount. Host-free (Foundation-only) so it is unit-tested — the local host names are injected;
+/// the app-side glue only calls the two `NSWorkspace` methods (same split as `ShellEscape`).
 public enum LinkPolicy {
     /// The schemes safe to hand to the system opener — web + mail only, none that hands off to a local
     /// executable/handler.
@@ -22,12 +21,11 @@ public enum LinkPolicy {
         case ignore
     }
 
-    /// Lowercased host names that count as "this machine" for a `file://` link: `localhost` and the
+    /// Lowercased host names counting as "this machine" for a `file://` link: `localhost` and the
     /// `gethostname()` name (what GNU `ls --hyperlink` emits, e.g. `file://<host>/…`; `eza` uses an empty
-    /// host, covered separately by the empty-host rule). Deliberately does NOT consult `Host.current()` or
-    /// `ProcessInfo.hostName`: those resolve names via mDNS/Bonjour, which trips the macOS "find devices on
-    /// local networks" permission prompt on first click — `gethostname()` is a pure syscall that touches no
-    /// network. Computed ONCE and used as the default for `disposition`.
+    /// host, covered by the empty-host rule). Deliberately NOT `Host.current()`/`ProcessInfo.hostName`:
+    /// those resolve via mDNS/Bonjour, tripping the macOS "find devices on local networks" prompt on first
+    /// click, while `gethostname()` is a pure syscall. Computed ONCE, the default for `disposition`.
     public static let localHostNames: Set<String> = {
         var raw: Set<String> = ["localhost"]
         var buffer = [CChar](repeating: 0, count: 256)   // gethostname() — the name GNU ls uses, no network
@@ -38,7 +36,7 @@ public enum LinkPolicy {
         return expandedHostNames(from: raw)
     }()
 
-    /// Normalize each raw host name and add the `.local`-stripped short form next to the full one. Pure (no
+    /// Normalize each raw host name and add the `.local`-stripped short form beside the full one. Pure (no
     /// syscalls), so the normalization + `.local` expansion feeding `localHostNames` stays unit-testable.
     static func expandedHostNames(from raw: Set<String>) -> Set<String> {
         var out: Set<String> = []
@@ -61,14 +59,12 @@ public enum LinkPolicy {
     }
 
     /// The macOS auto-mount roots where a Finder reveal can trigger an NFS/SMB automount: `/net` (`-hosts`),
-    /// `/Network` (`/Network/Servers`), and `/home` (`auto_home`), PLUS their canonical Data-volume paths
-    /// under `/System/Volumes/Data/…`. On modern macOS `/home` is a firmlink/symlink and `auto_home` is
-    /// actually mounted at `/System/Volumes/Data/home`, so a LITERAL `/System/Volumes/Data/home/<user>` link
-    /// would otherwise slip past the `/home` entry and still trip the mount. Matched against the EXACT root or
-    /// a `<root>/…` child, case-insensitively (the boot volume is case-insensitive, so `/NET/…` mounts too),
-    /// so a sibling like `/networkx` is NOT caught; the broad Data root `/System/Volumes/Data` itself is
-    /// deliberately NOT listed (it backs every real file, e.g. `/System/Volumes/Data/Users/…`). The path must
-    /// already be dot-normalized (see `disposition`).
+    /// `/Network` (`/Network/Servers`), `/home` (`auto_home`), PLUS their canonical `/System/Volumes/Data/…`
+    /// paths — `/home` is a firmlink/symlink and `auto_home` really lives at `/System/Volumes/Data/home`, so
+    /// a LITERAL `/System/Volumes/Data/home/<user>` link would slip past the `/home` entry and still mount.
+    /// Matched EXACT or as a `<root>/…` child, case-insensitively (the boot volume is case-insensitive, so
+    /// `/NET/…` mounts too), so `/networkx` is NOT caught; the Data root `/System/Volumes/Data` is
+    /// deliberately unlisted, backing every real file. The path must already be dot-normalized.
     static func isAutomountPath(_ path: String) -> Bool {
         let lower = path.lowercased()
         return ["/net", "/network", "/home",
@@ -77,11 +73,11 @@ public enum LinkPolicy {
                 "/system/volumes/data/network/servers"].contains { lower == $0 || lower.hasPrefix($0 + "/") }
     }
 
-    /// Collapse `.`/`..` segments in an ABSOLUTE path with a purely LEXICAL, string-only normalizer — no
-    /// filesystem access (unlike `URL.standardizedFileURL`, which stats the target) and no symlink resolution,
-    /// so the classifier never touches the very automount path it may be about to deny (a `stat` of a path
-    /// inside autofs could itself trigger the mount). A leading `..` at the root is dropped. The caller
-    /// guarantees an absolute input (`hasPrefix("/")`).
+    /// Collapse `.`/`..` in an ABSOLUTE path with a purely LEXICAL, string-only normalizer — no filesystem
+    /// access (unlike `URL.standardizedFileURL`, which stats the target) and no symlink resolution, so the
+    /// classifier never touches the automount path it may be about to deny (a `stat` inside autofs could
+    /// itself trigger the mount). A leading `..` at the root is dropped; the caller guarantees an absolute
+    /// input (`hasPrefix("/")`).
     static func lexicallyNormalizedAbsolutePath(_ path: String) -> String {
         var out: [Substring] = []
         for comp in path.split(separator: "/", omittingEmptySubsequences: true) {
@@ -93,27 +89,27 @@ public enum LinkPolicy {
     }
 
     /// Maps a raw terminal link to an action: a permitted web/mail scheme → `.open`; a LOCAL `file://` link
-    /// (empty host, or a host in `localHosts`) → `.reveal` of the HOST-STRIPPED, dot-normalized local path, so
-    /// Finder only ever sees a plain `/…` path and never leans on the original authority for host handling; a
-    /// `file://` with a non-local host, an empty/relative path, a UNC-style `//`-path, an auto-mount path
-    /// (`/net`, `/Network`, `/home` — checked AFTER `..` normalization so `/tmp/../net/x` can't sneak
-    /// through), or any other scheme / schemeless / unparseable input → `.ignore`. `localHosts` is injected
-    /// (default: this machine's names) so the decision stays host-free and unit-testable.
+    /// (empty host, or a host in `localHosts`) → `.reveal` of the HOST-STRIPPED, dot-normalized local path,
+    /// so Finder only ever sees a plain `/…` path and never leans on the original authority for host
+    /// handling; a `file://` with a non-local host, an empty/relative path, a UNC-style `//`-path, an
+    /// auto-mount path (`/net`, `/Network`, `/home`, checked AFTER `..` normalization so `/tmp/../net/x`
+    /// can't sneak through), or any other scheme / schemeless / unparseable input → `.ignore`. `localHosts`
+    /// is injected (default: this machine's names) so the decision stays host-free and unit-testable.
     public static func disposition(for raw: String, localHosts: Set<String> = localHostNames) -> LinkDisposition {
         guard let url = URL(string: raw), let scheme = url.scheme?.lowercased() else { return .ignore }
         if permittedSchemes.contains(scheme) { return .open(url) }
         guard scheme == "file" else { return .ignore }
         let host = normalizedHost(url.host(percentEncoded: false) ?? "")
         guard host.isEmpty || localHosts.contains(host) else { return .ignore }
-        // reject an empty/relative path (an empty path would make `URL(fileURLWithPath:)` the process CWD) and
-        // a UNC-style `//` path (a remote target hidden in the path where the host check can't see it).
+        // reject an empty/relative path (empty would make `URL(fileURLWithPath:)` the process CWD) and a
+        // UNC-style `//` path (a remote target hidden where the host check can't see it).
         let rawPath = url.path(percentEncoded: false)
         guard rawPath.hasPrefix("/"), !rawPath.hasPrefix("//") else { return .ignore }
-        // reveal a host-stripped local path, collapsing `.`/`..` with a purely LEXICAL normalizer (string
-        // only) so `/tmp/../net/x` can't sneak past the automount check AND the classifier never stats — and
-        // so never risks triggering — the automount path it is about to deny. It also never resolves symlinks:
-        // a `/tmp/link -> /net` link reveals the link itself, never the target (do NOT swap in
-        // `standardizedFileURL`/`resolvingSymlinksInPath()`, which touch the filesystem).
+        // reveal a host-stripped local path, collapsing `.`/`..` LEXICALLY so `/tmp/../net/x` can't sneak
+        // past the automount check and the classifier never stats — never risks triggering — the automount
+        // path it is about to deny. It also never resolves symlinks: `/tmp/link -> /net` reveals the link,
+        // not the target. Do NOT swap in `standardizedFileURL`/`resolvingSymlinksInPath()`, which touch the
+        // filesystem.
         let normalizedPath = Self.lexicallyNormalizedAbsolutePath(rawPath)
         guard !isAutomountPath(normalizedPath) else { return .ignore }
         return .reveal(URL(fileURLWithPath: normalizedPath, isDirectory: false))

--- a/agtermCore/Sources/agtermCore/Notifications.swift
+++ b/agtermCore/Sources/agtermCore/Notifications.swift
@@ -8,21 +8,19 @@ public enum PaneRole: String, Codable, Sendable, CaseIterable {
     case overlay
 }
 
-/// Pure helpers for terminal desktop notifications (OSC 9 / 777): the coalescing identity that ties
-/// a system notification back to a session/pane, and the suppression rule. Host-free and unit-tested;
-/// the app target's `NotificationManager` builds the actual `UNNotificationRequest` from these.
+/// Pure helpers for terminal desktop notifications (OSC 9 / 777): the coalescing identity tying a system
+/// notification to a session/pane, and the suppression rule. `NotificationManager` builds the request.
 public enum TerminalNotification {
-    /// The notification's identity, `"<windowID>:<sessionID>:<paneRole>"`. Repeated notifications
-    /// from the same pane share it, so the OS replaces the prior banner instead of stacking
-    /// duplicates. The windowID lets a click reopen the owning window when it was closed since the
-    /// banner fired (the firing surface is always in an open window at fire time, so it is known).
+    /// The notification's identity, `"<windowID>:<sessionID>:<paneRole>"`. Repeats from the same pane share
+    /// it, so the OS replaces the prior banner instead of stacking duplicates. The windowID lets a click
+    /// reopen the owning window if it closed since the banner fired (the firing surface is always in an
+    /// open window at fire time, so it is known).
     public static func identity(windowID: UUID, sessionID: UUID, pane: PaneRole) -> String {
         "\(windowID.uuidString):\(sessionID.uuidString):\(pane.rawValue)"
     }
 
-    /// Parses an `identity(windowID:sessionID:pane:)` string back into its parts, or nil if
-    /// malformed. The role is the suffix after the last colon; the two UUID strings (no colons of
-    /// their own) precede it, window id first.
+    /// Parses an `identity(windowID:sessionID:pane:)` string back into its parts, or nil if malformed. The
+    /// role is the suffix after the last colon, preceded by the two colon-free UUIDs, window id first.
     public static func parseIdentity(_ identity: String) -> (windowID: UUID, sessionID: UUID, pane: PaneRole)? {
         let parts = identity.split(separator: ":", omittingEmptySubsequences: false)
         guard parts.count == 3,

--- a/agtermCore/Sources/agtermCore/OSCBackgroundPolicy.swift
+++ b/agtermCore/Sources/agtermCore/OSCBackgroundPolicy.swift
@@ -4,51 +4,49 @@ import Foundation
 /// (`GHOSTTY_ACTION_COLOR_CHANGE`, kind background). Host-free so the routing is unit-tested; the app
 /// target owns only the config push.
 ///
-/// libghostty reports a SET (OSC 11) and a RESET (OSC 111) through the same action, with no flag telling
-/// them apart — a reset simply carries the terminal's default background, which is the theme color. So
-/// the theme background is what identifies a reset, and a program that deliberately sets OSC 11 to the
-/// exact theme color is indistinguishable from one resetting to it. That ambiguity is harmless: both
-/// render the theme background.
+/// libghostty reports a SET (OSC 11) and a RESET (OSC 111) through the same action with no flag telling
+/// them apart — a reset just carries the terminal's default background, i.e. the theme color. So the theme
+/// background is what identifies a reset, and a program deliberately setting OSC 11 to the exact theme
+/// color is indistinguishable from one resetting to it. Harmless: both render the theme background.
 public enum OSCBackgroundPolicy {
     /// What the surface should do with the reported color.
     public enum Decision: Equatable {
         /// Render this color as the surface's dynamic background.
         case apply(String)
-        /// The program reset to the theme default — drop the OSC overlay and fall back to the session's
-        /// own config (watermark or plain).
+        /// The program reset to the theme default — drop the OSC overlay and fall back to the session's own
+        /// config (watermark or plain).
         case reset
-        /// Nothing to do: a per-prompt re-emit of the color already applied, a reset with no overlay
-        /// live, or a malformed color.
+        /// Nothing to do: a per-prompt re-emit of the color already applied, a reset with no live overlay,
+        /// or a malformed color.
         case ignore
     }
 
-    /// Route a reported `incoming` color, given the theme's background (nil before the first config
+    /// Route a reported `incoming` color against the theme's background (nil before the first config
     /// resolve) and the color currently applied to this surface (`current`, nil for none).
     ///
     /// Comparison is case- and `#`-insensitive: the callback formats `#rrggbb` lowercase while the theme
-    /// color arrives from `NSColor.agtermHexString` as `#RRGGBB`, so a literal compare would miss every
-    /// reset.
+    /// color arrives from `NSColor.agtermHexString` as `#RRGGBB`, so a literal compare misses every reset.
     public static func decide(incoming: String, themeBackground: String?, current: String?) -> Decision {
         guard WatermarkConfig.isValidColorHex(incoming) else { return .ignore }
         let color = normalized(incoming)
         if let themeBackground, normalized(themeBackground) == color {
             return current == nil ? .ignore : .reset
         }
-        // dedupe the per-prompt re-emit storm: a shell re-asserting OSC 11 on every prompt would
-        // otherwise drive a full per-surface config rebuild each time.
+        // dedupe the per-prompt re-emit storm: a shell re-asserting OSC 11 on every prompt would otherwise
+        // drive a full per-surface config rebuild each time.
         if let current, normalized(current) == color { return .ignore }
         return .apply(incoming)
     }
 
-    /// The color a reported change must equal to count as a reset: whatever ghostty last seeded the
-    /// terminal's `default` layer from for this surface.
+    /// The color a reported change must equal to count as a reset: whatever ghostty last seeded this
+    /// surface's `default` layer from.
     ///
-    /// `surfaceBackground` is the color the surface's OWN config carries (a `.color` session watermark, a
-    /// sessionless overlay's `--background-color`), and `themeBackground` the base config's. The catch is
-    /// `oscOverlayActive`: the OSC overlay emits no `background` key, so while it is installed the config
-    /// in force is the base one and `default` holds the THEME, not the surface's color. Reporting the
-    /// surface color then makes a reset look like a set — the overlay is never released and the latch
-    /// stays pinned for a program that has already exited.
+    /// `surfaceBackground` is the surface's OWN config color (a `.color` session watermark, a sessionless
+    /// overlay's `--background-color`), `themeBackground` the base config's. The catch is
+    /// `oscOverlayActive`: the OSC overlay emits no `background` key, so while installed the config in force
+    /// is the base one and `default` holds the THEME, not the surface's color — reporting the surface color
+    /// there makes a reset look like a set, so the overlay is never released and the latch stays pinned for
+    /// an already-exited program.
     public static func baseline(oscOverlayActive: Bool, surfaceBackground: String?,
                                 themeBackground: String?) -> String? {
         guard !oscOverlayActive else { return themeBackground }

--- a/agtermCore/Sources/agtermCore/OpenPathResolver.swift
+++ b/agtermCore/Sources/agtermCore/OpenPathResolver.swift
@@ -1,9 +1,8 @@
 import Foundation
 
 /// Resolves a filesystem URL handed to the app by `open -a agterm <path>` (the OS "open terminal here"
-/// integration) to the directory a new session should start in: the path itself when it is a directory,
-/// else its parent directory when it is an existing file. Returns nil for a non-file URL or a path that
-/// does not exist, so the caller opens no stray session.
+/// integration) to the directory a new session starts in: the path itself when a directory, else its parent
+/// when an existing file. Nil for a non-file URL or a missing path, so the caller opens no stray session.
 public enum OpenPathResolver {
     public static func directory(for url: URL) -> String? {
         guard url.isFileURL else { return nil }

--- a/agtermCore/Sources/agtermCore/PaletteCatalog.swift
+++ b/agtermCore/Sources/agtermCore/PaletteCatalog.swift
@@ -8,13 +8,11 @@ public struct PaletteContext: Sendable, Equatable {
     public let sidebarShowsFlaggedOnly: Bool
     public let activeSessionFlagged: Bool
     /// Whether ANY workspace is MARKED in the focus set — membership, NOT whether the filter is applied
-    /// (`workspaceFilter`). Named for the fact it reports: the marked set is what Clear Focus empties and
-    /// what Toggle Workspace Filter has something to apply.
+    /// (`workspaceFilter`): the marked set is what Clear Focus empties and Toggle Workspace Filter applies.
     public let hasMarkedWorkspaces: Bool
     /// Whether the CURRENT workspace is already marked, so "Add Workspace to Focus" can hide instead of
-    /// offering a silent no-op (unlike the sidebar row's item, which has a clicked row and flips its label
-    /// to "Remove from Focus"). The ONLY term that entry keys on, matching the View-menu twin's disabled
-    /// predicate — marking is offered in either sidebar mode.
+    /// offering a silent no-op (the sidebar row's item has a clicked row and flips to "Remove from Focus").
+    /// The ONLY term that entry keys on, matching the View-menu twin — marking is offered in either mode.
     public let activeWorkspaceMarked: Bool
     public let activeSessionHasSplit: Bool
     public let hasPendingClose: Bool
@@ -66,18 +64,17 @@ public enum PaletteCommand: String, CaseIterable, Sendable {
         case .clearFlagged:
             return context.hasFlaggedSessions
         case .clearFocus, .toggleWorkspaceFilter:
-            // nothing marked means nothing to clear and nothing to filter to, and the store refuses to
-            // enable an empty set — the same state the bottom-bar toggle renders disabled in, so the two
-            // surfaces agree.
+            // nothing marked means nothing to clear and nothing to filter to, and the store refuses to enable
+            // an empty set — the state the bottom-bar toggle renders disabled in, so the two surfaces agree.
             return context.hasMarkedWorkspaces
         case .addWorkspaceToFocus:
-            // hidden only where it would be a silent no-op — the current workspace is already a member.
-            // The row menu instead flips to "Remove from Focus", which it can do having a clicked row;
-            // this keyless entry targets `currentWorkspaceID`. Deliberately NOT gated on the sidebar mode:
-            // membership is model state that the tree applies the moment it is shown again, and every
-            // sibling is mode-agnostic too — the View-menu item, Focus Workspace, Toggle Workspace Filter,
-            // Clear Focus, the `focus_workspace` keybind, and `workspace.focus`/`workspace.filter`. The
-            // tree-mode gate belongs to expand/collapse, which manipulate rows flagged mode never renders.
+            // hidden only where it would be a silent no-op: the current workspace is already a member (the
+            // row menu flips to "Remove from Focus" instead, having a clicked row, while this keyless entry
+            // targets `currentWorkspaceID`). NOT gated on sidebar mode — membership is model state the tree
+            // applies the moment it is shown again, and every sibling is mode-agnostic: the View-menu item,
+            // Focus Workspace, Toggle Workspace Filter, Clear Focus, the `focus_workspace` keybind,
+            // `workspace.focus`/`workspace.filter`. the tree-mode gate belongs to expand/collapse, whose rows
+            // flagged mode never renders.
             return !context.activeWorkspaceMarked
         case .expandWorkspaces, .collapseWorkspaces:
             return context.sidebarShowsWorkspaceTree

--- a/agtermCore/Sources/agtermCore/PaletteCustomRow.swift
+++ b/agtermCore/Sources/agtermCore/PaletteCustomRow.swift
@@ -1,8 +1,7 @@
 import Foundation
 
-/// Returns the synthetic free-text row label when a picker query has no item match.
-///
-/// Whitespace around the query is ignored so an empty search never becomes a selectable value.
+/// Returns the synthetic free-text row label when a picker query has no item match. Whitespace around the
+/// query is ignored so an empty search never becomes a selectable value.
 public func pickCustomRowLabel(query: String, filteredCount: Int, allowCustom: Bool) -> String? {
     let value = query.trimmingCharacters(in: .whitespacesAndNewlines)
     guard allowCustom, filteredCount == 0, !value.isEmpty else { return nil }

--- a/agtermCore/Sources/agtermCore/PersistenceStore.swift
+++ b/agtermCore/Sources/agtermCore/PersistenceStore.swift
@@ -1,21 +1,18 @@
 import Foundation
 
-/// Reads and writes the app `Snapshot` as JSON on disk. The storage directory is
-/// an init parameter (defaulting to `~/Library/Application Support/agterm`) so tests
-/// can point it at a temp dir.
+/// Reads and writes the app `Snapshot` as JSON on disk. The storage directory is an init parameter
+/// (defaulting to `~/Library/Application Support/agterm`) so tests can point it at a temp dir.
 ///
-/// Recovery contract: a missing file, corrupt JSON, or a version mismatch all
-/// resolve to a default empty `Snapshot` — `load()` never throws or crashes out to
-/// the caller. `save(_:)` writes atomically (temp file then replace).
+/// Recovery contract: a missing file, corrupt JSON, or a version mismatch all resolve to a default empty
+/// `Snapshot` — `load()` never throws out to the caller. `save(_:)` writes atomically (temp then replace).
 public struct PersistenceStore {
     private let directory: URL
     private let fileName: String
 
     private var fileURL: URL { directory.appendingPathComponent(fileName) }
 
-    /// Creates a store rooted at `directory`, defaulting to the app's Application
-    /// Support directory. `fileName` defaults to `workspaces.json`; a per-window
-    /// store overrides it to target `windows/<id>.json`.
+    /// Creates a store rooted at `directory`, defaulting to the app's Application Support directory.
+    /// `fileName` defaults to `workspaces.json`; a per-window store overrides it to `windows/<id>.json`.
     public init(directory: URL = PersistenceStore.defaultDirectory, fileName: String = "workspaces.json") {
         self.directory = directory
         self.fileName = fileName
@@ -27,8 +24,8 @@ public struct PersistenceStore {
         return base.appendingPathComponent("agterm", isDirectory: true)
     }
 
-    /// Loads the snapshot, recovering a default empty snapshot on any failure
-    /// (missing file, unreadable data, corrupt JSON, or version mismatch).
+    /// Loads the snapshot, recovering a default empty one on any failure (missing file, unreadable data,
+    /// corrupt JSON, or version mismatch).
     public func load() -> Snapshot {
         guard let data = try? Data(contentsOf: fileURL) else { return Snapshot() }
         guard let snapshot = try? JSONDecoder().decode(Snapshot.self, from: data) else { return Snapshot() }
@@ -36,10 +33,9 @@ public struct PersistenceStore {
         return snapshot
     }
 
-    /// Writes the snapshot atomically: `Data.write(options: .atomic)` encodes to an
-    /// auxiliary temp file in the same directory and renames it into place, so a
-    /// crashed write never leaves a half-written destination. Creates the directory
-    /// if needed.
+    /// Writes the snapshot atomically: `Data.write(options: .atomic)` writes an auxiliary temp file in the
+    /// same directory and renames it into place, so a crashed write never leaves a half-written destination.
+    /// Creates the directory if needed.
     public func save(_ snapshot: Snapshot) throws {
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         let encoder = JSONEncoder()

--- a/agtermCore/Sources/agtermCore/QuitPrompt.swift
+++ b/agtermCore/Sources/agtermCore/QuitPrompt.swift
@@ -3,9 +3,8 @@ import Foundation
 /// Pure builder for the quit-confirmation alert text. Host-free so the pluralization is unit-tested
 /// without an app host; the AppKit `NSAlert` lives in the app target's `AppDelegate`.
 public enum QuitPrompt {
-    /// The informative line for "Quit Agterm?", reporting how many windows and sessions the quit
-    /// closes so the loss is explicit (matching the workspace/window delete confirmations). Singular
-    /// and plural agree per count.
+    /// The informative line for "Quit Agterm?", reporting how many windows and sessions the quit closes so
+    /// the loss is explicit (matching the workspace/window delete confirmations). Singular/plural per count.
     public static func message(windows: Int, sessions: Int) -> String {
         let windowClause = windows == 1 ? "1 window" : "\(windows) windows"
         let sessionClause = sessions == 1 ? "1 session" : "\(sessions) sessions"

--- a/agtermCore/Sources/agtermCore/RecentClosed.swift
+++ b/agtermCore/Sources/agtermCore/RecentClosed.swift
@@ -47,13 +47,13 @@ public struct RecentClosedSession: Codable, Equatable, Sendable {
 public struct RecentClosedWorkspace: Codable, Equatable, Sendable {
     public let snapshot: WorkspaceSnapshot
     public let selectedSessionID: UUID?
-    /// Whether the workspace was a MEMBER of the sidebar focus set when it closed, so Reopen Closed Item
-    /// can mark it again instead of appending it invisibly behind a still-applied filter. Membership ONLY —
-    /// the filter FLAG is deliberately not recorded, because it is current window state, not a property of
-    /// the closed workspace (see `AppStore.markFocusMember`). OPTIONAL because this struct is persisted in
-    /// `recent-closed.json`: a required key would fail the whole decode on a file written before it
-    /// existed, and `RecentClosedStore.load()` turns a decode failure into an EMPTY list — the user's
-    /// entire recent list. Absent (nil) reads as "not a member", the behavior of every pre-existing entry.
+    /// Whether the workspace was a MEMBER of the sidebar focus set when it closed, so Reopen Closed Item can
+    /// mark it again instead of appending it invisibly behind a still-applied filter. Membership ONLY — the
+    /// filter FLAG is deliberately not recorded, being current window state rather than a property of the
+    /// closed workspace (see `AppStore.markFocusMember`). OPTIONAL because this struct persists in
+    /// `recent-closed.json`: a required key would fail the whole decode of an older file, and
+    /// `RecentClosedStore.load()` turns a decode failure into an EMPTY list — the user's entire recent list.
+    /// Absent (nil) reads as "not a member", the behavior of every pre-existing entry.
     public let focusMember: Bool?
 
     public init(snapshot: WorkspaceSnapshot, selectedSessionID: UUID?, focusMember: Bool? = nil) {

--- a/agtermCore/Sources/agtermCore/Session.swift
+++ b/agtermCore/Sources/agtermCore/Session.swift
@@ -3,62 +3,56 @@ import Observation
 
 /// One shell, backed by a single libghostty surface.
 ///
-/// `@MainActor`, so it is implicitly `Sendable` via isolation — never make it an `actor`. `surface` is
-/// `@ObservationIgnored` so assigning the lazily-created NSView never churns observation;
-/// `customName`/`currentCwd` are observed, so the sidebar refreshes on a rename or PWD report.
+/// `@MainActor`, so implicitly `Sendable` via isolation — never make it an `actor`. `surface` is
+/// `@ObservationIgnored` so assigning the lazy NSView never churns observation; `customName`/`currentCwd`
+/// are observed, so the sidebar refreshes on a rename or PWD report. "Ephemeral" below means absent from
+/// `SessionSnapshot`, so it never survives a relaunch.
 @Observable
 @MainActor
 public final class Session: Identifiable {
     public let id: UUID
     public var customName: String?
-    /// The live working directory from the latest OSC 7 / PWD report; the sidebar row refreshes on change.
-    /// Captured by `snapshot()`, so persisted on quit and on structural mutations; a bare `cd` triggers no
-    /// save (OSC 7 fires constantly), so a crash loses only cwd changes since the last one.
+    /// Live cwd from the latest OSC 7 / PWD report; the sidebar row refreshes. Persisted by `snapshot()` on
+    /// quit + structural mutations only (OSC 7 fires constantly), so a crash loses cwd since the last save.
     public var currentCwd: String?
     public let initialCwd: String
 
-    /// The terminal title from the latest OSC 0/1/2 set-title report — a shell `PROMPT_COMMAND`, ghostty's
-    /// shell integration, or a remote host over SSH; the sidebar row refreshes on change. Ephemeral like
-    /// `currentCwd`/`unseenCount`: absent from `SessionSnapshot`, and a prompt redraw triggers no save.
+    /// Terminal title from the latest OSC 0/1/2 set-title report — shell `PROMPT_COMMAND`, ghostty shell
+    /// integration, or a remote host over SSH; the sidebar row refreshes on change. Ephemeral, no save.
     public var oscTitle: String?
 
-    /// The split (right) pane's live cwd and terminal title, reported by the surface flagged `isSplitPane`.
-    /// Observed and ephemeral like `currentCwd`/`oscTitle`; nil when there is no split pane. While the split
-    /// pane has focus the sidebar row and title bar derive name/cwd from these, so the chrome tracks it.
+    /// The split (right) pane's live cwd and title, reported by the surface flagged `isSplitPane`. Observed,
+    /// ephemeral, nil with no split pane; while it has focus the sidebar row and title bar derive from these.
     public var splitCwd: String?
     public var splitTitle: String?
 
-    /// Count of unseen terminal notifications fired by this session's panes while it wasn't focused; the
-    /// sidebar badge reacts. Ephemeral: absent from `SessionSnapshot`, never survives a relaunch.
+    /// Unseen notifications fired by this session's panes while unfocused; the sidebar badge reacts. Ephemeral.
     public var unseenCount: Int = 0
 
-    /// The per-session agent status, driven over the control channel (`session.status`); the sidebar row's
-    /// status glyph reacts. Ephemeral like `unseenCount`: absent from `SessionSnapshot`.
+    /// Per-session agent status, driven over the control channel (`session.status`); the sidebar row's
+    /// status glyph reacts. Ephemeral.
     public var agentIndicator = AgentIndicator()
 
-    /// The most-recent time the agent status was set non-idle — stamped by `AppStore.setAgentIndicator` on
-    /// EVERY non-idle set (nil on idle), not only on an idle→non-idle transition. A sort key only (the
-    /// attention list orders same-status sessions newest-change-first), so no view reacts; ephemeral.
+    /// Last time the status was set non-idle — stamped by `AppStore.setAgentIndicator` on EVERY non-idle set
+    /// (nil on idle), not just on an idle→non-idle transition. Ephemeral sort key: the attention list orders
+    /// same-status sessions newest-change-first.
     @ObservationIgnored public var statusChangedAt: Date?
 
-    /// Whether idle auto-follow already pulled the user to THIS blocked episode. Set by
-    /// `AppStore.autoFollowFire` when it jumps here, so a later idle fire won't yank the user back to a block
-    /// already shown and left. Reset by `AppStore.setAgentIndicator` on a transition INTO blocked from a
-    /// non-blocked status — keyed off the transition, not `statusChangedAt`, so a hook re-asserting `blocked`
-    /// over `blocked` stays muted. No view reacts; ephemeral.
+    /// Whether idle auto-follow already pulled the user to THIS blocked episode; ephemeral. Set on jumping
+    /// here by `AppStore.autoFollowFire`, so a later idle fire won't yank the user back to a block already
+    /// shown and left. Reset by `AppStore.setAgentIndicator` on a transition INTO blocked — keyed off the
+    /// transition, not `statusChangedAt`, so a hook re-asserting `blocked` over `blocked` stays muted.
     @ObservationIgnored public var autoFollowConsumed = false
 
-    /// Whether this session is in the flagged working-set — a durable, user-set flag that surfaces it in the
-    /// sidebar's flat cross-workspace flagged view and swaps its tree row to the filled icon variant. The
-    /// sidebar reacts, and `SessionSnapshot.flagged` persists it across a relaunch and a workspace move.
+    /// User-set flagged working-set membership: surfaces the session in the sidebar's flat cross-workspace
+    /// flagged view with a filled row icon. Persisted, surviving a relaunch and a workspace move.
     public var flagged: Bool = false
 
-    /// Changes only when one live primary-slot surface is replaced by another. SwiftUI terminal hosts include
-    /// this stable revision in their identity: lazy nil → first-surface creation stays at zero, while
-    /// split-survivor promotion advances it so the host remounts the replacement AppKit view.
+    /// Changes only when one live primary-slot surface replaces another; SwiftUI hosts fold it into their
+    /// identity, so lazy nil→first creation stays at zero while split-survivor promotion remounts the view.
     @ObservationIgnored public private(set) var primarySurfaceHostRevision = 0
 
-    /// The app-side surface (a `GhosttySurfaceView`). Lazily created on first display and owned here so it
+    /// The app-side surface (a `GhosttySurfaceView`), created lazily on first display and owned here so it
     /// survives sidebar/detail view churn.
     @ObservationIgnored public var surface: (any TerminalSurface)? {
         didSet {
@@ -67,105 +61,90 @@ public final class Session: Identifiable {
         }
     }
 
-    /// Whether the session is shown as a one-level vertical split (two panes side by side); the detail pane
-    /// shows/hides the second pane on change.
+    /// Whether the session is SHOWN as a one-level vertical split; the detail pane shows/hides the second pane.
     public var isSplit: Bool = false
 
-    /// Whether the session HAS a split pane at all (shown side-by-side OR hidden/maximized to one pane), as
-    /// opposed to `isSplit` = "currently shown". Stays true across a hide, cleared only by `closeSplit`, so
-    /// the sidebar + title-bar split indicators persist while a split is merely hidden.
+    /// Whether the session HAS a split pane at all, shown or hidden/maximized, unlike `isSplit`. Stays true
+    /// across a hide, cleared only by `closeSplit`, so the sidebar + title-bar indicators persist while hidden.
     public var hasSplit: Bool = false
 
-    /// While split, whether the split (second) pane holds focus rather than the primary. Observed, so the
-    /// detail pane can dim the inactive pane. Meaningless when not split.
+    /// While split, whether the second pane holds focus rather than the primary; the detail pane dims the
+    /// inactive one. Meaningless when not split.
     public var splitFocused: Bool = false
 
-    /// The split divider's left-pane fraction, captured from the live `NSSplitView` by the split's
-    /// introspection accessor and persisted in `SessionSnapshot`, so it survives a hide/show and a relaunch.
-    /// Within `AppStore.splitRatioMin...splitRatioMax` (~0.05...0.95): capture skips degenerate extremes,
-    /// restore clamps and seeds. Read/written imperatively, never by a SwiftUI view; nil = even.
+    /// The split divider's left-pane fraction, captured from the live `NSSplitView` and persisted, so it
+    /// survives a hide/show and a relaunch. Within `AppStore.splitRatioMin...splitRatioMax` (~0.05...0.95):
+    /// capture skips degenerate extremes, restore clamps and seeds. nil = even; never read by a SwiftUI view.
     @ObservationIgnored public var splitRatio: Double?
 
-    /// The second pane's surface, lazily created on first split. Like `surface` it survives view churn, so
-    /// hiding the split keeps the shell alive rather than destroying it. Freed only on
-    /// `closeSplit`/`closeSession`.
+    /// The second pane's surface, created lazily on first split and, like `surface`, surviving view churn —
+    /// hiding the split keeps the shell alive. Freed only on `closeSplit`/`closeSession`.
     @ObservationIgnored public var splitSurface: (any TerminalSurface)?
 
-    /// The directory the split (right) pane re-spawns in on restore, from the persisted
-    /// `SessionSnapshot.splitCwd`, so each pane keeps its own cwd across relaunch; nil for a fresh
-    /// (never-restored) split, which seeds from `effectiveCwd`. Read by the split factory, captured by
-    /// `snapshot()`.
+    /// Where the split (right) pane re-spawns on restore (the split factory reads it), from the persisted
+    /// `SessionSnapshot.splitCwd`, so each pane keeps its own cwd across a relaunch; nil for a fresh split,
+    /// which seeds from `effectiveCwd`.
     @ObservationIgnored public var initialSplitCwd: String?
 
-    /// The terminal font size in points, or nil for the ghostty config default. Set on the surface at
-    /// creation, written back on cmd +/-, captured by `snapshot()`; nothing in SwiftUI reacts.
+    /// Terminal font size in points, nil for the ghostty config default. Set on the surface at creation,
+    /// written back on cmd +/-, persisted.
     @ObservationIgnored public var fontSize: Double?
 
-    /// The session's background watermark (an image or rasterized text composited behind the terminal), or
-    /// nil for none. Applied app-side to the session's surface(s) as a per-surface ghostty config overlay
-    /// (see `WatermarkConfig`) at creation, on change, and after a global config reload. Nothing in SwiftUI
-    /// reacts; captured by `snapshot()`, so it survives a relaunch (a `.text` watermark re-renders its PNG).
+    /// The session's background watermark — an image or rasterized text behind the terminal, nil for none.
+    /// Applied app-side as a per-surface ghostty config overlay (`WatermarkConfig`) at creation, on change, and
+    /// after a global config reload. Persisted, so it survives a relaunch (`.text` re-renders its PNG).
     @ObservationIgnored public var backgroundWatermark: BackgroundWatermark?
 
-    /// A command to run as the session's process instead of the login shell (like kitty's `launch <cmd>` /
-    /// ghostty's `command`), set at creation via `session.new --command`. The surface factory reads it once;
-    /// the session closes when the command exits (the normal single-pane exit path). Persisted via
-    /// `SessionSnapshot.initialCommand` so a command session — e.g. an `ssh …` shortcut, which exec-replaces
-    /// the shell and is thus invisible to the foreground-pid capture — re-runs it on restore, gated by
-    /// `restoreRunningCommand` (via `wasRestored`); a fresh session always runs it.
+    /// A command to run as the session's process instead of the login shell (kitty's `launch <cmd>`, ghostty's
+    /// `command`), set via `session.new --command`. The surface factory reads it once; the session closes when
+    /// the command exits. Persisted, so a command session — e.g. an `ssh …` shortcut, which exec-replaces the
+    /// shell and so escapes the foreground-pid capture — re-runs it on restore when `restoreRunningCommand` is
+    /// on (via `wasRestored`); a fresh session always runs it.
     @ObservationIgnored public var initialCommand: String?
 
-    /// Whether a `--command` session HOLDS its surface after the command exits — showing libghostty's "press
-    /// any key to close" prompt with the final output intact — instead of closing immediately; set via
-    /// `session.new --command … --wait`. The same libghostty `wait_after_command` the overlay's `overlayWait`
-    /// uses, applied to the PRIMARY surface (`makeSurface` reads it); meaningful only with `initialCommand`.
-    /// Persisted via `SessionSnapshot.commandWait`, so a restored command session that re-runs its command
-    /// holds again.
+    /// Whether a `--command` session HOLDS its surface after the command exits — libghostty's "press any key
+    /// to close" prompt, final output intact — instead of closing; set via `session.new --command … --wait`.
+    /// The same libghostty `wait_after_command` `overlayWait` uses, applied to the PRIMARY surface; meaningful
+    /// only with `initialCommand`. Persisted, so a restored session that re-runs its command holds again.
     @ObservationIgnored public var commandWait: Bool = false
 
-    /// True when this session was rebuilt by `AppStore.restore(from:)` rather than freshly created. The
-    /// surface factory reads it to gate the `initialCommand` re-run: a FRESH command session always runs its
-    /// command, a RESTORED one only when `restoreRunningCommand` is on (else a plain shell). Never persisted.
+    /// True when the session was rebuilt by `AppStore.restore(from:)` rather than freshly created; gates the
+    /// `initialCommand` re-run on `restoreRunningCommand` (a fresh session always runs it, a restored one gets
+    /// a plain shell when off). Never persisted.
     @ObservationIgnored public var wasRestored = false
 
-    /// The main pane's foreground command (full argv) captured at the last clean quit, for the
-    /// restore-running-command feature. Written by the quit-flush capture, read once by the surface factory
-    /// on restore then cleared (like `scratchCommand`). Persisted via `SessionSnapshot.foregroundCommand`;
-    /// nil when the pane was at its prompt.
+    /// The main pane's foreground command (full argv) for restore-running-command, captured at the last clean
+    /// quit and read once by the surface factory on restore, then cleared. Persisted; nil at a prompt.
     @ObservationIgnored public var foregroundCommand: [String]?
     /// The split (right) pane's foreground command (full argv), the split analogue of `foregroundCommand`.
     @ObservationIgnored public var splitForegroundCommand: [String]?
 
-    /// The main pane's PERSISTED restore-command override, set over the control channel (`session.restore`).
-    /// Tri-state: nil = no override (the auto-capture behavior), `""` = pinned to nothing (a plain shell,
-    /// suppressing both the capture and `initialCommand`), `"cmd"` = run that shell line. STICKY, unlike the
-    /// capture: never cleared on read, so it fires again after every restart until changed or cleared. It
-    /// needs its OWN slot — sharing `foregroundCommand` would let the quit-time capture clobber it with the
-    /// live process's argv. Persisted via `SessionSnapshot.restoreCommand`.
+    /// The main pane's PERSISTED restore-command override, set via `session.restore`. Tri-state: nil = no
+    /// override (auto-capture), `""` = pinned to a plain shell (suppressing both the capture and
+    /// `initialCommand`), `"cmd"` = run that shell line. STICKY, unlike the capture: never cleared on read, so
+    /// it fires after every restart until changed. Needs its OWN slot — sharing `foregroundCommand` would let
+    /// the quit-time capture clobber it with the live process's argv.
     @ObservationIgnored public var restoreCommand: String?
     /// The split (right) pane's persisted restore-command override, the split analogue of `restoreCommand`.
     @ObservationIgnored public var splitRestoreCommand: String?
 
-    /// The main pane's TRANSIENT override payload for THIS launch, copied from the persisted `restoreCommand`
-    /// by an app-bootstrap restore and consumed by `takePendingRestoreOverride(pane:)`. NEVER persisted. A
-    /// session that was not bootstrap-restored — freshly created, reopened from Recent Closed, duplicated, or
-    /// rebuilt when a closed window was reloaded mid-process — starts nil, so nothing fires. This is the ONLY
-    /// restore-override state a surface factory may read: it freezes what was eligible when the process
-    /// started, so a command written over the socket during this run can never execute during this run.
+    /// The main pane's TRANSIENT override for THIS launch, copied from `restoreCommand` by an app-bootstrap
+    /// restore, consumed by `takePendingRestoreOverride(pane:)`, never persisted. A session that was not
+    /// bootstrap-restored (fresh, Recent Closed, duplicated, rebuilt after a mid-process window reload) starts
+    /// nil, so nothing fires. The ONLY restore-override state a surface factory may read: it freezes what was
+    /// eligible at process start, so a command written over the socket during this run never executes in it.
     @ObservationIgnored public var pendingRestoreCommand: String?
-    /// The split (right) pane's transient override payload, the split analogue of `pendingRestoreCommand`.
-    /// Seeded only when the restored snapshot's split was SHOWN (`isSplit`): a hidden split builds no right
-    /// surface at bootstrap, so a payload left pending would fire on a later manual ⌘D instead.
+    /// The split analogue of `pendingRestoreCommand`, seeded only when the restored split was SHOWN
+    /// (`isSplit`) — a hidden split builds no right surface at bootstrap, so a pending payload would instead
+    /// fire on a later manual ⌘D.
     @ObservationIgnored public var pendingSplitRestoreCommand: String?
 
-    /// Whether an ephemeral overlay terminal is shown on top of this session (full single-pane size, hiding
-    /// the single/split content underneath); the detail pane shows/hides it. Driven only by the control
-    /// channel; NOT persisted, so it never survives a relaunch — it runs one program and vanishes.
+    /// Whether an ephemeral overlay terminal covers this session (full single-pane size); the detail pane
+    /// shows/hides it. Control-channel only and ephemeral — it runs one program and vanishes.
     public var overlayActive: Bool = false
 
-    /// The overlay's surface, created when the overlay opens and torn down when its program exits or the
-    /// control channel closes it (unlike the split, which is kept alive when hidden). The shell runs
-    /// `overlayCommand`; on its exit the surface's process-exit closes the overlay.
+    /// The overlay's surface, created on open and torn down when its `overlayCommand` exits or the control
+    /// channel closes it — unlike the split, never kept alive while hidden.
     @ObservationIgnored public var overlaySurface: (any TerminalSurface)?
 
     /// The command the overlay runs as its process (e.g. `revdiff`), read by the overlay factory at creation.
@@ -174,77 +153,66 @@ public final class Session: Identifiable {
     /// The overlay's working directory, or nil to inherit `effectiveCwd`. Read by the factory at creation.
     @ObservationIgnored public var overlayCwd: String?
 
-    /// The overlay's own solid background color as `#rrggbb`, or nil for the default theme background.
-    /// Independent of `backgroundWatermark` — the overlay surface is not wired to the session, so it carries
-    /// its own color, set via `session.overlay.open --background-color`. Read by the factory at creation; set
-    /// at open, cleared on close; never persisted.
+    /// The overlay's own solid background as `#rrggbb`, nil for the theme default; set via
+    /// `session.overlay.open --background-color`, read by the factory at creation, cleared on close, never
+    /// persisted. Independent of `backgroundWatermark`: the overlay surface is not wired to the session.
     @ObservationIgnored public var overlayBackgroundColor: String?
 
-    /// Whether the overlay keeps its surface open after the command exits, showing libghostty's "press any
-    /// key to close" prompt (useful to read final output) instead of closing immediately. Read by the factory
-    /// at creation.
+    /// Whether the overlay keeps its surface after the command exits, showing libghostty's "press any key to
+    /// close" prompt with the final output, instead of closing. Read by the factory at creation.
     @ObservationIgnored public var overlayWait: Bool = false
 
-    /// The overlay program's exit status, recorded on the surface's teardown from the wrapper's `echo $?`
-    /// temp file (NOT libghostty's child-exited status, which reflects the login-shell wrapper and is always
-    /// 0). Reset to nil when a new overlay opens; read by `session.overlay.result`. In-memory only.
+    /// The overlay program's exit status, from the wrapper's `echo $?` temp file at teardown, NOT libghostty's
+    /// child-exited status (always 0 — it reports the login-shell wrapper). Reset on the next open, read by
+    /// `session.overlay.result`; in-memory only.
     @ObservationIgnored public var overlayExitCode: Int?
 
-    /// For a *floating* overlay, the percent of the pane (both width and height) the panel occupies, 1...100;
-    /// nil for the default full-pane overlay. A floating overlay is an opaque, framed panel centered in the
-    /// pane with the session still VISIBLE behind it (the full overlay instead hides the session and draws
-    /// translucent); the detail pane picks the layout from it. Set at open, cleared on close; never persisted.
+    /// For a *floating* overlay, the percent of the pane (width and height) the panel occupies, 1...100; nil
+    /// for the default full-pane overlay. Floating = an opaque framed panel centered in the pane, session
+    /// still VISIBLE behind it (full instead hides it and draws translucent). Cleared on close, never persisted.
     public var overlaySizePercent: Int?
 
-    /// Whether a FULL-coverage overlay is up: `overlayActive` with no size percent. A full overlay hides the
-    /// session content beneath it — the pane(s) AND a shown scratch — so its translucent background reveals
-    /// the window backing, never a covered surface (under window translucency every surface renders a fully
-    /// transparent background, so anything left visible below would bleed through). A floating (sized)
-    /// overlay is not a cover: it draws an opaque panel over still-visible content.
+    /// Whether a FULL-coverage overlay is up: `overlayActive` with no size percent. It hides everything
+    /// beneath — the pane(s) AND a shown scratch — so its translucent background reveals the window backing,
+    /// never a covered surface: under window translucency every surface renders fully transparent, so anything
+    /// left visible below would bleed through. A floating (sized) overlay is not a cover.
     public var fullOverlayActive: Bool { overlayActive && overlaySizePercent == nil }
 
-    /// Whether a FLOATING overlay is up: `overlayActive` WITH a size percent — the complement of
-    /// `fullOverlayActive`, and not a cover (see there). Read by the detail pane to gate the floating panel.
+    /// Whether a FLOATING overlay is up: `overlayActive` WITH a size percent, the complement of
+    /// `fullOverlayActive` and not a cover. Read by the detail pane to gate the floating panel.
     public var floatingOverlayActive: Bool { overlayActive && overlaySizePercent != nil }
 
-    /// Whether the scratch terminal is shown on top of this session (full single-pane size, hiding the
-    /// single/split content underneath, like a full overlay); the detail pane shows/hides it. The scratch is
-    /// a third per-session shell that — unlike the ephemeral overlay — behaves like the split: hiding it
-    /// keeps the shell alive (`scratchSurface` retained), so a re-show reuses it. NOT persisted.
+    /// Whether the scratch terminal covers this session (full single-pane size, like a full overlay); the
+    /// detail pane shows/hides it. A third per-session shell that, unlike the ephemeral overlay, behaves like
+    /// the split: hiding it keeps the shell alive, so a re-show reuses it. Not persisted.
     public var scratchActive: Bool = false
 
-    /// The scratch terminal's surface: a login shell (or `scratchCommand` when set), lazily created on first
-    /// show and kept alive across hides (`scratchSurface != nil` is "alive but hidden"). Freed only on
-    /// `closeScratch` (an explicit close, the shell's own `exit`, or session/workspace/window teardown),
-    /// after which the next show spawns a fresh shell.
+    /// The scratch terminal's surface: a login shell (or `scratchCommand`), created lazily on first show and
+    /// kept alive across hides — non-nil means "alive, maybe hidden". Freed only on `closeScratch` (explicit
+    /// close, the shell's own `exit`, or session/workspace/window teardown), after which a show spawns fresh.
     @ObservationIgnored public var scratchSurface: (any TerminalSurface)?
 
-    /// A command to run as the scratch's process instead of a login shell (`session.scratch --command`), the
-    /// scratch analogue of `initialCommand`. RUN-ONCE: the scratch surface factory reads it once when it
-    /// spawns and clears it, so after the command exits the next show is a plain shell. Never persisted.
+    /// The scratch analogue of `initialCommand` (`session.scratch --command`). RUN-ONCE: the scratch factory
+    /// reads and clears it on spawn, so the next show is a plain shell. Never persisted.
     @ObservationIgnored public var scratchCommand: String?
 
     /// Whether the in-terminal search bar is shown over this session's focused pane (⌘F); the detail pane
-    /// shows/hides the bar. Written directly (surface-factory search callbacks + `AppActions`). NOT persisted.
+    /// shows/hides it. Written directly by surface-factory search callbacks and `AppActions`; ephemeral.
     public var searchActive: Bool = false
 
-    /// The current search query, mirrored from the bar's text field and the control channel. Observed +
-    /// written directly like `searchActive`. Ephemeral, never persisted.
+    /// The current search query, mirrored from the bar's text field and the control channel. Ephemeral.
     public var searchNeedle: String = ""
 
-    /// The number of matches for `searchNeedle`, from libghostty's `SEARCH_TOTAL` action; nil before a query
-    /// runs. Observed + written directly. Ephemeral, never persisted.
+    /// Match count for `searchNeedle` from libghostty's `SEARCH_TOTAL`; nil before a query runs. Ephemeral.
     public var searchTotal: Int?
 
-    /// The 1-based index of the currently selected match, from libghostty's `SEARCH_SELECTED` action; nil
-    /// when none is selected. Observed + written directly. Ephemeral, never persisted.
+    /// 1-based index of the selected match, from libghostty's `SEARCH_SELECTED`; nil when none. Ephemeral.
     public var searchSelected: Int?
 
-    /// The surface that owns the open search bar — the focused searchable pane at the time search opened.
-    /// Pinned so the bar's needle/navigate/close drive the SAME surface even if split focus moves afterwards
-    /// (re-resolving `activeSurface` would strand the original pane in libghostty search mode). Set on open
-    /// by the factory's START callback, cleared on close. Weak (the session strongly owns its panes);
-    /// ephemeral.
+    /// The surface owning the open search bar — the focused searchable pane when search opened. Pinned so the
+    /// bar's needle/navigate/close drive the SAME surface even if split focus moves (re-resolving
+    /// `activeSurface` would strand the original pane in libghostty search mode). Set on open by the factory's
+    /// START callback, cleared on close; weak, since the session strongly owns its panes. Ephemeral.
     @ObservationIgnored public weak var searchSurface: (any TerminalSurface)?
 
     public init(id: UUID = UUID(), initialCwd: String, customName: String? = nil) {
@@ -253,15 +221,13 @@ public final class Session: Identifiable {
         self.customName = customName
     }
 
-    /// The sidebar label: a non-blank `customName` (a manual rename) wins; else the non-blank terminal title
-    /// of the focused pane (`focusedOscTitle`); else the basename of `focusedCwd`, falling back to `initialCwd`.
+    /// The sidebar label: a non-blank `customName` (a manual rename) wins; else the focused pane's non-blank
+    /// terminal title; else the basename of `focusedCwd`, falling back to `initialCwd`. Name and title are
+    /// both trimmed, so a whitespace-only value falls through — `AppStore.renameSession` clears a blank name
+    /// to nil, so one can only arrive via a hand-edited snapshot.
     ///
-    /// `customName` and the title are both trimmed, so a whitespace-only value falls through to the next
-    /// source — matching `AppStore.renameSession`, which clears a blank name to nil, so a whitespace-only
-    /// `customName` can only arrive via a hand-edited snapshot.
-    ///
-    /// Basename pins: root `/` → `/` (`lastPathComponent` already returns this); a trailing slash is ignored
-    /// (`/a/b/` → `b`); an empty path → `~`, the home shorthand, since no sensible component exists.
+    /// Basename pins: root `/` → `/` (free from `lastPathComponent`); a trailing slash is ignored (`/a/b/` →
+    /// `b`); an empty path → `~`, the home shorthand, since no sensible component exists.
     public var displayName: String {
         if let trimmed = customName?.trimmedOrNil { return trimmed }
         if let title = focusedOscTitle?.trimmedOrNil { return title }
@@ -270,66 +236,59 @@ public final class Session: Identifiable {
         return (path as NSString).lastPathComponent
     }
 
-    /// The cwd of the focused pane: the split (right) pane's while it has focus (split shown OR hidden and
-    /// maximized), else the primary's, falling back to the primary cwd then `initialCwd`. The sidebar and
-    /// title bar use it so they track the focused pane, while `effectiveCwd` stays the primary's for seeding
-    /// new panes and the `AGTERM_SESSION_PWD` token. Guarded on `splitFocused && splitSurface != nil` (the
-    /// `activeSurface` idiom) so a promoted survivor that momentarily re-raised `splitFocused` after moving
-    /// into the main slot cannot mask the migrated main-pane cwd/title — the split fields describe the split
-    /// pane only while it exists.
+    /// The cwd of the focused pane: the split (right) pane's while it has focus (shown or hidden-maximized),
+    /// else the primary's, falling back to `initialCwd`. The sidebar and title bar track the focused pane
+    /// through it, while `effectiveCwd` stays the primary's. The `splitSurface != nil` guard (the
+    /// `activeSurface` idiom) stops a promoted survivor that momentarily re-raised `splitFocused` from masking
+    /// the migrated main-pane cwd — the split fields describe the split pane only while it exists.
     public var focusedCwd: String {
         if splitFocused, splitSurface != nil, let cwd = splitCwd { return cwd }
         return currentCwd ?? initialCwd
     }
 
-    /// The terminal title of the focused pane: the split pane's while it has focus AND exists, else the
-    /// primary's (see `focusedCwd` for why the split-existence guard).
+    /// The focused pane's terminal title: the split pane's while it has focus AND exists, else the primary's
+    /// (see `focusedCwd` for the existence guard).
     private var focusedOscTitle: String? { splitFocused && splitSurface != nil ? splitTitle : oscTitle }
 
-    /// The detail shown after the workspace name on the second line of the session palette, the Ctrl-Tab
-    /// switcher, and the title bar: the focused pane's terminal title when it isn't already the `displayName`
-    /// (so it ADDS context rather than repeating line 1), else the focused cwd.
-    ///
-    /// A remote (SSH) host sets the OSC title to its own `user@host:dir` while the local OSC 7 report stops
-    /// once the shell hops out, freezing `currentCwd` at a stale local path — so preferring the title
-    /// surfaces the remote location. An UNNAMED session already shows the title as line 1, so this falls
-    /// through to the cwd; a plain local session has no title (local auto-title is suppressed), so this is
-    /// just the cwd.
+    /// The detail after the workspace name on line two of the session palette, the Ctrl-Tab switcher, and the
+    /// title bar: the focused pane's terminal title unless that is already the `displayName` (so it ADDS
+    /// context), else the focused cwd. Over SSH the remote sets the OSC title to `user@host:dir` while local
+    /// OSC 7 stops, freezing `currentCwd` at a stale local path — so preferring the title surfaces the remote
+    /// location. An unnamed session already shows the title as line 1, so this falls through to the cwd; a
+    /// plain local session has no title (local auto-title is suppressed), so this is the cwd too.
     public var subtitleDetail: String {
         if let title = focusedOscTitle?.trimmedOrNil, title != displayName { return title }
         return focusedCwd
     }
 
-    /// The session's effective working directory: the live `currentCwd` once a PWD report has arrived, else
-    /// `initialCwd`. Always the PRIMARY pane's, NOT focus-aware — it seeds a new split/overlay/quick terminal
-    /// and backs `AGTERM_SESSION_PWD`, which should be stable regardless of focus. See `focusedCwd`.
+    /// The live `currentCwd` once a PWD report arrived, else `initialCwd`. Always the PRIMARY pane's, never
+    /// focus-aware (cf. `focusedCwd`): it seeds new split/overlay/quick terminals and backs
+    /// `AGTERM_SESSION_PWD`, which must stay stable regardless of focus.
     public var effectiveCwd: String { currentCwd ?? initialCwd }
 
-    /// The surface of the pane currently in focus: the split (right) pane while it has focus and exists,
-    /// otherwise the primary. When the split is hidden the detail pane shows this one maximized and the focus
-    /// helpers target it, so focus/typing always reaches the visible pane.
+    /// The focused pane's surface: the split (right) while it has focus and exists, else the primary. With the
+    /// split hidden the detail pane maximizes this one and focus helpers target it, so typing always reaches
+    /// the visible pane.
     public var activeSurface: (any TerminalSurface)? {
         splitFocused && splitSurface != nil ? splitSurface : surface
     }
 
-    /// The session's one addressable pane for the control arms acting on "the session" rather than a named
-    /// `--pane` (`session.copy`, `session.paste`, `session.selectall`, `font.*`): IDENTICAL to `surface` for
-    /// every ordinary or split session, including a promoted split survivor, which `closePrimaryPane` moves
-    /// into `surface` while nilling `splitSurface`. `?? splitSurface` is a defensive fallback keeping the
-    /// arms answering (not `session not realized`) should `surface` ever be nil while a split shell lives.
-    /// Deliberately NOT focus-aware, unlike `activeSurface`: a shown split keeps addressing the main pane,
-    /// which keeps `session.selectall` and its `session.copy` read-back on one surface.
+    /// The one addressable pane for control arms acting on "the session" rather than a named `--pane`
+    /// (`session.copy`, `session.paste`, `session.selectall`, `font.*`): IDENTICAL to `surface` everywhere,
+    /// including a promoted split survivor, which `closePrimaryPane` moves into `surface` while nilling
+    /// `splitSurface`. `?? splitSurface` is a defensive fallback keeping the arms answering (not `session not
+    /// realized`) should `surface` ever be nil while a split shell lives. NOT focus-aware, unlike
+    /// `activeSurface`: a shown split still addresses the main pane, so `session.selectall` and its
+    /// `session.copy` read-back stay on one surface.
     public var addressableSurface: (any TerminalSurface)? { surface ?? splitSurface }
 
     /// Resolves a surface's stable spawn token (`TerminalSurface.paneToken`, baked as `AGTERM_PANE_ID` and
-    /// forwarded by the agent-status hook as `session.status --pane-id`) to the role of the slot it CURRENTLY
-    /// occupies — `.left` main, `.right` split, `.scratch` scratch. Derived LIVE from slot occupancy, so a
-    /// promoted split survivor (moved into `surface` by `closePrimaryPane`) resolves `.left` while a fresh
-    /// re-split helper (in `splitSurface`) resolves `.right`, though BOTH shells were baked with the same
-    /// stale `right` role — the #199 fix. nil for an empty or unknown token (a torn-down surface, or a shell
-    /// spawned before the token existed), so the caller falls back to the baked `--pane`; mirrors the
-    /// live-role read the pane-scoped keystroke-clear does via `GhosttySurfaceView.isSplitPane` (see the
-    /// Notifications rule).
+    /// forwarded by the agent-status hook as `session.status --pane-id`) to the slot it CURRENTLY occupies.
+    /// Derived LIVE from slot occupancy, so a promoted split survivor resolves `.left` and a fresh re-split
+    /// helper `.right` even though both shells were baked with the same stale `right` role — the #199 fix.
+    /// nil for an empty or unknown token (torn-down surface, or a shell spawned before the token existed), so
+    /// the caller falls back to the baked `--pane`; mirrors the live-role read `GhosttySurfaceView.isSplitPane`
+    /// gives the pane-scoped keystroke-clear (see the Notifications rule).
     public func paneRole(forToken token: String) -> StatusPane? {
         guard !token.isEmpty else { return nil }
         if surface?.paneToken == token { return .left }
@@ -339,10 +298,10 @@ public final class Session: Identifiable {
     }
 
     /// Takes the pane's PENDING restore-command override, clearing it so a second surface for the same pane
-    /// this launch gets a plain shell — `makeSplitSurface` runs again when a split shell exits and the user
-    /// opens a fresh ⌘D split, and a payload left in place would fire a second time mid-session. The
-    /// PERSISTED `restoreCommand`/`splitRestoreCommand` are neither read nor written here: the override is
-    /// sticky and must fire again after the next restart. `.scratch` always returns nil — never restored.
+    /// this launch gets a plain shell: `makeSplitSurface` runs again on a fresh ⌘D after a split shell exits,
+    /// and a leftover payload would fire twice mid-session. The PERSISTED `restoreCommand`/`splitRestoreCommand`
+    /// are untouched — sticky, they must fire again after the next restart. `.scratch` returns nil, never
+    /// restored.
     public func takePendingRestoreOverride(pane: StatusPane) -> String? {
         switch pane {
         case .left:
@@ -359,37 +318,33 @@ public final class Session: Identifiable {
     }
 
     /// Drops both unconsumed override payloads, leaving the persisted fields alone. Called where a live
-    /// `Session` leaves the tree but may come back as the SAME object (the soft-close grace window): a
-    /// payload armed at bootstrap and never consumed would otherwise survive the round trip and fire when
-    /// the reinserted session's surface is finally built.
+    /// `Session` leaves the tree but may return as the SAME object (the soft-close grace window): a payload
+    /// armed at bootstrap would otherwise survive the round trip and fire when its surface is rebuilt.
     public func clearPendingRestoreOverrides() {
         pendingRestoreCommand = nil
         pendingSplitRestoreCommand = nil
     }
 
-    /// The surface currently on top and owning keyboard focus: an active overlay (full OR floating), else the
-    /// scratch, else the active pane. The overlay renders above the scratch, and a full overlay or the
-    /// scratch hides the pane(s) beneath it — so the session-focus helpers route through this to keep first
-    /// responder off a covered pane/scratch. (`TerminalView.focusIfNeeded` is the exception: it targets its
-    /// own deck slot, which a cover already gates off via `isActive`.)
+    /// The surface on top and owning keyboard focus: an active overlay (full OR floating), else the scratch,
+    /// else the active pane. The overlay renders above the scratch, and a full overlay or the scratch covers
+    /// the panes, so session-focus helpers route through this to keep first responder off a covered surface —
+    /// except `TerminalView.focusIfNeeded`, which targets its own deck slot, already gated by `isActive`.
     public var topmostSurface: (any TerminalSurface)? {
         if overlayActive { return overlaySurface }
         if scratchActive { return scratchSurface }
         return activeSurface
     }
 
-    /// The pane-or-scratch surface actually ON SCREEN: the scratch when it covers the panes (and no overlay
-    /// is up), else the focused pane. `session.text` with no `--pane` and `session.search` resolve through
-    /// this so they hit the scratch rather than a pane hidden beneath it (an active overlay routes to its own
-    /// surface via `topmostSurface`; this stays the pane-vs-scratch choice, matching `searchTarget`).
+    /// The pane-or-scratch surface actually ON SCREEN: the scratch when it covers the panes with no overlay up,
+    /// else the focused pane — so `session.text` (no `--pane`) and `session.search` hit the scratch, not the
+    /// pane beneath. An overlay routes via `topmostSurface`; this stays pane-vs-scratch, like `searchTarget`.
     public var onScreenSurface: (any TerminalSurface)? {
         scratchActive && !overlayActive ? topmostSurface : activeSurface
     }
 
-    /// The match counter shown in the search bar and returned by `session.search`: empty before a query runs
-    /// (`searchTotal` nil), `"no matches"` at zero, `"N matches"` while none is selected, `"S of N"` once one
-    /// is. `selected` is clamped to `total` so a stale index (the count shrank under it before the next
-    /// SEARCH_SELECTED lands) never reads "3 of 2".
+    /// The match counter for the search bar and `session.search`: empty before a query runs, `"no matches"` at
+    /// zero, `"N matches"` while none is selected, `"S of N"` once one is. `selected` is clamped to `total` so
+    /// a stale index (the count shrank before the next SEARCH_SELECTED lands) never reads "3 of 2".
     public var searchDisplayText: String {
         guard let total = searchTotal else { return "" }
         guard total > 0 else { return "no matches" }
@@ -397,10 +352,9 @@ public final class Session: Identifiable {
         return "\(min(selected, total)) of \(total)"
     }
 
-    /// Resets all search state: hides the bar, clears the needle/count/index, nils the pinned owner. Called
-    /// from the pane-teardown/promote paths (`closeSplit`, `closePrimaryPane`, `closeSplitPane`) so a session
-    /// whose searched pane was destroyed or promoted doesn't keep a stuck, no-op bar (the weak
-    /// `searchSurface` zeroes but `searchActive` would otherwise stay true).
+    /// Resets all search state. Called from the pane-teardown/promote paths (`closeSplit`, `closePrimaryPane`,
+    /// `closeSplitPane`) so a session whose searched pane was destroyed or promoted keeps no stuck, no-op bar:
+    /// the weak `searchSurface` zeroes but `searchActive` would otherwise stay true.
     public func clearSearch() {
         searchActive = false
         searchNeedle = ""
@@ -411,8 +365,8 @@ public final class Session: Identifiable {
 }
 
 extension String {
-    /// The string trimmed of leading/trailing whitespace and newlines, or nil if the result is empty. The
-    /// single normalizer for the rename/displayName "blank after trim" rule.
+    /// Trimmed of surrounding whitespace and newlines, nil if empty — the one normalizer for the
+    /// rename/displayName "blank after trim" rule.
     var trimmedOrNil: String? {
         let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed

--- a/agtermCore/Sources/agtermCore/Session.swift
+++ b/agtermCore/Sources/agtermCore/Session.swift
@@ -3,74 +3,63 @@ import Observation
 
 /// One shell, backed by a single libghostty surface.
 ///
-/// `@MainActor` (so it's implicitly `Sendable` via isolation — never made an
-/// `actor`). The `surface` slot is `@ObservationIgnored` so assigning the
-/// lazily-created NSView never churns observation; `customName`/`currentCwd` are
-/// observed, so the sidebar refreshes when a rename or PWD report lands.
+/// `@MainActor`, so it is implicitly `Sendable` via isolation — never make it an `actor`. `surface` is
+/// `@ObservationIgnored` so assigning the lazily-created NSView never churns observation;
+/// `customName`/`currentCwd` are observed, so the sidebar refreshes on a rename or PWD report.
 @Observable
 @MainActor
 public final class Session: Identifiable {
     public let id: UUID
     public var customName: String?
-    /// The live working directory from the latest OSC 7 / PWD report. Observed, so
-    /// the sidebar row refreshes when it changes. It is captured by `snapshot()`
-    /// and so persisted on quit and on structural mutations, but a bare `cd` does
-    /// not trigger a save (OSC 7 fires constantly), so a crash loses only cwd
-    /// changes since the last structural mutation.
+    /// The live working directory from the latest OSC 7 / PWD report; the sidebar row refreshes on change.
+    /// Captured by `snapshot()`, so persisted on quit and on structural mutations; a bare `cd` triggers no
+    /// save (OSC 7 fires constantly), so a crash loses only cwd changes since the last one.
     public var currentCwd: String?
     public let initialCwd: String
 
-    /// The terminal title from the latest OSC 0/1/2 set-title report — set by a shell
-    /// `PROMPT_COMMAND`, ghostty's shell integration, or a remote host over SSH. Observed, so the
-    /// sidebar row refreshes when it changes. Ephemeral like `currentCwd`/`unseenCount`:
-    /// `SessionSnapshot` doesn't capture it, and a bare prompt redraw doesn't trigger a save.
+    /// The terminal title from the latest OSC 0/1/2 set-title report — a shell `PROMPT_COMMAND`, ghostty's
+    /// shell integration, or a remote host over SSH; the sidebar row refreshes on change. Ephemeral like
+    /// `currentCwd`/`unseenCount`: absent from `SessionSnapshot`, and a prompt redraw triggers no save.
     public var oscTitle: String?
 
-    /// The split (right) pane's live cwd and terminal title, reported by the split surface (the one
-    /// flagged `isSplitPane`). Observed and ephemeral like `currentCwd`/`oscTitle`; nil when there is
-    /// no split pane. While the split pane has focus, the sidebar row and title bar derive their
-    /// name/cwd from these instead of the primary's, so the chrome tracks whichever pane you're in.
+    /// The split (right) pane's live cwd and terminal title, reported by the surface flagged `isSplitPane`.
+    /// Observed and ephemeral like `currentCwd`/`oscTitle`; nil when there is no split pane. While the split
+    /// pane has focus the sidebar row and title bar derive name/cwd from these, so the chrome tracks it.
     public var splitCwd: String?
     public var splitTitle: String?
 
-    /// Count of unseen terminal notifications fired by this session's panes while it wasn't focused.
-    /// Observed, so the sidebar badge reacts. Ephemeral: `SessionSnapshot` doesn't capture it, so it
-    /// never survives a relaunch.
+    /// Count of unseen terminal notifications fired by this session's panes while it wasn't focused; the
+    /// sidebar badge reacts. Ephemeral: absent from `SessionSnapshot`, never survives a relaunch.
     public var unseenCount: Int = 0
 
-    /// The per-session agent status, driven over the control channel (`session.status`). Observed, so
-    /// the sidebar row's status glyph reacts. Ephemeral like `unseenCount`: `SessionSnapshot` doesn't
-    /// capture it, so it never survives a relaunch.
+    /// The per-session agent status, driven over the control channel (`session.status`); the sidebar row's
+    /// status glyph reacts. Ephemeral like `unseenCount`: absent from `SessionSnapshot`.
     public var agentIndicator = AgentIndicator()
 
-    /// The most-recent time the agent status was set to a non-idle value — stamped by
-    /// `AppStore.setAgentIndicator` on EVERY non-idle set (`Date()` for any non-idle status, nil on idle),
-    /// not only on an idle→non-idle transition. Sort key only — the attention list orders same-status
-    /// sessions newest-change-first. `@ObservationIgnored` (no view reacts to it; the list reads it as a
-    /// sort key) and ephemeral: `SessionSnapshot` doesn't capture it, so it never survives a relaunch.
+    /// The most-recent time the agent status was set non-idle — stamped by `AppStore.setAgentIndicator` on
+    /// EVERY non-idle set (nil on idle), not only on an idle→non-idle transition. A sort key only (the
+    /// attention list orders same-status sessions newest-change-first), so no view reacts; ephemeral.
     @ObservationIgnored public var statusChangedAt: Date?
 
-    /// Whether idle auto-follow has already pulled the user to THIS blocked episode. Set by
-    /// `AppStore.autoFollowFire` when it jumps here, so a later idle fire won't yank the user back to a
-    /// block they've already been shown and left. Reset to false by `AppStore.setAgentIndicator` when the
-    /// session transitions INTO blocked from a non-blocked status (a new episode is eligible for one more
-    /// pull) — keyed off the transition, not `statusChangedAt`, so a hook re-asserting `blocked` over
-    /// `blocked` stays muted. `@ObservationIgnored` (no view reacts) and ephemeral (absent from `SessionSnapshot`).
+    /// Whether idle auto-follow already pulled the user to THIS blocked episode. Set by
+    /// `AppStore.autoFollowFire` when it jumps here, so a later idle fire won't yank the user back to a block
+    /// already shown and left. Reset by `AppStore.setAgentIndicator` on a transition INTO blocked from a
+    /// non-blocked status — keyed off the transition, not `statusChangedAt`, so a hook re-asserting `blocked`
+    /// over `blocked` stays muted. No view reacts; ephemeral.
     @ObservationIgnored public var autoFollowConsumed = false
 
-    /// Whether this session is in the flagged working-set — a durable, user-set flag that surfaces the
-    /// session in the sidebar's flat flagged view (across workspaces) and swaps its tree row to the
-    /// filled icon variant. Observed, so the sidebar reacts to a toggle. Persisted via `SessionSnapshot.flagged`,
-    /// so it survives a relaunch (and a workspace move — the flag travels with the session).
+    /// Whether this session is in the flagged working-set — a durable, user-set flag that surfaces it in the
+    /// sidebar's flat cross-workspace flagged view and swaps its tree row to the filled icon variant. The
+    /// sidebar reacts, and `SessionSnapshot.flagged` persists it across a relaunch and a workspace move.
     public var flagged: Bool = false
 
-    /// Changes only when one live primary-slot surface is replaced by another. SwiftUI terminal hosts
-    /// include this stable revision in their identity: lazy nil → first-surface creation stays at zero,
-    /// while split-survivor promotion advances it so the host remounts the replacement AppKit view.
+    /// Changes only when one live primary-slot surface is replaced by another. SwiftUI terminal hosts include
+    /// this stable revision in their identity: lazy nil → first-surface creation stays at zero, while
+    /// split-survivor promotion advances it so the host remounts the replacement AppKit view.
     @ObservationIgnored public private(set) var primarySurfaceHostRevision = 0
 
-    /// The app-side surface (a `GhosttySurfaceView`). Lazily created on first
-    /// display and owned here so it survives sidebar/detail view churn.
+    /// The app-side surface (a `GhosttySurfaceView`). Lazily created on first display and owned here so it
+    /// survives sidebar/detail view churn.
     @ObservationIgnored public var surface: (any TerminalSurface)? {
         didSet {
             guard let oldValue, let surface, oldValue !== surface else { return }
@@ -78,205 +67,184 @@ public final class Session: Identifiable {
         }
     }
 
-    /// Whether the session is shown as a one-level vertical split (two panes side by
-    /// side). Observed, so the detail pane shows/hides the second pane when toggled.
+    /// Whether the session is shown as a one-level vertical split (two panes side by side); the detail pane
+    /// shows/hides the second pane on change.
     public var isSplit: Bool = false
 
-    /// Whether the session HAS a split pane at all (shown side-by-side OR hidden/maximized to one
-    /// pane), as opposed to `isSplit` which is only "currently shown". Stays true across a hide, and
-    /// is cleared only when the split is closed (`closeSplit`). Observed, so the sidebar + title-bar
-    /// split indicators persist while a split is merely hidden.
+    /// Whether the session HAS a split pane at all (shown side-by-side OR hidden/maximized to one pane), as
+    /// opposed to `isSplit` = "currently shown". Stays true across a hide, cleared only by `closeSplit`, so
+    /// the sidebar + title-bar split indicators persist while a split is merely hidden.
     public var hasSplit: Bool = false
 
-    /// While split, whether the split (second) pane holds focus rather than the primary.
-    /// Observed, so the detail pane can dim the inactive pane. Meaningless when not split.
+    /// While split, whether the split (second) pane holds focus rather than the primary. Observed, so the
+    /// detail pane can dim the inactive pane. Meaningless when not split.
     public var splitFocused: Bool = false
 
-    /// The split divider's left-pane fraction, captured from the live `NSSplitView` so the side-by-side
-    /// ratio survives a hide/show and a relaunch (persisted in `SessionSnapshot`). Within
-    /// `AppStore.splitRatioMin...splitRatioMax` (~0.05...0.95) - the capture skips degenerate extremes and
-    /// restore clamps. Seeded on restore, kept current by the split's introspection accessor;
-    /// `@ObservationIgnored` because it is read/written imperatively, not by any SwiftUI view. nil = even.
+    /// The split divider's left-pane fraction, captured from the live `NSSplitView` by the split's
+    /// introspection accessor and persisted in `SessionSnapshot`, so it survives a hide/show and a relaunch.
+    /// Within `AppStore.splitRatioMin...splitRatioMax` (~0.05...0.95): capture skips degenerate extremes,
+    /// restore clamps and seeds. Read/written imperatively, never by a SwiftUI view; nil = even.
     @ObservationIgnored public var splitRatio: Double?
 
-    /// The second pane's surface, lazily created on first split. `@ObservationIgnored`
-    /// like `surface`; it survives view churn, so hiding the split keeps the shell alive
-    /// rather than destroying it. Freed only on `closeSplit`/`closeSession`.
+    /// The second pane's surface, lazily created on first split. Like `surface` it survives view churn, so
+    /// hiding the split keeps the shell alive rather than destroying it. Freed only on
+    /// `closeSplit`/`closeSession`.
     @ObservationIgnored public var splitSurface: (any TerminalSurface)?
 
-    /// The directory the split (right) pane re-spawns in on restore, set from the persisted
-    /// `SessionSnapshot.splitCwd` so each pane keeps its own cwd across relaunch. nil for a
-    /// fresh (never-restored) split, which seeds from the session's `effectiveCwd` instead.
-    /// `@ObservationIgnored`: read imperatively by the split factory, captured by `snapshot()`.
+    /// The directory the split (right) pane re-spawns in on restore, from the persisted
+    /// `SessionSnapshot.splitCwd`, so each pane keeps its own cwd across relaunch; nil for a fresh
+    /// (never-restored) split, which seeds from `effectiveCwd`. Read by the split factory, captured by
+    /// `snapshot()`.
     @ObservationIgnored public var initialSplitCwd: String?
 
-    /// The terminal font size in points, or nil to use the ghostty config default. The app
-    /// sets the surface's initial size from this on creation and writes it back when the
-    /// user changes it (cmd +/-). `@ObservationIgnored`: nothing in SwiftUI reacts to it —
-    /// it is read imperatively at surface creation and captured by `snapshot()`.
+    /// The terminal font size in points, or nil for the ghostty config default. Set on the surface at
+    /// creation, written back on cmd +/-, captured by `snapshot()`; nothing in SwiftUI reacts.
     @ObservationIgnored public var fontSize: Double?
 
-    /// The session's background watermark (an image or rasterized text composited behind the terminal),
-    /// or nil for none. The app target applies it to the session's surface(s) via a per-surface ghostty
-    /// config overlay (see `WatermarkConfig`) at creation, on change, and after a global config reload.
-    /// `@ObservationIgnored` like `fontSize`: nothing in SwiftUI reacts — it is read imperatively when a
-    /// surface is (re)configured and captured by `snapshot()`, so it survives a relaunch (a `.text`
-    /// watermark re-renders its PNG on restore).
+    /// The session's background watermark (an image or rasterized text composited behind the terminal), or
+    /// nil for none. Applied app-side to the session's surface(s) as a per-surface ghostty config overlay
+    /// (see `WatermarkConfig`) at creation, on change, and after a global config reload. Nothing in SwiftUI
+    /// reacts; captured by `snapshot()`, so it survives a relaunch (a `.text` watermark re-renders its PNG).
     @ObservationIgnored public var backgroundWatermark: BackgroundWatermark?
 
-    /// A command to run as the session's process instead of the login shell (like kitty's `launch
-    /// <cmd>` / ghostty's `command`), set at creation via `session.new --command`. The surface factory
-    /// reads it once; on the command exiting the session closes (the normal single-pane exit path).
-    /// `@ObservationIgnored`. Persisted via `SessionSnapshot.initialCommand` so a command session — e.g.
-    /// an `ssh …` shortcut, which exec-replaces the shell and so is invisible to the foreground-pid
-    /// capture — re-runs its command on restore instead of coming back a plain shell. The restore re-run
-    /// is gated by `restoreRunningCommand` (via `wasRestored`); a fresh session always runs it.
+    /// A command to run as the session's process instead of the login shell (like kitty's `launch <cmd>` /
+    /// ghostty's `command`), set at creation via `session.new --command`. The surface factory reads it once;
+    /// the session closes when the command exits (the normal single-pane exit path). Persisted via
+    /// `SessionSnapshot.initialCommand` so a command session — e.g. an `ssh …` shortcut, which exec-replaces
+    /// the shell and is thus invisible to the foreground-pid capture — re-runs it on restore, gated by
+    /// `restoreRunningCommand` (via `wasRestored`); a fresh session always runs it.
     @ObservationIgnored public var initialCommand: String?
 
-    /// Whether a `--command` session HOLDS its surface after the command exits (showing libghostty's
-    /// "press any key to close" prompt with the final output intact) instead of closing immediately, set
-    /// at creation via `session.new --command … --wait`. The same libghostty `wait_after_command` the
-    /// overlay's `overlayWait` uses, applied to the PRIMARY surface (`makeSurface` reads it). Meaningful
-    /// only with `initialCommand`; a plain shell has nothing to hold. `@ObservationIgnored`. Persisted via
-    /// `SessionSnapshot.commandWait` so a restored command session that re-runs its command holds again,
-    /// keeping the held/closed behavior consistent across restart.
+    /// Whether a `--command` session HOLDS its surface after the command exits — showing libghostty's "press
+    /// any key to close" prompt with the final output intact — instead of closing immediately; set via
+    /// `session.new --command … --wait`. The same libghostty `wait_after_command` the overlay's `overlayWait`
+    /// uses, applied to the PRIMARY surface (`makeSurface` reads it); meaningful only with `initialCommand`.
+    /// Persisted via `SessionSnapshot.commandWait`, so a restored command session that re-runs its command
+    /// holds again.
     @ObservationIgnored public var commandWait: Bool = false
 
     /// True when this session was rebuilt by `AppStore.restore(from:)` rather than freshly created. The
-    /// surface factory reads it to gate the `initialCommand` re-run: a FRESH command session always runs
-    /// its command, but a RESTORED one re-runs only when `restoreRunningCommand` is on (else a plain
-    /// shell). `@ObservationIgnored`; transient, never persisted.
+    /// surface factory reads it to gate the `initialCommand` re-run: a FRESH command session always runs its
+    /// command, a RESTORED one only when `restoreRunningCommand` is on (else a plain shell). Never persisted.
     @ObservationIgnored public var wasRestored = false
 
     /// The main pane's foreground command (full argv) captured at the last clean quit, for the
-    /// restore-running-command feature. `@ObservationIgnored`: written imperatively by the quit-flush
-    /// capture and read once by the surface factory on restore (then cleared, like `scratchCommand`).
-    /// Persisted via `SessionSnapshot.foregroundCommand`; nil when the pane was at its prompt.
+    /// restore-running-command feature. Written by the quit-flush capture, read once by the surface factory
+    /// on restore then cleared (like `scratchCommand`). Persisted via `SessionSnapshot.foregroundCommand`;
+    /// nil when the pane was at its prompt.
     @ObservationIgnored public var foregroundCommand: [String]?
     /// The split (right) pane's foreground command (full argv), the split analogue of `foregroundCommand`.
     @ObservationIgnored public var splitForegroundCommand: [String]?
 
-    /// The main pane's PERSISTED restore-command override, set over the control channel
-    /// (`session.restore`). Tri-state: nil = no override (the auto-capture behavior), `""` = pinned to
-    /// nothing (a plain shell, suppressing both the capture and `initialCommand`), `"cmd"` = run that
-    /// shell line. STICKY, unlike the capture: it is never cleared on read, so it fires again after every
-    /// restart until something changes or clears it. It needs its OWN slot rather than sharing
-    /// `foregroundCommand` because the quit-time capture would otherwise clobber it with the live
-    /// process's argv. `@ObservationIgnored`; persisted via `SessionSnapshot.restoreCommand`.
+    /// The main pane's PERSISTED restore-command override, set over the control channel (`session.restore`).
+    /// Tri-state: nil = no override (the auto-capture behavior), `""` = pinned to nothing (a plain shell,
+    /// suppressing both the capture and `initialCommand`), `"cmd"` = run that shell line. STICKY, unlike the
+    /// capture: never cleared on read, so it fires again after every restart until changed or cleared. It
+    /// needs its OWN slot — sharing `foregroundCommand` would let the quit-time capture clobber it with the
+    /// live process's argv. Persisted via `SessionSnapshot.restoreCommand`.
     @ObservationIgnored public var restoreCommand: String?
     /// The split (right) pane's persisted restore-command override, the split analogue of `restoreCommand`.
     @ObservationIgnored public var splitRestoreCommand: String?
 
-    /// The main pane's TRANSIENT override payload for THIS launch, copied from the persisted
-    /// `restoreCommand` by an app-bootstrap restore and consumed by `takePendingRestoreOverride(pane:)`.
-    /// NEVER persisted (absent from `snapshot()`). A session that was not bootstrap-restored — freshly
-    /// created, reopened from Recent Closed, duplicated, or rebuilt when a closed window was reloaded
-    /// mid-process — starts nil, so nothing fires. This is the ONLY restore-override state a surface
-    /// factory may read: it freezes what was eligible when the process started, so a command written over
-    /// the socket during this run can never execute during this run.
+    /// The main pane's TRANSIENT override payload for THIS launch, copied from the persisted `restoreCommand`
+    /// by an app-bootstrap restore and consumed by `takePendingRestoreOverride(pane:)`. NEVER persisted. A
+    /// session that was not bootstrap-restored — freshly created, reopened from Recent Closed, duplicated, or
+    /// rebuilt when a closed window was reloaded mid-process — starts nil, so nothing fires. This is the ONLY
+    /// restore-override state a surface factory may read: it freezes what was eligible when the process
+    /// started, so a command written over the socket during this run can never execute during this run.
     @ObservationIgnored public var pendingRestoreCommand: String?
     /// The split (right) pane's transient override payload, the split analogue of `pendingRestoreCommand`.
     /// Seeded only when the restored snapshot's split was SHOWN (`isSplit`): a hidden split builds no right
     /// surface at bootstrap, so a payload left pending would fire on a later manual ⌘D instead.
     @ObservationIgnored public var pendingSplitRestoreCommand: String?
 
-    /// Whether an ephemeral overlay terminal is shown on top of this session (full single-pane
-    /// size, hiding the single/split content underneath). Observed, so the detail pane shows/hides
-    /// the overlay. Driven only by the control channel; NOT persisted (absent from `snapshot()`), so
-    /// the overlay never survives a relaunch — it exists only to run one program and vanish.
+    /// Whether an ephemeral overlay terminal is shown on top of this session (full single-pane size, hiding
+    /// the single/split content underneath); the detail pane shows/hides it. Driven only by the control
+    /// channel; NOT persisted, so it never survives a relaunch — it runs one program and vanishes.
     public var overlayActive: Bool = false
 
-    /// The overlay's surface, created when the overlay opens and torn down when its program exits or
-    /// the control channel closes it (unlike the split, which is kept alive when hidden). The shell
-    /// runs `overlayCommand`; on its exit the surface's process-exit closes the overlay.
+    /// The overlay's surface, created when the overlay opens and torn down when its program exits or the
+    /// control channel closes it (unlike the split, which is kept alive when hidden). The shell runs
+    /// `overlayCommand`; on its exit the surface's process-exit closes the overlay.
     @ObservationIgnored public var overlaySurface: (any TerminalSurface)?
 
-    /// The command the overlay runs as its process (e.g. `revdiff`); read by the overlay surface
-    /// factory at creation. `@ObservationIgnored`: read imperatively, not reactive.
+    /// The command the overlay runs as its process (e.g. `revdiff`), read by the overlay factory at creation.
     @ObservationIgnored public var overlayCommand: String?
 
-    /// The overlay's working directory, or nil to inherit `effectiveCwd`. Read by the factory at
-    /// creation. `@ObservationIgnored`.
+    /// The overlay's working directory, or nil to inherit `effectiveCwd`. Read by the factory at creation.
     @ObservationIgnored public var overlayCwd: String?
 
     /// The overlay's own solid background color as `#rrggbb`, or nil for the default theme background.
-    /// Independent of the session's `backgroundWatermark` — the overlay surface is not wired to the
-    /// session, so it carries its own color, set via `session.overlay.open --background-color`. Read by
-    /// the factory at creation; set at open, cleared on close. `@ObservationIgnored`, never persisted.
+    /// Independent of `backgroundWatermark` — the overlay surface is not wired to the session, so it carries
+    /// its own color, set via `session.overlay.open --background-color`. Read by the factory at creation; set
+    /// at open, cleared on close; never persisted.
     @ObservationIgnored public var overlayBackgroundColor: String?
 
-    /// Whether the overlay keeps its surface open after the command exits, showing libghostty's
-    /// "press any key to close" prompt (useful to read a command's final output) instead of closing
-    /// immediately. Read by the factory at creation. `@ObservationIgnored`.
+    /// Whether the overlay keeps its surface open after the command exits, showing libghostty's "press any
+    /// key to close" prompt (useful to read final output) instead of closing immediately. Read by the factory
+    /// at creation.
     @ObservationIgnored public var overlayWait: Bool = false
 
-    /// The overlay program's exit status, recorded on the surface's teardown from the wrapper's
-    /// `echo $?` temp file (NOT libghostty's child-exited status, which reflects the login-shell
-    /// wrapper and is always 0). Reset to nil when a new overlay opens; read by `session.overlay.result`.
-    /// In-memory only (absent from `snapshot()`), so it never persists.
+    /// The overlay program's exit status, recorded on the surface's teardown from the wrapper's `echo $?`
+    /// temp file (NOT libghostty's child-exited status, which reflects the login-shell wrapper and is always
+    /// 0). Reset to nil when a new overlay opens; read by `session.overlay.result`. In-memory only.
     @ObservationIgnored public var overlayExitCode: Int?
 
-    /// For a *floating* overlay, the percent of the pane (both width and height) the panel occupies,
-    /// 1...100; nil for the default full-pane overlay. A floating overlay renders as an opaque, framed
-    /// panel centered in the pane with the session still VISIBLE behind it (the full overlay instead
-    /// hides the session and draws translucent). Observed, so the detail pane picks the right layout.
-    /// Set at open, cleared on close; never persisted.
+    /// For a *floating* overlay, the percent of the pane (both width and height) the panel occupies, 1...100;
+    /// nil for the default full-pane overlay. A floating overlay is an opaque, framed panel centered in the
+    /// pane with the session still VISIBLE behind it (the full overlay instead hides the session and draws
+    /// translucent); the detail pane picks the layout from it. Set at open, cleared on close; never persisted.
     public var overlaySizePercent: Int?
 
-    /// Whether a FULL-coverage overlay is up: `overlayActive` with no size percent. A full overlay hides
-    /// the session content beneath it — the pane(s) AND a shown scratch — so its translucent background
-    /// reveals the window backing, never a covered surface (under window translucency every surface
-    /// renders a fully transparent background, so anything left visible below would bleed through).
-    /// A floating (sized) overlay is not a cover: it draws an opaque panel over still-visible content.
+    /// Whether a FULL-coverage overlay is up: `overlayActive` with no size percent. A full overlay hides the
+    /// session content beneath it — the pane(s) AND a shown scratch — so its translucent background reveals
+    /// the window backing, never a covered surface (under window translucency every surface renders a fully
+    /// transparent background, so anything left visible below would bleed through). A floating (sized)
+    /// overlay is not a cover: it draws an opaque panel over still-visible content.
     public var fullOverlayActive: Bool { overlayActive && overlaySizePercent == nil }
 
     /// Whether a FLOATING overlay is up: `overlayActive` WITH a size percent — the complement of
-    /// `fullOverlayActive`. A floating overlay draws an opaque, framed panel sized to `overlaySizePercent`%
-    /// over the still-visible session rather than covering it, so it is not a cover. Read by the detail
-    /// pane to gate the floating panel.
+    /// `fullOverlayActive`, and not a cover (see there). Read by the detail pane to gate the floating panel.
     public var floatingOverlayActive: Bool { overlayActive && overlaySizePercent != nil }
 
-    /// Whether the scratch terminal is shown on top of this session (full single-pane size, hiding
-    /// the single/split content underneath, like a full overlay). The scratch is a third per-session
-    /// shell that — unlike the ephemeral overlay — behaves like the split: hiding it keeps the shell
-    /// alive (`scratchSurface` retained), so a re-show reuses it. Observed, so the detail pane shows/
-    /// hides the scratch. NOT persisted (absent from `snapshot()`), so it never survives a relaunch.
+    /// Whether the scratch terminal is shown on top of this session (full single-pane size, hiding the
+    /// single/split content underneath, like a full overlay); the detail pane shows/hides it. The scratch is
+    /// a third per-session shell that — unlike the ephemeral overlay — behaves like the split: hiding it
+    /// keeps the shell alive (`scratchSurface` retained), so a re-show reuses it. NOT persisted.
     public var scratchActive: Bool = false
 
-    /// The scratch terminal's surface: a login shell (or `scratchCommand` when set), lazily created on
-    /// first show and kept alive across hides (`scratchSurface != nil` is "alive but hidden"). Freed only
-    /// on `closeScratch` (an explicit close, the shell's own `exit`, or session/workspace/window
-    /// teardown) — after which the next show spawns a fresh shell. `@ObservationIgnored` like `surface`.
+    /// The scratch terminal's surface: a login shell (or `scratchCommand` when set), lazily created on first
+    /// show and kept alive across hides (`scratchSurface != nil` is "alive but hidden"). Freed only on
+    /// `closeScratch` (an explicit close, the shell's own `exit`, or session/workspace/window teardown),
+    /// after which the next show spawns a fresh shell.
     @ObservationIgnored public var scratchSurface: (any TerminalSurface)?
 
-    /// A command to run as the scratch's process instead of a login shell (set via `session.scratch
-    /// --command`), the scratch analogue of `initialCommand`. RUN-ONCE: the scratch surface factory reads
-    /// it once when it spawns and clears it, so after the command exits the next show is a plain shell.
-    /// `@ObservationIgnored` + absent from `snapshot()`: transient like the scratch itself, never persisted.
+    /// A command to run as the scratch's process instead of a login shell (`session.scratch --command`), the
+    /// scratch analogue of `initialCommand`. RUN-ONCE: the scratch surface factory reads it once when it
+    /// spawns and clears it, so after the command exits the next show is a plain shell. Never persisted.
     @ObservationIgnored public var scratchCommand: String?
 
-    /// Whether the in-terminal search bar is shown over this session's focused pane (⌘F). Observed,
-    /// so the detail pane shows/hides the bar. Written directly (from the surface factory's search
-    /// callbacks + `AppActions`). NOT persisted (absent from `snapshot()`), so it never survives a relaunch.
+    /// Whether the in-terminal search bar is shown over this session's focused pane (⌘F); the detail pane
+    /// shows/hides the bar. Written directly (surface-factory search callbacks + `AppActions`). NOT persisted.
     public var searchActive: Bool = false
 
-    /// The current search query, mirrored from the bar's text field and the control channel. Observed
-    /// + written directly like `searchActive`. Ephemeral, never persisted.
+    /// The current search query, mirrored from the bar's text field and the control channel. Observed +
+    /// written directly like `searchActive`. Ephemeral, never persisted.
     public var searchNeedle: String = ""
 
-    /// The number of matches for `searchNeedle`, from libghostty's `SEARCH_TOTAL` action; nil before a
-    /// query runs. Observed + written directly. Ephemeral, never persisted.
+    /// The number of matches for `searchNeedle`, from libghostty's `SEARCH_TOTAL` action; nil before a query
+    /// runs. Observed + written directly. Ephemeral, never persisted.
     public var searchTotal: Int?
 
-    /// The 1-based index of the currently selected match, from libghostty's `SEARCH_SELECTED` action;
-    /// nil when none is selected. Observed + written directly. Ephemeral, never persisted.
+    /// The 1-based index of the currently selected match, from libghostty's `SEARCH_SELECTED` action; nil
+    /// when none is selected. Observed + written directly. Ephemeral, never persisted.
     public var searchSelected: Int?
 
     /// The surface that owns the open search bar — the focused searchable pane at the time search opened.
-    /// Pinned here so the bar's needle/navigate/close drive the SAME surface that opened search even if
-    /// split focus moves afterwards (otherwise re-resolving `activeSurface` would strand the original pane
-    /// in libghostty search mode). Set on open by the surface factory's START callback, cleared on close.
-    /// `@ObservationIgnored` + weak (the session strongly owns its panes); ephemeral, never persisted.
+    /// Pinned so the bar's needle/navigate/close drive the SAME surface even if split focus moves afterwards
+    /// (re-resolving `activeSurface` would strand the original pane in libghostty search mode). Set on open
+    /// by the factory's START callback, cleared on close. Weak (the session strongly owns its panes);
+    /// ephemeral.
     @ObservationIgnored public weak var searchSurface: (any TerminalSurface)?
 
     public init(id: UUID = UUID(), initialCwd: String, customName: String? = nil) {
@@ -285,19 +253,15 @@ public final class Session: Identifiable {
         self.customName = customName
     }
 
-    /// The sidebar label: a non-blank `customName` (a manual rename) wins; otherwise a non-blank
-    /// terminal title of the focused pane (`focusedOscTitle` — the split pane's while it's focused in
-    /// a split, else the primary's); otherwise the basename of the focused pane's cwd (`focusedCwd`,
-    /// falling back to `initialCwd`).
+    /// The sidebar label: a non-blank `customName` (a manual rename) wins; else the non-blank terminal title
+    /// of the focused pane (`focusedOscTitle`); else the basename of `focusedCwd`, falling back to `initialCwd`.
     ///
-    /// `customName` and the title are both trimmed before use, so a whitespace-only value falls
-    /// through to the next source — matching `AppStore.renameSession`, which clears a blank name to
-    /// nil. (A whitespace-only `customName` can only reach here via a hand-edited snapshot;
-    /// `renameSession` never stores one.)
+    /// `customName` and the title are both trimmed, so a whitespace-only value falls through to the next
+    /// source — matching `AppStore.renameSession`, which clears a blank name to nil, so a whitespace-only
+    /// `customName` can only arrive via a hand-edited snapshot.
     ///
-    /// Basename pins: root `/` → `/` (`lastPathComponent` already returns this);
-    /// a trailing slash is ignored (`/a/b/` → `b`); an empty path → `~` (no
-    /// sensible component exists, so we show the home shorthand).
+    /// Basename pins: root `/` → `/` (`lastPathComponent` already returns this); a trailing slash is ignored
+    /// (`/a/b/` → `b`); an empty path → `~`, the home shorthand, since no sensible component exists.
     public var displayName: String {
         if let trimmed = customName?.trimmedOrNil { return trimmed }
         if let title = focusedOscTitle?.trimmedOrNil { return title }
@@ -306,14 +270,13 @@ public final class Session: Identifiable {
         return (path as NSString).lastPathComponent
     }
 
-    /// The cwd of the pane currently in focus: the split (right) pane's while it has focus (whether
-    /// the split is shown side-by-side OR hidden and maximized), otherwise the primary's; falls back
-    /// to the primary cwd then `initialCwd`. The sidebar and title bar use this so they track whichever
-    /// pane has focus, while `effectiveCwd` (below) stays the primary's for seeding new panes and the
-    /// `AGTERM_SESSION_PWD` token. Guarded on `splitFocused && splitSurface != nil` — the same idiom as
-    /// `activeSurface`: the split fields describe the split pane only while it exists, so a promoted
-    /// survivor that momentarily re-raised `splitFocused` after moving into the main slot can't mask the
-    /// migrated main-pane cwd/title.
+    /// The cwd of the focused pane: the split (right) pane's while it has focus (split shown OR hidden and
+    /// maximized), else the primary's, falling back to the primary cwd then `initialCwd`. The sidebar and
+    /// title bar use it so they track the focused pane, while `effectiveCwd` stays the primary's for seeding
+    /// new panes and the `AGTERM_SESSION_PWD` token. Guarded on `splitFocused && splitSurface != nil` (the
+    /// `activeSurface` idiom) so a promoted survivor that momentarily re-raised `splitFocused` after moving
+    /// into the main slot cannot mask the migrated main-pane cwd/title — the split fields describe the split
+    /// pane only while it exists.
     public var focusedCwd: String {
         if splitFocused, splitSurface != nil, let cwd = splitCwd { return cwd }
         return currentCwd ?? initialCwd
@@ -324,53 +287,49 @@ public final class Session: Identifiable {
     private var focusedOscTitle: String? { splitFocused && splitSurface != nil ? splitTitle : oscTitle }
 
     /// The detail shown after the workspace name on the second line of the session palette, the Ctrl-Tab
-    /// switcher, and the title bar: the focused pane's terminal title when it isn't already the
-    /// `displayName` (so it ADDS context rather than repeating line 1), otherwise the focused cwd.
+    /// switcher, and the title bar: the focused pane's terminal title when it isn't already the `displayName`
+    /// (so it ADDS context rather than repeating line 1), else the focused cwd.
     ///
-    /// A remote (SSH) host sets the OSC title to its own `user@host:dir` while the local OSC 7 cwd report
-    /// stops once the shell hops out, so `currentCwd` freezes at the stale local path. Preferring the
-    /// title surfaces the remote location instead of that misleading local path. For an UNNAMED session
-    /// the title is already line 1 (`displayName` prefers it over the cwd), so this falls through to the
-    /// cwd — no duplication. For a plain local session the title is nil (local auto-title is suppressed),
-    /// so this is just the cwd, unchanged.
+    /// A remote (SSH) host sets the OSC title to its own `user@host:dir` while the local OSC 7 report stops
+    /// once the shell hops out, freezing `currentCwd` at a stale local path — so preferring the title
+    /// surfaces the remote location. An UNNAMED session already shows the title as line 1, so this falls
+    /// through to the cwd; a plain local session has no title (local auto-title is suppressed), so this is
+    /// just the cwd.
     public var subtitleDetail: String {
         if let title = focusedOscTitle?.trimmedOrNil, title != displayName { return title }
         return focusedCwd
     }
 
-    /// The session's effective working directory: the live `currentCwd` once a PWD report has
-    /// arrived, otherwise `initialCwd`. Always the PRIMARY pane's (NOT focus-aware) — it seeds a new
-    /// split/overlay/quick-terminal and backs the `AGTERM_SESSION_PWD` token, which should be stable
-    /// regardless of which pane is focused. The focus-aware variant is `focusedCwd`.
+    /// The session's effective working directory: the live `currentCwd` once a PWD report has arrived, else
+    /// `initialCwd`. Always the PRIMARY pane's, NOT focus-aware — it seeds a new split/overlay/quick terminal
+    /// and backs `AGTERM_SESSION_PWD`, which should be stable regardless of focus. See `focusedCwd`.
     public var effectiveCwd: String { currentCwd ?? initialCwd }
 
-    /// The surface of the pane currently in focus: the split (right) pane while it has focus and
-    /// exists, otherwise the primary. When the split is hidden the detail pane shows this one
-    /// maximized, and the focus helpers target it, so focus/typing always reaches the visible pane.
+    /// The surface of the pane currently in focus: the split (right) pane while it has focus and exists,
+    /// otherwise the primary. When the split is hidden the detail pane shows this one maximized and the focus
+    /// helpers target it, so focus/typing always reaches the visible pane.
     public var activeSurface: (any TerminalSurface)? {
         splitFocused && splitSurface != nil ? splitSurface : surface
     }
 
-    /// The session's one addressable pane for the control arms that act on "the session" rather than on a
-    /// named `--pane`: `session.copy`, `session.paste`, `session.selectall`, and `font.*`. Normally the main
-    /// pane, and IDENTICAL to `surface` for every ordinary or split session — including a promoted split
-    /// survivor, which `closePrimaryPane` moves INTO the main slot (`surface`) and whose `splitSurface` it
-    /// nils. The `?? splitSurface` term is a defensive fallback only: it keeps the arms answering (instead
-    /// of `session not realized`) should `surface` ever be nil while a split shell is still alive.
-    /// Deliberately NOT focus-aware (unlike `activeSurface`): a shown split keeps
-    /// addressing the main pane, which is what keeps `session.selectall` and its `session.copy` read-back
-    /// pointed at the same surface.
+    /// The session's one addressable pane for the control arms acting on "the session" rather than a named
+    /// `--pane` (`session.copy`, `session.paste`, `session.selectall`, `font.*`): IDENTICAL to `surface` for
+    /// every ordinary or split session, including a promoted split survivor, which `closePrimaryPane` moves
+    /// into `surface` while nilling `splitSurface`. `?? splitSurface` is a defensive fallback keeping the
+    /// arms answering (not `session not realized`) should `surface` ever be nil while a split shell lives.
+    /// Deliberately NOT focus-aware, unlike `activeSurface`: a shown split keeps addressing the main pane,
+    /// which keeps `session.selectall` and its `session.copy` read-back on one surface.
     public var addressableSurface: (any TerminalSurface)? { surface ?? splitSurface }
 
     /// Resolves a surface's stable spawn token (`TerminalSurface.paneToken`, baked as `AGTERM_PANE_ID` and
-    /// forwarded by the agent-status hook as `session.status --pane-id`) to the pane role of the slot it
-    /// CURRENTLY occupies — `.left` for the main slot, `.right` for the split, `.scratch` for the scratch.
-    /// Because the role is derived LIVE from slot occupancy, a promoted split survivor (moved into `surface`
-    /// by `closePrimaryPane`) resolves `.left` and a fresh re-split helper (in `splitSurface`) resolves
-    /// `.right`, even though BOTH shells were baked with the same stale `right` role — the #199 fix. Returns
-    /// nil for an empty or unknown token (a torn-down surface, or a shell spawned before the token existed),
-    /// so the caller falls back to the baked `--pane` value. This mirrors the live-role read the pane-scoped
-    /// keystroke-clear already does via `GhosttySurfaceView.isSplitPane` (see the Notifications rule).
+    /// forwarded by the agent-status hook as `session.status --pane-id`) to the role of the slot it CURRENTLY
+    /// occupies — `.left` main, `.right` split, `.scratch` scratch. Derived LIVE from slot occupancy, so a
+    /// promoted split survivor (moved into `surface` by `closePrimaryPane`) resolves `.left` while a fresh
+    /// re-split helper (in `splitSurface`) resolves `.right`, though BOTH shells were baked with the same
+    /// stale `right` role — the #199 fix. nil for an empty or unknown token (a torn-down surface, or a shell
+    /// spawned before the token existed), so the caller falls back to the baked `--pane`; mirrors the
+    /// live-role read the pane-scoped keystroke-clear does via `GhosttySurfaceView.isSplitPane` (see the
+    /// Notifications rule).
     public func paneRole(forToken token: String) -> StatusPane? {
         guard !token.isEmpty else { return nil }
         if surface?.paneToken == token { return .left }
@@ -379,12 +338,11 @@ public final class Session: Identifiable {
         return nil
     }
 
-    /// Takes the pane's PENDING restore-command override, clearing it so a second surface for the same
-    /// pane this launch gets a plain shell — `makeSplitSurface` runs again when a split shell exits and
-    /// the user opens a fresh ⌘D split, and a payload left in place would fire a second time mid-session.
-    /// The PERSISTED `restoreCommand`/`splitRestoreCommand` are neither read nor written here: the
-    /// override is sticky and must fire again after the next restart. `.scratch` always returns nil —
-    /// the scratch terminal is never restored.
+    /// Takes the pane's PENDING restore-command override, clearing it so a second surface for the same pane
+    /// this launch gets a plain shell — `makeSplitSurface` runs again when a split shell exits and the user
+    /// opens a fresh ⌘D split, and a payload left in place would fire a second time mid-session. The
+    /// PERSISTED `restoreCommand`/`splitRestoreCommand` are neither read nor written here: the override is
+    /// sticky and must fire again after the next restart. `.scratch` always returns nil — never restored.
     public func takePendingRestoreOverride(pane: StatusPane) -> String? {
         switch pane {
         case .left:
@@ -401,38 +359,37 @@ public final class Session: Identifiable {
     }
 
     /// Drops both unconsumed override payloads, leaving the persisted fields alone. Called where a live
-    /// `Session` object leaves the tree but may come back as the SAME object (the soft-close grace
-    /// window): a payload armed at bootstrap and never consumed would otherwise survive the round trip and
-    /// fire when the reinserted session's surface is finally built.
+    /// `Session` leaves the tree but may come back as the SAME object (the soft-close grace window): a
+    /// payload armed at bootstrap and never consumed would otherwise survive the round trip and fire when
+    /// the reinserted session's surface is finally built.
     public func clearPendingRestoreOverrides() {
         pendingRestoreCommand = nil
         pendingSplitRestoreCommand = nil
     }
 
-    /// The surface currently on top and owning keyboard focus: an active overlay (full OR floating), else
-    /// the scratch, else the active pane. The overlay renders above the scratch, and a full overlay or the
+    /// The surface currently on top and owning keyboard focus: an active overlay (full OR floating), else the
+    /// scratch, else the active pane. The overlay renders above the scratch, and a full overlay or the
     /// scratch hides the pane(s) beneath it — so the session-focus helpers route through this to keep first
-    /// responder on the top surface and never on a covered pane/scratch. (`TerminalView.focusIfNeeded` is
-    /// the exception: it targets its own deck slot, which a cover already gates off via `isActive`.)
+    /// responder off a covered pane/scratch. (`TerminalView.focusIfNeeded` is the exception: it targets its
+    /// own deck slot, which a cover already gates off via `isActive`.)
     public var topmostSurface: (any TerminalSurface)? {
         if overlayActive { return overlaySurface }
         if scratchActive { return scratchSurface }
         return activeSurface
     }
 
-    /// The pane-or-scratch surface that is actually ON SCREEN: the scratch terminal when it covers the
-    /// panes (and no overlay is up), else the focused pane. The control arms that act on "what's visible"
-    /// — `session.text` with no `--pane` and `session.search` — resolve through this so they hit the
-    /// scratch rather than a pane hidden beneath it (an active overlay routes to its own surface via
-    /// `topmostSurface`; this stays the pane-vs-scratch choice those arms share, matching `searchTarget`).
+    /// The pane-or-scratch surface actually ON SCREEN: the scratch when it covers the panes (and no overlay
+    /// is up), else the focused pane. `session.text` with no `--pane` and `session.search` resolve through
+    /// this so they hit the scratch rather than a pane hidden beneath it (an active overlay routes to its own
+    /// surface via `topmostSurface`; this stays the pane-vs-scratch choice, matching `searchTarget`).
     public var onScreenSurface: (any TerminalSurface)? {
         scratchActive && !overlayActive ? topmostSurface : activeSurface
     }
 
-    /// The match counter shown in the search bar and returned by `session.search`: empty before a
-    /// query runs (`searchTotal` nil), `"no matches"` at zero, `"N matches"` while none is selected,
-    /// and `"S of N"` once a match is selected. `selected` is clamped to `total` so a stale selected
-    /// index (the count shrank under it before the next SEARCH_SELECTED lands) never reads "3 of 2".
+    /// The match counter shown in the search bar and returned by `session.search`: empty before a query runs
+    /// (`searchTotal` nil), `"no matches"` at zero, `"N matches"` while none is selected, `"S of N"` once one
+    /// is. `selected` is clamped to `total` so a stale index (the count shrank under it before the next
+    /// SEARCH_SELECTED lands) never reads "3 of 2".
     public var searchDisplayText: String {
         guard let total = searchTotal else { return "" }
         guard total > 0 else { return "no matches" }
@@ -440,10 +397,10 @@ public final class Session: Identifiable {
         return "\(min(selected, total)) of \(total)"
     }
 
-    /// Resets all search state to its defaults: hides the bar, clears the needle/count/index, and nils
-    /// the pinned owner. Called from the pane-teardown/promote paths (`closeSplit`, `closePrimaryPane`,
-    /// `closeSplitPane`) so a session whose searched pane was destroyed or promoted doesn't keep a stuck,
-    /// no-op bar (the weak `searchSurface` zeroes but `searchActive` would otherwise stay true).
+    /// Resets all search state: hides the bar, clears the needle/count/index, nils the pinned owner. Called
+    /// from the pane-teardown/promote paths (`closeSplit`, `closePrimaryPane`, `closeSplitPane`) so a session
+    /// whose searched pane was destroyed or promoted doesn't keep a stuck, no-op bar (the weak
+    /// `searchSurface` zeroes but `searchActive` would otherwise stay true).
     public func clearSearch() {
         searchActive = false
         searchNeedle = ""
@@ -454,9 +411,8 @@ public final class Session: Identifiable {
 }
 
 extension String {
-    /// The string trimmed of leading/trailing whitespace and newlines, or nil if
-    /// the result is empty. The single normalizer for the rename/displayName
-    /// "blank after trim" rule.
+    /// The string trimmed of leading/trailing whitespace and newlines, or nil if the result is empty. The
+    /// single normalizer for the rename/displayName "blank after trim" rule.
     var trimmedOrNil: String? {
         let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed

--- a/agtermCore/Sources/agtermCore/SettingsStore.swift
+++ b/agtermCore/Sources/agtermCore/SettingsStore.swift
@@ -1,28 +1,24 @@
 import Foundation
 
-/// Reads and writes `AppSettings` as JSON on disk, in the same directory as the workspace
-/// snapshot (so the `AGTERM_STATE_DIR` test override applies). Mirrors `PersistenceStore`.
-///
-/// Recovery contract: a missing file or corrupt JSON resolves to the default settings with the
-/// app's default theme seeded (`AppSettings.defaultTheme`) — a fresh install opens on the agterm
-/// theme rather than ghostty's built-in. `load()` never throws to the caller. `save(_:)` writes
-/// atomically (temp file then replace).
+/// Reads and writes `AppSettings` as JSON in the same directory as the workspace snapshot, so the
+/// `AGTERM_STATE_DIR` test override applies. Mirrors `PersistenceStore`: `load()` never throws to the
+/// caller, `save(_:)` writes atomically (temp file then replace).
 public struct SettingsStore {
     private let directory: URL
     private let fileName = "settings.json"
 
     private var fileURL: URL { directory.appendingPathComponent(fileName) }
 
-    /// Creates a store rooted at `directory`, defaulting to the app's Application Support directory
-    /// (the same root `PersistenceStore` uses).
+    /// Creates a store rooted at `directory`, defaulting to the app's Application Support directory — the
+    /// same root `PersistenceStore` uses.
     public init(directory: URL = PersistenceStore.defaultDirectory) {
         self.directory = directory
     }
 
-    /// Loads the settings, recovering the seeded default on any failure (missing file, unreadable
-    /// data, corrupt JSON). The seeded default carries the app's default theme so a fresh install
-    /// applies it; an existing file is decoded as-is (an absent `theme` key stays nil = ghostty
-    /// built-in, so an existing user is never silently re-themed).
+    /// Loads the settings, recovering the seeded default on any failure (missing file, unreadable data,
+    /// corrupt JSON) so a fresh install opens on the agterm theme rather than ghostty's built-in. An
+    /// existing file decodes as-is — an absent `theme` key stays nil = ghostty built-in, so an existing
+    /// user is never silently re-themed.
     public func load() -> AppSettings {
         guard let data = try? Data(contentsOf: fileURL) else { return Self.seededDefault }
         guard let settings = try? JSONDecoder().decode(AppSettings.self, from: data) else { return Self.seededDefault }

--- a/agtermCore/Sources/agtermCore/ShellEscape.swift
+++ b/agtermCore/Sources/agtermCore/ShellEscape.swift
@@ -1,17 +1,15 @@
 import Foundation
 
-/// ShellEscape backslash-escapes a filesystem path (or URL) for insertion into a terminal as literal text,
-/// the drag-drop / paste path-insertion case: a dropped path with spaces or parentheses lands as ONE shell
-/// argument, while a plain path with no shell-significant characters is returned UNCHANGED (no surrounding
-/// quotes), keeping the common case clean for a CLI agent that reads the path out of its prompt.
-///
-/// This differs from `CommandRestore.shellQuote`, which always single-quote-wraps an argv element for shell
-/// re-execution; that is the right choice for re-running a captured command, but wrong here because it would
-/// wrap even a clean `/path/image.png` in quotes.
+/// ShellEscape backslash-escapes a filesystem path (or URL) for insertion into a terminal as literal text —
+/// the drag-drop / paste case: a dropped path with spaces or parentheses lands as ONE shell argument, while
+/// a path with no shell-significant characters comes back UNCHANGED and unquoted, keeping the common case
+/// clean for a CLI agent reading the path out of its prompt. Unlike `CommandRestore.shellQuote`, which
+/// always single-quote-wraps an argv element for shell re-execution — right for re-running a captured
+/// command, wrong here, since it would quote even a clean `/path/image.png`.
 public enum ShellEscape {
-    /// The shell-significant characters that get a backslash prefix. Backslash is FIRST so the pass that
-    /// escapes it does not double-escape the backslashes added for the rest. `\n`/`\r` are escaped so a
-    /// dropped filename with a newline can't inject a command via `inject(text:)` (bare newline → Return).
+    /// The shell-significant characters that get a backslash prefix. Backslash is FIRST so its own pass
+    /// doesn't double-escape the backslashes added for the rest. `\n`/`\r` are escaped so a dropped filename
+    /// with a newline can't inject a command via `inject(text:)`, where a bare newline is a Return.
     private static let significant: [Character] = Array("\\ ()[]{}<>\"'`!#$&;|*?\t\n\r")
 
     /// Backslash-escape every shell-significant character in `path`; a path with none is returned unchanged.

--- a/agtermCore/Sources/agtermCore/SidebarDrop.swift
+++ b/agtermCore/Sources/agtermCore/SidebarDrop.swift
@@ -1,22 +1,22 @@
 import Foundation
 
-/// SidebarDrop holds the pure index arithmetic for sidebar drag-and-drop reorder, so the trickiest
-/// part of the drop handling (post-removal off-by-one, drop-on-row redirect, cross-workspace vs
-/// same-parent index spaces, no-op detection) is host-free and table-testable. The AppKit/store glue
-/// (reading the pasteboard, resolving the dragged/target ids) stays in `WorkspaceSidebar.Coordinator`,
-/// which feeds resolved indices in and applies the returned destination via `AppStore`.
+/// SidebarDrop holds the pure index arithmetic for sidebar drag-and-drop reorder, so the trickiest part
+/// (post-removal off-by-one, drop-on-row redirect, cross-workspace vs same-parent index spaces, no-op
+/// detection) is host-free and table-testable. The AppKit/store glue — reading the pasteboard, resolving
+/// the dragged/target ids — stays in `WorkspaceSidebar.Coordinator`, which feeds resolved indices in and
+/// applies the returned destination via `AppStore`.
 public enum SidebarDrop {
     /// Mirrors AppKit's `NSOutlineViewDropOnItemIndex`: a drop landing ON a row rather than between rows.
     public static let onItemIndex = -1
     /// Prevents an accidental Finder multi-selection from spawning an unbounded number of shells.
     public static let maximumDirectoryImportCount = 20
 
-    /// Resolves the workspace for a Finder directory drop. Folder import is a tree-only affordance; a drop
-    /// ON a row lands in that row's workspace, and an EMPTY-SPACE drop takes `fallbackWorkspaceID` when the
-    /// caller can name an unambiguous one (`AppStore.soleFocusedWorkspaceID`: the sole marked workspace
-    /// while the focus filter applies — the only state where the tree renders exactly one workspace), else
-    /// the current workspace. With no marked set, the filter off, or two or more members there is no such
-    /// workspace, so the caller passes nil and the drop falls through to `currentWorkspaceID`.
+    /// Resolves the workspace for a Finder directory drop. Folder import is tree-only; a drop ON a row lands
+    /// in that row's workspace, and an EMPTY-SPACE drop takes `fallbackWorkspaceID` when the caller can name
+    /// an unambiguous one (`AppStore.soleFocusedWorkspaceID`: the sole marked workspace while the focus
+    /// filter applies — the only state where the tree renders exactly one workspace), else the current
+    /// workspace. With no marked set, the filter off, or two or more members the caller passes nil and the
+    /// drop falls through to `currentWorkspaceID`.
     public static func resolveDirectoryWorkspace(sidebarMode: SidebarMode, rowWorkspaceID: UUID?,
                                                  fallbackWorkspaceID: UUID?, currentWorkspaceID: UUID?) -> UUID? {
         guard sidebarMode == .tree else { return nil }
@@ -50,11 +50,11 @@ public enum SidebarDrop {
         case sessionRow(workspace: UUID, sessionIndex: Int, sessionCount: Int)
     }
 
-    /// Resolves a session drop into the move it would perform (target workspace + post-removal index),
-    /// or nil for a no-op. `childIndex` is AppKit's proposed child index (`onItemIndex` for a drop ON
-    /// the target). For a same-workspace DOWNWARD move the slot shifts up by one after the removal, so
-    /// 1 is subtracted; cross-workspace and upward moves pass through. A same-workspace move that lands
-    /// the session back in its current slot (including appending an already-last session) is a no-op.
+    /// Resolves a session drop into the move it would perform (target workspace + post-removal index), or
+    /// nil for a no-op. `childIndex` is AppKit's proposed child index (`onItemIndex` for a drop ON the
+    /// target). A same-workspace DOWNWARD move subtracts 1, since the slot shifts up after the removal;
+    /// cross-workspace and upward moves pass through. A same-workspace move landing the session back in its
+    /// current slot (including appending an already-last session) is a no-op.
     public static func resolveSession(sourceWorkspace: UUID, sourceIndex: Int,
                                       target: SessionDropTarget, childIndex: Int) -> SessionResolution? {
         let workspace: UUID
@@ -80,8 +80,8 @@ public enum SidebarDrop {
         }
 
         if sameWorkspace {
-            // moveSession removes the source first (shrinking the array to targetCount - 1), then clamps,
-            // so the landed slot is the clamped destination; equal to the source slot means no change.
+            // moveSession removes the source first (shrinking to targetCount - 1) then clamps, so the landed
+            // slot is the clamped destination; equal to the source slot means no change.
             let landed = max(0, min(destination, targetCount - 1))
             if landed == sourceIndex { return nil }
         }
@@ -124,11 +124,11 @@ public enum SidebarDrop {
         return SessionResolution(workspace: workspace, dropChildIndex: dropChildIndex, destination: destination)
     }
 
-    /// Resolves an anchor-relative session placement (control `--after`/`--before <sid>`) into the same
-    /// move `resolveSession` produces for a drag. `placeAfter` lands just after the anchor row (via
-    /// `onItemIndex`, which maps to `anchorIndex + 1`); otherwise it lands at the anchor's slot. Reuses
-    /// the drop math verbatim, so the post-removal off-by-one, cross-workspace index space, and
-    /// anchor==source no-op all fall out unchanged. Returns nil for a no-op.
+    /// Resolves an anchor-relative session placement (control `--after`/`--before <sid>`) into the same move
+    /// `resolveSession` produces for a drag: `placeAfter` lands just after the anchor row (via `onItemIndex`,
+    /// which maps to `anchorIndex + 1`), otherwise at the anchor's slot. Reuses the drop math verbatim, so
+    /// the post-removal off-by-one, cross-workspace index space and anchor==source no-op all fall out
+    /// unchanged. Returns nil for a no-op.
     public static func resolveRelative(source: (workspace: UUID, index: Int),
                                        anchor: (workspace: UUID, index: Int, count: Int),
                                        placeAfter: Bool) -> SessionResolution? {
@@ -149,17 +149,16 @@ public enum SidebarDrop {
 
     /// Maps a drop slot read off the RENDERED workspace rows onto the FULL workspace array's index space,
     /// which is what `resolveWorkspace`/`AppStore.moveWorkspace` work in. `visibleIndices` holds the
-    /// full-array indices of the workspace rows the sidebar actually renders, in order — under the focus
-    /// filter those are the marked set's, so they can be non-contiguous; `slot` is how many of those rows
-    /// have their midpoint above the cursor (0 = the cursor is above every rendered row).
+    /// full-array indices of the rows the sidebar renders, in order — under the focus filter the marked
+    /// set's, so possibly non-contiguous; `slot` is how many of those rows have their midpoint above the
+    /// cursor (0 = above every rendered row).
     ///
     /// A drop lands IMMEDIATELY ADJACENT to the visible row it was aimed at, never at a raw array index the
-    /// filter has no row for: above the first rendered row it takes that row's own index (landing just
-    /// before it), otherwise the index just after the last rendered row above the cursor. Anything else
-    /// would jump the dragged workspace across the hidden workspaces in between — invisible at drop time
-    /// and only revealed once the filter is switched off. With every workspace rendered
-    /// (`visibleIndices == Array(0..<count)`) it returns `slot` unchanged, so the unfiltered tree behaves
-    /// exactly as before. Returns 0 for an empty `visibleIndices` (nothing to drop against).
+    /// filter has no row for: above the first rendered row it takes that row's own index, otherwise the
+    /// index just after the last rendered row above the cursor. Anything else would jump the dragged
+    /// workspace across the hidden workspaces in between — invisible at drop time, revealed only once the
+    /// filter is switched off. With every workspace rendered (`visibleIndices == Array(0..<count)`) it
+    /// returns `slot` unchanged. Returns 0 for an empty `visibleIndices` (nothing to drop against).
     public static func workspaceInsertIndex(visibleIndices: [Int], slot: Int) -> Int {
         guard let firstVisible = visibleIndices.first else { return 0 }
         guard slot > 0 else { return firstVisible }

--- a/agtermCore/Sources/agtermCore/SkillInstall.swift
+++ b/agtermCore/Sources/agtermCore/SkillInstall.swift
@@ -9,8 +9,8 @@ public enum SkillInstall {
     public static let skillName = "agterm"
 
     /// A sentinel embedded in the bundled `SKILL.md` (an HTML comment, invisible when rendered) so a
-    /// reinstall can tell an agterm-authored skill from a same-named skill the user wrote themselves,
-    /// and refuse to clobber the latter.
+    /// reinstall can tell an agterm-authored skill from a user's own same-named one, and refuse to
+    /// clobber the latter.
     public static let marker = "<!-- agterm-skill -->"
 
     /// One install destination: which agent, and the `…/skills/agterm` directory to write.
@@ -29,10 +29,9 @@ public enum SkillInstall {
         home + "/" + base + "/skills/" + skillName
     }
 
-    /// The install targets given which agent base dirs exist. Install into each agent that is present
-    /// (Claude Code and/or Codex); if NEITHER is present, fall back to creating Claude Code's (the
-    /// primary), so the install is never a no-op. Caller supplies the existence flags (a filesystem
-    /// check), keeping this pure and testable.
+    /// The install targets given which agent base dirs exist: each agent that is present (Claude Code
+    /// and/or Codex), falling back to creating Claude Code's (the primary) when NEITHER is, so the install
+    /// is never a no-op. The caller supplies the existence flags (a filesystem check), keeping this pure.
     public static func installTargets(home: String, claudeExists: Bool, codexExists: Bool) -> [Target] {
         var targets: [Target] = []
         if claudeExists {
@@ -47,11 +46,10 @@ public enum SkillInstall {
         return targets
     }
 
-    /// Whether the installer may overwrite a destination. An absent directory is always safe to write
-    /// (nothing to clobber). When the directory already exists, it is overwritable only when its
-    /// `SKILL.md` carries `marker` (i.e. agterm put it there) — a present directory with an absent,
-    /// unreadable, or unmarked `SKILL.md` is treated as user-authored content and refused, so a user's
-    /// own skill named `agterm` is preserved rather than recursively wiped.
+    /// Whether the installer may overwrite a destination. An absent directory is always safe (nothing to
+    /// clobber). An existing one is overwritable only when its `SKILL.md` carries `marker` (agterm put it
+    /// there); an absent, unreadable, or unmarked `SKILL.md` counts as user-authored and is refused, so a
+    /// user's own skill named `agterm` is preserved rather than recursively wiped.
     public static func mayOverwrite(directoryExists: Bool, existingSKILL contents: String?) -> Bool {
         guard directoryExists else { return true }
         guard let contents else { return false }

--- a/agtermCore/Sources/agtermCore/Snapshot.swift
+++ b/agtermCore/Sources/agtermCore/Snapshot.swift
@@ -1,13 +1,12 @@
 import Foundation
 
-/// The persisted form of the whole app state: a plain value tree mirroring the `@MainActor` model but
-/// carrying no live `Session`/`Workspace` references. `Codable` for JSON, `Equatable` so tests can assert
-/// round-trips, `Sendable` because the snapshot is built on `@MainActor` and handed to the file writer as a
-/// value.
+/// The persisted form of the whole app state: a plain value tree mirroring the `@MainActor` model with no
+/// live `Session`/`Workspace` references. `Equatable` for round-trip tests, `Sendable` because it is built
+/// on `@MainActor` and handed to the file writer as a value.
 ///
-/// Every field after `workspaces` is Optional purely for forward-compat: a snapshot written before the
-/// field existed still decodes — instead of failing the load and wiping the saved tree — with the default
-/// each doc names. The same holds for the `WorkspaceSnapshot`/`SessionSnapshot` fields below.
+/// Every field after `workspaces` is Optional for forward-compat: a snapshot written before the field
+/// existed decodes with the default each doc names, instead of failing the load and wiping the saved tree.
+/// Same for the `WorkspaceSnapshot`/`SessionSnapshot` fields below.
 public struct Snapshot: Codable, Equatable, Sendable {
     /// Bumped when the on-disk shape changes; a mismatch makes the loader start fresh.
     public static let currentVersion = 1
@@ -23,8 +22,7 @@ public struct Snapshot: Codable, Equatable, Sendable {
     public var sidebarMode: SidebarMode?
     /// The workspaces marked in the sidebar focus set, in tree order; nil = nothing marked.
     public var focusedWorkspaceIDs: [UUID]?
-    /// Whether the focus filter applies to the marked set; nil = off. Persisted apart from the set so an
-    /// off filter keeps its members.
+    /// Whether the focus filter applies to the marked set; nil = off. Persisted apart so it keeps members.
     public var focusEnabled: Bool?
     /// Most-recently-selected session ids, front = current, so the Ctrl-Tab switcher's order survives a
     /// relaunch. Restore drops ids no longer in the tree; nil = selection only.
@@ -50,24 +48,20 @@ public struct Snapshot: Codable, Equatable, Sendable {
         case focusedWorkspaceIDs, focusEnabled, sessionRecency
     }
 
-    /// The LEGACY single-workspace focus key, written by releases before the focus SET existed. Its own key
-    /// type, read only by `init(from:)`, with no stored property — so re-encoding a migrated snapshot drops
-    /// it rather than writing the legacy key back on every load-mutate-save path, and no extra case in
-    /// `CodingKeys` blocks the synthesized `encode(to:)`.
+    /// The legacy single-workspace focus key from before the focus SET existed. Its own key type with no
+    /// stored property, so re-encoding a migrated snapshot drops it instead of writing the legacy key back
+    /// on every load-mutate-save path, and no extra `CodingKeys` case blocks the synthesized `encode(to:)`.
     private enum LegacyCodingKeys: String, CodingKey {
         case focusedWorkspaceID
     }
 
-    /// Custom decode so `sessionRecency` is LOSSY: a present-but-invalid list (a malformed UUID string or a
-    /// wrong JSON type after a hand edit) drops to nil instead of throwing. `Optional` alone tolerates only
-    /// a MISSING key, so one bad MRU entry would fail the whole `Snapshot` and `PersistenceStore.load`
-    /// would start fresh, wiping every workspace and session over a non-essential field. Mirrors
-    /// `SessionSnapshot`'s `backgroundWatermark` below; every other field keeps strict/`decodeIfPresent`.
+    /// Custom decode so `sessionRecency` is LOSSY: a present-but-invalid list (a malformed UUID, a wrong
+    /// JSON type after a hand edit) drops to nil. `Optional` alone tolerates only a MISSING key, so one bad
+    /// MRU entry would fail the whole `Snapshot` and `PersistenceStore.load` would start fresh, wiping every
+    /// workspace and session over a non-essential field. Mirrors `backgroundWatermark` below; others strict.
     ///
-    /// Also where the LEGACY `focusedWorkspaceID` migrates: a file written before the focus set existed
-    /// carries only that single id, which becomes a one-member ENABLED set (the old field meant "focused on
-    /// this workspace", so its presence implied the filter was on). Neither key present decodes to nil/nil,
-    /// which restore reads as an empty, disabled filter. The legacy value is a LOCAL, not a stored property.
+    /// Also migrates the legacy `focusedWorkspaceID`: its presence implied the filter was on, so it becomes
+    /// a one-member ENABLED set. Neither key present decodes to nil/nil — an empty, disabled filter.
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         version = try c.decode(Int.self, forKey: .version)
@@ -95,9 +89,8 @@ public struct WorkspaceSnapshot: Codable, Equatable, Sendable {
     public var id: UUID
     public var name: String
     public var sessions: [SessionSnapshot]
-    /// Whether the sidebar row was collapsed — stored as the INVERSE of `isExpanded` so missing → nil →
-    /// expanded, the default. Only a collapsed workspace writes it (`true`); an expanded one omits it, so
-    /// an all-expanded tree serializes byte-identically to a legacy snapshot.
+    /// The INVERSE of `isExpanded`, so missing → expanded (the default) and only a collapsed workspace
+    /// writes it — an all-expanded tree serializes byte-identically to a legacy snapshot.
     public var collapsed: Bool?
 
     public init(id: UUID, name: String, sessions: [SessionSnapshot], collapsed: Bool? = nil) {
@@ -119,38 +112,31 @@ public struct SessionSnapshot: Codable, Equatable, Sendable {
     public var isSplit: Bool?
     /// The terminal font size in points; nil = the ghostty config default.
     public var fontSize: Double?
-    /// The split (right) pane's working directory, so each pane restores to its OWN cwd rather than both
-    /// re-spawning in the primary's. The live `splitCwd`, or its restore seed before the split reports a
-    /// PWD; nil when there is no split.
+    /// The split (right) pane's working directory, so each pane restores to its OWN cwd. The live
+    /// `splitCwd`, or its restore seed before the split reports a PWD; nil when there is no split.
     public var splitCwd: String?
-    /// The split divider's left-pane fraction, so the side-by-side ratio restores. Within
-    /// `AppStore.splitRatioMin...splitRatioMax` (~0.05...0.95): the live capture skips degenerate extremes
-    /// and restore clamps to the same bounds. nil restores the even default.
+    /// The split divider's left-pane fraction. Within `AppStore.splitRatioMin...splitRatioMax`
+    /// (~0.05...0.95) — capture skips degenerate extremes, restore clamps; nil restores the even default.
     public var splitRatio: Double?
     /// Whether the session is in the flagged working-set; nil = not flagged.
     public var flagged: Bool?
     /// The main pane's foreground command (full argv) at the last clean quit, re-run on restore when
-    /// `AppSettings.restoreRunningCommand` is on. nil when the pane was at its shell prompt (nothing to
-    /// restore) or the feature was off.
+    /// `AppSettings.restoreRunningCommand` is on. nil at a shell prompt, or with the feature off.
     public var foregroundCommand: [String]?
     /// The split (right) pane's foreground command (full argv), the split analogue of `foregroundCommand`.
     public var splitForegroundCommand: [String]?
-    /// The command the session was created with (`session.new --command`), which exec-replaces the login
-    /// shell and so is invisible to libghostty's foreground pid — persisted so a command session (e.g. an
-    /// `ssh …` shortcut) re-runs it on restore instead of coming back a plain shell. A live
-    /// `foregroundCommand` takes precedence at restore.
+    /// The command the session was created with (`session.new --command`); it exec-replaces the login shell
+    /// and so is invisible to libghostty's foreground pid, hence persisted separately so a command session
+    /// re-runs it on restore instead of coming back a plain shell. A live `foregroundCommand` wins.
     public var initialCommand: String?
-    /// Whether a `--command` session holds its surface after the command exits (`session.new --command …
-    /// --wait`), so a restored command session holds again instead of vanishing, keeping held/closed
-    /// behavior consistent across restart. nil (missing key) decodes as false.
+    /// Whether a `--command` session holds its surface after the command exits (`--wait`), so a restored
+    /// command session holds again instead of vanishing. nil (missing key) decodes as false.
     public var commandWait: Bool?
-    /// The session's background watermark (image or rasterized text); nil = none. A `.text` watermark
-    /// re-renders its PNG on restore.
+    /// The session's background watermark (image or rasterized text); nil = none. `.text` re-renders its PNG.
     public var backgroundWatermark: BackgroundWatermark?
     /// The main pane's restore-command override (`session.restore`), winning over `foregroundCommand` and
-    /// `initialCommand` on the next launch. Tri-state: nil = no override, `""` = pinned to nothing (a plain
-    /// shell), a command = run that shell line. Sticky — unlike `foregroundCommand` it is not consumed on
-    /// restore, so it fires again after every restart.
+    /// `initialCommand` on the next launch. Tri-state: nil = no override, `""` = a plain shell, a command =
+    /// that shell line. Sticky — unlike `foregroundCommand` it is not consumed, so it fires every restart.
     public var restoreCommand: String?
     /// The split (right) pane's restore-command override, the split analogue of `restoreCommand`.
     public var splitRestoreCommand: String?
@@ -184,12 +170,10 @@ public struct SessionSnapshot: Codable, Equatable, Sendable {
         case restoreCommand, splitRestoreCommand
     }
 
-    /// Custom decode so `backgroundWatermark` is LOSSY: a present-but-invalid spec (an unknown
-    /// `kind`/`fit`/`position` — a DOWNGRADE after a newer release added a value this build can't decode,
-    /// or a hand-edit typo) drops to nil instead of throwing `DataCorrupted`. `Optional` alone tolerates
-    /// only a MISSING key, so one bad watermark would fail the whole `SessionSnapshot` and
-    /// `PersistenceStore.load` would start fresh, wiping every workspace and session. Every other field
-    /// keeps `decodeIfPresent`, the missing-key-tolerant forward-compat the field docs describe.
+    /// Custom decode so `backgroundWatermark` is LOSSY: an unknown `kind`/`fit`/`position` — a DOWNGRADE
+    /// after a newer release added a value this build can't decode, or a hand-edit typo — drops to nil
+    /// instead of throwing `DataCorrupted`, which would fail the whole `SessionSnapshot` and make
+    /// `PersistenceStore.load` start fresh, wiping everything. Others keep missing-key `decodeIfPresent`.
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         id = try c.decode(UUID.self, forKey: .id)

--- a/agtermCore/Sources/agtermCore/Snapshot.swift
+++ b/agtermCore/Sources/agtermCore/Snapshot.swift
@@ -1,11 +1,13 @@
 import Foundation
 
-/// The persisted form of the whole app state: a plain value tree that mirrors the
-/// `@MainActor` model but carries no live `Session`/`Workspace` references.
+/// The persisted form of the whole app state: a plain value tree mirroring the `@MainActor` model but
+/// carrying no live `Session`/`Workspace` references. `Codable` for JSON, `Equatable` so tests can assert
+/// round-trips, `Sendable` because the snapshot is built on `@MainActor` and handed to the file writer as a
+/// value.
 ///
-/// `Codable` for JSON, `Equatable` so tests can assert round-trips, `Sendable` so
-/// it can cross the actor boundary — the snapshot is built on `@MainActor` and
-/// handed to the file writer as a value.
+/// Every field after `workspaces` is Optional purely for forward-compat: a snapshot written before the
+/// field existed still decodes — instead of failing the load and wiping the saved tree — with the default
+/// each doc names. The same holds for the `WorkspaceSnapshot`/`SessionSnapshot` fields below.
 public struct Snapshot: Codable, Equatable, Sendable {
     /// Bumped when the on-disk shape changes; a mismatch makes the loader start fresh.
     public static let currentVersion = 1
@@ -13,25 +15,19 @@ public struct Snapshot: Codable, Equatable, Sendable {
     public var version: Int
     public var selectedSessionID: UUID?
     public var workspaces: [WorkspaceSnapshot]
-    /// The window's sidebar width in points, or nil for the default. Optional so a snapshot already on
-    /// disk before this field was added still decodes, like the SessionSnapshot fields below.
+    /// The window's sidebar width in points; nil = the default.
     public var sidebarWidth: Double?
-    /// Whether the window's sidebar is shown, or nil for the default (shown). Optional for forward-compat.
+    /// Whether the window's sidebar is shown; nil = the default (shown).
     public var sidebarVisible: Bool?
-    /// Which view the sidebar renders (tree or flagged flat list), or nil for the default (`.tree`).
-    /// Optional so a snapshot already on disk before this field was added still decodes instead of
-    /// failing the load and wiping the saved tree, like the fields above.
+    /// Which view the sidebar renders (tree or flagged flat list); nil = `.tree`.
     public var sidebarMode: SidebarMode?
-    /// The workspaces marked in the sidebar focus set, in tree order, or nil for none. Optional so a
-    /// snapshot already on disk before this field was added still decodes (as nil → nothing marked)
-    /// instead of failing the load and wiping the saved tree, like the fields above.
+    /// The workspaces marked in the sidebar focus set, in tree order; nil = nothing marked.
     public var focusedWorkspaceIDs: [UUID]?
-    /// Whether the focus filter applies to the marked set, or nil for the default (off). Persisted apart
-    /// from the set so an off filter keeps its members. Optional for forward-compat like the fields above.
+    /// Whether the focus filter applies to the marked set; nil = off. Persisted apart from the set so an
+    /// off filter keeps its members.
     public var focusEnabled: Bool?
-    /// Most-recently-selected session ids, front = current, so the Ctrl-Tab switcher's order survives
-    /// a relaunch. Restore drops ids no longer in the tree. Optional so a snapshot already on disk
-    /// before this field was added still decodes (as nil → selection only), like the fields above.
+    /// Most-recently-selected session ids, front = current, so the Ctrl-Tab switcher's order survives a
+    /// relaunch. Restore drops ids no longer in the tree; nil = selection only.
     public var sessionRecency: [UUID]?
 
     public init(version: Int = Snapshot.currentVersion, selectedSessionID: UUID? = nil,
@@ -54,27 +50,24 @@ public struct Snapshot: Codable, Equatable, Sendable {
         case focusedWorkspaceIDs, focusEnabled, sessionRecency
     }
 
-    /// The LEGACY single-workspace focus key, written by releases before the focus SET existed. It lives
-    /// in its OWN key type, read only by `init(from:)`: it has no stored property (so re-encoding a
-    /// migrated snapshot drops it, instead of writing the legacy key back on every load-mutate-save path),
-    /// and an extra case in `CodingKeys` above would block the synthesized `encode(to:)` outright.
+    /// The LEGACY single-workspace focus key, written by releases before the focus SET existed. Its own key
+    /// type, read only by `init(from:)`, with no stored property — so re-encoding a migrated snapshot drops
+    /// it rather than writing the legacy key back on every load-mutate-save path, and no extra case in
+    /// `CodingKeys` blocks the synthesized `encode(to:)`.
     private enum LegacyCodingKeys: String, CodingKey {
         case focusedWorkspaceID
     }
 
-    /// Custom decode so `sessionRecency` is LOSSY: a present-but-invalid list (a malformed UUID
-    /// string or a wrong JSON type after a hand edit) drops to nil instead of throwing. Without
-    /// this, `Optional` tolerates only a MISSING key, so one bad MRU entry would fail the entire
-    /// `Snapshot` and `PersistenceStore.load` would start fresh — wiping every workspace and
-    /// session over a non-essential field. Mirrors `SessionSnapshot`'s `backgroundWatermark`
-    /// handling below; every other field keeps its strict/`decodeIfPresent` behavior.
+    /// Custom decode so `sessionRecency` is LOSSY: a present-but-invalid list (a malformed UUID string or a
+    /// wrong JSON type after a hand edit) drops to nil instead of throwing. `Optional` alone tolerates only
+    /// a MISSING key, so one bad MRU entry would fail the whole `Snapshot` and `PersistenceStore.load`
+    /// would start fresh, wiping every workspace and session over a non-essential field. Mirrors
+    /// `SessionSnapshot`'s `backgroundWatermark` below; every other field keeps strict/`decodeIfPresent`.
     ///
-    /// It is also where the LEGACY `focusedWorkspaceID` migrates: a file written before the focus set
-    /// existed carries only that single id, which becomes a one-member ENABLED set (the old field meant
-    /// "focused on this workspace", so its presence implied the filter was on). A file carrying neither
-    /// key decodes to nil/nil, which restore reads as an empty, disabled filter. The legacy value is a
-    /// LOCAL here rather than a stored property, so re-encoding a migrated snapshot drops the key instead
-    /// of writing it back alongside the new ones.
+    /// Also where the LEGACY `focusedWorkspaceID` migrates: a file written before the focus set existed
+    /// carries only that single id, which becomes a one-member ENABLED set (the old field meant "focused on
+    /// this workspace", so its presence implied the filter was on). Neither key present decodes to nil/nil,
+    /// which restore reads as an empty, disabled filter. The legacy value is a LOCAL, not a stored property.
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         version = try c.decode(Int.self, forKey: .version)
@@ -102,11 +95,9 @@ public struct WorkspaceSnapshot: Codable, Equatable, Sendable {
     public var id: UUID
     public var name: String
     public var sessions: [SessionSnapshot]
-    /// Whether the sidebar row was collapsed. Optional AND stored as the inverse of `isExpanded` so a
-    /// snapshot already on disk before this field was added still decodes (missing → nil → not collapsed
-    /// → expanded, the default) instead of failing the load and wiping the saved tree, like the fields on
-    /// `SessionSnapshot`. Only a collapsed workspace writes it (`true`); an expanded one omits it, so an
-    /// all-expanded tree serializes byte-identically to a legacy snapshot.
+    /// Whether the sidebar row was collapsed — stored as the INVERSE of `isExpanded` so missing → nil →
+    /// expanded, the default. Only a collapsed workspace writes it (`true`); an expanded one omits it, so
+    /// an all-expanded tree serializes byte-identically to a legacy snapshot.
     public var collapsed: Bool?
 
     public init(id: UUID, name: String, sessions: [SessionSnapshot], collapsed: Bool? = nil) {
@@ -117,61 +108,49 @@ public struct WorkspaceSnapshot: Codable, Equatable, Sendable {
     }
 }
 
-/// One persisted session: its identity, optional custom name, and the working
-/// directory to re-spawn a fresh shell in. `cwd` is the live `currentCwd`, or the
-/// `initialCwd` when no PWD report has arrived yet.
+/// One persisted session: its identity, optional custom name, and the working directory to re-spawn a
+/// fresh shell in. `cwd` is the live `currentCwd`, or the `initialCwd` before any PWD report.
 public struct SessionSnapshot: Codable, Equatable, Sendable {
     public var id: UUID
     public var customName: String?
     public var cwd: String
-    /// Whether the session was shown as a vertical split. Optional so a snapshot already
-    /// on disk before this field was added still decodes (as nil → not split) instead of
-    /// failing the load and wiping the saved tree. On restore the split pane re-spawns a
-    /// fresh shell, like the primary.
+    /// Whether the session was shown as a vertical split; nil = not split. On restore the split pane
+    /// re-spawns a fresh shell, like the primary.
     public var isSplit: Bool?
-    /// The terminal font size in points, or nil to use the ghostty config default. Optional
-    /// so a snapshot already on disk before this field was added still decodes (as nil →
-    /// default) instead of failing the load and wiping the saved tree.
+    /// The terminal font size in points; nil = the ghostty config default.
     public var fontSize: Double?
-    /// The split (right) pane's working directory, so each pane restores to its OWN cwd rather than
-    /// both re-spawning in the primary's. The live `splitCwd`, or its restore seed when the split
-    /// hasn't reported a PWD yet; nil when there is no split. Optional for forward-compat like the
-    /// fields above.
+    /// The split (right) pane's working directory, so each pane restores to its OWN cwd rather than both
+    /// re-spawning in the primary's. The live `splitCwd`, or its restore seed before the split reports a
+    /// PWD; nil when there is no split.
     public var splitCwd: String?
     /// The split divider's left-pane fraction, so the side-by-side ratio restores. Within
     /// `AppStore.splitRatioMin...splitRatioMax` (~0.05...0.95): the live capture skips degenerate extremes
-    /// and restore clamps to the same bounds. Optional for forward-compat; nil restores the even default.
+    /// and restore clamps to the same bounds. nil restores the even default.
     public var splitRatio: Double?
-    /// Whether the session is in the flagged working-set. Optional so a snapshot already on disk before
-    /// this field was added still decodes (as nil → not flagged) instead of failing the load and wiping
-    /// the saved tree, like the fields above.
+    /// Whether the session is in the flagged working-set; nil = not flagged.
     public var flagged: Bool?
     /// The main pane's foreground command (full argv) at the last clean quit, re-run on restore when
     /// `AppSettings.restoreRunningCommand` is on. nil when the pane was at its shell prompt (nothing to
-    /// restore) or the feature was off. Optional for forward-compat like the fields above.
+    /// restore) or the feature was off.
     public var foregroundCommand: [String]?
     /// The split (right) pane's foreground command (full argv), the split analogue of `foregroundCommand`.
     public var splitForegroundCommand: [String]?
     /// The command the session was created with (`session.new --command`), which exec-replaces the login
-    /// shell and so is invisible to libghostty's foreground pid — persisted here so a command session
-    /// (e.g. an `ssh …` shortcut) re-runs its command on restore instead of coming back a plain shell. A
-    /// live `foregroundCommand` takes precedence at restore. Optional for forward-compat like the fields above.
+    /// shell and so is invisible to libghostty's foreground pid — persisted so a command session (e.g. an
+    /// `ssh …` shortcut) re-runs it on restore instead of coming back a plain shell. A live
+    /// `foregroundCommand` takes precedence at restore.
     public var initialCommand: String?
     /// Whether a `--command` session holds its surface after the command exits (`session.new --command …
-    /// --wait`), so a restored command session that re-runs its command holds again instead of vanishing —
-    /// keeping the held/closed behavior consistent across restart. nil (missing key) decodes as false.
-    /// Optional for forward-compat like the fields above.
+    /// --wait`), so a restored command session holds again instead of vanishing, keeping held/closed
+    /// behavior consistent across restart. nil (missing key) decodes as false.
     public var commandWait: Bool?
-    /// The session's background watermark (image or rasterized text), or nil for none. Optional so a
-    /// snapshot already on disk before this field was added still decodes (as nil → no watermark) instead
-    /// of failing the load and wiping the saved tree, like the fields above. A `.text` watermark
+    /// The session's background watermark (image or rasterized text); nil = none. A `.text` watermark
     /// re-renders its PNG on restore.
     public var backgroundWatermark: BackgroundWatermark?
-    /// The main pane's restore-command override (`session.restore`), which wins over `foregroundCommand`
-    /// and `initialCommand` on the next launch. Tri-state: nil = no override, `""` = pinned to nothing (a
-    /// plain shell), a command = run that shell line. Sticky — unlike `foregroundCommand` it is not
-    /// consumed on restore, so it fires again after every restart. Optional for forward-compat like the
-    /// fields above.
+    /// The main pane's restore-command override (`session.restore`), winning over `foregroundCommand` and
+    /// `initialCommand` on the next launch. Tri-state: nil = no override, `""` = pinned to nothing (a plain
+    /// shell), a command = run that shell line. Sticky — unlike `foregroundCommand` it is not consumed on
+    /// restore, so it fires again after every restart.
     public var restoreCommand: String?
     /// The split (right) pane's restore-command override, the split analogue of `restoreCommand`.
     public var splitRestoreCommand: String?
@@ -206,11 +185,11 @@ public struct SessionSnapshot: Codable, Equatable, Sendable {
     }
 
     /// Custom decode so `backgroundWatermark` is LOSSY: a present-but-invalid spec (an unknown
-    /// `kind`/`fit`/`position` — e.g. a DOWNGRADE after a newer release added a value the older build
-    /// can't decode, or a hand-edit typo) drops to nil instead of throwing `DataCorrupted`. Without this,
-    /// `Optional` tolerates only a MISSING key, so one bad watermark would fail the entire `SessionSnapshot`
-    /// and `PersistenceStore.load` would start fresh — wiping every workspace and session. Every other
-    /// field keeps `decodeIfPresent` (missing-key tolerant, the forward-compat the field docs describe).
+    /// `kind`/`fit`/`position` — a DOWNGRADE after a newer release added a value this build can't decode,
+    /// or a hand-edit typo) drops to nil instead of throwing `DataCorrupted`. `Optional` alone tolerates
+    /// only a MISSING key, so one bad watermark would fail the whole `SessionSnapshot` and
+    /// `PersistenceStore.load` would start fresh, wiping every workspace and session. Every other field
+    /// keeps `decodeIfPresent`, the missing-key-tolerant forward-compat the field docs describe.
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         id = try c.decode(UUID.self, forKey: .id)

--- a/agtermCore/Sources/agtermCore/SoundThrottle.swift
+++ b/agtermCore/Sources/agtermCore/SoundThrottle.swift
@@ -1,8 +1,7 @@
 /// SoundThrottle suppresses a replay of the SAME sound within a short window, so a burst of rapid
-/// `session.status --sound` calls (or repeated `blocked` transitions) can't machine-gun an identical
-/// clip. It tracks the last play time per sound name; a DIFFERENT sound is never suppressed. Host-free
-/// and clock-injected (the caller passes a monotonic `now`) so the window decision is unit-testable
-/// without real time.
+/// `session.status --sound` calls (or repeated `blocked` transitions) can't machine-gun one clip. It tracks
+/// the last play time per sound name; a DIFFERENT sound is never suppressed. Host-free and clock-injected (a
+/// monotonic `now` from the caller), so the window decision is unit-testable without real time.
 public struct SoundThrottle: Sendable {
     /// Minimum gap before the same sound name may play again.
     private let window: Duration
@@ -10,10 +9,10 @@ public struct SoundThrottle: Sendable {
 
     public init(window: Duration) { self.window = window }
 
-    /// Whether `name` may play at `now`, recording the play when it may. Returns false WITHOUT changing
-    /// state for a same-sound replay still inside `window` (so the window is always measured from the last
-    /// ALLOWED play, not the last attempt); otherwise records `now` and returns true — including the first
-    /// play of a name and any play at or past the window boundary.
+    /// Whether `name` may play at `now`, recording the play when it may. False WITHOUT changing state for a
+    /// same-sound replay still inside `window`, so the window is measured from the last ALLOWED play, not
+    /// the last attempt; otherwise records `now` and returns true, including a name's first play and any
+    /// play at or past the window boundary.
     public mutating func allow(_ name: String, at now: ContinuousClock.Instant) -> Bool {
         if let last = lastPlayed[name], now - last < window { return false }
         lastPlayed[name] = now

--- a/agtermCore/Sources/agtermCore/SurfaceEnvironment.swift
+++ b/agtermCore/Sources/agtermCore/SurfaceEnvironment.swift
@@ -3,12 +3,12 @@ import Foundation
 /// Pure builders for the agterm identity and `AGTERM_*` values injected into spawned shells.
 /// The platform surface owns shell creation; this keeps the variable set testable.
 public enum SurfaceEnvironment {
-    /// Environment for a session-owned surface: main pane, split pane, overlay, or scratch.
-    /// `pane`, when non-nil, adds `AGTERM_PANE` so the hook wrapper can forward `--pane` and a status
-    /// set from a background pane records which surface blocked; overlay surfaces pass nil (nil→main).
-    /// `paneToken`, when non-empty, adds `AGTERM_PANE_ID` — the surface's STABLE spawn identity (see
-    /// `TerminalSurface.paneToken`), which the hook forwards as `--pane-id` so the status handler resolves
-    /// the surface's LIVE role instead of the stale baked `AGTERM_PANE` after a promote + re-split (#199).
+    /// Environment for a session-owned surface: main pane, split pane, overlay, or scratch. `pane`, when
+    /// non-nil, adds `AGTERM_PANE` so the hook wrapper can forward `--pane` and a status set from a
+    /// background pane records which surface blocked; overlay surfaces pass nil (nil→main). `paneToken`,
+    /// when non-empty, adds `AGTERM_PANE_ID` — the surface's STABLE spawn identity
+    /// (`TerminalSurface.paneToken`), which the hook forwards as `--pane-id` so the status handler resolves
+    /// the LIVE role instead of the stale baked `AGTERM_PANE` after a promote + re-split (#199).
     public static func session(sessionID: UUID, windowID: UUID?, workspaceID: UUID?,
                                socketPath: String, programVersion: String,
                                pane: StatusPane? = nil, paneToken: String? = nil) -> [String: String] {
@@ -43,8 +43,8 @@ public enum SurfaceEnvironment {
     }
 
     private static func terminalIdentity(programVersion: String) -> [String: String] {
-        // Embedded libghostty defaults these to Ghostty, then reapplies the surface env as overrides.
-        // Identify the actual host so Ghostty-aware shell tools do not invoke a standalone Ghostty.app.
+        // embedded libghostty defaults these to Ghostty, then reapplies the surface env as overrides.
+        // identify the actual host so Ghostty-aware shell tools do not invoke a standalone Ghostty.app.
         [
             "TERM_PROGRAM": "agterm",
             "TERM_PROGRAM_VERSION": programVersion,

--- a/agtermCore/Sources/agtermCore/TerminalSurface.swift
+++ b/agtermCore/Sources/agtermCore/TerminalSurface.swift
@@ -1,49 +1,45 @@
 import Foundation
 
-/// The app-side terminal surface (a libghostty-backed NSView) seen by the
-/// host-free model. Kept minimal so `agtermCore` stays free of GhosttyKit/AppKit:
-/// the concrete `GhosttySurfaceView` in the app target conforms to it.
+/// The app-side terminal surface (a libghostty-backed NSView) seen by the host-free model. Kept minimal so
+/// `agtermCore` stays free of GhosttyKit/AppKit; the app target's `GhosttySurfaceView` conforms to it.
 ///
-/// `@MainActor`-isolated: the only owner is the `@MainActor` `Session`, and the
-/// concrete conformer is a `@MainActor` `NSView`, so isolation lines up without
-/// crossing actor boundaries.
+/// `@MainActor`-isolated: the only owner is the `@MainActor` `Session` and the concrete conformer is a
+/// `@MainActor` `NSView`, so isolation lines up without crossing actor boundaries.
 @MainActor
 public protocol TerminalSurface: AnyObject {
-    /// Frees the underlying libghostty surface and shell. Called when the
-    /// owning session is closed.
+    /// Frees the underlying libghostty surface and shell. Called when the owning session is closed.
     func teardown()
 
-    /// Reassigns this surface from the split (right) pane role to the primary pane, so its live
-    /// pwd/title reports flow to the session's main fields (`currentCwd`/`oscTitle`) instead of the
-    /// split fields (`splitCwd`/`splitTitle`). Called by `closePrimaryPane` when the primary pane's
-    /// shell exits and the surviving split pane is promoted to the session's sole pane. A hard
-    /// requirement (no default) like `teardown()`: a conformer that routes pwd/title by role MUST
-    /// reassign here, so a future surface fails to compile rather than silently mis-reporting.
+    /// Reassigns this surface from the split (right) pane role to the primary, so its live pwd/title reports
+    /// flow to the session's main fields (`currentCwd`/`oscTitle`) not the split ones
+    /// (`splitCwd`/`splitTitle`). Called by `closePrimaryPane` when the primary pane's shell exits and the
+    /// surviving split pane becomes the session's sole pane. A hard requirement (no default) like
+    /// `teardown()`: a conformer routing pwd/title by role MUST reassign here, so a future surface fails to
+    /// compile rather than silently mis-reporting.
     func promoteToPrimaryPane()
 
-    /// A stable per-surface identity assigned when the surface spawns, distinct from the pane ROLE
-    /// (`left|right|scratch`), which is NOT stable: a promoted split survivor keeps its baked `right`
-    /// role but moves into the main slot. Baked into the shell's env as `AGTERM_PANE_ID` and forwarded by
-    /// the agent-status hook as `session.status --pane-id`, it lets `Session.paneRole(forToken:)` resolve
-    /// the surface's CURRENT slot rather than trusting the stale baked role — the fix for a status set from
-    /// a promoted-then-re-split pane (#199). Empty for a surface spawned without a pane identity (overlay /
-    /// quick terminal, or a test stub), which `paneRole(forToken:)` never matches.
+    /// A stable per-surface identity assigned at spawn, distinct from the pane ROLE (`left|right|scratch`),
+    /// which is NOT stable: a promoted split survivor keeps its baked `right` role while moving into the main
+    /// slot. Baked into the shell env as `AGTERM_PANE_ID` and forwarded by the agent-status hook as
+    /// `session.status --pane-id`, it lets `Session.paneRole(forToken:)` resolve the CURRENT slot instead of
+    /// the stale baked role — the fix for a status set from a promoted-then-re-split pane (#199). Empty for a
+    /// surface spawned with no pane identity (overlay / quick terminal, or a test stub), which
+    /// `paneRole(forToken:)` never matches.
     var paneToken: String { get }
 }
 
-/// The direction the search selection steps, in agterm's natural convention:
-/// `next` = forward = visually DOWN the screen (toward newer output), `previous` = back = visually UP
-/// (toward older scrollback). Host-free so the inversion to libghostty's own `navigate_search` strings is
-/// unit-testable without GhosttyKit.
+/// The direction the search selection steps, in agterm's natural convention: `next` = forward = visually DOWN
+/// the screen (toward newer output), `previous` = back = visually UP (toward older scrollback). Host-free so
+/// the inversion to libghostty's own `navigate_search` strings is unit-testable without GhosttyKit.
 public enum SearchDirection: String, Sendable {
     case next
     case previous
 
-    /// The libghostty `navigate_search:<dir>` argument for this direction. libghostty's own `next` walks
-    /// matches newest→oldest (visually UP) and its `previous` walks oldest→newest (visually DOWN), the
-    /// OPPOSITE of agterm's convention — so agterm's `.next` (down) maps to `previous` and `.previous`
-    /// (up) maps to `next`. Centralizing the inversion here keeps the DOWN chevron / Enter / `--next`
-    /// moving visually down and the UP chevron / Shift-Enter / `--prev` moving visually up.
+    /// The libghostty `navigate_search:<dir>` argument for this direction. libghostty's `next` walks matches
+    /// newest→oldest (visually UP) and its `previous` oldest→newest (visually DOWN), the OPPOSITE of agterm's
+    /// convention, so `.next` (down) maps to `previous` and `.previous` (up) to `next`. Centralizing the
+    /// inversion keeps the DOWN chevron / Enter / `--next` moving down and the UP chevron / Shift-Enter /
+    /// `--prev` moving up.
     public var ghosttyAction: String {
         switch self {
         case .next: return "navigate_search:previous"

--- a/agtermCore/Sources/agtermCore/TerminalText.swift
+++ b/agtermCore/Sources/agtermCore/TerminalText.swift
@@ -1,21 +1,21 @@
 import Foundation
 
-/// TerminalText sanitizes strings a terminal program reports over OSC sequences — the window title
-/// (OSC 0/1/2) and the working directory (OSC 7) — before agterm stores them on a `Session`. Those
-/// values are attacker-influenceable (a remote SSH host or any program's output sets them) and flow,
-/// unquoted, into a `/bin/sh -c` line via the `{AGT_SESSION_NAME}`/`{AGT_SESSION_PWD}` custom-command
-/// tokens, so a control character — a newline above all, which `sh -c` reads as a command separator —
-/// must never survive into the stored value. A title or a directory path never legitimately contains
-/// a control character, so stripping the whole C0 range is lossless for real input.
+/// TerminalText sanitizes strings a terminal program reports over OSC sequences — the window title (OSC
+/// 0/1/2) and the working directory (OSC 7) — before agterm stores them on a `Session`. Those values are
+/// attacker-influenceable (a remote SSH host or any program's output sets them) and flow unquoted into a
+/// `/bin/sh -c` line via the `{AGT_SESSION_NAME}`/`{AGT_SESSION_PWD}` custom-command tokens, so a control
+/// character — above all a newline, which `sh -c` reads as a command separator — must never survive into
+/// the stored value. A title or directory path never legitimately contains one, so stripping the whole C0
+/// range is lossless for real input.
 ///
-/// This does NOT make raw `{AGT_X}` interpolation safe against visible shell metacharacters (`;`,
-/// `$()`, backticks); those are legitimate in titles/paths and are the caller's concern via the
-/// shell-quoted `$AGT_X` environment form. This closes only the invisible control-character vector.
+/// This closes only the invisible control-character vector: raw `{AGT_X}` interpolation stays unsafe
+/// against visible shell metacharacters (`;`, `$()`, backticks), which are legitimate in titles/paths and
+/// are the caller's concern via the shell-quoted `$AGT_X` environment form.
 public enum TerminalText {
-    /// Strip the C0 control range (U+0000–U+001F, including tab/newline/carriage-return) and DEL
-    /// (U+007F) from an OSC-reported title or working directory; every other scalar is preserved.
-    /// The common case (no control characters, which is every real title/path) returns the input
-    /// unchanged with no allocation, since these callbacks run on every OSC redraw.
+    /// Strip the C0 control range (U+0000–U+001F, including tab/newline/carriage-return) and DEL (U+007F)
+    /// from an OSC-reported title or working directory; every other scalar is preserved. The common case
+    /// (no control characters, i.e. every real title/path) returns the input unchanged with no allocation,
+    /// since these callbacks run on every OSC redraw.
     public static func sanitized(_ value: String) -> String {
         guard value.unicodeScalars.contains(where: { $0.value < 0x20 || $0.value == 0x7F })
         else { return value }

--- a/agtermCore/Sources/agtermCore/ThemeName.swift
+++ b/agtermCore/Sources/agtermCore/ThemeName.swift
@@ -1,10 +1,8 @@
 import Foundation
 
-/// Reduces a ghostty `theme` value to the theme name active for the current appearance.
-///
-/// The `light:…,dark:…` form must collapse to one name before agterm's by-hand `selection-*` lookup:
-/// the raw form matches no theme file, so the selected sidebar row falls back to an unreadable wash.
-/// Host-free so it is unit-tested.
+/// Reduces a ghostty `theme` value to the name active for the current appearance. The `light:…,dark:…`
+/// form must collapse to one name before agterm's by-hand `selection-*` lookup: the raw form matches no
+/// theme file, so the selected sidebar row falls back to an unreadable wash. Host-free, so unit-tested.
 public enum ThemeName {
     /// The theme name for `value` under the appearance. Only a well-formed `light:…,dark:…` (both sides
     /// present) resolves to a variant; a plain or malformed value is returned as-is.
@@ -20,7 +18,6 @@ public enum ThemeName {
                 dark = name
             }
         }
-        // The split form needs both sides; one-sided or malformed is a plain name.
         guard let light, let dark else { return trimmed }
         return isDark ? dark : light
     }

--- a/agtermCore/Sources/agtermCore/WatermarkConfig.swift
+++ b/agtermCore/Sources/agtermCore/WatermarkConfig.swift
@@ -11,10 +11,9 @@ public enum WatermarkConfig {
     /// The libghostty `background-image-position` values, derived from `BackgroundWatermark.Position`.
     public static var validPositions: [String] { BackgroundWatermark.Position.allCases.map(\.rawValue) }
 
-    /// Upper bound on watermark text length accepted at the control boundary. `WatermarkRenderer`
-    /// rasterizes the string at a fixed 256pt font with a bitmap sized to the glyph run, so the canvas
-    /// width grows linearly with character count — an uncapped string would drive a multi-GB allocation.
-    /// A watermark is a word or two; 256 is far beyond any real use and keeps the bitmap small.
+    /// Upper bound on watermark text at the control boundary. `WatermarkRenderer` rasterizes at a fixed
+    /// 256pt font with a bitmap sized to the glyph run, so canvas width grows linearly with character count
+    /// and an uncapped string would drive a multi-GB allocation; 256 is far beyond a word-or-two watermark.
     public static let maxTextLength = 256
 
     public static func isValidFit(_ fit: String) -> Bool { BackgroundWatermark.Fit(rawValue: fit) != nil }
@@ -31,12 +30,11 @@ public enum WatermarkConfig {
         !text.isEmpty && text.count <= maxTextLength
     }
 
-    /// Valid `#rrggbb` hex color — exactly what `NSColor(agtermHex:)` parses (an optional leading `#` then
-    /// six hex digits). A malformed value is rejected at the boundary rather than silently falling back to
-    /// the terminal foreground, matching the fit/position rejection. The digit check is ASCII-only
-    /// (`isASCII && isHexDigit`): plain `isHexDigit` also accepts fullwidth Unicode forms (e.g. `ＦＦ００００`)
-    /// that `NSColor(agtermHex:)`'s `UInt32(radix:)` cannot parse, which would pass validation and then
-    /// silently render the default color.
+    /// Valid `#rrggbb` hex color — exactly what `NSColor(agtermHex:)` parses (optional leading `#`, six hex
+    /// digits). Malformed is rejected at the boundary rather than silently falling back to the terminal
+    /// foreground, like fit/position. The digit check is ASCII-only: plain `isHexDigit` also accepts
+    /// fullwidth forms (e.g. `ＦＦ００００`) that `NSColor(agtermHex:)`'s `UInt32(radix:)` cannot parse, which
+    /// would pass validation and then silently render the default color.
     public static func isValidColorHex(_ hex: String) -> Bool {
         var s = Substring(hex)
         if s.first == "#" { s = s.dropFirst() }
@@ -44,12 +42,12 @@ public enum WatermarkConfig {
     }
 
     /// Valid `.image` watermark path: no ASCII control character (any scalar `< 0x20`). `imagePath` is the
-    /// ONLY free-text field that reaches a ghostty config line, and it is emitted RAW/unquoted as
-    /// `background-image = <path>` (`overlayText`) — so an embedded newline would split the value and let
-    /// the line's tail inject an arbitrary ghostty key (e.g. `clipboard-read = allow`) into the per-surface
-    /// overlay, which wins on that surface. The owner-only socket + the `fileExists` gate keep it well short
-    /// of RCE, but the spec is persisted and re-applied on restore from semi-trusted (agent) input, so the
-    /// injection vector is closed at the boundary. Shared by the control server and the CLI `validate()`.
+    /// ONLY free-text field reaching a ghostty config line, emitted RAW/unquoted as `background-image =
+    /// <path>` (`overlayText`), so an embedded newline would split the value and let the tail inject an
+    /// arbitrary ghostty key (e.g. `clipboard-read = allow`) into the per-surface overlay, which wins there.
+    /// Well short of RCE (owner-only socket, `fileExists` gate), but the spec is persisted and re-applied on
+    /// restore from semi-trusted agent input, so the vector is closed at the boundary. Shared by the control
+    /// server and the CLI `validate()`.
     public static func isValidImagePath(_ path: String) -> Bool {
         !path.unicodeScalars.contains { $0.value < 0x20 }
     }
@@ -57,29 +55,28 @@ public enum WatermarkConfig {
     /// The per-surface ghostty config overlay (loaded LAST, so it wins) for `watermark` pointed at
     /// `resolvedImagePath` (the user's file for `.image`, the rendered PNG for `.text`, nil for `.color`):
     ///
-    /// - for `.color`: a `background = <hex>` line plus `background-opacity = <windowOpacity>` so the color
-    ///   honors the window translucency the user set in Settings (the base config pins the global
-    ///   `background-opacity` to 0 under translucency, which would otherwise make the color invisible;
-    ///   `windowOpacity` = 1 when translucency is off = a solid color) — no image keys, and the window
-    ///   blur is composited at the AppKit level, so it shows through a translucent color unchanged;
-    /// - for `.image`/`.text`: the `background-image*` lines, plus `background-opacity = 1` so the image is
-    ///   visible even when window translucency pins the global `background-opacity` to 0 (image opacity is
-    ///   RELATIVE to it, so `0 × anything = 0` = invisible) — the user-chosen "auto-raise" behavior;
-    /// - a `font-size` line preserving the session's cmd-+/- zoom (a per-surface `update_config` otherwise
-    ///   resets font size to the config default).
+    /// - `.color`: `background = <hex>` plus `background-opacity = <windowOpacity>`, so the color honors the
+    ///   Settings window translucency — the base config pins the global `background-opacity` to 0 under
+    ///   translucency, which would make the color invisible (`windowOpacity` = 1 when off = solid). No image
+    ///   keys; the window blur composites at the AppKit level and shows through a translucent color unchanged.
+    /// - `.image`/`.text`: the `background-image*` lines plus `background-opacity = 1`, the user-chosen
+    ///   "auto-raise", so the image stays visible when translucency pins the global value to 0 (image
+    ///   opacity is RELATIVE to it: `0 × anything = 0`).
+    /// - a `font-size` line preserving the session's cmd-+/- zoom, which a per-surface `update_config`
+    ///   otherwise resets to the config default.
     ///
-    /// A nil `watermark` (or an `.image`/`.text` whose `resolvedImagePath` is missing) yields ONLY the
-    /// font-size line — clearing the image while keeping zoom; a `.color` still emits its `background`
-    /// lines (it needs no `resolvedImagePath`). Returns "" when there is nothing to override (no watermark, no zoom).
-    /// Values are emitted RAW (no quotes): ghostty takes the whole line remainder as the value, so a path
-    /// with spaces works unquoted — matching `AppSettings.ghosttyConfigLines()`.
+    /// A nil `watermark` (or an `.image`/`.text` with no `resolvedImagePath`) yields ONLY the font-size line,
+    /// clearing the image while keeping zoom; a `.color` still emits its `background` lines, needing no path.
+    /// Returns "" when there is nothing to override (no watermark, no zoom). Values are emitted RAW (no
+    /// quotes): ghostty takes the whole line remainder as the value, so a path with spaces works unquoted —
+    /// matching `AppSettings.ghosttyConfigLines()`.
     public static func overlayText(watermark: BackgroundWatermark?, resolvedImagePath: String?,
                                    fontSize: Double?, windowOpacity: Double = 1) -> String {
         var lines: [String] = []
-        // re-validate the free-text fields on EMIT, not just at the control boundary: `AppStore.restore`
-        // assigns a persisted spec raw, so a hand-edited `workspaces.json` could carry a control-char path
-        // or a malformed color that would inject a ghostty key here. A poisoned value drops the background
-        // entirely (font-size still emitted). `fit`/`position` are typed enums, so they can't inject.
+        // re-validate free text on EMIT, not just at the control boundary: `AppStore.restore` assigns a
+        // persisted spec raw, so a hand-edited `workspaces.json` could carry a control-char path or a
+        // malformed color. A poisoned value drops the background entirely (font-size still emitted);
+        // `fit`/`position` are typed enums, so they can't inject.
         if let watermark, watermark.kind == .color, let hex = watermark.colorHex, isValidColorHex(hex) {
             let opacity = windowOpacity.isFinite ? min(max(windowOpacity, 0), 1) : 1
             lines.append("background = \(hex)")
@@ -96,18 +93,16 @@ public enum WatermarkConfig {
         return lines.isEmpty ? "" : lines.joined(separator: "\n") + "\n"
     }
 
-    /// The per-surface ghostty config overlay that makes a program's LIVE OSC 11 background visible: a
+    /// The per-surface overlay that makes a program's LIVE OSC 11 background visible: a
     /// `background-opacity = <windowOpacity>` line plus the usual `font-size` zoom preservation.
     ///
-    /// It deliberately carries NO `background` key, which is what separates it from the `.color` overlay
-    /// above. libghostty holds the OSC color in the terminal's dynamic `override` layer and the renderer
-    /// already draws `override orelse default`, so the color needs no restating — only the opacity, which
-    /// the base config pins to 0 under window translucency (leaving the OSC tint invisible).
-    ///
-    /// Writing the color into `background` instead would reach ghostty's `Termio.changeConfig`, which
-    /// seeds the terminal's `default` color layer from the config on every surface update. Since OSC 111
-    /// resets the override TO that default, restating the OSC color here makes the reset a no-op and
-    /// strands the pane on the program's color after it exits.
+    /// It deliberately carries NO `background` key, unlike the `.color` overlay above. libghostty holds the
+    /// OSC color in the terminal's dynamic `override` layer and the renderer draws `override orelse
+    /// default`, so only the opacity needs restating — the base config pins it to 0 under window
+    /// translucency, leaving the OSC tint invisible. Writing the color into `background` would reach
+    /// ghostty's `Termio.changeConfig`, which seeds the `default` color layer from the config on every
+    /// surface update; since OSC 111 resets the override TO that default, the reset would become a no-op
+    /// and strand the pane on the program's color after it exits.
     public static func oscBackgroundOverlayText(fontSize: Double?, windowOpacity: Double) -> String {
         let opacity = windowOpacity.isFinite ? min(max(windowOpacity, 0), 1) : 1
         var lines = ["background-opacity = \(formatted(opacity))"]
@@ -115,15 +110,14 @@ public enum WatermarkConfig {
         return lines.joined(separator: "\n") + "\n"
     }
 
-    /// Format a `Double` for a ghostty config value: an integral value without a trailing `.0`
-    /// (`14.0` → `14`), else the minimal decimal (`0.15` → `0.15`). Locale-independent (always `.`):
-    /// `String(format:)` uses the C locale. Uses fixed-point, NOT `String(Double)`, because the latter
-    /// emits scientific notation for tiny magnitudes (`0.00001` → `1e-05`) which ghostty's config parser
-    /// rejects — it would silently drop the line and fall back to the default opacity.
+    /// Format a `Double` for a ghostty config value: integral without a trailing `.0` (`14.0` → `14`), else
+    /// the minimal decimal (`0.15` → `0.15`). Locale-independent (always `.`) — `String(format:)` uses the C
+    /// locale. Fixed-point, NOT `String(Double)`, which emits scientific notation for tiny magnitudes
+    /// (`0.00001` → `1e-05`) that ghostty's config parser rejects, silently dropping the line back to the
+    /// default opacity.
     static func formatted(_ value: Double) -> String {
-        // guard the integral fast-path against non-finite / out-of-Int-range values: `Int(value)` TRAPS on
-        // .infinity or |value| ≥ ~9.2e18. Those never arise from a validated opacity or a live font size,
-        // but `fontSize` is read straight from a (possibly hand-edited) snapshot, so stay total.
+        // `Int(value)` TRAPS on .infinity or |value| ≥ ~9.2e18, so guard the integral fast-path: a validated
+        // opacity or live font size never gets there, but `fontSize` comes from a hand-editable snapshot.
         if value == value.rounded(), value.isFinite, abs(value) < Double(Int.max) { return String(Int(value)) }
         var s = String(format: "%.6f", value)
         while s.hasSuffix("0") { s.removeLast() }

--- a/agtermCore/Sources/agtermCore/WatermarkConfig.swift
+++ b/agtermCore/Sources/agtermCore/WatermarkConfig.swift
@@ -1,26 +1,23 @@
 import Foundation
 
-/// Host-free helpers that turn a `BackgroundWatermark` into the ghostty config-overlay TEXT applied to
-/// one surface, plus the `fit`/`position` enum validation shared by the CLI and the control server. No
-/// AppKit: the `.text` rasterization lives in the app target; this only formats the `background-image*`
-/// lines once a PNG path is known.
+/// Host-free: formats a `BackgroundWatermark` into one surface's ghostty config-overlay text, plus the
+/// `fit`/`position` validation the CLI and control server share. No AppKit — `.text` rasterization lives in
+/// the app target, so this only emits the `background-image*` lines once a PNG path is known.
 public enum WatermarkConfig {
-    /// The libghostty `background-image-fit` values, derived from the `BackgroundWatermark.Fit` enum
-    /// (single source of truth) — used for the CLI/server error messages.
+    /// The libghostty `background-image-fit` values, from `BackgroundWatermark.Fit`, for error messages.
     public static var validFits: [String] { BackgroundWatermark.Fit.allCases.map(\.rawValue) }
-    /// The libghostty `background-image-position` values, derived from `BackgroundWatermark.Position`.
+    /// The libghostty `background-image-position` values, from `BackgroundWatermark.Position`.
     public static var validPositions: [String] { BackgroundWatermark.Position.allCases.map(\.rawValue) }
 
-    /// Upper bound on watermark text at the control boundary. `WatermarkRenderer` rasterizes at a fixed
-    /// 256pt font with a bitmap sized to the glyph run, so canvas width grows linearly with character count
-    /// and an uncapped string would drive a multi-GB allocation; 256 is far beyond a word-or-two watermark.
+    /// Upper bound on watermark text at the control boundary: `WatermarkRenderer` rasterizes at a fixed
+    /// 256pt font into a bitmap sized to the glyph run, so an uncapped string would allocate multiple GB.
     public static let maxTextLength = 256
 
     public static func isValidFit(_ fit: String) -> Bool { BackgroundWatermark.Fit(rawValue: fit) != nil }
     public static func isValidPosition(_ position: String) -> Bool { BackgroundWatermark.Position(rawValue: position) != nil }
 
-    /// Valid `background-image-opacity`: a finite value in `0...1` (the documented range). Rejects NaN/Inf
-    /// (which `formatted` would otherwise emit as `nan`/`inf` into the config) and out-of-range values.
+    /// Valid `background-image-opacity`: finite and within `0...1`. NaN/Inf would otherwise reach the
+    /// config as `nan`/`inf` via `formatted`.
     public static func isValidOpacity(_ opacity: Double) -> Bool {
         opacity.isFinite && opacity >= 0 && opacity <= 1
     }
@@ -30,24 +27,21 @@ public enum WatermarkConfig {
         !text.isEmpty && text.count <= maxTextLength
     }
 
-    /// Valid `#rrggbb` hex color — exactly what `NSColor(agtermHex:)` parses (optional leading `#`, six hex
-    /// digits). Malformed is rejected at the boundary rather than silently falling back to the terminal
-    /// foreground, like fit/position. The digit check is ASCII-only: plain `isHexDigit` also accepts
-    /// fullwidth forms (e.g. `ＦＦ００００`) that `NSColor(agtermHex:)`'s `UInt32(radix:)` cannot parse, which
-    /// would pass validation and then silently render the default color.
+    /// Valid `#rrggbb` hex — exactly `NSColor(agtermHex:)`'s grammar (optional leading `#`, six hex digits);
+    /// malformed is rejected here, not silently fallen back to the terminal foreground. ASCII-only: bare
+    /// `isHexDigit` accepts fullwidth forms (`ＦＦ００００`) that `UInt32(radix:)` cannot parse and would then
+    /// render the default color.
     public static func isValidColorHex(_ hex: String) -> Bool {
         var s = Substring(hex)
         if s.first == "#" { s = s.dropFirst() }
         return s.count == 6 && s.allSatisfy { $0.isASCII && $0.isHexDigit }
     }
 
-    /// Valid `.image` watermark path: no ASCII control character (any scalar `< 0x20`). `imagePath` is the
-    /// ONLY free-text field reaching a ghostty config line, emitted RAW/unquoted as `background-image =
-    /// <path>` (`overlayText`), so an embedded newline would split the value and let the tail inject an
-    /// arbitrary ghostty key (e.g. `clipboard-read = allow`) into the per-surface overlay, which wins there.
-    /// Well short of RCE (owner-only socket, `fileExists` gate), but the spec is persisted and re-applied on
-    /// restore from semi-trusted agent input, so the vector is closed at the boundary. Shared by the control
-    /// server and the CLI `validate()`.
+    /// Valid `.image` watermark path: no ASCII control character (scalar `< 0x20`). The ONLY free-text field
+    /// reaching a ghostty config line, emitted RAW/unquoted, so an embedded newline splits the value and lets
+    /// the tail inject an arbitrary ghostty key (`clipboard-read = allow`) into the per-surface overlay, which
+    /// wins there. Short of RCE (owner-only socket, `fileExists` gate), but the spec is persisted and
+    /// re-applied on restore from semi-trusted agent input. Shared by the server and CLI `validate()`.
     public static func isValidImagePath(_ path: String) -> Bool {
         !path.unicodeScalars.contains { $0.value < 0x20 }
     }
@@ -55,28 +49,24 @@ public enum WatermarkConfig {
     /// The per-surface ghostty config overlay (loaded LAST, so it wins) for `watermark` pointed at
     /// `resolvedImagePath` (the user's file for `.image`, the rendered PNG for `.text`, nil for `.color`):
     ///
-    /// - `.color`: `background = <hex>` plus `background-opacity = <windowOpacity>`, so the color honors the
-    ///   Settings window translucency — the base config pins the global `background-opacity` to 0 under
-    ///   translucency, which would make the color invisible (`windowOpacity` = 1 when off = solid). No image
-    ///   keys; the window blur composites at the AppKit level and shows through a translucent color unchanged.
-    /// - `.image`/`.text`: the `background-image*` lines plus `background-opacity = 1`, the user-chosen
-    ///   "auto-raise", so the image stays visible when translucency pins the global value to 0 (image
-    ///   opacity is RELATIVE to it: `0 × anything = 0`).
+    /// - `.color`: `background = <hex>` plus `background-opacity = <windowOpacity>` (1 when translucency is
+    ///   off) — the base config pins the global opacity to 0 under translucency, hiding the color. No image
+    ///   keys; the window blur composites in AppKit and shows through unchanged.
+    /// - `.image`/`.text`: the `background-image*` lines plus `background-opacity = 1` (the user-chosen
+    ///   "auto-raise"), since image opacity is RELATIVE to it (`0 × anything = 0`).
     /// - a `font-size` line preserving the session's cmd-+/- zoom, which a per-surface `update_config`
     ///   otherwise resets to the config default.
     ///
-    /// A nil `watermark` (or an `.image`/`.text` with no `resolvedImagePath`) yields ONLY the font-size line,
-    /// clearing the image while keeping zoom; a `.color` still emits its `background` lines, needing no path.
-    /// Returns "" when there is nothing to override (no watermark, no zoom). Values are emitted RAW (no
-    /// quotes): ghostty takes the whole line remainder as the value, so a path with spaces works unquoted —
-    /// matching `AppSettings.ghosttyConfigLines()`.
+    /// A nil `watermark` (or `.image`/`.text` with no `resolvedImagePath`) yields ONLY the font-size line,
+    /// clearing the image while keeping zoom; `.color` needs no path. Returns "" with nothing to override.
+    /// Values are emitted RAW: ghostty takes the whole line remainder as the value, so a path with spaces
+    /// works unquoted, matching `AppSettings.ghosttyConfigLines()`.
     public static func overlayText(watermark: BackgroundWatermark?, resolvedImagePath: String?,
                                    fontSize: Double?, windowOpacity: Double = 1) -> String {
         var lines: [String] = []
-        // re-validate free text on EMIT, not just at the control boundary: `AppStore.restore` assigns a
-        // persisted spec raw, so a hand-edited `workspaces.json` could carry a control-char path or a
-        // malformed color. A poisoned value drops the background entirely (font-size still emitted);
-        // `fit`/`position` are typed enums, so they can't inject.
+        // re-validate free text on EMIT: `AppStore.restore` assigns a persisted spec raw, so a hand-edited
+        // `workspaces.json` could carry a control-char path or a malformed color. a poisoned value drops the
+        // background entirely, font-size still emitted; `fit`/`position` are typed enums and can't inject.
         if let watermark, watermark.kind == .color, let hex = watermark.colorHex, isValidColorHex(hex) {
             let opacity = windowOpacity.isFinite ? min(max(windowOpacity, 0), 1) : 1
             lines.append("background = \(hex)")
@@ -96,13 +86,12 @@ public enum WatermarkConfig {
     /// The per-surface overlay that makes a program's LIVE OSC 11 background visible: a
     /// `background-opacity = <windowOpacity>` line plus the usual `font-size` zoom preservation.
     ///
-    /// It deliberately carries NO `background` key, unlike the `.color` overlay above. libghostty holds the
-    /// OSC color in the terminal's dynamic `override` layer and the renderer draws `override orelse
-    /// default`, so only the opacity needs restating — the base config pins it to 0 under window
-    /// translucency, leaving the OSC tint invisible. Writing the color into `background` would reach
-    /// ghostty's `Termio.changeConfig`, which seeds the `default` color layer from the config on every
-    /// surface update; since OSC 111 resets the override TO that default, the reset would become a no-op
-    /// and strand the pane on the program's color after it exits.
+    /// NO `background` key, unlike the `.color` overlay above: libghostty holds the OSC color in the
+    /// terminal's dynamic `override` layer and draws `override orelse default`, so only the opacity needs
+    /// restating (the base config pins it to 0 under translucency, hiding the tint). Writing the color into
+    /// `background` would reach `Termio.changeConfig`, which reseeds the `default` layer from the config on
+    /// every surface update; OSC 111 resets the override TO that default, so the reset would no-op and
+    /// strand the pane on the program's color after it exits.
     public static func oscBackgroundOverlayText(fontSize: Double?, windowOpacity: Double) -> String {
         let opacity = windowOpacity.isFinite ? min(max(windowOpacity, 0), 1) : 1
         var lines = ["background-opacity = \(formatted(opacity))"]
@@ -111,10 +100,9 @@ public enum WatermarkConfig {
     }
 
     /// Format a `Double` for a ghostty config value: integral without a trailing `.0` (`14.0` → `14`), else
-    /// the minimal decimal (`0.15` → `0.15`). Locale-independent (always `.`) — `String(format:)` uses the C
-    /// locale. Fixed-point, NOT `String(Double)`, which emits scientific notation for tiny magnitudes
-    /// (`0.00001` → `1e-05`) that ghostty's config parser rejects, silently dropping the line back to the
-    /// default opacity.
+    /// the minimal decimal. Locale-independent (always `.`) — `String(format:)` uses the C locale.
+    /// Fixed-point, NOT `String(Double)`, whose scientific notation for tiny magnitudes (`1e-05`) ghostty's
+    /// config parser rejects, silently dropping the line back to the default opacity.
     static func formatted(_ value: Double) -> String {
         // `Int(value)` TRAPS on .infinity or |value| ≥ ~9.2e18, so guard the integral fast-path: a validated
         // opacity or live font size never gets there, but `fontSize` comes from a hand-editable snapshot.

--- a/agtermCore/Sources/agtermCore/WatermarkStorage.swift
+++ b/agtermCore/Sources/agtermCore/WatermarkStorage.swift
@@ -2,12 +2,11 @@ import Foundation
 
 /// Host-free on-disk location of rendered `.text` watermark PNGs — a `watermarks/` subdir of the state
 /// directory (honoring `AGTERM_STATE_DIR` for test isolation, like the snapshot/settings files). Pure
-/// Foundation (no AppKit), so both the app-target renderer (`WatermarkRenderer`, which writes the PNGs)
-/// and the host-free store (`AppStore`, which removes a session's PNG when the session is permanently
-/// destroyed) share one path definition instead of duplicating it.
-///
-/// Each function takes an optional `stateDir` override (default nil = the `AGTERM_STATE_DIR`/app-support
-/// resolution) so tests can inject a temp directory without mutating process-global env (parallel-safe).
+/// Foundation (no AppKit), so the app-target renderer (`WatermarkRenderer`, which writes the PNGs) and
+/// the host-free `AppStore` (which removes a session's PNG when the session is permanently destroyed)
+/// share one path definition. Each function takes an optional `stateDir` override (default nil = the
+/// `AGTERM_STATE_DIR`/app-support resolution) so tests can inject a temp directory without mutating
+/// process-global env (parallel-safe).
 public enum WatermarkStorage {
     /// `<stateDir>/watermarks` — NOT created. Use `ensureDirectory()` before writing.
     public static func directoryURL(stateDir: URL? = nil) -> URL {

--- a/agtermCore/Sources/agtermCore/WindowGeometry.swift
+++ b/agtermCore/Sources/agtermCore/WindowGeometry.swift
@@ -1,14 +1,12 @@
 import Foundation
 
 /// Pure geometry clamps for the `window.resize`/`window.move` control commands. Host-free —
-/// `WindowRegistry` (the only place with the live `NSWindow` and its `NSScreen`) supplies the
-/// actual display bounds and window min/size, this just does the arithmetic so it can be unit-tested.
-///
-/// Uses plain `Double`-backed `Size`/`Point`/`Rect` rather than `CGSize`/`CGPoint`/`CGRect` on purpose:
-/// `agtermCore` is Foundation-only, and a CoreGraphics member reference (e.g. `CGSize.width`) in a
-/// Foundation-only module serializes as an unresolvable cross-reference that crashes the release
-/// whole-module-optimizer's SIL deserializer (Xcode 26.5). The app target converts to/from CG at the
-/// `WindowRegistry` call site, where CoreGraphics is in scope.
+/// `WindowRegistry` (the only place with the live `NSWindow` and its `NSScreen`) supplies the actual
+/// display bounds and window min/size, this just does the unit-testable arithmetic. The plain
+/// `Double`-backed `Size`/`Point`/`Rect` are deliberate, NOT `CGSize`/`CGPoint`/`CGRect`: a CoreGraphics
+/// member reference (e.g. `CGSize.width`) in Foundation-only `agtermCore` serializes as an unresolvable
+/// cross-reference that crashes the release whole-module-optimizer's SIL deserializer (Xcode 26.5). The
+/// app target converts to/from CG at the `WindowRegistry` call site, where CoreGraphics is in scope.
 public enum WindowGeometry {
     /// A width/height pair in points.
     public struct Size: Equatable, Sendable {
@@ -51,15 +49,11 @@ public enum WindowGeometry {
              height: clamp(requested.height, min.height, max.height))
     }
 
-    /// Clamps a window's origin so the window rect (`[origin, origin + windowSize]`) stays at least
-    /// `visibleMargin` points overlapping `displayFrame` in each axis — a window dragged off-screen
-    /// keeps a grabbable strip visible. Coordinate-system agnostic: `requested`, `windowSize`, and
-    /// `displayFrame` must share one space (the caller works in AppKit y-up screen coords).
-    ///
-    /// The rule per axis (x shown; y identical): origin.x is clamped to
-    /// `[displayFrame.minX + visibleMargin - windowSize.width, displayFrame.maxX - visibleMargin]`,
-    /// so the window's right edge can't fall left of `minX + margin` and its left edge can't fall
-    /// right of `maxX - margin`. An already-on-screen origin is returned unchanged.
+    /// Clamps a window's origin so the window rect (`[origin, origin + windowSize]`) keeps at least
+    /// `visibleMargin` points overlapping `displayFrame` in each axis — a window dragged off-screen keeps
+    /// a grabbable strip visible, its right edge never left of `minX + margin` nor its left edge right of
+    /// `maxX - margin`. An already-on-screen origin is returned unchanged. Coordinate-system agnostic:
+    /// `requested`, `windowSize` and `displayFrame` must share one space (the caller uses AppKit y-up).
     public static func clampOrigin(_ requested: Point, windowSize: Size, displayFrame: Rect) -> Point {
         let displayMinX = displayFrame.origin.x
         let displayMaxX = displayFrame.origin.x + displayFrame.size.width

--- a/agtermCore/Sources/agtermCore/WindowLibrary.swift
+++ b/agtermCore/Sources/agtermCore/WindowLibrary.swift
@@ -1,9 +1,8 @@
 import Foundation
 import Observation
 
-/// Metadata for one window — a named bundle of workspaces + sessions rendered in its
-/// own on-screen macOS window. Named `WindowInfo` (not `Window`) to avoid clashing with
-/// SwiftUI/AppKit `Window` types in the app target.
+/// Metadata for one window — a named bundle of workspaces + sessions in its own on-screen macOS window.
+/// Named `WindowInfo`, not `Window`, to avoid clashing with the SwiftUI/AppKit `Window` types app-side.
 public struct WindowInfo: Codable, Sendable, Identifiable, Equatable {
     public let id: UUID
     public var name: String
@@ -13,12 +12,12 @@ public struct WindowInfo: Codable, Sendable, Identifiable, Equatable {
         self.name = name
     }
 
-    /// Whether `name` is a user-set name rather than an auto-assigned default. The title bar shows
-    /// the window name only when this is true, so default "window N" names stay hidden.
+    /// Whether `name` is user-set rather than auto-assigned. The title bar shows the name only when true,
+    /// so default "window N" names stay hidden.
     public var hasCustomName: Bool { !Self.isAutoName(name) }
 
-    /// Whether `name` matches the auto-assigned scheme `WindowLibrary.defaultWindowName` produces —
-    /// the literal word "window" followed by a positive integer ("window 1", "window 2", …).
+    /// Whether `name` matches the scheme `WindowLibrary.defaultWindowName` produces: the literal word
+    /// "window" followed by a positive integer.
     public static func isAutoName(_ name: String) -> Bool {
         let parts = name.split(separator: " ", omittingEmptySubsequences: true)
         guard parts.count == 2, parts[0] == "window", let number = Int(parts[1]), number >= 1 else { return false }
@@ -26,8 +25,8 @@ public struct WindowInfo: Codable, Sendable, Identifiable, Equatable {
     }
 }
 
-/// One entry in the persisted window index: identity, name, and whether the window was
-/// open at quit (drives reopen-all on the next launch).
+/// One entry in the persisted window index: identity, name, and whether the window was open at quit
+/// (which drives reopen-all on the next launch).
 public struct WindowEntry: Codable, Sendable, Equatable {
     public var id: UUID
     public var name: String
@@ -40,9 +39,8 @@ public struct WindowEntry: Codable, Sendable, Equatable {
     }
 }
 
-/// The persisted `windows.json` index: the ordered window list plus the frontmost id.
-/// Carries its own `version`, deliberately independent of `Snapshot.version` (the
-/// per-window file shape) so the two can evolve separately.
+/// The persisted `windows.json` index: ordered window list plus frontmost id. Its `version` is
+/// deliberately independent of `Snapshot.version` (the per-window file shape) so the two evolve separately.
 public struct WindowsIndex: Codable, Equatable, Sendable {
     /// Bumped when the index shape changes; a mismatch makes the loader treat it as absent.
     public static let currentVersion = 1
@@ -58,20 +56,17 @@ public struct WindowsIndex: Codable, Equatable, Sendable {
     }
 }
 
-/// The app-global owner of the window set: the ordered window metadata, the lazily-loaded
-/// per-window `AppStore`s, the open-set, and the frontmost id, plus per-window + index
-/// persistence.
+/// The app-global owner of the window set: ordered window metadata, the lazily-loaded per-window
+/// `AppStore`s, the open-set, the frontmost id, and per-window + index persistence.
 ///
-/// `@Observable @MainActor` like `AppStore` — SwiftUI observes the window list and frontmost
-/// id, and all access is main-actor isolated. A window is "open" iff its `AppStore` is loaded
-/// (`stores[id] != nil`); the persisted open-set in `windows.json` records which to reopen on
-/// the next launch.
+/// `@Observable @MainActor` like `AppStore` — SwiftUI observes the window list and frontmost id, all
+/// access is main-actor isolated. A window is "open" iff its `AppStore` is loaded (`stores[id] != nil`);
+/// the persisted open-set in `windows.json` records which to reopen on the next launch.
 ///
-/// Recovery contract (never throws to the caller, mirrors `PersistenceStore.load()`): a
-/// corrupt or version-mismatched `windows.json` is treated as absent → migrate from legacy
-/// `workspaces.json` if present, else seed one window. A missing/corrupt per-window file opens
-/// that window with an empty `Snapshot` (one default workspace + session). The app always
-/// reaches a valid, non-empty window set.
+/// Recovery contract (never throws to the caller, mirrors `PersistenceStore.load()`): a corrupt or
+/// version-mismatched `windows.json` is treated as absent → migrate legacy `workspaces.json` if present,
+/// else seed one window; a missing/corrupt per-window file opens with an empty `Snapshot` (one default
+/// workspace + session). The app always reaches a valid, non-empty window set.
 @Observable
 @MainActor
 public final class WindowLibrary {
@@ -102,16 +97,16 @@ public final class WindowLibrary {
     /// it exactly once. `@ObservationIgnored`: a launch-flow latch, not view state.
     @ObservationIgnored public private(set) var hasReopened = false
 
-    /// FIFO of window ids each freshly-appearing SwiftUI window claims as its own. The scene is a
-    /// plain `WindowGroup` (which auto-opens one window at launch and one per `openWindow()`), so a
-    /// window has no presented id — it pops the next id here on appear instead. Seeded with the open
-    /// set (launch window first) by `consumeReopen()`. `@ObservationIgnored`: a launch-flow queue.
+    /// FIFO of window ids each freshly-appearing SwiftUI window pops on appear: the scene is a plain
+    /// `WindowGroup` (auto-opens one window at launch, one per `openWindow()`), so a window has no
+    /// presented id. Seeded with the open set, launch window first, by `consumeReopen()`.
+    /// `@ObservationIgnored`: a launch-flow queue.
     @ObservationIgnored private var pendingClaim: [UUID] = []
 
-    /// The launch id the launch window adopted via the pre-seed fallback (`adoptLaunchWindowID()`),
-    /// when its `.onAppear` ran before the scene `.task` seeded the queue. `consumeReopen()` excludes
-    /// it from the seeded queue so the first reopened window can't claim it a second time (the
-    /// duplicate-store collision). `@ObservationIgnored`: a launch-flow latch.
+    /// The launch id adopted via `adoptLaunchWindowID()`'s pre-seed fallback, when the launch window's
+    /// `.onAppear` beat the scene `.task`'s seeding. `consumeReopen()` excludes it from the seeded queue
+    /// so the first reopened window can't claim it twice (the duplicate-store collision).
+    /// `@ObservationIgnored`: a launch-flow latch.
     @ObservationIgnored private var adoptedLaunchID: UUID?
 
     /// Set at quit so the per-window `willClose` close-reporting becomes a no-op — the open-set must
@@ -149,20 +144,18 @@ public final class WindowLibrary {
         return stores[id]
     }
 
-    /// The frontmost open window's id, falling back to the first open window (in window order)
-    /// when the frontmost id is unset/closed. The app-side seams that key off the window — the
-    /// frontmost store and the frontmost quick terminal — resolve through this. Nil only in the
-    /// degenerate all-windows-closed state (the app is quitting).
+    /// The frontmost open window's id, falling back to the first open window (in window order) when the
+    /// frontmost id is unset/closed — the resolution every app-side window-keyed seam (frontmost store,
+    /// frontmost quick terminal) uses. Nil only when all windows are closed (the app is quitting).
     public var activeWindowID: UUID? {
         if let frontmostWindowID, stores[frontmostWindowID] != nil { return frontmostWindowID }
         for id in windows.map(\.id) where stores[id] != nil { return id }
         return nil
     }
 
-    /// The frontmost open window's store, falling back to the first open store (in window order)
-    /// when the frontmost id is unset/closed. The app-side action/control/settings seams resolve
-    /// the store to act on through this — it stays non-nil because the library is never windowless
-    /// at launch. Nil only in the degenerate all-windows-closed state (the app is quitting).
+    /// The frontmost open window's store, falling back to the first open store (in window order) — how
+    /// the app-side action/control/settings seams resolve the store to act on. Non-nil in practice (the
+    /// library is never windowless at launch); nil only when all windows are closed (the app is quitting).
     public var activeStore: AppStore? {
         store(for: activeWindowID)
     }
@@ -172,12 +165,11 @@ public final class WindowLibrary {
         stores[id] != nil
     }
 
-    /// Auto-hide-inactive-sidebars driver: the frontmost open window shows its sidebar and every OTHER
-    /// open window collapses its own. With a single open window it force-shows that (active) window's
-    /// sidebar and collapses nothing. Host-free so it is unit-testable; the app-side caller gates it on the
-    /// `autoHideSidebarInactiveWindows` setting and invokes it on every frontmost change (and once when the
-    /// toggle flips on). `setSidebarVisible` no-ops a window already in its target state, so the
-    /// write/persist/notify happens only for the windows that actually change.
+    /// Auto-hide-inactive-sidebars driver: the frontmost open window shows its sidebar, every OTHER open
+    /// window collapses its own (a lone window has its sidebar force-shown and nothing collapsed).
+    /// Host-free so it is unit-testable; the app-side caller gates it on `autoHideSidebarInactiveWindows`
+    /// and invokes it on every frontmost change, plus once when the toggle flips on. `setSidebarVisible`
+    /// no-ops an already-correct window, so only the windows that change write/persist/notify.
     public func applyInactiveWindowSidebarHiding() {
         guard let active = activeWindowID else { return }
         for id in openIDs() {
@@ -185,19 +177,18 @@ public final class WindowLibrary {
         }
     }
 
-    /// The window set projected into the `window.list` control payload (id/name + open/active flags),
-    /// in window order.
-    /// The `geometry` closure supplies each open window's live on-screen frame; it is app-side (the NSWindow
-    /// handles live in `WindowRegistry`, not this host-free model), defaulting to nil so unit tests and any
-    /// non-AppKit caller get a geometry-free list.
+    /// The window set projected into the `window.list` control payload (id/name + open/active flags), in
+    /// window order. The `geometry` closure supplies each open window's live on-screen frame — app-side,
+    /// since the NSWindow handles live in `WindowRegistry`, not this host-free model; nil by default so
+    /// unit tests and non-AppKit callers get a geometry-free list.
     public func controlWindowNodes(geometry: (WindowInfo.ID) -> ControlWindowFrame? = { _ in nil },
                                    flags: (WindowInfo.ID) -> (fullscreen: Bool, zoomed: Bool, minimized: Bool)? = { _ in nil })
         -> [ControlWindowNode] {
         let active = activeWindowID
         return windows.map {
-            // reach each open store for its auto-follow timeout + sidebar visibility (per-window state); a
-            // closed window has no store and reports nil for both. The frame + fullscreen/zoom/minimized
-            // flags come from the app-side closures (nil for a closed window with no NSWindow).
+            // auto-follow timeout + sidebar visibility are per-window store state (nil for a closed window,
+            // which has no store); the frame + fullscreen/zoom/minimized flags come from the app-side
+            // closures (nil for a closed window with no NSWindow).
             let live = flags($0.id)
             return ControlWindowNode(id: $0.id.uuidString, name: $0.name, open: isOpen($0.id), active: $0.id == active,
                                      autoFollowMs: stores[$0.id]?.autoFollowMs,
@@ -225,8 +216,8 @@ public final class WindowLibrary {
     }
 
     /// Resolve a control window target against the library's ordered window set. All known windows are
-    /// candidates, including closed windows; `active` resolves to the frontmost open window, with the
-    /// same fallback as `activeWindowID`.
+    /// candidates, closed ones included; `active` resolves like `activeWindowID` (frontmost open window,
+    /// with its fallback).
     public func resolveWindow(_ target: String) -> TargetResolution {
         ControlResolve.resolve(target, candidates: windows.map(\.id), active: activeWindowID)
     }
@@ -243,13 +234,12 @@ public final class WindowLibrary {
         openIDs().compactMap { stores[$0] }.flatMap { $0.workspaces.flatMap(\.sessions) }
     }
 
-    /// The total unseen-notification count across every session in every OPEN window — the number the
-    /// Dock tile badge shows (`DockBadgeController`), the app-wide roll-up of the same `Session.unseenCount`
-    /// the sidebar's red pills track. Reads the observable `windows` list, each open store's `workspaces`,
-    /// and each session's `unseenCount`, so a `withObservationTracking` observer over this re-fires on a
-    /// notification bump, a focus/select clear, and a session add/remove. A window CLOSE drops a store
-    /// (`@ObservationIgnored stores`), which is NOT observable — the app refreshes the badge explicitly on
-    /// the `willClose` teardown for that case.
+    /// The total unseen-notification count across every session in every OPEN window — what the Dock tile
+    /// badge (`DockBadgeController`) shows, rolling up the same `Session.unseenCount` the sidebar's red
+    /// pills track. Reads the observable `windows`, each open store's `workspaces`, and each session's
+    /// `unseenCount`, so a `withObservationTracking` observer re-fires on a notification bump, a
+    /// focus/select clear, and a session add/remove. A window CLOSE drops a store (`@ObservationIgnored
+    /// stores`), which is NOT observable — the app refreshes the badge explicitly in the `willClose` teardown.
     public var totalUnseenCount: Int {
         allOpenSessions().reduce(0) { $0 + $1.unseenCount }
     }
@@ -264,65 +254,56 @@ public final class WindowLibrary {
         return (openStores.count, sessions)
     }
 
-    /// The id SwiftUI's auto-opened launch window claims: the frontmost open window, else the first.
-    /// `nil` only in the degenerate all-windows-closed state. Guards the frontmost on openness (like
-    /// `activeWindowID`) — a frontmost pointing at a closed window must fall through to the first open
-    /// one, else `consumeReopen` seeds a closed id and undercounts the open set.
+    /// The id SwiftUI's auto-opened launch window claims: the frontmost open window, else the first; nil
+    /// only when all windows are closed. Guards the frontmost on openness (like `activeWindowID`) — a
+    /// frontmost pointing at a closed window must fall through to the first open one, else `consumeReopen`
+    /// seeds a closed id and undercounts the open set.
     private var launchWindowID: UUID? {
         if let frontmostWindowID, stores[frontmostWindowID] != nil { return frontmostWindowID }
         return openIDs().first
     }
 
-    /// Latches the launch reopen-all so it runs once across the per-window scene `.task`s, seeding
-    /// the claim queue with the open set and returning the *additional* `openWindow()` calls needed
-    /// beyond the one window SwiftUI auto-opens at launch. So with N open windows it returns N-1 (each
-    /// ≥0). Empty on every subsequent call.
+    /// Latches the launch reopen-all so it runs once across the per-window scene `.task`s, seeds the claim
+    /// queue with the open set, and returns the ADDITIONAL `openWindow()` calls needed beyond the one
+    /// window SwiftUI auto-opens at launch — N-1 for N open windows (≥0), 0 on every later call.
     ///
-    /// The launch window takes exactly one id: via the queue (when this runs before its `.onAppear`)
-    /// or via `adoptLaunchWindowID()`'s fallback (when its `.onAppear` ran first). An already-adopted
-    /// launch id is excluded from the queue so the first reopened window can't claim it a second time
-    /// (two windows binding one store — the duplicate-store collision). The N-1 count is independent
-    /// of which path the launch window took.
+    /// The launch window takes exactly one id: from the queue (this ran before its `.onAppear`) or from
+    /// `adoptLaunchWindowID()`'s fallback (its `.onAppear` ran first). An already-adopted launch id is
+    /// excluded from the queue so the first reopened window can't claim it twice (two windows binding one
+    /// store — the duplicate-store collision). The N-1 count is the same either way.
     public func consumeReopen() -> Int {
         guard !hasReopened else { return 0 }
         hasReopened = true
         let open = openIDs()
-        // launch window first, then the rest in window order — minus any id the fallback already
-        // handed the launch window (so it isn't claimed twice).
         let ordered = (launchWindowID.map { [$0] } ?? []) + open.filter { $0 != launchWindowID }
         pendingClaim = ordered.filter { $0 != adoptedLaunchID }
         return max(open.count - 1, 0)
     }
 
-    /// Pops the next window id for a freshly-appearing SwiftUI window to render. Returns nil once the
-    /// queue is drained (a window beyond the open set — e.g. a SwiftUI-restored extra — which the app
-    /// dismisses).
+    /// Pops the next window id for a freshly-appearing SwiftUI window to render. Nil once the queue is
+    /// drained — a window beyond the open set (e.g. a SwiftUI-restored extra), which the app dismisses.
     public func claimNextWindowID() -> UUID? {
         guard !pendingClaim.isEmpty else { return nil }
         return pendingClaim.removeFirst()
     }
 
-    /// The launch window's fallback id when its `.onAppear` fires before the scene `.task` seeds the
-    /// claim queue. Records the id as adopted so a later `consumeReopen()` excludes it from the queue
-    /// — without this, `consumeReopen` re-seeds the launch id and the first reopened window claims it
-    /// again, leaving two windows bound to one store. Idempotent-per-launch: only the FIRST caller gets
-    /// the launch id; a second caller before `consumeReopen()` runs (SwiftUI restored more than one
-    /// window, each hitting the empty-queue fallback) gets nil and dismisses itself, so two windows
-    /// can't both bind the one launch store. Returns nil in the degenerate all-windows-closed state.
+    /// The launch window's fallback id when its `.onAppear` beats the scene `.task`'s queue seeding.
+    /// Records the id as adopted so a later `consumeReopen()` excludes it — otherwise the first reopened
+    /// window claims it again and two windows bind one store. Idempotent-per-launch: only the FIRST caller
+    /// gets the launch id; a second before `consumeReopen()` runs (SwiftUI restored several windows, each
+    /// hitting the empty-queue fallback) gets nil and dismisses itself. Nil too when all windows are closed.
     public func adoptLaunchWindowID() -> UUID? {
         guard adoptedLaunchID == nil, let id = launchWindowID else { return nil }
         adoptedLaunchID = id
         return id
     }
 
-    /// Enqueues a window id to be claimed by the next appearing window — used when the app opens a
-    /// window (`newWindow` + `openWindow()`, or a `window.select` / reveal of a closed window), so the
-    /// new SwiftUI window adopts that id. Pure queue-membership dedup: an id already pending (a repeated
-    /// `window.select` of the same window before the first claim is consumed) is not appended again, so
-    /// one bundle never spawns two windows. It does NOT skip an id whose store is loaded — `newWindow`
-    /// pre-loads the store before enqueueing, so a store-loaded guard would silently drop the claim and
-    /// the spawned window would self-dismiss. The "already on-screen, raise instead of spawn" check
-    /// lives at the call site (`WindowRegistry.raise`), not here.
+    /// Enqueues a window id for the next appearing SwiftUI window to adopt — used when the app opens a
+    /// window (`newWindow` + `openWindow()`, or a `window.select`/reveal of a closed window). Dedups on
+    /// queue MEMBERSHIP only, so a repeated `window.select` before the first claim is consumed never spawns
+    /// two windows. It must NOT skip an id whose store is loaded: `newWindow` pre-loads the store, so such
+    /// a guard would silently drop the claim and the spawned window would self-dismiss. The "already
+    /// on-screen, raise instead of spawn" check lives at the call site (`WindowRegistry.raise`).
     public func enqueueClaim(_ id: UUID) {
         guard !pendingClaim.contains(id) else { return }
         pendingClaim.append(id)
@@ -362,8 +343,7 @@ public final class WindowLibrary {
     // MARK: - Mutation
 
     /// Creates a fresh window seeded with one default workspace ("workspace 1") and one session
-    /// at $HOME (the seeding that used to live in the app's `restoredStore()`), opens it (loads
-    /// its store), and persists the index. Defaults the name to "window N".
+    /// at $HOME, opens it (loads its store), and persists the index. Defaults the name to "window N".
     @discardableResult
     public func newWindow(name: String? = nil) -> WindowInfo {
         let info = WindowInfo(name: name?.trimmedOrNil ?? defaultWindowName)
@@ -372,23 +352,22 @@ public final class WindowLibrary {
         store.addSession(toWorkspace: workspace.id, cwd: FileManager.default.homeDirectoryForCurrentUser.path)
         windows.append(info)
         stores[info.id] = store
-        // a newly created window is the active one: mark it frontmost so the seams that key off the
-        // window (the active store, the command palette, the quick terminal) target it immediately,
-        // rather than waiting on the new on-screen window's first `didBecomeKey` (which loses to the
-        // File-menu focus returning to the previous window after New Window).
+        // mark the new window frontmost so the window-keyed seams (active store, command palette, quick
+        // terminal) target it immediately instead of waiting on its first `didBecomeKey` — which loses to
+        // the File-menu focus returning to the previous window after New Window.
         frontmostWindowID = info.id
         saveIndex()
         return info
     }
 
-    /// Lazily builds (or returns the cached) `AppStore` for a window, loading its persisted
-    /// `windows/<id>.json` (an empty `Snapshot` when missing/corrupt, per the recovery contract).
-    /// No-op returning nil for an id with no index entry. Marks the window open and persists.
+    /// Lazily builds (or returns the cached) `AppStore` for a window from its persisted
+    /// `windows/<id>.json` (an empty `Snapshot` when missing/corrupt, per the recovery contract), marks
+    /// the window open, and persists. Nil for an id with no index entry.
     ///
-    /// `launchRestore` marks an APP-BOOTSTRAP load — passed only by `reopen`/`recoverOrphanedWindows`,
-    /// and the only thing that arms a session's persisted `session.restore` override for this launch. It
-    /// defaults to false because `ContentView.resolveStore()` calls this at RUNTIME when a closed window
-    /// is reopened mid-process, which must not execute anything.
+    /// `launchRestore` marks an APP-BOOTSTRAP load — passed only by `reopen`/`recoverOrphanedWindows`, and
+    /// the only thing that arms a session's persisted `session.restore` override for this launch. It
+    /// defaults to false because `ContentView.resolveStore()` calls this at RUNTIME for a mid-process
+    /// reopen, which must not execute anything.
     @discardableResult
     public func loadStore(for id: UUID, launchRestore: Bool = false) -> AppStore? {
         guard windows.contains(where: { $0.id == id }) else { return nil }
@@ -474,20 +453,18 @@ public final class WindowLibrary {
             }
         }
         scheduleTreeChanged(for: id)
-        // cancel the store's pending debounced save BEFORE deleting the file — a save scheduled by a
-        // just-before-delete selectSession/setFontSize captures the store weakly and fires ~0.3 s out;
-        // since the delete-path willClose teardown skips its own save() (the window is no longer open),
-        // an un-cancelled pending save would fire after removeItem and re-create windows/<id>.json as an
-        // orphan that a future index loss would resurrect via recoverOrphanedWindows().
+        // cancel the pending debounced save BEFORE deleting the file: a just-before-delete
+        // selectSession/setFontSize schedules one ~0.3 s out and the delete-path willClose skips its own
+        // save() (the window is no longer open), so it would land after removeItem and re-create
+        // windows/<id>.json as an orphan a future index loss resurrects via recoverOrphanedWindows().
         stores[id]?.cancelPendingSave()
-        // sweep each session's rendered `.text` watermark PNG before dropping the store: deleting a window
-        // permanently destroys its sessions (like closeSession/removeWorkspace), so their PNGs must go too —
-        // window-CLOSE keeps the sessions and is handled elsewhere, but window-DELETE has no later sweep.
-        // An OPEN window's session ids come from its live store; a CLOSED one has no store, so read them from
-        // the persisted snapshot — else deleting a closed window orphans its PNGs in <stateDir>/watermarks/.
-        // `directory` is the state-dir root WatermarkStorage resolves against (both default to
-        // AGTERM_STATE_DIR else PersistenceStore.defaultDirectory), so passing it is production-identical
-        // and lets a test sweep into an injected temp dir without touching process-global env.
+        // sweep each session's rendered `.text` watermark PNG before dropping the store: window-DELETE
+        // destroys its sessions permanently (like closeSession/removeWorkspace) and has no later sweep,
+        // unlike window-CLOSE, which keeps them. Ids come from the live store when open, from the persisted
+        // snapshot when closed — else a closed window's PNGs orphan in <stateDir>/watermarks/. `directory`
+        // is the same state-dir root WatermarkStorage resolves against (AGTERM_STATE_DIR else
+        // PersistenceStore.defaultDirectory), so passing it is production-identical and lets a test sweep
+        // into an injected temp dir without touching process-global env.
         let sessionIDsToSweep: [UUID] = stores[id].map { $0.workspaces.flatMap(\.sessions).map(\.id) }
             ?? persistenceStore(for: id).load().workspaces.flatMap(\.sessions).map(\.id)
         for sessionID in sessionIDsToSweep {
@@ -501,11 +478,10 @@ public final class WindowLibrary {
         saveIndex()
     }
 
-    /// Clears every session's per-window font-size override across ALL windows — open ones through
-    /// their live store, closed ones by rewriting the persisted `windows/<id>.json` in place. A global
-    /// font/appearance change resets every surface to the new default, so a closed window must drop its
-    /// stale per-session sizes too, else it reopens later overriding the new default. No-ops a window
-    /// (open or closed) whose snapshot has no overrides.
+    /// Clears every session's per-window font-size override across ALL windows — open ones through their
+    /// live store, closed ones by rewriting `windows/<id>.json` in place. A global font/appearance change
+    /// resets every surface to the new default, so a closed window must drop its stale per-session sizes
+    /// too, else it reopens overriding the new default. No-ops a window with no overrides.
     public func resetSessionFontSizesAllWindows() {
         for info in windows {
             if let store = stores[info.id] {
@@ -563,11 +539,10 @@ public final class WindowLibrary {
 
     // MARK: - Bootstrap (migration + recovery)
 
-    /// Resolves the window set on init: load `windows.json` if valid; else recover orphaned per-window
-    /// `windows/<id>.json` files into a fresh index when any are present (so a future schema bump that
-    /// invalidates the index doesn't lose the trees); else migrate from legacy `workspaces.json`; else
-    /// seed one empty window. Reopens the persisted open-set (never windowless — falls back to the
-    /// frontmost/first window).
+    /// Resolves the window set on init: load `windows.json` if valid; else recover any orphaned per-window
+    /// `windows/<id>.json` files into a fresh index (so a future schema bump that invalidates the index
+    /// doesn't lose the trees); else migrate from legacy `workspaces.json`; else seed one empty window.
+    /// Reopens the persisted open-set, never windowless — falls back to the frontmost/first window.
     private func bootstrap() {
         if let index = loadIndex() {
             windows = index.windows.map { WindowInfo(id: $0.id, name: $0.name) }
@@ -575,11 +550,8 @@ public final class WindowLibrary {
             reopen(index)
             return
         }
-        // index unreadable but per-window files survive: recover them rather than discard the user's
-        // sessions (a future schema bump that invalidates the index must not lose the trees).
         if recoverOrphanedWindows() { return }
         if migrateLegacy() { return }
-        // no index, no orphans, and no legacy file: seed one empty default-named window ("window 1").
         newWindow()
     }
 
@@ -592,11 +564,10 @@ public final class WindowLibrary {
         return index
     }
 
-    /// Reopens the persisted open-set after loading the index: loads a store for each window
-    /// marked open. If none were open, opens the frontmost (else the first) so the app is never
-    /// windowless. The frontmost id is used only when it actually exists in `windows` — a stale
-    /// frontmost (pointing at a deleted window) would otherwise no-op `loadStore` and leave the app
-    /// windowless; in that case fall through to the first window.
+    /// Reopens the persisted open-set: loads a store for each window marked open, and if none were, opens
+    /// the frontmost (else the first) so the app is never windowless. The frontmost id is used only when it
+    /// still exists in `windows` — a stale one (a deleted window) would no-op `loadStore` and leave the app
+    /// windowless, so that case falls through to the first window.
     private func reopen(_ index: WindowsIndex) {
         for entry in index.windows where entry.isOpen { loadStore(for: entry.id, launchRestore: true) }
         guard openIDs().isEmpty else { return }
@@ -606,18 +577,16 @@ public final class WindowLibrary {
     }
 
     /// When `windows.json` is unreadable/version-mismatched but per-window `windows/<id>.json` files
-    /// survive, recovers them into a fresh index instead of falling through to legacy/seeding (which
-    /// would discard the user's sessions). Each file whose name stem is a valid UUID becomes an OPEN
-    /// window named "window N", numbered in filename order so the numbering and the frontmost pick are
-    /// deterministic; the first recovered window becomes frontmost. Files with a non-UUID stem are
-    /// skipped. Returns false when no recoverable per-window files exist (the caller then tries
-    /// legacy migration, else seeds). Recovering every orphan as open means the launch reopen-all
-    /// opens them all on screen at once — acceptable for this rare recovery path.
+    /// survive, recovers them into a fresh index rather than falling through to legacy/seeding (which
+    /// would discard the user's sessions). Each UUID-stemmed file becomes an OPEN window named "window N",
+    /// numbered in filename order so the numbering and the frontmost pick are deterministic (the first
+    /// recovered becomes frontmost); non-UUID stems are skipped. False when nothing is recoverable, so the
+    /// caller tries legacy migration, else seeds. Every orphan being open means the launch reopen-all puts
+    /// them all on screen at once — acceptable for this rare recovery path.
     @discardableResult
     private func recoverOrphanedWindows() -> Bool {
         let contents = (try? FileManager.default.contentsOfDirectory(at: windowsDirectory,
                                                                      includingPropertiesForKeys: nil)) ?? []
-        // stable filename order so "window N" numbering and the frontmost pick are deterministic.
         let ids = contents
             .filter { $0.pathExtension == "json" }
             .sorted { $0.lastPathComponent < $1.lastPathComponent }

--- a/agtermCore/Sources/agtermCore/WindowLibrary.swift
+++ b/agtermCore/Sources/agtermCore/WindowLibrary.swift
@@ -1,8 +1,8 @@
 import Foundation
 import Observation
 
-/// Metadata for one window — a named bundle of workspaces + sessions in its own on-screen macOS window.
-/// Named `WindowInfo`, not `Window`, to avoid clashing with the SwiftUI/AppKit `Window` types app-side.
+/// Metadata for one window — a named bundle of workspaces + sessions in its own macOS window.
+/// Named `WindowInfo`, not `Window`, to avoid clashing with the SwiftUI/AppKit `Window` types.
 public struct WindowInfo: Codable, Sendable, Identifiable, Equatable {
     public let id: UUID
     public var name: String
@@ -12,12 +12,10 @@ public struct WindowInfo: Codable, Sendable, Identifiable, Equatable {
         self.name = name
     }
 
-    /// Whether `name` is user-set rather than auto-assigned. The title bar shows the name only when true,
-    /// so default "window N" names stay hidden.
+    /// Whether `name` is user-set; the title bar shows it only when true, so "window N" stays hidden.
     public var hasCustomName: Bool { !Self.isAutoName(name) }
 
-    /// Whether `name` matches the scheme `WindowLibrary.defaultWindowName` produces: the literal word
-    /// "window" followed by a positive integer.
+    /// Whether `name` matches `WindowLibrary.defaultWindowName`: "window" plus a positive integer.
     public static func isAutoName(_ name: String) -> Bool {
         let parts = name.split(separator: " ", omittingEmptySubsequences: true)
         guard parts.count == 2, parts[0] == "window", let number = Int(parts[1]), number >= 1 else { return false }
@@ -25,8 +23,7 @@ public struct WindowInfo: Codable, Sendable, Identifiable, Equatable {
     }
 }
 
-/// One entry in the persisted window index: identity, name, and whether the window was open at quit
-/// (which drives reopen-all on the next launch).
+/// One entry in the persisted window index: id, name, and open-at-quit, which drives reopen-all.
 public struct WindowEntry: Codable, Sendable, Equatable {
     public var id: UUID
     public var name: String
@@ -39,10 +36,10 @@ public struct WindowEntry: Codable, Sendable, Equatable {
     }
 }
 
-/// The persisted `windows.json` index: ordered window list plus frontmost id. Its `version` is
-/// deliberately independent of `Snapshot.version` (the per-window file shape) so the two evolve separately.
+/// The persisted `windows.json` index: ordered window list plus frontmost id. `version` is independent of
+/// `Snapshot.version` (the per-window file shape) so the two evolve separately.
 public struct WindowsIndex: Codable, Equatable, Sendable {
-    /// Bumped when the index shape changes; a mismatch makes the loader treat it as absent.
+    /// Bumped when the index shape changes; a mismatch makes the index count as absent.
     public static let currentVersion = 1
 
     public var version: Int
@@ -56,36 +53,32 @@ public struct WindowsIndex: Codable, Equatable, Sendable {
     }
 }
 
-/// The app-global owner of the window set: ordered window metadata, the lazily-loaded per-window
-/// `AppStore`s, the open-set, the frontmost id, and per-window + index persistence.
+/// The app-global owner of the window set: ordered window metadata, lazily-loaded per-window `AppStore`s,
+/// the open-set, the frontmost id, and per-window + index persistence. `@Observable` so SwiftUI tracks the
+/// window list + frontmost id; all access is main-actor isolated. A window is "open" iff its `AppStore` is
+/// loaded; the persisted open-set in `windows.json` records which to reopen on the next launch.
 ///
-/// `@Observable @MainActor` like `AppStore` — SwiftUI observes the window list and frontmost id, all
-/// access is main-actor isolated. A window is "open" iff its `AppStore` is loaded (`stores[id] != nil`);
-/// the persisted open-set in `windows.json` records which to reopen on the next launch.
-///
-/// Recovery contract (never throws to the caller, mirrors `PersistenceStore.load()`): a corrupt or
-/// version-mismatched `windows.json` is treated as absent → migrate legacy `workspaces.json` if present,
-/// else seed one window; a missing/corrupt per-window file opens with an empty `Snapshot` (one default
-/// workspace + session). The app always reaches a valid, non-empty window set.
+/// Recovery contract (never throws, mirrors `PersistenceStore.load()`): a corrupt or version-mismatched
+/// `windows.json` counts as absent → migrate legacy `workspaces.json` if present, else seed one window; a
+/// missing/corrupt per-window file opens with an empty `Snapshot` (one default workspace + session), so the
+/// window set is always valid and non-empty.
 @Observable
 @MainActor
 public final class WindowLibrary {
     /// The ordered window metadata, for the menu/palette.
     public private(set) var windows: [WindowInfo]
 
-    /// App-wide recent closed sessions/workspaces, newest first. Reopening inserts the saved item into
-    /// the active window; this list is independent of window reopen semantics.
+    /// App-wide recent closed sessions/workspaces, newest first. Reopening inserts into the active window;
+    /// independent of window reopen semantics.
     public private(set) var recentClosedItems: [RecentClosedItem]
 
     /// The id of the frontmost on-screen window, mirrored into the index on change.
     public var frontmostWindowID: UUID?
 
-    /// Live per-window stores. A window is open iff it has a loaded store. `@ObservationIgnored`:
-    /// read imperatively (scene/control), not by any SwiftUI view.
+    /// Live per-window stores. `@ObservationIgnored`: read imperatively (scene/control), never by a view.
     @ObservationIgnored private var stores: [UUID: AppStore]
 
-    /// The state directory (AGTERM_STATE_DIR-aware); the index lives here and per-window files in
-    /// the `windows/` subdirectory.
+    /// The state directory (AGTERM_STATE_DIR-aware): the index here, per-window files in `windows/`.
     @ObservationIgnored private let directory: URL
     @ObservationIgnored private let recentClosedStore: RecentClosedStore
     /// One bounded run-identified ring shared by every window store for this library/app lifetime.
@@ -93,24 +86,20 @@ public final class WindowLibrary {
     @ObservationIgnored private var treeEventDebouncers: [UUID: Debouncer]
     @ObservationIgnored private var isBootstrapping = true
 
-    /// Set once the launch reopen-all has run, so the scene `.task` (which fires per window) drives
-    /// it exactly once. `@ObservationIgnored`: a launch-flow latch, not view state.
+    /// Set once the launch reopen-all has run, so the per-window scene `.task` drives it exactly once.
     @ObservationIgnored public private(set) var hasReopened = false
 
-    /// FIFO of window ids each freshly-appearing SwiftUI window pops on appear: the scene is a plain
-    /// `WindowGroup` (auto-opens one window at launch, one per `openWindow()`), so a window has no
-    /// presented id. Seeded with the open set, launch window first, by `consumeReopen()`.
-    /// `@ObservationIgnored`: a launch-flow queue.
+    /// FIFO of window ids each freshly-appearing SwiftUI window pops on appear: the plain `WindowGroup`
+    /// (one window at launch, one per `openWindow()`) gives a window no presented id. Seeded with the open
+    /// set, launch window first, by `consumeReopen()`.
     @ObservationIgnored private var pendingClaim: [UUID] = []
 
-    /// The launch id adopted via `adoptLaunchWindowID()`'s pre-seed fallback, when the launch window's
-    /// `.onAppear` beat the scene `.task`'s seeding. `consumeReopen()` excludes it from the seeded queue
-    /// so the first reopened window can't claim it twice (the duplicate-store collision).
-    /// `@ObservationIgnored`: a launch-flow latch.
+    /// The launch id already adopted via `adoptLaunchWindowID()`'s fallback; `consumeReopen()` excludes it
+    /// from the seeded queue so the first reopened window can't claim it twice.
     @ObservationIgnored private var adoptedLaunchID: UUID?
 
-    /// Set at quit so the per-window `willClose` close-reporting becomes a no-op — the open-set must
-    /// be preserved for the next launch's reopen-all, not zeroed as each window tears down on quit.
+    /// Set at quit so per-window `willClose` close-reporting no-ops — the open-set must survive for the
+    /// next launch's reopen-all instead of being zeroed as each window tears down.
     @ObservationIgnored public var isTerminating = false
 
     private static let indexFileName = "windows.json"
@@ -120,8 +109,7 @@ public final class WindowLibrary {
     private var indexURL: URL { directory.appendingPathComponent(Self.indexFileName) }
     private var windowsDirectory: URL { directory.appendingPathComponent(Self.windowsSubdirectory, isDirectory: true) }
 
-    /// Creates the library rooted at `directory`, running migration/recovery so the resulting
-    /// window set is always valid and non-empty.
+    /// Creates the library rooted at `directory`, running migration/recovery per the recovery contract.
     public init(directory: URL = PersistenceStore.defaultDirectory,
                 controlEventRing: ControlEventRing? = nil) {
         self.directory = directory
@@ -138,38 +126,34 @@ public final class WindowLibrary {
 
     // MARK: - Lookup
 
-    /// The live store of an open window, or nil when the window is closed/unknown.
     public func store(for id: UUID?) -> AppStore? {
         guard let id else { return nil }
         return stores[id]
     }
 
-    /// The frontmost open window's id, falling back to the first open window (in window order) when the
-    /// frontmost id is unset/closed — the resolution every app-side window-keyed seam (frontmost store,
-    /// frontmost quick terminal) uses. Nil only when all windows are closed (the app is quitting).
+    /// The frontmost open window's id, falling back to the first open window when the frontmost is
+    /// unset/closed — the resolution every window-keyed seam uses. Nil only when all windows are closed
+    /// (the app is quitting).
     public var activeWindowID: UUID? {
         if let frontmostWindowID, stores[frontmostWindowID] != nil { return frontmostWindowID }
         for id in windows.map(\.id) where stores[id] != nil { return id }
         return nil
     }
 
-    /// The frontmost open window's store, falling back to the first open store (in window order) — how
-    /// the app-side action/control/settings seams resolve the store to act on. Non-nil in practice (the
-    /// library is never windowless at launch); nil only when all windows are closed (the app is quitting).
+    /// The store for `activeWindowID` — how the action/control/settings seams resolve what to act on.
+    /// Non-nil in practice (never windowless at launch); nil only when all windows are closed.
     public var activeStore: AppStore? {
         store(for: activeWindowID)
     }
 
-    /// Whether the window is currently open (its store is loaded).
     public func isOpen(_ id: UUID) -> Bool {
         stores[id] != nil
     }
 
-    /// Auto-hide-inactive-sidebars driver: the frontmost open window shows its sidebar, every OTHER open
-    /// window collapses its own (a lone window has its sidebar force-shown and nothing collapsed).
-    /// Host-free so it is unit-testable; the app-side caller gates it on `autoHideSidebarInactiveWindows`
-    /// and invokes it on every frontmost change, plus once when the toggle flips on. `setSidebarVisible`
-    /// no-ops an already-correct window, so only the windows that change write/persist/notify.
+    /// Auto-hide-inactive-sidebars driver: the frontmost open window shows its sidebar, every OTHER open one
+    /// collapses (a lone window is force-shown). The caller gates on `autoHideSidebarInactiveWindows` and
+    /// calls it on every frontmost change plus once when the toggle flips on. `setSidebarVisible` no-ops an
+    /// already-correct window, so only changed windows write/persist/notify.
     public func applyInactiveWindowSidebarHiding() {
         guard let active = activeWindowID else { return }
         for id in openIDs() {
@@ -177,18 +161,16 @@ public final class WindowLibrary {
         }
     }
 
-    /// The window set projected into the `window.list` control payload (id/name + open/active flags), in
-    /// window order. The `geometry` closure supplies each open window's live on-screen frame — app-side,
-    /// since the NSWindow handles live in `WindowRegistry`, not this host-free model; nil by default so
-    /// unit tests and non-AppKit callers get a geometry-free list.
+    /// The window set projected into the `window.list` payload, in window order. The `geometry` closure
+    /// supplies each open window's live frame app-side (NSWindow handles live in `WindowRegistry`, not this
+    /// host-free model); nil by default so tests and non-AppKit callers get a geometry-free list.
     public func controlWindowNodes(geometry: (WindowInfo.ID) -> ControlWindowFrame? = { _ in nil },
                                    flags: (WindowInfo.ID) -> (fullscreen: Bool, zoomed: Bool, minimized: Bool)? = { _ in nil })
         -> [ControlWindowNode] {
         let active = activeWindowID
         return windows.map {
-            // auto-follow timeout + sidebar visibility are per-window store state (nil for a closed window,
-            // which has no store); the frame + fullscreen/zoom/minimized flags come from the app-side
-            // closures (nil for a closed window with no NSWindow).
+            // auto-follow timeout + sidebar visibility come from the per-window store, the frame +
+            // fullscreen/zoom/minimized flags from the app-side closures; both nil for a closed window.
             let live = flags($0.id)
             return ControlWindowNode(id: $0.id.uuidString, name: $0.name, open: isOpen($0.id), active: $0.id == active,
                                      autoFollowMs: stores[$0.id]?.autoFollowMs,
@@ -209,43 +191,39 @@ public final class WindowLibrary {
         }
     }
 
-    /// Test/quit seam: synchronously fires every pending per-window structural invalidation,
-    /// including one queued for a window that has just been removed from the catalog.
+    /// Test/quit seam: fires every pending structural invalidation synchronously, even one queued for a
+    /// window already removed from the catalog.
     func flushTreeEvents() {
         for debouncer in treeEventDebouncers.values { debouncer.flush() }
     }
 
-    /// Resolve a control window target against the library's ordered window set. All known windows are
-    /// candidates, closed ones included; `active` resolves like `activeWindowID` (frontmost open window,
-    /// with its fallback).
+    /// Resolve a control window target against the ordered window set. All known windows are candidates,
+    /// closed ones included; `active` resolves like `activeWindowID`.
     public func resolveWindow(_ target: String) -> TargetResolution {
         ControlResolve.resolve(target, candidates: windows.map(\.id), active: activeWindowID)
     }
 
-    /// The persisted open-set in window order, for the launch reopen-all. A window is open iff
-    /// its store is loaded.
+    /// The persisted open-set in window order, for the launch reopen-all.
     public func openIDs() -> [UUID] {
         windows.map(\.id).filter { stores[$0] != nil }
     }
 
-    /// Every session across all open windows, flattened — the shared walk for the per-session sweeps
+    /// Every session across all open windows, flattened — the walk the per-session sweeps share
     /// (restore-running-command capture + `restore.clear`).
     public func allOpenSessions() -> [Session] {
         openIDs().compactMap { stores[$0] }.flatMap { $0.workspaces.flatMap(\.sessions) }
     }
 
-    /// The total unseen-notification count across every session in every OPEN window — what the Dock tile
-    /// badge (`DockBadgeController`) shows, rolling up the same `Session.unseenCount` the sidebar's red
-    /// pills track. Reads the observable `windows`, each open store's `workspaces`, and each session's
-    /// `unseenCount`, so a `withObservationTracking` observer re-fires on a notification bump, a
-    /// focus/select clear, and a session add/remove. A window CLOSE drops a store (`@ObservationIgnored
-    /// stores`), which is NOT observable — the app refreshes the badge explicitly in the `willClose` teardown.
+    /// The total unseen count across every session in every OPEN window — what the Dock badge shows,
+    /// rolling up the `Session.unseenCount` the sidebar's red pills track. Reads only observable state
+    /// (`windows`, each store's `workspaces`, `unseenCount`), so a `withObservationTracking` observer
+    /// re-fires on a bump, a focus/select clear, and a session add/remove. A window CLOSE drops a store,
+    /// which is NOT observable — the app refreshes the badge explicitly in the `willClose` teardown.
     public var totalUnseenCount: Int {
         allOpenSessions().reduce(0) { $0 + $1.unseenCount }
     }
 
-    /// The number of currently-open windows and the total number of sessions across them — the
-    /// counts the quit confirmation reports. A window is open iff its store is loaded.
+    /// Open-window count plus total sessions across them — the counts the quit confirmation reports.
     public func openCounts() -> (windows: Int, sessions: Int) {
         let openStores = windows.map(\.id).compactMap { stores[$0] }
         let sessions = openStores.reduce(0) { total, store in
@@ -254,23 +232,21 @@ public final class WindowLibrary {
         return (openStores.count, sessions)
     }
 
-    /// The id SwiftUI's auto-opened launch window claims: the frontmost open window, else the first; nil
-    /// only when all windows are closed. Guards the frontmost on openness (like `activeWindowID`) — a
-    /// frontmost pointing at a closed window must fall through to the first open one, else `consumeReopen`
-    /// seeds a closed id and undercounts the open set.
+    /// The id SwiftUI's auto-opened launch window claims: the frontmost open window, else the first, nil
+    /// when all are closed. Guards the frontmost on openness — one pointing at a closed window must fall
+    /// through, else `consumeReopen` seeds a closed id and undercounts the open set.
     private var launchWindowID: UUID? {
         if let frontmostWindowID, stores[frontmostWindowID] != nil { return frontmostWindowID }
         return openIDs().first
     }
 
     /// Latches the launch reopen-all so it runs once across the per-window scene `.task`s, seeds the claim
-    /// queue with the open set, and returns the ADDITIONAL `openWindow()` calls needed beyond the one
-    /// window SwiftUI auto-opens at launch — N-1 for N open windows (≥0), 0 on every later call.
+    /// queue with the open set, and returns the ADDITIONAL `openWindow()` calls needed beyond SwiftUI's
+    /// auto-opened launch window — N-1 for N open windows (≥0), 0 on every later call.
     ///
     /// The launch window takes exactly one id: from the queue (this ran before its `.onAppear`) or from
-    /// `adoptLaunchWindowID()`'s fallback (its `.onAppear` ran first). An already-adopted launch id is
-    /// excluded from the queue so the first reopened window can't claim it twice (two windows binding one
-    /// store — the duplicate-store collision). The N-1 count is the same either way.
+    /// `adoptLaunchWindowID()`'s fallback (its `.onAppear` ran first); an already-adopted id is excluded so
+    /// the first reopened window can't claim it twice. The N-1 count is the same either way.
     public func consumeReopen() -> Int {
         guard !hasReopened else { return 0 }
         hasReopened = true
@@ -287,63 +263,58 @@ public final class WindowLibrary {
         return pendingClaim.removeFirst()
     }
 
-    /// The launch window's fallback id when its `.onAppear` beats the scene `.task`'s queue seeding.
-    /// Records the id as adopted so a later `consumeReopen()` excludes it — otherwise the first reopened
-    /// window claims it again and two windows bind one store. Idempotent-per-launch: only the FIRST caller
-    /// gets the launch id; a second before `consumeReopen()` runs (SwiftUI restored several windows, each
-    /// hitting the empty-queue fallback) gets nil and dismisses itself. Nil too when all windows are closed.
+    /// The launch window's fallback id when its `.onAppear` beats the scene `.task`'s queue seeding. Records
+    /// it as adopted so a later `consumeReopen()` excludes it — else the first reopened window claims it
+    /// again and two windows bind one store. Only the FIRST caller gets an id; a second (several restored
+    /// windows all hitting the empty-queue fallback) gets nil and dismisses itself, as does an all-closed set.
     public func adoptLaunchWindowID() -> UUID? {
         guard adoptedLaunchID == nil, let id = launchWindowID else { return nil }
         adoptedLaunchID = id
         return id
     }
 
-    /// Enqueues a window id for the next appearing SwiftUI window to adopt — used when the app opens a
-    /// window (`newWindow` + `openWindow()`, or a `window.select`/reveal of a closed window). Dedups on
-    /// queue MEMBERSHIP only, so a repeated `window.select` before the first claim is consumed never spawns
-    /// two windows. It must NOT skip an id whose store is loaded: `newWindow` pre-loads the store, so such
-    /// a guard would silently drop the claim and the spawned window would self-dismiss. The "already
-    /// on-screen, raise instead of spawn" check lives at the call site (`WindowRegistry.raise`).
+    /// Enqueues a window id for the next appearing SwiftUI window to adopt (`newWindow` + `openWindow()`, or
+    /// a `window.select`/reveal of a closed window). Dedups on queue MEMBERSHIP only, so a repeated
+    /// `window.select` before the first claim is consumed never spawns two windows; it must NOT also skip an
+    /// id whose store is loaded, since `newWindow` pre-loads the store and the window would self-dismiss.
+    /// The "already on-screen, raise instead of spawn" check lives in `WindowRegistry.raise`.
     public func enqueueClaim(_ id: UUID) {
         guard !pendingClaim.contains(id) else { return }
         pendingClaim.append(id)
     }
 
-    /// The id of the open window that owns the given session, or nil when no open window has it.
-    /// Searches only OPEN windows (closed windows aren't loaded).
+    /// The id of the OPEN window owning the given session, or nil — closed windows aren't loaded/searched.
     public func windowID(forSession sessionID: UUID) -> UUID? {
         for id in windows.map(\.id) where stores[id]?.session(withID: sessionID) != nil { return id }
         return nil
     }
 
-    /// The open store that owns the given session, searching only OPEN windows. Backs cross-window
-    /// session targeting (notification reveal + ControlServer).
+    /// The open store owning the given session — backs cross-window targeting (reveal + ControlServer).
     public func store(forSession sessionID: UUID) -> AppStore? {
         store(for: windowID(forSession: sessionID))
     }
 
-    /// The id of the open window backed by `store` (by identity), or nil — the reverse of `store(for:)`,
-    /// used to reach a window's per-window controllers (quick terminal / zoom / dashboard) from its store.
+    /// The id of the open window backed by `store` (by identity) — the reverse of `store(for:)`, for
+    /// reaching a window's per-window controllers (quick terminal / zoom / dashboard).
     public func windowID(for store: AppStore) -> UUID? {
         openIDs().first { stores[$0] === store }
     }
 
-    /// The display name of the window with `id`, or "" when `id` is nil or no window has that id — the
-    /// name half of the `{AGT_WINDOW_NAME}`/`$AGT_WINDOW_NAME` command context.
+    /// The window's display name, "" for a nil or unknown id — the name half of the
+    /// `{AGT_WINDOW_NAME}`/`$AGT_WINDOW_NAME` command context.
     public func windowName(for id: UUID?) -> String {
         guard let id else { return "" }
         return windows.first { $0.id == id }?.name ?? ""
     }
 
-    /// The auto-generated name for the next new window (`window 1`, `window 2`, …).
     public var defaultWindowName: String {
         "window \(windows.count + 1)"
     }
 
     // MARK: - Mutation
 
-    /// Creates a fresh window seeded with one default workspace ("workspace 1") and one session
-    /// at $HOME, opens it (loads its store), and persists the index. Defaults the name to "window N".
+    /// Creates a window seeded with "workspace 1" and one $HOME session, opens it, and persists the index.
+    /// Defaults the name to "window N".
     @discardableResult
     public func newWindow(name: String? = nil) -> WindowInfo {
         let info = WindowInfo(name: name?.trimmedOrNil ?? defaultWindowName)
@@ -352,22 +323,19 @@ public final class WindowLibrary {
         store.addSession(toWorkspace: workspace.id, cwd: FileManager.default.homeDirectoryForCurrentUser.path)
         windows.append(info)
         stores[info.id] = store
-        // mark the new window frontmost so the window-keyed seams (active store, command palette, quick
-        // terminal) target it immediately instead of waiting on its first `didBecomeKey` — which loses to
-        // the File-menu focus returning to the previous window after New Window.
+        // mark frontmost now so the window-keyed seams target it immediately instead of waiting on its
+        // first `didBecomeKey` — which loses to the File-menu focus returning to the previous window.
         frontmostWindowID = info.id
         saveIndex()
         return info
     }
 
-    /// Lazily builds (or returns the cached) `AppStore` for a window from its persisted
-    /// `windows/<id>.json` (an empty `Snapshot` when missing/corrupt, per the recovery contract), marks
-    /// the window open, and persists. Nil for an id with no index entry.
+    /// Lazily builds (or returns the cached) `AppStore` from `windows/<id>.json`, marks the window open, and
+    /// persists. Nil for an id with no index entry.
     ///
     /// `launchRestore` marks an APP-BOOTSTRAP load — passed only by `reopen`/`recoverOrphanedWindows`, and
-    /// the only thing that arms a session's persisted `session.restore` override for this launch. It
-    /// defaults to false because `ContentView.resolveStore()` calls this at RUNTIME for a mid-process
-    /// reopen, which must not execute anything.
+    /// the only thing that arms a session's persisted `session.restore` override. False by default because
+    /// `ContentView.resolveStore()` calls this at RUNTIME for a mid-process reopen, which must not execute.
     @discardableResult
     public func loadStore(for id: UUID, launchRestore: Bool = false) -> AppStore? {
         guard windows.contains(where: { $0.id == id }) else { return nil }
@@ -410,13 +378,12 @@ public final class WindowLibrary {
         refreshRecentClosedItems()
     }
 
-    /// Closes a window: drops its store (marking it closed) and persists the index. The caller
-    /// (app target) tears down the window's surfaces first — `WindowLibrary` only drops the store.
-    /// No-op for an unknown/closed id, or while terminating (the open-set must survive for reopen-all).
+    /// Closes a window: drops its store and persists the index. The app-target caller tears down the
+    /// window's surfaces first. No-op for an unknown/closed id, or while terminating (see `isTerminating`).
     public func closeWindow(_ id: UUID) {
         guard !isTerminating else { return }
-        // cancel any queued claim for this id so a window still attaching can't re-open it after a
-        // close that raced its registration (window.new immediately followed by window.close).
+        // cancel any queued claim so a window still attaching can't re-open it after a close that raced
+        // its registration (window.new immediately followed by window.close).
         pendingClaim.removeAll { $0 == id }
         guard let store = stores[id] else { return }
         for workspace in store.workspaces {
@@ -428,8 +395,7 @@ public final class WindowLibrary {
         saveIndex()
     }
 
-    /// Renames a window (and its open store is unaffected — the name lives only in the index).
-    /// An empty/whitespace-only name is ignored. Persists the index.
+    /// Renames a window; the name lives only in the index. An empty/whitespace-only name is ignored.
     public func renameWindow(_ id: UUID, to name: String) {
         guard let trimmed = name.trimmedOrNil, let index = windows.firstIndex(where: { $0.id == id }) else { return }
         guard windows[index].name != trimmed else { return }
@@ -438,13 +404,11 @@ public final class WindowLibrary {
         saveIndex()
     }
 
-    /// Whether a window may be removed: one window is always kept, so removal is allowed only
-    /// when more than one exists.
+    /// Whether a window may be removed — one window is always kept.
     public var canRemoveWindow: Bool { windows.count > 1 }
 
-    /// Removes a window: drops its store, deletes its per-window file, removes the index entry,
-    /// and persists. No-ops unless more than one window exists (the last one is kept). Clears
-    /// `frontmostWindowID` if it pointed at the removed window.
+    /// Removes a window: drops its store, deletes its per-window file, removes the index entry, and
+    /// persists. No-ops on the last window. Clears `frontmostWindowID` if it pointed at the removed one.
     public func removeWindow(_ id: UUID) {
         guard canRemoveWindow, let index = windows.firstIndex(where: { $0.id == id }) else { return }
         if let store = stores[id] {
@@ -453,18 +417,16 @@ public final class WindowLibrary {
             }
         }
         scheduleTreeChanged(for: id)
-        // cancel the pending debounced save BEFORE deleting the file: a just-before-delete
-        // selectSession/setFontSize schedules one ~0.3 s out and the delete-path willClose skips its own
-        // save() (the window is no longer open), so it would land after removeItem and re-create
-        // windows/<id>.json as an orphan a future index loss resurrects via recoverOrphanedWindows().
+        // cancel the pending debounced save BEFORE deleting the file: a ~0.3 s save from a just-before-delete
+        // selectSession/setFontSize outlives the delete-path willClose (which skips its own save, the window
+        // being closed) and would land after removeItem, re-creating windows/<id>.json as an orphan that a
+        // future index loss resurrects via recoverOrphanedWindows().
         stores[id]?.cancelPendingSave()
         // sweep each session's rendered `.text` watermark PNG before dropping the store: window-DELETE
-        // destroys its sessions permanently (like closeSession/removeWorkspace) and has no later sweep,
-        // unlike window-CLOSE, which keeps them. Ids come from the live store when open, from the persisted
-        // snapshot when closed — else a closed window's PNGs orphan in <stateDir>/watermarks/. `directory`
-        // is the same state-dir root WatermarkStorage resolves against (AGTERM_STATE_DIR else
-        // PersistenceStore.defaultDirectory), so passing it is production-identical and lets a test sweep
-        // into an injected temp dir without touching process-global env.
+        // destroys its sessions permanently and has no later sweep, unlike window-CLOSE. Ids come from the
+        // live store when open, the persisted snapshot when closed — else a closed window's PNGs orphan in
+        // <stateDir>/watermarks/. `directory` is the same root WatermarkStorage resolves against, so passing
+        // it is production-identical and lets a test sweep into an injected temp dir.
         let sessionIDsToSweep: [UUID] = stores[id].map { $0.workspaces.flatMap(\.sessions).map(\.id) }
             ?? persistenceStore(for: id).load().workspaces.flatMap(\.sessions).map(\.id)
         for sessionID in sessionIDsToSweep {
@@ -478,10 +440,9 @@ public final class WindowLibrary {
         saveIndex()
     }
 
-    /// Clears every session's per-window font-size override across ALL windows — open ones through their
-    /// live store, closed ones by rewriting `windows/<id>.json` in place. A global font/appearance change
-    /// resets every surface to the new default, so a closed window must drop its stale per-session sizes
-    /// too, else it reopens overriding the new default. No-ops a window with no overrides.
+    /// Clears every session's font-size override across ALL windows — open ones through their live store,
+    /// closed ones by rewriting `windows/<id>.json`. A closed window must drop its stale sizes too, else it
+    /// reopens overriding the new global default. No-ops a window with no overrides.
     public func resetSessionFontSizesAllWindows() {
         for info in windows {
             if let store = stores[info.id] {
@@ -492,9 +453,9 @@ public final class WindowLibrary {
         }
     }
 
-    /// Loads a closed window's snapshot, strips every `fontSize` override, and rewrites the file only
-    /// when something changed (so it doesn't churn untouched windows). Best-effort: a missing/corrupt
-    /// file loads as empty (no overrides to clear) and a write failure is swallowed by the store.
+    /// Strips every `fontSize` override from a closed window's snapshot, rewriting only when something
+    /// changed so untouched windows don't churn. Best-effort: a missing/corrupt file loads as empty (no
+    /// overrides to clear) and a write failure is swallowed.
     private func clearClosedWindowFontSizes(_ id: UUID) {
         let persistence = persistenceStore(for: id)
         var snapshot = persistence.load()
@@ -511,8 +472,8 @@ public final class WindowLibrary {
 
     // MARK: - Persistence
 
-    /// Flushes every open window's store, so per-window cwd changes since the last structural
-    /// mutation are persisted (the quit-time flush the app's terminate path drives).
+    /// Flushes every open window's store — the quit-time flush persisting cwd changes made since the last
+    /// structural mutation.
     public func saveAllOpen() {
         for store in stores.values { store.save() }
     }
@@ -522,8 +483,8 @@ public final class WindowLibrary {
         for store in stores.values { store.finalizeAllPendingCloses() }
     }
 
-    /// Writes `windows.json`: the ordered window list (with each window's open flag) and the
-    /// frontmost id. A write failure is logged and swallowed.
+    /// Writes `windows.json`: ordered window list with open flags, plus the frontmost id. A write failure
+    /// is logged and swallowed.
     public func saveIndex() {
         let entries = windows.map { WindowEntry(id: $0.id, name: $0.name, isOpen: stores[$0.id] != nil) }
         let index = WindowsIndex(frontmost: frontmostWindowID, windows: entries)
@@ -539,10 +500,10 @@ public final class WindowLibrary {
 
     // MARK: - Bootstrap (migration + recovery)
 
-    /// Resolves the window set on init: load `windows.json` if valid; else recover any orphaned per-window
-    /// `windows/<id>.json` files into a fresh index (so a future schema bump that invalidates the index
-    /// doesn't lose the trees); else migrate from legacy `workspaces.json`; else seed one empty window.
-    /// Reopens the persisted open-set, never windowless — falls back to the frontmost/first window.
+    /// Resolves the window set on init: a valid `windows.json`; else recover orphaned `windows/<id>.json`
+    /// files into a fresh index (so a schema bump invalidating the index doesn't lose the trees); else
+    /// migrate legacy `workspaces.json`; else seed one window. Reopens the persisted open-set, never
+    /// windowless — falls back to the frontmost/first window.
     private func bootstrap() {
         if let index = loadIndex() {
             windows = index.windows.map { WindowInfo(id: $0.id, name: $0.name) }
@@ -555,8 +516,8 @@ public final class WindowLibrary {
         newWindow()
     }
 
-    /// Reads `windows.json`, treating a missing/corrupt/version-mismatched file as absent (nil),
-    /// so the caller falls through to migration/seeding.
+    /// Reads `windows.json`; a missing/corrupt/version-mismatched file reads as nil, so the caller falls
+    /// through to recovery/migration/seeding.
     private func loadIndex() -> WindowsIndex? {
         guard let data = try? Data(contentsOf: indexURL) else { return nil }
         guard let index = try? JSONDecoder().decode(WindowsIndex.self, from: data) else { return nil }
@@ -564,10 +525,9 @@ public final class WindowLibrary {
         return index
     }
 
-    /// Reopens the persisted open-set: loads a store for each window marked open, and if none were, opens
-    /// the frontmost (else the first) so the app is never windowless. The frontmost id is used only when it
-    /// still exists in `windows` — a stale one (a deleted window) would no-op `loadStore` and leave the app
-    /// windowless, so that case falls through to the first window.
+    /// Reopens the persisted open-set, falling back to the frontmost (else the first) so the app is never
+    /// windowless. The frontmost is used only when it still exists in `windows` — a stale id (a deleted
+    /// window) would no-op `loadStore` and leave the app windowless.
     private func reopen(_ index: WindowsIndex) {
         for entry in index.windows where entry.isOpen { loadStore(for: entry.id, launchRestore: true) }
         guard openIDs().isEmpty else { return }
@@ -576,13 +536,11 @@ public final class WindowLibrary {
         if let fallback { loadStore(for: fallback, launchRestore: true) }
     }
 
-    /// When `windows.json` is unreadable/version-mismatched but per-window `windows/<id>.json` files
-    /// survive, recovers them into a fresh index rather than falling through to legacy/seeding (which
-    /// would discard the user's sessions). Each UUID-stemmed file becomes an OPEN window named "window N",
-    /// numbered in filename order so the numbering and the frontmost pick are deterministic (the first
-    /// recovered becomes frontmost); non-UUID stems are skipped. False when nothing is recoverable, so the
-    /// caller tries legacy migration, else seeds. Every orphan being open means the launch reopen-all puts
-    /// them all on screen at once — acceptable for this rare recovery path.
+    /// Recovers surviving `windows/<id>.json` files into a fresh index rather than falling through to
+    /// legacy/seeding, which would discard the user's sessions. Each UUID-stemmed file becomes an OPEN
+    /// window named "window N" in filename order, so numbering and the frontmost pick (the first) are
+    /// deterministic; non-UUID stems are skipped. False when nothing is recoverable. All orphans open means
+    /// the launch reopen-all puts them on screen at once — acceptable for this rare path.
     @discardableResult
     private func recoverOrphanedWindows() -> Bool {
         let contents = (try? FileManager.default.contentsOfDirectory(at: windowsDirectory,
@@ -593,8 +551,7 @@ public final class WindowLibrary {
             .compactMap { UUID(uuidString: $0.deletingPathExtension().lastPathComponent) }
         guard !ids.isEmpty else { return false }
         let infos = ids.enumerated().map { WindowInfo(id: $0.element, name: "window \($0.offset + 1)") }
-        // append ALL infos FIRST — loadStore(for:) guards on `windows.contains(id)`, so loading a
-        // store before the append would silently no-op.
+        // append ALL infos FIRST — `loadStore` guards on `windows.contains(id)` and would silently no-op.
         windows.append(contentsOf: infos)
         for info in infos { loadStore(for: info.id, launchRestore: true) }
         frontmostWindowID = infos.first?.id
@@ -602,15 +559,14 @@ public final class WindowLibrary {
         return true
     }
 
-    /// If `windows.json` is absent but legacy `workspaces.json` exists, wraps it into one window
-    /// ("window 1"): writes the loaded snapshot to `windows/<id>.json` + the index marking it
-    /// open/frontmost, and opens it. Returns false (no migration) when no legacy file exists.
+    /// Wraps a legacy `workspaces.json` into one window ("window 1"): writes its snapshot to
+    /// `windows/<id>.json` + an index marking it open/frontmost, and opens it. False when no legacy file.
     @discardableResult
     private func migrateLegacy() -> Bool {
         let legacy = PersistenceStore(directory: directory, fileName: Self.legacyFileName)
         let snapshot = legacy.load()
         guard !snapshot.workspaces.isEmpty else { return false }
-        // first window, so `defaultWindowName` yields "window 1" (windows is empty at this point).
+        // windows is empty here, so `defaultWindowName` yields "window 1".
         let info = WindowInfo(name: defaultWindowName)
         let store = makeStore(for: info.id, persistence: persistenceStore(for: info.id))
         store.restore(from: snapshot, launchRestore: true)
@@ -624,12 +580,10 @@ public final class WindowLibrary {
 
     // MARK: - Helpers
 
-    /// The per-window persistence file `windows/<id>.json`.
     private func windowFileURL(for id: UUID) -> URL {
         windowsDirectory.appendingPathComponent("\(id.uuidString).json")
     }
 
-    /// A `PersistenceStore` pointed at the window's `windows/<id>.json` file.
     private func persistenceStore(for id: UUID) -> PersistenceStore {
         PersistenceStore(directory: windowsDirectory, fileName: "\(id.uuidString).json")
     }

--- a/agtermCore/Sources/agtermctlKit/Commands.swift
+++ b/agtermCore/Sources/agtermctlKit/Commands.swift
@@ -2,10 +2,9 @@ import ArgumentParser
 import Foundation
 import agtermCore
 
-/// The connection/print surface every subcommand shares: where to connect and how to print. The
-/// `RequestCommand.run()` default drives only these, so a command's options can be `BasicOptions`
-/// (socket/json only, for `window.*` which target via the positional id) or `ClientOptions` (those
-/// plus `--window`).
+/// The connection/print surface every subcommand shares. The `RequestCommand.run()` default drives only
+/// these, so a command's options can be `BasicOptions` (socket/json only, for `window.*`, which targets via
+/// the positional id) or `ClientOptions` (those plus `--window`).
 protocol ConnectionOptions {
     /// Print the raw JSON response instead of a human-readable line.
     var json: Bool { get }
@@ -18,8 +17,8 @@ extension ConnectionOptions {
     func socketPath() -> String { socketPath(env: ProcessInfo.processInfo.environment) }
 }
 
-/// Where to connect and how to print — the options every subcommand accepts. `window.*` commands use
-/// this directly (they target via the positional id, so `--window` has no meaning for them); the
+/// Where to connect and how to print — the options every subcommand accepts. `window.*` commands use this
+/// directly (they target via the positional id, so `--window` has no meaning for them); the
 /// session/workspace/tree/font commands layer `--window` on top via `ClientOptions`.
 struct BasicOptions: ParsableArguments, ConnectionOptions {
     /// Override the resolved socket path. Defaults to the `AGTERM_STATE_DIR`/app-support rendezvous.
@@ -29,10 +28,9 @@ struct BasicOptions: ParsableArguments, ConnectionOptions {
     @Flag(name: .long, help: "Print the raw JSON response.")
     var json = false
 
-    /// Resolve the socket path: explicit `--socket`, else the agtermCore rendezvous resolver. Precedence:
-    /// `--socket` → `<AGTERM_STATE_DIR>/agterm.sock` → `<$HOME>/Library/Application Support/agterm/agterm.sock` →
-    /// `/tmp/agterm/agterm.sock`. `env` is injectable so the precedence is unit-testable; production passes the
-    /// process environment.
+    /// Resolve the socket path, in precedence order: `--socket` → `<AGTERM_STATE_DIR>/agterm.sock` →
+    /// `<$HOME>/Library/Application Support/agterm/agterm.sock` → `/tmp/agterm/agterm.sock`. `env` is
+    /// injectable so the precedence is unit-testable; production passes the process environment.
     func socketPath(env: [String: String] = ProcessInfo.processInfo.environment) -> String {
         if let socket { return socket }
         let appSupport = (env["HOME"].map { ($0 as NSString).appendingPathComponent("Library/Application Support/agterm") })
@@ -46,7 +44,7 @@ struct ClientOptions: ParsableArguments, ConnectionOptions {
     @OptionGroup var basic: BasicOptions
 
     /// Target window for session/workspace/tree/font commands: id / prefix / `active` (=frontmost).
-    /// Selects the window whose tree the command operates on; maps to `ControlArgs.window`.
+    /// Maps to `ControlArgs.window`.
     @Option(name: .long, help: "Target window id, unique prefix, or 'active' (defaults to the frontmost).")
     var window: String?
 
@@ -54,9 +52,9 @@ struct ClientOptions: ParsableArguments, ConnectionOptions {
 
     func socketPath(env: [String: String] = ProcessInfo.processInfo.environment) -> String { basic.socketPath(env: env) }
 
-    /// Fold the `--window` selector into an existing args bag, or build one carrying only the window.
-    /// Returns `nil` when there is no window and no base bag, so the request stays in its compact form
-    /// (no empty `args` object on the wire) and matches the no-window request value.
+    /// Fold the `--window` selector into an existing args bag, or build one carrying only the window. Nil
+    /// when there is no window and no base bag, so the request stays compact (no empty `args` object on
+    /// the wire) and matches the no-window request value.
     func withWindow(_ base: ControlArgs? = nil) -> ControlArgs? {
         guard window != nil else { return base }
         var args = base ?? ControlArgs()
@@ -97,16 +95,16 @@ public struct Agtermctl: ParsableCommand {
     public init() {}
 }
 
-/// A subcommand that knows how to build the `ControlRequest` it should send. The default `run()`
-/// sends it and prints the response; tests build the request directly via `makeRequest()`. `Options`
-/// is `ClientOptions` for the window-targeting commands and `BasicOptions` for `window.*`.
+/// A subcommand that knows how to build the `ControlRequest` it should send. The default `run()` sends it
+/// and prints the response; tests build the request directly via `makeRequest()`. `Options` is
+/// `ClientOptions` for the window-targeting commands and `BasicOptions` for `window.*`.
 protocol RequestCommand: ParsableCommand {
     associatedtype Options: ParsableArguments & ConnectionOptions
     var options: Options { get }
     func makeRequest() throws -> ControlRequest
-    /// Whether the human-readable output should echo `result.id`. Default false — the id is just noise
-    /// when the caller already named the target; the create commands (`*.new`) override it to true,
-    /// since the new id isn't known until the command runs. The id is always present under `--json`.
+    /// Whether the human-readable output should echo `result.id`. Default false — the id is noise when the
+    /// caller already named the target; the create commands (`*.new`) override it to true, since the new id
+    /// isn't known until the command runs. The id is always present under `--json`.
     var echoesResultID: Bool { get }
 }
 

--- a/agtermCore/Sources/agtermctlKit/MiscCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/MiscCommands.swift
@@ -12,7 +12,7 @@ struct Keymap: ParsableCommand {
 
     struct Reload: RequestCommand {
         static let configuration = CommandConfiguration(abstract: "Re-read and apply keymap.conf (prints the diagnostic count).")
-        // keymap.reload is app-global (the frontmost window's settings model), so no `--window` selector.
+        // the keymap commands are app-global (the frontmost window's settings model), so no `--window`.
         @OptionGroup var options: BasicOptions
 
         func makeRequest() throws -> ControlRequest { ControlRequest(cmd: .keymapReload) }
@@ -28,7 +28,6 @@ struct Keymap: ParsableCommand {
             the next app activation, so a chord can be right in the keymap and wrong in the menu.
             """
         )
-        // keymap.list is app-global like keymap.reload, so no `--window` selector.
         @OptionGroup var options: BasicOptions
 
         func makeRequest() throws -> ControlRequest { ControlRequest(cmd: .keymapList) }
@@ -129,8 +128,7 @@ struct Quick: ParsableCommand {
         defaultSubcommand: Visibility.self
     )
 
-    /// `agtermctl quick [show|hide|toggle]` — the default, so the bare verb keeps working. Shows/hides the
-    /// frontmost window's quick terminal.
+    /// `agtermctl quick [show|hide|toggle]` — the default subcommand, so the bare verb keeps working.
     struct Visibility: RequestCommand {
         static let configuration = CommandConfiguration(commandName: "visibility", abstract: "Quick terminal visibility (show|hide|toggle).")
         @Argument(help: "Mode: show, hide, or toggle (default).") var mode: String = "toggle"
@@ -142,8 +140,8 @@ struct Quick: ParsableCommand {
         }
     }
 
-    /// `agtermctl quick type TEXT` — inject literal keystrokes into the frontmost window's quick terminal
-    /// (the quick-terminal twin of `session type`). No `--target`/`--window`: always the frontmost window's.
+    /// `agtermctl quick type TEXT` — inject literal keystrokes into the quick terminal, the twin of
+    /// `session type`. No `--target`/`--window`: always the frontmost window's.
     struct TypeText: RequestCommand {
         static let configuration = CommandConfiguration(commandName: "type", abstract: "Inject text into the quick terminal.")
         @Argument(help: "Text to inject (omit with --stdin).") var text: String?
@@ -211,12 +209,8 @@ struct Surface: ParsableCommand {
 
 // MARK: - dashboard
 
-/// `agtermctl dashboard <ids…> [--font-size N | --auto-size] [--window W]` opens a view-only grid of the
-/// named sessions (max 9), `--mru` populates it from the window's most-recently-used sessions (up to 9)
-/// instead of naming ids, and `--close [--window W]` closes the open one. Positional ids map to
-/// `ControlArgs.targets`; the dispatcher caps them at 9, dedups, and reports any drop. The CLI re-checks the
-/// flag combinations in `validate()`, so a bad invocation is a clean usage error with no socket round-trip
-/// (the dispatcher enforces the same rules server-side).
+/// Opens a view-only grid of the named sessions (max 9), or of the window's most-recently-used sessions
+/// with `--mru`; `--close` closes the open one. The dispatcher caps ids at 9, dedups, and reports any drop.
 struct Dashboard: RequestCommand {
     static let configuration = CommandConfiguration(
         abstract: "Open a view-only grid of live sessions, or --close the open one.",
@@ -236,8 +230,7 @@ struct Dashboard: RequestCommand {
     @Flag(name: .long, help: "Close the open dashboard (takes no ids, --mru, or font options).") var close = false
     @OptionGroup var options: ClientOptions
 
-    // reject the invalid flag combinations at parse time (before any connection) so they are clean usage
-    // errors, unit-testable without a socket; the dispatcher re-checks the same rules server-side.
+    // reject invalid flag combinations at parse time — clean usage errors, no socket; re-checked server-side.
     func validate() throws {
         if close {
             guard ids.isEmpty, !mru, fontSize == nil, !autoSize else {
@@ -254,7 +247,7 @@ struct Dashboard: RequestCommand {
         if fontSize != nil, autoSize {
             throw ValidationError("--font-size is mutually exclusive with --auto-size")
         }
-        // nan/inf parse as Double but aren't a valid size; reject non-finite/non-positive here with a clean error.
+        // nan/inf parse as Double but aren't valid sizes; reject non-finite/non-positive with a clean error.
         if let fontSize, !fontSize.isFinite || fontSize <= 0 {
             throw ValidationError("--font-size must be a positive number")
         }
@@ -272,9 +265,8 @@ struct Dashboard: RequestCommand {
 
 // MARK: - pick
 
-/// Native fuzzy-picker commands. `Open` is the default so the shell-friendly common case is simply
-/// `printf 'one\ntwo\n' | agtermctl pick`; explicit `result` and `cancel` verbs make `--no-block`
-/// useful without requiring callers to speak the socket protocol themselves.
+/// Native fuzzy-picker commands. `Open` is the default, so the shell-friendly common case is simply
+/// `printf 'one\ntwo\n' | agtermctl pick`; `result`/`cancel` make `--no-block` usable without the protocol.
 struct Pick: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Open, poll, or cancel a native fuzzy picker.",
@@ -297,8 +289,7 @@ struct Pick: ParsableCommand {
             try makeRequest(input: FileHandle.standardInput.readDataToEndOfFile())
         }
 
-        /// Build the open request from injected stdin bytes. Production passes standard input; tests pass
-        /// data directly so parsing and argument mapping never block on the process's real stdin.
+        /// Build the open request from injected stdin bytes, so tests never block on the process's real stdin.
         func makeRequest(input: Data) throws -> ControlRequest {
             let args = ControlArgs(
                 follow: follow ? true : nil,
@@ -336,8 +327,8 @@ struct Pick: ParsableCommand {
             )
         }
 
-        /// Execute open → poll with injectable I/O: production supplies the socket, sleep, stdin, stdout and
-        /// stderr, while unit tests exercise the unbounded blocking flow without real delays or process fds.
+        /// Execute open → poll with injectable I/O, so tests exercise the unbounded blocking flow without
+        /// real delays or process fds.
         func execute(
             input: Data,
             send: (ControlRequest) throws -> ControlResponse,
@@ -365,9 +356,8 @@ struct Pick: ParsableCommand {
                 do {
                     response = try send(ControlRequest(cmd: .pickResult, target: pickID))
                 } catch {
-                    // a transport failure mid-wait (refused connect, truncated or empty reply) leaves the
-                    // picker up with nobody waiting on it; every request opens its own connection, so the
-                    // cancel can still land even though this poll could not.
+                    // a transport failure mid-wait leaves the picker up with nobody waiting; every request
+                    // opens its own connection, so the cancel can still land though this poll could not.
                     abandon(pickID, send: send)
                     throw error
                 }
@@ -395,9 +385,8 @@ struct Pick: ParsableCommand {
             }
         }
 
-        /// Dismiss the picker this command opened but can no longer wait on, so the window is not left
-        /// holding one whose owner is gone and the next `pick.open` there is not refused. Best effort: the
-        /// poll already failed, so a failing cancel adds nothing to report.
+        /// Dismiss a picker this command opened but can no longer wait on: else the window holds one whose
+        /// owner is gone and refuses the next `pick.open`. Best effort — the poll already failed anyway.
         private func abandon(_ pickID: String, send: (ControlRequest) throws -> ControlResponse) {
             _ = try? send(ControlRequest(cmd: .pickCancel, target: pickID))
         }
@@ -440,8 +429,8 @@ struct Pick: ParsableCommand {
             )
         }
 
-        /// Execute a one-shot read with injectable transport/stdout/stderr so every wire outcome and exit
-        /// mapping is covered without replacing process file descriptors.
+        /// One-shot read with injectable transport/stdout/stderr, so every wire outcome and exit mapping is
+        /// covered without replacing process file descriptors.
         func execute(
             send: (ControlRequest) throws -> ControlResponse,
             output: (String) -> Void,
@@ -491,8 +480,7 @@ struct Sidebar: ParsableCommand {
         defaultSubcommand: Visibility.self
     )
 
-    /// `agtermctl sidebar [show|hide|toggle]` — the default, so the bare verb keeps working. Toggles the
-    /// frontmost window's sidebar visibility.
+    /// `agtermctl sidebar [show|hide|toggle]` — the default subcommand, so the bare verb keeps working.
     struct Visibility: RequestCommand {
         static let configuration = CommandConfiguration(commandName: "visibility", abstract: "Sidebar visibility (show|hide|toggle).")
         @Argument(help: "Mode: show, hide, or toggle (default).") var mode: String = "toggle"
@@ -504,8 +492,7 @@ struct Sidebar: ParsableCommand {
         }
     }
 
-    /// `agtermctl sidebar mode [tree|flagged|toggle]` — flips the frontmost window's sidebar view between
-    /// the workspace tree and the flat flagged working-set list.
+    /// Flips the frontmost window's sidebar between the workspace tree and the flat flagged working-set list.
     struct Mode: RequestCommand {
         static let configuration = CommandConfiguration(commandName: "mode", abstract: "Sidebar view mode (tree|flagged|toggle).")
         @Argument(help: "Mode: tree, flagged, or toggle (default).") var mode: String = "toggle"
@@ -531,8 +518,7 @@ struct Sidebar: ParsableCommand {
         func makeRequest() throws -> ControlRequest { ControlRequest(cmd: .sidebarExpand, args: options.withWindow()) }
     }
 
-    /// `agtermctl sidebar collapse [--window W]` — collapse every workspace except the active one (it
-    /// stays expanded) in a window's sidebar (defaults to the frontmost).
+    /// Collapse every workspace except the active one in a window's sidebar (frontmost by default).
     struct Collapse: RequestCommand {
         static let configuration = CommandConfiguration(abstract: "Collapse all workspaces except the active one.")
         @OptionGroup var options: ClientOptions
@@ -563,8 +549,7 @@ struct Font: ParsableCommand {
         subcommands: [Inc.self, Dec.self, Reset.self]
     )
 
-    /// Help text for the shared `--pane` option on the font subcommands. Reuses the `left|right|scratch`
-    /// vocabulary of `session type`/`session text`; omitted defaults to the main pane.
+    /// Help for the shared `--pane` option, reusing the `left|right|scratch` vocabulary of `session type`.
     static let paneHelp = "Which pane's font to change: left (main), right (split), or scratch (the "
         + "session's scratch terminal, even when hidden). Defaults to the left pane."
 

--- a/agtermCore/Sources/agtermctlKit/MiscCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/MiscCommands.swift
@@ -143,8 +143,7 @@ struct Quick: ParsableCommand {
     }
 
     /// `agtermctl quick type TEXT` — inject literal keystrokes into the frontmost window's quick terminal
-    /// (the quick-terminal twin of `session type`). No `--target`/`--window`: it's always the frontmost
-    /// window's quick terminal.
+    /// (the quick-terminal twin of `session type`). No `--target`/`--window`: always the frontmost window's.
     struct TypeText: RequestCommand {
         static let configuration = CommandConfiguration(commandName: "type", abstract: "Inject text into the quick terminal.")
         @Argument(help: "Text to inject (omit with --stdin).") var text: String?
@@ -166,9 +165,8 @@ struct Quick: ParsableCommand {
         }
     }
 
-    /// `agtermctl quick text` — print the frontmost window's quick-terminal buffer as plain text (the
-    /// read-back for `quick type`; does not touch the system clipboard). No `--pane`: the quick terminal
-    /// has a single surface.
+    /// `agtermctl quick text` — print the frontmost window's quick-terminal buffer as plain text, the
+    /// read-back for `quick type`; does not touch the system clipboard. No `--pane`: one surface only.
     struct Text: RequestCommand {
         static let configuration = CommandConfiguration(commandName: "text", abstract: "Print the quick terminal's buffer as plain text.")
         @Flag(name: .long, help: "Read the full screen + scrollback instead of just the visible screen.") var all = false
@@ -214,12 +212,11 @@ struct Surface: ParsableCommand {
 // MARK: - dashboard
 
 /// `agtermctl dashboard <ids…> [--font-size N | --auto-size] [--window W]` opens a view-only grid of the
-/// named sessions (max 9); `agtermctl dashboard --mru [--font-size N | --auto-size] [--window W]` opens one
-/// of the window's most-recently-used sessions (up to 9) instead of naming ids; `agtermctl dashboard --close
-/// [--window W]` closes the open one. The positional ids map to `ControlArgs.targets`; the dispatcher caps
-/// them at 9, dedups, and reports any drop. The CLI re-checks the flag combinations `validate()`-style so a
-/// bad invocation is a clean usage error without a socket round-trip (the dispatcher enforces the same rules
-/// server-side).
+/// named sessions (max 9), `--mru` populates it from the window's most-recently-used sessions (up to 9)
+/// instead of naming ids, and `--close [--window W]` closes the open one. Positional ids map to
+/// `ControlArgs.targets`; the dispatcher caps them at 9, dedups, and reports any drop. The CLI re-checks the
+/// flag combinations in `validate()`, so a bad invocation is a clean usage error with no socket round-trip
+/// (the dispatcher enforces the same rules server-side).
 struct Dashboard: RequestCommand {
     static let configuration = CommandConfiguration(
         abstract: "Open a view-only grid of live sessions, or --close the open one.",
@@ -251,7 +248,6 @@ struct Dashboard: RequestCommand {
         if mru, !ids.isEmpty {
             throw ValidationError("--mru cannot be combined with session ids")
         }
-        // an open needs explicit ids OR --mru (which supplies them from the window's recency).
         guard !ids.isEmpty || mru else {
             throw ValidationError("dashboard requires at least one session id (or --mru, or --close)")
         }
@@ -340,9 +336,8 @@ struct Pick: ParsableCommand {
             )
         }
 
-        /// Execute open → poll with injectable I/O. The production wrapper supplies the socket, sleep,
-        /// stdin, stdout, and stderr; unit tests exercise the unbounded blocking flow without real delays
-        /// or process file descriptors.
+        /// Execute open → poll with injectable I/O: production supplies the socket, sleep, stdin, stdout and
+        /// stderr, while unit tests exercise the unbounded blocking flow without real delays or process fds.
         func execute(
             input: Data,
             send: (ControlRequest) throws -> ControlResponse,
@@ -370,15 +365,14 @@ struct Pick: ParsableCommand {
                 do {
                     response = try send(ControlRequest(cmd: .pickResult, target: pickID))
                 } catch {
-                    // a transport failure mid-wait — a refused connect, a truncated or empty reply —
-                    // leaves the picker up with nobody waiting on it. every request opens its own
-                    // connection, so the cancel can still land even though this poll could not.
+                    // a transport failure mid-wait (refused connect, truncated or empty reply) leaves the
+                    // picker up with nobody waiting on it; every request opens its own connection, so the
+                    // cancel can still land even though this poll could not.
                     abandon(pickID, send: send)
                     throw error
                 }
-                // the poll carries no window selector, so a pending picker is always found by id and
-                // answers ok. a not-ok response therefore means the server no longer holds one, and
-                // there is nothing left to dismiss.
+                // the poll carries no window selector, so a pending picker is always found by id and answers
+                // ok; a not-ok response means the server no longer holds one, with nothing left to dismiss.
                 guard response.ok else {
                     Self.writeResponse(response, json: options.json, output: output, errorOutput: errorOutput)
                     throw ExitCode.failure
@@ -402,8 +396,8 @@ struct Pick: ParsableCommand {
         }
 
         /// Dismiss the picker this command opened but can no longer wait on, so the window is not left
-        /// holding a picker whose owner is gone and the next `pick.open` there is not refused. Best effort:
-        /// the poll already failed, so a failing cancel adds nothing to report.
+        /// holding one whose owner is gone and the next `pick.open` there is not refused. Best effort: the
+        /// poll already failed, so a failing cancel adds nothing to report.
         private func abandon(_ pickID: String, send: (ControlRequest) throws -> ControlResponse) {
             _ = try? send(ControlRequest(cmd: .pickCancel, target: pickID))
         }
@@ -528,9 +522,8 @@ struct Sidebar: ParsableCommand {
         }
     }
 
-    /// `agtermctl sidebar expand [--window W]` — expand every workspace in a window's sidebar tree
-    /// (defaults to the frontmost). Unlike `visibility`/`mode`, this carries the `--window` selector so a
-    /// script can expand a background window's tree.
+    /// `agtermctl sidebar expand [--window W]` — expand every workspace in a window's sidebar tree (default
+    /// frontmost). Unlike `visibility`/`mode` it carries `--window`, so a script can reach a background one.
     struct Expand: RequestCommand {
         static let configuration = CommandConfiguration(abstract: "Expand every workspace in the sidebar.")
         @OptionGroup var options: ClientOptions

--- a/agtermCore/Sources/agtermctlKit/SessionCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/SessionCommands.swift
@@ -2,11 +2,10 @@ import ArgumentParser
 import Foundation
 import agtermCore
 
-/// Shared `--pane` validation for the commands that accept `left|right|scratch` (session type, text, status,
-/// and font). Rejects any other value with a clean usage error before the socket round-trip, matching the
-/// server-side switch (so the CLI and server can't drift, and a raw socket client still hits the same check
-/// server-side). These commands intentionally reuse `StatusPane`'s `left|right|scratch` value set as the
-/// shared pane-addressing vocabulary — the enum is named for agent status but its cases are the pane names.
+/// Shared `--pane` validation for the commands accepting `left|right|scratch` (session type, text, status,
+/// font). Rejects anything else with a clean usage error before the socket round-trip, matching the
+/// server-side switch, which still catches a raw socket client. They reuse `StatusPane`'s value set as the
+/// shared pane-addressing vocabulary — named for agent status, but its cases are the pane names.
 func validatePaneArgument(_ pane: String?) throws {
     if let pane, StatusPane(rawValue: pane) == nil {
         throw ValidationError("--pane must be left, right, or scratch")
@@ -144,10 +143,9 @@ struct Session: ParsableCommand {
         @OptionGroup var target: BatchTargetOptions
         @OptionGroup var options: ClientOptions
 
-        // exactly one placement intent among {workspace positional (relocate), --to (reorder),
-        // --after/--before (anchor-relative place)}; reject the empty/conflicting cases at parse time so
-        // it's a clean usage error, unit-testable without a socket. The anchor carries its own workspace,
-        // so placement is mutually exclusive with both --to and a destination workspace.
+        // exactly one placement intent among {workspace positional (relocate), --to (reorder), --after/--before
+        // (anchor-relative)}; reject empty/conflicting cases at parse time as a clean usage error, unit-testable
+        // without a socket. the anchor carries its own workspace, so placement excludes --to and a workspace.
         func validate() throws {
             if after != nil, before != nil {
                 throw ValidationError("use either --after or --before, not both")
@@ -390,9 +388,8 @@ struct Session: ParsableCommand {
         }
     }
 
-    /// The per-session, per-pane restore-command override. Nested under `Session`, so it is a different
-    /// verb from the top-level `restore clear` in `MiscCommands.swift` — that one is app-global and
-    /// capture-scoped, this one is per-session and override-scoped.
+    /// The per-session, per-pane restore-command override. Nested under `Session`, a different verb from the
+    /// top-level `restore clear` (app-global and capture-scoped; this one per-session and override-scoped).
     struct Restore: RequestCommand {
         static let configuration = CommandConfiguration(
             abstract: "Pin the command a session's pane re-runs on the next launch.",
@@ -507,9 +504,9 @@ struct Session: ParsableCommand {
             subcommands: [Image.self, Text.self, Color.self, Clear.self]
         )
 
-        /// Shared input validation against the host-free `WatermarkConfig`, so a bad value is a clean
-        /// parse error before any socket round-trip, matching the server's rejection exactly. The enum
-        /// checks reject `""` too, so no separate empty-string special-case is needed.
+        /// Shared input validation against the host-free `WatermarkConfig`, so a bad value is a clean parse
+        /// error before any socket round-trip, matching the server's rejection exactly. The enum checks
+        /// reject `""` too, so no separate empty-string case is needed.
         static func validate(fit: String? = nil, position: String? = nil, opacity: Double? = nil,
                              color: String? = nil, text: String? = nil, path: String? = nil) throws {
             if let fit, !WatermarkConfig.isValidFit(fit) {
@@ -637,17 +634,17 @@ struct Session: ParsableCommand {
             func run() throws {
                 guard block else { try defaultRun(); return }
                 let client = SocketClient(path: options.socketPath())
-                // open via the same `makeRequest()` the non-block path uses (DRY): in block mode `validate()`
-                // guarantees `!wait`, so its `wait` is nil — identical to opening non-wait, and the floating
-                // `--size-percent` is carried through the single source instead of a duplicated ControlArgs.
+                // open via the same `makeRequest()` as the non-block path: in block mode `validate()` guarantees
+                // `!wait`, so its `wait` is nil, and the floating `--size-percent` rides that single source
+                // instead of a duplicated ControlArgs.
                 let opened = try client.send(makeRequest())
                 guard opened.ok, let id = opened.result?.id else {
                     SocketClient.printResponse(opened, json: options.json)
                     throw ExitCode.failure
                 }
-                // poll session.overlay.result until the program exits. target the returned id with NO
-                // window scope: the id is globally unique and resolves cross-window, so a frontmost-window
-                // change during the run can't make the poll miss the session.
+                // poll session.overlay.result until the program exits, targeting the returned id with NO window
+                // scope: it is globally unique and resolves cross-window, so a frontmost-window change during
+                // the run can't make the poll miss the session.
                 while true {
                     let res = try client.send(ControlRequest(cmd: .sessionOverlayResult, target: id))
                     if res.ok {

--- a/agtermCore/Sources/agtermctlKit/SocketClient.swift
+++ b/agtermCore/Sources/agtermctlKit/SocketClient.swift
@@ -198,10 +198,10 @@ struct SocketClient {
         return "ok"
     }
 
-    /// Render the `theme.list` payload as one theme name per line, the active theme(s) marked with `* `
-    /// and a leading "default ghostty" entry for the no-theme (ghostty built-in) case (no trailing newline).
-    /// When `sync` is on, both the light and dark themes are marked and a header notes the appearance pair;
-    /// otherwise the single `current` theme is marked.
+    /// Render the `theme.list` payload as one theme name per line (no trailing newline), the active
+    /// theme(s) marked `* `, with a leading "default ghostty" entry for the no-theme (ghostty built-in)
+    /// case. With `sync` on, both the light and dark themes are marked under a header naming the
+    /// appearance pair; otherwise the single `current` theme is marked.
     static func formatThemes(_ themes: [String], current: String?, sync: Bool = false,
                              light: String? = nil, dark: String? = nil) -> String {
         let active: (String?) -> Bool = sync ? { $0 != nil && ($0 == light || $0 == dark) } : { $0 == current }
@@ -214,11 +214,10 @@ struct SocketClient {
 
     /// Render the `keymap.list` payload as sections: the resolved built-ins, then custom commands, parse
     /// diagnostics, and the live menu key equivalents (no trailing newline). An overridden built-in is
-    /// marked `*`, and a keyless one prints `-` rather than being dropped, so the listing is the full
-    /// action set.
+    /// marked `*`, a keyless one prints `-` rather than being dropped, so the listing is the full action set.
     ///
     /// The menu section is the point of the command: comparing it against the actions above is what shows
-    /// a chord the keymap resolved but the menu is not carrying. Menu items are printed in menu-bar order.
+    /// a chord the keymap resolved but the menu is not carrying. Menu items print in menu-bar order.
     static func formatKeymap(_ keymap: ControlKeymap) -> String {
         var lines = ["keymap: \(keymap.path)", "", "actions:"]
         let width = keymap.actions.map(\.action.count).max() ?? 0

--- a/agtermCore/Sources/agtermctlKit/WorkspaceCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/WorkspaceCommands.swift
@@ -64,11 +64,10 @@ struct Workspace: ParsableCommand {
         }
     }
 
-    /// `agtermctl workspace focus [on|off|toggle|add] [--target W]` — marks or unmarks ONE workspace in
-    /// the sidebar's focus set. `add` only marks; applying the set is `workspace filter on`. The accepted
-    /// list, the per-mode help prose, and the local rejection message ALL derive from
-    /// `ControlWorkspaceFocusMode.allCases` (via `validNamesList`/`helpPhrase`/`validNamesPhrase`), so a
-    /// new case reaches every one of them and the CLI cannot drift from the dispatcher's parse.
+    /// `agtermctl workspace focus [on|off|toggle|add] [--target W]` — marks or unmarks ONE workspace in the
+    /// sidebar's focus set; `add` only marks, applying the set is `workspace filter on`. The accepted list, the
+    /// per-mode help prose, and the rejection message all derive from `ControlWorkspaceFocusMode.allCases` (via
+    /// `validNamesList`/`helpPhrase`/`validNamesPhrase`), so a new case reaches each and cannot drift from it.
     struct Focus: RequestCommand {
         static let configuration = CommandConfiguration(
             abstract: "Mark a workspace in the sidebar focus set (\(ControlWorkspaceFocusMode.validNamesList))."
@@ -89,13 +88,12 @@ struct Workspace: ParsableCommand {
         }
     }
 
-    /// `agtermctl workspace filter [on|off|toggle] [--window W]` — turns the sidebar's workspace focus
-    /// filter on or off for a WHOLE window, leaving the marked set intact. It deliberately carries NO
-    /// `--target`: it flips the window's filter rather than acting on one workspace, so its shape is
-    /// `sidebar expand`/`sidebar collapse` (`ClientOptions` only), not the `workspace.*` target commands.
-    /// The three mode names are spelled out here rather than derived: `ControlToggleMode` carries no
-    /// `validNames` (its tokens are per-command — `sidebar` spells the same three `show|hide|toggle`), so
-    /// this matches its siblings (`session flag`, `sidebar mode`) instead of the enum-derived `Focus` above.
+    /// `agtermctl workspace filter [on|off|toggle] [--window W]` — turns the sidebar's workspace focus filter
+    /// on or off for a WHOLE window, leaving the marked set intact. Deliberately NO `--target`: it flips the
+    /// window's filter rather than one workspace, so its shape is `sidebar expand`/`collapse` (`ClientOptions`
+    /// only), not the `workspace.*` target commands. The three mode names are spelled out rather than derived:
+    /// `ControlToggleMode` carries no `validNames` (its tokens are per-command — `sidebar` spells the same
+    /// three `show|hide|toggle`), so this matches `session flag`/`sidebar mode`, not the enum-derived `Focus`.
     struct Filter: RequestCommand {
         static let configuration = CommandConfiguration(
             abstract: "Turn the sidebar workspace focus filter on or off (on|off|toggle)."

--- a/agtermCore/Tests/agtermCoreTests/AgentHooksInstallTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AgentHooksInstallTests.swift
@@ -5,7 +5,6 @@ import Testing
 struct AgentHooksInstallTests {
     private let scriptDir = "/Users/me/.config/agterm/agent-status"
 
-    // decode the merged JSON back to a dictionary for structural assertions
     private func object(_ json: String) -> [String: Any] {
         let data = json.data(using: .utf8)!
         return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] ?? [:]
@@ -41,7 +40,6 @@ struct AgentHooksInstallTests {
         #expect(command(evts["UserPromptSubmit"]![0])?.contains("--auto-reset") == false)
         #expect(command(evts["Notification"]![0])?.contains("--auto-reset") == false)
         #expect(evts["Notification"]![0]["matcher"] as? String == "permission_prompt")
-        // the unmatched events carry no matcher key
         #expect(evts["UserPromptSubmit"]![0]["matcher"] == nil)
         #expect(evts["PostToolUse"]![0]["matcher"] == nil)
     }
@@ -70,17 +68,14 @@ struct AgentHooksInstallTests {
         let result = try AgentHooksInstall.mergeClaudeSettings(existing: existing, scriptDir: scriptDir)
         #expect(result.changed)
         let root = object(result.json)
-        #expect(root["model"] as? String == "opus") // unrelated top-level key preserved
+        #expect(root["model"] as? String == "opus")
         let evts = events(result.json)
-        // the pre-existing PreToolUse hook is untouched
         #expect(evts["PreToolUse"]?.count == 1)
         #expect(command(evts["PreToolUse"]![0]) == "/usr/bin/guard.sh")
-        // UserPromptSubmit keeps the other hook AND gains the agterm one
         #expect(evts["UserPromptSubmit"]?.count == 2)
         let commands = evts["UserPromptSubmit"]!.compactMap { command($0) }
         #expect(commands.contains("/usr/bin/other-hook.sh"))
         #expect(commands.contains { $0.hasSuffix("agent-status.sh' active --blink") })
-        // PostToolUse + Stop + Notification are still added fresh
         #expect(evts["PostToolUse"]?.count == 1)
         #expect(evts["Stop"]?.count == 1)
         #expect(evts["Notification"]?.count == 1)
@@ -92,14 +87,13 @@ struct AgentHooksInstallTests {
         """
         let first = try AgentHooksInstall.mergeClaudeSettings(existing: existing, scriptDir: scriptDir)
         let second = try AgentHooksInstall.mergeClaudeSettings(existing: first.json, scriptDir: scriptDir)
-        #expect(!second.changed) // re-running is idempotent even with the foreign hook present
+        #expect(!second.changed)
         let commands = events(second.json)["UserPromptSubmit"]!.compactMap { command($0) }
         #expect(commands.contains("/usr/bin/other.sh"))
     }
 
     @Test func mergeRefusesMalformedExisting() {
-        // a non-empty file that isn't a valid JSON object must NOT be overwritten — refuse so the
-        // installer leaves the user's hand-maintained settings.json untouched
+        // refusing leaves the user's hand-maintained settings.json untouched
         #expect(throws: AgentHooksInstall.MergeError.self) {
             try AgentHooksInstall.mergeClaudeSettings(existing: "{ this is not json", scriptDir: scriptDir)
         }
@@ -133,8 +127,8 @@ struct AgentHooksInstallTests {
     @Test func codexHooksBlockMapsActionsAndBakesWrapperPath() {
         let block = AgentHooksInstall.codexHooksBlock(scriptDir: scriptDir)
         let hook = scriptDir + "/agterm-codex-status.sh"
-        // Codex-specific behavior stays in the installed Codex hook. agterm only generates the six
-        // lifecycle entries and copies the hook package from its app resources.
+        // Codex-specific behavior stays in the installed adapter; agterm only generates the six
+        // lifecycle entries.
         #expect(block.contains("command = \"'\(hook)' session-start\""))
         #expect(block.contains("command = \"'\(hook)' user-prompt-submit\""))
         #expect(block.contains("command = \"'\(hook)' pre-tool-use\""))
@@ -158,7 +152,6 @@ struct AgentHooksInstallTests {
         #expect(block.contains("'/Users/O'\\\\''Brien/agent-status/agterm-codex-status.sh' session-start"))
     }
 
-    // extract the written contents from a `.merged` outcome, failing the test otherwise.
     private func mergedContents(_ outcome: AgentHooksInstall.CodexMergeOutcome) -> String {
         guard case .merged(let contents) = outcome else {
             Issue.record("expected .merged, got \(outcome)")
@@ -228,7 +221,7 @@ struct AgentHooksInstallTests {
     @Test func mergeCodexConfigStripsLegacyNotifyLine() {
         let existing = "notify = [\"/Users/me/.config/agterm/agent-status/codex-notify.sh\"]\n"
         let contents = mergedContents(AgentHooksInstall.mergeCodexConfig(existing: existing, scriptDir: scriptDir))
-        #expect(!contents.contains("codex-notify.sh")) // the retired notify line is removed
+        #expect(!contents.contains("codex-notify.sh"))
         #expect(contents.contains("[[hooks.Stop]]"))
     }
 
@@ -239,24 +232,22 @@ struct AgentHooksInstallTests {
         notify = ["/home/me/my-own-notify.sh"]
         """
         let contents = mergedContents(AgentHooksInstall.mergeCodexConfig(existing: existing, scriptDir: scriptDir))
-        #expect(contents.contains("# my codex config")) // comments preserved (surgical append, no reserialize)
+        #expect(contents.contains("# my codex config")) // surgical append, no reserialize
         #expect(contents.contains("model = \"gpt-5\""))
-        #expect(contents.contains("notify = [\"/home/me/my-own-notify.sh\"]")) // user's own notify kept
+        #expect(contents.contains("notify = [\"/home/me/my-own-notify.sh\"]"))
         #expect(contents.contains("[[hooks.PermissionRequest]]"))
         #expect(contents.contains("my-own-notify.sh\"]\n\n\(AgentHooksInstall.rcMarkerBegin)"))
     }
 
     @Test func mergeCodexConfigKeepsNotifyWhenCodexNameOnlyInComment() {
-        // over-match guard: the notify VALUE is a custom program; codex-notify.sh appears only in a
-        // comment, so the parsed value has no codex-notify.sh and the line must be KEPT
+        // over-match guard: codex-notify.sh appears only in a COMMENT, so the parsed value never names it
         let existing = "notify = [\"/home/me/custom.sh\"] # replaces codex-notify.sh\n"
         let contents = mergedContents(AgentHooksInstall.mergeCodexConfig(existing: existing, scriptDir: scriptDir))
-        #expect(contents.contains("notify = [\"/home/me/custom.sh\"]")) // user's notify survives
+        #expect(contents.contains("notify = [\"/home/me/custom.sh\"]"))
     }
 
     @Test func mergeCodexConfigSkipsWhenUserHasOwnHooks() {
-        // a config that already defines hooks (its own array-of-tables) must NOT be appended to — that
-        // would duplicate/break them; the merge reports .hooksExist so the caller prints the block
+        // appending to a config that already defines hooks would duplicate/break them
         let existing = """
         [[hooks.Stop]]
         [[hooks.Stop.hooks]]
@@ -267,7 +258,6 @@ struct AgentHooksInstallTests {
     }
 
     @Test func mergeCodexConfigReportsUnparseable() {
-        // a file that is not valid TOML must be left untouched, not rewritten
         #expect(AgentHooksInstall.mergeCodexConfig(existing: "this = is = not = toml\n", scriptDir: scriptDir) == .unparseable)
     }
 
@@ -277,7 +267,7 @@ struct AgentHooksInstallTests {
         #expect(result.contents.contains(AgentHooksInstall.rcMarkerBegin))
         #expect(result.contents.contains(AgentHooksInstall.rcMarkerEnd))
         #expect(result.contents.contains("source '\(scriptDir)/shell/integration.sh'"))
-        #expect(result.contents.hasPrefix("export FOO=1\n")) // prior content preserved
+        #expect(result.contents.hasPrefix("export FOO=1\n"))
     }
 
     @Test func appendShellRCSecondCallIsNoOp() {
@@ -285,7 +275,6 @@ struct AgentHooksInstallTests {
         let second = AgentHooksInstall.appendShellRC(existing: first.contents, scriptDir: scriptDir)
         #expect(!second.changed)
         #expect(second.contents == first.contents)
-        // exactly one occurrence of the begin marker
         let count = first.contents.components(separatedBy: AgentHooksInstall.rcMarkerBegin).count - 1
         #expect(count == 1)
     }
@@ -399,7 +388,7 @@ struct AgentHooksInstallTests {
         try FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o600)], ofItemAtPath: path)
         let mode = AgentHooksInstall.posixMode(ofFile: path)
         try AgentHooksInstall.writeFile("new contents", toPath: path, posixMode: mode)
-        #expect(AgentHooksInstall.posixMode(ofFile: path)?.intValue == 0o600) // mode survives the rewrite
+        #expect(AgentHooksInstall.posixMode(ofFile: path)?.intValue == 0o600)
         #expect((try? String(contentsOfFile: path, encoding: .utf8)) == "new contents")
     }
 
@@ -410,7 +399,7 @@ struct AgentHooksInstallTests {
         try AgentHooksInstall.writeFile("hello", toPath: path, posixMode: nil)
         #expect(FileManager.default.fileExists(atPath: path))
         #expect((try? String(contentsOfFile: path, encoding: .utf8)) == "hello")
-        #expect(AgentHooksInstall.posixMode(ofFile: path) != nil) // some default mode was assigned
+        #expect(AgentHooksInstall.posixMode(ofFile: path) != nil)
     }
 
     @Test func posixModeReturnsModeAndNilForAbsent() throws {

--- a/agtermCore/Tests/agtermCoreTests/AgentStatusTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AgentStatusTests.swift
@@ -27,15 +27,13 @@ struct AgentStatusTests {
     }
 
     @Test func clearedByKeystrokeClearsAttentionAlwaysAndActiveOnlyOnInterrupt() {
-        // blocked/completed clear on ANY key — you've engaged with the prompt / finished result
         #expect(AgentStatus.blocked.clearedByKeystroke(isInterrupt: false))
         #expect(AgentStatus.blocked.clearedByKeystroke(isInterrupt: true))
         #expect(AgentStatus.completed.clearedByKeystroke(isInterrupt: false))
         #expect(AgentStatus.completed.clearedByKeystroke(isInterrupt: true))
-        // active clears ONLY on an interrupt keystroke (Esc or Ctrl-C); ordinary typing leaves the glyph
+        // isInterrupt = Esc or Ctrl-C; ordinary typing leaves the glyph
         #expect(!AgentStatus.active.clearedByKeystroke(isInterrupt: false))
         #expect(AgentStatus.active.clearedByKeystroke(isInterrupt: true))
-        // idle has no glyph to clear
         #expect(!AgentStatus.idle.clearedByKeystroke(isInterrupt: false))
         #expect(!AgentStatus.idle.clearedByKeystroke(isInterrupt: true))
     }
@@ -79,19 +77,15 @@ struct AgentStatusTests {
     }
 
     @Test func clearedByMatchingPaneFollowsClearedByKeystroke() {
-        // matching pane clears iff the status itself is clearable by that keystroke
         #expect(AgentIndicator(status: .blocked, statusPane: .right).clearedBy(pane: .right, isInterrupt: false))
         #expect(AgentIndicator(status: .blocked, statusPane: .right).clearedBy(pane: .right, isInterrupt: true))
         #expect(AgentIndicator(status: .completed, statusPane: .scratch).clearedBy(pane: .scratch, isInterrupt: false))
-        // active clears only on an interrupt keystroke, and only for its own pane
         #expect(!AgentIndicator(status: .active, statusPane: .right).clearedBy(pane: .right, isInterrupt: false))
         #expect(AgentIndicator(status: .active, statusPane: .right).clearedBy(pane: .right, isInterrupt: true))
-        // idle never clears
         #expect(!AgentIndicator(status: .idle, statusPane: .right).clearedBy(pane: .right, isInterrupt: true))
     }
 
     @Test func clearedByNonMatchingPaneNeverClears() {
-        // a keystroke from a different pane must never clear a background block
         #expect(!AgentIndicator(status: .blocked, statusPane: .right).clearedBy(pane: .left, isInterrupt: false))
         #expect(!AgentIndicator(status: .blocked, statusPane: .right).clearedBy(pane: .left, isInterrupt: true))
         #expect(!AgentIndicator(status: .blocked, statusPane: .scratch).clearedBy(pane: .left, isInterrupt: false))
@@ -99,7 +93,6 @@ struct AgentStatusTests {
     }
 
     @Test func clearedByNilStatusPaneTreatedAsLeft() {
-        // nil statusPane behaves as .left (main): a left keystroke clears, right/scratch do not
         #expect(AgentIndicator(status: .blocked).clearedBy(pane: .left, isInterrupt: false))
         #expect(!AgentIndicator(status: .blocked).clearedBy(pane: .right, isInterrupt: false))
         #expect(!AgentIndicator(status: .blocked).clearedBy(pane: .scratch, isInterrupt: true))
@@ -114,13 +107,11 @@ struct AgentStatusTests {
     }
 
     @Test func effectiveSoundPrefersPerCallOverDefault() {
-        // explicit per-call sound wins on any status, even when a blocked default is set.
         #expect(AgentStatus.blocked.effectiveSound(perCall: "Glass", blockedDefault: "Sosumi") == "Glass")
         #expect(AgentStatus.active.effectiveSound(perCall: "Glass", blockedDefault: "Sosumi") == "Glass")
     }
 
     @Test func effectiveSoundUsesBlockedDefaultOnlyForBlocked() {
-        // no per-call sound: the configured default plays for blocked, but never for the other states.
         #expect(AgentStatus.blocked.effectiveSound(perCall: nil, blockedDefault: "Sosumi") == "Sosumi")
         #expect(AgentStatus.active.effectiveSound(perCall: nil, blockedDefault: "Sosumi") == nil)
         #expect(AgentStatus.completed.effectiveSound(perCall: nil, blockedDefault: "Sosumi") == nil)
@@ -143,13 +134,12 @@ struct AgentStatusTests {
     }
 
     @Test func attentionRankOrdersBlockedActiveCompleted() {
-        // blocked is most urgent, then active, then completed
         #expect(AgentStatus.blocked.attentionRank < AgentStatus.active.attentionRank)
         #expect(AgentStatus.active.attentionRank < AgentStatus.completed.attentionRank)
         #expect(AgentStatus.blocked.attentionRank == 0)
         #expect(AgentStatus.active.attentionRank == 1)
         #expect(AgentStatus.completed.attentionRank == 2)
-        // idle is never sorted (filtered out first); sorts after the non-idle states
+        // idle is filtered out before sorting, so it ranks after the non-idle states
         #expect(AgentStatus.completed.attentionRank < AgentStatus.idle.attentionRank)
     }
 
@@ -158,7 +148,6 @@ struct AgentStatusTests {
         #expect(AgentStatus.active.symbolName(override: nil, configured: nil) == "circle.fill")
         #expect(AgentStatus.blocked.symbolName(override: nil, configured: nil) == "circle.fill")
         #expect(AgentStatus.completed.symbolName(override: nil, configured: nil) == "circle.fill")
-        // idle never renders a glyph
         #expect(AgentStatus.idle.symbolName(override: nil, configured: nil) == "")
     }
 
@@ -172,8 +161,7 @@ struct AgentStatusTests {
     }
 
     @Test func statusShapeDisplayNamesAreCapitalizedRawValues() {
-        // the Settings picker's option label and its accessibility value, so the e2e's menu-item titles
-        // ("Triangle") and its post-relaunch picker value are pinned here rather than in the view.
+        // the e2e's menu-item titles and its post-relaunch picker value are pinned here, not in the view
         #expect(StatusShape.circle.displayName == "Circle")
         #expect(StatusShape.square.displayName == "Square")
         #expect(StatusShape.triangle.displayName == "Triangle")
@@ -214,8 +202,6 @@ struct AgentStatusTests {
     }
 
     @Test func symbolNameBothNilIsThePlainCircleDefault() {
-        // the built-in default is StatusShape.circle for every non-idle state, so an unset shape and an
-        // explicit circle render identically
         #expect(AgentStatus.active.symbolName(override: nil, configured: nil) == StatusShape.circle.symbolName)
         #expect(AgentStatus.blocked.symbolName(override: nil, configured: nil) == StatusShape.circle.symbolName)
         #expect(AgentStatus.completed.symbolName(override: nil, configured: nil) == StatusShape.circle.symbolName)
@@ -224,7 +210,6 @@ struct AgentStatusTests {
     }
 
     @Test func symbolNameIdleIsEmptyInEveryCombination() {
-        // idle renders no glyph, so a shape is accepted and ignored
         #expect(AgentStatus.idle.symbolName(override: nil, configured: nil) == "")
         #expect(AgentStatus.idle.symbolName(override: .star, configured: nil) == "")
         #expect(AgentStatus.idle.symbolName(override: nil, configured: .square) == "")
@@ -236,7 +221,7 @@ struct AgentStatusTests {
         #expect(AgentIndicator(status: .blocked, shape: .triangle) != AgentIndicator(status: .blocked))
         #expect(AgentIndicator(status: .blocked, shape: .triangle) != AgentIndicator(status: .blocked, shape: .square))
         #expect(AgentIndicator(status: .blocked, shape: .triangle) == AgentIndicator(status: .blocked, shape: .triangle))
-        #expect(AgentIndicator(status: .blocked).shape == nil) // unset by default
+        #expect(AgentIndicator(status: .blocked).shape == nil)
     }
 
     @Test func tooltipTextNamesVisibleStatusesAndOmitsIdle() {

--- a/agtermCore/Tests/agtermCoreTests/AgentStatusWrapperTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AgentStatusWrapperTests.swift
@@ -2,10 +2,8 @@ import Foundation
 import Testing
 
 // Tests the shipped hook wrapper `agterm/Resources/agent-status/agterm-agent-status.sh` by running it
-// with a stub `agtermctl` that records its argv. The two bugs that shipped and broke the live hooks —
-// `--socket` placed BEFORE the subcommand (agtermctl rejected every call) and stdout leaking into the
-// prompt (UserPromptSubmit injects a hook's stdout) — had no test. This is that test. It reaches the
-// app target's resource on purpose: the wrapper is the shell half of the agtermCore agent-status model.
+// with a stub `agtermctl` that records its argv. It reaches the app target's resource on purpose: the
+// wrapper is the shell half of the agtermCore agent-status model.
 struct AgentStatusWrapperTests {
     // the shipped wrapper, located relative to this test source file (fixed repo layout).
     private static var wrapper: String {
@@ -77,59 +75,53 @@ struct AgentStatusWrapperTests {
     }
 
     @Test func noOpOutsideAgterm() throws {
-        // no AGTERM_SESSION_ID: must exit 0 and never call agtermctl (no recorded argv)
         let r = try runWrapper(["active"], env: [:])
         #expect(r.argv.isEmpty)
         #expect(r.exit == 0)
     }
 
     @Test func suppressesStdoutSoItCannotPolluteThePrompt() throws {
-        // agtermctl prints "ok"; the wrapper must swallow it (UserPromptSubmit injects hook stdout)
+        // UserPromptSubmit injects a hook's stdout, so the wrapper must swallow agtermctl's "ok"
         let r = try runWrapper(["active"], env: ["AGTERM_SESSION_ID": "sid", "AGTERM_SOCKET": "/tmp/s.sock"], stubStdout: "ok")
         #expect(r.stdout.isEmpty)
     }
 
     @Test func alwaysExitsZeroEvenWhenAgtermctlFails() throws {
-        // a status hook must never block the turn, so a non-zero agtermctl still yields wrapper exit 0
         let r = try runWrapper(["active"], env: ["AGTERM_SESSION_ID": "sid", "AGTERM_SOCKET": "/tmp/s.sock"], stubExit: 64)
         #expect(r.exit == 0)
     }
 
     @Test func paneForwardedWhenAgtermPaneSet() throws {
-        // the app injects AGTERM_PANE per surface; the wrapper splices `--pane <value>` before "$@"
+        // the app injects AGTERM_PANE per surface
         let r = try runWrapper(["blocked"], env: ["AGTERM_SESSION_ID": "sid", "AGTERM_SOCKET": "/tmp/s.sock", "AGTERM_PANE": "right"])
         #expect(r.argv == ["session", "status", "blocked", "--target", "sid", "--socket", "/tmp/s.sock", "--pane", "right"])
         #expect(r.exit == 0)
     }
 
     @Test func paneForwardedWithoutSocket() throws {
-        // no socket branch also carries the pane, right after --target
         let r = try runWrapper(["blocked"], env: ["AGTERM_SESSION_ID": "sid", "AGTERM_PANE": "scratch"])
         #expect(r.argv == ["session", "status", "blocked", "--target", "sid", "--pane", "scratch"])
     }
 
     @Test func paneSplicedBeforeExtraArgs() throws {
-        // --pane comes before the forwarded "$@" (e.g. --blink), never after
         let r = try runWrapper(["blocked", "--blink"], env: ["AGTERM_SESSION_ID": "sid", "AGTERM_SOCKET": "/tmp/s.sock", "AGTERM_PANE": "right"])
         #expect(r.argv == ["session", "status", "blocked", "--target", "sid", "--socket", "/tmp/s.sock", "--pane", "right", "--blink"])
     }
 
     @Test func paneOmittedWhenAgtermPaneUnset() throws {
-        // no AGTERM_PANE: no --pane flag at all
         let r = try runWrapper(["active"], env: ["AGTERM_SESSION_ID": "sid", "AGTERM_SOCKET": "/tmp/s.sock"])
         #expect(!r.argv.contains("--pane"))
     }
 
     @Test func paneNoOpWithoutSessionID() throws {
-        // AGTERM_PANE set but no AGTERM_SESSION_ID: still a no-op, exit 0, no call
         let r = try runWrapper(["active"], env: ["AGTERM_PANE": "right"])
         #expect(r.argv.isEmpty)
         #expect(r.exit == 0)
     }
 
     @Test func paneIDForwardedWithRole() throws {
-        // the app injects AGTERM_PANE_ID (stable surface token) alongside AGTERM_PANE (role); the wrapper
-        // forwards both, --pane then --pane-id, so the app can resolve the live slot from the token (#199).
+        // AGTERM_PANE_ID is a stable per-surface token beside AGTERM_PANE's role, so the app can
+        // resolve the live slot even when the baked role went stale (#199).
         let r = try runWrapper(["blocked"], env: ["AGTERM_SESSION_ID": "sid", "AGTERM_SOCKET": "/tmp/s.sock",
                                                   "AGTERM_PANE": "right", "AGTERM_PANE_ID": "agent-tok"])
         #expect(r.argv == ["session", "status", "blocked", "--target", "sid", "--socket", "/tmp/s.sock",
@@ -137,7 +129,6 @@ struct AgentStatusWrapperTests {
     }
 
     @Test func paneIDSplicedBeforeExtraArgs() throws {
-        // both discriminators come before the forwarded "$@" (e.g. --blink), never after
         let r = try runWrapper(["blocked", "--blink"], env: ["AGTERM_SESSION_ID": "sid",
                                                              "AGTERM_PANE": "right", "AGTERM_PANE_ID": "agent-tok"])
         #expect(r.argv == ["session", "status", "blocked", "--target", "sid",
@@ -145,13 +136,11 @@ struct AgentStatusWrapperTests {
     }
 
     @Test func paneIDForwardedWithoutRole() throws {
-        // defensively, a token with no role still forwards --pane-id alone (no --pane)
         let r = try runWrapper(["blocked"], env: ["AGTERM_SESSION_ID": "sid", "AGTERM_PANE_ID": "agent-tok"])
         #expect(r.argv == ["session", "status", "blocked", "--target", "sid", "--pane-id", "agent-tok"])
     }
 
     @Test func paneIDOmittedWhenUnset() throws {
-        // AGTERM_PANE set but no AGTERM_PANE_ID: no --pane-id flag
         let r = try runWrapper(["active"], env: ["AGTERM_SESSION_ID": "sid", "AGTERM_PANE": "right"])
         #expect(!r.argv.contains("--pane-id"))
     }

--- a/agtermCore/Tests/agtermCoreTests/AppSettingsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppSettingsTests.swift
@@ -28,35 +28,30 @@ struct AppSettingsTests {
     }
 
     @Test func emptySettingsEmitOnlyAlwaysOnDefaults() {
-        // every other field is unset (omitted); only the two always-on keys emit — mouse-scroll-multiplier
-        // at its default of 3 and right-click-action at its default of paste.
         #expect(AppSettings().ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
     @Test func configLinesCoverSetFieldsRawNoQuoting() {
         let settings = AppSettings(fontFamily: "SF Mono", fontSize: 14, theme: "3024 Night")
         let lines = settings.ghosttyConfigLines()
-        // raw values — names with spaces are NOT quoted (ghostty takes the line remainder).
+        // names with spaces are NOT quoted — ghostty takes the line remainder.
         #expect(lines.contains("font-family = SF Mono"))
         #expect(lines.contains("theme = 3024 Night"))
-        #expect(lines.contains("font-size = 14")) // integer renders without ".0"
+        #expect(lines.contains("font-size = 14"))
     }
 
     @Test func configLinesOmitUnsetFields() {
         let lines = AppSettings(theme: "Alabaster").ghosttyConfigLines()
-        // theme is set; font lines omitted; the always-on defaults (scroll + right-click) trail.
         #expect(lines == ["theme = Alabaster", "mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
     @Test func followingEmitsRawDual() {
-        // following the appearance emits ghostty's dual conditional RAW (written unquoted); libghostty
-        // resolves the active side itself on a color-scheme change, so agterm never picks a side.
+        // libghostty resolves the active side of the dual conditional itself, so agterm never picks one.
         let settings = AppSettings(theme: "Builtin Light", darkTheme: "Nord", followSystemAppearance: true)
         #expect(settings.ghosttyConfigLines().contains("theme = light:Builtin Light,dark:Nord"))
     }
 
     @Test func notFollowingEmitsSingleTheme() {
-        // a plain theme, or a set dark slot with following OFF, emits one theme (no dual).
         #expect(AppSettings(theme: "Alabaster").ghosttyConfigLines().contains("theme = Alabaster"))
         let darkKept = AppSettings(theme: "Alabaster", darkTheme: "Nord", followSystemAppearance: false)
         #expect(darkKept.ghosttyConfigLines().contains("theme = Alabaster"))
@@ -64,8 +59,7 @@ struct AppSettingsTests {
     }
 
     @Test func activeThemeTracksAppearanceWhenFollowing() {
-        // the palette badge/selection resolver: the dark slot in dark mode (else `theme`), `theme` in
-        // light mode. Not following → the appearance is ignored.
+        // the palette badge/selection resolver.
         let synced = AppSettings(theme: "Builtin Light", darkTheme: "Nord", followSystemAppearance: true)
         #expect(synced.activeTheme(isDark: true) == "Nord")
         #expect(synced.activeTheme(isDark: false) == "Builtin Light")
@@ -76,8 +70,8 @@ struct AppSettingsTests {
     }
 
     @Test func followingWithoutDarkSlotEmitsSingle() {
-        // following on but the dark slot unset (an inconsistent hand-edit): fall back to the single
-        // theme rather than an ill-formed `light:X,dark:`.
+        // an inconsistent hand-edit: fall back to the single theme rather than an ill-formed
+        // `light:X,dark:`.
         let settings = AppSettings(theme: "Alabaster", darkTheme: nil, followSystemAppearance: true)
         #expect(settings.ghosttyConfigLines().contains("theme = Alabaster"))
         #expect(!settings.ghosttyConfigLines().contains { $0.hasPrefix("theme = light:") })
@@ -109,9 +103,7 @@ struct AppSettingsTests {
     }
 
     @Test func opaqueOrUnsetOpacityEmitsNoBackgroundPins() {
-        // full opacity, unset opacity, and a blur with no translucency all render normally: ghostty
-        // paints its own background (blur needs opacity < 1 to be visible). none emit the background
-        // pins (the always-present scroll default means the line set is not empty).
+        // blur needs opacity < 1 to be visible, so a blur with no translucency emits no pins either.
         for settings in [AppSettings(backgroundOpacity: 1), AppSettings(), AppSettings(backgroundBlur: 40)] {
             let lines = settings.ghosttyConfigLines()
             #expect(!lines.contains("background-opacity = 0"))
@@ -120,13 +112,11 @@ struct AppSettingsTests {
     }
 
     @Test func mouseScrollMultiplierAlwaysEmittedAtDefaultThree() {
-        // unset → the default 3 is emitted (NOT omitted), so the default speed is effective.
         #expect(AppSettings().ghosttyConfigLines().contains("mouse-scroll-multiplier = 3"))
     }
 
     @Test func mouseScrollMultiplierEmitsSetValue() {
         #expect(AppSettings(mouseScrollMultiplier: 5).ghosttyConfigLines().contains("mouse-scroll-multiplier = 5"))
-        // fractional keeps the decimal via the shared format helper
         #expect(AppSettings(mouseScrollMultiplier: 1.5).ghosttyConfigLines().contains("mouse-scroll-multiplier = 1.5"))
     }
 
@@ -140,8 +130,6 @@ struct AppSettingsTests {
                                    completedStatusColorHex: "#778899")
         let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(original))
         #expect(decoded == original)
-        // the glyph colors are applied at the AppKit level, never as ghostty config keys — so the only
-        // lines are the always-on defaults (scroll + right-click).
         #expect(decoded.ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
@@ -153,8 +141,6 @@ struct AppSettingsTests {
         #expect(decoded.effectiveStatusShape(for: .active) == .square)
         #expect(decoded.effectiveStatusShape(for: .blocked) == .triangle)
         #expect(decoded.effectiveStatusShape(for: .completed) == .star)
-        // the glyph shapes are applied at the AppKit level, never as ghostty config keys — so the only
-        // lines are the always-on defaults (scroll + right-click).
         #expect(decoded.ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
@@ -168,7 +154,7 @@ struct AppSettingsTests {
     }
 
     @Test func statusShapesDefaultNilAndOmitFromJSON() throws {
-        // unset means the default plain circle, and nothing serializes, keeping settings.json minimal.
+        // unset means the default plain circle.
         let settings = AppSettings()
         #expect(settings.activeStatusShape == nil)
         #expect(settings.effectiveStatusShape(for: .active) == nil)
@@ -176,7 +162,6 @@ struct AppSettingsTests {
         #expect(settings.effectiveStatusShape(for: .completed) == nil)
         let json = String(decoding: try JSONEncoder().encode(settings), as: UTF8.self)
         #expect(!json.contains("StatusShape"))
-        // a settings.json written before the fields existed decodes them to nil.
         let legacy = try JSONDecoder().decode(AppSettings.self, from: Data(#"{ "fontSize": 16 }"#.utf8))
         #expect(legacy.activeStatusShape == nil)
         #expect(legacy.blockedStatusShape == nil)
@@ -185,19 +170,18 @@ struct AppSettingsTests {
     }
 
     @Test func unknownStatusShapeResolvesToNilAndPreservesOtherSettings() throws {
-        // a future-written or hand-edited shape must decode tolerantly (the forward-compat rule): the raw
-        // string is kept, resolves to nil (the built-in glyph), and the rest of the file survives.
+        // forward-compat rule: an unknown shape keeps its raw string, resolves to nil (the built-in
+        // glyph), and must not fail the whole decode.
         let decoded = try JSONDecoder().decode(
             AppSettings.self, from: Data(#"{ "blockedStatusShape": "trapezoid", "fontSize": 16 }"#.utf8))
         #expect(decoded.fontSize == 16)
         #expect(decoded.blockedStatusShape == "trapezoid")
         #expect(decoded.effectiveStatusShape(for: .blocked) == nil)
-        // an empty string is likewise unknown, not a shape.
         #expect(AppSettings(activeStatusShape: "").effectiveStatusShape(for: .active) == nil)
     }
 
     @Test func effectiveStatusShapeIsNilForIdle() {
-        // idle renders no glyph, so it resolves to no shape even with every field set.
+        // idle renders no glyph at all.
         let settings = AppSettings(activeStatusShape: "circle", blockedStatusShape: "square",
                                    completedStatusShape: "star")
         #expect(settings.effectiveStatusShape(for: .idle) == nil)
@@ -206,17 +190,14 @@ struct AppSettingsTests {
     @Test func notificationsEnabledRoundTripsAndIsNotAConfigLine() throws {
         let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(AppSettings(notificationsEnabled: false)))
         #expect(decoded.notificationsEnabled == false)
-        // it's an app-level toggle, never a ghostty config key — only the always-on defaults (scroll + right-click) are emitted.
         #expect(AppSettings(notificationsEnabled: false).ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
     @Test func restoreRunningCommandRoundTripsAndIsNotAConfigLine() throws {
         let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(AppSettings(restoreRunningCommand: true)))
         #expect(decoded.restoreRunningCommand == true)
-        // absent in a legacy file decodes to nil (off).
         let legacy = try JSONDecoder().decode(AppSettings.self, from: Data(#"{"theme":"Nord"}"#.utf8))
         #expect(legacy.restoreRunningCommand == nil)
-        // an app-level behavior flag, never a ghostty config key — only the always-on defaults (scroll + right-click) are emitted.
         #expect(AppSettings(restoreRunningCommand: true).ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
@@ -225,10 +206,8 @@ struct AppSettingsTests {
         let decoded = try JSONDecoder().decode(
             AppSettings.self, from: JSONEncoder().encode(AppSettings(autoHideSidebarInactiveWindows: true)))
         #expect(decoded.autoHideSidebarInactiveWindows == true)
-        // absent in a legacy file decodes to nil (off).
         let legacy = try JSONDecoder().decode(AppSettings.self, from: Data(#"{"theme":"Nord"}"#.utf8))
         #expect(legacy.autoHideSidebarInactiveWindows == nil)
-        // a behavior flag, never a ghostty config key — only the always-on defaults (scroll + right-click) are emitted.
         #expect(AppSettings(autoHideSidebarInactiveWindows: true).ghosttyConfigLines()
             == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
@@ -236,30 +215,24 @@ struct AppSettingsTests {
     @Test func confirmCloseSessionRoundTripsAndIsNotAConfigLine() throws {
         let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(AppSettings(confirmCloseSession: true)))
         #expect(decoded.confirmCloseSession == true)
-        // absent in a legacy file decodes to nil (off — today's silent close).
         let legacy = try JSONDecoder().decode(AppSettings.self, from: Data(#"{"theme":"Nord"}"#.utf8))
         #expect(legacy.confirmCloseSession == nil)
-        // an app-level behavior flag, never a ghostty config key — only the always-on defaults (scroll + right-click) are emitted.
         #expect(AppSettings(confirmCloseSession: true).ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
     @Test func notificationSoundNameRoundTripsAndIsNotAConfigLine() throws {
         let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(AppSettings(notificationSoundName: "Glass")))
         #expect(decoded.notificationSoundName == "Glass")
-        // absent in a legacy file decodes to nil (no sound).
         let legacy = try JSONDecoder().decode(AppSettings.self, from: Data(#"{"theme":"Nord"}"#.utf8))
         #expect(legacy.notificationSoundName == nil)
-        // an app-level value, never a ghostty config key — only the always-on defaults (scroll + right-click) are emitted.
         #expect(AppSettings(notificationSoundName: "Glass").ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
     @Test func blockedStatusSoundNameRoundTripsAndIsNotAConfigLine() throws {
         let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(AppSettings(blockedStatusSoundName: "Glass")))
         #expect(decoded.blockedStatusSoundName == "Glass")
-        // absent in a legacy file decodes to nil (no sound).
         let legacy = try JSONDecoder().decode(AppSettings.self, from: Data(#"{"theme":"Nord"}"#.utf8))
         #expect(legacy.blockedStatusSoundName == nil)
-        // an app-level value, never a ghostty config key — only the always-on defaults (scroll + right-click) are emitted.
         #expect(AppSettings(blockedStatusSoundName: "Glass").ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
@@ -269,19 +242,15 @@ struct AppSettingsTests {
             #expect(decoded.toolbarMode == mode.rawValue)
             #expect(decoded.effectiveToolbarMode == mode)
         }
-        // window-chrome mode applied at the AppKit level, never a ghostty config key — only the always-on
-        // defaults (scroll + right-click) are emitted.
         #expect(AppSettings(toolbarMode: ToolbarMode.hidden.rawValue).ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
     @Test func toolbarModeOmittedWhenNil() throws {
-        // nil (default) never serializes, keeping settings.json minimal; the legacy shim is likewise absent.
         #expect(AppSettings().toolbarMode == nil)
         let json = String(decoding: try JSONEncoder().encode(AppSettings()), as: UTF8.self)
         #expect(!json.contains("toolbarMode"))
         #expect(!json.contains("compactToolbar"))
-        // a set mode serializes its raw value while the (nil) legacy shim stays absent — the write path
-        // that lets the legacy key evaporate on the next save.
+        // the write path that lets the legacy key evaporate on the next save.
         let withMode = String(decoding: try JSONEncoder().encode(AppSettings(toolbarMode: ToolbarMode.hidden.rawValue)), as: UTF8.self)
         #expect(withMode.contains("toolbarMode"))
         #expect(withMode.contains("hidden"))
@@ -289,20 +258,17 @@ struct AppSettingsTests {
     }
 
     @Test func effectiveToolbarModeDefaultsCompact() {
-        // nil toolbarMode + nil legacy shim resolves to compact (the app default).
         #expect(AppSettings().effectiveToolbarMode == .compact)
     }
 
     @Test func effectiveToolbarModeResolvesExplicitModes() {
-        // an explicit mode with no legacy shim resolves to itself, including the compact default.
         #expect(AppSettings(toolbarMode: ToolbarMode.compact.rawValue).effectiveToolbarMode == .compact)
         #expect(AppSettings(toolbarMode: ToolbarMode.normal.rawValue).effectiveToolbarMode == .normal)
         #expect(AppSettings(toolbarMode: ToolbarMode.hidden.rawValue).effectiveToolbarMode == .hidden)
     }
 
     @Test func unknownToolbarModePreservesOtherSettings() throws {
-        // a future-written mode must decode tolerantly (the forward-compat rule): it may NOT fail the whole
-        // decode and discard every other field. the unknown raw value falls through to the default.
+        // forward-compat rule: an unknown mode must not fail the decode and discard every other field.
         let decoded = try JSONDecoder().decode(AppSettings.self, from: Data(#"{ "toolbarMode": "floating", "fontSize": 16 }"#.utf8))
         #expect(decoded.fontSize == 16)
         #expect(decoded.toolbarMode == "floating")
@@ -310,14 +276,12 @@ struct AppSettingsTests {
     }
 
     @Test func toolbarModeWinsOverLegacyCompactToolbar() {
-        // when both are present, the explicit toolbarMode wins over the legacy shim.
         #expect(AppSettings(toolbarMode: ToolbarMode.hidden.rawValue, compactToolbar: false).effectiveToolbarMode == .hidden)
         #expect(AppSettings(toolbarMode: ToolbarMode.normal.rawValue, compactToolbar: true).effectiveToolbarMode == .normal)
     }
 
     @Test func legacyCompactToolbarMigratesToMode() throws {
-        // a settings.json written before toolbarMode existed resolves via the compactToolbar shim:
-        // false → normal, true/nil → compact.
+        // the legacy shim maps false → normal, true/nil → compact.
         let normal = try JSONDecoder().decode(AppSettings.self, from: Data(#"{ "compactToolbar": false }"#.utf8))
         #expect(normal.toolbarMode == nil)
         #expect(normal.effectiveToolbarMode == .normal)
@@ -334,7 +298,6 @@ struct AppSettingsTests {
     @Test func notificationBadgeEnabledRoundTripsAndIsNotAConfigLine() throws {
         let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(AppSettings(notificationBadgeEnabled: false)))
         #expect(decoded.notificationBadgeEnabled == false)
-        // app-level sidebar render toggle, never a ghostty config key — only the always-on defaults (scroll + right-click) are emitted.
         #expect(AppSettings(notificationBadgeEnabled: false).ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
@@ -342,12 +305,10 @@ struct AppSettingsTests {
         let original = AppSettings(configDirectory: "/tmp/agterm-config")
         let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(original))
         #expect(decoded.configDirectory == "/tmp/agterm-config")
-        // app-level path, never a ghostty config key — only the always-on defaults (scroll + right-click) appear.
         #expect(decoded.ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
     @Test func configDirectoryDecodesNilWhenAbsent() throws {
-        // a settings.json written before `configDirectory` existed still decodes.
         let json = #"{ "fontSize": 16 }"#
         let decoded = try JSONDecoder().decode(AppSettings.self, from: Data(json.utf8))
         #expect(decoded.configDirectory == nil)
@@ -356,7 +317,6 @@ struct AppSettingsTests {
     @Test func inactivePaneMuteStrengthRoundTripsAndIsNotAConfigLine() throws {
         let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(AppSettings(inactivePaneMuteStrength: 7)))
         #expect(decoded.inactivePaneMuteStrength == 7)
-        // SwiftUI overlay opacity applied in the app target, never a ghostty config key.
         #expect(AppSettings(inactivePaneMuteStrength: 7).ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
@@ -369,7 +329,6 @@ struct AppSettingsTests {
         #expect(AppSettings.muteOpacity(strength: 0) == 0)
         #expect(AppSettings.muteOpacity(strength: 5) == 0.4)
         #expect(AppSettings.muteOpacity(strength: 10) == 0.8)
-        // out-of-range strengths clamp to the 0...10 ends rather than over/undershooting.
         #expect(AppSettings.muteOpacity(strength: -3) == 0)
         #expect(AppSettings.muteOpacity(strength: 99) == 0.8)
         #expect(AppSettings.defaultInactivePaneMuteStrength == 5)
@@ -378,7 +337,6 @@ struct AppSettingsTests {
     @Test func sidebarBackgroundShiftRoundTripsAndIsNotAConfigLine() throws {
         let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(AppSettings(sidebarBackgroundShift: 8)))
         #expect(decoded.sidebarBackgroundShift == 8)
-        // AppKit-level sidebar tint applied in the app target, never a ghostty config key.
         #expect(AppSettings(sidebarBackgroundShift: 8).ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
@@ -393,7 +351,6 @@ struct AppSettingsTests {
         #expect(abs(AppSettings.sidebarShiftAmount(strength: 10) - 0.30) < 1e-9)   // full darken
         #expect(AppSettings.sidebarShiftAmount(strength: 7) > 0)                   // above center darkens
         #expect(AppSettings.sidebarShiftAmount(strength: 3) < 0)                   // below center lightens
-        // out-of-range strengths clamp to the 0...10 ends.
         #expect(AppSettings.sidebarShiftAmount(strength: -4) == AppSettings.sidebarShiftAmount(strength: 0))
         #expect(AppSettings.sidebarShiftAmount(strength: 99) == AppSettings.sidebarShiftAmount(strength: 10))
         #expect(AppSettings.defaultSidebarBackgroundShift == 5)
@@ -402,7 +359,6 @@ struct AppSettingsTests {
     @Test func sidebarFontSizeRoundTripsAndIsNotAConfigLine() throws {
         let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(AppSettings(sidebarFontSize: 16)))
         #expect(decoded.sidebarFontSize == 16)
-        // AppKit-level sidebar font applied in the app target, never a ghostty config key.
         #expect(AppSettings(sidebarFontSize: 16).ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
@@ -440,10 +396,8 @@ struct AppSettingsTests {
     }
 
     @Test func inheritGlobalGhosttyConfigDefaultsOffAndIsNotAGhosttyKey() throws {
-        // default (nil) = off; an app-level flag, so it adds NO ghostty config line.
         #expect(AppSettings().inheritGlobalGhosttyConfig == nil)
         #expect(AppSettings(inheritGlobalGhosttyConfig: true).ghosttyConfigLines() == AppSettings().ghosttyConfigLines())
-        // round-trips each state; a legacy settings.json without the key decodes to nil (off).
         for value: Bool? in [nil, true, false] {
             let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(AppSettings(inheritGlobalGhosttyConfig: value)))
             #expect(decoded.inheritGlobalGhosttyConfig == value)
@@ -453,10 +407,8 @@ struct AppSettingsTests {
     }
 
     @Test func attentionButtonEnabledDefaultsOffAndIsNotAGhosttyKey() throws {
-        // default (nil) = off; an app-level chrome flag, so it adds NO ghostty config line.
         #expect(AppSettings().attentionButtonEnabled == nil)
         #expect(AppSettings(attentionButtonEnabled: true).ghosttyConfigLines() == AppSettings().ghosttyConfigLines())
-        // round-trips each state; a legacy settings.json without the key decodes to nil (off).
         for value: Bool? in [nil, true, false] {
             let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(AppSettings(attentionButtonEnabled: value)))
             #expect(decoded.attentionButtonEnabled == value)
@@ -466,16 +418,14 @@ struct AppSettingsTests {
     }
 
     @Test func dockBounceDefaultsToOffResolvesTolerantlyAndIsNotAGhosttyKey() throws {
-        // default (nil) resolves to off; an app-level attention setting, so it adds NO ghostty line.
         #expect(AppSettings().effectiveDockBounce == .off)
         #expect(AppSettings(dockBounce: "once").ghosttyConfigLines() == AppSettings().ghosttyConfigLines())
-        // each known raw value round-trips and resolves to its case.
         for mode in DockBounce.allCases {
             let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(AppSettings(dockBounce: mode.rawValue)))
             #expect(decoded.dockBounce == mode.rawValue)
             #expect(decoded.effectiveDockBounce == mode)
         }
-        // an unknown/future raw value degrades to off instead of failing the decode; a legacy file omits it.
+        // an unknown/future raw value degrades to off instead of failing the decode.
         #expect(AppSettings(dockBounce: "supernova").effectiveDockBounce == .off)
         let legacy = try JSONDecoder().decode(AppSettings.self, from: Data(#"{ "fontSize": 16 }"#.utf8))
         #expect(legacy.dockBounce == nil)
@@ -483,13 +433,11 @@ struct AppSettingsTests {
     }
 
     @Test func rightClickPasteDefaultsOnAndIsAGhosttyKey() throws {
-        // default (nil) = on → emits `right-click-action = paste`; off → `ignore`. UNLIKE the app-level
-        // flags this IS a ghostty key (the toggle owns it, always emitted).
+        // UNLIKE the app-level flags this IS a ghostty key — the toggle owns it, always emitted.
         #expect(AppSettings().rightClickPaste == nil)
         #expect(AppSettings().ghosttyConfigLines().contains("right-click-action = paste"))
         #expect(AppSettings(rightClickPaste: true).ghosttyConfigLines().contains("right-click-action = paste"))
         #expect(AppSettings(rightClickPaste: false).ghosttyConfigLines().contains("right-click-action = ignore"))
-        // round-trips each state; a legacy settings.json without the key decodes to nil (on).
         for value: Bool? in [nil, true, false] {
             let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(AppSettings(rightClickPaste: value)))
             #expect(decoded.rightClickPaste == value)
@@ -502,26 +450,22 @@ struct AppSettingsTests {
         let original = AppSettings(newSessionDirectory: "custom", newSessionCustomDirectory: "/tmp/work")
         let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(original))
         #expect(decoded == original)
-        // absent in a legacy file decodes to nil (the home default).
         let legacy = try JSONDecoder().decode(AppSettings.self, from: Data(#"{ "fontSize": 16 }"#.utf8))
         #expect(legacy.newSessionDirectory == nil)
         #expect(legacy.newSessionCustomDirectory == nil)
-        // an app-level behavior value, never a ghostty config key — only the always-on defaults are emitted.
         #expect(original.ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
     @Test func resolveNewSessionCwdHomeIsDefault() {
-        // nil mode (default) and an explicit "home" both resolve to home, ignoring the session cwd.
         #expect(AppSettings().resolveNewSessionCwd(currentSessionCwd: "/proj", home: "/home") == "/home")
         #expect(AppSettings(newSessionDirectory: "home").resolveNewSessionCwd(currentSessionCwd: "/proj", home: "/home") == "/home")
-        // an unknown future mode falls back to home rather than crashing.
+        // an unknown future mode falls back to home.
         #expect(AppSettings(newSessionDirectory: "future").resolveNewSessionCwd(currentSessionCwd: "/proj", home: "/home") == "/home")
     }
 
     @Test func resolveNewSessionCwdCurrentSessionInheritsOrFallsBack() {
         let settings = AppSettings(newSessionDirectory: "currentSession")
         #expect(settings.resolveNewSessionCwd(currentSessionCwd: "/proj", home: "/home") == "/proj")
-        // no active session (nil cwd) or a blank cwd falls back to home.
         #expect(settings.resolveNewSessionCwd(currentSessionCwd: nil, home: "/home") == "/home")
         #expect(settings.resolveNewSessionCwd(currentSessionCwd: "", home: "/home") == "/home")
     }
@@ -529,7 +473,6 @@ struct AppSettingsTests {
     @Test func resolveNewSessionCwdCustomUsesPathElseHome() {
         #expect(AppSettings(newSessionDirectory: "custom", newSessionCustomDirectory: "/fixed")
             .resolveNewSessionCwd(currentSessionCwd: "/proj", home: "/home") == "/fixed")
-        // custom mode with an unset or blank path falls back to home.
         #expect(AppSettings(newSessionDirectory: "custom")
             .resolveNewSessionCwd(currentSessionCwd: "/proj", home: "/home") == "/home")
         #expect(AppSettings(newSessionDirectory: "custom", newSessionCustomDirectory: "")
@@ -537,15 +480,12 @@ struct AppSettingsTests {
     }
 
     @Test func autoFollowAttentionUnknownDecodesToOff() {
-        // an unknown future raw value decodes tolerantly to off (the forward-compat rule), not a crash.
         #expect(AppSettings.AutoFollowAttention(rawValue: "s5") == .s5)
         #expect(AppSettings.AutoFollowAttention(rawValue: "future") == nil)
-        // a nil/unknown stored string maps to the disabled default via the ?? off fallback.
         #expect((AppSettings.AutoFollowAttention(rawValue: "future") ?? .off) == .off)
     }
 
     @Test func autoFollowAttentionTolerantInit() {
-        // the shared tolerant lookup: a known raw resolves, nil and an unknown string both fall back to off.
         #expect(AppSettings.AutoFollowAttention(tolerant: "s30") == .s30)
         #expect(AppSettings.AutoFollowAttention(tolerant: nil) == .off)
         #expect(AppSettings.AutoFollowAttention(tolerant: "") == .off)
@@ -558,14 +498,11 @@ struct AppSettingsTests {
         #expect(AppSettings.AutoFollowAttention.s10.timeout == 10)
         #expect(AppSettings.AutoFollowAttention.s30.timeout == 30)
         #expect(AppSettings.AutoFollowAttention.s60.timeout == 60)
-        // m5 is the largest boundary (5 minutes = 300s); s5 the smallest non-off.
         #expect(AppSettings.AutoFollowAttention.m5.timeout == 300)
-        // every case is enumerable and only off has a nil timeout.
         #expect(AppSettings.AutoFollowAttention.allCases.filter { $0.timeout == nil } == [.off])
     }
 
     @Test func autoFollowFieldsDefaultNilAndOmitFromJSON() throws {
-        // both default nil (feature off) and neither serializes when unset, keeping settings.json minimal.
         #expect(AppSettings().autoFollowAttention == nil)
         #expect(AppSettings().autoFollowStayOnActive == nil)
         let json = String(decoding: try JSONEncoder().encode(AppSettings()), as: UTF8.self)
@@ -579,11 +516,9 @@ struct AppSettingsTests {
         #expect(decoded == original)
         #expect(decoded.autoFollowAttention == "s30")
         #expect(decoded.autoFollowStayOnActive == true)
-        // absent in a legacy file decodes to nil (off).
         let legacy = try JSONDecoder().decode(AppSettings.self, from: Data(#"{"theme":"Nord"}"#.utf8))
         #expect(legacy.autoFollowAttention == nil)
         #expect(legacy.autoFollowStayOnActive == nil)
-        // app-level per-window behavior values, never ghostty config keys — only the always-on defaults emit.
         #expect(original.ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
@@ -603,32 +538,30 @@ struct AppSettingsTests {
         #expect(decoded.isInterfaceElementHidden(.scratch))
         #expect(decoded.isInterfaceElementHidden(.flaggedView))
         #expect(!decoded.isInterfaceElementHidden(.split))
-        // a GUI-only chrome value, never a ghostty config key — only the always-on defaults emit.
         #expect(original.ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
     @Test func workspaceAddSessionIsADistinctSidebarInterfaceElement() {
-        // the workspace-row hover "+" is a separate, sidebar-section toggle from the footer newSession button.
+        // the workspace-row hover "+", a separate toggle from the footer newSession button.
         #expect(InterfaceElement.workspaceAddSession.section == .sidebar)
         #expect(InterfaceElement.workspaceAddSession.displayName == "Workspace add-session")
         let hidden = AppSettings(hiddenInterfaceElements: ["workspaceAddSession"])
         #expect(hidden.isInterfaceElementHidden(.workspaceAddSession))
-        #expect(!hidden.isInterfaceElementHidden(.newSession)) // hiding one does not hide the other
+        #expect(!hidden.isInterfaceElementHidden(.newSession))
     }
 
     @Test func focusFilterIsASidebarInterfaceElement() {
-        // the bottom-bar workspace-filter toggle is its own sidebar-section element, hidden independently
-        // of the flagged-view toggle beside it.
+        // the bottom-bar workspace-filter toggle, hidden independently of the flagged-view toggle beside it.
         #expect(InterfaceElement.focusFilter.section == .sidebar)
         #expect(InterfaceElement.focusFilter.displayName == "Workspace filter")
         let hidden = AppSettings(hiddenInterfaceElements: ["focusFilter"])
         #expect(hidden.isInterfaceElementHidden(.focusFilter))
-        #expect(!hidden.isInterfaceElementHidden(.flaggedView)) // hiding one does not hide the other
+        #expect(!hidden.isInterfaceElementHidden(.flaggedView))
     }
 
     @Test func unknownInterfaceElementDecodesTolerantly() throws {
-        // a future-written element name must decode tolerantly (the forward-compat rule): the unknown name
-        // is dropped from the resolved set, and it must NOT fail the whole decode and discard other fields.
+        // forward-compat rule: an unknown name is dropped from the resolved set and must not fail the
+        // whole decode.
         let decoded = try JSONDecoder().decode(
             AppSettings.self,
             from: Data(#"{ "hiddenInterfaceElements": ["scratch", "teleporter"], "fontSize": 16 }"#.utf8))
@@ -638,8 +571,7 @@ struct AppSettingsTests {
     }
 
     @Test func interfaceElementSectionsPartitionAllCases() {
-        // every case belongs to exactly one section, and both sections are non-empty — the Settings tab
-        // relies on this to group the toggles.
+        // the Settings tab relies on this partition to group the toggles.
         let titleBar = InterfaceElement.allCases.filter { $0.section == .titleBar }
         let sidebar = InterfaceElement.allCases.filter { $0.section == .sidebar }
         #expect(titleBar.count + sidebar.count == InterfaceElement.allCases.count)

--- a/agtermCore/Tests/agtermCoreTests/AppStore+DashboardTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStore+DashboardTests.swift
@@ -9,13 +9,12 @@ struct AppStoreDashboardTests {
         let ws = store.addWorkspace(name: "work")
         let a = store.addSession(toWorkspace: ws.id, cwd: "/a")!
         let b = store.addSession(toWorkspace: ws.id, cwd: "/b")!
-        b.hasSplit = true // a split session expands into two cells (primary + split)
+        b.hasSplit = true
         let (members, dropped) = store.dashboardMembers(for: [a.id, b.id], limit: 9)
         #expect(dropped == 0)
         #expect(members == [DashboardMember(session: a.id, surface: .primary),
                             DashboardMember(session: b.id, surface: .primary),
                             DashboardMember(session: b.id, surface: .split)])
-        // control refs: a non-split session is one `:left` cell, a split session is `:left` + `:right`.
         #expect(members.map(\.controlRef) ==
                 ["\(a.id.uuidString):left", "\(b.id.uuidString):left", "\(b.id.uuidString):right"])
     }
@@ -25,8 +24,8 @@ struct AppStoreDashboardTests {
         let ws = store.addWorkspace(name: "work")
         let ids = (0..<5).map { store.addSession(toWorkspace: ws.id, cwd: "/\($0)")!.id }
         let (members, dropped) = store.dashboardMembers(for: ids, limit: 3)
-        #expect(members == ids.prefix(3).map { DashboardMember(session: $0, surface: .primary) }) // first 3 kept
-        #expect(dropped == 2) // two panes past the cap
+        #expect(members == ids.prefix(3).map { DashboardMember(session: $0, surface: .primary) })
+        #expect(dropped == 2)
     }
 
     @Test func dashboardMembersSkipsUnresolvedIDs() {
@@ -35,7 +34,7 @@ struct AppStoreDashboardTests {
         let a = store.addSession(toWorkspace: ws.id, cwd: "/a")!
         let (members, dropped) = store.dashboardMembers(for: [UUID(), a.id, UUID()], limit: 9)
         #expect(dropped == 0)
-        #expect(members == [DashboardMember(session: a.id, surface: .primary)]) // only the real id yields a cell
+        #expect(members == [DashboardMember(session: a.id, surface: .primary)])
     }
 
     @Test func dashboardMRUMembersFollowsRecencyOrderAndExpands() {
@@ -45,7 +44,7 @@ struct AppStoreDashboardTests {
         let b = store.addSession(toWorkspace: ws.id, cwd: "/b")!
         b.hasSplit = true
         store.selectSession(a.id)
-        store.selectSession(b.id) // most-recent-first recency: [b, a]
+        store.selectSession(b.id)
         #expect(store.dashboardMRUMembers(limit: 9) == [DashboardMember(session: b.id, surface: .primary),
                                                         DashboardMember(session: b.id, surface: .split),
                                                         DashboardMember(session: a.id, surface: .primary)])
@@ -53,6 +52,6 @@ struct AppStoreDashboardTests {
 
     @Test func dashboardMRUMembersEmptyWhenNoSessions() {
         let store = makeStore()
-        #expect(store.dashboardMRUMembers(limit: 9).isEmpty) // no sessions → no recent members
+        #expect(store.dashboardMRUMembers(limit: 9).isEmpty)
     }
 }

--- a/agtermCore/Tests/agtermCoreTests/AppStoreAutoFollowTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreAutoFollowTests.swift
@@ -29,7 +29,6 @@ struct AppStoreAutoFollowTests {
         let ws = store.addWorkspace(name: "w")
         let current = addBlocked(store, to: ws.id, cwd: "/cur", at: 50)
         let other = addBlocked(store, to: ws.id, cwd: "/other", at: 200)
-        // parked on a blocked session -> stay put, regardless of another older/newer block
         #expect(store.autoFollowTarget(current: current, blocked: [current, other], stayOnActive: false) == nil)
         #expect(store.autoFollowTarget(current: current, blocked: [current, other], stayOnActive: true) == nil)
     }
@@ -40,9 +39,7 @@ struct AppStoreAutoFollowTests {
         let current = store.addSession(toWorkspace: ws.id, cwd: "/cur")!
         store.setAgentIndicator(AgentIndicator(status: .active), forSession: current.id)
         let blocked = addBlocked(store, to: ws.id, cwd: "/b", at: 100)
-        // opt-in on: don't leave a running agent
         #expect(store.autoFollowTarget(current: current, blocked: [blocked], stayOnActive: true) == nil)
-        // opt-in off: an active current does not suppress
         #expect(store.autoFollowTarget(current: current, blocked: [blocked], stayOnActive: false) == blocked.id)
     }
 
@@ -60,7 +57,7 @@ struct AppStoreAutoFollowTests {
         let stamped = addBlocked(store, to: ws.id, cwd: "/stamped", at: 500)
         let unstamped = store.addSession(toWorkspace: ws.id, cwd: "/unstamped")!
         store.setAgentIndicator(AgentIndicator(status: .blocked), forSession: unstamped.id)
-        unstamped.statusChangedAt = nil // a missing stamp is treated as newest, so the stamped one wins
+        unstamped.statusChangedAt = nil
         #expect(store.autoFollowTarget(current: nil, blocked: [unstamped, stamped], stayOnActive: false) == stamped.id)
     }
 
@@ -71,11 +68,11 @@ struct AppStoreAutoFollowTests {
         let here = store.addWorkspace(name: "here")
         let away = store.addWorkspace(name: "away")
         let idle = store.addSession(toWorkspace: here.id, cwd: "/idle")!
-        let older = addBlocked(store, to: away.id, cwd: "/older", at: 100) // window-wide: another workspace
+        let older = addBlocked(store, to: away.id, cwd: "/older", at: 100)
         _ = addBlocked(store, to: here.id, cwd: "/newer", at: 200)
         store.selectSession(idle.id)
         store.autoFollowFire()
-        #expect(store.selectedSessionID == older.id) // jumps to the oldest blocked, crossing workspaces
+        #expect(store.selectedSessionID == older.id)
     }
 
     @Test func autoFollowFireSuppressedWhenParkedOnBlocked() {
@@ -85,7 +82,7 @@ struct AppStoreAutoFollowTests {
         _ = addBlocked(store, to: ws.id, cwd: "/other", at: 200)
         store.selectSession(current.id)
         store.autoFollowFire()
-        #expect(store.selectedSessionID == current.id) // stays; being on a blocked session is the suppressor
+        #expect(store.selectedSessionID == current.id)
     }
 
     @Test func autoFollowFireNoOpWhenNoBlocked() {
@@ -96,7 +93,7 @@ struct AppStoreAutoFollowTests {
         store.setAgentIndicator(AgentIndicator(status: .active), forSession: b.id)
         store.selectSession(a.id)
         store.autoFollowFire()
-        #expect(store.selectedSessionID == a.id) // no blocked session -> no jump
+        #expect(store.selectedSessionID == a.id)
     }
 
     @Test func autoFollowFireAdvancesAfterCurrentCleared() {
@@ -107,10 +104,10 @@ struct AppStoreAutoFollowTests {
         let newer = addBlocked(store, to: ws.id, cwd: "/newer", at: 200)
         store.selectSession(idle.id)
         store.autoFollowFire()
-        #expect(store.selectedSessionID == older.id) // first fire -> oldest
-        store.setAgentIndicator(AgentIndicator(), forSession: older.id) // typing a reply clears the block
+        #expect(store.selectedSessionID == older.id)
+        store.setAgentIndicator(AgentIndicator(), forSession: older.id)
         store.autoFollowFire()
-        #expect(store.selectedSessionID == newer.id) // next fire advances to the next oldest
+        #expect(store.selectedSessionID == newer.id)
     }
 
     @Test func autoFollowFireDoesNotNoteActivity() {
@@ -120,7 +117,7 @@ struct AppStoreAutoFollowTests {
         _ = addBlocked(store, to: ws.id, cwd: "/b", at: 100)
         store.selectSession(idle.id)
         store.autoFollowFire()
-        #expect(store.lastActivityAt == nil) // the app's own jump must not stamp activity (no self-reset)
+        #expect(store.lastActivityAt == nil)
     }
 
     // MARK: - mute a block already followed (autoFollowConsumed)
@@ -130,9 +127,9 @@ struct AppStoreAutoFollowTests {
         let ws = store.addWorkspace(name: "w")
         let older = addBlocked(store, to: ws.id, cwd: "/older", at: 100)
         let newer = addBlocked(store, to: ws.id, cwd: "/newer", at: 200)
-        older.autoFollowConsumed = true // already pulled to the older block once
+        older.autoFollowConsumed = true
         #expect(store.autoFollowTarget(current: nil, blocked: [older, newer], stayOnActive: false) == newer.id)
-        newer.autoFollowConsumed = true // both consumed -> nothing left to follow
+        newer.autoFollowConsumed = true
         #expect(store.autoFollowTarget(current: nil, blocked: [older, newer], stayOnActive: false) == nil)
     }
 
@@ -143,12 +140,11 @@ struct AppStoreAutoFollowTests {
         let x = addBlocked(store, to: ws.id, cwd: "/x", at: 100)
         store.selectSession(idle.id)
         store.autoFollowFire()
-        #expect(store.selectedSessionID == x.id) // pulled to the block once
+        #expect(store.selectedSessionID == x.id)
         #expect(x.autoFollowConsumed == true)
-        // user looks, decides to do nothing, navigates back to another session, then goes idle again
         store.selectSession(idle.id)
         store.autoFollowFire()
-        #expect(store.selectedSessionID == idle.id) // NOT yanked back to the same still-blocked session
+        #expect(store.selectedSessionID == idle.id)
     }
 
     @Test func autoFollowFireWalksEachBlockOnceThenStops() {
@@ -159,13 +155,13 @@ struct AppStoreAutoFollowTests {
         let z = addBlocked(store, to: ws.id, cwd: "/z", at: 200)
         store.selectSession(idle.id)
         store.autoFollowFire()
-        #expect(store.selectedSessionID == x.id) // oldest unseen block first
-        store.selectSession(idle.id) // leave without acting
+        #expect(store.selectedSessionID == x.id)
+        store.selectSession(idle.id)
         store.autoFollowFire()
-        #expect(store.selectedSessionID == z.id) // next unseen block
-        store.selectSession(idle.id) // leave again
+        #expect(store.selectedSessionID == z.id)
+        store.selectSession(idle.id)
         store.autoFollowFire()
-        #expect(store.selectedSessionID == idle.id) // both blocks already followed -> quiet
+        #expect(store.selectedSessionID == idle.id)
     }
 
     @Test func autoFollowConsumedSurvivesBlockedReassert() {
@@ -181,7 +177,7 @@ struct AppStoreAutoFollowTests {
         store.setAgentIndicator(AgentIndicator(status: .blocked), forSession: x.id)
         #expect(x.autoFollowConsumed == true)
         store.autoFollowFire()
-        #expect(store.selectedSessionID == idle.id) // still muted, no re-jump
+        #expect(store.selectedSessionID == idle.id)
     }
 
     @Test func autoFollowFireReturnsAfterBlockReenters() {
@@ -193,13 +189,13 @@ struct AppStoreAutoFollowTests {
         store.autoFollowFire()
         store.selectSession(idle.id)
         store.autoFollowFire()
-        #expect(store.selectedSessionID == idle.id) // muted while it stays the same block
-        // the agent resumes (blocked -> active) then blocks again (active -> blocked): a new episode
+        #expect(store.selectedSessionID == idle.id)
+        // blocked -> active -> blocked is a new episode, so it clears the mute
         store.setAgentIndicator(AgentIndicator(status: .active), forSession: x.id)
         store.setAgentIndicator(AgentIndicator(status: .blocked), forSession: x.id)
-        #expect(x.autoFollowConsumed == false) // re-entering blocked cleared the mute
+        #expect(x.autoFollowConsumed == false)
         store.autoFollowFire()
-        #expect(store.selectedSessionID == x.id) // pulled once more for the fresh block
+        #expect(store.selectedSessionID == x.id)
     }
 
     @Test func selectSessionAloneDoesNotNoteActivity() {
@@ -209,12 +205,9 @@ struct AppStoreAutoFollowTests {
         let b = store.addSession(toWorkspace: ws.id, cwd: "/b")!
         store.selectSession(a.id)
         store.selectSession(b.id)
-        // selectSession is the shared seam auto-follow also drives; it must stay silent so the app's own
-        // jump never resets the idle timer. only the user entry points (which pair it with noteUserActivity)
-        // count -- Task 4 wires those, not selectSession itself.
+        // selectSession is the seam auto-follow itself drives, so it must not stamp; only the user entry
+        // points, which pair it with noteUserActivity, buy the idle grace.
         #expect(store.lastActivityAt == nil)
-        // a user-initiated selection (the AppActions nav wrappers / sidebar row click) additionally calls
-        // noteUserActivity, which DOES stamp -- this is what buys the idle grace.
         store.noteUserActivity()
         store.selectSession(a.id)
         #expect(store.lastActivityAt != nil)
@@ -230,10 +223,10 @@ struct AppStoreAutoFollowTests {
         store.selectSession(idle.id)
         store.suppressAutoFollow() // a sidebar rename / command palette owns first responder
         store.autoFollowFire()
-        #expect(store.selectedSessionID == idle.id) // suppressed: the armed jump no-ops, selection stays put
-        store.resumeAutoFollow() // editor/overlay closed
+        #expect(store.selectedSessionID == idle.id)
+        store.resumeAutoFollow()
         store.autoFollowFire()
-        #expect(store.selectedSessionID == blocked.id) // resumed: the next fire follows the waiting block
+        #expect(store.selectedSessionID == blocked.id)
     }
 
     @Test func autoFollowSuppressionNestsAndClampsAtZero() {
@@ -244,13 +237,13 @@ struct AppStoreAutoFollowTests {
         store.selectSession(idle.id)
         store.suppressAutoFollow() // two overlapping suppressors (e.g. a palette opened over a rename)
         store.suppressAutoFollow()
-        store.resumeAutoFollow() // one lifts; the other still holds
+        store.resumeAutoFollow()
         store.autoFollowFire()
-        #expect(store.selectedSessionID == idle.id) // still suppressed while any suppressor holds
-        store.resumeAutoFollow() // both lifted
-        store.resumeAutoFollow() // an extra unbalanced resume clamps at zero (no underflow wedging the gate)
+        #expect(store.selectedSessionID == idle.id)
+        store.resumeAutoFollow()
+        store.resumeAutoFollow() // an extra unbalanced resume must clamp at zero, not underflow the gate
         store.autoFollowFire()
-        #expect(store.selectedSessionID == blocked.id) // fully resumed -> follows the block
+        #expect(store.selectedSessionID == blocked.id)
     }
 
     // MARK: - noteUserActivity + idleMs
@@ -258,7 +251,7 @@ struct AppStoreAutoFollowTests {
     @Test func noteUserActivityStampsLastActivity() {
         let store = makeStore()
         #expect(store.lastActivityAt == nil)
-        #expect(store.idleMs() == nil) // nil before any activity
+        #expect(store.idleMs() == nil)
         store.noteUserActivity()
         #expect(store.lastActivityAt != nil)
         #expect(store.idleMs() != nil)
@@ -281,7 +274,7 @@ struct AppStoreAutoFollowTests {
         store.selectSession(idle.id)
         store.autoFollowTimeout = 100 // long delay so only the manual flush drives the fire
         store.noteUserActivity()
-        store.autoFollowDebouncer.flush() // drive the scheduled fire deterministically
+        store.autoFollowDebouncer.flush()
         #expect(store.selectedSessionID == blocked.id)
     }
 
@@ -292,11 +285,11 @@ struct AppStoreAutoFollowTests {
         _ = addBlocked(store, to: ws.id, cwd: "/b", at: 100)
         store.selectSession(idle.id)
         store.autoFollowTimeout = 100
-        store.noteUserActivity() // schedules a fire
+        store.noteUserActivity()
         store.autoFollowTimeout = nil
-        store.noteUserActivity() // disabled now -> cancels the pending fire
-        store.autoFollowDebouncer.flush() // nothing pending
-        #expect(store.selectedSessionID == idle.id) // no jump when disabled
+        store.noteUserActivity()
+        store.autoFollowDebouncer.flush()
+        #expect(store.selectedSessionID == idle.id)
     }
 
     // MARK: - setAutoFollow lifecycle + status-change arming
@@ -307,11 +300,11 @@ struct AppStoreAutoFollowTests {
         let idle = store.addSession(toWorkspace: ws.id, cwd: "/idle")!
         let blocked = addBlocked(store, to: ws.id, cwd: "/b", at: 100)
         store.selectSession(idle.id)
-        store.setAutoFollow(timeout: 100, stayOnActive: false) // enable arms a fire from the current state
+        store.setAutoFollow(timeout: 100, stayOnActive: false)
         #expect(store.autoFollowTimeout == 100)
         #expect(store.autoFollowStayOnActive == false)
-        store.autoFollowDebouncer.flush() // drive the enable's arm deterministically
-        #expect(store.selectedSessionID == blocked.id) // already-idle user is pulled to the waiting block
+        store.autoFollowDebouncer.flush()
+        #expect(store.selectedSessionID == blocked.id)
     }
 
     @Test func setAutoFollowEnableStoresStayOnActive() {
@@ -324,7 +317,7 @@ struct AppStoreAutoFollowTests {
         store.setAutoFollow(timeout: 100, stayOnActive: true)
         #expect(store.autoFollowStayOnActive == true)
         store.autoFollowDebouncer.flush()
-        #expect(store.selectedSessionID == active.id) // stayOnActive suppresses leaving a running agent
+        #expect(store.selectedSessionID == active.id)
     }
 
     @Test func setAutoFollowDisableCancelsPendingFire() {
@@ -333,11 +326,11 @@ struct AppStoreAutoFollowTests {
         let idle = store.addSession(toWorkspace: ws.id, cwd: "/idle")!
         _ = addBlocked(store, to: ws.id, cwd: "/b", at: 100)
         store.selectSession(idle.id)
-        store.setAutoFollow(timeout: 100, stayOnActive: false) // arms a fire
-        store.setAutoFollow(timeout: nil, stayOnActive: false) // disable cancels it
+        store.setAutoFollow(timeout: 100, stayOnActive: false)
+        store.setAutoFollow(timeout: nil, stayOnActive: false)
         #expect(store.autoFollowTimeout == nil)
-        store.autoFollowDebouncer.flush() // nothing pending after cancel
-        #expect(store.selectedSessionID == idle.id) // no jump once disabled
+        store.autoFollowDebouncer.flush()
+        #expect(store.selectedSessionID == idle.id)
     }
 
     @Test func autoFollowFireSelfTriggerTerminates() {
@@ -348,12 +341,12 @@ struct AppStoreAutoFollowTests {
         store.selectSession(completed.id) // select first, THEN stamp the one-time glyph so it rides selected
         store.setAgentIndicator(AgentIndicator(status: .completed, autoReset: true), forSession: completed.id)
         store.autoFollowFire()
-        #expect(store.selectedSessionID == blocked.id) // jumps to the block
-        // moving away cleared completed's autoReset glyph — the agentIndicator change the observer re-arms
-        // on. that self-trigger must not loop: the next fire is now parked on the block, so it no-ops.
+        #expect(store.selectedSessionID == blocked.id)
+        // moving away cleared completed's autoReset glyph, which is itself an indicator change the observer
+        // re-arms on; that self-trigger must not loop.
         #expect(completed.agentIndicator.status == .idle)
         store.autoFollowFire()
-        #expect(store.selectedSessionID == blocked.id) // stays put -> the cycle terminates, no loop
+        #expect(store.selectedSessionID == blocked.id)
     }
 
     @Test func statusChangeWhileEnabledArmsAutoFollow() async {
@@ -363,20 +356,17 @@ struct AppStoreAutoFollowTests {
         let s = store.addSession(toWorkspace: ws.id, cwd: "/s")! // idle at enable, so the observer tracks it
         store.selectSession(idle.id)
         store.setAutoFollow(timeout: 100, stayOnActive: false)
-        store.autoFollowDebouncer.flush() // consume the enable's arm (no-op: nothing blocked yet)
+        store.autoFollowDebouncer.flush() // consume the enable's arm; nothing is blocked yet
         #expect(store.selectedSessionID == idle.id)
-        store.setAgentIndicator(AgentIndicator(status: .blocked), forSession: s.id) // a block LANDS while idle
-        // the block landing re-arms the debouncer through a coalesced, deferred chain (observer onChange ->
-        // scheduleAutoFollowRearm, currently two main-queue hops). drain-then-flush in a bounded loop until the
-        // re-armed fire lands, so a deeper deferral chain can't silently break this (vs a fixed drain count
-        // coupled to the depth). deterministic: each drain is a FIFO marker (no real sleep) and a flush before
-        // the re-arm arms is a harmless no-op.
+        store.setAgentIndicator(AgentIndicator(status: .blocked), forSession: s.id)
+        // the re-arm rides a coalesced, deferred chain (currently two main-queue hops), so drain-then-flush
+        // in a bounded loop rather than a fixed drain count coupled to that depth.
         for _ in 0..<20 {
             await drainMainQueue()
             store.autoFollowDebouncer.flush()
             if store.selectedSessionID == s.id { break }
         }
-        #expect(store.selectedSessionID == s.id) // the status change armed the follow, which then jumped
+        #expect(store.selectedSessionID == s.id)
     }
 
     @Test func setAutoFollowTimeoutChangeWhileEnabledRearms() {
@@ -385,11 +375,10 @@ struct AppStoreAutoFollowTests {
         let idle = store.addSession(toWorkspace: ws.id, cwd: "/idle")!
         let blocked = addBlocked(store, to: ws.id, cwd: "/b", at: 100)
         store.selectSession(idle.id)
-        store.setAutoFollow(timeout: 100, stayOnActive: false) // enable at a long grace
-        store.setAutoFollow(timeout: 30, stayOnActive: false) // change the grace while still enabled -> re-arm
+        store.setAutoFollow(timeout: 100, stayOnActive: false)
+        store.setAutoFollow(timeout: 30, stayOnActive: false)
         #expect(store.autoFollowTimeout == 30)
-        // the changed grace re-armed the debouncer from the current state (previousTimeout != nil, so the
-        // status observer is NOT re-registered — only the debouncer re-arms); the flush drives that fire.
+        // previousTimeout != nil here, so the status observer is not re-registered — only the debouncer re-arms.
         store.autoFollowDebouncer.flush()
         #expect(store.selectedSessionID == blocked.id)
     }
@@ -401,14 +390,14 @@ struct AppStoreAutoFollowTests {
         store.setAgentIndicator(AgentIndicator(status: .active), forSession: active.id)
         let blocked = addBlocked(store, to: ws.id, cwd: "/b", at: 100)
         store.selectSession(active.id)
-        store.setAutoFollow(timeout: 100, stayOnActive: true) // enable: an active current suppresses the block
+        store.setAutoFollow(timeout: 100, stayOnActive: true)
         store.autoFollowDebouncer.flush()
-        #expect(store.selectedSessionID == active.id) // stayOnActive keeps us on the running agent
-        // toggle stayOnActive OFF at the SAME grace: no pending fire remains (the last one no-op'd), so the
-        // config change alone must re-arm and re-decide, else the waiting block is never followed.
+        #expect(store.selectedSessionID == active.id)
+        // the SAME grace leaves no pending fire (the last one no-op'd), so the config change alone has to
+        // re-arm and re-decide.
         store.setAutoFollow(timeout: 100, stayOnActive: false)
         store.autoFollowDebouncer.flush()
-        #expect(store.selectedSessionID == blocked.id) // no longer suppressed -> follows the waiting block
+        #expect(store.selectedSessionID == blocked.id)
     }
 
     @Test func setAutoFollowDisableStopsStatusRearm() async {
@@ -417,17 +406,15 @@ struct AppStoreAutoFollowTests {
         let idle = store.addSession(toWorkspace: ws.id, cwd: "/idle")!
         let s = store.addSession(toWorkspace: ws.id, cwd: "/s")! // idle at enable, so the observer tracks it
         store.selectSession(idle.id)
-        store.setAutoFollow(timeout: 100, stayOnActive: false) // enable + start observing
-        store.autoFollowDebouncer.flush() // consume the enable's arm (nothing blocked yet)
-        store.setAutoFollow(timeout: nil, stayOnActive: false) // DISABLE before any block lands
-        store.setAgentIndicator(AgentIndicator(status: .blocked), forSession: s.id) // a block lands AFTER disable
-        // disabled: the surviving observer tracker must self-tear-down WITHOUT re-arming. this is a non-event,
-        // so it can't be polled for — instead drain generously (well past the re-arm's ~2-hop depth) to give
-        // any stray re-arm every chance to fire, then confirm nothing armed: the flush stays a no-op and the
-        // selection never moves. deterministic: each drain is a FIFO marker, no real sleep.
+        store.setAutoFollow(timeout: 100, stayOnActive: false)
+        store.autoFollowDebouncer.flush() // consume the enable's arm; nothing is blocked yet
+        store.setAutoFollow(timeout: nil, stayOnActive: false)
+        store.setAgentIndicator(AgentIndicator(status: .blocked), forSession: s.id)
+        // a missing re-arm is a non-event that can't be polled for, so drain well past the re-arm's ~2-hop
+        // depth to give any stray one every chance to fire before asserting nothing armed.
         for _ in 0..<20 { await drainMainQueue() }
-        store.autoFollowDebouncer.flush() // nothing should be pending
-        #expect(store.selectedSessionID == idle.id) // disabled: the one-shot tracker self-teardown means no re-arm
+        store.autoFollowDebouncer.flush()
+        #expect(store.selectedSessionID == idle.id)
     }
 
     // MARK: - Control tree projection (idleMs live, autoFollowMs config) + the focus-bridge notification
@@ -436,17 +423,14 @@ struct AppStoreAutoFollowTests {
         let store = makeStore()
         let ws = store.addWorkspace(name: "w")
         _ = store.addSession(toWorkspace: ws.id, cwd: "/a")!
-        // before any activity + disabled: both live fields are nil.
         var tree = store.controlTree()
         #expect(tree.idleMs == nil)
         #expect(tree.autoFollowMs == nil)
-        // a configured timeout projects as ms (the * 1000 scaling) and activity makes idleMs live (>= 0).
         store.autoFollowTimeout = 30
         store.lastActivityAt = Date()
         tree = store.controlTree()
         #expect(tree.autoFollowMs == 30_000)
         #expect((tree.idleMs ?? -1) >= 0)
-        // disabling clears autoFollowMs back to nil.
         store.autoFollowTimeout = nil
         #expect(store.controlTree().autoFollowMs == nil)
     }
@@ -463,8 +447,8 @@ struct AppStoreAutoFollowTests {
         )
         store.setAgentIndicator(expectedIndicator, forSession: blocked.id)
         blocked.statusChangedAt = Date(timeIntervalSince1970: 100)
-        // The app-target focus bridge relies on this post carrying both the destination id and the
-        // pre-selection indicator. Observe synchronously and prove the auto-reset clear cannot erase routing.
+        // the app-target focus bridge routes off the posted PRE-selection indicator, so the auto-reset clear
+        // must not erase it.
         let box = NotificationBox()
         let token = NotificationCenter.default.addObserver(forName: .agtermAutoFollowed, object: nil,
                                                            queue: nil) { note in

--- a/agtermCore/Tests/agtermCoreTests/AppStoreDuplicateTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreDuplicateTests.swift
@@ -15,15 +15,12 @@ struct AppStoreDuplicateTests {
 
         let dupe = try! #require(store.duplicateSession(first.id))
 
-        // lands directly AFTER its source, not appended at the end.
         #expect(store.workspaces[0].sessions.map(\.id) == [first.id, dupe.id, last.id])
         #expect(dupe.initialCwd == "/a")
         #expect(store.selectedSessionID == dupe.id)
     }
 
-    /// The seed is the FOCUSED pane's cwd, not the primary's: a split focused on its non-primary pane
-    /// duplicates into the split pane's directory (`focusedCwd`), not the primary's (`effectiveCwd`). Pins
-    /// the `focusedCwd`-over-`effectiveCwd` choice — swapping the seed to `effectiveCwd` fails only here.
+    // pins the `focusedCwd`-over-`effectiveCwd` seed choice — swapping to `effectiveCwd` fails only here.
     @Test func duplicateSessionSeedsFromFocusedSplitPane() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
@@ -37,7 +34,6 @@ struct AppStoreDuplicateTests {
 
         let dupe = try! #require(store.duplicateSession(source.id))
 
-        // the duplicate opens where FOCUS is (the split pane), not the primary pane's cwd.
         #expect(dupe.initialCwd == "/split-pane")
     }
 
@@ -49,11 +45,9 @@ struct AppStoreDuplicateTests {
 
         let dupe = try! #require(store.duplicateSession(source.id))
 
-        // the duplicate opens where the shell IS, not where it started.
         #expect(dupe.initialCwd == "/moved")
     }
 
-    /// The directory-only contract: a duplicate is a plain new session, NOT a clone of the source's state.
     @Test func duplicateSessionCopiesOnlyTheDirectory() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
@@ -66,7 +60,7 @@ struct AppStoreDuplicateTests {
         let dupe = try! #require(store.duplicateSession(source.id))
 
         #expect(dupe.initialCwd == "/a")
-        #expect(dupe.customName == nil) // auto basename, NOT "prod"
+        #expect(dupe.customName == nil)
         #expect(dupe.initialCommand == nil)
         #expect(dupe.flagged == false)
         #expect(dupe.isSplit == false)
@@ -75,8 +69,6 @@ struct AppStoreDuplicateTests {
         #expect(dupe.id != source.id)
     }
 
-    /// A duplicate is a fresh `Session` from `addSession`, so it inherits no restore-command override —
-    /// neither the persisted pin (which names the SOURCE's command) nor an armed payload.
     @Test func duplicateSessionCopiesNoRestoreOverride() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
@@ -92,7 +84,7 @@ struct AppStoreDuplicateTests {
         #expect(dupe.splitRestoreCommand == nil)
         #expect(dupe.pendingRestoreCommand == nil)
         #expect(dupe.pendingSplitRestoreCommand == nil)
-        #expect(source.restoreCommand == "claude --resume abc") // the source keeps its own
+        #expect(source.restoreCommand == "claude --resume abc")
     }
 
     @Test func duplicateSessionOfUnknownSessionReturnsNil() {

--- a/agtermCore/Tests/agtermCoreTests/AppStoreEventTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreEventTests.swift
@@ -121,12 +121,10 @@ final class AppStoreEventTests {
         store.setAgentIndicator(AgentIndicator(status: .blocked), forSession: session.id)
         let anchor = try eventBatch(library.readEvents(ControlEventReadOptions(cursor: nil, kinds: nil, limit: 100)))
 
-        // only the shape differs, so the `previous != indicator` guard passes and an event fires — a
-        // consumer must be able to explain it, which is what the payload field is for
+        // only the shape differs, so the `previous != indicator` guard still admits it and an event fires
         store.setAgentIndicator(AgentIndicator(status: .blocked, shape: .star), forSession: session.id)
-        // the negative leg of the same guard: re-asserting the IDENTICAL shaped indicator is not a change,
-        // so a repeated hook call must stay silent — this is what breaks if `shape` ever stops
-        // participating in `AgentIndicator` equality
+        // the negative leg: an identical re-assert must stay silent, which breaks the moment `shape`
+        // stops participating in `AgentIndicator` equality
         store.setAgentIndicator(AgentIndicator(status: .blocked, shape: .star), forSession: session.id)
 
         let batch = try eventBatch(library.readEvents(ControlEventReadOptions(

--- a/agtermCore/Tests/agtermCoreTests/AppStoreNavigationTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreNavigationTests.swift
@@ -12,9 +12,9 @@ struct AppStoreNavigationTests {
         _ = store.addSession(toWorkspace: personal.id, cwd: "/b")!
         store.selectSession(a.id)
         store.setFocusedWorkspace(work.id)
-        store.navigateSession(.next) // nav is scoped to the focused workspace (only a); wrap cycles to itself
-        #expect(store.selectedSessionID == a.id) // stays on a — the off-focus session is never revealed
-        #expect(store.focusedWorkspaceIDs == [work.id] && store.focusEnabled) // nav never crosses the focus boundary, so focus stands
+        store.navigateSession(.next) // a is the only in-focus session, so the wrap cycles to itself
+        #expect(store.selectedSessionID == a.id)
+        #expect(store.focusedWorkspaceIDs == [work.id] && store.focusEnabled)
     }
 
     /// Builds a two-workspace tree (work: a, b; personal: c, d) so flattened order is [a, b, c, d].
@@ -34,7 +34,7 @@ struct AppStoreNavigationTests {
         store.selectSession(ids[0])
         store.navigateSession(.next)
         #expect(store.selectedSessionID == ids[1])
-        store.navigateSession(.next) // crosses from work into personal
+        store.navigateSession(.next)
         #expect(store.selectedSessionID == ids[2])
         store.navigateSession(.next)
         #expect(store.selectedSessionID == ids[3])
@@ -45,7 +45,7 @@ struct AppStoreNavigationTests {
         store.selectSession(ids[3])
         store.navigateSession(.previous)
         #expect(store.selectedSessionID == ids[2])
-        store.navigateSession(.previous) // crosses from personal into work
+        store.navigateSession(.previous)
         #expect(store.selectedSessionID == ids[1])
         store.navigateSession(.previous)
         #expect(store.selectedSessionID == ids[0])
@@ -54,14 +54,14 @@ struct AppStoreNavigationTests {
     @Test func navigateNextAtLastWrapsToFirst() {
         let (store, ids) = Self.makeNavTree()
         store.selectSession(ids.last!)
-        store.navigateSession(.next) // at the end: wraps around to the first
+        store.navigateSession(.next)
         #expect(store.selectedSessionID == ids.first!)
     }
 
     @Test func navigatePreviousAtFirstWrapsToLast() {
         let (store, ids) = Self.makeNavTree()
         store.selectSession(ids.first!)
-        store.navigateSession(.previous) // at the start: wraps around to the last
+        store.navigateSession(.previous)
         #expect(store.selectedSessionID == ids.last!)
     }
 
@@ -88,10 +88,10 @@ struct AppStoreNavigationTests {
         let (store, ids) = Self.makeNavTree()
         store.selectSession(nil)
         store.navigateSession(.last)
-        #expect(store.selectedSessionID == ids.last!) // .last ignores the (absent) selection
+        #expect(store.selectedSessionID == ids.last!)
         store.selectSession(nil)
         store.navigateSession(.first)
-        #expect(store.selectedSessionID == ids.first!) // .first ignores the (absent) selection
+        #expect(store.selectedSessionID == ids.first!)
     }
 
     @Test func navigateSingleSessionStaysSelected() {
@@ -107,7 +107,7 @@ struct AppStoreNavigationTests {
 
     @Test func navigateEmptyTreeIsNoOp() {
         let store = makeStore()
-        store.addWorkspace(name: "work") // no sessions
+        store.addWorkspace(name: "work")
         store.navigateSession(.next)
         #expect(store.selectedSessionID == nil)
         store.navigateSession(.first)
@@ -120,8 +120,8 @@ struct AppStoreNavigationTests {
         store.selectSession(ids[0])
         store.navigateSession(.next)
         #expect(store.selectedSessionID == ids[1])
-        #expect(store.session(withID: ids[1])?.unseenCount == 0) // selectSession cleared the badge
-        // the navigation pushed a NEW recency entry on top of the prior selection (most-recent first).
+        #expect(store.session(withID: ids[1])?.unseenCount == 0)
+        // recency is most-recent first, so the navigation tops the prior selection.
         #expect(Array(store.sessionRecency.items.prefix(2)) == [ids[1], ids[0]])
     }
 
@@ -138,42 +138,42 @@ struct AppStoreNavigationTests {
     }
 
     @Test func navigateAttentionStepsThroughAttentionSessionsOnly() {
-        let (store, ids) = Self.makeNavTree() // a, b, c, d
-        store.session(withID: ids[1])?.agentIndicator = AgentIndicator(status: .blocked)   // b
-        store.session(withID: ids[3])?.agentIndicator = AgentIndicator(status: .completed) // d
-        store.selectSession(ids[0]) // a (idle)
+        let (store, ids) = Self.makeNavTree()
+        store.session(withID: ids[1])?.agentIndicator = AgentIndicator(status: .blocked)
+        store.session(withID: ids[3])?.agentIndicator = AgentIndicator(status: .completed)
+        store.selectSession(ids[0])
         store.navigateSession(.nextAttention)
-        #expect(store.selectedSessionID == ids[1]) // skips to blocked b
+        #expect(store.selectedSessionID == ids[1])
         store.navigateSession(.nextAttention)
-        #expect(store.selectedSessionID == ids[3]) // skips idle c, lands on completed d
+        #expect(store.selectedSessionID == ids[3])
     }
 
     @Test func navigateAttentionWrapsAround() {
         let (store, ids) = Self.makeNavTree()
-        store.session(withID: ids[1])?.agentIndicator = AgentIndicator(status: .blocked)   // b
-        store.session(withID: ids[3])?.agentIndicator = AgentIndicator(status: .completed) // d
-        store.selectSession(ids[3]) // d (last attention)
+        store.session(withID: ids[1])?.agentIndicator = AgentIndicator(status: .blocked)
+        store.session(withID: ids[3])?.agentIndicator = AgentIndicator(status: .completed)
+        store.selectSession(ids[3])
         store.navigateSession(.nextAttention)
-        #expect(store.selectedSessionID == ids[1]) // wraps forward to b
+        #expect(store.selectedSessionID == ids[1])
         store.navigateSession(.previousAttention)
-        #expect(store.selectedSessionID == ids[3]) // wraps backward to d
+        #expect(store.selectedSessionID == ids[3])
     }
 
     @Test func navigateAttentionSkipsActiveAndIdle() {
         let (store, ids) = Self.makeNavTree()
-        store.session(withID: ids[1])?.agentIndicator = AgentIndicator(status: .active)  // b active - excluded
-        store.session(withID: ids[2])?.agentIndicator = AgentIndicator(status: .blocked) // c blocked - included
+        store.session(withID: ids[1])?.agentIndicator = AgentIndicator(status: .active)
+        store.session(withID: ids[2])?.agentIndicator = AgentIndicator(status: .blocked)
         store.selectSession(ids[0])
         store.navigateSession(.nextAttention)
-        #expect(store.selectedSessionID == ids[2]) // skips active b, lands on blocked c
+        #expect(store.selectedSessionID == ids[2])
     }
 
     @Test func navigateAttentionWithSingleAttentionSessionStaysPut() {
         let (store, ids) = Self.makeNavTree()
-        store.session(withID: ids[2])?.agentIndicator = AgentIndicator(status: .completed) // c, the only one
+        store.session(withID: ids[2])?.agentIndicator = AgentIndicator(status: .completed)
         store.selectSession(ids[2])
         store.navigateSession(.nextAttention)
-        #expect(store.selectedSessionID == ids[2]) // no other attention session -> no-op
+        #expect(store.selectedSessionID == ids[2])
         store.navigateSession(.previousAttention)
         #expect(store.selectedSessionID == ids[2])
     }
@@ -187,30 +187,30 @@ struct AppStoreNavigationTests {
 
     @Test func navigateAttentionWithNoSelectionLandsOnAnAttentionEnd() {
         let (store, ids) = Self.makeNavTree()
-        store.session(withID: ids[1])?.agentIndicator = AgentIndicator(status: .blocked)   // b
-        store.session(withID: ids[3])?.agentIndicator = AgentIndicator(status: .completed) // d
+        store.session(withID: ids[1])?.agentIndicator = AgentIndicator(status: .blocked)
+        store.session(withID: ids[3])?.agentIndicator = AgentIndicator(status: .completed)
+        // a nil selection acts as before-first going forward, after-last going backward.
         store.selectSession(nil)
         store.navigateSession(.nextAttention)
-        #expect(store.selectedSessionID == ids[1]) // forward from before-first -> first attention
+        #expect(store.selectedSessionID == ids[1])
         store.selectSession(nil)
         store.navigateSession(.previousAttention)
-        #expect(store.selectedSessionID == ids[3]) // backward from after-last -> last attention
+        #expect(store.selectedSessionID == ids[3])
     }
 
     // MARK: - navigation scoping (filtered set)
 
     @Test func navigableSessionsReflectsFlaggedFocusAndUnfocused() {
-        let (store, ids) = Self.makeNavTree() // work={a,b}, personal={c,d}
-        #expect(store.navigableSessions.map(\.id) == ids) // unfocused tree mode -> all sessions
+        let (store, ids) = Self.makeNavTree()
+        #expect(store.navigableSessions.map(\.id) == ids)
         let work = store.workspace(forSession: ids[0])!
         store.setFocusedWorkspace(work.id)
-        #expect(store.navigableSessions.map(\.id) == [ids[0], ids[1]]) // focused -> only that workspace
+        #expect(store.navigableSessions.map(\.id) == [ids[0], ids[1]])
         // marking an id that names no workspace is REFUSED by the mutator, so the focus survives intact.
         store.setFocusedWorkspace(UUID())
         #expect(store.navigableSessions.map(\.id) == [ids[0], ids[1]])
-        // the all-stale set is therefore only reachable by writing the fields directly (a hand-edited file
-        // that skipped the restore prune); `visibleWorkspaces` then falls back to the whole tree, and nav
-        // with it.
+        // an all-stale set is only reachable by writing the fields directly (a hand-edited file that
+        // skipped the restore prune); `visibleWorkspaces` then falls back to the whole tree, and nav with it.
         store.focusedWorkspaceIDs = [UUID()]
         store.focusEnabled = true
         #expect(store.navigableSessions.map(\.id) == ids)
@@ -218,23 +218,23 @@ struct AppStoreNavigationTests {
         store.setFlag(true, forSession: ids[1])
         store.setFlag(true, forSession: ids[2])
         store.setSidebarMode(.flagged)
-        #expect(store.navigableSessions.map(\.id) == [ids[1], ids[2]]) // flagged mode -> the flagged set
+        #expect(store.navigableSessions.map(\.id) == [ids[1], ids[2]])
     }
 
     @Test func navigateScopesToFocusedWorkspace() {
-        let (store, ids) = Self.makeNavTree() // work={a,b}, personal={c,d}
+        let (store, ids) = Self.makeNavTree()
         let work = store.workspace(forSession: ids[0])!
         store.setFocusedWorkspace(work.id)
         store.selectSession(ids[0])
         store.navigateSession(.next)
-        #expect(store.selectedSessionID == ids[1]) // a -> b within the focused workspace
+        #expect(store.selectedSessionID == ids[1])
         store.navigateSession(.next)
-        #expect(store.selectedSessionID == ids[0]) // b is the in-set last: wraps within {a,b} to a, never crosses to c
+        #expect(store.selectedSessionID == ids[0])
         store.navigateSession(.last)
-        #expect(store.selectedSessionID == ids[1]) // .last is the focused workspace's last, not the tree's
+        #expect(store.selectedSessionID == ids[1])
         store.navigateSession(.first)
-        #expect(store.selectedSessionID == ids[0]) // .first is the focused workspace's first
-        #expect(store.focusedWorkspaceIDs == [work.id] && store.focusEnabled) // never suspends the filter — every target was in-set
+        #expect(store.selectedSessionID == ids[0])
+        #expect(store.focusedWorkspaceIDs == [work.id] && store.focusEnabled)
     }
 
     /// Builds a three-workspace tree (work: a, b; personal: c, d; archive: e, f) so the flattened order is
@@ -253,87 +253,89 @@ struct AppStoreNavigationTests {
     }
 
     @Test func navigateScopesToEveryMemberOfAMultiWorkspaceSet() {
-        let (store, workspaces, ids) = Self.makeThreeWorkspaceNavTree() // work={a,b}, personal={c,d}, archive={e,f}
-        store.setFocusMembership(workspaces[0], member: true) // work
+        let (store, workspaces, ids) = Self.makeThreeWorkspaceNavTree()
+        store.setFocusMembership(workspaces[0], member: true)
         store.setFocusMembership(workspaces[2], member: true) // archive — the UNMARKED personal sits between them
         store.setFocusEnabled(true)
-        #expect(store.navigableSessions.map(\.id) == [ids[0], ids[1], ids[4], ids[5]]) // personal's c and d are out
+        #expect(store.navigableSessions.map(\.id) == [ids[0], ids[1], ids[4], ids[5]])
         store.selectSession(ids[0])
         store.navigateSession(.next)
-        #expect(store.selectedSessionID == ids[1]) // a -> b, within the first marked workspace
+        #expect(store.selectedSessionID == ids[1])
         store.navigateSession(.next)
-        #expect(store.selectedSessionID == ids[4]) // b -> e: crosses INTO the second marked workspace, skipping c and d
+        #expect(store.selectedSessionID == ids[4])
         store.navigateSession(.next)
-        #expect(store.selectedSessionID == ids[5]) // e -> f, within the second marked workspace
+        #expect(store.selectedSessionID == ids[5])
         store.navigateSession(.next)
-        #expect(store.selectedSessionID == ids[0]) // f is the in-set last: wraps to a, never reaching the unmarked workspace
+        #expect(store.selectedSessionID == ids[0])
         store.navigateSession(.previous)
-        #expect(store.selectedSessionID == ids[5]) // and backward over the same gap
+        #expect(store.selectedSessionID == ids[5])
         store.navigateSession(.previous)
-        #expect(store.selectedSessionID == ids[4]) // f -> e, still skipping d
+        #expect(store.selectedSessionID == ids[4])
         store.navigateSession(.last)
-        #expect(store.selectedSessionID == ids[5]) // .last is the marked set's last, not the tree's
+        #expect(store.selectedSessionID == ids[5])
         store.navigateSession(.first)
-        #expect(store.selectedSessionID == ids[0]) // .first is the marked set's first
+        #expect(store.selectedSessionID == ids[0])
         // every target was in-set, so the filter never trips disableFocusIfSelectionOutsideSet
         #expect(store.focusedWorkspaceIDs == [workspaces[0], workspaces[2]] && store.focusEnabled)
     }
 
     @Test func navigateAttentionScopesToEveryMemberOfAMultiWorkspaceSet() {
         let (store, workspaces, ids) = Self.makeThreeWorkspaceNavTree()
-        store.session(withID: ids[1])?.agentIndicator = AgentIndicator(status: .blocked)   // b, in the marked work
-        store.session(withID: ids[3])?.agentIndicator = AgentIndicator(status: .blocked)   // d, in the UNMARKED personal
-        store.session(withID: ids[5])?.agentIndicator = AgentIndicator(status: .completed) // f, in the marked archive
+        // b and f sit in the marked workspaces, d in the unmarked one between them.
+        store.session(withID: ids[1])?.agentIndicator = AgentIndicator(status: .blocked)
+        store.session(withID: ids[3])?.agentIndicator = AgentIndicator(status: .blocked)
+        store.session(withID: ids[5])?.agentIndicator = AgentIndicator(status: .completed)
         store.setFocusMembership(workspaces[0], member: true)
         store.setFocusMembership(workspaces[2], member: true)
         store.setFocusEnabled(true)
-        store.selectSession(ids[0]) // a, idle
+        store.selectSession(ids[0])
         store.navigateSession(.nextAttention)
-        #expect(store.selectedSessionID == ids[1]) // blocked b, the first in-set attention session
+        #expect(store.selectedSessionID == ids[1])
         store.navigateSession(.nextAttention)
-        #expect(store.selectedSessionID == ids[5]) // jumps the unmarked workspace's blocked d, lands on completed f
+        #expect(store.selectedSessionID == ids[5])
         store.navigateSession(.nextAttention)
-        #expect(store.selectedSessionID == ids[1]) // wraps within the marked set, still never reaching d
+        #expect(store.selectedSessionID == ids[1])
     }
 
     @Test func navigateScopesToFlaggedSet() {
-        let (store, ids) = Self.makeNavTree() // a, b, c, d
-        store.setFlag(true, forSession: ids[0]) // a
-        store.setFlag(true, forSession: ids[2]) // c
+        let (store, ids) = Self.makeNavTree()
+        store.setFlag(true, forSession: ids[0])
+        store.setFlag(true, forSession: ids[2])
         store.setSidebarMode(.flagged)
         store.selectSession(ids[0])
         store.navigateSession(.next)
-        #expect(store.selectedSessionID == ids[2]) // a -> c, skipping the unflagged b
+        #expect(store.selectedSessionID == ids[2])
         store.navigateSession(.next)
-        #expect(store.selectedSessionID == ids[0]) // c is the flagged-set last: wraps to a, the flagged-set first
+        #expect(store.selectedSessionID == ids[0])
         store.navigateSession(.first)
-        #expect(store.selectedSessionID == ids[0]) // .first is the flagged set's first
+        #expect(store.selectedSessionID == ids[0])
     }
 
     @Test func navigateAttentionScopesToFocusedWorkspace() {
-        let (store, ids) = Self.makeNavTree() // work={a,b}, personal={c,d}
-        store.session(withID: ids[1])?.agentIndicator = AgentIndicator(status: .blocked)   // b (in focus)
-        store.session(withID: ids[3])?.agentIndicator = AgentIndicator(status: .completed) // d (off focus)
+        let (store, ids) = Self.makeNavTree()
+        // b lands in the focused workspace, d outside it.
+        store.session(withID: ids[1])?.agentIndicator = AgentIndicator(status: .blocked)
+        store.session(withID: ids[3])?.agentIndicator = AgentIndicator(status: .completed)
         let work = store.workspace(forSession: ids[0])!
         store.setFocusedWorkspace(work.id)
         store.selectSession(ids[0])
         store.navigateSession(.nextAttention)
-        #expect(store.selectedSessionID == ids[1]) // only b is in the focused set; d is never reached
+        #expect(store.selectedSessionID == ids[1])
         store.navigateSession(.nextAttention)
-        #expect(store.selectedSessionID == ids[1]) // b is the single in-set attention session: stays
+        #expect(store.selectedSessionID == ids[1])
     }
 
     @Test func navigateRestoresFullSetWhenFocusCleared() {
         let (store, ids) = Self.makeNavTree()
         let work = store.workspace(forSession: ids[0])!
         store.setFocusedWorkspace(work.id)
-        store.selectSession(ids[1]) // b, the in-set last of {a,b}
+        store.selectSession(ids[1])
         store.navigateSession(.next)
-        #expect(store.selectedSessionID == ids[0]) // scoped: wraps within {a,b} back to a, never crosses to c
-        store.clearFocus() // clearing focus restores the full navigable set
-        store.selectSession(ids[1]) // b again, now in the full set [a,b,c,d]
+        #expect(store.selectedSessionID == ids[0])
+        store.clearFocus()
+        store.selectSession(ids[1])
         store.navigateSession(.next)
-        #expect(store.selectedSessionID == ids[2]) // now crosses into the personal workspace
+        #expect(store.selectedSessionID == ids[2])
     }
 
     // MARK: - attentionSessions
@@ -341,10 +343,9 @@ struct AppStoreNavigationTests {
     @Test func attentionSessionsFiltersOutIdle() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
-        _ = store.addSession(toWorkspace: ws.id, cwd: "/idle") // stays idle
+        _ = store.addSession(toWorkspace: ws.id, cwd: "/idle")
         let active = store.addSession(toWorkspace: ws.id, cwd: "/active")!
         store.setAgentIndicator(AgentIndicator(status: .active), forSession: active.id)
-        // idle sessions are dropped; only the non-idle one is listed
         #expect(store.attentionSessions.map(\.id) == [active.id])
     }
 
@@ -354,7 +355,7 @@ struct AppStoreNavigationTests {
         let completed = store.addSession(toWorkspace: ws.id, cwd: "/c")!
         let active = store.addSession(toWorkspace: ws.id, cwd: "/a")!
         let blocked = store.addSession(toWorkspace: ws.id, cwd: "/b")!
-        // set in a non-rank order; the list must still sort blocked -> active -> completed
+        // set in a non-rank order, so insertion order alone cannot pass this
         store.setAgentIndicator(AgentIndicator(status: .completed), forSession: completed.id)
         store.setAgentIndicator(AgentIndicator(status: .active), forSession: active.id)
         store.setAgentIndicator(AgentIndicator(status: .blocked), forSession: blocked.id)
@@ -367,13 +368,13 @@ struct AppStoreNavigationTests {
         let oldest = store.addSession(toWorkspace: ws.id, cwd: "/old")!
         let newest = store.addSession(toWorkspace: ws.id, cwd: "/new")!
         let unstamped = store.addSession(toWorkspace: ws.id, cwd: "/none")!
-        // all three are blocked (same rank), so the tie-break is statusChangedAt descending, nil last
+        // all three share a rank, so only the statusChangedAt tie-break is under test
         store.setAgentIndicator(AgentIndicator(status: .blocked), forSession: oldest.id)
         store.setAgentIndicator(AgentIndicator(status: .blocked), forSession: newest.id)
         store.setAgentIndicator(AgentIndicator(status: .blocked), forSession: unstamped.id)
         oldest.statusChangedAt = Date(timeIntervalSince1970: 100)
         newest.statusChangedAt = Date(timeIntervalSince1970: 200)
-        unstamped.statusChangedAt = nil // a missing stamp sorts last within the rank group
+        unstamped.statusChangedAt = nil
         #expect(store.attentionSessions.map(\.id) == [newest.id, oldest.id, unstamped.id])
     }
 
@@ -384,12 +385,11 @@ struct AppStoreNavigationTests {
         let stampedB = store.addSession(toWorkspace: ws.id, cwd: "/sb")!
         let nilA = store.addSession(toWorkspace: ws.id, cwd: "/na")!
         let nilB = store.addSession(toWorkspace: ws.id, cwd: "/nb")!
-        // all blocked (same rank); two share an equal stamp, two share a nil stamp — exercising the
-        // comparator's (l?, r?)-equal and (nil, nil) branches (both return false). the stamped pair still
-        // precedes the nil pair, and within each tie group the stable sort keeps insertion order.
+        // two share a stamp and two share nil, exercising the comparator's equal and (nil, nil) branches;
+        // within each tie group the stable sort keeps insertion order.
         for s in [stampedA, stampedB, nilA, nilB] { store.setAgentIndicator(AgentIndicator(status: .blocked), forSession: s.id) }
         stampedA.statusChangedAt = Date(timeIntervalSince1970: 500)
-        stampedB.statusChangedAt = Date(timeIntervalSince1970: 500) // equal stamp -> stable, keeps order
+        stampedB.statusChangedAt = Date(timeIntervalSince1970: 500)
         nilA.statusChangedAt = nil
         nilB.statusChangedAt = nil
         #expect(store.attentionSessions.map(\.id) == [stampedA.id, stampedB.id, nilA.id, nilB.id])
@@ -403,10 +403,9 @@ struct AppStoreNavigationTests {
         let away = store.addSession(toWorkspace: other.id, cwd: "/away")!
         store.setAgentIndicator(AgentIndicator(status: .active), forSession: here.id)
         store.setAgentIndicator(AgentIndicator(status: .blocked), forSession: away.id)
-        // focusing one workspace must NOT shrink the list — a blocked session in another workspace still shows
         store.setFocusedWorkspace(work.id)
-        #expect(store.attentionSessions.map(\.id) == [away.id, here.id]) // blocked(away) before active(here)
-        // flagged mode is likewise ignored: nothing is flagged, but the non-idle sessions still list
+        #expect(store.attentionSessions.map(\.id) == [away.id, here.id])
+        // nothing is flagged, so a flagged-aware list would come back empty here
         store.setSidebarMode(.flagged)
         #expect(store.attentionSessions.map(\.id) == [away.id, here.id])
     }
@@ -416,7 +415,6 @@ struct AppStoreNavigationTests {
         let ws = store.addWorkspace(name: "work")
         _ = store.addSession(toWorkspace: ws.id, cwd: "/a")
         _ = store.addSession(toWorkspace: ws.id, cwd: "/b")
-        // no statuses set: every session is idle, so the attention list is empty
         #expect(store.attentionSessions.isEmpty)
     }
 }

--- a/agtermCore/Tests/agtermCoreTests/AppStoreOrganizationTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreOrganizationTests.swift
@@ -184,7 +184,6 @@ struct AppStoreOrganizationTests {
         store.setFlag(true, forSession: a.id)
         store.setFlag(true, forSession: b.id)
         #expect(store.flaggedSessions.map(\.id) == [a.id, b.id])
-        // moving a into personal (after b) keeps its flag and re-sorts the derived list
         store.moveSession(a.id, toWorkspace: personal.id)
         #expect(a.flagged)
         #expect(store.flaggedSessions.map(\.id) == [b.id, a.id])
@@ -195,26 +194,17 @@ struct AppStoreOrganizationTests {
         let ws1 = store.addWorkspace(name: "one")
         store.setFocusedWorkspace(ws1.id)
         #expect(store.focusedWorkspaceIDs == [ws1.id] && store.focusEnabled)
-        // a normal create joins the marked set so the new workspace is revealed without dropping the filter.
         let two = store.addWorkspace(name: "two")
         #expect(store.focusedWorkspaceIDs == [ws1.id, two.id] && store.focusEnabled)
-        // re-focus, then a background create (revealNewWorkspace: false, backing session.new --no-select
-        // --create-workspace) leaves the focus filter untouched.
+        // revealNewWorkspace: false backs `session.new --no-select --create-workspace`
         store.setFocusedWorkspace(ws1.id)
         let created = store.ensureWorkspace(named: "bg", revealNewWorkspace: false)
         #expect(created != nil)
         #expect(store.focusedWorkspaceIDs == [ws1.id] && store.focusEnabled)
-        // reusing an existing workspace never touches focus regardless of revealNewWorkspace.
         let reused = store.ensureWorkspace(named: "bg", revealNewWorkspace: true)
         #expect(reused?.id == created?.id)
         #expect(store.focusedWorkspaceIDs == [ws1.id] && store.focusEnabled)
     }
-
-    // the focus-filter cases that used to sit here (remove a focused / non-focused workspace, select a
-    // session outside / inside the set) now live in `AppStoreFocusTests` as multi-member supersets of the
-    // same behavior — `removingTheLastMemberWorkspaceDisablesTheFilter`,
-    // `removingANonMemberWorkspaceLeavesTheFilterUntouched`,
-    // `selectingOutsideTheSetDisablesTheFilterButKeepsEveryMember`, `selectingInsideTheSetChangesNothing`.
 
     @Test func newWorkspaceStartsExpanded() {
         let store = makeStore()
@@ -236,7 +226,6 @@ struct AppStoreOrganizationTests {
         let store = AppStore(persistence: persistence)
         let a = store.addWorkspace(name: "a")
         let b = store.addWorkspace(name: "b")
-        // only `a` stays expanded; `b` collapses.
         store.setWorkspacesExpanded([a.id])
         #expect(store.workspaces[0].isExpanded)
         #expect(!store.workspaces[1].isExpanded)
@@ -251,8 +240,7 @@ struct AppStoreOrganizationTests {
         let persistence = PersistenceStore(directory: dir)
         let store = AppStore(persistence: persistence)
         let a = store.addWorkspace(name: "a")
-        // collapse a, flush to disk, then hand-edit the on-disk file to a sentinel and re-issue the SAME
-        // state: a no-op mutator must not overwrite the sentinel (proving it skipped save()).
+        // the sentinel proves the no-op setter skipped save(): a real write would replace this bad JSON.
         store.setWorkspacesExpanded([]) // a collapsed, saved
         let sentinelURL = dir.appendingPathComponent("workspaces.json")
         try! Data("{ not json }".utf8).write(to: sentinelURL)
@@ -304,7 +292,6 @@ struct AppStoreOrganizationTests {
         store.closeSession(only.id) // reselects the personal session — outside the now-empty focused work
         #expect(store.activeSession != nil)
         #expect(store.workspace(forSession: store.selectedSessionID!)?.id == personal.id)
-        // the filter switches off to reveal the new active session; the marked set is preserved.
         #expect(store.focusedWorkspaceIDs == [work.id] && !store.focusEnabled)
     }
 
@@ -423,7 +410,6 @@ struct AppStoreOrganizationTests {
         store.setFocusedWorkspace(work.id)
         let created = store.addSession(toWorkspace: other.id, cwd: "/o")! // a control add into another workspace
         #expect(store.selectedSessionID == created.id)
-        // the filter switches off to reveal the just-created off-set session; the marked set is preserved.
         #expect(store.focusedWorkspaceIDs == [work.id] && !store.focusEnabled)
     }
 
@@ -456,7 +442,6 @@ struct AppStoreOrganizationTests {
         store.setFocusedWorkspace(work.id)
         store.moveSession(a.id, toWorkspace: other.id) // the active session leaves the focused workspace
         #expect(store.selectedSessionID == a.id)
-        // the filter switches off to reveal the moved active session; the marked set is preserved.
         #expect(store.focusedWorkspaceIDs == [work.id] && !store.focusEnabled)
     }
 

--- a/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
@@ -18,8 +18,6 @@ struct AppStorePaneTests {
         #expect(session.splitFocused == true)  // opening focuses the new (right) pane
         store.toggleSplit(session.id)
         #expect(session.isSplit == false)
-        // hiding the split keeps hasSplit so the sidebar/title split indicators persist, and keeps
-        // splitFocused so the focused pane is the one shown maximized.
         #expect(session.hasSplit == true)
         #expect(session.splitFocused == true)
     }
@@ -63,8 +61,8 @@ struct AppStorePaneTests {
 
     @Test func clampSplitRatioBoundsValue() {
         #expect(AppStore.clampSplitRatio(0.7) == 0.7)
-        #expect(AppStore.clampSplitRatio(2.0) == AppStore.splitRatioMax)   // above the cap
-        #expect(AppStore.clampSplitRatio(-1.0) == AppStore.splitRatioMin)  // below the floor
+        #expect(AppStore.clampSplitRatio(2.0) == AppStore.splitRatioMax)
+        #expect(AppStore.clampSplitRatio(-1.0) == AppStore.splitRatioMin)
         #expect(AppStore.clampSplitRatio(AppStore.splitRatioMin) == AppStore.splitRatioMin)
         #expect(AppStore.clampSplitRatio(AppStore.splitRatioMax) == AppStore.splitRatioMax)
     }
@@ -75,7 +73,6 @@ struct AppStorePaneTests {
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
         #expect(store.applySplitRatio(0.7, forSession: session.id) == 0.7)
         #expect(session.splitRatio == 0.7)
-        // out-of-range clamps to the cap, on both the return and the stored value.
         #expect(store.applySplitRatio(2.0, forSession: session.id) == AppStore.splitRatioMax)
         #expect(session.splitRatio == AppStore.splitRatioMax)
     }
@@ -100,11 +97,10 @@ struct AppStorePaneTests {
         session.splitRatio = 0.3
         session.initialCommand = "ssh host" // a --command primary whose command has now exited
         store.closePrimaryPane(session.id)
-        #expect(store.session(withID: session.id) != nil) // session survives
-        #expect(primary.teardownCount == 1)               // the dead primary is torn down
-        #expect(split.teardownCount == 0)                 // the survivor is kept
+        #expect(store.session(withID: session.id) != nil)
+        #expect(primary.teardownCount == 1)
+        #expect(split.teardownCount == 0)
         #expect(split.promotedCount == 1)                 // the survivor is promoted to the primary role
-        // the survivor MOVES into the primary slot — the session is now a plain single pane
         #expect(session.surface === split)
         #expect(session.splitSurface == nil)
         #expect(session.isSplit == false)
@@ -112,16 +108,13 @@ struct AppStorePaneTests {
         #expect(session.splitFocused == false)            // no split anymore; the survivor is the main pane
         #expect(session.splitRatio == nil)                // promoted to single, so a later split opens even
         #expect(session.initialCommand == nil)            // the command pane is gone; a restart must NOT resurrect it
-        // the survivor's metadata migrates up to the session (main) fields, and the split fields clear
         #expect(session.currentCwd == "/var/log")
         #expect(session.oscTitle == "remote-host")
         #expect(session.foregroundCommand == ["ssh", "host"])
         #expect(session.splitCwd == nil)
         #expect(session.splitTitle == nil)
         #expect(session.splitForegroundCommand == nil)
-        // the session-scoped control arms (session.copy/paste/selectall, font.*) must still reach the live
-        // shell: the survivor now sits IN `surface`, so `addressableSurface` resolves it through the primary
-        // slot (the `?? splitSurface` fallback is for a shown split pre-collapse, not for promotion).
+        // the `?? splitSurface` fallback is for a shown split pre-collapse, not for a promoted survivor.
         #expect(session.addressableSurface === split)
     }
 
@@ -130,7 +123,7 @@ struct AppStorePaneTests {
         let ws = store.addWorkspace(name: "work")
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
         let primary = SpySurface(); session.surface = primary
-        #expect(session.addressableSurface === primary)   // plain session
+        #expect(session.addressableSurface === primary)
 
         let split = SpySurface(); session.splitSurface = split
         session.isSplit = true
@@ -149,10 +142,7 @@ struct AppStorePaneTests {
     }
 
     @Test func closePrimaryPaneUsesRestoredSplitCwdAndClearsTitleWhenSplitHasNoOSCYet() {
-        // a RESTORED split whose shell hasn't emitted OSC yet: `initialSplitCwd` is seeded but the live
-        // `splitCwd`/`splitTitle` are still nil. Exiting the primary must promote the survivor showing ITS
-        // restore-seed cwd and NO title — not the exited primary's cwd/title lingering until the survivor's
-        // next report.
+        // a RESTORED split has `initialSplitCwd` seeded while the live `splitCwd`/`splitTitle` are nil.
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
@@ -166,7 +156,7 @@ struct AppStorePaneTests {
         store.closePrimaryPane(session.id)
         #expect(session.currentCwd == "/restored-split") // the survivor's restore-seed cwd, not the primary's
         #expect(session.oscTitle == nil)                 // the primary's title must NOT linger on the survivor
-        #expect(session.initialSplitCwd == nil)          // split fields cleared after promotion
+        #expect(session.initialSplitCwd == nil)
     }
 
     @Test func closePrimaryPaneKeepsSearchOwnedBySurvivor() {
@@ -180,7 +170,7 @@ struct AppStorePaneTests {
         session.searchActive = true       // the SURVIVING (split) pane owns an open search bar
         session.searchSurface = split
         store.closePrimaryPane(session.id)
-        #expect(session.searchActive)              // the survivor's search stays valid across promotion
+        #expect(session.searchActive)
         #expect(session.searchSurface === split)
     }
 
@@ -199,10 +189,8 @@ struct AppStorePaneTests {
         #expect(session.searchSurface == nil)
     }
 
-    // Regression: after the primary exits and the split is promoted into the main slot, the promoted
-    // surface still carries the split pane's `onExit` (→ `closeSplitPane`). Since it is now the session's
-    // sole pane, that exit must CLOSE the session — not collapse a split that no longer exists, which left
-    // a zombie session with a torn-down surface before `closeSplitPane`'s guard was tightened.
+    // the promoted surface still carries the split pane's `onExit`, so it lands in `closeSplitPane` even
+    // though it is now the sole pane.
     @Test func closeSplitPaneAfterPromotionClosesSession() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
@@ -213,17 +201,15 @@ struct AppStorePaneTests {
         session.hasSplit = true
         session.splitFocused = true
         store.closePrimaryPane(session.id)                 // primary exits → split promoted into the main slot
-        #expect(session.surface === split)                 // precondition: the survivor is now the sole pane
+        #expect(session.surface === split)
         #expect(session.splitSurface == nil)
         store.closeSplitPane(session.id)                   // the survivor's stale split `onExit` fires
         #expect(store.session(withID: session.id) == nil)  // last pane → session closed, no zombie
         #expect(split.teardownCount == 1)                  // the promoted surface is torn down exactly once
     }
 
-    // Regression (the fix `handlePaneExit` routes to): promote a survivor into the main slot, split AGAIN,
-    // then exit the (promoted) MAIN pane. Because the survivor's role is now primary, its exit runs
-    // `closePrimaryPane` — which must collapse onto the FRESH right pane (promote it, tear down the exited
-    // main), not the stale `closeSplitPane` that would tear down the new split and strand the dead main.
+    // the survivor's role is primary now, so its exit runs `closePrimaryPane` and must collapse onto the
+    // FRESH right pane rather than tearing it down.
     @Test func closePrimaryPaneAfterPromotionAndResplitCollapsesToNewSplit() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
@@ -234,9 +220,8 @@ struct AppStorePaneTests {
         session.hasSplit = true
         session.splitFocused = true
         store.closePrimaryPane(session.id)                 // primary exits → firstSplit promoted into main
-        #expect(session.surface === firstSplit)            // precondition: firstSplit is now the sole pane
+        #expect(session.surface === firstSplit)
         #expect(session.splitSurface == nil)
-        // re-split the promoted single pane: a fresh right pane mounts beside the survivor.
         let secondSplit = SpySurface(); session.splitSurface = secondSplit
         session.isSplit = true
         session.hasSplit = true
@@ -245,7 +230,7 @@ struct AppStorePaneTests {
         #expect(store.session(withID: session.id) != nil)  // session survives — the split is promoted, not lost
         #expect(session.surface === secondSplit)           // the FRESH right pane took over the main slot
         #expect(session.splitSurface == nil)
-        #expect(secondSplit.promotedCount == 1)            // it was promoted, not torn down
+        #expect(secondSplit.promotedCount == 1)
         #expect(secondSplit.teardownCount == 0)
         #expect(firstSplit.teardownCount == 1)             // the exited (promoted) main pane is torn down
     }
@@ -256,7 +241,7 @@ struct AppStorePaneTests {
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
         let primary = SpySurface(); session.surface = primary
         store.closePrimaryPane(session.id)
-        #expect(store.session(withID: session.id) == nil) // single session → closed
+        #expect(store.session(withID: session.id) == nil)
         #expect(primary.teardownCount == 1)
     }
 
@@ -270,9 +255,9 @@ struct AppStorePaneTests {
         session.hasSplit = true
         session.splitRatio = 0.4
         store.closeSplitPane(session.id)
-        #expect(store.session(withID: session.id) != nil) // session survives
-        #expect(split.teardownCount == 1)                 // the split is torn down
-        #expect(primary.teardownCount == 0)               // the primary is kept
+        #expect(store.session(withID: session.id) != nil)
+        #expect(split.teardownCount == 1)
+        #expect(primary.teardownCount == 0)
         #expect(session.splitSurface == nil)
         #expect(session.isSplit == false)
         #expect(session.splitRatio == nil)                // delegates to closeSplit, which clears the ratio
@@ -282,17 +267,14 @@ struct AppStorePaneTests {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
-        // the primary already exited (surface nil); only the split survives, so this is the last pane.
         let split = SpySurface(); session.splitSurface = split
         store.closeSplitPane(session.id)
-        #expect(store.session(withID: session.id) == nil) // last pane → closed
+        #expect(store.session(withID: session.id) == nil)
         #expect(split.teardownCount == 1)
     }
 
     @Test func closePrimaryPaneMigratesBothRestoreOverrideHalvesUp() {
-        // the survivor's restore-command override follows it into the main slot: the persisted pin (so the
-        // next launch restores the promoted pane's command, not the dead primary's) AND any payload still
-        // armed for this launch (so a surface built after promotion still runs it).
+        // both legs follow the survivor: the persisted pin AND any payload still armed for this launch.
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!

--- a/agtermCore/Tests/agtermCoreTests/AppStoreRestoreSeedTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreRestoreSeedTests.swift
@@ -4,8 +4,7 @@ import Testing
 
 // The `launchRestore` seeding gate: which rebuild paths arm a persisted `session.restore` override for
 // this launch by copying it into the transient pending slots the surface factories consume. Only an
-// app-bootstrap restore may; everything else defaults to arming nothing. Split out of AppStoreTests to
-// keep that file within the line budget.
+// app-bootstrap restore may; everything else defaults to arming nothing.
 @MainActor
 struct AppStoreRestoreSeedTests {
     private func snapshot(restore: String?, splitRestore: String?, isSplit: Bool) -> Snapshot {
@@ -28,10 +27,8 @@ struct AppStoreRestoreSeedTests {
     }
 
     @Test func bootstrapRestoreDropsAHiddenSplitsOverrideEntirely() {
-        // a split hidden at quit is not rebuilt, so makeSplitSurface never runs and its pin describes a
-        // pane that no longer exists. Nothing may be armed for it, and the PERSISTED pin is dropped too —
-        // otherwise `tree` reports a value `session.restore --pane right` cannot clear (no split), and a
-        // fresh ⌘D split shown at the next quit would inherit and run it.
+        // a split hidden at quit is not rebuilt, so its pin describes a pane that no longer exists:
+        // `tree` would report a value `--pane right` cannot clear, and a fresh split would inherit it.
         let store = makeStore()
         store.restore(from: snapshot(restore: "claude --resume abc", splitRestore: "tail -f /var/log/x",
                                      isSplit: false),
@@ -40,13 +37,11 @@ struct AppStoreRestoreSeedTests {
         #expect(session.pendingRestoreCommand == "claude --resume abc")
         #expect(session.pendingSplitRestoreCommand == nil)
         #expect(session.splitRestoreCommand == nil)
-        // the drop reaches persistence on the next save, so the orphan does not come back.
         #expect(store.snapshot().workspaces[0].sessions[0].splitRestoreCommand == nil)
     }
 
     @Test func rebuildDropsAHiddenSplitsOverrideOnEveryPath() {
-        // the drop is a property of the rebuild, not of bootstrap: Reopen Closed Item and a mid-process
-        // window reload rebuild the same split-less session and must not resurrect the orphan either.
+        // Reopen Closed Item and a mid-process window reload rebuild the same split-less session.
         let store = makeStore()
         let snap = SessionSnapshot(id: UUID(), customName: nil, cwd: "/a", isSplit: false,
                                    restoreCommand: "claude --resume abc", splitRestoreCommand: "tail -f")
@@ -55,8 +50,7 @@ struct AppStoreRestoreSeedTests {
     }
 
     @Test func bootstrapRestoreSeedsTheEmptyPinnedToNothingValue() {
-        // "" is a real override (a plain shell, suppressing the capture and initialCommand), so it must be
-        // armed like any other value rather than dropped as "no override".
+        // "" is a real override (a plain shell, suppressing the capture and initialCommand), not "none".
         let store = makeStore()
         store.restore(from: snapshot(restore: "", splitRestore: "", isSplit: true), launchRestore: true)
         let session = store.workspaces[0].sessions[0]
@@ -73,13 +67,11 @@ struct AppStoreRestoreSeedTests {
         let session = store.workspaces[0].sessions[0]
         #expect(session.pendingRestoreCommand == nil)
         #expect(session.pendingSplitRestoreCommand == nil)
-        // but the persisted values are still restored, so `tree` reads them back and the next launch fires.
         #expect(session.restoreCommand == "claude --resume abc")
         #expect(session.splitRestoreCommand == "tail -f /var/log/x")
     }
 
     @Test func sessionRebuildDefaultsToSeedingNeitherPane() {
-        // the default on session(from:) is the safe direction, so a caller added later arms nothing.
         let store = makeStore()
         let snap = SessionSnapshot(id: UUID(), customName: nil, cwd: "/a", isSplit: true,
                                    restoreCommand: "claude --resume abc", splitRestoreCommand: "tail -f")

--- a/agtermCore/Tests/agtermCoreTests/AppStoreRestoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreRestoreTests.swift
@@ -55,15 +55,15 @@ final class AppStoreRestoreTests {
 
         store.setRestoreCommand(nil, pane: .left, forSession: session.id)
         #expect(session.restoreCommand == nil)
-        #expect(session.splitRestoreCommand == "tail -f /var/log/x") // clearing one pane leaves the other
+        #expect(session.splitRestoreCommand == "tail -f /var/log/x")
 
         store.setRestoreCommand(nil, pane: .right, forSession: session.id)
         #expect(session.splitRestoreCommand == nil)
     }
 
     @Test func setRestoreCommandStoresTheEmptyPinnedToNothingValue() {
-        // "" is a real override (a plain shell, suppressing the capture and initialCommand) and must not
-        // collapse to nil, which would mean "no override" and let the auto-capture restore instead.
+        // "" is a real override (a plain shell); collapsing it to nil would mean "no override" and let the
+        // auto-capture restore instead.
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
@@ -75,8 +75,8 @@ final class AppStoreRestoreTests {
     }
 
     @Test func setRestoreCommandNeverPopulatesThePendingSlots() {
-        // the whole safety property: a write during this run must not execute during this run. Only an
-        // app-bootstrap restore arms the pending slots the surface factories consume.
+        // a write during this run must not execute during this run — only an app-bootstrap restore arms
+        // the pending slots the surface factories consume.
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
@@ -86,14 +86,11 @@ final class AppStoreRestoreTests {
 
         #expect(session.pendingRestoreCommand == nil)
         #expect(session.pendingSplitRestoreCommand == nil)
-        // and the factory-facing read stays empty, so nothing can fire this launch
         #expect(session.takePendingRestoreOverride(pane: .left) == nil)
         #expect(session.takePendingRestoreOverride(pane: .right) == nil)
     }
 
     @Test func setRestoreCommandDoesNotDisarmAnAlreadyArmedPayload() {
-        // a rewrite mid-launch (a hook firing on every session start) must not cancel the override the
-        // bootstrap already armed, nor swap in the new value — the pending payload is frozen at bootstrap.
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
@@ -116,8 +113,7 @@ final class AppStoreRestoreTests {
     }
 
     @Test func setRestoreCommandPersistsImmediately() throws {
-        // the eager save is a stated requirement: a hook's write has to survive a SIGKILL, which never
-        // runs the quit-time flush. The reported outcome is the write, not the memory mutation.
+        // a hook's write has to survive a SIGKILL, which never runs the quit-time flush — hence the eager save.
         let store = makePersistedStore()
         let ws = store.addWorkspace(name: "work")
         let session = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
@@ -129,9 +125,8 @@ final class AppStoreRestoreTests {
     }
 
     @Test func setRestoreCommandRollsBackAndReportsAFailedWrite() throws {
-        // clearing is the dangerous case: acking a clear whose write never landed would leave the OLD
-        // shell line re-typed on every launch while the user believes it is gone. So the failure is
-        // reported AND the in-memory value goes back to what is still on disk.
+        // acking a clear whose write never landed would re-type the OLD shell line on every launch, so the
+        // failure is reported AND the in-memory value goes back to what is still on disk.
         let store = makeUnwritableStore()
         let ws = store.addWorkspace(name: "work")
         let session = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
@@ -140,15 +135,12 @@ final class AppStoreRestoreTests {
         #expect(!store.setRestoreCommand(nil, pane: .left, forSession: session.id))
         #expect(session.restoreCommand == "claude --resume abc")
 
-        // a replacement that fails leaves the old command armed too, not the half-applied new one
         #expect(!store.setRestoreCommand("claude --resume def", pane: .left, forSession: session.id))
         #expect(session.restoreCommand == "claude --resume abc")
     }
 
     @Test func setRestoreCommandRetriesTheSameRequestAfterAFailedWrite() throws {
-        // the rollback is what keeps the retry possible: without it memory would already hold the
-        // requested value and the unchanged-value guard would swallow the repeat as a no-op success.
-        // A blocking FILE rather than the /dev/null idiom above, because this case needs the disk to
+        // a blocking FILE rather than the /dev/null idiom above, because this case needs the disk to
         // RECOVER between the two calls — deleting the blocker makes the same path writable.
         let blocker = directory.appendingPathComponent("blocker")
         try Data().write(to: blocker)
@@ -159,7 +151,7 @@ final class AppStoreRestoreTests {
         session.restoreCommand = "claude --resume abc"
         #expect(!store.setRestoreCommand(nil, pane: .left, forSession: session.id))
 
-        try FileManager.default.removeItem(at: blocker) // the disk recovers
+        try FileManager.default.removeItem(at: blocker)
 
         #expect(store.setRestoreCommand(nil, pane: .left, forSession: session.id))
         #expect(session.restoreCommand == nil)
@@ -169,8 +161,7 @@ final class AppStoreRestoreTests {
     }
 
     @Test func setRestoreCommandSkipsTheSaveWhenUnchanged() throws {
-        // idempotent like setFlag: re-pinning the same value writes nothing. Proven by deleting the
-        // persisted file and asserting the repeat call does not recreate it.
+        // deleting the persisted file is the oracle: a skipped save never recreates it.
         let store = makePersistedStore()
         let ws = store.addWorkspace(name: "work")
         let session = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
@@ -179,10 +170,10 @@ final class AppStoreRestoreTests {
         try FileManager.default.removeItem(at: fileURL)
 
         store.setRestoreCommand("claude --resume abc", pane: .left, forSession: session.id)
-        #expect(!FileManager.default.fileExists(atPath: fileURL.path)) // unchanged → no save
+        #expect(!FileManager.default.fileExists(atPath: fileURL.path))
 
         store.setRestoreCommand("claude --resume def", pane: .left, forSession: session.id)
-        #expect(FileManager.default.fileExists(atPath: fileURL.path)) // a real change saves again
+        #expect(FileManager.default.fileExists(atPath: fileURL.path))
     }
 
     @Test func setRestoreCommandSkipsTheSaveWhenClearingAnAlreadyClearPane() throws {
@@ -192,13 +183,13 @@ final class AppStoreRestoreTests {
         store.setRestoreCommand("claude --resume abc", pane: .left, forSession: session.id)
         try FileManager.default.removeItem(at: fileURL)
 
-        store.setRestoreCommand(nil, pane: .right, forSession: session.id) // never pinned
+        store.setRestoreCommand(nil, pane: .right, forSession: session.id)
         #expect(!FileManager.default.fileExists(atPath: fileURL.path))
         #expect(session.splitRestoreCommand == nil)
     }
 
     @Test func setRestoreCommandIgnoresTheScratchPane() {
-        // the scratch terminal is never restored; the command layer rejects it, and the store is a no-op.
+        // the scratch terminal is never restored, so there is no slot to pin.
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
@@ -209,8 +200,8 @@ final class AppStoreRestoreTests {
     }
 
     @Test func softClosedSessionUndoneWithinGraceHasNothingPending() throws {
-        // undo reinserts the SAME object, so a payload armed at bootstrap and never consumed would
-        // otherwise survive the round trip and fire when the restored session's surface is built.
+        // undo reinserts the SAME object, so an unconsumed payload would otherwise survive the round trip
+        // and fire when the restored session's surface is built.
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let session = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
@@ -224,10 +215,9 @@ final class AppStoreRestoreTests {
         #expect(store.undoPendingClose(closeID))
 
         let restored = try #require(store.session(withID: session.id))
-        #expect(restored === session) // the same live object came back
+        #expect(restored === session)
         #expect(restored.pendingRestoreCommand == nil)
         #expect(restored.pendingSplitRestoreCommand == nil)
-        // the persisted pin is untouched, so the next launch still fires it
         #expect(restored.restoreCommand == "claude --resume abc")
         #expect(restored.splitRestoreCommand == "tail -f /var/log/x")
     }

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -18,7 +18,7 @@ struct AppStoreTests {
         #expect(!store.sidebarVisible)
         store.setSidebarVisible(true)
         #expect(store.sidebarVisible)
-        store.setSidebarVisible(true) // unchanged: clean no-op
+        store.setSidebarVisible(true)
         #expect(store.sidebarVisible)
     }
 
@@ -34,13 +34,10 @@ struct AppStoreTests {
         #expect(store.currentWorkspaceID == nil)
         let work = store.addWorkspace(name: "work")
         let personal = store.addWorkspace(name: "personal")
-        // no selection -> last workspace.
         #expect(store.currentWorkspaceID == personal.id)
-        // a selected session pins its owning workspace.
         let session = try! #require(store.addSession(toWorkspace: work.id, cwd: "/a"))
         store.selectSession(session.id)
         #expect(store.currentWorkspaceID == work.id)
-        // deselecting falls back to the last workspace again.
         store.selectSession(nil)
         #expect(store.currentWorkspaceID == personal.id)
     }
@@ -69,8 +66,7 @@ struct AppStoreTests {
         let ws = store.addWorkspace(name: "work")
         let first = try! #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
         #expect(store.selectedSessionID == first.id)
-        // a background add (control `session.new --no-select`) appends the session but keeps the current
-        // selection and recency, so `active` still points at the first session.
+        // the control `session.new --no-select` path: appended, but selection and recency untouched
         let background = try! #require(store.addSession(toWorkspace: ws.id, cwd: "/b", select: false))
         #expect(store.workspaces[0].sessions.map(\.id) == [first.id, background.id])
         #expect(store.selectedSessionID == first.id)
@@ -83,7 +79,6 @@ struct AppStoreTests {
         let ws = store.addWorkspace(name: "work")
         let withCmd = try! #require(store.addSession(toWorkspace: ws.id, cwd: "/tmp", command: "ssh host"))
         #expect(withCmd.initialCommand == "ssh host")
-        // default is nil — a plain session runs the login shell.
         let plain = try! #require(store.addSession(toWorkspace: ws.id, cwd: "/tmp"))
         #expect(plain.initialCommand == nil)
     }
@@ -107,7 +102,6 @@ struct AppStoreTests {
         // blank/whitespace name clears to nil, leaving the auto basename (matches renameSession).
         let blank = try! #require(store.addSession(toWorkspace: ws.id, cwd: "/tmp", name: "  "))
         #expect(blank.customName == nil)
-        // default is nil — no custom name.
         let plain = try! #require(store.addSession(toWorkspace: ws.id, cwd: "/tmp"))
         #expect(plain.customName == nil)
     }
@@ -133,17 +127,13 @@ struct AppStoreTests {
         let store = makeStore()
         let existing = store.addWorkspace(name: "servers")
         let before = store.workspaces.count
-        // reuse: the same name returns the existing workspace, no new one appended.
         #expect(store.ensureWorkspace(named: "servers")?.id == existing.id)
         #expect(store.workspaces.count == before)
-        // create: a new name appends exactly one workspace, trimmed.
         let created = try! #require(store.ensureWorkspace(named: "  fresh  "))
         #expect(created.name == "fresh")
         #expect(store.workspaces.count == before + 1)
-        // idempotent: ensuring the just-created name again reuses it.
         #expect(store.ensureWorkspace(named: "fresh")?.id == created.id)
         #expect(store.workspaces.count == before + 1)
-        // a blank name creates nothing.
         #expect(store.ensureWorkspace(named: "   ") == nil)
         #expect(store.workspaces.count == before + 1)
     }
@@ -175,8 +165,8 @@ struct AppStoreTests {
         a.unseenCount = 3
         b.unseenCount = 2
         store.selectSession(a.id)
-        #expect(a.unseenCount == 0) // selecting a session clears its own badge
-        #expect(b.unseenCount == 2) // other sessions are untouched
+        #expect(a.unseenCount == 0)
+        #expect(b.unseenCount == 2)
     }
 
     @Test func clearUnseenResetsCountAndIgnoresUnknownID() {
@@ -190,8 +180,7 @@ struct AppStoreTests {
     }
 
     @Test func clearUnseenDoesNotChangeSelection() {
-        // the focus-free invariant behind session.seen: clearing a NON-selected session's badge must
-        // leave the selection put (markSessionSeen calls clearUnseen and nothing else).
+        // the focus-free invariant behind session.seen: markSessionSeen calls clearUnseen and nothing else
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let a = store.addSession(toWorkspace: ws.id, cwd: "/a")!
@@ -199,8 +188,8 @@ struct AppStoreTests {
         a.unseenCount = 3
         store.selectSession(b.id)
         store.clearUnseen(a.id)
-        #expect(store.selectedSessionID == b.id) // focus-free: selecting is untouched
-        #expect(a.unseenCount == 0)              // the target's badge is cleared
+        #expect(store.selectedSessionID == b.id)
+        #expect(a.unseenCount == 0)
     }
 
     @Test func setAgentIndicatorSetsFieldOnRightSession() {
@@ -210,7 +199,7 @@ struct AppStoreTests {
         let b = store.addSession(toWorkspace: ws.id, cwd: "/b")!
         store.setAgentIndicator(AgentIndicator(status: .active, blink: true), forSession: a.id)
         #expect(a.agentIndicator == AgentIndicator(status: .active, blink: true))
-        #expect(b.agentIndicator == AgentIndicator()) // other sessions are untouched
+        #expect(b.agentIndicator == AgentIndicator())
     }
 
     @Test func setAgentIndicatorUnknownSessionIsNoop() {
@@ -218,17 +207,17 @@ struct AppStoreTests {
         let ws = store.addWorkspace(name: "work")
         let a = store.addSession(toWorkspace: ws.id, cwd: "/a")!
         store.setAgentIndicator(AgentIndicator(status: .blocked), forSession: UUID()) // unknown id: no crash
-        #expect(a.agentIndicator == AgentIndicator()) // existing session untouched
+        #expect(a.agentIndicator == AgentIndicator())
     }
 
     @Test func setAgentIndicatorStampsStatusChangedAtOnNonIdle() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let a = store.addSession(toWorkspace: ws.id, cwd: "/a")!
-        #expect(a.statusChangedAt == nil) // a fresh session has no stamp
+        #expect(a.statusChangedAt == nil)
         let before = Date()
         store.setAgentIndicator(AgentIndicator(status: .active), forSession: a.id)
-        let stamp = try! #require(a.statusChangedAt) // a non-idle status stamps the change time
+        let stamp = try! #require(a.statusChangedAt)
         #expect(stamp >= before)
     }
 
@@ -238,7 +227,7 @@ struct AppStoreTests {
         let a = store.addSession(toWorkspace: ws.id, cwd: "/a")!
         store.setAgentIndicator(AgentIndicator(status: .blocked), forSession: a.id)
         #expect(a.statusChangedAt != nil)
-        store.setAgentIndicator(AgentIndicator(), forSession: a.id) // back to idle clears the stamp
+        store.setAgentIndicator(AgentIndicator(), forSession: a.id)
         #expect(a.statusChangedAt == nil)
     }
 
@@ -261,7 +250,6 @@ struct AppStoreTests {
         #expect(session.statusChangedAt != nil)
         let restored = makeStore()
         restored.restore(from: store.snapshot())
-        // the stamp is ephemeral like the indicator: a restored session falls back to nil.
         #expect(restored.workspaces[0].sessions[0].statusChangedAt == nil)
     }
 
@@ -272,7 +260,6 @@ struct AppStoreTests {
         store.setAgentIndicator(AgentIndicator(status: .completed, blink: true), forSession: session.id)
         let restored = makeStore()
         restored.restore(from: store.snapshot())
-        // the indicator is ephemeral: a restored session falls back to the default idle state.
         #expect(restored.workspaces[0].sessions[0].agentIndicator == AgentIndicator())
     }
 
@@ -282,10 +269,10 @@ struct AppStoreTests {
         let a = store.addSession(toWorkspace: ws.id, cwd: "/a")!
         let b = store.addSession(toWorkspace: ws.id, cwd: "/b")!
         store.setAgentIndicator(AgentIndicator(status: .active), forSession: a.id) // autoReset defaults false
-        store.selectSession(a.id) // a non-auto-reset indicator survives a visit (keep-state)
+        store.selectSession(a.id)
         #expect(a.agentIndicator == AgentIndicator(status: .active))
         store.selectSession(b.id)
-        #expect(a.agentIndicator == AgentIndicator(status: .active)) // still set after switching away
+        #expect(a.agentIndicator == AgentIndicator(status: .active))
     }
 
     @Test func selectSessionResetsAutoResetIndicator() {
@@ -306,7 +293,7 @@ struct AppStoreTests {
         let a = store.addSession(toWorkspace: ws.id, cwd: "/a")!
         let b = store.addSession(toWorkspace: ws.id, cwd: "/b")!
         store.setAgentIndicator(AgentIndicator(status: .completed, autoReset: true), forSession: a.id)
-        store.selectSession(b.id) // selecting a different session leaves a background indicator alone
+        store.selectSession(b.id)
         #expect(a.agentIndicator == AgentIndicator(status: .completed, autoReset: true))
     }
 
@@ -319,10 +306,9 @@ struct AppStoreTests {
         // the agent finishes WHILE a is the selected session, so no visit fires and its completed flash lingers
         store.setAgentIndicator(AgentIndicator(status: .completed, autoReset: true), forSession: a.id)
         #expect(a.agentIndicator == AgentIndicator(status: .completed, autoReset: true))
-        // switching away from a clears its one-time completed flash (it must not persist on the row you left)
         store.selectSession(b.id)
         #expect(a.agentIndicator == AgentIndicator())
-        #expect(b.agentIndicator == AgentIndicator()) // and b (the one moved to) carries nothing
+        #expect(b.agentIndicator == AgentIndicator())
     }
 
     @Test func workspaceForSessionDerivesOwner() {
@@ -500,8 +486,7 @@ struct AppStoreTests {
 
     @Test func softCloseSessionsAdjustsReselectionForEarlierBatchRemovals() throws {
         // the index adjustment feeds the POSITIONAL fallback, which only runs when the scoped recency is
-        // empty, so drive it through a restore: nothing has been activated but the restored selection, and
-        // once that is the session being closed the fallback is the only thing left to pick with.
+        // empty — hence the restore: nothing is activated but the selection that is then closed.
         let store = makeStore()
         let wsID = UUID()
         let ids = [UUID(), UUID(), UUID(), UUID()]
@@ -609,11 +594,9 @@ struct AppStoreTests {
         session.surface = surface
 
         #expect(store.softCloseSession(session.id, grace: 0.01))
-        // poll for the scheduled finalize rather than racing one fixed sleep. the suites run in parallel, so
-        // the 10 ms grace timer can land well past a flat 30 ms window under load (reproduced: ~1 run in 6).
-        // poll the TEARDOWN, not `session(withID:)`: softCloseSession removes the session from its workspace
-        // synchronously and only defers the teardown to the timer, so a session-lookup poll exits immediately
-        // and proves nothing. bounded at ~1 s, so a finalize that never fires fails the expectations below.
+        // the suites run in parallel, so the 10 ms grace timer can land well past a flat 30 ms sleep
+        // (reproduced: ~1 run in 6). poll the TEARDOWN, not `session(withID:)`: the session is removed
+        // synchronously and only the teardown deferred, so a lookup poll exits at once and proves nothing.
         for _ in 0..<200 {
             if surface.teardownCount == 1 { break }
             try await Task.sleep(nanoseconds: 5_000_000)
@@ -716,7 +699,6 @@ struct AppStoreTests {
         let workspaceClose = try #require(store.pendingCloseSummary?.id)
 
         #expect(store.undoPendingClose(sessionClose))
-        // the shell is seeded from the still-pending workspace record, not the stale session record
         let shell = try #require(store.workspaces.first { $0.id == doomed.id })
         #expect(shell.name == "renamed")
         #expect(shell.isExpanded == false)
@@ -740,7 +722,6 @@ struct AppStoreTests {
         let workspaceClose = try #require(store.pendingCloseSummary?.id)
 
         #expect(store.undoPendingClose(sessionClose))
-        // edits to the rebuilt shell are newer than the pending record and must survive the merge
         store.renameWorkspace(doomed.id, to: "new")
         store.setWorkspaceExpanded(doomed.id, expanded: false)
         #expect(store.undoPendingClose(workspaceClose))
@@ -778,8 +759,7 @@ struct AppStoreTests {
         #expect(Set(restored.sessions.map(\.id)) == Set([first.id, second.id]))
         #expect(restored.sessions.count == 2)
         #expect(store.selectedSessionID == second.id)
-        // the reopened session is rebuilt from its snapshot, so it is a fresh object; the merged-in
-        // one is the live object the pending record held
+        // the reopened session is a fresh object rebuilt from its snapshot; the merged-in one is live
         #expect(restored.sessions.contains { $0 === second })
         #expect(restored.sessions.allSatisfy { $0 !== first })
     }
@@ -819,13 +799,11 @@ struct AppStoreTests {
         // rebuilds. a disjoint snapshot would merge cleanly even without the live-session filter.
         let workspaceSnapshot = store.workspaceSnapshot(try #require(store.workspaces.first { $0.id == doomed.id }))
 
-        // both closes finalize, so only the recent snapshots remain
         #expect(store.softCloseSession(first.id, grace: 60))
         store.finalizePendingClose(try #require(store.pendingCloseSummary?.id))
         #expect(store.softRemoveWorkspace(doomed.id, grace: 60))
         store.finalizePendingClose(try #require(store.pendingCloseSummary?.id))
 
-        // reopening the session rebuilds the workspace as a shell holding only that session
         let recentSession = RecentClosedItem(
             kind: .session, title: "a", subtitle: "doomed",
             session: RecentClosedSession(workspaceID: doomed.id, workspaceName: "doomed",
@@ -833,7 +811,6 @@ struct AppStoreTests {
         )
         #expect(store.restoreRecentClosed(recentSession))
 
-        // reopening the workspace must bring back the session the shell doesn't hold
         let recentWorkspace = RecentClosedItem(
             kind: .workspace, title: "doomed", subtitle: "2 sessions",
             workspace: RecentClosedWorkspace(snapshot: workspaceSnapshot, selectedSessionID: second.id)
@@ -874,8 +851,7 @@ struct AppStoreTests {
         let rebuiltFirst = try #require(store.workspaces.first { $0.id == doomed.id }?.sessions.first)
         #expect(store.softCloseSession(rebuiltFirst.id, grace: 60))
 
-        // the pending session close matches the workspace's recent entry, but undoing it restores only
-        // `first`. the workspace restore must still rebuild `second`, which nothing else holds.
+        // the pending close would restore only `first`; the workspace restore must still rebuild `second`
         let recentWorkspace = RecentClosedItem(
             kind: .workspace, title: "doomed", subtitle: "2 sessions",
             workspace: RecentClosedWorkspace(snapshot: workspaceSnapshot, selectedSessionID: second.id)
@@ -898,8 +874,7 @@ struct AppStoreTests {
         first.surface = firstSurface
         let workspaceSnapshot = store.workspaceSnapshot(try #require(store.workspaces.first { $0.id == doomed.id }))
 
-        // both sessions are held by their own pending close, so neither is live when the workspace's
-        // recent entry is reopened
+        // both sessions are held by their own pending close, so neither is live at the reopen
         #expect(store.softCloseSession(first.id, grace: 60))
         let firstClose = try #require(store.pendingCloseSummary?.id)
         #expect(store.softCloseSession(second.id, grace: 60))
@@ -930,9 +905,8 @@ struct AppStoreTests {
         let first = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/a"))
         let second = try #require(store.addSession(toWorkspace: doomed.id, cwd: "/b"))
 
-        // close `first`, then the workspace holding `second`, then undo `first` so it lands in a rebuilt
-        // shell. closing that shell must not leave a second pending record sharing the workspace id:
-        // both would key one Open Recent entry, and the newer snapshot evicts the older one's sessions.
+        // two pending records must never share a workspace id: both would key one Open Recent entry, and
+        // the newer snapshot evicts the older one's sessions.
         #expect(store.softCloseSession(first.id, grace: 60))
         let sessionClose = try #require(store.pendingCloseSummary?.id)
         #expect(store.softRemoveWorkspace(doomed.id, grace: 60))
@@ -994,7 +968,6 @@ struct AppStoreTests {
                                        workspace: RecentClosedWorkspace(snapshot: staleSnapshot, selectedSessionID: moved.id))
         _ = store.restoreRecentClosed(recentW)
 
-        // reopening W must not resurrect V, and must not rebuild `moved` beside the original V still holds
         #expect(store.workspaces.contains { $0.id == wsV.id } == false)
         #expect(store.pendingCloseRecords.count == 1)
         #expect(store.workspaces.flatMap(\.sessions).count { $0.id == moved.id } == 0)
@@ -1021,7 +994,6 @@ struct AppStoreTests {
         _ = store.restoreRecentClosed(recentW)
         #expect(store.pendingCloseRecords[vClose] != nil)
 
-        // undoing V returns the original `moved`; the rebuilt W must not have made a second one
         #expect(store.undoPendingClose(vClose))
         #expect(store.workspaces.flatMap(\.sessions).count { $0.id == moved.id } == 1)
         #expect(store.workspaces.flatMap(\.sessions).contains { $0 === moved })
@@ -1155,7 +1127,7 @@ struct AppStoreTests {
         let b = store.addSession(toWorkspace: ws.id, cwd: "/b")!
         #expect(store.sessionRecency.items == [b.id, a.id]) // b selected last
         store.selectSession(a.id)
-        #expect(store.sessionRecency.items == [a.id, b.id]) // a now front, b is the previous
+        #expect(store.sessionRecency.items == [a.id, b.id])
         #expect(store.sessionRecency.items[1] == b.id)
     }
 
@@ -1179,8 +1151,8 @@ struct AppStoreTests {
         store.selectSession(a.id)
         store.selectSession(c.id)
         store.selectSession(b.id)
-        #expect(store.recentSessions(limit: 9) == [b.id, c.id, a.id]) // fewer than the limit → all, mru first
-        #expect(store.recentSessions(limit: 2) == [b.id, c.id]) // limit clamps the count
+        #expect(store.recentSessions(limit: 9) == [b.id, c.id, a.id])
+        #expect(store.recentSessions(limit: 2) == [b.id, c.id])
     }
 
     @Test func recentSessionsSpansWorkspacesAndSkipsClosed() {
@@ -1191,7 +1163,7 @@ struct AppStoreTests {
         let b = store.addSession(toWorkspace: personal.id, cwd: "/b")!
         store.selectSession(a.id)
         store.selectSession(b.id)
-        #expect(store.recentSessions(limit: 9) == [b.id, a.id]) // recency spans every workspace
+        #expect(store.recentSessions(limit: 9) == [b.id, a.id])
         store.closeSession(b.id) // closed sessions are pruned from recency, so they drop out
         #expect(store.recentSessions(limit: 9) == [a.id])
     }
@@ -1223,7 +1195,7 @@ struct AppStoreTests {
         #expect(session.fontSize == nil)
         store.setFontSize(session.id, 16)
         #expect(session.fontSize == 16)
-        store.setFontSize(session.id, 16) // unchanged: no-op, value unchanged
+        store.setFontSize(session.id, 16)
         #expect(session.fontSize == 16)
         store.setFontSize(session.id, 13)
         #expect(session.fontSize == 13)
@@ -1258,7 +1230,7 @@ struct AppStoreTests {
         _ = store.addSession(toWorkspace: ws.id, cwd: "/b")!
         store.selectSession(a.id)
         store.save() // selection saves are debounced; save() flushes the write
-        #expect(persistence.load().selectedSessionID == a.id) // persisted to disk, not just in-memory
+        #expect(persistence.load().selectedSessionID == a.id)
     }
 
     @Test func rapidSelectionAndFontThenSavePersistsLatestSnapshot() {
@@ -1269,21 +1241,18 @@ struct AppStoreTests {
         let a = store.addSession(toWorkspace: ws.id, cwd: "/a")!
         _ = store.addSession(toWorkspace: ws.id, cwd: "/b")!
         let c = store.addSession(toWorkspace: ws.id, cwd: "/c")!
-        // a burst of debounced selection/font changes; save() writes the latest state once
         store.selectSession(a.id)
         store.selectSession(c.id)
         store.setFontSize(c.id, 18)
         store.save()
         let loaded = persistence.load()
-        #expect(loaded.selectedSessionID == c.id)               // the latest selection won
-        #expect(loaded.workspaces[0].sessions[2].fontSize == 18) // and the latest font change landed
+        #expect(loaded.selectedSessionID == c.id)
+        #expect(loaded.workspaces[0].sessions[2].fontSize == 18)
     }
 
     @Test func selectSessionDefersWriteUntilSaveFlushes() {
-        // guards the DEBOUNCE itself: selectSession must NOT write synchronously. addSession saves
-        // immediately (structural), so disk shows the last-added session selected; a debounced
-        // selectSession leaves the disk unchanged until save() flushes. A revert to a synchronous
-        // save() in selectSession fails the middle assertion.
+        // addSession saves immediately (structural), so disk shows the last-added session selected; a
+        // revert to a synchronous save() in selectSession fails the middle assertion.
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent("agterm-tests-\(UUID().uuidString)")
         let persistence = PersistenceStore(directory: dir)
         let store = AppStore(persistence: persistence)
@@ -1291,10 +1260,10 @@ struct AppStoreTests {
         let a = store.addSession(toWorkspace: ws.id, cwd: "/a")!
         let b = store.addSession(toWorkspace: ws.id, cwd: "/b")! // structural save: disk now selects b
         #expect(persistence.load().selectedSessionID == b.id)
-        store.selectSession(a.id)                                // debounced — must not hit disk yet
-        #expect(persistence.load().selectedSessionID == b.id)    // still b: the write was deferred
-        store.save()                                             // flush
-        #expect(persistence.load().selectedSessionID == a.id)    // now a is persisted
+        store.selectSession(a.id) // debounced — must not hit disk yet
+        #expect(persistence.load().selectedSessionID == b.id)
+        store.save()
+        #expect(persistence.load().selectedSessionID == a.id)
     }
 
     @Test func setFontSizeDefersWriteUntilSaveFlushes() {
@@ -1305,9 +1274,9 @@ struct AppStoreTests {
         let ws = store.addWorkspace(name: "work")
         let a = store.addSession(toWorkspace: ws.id, cwd: "/a")! // structural save: fontSize nil on disk
         #expect(persistence.load().workspaces[0].sessions[0].fontSize == nil)
-        store.setFontSize(a.id, 18)                              // debounced — must not hit disk yet
-        #expect(persistence.load().workspaces[0].sessions[0].fontSize == nil) // still nil: deferred
-        store.save()                                             // flush
+        store.setFontSize(a.id, 18) // debounced — must not hit disk yet
+        #expect(persistence.load().workspaces[0].sessions[0].fontSize == nil)
+        store.save()
         #expect(persistence.load().workspaces[0].sessions[0].fontSize == 18)
     }
 
@@ -1333,7 +1302,6 @@ struct AppStoreTests {
         let unwritable = URL(fileURLWithPath: "/dev/null/agterm-cannot-write")
         let store = AppStore(persistence: PersistenceStore(directory: unwritable))
         let ws = store.addWorkspace(name: "work")
-        // save() to an unwritable directory is swallowed; the in-memory mutation stands.
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")
         #expect(session != nil)
         #expect(store.workspaces[0].sessions.count == 1)
@@ -1388,11 +1356,11 @@ struct AppStoreTests {
         let session = store.addSession(toWorkspace: ws.id, cwd: "/tmp")!
         let mark = BackgroundWatermark(kind: .text, text: "PROD")
 
-        #expect(store.setBackgroundWatermark(mark, forSession: session.id))       // first set changes
-        #expect(!store.setBackgroundWatermark(mark, forSession: session.id))      // identical re-set: no change
-        #expect(store.setBackgroundWatermark(nil, forSession: session.id))        // clear changes
-        #expect(!store.setBackgroundWatermark(nil, forSession: session.id))       // clear again: no change
-        #expect(!store.setBackgroundWatermark(mark, forSession: UUID()))          // unknown id: no change
+        #expect(store.setBackgroundWatermark(mark, forSession: session.id))
+        #expect(!store.setBackgroundWatermark(mark, forSession: session.id))
+        #expect(store.setBackgroundWatermark(nil, forSession: session.id))
+        #expect(!store.setBackgroundWatermark(nil, forSession: session.id))
+        #expect(!store.setBackgroundWatermark(mark, forSession: UUID()))
     }
 
     @Test func controlTreeProjectsWorkspaceAndSessionShape() throws {
@@ -1448,7 +1416,7 @@ struct AppStoreTests {
 
     @Test func controlTreeReportsSidebarVisibility() {
         let store = makeStore()
-        #expect(store.controlTree().sidebarVisible == true) // default: sidebar shown
+        #expect(store.controlTree().sidebarVisible == true)
         store.setSidebarVisible(false)
         #expect(store.controlTree().sidebarVisible == false)
         store.setSidebarVisible(true)
@@ -1458,14 +1426,11 @@ struct AppStoreTests {
     @Test func controlTreeReportsCollapsedWorkspace() {
         let store = makeStore()
         let ws2 = store.addWorkspace(name: "second")
-        // all workspaces expanded by default: no node reports collapsed.
         #expect(store.controlTree().workspaces.allSatisfy { $0.collapsed == nil })
-        // collapse the second workspace: ONLY its node reports collapsed == true.
         store.setWorkspaceExpanded(ws2.id, expanded: false)
         let nodes = store.controlTree().workspaces
         #expect(nodes.first { $0.id == ws2.id.uuidString }?.collapsed == true)
         #expect(nodes.filter { $0.collapsed == true }.count == 1)
-        // re-expanding it omits the field again.
         store.setWorkspaceExpanded(ws2.id, expanded: true)
         #expect(store.controlTree().workspaces.allSatisfy { $0.collapsed == nil })
     }
@@ -1473,7 +1438,6 @@ struct AppStoreTests {
     @Test func controlTreeCollapsedIsIdempotentAndFocusIndependent() {
         let store = makeStore()
         let ws2 = store.addWorkspace(name: "second")
-        // idempotent: collapsing twice leaves exactly one collapsed node reporting true (delta-guarded).
         store.setWorkspaceExpanded(ws2.id, expanded: false)
         store.setWorkspaceExpanded(ws2.id, expanded: false)
         let afterTwice = store.controlTree().workspaces
@@ -1489,7 +1453,7 @@ struct AppStoreTests {
 
     @Test func controlTreeReportsSidebarMode() {
         let store = makeStore()
-        #expect(store.controlTree().sidebarMode == "tree") // default: the workspace tree
+        #expect(store.controlTree().sidebarMode == "tree")
         store.setSidebarMode(.flagged)
         #expect(store.controlTree().sidebarMode == "flagged")
         store.setSidebarMode(.tree)
@@ -1498,7 +1462,6 @@ struct AppStoreTests {
 
     @Test func controlTreeReportsQuickVisibleFromClosure() {
         let store = makeStore()
-        // no closure (host-free / default): omitted (nil).
         #expect(store.controlTree().quickVisible == nil)
         // the app supplies the live QuickTerminalController.isVisible via the closure.
         #expect(store.controlTree(quickVisible: { true }).quickVisible == true)
@@ -1507,7 +1470,6 @@ struct AppStoreTests {
 
     @Test func controlTreeReportsZoomedSurfaceFromClosure() {
         let store = makeStore()
-        // no closure (host-free / default) or nothing zoomed: omitted (nil).
         #expect(store.controlTree().zoomedSurface == nil)
         #expect(store.controlTree(zoomedSurface: { nil }).zoomedSurface == nil)
         // the app supplies the live TerminalZoomController.target?.controlID via the closure.
@@ -1529,14 +1491,12 @@ struct AppStoreTests {
 
     @Test func controlTreeReportsDashboardFieldsFromClosures() {
         let store = makeStore()
-        // no closures (host-free / default) or nothing open: all four omitted (nil).
         let bare = store.controlTree()
         #expect(bare.dashboardMembers == nil)
         #expect(bare.dashboardHighlighted == nil)
         #expect(bare.dashboardFontSize == nil)
         #expect(bare.dashboardFontMode == nil)
-        // the app supplies the live DashboardController state via the closures. Members are pane refs now
-        // (`<uuid>:left`/`:right`): a split session shows as both its `:left` and `:right` cells.
+        // members are pane refs (`<uuid>:left`/`:right`), so a split session shows as two cells
         let members = ["9f3c:left", "9f3c:right", "abcd:left"]
         let tree = store.controlTree(dashboardMembers: { members }, dashboardHighlighted: { "9f3c:right" },
                                      dashboardFontSize: { 12 }, dashboardFontMode: { "auto" })
@@ -1547,9 +1507,8 @@ struct AppStoreTests {
     }
 
     @Test func controlTreeDashboardMembersClosurePassesThroughVerbatim() {
-        // the closure value is threaded verbatim: an EMPTY array is distinct from nil (omitted). The app
-        // side never emits [] (its closure returns nil while the dashboard is closed, and a non-empty member
-        // set otherwise), so this pins the boundary — [] passes through as [], nil omits.
+        // an EMPTY array is distinct from nil (omitted). The app side never emits [], so this pins a
+        // boundary nothing else reaches.
         let store = makeStore()
         #expect(store.controlTree(dashboardMembers: { [] }).dashboardMembers == [])
         #expect(store.controlTree(dashboardMembers: { nil }).dashboardMembers == nil)
@@ -1564,13 +1523,13 @@ struct AppStoreTests {
         let token = NotificationCenter.default.addObserver(forName: .agtermSidebarVisibilityChanged, object: nil,
                                                            queue: nil) { _ in counter.n += 1 }
         defer { NotificationCenter.default.removeObserver(token) }
-        store.setSidebarVisible(true)   // unchanged from default -> no post
+        store.setSidebarVisible(true)
         #expect(counter.n == 0)
-        store.setSidebarVisible(false)  // change -> post
+        store.setSidebarVisible(false)
         #expect(counter.n == 1)
-        store.setSidebarVisible(false)  // unchanged -> no post
+        store.setSidebarVisible(false)
         #expect(counter.n == 1)
-        store.setSidebarVisible(true)   // change -> post
+        store.setSidebarVisible(true)
         #expect(counter.n == 2)
     }
 
@@ -1614,8 +1573,6 @@ struct AppStoreTests {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let session = try #require(store.addSession(toWorkspace: ws.id, cwd: "/repo"))
-        // an idle indicator carrying a pane must project BOTH status and statusPane as nil, never a
-        // self-contradictory (status == nil while statusPane == "right") node
         store.setAgentIndicator(AgentIndicator(status: .idle, statusPane: .right), forSession: session.id)
 
         let node = try #require(store.controlTree().workspaces[0].sessions.first)
@@ -1628,7 +1585,6 @@ struct AppStoreTests {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let session = try #require(store.addSession(toWorkspace: ws.id, cwd: "/repo"))
-        // non-idle status with no pane recorded: status present, statusPane stays nil
         store.setAgentIndicator(AgentIndicator(status: .completed), forSession: session.id)
 
         let node = try #require(store.controlTree().workspaces[0].sessions.first)
@@ -1655,15 +1611,14 @@ struct AppStoreTests {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let session = try #require(store.addSession(toWorkspace: ws.id, cwd: "/repo"))
-        // the per-call shape is ephemeral: each session.status builds a whole new indicator, so a following
-        // set that names no shape replaces it rather than inheriting it — the discard contract itself
+        // each session.status builds a whole new indicator, so a following set with no shape replaces it
         store.setAgentIndicator(AgentIndicator(status: .blocked, shape: .triangle), forSession: session.id)
         #expect(store.controlTree().workspaces[0].sessions[0].statusShape == "triangle")
 
         store.setAgentIndicator(AgentIndicator(status: .blocked), forSession: session.id)
 
         #expect(store.controlTree().workspaces[0].sessions[0].statusShape == nil)
-        #expect(store.controlTree().workspaces[0].sessions[0].status == "blocked") // only the shape reverted
+        #expect(store.controlTree().workspaces[0].sessions[0].status == "blocked")
     }
 
     @Test func controlTreeNilsStatusShapeWhenIdleEvenWithShape() throws {
@@ -1785,9 +1740,8 @@ extension AppStoreTests {
         #expect(store.sidebarSelectionTargets(forContextSession: a.id) == [a.id])
     }
 
-    // The prune-guard tests below all share one shape: hide selected rows (assert), then RE-SHOW them
-    // and assert a second time. `sidebarSelectionIDs` filters on read, so the first assert passes
-    // whether or not the raw list was pruned — only the second step catches a missing prune.
+    // the prune-guard tests below hide selected rows, then RE-SHOW them and assert again:
+    // `sidebarSelectionIDs` filters on read, so only the second step catches a missing prune.
     @Test func modeChangePrunesRowsHiddenInFlaggedMode() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/BuiltinActionTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/BuiltinActionTests.swift
@@ -10,7 +10,6 @@ struct BuiltinActionTests {
     }
 
     @Test func rawNamesAreTheKittyStyleNames() {
-        // spot-check the documented raw names so a rename can't drift silently.
         #expect(BuiltinAction.newWindow.rawValue == "new_window")
         #expect(BuiltinAction.toggleSplit.rawValue == "toggle_split")
         #expect(BuiltinAction.toggleTerminalZoom.rawValue == "toggle_terminal_zoom")
@@ -56,9 +55,8 @@ struct BuiltinActionTests {
     }
 
     @Test func everyShippedDefaultRoundTripsExceptTheDocumentedPlusKey() {
-        // a default that can't round-trip renders as "(not expressible)" in the starter file and can't be
-        // re-typed by the user. increase_font_size's ⌘+ is the ONE documented exception (`+` is the chord
-        // joiner); anything else appearing here is a bug in the new default, not a new exception.
+        // a default that can't round-trip renders as "(not expressible)" in the starter file. ⌘+ is the
+        // ONE documented exception (`+` is the chord joiner); anything else here is a bug in that default.
         let notExpressible = BuiltinAction.allCases.filter { action in
             guard let chord = action.defaultChord else { return false }
             return parseKeybind(chord.displayString) != [chord]
@@ -84,7 +82,7 @@ struct BuiltinActionTests {
             .newSession: Chord(mods: [.command], key: "n"),
             .openDirectory: Chord(mods: [.command], key: "o"),
             .renameSession: nil,
-            .duplicateSession: nil,  // keyless — gains a key only when the user maps one
+            .duplicateSession: nil,
             .closeSession: Chord(mods: [.command], key: "w"),
             .reopenRecent: Chord(mods: [.command, .shift], key: "t"),
             .undoClose: Chord(mods: [.command], key: "z"),
@@ -98,11 +96,11 @@ struct BuiltinActionTests {
             .toggleSearch: Chord(mods: [.command], key: "f"),
             .toggleSidebar: Chord(mods: [.command, .control], key: "s"),
             .toggleFullscreen: Chord(mods: [.command, .control], key: "f"),
-            .selectTheme: nil,      // keyless — gains a key only when the user maps one
-            .toggleFlaggedView: nil, // keyless — gains a key only when the user maps one
-            .toggleWorkspaceFilter: nil, // keyless — gains a key only when the user maps one
+            .selectTheme: nil,
+            .toggleFlaggedView: nil,
+            .toggleWorkspaceFilter: nil,
             .toggleFlag: Chord(mods: [.command, .shift], key: "f"),
-            .focusWorkspace: nil,   // keyless — gains a key only when the user maps one
+            .focusWorkspace: nil,
             .focusLeftPane: Chord(mods: [.command, .option], key: "left"),
             .focusRightPane: Chord(mods: [.command, .option], key: "right"),
             .previousSession: Chord(mods: [.command, .option], key: "up"),
@@ -118,7 +116,6 @@ struct BuiltinActionTests {
             .showAttention: Chord(mods: [.control, .shift], key: "i"),
             .dashboard: Chord(mods: [.command, .shift], key: "d"),
         ]
-        // the table must cover every case so a new action can't be added without a documented default.
         #expect(expected.count == BuiltinAction.allCases.count)
         for action in BuiltinAction.allCases {
             #expect(expected[action] == action.defaultChord, "default chord mismatch for \(action.rawValue)")
@@ -128,8 +125,6 @@ struct BuiltinActionTests {
     @Test func toggleSearchDefaultIsCmdFAndRoundTrips() {
         let chord = Chord(mods: [.command], key: "f")
         #expect(BuiltinAction.toggleSearch.defaultChord == chord)
-        // the chord must round-trip through the keymap grammar so the starter renders it as `cmd+f`,
-        // not `(not expressible)` (the same check chordSyntax runs app-side).
         #expect(chord.displayString == "cmd+f")
         #expect(parseKeybind(chord.displayString) == [chord])
     }
@@ -137,21 +132,18 @@ struct BuiltinActionTests {
     @Test func toggleSidebarDefaultIsCmdCtrlSAndRoundTrips() {
         let chord = Chord(mods: [.command, .control], key: "s")
         #expect(BuiltinAction.toggleSidebar.defaultChord == chord)
-        // must round-trip through the keymap grammar (so the starter renders it, not "(not expressible)").
         #expect(parseKeybind(chord.displayString) == [chord])
     }
 
     @Test func toggleFullscreenDefaultIsCmdCtrlFAndRoundTrips() {
         let chord = Chord(mods: [.command, .control], key: "f")
         #expect(BuiltinAction.toggleFullscreen.defaultChord == chord)
-        // must round-trip through the keymap grammar (so the starter renders it, not "(not expressible)").
         #expect(parseKeybind(chord.displayString) == [chord])
     }
 
     @Test func customCommandPaletteDefaultIsCtrlShiftOAndRoundTrips() {
         let chord = Chord(mods: [.control, .shift], key: "o")
         #expect(BuiltinAction.customCommandPalette.defaultChord == chord)
-        // must round-trip through the keymap grammar (so the starter renders it, not "(not expressible)").
         #expect(chord.displayString == "ctrl+shift+o")
         #expect(parseKeybind(chord.displayString) == [chord])
     }
@@ -159,7 +151,6 @@ struct BuiltinActionTests {
     @Test func toggleFlagDefaultIsCmdShiftFAndRoundTrips() {
         let chord = Chord(mods: [.command, .shift], key: "f")
         #expect(BuiltinAction.toggleFlag.defaultChord == chord)
-        // must round-trip through the keymap grammar (so the starter renders it, not "(not expressible)").
         #expect(chord.displayString == "cmd+shift+f")
         #expect(parseKeybind(chord.displayString) == [chord])
     }
@@ -173,7 +164,6 @@ struct BuiltinActionTests {
         let override = Chord(mods: [.command, .shift], key: "g")
         #expect(keymap.builtinOverrides == [.toggleWorkspaceFilter: override])
         #expect(keymap.equivalent(for: .toggleWorkspaceFilter) == override)
-        // unmapped it shows no shortcut anywhere (menu, palette hint, tooltip).
         #expect(Keymap(builtinOverrides: [:], commands: []).glyphHint(for: .toggleWorkspaceFilter) == nil)
     }
 
@@ -186,7 +176,6 @@ struct BuiltinActionTests {
         for action in keyless {
             #expect(action.defaultChord == nil, "expected nil default for \(action.rawValue)")
         }
-        // nothing else is keyless — every remaining action ships a chord.
         #expect(BuiltinAction.allCases.filter { $0.defaultChord == nil } == BuiltinAction.allCases.filter { keyless.contains($0) })
     }
 }

--- a/agtermCore/Tests/agtermCoreTests/CommandRestoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/CommandRestoreTests.swift
@@ -26,7 +26,6 @@ struct CommandRestoreTests {
 
     @Test func parseProcArgsRejectsTruncatedAndEmpty() {
         #expect(CommandRestore.parseProcArgs(Data()) == nil)
-        // argc says 2 but only one arg present -> nil (no overread, no partial result).
         let truncated = blob(argc: 2, execPath: "/bin/sh", padding: 0, args: ["sh"])
         #expect(CommandRestore.parseProcArgs(truncated) == nil)
         // a blob shorter than the argc header.
@@ -44,22 +43,19 @@ struct CommandRestoreTests {
         #expect(CommandRestore.isKnownShell("-zsh"))
         #expect(CommandRestore.isKnownShell("-bash", extra: "bash"))
         #expect(CommandRestore.isKnownShell(CommandRestore.basename("-/bin/zsh"))) // path form -> "zsh"
-        // an empty $SHELL basename must not classify an empty argv0 as a shell.
         #expect(!CommandRestore.isKnownShell("", extra: ""))
     }
 
     @Test func isIdleShellSkipsBarePromptButNotScripts() {
-        // a bare interactive/login shell at its prompt is idle (skip).
         #expect(CommandRestore.isIdleShell(argv: ["-zsh"]))
         #expect(CommandRestore.isIdleShell(argv: ["/bin/zsh"]))
         #expect(CommandRestore.isIdleShell(argv: ["-/bin/zsh"]))
         #expect(CommandRestore.isIdleShell(argv: ["zsh", "-i", "-l"]))            // only option flags
         #expect(CommandRestore.isIdleShell(argv: ["bash"], extra: "bash"))
-        // a shell RUNNING a script or -c command is NOT idle — capture it (the cld bug).
+        // a shell running a script or -c is NOT idle — the real-world `cld` launcher bug.
         #expect(!CommandRestore.isIdleShell(argv: ["/bin/sh", "/usr/local/bin/cld"]))
         #expect(!CommandRestore.isIdleShell(argv: ["/bin/sh", "/usr/local/bin/cld", "--flag"]))
         #expect(!CommandRestore.isIdleShell(argv: ["bash", "-c", "echo hi"]))
-        // not a shell at all, or empty.
         #expect(!CommandRestore.isIdleShell(argv: ["htop"]))
         #expect(!CommandRestore.isIdleShell(argv: []))
     }
@@ -71,11 +67,9 @@ struct CommandRestoreTests {
         // interpreters / servers are NOT denied (not in the list): usually scripts or servers worth restoring.
         #expect(CommandRestore.shouldRestore(argv: ["python3", "worker.py"], denylist: denylist))
         #expect(CommandRestore.shouldRestore(argv: ["node", "server.js"], denylist: denylist))
-        // denylisted entries are matched on the basename.
         #expect(!CommandRestore.shouldRestore(argv: ["/usr/bin/vim", "file"], denylist: denylist))
         #expect(!CommandRestore.shouldRestore(argv: ["tmux"], denylist: denylist))
         #expect(!CommandRestore.shouldRestore(argv: ["/opt/homebrew/bin/hx", "."], denylist: denylist))
-        // an empty denylist restores every non-empty argv; an empty argv never restores.
         #expect(CommandRestore.shouldRestore(argv: ["vim", "x"], denylist: []))
         #expect(!CommandRestore.shouldRestore(argv: [], denylist: denylist))
         #expect(!CommandRestore.shouldRestore(argv: [""], denylist: denylist))
@@ -112,8 +106,7 @@ struct CommandRestoreTests {
     }
 
     @Test func parseProcArgsRejectsUnterminatedExecPath() {
-        // argc=1 but the bytes after it run to EOF with no NUL: the exec-path walk hits EOF, no args
-        // are parsed, and the count mismatch returns nil (no overread).
+        // the exec-path walk hits EOF, so no args are parsed and the count mismatch returns nil.
         var d = withUnsafeBytes(of: Int32(1)) { Data($0) }
         d.append(Data("/bin/shhhhhh".utf8)) // no terminating NUL
         #expect(CommandRestore.parseProcArgs(d) == nil)
@@ -136,7 +129,6 @@ struct CommandRestoreTests {
     // MARK: - restorePlan (the surface-seed gate/precedence)
 
     @Test func freshCommandSessionAlwaysRunsItsCommand() {
-        // a freshly created --command session runs its command via the exec path, toggle irrelevant
         for enabled in [true, false] {
             let plan = CommandRestore.restorePlan(.init(wasRestored: false, restoreEnabled: enabled, hadForeground: false,
                                                         foregroundInput: nil, initialCommand: "ssh host", restoreOverride: nil))
@@ -154,15 +146,13 @@ struct CommandRestoreTests {
     }
 
     @Test func capturedForegroundPreemptsInitialCommand() {
-        // a live child captured at quit wins over the persisted creation command (typed, not exec)
         let plan = CommandRestore.restorePlan(.init(wasRestored: true, restoreEnabled: true, hadForeground: true,
                                                     foregroundInput: "top\n", initialCommand: "ssh host", restoreOverride: nil))
         #expect(plan == CommandRestore.RestorePlan(command: nil, initialInput: "top\n"))
     }
 
     @Test func suppressedForegroundYieldsPlainShellNotStaleCommand() {
-        // a foreground was captured but suppressed (denylisted/off → nil input): a plain shell, NOT a
-        // fall-through to the stale creation command
+        // hadForeground with a nil input = captured but suppressed (denylisted, or the toggle off)
         let plan = CommandRestore.restorePlan(.init(wasRestored: true, restoreEnabled: true, hadForeground: true,
                                                     foregroundInput: nil, initialCommand: "ssh host", restoreOverride: nil))
         #expect(plan == CommandRestore.RestorePlan(command: nil, initialInput: nil))
@@ -177,8 +167,7 @@ struct CommandRestoreTests {
     // MARK: - restoreInput (the pinned-override precedence)
 
     @Test func restoreInputFallsThroughWithoutOverride() {
-        // nil override = today's behavior: the captured input passes through untouched, gate irrelevant
-        // (the app side already applied the toggle + denylist to it)
+        // the app side already applied the toggle + denylist to the captured input, so the gate is moot
         for enabled in [true, false] {
             #expect(CommandRestore.restoreInput(restoreEnabled: enabled, restoreOverride: nil,
                                                 capturedInput: "top\n") == "top\n")
@@ -187,10 +176,9 @@ struct CommandRestoreTests {
     }
 
     @Test func restoreInputRunsPinnedCommandOnlyWhenEnabled() {
-        // pinned + enabled: typed verbatim with a newline, never re-quoted, and it beats the capture
+        // a pinned command is typed verbatim with a newline, never re-quoted
         #expect(CommandRestore.restoreInput(restoreEnabled: true, restoreOverride: "cd x && claude --resume y",
                                             capturedInput: "top\n") == "cd x && claude --resume y\n")
-        // the toggle stays the master switch: pinned but disabled → a plain shell, capture ignored too
         #expect(CommandRestore.restoreInput(restoreEnabled: false, restoreOverride: "claude --resume y",
                                             capturedInput: "top\n") == nil)
     }
@@ -203,12 +191,10 @@ struct CommandRestoreTests {
     }
 
     @Test func overrideNeverTakesExecPathAndBeatsInitialCommand() {
-        // an override is typed into the login shell, never exec'd — even for a fresh --command session
         let fresh = CommandRestore.restorePlan(.init(wasRestored: false, restoreEnabled: true, hadForeground: false,
                                                      foregroundInput: nil, initialCommand: "ssh host",
                                                      restoreOverride: "claude --resume y"))
         #expect(fresh == CommandRestore.RestorePlan(command: nil, initialInput: "claude --resume y\n"))
-        // and it wins over a captured foreground too
         let captured = CommandRestore.restorePlan(.init(wasRestored: true, restoreEnabled: true, hadForeground: true,
                                                         foregroundInput: "top\n", initialCommand: nil,
                                                         restoreOverride: "claude --resume y"))

--- a/agtermCore/Tests/agtermCoreTests/ConfigPathsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ConfigPathsTests.swift
@@ -21,7 +21,6 @@ struct ConfigPathsTests {
     }
 
     @Test func emptyStringsFallThrough() {
-        // an empty setting falls through to stateDir; an empty stateDir falls through to the default.
         #expect(ConfigPaths.configDirectory(setting: "", stateDir: "/state", home: home).path == "/state/config")
         #expect(ConfigPaths.configDirectory(setting: "", stateDir: "", home: home).path == "/Users/test/.config/agterm")
     }
@@ -51,7 +50,7 @@ struct ConfigPathsTests {
         #expect(starter.contains("(not expressible)"))
         #expect(starter.contains("#   rename_session"))
         #expect(starter.contains("(no default)"))
-        // the six arrow-bound actions print their real chords — they used to claim "(no default)".
+        // the six arrow-bound actions must print their real chords, not "(no default)".
         #expect(starter.contains("cmd+opt+left"))
         #expect(starter.contains("cmd+opt+right"))
         #expect(starter.contains("cmd+opt+up"))
@@ -92,17 +91,15 @@ struct ConfigPathsTests {
     }
 
     @Test func editorCommandRunsThroughInteractiveLoginShellThenPosixSh() {
-        // the login shell (-ilc) sources its rc + exports $EDITOR/$VISUAL, then execs /bin/sh which does the
-        // POSIX ${VISUAL:-${EDITOR:-vi}} resolution — the POSIX text rides inside single quotes so a
-        // non-POSIX login shell (fish) passes it through verbatim instead of choking on `${`.
+        // the POSIX ${VISUAL:-${EDITOR:-vi}} text rides inside single quotes so a non-POSIX login shell
+        // (fish) passes it verbatim to the exec'd /bin/sh instead of choking on `${`.
         #expect(ConfigPaths.editorCommand(forPath: "/Users/test/.config/agterm/keymap.conf")
                 == "${SHELL:-/bin/zsh} -ilc 'exec /bin/sh -c '\\''${VISUAL:-${EDITOR:-vi}} \"$1\"'\\'' agterm-config-edit '\\''/Users/test/.config/agterm/keymap.conf'\\'''")
     }
 
     @Test func editorCommandEmbedsAnyPathForBothEditorOverlays() {
-        // both the keymap and ghostty-config Edit overlays call this one function; a different path is
-        // embedded single-quoted with the same shape. Arbitrary-path integrity is proven behaviorally
-        // below, so this only checks the call site, not the full golden string again.
+        // arbitrary-path integrity is proven behaviorally below, so this only checks the call site rather
+        // than repeating the full golden string.
         let dir = URL(fileURLWithPath: "/Users/test/.config/agterm")
         let cmd = ConfigPaths.editorCommand(forPath: ConfigPaths.ghosttyConfigPath(configDirectory: dir).path)
         #expect(cmd.hasPrefix("${SHELL:-/bin/zsh} -ilc 'exec /bin/sh -c "))
@@ -111,12 +108,9 @@ struct ConfigPathsTests {
 
     // MARK: - Cross-shell behavioral tests
     //
-    // These run the command exactly as libghostty does (`/bin/sh -c "<cmd>"`) with a fake "editor" that
-    // records its argument, isolating the login shell from the machine's rc via HOME/ZDOTDIR/XDG_CONFIG_HOME.
-    // The `vi` fallback is intentionally not exercised behaviorally: it is the standard POSIX
-    // `${VISUAL:-${EDITOR:-vi}}` default (pinned literally by the golden test above), and a behavioral check
-    // would risk launching the real, tty-blocking `vi` — a login shell's /etc/{profile,zprofile} path_helper
-    // reorders PATH so a system `/usr/bin/vi` would win over a fake one.
+    // These run the command exactly as libghostty does (`/bin/sh -c "<cmd>"`). The `vi` fallback is
+    // deliberately not exercised behaviorally: a login shell's path_helper reorders PATH so the real,
+    // tty-blocking `/usr/bin/vi` would win over a fake one. The golden test above pins it literally instead.
 
     /// Writes an executable recorder at `<dir>/<name>` that records its first argument to `<dir>/<name>.got`,
     /// returning the script path and the marker URL.
@@ -158,8 +152,7 @@ struct ConfigPathsTests {
     }
 
     @Test func editorCommandResolvesExportedEditorAndPreservesPath() throws {
-        // an exported $EDITOR resolves and a path with a space AND an embedded single quote survives the
-        // nested quoting, under zsh (a POSIX login shell, always present).
+        // the fixture path carries a space AND a single quote, the characters the nested quoting can break.
         let tmp = try makeTmp(); defer { try? FileManager.default.removeItem(at: tmp) }
         let (editor, got) = try makeRecorder(in: tmp, named: "editor")
         let path = tmp.appendingPathComponent("a b/o'd.conf").path
@@ -169,7 +162,6 @@ struct ConfigPathsTests {
     }
 
     @Test func editorCommandPrefersVisualOverEditor() throws {
-        // $VISUAL wins over $EDITOR (the ${VISUAL:-${EDITOR:-vi}} precedence), under zsh.
         let tmp = try makeTmp(); defer { try? FileManager.default.removeItem(at: tmp) }
         let (visual, visualGot) = try makeRecorder(in: tmp, named: "visual")
         let (editor, editorGot) = try makeRecorder(in: tmp, named: "editor")
@@ -182,12 +174,11 @@ struct ConfigPathsTests {
     }
 
     @Test func editorCommandSourcesLoginShellRcForExportedEditor() throws {
-        // the `-ilc` hop is load-bearing: an $EDITOR exported only in the shell rc (NOT in the process env)
-        // still resolves, because the login shell sources its rc before exec'ing /bin/sh. Without `-ilc` the
-        // rc isn't sourced and this would fall back to vi.
+        // the `-ilc` hop is load-bearing: $EDITOR is exported only in the rc, never in the process env, so
+        // without it the rc is not sourced and this falls back to vi.
         let tmp = try makeTmp(); defer { try? FileManager.default.removeItem(at: tmp) }
         let (editor, got) = try makeRecorder(in: tmp, named: "rc-editor")
-        // zsh -i sources $ZDOTDIR/.zshrc; export EDITOR there and pass no EDITOR in the env.
+        // zsh -i sources $ZDOTDIR/.zshrc
         try "export EDITOR='\(editor)'\n".write(to: tmp.appendingPathComponent(".zshrc"), atomically: true, encoding: .utf8)
         let path = tmp.appendingPathComponent("k.conf").path
         let status = try runEditorCommand(forPath: path, tmp: tmp, env: ["SHELL": "/bin/zsh"])
@@ -198,9 +189,7 @@ struct ConfigPathsTests {
     @Test(.enabled(if: ConfigPathsTests.fishPath() != nil,
                    "no non-POSIX login shell (fish) installed — the cross-shell parse assertion is skipped here"))
     func editorCommandWorksUnderNonPosixLoginShell() throws {
-        // the actual bug fix: a non-POSIX login shell (fish) must run the command without choking on `${`.
-        // SKIPPED (visibly) when no fish is installed, so a green run on a POSIX-only box is not mistaken for
-        // cross-shell verification.
+        // a non-POSIX login shell (fish) must run the command without choking on `${`.
         let fish = try #require(ConfigPathsTests.fishPath())
         let tmp = try makeTmp(); defer { try? FileManager.default.removeItem(at: tmp) }
         let (editor, got) = try makeRecorder(in: tmp, named: "editor")

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherDashboardTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherDashboardTests.swift
@@ -2,10 +2,8 @@ import Foundation
 import Testing
 @testable import agtermCore
 
-// dispatcher tests for the `dashboard --mru` open path. They live here rather than in
-// `ControlDispatcherTests.swift` only because that file is already at the 2000-line test-file cap; they
-// share its `MockControlActions` (made internal for that reason). The other dashboard dispatcher cases
-// (explicit ids, font modes, close, cap-to-9) stay in `ControlDispatcherTests`.
+// the `dashboard --mru` dispatcher cases live here because `ControlDispatcherTests.swift` is already
+// at the 2000-line test-file cap; they share its `MockControlActions` (internal for that reason).
 @MainActor
 struct ControlDispatcherDashboardTests {
     @Test func dashboardMruRoutesWithMruTrueAndNoTargets() async {

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -193,8 +193,7 @@ struct ControlDispatcherTests {
         #expect(actions.calls == [.sessionDuplicate(target: "abc", window: "win")])
     }
 
-    /// `session.duplicate` takes no options at all — the target names its own workspace and cwd — so a bare
-    /// request must still route (the host defaults the target to `active`).
+    // `session.duplicate` takes no options — the target names its own workspace and cwd.
     @Test func sessionDuplicateRoutesWithoutArgs() async {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)
@@ -645,7 +644,6 @@ struct ControlDispatcherTests {
         #expect(status == ControlResponse(ok: true))
         #expect(bad == ControlResponse(ok: false, error: "invalid status"))
         #expect(badColor == ControlResponse(ok: false, error: "invalid color (expected #rrggbb)"))
-        // the bad-color request errors before reaching the actions, so only the good one is recorded.
         #expect(actions.calls == [
             .sessionStatus(target: "session", window: "win",
                            ControlSessionStatusUpdate(status: .blocked, blink: true,
@@ -657,9 +655,8 @@ struct ControlDispatcherTests {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)
 
-        // set a per-call color, then set again with NO color: the second update must carry color nil,
-        // proving the "next call without --color discards it" contract at the dispatch/update layer (the
-        // app arm builds a fresh AgentIndicator from update.color, so a nil update.color clears the tint).
+        // the second update must carry color nil: the app arm builds a fresh AgentIndicator from
+        // update.color, so a call without --color clears the tint.
         _ = await dispatcher.dispatch(ControlRequest(cmd: .sessionStatus, target: "session",
                                                      args: ControlArgs(status: "blocked", color: "#ff0000")))
         _ = await dispatcher.dispatch(ControlRequest(cmd: .sessionStatus, target: "session",
@@ -694,7 +691,6 @@ struct ControlDispatcherTests {
 
         #expect(tagged == ControlResponse(ok: true))
         #expect(badPane == ControlResponse(ok: false, error: "--pane must be left, right, or scratch"))
-        // the invalid pane never reaches actions (status unchanged), only the valid one is recorded.
         #expect(actions.calls == [
             .sessionStatus(target: "session", window: nil,
                            ControlSessionStatusUpdate(status: .blocked, blink: nil, autoReset: nil,
@@ -725,9 +721,8 @@ struct ControlDispatcherTests {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)
 
-        // the dispatcher carries the arg through verbatim: present → the parsed shape, absent → nil. The
-        // user-facing "next call without --shape discards it" contract is the STORE replacing the whole
-        // ephemeral indicator (AppStoreTests.controlTreeDropsStatusShapeOnTheNextSetWithoutOne).
+        // present → the parsed shape, absent → nil. The user-facing "next call without --shape discards
+        // it" contract is the store's (AppStoreTests.controlTreeDropsStatusShapeOnTheNextSetWithoutOne).
         _ = await dispatcher.dispatch(ControlRequest(cmd: .sessionStatus, target: "session",
                                                      args: ControlArgs(status: "blocked", shape: "triangle")))
         _ = await dispatcher.dispatch(ControlRequest(cmd: .sessionStatus, target: "session",
@@ -782,7 +777,6 @@ struct ControlDispatcherTests {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)
 
-        // both --color and --pane are invalid; color is validated first, so the color error wins.
         let response = await dispatcher.dispatch(ControlRequest(
             cmd: .sessionStatus,
             target: "session",
@@ -798,8 +792,8 @@ struct ControlDispatcherTests {
         let dispatcher = ControlDispatcher(actions: actions)
         let accepted = StatusShape.allCases.map(\.rawValue).joined(separator: "|")
 
-        // the shape check was inserted BETWEEN the existing color and pane checks; pin both boundaries so
-        // reordering the three guards can't change which error a caller sees without failing here.
+        // pin both boundaries, so reordering the three guards cannot change which error a caller sees
+        // without failing here.
         let colorOverShape = await dispatcher.dispatch(ControlRequest(
             cmd: .sessionStatus, target: "session",
             args: ControlArgs(status: "blocked", color: "nope", shape: "hexagon")
@@ -841,8 +835,6 @@ struct ControlDispatcherTests {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)
 
-        // the opaque --pane-id rides through untouched (the app-side arm resolves it against the live
-        // surfaces); the role --pane is parsed to StatusPane here.
         let response = await dispatcher.dispatch(ControlRequest(
             cmd: .sessionRestore, target: "session",
             args: ControlArgs(mode: "set", command: "htop", pane: "right", paneID: "pane-tok")
@@ -890,9 +882,8 @@ struct ControlDispatcherTests {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)
 
-        // an empty command is a present-but-empty pin, which IS the tri-state's "pinned to nothing" value
-        // — the same state `none` writes. It reaches the host as `.pin("")` rather than being rejected, so
-        // `agtermctl session restore ""` and `--none` agree instead of one erroring.
+        // an empty command is the tri-state's "pinned to nothing" — the same state `none` writes — so it
+        // reaches the host as `.pin("")` and `agtermctl session restore ""` agrees with `--none`.
         _ = await dispatcher.dispatch(ControlRequest(cmd: .sessionRestore, target: "session",
                                                      args: ControlArgs(mode: "set", command: "")))
 
@@ -918,8 +909,7 @@ struct ControlDispatcherTests {
             args: ControlArgs(mode: "set", command: "htop", pane: "middle")
         ))
 
-        // the rejection covers every control scalar, tab included — the message names the class rather
-        // than only the newline case, so a tab rejection is not described as a multi-line one.
+        // the message names the whole control-character class, so a tab rejection is not called multi-line.
         #expect(newline == ControlResponse(ok: false, error: "command must not contain control characters"))
         #expect(tab == ControlResponse(ok: false, error: "command must not contain control characters"))
         #expect(badPane == ControlResponse(ok: false, error: "--pane must be left, right, or scratch"))
@@ -947,8 +937,8 @@ struct ControlDispatcherTests {
 
         let exact = String(repeating: "a", count: cap)
         let over = String(repeating: "a", count: cap + 1)
-        // 400 four-byte scalars = 1600 UTF-8 bytes but only 400 characters: well under the cap by
-        // grapheme count, over it by BYTES — the cap is a storage bound, so this must be rejected.
+        // 400 four-byte scalars = 1600 UTF-8 bytes but only 400 characters: under the cap by grapheme
+        // count, over it by BYTES — the cap is a storage bound, so this must be rejected.
         let multiByte = String(repeating: "🌍", count: 400)
 
         let exactResponse = await dispatcher.dispatch(ControlRequest(
@@ -963,7 +953,6 @@ struct ControlDispatcherTests {
         #expect(exactResponse == ControlResponse(ok: true))
         #expect(overResponse == ControlResponse(ok: false, error: "command too long (max \(cap) bytes)"))
         #expect(multiByteResponse == ControlResponse(ok: false, error: "command too long (max \(cap) bytes)"))
-        // only the exactly-at-cap command reached the host.
         #expect(actions.calls == [
             .sessionRestore(target: "session", window: nil, ControlSessionRestoreUpdate(pin: .pin(exact)))
         ])
@@ -1098,8 +1087,7 @@ struct ControlDispatcherTests {
         #expect(actions.calls == [.keymapList])
     }
 
-    // keymap.list takes no target and no args, so anything a caller attaches must be ignored rather than
-    // rejected or forwarded — it is a pure read.
+    // keymap.list is a pure read: a target or args a caller attaches are ignored, not rejected.
     @Test func keymapListIgnoresTargetAndArgs() async {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)
@@ -1738,9 +1726,8 @@ struct ControlDispatcherTests {
     }
 
     @Test func dashboardForwardsAllTargetsWithoutCapping() async {
-        // the 9-cell cap now counts PANES and lives app-side (a split session expands to two cells), so the
-        // dispatcher forwards ALL raw ids untouched and appends no drop text — the drop is computed and
-        // reported in `ControlServer.setDashboard`, which owns the pane expansion.
+        // the 9-cell cap counts PANES and lives app-side (a split session expands to two cells), so the
+        // dispatcher forwards all raw ids untouched and appends no drop text.
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)
         let ids = (1...11).map { "s\($0)" }
@@ -1752,8 +1739,7 @@ struct ControlDispatcherTests {
             .dashboard(targets: ids, window: nil, close: false, fontMode: .untouched, mru: false)
         ])
 
-        // whatever the app-side response is (unresolved / dropped-pane text), the dispatcher passes it through
-        // verbatim — it no longer post-processes the message.
+        // the dispatcher post-processes nothing: the app-side text rides through verbatim.
         actions.nextDashboardResponse = ControlResponse(ok: true, result: ControlResult(text: "unresolved: s3"))
         let passed = await dispatcher.dispatch(ControlRequest(cmd: .dashboard, args: ControlArgs(targets: ids)))
         #expect(passed?.result?.text == "unresolved: s3")

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherWorkspaceTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherWorkspaceTests.swift
@@ -2,14 +2,10 @@ import Foundation
 import Testing
 @testable import agtermCore
 
-// dispatcher tests for the `workspace.*` commands — the focus-mode parse and the `workspace.filter`
-// routing. They live here rather than in `ControlDispatcherTests.swift` only because that file is
-// already close to the 2000-line test-file cap; they share its `MockControlActions` (internal for
-// exactly that reason), the same split `ControlDispatcherDashboardTests` uses.
+// dispatcher tests for the `workspace.*` commands. Split out of `ControlDispatcherTests.swift` (near the
+// 2000-line test-file cap); they share its `MockControlActions`, which is internal for exactly that reason.
 @MainActor
 struct ControlDispatcherWorkspaceTests {
-    // migrated here from `ControlDispatcherTests.workspaceFocusRoutesModeForHostSideValidation`, whose
-    // contract (the raw mode routed through for the host to validate) this task moved into the dispatcher.
     @Test func workspaceFocusRoutesToTheAction() async {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)

--- a/agtermCore/Tests/agtermCoreTests/ControlKeymapTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlKeymapTests.swift
@@ -30,8 +30,8 @@ import Testing
         #expect(close.overridden == true)
     }
 
-    // a keyless action must still appear, so the listing is the whole action set rather than only the
-    // bound subset — a caller checking "what is free" needs the gaps.
+    // the listing is the whole action set, not the bound subset — a caller checking "what is free"
+    // needs the gaps.
     @Test func keylessActionsAppearWithNoChord() throws {
         let payload = ControlKeymap.project(keymap: Keymap(builtinOverrides: [:], commands: []),
                                             diagnostics: [], path: "/tmp/keymap.conf")
@@ -44,9 +44,7 @@ import Testing
         }
     }
 
-    // a redundant `map cmd+w close_session` parses fine and leaves the action on its shipped default.
-    // `overridden` compares CHORDS, not "is there a map line", so it does not claim a difference the
-    // caller cannot see anywhere else.
+    // `overridden` compares CHORDS, not "is there a map line".
     @Test func mappingAnActionToItsOwnDefaultIsNotAnOverride() throws {
         let parsed = parseKeymap("map cmd+w close_session\n")
         try #require(parsed.diagnostics.isEmpty, "an identity map is a clean line")
@@ -58,8 +56,6 @@ import Testing
         #expect(close.overridden == nil, "the action is still on its default, so nothing was overridden")
     }
 
-    // the mirror: mapping a keyless action gives it a chord it never had, which IS a difference from its
-    // (absent) default and must be marked.
     @Test func mappingAKeylessActionCountsAsAnOverride() throws {
         let keyless = try #require(BuiltinAction.allCases.first { $0.defaultChord == nil })
         let keymap = Keymap(builtinOverrides: [keyless: Chord(mods: [.command], key: "y")], commands: [])
@@ -101,8 +97,8 @@ import Testing
         #expect(payload.menu == nil)
     }
 
-    // the whole point of the command: the model can say cmd+w while the menu carries it elsewhere, and
-    // both halves have to survive the wire for a caller to see that.
+    // the model can say cmd+w while the menu carries it elsewhere; both halves must survive the wire
+    // for a caller to see that.
     @Test func roundTripsWithDivergingModelAndMenuChords() throws {
         let keymap = Keymap(builtinOverrides: [.closeSession: Chord(mods: [.command], key: "e")], commands: [])
         let menu = [ControlKeymapMenuItem(menu: "File", title: "Close", chord: "cmd+w", selector: "performClose:")]

--- a/agtermCore/Tests/agtermCoreTests/ControlModesTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlModesTests.swift
@@ -75,7 +75,6 @@ struct ControlModesTests {
     }
 
     @Test func workspaceFocusModeDerivesValidNamesFromAllCases() {
-        // both spellings derive from allCases, so a new mode cannot leave an error/help string stale.
         #expect(ControlWorkspaceFocusMode.validNamesList == ControlWorkspaceFocusMode.allCases.map(\.rawValue).joined(separator: "|"))
         #expect(ControlWorkspaceFocusMode.validNamesPhrase == ControlWorkspaceFocusMode.allCases.map(\.rawValue).joined(separator: ", "))
         #expect(ControlWorkspaceFocusMode.validNamesList == "on|off|toggle|add")
@@ -83,9 +82,8 @@ struct ControlModesTests {
     }
 
     @Test func workspaceFocusModeHelpNamesEveryModeAndItsFilterEffect() {
-        // the CLI's `--help` prose is assembled from these clauses, so a new case reaches the help text by
-        // construction. Each clause has to name what the mode does to the FILTER FLAG: `add` is the only
-        // one that leaves it alone, and stating that in isolation reads as if the others did too.
+        // each clause has to name what the mode does to the FILTER FLAG: `add` is the only one that
+        // leaves it alone, and stating that in isolation reads as if the others did too.
         let phrase = ControlWorkspaceFocusMode.helpPhrase
         for mode in ControlWorkspaceFocusMode.allCases {
             #expect(phrase.contains(mode.helpSummary), "the help phrase should carry \(mode.rawValue)'s clause")

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -140,7 +140,6 @@ struct ControlProtocolTests {
         let decoded = try roundTrip(request)
         #expect(decoded == request)
         #expect(decoded.args?.full == nil)
-        // omit-when-nil WIRE contract for the new `full` field: a percent resize must not emit `full` at all.
         let json = String(data: try JSONEncoder().encode(request), encoding: .utf8) ?? ""
         #expect(!json.contains("full"), "a nil full must be omitted from the JSON; got \(json)")
     }
@@ -164,8 +163,6 @@ struct ControlProtocolTests {
         let decoded = try roundTrip(request)
         #expect(decoded == request)
         #expect(decoded.args?.follow == nil)
-        // verify the omit-when-nil WIRE contract (the reason follow is Bool?): a nil follow must not be
-        // encoded at all, not emitted as null.
         let json = String(data: try JSONEncoder().encode(request), encoding: .utf8) ?? ""
         #expect(!json.contains("follow"), "a nil follow must be omitted from the JSON; got \(json)")
     }
@@ -345,7 +342,6 @@ struct ControlProtocolTests {
     }
 
     @Test func sessionStatusUnknownStateDecodesForServerToReject() throws {
-        // an unknown status string decodes fine; the server rejects it via AgentStatus(rawValue:) -> nil.
         let json = #"{"cmd":"session.status","args":{"status":"bogus"}}"#
         let decoded = try JSONDecoder().decode(ControlRequest.self, from: Data(json.utf8))
         #expect(decoded.cmd == .sessionStatus)
@@ -448,8 +444,7 @@ struct ControlProtocolTests {
     }
 
     @Test func workspaceFilterRoundTripsWithWindow() throws {
-        // workspace.filter is window-scoped and takes no --target: it flips the whole focus filter, so the
-        // only selector it carries is the global --window.
+        // workspace.filter is window-scoped and takes no --target.
         let request = ControlRequest(cmd: .workspaceFilter, args: ControlArgs(mode: "on", window: "9f3c"))
         let decoded = try roundTrip(request)
         #expect(decoded == request)
@@ -519,7 +514,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeOmitsTitleWhenNil() throws {
-        // a session with no reported title must omit the key entirely (backward-compatible), not emit null.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false)
         let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
         #expect(!json.contains("title"), "a nil title must be omitted from the JSON; got \(json)")
@@ -540,7 +534,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeOmitsForegroundWhenNil() throws {
-        // a pane at its prompt has no foreground command — the keys must be omitted, not emitted as null.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false)
         let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
         #expect(!json.contains("foreground"), "a nil foreground must be omitted from the JSON; got \(json)")
@@ -560,11 +553,9 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeOmitsFontSizesWhenNil() throws {
-        // an unrealized pane has no live font size — the keys must be omitted, not emitted as null.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false)
         let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
-        // contains is case-sensitive: "fontSize" catches only the main key, "FontSize" catches the
-        // suffixed splitFontSize/scratchFontSize keys — assert both so all three omissions are covered.
+        // contains is case-sensitive: assert both "fontSize" and "FontSize" so all three keys are covered.
         #expect(!json.contains("fontSize"), "the main fontSize key must be omitted when nil; got \(json)")
         #expect(!json.contains("FontSize"), "splitFontSize/scratchFontSize must be omitted when nil; got \(json)")
     }
@@ -579,7 +570,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeOmitsStatusWhenNil() throws {
-        // an idle session has no agent status — the key must be omitted, not emitted as null.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false)
         let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
         #expect(!json.contains("status"), "a nil status must be omitted from the JSON; got \(json)")
@@ -588,7 +578,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeRoundTripsWithStatusPane() throws {
-        // the read side of session.status --pane: which pane set the status rides the tree node.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: true,
                                          status: "blocked", statusPane: "right")
         let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(
@@ -599,7 +588,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeOmitsStatusPaneWhenNil() throws {
-        // a session with no pane tag — the key must be omitted, not emitted as null.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false)
         let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
         #expect(!json.contains("statusPane"), "a nil statusPane must be omitted from the JSON; got \(json)")
@@ -608,7 +596,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeRoundTripsWithStatusBlinkAndColor() throws {
-        // the read side of session.status --blink/--color: the status modifiers ride the tree node.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false,
                                          status: "blocked", statusBlink: true, statusColor: "#ff8800")
         let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(
@@ -621,7 +608,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeOmitsStatusBlinkAndColorWhenNil() throws {
-        // an idle / non-blinking / default-color status — both keys must be omitted, not emitted as null.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false, status: "blocked")
         let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
         #expect(!json.contains("statusBlink"), "a nil statusBlink must be omitted; got \(json)")
@@ -632,7 +618,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeRoundTripsWithStatusShape() throws {
-        // the read side of session.status --shape: the per-call silhouette rides the tree node.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false,
                                          status: "blocked", statusShape: "triangle")
         let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(
@@ -643,7 +628,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeOmitsStatusShapeWhenNil() throws {
-        // a glyph using the Settings shape or the built-in circle — the key must be omitted, not null.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false, status: "blocked")
         let json = String(decoding: try JSONEncoder().encode(session), as: UTF8.self)
         #expect(!json.contains("statusShape"), "a nil statusShape must be omitted; got \(json)")
@@ -652,7 +636,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeRoundTripsWithBackground() throws {
-        // the read side of session.background: the watermark spec rides the tree node so a script can query it.
         let watermark = BackgroundWatermark(kind: .text, text: "PROD", colorHex: "#ff0000",
                                             opacity: 0.2, fit: .cover, position: .topRight)
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false,
@@ -663,12 +646,11 @@ struct ControlProtocolTests {
         #expect(decoded == response)
         let node = decoded.result?.tree?.workspaces.first?.sessions.first
         #expect(node?.background == watermark)
-        #expect(node?.background?.fit == .cover)          // the typed enum survives the wire round-trip
+        #expect(node?.background?.fit == .cover)
         #expect(node?.background?.position == .topRight)
     }
 
     @Test func treeSessionNodeOmitsBackgroundWhenNil() throws {
-        // a session with no watermark — the key must be omitted, not emitted as null.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false)
         let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
         #expect(!json.contains("background"), "a nil background must be omitted from the JSON; got \(json)")
@@ -677,8 +659,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeRoundTripsWithUnseen() throws {
-        // the read side of the notification badge: the unseen count rides the tree node so a script can
-        // query it (and pair it with session.seen to clear).
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: false, split: false, unseen: 3)
         let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(
             workspaces: [ControlWorkspaceNode(id: "w1", name: "work", active: true, sessions: [session])])))
@@ -688,7 +668,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeOmitsUnseenWhenNil() throws {
-        // a session with no pending notifications — the key must be omitted, not emitted as null or 0.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false)
         let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
         #expect(!json.contains("unseen"), "a nil unseen count must be omitted from the JSON; got \(json)")
@@ -697,8 +676,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeRoundTripsWithCommandWait() throws {
-        // the read side of session.new --wait: a held command session carries the flag so a script can
-        // record it and restore the session with --wait (it persists across restart, unlike overlay wait).
         let session = ControlSessionNode(id: "s1", name: "build", cwd: "/tmp", active: false, split: false,
                                          commandWait: true)
         let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(
@@ -709,7 +686,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeOmitsCommandWaitWhenNil() throws {
-        // a plain session or a non-holding command session — the key must be omitted, not emitted as null.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false)
         let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
         #expect(!json.contains("commandWait"), "a nil commandWait must be omitted from the JSON; got \(json)")
@@ -718,8 +694,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeRoundTripsWithOverlaySizePercent() throws {
-        // the read side of session.overlay.resize: a floating overlay's percent rides the tree node so a
-        // script can record it before resizing to full and restore the exact size afterwards.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false,
                                          overlay: true, overlaySizePercent: 95)
         let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(
@@ -730,8 +704,7 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeOmitsOverlaySizePercentWhenNil() throws {
-        // no overlay, or a FULL-pane overlay — the key must be omitted, not emitted as null (so a script
-        // reads absent as "full or no overlay", gating on the `overlay` bool first).
+        // an absent key means a full-pane overlay OR no overlay — gate on the `overlay` bool first.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false, overlay: true)
         let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
         #expect(!json.contains("overlaySizePercent"), "a nil overlay size must be omitted from the JSON; got \(json)")
@@ -740,8 +713,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeRoundTripsWithRestoreCommand() throws {
-        // the read side of session.restore: the pinned shell line rides the tree node per pane so a script
-        // can record what is pinned, change it, and restore the original.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: true,
                                          restoreCommand: "claude --resume abc",
                                          splitRestoreCommand: "tail -f log")
@@ -755,8 +726,7 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeRoundTripsRestoreCommandPinnedToNothing() throws {
-        // "" = pinned to nothing (a plain shell). The key must be PRESENT and empty — distinct from the
-        // omitted no-override state, which is the whole tri-state, so assert on the encoded JSON too.
+        // "" = pinned to nothing (a plain shell); the key must be present and empty, not omitted.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: true,
                                          restoreCommand: "", splitRestoreCommand: "")
         let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
@@ -768,8 +738,7 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeOmitsRestoreCommandWhenNil() throws {
-        // no override — the keys must be omitted, not emitted as null or as an empty string, so a script
-        // can tell "auto-capture" (absent) from "pinned to nothing" ("").
+        // absent (auto-capture) must stay distinguishable from "" (pinned to nothing).
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false)
         let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
         #expect(!json.contains("restoreCommand"), "a nil override must be omitted from the JSON; got \(json)")
@@ -780,8 +749,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeRoundTripsWithSplitRatio() throws {
-        // the read side of session.resize: the current divider fraction rides the tree node so a script
-        // can record it before maximizing a pane and restore the exact ratio afterwards.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: true, splitRatio: 0.35)
         let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(
             workspaces: [ControlWorkspaceNode(id: "w1", name: "work", active: true, sessions: [session])])))
@@ -791,7 +758,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeOmitsSplitRatioWhenNil() throws {
-        // no split, or a split still at the default 0.5 — the key must be omitted, not emitted as null.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false)
         let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
         #expect(!json.contains("splitRatio"), "a nil split ratio must be omitted from the JSON; got \(json)")
@@ -800,8 +766,7 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeRoundTripsWithSplitFocused() throws {
-        // the read side of session.focus: which pane holds focus rides the tree node so a script can record
-        // it and restore focus afterwards. false = the main (left) pane, true = the split (right) pane.
+        // false = the main (left) pane, true = the split (right) pane.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: true, splitFocused: false)
         let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(
             workspaces: [ControlWorkspaceNode(id: "w1", name: "work", active: true, sessions: [session])])))
@@ -811,8 +776,7 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeOmitsSplitFocusedWhenNil() throws {
-        // no split — the key must be omitted, not emitted as null (a false value IS emitted, since it means
-        // the left pane is focused, distinct from "no split").
+        // a false IS emitted (the left pane is focused); only "no split" omits the key.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false)
         let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
         #expect(!json.contains("splitFocused"), "a nil split focus must be omitted from the JSON; got \(json)")
@@ -837,8 +801,7 @@ struct ControlProtocolTests {
     }
 
     @Test func treeSessionNodeToleratesMissingSurfaces() throws {
-        // a pre-`surface.zoom` server omits the key — it must decode as nil, and a node built without
-        // surfaces must omit the key from the JSON (the optional-field pattern of the other tree additions).
+        // a pre-`surface.zoom` server omits the key entirely, so it must decode as nil.
         let raw = #"{"id":"s1","name":"shell","cwd":"/tmp","active":true,"split":false,"# +
             #""overlay":false,"scratch":false,"flagged":false}"#
         let decoded = try JSONDecoder().decode(ControlSessionNode.self, from: Data(raw.utf8))
@@ -849,7 +812,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeRoundTripsWithLiveWindowFields() throws {
-        // the tree carries the live idle metric + the auto-follow config (both ms) + sidebar visibility.
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false)
         let tree = ControlTree(workspaces: [ControlWorkspaceNode(id: "w1", name: "work", active: true,
                                                                  sessions: [session])],
@@ -863,7 +825,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeOmitsLiveWindowFieldsWhenNil() throws {
-        // no activity yet + auto-follow disabled + unknown sidebar — every key must be omitted, not null.
         let tree = ControlTree(workspaces: [])
         let json = String(data: try JSONEncoder().encode(tree), encoding: .utf8) ?? ""
         #expect(!json.contains("idleMs"), "a nil idleMs must be omitted from the JSON; got \(json)")
@@ -886,7 +847,6 @@ struct ControlProtocolTests {
     }
 
     @Test func windowNodeOmitsPerWindowFieldsWhenNil() throws {
-        // auto-follow disabled + a closed window with no store — both keys must be omitted, not null.
         let node = ControlWindowNode(id: "w1", name: "work", open: true, active: false)
         let json = String(data: try JSONEncoder().encode(node), encoding: .utf8) ?? ""
         #expect(!json.contains("autoFollowMs"), "a nil autoFollowMs must be omitted from the JSON; got \(json)")
@@ -897,8 +857,7 @@ struct ControlProtocolTests {
     }
 
     @Test func windowNodeRoundTripsWithGeometry() throws {
-        // the read side of window.move/window.resize: the live frame rides the window node so a script can
-        // record it, resize/move, then restore the exact frame (fields match the CLI's --x/--y/--width/etc).
+        // the frame fields match the CLI's --x/--y/--width/--height, so a read-back restores verbatim.
         let node = ControlWindowNode(id: "w1", name: "work", open: true, active: true,
                                      geometry: ControlWindowFrame(x: 100, y: 40, width: 1200, height: 800, display: 1))
         let response = ControlResponse(ok: true, result: ControlResult(windows: [node]))
@@ -909,7 +868,6 @@ struct ControlProtocolTests {
     }
 
     @Test func windowNodeOmitsGeometryWhenNil() throws {
-        // a closed window with no live NSWindow — the key must be omitted, not emitted as null.
         let node = ControlWindowNode(id: "w1", name: "work", open: false, active: false)
         let json = String(data: try JSONEncoder().encode(node), encoding: .utf8) ?? ""
         #expect(!json.contains("geometry"), "a nil geometry must be omitted from the JSON; got \(json)")
@@ -918,8 +876,6 @@ struct ControlProtocolTests {
     }
 
     @Test func windowNodeRoundTripsWithFullscreenAndZoom() throws {
-        // the read side of window.fullscreen/window.zoom: both live toggle states ride the window node so a
-        // script can make the toggles idempotent (only enter/exit when needed).
         let node = ControlWindowNode(id: "w1", name: "work", open: true, active: true, fullscreen: true, zoomed: false)
         let response = ControlResponse(ok: true, result: ControlResult(windows: [node]))
         let decoded = try roundTrip(response)
@@ -929,7 +885,6 @@ struct ControlProtocolTests {
     }
 
     @Test func windowNodeOmitsFullscreenAndZoomWhenNil() throws {
-        // a closed window with no live NSWindow — both keys must be omitted, not emitted as null.
         let node = ControlWindowNode(id: "w1", name: "work", open: false, active: false)
         let json = String(data: try JSONEncoder().encode(node), encoding: .utf8) ?? ""
         #expect(!json.contains("fullscreen"), "a nil fullscreen must be omitted from the JSON; got \(json)")
@@ -940,8 +895,6 @@ struct ControlProtocolTests {
     }
 
     @Test func windowNodeRoundTripsWithMinimized() throws {
-        // the read side of window.minimize, so a script can skip a redundant minimize and restore the set of
-        // windows it put away. A minimized window still reports the frame it comes back to.
         let frame = ControlWindowFrame(x: 100, y: 50, width: 900, height: 600, display: 0)
         let node = ControlWindowNode(id: "w1", name: "work", open: true, active: false,
                                      geometry: frame, minimized: true)
@@ -953,7 +906,6 @@ struct ControlProtocolTests {
     }
 
     @Test func windowNodeOmitsMinimizedWhenNil() throws {
-        // a closed window with no live NSWindow — the key must be omitted, not emitted as null.
         let node = ControlWindowNode(id: "w1", name: "work", open: false, active: false)
         let json = String(data: try JSONEncoder().encode(node), encoding: .utf8) ?? ""
         #expect(!json.contains("minimized"), "a nil minimized must be omitted from the JSON; got \(json)")
@@ -962,8 +914,7 @@ struct ControlProtocolTests {
     }
 
     @Test func workspaceNodeRoundTripsWithFocused() throws {
-        // the read side of workspace.focus: the sidebar-focused workspace is flagged so a script can record
-        // which one is focused and restore it (distinct from `active`, the selected workspace).
+        // `focused` (a member of the sidebar focus set) is distinct from `active` (the selected one).
         let ws = ControlWorkspaceNode(id: "w1", name: "work", active: true, focused: true, sessions: [])
         let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(workspaces: [ws])))
         let decoded = try roundTrip(response)
@@ -972,7 +923,6 @@ struct ControlProtocolTests {
     }
 
     @Test func workspaceNodeOmitsFocusedWhenNil() throws {
-        // not the focused workspace (or none focused) — the key must be omitted, not emitted as null.
         let ws = ControlWorkspaceNode(id: "w1", name: "work", active: true, sessions: [])
         let json = String(data: try JSONEncoder().encode(ws), encoding: .utf8) ?? ""
         #expect(!json.contains("focused"), "a nil focused must be omitted from the JSON; got \(json)")
@@ -981,8 +931,6 @@ struct ControlProtocolTests {
     }
 
     @Test func workspaceNodeRoundTripsWithCollapsed() throws {
-        // the read side of workspace.collapse/expand: a collapsed workspace is flagged so a script can
-        // record its open/closed state and restore it, or toggle by reading it first.
         let ws = ControlWorkspaceNode(id: "w1", name: "work", active: true, collapsed: true, sessions: [])
         let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(workspaces: [ws])))
         let decoded = try roundTrip(response)
@@ -991,8 +939,6 @@ struct ControlProtocolTests {
     }
 
     @Test func workspaceNodeOmitsCollapsedWhenNil() throws {
-        // an expanded workspace (the default) omits the key rather than emitting null, so an all-expanded
-        // tree stays byte-compatible with a legacy response.
         let ws = ControlWorkspaceNode(id: "w1", name: "work", active: true, sessions: [])
         let json = String(data: try JSONEncoder().encode(ws), encoding: .utf8) ?? ""
         #expect(!json.contains("collapsed"), "a nil collapsed must be omitted from the JSON; got \(json)")
@@ -1012,7 +958,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeRoundTripsWithSidebarMode() throws {
-        // the read side of sidebar.mode: the sidebar view mode (tree/flagged) rides the tree top level.
         let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(
             workspaces: [], sidebarMode: "flagged")))
         let decoded = try roundTrip(response)
@@ -1021,9 +966,7 @@ struct ControlProtocolTests {
     }
 
     @Test func treeRoundTripsWithWorkspaceFilter() throws {
-        // the read side of workspace.filter: the flag half of the focus set rides the tree top level, while
-        // the member half rides each workspace node's `focused` — the two together are the filter term of
-        // the row-visibility contract, which also requires sidebarVisible and tree mode.
+        // a workspace row is visible only when sidebarVisible && tree mode && (filter off || focused).
         let marked = ControlWorkspaceNode(id: "w1", name: "work", active: true, focused: true, sessions: [])
         let other = ControlWorkspaceNode(id: "w2", name: "play", active: false, sessions: [])
         let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(
@@ -1036,8 +979,7 @@ struct ControlProtocolTests {
     }
 
     @Test func treeRoundTripsWithWorkspaceFilterOff() throws {
-        // a marked set with the filter OFF must round-trip as false, not omitted — membership is reported
-        // independently of the flag, so `false` is a real state a script restores.
+        // membership is reported independently of the flag, so `false` is a real state, not an omission.
         let marked = ControlWorkspaceNode(id: "w1", name: "work", active: true, focused: true, sessions: [])
         let tree = ControlTree(workspaces: [marked], workspaceFilter: false)
         let json = String(data: try JSONEncoder().encode(tree), encoding: .utf8) ?? ""
@@ -1048,7 +990,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeOmitsWorkspaceFilterWhenNil() throws {
-        // a host-produced tree that projects no window — the key must be omitted, not emitted as null.
         let tree = ControlTree(workspaces: [])
         let json = String(data: try JSONEncoder().encode(tree), encoding: .utf8) ?? ""
         #expect(!json.contains("workspaceFilter"), "a nil workspaceFilter must be omitted from the JSON; got \(json)")
@@ -1057,8 +998,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeRoundTripsWithQuickVisible() throws {
-        // the read side of quick: the quick-terminal visibility rides the tree top level so a script can
-        // make the toggle idempotent.
         let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(
             workspaces: [], quickVisible: true)))
         let decoded = try roundTrip(response)
@@ -1067,7 +1006,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeOmitsQuickVisibleWhenNil() throws {
-        // a host-produced tree with no app closure — the key must be omitted, not emitted as null.
         let tree = ControlTree(workspaces: [])
         let json = String(data: try JSONEncoder().encode(tree), encoding: .utf8) ?? ""
         #expect(!json.contains("quickVisible"), "a nil quickVisible must be omitted from the JSON; got \(json)")
@@ -1076,8 +1014,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeRoundTripsWithZoomedSurface() throws {
-        // the read side of surface.zoom: the zoomed surface's control id rides the tree top level so a
-        // script can check "is it already zoomed" and record-then-restore.
         let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(
             workspaces: [], zoomedSurface: "surface:5E5B1C5B-75C5-49E6-8806-2C61D8D6BBA9:right")))
         let decoded = try roundTrip(response)
@@ -1086,7 +1022,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeOmitsZoomedSurfaceWhenNil() throws {
-        // nothing zoomed (or a host-produced tree with no app closure) — the key must be omitted, not null.
         let tree = ControlTree(workspaces: [])
         let json = String(data: try JSONEncoder().encode(tree), encoding: .utf8) ?? ""
         #expect(!json.contains("zoomedSurface"), "a nil zoomedSurface must be omitted from the JSON; got \(json)")
@@ -1119,8 +1054,6 @@ struct ControlProtocolTests {
     }
 
     @Test func dashboardArgsOmitFieldsWhenNil() throws {
-        // the new fields ride Bool?/Double? for the omit-when-nil wire contract: an open request with only
-        // targets must not emit close/fontSize/autoSize at all.
         let request = ControlRequest(cmd: .dashboard, args: ControlArgs(targets: ["9f3c"]))
         let json = String(data: try JSONEncoder().encode(request), encoding: .utf8) ?? ""
         #expect(!json.contains("close"), "a nil close must be omitted from the JSON; got \(json)")
@@ -1130,9 +1063,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeRoundTripsWithDashboardFields() throws {
-        // the read side of dashboard: members / highlighted / applied font / mode ride the tree top level so
-        // a script can read the live grid state. Members/highlighted are pane refs (`<uuid>:left`/`:right`) —
-        // a split session appears as both its `:left` and `:right` cells. LIVE, tree-only like zoomedSurface.
         let members = ["9f3c:left", "9f3c:right", "abcd:left"]
         let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(
             workspaces: [], dashboardMembers: members, dashboardHighlighted: "9f3c:right",
@@ -1147,7 +1077,6 @@ struct ControlProtocolTests {
     }
 
     @Test func treeOmitsDashboardFieldsWhenNil() throws {
-        // no dashboard open (or a host-produced tree with no app closure) — the keys must be omitted, not null.
         let tree = ControlTree(workspaces: [])
         let json = String(data: try JSONEncoder().encode(tree), encoding: .utf8) ?? ""
         #expect(!json.contains("dashboardMembers"), "a nil dashboardMembers must be omitted; got \(json)")
@@ -1162,21 +1091,17 @@ struct ControlProtocolTests {
     }
 
     @Test func backgroundWatermarkFitPositionSerializeAsRawStrings() throws {
-        // the Fit/Position enums must serialize to ghostty's exact key strings (identical to the former
-        // String), so the wire + persisted JSON are unchanged by the enum migration.
+        // the enums must serialize as ghostty's exact key strings.
         let watermark = BackgroundWatermark(kind: .image, imagePath: "/a.png", fit: .stretch, position: .bottomCenter)
         let json = String(data: try JSONEncoder().encode(watermark), encoding: .utf8) ?? ""
         #expect(json.contains("\"fit\":\"stretch\""))
         #expect(json.contains("\"position\":\"bottom-center\""))
-        // a decoded-back value equals the original (rawValue mapping is lossless).
         let decoded = try JSONDecoder().decode(BackgroundWatermark.self, from: Data(json.utf8))
         #expect(decoded == watermark)
     }
 
     @Test func backgroundWatermarkColorKindSerializes() throws {
-        // the `.color` kind serializes as "color" and carries only the hex (no opacity — a solid color
-        // honors the Settings window translucency at render time). Round-trip through ControlSessionNode too,
-        // so the actual `tree` wire path (not just the struct in isolation) covers the color read-back.
+        // a `.color` watermark carries only the hex — no opacity, since it takes the window translucency.
         let watermark = BackgroundWatermark(kind: .color, colorHex: "#112233")
         let json = String(decoding: try JSONEncoder().encode(watermark), as: UTF8.self)
         #expect(json.contains("\"kind\":\"color\""))

--- a/agtermCore/Tests/agtermCoreTests/ControlResolveTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlResolveTests.swift
@@ -75,8 +75,8 @@ struct ControlResolveTests {
         #expect(ControlResolve.errorMessage(noun: "session", target: "active", resolution: .resolved(a)) == "no such session: active")
     }
 
-    // window-id targets reuse the same pure matcher semantics. WindowLibrary wires those semantics to
-    // its own ordered window set and active-window fallback; these tests keep the raw matcher pinned.
+    // window-id targets reuse the same pure matcher; WindowLibrary supplies the ordered window set and
+    // the active-window fallback around it.
     private let w1 = UUID(uuidString: "0A11AAAA-0000-0000-0000-000000000011")!
     private let w2 = UUID(uuidString: "0A22BBBB-0000-0000-0000-000000000012")!
     private let w3 = UUID(uuidString: "7B33CCCC-0000-0000-0000-000000000013")!

--- a/agtermCore/Tests/agtermCoreTests/CustomCommandTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/CustomCommandTests.swift
@@ -21,14 +21,12 @@ struct CustomCommandTests {
     }
 
     @Test func expandEmptyTokenValueBecomesEmptyString() {
-        // a recognized token whose context value is empty (missing) substitutes to "".
         let ctx = CommandContext(sessionPWD: "/tmp")
         #expect(ctx.expand("[{AGT_SELECTION}]") == "[]")
         #expect(ctx.expand("cd {AGT_SESSION_PWD}") == "cd /tmp")
     }
 
     @Test func expandLeavesUnknownBracesUntouched() {
-        // not one of the AGT_X tokens — left as-is so unrelated shell braces survive.
         let ctx = sampleContext()
         #expect(ctx.expand("echo {FOO} ${BAR}") == "echo {FOO} ${BAR}")
     }
@@ -40,8 +38,7 @@ struct CustomCommandTests {
     }
 
     @Test func expandDoesNotReSubstituteTokenInsideAValue() {
-        // a token's value that contains another token's literal text must survive verbatim — the
-        // single-pass scan never re-substitutes already-replaced text (no injection via a value).
+        // the single-pass scan never re-substitutes replaced text, so a value cannot inject a token.
         let ctx = CommandContext(selection: "{AGT_SOCKET}", socket: "/tmp/agt.sock")
         #expect(ctx.expand("echo {AGT_SELECTION}") == "echo {AGT_SOCKET}")
         #expect(ctx.expand("{AGT_SELECTION} {AGT_SOCKET}") == "{AGT_SOCKET} /tmp/agt.sock")
@@ -68,9 +65,8 @@ struct CustomCommandTests {
     }
 
     @Test func paneDefaultsToLeft() {
-        // an unspecified pane is the main pane — always a valid `session.type --pane` argument, so a
-        // split-less session's context still round-trips into a pane-addressed control call. The typed
-        // `Pane` enum guarantees the value is left/right/scratch by construction; its rawValue feeds the token.
+        // the default must stay a valid `session.type --pane` value, so a split-less session's context
+        // still round-trips into a pane-addressed control call.
         #expect(CommandContext().pane == .left)
         #expect(CommandContext().environment()["AGT_PANE"] == "left")
         #expect(CommandContext().expand("{AGT_PANE}") == "left")
@@ -78,8 +74,6 @@ struct CustomCommandTests {
     }
 
     @Test func paneScratchExpandsToScratch() {
-        // the scratch is a pane too — a chord fired from the session's scratch terminal reports
-        // `scratch`, which round-trips straight back through `session type --pane scratch`.
         let ctx = CommandContext(pane: .scratch)
         #expect(ctx.pane == .scratch)
         #expect(ctx.environment()["AGT_PANE"] == "scratch")
@@ -87,26 +81,22 @@ struct CustomCommandTests {
     }
 
     @Test func referencesSessionScopedContextDetectsSessionTokensButNotLaunchers() {
-        // session/workspace/selection tokens (in {AGT_X}, $AGT_X, or ${AGT_X} form) -> true.
         #expect(CommandContext.referencesSessionScopedContext("echo {AGT_SESSION_PWD}"))
         #expect(CommandContext.referencesSessionScopedContext(#"rm -rf "$AGT_SESSION_PWD"/*"#))
         #expect(CommandContext.referencesSessionScopedContext("echo ${AGT_WORKSPACE_NAME}"))
         #expect(CommandContext.referencesSessionScopedContext("printf %s {AGT_SELECTION}"))
-        // launcher tokens (socket/window/pane) and no tokens -> false, so a launcher stays firable.
+        // launcher tokens (socket/window/pane) must not count, so a launcher stays firable.
         #expect(!CommandContext.referencesSessionScopedContext(#"agtermctl session new --command "ssh work""#))
         #expect(!CommandContext.referencesSessionScopedContext("agtermctl --socket {AGT_SOCKET} session new"))
         #expect(!CommandContext.referencesSessionScopedContext("open -a Safari {AGT_WINDOW_ID} {AGT_PANE}"))
     }
 
     @Test func environmentKeySetMatchesTheTokensExpandSubstitutes() {
-        // the symmetric guarantee: every env key is a token expand replaces, and vice versa.
         let ctx = sampleContext()
         let envKeys = Set(ctx.environment().keys)
         for key in envKeys {
-            // the key, wrapped as a token, must be substituted out by expand.
             #expect(!ctx.expand("{\(key)}").contains("{"))
         }
-        // and there is no extra token expand handles that environment omits.
         let expected: Set<String> = ["AGT_SESSION_ID", "AGT_SESSION_NAME", "AGT_SESSION_PWD",
                                      "AGT_WORKSPACE_ID", "AGT_WORKSPACE_NAME", "AGT_WINDOW_ID",
                                      "AGT_WINDOW_NAME", "AGT_PANE", "AGT_SELECTION", "AGT_SOCKET"]
@@ -114,11 +104,9 @@ struct CustomCommandTests {
     }
 
     @Test func tokenNamesMatchTheExpansionTokenSet() {
-        // the public token-name list (used by the Settings token reference) must stay equal to the
-        // set of tokens expand/environment handle, so the UI can't list a stale or missing token.
+        // the list feeds the Settings token reference, so a stale or missing name would show up there.
         let names = CommandContext.tokenNames
         #expect(Set(names) == Set(sampleContext().environment().keys))
-        // every advertised name must actually substitute out via expand.
         let ctx = sampleContext()
         for name in names {
             #expect(!ctx.expand("{\(name)}").contains("{"))

--- a/agtermCore/Tests/agtermCoreTests/DashboardControllerTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/DashboardControllerTests.swift
@@ -33,8 +33,6 @@ struct DashboardControllerTests {
     }
 
     @Test func splitSessionExpandsToTwoPaneCells() {
-        // a split session contributes two cells — its primary AND its split pane — and the highlight/move
-        // treat them as distinct grid positions of the same session.
         let controller = DashboardController()
         let a = UUID()
         controller.open(members: [primary(a), split(a)])
@@ -49,15 +47,12 @@ struct DashboardControllerTests {
         let a = UUID(), b = UUID(), c = UUID()
         let members = [primary(a), primary(b), primary(c)]
 
-        // no supplied highlight → first member.
         controller.open(members: members)
         #expect(controller.highlighted == primary(a))
 
-        // supplied member in the set → that member.
         controller.open(members: members, highlighted: primary(c))
         #expect(controller.highlighted == primary(c))
 
-        // supplied member not in the set → falls back to the first member.
         controller.open(members: members, highlighted: primary(UUID()))
         #expect(controller.highlighted == primary(a))
     }
@@ -75,7 +70,6 @@ struct DashboardControllerTests {
         #expect(controller.highlighted == ids[2])
         controller.move(.up)
         #expect(controller.highlighted == ids[0])
-        // clamp: up/left at the top-left corner stays put.
         controller.move(.up)
         #expect(controller.highlighted == ids[0])
         controller.move(.left)
@@ -86,10 +80,9 @@ struct DashboardControllerTests {
         let controller = DashboardController()
         let ids = (0..<5).map { _ in primary(UUID()) } // cols=3: 0 1 2 / 3 4
         controller.open(members: ids, highlighted: ids[4])
-        // no cell right of the last member in a ragged row.
         controller.move(.right)
         #expect(controller.highlighted == ids[4])
-        // no cell below index 4 (would be index 7, out of range).
+        // below index 4 would be index 7, out of range.
         controller.move(.down)
         #expect(controller.highlighted == ids[4])
         controller.move(.up)
@@ -102,11 +95,9 @@ struct DashboardControllerTests {
         controller.open(members: [primary(a), primary(b), primary(c)])
         #expect(controller.highlighted == primary(a))
 
-        // a click flashes the highlight onto that member.
         controller.highlight(primary(c))
         #expect(controller.highlighted == primary(c))
 
-        // a non-member leaves the highlight where it was.
         controller.highlight(primary(UUID()))
         #expect(controller.highlighted == primary(c))
     }
@@ -147,8 +138,7 @@ struct DashboardControllerTests {
     }
 
     @Test func reopenOverSameMembersUpdatesFontMode() {
-        // a same-members re-open with a new font mode must update the mode (the app-side wiring keys its
-        // font re-apply off members+fontMode, so this is what a `dashboard A B --font-size 20` re-open sees).
+        // the app-side wiring keys its font re-apply off members+fontMode.
         let controller = DashboardController()
         let a = UUID(), b = UUID()
         let members = [primary(a), primary(b)]
@@ -167,19 +157,15 @@ struct DashboardControllerTests {
         let a = UUID(), b = UUID(), c = UUID()
         controller.open(members: [primary(a), primary(b), primary(c)], highlighted: primary(b))
 
-        // b closed while open: it is pruned, order preserved, and the highlight moves to the first survivor.
         controller.reconcile(existing: [primary(a), primary(c)])
         #expect(controller.members == [primary(a), primary(c)])
         #expect(controller.highlighted == primary(a))
 
-        // a survivor highlight is left in place.
         controller.reconcile(existing: [primary(a), primary(c)])
         #expect(controller.highlighted == primary(a), "a no-op reconcile leaves state unchanged")
     }
 
     @Test func reconcileDropsSplitPaneWhenSplitClosesButKeepsPrimary() {
-        // a split session opens as two cells; closing just its split pane (primary stays valid) prunes ONLY
-        // the split cell and moves the highlight off it, leaving the primary cell in place.
         let controller = DashboardController()
         let a = UUID(), b = UUID()
         controller.open(members: [primary(a), split(a), primary(b)], highlighted: split(a))
@@ -210,11 +196,10 @@ struct DashboardControllerTests {
     }
 
     @Test func appliedFontSizeResolvesPerMode() {
-        // .untouched → nil regardless of grid; .fixed → its exact value; .auto → the grid-derived size.
         #expect(DashboardFontMode.untouched.appliedFontSize(memberCount: 4, base: 13) == nil)
         #expect(DashboardFontMode.fixed(20).appliedFontSize(memberCount: 9, base: 13) == 20)
 
-        // .auto matches DashboardLayout.dashboardFontSize for the count's grid (4 → 2×2, 9 → 3×3).
+        // the counts resolve to 4 → 2×2 and 9 → 3×3.
         let (c4, r4) = DashboardLayout.grid(count: 4)
         #expect(DashboardFontMode.auto.appliedFontSize(memberCount: 4, base: 16)
             == DashboardLayout.dashboardFontSize(cols: c4, rows: r4, base: 16))

--- a/agtermCore/Tests/agtermCoreTests/DashboardLayoutTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/DashboardLayoutTests.swift
@@ -3,7 +3,6 @@ import Testing
 
 struct DashboardLayoutTests {
     @Test func gridDimensionsFollowCeilSqrt() {
-        // (count, cols, rows) for the full 1...9 range: cols = ceil(sqrt(n)), rows = ceil(n / cols).
         let table: [(count: Int, cols: Int, rows: Int)] = [
             (1, 1, 1), (2, 2, 1), (3, 2, 2), (4, 2, 2), (5, 3, 2),
             (6, 3, 2), (7, 3, 3), (8, 3, 3), (9, 3, 3),
@@ -22,13 +21,11 @@ struct DashboardLayoutTests {
     }
 
     @Test func cellPlacementIsRowMajor() {
-        // 3-wide grid: indices lay out row by row.
         #expect(DashboardLayout.cell(index: 0, cols: 3) == (0, 0))
         #expect(DashboardLayout.cell(index: 2, cols: 3) == (2, 0))
         #expect(DashboardLayout.cell(index: 3, cols: 3) == (0, 1))
         #expect(DashboardLayout.cell(index: 5, cols: 3) == (2, 1))
         #expect(DashboardLayout.cell(index: 6, cols: 3) == (0, 2))
-        // 2-wide grid.
         #expect(DashboardLayout.cell(index: 0, cols: 2) == (0, 0))
         #expect(DashboardLayout.cell(index: 1, cols: 2) == (1, 0))
         #expect(DashboardLayout.cell(index: 2, cols: 2) == (0, 1))
@@ -52,7 +49,6 @@ struct DashboardLayoutTests {
         #expect(DashboardLayout.move(from: 0, direction: .down, cols: 2, count: 4) == 2)
         #expect(DashboardLayout.move(from: 3, direction: .up, cols: 2, count: 4) == 1)
         #expect(DashboardLayout.move(from: 3, direction: .left, cols: 2, count: 4) == 2)
-        // edges stay put.
         #expect(DashboardLayout.move(from: 1, direction: .right, cols: 2, count: 4) == 1)
         #expect(DashboardLayout.move(from: 2, direction: .down, cols: 2, count: 4) == 2)
         #expect(DashboardLayout.move(from: 0, direction: .up, cols: 2, count: 4) == 0)
@@ -68,7 +64,6 @@ struct DashboardLayoutTests {
         #expect(DashboardLayout.move(from: 4, direction: .down, cols: 3, count: 9) == 7)
         #expect(DashboardLayout.move(from: 4, direction: .left, cols: 3, count: 9) == 3)
         #expect(DashboardLayout.move(from: 4, direction: .right, cols: 3, count: 9) == 5)
-        // corner clamps.
         #expect(DashboardLayout.move(from: 0, direction: .up, cols: 3, count: 9) == 0)
         #expect(DashboardLayout.move(from: 0, direction: .left, cols: 3, count: 9) == 0)
         #expect(DashboardLayout.move(from: 8, direction: .down, cols: 3, count: 9) == 8)
@@ -83,15 +78,13 @@ struct DashboardLayoutTests {
         #expect(DashboardLayout.move(from: 4, direction: .up, cols: 3, count: 6) == 1)
         #expect(DashboardLayout.move(from: 5, direction: .left, cols: 3, count: 6) == 4)
         #expect(DashboardLayout.move(from: 3, direction: .right, cols: 3, count: 6) == 4)
-        // edges stay put.
         #expect(DashboardLayout.move(from: 2, direction: .right, cols: 3, count: 6) == 2)
         #expect(DashboardLayout.move(from: 5, direction: .down, cols: 3, count: 6) == 5)
     }
 
     @Test func cellAndMoveDefendAgainstZeroCols() {
-        // cols:0 must not divide/modulo by zero — the width clamps to 1 (a single column).
+        // cols:0 must not divide/modulo by zero — the width clamps to 1, a single column.
         #expect(DashboardLayout.cell(index: 2, cols: 0) == (0, 2))
-        // in a 1-wide grid: left/right stay put, up/down step by one within range.
         #expect(DashboardLayout.move(from: 1, direction: .right, cols: 0, count: 3) == 1)
         #expect(DashboardLayout.move(from: 1, direction: .up, cols: 0, count: 3) == 0)
         #expect(DashboardLayout.move(from: 1, direction: .down, cols: 0, count: 3) == 2)
@@ -103,9 +96,7 @@ struct DashboardLayoutTests {
         //   0 1
         //   2
         #expect(DashboardLayout.move(from: 0, direction: .down, cols: 2, count: 3) == 2)
-        // no cell below index 1 (would be index 3, out of range).
         #expect(DashboardLayout.move(from: 1, direction: .down, cols: 2, count: 3) == 1)
-        // no cell right of index 2.
         #expect(DashboardLayout.move(from: 2, direction: .right, cols: 2, count: 3) == 2)
         #expect(DashboardLayout.move(from: 2, direction: .up, cols: 2, count: 3) == 0)
     }
@@ -128,7 +119,6 @@ struct DashboardLayoutTests {
         //   6
         #expect(DashboardLayout.move(from: 6, direction: .right, cols: 3, count: 7) == 6)
         #expect(DashboardLayout.move(from: 3, direction: .down, cols: 3, count: 7) == 6)
-        // no cell below index 4 (would be index 7, out of range).
         #expect(DashboardLayout.move(from: 4, direction: .down, cols: 3, count: 7) == 4)
         #expect(DashboardLayout.move(from: 6, direction: .up, cols: 3, count: 7) == 3)
     }
@@ -172,7 +162,6 @@ struct DashboardLayoutTests {
         #expect(DashboardLayout.dashboardFontSize(cols: 3, rows: 3, base: 8) == DashboardLayout.minFontSize)
         // base 6, 2×2: 6 * 0.75 = 4.5 → 5, still below the floor.
         #expect(DashboardLayout.dashboardFontSize(cols: 2, rows: 2, base: 6) == DashboardLayout.minFontSize)
-        // base 6, 1×1 stays at base (above the floor).
         #expect(DashboardLayout.dashboardFontSize(cols: 1, rows: 1, base: 6) == 6)
     }
 }

--- a/agtermCore/Tests/agtermCoreTests/DebouncerTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/DebouncerTests.swift
@@ -20,23 +20,22 @@ struct DebouncerTests {
         var ran = 0
         debouncer.schedule(after: 100) { ran += 1 }
         debouncer.cancel()
-        debouncer.flush() // nothing pending after cancel
+        debouncer.flush()
         #expect(ran == 0)
     }
 
     @Test func flushWithNothingPendingIsNoOp() {
         let debouncer = Debouncer()
-        debouncer.flush() // must not crash or run anything
+        debouncer.flush()
         var ran = 0
         debouncer.schedule(after: 100) { ran += 1 }
         debouncer.flush()
-        debouncer.flush() // second flush has nothing pending
+        debouncer.flush()
         #expect(ran == 1)
     }
 
     @Test func scheduledActionFiresWhenTimerElapses() async {
-        // exercise the asyncAfter timer -> fire() path (the other tests use a 100s delay + flush, so the
-        // timer never runs); a short real delay lets the deferred dispatch fire on its own.
+        // the other tests use a 100s delay plus flush, so only here does the timer itself fire.
         let debouncer = Debouncer()
         await confirmation { confirmed in
             debouncer.schedule(after: 0.01) { confirmed() }
@@ -45,7 +44,6 @@ struct DebouncerTests {
     }
 
     @Test func reschedulingBeforeTimerFiresRunsOnlyLatestViaTimer() async {
-        // rescheduling cancels the prior pending work, so only the latest action fires through the timer.
         let debouncer = Debouncer()
         var first = 0
         await confirmation { confirmedLatest in
@@ -53,7 +51,7 @@ struct DebouncerTests {
             debouncer.schedule(after: 0.01) { confirmedLatest() }
             try? await Task.sleep(for: .milliseconds(200))
         }
-        #expect(first == 0) // the first action was cancelled by the reschedule, never fired
+        #expect(first == 0)
     }
 
     @Test func actionCallingFlushReentrantlyIsSafeNoOp() {
@@ -63,7 +61,7 @@ struct DebouncerTests {
         var ran = 0
         debouncer.schedule(after: 100) {
             ran += 1
-            debouncer.flush() // re-entrant: nothing pending now, must not run the action again
+            debouncer.flush()
         }
         debouncer.flush()
         #expect(ran == 1)

--- a/agtermCore/Tests/agtermCoreTests/FuzzyTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/FuzzyTests.swift
@@ -39,8 +39,7 @@ struct FuzzyTests {
     }
 
     @Test func multiTermMatchesAcrossWordBoundaries() {
-        // "cap dev" (two whitespace-separated terms) matches "caprica-dev": "cap" is a prefix and
-        // "dev" a later substring, even though the literal "cap dev" is neither.
+        // "cap" is a prefix and "dev" a later substring, though the literal "cap dev" is neither.
         #expect(fuzzyScore(query: "cap dev", target: "caprica-dev") != nil)
     }
 
@@ -50,7 +49,6 @@ struct FuzzyTests {
     }
 
     @Test func multiTermRequiresEveryTerm() {
-        // one term matches, the other doesn't → no match.
         #expect(fuzzyScore(query: "cap xyz", target: "caprica-dev") == nil)
     }
 

--- a/agtermCore/Tests/agtermCoreTests/InterruptKeystrokeTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/InterruptKeystrokeTests.swift
@@ -14,7 +14,6 @@ struct InterruptKeystrokeTests {
     }
 
     @Test func bareControlCInterrupts() {
-        // latin layout: base letter is "c"
         #expect(InterruptKeystroke.isInterrupt(keyCode: Self.cKey, character: "c", modifiers: [.control]))
         // dvorak: the C letter is a different physical key, caught by the character check
         #expect(InterruptKeystroke.isInterrupt(keyCode: Self.dvorakCKey, character: "c", modifiers: [.control]))
@@ -25,18 +24,15 @@ struct InterruptKeystrokeTests {
     }
 
     @Test func dvorakControlJDoesNotInterrupt() {
-        // dvorak: the physical C key (keyCode 8) produces "j"; the keyCode fallback must NOT fire for a
-        // latin letter other than "c", so ctrl-j is not a false interrupt
+        // dvorak: the physical C key produces "j", and the keyCode fallback must not fire for another
+        // latin letter
         #expect(!InterruptKeystroke.isInterrupt(keyCode: Self.cKey, character: "j", modifiers: [.control]))
     }
 
     @Test func nonInterruptKeystrokesDoNotClear() {
-        // ordinary typing, no control
         #expect(!InterruptKeystroke.isInterrupt(keyCode: Self.cKey, character: "c", modifiers: []))
         #expect(!InterruptKeystroke.isInterrupt(keyCode: 0, character: "a", modifiers: []))
-        // control chords that are not an interrupt
         #expect(!InterruptKeystroke.isInterrupt(keyCode: 2, character: "d", modifiers: [.control]))   // ctrl-d
-        // c with the wrong modifiers: cmd-c / opt-c / ctrl-cmd-c must not clear
         #expect(!InterruptKeystroke.isInterrupt(keyCode: Self.cKey, character: "c", modifiers: [.command]))
         #expect(!InterruptKeystroke.isInterrupt(keyCode: Self.cKey, character: "c", modifiers: [.option]))
         #expect(!InterruptKeystroke.isInterrupt(keyCode: Self.cKey, character: "c", modifiers: [.control, .command]))

--- a/agtermCore/Tests/agtermCoreTests/KeybindMatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/KeybindMatcherTests.swift
@@ -37,7 +37,6 @@ struct KeybindMatcherTests {
         #expect(matcher.advance(ctrlA) == .armed)
         #expect(matcher.advance(c) == .unmatched)
         #expect(!matcher.isArmed)
-        // after reset the leader can be re-armed.
         #expect(matcher.advance(ctrlA) == .armed)
     }
 
@@ -47,7 +46,6 @@ struct KeybindMatcherTests {
         #expect(matcher.advance(ctrlA) == .armed)
         matcher.reset()
         #expect(!matcher.isArmed)
-        // the follow-key alone now no longer completes the sequence.
         #expect(matcher.advance(b) == .unmatched)
     }
 
@@ -72,8 +70,6 @@ struct KeybindMatcherTests {
     }
 
     @Test func rePressingLeaderWhileArmedReArms() {
-        // armed on ctrl+a, a second ctrl+a is not a valid continuation but IS a fresh leader: it
-        // restarts the sequence rather than abandoning it, so the next 'b' still completes.
         let id = UUID()
         var matcher = KeybindMatcher([([ctrlA, b], id)])
         #expect(matcher.advance(ctrlA) == .armed)
@@ -83,8 +79,6 @@ struct KeybindMatcherTests {
     }
 
     @Test func wrongChordWhileArmedThatIsItselfASimpleBindFires() {
-        // armed on ctrl+a, a chord that completes no sequence but is itself a simple bind fires it
-        // (the press is not dropped just because a leader was pending).
         let seqID = UUID()
         let simpleID = UUID()
         var matcher = KeybindMatcher([([ctrlA, b], seqID), ([cmdShiftU], simpleID)])

--- a/agtermCore/Tests/agtermCoreTests/KeybindTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/KeybindTests.swift
@@ -135,10 +135,9 @@ struct KeybindTests {
         }
     }
 
-    // every entry of the table, pinned one by one. The aggregate tests above hold under any permutation of
-    // the 47 entries, and the real kVK_ANSI_* constants are non-monotonic at 4/5 (h/g), 22/23 (6/5) and
-    // 25/26/28/29 (9/7/8/0) — where a transposition is both easiest to make and hardest to eyeball. A swap
-    // would bind a chord to the wrong physical key on every non-Latin layout.
+    // the aggregate tests above hold under any permutation of the 47 entries, and the real kVK_ANSI_*
+    // constants are non-monotonic at 4/5 (h/g), 22/23 (6/5) and 25/26/28/29 (9/7/8/0), where a transposition
+    // is easiest to make and hardest to eyeball.
     @Test func latinKeyMapsEachKeyCodeToItsOwnAnsiCharacter() {
         let table: [UInt16: String] = [
             0: "a", 1: "s", 2: "d", 3: "f", 4: "h", 5: "g", 6: "z", 7: "x", 8: "c", 9: "v",
@@ -169,12 +168,12 @@ struct KeybindTests {
         #expect(chordKey(forKeyCode: 31, produced: "щ", layoutIsASCIICapable: false) == "o")
         #expect(chordKey(forKeyCode: 17, produced: "е", layoutIsASCIICapable: false) == "t")
         #expect(chordKey(forKeyCode: 6, produced: "я", layoutIsASCIICapable: false) == "z")
-        // the positions the per-key ASCII test got wrong: Greek types ';' on Q and Hebrew types '/' there,
-        // so a letter chord stayed dead on the layouts this exists to serve.
+        // Greek types ';' on Q and Hebrew types '/' there, so keeping the produced character leaves a letter
+        // chord dead on exactly the layouts this serves.
         #expect(chordKey(forKeyCode: 12, produced: ";", layoutIsASCIICapable: false) == "q", "Greek Q")
         #expect(chordKey(forKeyCode: 12, produced: "/", layoutIsASCIICapable: false) == "q", "Hebrew Q")
         #expect(chordKey(forKeyCode: 13, produced: "'", layoutIsASCIICapable: false) == "w", "Hebrew-PC W")
-        // and the punctuation the standard Russian layout re-homes: '/' types '.', which used to be kept.
+        // the standard Russian layout re-homes punctuation: '/' types '.'.
         #expect(chordKey(forKeyCode: 44, produced: ".", layoutIsASCIICapable: false) == "/")
     }
 
@@ -243,7 +242,6 @@ struct KeybindTests {
     }
 
     @Test func parseRejectsModifierOnly() {
-        // no base key after the modifiers.
         #expect(parseKeybind("ctrl+cmd") == nil)
     }
 
@@ -284,7 +282,6 @@ struct KeybindTests {
     }
 
     @Test func detectsPrefixOverlapRegardlessOfOrder() {
-        // the longer bind listed first still conflicts with the shorter prefix.
         let seq = CustomCommand(name: "seq", command: "", shortcut: "ctrl+a>b")
         let leader = CustomCommand(name: "leader", command: "", shortcut: "ctrl+a")
         let conflicts = keybindConflicts([seq, leader])
@@ -292,8 +289,7 @@ struct KeybindTests {
     }
 
     @Test func detectsThreeWayOverlap() {
-        // ctrl+a, ctrl+a>b, ctrl+a>b>c — every shorter bind is a prefix of every longer one, so all
-        // three pairs conflict.
+        // every shorter bind is a prefix of every longer one, so all three pairs conflict.
         let leader = CustomCommand(name: "leader", command: "", shortcut: "ctrl+a")
         let two = CustomCommand(name: "two", command: "", shortcut: "ctrl+a>b")
         let three = CustomCommand(name: "three", command: "", shortcut: "ctrl+a>b>c")
@@ -305,7 +301,6 @@ struct KeybindTests {
     }
 
     @Test func siblingSequencesSharingLeaderDoNotConflict() {
-        // ctrl+a>b and ctrl+a>c share a leader but neither is a prefix of the other.
         let b = CustomCommand(name: "b", command: "", shortcut: "ctrl+a>b")
         let c = CustomCommand(name: "c", command: "", shortcut: "ctrl+a>c")
         #expect(keybindConflicts([b, c]).isEmpty)
@@ -319,8 +314,8 @@ struct KeybindTests {
     }
 
     @Test func isReservedMonitorChordMatchesTheMonitorPredicates() {
-        // Ctrl-Tab switcher: Tab while Control is held, with ANY other modifiers (it checks
-        // .contains(.control), not exact equality), so all four combinations are reserved.
+        // the switcher checks .contains(.control), not exact equality, so Tab is reserved under any extra
+        // modifiers.
         #expect(isReservedMonitorChord(Chord(mods: [.control], key: "tab")))
         #expect(isReservedMonitorChord(Chord(mods: [.control, .shift], key: "tab")))
         #expect(isReservedMonitorChord(Chord(mods: [.control, .option], key: "tab")))
@@ -331,8 +326,6 @@ struct KeybindTests {
     }
 
     @Test func isReservedMonitorChordRejectsNonMonitorChords() {
-        // tab without control is fine; 1/2 with an extra modifier is NOT reserved (the monitor needs
-        // control alone); 3 is never reserved.
         #expect(!isReservedMonitorChord(Chord(mods: [.command], key: "tab")))
         #expect(!isReservedMonitorChord(Chord(mods: [], key: "tab")))
         #expect(!isReservedMonitorChord(Chord(mods: [.control, .shift], key: "1")))
@@ -347,7 +340,6 @@ struct KeybindTests {
         #expect(Chord(mods: [.control], key: "tab").displayString == "ctrl+tab")
         // fixed ctrl+cmd+opt+shift modifier order regardless of insertion order.
         #expect(Chord(mods: [.shift, .option, .command, .control], key: "x").displayString == "ctrl+cmd+opt+shift+x")
-        // every displayString parses back to the same single chord.
         let chord = Chord(mods: [.command, .option], key: "n")
         #expect(parseKeybind(chord.displayString) == [chord])
     }
@@ -358,7 +350,6 @@ struct KeybindTests {
         #expect(Chord(mods: [.command, .option], key: "n").glyphString == "⌥⌘N")
         #expect(Chord(mods: [.command, .shift], key: "n").glyphString == "⇧⌘N")
         #expect(Chord(mods: [.control], key: "p").glyphString == "⌃P")
-        // fixed macOS ⌃⌥⇧⌘ modifier order regardless of insertion order.
         #expect(Chord(mods: [.shift, .option, .command, .control], key: "x").glyphString == "⌃⌥⇧⌘X")
         // symbols are left as-is; named keys render as their glyphs.
         #expect(Chord(mods: [.command], key: "+").glyphString == "⌘+")

--- a/agtermCore/Tests/agtermCoreTests/KeymapTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/KeymapTests.swift
@@ -18,7 +18,6 @@ struct KeymapTests {
     }
 
     @Test func keylessActionWithOverrideReturnsOverride() {
-        // firstSession has no default chord; an override gives it one.
         #expect(BuiltinAction.firstSession.defaultChord == nil)
         let override = Chord(mods: [.command], key: "1")
         let keymap = Keymap(builtinOverrides: [.firstSession: override], commands: [])
@@ -28,7 +27,6 @@ struct KeymapTests {
     @Test func keylessActionWithoutOverrideReturnsNil() {
         let keymap = Keymap(builtinOverrides: [:], commands: [])
         #expect(keymap.equivalent(for: .firstSession) == nil)
-        // an arrow-bound action resolves to its shipped default, like any other keyed action.
         #expect(keymap.equivalent(for: .focusLeftPane) == Chord(mods: [.command, .option], key: "left"))
     }
 
@@ -54,30 +52,25 @@ struct KeymapTests {
     }
 
     @Test func glyphHintRendersArrowDefaultsAsGlyphs() {
-        // the arrow-bound actions resolve through defaultChord like any other keyed action.
         let keymap = Keymap(builtinOverrides: [:], commands: [])
         #expect(keymap.glyphHint(for: .previousSession) == "⌥⌘↑")
         #expect(keymap.glyphHint(for: .focusLeftPane) == "⌥⌘←")
     }
 
     @Test func glyphHintOverrideWinsOverArrowDefault() {
-        // a user-mapped chord beats the shipped arrow default.
         let keymap = Keymap(builtinOverrides: [.previousSession: Chord(mods: [.command], key: "p")], commands: [])
         #expect(keymap.glyphHint(for: .previousSession) == "⌘P")
     }
 
     @Test func glyphHintIsNilForUnconfiguredAction() {
-        // a keyless, non-arrow action shows nothing until the user maps a chord — the "if not
-        // configured, don't add" rule that keeps tooltips clean.
+        // the "if not configured, don't add" rule that keeps tooltips clean.
         let keymap = Keymap(builtinOverrides: [:], commands: [])
         #expect(keymap.glyphHint(for: .toggleFlaggedView) == nil)
         #expect(keymap.glyphHint(for: .firstSession) == nil)
     }
 
     @Test func rebindToggleSearchResolvesThroughGenericPath() {
-        // toggle_search rebinds like any other built-in: the generic parse/resolve path (no per-action
-        // special-casing) parses the chord, maps the raw name to .toggleSearch, and equivalent(for:)
-        // returns the override instead of the cmd+f default.
+        // toggle_search resolves through the generic path, with no per-action special-casing.
         let (keymap, diagnostics) = parseKeymap("map cmd+shift+l toggle_search")
         #expect(diagnostics.isEmpty)
         let override = Chord(mods: [.command, .shift], key: "l")
@@ -119,9 +112,7 @@ struct KeymapTests {
     }
 
     @Test func parseCommandBareKeyRejectedAsShortcut() {
-        // a modifier-less first token (a bare key) is NOT consumed as a shortcut: it would shadow that
-        // key in the terminal, so the line stays palette-only with the token kept in the shell line and
-        // a diagnostic is emitted.
+        // a bare key would shadow that key in the terminal, so it is never consumed as a shortcut.
         let (keymap, diagnostics) = parseKeymap("command \"X\" a echo hi")
         #expect(keymap.commands.count == 1)
         #expect(keymap.commands[0].shortcut.isEmpty)
@@ -131,7 +122,6 @@ struct KeymapTests {
     }
 
     @Test func parseCommandModifierShortcutAccepted() {
-        // a single chord WITH a modifier is a valid custom shortcut.
         let (keymap, diagnostics) = parseKeymap("command \"X\" cmd+e echo hi")
         #expect(diagnostics.isEmpty)
         #expect(keymap.commands.count == 1)
@@ -140,8 +130,8 @@ struct KeymapTests {
     }
 
     @Test func parseCommandPaletteOnlyShellTokenNotSwallowed() {
-        // the trap: a palette-only command whose shell line starts with a single-char token (`[`, `:`,
-        // a one-letter alias) must NOT have that token silently bound as a shortcut.
+        // the trap: a shell line starting with a single-char token (`[`, `:`, a one-letter alias) must
+        // not have that token silently bound as a shortcut.
         let (keymap, diagnostics) = parseKeymap("command \"Check\" [ -f /tmp ] && echo ok")
         #expect(keymap.commands.count == 1)
         #expect(keymap.commands[0].shortcut.isEmpty)
@@ -179,7 +169,6 @@ struct KeymapTests {
     }
 
     @Test func hashInsideSingleQuotedShellArgIsKept() {
-        // a `#` in a single-quoted arg (a commit message) must survive — it is not an inline comment.
         let (keymap, diagnostics) = parseKeymap("command \"Commit\" cmd+shift+c git commit -m 'fix #42'")
         #expect(diagnostics.isEmpty)
         #expect(keymap.commands.count == 1)
@@ -187,7 +176,6 @@ struct KeymapTests {
     }
 
     @Test func trailingCommentAfterSingleQuotedArgIsStripped() {
-        // once the single quote closes, a whitespace-preceded `#` is still a real inline comment.
         let (keymap, diagnostics) = parseKeymap("command \"X\" cmd+shift+x echo 'hi' # real comment")
         #expect(diagnostics.isEmpty)
         #expect(keymap.commands.count == 1)
@@ -246,18 +234,16 @@ struct KeymapTests {
     }
 
     @Test func parseBareArrowMapIsRejected() {
-        // a modifier-less arrow would install an always-on menu key-equivalent swallowing the key in the
+        // a bare arrow would install an always-on menu key-equivalent, swallowing the key in the
         // terminal, the palettes, the dashboard grid, and every text field.
         let (keymap, diagnostics) = parseKeymap("map left previous_session")
         #expect(keymap.builtinOverrides.isEmpty)
-        // the action keeps its shipped default.
         #expect(keymap.equivalent(for: .previousSession) == Chord(mods: [.command, .option], key: "up"))
         #expect(diagnostics.count == 1)
         #expect(diagnostics[0].message.contains("needs a modifier"))
     }
 
     @Test func parseModifiedArrowMapIsAcceptedForEveryArrow() {
-        // only the BARE form is rejected — any modifier makes an arrow bindable.
         for key in ["left", "right", "up", "down"] {
             let (keymap, diagnostics) = parseKeymap("map cmd+shift+\(key) new_session")
             #expect(diagnostics.isEmpty, "unexpected diagnostics for cmd+shift+\(key)")
@@ -266,8 +252,8 @@ struct KeymapTests {
     }
 
     @Test func mapOntoAnArrowActionsUnmovedDefaultIsRejected() {
-        // the six arrow defaults are now visible to the conflict checker: cmd+opt+up is previous_session's
-        // UNMOVED default, so claiming it for another action must be diagnosed, not silently double-bound.
+        // cmd+opt+up is previous_session's UNMOVED default, so claiming it for another action must be
+        // diagnosed, not silently double-bound.
         let (keymap, diagnostics) = parseKeymap("map cmd+opt+up new_session")
         #expect(keymap.builtinOverrides.isEmpty)
         #expect(keymap.equivalent(for: .newSession) == Chord(mods: [.command], key: "n"))
@@ -277,10 +263,9 @@ struct KeymapTests {
     }
 
     @Test func customCommandOnAnArrowDefaultIsDropped() {
-        // cross-section validation sees the arrow defaults too, so a custom command can't shadow one.
+        // cmd+opt+down is next_session's shipped default.
         let (keymap, diagnostics) = parseKeymap(#"command "Nav" cmd+opt+down echo hi"#)
         #expect(keymap.commands.count == 1)
-        // the keybind is dropped but the palette entry survives.
         #expect(keymap.commands[0].name == "Nav")
         #expect(keymap.commands[0].shortcut.isEmpty)
         #expect(diagnostics.count == 1)
@@ -288,15 +273,13 @@ struct KeymapTests {
     }
 
     @Test func parseBareNonArrowMapIsStillAccepted() {
-        // the modifier requirement is arrow-ONLY — a bare non-arrow map predates the rule and stays
-        // legal. Pins the guard's scope so widening it to every chord can't slip through unnoticed.
+        // the modifier requirement is arrow-ONLY; a bare non-arrow map stays legal.
         let (keymap, diagnostics) = parseKeymap("map a new_session")
         #expect(diagnostics.isEmpty)
         #expect(keymap.equivalent(for: .newSession) == Chord(mods: [], key: "a"))
     }
 
     @Test func parseDuplicateBuiltinChordDiagnostic() {
-        // two maps to the same chord for DIFFERENT actions: the later one (line 2) is skipped.
         let text = """
         map cmd+shift+e toggle_split
         map cmd+shift+e new_session
@@ -309,12 +292,10 @@ struct KeymapTests {
     }
 
     @Test func mapToOtherBuiltinUnmovedDefaultIsRejected() {
-        // cmd+d is toggle_split's UNMOVED default; mapping new_session to it must be diagnosed and the
-        // override dropped (otherwise two menu items would carry the same key equivalent). The CRITICAL
-        // case: the prior check only caught override-vs-override, not override-vs-other-default.
+        // cmd+d is toggle_split's UNMOVED default; two menu items would otherwise carry the same key
+        // equivalent.
         let (keymap, diagnostics) = parseKeymap("map cmd+d new_session")
         #expect(keymap.builtinOverrides.isEmpty)
-        // new_session keeps its own default (the map was skipped, not applied).
         #expect(keymap.equivalent(for: .newSession) == Chord(mods: [.command], key: "n"))
         #expect(diagnostics.count == 1)
         #expect(diagnostics[0].line == 1)
@@ -322,9 +303,8 @@ struct KeymapTests {
     }
 
     @Test func mapToFreedDefaultOfMovedBuiltinSucceeds() {
-        // moving toggle_split off cmd+d frees that chord; new_session may then take it. order is
-        // intentionally move-then-take, and the resolution is a single FINAL pass so it succeeds with
-        // no diagnostic — the freed-default case must not regress.
+        // order is intentionally move-then-take: resolution is a single FINAL pass, so the freed
+        // default is takeable.
         let text = """
         map cmd+shift+e toggle_split
         map cmd+d new_session
@@ -336,9 +316,8 @@ struct KeymapTests {
     }
 
     @Test func mapToOtherBuiltinDefaultThenMoveThatBuiltinBothSucceed() {
-        // codex's reverse-order case: take cmd+d for new_session FIRST, then move toggle_split off cmd+d.
-        // resolution is order-independent and decided against the final state, so both succeed with NO
-        // diagnostic (final state is conflict-free: new_session=cmd+d, toggle_split=cmd+shift+e).
+        // the reverse order: resolution is decided against the FINAL state, so taking cmd+d before
+        // toggle_split moves off it still succeeds.
         let text = """
         map cmd+d new_session
         map cmd+shift+e toggle_split
@@ -350,23 +329,20 @@ struct KeymapTests {
     }
 
     @Test func mapTabSeparatedLineParses() {
-        // a tab between the chord and the action must parse the same as a space.
         let (keymap, diagnostics) = parseKeymap("map\tcmd+shift+e\ttoggle_split")
         #expect(diagnostics.isEmpty)
         #expect(keymap.builtinOverrides == [.toggleSplit: Chord(mods: [.command, .shift], key: "e")])
     }
 
     @Test func mapCascadingCollisionDropsBothRevertsToDefaults() {
-        // cascade: toggle_split's override (cmd+o) loses to open_directory's UNMOVED default cmd+o, so
-        // it is dropped → reverts to its OWN default cmd+d → which then collides with new_session's
-        // accepted override cmd+d. Resolution must iterate to a fixpoint and drop BOTH overrides, leaving
-        // a conflict-free all-defaults state with two diagnostics.
+        // cascade: toggle_split's cmd+o override loses to open_directory's UNMOVED default, reverts to
+        // its own cmd+d default, and that then collides with new_session's accepted cmd+d — so
+        // resolution must iterate to a fixpoint and drop BOTH.
         let text = """
         map cmd+o toggle_split
         map cmd+d new_session
         """
         let (keymap, diagnostics) = parseKeymap(text)
-        // both overrides dropped → every action sits on its shipped default.
         #expect(keymap.builtinOverrides.isEmpty)
         #expect(keymap.equivalent(for: .toggleSplit) == BuiltinAction.toggleSplit.defaultChord)
         #expect(keymap.equivalent(for: .newSession) == BuiltinAction.newSession.defaultChord)
@@ -374,7 +350,6 @@ struct KeymapTests {
         // the final state is collision-free: no two distinct actions resolve to the same chord.
         let chords = BuiltinAction.allCases.compactMap { keymap.equivalent(for: $0) }
         #expect(chords.count == Set(chords).count)
-        // two diagnostics, one per dropped override, in file order.
         #expect(diagnostics.count == 2)
         #expect(diagnostics[0].line == 1)
         #expect(diagnostics[1].line == 2)
@@ -382,8 +357,7 @@ struct KeymapTests {
     }
 
     @Test func mapBuiltinToReservedMonitorChordIsRejected() {
-        // ctrl+1 is owned by the Ctrl-1/2 pane monitor; a built-in map to it must be diagnosed + skipped
-        // (it would dead-race the monitor), so the action keeps its default.
+        // ctrl+1 is owned by the Ctrl-1/2 pane monitor, so a built-in mapped to it would dead-race it.
         let (keymap, diagnostics) = parseKeymap("map ctrl+1 new_session")
         #expect(keymap.builtinOverrides.isEmpty)
         #expect(keymap.equivalent(for: .newSession) == Chord(mods: [.command], key: "n"))
@@ -393,7 +367,7 @@ struct KeymapTests {
     }
 
     @Test func mapBuiltinToReservedCtrlTabIsRejected() {
-        // ctrl+tab is the Ctrl-Tab switcher's chord; a built-in map to it is reserved and skipped.
+        // ctrl+tab is the Ctrl-Tab switcher's chord.
         let (keymap, diagnostics) = parseKeymap("map ctrl+tab quick_terminal")
         #expect(keymap.builtinOverrides.isEmpty)
         #expect(diagnostics.count == 1)
@@ -401,8 +375,8 @@ struct KeymapTests {
     }
 
     @Test func parseHandlesCRLFLineEndings() {
-        // a CRLF file leaves a trailing \r that .whitespaces does not strip; normalization must let the
-        // line parse normally rather than reading `toggle_split\r` as an unknown action.
+        // a CRLF file leaves a trailing \r that .whitespaces does not strip, so without normalization
+        // the action reads as `toggle_split\r`.
         let text = "map cmd+shift+e toggle_split\r\ncommand \"Deploy\" ./deploy.sh\r\n"
         let (keymap, diagnostics) = parseKeymap(text)
         #expect(diagnostics.isEmpty)
@@ -412,7 +386,6 @@ struct KeymapTests {
     }
 
     @Test func mapSameActionTwiceIsLastWins() {
-        // re-mapping the SAME action can't collide with itself: the later chord wins, no diagnostic.
         let text = """
         map cmd+shift+e toggle_split
         map cmd+shift+x toggle_split
@@ -444,11 +417,9 @@ struct KeymapTests {
         map ctrl+a>g new_session
         """
         let (keymap, diagnostics) = parseKeymap(text)
-        // the two valid lines still parse.
         #expect(keymap.builtinOverrides == [.toggleSplit: Chord(mods: [.command, .shift], key: "e")])
         #expect(keymap.commands.count == 1)
         #expect(keymap.commands[0].name == "Deploy")
-        // the two bad lines each yield a diagnostic at the correct line number.
         #expect(diagnostics.count == 2)
         #expect(diagnostics[0].line == 2)
         #expect(diagnostics[0].message.contains("unknown verb"))
@@ -457,8 +428,7 @@ struct KeymapTests {
     }
 
     @Test func customChordEqualsBuiltinDefaultIsDropped() {
-        // cmd+d is toggle_split's shipped default; the custom command keeps its palette entry but
-        // loses the keybind.
+        // cmd+d is toggle_split's shipped default.
         let (keymap, diagnostics) = parseKeymap("command \"Boom\" cmd+d echo boom")
         #expect(keymap.commands.count == 1)
         #expect(keymap.commands[0].name == "Boom")
@@ -470,8 +440,7 @@ struct KeymapTests {
     }
 
     @Test func customChordEqualsOverriddenBuiltinChordIsDropped() {
-        // the built-in toggle_split is moved to cmd+shift+e; a custom command bound to the NEW
-        // built-in chord collides and is dropped.
+        // the custom command claims the chord toggle_split was just MOVED to, not its shipped default.
         let text = """
         map cmd+shift+e toggle_split
         command "Boom" cmd+shift+e echo boom
@@ -485,8 +454,8 @@ struct KeymapTests {
     }
 
     @Test func freedDefaultChordIsUsableByCustomAfterBuiltinMoves() {
-        // moving toggle_split off cmd+d frees that chord; a custom command may then take it. order
-        // is intentionally custom-before-map to prove validation is a single FINAL pass.
+        // order is intentionally custom-before-map: validation is a single FINAL pass, so the freed
+        // default is takeable.
         let text = """
         command "Boom" cmd+d echo boom
         map cmd+shift+e toggle_split
@@ -508,8 +477,7 @@ struct KeymapTests {
     }
 
     @Test func customBoundToReservedMonitorChordIsDropped() {
-        // ctrl+1 is owned by the Ctrl-1/2 pane monitor; a custom command bound to it keeps its palette
-        // entry but loses the keybind, with a diagnostic.
+        // ctrl+1 is owned by the Ctrl-1/2 pane monitor.
         let (keymap, diagnostics) = parseKeymap("command \"Boom\" ctrl+1 echo boom")
         #expect(keymap.commands.count == 1)
         #expect(keymap.commands[0].name == "Boom")
@@ -521,7 +489,7 @@ struct KeymapTests {
     }
 
     @Test func customLeaderStartingWithReservedMonitorChordIsDropped() {
-        // ctrl+tab is the Ctrl-Tab switcher's chord; a custom leader STARTING with it is reserved.
+        // ctrl+tab is the Ctrl-Tab switcher's chord.
         let (keymap, diagnostics) = parseKeymap("command \"Boom\" ctrl+tab>g echo boom")
         #expect(keymap.commands.count == 1)
         #expect(keymap.commands[0].shortcut.isEmpty)
@@ -530,9 +498,8 @@ struct KeymapTests {
     }
 
     @Test func customLeaderWhoseLaterChordIsReservedMonitorChordIsDropped() {
-        // ctrl+a>ctrl+1 — the FIRST chord (ctrl+a) is not reserved, but ctrl+1 (the later chord) is
-        // owned by the Ctrl-1/2 pane monitor, which consumes it wherever it lands in the leader, so the
-        // leader can never complete. the keybind is dropped (palette entry kept) with a diagnostic.
+        // the FIRST chord is free, but the pane monitor consumes ctrl+1 wherever it lands in the
+        // leader, so the sequence can never complete.
         let (keymap, diagnostics) = parseKeymap("command \"Boom\" ctrl+a>ctrl+1 echo boom")
         #expect(keymap.commands.count == 1)
         #expect(keymap.commands[0].name == "Boom")
@@ -544,7 +511,6 @@ struct KeymapTests {
     }
 
     @Test func customLeaderWithNoReservedChordIsAccepted() {
-        // a normal leader with no reserved chord at any position keeps its keybind, no diagnostic.
         let (keymap, diagnostics) = parseKeymap("command \"Lazygit\" ctrl+a>g lazygit")
         #expect(keymap.commands.count == 1)
         #expect(keymap.commands[0].shortcut == "ctrl+a>g")
@@ -552,7 +518,6 @@ struct KeymapTests {
     }
 
     @Test func commandWithEmptyShellLineIsDiagnosed() {
-        // a name with no shell line (or a name + chord with no command) is a no-op; skip it + diagnose.
         let (keymap, diagnostics) = parseKeymap("command \"Empty\"")
         #expect(keymap.commands.isEmpty)
         #expect(diagnostics.count == 1)
@@ -576,11 +541,9 @@ struct KeymapTests {
         #expect(keymap.commands.count == 2)
         #expect(keymap.commands[0].shortcut.isEmpty)
         #expect(keymap.commands[1].shortcut.isEmpty)
-        // both commands stay in the palette, just unkeyed.
         #expect(keymap.commands[0].command == "echo one")
         #expect(keymap.commands[1].command == "echo two")
         #expect(diagnostics.count == 2)
-        // each diagnostic names the OTHER offending command by name.
         #expect(diagnostics.contains { $0.message.contains("'First'") && $0.message.contains("'Second'") })
         #expect(diagnostics.contains { $0.message.contains("'Second'") && $0.message.contains("'First'") })
     }
@@ -596,7 +559,6 @@ struct KeymapTests {
         #expect(keymap.commands[0].shortcut.isEmpty)
         #expect(keymap.commands[1].shortcut.isEmpty)
         #expect(diagnostics.count == 2)
-        // each diagnostic names the OTHER offending command by name.
         #expect(diagnostics.contains { $0.message.contains("'Lead'") && $0.message.contains("'Leader'") })
         #expect(diagnostics.contains { $0.message.contains("'Leader'") && $0.message.contains("'Lead'") })
     }

--- a/agtermCore/Tests/agtermCoreTests/LinkPolicyTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/LinkPolicyTests.swift
@@ -5,9 +5,8 @@ import Testing
 struct LinkPolicyTests {
     // MARK: disposition (open / reveal / ignore)
 
-    /// A URL followed by garbage (what the pre-fix `String(cString:)` over-read past `len` could produce)
-    /// does not silently become an openable web link: the trailing space + junk make it unparseable or
-    /// non-web, so the disposition is never `.open`.
+    /// The garbage suffixes model a `String(cString:)` over-read past `len`: the trailing space + junk
+    /// leave the URL unparseable or non-web, so it can never come back `.open`.
     @Test func trailingGarbageDoesNotYieldAWebURL() {
         #expect(LinkPolicy.disposition(for: "https://example.com\u{00}/etc/other", localHosts: Self.localHosts) == .ignore)
         #expect(LinkPolicy.disposition(for: "https://example.com extra junk", localHosts: Self.localHosts) == .ignore)
@@ -81,12 +80,11 @@ struct LinkPolicyTests {
         guard case let .reveal(url) = LinkPolicy.disposition(for: raw, localHosts: Self.localHosts) else {
             Issue.record("expected .reveal for \(raw)"); return
         }
-        #expect(url.absoluteString == expected)   // and the revealed path is the exact one, not a mis-normalized neighbor
+        #expect(url.absoluteString == expected)
     }
 
     /// The classifier never resolves symlinks: revealing a link INSIDE a symlinked directory keeps the LINK
-    /// path, not the resolved target — so a `link -> /net` can never be followed into an automount root. This
-    /// is a value-result assertion (the reveal URL string), the invariant the lexical normalizer guarantees.
+    /// path, not the resolved target — so a `link -> /net` can never be followed into an automount root.
     @Test func revealDoesNotResolveSymlinks() throws {
         let base = FileManager.default.temporaryDirectory.appendingPathComponent("agt-linkpolicy-symlink-test", isDirectory: true)
         try? FileManager.default.removeItem(at: base)

--- a/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
+++ b/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
@@ -87,14 +87,11 @@ final class MockControlActions: ControlActions {
     var nextSessionNewResponse = ControlResponse(ok: true)
     var nextSessionDuplicateResponse = ControlResponse(ok: true)
     var nextWorkspaceFilterResponse = ControlResponse(ok: true)
-    /// The store the `workspace.filter` / `workspace.focus` arms drive when set (nil = record-only, the
-    /// default for every other dispatcher test). It lets a test run the REAL command path — the
-    /// dispatcher's parse plus the host-free `AppStore.applyWorkspaceFilter`/`applyFocusMode` the app-side
-    /// arms call — against a live `AppStore`, instead of asserting only on what was routed. The double
-    /// supplies ONLY the target resolution the real arm supplies, and only its id-spelling half: the
-    /// `active`/prefix sugar and the `window` selector need the app-side `ControlTargetResolver`, so a
-    /// test driving this store must address workspaces by full id and stay single-window. It must never
-    /// re-implement a mode's semantics, or the test would be exercising the double.
+    /// The store the `workspace.filter` / `workspace.focus` arms drive when set (nil = record-only), so a
+    /// test can run the real command path against a live `AppStore` instead of asserting on routing alone.
+    /// Only the id-spelling half of target resolution is supplied — `active`/prefix sugar and the `window`
+    /// selector need the app-side `ControlTargetResolver` — so a test driving this store must address
+    /// workspaces by full id and stay single-window, and must never re-implement a mode's semantics.
     var focusStore: AppStore?
 
     /// Target strings that reached a `focusStore`-backed arm but could not be resolved, so a "the store
@@ -231,8 +228,7 @@ final class MockControlActions: ControlActions {
 
     func focusWorkspace(_ target: String?, window: String?, mode: ControlWorkspaceFocusMode) -> ControlResponse {
         calls.append(.workspaceFocus(target: target, window: window, mode))
-        // with a store supplied, stand in for the app-side arm: resolve the target (here just the id
-        // spelling) and hand the parsed mode to the SAME `applyFocusMode` the real arm calls.
+        // hands the parsed mode to the SAME `applyFocusMode` the real arm calls, never its own version.
         if let store = focusStore {
             if let id = UUID(uuidString: target ?? "") {
                 store.applyFocusMode(mode, to: id)
@@ -245,8 +241,6 @@ final class MockControlActions: ControlActions {
 
     func setWorkspaceFilter(window: String?, mode: ControlToggleMode) -> ControlResponse {
         calls.append(.workspaceFilter(window: window, mode))
-        // as above: the real arm resolves the window then calls `applyWorkspaceFilter`, so the double
-        // calls the same host-free helper rather than re-deriving the flag.
         if let store = focusStore { store.applyWorkspaceFilter(mode) }
         return nextWorkspaceFilterResponse
     }

--- a/agtermCore/Tests/agtermCoreTests/OSCBackgroundPolicyTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/OSCBackgroundPolicyTests.swift
@@ -74,9 +74,8 @@ struct OSCBackgroundPolicyTests {
     }
 
     @Test func resetOnAColoredSurfaceRoutesToResetNotApply() {
-        // the regression this pairs with: a `.color` session runs OSC 11, then the program resets. The
-        // reset reports the THEME (the OSC overlay dropped the watermark's background key), so a baseline
-        // still claiming the watermark color would return .apply and never release the overlay.
+        // the reset reports the THEME (the OSC overlay dropped the watermark's background key), so a
+        // baseline still claiming the watermark color would return .apply and never release the overlay.
         let baseline = OSCBackgroundPolicy.baseline(oscOverlayActive: true, surfaceBackground: "#aa0000",
                                                     themeBackground: "#1d1f21")
         #expect(OSCBackgroundPolicy.decide(incoming: "#1d1f21", themeBackground: baseline,

--- a/agtermCore/Tests/agtermCoreTests/OpenCodeStatusHookTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/OpenCodeStatusHookTests.swift
@@ -60,10 +60,9 @@ private enum OpenCodeStatusHookSupport {
     }
 }
 
-// Exercises the OpenCode plugin shipped by the Help-menu installer. Event-to-status mapping and
-// wrapper spawning belong to this installed plugin, not to agterm's runtime status engine.
-// Drives the plugin through Node (same host OpenCode uses) with AGTERM_STATUS_WRAPPER recording argv.
-// Skipped when node is absent or below the module-syntax floor — the app does not need Node at runtime.
+// Exercises the OpenCode plugin shipped by the Help-menu installer: event-to-status mapping and wrapper
+// spawning belong to the installed plugin, not to agterm's runtime status engine. Drives it through Node
+// (the host OpenCode uses) with AGTERM_STATUS_WRAPPER recording argv; skipped when Node is absent.
 @Suite(.enabled(if: OpenCodeStatusHookSupport.node != nil,
                 "Node.js 22.7+ (or 20.19+ on the 20.x line) is required to exercise the OpenCode status plugin"))
 struct OpenCodeStatusHookTests {
@@ -300,10 +299,9 @@ struct OpenCodeStatusHookTests {
     }
 
     @Test func subagentIdleDoesNotCompleteWhileParentIsActive() throws {
-        // Task tool creates a child session with its own busy/idle; parent stays busy until the tool
-        // returns. COMPLETED must wait until the active set is empty (set-wide gate). The permission
-        // between the two idles is the oracle: a gate that completed on the child's idle would place
-        // completed BEFORE blocked instead of after it.
+        // Task tool creates a child session with its own busy/idle while the parent stays busy. The
+        // permission between the two idles is the oracle: a gate that completed on the child's idle
+        // would place completed BEFORE blocked instead of after it.
         let calls = try runEvents([
             status("busy", sessionID: "ses_parent"),
             status("busy", sessionID: "ses_child"),
@@ -320,8 +318,6 @@ struct OpenCodeStatusHookTests {
     }
 
     @Test func interleavedTopLevelSessionsCompleteOnlyWhenAllIdle() throws {
-        // Different interleaving: ses_a idles, then goes busy again while ses_b is still running, so
-        // the set empties only on the very last idle.
         let calls = try runEvents([
             status("busy", sessionID: "ses_a"),
             status("busy", sessionID: "ses_b"),
@@ -339,9 +335,8 @@ struct OpenCodeStatusHookTests {
     }
 
     @Test func siblingIdleDoesNotCompleteOverAnotherSessionsError() throws {
-        // halt() publishes session.error and then that session's own idle, while a sibling is still
-        // running. The error latch must outlive the swallowed idle, or the sibling's idle finds an
-        // empty active set and paints completed over the blocked.
+        // halt() publishes session.error then that session's own idle while a sibling still runs: the
+        // latch must outlive the swallowed idle, or the sibling's idle paints completed over blocked.
         let calls = try runEvents([
             status("busy", sessionID: "ses_a"),
             status("busy", sessionID: "ses_b"),

--- a/agtermCore/Tests/agtermCoreTests/PaletteCatalogTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/PaletteCatalogTests.swift
@@ -101,10 +101,8 @@ struct PaletteCatalogTests {
     }
 
     @Test func workspaceFocusEntriesFollowTheMarkedSet() {
-        // marking is offered wherever it would DO something: in EITHER sidebar mode (membership is model
-        // state the tree applies as soon as it is shown, and the View-menu twin gates on the same single
-        // term) and while the current workspace is not already a member — this keyless entry targets
-        // `currentWorkspaceID`, so on a member it would be a silent no-op.
+        // membership is model state the tree applies as soon as it is shown, so marking is offered in
+        // EITHER mode; the entry targets `currentWorkspaceID`, so on a member it would be a silent no-op.
         let tree = PaletteContext(sidebarShowsWorkspaceTree: true)
         let flagged = PaletteContext(sidebarShowsFlaggedOnly: true)
         #expect(PaletteCommand.addWorkspaceToFocus.isVisible(in: tree))
@@ -113,11 +111,9 @@ struct PaletteCatalogTests {
             in: PaletteContext(sidebarShowsWorkspaceTree: true, activeWorkspaceMarked: true)))
         #expect(!PaletteCommand.addWorkspaceToFocus.isVisible(
             in: PaletteContext(sidebarShowsFlaggedOnly: true, activeWorkspaceMarked: true)))
-        // marking OTHER workspaces does not hide it — only the CURRENT one being a member does.
         #expect(PaletteCommand.addWorkspaceToFocus.isVisible(
             in: PaletteContext(sidebarShowsWorkspaceTree: true, hasMarkedWorkspaces: true)))
-        // applying/suspending the filter appears only once something is marked — the same empty-set rule
-        // the bottom-bar toggle renders as disabled.
+        // the same empty-set rule the bottom-bar toggle renders as disabled.
         #expect(!PaletteCommand.toggleWorkspaceFilter.isVisible(in: PaletteContext(hasMarkedWorkspaces: false)))
         #expect(PaletteCommand.toggleWorkspaceFilter.isVisible(in: PaletteContext(hasMarkedWorkspaces: true)))
         // both titles are static — the marked set is read off the sidebar, not the palette row.

--- a/agtermCore/Tests/agtermCoreTests/PersistenceTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/PersistenceTests.swift
@@ -83,10 +83,9 @@ final class PersistenceTests {
         #expect(first.sessions[1].initialCwd == "/var/log")
         #expect(first.sessions[1].displayName == "log")
         #expect(app.workspaces[1].sessions[0].displayName == "/")
-        // surfaces stay lazy/nil until first display
+        // surfaces stay lazy until first display
         #expect(first.sessions[0].surface == nil)
-        // currentCwd is nil after restore — only a live PWD report sets it; the
-        // persisted cwd becomes initialCwd.
+        // only a live PWD report sets currentCwd; the persisted cwd becomes initialCwd.
         #expect(first.sessions[0].currentCwd == nil)
         #expect(first.sessions[1].currentCwd == nil)
     }
@@ -99,7 +98,6 @@ final class PersistenceTests {
         ])
         let app = AppStore(persistence: store)
         app.restore(from: snapshot)
-        // the persisted selection points at no existing session, so it's cleared.
         #expect(app.selectedSessionID == nil)
         #expect(app.activeSession == nil)
     }
@@ -113,7 +111,6 @@ final class PersistenceTests {
         ])
         let app = AppStore(persistence: store)
         app.restore(from: snapshot)
-        // restore loads what was just read from disk; it must not re-persist.
         #expect(!FileManager.default.fileExists(atPath: fileURL.path))
     }
 
@@ -133,8 +130,7 @@ final class PersistenceTests {
     }
 
     @Test func legacyFileWithRemovedKeysLoadsAndKeepsWorkspaces() throws {
-        // a workspaces.json written by an older build carries removed keys (statusBarHidden,
-        // titleBarHidden). they must be ignored, not fail the load and wipe the tree.
+        // removed keys from an older build must be ignored, not fail the load and wipe the tree.
         let id = UUID()
         let json = #"{ "version": 1, "statusBarHidden": true, "titleBarHidden": true, "workspaces": [ { "id": "\#(id.uuidString)", "name": "work", "sessions": [] } ] }"#
         try Data(json.utf8).write(to: fileURL)
@@ -172,8 +168,7 @@ final class PersistenceTests {
     }
 
     @Test func legacySnapshotWithoutFlaggedDecodesUnflagged() throws {
-        // a workspaces.json written before `flagged` existed has no key; it must decode (not throw and
-        // wipe the tree) with the session unflagged.
+        // a file written before `flagged` existed has no key; it must decode rather than wipe the tree.
         let ws = UUID()
         let sid = UUID()
         let json = #"{ "version": 1, "workspaces": [ { "id": "\#(ws.uuidString)", "name": "work", "sessions": [ { "id": "\#(sid.uuidString)", "customName": null, "cwd": "/a" } ] } ] }"#
@@ -222,8 +217,7 @@ final class PersistenceTests {
     }
 
     @Test func legacySnapshotWithoutSidebarModeDecodesTree() throws {
-        // a workspaces.json written before `sidebarMode` existed has no key; it must decode (not throw
-        // and wipe the tree) and restore to `.tree`.
+        // a file written before `sidebarMode` existed has no key; it must decode rather than wipe the tree.
         let ws = UUID()
         let json = #"{ "version": 1, "workspaces": [ { "id": "\#(ws.uuidString)", "name": "work", "sessions": [] } ] }"#
         try Data(json.utf8).write(to: fileURL)
@@ -239,7 +233,7 @@ final class PersistenceTests {
     @Test func focusedWorkspacePersistsAndRestores() {
         let app = AppStore(persistence: store)
         let work = app.addWorkspace(name: "work")
-        #expect(store.load().focusedWorkspaceIDs == nil) // default: nothing marked
+        #expect(store.load().focusedWorkspaceIDs == nil)
         app.setFocusedWorkspace(work.id)
         #expect(store.load().focusedWorkspaceIDs == [work.id] && store.load().focusEnabled == true)
 
@@ -254,8 +248,7 @@ final class PersistenceTests {
     }
 
     @Test func legacySnapshotWithoutFocusedWorkspaceDecodesUnfocused() throws {
-        // a workspaces.json written before any focus key existed has neither; it must decode (not throw
-        // and wipe the tree) and restore to an empty, disabled filter.
+        // a file written before any focus key existed has neither; it must decode rather than wipe the tree.
         let ws = UUID()
         let json = #"{ "version": 1, "workspaces": [ { "id": "\#(ws.uuidString)", "name": "work", "sessions": [] } ] }"#
         try Data(json.utf8).write(to: fileURL)
@@ -269,8 +262,8 @@ final class PersistenceTests {
     }
 
     @Test func legacySnapshotWithSingleFocusedWorkspaceMigratesToAnEnabledSet() throws {
-        // a workspaces.json written by the release BEFORE the focus set existed carries only the single
-        // `focusedWorkspaceID`; it must migrate to a one-member ENABLED set rather than losing the filter.
+        // the release BEFORE the focus set wrote only `focusedWorkspaceID`; it must migrate to a one-member
+        // ENABLED set rather than losing the filter.
         let ws = UUID()
         let json = #"""
         { "version": 1, "focusedWorkspaceID": "\#(ws.uuidString)",
@@ -287,8 +280,8 @@ final class PersistenceTests {
     }
 
     @Test func savedSnapshotStopsWritingTheLegacyFocusKey() throws {
-        // the legacy key is decode-only: once this build saves, the file must carry the set instead, so a
-        // multi-member filter cannot be silently narrowed to one member on the next load.
+        // the legacy key is decode-only, so a multi-member filter cannot be silently narrowed to one
+        // member on the next load.
         let app = AppStore(persistence: store)
         let work = app.addWorkspace(name: "work")
         let personal = app.addWorkspace(name: "personal")
@@ -325,13 +318,13 @@ final class PersistenceTests {
         ], sessionRecency: [stale, id])
         let app = AppStore(persistence: store)
         app.restore(from: snapshot)
-        // the stale id points at no restored session; it must never reach the switcher.
         #expect(app.sessionRecency.items == [id])
     }
 
     @Test func restoreFloatsSelectionToRecencyFront() {
         let a = UUID()
         let b = UUID()
+        // the persisted order is out of sync with the selection, as a hand-edited file can be.
         let snapshot = Snapshot(selectedSessionID: b, workspaces: [
             WorkspaceSnapshot(id: UUID(), name: "work", sessions: [
                 SessionSnapshot(id: a, customName: nil, cwd: "/a"),
@@ -340,13 +333,12 @@ final class PersistenceTests {
         ], sessionRecency: [a, b])
         let app = AppStore(persistence: store)
         app.restore(from: snapshot)
-        // a hand-edited/out-of-sync order still puts the restored selection first.
         #expect(app.sessionRecency.items == [b, a])
     }
 
     @Test func malformedRecencyDropsToNilKeepingTree() throws {
-        // a present-but-invalid sessionRecency (hand-edit typo, wrong type) must drop to nil
-        // lossily — never fail the whole Snapshot decode and wipe the tree on the next save.
+        // an invalid sessionRecency must drop to nil lossily, never fail the whole Snapshot decode and
+        // wipe the tree on the next save.
         let ws = UUID()
         let session = UUID()
         let tree = #""selectedSessionID": "\#(session.uuidString)", "workspaces": "# +
@@ -373,13 +365,12 @@ final class PersistenceTests {
         ], sessionRecency: [a, b])
         let app = AppStore(persistence: store)
         app.restore(from: snapshot)
-        // a selection missing from the persisted seed is inserted at the FRONT, not appended.
         #expect(app.sessionRecency.items == [c, a, b])
     }
 
     @Test func legacySnapshotWithoutRecencyDecodesSelectionOnly() throws {
-        // a workspaces.json written before `sessionRecency` existed has no key; it must decode (not
-        // throw and wipe the tree) and restore with just the selection in the Ctrl-Tab order.
+        // a file written before `sessionRecency` existed has no key; it must decode rather than wipe the
+        // tree, leaving just the selection in the Ctrl-Tab order.
         let ws = UUID()
         let session = UUID()
         let json = #"{ "version": 1, "selectedSessionID": "\#(session.uuidString)", "workspaces": "# +
@@ -412,19 +403,18 @@ final class PersistenceTests {
         let b = app.addWorkspace(name: "b")
         app.setWorkspacesExpanded([a.id]) // collapse b, keep a expanded
         let disk = store.load()
-        #expect(disk.workspaces[0].collapsed == nil)  // expanded → omitted
-        #expect(disk.workspaces[1].collapsed == true) // collapsed → written
+        #expect(disk.workspaces[0].collapsed == nil)  // expanded → omitted from the file
+        #expect(disk.workspaces[1].collapsed == true)
 
         let restored = AppStore(persistence: store)
         restored.restore(from: disk)
-        #expect(restored.workspaces[0].isExpanded)     // a
-        #expect(!restored.workspaces[1].isExpanded)    // b
+        #expect(restored.workspaces[0].isExpanded)
+        #expect(!restored.workspaces[1].isExpanded)
         _ = b
     }
 
     @Test func legacyWorkspaceWithoutCollapsedDecodesExpanded() throws {
-        // a workspaces.json written before `collapsed` existed has no key; it must decode (not throw and
-        // wipe the tree) and restore expanded — lack of the field means expanded, for back-compat.
+        // a file written before `collapsed` existed has no key; lack of the field means expanded.
         let ws = UUID()
         let session = UUID()
         let json = #"{ "version": 1, "workspaces": "# +
@@ -440,8 +430,8 @@ final class PersistenceTests {
     }
 
     @Test func explicitCollapsedFalseDecodesExpanded() throws {
-        // an explicit `collapsed: false` (a hand-edit, or a snapshot from a future build that always writes
-        // the field) must decode to expanded, same as an absent key — `!(false ?? false)` == expanded.
+        // an explicit `collapsed: false` (a hand-edit, or a future build that always writes the field)
+        // must decode to expanded, same as an absent key.
         let ws = UUID()
         let session = UUID()
         let json = #"{ "version": 1, "workspaces": [ { "id": "\#(ws.uuidString)", "name": "work", "# +

--- a/agtermCore/Tests/agtermCoreTests/RecencyStackTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/RecencyStackTests.swift
@@ -6,7 +6,7 @@ struct RecencyStackTests {
         var stack = RecencyStack<Int>()
         stack.push(1); stack.push(2); stack.push(3)
         #expect(stack.items == [3, 2, 1])
-        stack.push(1) // existing id moves to front, no duplicate
+        stack.push(1)
         #expect(stack.items == [1, 3, 2])
     }
 
@@ -43,14 +43,13 @@ struct RecencyStackTests {
 
     @Test func topReturnsRecentValidIdsSkippingStale() {
         let stack = RecencyStack<Int>(items: [4, 3, 2, 1])
-        // 3 is stale (not in valid); it's skipped, the rest stay most-recent-first.
+        // 3 is stale (not in valid), so it is skipped
         #expect(stack.top(2, in: [1, 2, 4]) == [4, 2])
         #expect(stack.top(10, in: [1, 2, 4]) == [4, 2, 1])
     }
 
     @Test func topCapsResultAtRequestedCount() {
-        // the Ctrl-Tab switcher feeds top() its 10-item display cap; with more valid ids than the cap,
-        // top returns exactly n, most-recent-first, and drops the oldest beyond it.
+        // 10 is the Ctrl-Tab switcher's display cap
         var stack = RecencyStack<Int>()
         for i in 1...12 { stack.push(i) }
         let capped = stack.top(10, in: Set(1...12))

--- a/agtermCore/Tests/agtermCoreTests/RecentClosedTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/RecentClosedTests.swift
@@ -78,13 +78,12 @@ final class RecentClosedTests {
 
         let loaded = RecentClosedStore(directory: directory).load()
         #expect(loaded.count == 1)
-        #expect(loaded[0].workspace?.focusMember == nil) // absent reads as "not a member"
+        #expect(loaded[0].workspace?.focusMember == nil)
     }
 
     @Test func workspaceEntryWithALegacyFocusEnabledKeyStillDecodes() throws {
-        // the other direction of the same rule: a key that was DROPPED must not fail the decode either, or
-        // the first launch after the upgrade wipes the recent list of anyone who ran the build that wrote
-        // it. `focusEnabled` was one — the reopen leg marks only, so nothing reads a stored filter flag.
+        // the other direction of the same rule: a DROPPED key must not fail the decode either.
+        // `focusEnabled` was one — the reopen leg marks only, so nothing reads a stored filter flag.
         let encoded = try JSONEncoder().encode(RecentClosedState(items: [workspaceItem(title: "work")]))
         var object = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
         var items = try #require(object["items"] as? [[String: Any]])
@@ -97,12 +96,11 @@ final class RecentClosedTests {
 
         let loaded = RecentClosedStore(directory: directory).load()
         #expect(loaded.count == 1) // not the empty list a decode failure would produce
-        #expect(loaded[0].workspace?.focusMember == true) // and the surviving field still reads back
+        #expect(loaded[0].workspace?.focusMember == true)
     }
 
-    /// Reopen Closed Item rebuilds the session from its snapshot through `session(from:)`, which defaults
-    /// to arming nothing: the persisted pin comes back (so `tree` reads it and the next launch fires it),
-    /// but no payload is pending, so reopening cannot execute a sticky override mid-process.
+    // the persisted pin comes back, but nothing is armed — a reopen cannot execute a sticky override
+    // mid-process.
     @MainActor
     @Test func reopeningAClosedSessionRestoresThePinWithoutArmingIt() throws {
         let (store, recentClosed, _) = makeStoreWithRecentClosed()
@@ -115,7 +113,7 @@ final class RecentClosedTests {
         #expect(store.restoreRecentClosed(item))
 
         let reopened = try #require(store.session(withID: session.id))
-        #expect(reopened !== session) // rebuilt from the snapshot, not the original object
+        #expect(reopened !== session)
         #expect(reopened.restoreCommand == "claude --resume abc")
         #expect(reopened.pendingRestoreCommand == nil)
         #expect(reopened.pendingSplitRestoreCommand == nil)

--- a/agtermCore/Tests/agtermCoreTests/ReorderTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ReorderTests.swift
@@ -3,12 +3,11 @@ import Testing
 
 struct ReorderTests {
     @Test func middleIndexUp() {
-        // list of 5, current 2 → up moves to 1.
         #expect(ReorderDirection.up.destinationIndex(from: 2, count: 5) == 1)
     }
 
     @Test func middleIndexDown() {
-        // current 2 → down moves to 3 (post-removal index lands the element after its old neighbor).
+        // the post-removal index lands the element after its old neighbor, so down from 2 is 3.
         #expect(ReorderDirection.down.destinationIndex(from: 2, count: 5) == 3)
     }
 
@@ -45,7 +44,6 @@ struct ReorderTests {
     }
 
     @Test func twoElementListFromFirst() {
-        // only down/bottom move; up/top are no-ops.
         #expect(ReorderDirection.up.destinationIndex(from: 0, count: 2) == nil)
         #expect(ReorderDirection.top.destinationIndex(from: 0, count: 2) == nil)
         #expect(ReorderDirection.down.destinationIndex(from: 0, count: 2) == 1)
@@ -53,7 +51,6 @@ struct ReorderTests {
     }
 
     @Test func twoElementListFromLast() {
-        // only up/top move; down/bottom are no-ops.
         #expect(ReorderDirection.down.destinationIndex(from: 1, count: 2) == nil)
         #expect(ReorderDirection.bottom.destinationIndex(from: 1, count: 2) == nil)
         #expect(ReorderDirection.up.destinationIndex(from: 1, count: 2) == 0)

--- a/agtermCore/Tests/agtermCoreTests/SessionTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SessionTests.swift
@@ -43,22 +43,18 @@ struct SessionTests {
     }
 
     @Test func whitespaceOnlyCustomNameFallsBackToAuto() {
-        // a whitespace-only customName can only reach displayName via a hand-edited
-        // snapshot (renameSession clears blanks to nil); it's trimmed and falls back
-        // to the basename, matching renameSession's behavior.
+        // a whitespace-only customName can only arrive via a hand-edited snapshot — renameSession clears
+        // blanks to nil.
         let session = Session(initialCwd: "/Users/user/dev/foo", customName: "   \t")
         #expect(session.displayName == "foo")
     }
 
     @Test func paddedCustomNameDisplaysTrimmed() {
-        // a padded customName (e.g. from a hand-edited snapshot) displays trimmed,
-        // matching the "trimmed before use" contract.
         let session = Session(initialCwd: "/Users/user/dev/foo", customName: "  build  ")
         #expect(session.displayName == "build")
     }
 
     @Test func oscTitleOverridesCwd() {
-        // no manual rename: the terminal title (e.g. a remote host over SSH) wins over the cwd basename.
         let session = Session(initialCwd: "/Users/user/dev/foo")
         #expect(session.displayName == "foo")
         session.oscTitle = "user@web1: ~/srv"
@@ -66,14 +62,12 @@ struct SessionTests {
     }
 
     @Test func customNameOverridesOscTitle() {
-        // a manual rename outranks the terminal title.
         let session = Session(initialCwd: "/Users/user/dev/foo", customName: "build")
         session.oscTitle = "user@web1: ~/srv"
         #expect(session.displayName == "build")
     }
 
     @Test func blankOscTitleFallsBackToCwd() {
-        // a whitespace-only or empty title is trimmed and falls through to the cwd basename.
         let session = Session(initialCwd: "/Users/user/dev/foo")
         session.oscTitle = "   \t"
         #expect(session.displayName == "foo")
@@ -88,8 +82,7 @@ struct SessionTests {
     }
 
     @Test func subtitleDetailPrefersTitleForNamedSession() {
-        // named remote (SSH) session: the OSC title carries host/path the stale local cwd can't, and the
-        // name occupies line 1, so the second line shows the title instead of the misleading local path.
+        // on an SSH session the local cwd is stale, so the second line shows the title, not the path.
         let session = Session(initialCwd: "/Users/user", customName: "web1")
         session.currentCwd = "/Users/user"
         session.oscTitle = "user@web1: ~"
@@ -97,19 +90,17 @@ struct SessionTests {
     }
 
     @Test func promotedSurvivorTitleNotMaskedByStaleSplitFocused() {
-        // regression: a promoted survivor can momentarily carry `splitFocused == true` while it is the
-        // session's SOLE pane (`splitSurface == nil`, split fields cleared) — the split factory's focus
-        // callback keeps firing on it. The focus-aware readers must ignore that stale flag and surface the
-        // MIGRATED main-pane title/cwd, not the nil'd split fields (which would drop the SSH title).
+        // a promoted survivor can momentarily carry `splitFocused == true` while it is the session's SOLE
+        // pane — the split factory's focus callback keeps firing on it.
         let session = Session(initialCwd: "/Users/user", customName: "web1")
         session.currentCwd = "/Users/user"
-        session.oscTitle = "user@web1: ~" // migrated up from the split on promotion
-        session.splitFocused = true        // stale — no split exists
+        session.oscTitle = "user@web1: ~"
+        session.splitFocused = true
         session.splitSurface = nil
         session.splitTitle = nil
         session.splitCwd = nil
-        #expect(session.subtitleDetail == "user@web1: ~") // the migrated title, not the cwd
-        #expect(session.focusedCwd == "/Users/user")       // the main cwd, not an initialCwd fallback
+        #expect(session.subtitleDetail == "user@web1: ~")
+        #expect(session.focusedCwd == "/Users/user")
     }
 
     @Test func primarySurfaceHostRevisionChangesOnlyForLiveReplacement() {
@@ -127,14 +118,12 @@ struct SessionTests {
     }
 
     @Test func subtitleDetailUsesCwdForNamedSessionWithoutTitle() {
-        // named local session: local auto-title is suppressed so oscTitle is nil; the second line is the cwd.
+        // a local session's auto-title is suppressed, so oscTitle is nil here.
         let session = Session(initialCwd: "/Users/user/dev/foo", customName: "build")
         #expect(session.subtitleDetail == "/Users/user/dev/foo")
     }
 
     @Test func subtitleDetailUsesCwdWhenTitleIsAlreadyDisplayName() {
-        // unnamed session: the OSC title is already line 1 (displayName), so the second line falls
-        // through to the cwd rather than repeating it.
         let session = Session(initialCwd: "/Users/user")
         session.currentCwd = "/Users/user"
         session.oscTitle = "user@web1: ~"
@@ -148,15 +137,13 @@ struct SessionTests {
     }
 
     @Test func subtitleDetailBlankTitleFallsBackToCwd() {
-        // a whitespace-only title is trimmed away, so a named session with no real title shows the cwd.
         let session = Session(initialCwd: "/Users/user/dev/foo", customName: "build")
         session.oscTitle = "  \t"
         #expect(session.subtitleDetail == "/Users/user/dev/foo")
     }
 
     @Test func subtitleDetailTitleEqualToCustomNameFallsBackToCwd() {
-        // edge: the remote titles the tab exactly what the user named the session, so the title would
-        // just repeat line 1 — the second line falls through to the cwd.
+        // the remote titles the tab exactly what the user named the session, so the title repeats line 1.
         let session = Session(initialCwd: "/Users/user", customName: "web1")
         session.currentCwd = "/Users/user"
         session.oscTitle = "web1"
@@ -164,8 +151,6 @@ struct SessionTests {
     }
 
     @Test func subtitleDetailFollowsFocusedPane() {
-        // focus-aware like displayName/focusedCwd: a named session's second line uses the focused pane's
-        // title (the split pane's while it has focus, else the primary's).
         let session = Session(initialCwd: "/repo", customName: "build")
         session.isSplit = true
         session.splitSurface = FakeSurface() // a focused split always has a live split surface
@@ -177,8 +162,8 @@ struct SessionTests {
     }
 
     @Test func effectiveCwdFallsBackToInitialUntilPwdReport() {
-        // a restored session has no currentCwd until OSC 7 arrives; effectiveCwd is
-        // initialCwd so git status refreshes immediately on launch/select.
+        // a restored session has no currentCwd until OSC 7 arrives, and the fallback is what lets git
+        // status refresh at launch.
         let session = Session(initialCwd: "/repo")
         #expect(session.effectiveCwd == "/repo")
     }
@@ -195,11 +180,9 @@ struct SessionTests {
         session.isSplit = true
         session.splitSurface = FakeSurface() // a focused split always has a live split surface
         session.splitCwd = "/var/log"
-        // split not focused: the primary pane drives name + cwd.
         #expect(session.displayName == "foo")
         #expect(session.focusedCwd == "/Users/user/dev/foo")
         session.splitFocused = true
-        // split focused: the split pane drives name + cwd.
         #expect(session.displayName == "log")
         #expect(session.focusedCwd == "/var/log")
     }
@@ -225,9 +208,8 @@ struct SessionTests {
     }
 
     @Test func hiddenSplitStillShowsFocusedSplitPane() {
-        // split hidden (isSplit false) but the right pane is the one shown maximized + focused: the
-        // title/sidebar follow the split pane, NOT the hidden primary. (guarded on splitFocused, not
-        // isSplit — closeSplit resets the flag, so splitFocused is true only while the pane exists.)
+        // split hidden but the right pane is shown maximized + focused. The guard is splitFocused, not
+        // isSplit — closeSplit resets the flag, so it is true only while the pane exists.
         let session = Session(initialCwd: "/repo")
         session.currentCwd = "/repo/sub"
         session.splitSurface = FakeSurface()
@@ -238,9 +220,8 @@ struct SessionTests {
     }
 
     @Test func focusedCwdFallsBackUntilSplitReports() {
-        // split focused and ALIVE, but the split pane hasn't reported a cwd yet: fall back to the primary's.
-        // splitSurface must be set (else the split-existence guard alone short-circuits) so this exercises
-        // the `let cwd = splitCwd` nil-fallback branch, not the missing-surface one.
+        // splitSurface must be set, else the split-existence guard short-circuits and this exercises the
+        // missing-surface branch instead of the `let cwd = splitCwd` nil fallback.
         let session = Session(initialCwd: "/repo")
         session.currentCwd = "/repo/primary"
         session.isSplit = true
@@ -261,7 +242,6 @@ struct SessionTests {
     }
 
     @Test func agentIndicatorDefaultsToIdle() {
-        // a fresh session shows no agent status (.idle, no blink) until the control channel sets one.
         let session = Session(initialCwd: "/repo")
         #expect(session.agentIndicator == AgentIndicator())
         #expect(session.agentIndicator.status == .idle)
@@ -284,7 +264,6 @@ struct SessionTests {
     }
 
     @Test func searchDisplayTextIsEmptyBeforeAnyQuery() {
-        // searchTotal nil (no query run yet): empty string, so the bar shows no counter.
         let session = Session(initialCwd: "/repo")
         #expect(session.searchDisplayText == "")
     }
@@ -312,8 +291,7 @@ struct SessionTests {
     }
 
     @Test func searchDisplayTextClampsStaleSelectedToTotal() {
-        // the count can shrink under a stale selected index before the next SEARCH_SELECTED lands;
-        // selected is clamped to total so it never reads "3 of 2".
+        // the count can shrink before the next SEARCH_SELECTED lands, so selected is clamped to total.
         let session = Session(initialCwd: "/repo")
         session.searchTotal = 2
         session.searchSelected = 3
@@ -321,8 +299,6 @@ struct SessionTests {
     }
 
     @Test func searchFieldsAreNotPersistedAcrossSnapshot() {
-        // the search state is ephemeral like overlay/scratch: a snapshot round-trip leaves it at
-        // defaults on the restored session.
         let store = AppStore(persistence: PersistenceStore(
             directory: FileManager.default.temporaryDirectory.appendingPathComponent("agterm-tests-\(UUID().uuidString)")))
         let ws = store.addWorkspace(name: "work")
@@ -342,9 +318,7 @@ struct SessionTests {
     }
 
     @Test func searchSurfacePinsTheOwnerAndIsWeak() {
-        // the pinned search owner is what the bar's needle/navigate/close drive, surviving a split focus
-        // move (it is NOT re-resolved from `activeSurface`). it is weak: the session strongly owns its
-        // panes, so it must not retain a surface.
+        // weak on purpose: the session strongly owns its panes, so the pin must not retain a surface.
         let session = Session(initialCwd: "/repo")
         var owner: FakeSurface? = FakeSurface()
         session.searchSurface = owner
@@ -375,59 +349,45 @@ struct SessionTests {
         session.surface = primary
         session.scratchSurface = scratch
         session.overlaySurface = overlay
-        // no cover active: the active pane.
         #expect(session.topmostSurface === primary)
-        // scratch shown: scratch is on top.
         session.scratchActive = true
         #expect(session.topmostSurface === scratch)
-        // overlay over the scratch: the overlay wins (it renders above the scratch).
         session.overlayActive = true
         #expect(session.topmostSurface === overlay)
-        // overlay closed, scratch still up: back to the scratch.
         session.overlayActive = false
         #expect(session.topmostSurface === scratch)
-        // scratch hidden too: the active pane again.
         session.scratchActive = false
         #expect(session.topmostSurface === primary)
     }
 
     @Test func onScreenSurfaceIsCoveringScratchElseFocusedPane() {
-        // the "what's visible" surface for session.text (no --pane) / session.search: the scratch when it
-        // covers the panes (and no overlay is up), else the FOCUSED pane. An overlay falls back to the pane
-        // (search/text don't target the ephemeral overlay), matching AppActions.searchTarget.
+        // an overlay falls back to the pane — search/text don't target the ephemeral overlay, matching
+        // AppActions.searchTarget.
         let session = Session(initialCwd: "/repo")
         let primary = FakeSurface(), split = FakeSurface(), scratch = FakeSurface(), overlay = FakeSurface()
         session.surface = primary
         session.splitSurface = split
         session.scratchSurface = scratch
         session.overlaySurface = overlay
-        // no cover, no split focus: the primary pane.
         #expect(session.onScreenSurface === primary)
-        // split focused: the focused split pane, not the primary.
         session.splitFocused = true
         #expect(session.onScreenSurface === split)
         session.splitFocused = false
-        // scratch shown (no overlay): the scratch is what's on screen.
         session.scratchActive = true
         #expect(session.onScreenSurface === scratch)
-        // an overlay over the scratch falls back to the pane beneath, not the scratch or the overlay.
         session.overlayActive = true
         #expect(session.onScreenSurface === primary)
     }
 
     @Test func fullOverlayActiveOnlyForFullCoverageOverlay() {
-        // the full-coverage overlay (no size) hides the session content beneath it — panes AND scratch —
-        // so its translucent background reveals the window backing, never the covered surfaces.
+        // only the full-coverage overlay hides the panes AND scratch, so its translucent background
+        // reveals the window backing rather than the covered surfaces.
         let session = Session(initialCwd: "/repo")
-        // no overlay: nothing to hide behind.
         #expect(session.fullOverlayActive == false)
-        // full-coverage overlay (no size percent): active.
         session.overlayActive = true
         #expect(session.fullOverlayActive == true)
-        // floating (sized) overlay: draws an opaque panel over visible content, not a full cover.
         session.overlaySizePercent = 80
         #expect(session.fullOverlayActive == false)
-        // overlay closed with a stale size percent lingering: still not a cover.
         session.overlayActive = false
         #expect(session.fullOverlayActive == false)
     }
@@ -441,16 +401,14 @@ struct SessionTests {
         #expect(session.paneRole(forToken: "main-tok") == .left)
         #expect(session.paneRole(forToken: "split-tok") == .right)
         #expect(session.paneRole(forToken: "scratch-tok") == .scratch)
-        // an empty or unknown token never matches — the caller falls back to the baked --pane role.
+        // no match — the caller then falls back to the baked --pane role.
         #expect(session.paneRole(forToken: "") == nil)
         #expect(session.paneRole(forToken: "no-such-tok") == nil)
     }
 
     @Test func paneRoleFollowsAPromotedSurvivorAndReSplit() {
-        // #199: a split survivor (baked `right`, token `agent-tok`) is promoted into the MAIN slot, then a
-        // fresh helper (also baked `right`, token `helper-tok`) opens as the new split. Both shells were
-        // baked with the SAME stale `right` role, so only the stable token disambiguates them: the survivor
-        // now resolves to the main slot (.left), the helper to the split slot (.right).
+        // #199: a promoted survivor and the fresh helper that re-splits it were both baked with the SAME
+        // stale `right` role, so only the stable token disambiguates them.
         let session = Session(initialCwd: "/repo")
         let survivor = FakeSurface(paneToken: "agent-tok")
         session.surface = survivor
@@ -465,11 +423,9 @@ struct SessionTests {
         session.pendingRestoreCommand = "claude --resume main"
         session.pendingSplitRestoreCommand = "tail -f /var/log/x"
 
-        // each pane hands back its own payload, independently...
         #expect(session.takePendingRestoreOverride(pane: .left) == "claude --resume main")
-        #expect(session.pendingSplitRestoreCommand == "tail -f /var/log/x") // taking left leaves right alone
+        #expect(session.pendingSplitRestoreCommand == "tail -f /var/log/x")
         #expect(session.takePendingRestoreOverride(pane: .right) == "tail -f /var/log/x")
-        // ...and only once: a second surface for the same pane this launch gets a plain shell.
         #expect(session.takePendingRestoreOverride(pane: .left) == nil)
         #expect(session.takePendingRestoreOverride(pane: .right) == nil)
     }
@@ -481,8 +437,8 @@ struct SessionTests {
     }
 
     @Test func takePendingRestoreOverrideReturnsEmptyStringAsAValue() {
-        // "" is "pinned to nothing" — a real tri-state value, not an absent override, so the first take
-        // must return it (the caller maps it to a plain shell) rather than collapsing it to nil.
+        // "" is "pinned to nothing" — a real tri-state value the caller maps to a plain shell, so the
+        // first take must return it rather than collapsing it to nil.
         let session = Session(initialCwd: "/repo")
         session.pendingRestoreCommand = ""
         session.pendingSplitRestoreCommand = ""
@@ -497,13 +453,12 @@ struct SessionTests {
         let session = Session(initialCwd: "/repo")
         session.pendingRestoreCommand = "claude --resume main"
         #expect(session.takePendingRestoreOverride(pane: .scratch) == nil)
-        // and the take must not have drained another pane's payload.
         #expect(session.takePendingRestoreOverride(pane: .left) == "claude --resume main")
     }
 
     @Test func clearPendingRestoreOverridesDropsBothPayloadsAndKeepsThePins() {
-        // the soft-close teardown: the same object comes back on undo, so an unconsumed payload must not
-        // survive the round trip — while the persisted pins stay, to fire on the next launch.
+        // the same object comes back on undo, so an unconsumed payload must not survive the round trip —
+        // while the persisted pins stay, to fire on the next launch.
         let session = Session(initialCwd: "/repo")
         session.restoreCommand = "claude --resume main"
         session.splitRestoreCommand = "tail -f /var/log/x"
@@ -518,8 +473,8 @@ struct SessionTests {
     }
 
     @Test func takePendingRestoreOverrideLeavesThePersistedValueIntact() {
-        // the override is STICKY: consuming this launch's payload must not clear the persisted field, or
-        // it would fire once and never again (the capture's consume-on-read semantics, wrongly mirrored).
+        // STICKY: consuming this launch's payload must not clear the persisted field, or it would fire
+        // once and never again.
         let session = Session(initialCwd: "/repo")
         session.restoreCommand = "claude --resume main"
         session.splitRestoreCommand = "tail -f /var/log/x"
@@ -533,8 +488,8 @@ struct SessionTests {
     }
 
     @Test func takePendingRestoreOverrideNeverReadsThePersistedValue() {
-        // the factory path can only reach the transient payload: a persisted override with nothing armed
-        // (a mid-process window reload, a socket write during this run) must not fire.
+        // a persisted override with nothing armed (a mid-process window reload, a socket write during this
+        // run) must not fire — the factory path can only reach the transient payload.
         let session = Session(initialCwd: "/repo")
         session.restoreCommand = "claude --resume main"
         session.splitRestoreCommand = "tail -f /var/log/x"

--- a/agtermCore/Tests/agtermCoreTests/SettingsStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SettingsStoreTests.swift
@@ -28,7 +28,6 @@ final class SettingsStoreTests {
 
     @Test func missingFileSeedsDefaultTheme() {
         #expect(!FileManager.default.fileExists(atPath: fileURL.path))
-        // a fresh install opens on the app's default theme, not ghostty's built-in.
         #expect(store.load() == AppSettings(theme: AppSettings.defaultTheme))
         #expect(store.load().theme == "agterm")
     }
@@ -40,8 +39,8 @@ final class SettingsStoreTests {
     }
 
     @Test func existingFileWithoutThemeKeyStaysGhosttyDefault() throws {
-        // an existing settings.json with no `theme` key decodes to nil (ghostty built-in) — an
-        // existing user is never silently re-themed to the new app default.
+        // an existing user is never silently re-themed: a missing `theme` key decodes to nil, ghostty's
+        // built-in, not the app default.
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         try Data(#"{"fontSize":14}"#.utf8).write(to: fileURL)
         #expect(store.load().theme == nil)

--- a/agtermCore/Tests/agtermCoreTests/ShellEscapeTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ShellEscapeTests.swift
@@ -20,8 +20,7 @@ struct ShellEscapeTests {
     }
 
     @Test func escapesNewlinesSoADroppedNameCannotInjectACommand() {
-        // a filename may contain a newline; unescaped it would submit the rest as a shell command via
-        // inject(text:). Backslash-escaped, the line terminator can't terminate a command.
+        // unescaped, the rest of the name would submit as a shell command via inject(text:).
         #expect(ShellEscape.path("report.txt\ndate") == "report.txt\\\ndate")
         #expect(ShellEscape.path("a\rb") == "a\\\rb")
         #expect(ShellEscape.path("a\r\nb") == "a\\\r\\\nb")

--- a/agtermCore/Tests/agtermCoreTests/SidebarDropTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SidebarDropTests.swift
@@ -44,9 +44,8 @@ struct SidebarDropTests {
     }
 
     @Test func sessionSameWorkspaceDownPastMiddleRowAppliesMinusOne() {
-        // [a(0), b(1), c(2), d(3)]; drag a DOWN onto c's row (NOT the last) → insert after c.
-        // childIndex onItem → c's idx + 1 = 3; same-workspace downward (0 < 3) subtracts 1 → destination 2.
-        // This is the discriminating case: without the -1 the element would land at 3, not 2.
+        // [a(0), b(1), c(2), d(3)]; drag a DOWN onto c's row → insert after c at 3, then same-workspace
+        // downward subtracts 1 → 2. Discriminating case: without the -1 the element lands at 3.
         let move = SidebarDrop.resolveSession(
             sourceWorkspace: Self.wsA, sourceIndex: 0,
             target: .sessionRow(workspace: Self.wsA, sessionIndex: 2, sessionCount: 4), childIndex: Self.onItem)
@@ -54,8 +53,7 @@ struct SidebarDropTests {
     }
 
     @Test func sessionSameWorkspaceDownBetweenRowsAppliesMinusOne() {
-        // [a(0), b(1), c(2), d(3)]; drag a into the slot before d (between-rows childIndex 3).
-        // same-workspace downward (0 < 3) subtracts 1 → destination 2.
+        // [a(0), b(1), c(2), d(3)]; drag a into the slot before d (childIndex 3); downward subtracts 1 → 2.
         let move = SidebarDrop.resolveSession(
             sourceWorkspace: Self.wsA, sourceIndex: 0,
             target: .workspaceRow(id: Self.wsA, sessionCount: 4), childIndex: 3)
@@ -63,8 +61,7 @@ struct SidebarDropTests {
     }
 
     @Test func sessionSameWorkspaceUpBetweenRowsNoAdjustment() {
-        // [a(0), b(1), c(2)]; drag c into the slot before b (between-rows childIndex 1). Upward (2 > 1),
-        // so no -1; destination stays 1.
+        // [a(0), b(1), c(2)]; drag c into the slot before b (childIndex 1). Upward (2 > 1), so no -1.
         let move = SidebarDrop.resolveSession(
             sourceWorkspace: Self.wsA, sourceIndex: 2,
             target: .workspaceRow(id: Self.wsA, sessionCount: 3), childIndex: 1)
@@ -72,8 +69,7 @@ struct SidebarDropTests {
     }
 
     @Test func sessionSameWorkspaceNoOpWhenDroppedIntoOwnSlot() {
-        // [a(0), b(1), c(2)]; drag b into the slot before c (between-rows childIndex 2). Downward (1 < 2)
-        // subtracts 1 → destination 1 == sourceIndex → no-op.
+        // [a(0), b(1), c(2)]; drag b into the slot before c (childIndex 2); downward -1 → 1 == sourceIndex.
         let move = SidebarDrop.resolveSession(
             sourceWorkspace: Self.wsA, sourceIndex: 1,
             target: .workspaceRow(id: Self.wsA, sessionCount: 3), childIndex: 2)
@@ -81,9 +77,8 @@ struct SidebarDropTests {
     }
 
     @Test func sessionSameWorkspaceAppendAlreadyLastIsNoOp() {
-        // [a(0), b(1), c(2)]; drop c ON its OWN workspace header (childIndex onItem → append at count 3).
-        // moveSession removes c then clamps 3 to 2 → lands at 2 == sourceIndex → no-op (the bug fix: the
-        // unclamped sourceIndex == destination check, 2 != 3, missed this).
+        // [a(0), b(1), c(2)]; drop c ON its OWN workspace header (append at count 3). moveSession removes c
+        // then clamps 3 to 2 == sourceIndex; an unclamped sourceIndex == destination check (2 != 3) misses it.
         let move = SidebarDrop.resolveSession(
             sourceWorkspace: Self.wsA, sourceIndex: 2,
             target: .workspaceRow(id: Self.wsA, sessionCount: 3), childIndex: Self.onItem)
@@ -91,8 +86,7 @@ struct SidebarDropTests {
     }
 
     @Test func sessionSameWorkspaceAppendFromMiddleMovesToEnd() {
-        // [a(0), b(1), c(2)]; drop a ON its OWN workspace header (append at count 3). a is not last, so it
-        // really moves to the end → not a no-op; destination 3 (moveSession clamps to land it last).
+        // [a(0), b(1), c(2)]; drop a ON its OWN header (append at 3). a is not last, so this really moves.
         let move = SidebarDrop.resolveSession(
             sourceWorkspace: Self.wsA, sourceIndex: 0,
             target: .workspaceRow(id: Self.wsA, sessionCount: 3), childIndex: Self.onItem)
@@ -102,8 +96,7 @@ struct SidebarDropTests {
     // MARK: - Session, cross workspace (no -1, no same-slot no-op)
 
     @Test func sessionCrossWorkspaceInsertAtMiddleSlot() {
-        // target wsB = [x(0), y(1), z(2)]; drag a session from wsA into the slot before z (childIndex 2).
-        // different workspace → no -1, destination 2 (precise placement, not append).
+        // wsB = [x(0), y(1), z(2)]; a wsA session into the slot before z; cross-workspace, so no -1.
         let move = SidebarDrop.resolveSession(
             sourceWorkspace: Self.wsA, sourceIndex: 0,
             target: .workspaceRow(id: Self.wsB, sessionCount: 3), childIndex: 2)
@@ -200,8 +193,8 @@ struct SidebarDropTests {
     }
 
     @Test func relativeSameWorkspaceAfterAnchorDownwardAppliesMinusOne() {
-        // [a(0), b(1), c(2), d(3)]; place a (source 0) AFTER c (anchor idx 2). after → dropChildIndex 3;
-        // same-workspace downward (0 < 3) subtracts 1 → destination 2 (the discriminating off-by-one).
+        // [a(0), b(1), c(2), d(3)]; place a (source 0) AFTER c (anchor idx 2) → dropChildIndex 3, then
+        // same-workspace downward subtracts 1 → 2 (the discriminating off-by-one).
         let move = SidebarDrop.resolveRelative(
             source: (Self.wsA, 0), anchor: (Self.wsA, 2, 4), placeAfter: true)
         #expect(move == SidebarDrop.SessionResolution(workspace: Self.wsA, dropChildIndex: 3, destination: 2))
@@ -229,14 +222,14 @@ struct SidebarDropTests {
     }
 
     @Test func relativeAnchorIsSourceBeforeIsNoOp() {
-        // [a(0), b(1), c(2)]; place b (source 1) BEFORE itself → lands in its own slot → no-op.
+        // [a(0), b(1), c(2)]; place b (source 1) BEFORE itself → lands in its own slot.
         let move = SidebarDrop.resolveRelative(
             source: (Self.wsA, 1), anchor: (Self.wsA, 1, 3), placeAfter: false)
         #expect(move == nil)
     }
 
     @Test func relativeAnchorIsSourceAfterIsNoOp() {
-        // [a(0), b(1), c(2)]; place b (source 1) AFTER itself → after the -1 lands in its own slot → no-op.
+        // [a(0), b(1), c(2)]; place b (source 1) AFTER itself → after the -1 it lands in its own slot.
         let move = SidebarDrop.resolveRelative(
             source: (Self.wsA, 1), anchor: (Self.wsA, 1, 3), placeAfter: true)
         #expect(move == nil)
@@ -245,15 +238,13 @@ struct SidebarDropTests {
     // MARK: - Workspace reorder
 
     @Test func workspaceMoveUp() {
-        // 3 workspaces; drag the one at index 2 into the slot before index 1 (between-rows childIndex 1).
-        // upward (2 > 1) → no -1, destination 1.
+        // 3 workspaces; drag index 2 into the slot before index 1 (childIndex 1). Upward, so no -1.
         let move = SidebarDrop.resolveWorkspace(sourceIndex: 2, count: 3, childIndex: 1)
         #expect(move == SidebarDrop.WorkspaceResolution(dropChildIndex: 1, destination: 1))
     }
 
     @Test func workspaceMoveDownAppliesMinusOne() {
-        // drag the workspace at index 0 into the slot before index 2 (between-rows childIndex 2).
-        // downward (0 < 2) subtracts 1 → destination 1.
+        // drag index 0 into the slot before index 2 (childIndex 2); downward subtracts 1 → 1.
         let move = SidebarDrop.resolveWorkspace(sourceIndex: 0, count: 3, childIndex: 2)
         #expect(move == SidebarDrop.WorkspaceResolution(dropChildIndex: 2, destination: 1))
     }
@@ -265,22 +256,19 @@ struct SidebarDropTests {
     }
 
     @Test func workspaceMoveNoOpIntoOwnSlot() {
-        // drag the workspace at index 1 into the slot before index 2 (childIndex 2). downward (1 < 2)
-        // subtracts 1 → destination 1 == sourceIndex → no-op.
+        // drag index 1 into the slot before index 2 (childIndex 2); downward -1 → 1 == sourceIndex.
         #expect(SidebarDrop.resolveWorkspace(sourceIndex: 1, count: 3, childIndex: 2) == nil)
     }
 
     @Test func workspaceMoveNoOpAppendAlreadyLast() {
-        // workspace already last (index 2 of 3) dropped at the end (childIndex onItem → 3). 2 < 3
-        // subtracts 1 → destination 2 == sourceIndex → no-op.
+        // index 2 of 3 (already last) dropped at the end (onItem → 3); -1 → 2 == sourceIndex.
         #expect(SidebarDrop.resolveWorkspace(sourceIndex: 2, count: 3, childIndex: Self.onItem) == nil)
     }
 
     // MARK: - Workspace reorder against a FILTERED tree
 
     @Test func workspaceInsertIndexPassesTheSlotThroughOnAnUnfilteredTree() {
-        // every workspace rendered: the visible slot IS the full-array index, so the pre-filter behavior
-        // (including the append slot past the last row) is unchanged.
+        // every workspace rendered: the visible slot IS the full-array index, append slot included.
         let all = Array(0..<4)
         #expect((0...4).allSatisfy { SidebarDrop.workspaceInsertIndex(visibleIndices: all, slot: $0) == $0 })
     }
@@ -308,9 +296,8 @@ struct SidebarDropTests {
     }
 
     @Test func filteredWorkspaceDropBeforeTheFirstVisibleRowKeepsTheHiddenWorkspaceAhead() {
-        // A B C D with {B, D} marked: drag D above B. The mapped index 1 moves D to full-array slot 1,
-        // leaving hidden A first — the visible result is D before B either way, but the raw slot 0 would
-        // also have jumped D ahead of A, a reorder the user never saw and could not have aimed at.
+        // A B C D with {B, D} marked: drag D above B. The mapped index 1 leaves hidden A first; the raw
+        // slot 0 would have jumped D ahead of A too — a reorder the user never saw and could not aim at.
         let insert = SidebarDrop.workspaceInsertIndex(visibleIndices: [1, 3], slot: 0)
         let move = SidebarDrop.resolveWorkspace(sourceIndex: 3, count: 4, childIndex: insert)
         #expect(move == SidebarDrop.WorkspaceResolution(dropChildIndex: 1, destination: 1))

--- a/agtermCore/Tests/agtermCoreTests/SkillInstallTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SkillInstallTests.swift
@@ -31,12 +31,9 @@ struct SkillInstallTests {
         #expect(reference.contains("## events"))
         #expect(reference.contains("event cursor expired"))
         #expect(examples.contains("agtermctl events --json"))
-        // the window-minimize mirror: summary line, per-command detail, and a recipe
         #expect(skill.contains("minimize <id> [on|off|toggle]"))
         #expect(reference.contains("`window minimize <id> [on|off|toggle]`"))
         #expect(examples.contains("agtermctl window minimize"))
-        // the workspace focus-set mirror: the fourth `add` mode, the new workspace.filter command, and
-        // the tree read-back pair a script builds a working set with
         #expect(skill.contains("focus [on|off|toggle|add]"))
         #expect(skill.contains("filter [on|off|toggle]"))
         #expect(reference.contains("`workspace focus [on|off|toggle|add] [--target] [--window W]`"))
@@ -46,9 +43,8 @@ struct SkillInstallTests {
         #expect(examples.contains("agtermctl workspace filter on"))
     }
 
-    // the plugin manifests and the app bundle read the SAME directory, so nothing here may drift:
-    // a moved skill, a renamed leaf, or a manifest pointing somewhere else breaks one consumer
-    // silently while the others keep working.
+    // the plugin manifests and the app bundle read the SAME directory, so a moved skill or a renamed leaf
+    // breaks one consumer silently while the others keep working.
     @Test func pluginManifestsPointAtTheBundledSkillDirectory() throws {
         let pluginRoot = "plugins/agterm"
         let skillLeaf = "skills/\(SkillInstall.skillName)"
@@ -61,12 +57,11 @@ struct SkillInstallTests {
         let codexPlugin = try json("\(pluginRoot)/.codex-plugin/plugin.json")
         #expect(codexPlugin["skills"] as? String == "./skills/")
 
-        // both manifests name the plugin after the skill, which is what makes the codex namespace
-        // `agterm:agterm` and keeps the claude install name stable
+        // naming the plugin after the skill is what makes the codex namespace `agterm:agterm` and keeps
+        // the claude install name stable
         #expect(claudePlugin["name"] as? String == SkillInstall.skillName)
         #expect(codexPlugin["name"] as? String == SkillInstall.skillName)
 
-        // every declared path resolves to the one real skill directory
         let skill = repository.appendingPathComponent("\(pluginRoot)/\(skillLeaf)")
         for file in ["SKILL.md", "reference.md", "examples.md", "troubleshooting.md", "scripts/show-image.sh"] {
             #expect(FileManager.default.fileExists(atPath: skill.appendingPathComponent(file).path),
@@ -80,16 +75,16 @@ struct SkillInstallTests {
         let claudeEntry = try #require(claudeEntries.first)
         #expect(claudeEntry["source"] as? String == "./plugins/agterm")
 
-        // codex's marketplace manifest lives at .agents/plugins/, NOT alongside .codex-plugin/,
-        // and takes a source object rather than a bare path
+        // codex's marketplace manifest lives at .agents/plugins/, NOT alongside .codex-plugin/, and takes
+        // a source object rather than a bare path
         let codexMarketplace = try json(".agents/plugins/marketplace.json")
         let codexEntries = try #require(codexMarketplace["plugins"] as? [[String: Any]])
         let codexSource = try #require(codexEntries.first?["source"] as? [String: Any])
         #expect(codexSource["source"] as? String == "local")
         #expect(codexSource["path"] as? String == "./plugins/agterm")
 
-        // the plugin managers key their install cache on the manifest version, so a release that
-        // bumps one and not the other leaves an agent pinned to a stale skill
+        // the plugin managers key their install cache on the manifest version, so bumping one and not the
+        // other leaves an agent pinned to a stale skill
         let version = try #require(claudeEntry["version"] as? String)
         #expect(try json("plugins/agterm/.claude-plugin/plugin.json")["version"] as? String == version)
         #expect(try json("plugins/agterm/.codex-plugin/plugin.json")["version"] as? String == version)

--- a/agtermCore/Tests/agtermCoreTests/SnapshotRoundTripTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SnapshotRoundTripTests.swift
@@ -3,7 +3,7 @@ import Testing
 @testable import agtermCore
 
 // SessionSnapshot / Snapshot serialization + restore round-trips, forward-compat legacy decodes, and
-// restore-time clamping. Split out of AppStoreTests to keep both files within the line budget.
+// restore-time clamping.
 @MainActor
 struct SnapshotRoundTripTests {
     @Test func splitCwdRoundTripsThroughSnapshot() {
@@ -17,7 +17,6 @@ struct SnapshotRoundTripTests {
         let snapped = snap.workspaces[0].sessions[0]
         #expect(snapped.cwd == "/a/primary")
         #expect(snapped.splitCwd == "/var/log")
-        // restore into a fresh store: each pane keeps its own seed.
         let restored = makeStore()
         restored.restore(from: snap)
         let r = restored.workspaces[0].sessions[0]
@@ -44,7 +43,6 @@ struct SnapshotRoundTripTests {
     }
 
     @Test func legacySnapshotWithoutForegroundCommandDecodesNil() throws {
-        // a snapshot written before this field existed must still decode (nil = plain shell on restore).
         let json = #"{"id":"00000000-0000-0000-0000-000000000001","cwd":"/tmp"}"#
         let snap = try JSONDecoder().decode(SessionSnapshot.self, from: Data(json.utf8))
         #expect(snap.foregroundCommand == nil)
@@ -54,25 +52,22 @@ struct SnapshotRoundTripTests {
     }
 
     @Test func initialCommandRoundTripsThroughSnapshot() {
-        // a command session (e.g. `--command ssh …`) persists its creation command so it re-runs on
-        // restore instead of coming back a plain shell.
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
         session.initialCommand = "ssh user@host -t 'ssh inner'"
-        #expect(session.wasRestored == false) // a fresh session is not marked restored
+        #expect(session.wasRestored == false)
         let snap = store.snapshot()
         #expect(snap.workspaces[0].sessions[0].initialCommand == "ssh user@host -t 'ssh inner'")
         let restored = makeStore()
         restored.restore(from: snap)
         let r = restored.workspaces[0].sessions[0]
         #expect(r.initialCommand == "ssh user@host -t 'ssh inner'")
-        #expect(r.wasRestored == true) // restore marks the session, so the surface factory can gate its re-run
+        #expect(r.wasRestored == true) // the surface factory gates the re-run on this
     }
 
     @Test func commandWaitRoundTripsThroughSnapshot() {
-        // a held --command session persists the flag so a restored session that re-runs its command holds
-        // again, keeping the held/closed behavior consistent across restart (issue #254).
+        // a restored session that re-runs its command must hold again, like the original (issue #254).
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a", command: "make test", wait: true)!
@@ -85,9 +80,8 @@ struct SnapshotRoundTripTests {
     }
 
     @Test func commandWaitFalseRoundTripsAsNilAndRestoresFalse() {
-        // a command session created WITHOUT --wait writes commandWait as nil (false is omitted), and restore
-        // maps that nil back to false via session(from:)'s `?? false` — not true. Exercises both the write
-        // gate and the nil->false restore mapping (a `?? true` mutant would restore true and fail here).
+        // false is omitted on write, so restore maps the resulting nil back through `?? false`; a `?? true`
+        // mutant would restore true and fail here.
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a", command: "make test")!
@@ -100,8 +94,7 @@ struct SnapshotRoundTripTests {
     }
 
     @Test func legacySnapshotWithoutCommandWaitDecodesNil() throws {
-        // a snapshot written before --wait existed has no commandWait key; it must decode as nil (not fail
-        // the whole load), like every other post-v1 optional field; restore maps nil to false.
+        // the missing key must decode as nil rather than failing the whole load, like every post-v1 field.
         let json = #"{"id":"\#(UUID().uuidString)","customName":null,"cwd":"/a","initialCommand":"make test"}"#
         let snap = try JSONDecoder().decode(SessionSnapshot.self, from: Data(json.utf8))
         #expect(snap.commandWait == nil)
@@ -122,7 +115,6 @@ struct SnapshotRoundTripTests {
     }
 
     @Test func sidebarDefaultsWhenSnapshotOmitsThem() {
-        // a snapshot written before these fields existed decodes them as nil; restore falls back to defaults.
         let store = makeStore()
         store.sidebarWidth = 400
         store.sidebarVisible = false
@@ -132,7 +124,6 @@ struct SnapshotRoundTripTests {
     }
 
     @Test func restoreClampsOutOfRangeSidebarWidth() {
-        // a corrupt or hand-edited snapshot must not drive an out-of-range frame width; restore clamps it.
         let store = makeStore()
         store.restore(from: Snapshot(workspaces: [], sidebarWidth: 2000))
         #expect(store.sidebarWidth == AppStore.sidebarWidthMax)
@@ -141,7 +132,7 @@ struct SnapshotRoundTripTests {
     }
 
     @Test func restoreClampsOutOfRangeSplitRatio() {
-        // a corrupt snapshot ratio must not feed an out-of-range fraction into NSSplitView.setPosition.
+        // an out-of-range fraction would reach NSSplitView.setPosition unclamped.
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
@@ -183,8 +174,8 @@ struct SnapshotRoundTripTests {
     }
 
     @Test func emptyRestoreCommandRoundTripsAsEmptyNotNil() throws {
-        // "" is the "pinned to nothing" state of the tri-state and must survive JSON as an empty string —
-        // collapsing it to nil would silently turn the opt-out back into auto-capture.
+        // "" is the tri-state's "pinned to nothing"; collapsing it to nil turns the opt-out back into
+        // auto-capture.
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
@@ -202,8 +193,7 @@ struct SnapshotRoundTripTests {
     }
 
     @Test func legacySnapshotWithoutRestoreCommandDecodesNil() throws {
-        // a snapshot written before the override existed must still decode (nil = no override, the
-        // auto-capture behavior) rather than throwing and wiping the saved tree.
+        // a throw here would fail the whole load and wipe the saved tree.
         let json = #"{"id":"\#(UUID().uuidString)","cwd":"/tmp","foregroundCommand":["claude"]}"#
         let snap = try JSONDecoder().decode(SessionSnapshot.self, from: Data(json.utf8))
         #expect(snap.restoreCommand == nil)
@@ -220,7 +210,7 @@ struct SnapshotRoundTripTests {
         store.setFocusMembership(one.id, member: true)
         store.setFocusEnabled(true) // marking only marks; applying the set is its own step
         let snap = store.snapshot()
-        #expect(snap.focusedWorkspaceIDs == [one.id, three.id]) // written in tree order, not Set order
+        #expect(snap.focusedWorkspaceIDs == [one.id, three.id]) // tree order, never the Set's hash order
         #expect(snap.focusEnabled == true)
         let decoded = try JSONDecoder().decode(Snapshot.self, from: JSONEncoder().encode(snap))
         let restored = makeStore()
@@ -230,8 +220,6 @@ struct SnapshotRoundTripTests {
     }
 
     @Test func disabledFilterRoundTripsKeepingItsMarkedSet() {
-        // the set persists apart from the flag, so a relaunch with the filter off still remembers what
-        // was marked — one flip of the bottom-bar toggle brings the working set back.
         let store = makeStore()
         let work = store.addWorkspace(name: "work")
         _ = store.addWorkspace(name: "personal")
@@ -246,20 +234,18 @@ struct SnapshotRoundTripTests {
     }
 
     @Test func unmarkedStoreOmitsBothFocusKeys() throws {
-        // nothing marked writes neither key, so an unfiltered tree serializes like a legacy snapshot.
+        // an unfiltered tree must serialize byte-identically to a legacy snapshot.
         let store = makeStore()
         _ = store.addWorkspace(name: "work")
         let snap = store.snapshot()
         #expect(snap.focusedWorkspaceIDs == nil && snap.focusEnabled == nil)
         let json = try String(decoding: JSONEncoder().encode(snap), as: UTF8.self)
-        // covers the legacy `focusedWorkspaceID` too — it has no stored property at all now, so nothing
-        // starting with `focusedWorkspace` may appear.
+        // the prefix match also covers the legacy `focusedWorkspaceID` key.
         #expect(!json.contains("focusedWorkspace") && !json.contains("focusEnabled"))
     }
 
     @Test func legacySnapshotWithSingleFocusedWorkspaceDecodesAsAnEnabledSet() throws {
-        // the pre-set release wrote only `focusedWorkspaceID`, whose presence meant the filter was on;
-        // it must migrate to a one-member enabled set instead of decoding as nothing marked.
+        // in the pre-set format the key's mere presence meant the filter was on.
         let ws = UUID()
         let json = #"{"version":1,"workspaces":[],"focusedWorkspaceID":"\#(ws.uuidString)"}"#
         let snap = try JSONDecoder().decode(Snapshot.self, from: Data(json.utf8))
@@ -268,10 +254,8 @@ struct SnapshotRoundTripTests {
     }
 
     @Test func reEncodingAMigratedSnapshotDropsTheLegacyFocusKey() throws {
-        // decode-only means decode-only: a legacy file that rides a load -> mutate -> save path (e.g.
-        // `WindowLibrary.clearClosedWindowFontSizes`) must be rewritten with the SET keys alone. While the
-        // legacy value was kept in a stored property it was re-encoded alongside them, so the file kept a
-        // key this build never means to write.
+        // a legacy file riding a load -> mutate -> save path (e.g. `WindowLibrary.clearClosedWindowFontSizes`)
+        // must be rewritten with the SET keys alone.
         let ws = UUID()
         let json = #"{"version":1,"workspaces":[],"focusedWorkspaceID":"\#(ws.uuidString)"}"#
         let decoded = try JSONDecoder().decode(Snapshot.self, from: Data(json.utf8))
@@ -281,12 +265,12 @@ struct SnapshotRoundTripTests {
         #expect(!reEncoded.contains("\"focusedWorkspaceID\""))
         #expect(reEncoded.contains("\"focusedWorkspaceIDs\"") && reEncoded.contains("\"focusEnabled\""))
         let again = try JSONDecoder().decode(Snapshot.self, from: Data(reEncoded.utf8))
-        #expect(again.focusedWorkspaceIDs == [ws] && again.focusEnabled == true) // the filter survives the rewrite
+        #expect(again.focusedWorkspaceIDs == [ws] && again.focusEnabled == true)
     }
 
     @Test func snapshotWithBothFocusKeysPrefersTheSet() throws {
-        // a file carrying both (a downgrade-then-upgrade round trip) must take the SET: the legacy key
-        // holds at most one member and would silently narrow a multi-workspace filter.
+        // both keys means a downgrade-then-upgrade round trip; the legacy key holds at most one member,
+        // so taking it would silently narrow a multi-workspace filter.
         let a = UUID(), b = UUID(), stale = UUID()
         let json = #"""
         {"version":1,"workspaces":[],"focusedWorkspaceID":"\#(stale.uuidString)",
@@ -298,8 +282,7 @@ struct SnapshotRoundTripTests {
     }
 
     @Test func snapshotWithoutAnyFocusKeyDecodesToNilWithoutThrowing() throws {
-        // neither key present must decode (nil/nil) rather than throwing — a throw here would fail the
-        // whole load and wipe the saved tree over a per-window view filter.
+        // a throw here would wipe the saved tree over a per-window view filter.
         let json = #"{"version":1,"workspaces":[]}"#
         let snap = try JSONDecoder().decode(Snapshot.self, from: Data(json.utf8))
         #expect(snap.focusedWorkspaceIDs == nil && snap.focusEnabled == nil)
@@ -309,8 +292,6 @@ struct SnapshotRoundTripTests {
     }
 
     @Test func sessionSnapshotDecodesWithoutSplitRatio() throws {
-        // a SessionSnapshot persisted before splitRatio existed (the key absent) must decode to nil, not
-        // fail the load — the forward-compat contract the optional field documents.
         let json = "{\"id\":\"\(UUID().uuidString)\",\"cwd\":\"/a\"}"
         let snap = try JSONDecoder().decode(SessionSnapshot.self, from: Data(json.utf8))
         #expect(snap.splitRatio == nil)

--- a/agtermCore/Tests/agtermCoreTests/SoundThrottleTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SoundThrottleTests.swift
@@ -25,7 +25,7 @@ struct SoundThrottleTests {
         var throttle = SoundThrottle(window: .milliseconds(200))
         let t0 = ContinuousClock().now
         let first = throttle.allow("Ping", at: t0)
-        let atBoundary = throttle.allow("Ping", at: t0 + .milliseconds(200)) // >= window plays
+        let atBoundary = throttle.allow("Ping", at: t0 + .milliseconds(200))
         let wellPast = throttle.allow("Ping", at: t0 + .milliseconds(450))
         #expect(first)
         #expect(atBoundary)
@@ -36,9 +36,9 @@ struct SoundThrottleTests {
         var throttle = SoundThrottle(window: .milliseconds(200))
         let t0 = ContinuousClock().now
         let ping = throttle.allow("Ping", at: t0)
-        let hero = throttle.allow("Hero", at: t0 + .milliseconds(10))  // different name, not suppressed
-        let pingAgain = throttle.allow("Ping", at: t0 + .milliseconds(20)) // Ping still inside its window
-        let heroAgain = throttle.allow("Hero", at: t0 + .milliseconds(30)) // Hero now inside its window
+        let hero = throttle.allow("Hero", at: t0 + .milliseconds(10))
+        let pingAgain = throttle.allow("Ping", at: t0 + .milliseconds(20))
+        let heroAgain = throttle.allow("Hero", at: t0 + .milliseconds(30))
         #expect(ping)
         #expect(hero)
         #expect(!pingAgain)
@@ -46,13 +46,13 @@ struct SoundThrottleTests {
     }
 
     @Test func suppressedReplayDoesNotAdvanceTheWindow() {
-        // the window is measured from the last ALLOWED play, not the last attempt — a suppressed call
-        // must not re-stamp, else a steady stream just under the window would never play.
+        // measured from the last ALLOWED play, not the last attempt — else a steady stream just under the
+        // window would never play.
         var throttle = SoundThrottle(window: .milliseconds(200))
         let t0 = ContinuousClock().now
         let first = throttle.allow("Ping", at: t0)
-        let suppressed = throttle.allow("Ping", at: t0 + .milliseconds(150)) // must not re-stamp
-        let atBoundary = throttle.allow("Ping", at: t0 + .milliseconds(200)) // 200ms since ALLOWED play → plays
+        let suppressed = throttle.allow("Ping", at: t0 + .milliseconds(150))
+        let atBoundary = throttle.allow("Ping", at: t0 + .milliseconds(200))
         #expect(first)
         #expect(!suppressed)
         #expect(atBoundary)

--- a/agtermCore/Tests/agtermCoreTests/SurfaceEnvironmentTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SurfaceEnvironmentTests.swift
@@ -88,7 +88,6 @@ struct SurfaceEnvironmentTests {
         )
 
         #expect(env["AGTERM_PANE"] == expected)
-        // pane injection must not disturb the existing identifiers
         #expect(env["AGTERM_ENABLED"] == "1")
         #expect(env["AGTERM_SESSION_ID"] == "11111111-1111-1111-1111-111111111111")
         #expect(env["AGTERM_SOCKET"] == "/tmp/agterm.sock")
@@ -109,7 +108,6 @@ struct SurfaceEnvironmentTests {
         )
 
         #expect(env["AGTERM_PANE"] == nil)
-        // the full identifier set is unchanged when no pane is given
         #expect(env == [
             "AGTERM_ENABLED": "1",
             "AGTERM_SESSION_ID": "11111111-1111-1111-1111-111111111111",
@@ -135,7 +133,6 @@ struct SurfaceEnvironmentTests {
         )
 
         #expect(env["AGTERM_PANE_ID"] == "surface-token-abc")
-        // the token rides alongside the role, not instead of it
         #expect(env["AGTERM_PANE"] == "right")
     }
 

--- a/agtermCore/Tests/agtermCoreTests/TerminalSurfaceTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/TerminalSurfaceTests.swift
@@ -3,11 +3,8 @@ import Testing
 @testable import agtermCore
 
 struct TerminalSurfaceTests {
-    // agterm's natural direction is INVERTED to libghostty's navigate_search string: libghostty's `next`
-    // walks newest→oldest (visually UP) and `previous` walks oldest→newest (visually DOWN), so agterm's
-    // `.next` (down) must emit `navigate_search:previous` and `.previous` (up) must emit
-    // `navigate_search:next`. This pins the corrected mapping so a future "simplify back to rawValue"
-    // re-inverts the chevrons and fails here.
+    // libghostty's `next` walks newest→oldest (visually UP) and `previous` the other way, so agterm's
+    // directions map INVERTED. A "simplify back to rawValue" re-inverts the chevrons and fails here.
     @Test(arguments: [
         (SearchDirection.next, "navigate_search:previous"),
         (SearchDirection.previous, "navigate_search:next"),

--- a/agtermCore/Tests/agtermCoreTests/TerminalZoomTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/TerminalZoomTests.swift
@@ -48,8 +48,7 @@ struct TerminalZoomTests {
         #expect(session.hasSplit == true)
         #expect(TerminalZoomController.isTargetValid(.session(session.id, .split), in: store, quickTerminalVisible: false))
 
-        // the primary exits: the survivor is PROMOTED into the main slot, so no right pane exists
-        // anymore — a zoom on the split target must end, not keep covering the promoted main pane.
+        // the primary exiting PROMOTES the survivor into the main slot, leaving no right pane to zoom.
         session.surface = SpySurface()
         session.splitSurface = SpySurface()
         store.closePrimaryPane(session.id)
@@ -57,7 +56,6 @@ struct TerminalZoomTests {
         #expect(session.splitSurface == nil)
         #expect(!TerminalZoomController.isTargetValid(.session(session.id, .split), in: store, quickTerminalVisible: false))
 
-        // closing a live split clears the target the ordinary way too.
         store.toggleSplit(session.id)
         #expect(TerminalZoomController.isTargetValid(.session(session.id, .split), in: store, quickTerminalVisible: false))
         store.closeSplit(session.id)
@@ -78,8 +76,6 @@ struct TerminalZoomTests {
         session.hasSplit = true
         store.closePrimaryPane(session.id)
 
-        // the survivor MOVES into the primary slot: the primary target keeps pointing at the live
-        // shell (now the survivor), and the split target dies with the vacated right pane.
         #expect(session.surface === survivor)
         #expect(session.splitSurface == nil)
         #expect(session.splitFocused == false)

--- a/agtermCore/Tests/agtermCoreTests/ThemeBrightnessTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ThemeBrightnessTests.swift
@@ -17,35 +17,31 @@ struct ThemeBrightnessTests {
     }
 
     @Test func greenDominatesTheLumaWeighting() {
-        // pure green is the brightest primary under Rec. 601 (0.587) → light
+        // Rec. 601 weights: green 0.587 clears the 0.5 midpoint, red 0.299 and blue 0.114 do not
         #expect(!ThemeBrightness.isDark(red: 0, green: 1, blue: 0))
-        // pure blue is the dimmest (0.114) → dark
         #expect(ThemeBrightness.isDark(red: 0, green: 0, blue: 1))
-        // pure red sits below the 0.5 midpoint (0.299) → dark
         #expect(ThemeBrightness.isDark(red: 1, green: 0, blue: 0))
     }
 
     @Test func grayScaleAroundTheMidpoint() {
-        // a mid gray's luminance equals its component, so it pins the 0.5 threshold: brighter than the
-        // midpoint reads light, dimmer reads dark. (exactly 0.5 is a float-rounding knife edge no real
-        // theme lands on, so it isn't asserted.)
+        // a mid gray's luminance equals its component, so it pins the 0.5 threshold; exactly 0.5 is a
+        // float-rounding knife edge no real theme lands on, so it isn't asserted.
         #expect(!ThemeBrightness.isDark(red: 0.55, green: 0.55, blue: 0.55))
         #expect(ThemeBrightness.isDark(red: 0.45, green: 0.45, blue: 0.45))
     }
 
     @Test func neutralShiftMatchesTheRawClassifier() {
-        // shiftAmount 0 (the neutral tint) applies no wash, so it agrees with the un-shifted classifier.
         #expect(ThemeBrightness.isDark(red: 0.114, green: 0.125, blue: 0.129, shiftAmount: 0))
         #expect(!ThemeBrightness.isDark(red: 0.992, green: 0.965, blue: 0.890, shiftAmount: 0))
     }
 
     @Test func strongTintCrossesTheMidpoint() {
-        // hot dog stand #ea3323 has raw luma ~0.41 → dark, but a full lightening wash (shiftAmount -0.30,
-        // the sidebar-tint slider at its lightest) raises the effective sidebar to ~0.59 → light.
+        // hot dog stand #ea3323, raw luma ~0.41; -0.30 is the sidebar-tint slider at its lightest, which
+        // raises the effective sidebar to ~0.59.
         let (r, g, b) = (0.918, 0.200, 0.137)
-        #expect(ThemeBrightness.isDark(red: r, green: g, blue: b))                       // raw background: dark
-        #expect(!ThemeBrightness.isDark(red: r, green: g, blue: b, shiftAmount: -0.30))  // washed sidebar: light
-        // mirror direction: a light gray (raw ~0.55 → light) with a full darkening wash (+0.30) → ~0.385 → dark.
+        #expect(ThemeBrightness.isDark(red: r, green: g, blue: b))
+        #expect(!ThemeBrightness.isDark(red: r, green: g, blue: b, shiftAmount: -0.30))
+        // mirror direction: +0.30 is the full darkening wash, taking ~0.55 to ~0.385.
         #expect(!ThemeBrightness.isDark(red: 0.55, green: 0.55, blue: 0.55))
         #expect(ThemeBrightness.isDark(red: 0.55, green: 0.55, blue: 0.55, shiftAmount: 0.30))
     }

--- a/agtermCore/Tests/agtermCoreTests/WatermarkConfigTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/WatermarkConfigTests.swift
@@ -22,7 +22,7 @@ struct WatermarkConfigTests {
         #expect(text.contains("background-image-fit = contain\n"))
         #expect(text.contains("background-image-position = center\n"))
         #expect(text.contains("background-image-repeat = false\n"))
-        // no opacity line when unset (ghostty's 1.0 default applies).
+        // unset means no line at all — ghostty's own 1.0 default applies.
         #expect(!text.contains("background-image-opacity"))
     }
 
@@ -43,7 +43,7 @@ struct WatermarkConfigTests {
     }
 
     @Test func missingResolvedPathDropsImageKeysButKeepsZoom() {
-        // a `.text` watermark whose PNG failed to render: no image keys, but zoom is preserved.
+        // a nil resolved path is a `.text` watermark whose PNG failed to render.
         let watermark = BackgroundWatermark(kind: .text, text: "x")
         let text = WatermarkConfig.overlayText(watermark: watermark, resolvedImagePath: nil, fontSize: 14)
         #expect(!text.contains("background-image"))
@@ -51,10 +51,8 @@ struct WatermarkConfigTests {
     }
 
     @Test func overlayDropsImageForControlCharPath() {
-        // defense-in-depth on the restore path: a persisted spec whose path carries a control char (only
-        // reachable by hand-editing workspaces.json) must NOT inject a ghostty key. The image lines are
-        // dropped entirely; the font-size line still emits. fit/position are enums now, so only the path
-        // is free text and needs this guard.
+        // defense-in-depth on the restore path: a control char in the path is only reachable by hand-editing
+        // workspaces.json, and fit/position are enums, so the path is the one free-text field to guard.
         let poisoned = "/tmp/x.png\nclipboard-read = allow"
         let watermark = BackgroundWatermark(kind: .image, imagePath: poisoned)
         let text = WatermarkConfig.overlayText(watermark: watermark, resolvedImagePath: poisoned, fontSize: 14)
@@ -67,13 +65,13 @@ struct WatermarkConfigTests {
         let watermark = BackgroundWatermark(kind: .color, colorHex: "#ff0000")
         let text = WatermarkConfig.overlayText(watermark: watermark, resolvedImagePath: nil, fontSize: nil)
         #expect(text.contains("background = #ff0000\n"))
-        #expect(text.contains("background-opacity = 1\n"))   // default windowOpacity = solid
-        #expect(!text.contains("background-image"))          // a solid color emits no image keys
+        #expect(text.contains("background-opacity = 1\n"))   // the default windowOpacity is solid
+        #expect(!text.contains("background-image"))
     }
 
     @Test func colorOverlayHonorsWindowTranslucency() {
-        // a solid color is drawn at the window translucency (Settings), not a per-call opacity, so the
-        // window blur shows through when translucency is on. font zoom is preserved alongside.
+        // a solid color is drawn at the Settings window translucency, not a per-call opacity, so the window
+        // blur shows through.
         let watermark = BackgroundWatermark(kind: .color, colorHex: "#00ff88")
         let text = WatermarkConfig.overlayText(watermark: watermark, resolvedImagePath: nil, fontSize: 15, windowOpacity: 0.8)
         #expect(text.contains("background = #00ff88\n"))
@@ -82,8 +80,8 @@ struct WatermarkConfigTests {
     }
 
     @Test func colorOverlayClampsWindowOpacity() {
-        // windowOpacity traces back to a persisted, hand-editable AppSettings value, so a bad one must not
-        // emit nan/inf or an out-of-range opacity into the config: >1 clamps to 1, <0 to 0, non-finite to 1.
+        // windowOpacity traces back to a persisted, hand-editable AppSettings value, so nan/inf and
+        // out-of-range values reach this call.
         let watermark = BackgroundWatermark(kind: .color, colorHex: "#ff0000")
         func overlay(_ windowOpacity: Double) -> String {
             WatermarkConfig.overlayText(watermark: watermark, resolvedImagePath: nil, fontSize: nil, windowOpacity: windowOpacity)
@@ -95,8 +93,7 @@ struct WatermarkConfigTests {
     }
 
     @Test func colorOverlayDropsMalformedHex() {
-        // defense-in-depth on the restore path: a persisted `.color` spec with a malformed hex (only
-        // reachable by hand-editing workspaces.json) must NOT emit a `background` line; font-size still emits.
+        // a malformed persisted hex is only reachable by hand-editing workspaces.json.
         let watermark = BackgroundWatermark(kind: .color, colorHex: "not-a-color")
         let text = WatermarkConfig.overlayText(watermark: watermark, resolvedImagePath: nil, fontSize: 14)
         #expect(!text.contains("background ="))
@@ -146,28 +143,26 @@ struct WatermarkConfigTests {
     }
 
     @Test func legacySnapshotWithoutWatermarkDecodes() throws {
-        // a snapshot written before the field existed (no `backgroundWatermark` key) decodes as nil.
         let raw = #"{"id":"\#(UUID().uuidString)","cwd":"/tmp"}"#
         let decoded = try JSONDecoder().decode(SessionSnapshot.self, from: Data(raw.utf8))
         #expect(decoded.backgroundWatermark == nil)
     }
 
     @Test(arguments: [
-        #"{"kind":"text","text":"X","fit":"bogus"}"#,      // unknown fit (e.g. a downgrade / hand-edit typo)
-        #"{"kind":"text","text":"X","position":"middle"}"#, // unknown position
-        #"{"kind":"hologram","text":"X"}"#,                 // unknown kind
+        #"{"kind":"text","text":"X","fit":"bogus"}"#,
+        #"{"kind":"text","text":"X","position":"middle"}"#,
+        #"{"kind":"hologram","text":"X"}"#,
     ])
     func invalidWatermarkDecodesLossilyWithoutWipingTheSession(_ badWatermark: String) throws {
-        // a present-but-invalid watermark must NOT throw DataCorrupted and fail the whole SessionSnapshot
-        // (which would make PersistenceStore.load start fresh and wipe every workspace/session). It drops
-        // to nil while the rest of the session decodes intact.
+        // a DataCorrupted throw would fail the whole SessionSnapshot, making PersistenceStore.load start
+        // fresh and wipe every workspace/session.
         let id = UUID()
         let raw = #"{"id":"\#(id.uuidString)","cwd":"/tmp","customName":"keep","backgroundWatermark":\#(badWatermark)}"#
         let decoded = try JSONDecoder().decode(SessionSnapshot.self, from: Data(raw.utf8))
-        #expect(decoded.id == id)                    // the session survives the bad watermark
+        #expect(decoded.id == id)
         #expect(decoded.cwd == "/tmp")
         #expect(decoded.customName == "keep")
-        #expect(decoded.backgroundWatermark == nil)  // the invalid spec dropped to nil, not a throw
+        #expect(decoded.backgroundWatermark == nil)
     }
 
     @Test(arguments: [0.0, 0.15, 0.5, 1.0])
@@ -194,8 +189,8 @@ struct WatermarkConfigTests {
 
     @Test(arguments: ["/tmp/bg.png", "/Users/me/My Pictures/x.png", "relative/path.png", "/tmp/日本語.png", ""])
     func imagePathWithoutControlCharsAccepted(_ path: String) {
-        // spaces + unicode are fine (the path rides a raw, whole-line-remainder config value); emptiness is
-        // a separate boundary check, so "" passes the control-char gate.
+        // the path rides a raw whole-line-remainder config value, so spaces and unicode are fine; emptiness
+        // is a separate boundary check, so "" passes this gate.
         #expect(WatermarkConfig.isValidImagePath(path))
     }
 

--- a/agtermCore/Tests/agtermCoreTests/WatermarkStorageTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/WatermarkStorageTests.swift
@@ -32,7 +32,7 @@ struct WatermarkStorageTests {
         let stateDir = try makeTempStateDir()
         defer { try? FileManager.default.removeItem(at: stateDir) }
         let dir = WatermarkStorage.directoryURL(stateDir: stateDir)
-        #expect(!FileManager.default.fileExists(atPath: dir.path)) // pure path resolution, no side effect
+        #expect(!FileManager.default.fileExists(atPath: dir.path))
         let ensured = WatermarkStorage.ensureDirectory(stateDir: stateDir)
         #expect(ensured == dir)
         var isDir: ObjCBool = false
@@ -44,7 +44,6 @@ struct WatermarkStorageTests {
         let stateDir = try makeTempStateDir()
         defer { try? FileManager.default.removeItem(at: stateDir) }
         let id = UUID()
-        // no-op when absent (must not throw)
         WatermarkStorage.removeRenderedText(sessionID: id, stateDir: stateDir)
 
         WatermarkStorage.ensureDirectory(stateDir: stateDir)

--- a/agtermCore/Tests/agtermCoreTests/WindowGeometryTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/WindowGeometryTests.swift
@@ -45,8 +45,8 @@ struct WindowGeometryTests {
     }
 
     @Test func clampSizeWithMinGreaterThanMaxReturnsMax() {
-        // degenerate range (a window minSize larger than the visible frame): the documented `lo > hi`
-        // branch makes the upper bound (max) win in each dimension.
+        // degenerate range (a window minSize larger than the visible frame): the `lo > hi` branch makes
+        // the upper bound win in each dimension.
         let result = WindowGeometry.clampSize(WindowGeometry.Size(width: 2000, height: 1500),
                                               min: WindowGeometry.Size(width: 1200, height: 900),
                                               max: WindowGeometry.Size(width: 800, height: 600))
@@ -64,7 +64,6 @@ struct WindowGeometryTests {
         let result = WindowGeometry.clampOrigin(WindowGeometry.Point(x: 5000, y: 100),
                                                 windowSize: WindowGeometry.Size(width: 800, height: 600),
                                                 displayFrame: display())
-        // maxX = 1920 - margin; y stays in range and is unchanged.
         expectPoint(result, 1920 - WindowGeometry.visibleMargin, 100)
     }
 
@@ -73,7 +72,6 @@ struct WindowGeometryTests {
         let result = WindowGeometry.clampOrigin(WindowGeometry.Point(x: -5000, y: -5000),
                                                 windowSize: WindowGeometry.Size(width: 800, height: 600),
                                                 displayFrame: display())
-        // minX = margin - width; minY = margin - height.
         expectPoint(result, WindowGeometry.visibleMargin - 800, WindowGeometry.visibleMargin - 600)
     }
 
@@ -82,7 +80,6 @@ struct WindowGeometryTests {
         let result = WindowGeometry.clampOrigin(WindowGeometry.Point(x: 100, y: 5000),
                                                 windowSize: WindowGeometry.Size(width: 800, height: 600),
                                                 displayFrame: display())
-        // maxY = 1080 - margin; x stays in range and is unchanged.
         expectPoint(result, 100, 1080 - WindowGeometry.visibleMargin)
     }
 

--- a/agtermCore/Tests/agtermCoreTests/WindowLibraryTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/WindowLibraryTests.swift
@@ -52,13 +52,13 @@ final class WindowLibraryTests {
         #expect(library.windowName(for: library.windows[0].id) == "window 1")
         let work = library.newWindow(name: "work")
         #expect(library.windowName(for: work.id) == "work")
-        #expect(library.windowName(for: nil) == "")       // nil id -> empty (the command-context default)
-        #expect(library.windowName(for: UUID()) == "")    // unknown id -> empty
+        #expect(library.windowName(for: nil) == "")
+        #expect(library.windowName(for: UUID()) == "")
     }
 
     @Test func allOpenSessionsFlattensEverySessionAcrossWindows() {
         let library = WindowLibrary(directory: directory)
-        #expect(library.allOpenSessions().count == 1) // the seeded window's one session
+        #expect(library.allOpenSessions().count == 1)
         let second = library.newWindow(name: "work")
         let store = try! #require(library.store(for: second.id))
         _ = store.addSession(toWorkspace: store.workspaces[0].id, cwd: "/tmp")
@@ -68,7 +68,7 @@ final class WindowLibraryTests {
 
     @Test func totalUnseenCountSumsEverySessionAcrossWindows() {
         let library = WindowLibrary(directory: directory)
-        #expect(library.totalUnseenCount == 0) // a fresh tree has nothing unseen
+        #expect(library.totalUnseenCount == 0)
         let firstStore = try! #require(library.store(for: library.windows[0].id))
         firstStore.workspaces[0].sessions[0].unseenCount = 2
         let second = library.newWindow(name: "work")
@@ -78,7 +78,6 @@ final class WindowLibraryTests {
         extra.unseenCount = 5
         // 2 (window 1) + 3 + 5 (work) = 10 across both open windows.
         #expect(library.totalUnseenCount == 10)
-        // closing a window drops its sessions from the roll-up.
         library.closeWindow(second.id)
         #expect(library.totalUnseenCount == 2)
     }
@@ -263,11 +262,10 @@ final class WindowLibraryTests {
     }
 
     @Test func windowInfoDistinguishesAutoFromCustomNames() {
-        // auto-assigned "window N" → not custom (omitted from the title bar)
+        // auto "window N" names are omitted from the title bar
         #expect(WindowInfo(name: "window 1").hasCustomName == false)
         #expect(WindowInfo(name: "window 12").hasCustomName == false)
         #expect(WindowInfo.isAutoName("window 1"))
-        // user-set names → custom
         #expect(WindowInfo(name: "work").hasCustomName)
         #expect(WindowInfo(name: "window").hasCustomName)        // no number
         #expect(WindowInfo(name: "window 0").hasCustomName)      // number must be >= 1
@@ -309,7 +307,6 @@ final class WindowLibraryTests {
         #expect(library.store(for: second)?.sidebarVisible == false)
         #expect(library.store(for: third)?.sidebarVisible == true)
 
-        // re-focus the first window and re-apply — only the new frontmost keeps its sidebar.
         library.frontmostWindowID = first
         library.applyInactiveWindowSidebarHiding()
         #expect(library.store(for: first)?.sidebarVisible == true)
@@ -327,11 +324,10 @@ final class WindowLibraryTests {
 
     @Test func applyInactiveWindowSidebarHidingReshowsManuallyHiddenFrontmost() {
         let library = WindowLibrary(directory: directory)
-        _ = library.newWindow(name: "work") // second window, now frontmost
+        _ = library.newWindow(name: "work")
         let front = library.activeWindowID
-        library.store(for: front)?.setSidebarVisible(false) // user hid the active window's sidebar
+        library.store(for: front)?.setSidebarVisible(false)
         library.applyInactiveWindowSidebarHiding()
-        // absolute rule: the frontmost window always shows its sidebar, overriding the manual hide.
         #expect(library.store(for: front)?.sidebarVisible == true)
     }
 
@@ -340,8 +336,6 @@ final class WindowLibraryTests {
         let first = library.windows[0]
         let second = library.newWindow(name: "work")
 
-        // the second window has auto-follow enabled (30s) and its sidebar hidden; the first leaves
-        // auto-follow off (nil autoFollowMs) with the sidebar visible (the default).
         library.store(for: second.id)?.autoFollowTimeout = 30
         library.store(for: second.id)?.setSidebarVisible(false)
 
@@ -361,8 +355,8 @@ final class WindowLibraryTests {
         let frame = ControlWindowFrame(x: 10, y: 20, width: 800, height: 600, display: 0)
         let nodes = library.controlWindowNodes(geometry: { $0 == second.id ? frame : nil })
         #expect(nodes[0].id == first.id.uuidString)
-        #expect(nodes[0].geometry == nil)   // no frame supplied for the first window
-        #expect(nodes[1].geometry == frame) // the closure's frame rides the second node
+        #expect(nodes[0].geometry == nil)
+        #expect(nodes[1].geometry == frame)
         // the default (no closure) omits geometry entirely — the host-free / non-AppKit path.
         #expect(library.controlWindowNodes().allSatisfy { $0.geometry == nil })
     }
@@ -371,18 +365,16 @@ final class WindowLibraryTests {
         let library = WindowLibrary(directory: directory)
         let first = library.windows[0]
         let second = library.newWindow(name: "work")
-        // the app-side flags closure supplies each window's live fullscreen/zoom/minimized state.
         let nodes = library.controlWindowNodes(flags: {
             $0 == second.id ? (fullscreen: true, zoomed: false, minimized: true) : nil
         })
         #expect(nodes[0].id == first.id.uuidString)
-        #expect(nodes[0].fullscreen == nil) // no flags supplied for the first window
+        #expect(nodes[0].fullscreen == nil)
         #expect(nodes[0].zoomed == nil)
         #expect(nodes[0].minimized == nil)
-        #expect(nodes[1].fullscreen == true) // the closure's flags ride the second node
+        #expect(nodes[1].fullscreen == true)
         #expect(nodes[1].zoomed == false)
         #expect(nodes[1].minimized == true)
-        // the default (no closure) omits all three — the host-free / non-AppKit path.
         #expect(library.controlWindowNodes().allSatisfy {
             $0.fullscreen == nil && $0.zoomed == nil && $0.minimized == nil
         })
@@ -499,12 +491,9 @@ final class WindowLibraryTests {
     }
 
     @Test func removeWindowCancelsPendingSaveSoFileStaysDeleted() throws {
-        // a debounced save scheduled just before delete must NOT re-create the per-window file after
-        // removeWindow deletes it. removeWindow cancels the store's pending save first, so even holding
-        // the store reference (keeping it alive past the drop, as the real-world willClose closure does)
-        // leaves no scheduled write to resurrect windows/<id>.json. The async timer can't fire in
-        // synchronous test code, so the assertion is the deterministic observable contract: the file is
-        // gone and stays gone.
+        // a debounced save scheduled just before delete must NOT re-create the per-window file;
+        // removeWindow cancels the store's pending save first. The async timer can't fire in
+        // synchronous test code, so the assertion is the file being gone and staying gone.
         let library = WindowLibrary(directory: directory)
         let extra = library.newWindow(name: "extra")
         let store = try #require(library.store(for: extra.id)) // hold a strong ref past the store drop
@@ -519,9 +508,8 @@ final class WindowLibraryTests {
 
     @Test func removeWindowSweepsRenderedTextPNGsOfAClosedWindow() throws {
         // deleting a CLOSED window (no live store) must still sweep its sessions' rendered `.text`
-        // watermark PNGs — `removeWindow` reads the session ids from the persisted snapshot, not the
-        // (absent) store. The state-dir root is the test `directory` (WindowLibrary + WatermarkStorage
-        // resolve against the same root), so the PNGs land where the sweep looks, no env mutation.
+        // watermark PNGs — `removeWindow` reads the session ids from the persisted snapshot. The
+        // state-dir root is the test `directory`, so the PNGs land where the sweep looks.
         let closed = UUID(), kept = UUID()
         let doomedSession = UUID(), keptSession = UUID()
         try writeWindowFile(closed, Snapshot(workspaces: [WorkspaceSnapshot(
@@ -544,13 +532,13 @@ final class WindowLibraryTests {
         #expect(!library.isOpen(closed)) // precondition: the target window is closed (no store to sweep from)
         library.removeWindow(closed)
 
-        #expect(!FileManager.default.fileExists(atPath: doomedPNG.path)) // deleted window's PNG swept
-        #expect(FileManager.default.fileExists(atPath: keptPNG.path))    // surviving window's PNG untouched
+        #expect(!FileManager.default.fileExists(atPath: doomedPNG.path))
+        #expect(FileManager.default.fileExists(atPath: keptPNG.path))
     }
 
     @Test func removeWindowSweepsRenderedTextPNGsOfAnOpenWindow() throws {
         // the OPEN-window path reads session ids from the live store; it must sweep into the same
-        // state-dir root (the test `directory`) so a deleted open window's PNGs go too.
+        // state-dir root (the test `directory`).
         let library = WindowLibrary(directory: directory)
         let extra = library.newWindow(name: "extra")
         let store = try #require(library.store(for: extra.id))
@@ -658,12 +646,9 @@ final class WindowLibraryTests {
         let extra = library.newWindow(name: "extra")
         let store = try #require(library.store(for: extra.id))
         let session = try #require(store.workspaces.first?.sessions.first)
-        // a session in an open window is found.
         #expect(library.store(forSession: session.id) === store)
-        // an unknown id misses.
         #expect(library.store(forSession: UUID()) == nil)
         #expect(library.windowID(forSession: UUID()) == nil)
-        // once the window closes, its sessions are no longer searchable.
         library.closeWindow(extra.id)
         #expect(library.store(forSession: session.id) == nil)
         #expect(library.windowID(forSession: session.id) == nil)
@@ -679,9 +664,7 @@ final class WindowLibraryTests {
         // two open windows → SwiftUI auto-opens one, so one extra openWindow() call is needed.
         #expect(library.consumeReopen() == 1)
         #expect(library.hasReopened)
-        // a second call (another window's .task) is a no-op.
         #expect(library.consumeReopen() == 0)
-        // the claim queue is launch window (frontmost a) first, then b.
         #expect(library.claimNextWindowID() == a)
         #expect(library.claimNextWindowID() == b)
         // drained → nil (an extra restored window dismisses itself).
@@ -704,10 +687,7 @@ final class WindowLibraryTests {
         let a = library.windows[0].id
         let b = library.newWindow(name: "b").id
         library.frontmostWindowID = a
-        // launch window's .onAppear runs first: queue empty + not reopened → adopt the launch id (a).
         #expect(library.adoptLaunchWindowID() == a)
-        // now the scene .task runs: still one extra openWindow() needed (N-1 = 1), but the queue must
-        // NOT re-offer a — only b remains for the reopened window.
         #expect(library.consumeReopen() == 1)
         #expect(library.claimNextWindowID() == b)
         #expect(library.claimNextWindowID() == nil)
@@ -725,9 +705,7 @@ final class WindowLibraryTests {
 
     // the persisted frontmost may point at a CLOSED window (quit with a closed window frontmost, two
     // others open). `launchWindowID` must fall through to an OPEN id, so `consumeReopen` seeds the
-    // whole open set and returns open.count - 1 — every open window gets claimed, none binds the
-    // closed store. Pre-fix `launchWindowID` returned the closed frontmost unconditionally, seeding a
-    // 3-entry queue but returning 1, so the last open window never reopened (off-by-two).
+    // whole open set and returns open.count - 1 — none binds the closed store.
     @Test func consumeReopenSeedsAllOpenWhenFrontmostIsClosed() throws {
         let x = UUID()
         let y = UUID()
@@ -735,7 +713,6 @@ final class WindowLibraryTests {
         try writeWindowFile(x, Snapshot(workspaces: [WorkspaceSnapshot(id: UUID(), name: "x", sessions: [])]))
         try writeWindowFile(y, Snapshot(workspaces: [WorkspaceSnapshot(id: UUID(), name: "y", sessions: [])]))
         try writeWindowFile(z, Snapshot(workspaces: [WorkspaceSnapshot(id: UUID(), name: "z", sessions: [])]))
-        // frontmost z is CLOSED; x and y are open.
         try writeIndex(WindowsIndex(frontmost: z, windows: [
             WindowEntry(id: x, name: "x", isOpen: true),
             WindowEntry(id: y, name: "y", isOpen: true),
@@ -744,15 +721,12 @@ final class WindowLibraryTests {
         let library = WindowLibrary(directory: directory)
         #expect(Set(library.openIDs()) == Set([x, y]))
         #expect(library.frontmostWindowID == z)
-        // two open windows → SwiftUI auto-opens one, one extra openWindow() for the other.
         #expect(library.consumeReopen() == 1)
-        // the launch window claims an OPEN id (not the closed frontmost z), the reopened window the other.
         let launchID = try #require(library.claimNextWindowID())
         let reopenedID = try #require(library.claimNextWindowID())
         #expect(launchID != z)
         #expect(reopenedID != z)
         #expect(Set([launchID, reopenedID]) == Set([x, y]))
-        // queue exactly covers the open set — no stray, no undercount.
         #expect(library.claimNextWindowID() == nil)
     }
 
@@ -779,13 +753,11 @@ final class WindowLibraryTests {
         library.closeWindow(extra)
         _ = library.consumeReopen()
         _ = library.claimNextWindowID() // drain the launch id so the queue starts empty.
-        // three rapid opens of the same closed window before any claim is consumed enqueue it once.
         library.enqueueClaim(extra)
         library.enqueueClaim(extra)
         library.enqueueClaim(extra)
         #expect(library.claimNextWindowID() == extra)
         #expect(library.claimNextWindowID() == nil)
-        // once the first claim is consumed, a fresh enqueue of the same id is queued again.
         library.enqueueClaim(extra)
         #expect(library.claimNextWindowID() == extra)
         #expect(library.claimNextWindowID() == nil)
@@ -800,7 +772,7 @@ final class WindowLibraryTests {
         _ = library.consumeReopen()
         _ = library.claimNextWindowID() // drain the launch id so the queue starts empty.
         let info = library.newWindow(name: "fresh") // pre-loads stores[info.id].
-        #expect(library.isOpen(info.id)) // store is loaded, as the app does before enqueueing.
+        #expect(library.isOpen(info.id))
         library.enqueueClaim(info.id)
         #expect(library.claimNextWindowID() == info.id)
         #expect(library.claimNextWindowID() == nil)
@@ -813,7 +785,6 @@ final class WindowLibraryTests {
         let library = WindowLibrary(directory: directory)
         let only = library.windows[0].id
         #expect(library.adoptLaunchWindowID() == only)
-        // a second caller before consumeReopen gets nil (not the same id again).
         #expect(library.adoptLaunchWindowID() == nil)
     }
 
@@ -836,7 +807,6 @@ final class WindowLibraryTests {
         let first = try #require(library.store(for: library.windows[0].id))
         library.newWindow(name: "extra")
         library.frontmostWindowID = nil
-        // with no frontmost set, the first open window's store is used.
         #expect(library.activeStore === first)
     }
 
@@ -845,7 +815,6 @@ final class WindowLibraryTests {
         let a = library.windows[0]
         let b = library.newWindow(name: "b")
         let storeA = try #require(library.store(for: a.id))
-        // frontmost points at b, then b closes → fall back to the first open store (a).
         library.frontmostWindowID = b.id
         library.closeWindow(b.id)
         #expect(library.activeStore === storeA)
@@ -857,10 +826,8 @@ final class WindowLibraryTests {
         let b = library.newWindow(name: "b")
         library.frontmostWindowID = b.id
         #expect(library.activeWindowID == b.id)
-        // closing the frontmost falls back to the first open window.
         library.closeWindow(b.id)
         #expect(library.activeWindowID == a.id)
-        // an unset frontmost also falls back to the first open window.
         library.frontmostWindowID = nil
         #expect(library.activeWindowID == a.id)
     }
@@ -877,7 +844,6 @@ final class WindowLibraryTests {
         #expect(reloaded.windows.map(\.name) == ["window 1", "personal"])
         #expect(reloaded.windows.map(\.id) == [library.windows[0].id, extra.id])
         #expect(reloaded.frontmostWindowID == extra.id)
-        // both were open at save → both reopen.
         #expect(Set(reloaded.openIDs()) == Set([library.windows[0].id, extra.id]))
     }
 
@@ -936,7 +902,6 @@ final class WindowLibraryTests {
         try writeWindowFile(a, Snapshot(workspaces: [WorkspaceSnapshot(id: UUID(), name: "ws", sessions: [])]))
         try writeIndex(WindowsIndex(frontmost: stale, windows: [WindowEntry(id: a, name: "a", isOpen: false)]))
         let library = WindowLibrary(directory: directory)
-        // never windowless: the stale frontmost is ignored, the first (only) window opens.
         #expect(library.openIDs() == [a])
     }
 
@@ -959,7 +924,6 @@ final class WindowLibraryTests {
         let store = try #require(library.store(for: library.windows[0].id))
         #expect(store.workspaces.map(\.name) == ["legacy"])
         #expect(store.workspaces[0].sessions[0].displayName == "build")
-        // migration wrote a per-window file and the index.
         #expect(FileManager.default.fileExists(atPath: windowFileURL(library.windows[0].id).path))
         #expect(FileManager.default.fileExists(atPath: indexURL.path))
         // the legacy file is left in place.
@@ -999,7 +963,6 @@ final class WindowLibraryTests {
     @Test func emptyLegacyFileSeedsInsteadOfMigrating() throws {
         try PersistenceStore(directory: directory).save(Snapshot())
         let library = WindowLibrary(directory: directory)
-        // empty legacy tree → seed a fresh default window, not an empty migrated one.
         #expect(library.windows.count == 1)
         let store = try #require(library.store(for: library.windows[0].id))
         #expect(store.workspaces[0].name == "workspace 1")
@@ -1007,7 +970,6 @@ final class WindowLibraryTests {
     }
 
     @Test func existingIndexIgnoresLegacy() throws {
-        // legacy present AND a valid index → the index wins, legacy ignored.
         try PersistenceStore(directory: directory).save(Snapshot(workspaces: [
             WorkspaceSnapshot(id: UUID(), name: "legacy", sessions: []),
         ]))
@@ -1026,7 +988,6 @@ final class WindowLibraryTests {
     @Test func corruptIndexFallsBackToSeed() throws {
         try Data("{ not valid json ]".utf8).write(to: indexURL)
         let library = WindowLibrary(directory: directory)
-        // no legacy → seed one default window.
         #expect(library.windows.count == 1)
         #expect(library.windows[0].name == "window 1")
         let store = try #require(library.store(for: library.windows[0].id))
@@ -1039,7 +1000,6 @@ final class WindowLibraryTests {
             WorkspaceSnapshot(id: UUID(), name: "legacy", sessions: []),
         ]))
         let library = WindowLibrary(directory: directory)
-        // corrupt index treated as absent → migrate from legacy.
         let store = try #require(library.store(for: library.windows[0].id))
         #expect(store.workspaces.map(\.name) == ["legacy"])
     }
@@ -1049,7 +1009,6 @@ final class WindowLibraryTests {
         future.version = WindowsIndex.currentVersion + 1
         try writeIndex(future)
         let library = WindowLibrary(directory: directory)
-        // mismatched version → seeded default, not the future entry.
         #expect(library.windows.map(\.name) == ["window 1"])
     }
 
@@ -1066,7 +1025,6 @@ final class WindowLibraryTests {
         let library = WindowLibrary(directory: directory)
         #expect(library.windows.map(\.name) == ["orphan"])
         let store = try #require(library.store(for: id))
-        // a missing per-window file opens an empty tree (no crash, no abort).
         #expect(store.workspaces.isEmpty)
         #expect(library.isOpen(id))
     }
@@ -1103,12 +1061,10 @@ final class WindowLibraryTests {
         try Data("{ not valid json ]".utf8).write(to: indexURL)
 
         let library = WindowLibrary(directory: directory)
-        // both windows recovered and open, with auto-assigned default names.
         #expect(library.windows.count == 2)
         #expect(Set(library.windows.map(\.id)) == Set([aID, bID]))
         #expect(Set(library.openIDs()) == Set([aID, bID]))
         #expect(library.windows.allSatisfy { WindowInfo.isAutoName($0.name) })
-        // sessions from the per-window snapshots survived intact.
         let storeA = try #require(library.store(for: aID))
         let storeB = try #require(library.store(for: bID))
         #expect(storeA.workspaces.map(\.name) == ["alpha"])
@@ -1122,7 +1078,6 @@ final class WindowLibraryTests {
         #expect(Set(reloaded.windows.map(\.id)) == Set([aID, bID]))
     }
 
-    // a version-mismatched index is treated as absent too — the surviving per-window files recover.
     @Test func versionMismatchIndexRecoversOrphanedPerWindowFiles() throws {
         let id = UUID()
         let sessionID = UUID()
@@ -1136,7 +1091,6 @@ final class WindowLibraryTests {
         try writeIndex(future)
 
         let library = WindowLibrary(directory: directory)
-        // the mismatched index is ignored; the orphan file recovers (not the "future" entry, not a seed).
         #expect(library.windows.map(\.id) == [id])
         #expect(library.windows[0].name == "window 1")
         let store = try #require(library.store(for: id))
@@ -1148,7 +1102,6 @@ final class WindowLibraryTests {
     // legacy file, bootstrap still falls through to legacy migration (one "window 1").
     @Test func noOrphanFilesFallsThroughToLegacyMigration() throws {
         try Data("garbage".utf8).write(to: indexURL)
-        // a stray non-UUID file in the windows dir must NOT be mistaken for a recoverable window.
         try FileManager.default.createDirectory(at: directory.appendingPathComponent("windows"),
                                                 withIntermediateDirectories: true)
         try Data("noise".utf8).write(to: directory.appendingPathComponent("windows").appendingPathComponent("notes.json"))
@@ -1157,7 +1110,6 @@ final class WindowLibraryTests {
         ]))
 
         let library = WindowLibrary(directory: directory)
-        // no recoverable per-window files → legacy migration, one default-named window.
         #expect(library.windows.count == 1)
         #expect(library.windows[0].name == "window 1")
         let store = try #require(library.store(for: library.windows[0].id))
@@ -1180,7 +1132,6 @@ final class WindowLibraryTests {
     // overrides must be cleared in CLOSED windows too — else a closed window reopens later overriding
     // the new default. The open window clears live; the closed one's snapshot file is rewritten.
     @Test func resetSessionFontSizesAllWindowsClearsClosedAndOpen() throws {
-        // a closed window whose persisted session carries a font-size override.
         let closedID = UUID()
         let closedSession = UUID()
         try writeWindowFile(closedID, Snapshot(workspaces: [
@@ -1188,7 +1139,6 @@ final class WindowLibraryTests {
                 SessionSnapshot(id: closedSession, customName: nil, cwd: "/tmp", fontSize: 18),
             ]),
         ]))
-        // an open window whose live session also carries an override.
         let openID = UUID()
         try writeWindowFile(openID, Snapshot(workspaces: [WorkspaceSnapshot(id: UUID(), name: "ws", sessions: [])]))
         try writeIndex(WindowsIndex(frontmost: openID, windows: [
@@ -1205,9 +1155,7 @@ final class WindowLibraryTests {
 
         library.resetSessionFontSizesAllWindows()
 
-        // open window: live override cleared.
         #expect(openStore.session(withID: openSession.id)?.fontSize == nil)
-        // closed window: its snapshot file rewritten with the override stripped.
         let reloaded = PersistenceStore(directory: directory.appendingPathComponent("windows"),
                                         fileName: "\(closedID.uuidString).json").load()
         #expect(reloaded.workspaces.first?.sessions.first?.fontSize == nil)
@@ -1219,11 +1167,10 @@ final class WindowLibraryTests {
 
     @Test func openCountsSumsOpenWindowsAndSessions() throws {
         let library = WindowLibrary(directory: directory)
-        // the seeded window already has one workspace + one session; add a second session to it.
+        // the seeded window already has one workspace + one session.
         let firstStore = try #require(library.store(for: library.windows[0].id))
         let firstWs = try #require(firstStore.workspaces.first)
         _ = try #require(firstStore.addSession(toWorkspace: firstWs.id, cwd: "/tmp"))
-        // a second open window seeds one more session.
         _ = library.newWindow(name: "work")
         let counts = library.openCounts()
         #expect(counts.windows == 2)
@@ -1249,11 +1196,9 @@ final class WindowLibraryTests {
         let session = try #require(store.workspaces.first?.sessions.first)
         // simulate a live cwd change that AppStore doesn't auto-persist.
         session.currentCwd = "/changed"
-        // add another open window too.
         library.newWindow(name: "extra")
         library.saveAllOpen()
 
-        // the cwd change is now on disk for the first window.
         let reloaded = WindowLibrary(directory: directory)
         let reloadedStore = try #require(reloaded.store(for: reloaded.windows[0].id))
         let reloadedSession = try #require(reloadedStore.session(withID: session.id))

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -60,7 +60,6 @@ struct CommandsTests {
     }
 
     @Test func workspaceMoveRequiresToFails() {
-        // --to has no default, so omitting it must fail to parse (the direction is validated server-side).
         #expect(throws: (any Error).self) { try Agtermctl.parseAsRoot(["workspace", "move"]) }
     }
 
@@ -79,16 +78,13 @@ struct CommandsTests {
     }
 
     @Test func workspaceFocusRejectsBadMode() {
-        // rejected by validate() before any request is built; pin the exact allCases-derived message so an
-        // unrelated parse failure can't pass for it.
+        // pin the exact allCases-derived message so an unrelated parse failure can't pass for it.
         #expect(validationMessage(["workspace", "focus", "sideways"]) == "mode must be one of: on, off, toggle, add")
     }
 
     @Test func workspaceFocusHelpListsEveryModeAndWhatItDoesToTheFilter() {
-        // the abstract AND the argument's per-mode prose are both built from allCases, so `--help` can't go
-        // stale when a mode is added. Asserting the raw values alone was NOT enough — the abstract carries
-        // those on its own, so a hand-written argument help could rot undetected; assert each mode's whole
-        // clause (which names its effect on the filter flag) survives into the rendered help.
+        // the abstract lists the raw values on its own, so asserting those alone would pass over a rotted
+        // hand-written argument help — assert each mode's whole clause instead.
         let help = Workspace.Focus.helpMessage(columns: 400)
         for mode in ControlWorkspaceFocusMode.allCases {
             #expect(help.contains(mode.rawValue), "workspace focus help should list \(mode.rawValue), got: \(help)")
@@ -119,8 +115,7 @@ struct CommandsTests {
     }
 
     @Test func workspaceFilterTakesNoTarget() {
-        // window-scoped: it flips the whole window's filter, so a --target would imply it acts on one
-        // workspace. Carrying only ClientOptions is what makes the flag unknown here.
+        // carrying only ClientOptions is what makes --target unknown here.
         #expect(throws: (any Error).self) { try Agtermctl.parseAsRoot(["workspace", "filter", "on", "--target", "9f3c"]) }
     }
 
@@ -153,36 +148,30 @@ struct CommandsTests {
     }
 
     @Test func sessionNewWithCreateWorkspace() throws {
-        // --create-workspace sets createWorkspace=true on the wire (omitted when the flag is absent).
         let expected = ControlRequest(cmd: .sessionNew, args: ControlArgs(workspaceName: "servers", createWorkspace: true))
         #expect(try request(["session", "new", "--workspace-name", "servers", "--create-workspace"]) == expected)
     }
 
     @Test func sessionNewWithNoSelect() throws {
-        // --no-select sets noSelect=true on the wire (omitted when the flag is absent).
         let expected = ControlRequest(cmd: .sessionNew, args: ControlArgs(noSelect: true))
         #expect(try request(["session", "new", "--no-select"]) == expected)
     }
 
     @Test func sessionNewWithCommandWait() throws {
-        // --wait rides with --command to hold the session open after the command exits (omitted otherwise).
         let expected = ControlRequest(cmd: .sessionNew, args: ControlArgs(command: "make test", wait: true))
         #expect(try request(["session", "new", "--command", "make test", "--wait"]) == expected)
     }
 
     @Test func sessionNewRejectsWaitWithoutCommand() {
-        // --wait holds a command surface, so it is meaningless without --command — validate() rejects it.
         #expect(validationMessage(["session", "new", "--wait"]) == "--wait requires --command")
     }
 
     @Test func sessionNewRejectsWorkspaceAndWorkspaceName() {
-        // both addressing modes set — validate() rejects it before any request is built.
         #expect(validationMessage(["session", "new", "--workspace", "active", "--workspace-name", "servers"])
             == "use either --workspace or --workspace-name, not both")
     }
 
     @Test func sessionNewRequiresWorkspaceNameForCreateWorkspace() {
-        // --create-workspace with no --workspace-name has nothing to create by id — validate() rejects it.
         #expect(validationMessage(["session", "new", "--create-workspace"]) == "--create-workspace requires --workspace-name")
     }
 
@@ -202,7 +191,6 @@ struct CommandsTests {
     }
 
     @Test func sessionNewRejectsAfterAndWorkspace() {
-        // the anchor sid already names the workspace, so placement can't also address one.
         #expect(validationMessage(["session", "new", "--after", "a", "--workspace", "ws1"])
             == "session.new takes --after/--before or a workspace, not both")
     }
@@ -218,7 +206,6 @@ struct CommandsTests {
     }
 
     @Test func sessionDuplicateDefaultsToActive() throws {
-        // no options at all: the target defaults to `active`, which names its own workspace and cwd.
         let expected = ControlRequest(cmd: .sessionDuplicate, target: "active")
         #expect(try request(["session", "duplicate"]) == expected)
     }
@@ -267,12 +254,10 @@ struct CommandsTests {
     }
 
     @Test func sessionMoveRequiresWorkspaceOrTo() {
-        // no placement intent at all — validate() rejects it with a usage message naming all three forms.
         #expect(validationMessage(["session", "move"]) == "provide a destination workspace, --to, or --after/--before")
     }
 
     @Test func sessionMoveRejectsWorkspaceAndTo() {
-        // both the workspace positional and --to are set — validate() rejects it with a usage message.
         #expect(validationMessage(["session", "move", "ws2", "--to", "up"]) == "provide a destination workspace or --to, not both")
     }
 
@@ -308,7 +293,6 @@ struct CommandsTests {
     }
 
     @Test func sessionMoveRejectsAfterAndWorkspace() {
-        // the anchor already names the workspace, so it can't also take a destination workspace.
         #expect(validationMessage(["session", "move", "ws2", "--after", "a"])
             == "session.move takes --after/--before or a workspace, not both")
     }
@@ -343,8 +327,8 @@ struct CommandsTests {
     }
 
     @Test func sessionTypeWithPaneLeft() throws {
-        // explicit --pane left is forwarded as "left"; the server treats nil and "left" identically (both
-        // the main pane), but the CLI still passes the value through rather than dropping it.
+        // the server treats nil and "left" identically, but the CLI passes the value through rather than
+        // dropping it.
         let req = try request(["session", "type", "ls\n", "--pane", "left"])
         #expect(req.args?.pane == "left")
     }
@@ -355,7 +339,7 @@ struct CommandsTests {
     }
 
     @Test func sessionTypeRejectsBadPane() {
-        // `other` is a session.focus mode, not a typable pane — type accepts left|right|scratch only.
+        // `other` is a session.focus mode, not a typable pane.
         #expect(validationMessage(["session", "type", "x", "--pane", "other"]) == "--pane must be left, right, or scratch")
     }
 
@@ -405,14 +389,13 @@ struct CommandsTests {
     }
 
     @Test func sessionResizeRequiresExactlyOneForm() {
-        // neither form set, and two forms set — validate() rejects both with the same usage message.
         #expect(validationMessage(["session", "resize"])?.contains("exactly one") == true)
         #expect(validationMessage(["session", "resize", "--split-ratio", "0.7", "--grow-left", "0.1"])?
             .contains("exactly one") == true)
     }
 
     @Test func sessionResizeRejectsNonFinite() {
-        // nan/inf parse as Double but can't JSON-encode; validate() rejects them with a clean usage error.
+        // nan/inf parse as Double but can't JSON-encode, so validate() rejects them.
         #expect(validationMessage(["session", "resize", "--split-ratio", "nan"])?.contains("finite") == true)
         #expect(validationMessage(["session", "resize", "--grow-left", "inf"])?.contains("finite") == true)
         #expect(validationMessage(["session", "resize", "--split-ratio", "1e999"])?.contains("finite") == true)
@@ -434,7 +417,6 @@ struct CommandsTests {
     }
 
     @Test func sessionGoRequiresToFails() {
-        // --to has no default, so omitting it must fail to parse (the direction is validated server-side).
         #expect(throws: (any Error).self) { try Agtermctl.parseAsRoot(["session", "go"]) }
     }
 
@@ -473,7 +455,6 @@ struct CommandsTests {
     }
 
     @Test func sessionTextDefaultsActive() throws {
-        // bare `session text` reads the visible screen of the focused pane (no args beyond the base bag).
         #expect(try request(["session", "text"]) == ControlRequest(cmd: .sessionText, target: "active", args: ControlArgs()))
     }
 
@@ -502,8 +483,8 @@ struct CommandsTests {
     }
 
     @Test func sessionTextRejectsZeroLines() {
-        // a negative --lines (`-5`) is intercepted by ArgumentParser as a flag before validate() runs, so
-        // 0 is the CLI-reachable non-positive case the validation guards against.
+        // ArgumentParser intercepts a negative `-5` as a flag before validate() runs, so 0 is the only
+        // CLI-reachable non-positive case.
         #expect(validationMessage(["session", "text", "--lines", "0"]) == "--lines must be greater than 0")
     }
 
@@ -566,9 +547,7 @@ struct CommandsTests {
     }
 
     @Test func sessionStatusRejectsBadColor() {
-        // a non-#rrggbb color is rejected by validate() before any request is built; pin the exact message
-        // so an unrelated parse failure can't masquerade as color validation (matches the sibling
-        // `session background color` rejection tests).
+        // pin the exact message so an unrelated parse failure can't masquerade as color validation.
         #expect(validationMessage(["session", "status", "blocked", "--color", "nope"]) == "color must be a #rrggbb hex value")
     }
 
@@ -592,15 +571,13 @@ struct CommandsTests {
     }
 
     @Test func sessionStatusRejectsUnknownShape() {
-        // an unknown shape is rejected by validate() before any request is built, so it never reaches the
-        // socket; pin the exact allCases-derived message so an unrelated parse failure can't pass for it.
+        // pin the exact allCases-derived message so an unrelated parse failure can't pass for it.
         #expect(validationMessage(["session", "status", "blocked", "--shape", "hexagon"])
             == "shape must be one of: circle, square, triangle, diamond, capsule, star")
     }
 
     @Test func sessionStatusShapeHelpListsEveryShape() {
-        // the --shape help is built from allCases like the validation message, so `--help` can't go stale
-        // when the set changes; assert every raw value survives into the rendered help.
+        // the help is built from allCases, so a shape added later cannot leave `--help` stale.
         let help = Session.Status.helpMessage(columns: 200)
         for shape in StatusShape.allCases {
             #expect(help.contains(shape.rawValue), "--shape help should list \(shape.rawValue), got: \(help)")
@@ -636,7 +613,6 @@ struct CommandsTests {
     }
 
     @Test func sessionStatusRejectsBadPane() {
-        // `other` is a session.focus mode, not a status pane — status accepts left|right|scratch only.
         #expect(validationMessage(["session", "status", "blocked", "--pane", "other"]) == "--pane must be left, right, or scratch")
     }
 
@@ -647,7 +623,6 @@ struct CommandsTests {
     }
 
     @Test func sessionRestoreCarriesShellLineVerbatim() throws {
-        // the pinned value is a shell line, so metacharacters must reach the wire untouched.
         let line = "cd /tmp && claude --resume abc | tee out"
         let req = try request(["session", "restore", line])
         #expect(req.args?.command == line)
@@ -711,8 +686,7 @@ struct CommandsTests {
     }
 
     @Test func sessionSearchOpensWithoutNeedleOrFlag() throws {
-        // a bare `session search` opens the bar: no needle, no direction (an empty args bag, since the
-        // command always passes a base ControlArgs to withWindow).
+        // the command always passes a base ControlArgs to withWindow, so the bag is empty rather than nil.
         let expected = ControlRequest(cmd: .sessionSearch, target: "active", args: ControlArgs())
         #expect(try request(["session", "search"]) == expected)
     }
@@ -739,12 +713,10 @@ struct CommandsTests {
 
     @Test(arguments: [["--next", "--close"], ["--next", "--prev"], ["--prev", "--close"]])
     func sessionSearchRejectsFlagCombos(_ flags: [String]) {
-        // the three navigation flags are mutually exclusive — validate() rejects combining any two.
         #expect(validationMessage(["session", "search"] + flags) == "--next, --prev, and --close are mutually exclusive")
     }
 
     @Test func sessionSearchRejectsNeedleWithClose() {
-        // --close ignores the needle, so the combo is a usage error rather than a silent no-op.
         #expect(validationMessage(["session", "search", "foo", "--close"]) == "--close cannot be combined with a needle")
     }
 
@@ -784,21 +756,18 @@ struct CommandsTests {
     }
 
     @Test func sessionOverlayOpenRejectsBadBackgroundColor() {
-        // validate() rejects a malformed hex at parse time (before any connection).
         #expect(throws: (any Error).self) {
             try Agtermctl.parseAsRoot(["session", "overlay", "open", "cmd", "--background-color", "purple"])
         }
     }
 
     @Test func sessionOverlayOpenWithFollow() throws {
-        // --follow maps to ControlArgs.follow = true; the server selects the target after opening.
         let expected = ControlRequest(cmd: .sessionOverlayOpen, target: "active",
                                       args: ControlArgs(command: "revdiff", follow: true))
         #expect(try request(["session", "overlay", "open", "revdiff", "--follow"]) == expected)
     }
 
     @Test func sessionOverlayOpenWithoutFollow() throws {
-        // omitting --follow leaves follow nil (omitted-when-nil on the wire = the no-switch default).
         let expected = ControlRequest(cmd: .sessionOverlayOpen, target: "active", args: ControlArgs(command: "revdiff"))
         let built = try request(["session", "overlay", "open", "revdiff"])
         #expect(built == expected)
@@ -806,7 +775,6 @@ struct CommandsTests {
     }
 
     @Test func sessionOverlayOpenFollowWithBlockAndSizePercentAndTarget() throws {
-        // --follow composes with --block, --size-percent, and --target; follow rides through makeRequest.
         let expected = ControlRequest(cmd: .sessionOverlayOpen, target: "9f3c",
                                       args: ControlArgs(command: "htop", sizePercent: 60, follow: true))
         #expect(try request(["session", "overlay", "open", "htop", "--follow", "--block",
@@ -824,7 +792,6 @@ struct CommandsTests {
     }
 
     @Test func sessionOverlayOpenWithBlockAndSizePercentParses() throws {
-        // --block composes with --size-percent; the block run() opens via makeRequest, so sizePercent rides through.
         let expected = ControlRequest(cmd: .sessionOverlayOpen, target: "active",
                                       args: ControlArgs(command: "htop", sizePercent: 60))
         #expect(try request(["session", "overlay", "open", "htop", "--block", "--size-percent", "60"]) == expected)
@@ -846,7 +813,6 @@ struct CommandsTests {
     }
 
     @Test func sessionOverlayResizeRejectsBadArgs() {
-        // validate() enforces exactly-one-of --size-percent/--full and the 1...100 range at parse time.
         #expect(throws: (any Error).self) { try Agtermctl.parseAsRoot(["session", "overlay", "resize"]) }
         #expect(throws: (any Error).self) {
             try Agtermctl.parseAsRoot(["session", "overlay", "resize", "--full", "--size-percent", "50"])
@@ -856,7 +822,6 @@ struct CommandsTests {
     }
 
     @Test func sessionOverlayBlockRejectsWait() {
-        // validate() enforces the mutually-exclusive flags at parse time (before any connection).
         #expect(throws: (any Error).self) {
             try Agtermctl.parseAsRoot(["session", "overlay", "open", "cmd", "--block", "--wait"])
         }
@@ -882,8 +847,7 @@ struct CommandsTests {
     }
 
     @Test func quickTypeWithoutTextOrStdinThrows() {
-        // "provide TEXT or --stdin" is raised in makeRequest (not validate), so it's reached via request(),
-        // which calls makeRequest, rather than parseAsRoot alone.
+        // the message is raised in makeRequest, not validate, so parseAsRoot alone would not reach it.
         #expect(throws: (any Error).self) { try request(["quick", "type"]) }
     }
 
@@ -1169,7 +1133,6 @@ struct CommandsTests {
     }
 
     @Test func keymapReloadRejectsWindowSelector() {
-        // keymap.reload is app-global, so --window is meaningless and must not be accepted.
         #expect(throws: (any Error).self) { try Agtermctl.parseAsRoot(["keymap", "reload", "--window", "w1"]) }
     }
 
@@ -1178,7 +1141,6 @@ struct CommandsTests {
     }
 
     @Test func keymapListRejectsWindowSelector() {
-        // keymap.list is app-global like keymap.reload, so --window is meaningless.
         #expect(throws: (any Error).self) { try Agtermctl.parseAsRoot(["keymap", "list", "--window", "w1"]) }
     }
 
@@ -1187,7 +1149,6 @@ struct CommandsTests {
     }
 
     @Test func configReloadRejectsWindowSelector() {
-        // config.reload is app-global, so --window is meaningless and must not be accepted.
         #expect(throws: (any Error).self) { try Agtermctl.parseAsRoot(["config", "reload", "--window", "w1"]) }
     }
 
@@ -1207,7 +1168,6 @@ struct CommandsTests {
     }
 
     @Test func themeSetOneSlotAlone() throws {
-        // theme.set is per-slot: either side alone is a valid request (the server keeps/seeds the other).
         #expect(try request(["theme", "set", "--light", "Builtin Light"])
             == ControlRequest(cmd: .themeSet, args: ControlArgs(light: "Builtin Light")))
         #expect(try request(["theme", "set", "--dark", "Nord"])
@@ -1218,7 +1178,6 @@ struct CommandsTests {
     }
 
     @Test func themeSetRejectsNamePlusLight() {
-        // a positional NAME plus --light targets the same slot twice — validate() rejects it.
         #expect(throws: (any Error).self) {
             try Agtermctl.parseAsRoot(["theme", "set", "Dracula", "--light", "Builtin Light"])
         }
@@ -1229,7 +1188,6 @@ struct CommandsTests {
     }
 
     @Test func themeRejectsWindowSelector() {
-        // theme is app-global (one settings model), so --window is meaningless and must not be accepted.
         #expect(throws: (any Error).self) { try Agtermctl.parseAsRoot(["theme", "set", "Nord", "--window", "w1"]) }
     }
 
@@ -1321,8 +1279,8 @@ struct CommandsTests {
     }
 
     @Test func windowMinimizeBareModeTargetsActive() throws {
-        // both positionals are optional, so a bare mode word would otherwise bind to the id. A window
-        // address is a hex UUID prefix or `active`, never a mode word, so the recovery can't misfire.
+        // both positionals are optional, so a bare mode word would otherwise bind to the id; a window
+        // address is a hex prefix or `active`, never a mode word, so the recovery can't misfire.
         #expect(try request(["window", "minimize", "on"])
             == ControlRequest(cmd: .windowMinimize, target: "active", args: ControlArgs(mode: "on")))
         #expect(try request(["window", "minimize", "toggle"])
@@ -1337,19 +1295,16 @@ struct CommandsTests {
     }
 
     @Test func windowRenameRequiresBothArgsFails() {
-        // rename needs an id AND a name; only one positional must fail to parse.
         #expect(throws: (any Error).self) { try Agtermctl.parseAsRoot(["window", "rename", "9f3c"]) }
     }
 
     @Test func windowCommandsRejectWindowSelector() {
-        // window.* target via the positional id, so --window is meaningless and must not be accepted.
         #expect(throws: (any Error).self) { try Agtermctl.parseAsRoot(["window", "list", "--window", "w1"]) }
         #expect(throws: (any Error).self) { try Agtermctl.parseAsRoot(["window", "select", "9f3c", "--window", "w1"]) }
         #expect(throws: (any Error).self) { try Agtermctl.parseAsRoot(["quick", "--window", "w1"]) }
     }
 
     @Test func windowCommandsKeepSocketAndJSON() throws {
-        // --socket / --json stay available on window.* (they share the connection/print surface).
         let parsed = try Agtermctl.parseAsRoot(["window", "list", "--socket", "/tmp/x.sock", "--json"])
         let command = try #require(parsed as? Window.List)
         #expect(command.options.json)
@@ -1378,12 +1333,10 @@ struct CommandsTests {
     }
 
     @Test func treeWithoutWindowOmitsArgs() throws {
-        // no --window keeps tree in its compact form (args nil), matching the no-window request value.
         #expect(try request(["tree"]) == ControlRequest(cmd: .tree))
     }
 
-    // --window must populate args.window AND leave the command's own args intact (the merge folds it
-    // into the existing bag rather than replacing it).
+    // --window folds into the command's existing args bag rather than replacing it.
 
     @Test func sessionTypeWithWindow() throws {
         let expected = ControlRequest(cmd: .sessionType, target: "active",
@@ -1539,8 +1492,7 @@ struct CommandsTests {
     }
 
     @Test func sessionBackgroundImageRejectsControlCharPath() {
-        // the config-injection vector: a newline in the path would smuggle an extra ghostty key into the
-        // per-surface overlay. Caught CLI-side (matching the server boundary) before any round-trip.
+        // a newline in the path would smuggle an extra ghostty key into the per-surface overlay.
         #expect(validationMessage(["session", "background", "image", "x.png\nclipboard-read = allow\ny.png"]) != nil)
     }
 }

--- a/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
@@ -9,9 +9,8 @@ import Testing
 import agtermCore
 @testable import agtermctlKit
 
-// serialized: runSucceedsOnOkResponse and runThrowsExitCodeFailureOnErrorResponse both redirect the
-// process-global STDOUT_FILENO via captureStdout, so running them in parallel races on stdout (one
-// test's output lands in the other's pipe). serial execution keeps the redirect exclusive.
+// serialized: the stdout-capturing tests redirect the process-global STDOUT_FILENO, so in parallel
+// one test's output lands in the other's pipe.
 @Suite(.serialized)
 struct SocketClientTests {
     @Test func consecutiveEventReadsUseIndependentOneShotConnections() throws {
@@ -43,7 +42,6 @@ struct SocketClientTests {
 
         #expect(response.ok)
         #expect(response.result?.id == "9f3c")
-        // the server echoed the request it received — confirm the client wrote it correctly.
         #expect(server.received?.cmd == .sessionSelect)
         #expect(server.received?.target == "active")
     }
@@ -61,8 +59,7 @@ struct SocketClientTests {
         #expect(response.error == "cannot delete last workspace")
     }
 
-    /// A `session.text --all` response can exceed the old 1 MiB cap (full scrollback). A >1 MiB text
-    /// payload must round-trip intact, not fail with "no response".
+    // a `session.text --all` payload exceeds the old 1 MiB read cap; it must round-trip, not fail.
     @Test func roundTripLargeResponse() throws {
         let big = String(repeating: "scrollback line\n", count: 200_000) // ~3 MiB, well over 1 MiB
         let server = StubServer(response: ControlResponse(ok: true, result: ControlResult(text: big)))
@@ -106,7 +103,6 @@ struct SocketClientTests {
         }
     }
 
-    /// A create command's `run()` returns without throwing on `{"ok":true}` and prints the new id.
     @Test func formatsKeymapWithEveryActionAndTheLiveMenu() {
         let keymap = Keymap(builtinOverrides: [.closeSession: Chord(mods: [.command], key: "e")], commands: [])
         let payload = ControlKeymap.project(
@@ -126,8 +122,7 @@ struct SocketClientTests {
         for action in BuiltinAction.allCases { #expect(out.contains(action.rawValue)) }
     }
 
-    // line 0 is the whole-file / cross-section sentinel, not a real line. The GUI already drops the
-    // number for it (SettingsView.diagnosticLine), so the CLI must not send a reader hunting for line 0.
+    // line 0 is the whole-file sentinel, not a real line (SettingsView.diagnosticLine drops it too).
     @Test func formatsKeymapDroppingTheLineNumberForWholeFileDiagnostics() {
         let payload = ControlKeymap.project(
             keymap: Keymap(builtinOverrides: [:], commands: []),
@@ -143,8 +138,7 @@ struct SocketClientTests {
         #expect(out.contains("line 7: unknown action"), "a real line number is still shown")
     }
 
-    // a disabled item's chord is inert, and the default (non-JSON) output is the documented human
-    // workflow — leaving the flag out of the rendering drops the one fact that explains a dead binding.
+    // a disabled item's chord is inert, so the marker is the one fact that explains a dead binding.
     @Test func formatsKeymapMarkingDisabledMenuItems() {
         let payload = ControlKeymap.project(
             keymap: Keymap(builtinOverrides: [:], commands: []), diagnostics: [], path: "/tmp/keymap.conf",
@@ -191,7 +185,6 @@ struct SocketClientTests {
         #expect(printed == "9f3c\n")
     }
 
-    /// A non-create command suppresses the id echo (prints `ok`) even when the response carries an id.
     @Test func runQuietsIdForNonCreateCommand() throws {
         let server = StubServer(response: ControlResponse(ok: true, result: ControlResult(id: "9f3c")))
         try server.start()
@@ -217,7 +210,6 @@ struct SocketClientTests {
         return String(data: data, encoding: .utf8) ?? ""
     }
 
-    /// `RequestCommand.run()` throws `ExitCode.failure` on a `{"ok":false}` response.
     @Test func runThrowsExitCodeFailureOnErrorResponse() throws {
         let server = StubServer(response: ControlResponse(ok: false, error: "boom"))
         try server.start()
@@ -227,8 +219,7 @@ struct SocketClientTests {
         #expect(throws: ExitCode.failure) { try command.run() }
     }
 
-    // the --block path: open → poll session.overlay.result (retry while still running) → exit with the
-    // captured status. drives the real run() against a scripted multi-connection server.
+    // drives the real run() against a scripted multi-connection server: open, poll, exit with the status.
     @Test func blockPollsResultThenExitsWithStatus() throws {
         let script = OverlayResultScript(stillRunningTimes: 1,
                                          finalResult: ControlResponse(ok: true, result: ControlResult(id: "abc", exitCode: 7)))
@@ -257,7 +248,6 @@ struct SocketClientTests {
         #expect(throws: ExitCode.failure) { try command.run() }
     }
 
-    // a failed open short-circuits --block before any poll.
     @Test func blockFailsWhenOpenFails() throws {
         let server = ScriptedStubServer { req in
             req.cmd == .sessionOverlayOpen
@@ -652,13 +642,11 @@ struct SocketClientTests {
     }
 
     @Test func formatResponseRatio() {
-        // session.resize echoes the applied (clamped) left-pane fraction as a bare 3-decimal number.
         let response = ControlResponse(ok: true, result: ControlResult(id: "9f3c", ratio: 0.85))
         #expect(SocketClient.formatResponse(response, json: false) == "0.850")
     }
 
     @Test func formatResponseErrorFallback() {
-        // an error response with no message falls back to a generic line.
         #expect(SocketClient.formatResponse(ControlResponse(ok: false), json: false) == "error: unknown error")
     }
 
@@ -678,7 +666,6 @@ struct SocketClientTests {
         let lines = out.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
         #expect(lines.count == 2)
         #expect(lines[0] == "* work  [w1]")
-        // active session (*), the (split) suffix, id and cwd columns.
         #expect(lines[1] == "  * shell (split)  [s1]  /tmp")
     }
 
@@ -707,8 +694,7 @@ struct SocketClientTests {
             ControlWindowNode(id: "w1", name: "work", open: true, active: true),
             ControlWindowNode(id: "w2", name: "personal", open: true, active: false),
             ControlWindowNode(id: "w3", name: "archive", open: false, active: false),
-            // a closed-but-active window (frontmost id pointing at a window not yet loaded) still
-            // renders the [active] tag without [open].
+            // a closed-but-active window (a frontmost id not yet loaded) renders [active] without [open].
             ControlWindowNode(id: "w4", name: "pending", open: false, active: true),
         ]
         let out = SocketClient.formatResponse(ControlResponse(ok: true, result: ControlResult(windows: windows)), json: false)
@@ -722,8 +708,7 @@ struct SocketClientTests {
 
     @Test func formatResponseEmptyWindows() {
         let out = SocketClient.formatResponse(ControlResponse(ok: true, result: ControlResult(windows: [])), json: false)
-        // an empty window list renders an empty string (no per-window lines), not the bare ok line —
-        // a present-but-empty `windows` payload still takes the windows branch.
+        // a present-but-empty `windows` payload still takes the windows branch, so it renders empty.
         #expect(out == "")
     }
 
@@ -749,7 +734,6 @@ struct SocketClientTests {
     }
 
     @Test func formatResponseThemesMarksBothSyncedSides() {
-        // when syncing, both the light and dark themes are marked and a header notes the pair.
         let response = ControlResponse(ok: true, result: ControlResult(
             theme: nil, themes: ["agterm", "Builtin Light", "Nord"], sync: true, light: "Builtin Light", dark: "agterm"))
         let out = SocketClient.formatResponse(response, json: false)
@@ -758,7 +742,7 @@ struct SocketClientTests {
         #expect(lines.contains("* agterm"))
         #expect(lines.contains("* Builtin Light"))
         #expect(lines.contains("  Nord"))
-        #expect(lines.contains("  default ghostty")) // unmarked while syncing
+        #expect(lines.contains("  default ghostty"))
     }
 }
 
@@ -836,7 +820,6 @@ private final class StubServer: @unchecked Sendable {
         guard conn >= 0 else { return }
         defer { close(conn) }
 
-        // read one request line.
         var buffer = Data()
         var byte: UInt8 = 0
         while true {
@@ -847,7 +830,6 @@ private final class StubServer: @unchecked Sendable {
         }
         received = try? JSONDecoder().decode(ControlRequest.self, from: buffer)
 
-        // write the canned response.
         guard var data = try? JSONEncoder().encode(canned) else { return }
         data.append(UInt8(ascii: "\n"))
         data.withUnsafeBytes { raw in

--- a/agtermTests/CloseSessionChordTests.swift
+++ b/agtermTests/CloseSessionChordTests.swift
@@ -55,8 +55,6 @@ final class CloseSessionChordTests: XCTestCase {
         assertNoChord(menu.stock, "the stock Close must not compete for ⌘W")
     }
 
-    // the reported state: SwiftUI resolved the collision by unbinding its own item, so Close Session
-    // carries NOTHING while the stock Close holds ⌘W. Reconcile has to undo exactly that.
     func testRecoversFromSwiftUIUnbindingOurItem() {
         let menu = makeFileMenu(oursKey: "", stockKey: "w")
         AppDelegate.applyCloseSessionChord(keymap(), in: menu.menu)
@@ -72,8 +70,7 @@ final class CloseSessionChordTests: XCTestCase {
         assertOwnsCommandW(menu.stock, "nothing of agterm's wants ⌘W, so the stock Close keeps it")
     }
 
-    // a previous reconcile cleared the stock Close while close_session held ⌘W; rebinding away must hand
-    // the chord back rather than leaving ⌘W dead.
+    // the empty stock key is what a previous reconcile leaves behind while close_session held ⌘W.
     func testRebindingAwayRestoresAClearedStockChord() {
         let menu = makeFileMenu(oursKey: "e", stockKey: "")
         AppDelegate.applyCloseSessionChord(keymap([.closeSession: Chord(mods: [.command], key: "e")]), in: menu.menu)
@@ -82,8 +79,7 @@ final class CloseSessionChordTests: XCTestCase {
     }
 
     // SwiftUI defers its rebuild to the next activation, so straight after a reload that rebound
-    // close_session away our item still advertises ⌘W. Arming the stock item without clearing that stale
-    // one would leave the File menu showing ⌘W twice, one of them on the close-the-whole-window item.
+    // close_session away our item still advertises ⌘W — leaving it would show ⌘W twice in the File menu.
     func testStaleOurChordIsClearedWhenTheStockCloseTakesCommandW() {
         let menu = makeFileMenu(oursKey: "w", stockKey: "")
         AppDelegate.applyCloseSessionChord(keymap([.closeSession: Chord(mods: [.command], key: "e")]), in: menu.menu)
@@ -93,8 +89,7 @@ final class CloseSessionChordTests: XCTestCase {
     }
 
     // `parseKeymap` rejects a chord only when two DISTINCT actions resolve to it, so moving close_session
-    // off ⌘W frees the chord for any other built-in. Deciding stock ownership from close_session alone
-    // would arm the stock item against a live built-in binding and re-create the reported failure.
+    // off ⌘W frees the chord for any other built-in — stock ownership cannot be decided from it alone.
     func testAnotherBuiltinOwningCommandWKeepsTheStockCloseBare() {
         let menu = makeFileMenu(oursKey: "e", stockKey: "w")
         let overrides: [BuiltinAction: Chord] = [
@@ -117,8 +112,8 @@ final class CloseSessionChordTests: XCTestCase {
         assertNoChord(menu.ours, "an item whose action does not own ⌘W must not be given the chord")
     }
 
-    // repeated flips are the reported workflow (rebind away, rebind back, both via `keymap reload`), so
-    // the reconcile has to be stable across them rather than correct only on the first transition.
+    // repeated `keymap reload` flips are the reported workflow, so being correct on the first transition
+    // alone is not enough.
     func testRepeatedFlipsKeepOwnershipConsistent() {
         let menu = makeFileMenu(oursKey: "w")
         let away = keymap([.closeSession: Chord(mods: [.command], key: "e")])
@@ -133,8 +128,7 @@ final class CloseSessionChordTests: XCTestCase {
         }
     }
 
-    // a menu missing either half (no `performClose:`, or no Close Session) must be left untouched rather
-    // than half-reconciled — the Edit/View menus go through the same walk.
+    // the Edit/View menus go through the same walk, so a menu missing either half must be left alone.
     func testMenuWithoutBothItemsIsLeftAlone() {
         let lone = NSMenuItem(title: "Something Else", action: nil, keyEquivalent: "w")
         lone.keyEquivalentModifierMask = .command

--- a/agtermTests/DockMenuTests.swift
+++ b/agtermTests/DockMenuTests.swift
@@ -62,11 +62,9 @@ final class DockMenuTests: XCTestCase {
         try await super.tearDown()
     }
 
-    // Covers the two legs that keep a hosted run off the user's real environment: the state dir and the
-    // control-socket path Xcode expands into the launch environment. It deliberately does NOT claim to
-    // cover the shell-free scene — nothing here observes the `isHostedUnitTest` branch being CONSUMED, and
-    // the only obvious probe (`AppDelegate.controlServer == nil`) rides the scene's async `.task`, so it
-    // would pass even with the branch deleted. Renaming rather than adding a assertion that cannot fail.
+    // deliberately does NOT cover the shell-free scene: the only obvious probe
+    // (`AppDelegate.controlServer == nil`) rides the scene's async `.task`, so it would pass even with
+    // the `isHostedUnitTest` branch deleted.
     func testHostProcessStartsWithIsolatedStateAndSocket() throws {
         let environment = ProcessInfo.processInfo.environment
         let statePath = try XCTUnwrap(environment["AGTERM_STATE_DIR"])
@@ -130,17 +128,14 @@ final class DockMenuTests: XCTestCase {
         XCTAssertTrue(try item("Dashboard", in: menu).isEnabled,
                       "an open dashboard remains enabled so the Dock action can close it")
 
-        // and the enabled item must actually CLOSE it. This is the `dashboardWasOpen == true` half of the
-        // staleness guard (`dashboard.isOpen == dashboardWasOpen`), which nothing else invokes: every other
-        // dashboard case builds the menu while it is closed. Tightening that guard to `!dashboard.isOpen`
-        // would make the item inert here with the rest of the suite still green.
+        // the `dashboardWasOpen == true` half of the staleness guard, which nothing else invokes — every
+        // other dashboard case builds the menu while it is closed.
         try invokeWithNilSender(try item("Dashboard", in: menu))
         XCTAssertFalse(dashboard.isOpen, "a Dashboard item built while the dashboard was open should close it")
     }
 
-    // New Window is the one app-level item: it captures no window, so unlike its neighbours it must stay
-    // enabled and live through every modal state that makes them inert, and it must open a window the
-    // library actually counts. Discussion #313.
+    // New Window captures no window, so unlike its neighbours it must stay live through every modal
+    // state that makes them inert. Discussion #313.
     func testNewWindowStaysEnabledUnderModalsAndOpensAWindow() throws {
         let windowID = try activeWindowID()
         let quick = QuickTerminalController()
@@ -162,8 +157,7 @@ final class DockMenuTests: XCTestCase {
         XCTAssertTrue(try item("New Window", in: menu).isEnabled,
                       "an open dashboard in the last-active window must not disable it either")
 
-        // the opener is the scene's, nil outside a mounted scene, so stand in for it and assert the
-        // action both creates the library entry and hands that id over to be opened.
+        // the opener is the scene's and nil outside a mounted scene, so stand in for it.
         var openedIDs: [UUID] = []
         actions.openWindow = { openedIDs.append($0) }
         let windowsBefore = library.windows.count
@@ -176,9 +170,8 @@ final class DockMenuTests: XCTestCase {
         XCTAssertEqual(openedIDs.first, created.id)
     }
 
-    // `actions` is wired in the scene `.task`, so during the launch window it is nil while every other item
-    // is already disabled by the nil library — leaving New Window the only enabled item in the menu, one
-    // that would activate the app and then do nothing. It reads as unavailable instead.
+    // `actions` is wired in the scene `.task`, so during the launch window it is nil while the nil library
+    // already disables every other item — New Window would be the only enabled one.
     func testNewWindowIsDisabledUntilTheActionHubIsWired() throws {
         delegate.actions = nil
 
@@ -187,16 +180,14 @@ final class DockMenuTests: XCTestCase {
         XCTAssertFalse(newWindow.isEnabled, "with no action hub there is nothing for the item to drive")
         try invokeWithNilSender(newWindow)
 
-        // and once wired it is enabled again even with no library on the delegate, since creating a window
-        // needs neither a captured window nor that reference.
+        // creating a window needs neither a captured window nor the library reference.
         delegate.actions = actions
         delegate.library = nil
         XCTAssertTrue(try item("New Window", in: try dockMenu()).isEnabled)
     }
 
-    // The counterpart to the guard in `AppActions.newWindow`: with no opener wired there is nowhere to put
-    // a window, and creating one anyway would leave the library counting an open window with no NSWindow
-    // behind it — which `applicationShouldTerminateAfterLastWindowClosed` reads to decide whether to quit.
+    // an orphaned entry would leave the library counting an open window with no NSWindow behind it, which
+    // `applicationShouldTerminateAfterLastWindowClosed` reads to decide whether to quit.
     func testNewWindowWithoutAnOpenerCreatesNothing() throws {
         let menu = try dockMenu()
         let windowsBefore = library.windows.count

--- a/agtermTests/InlineRenameScopeTests.swift
+++ b/agtermTests/InlineRenameScopeTests.swift
@@ -39,10 +39,8 @@ final class InlineRenameScopeTests: XCTestCase {
         try await super.tearDown()
     }
 
-    // A rename started from the menu / palette / keymap must open an editor in the FRONTMOST window only.
-    // Posting with a nil object reached every open window's coordinator — their `selectedSessionID` guard
-    // is not a scope, since every window has a selection — so each one opened an editor the user never
-    // asked for and leaked an unbalanced `suppressAutoFollow`, wedging that window's idle auto-follow off.
+    // the coordinator's own `selectedSessionID` guard is not a scope — every window has a selection — so
+    // the post's object is the only thing that narrows delivery.
     func testRenameSessionPostsScopedToTheFrontmostStore() throws {
         let (frontStore, otherStore) = try twoWindows()
         let front = observe(.agtermBeginRenameSession, object: frontStore)

--- a/agtermTests/LiveMenuKeyEquivalentsTests.swift
+++ b/agtermTests/LiveMenuKeyEquivalentsTests.swift
@@ -28,9 +28,7 @@ final class LiveMenuKeyEquivalentsTests: XCTestCase {
         return menu
     }
 
-    // the reason the recursion exists: AppKit's performKeyEquivalent recurses, so a chord one level down
-    // is live and can shadow an agterm binding. Reporting only the top level would let a caller compare
-    // the two lists and conclude nothing holds a chord when something does.
+    // AppKit's performKeyEquivalent recurses, so a chord one level down is live and can shadow a binding.
     func testCollectsKeyEquivalentsFromNestedSubmenus() {
         let nested = menu("Services", [item("Nested Service", key: "j", mods: [.command, .shift])])
         let parent = item("Services", key: "", action: nil)
@@ -67,8 +65,7 @@ final class LiveMenuKeyEquivalentsTests: XCTestCase {
         XCTAssertEqual(found.map(\.title), ["Has Chord"])
     }
 
-    // a disabled item's chord is INERT — AppKit consumes the key equivalent and fires nothing, so a
-    // caller comparing the two lists must be able to tell it apart from a live binding.
+    // a disabled item's chord is INERT: AppKit consumes the key equivalent and fires nothing.
     func testDisabledItemsAreMarkedAndEnabledOnesAreNot() throws {
         let file = menu("File", [item("Live", key: "n"), item("Inert", key: "d", enabled: false)])
 
@@ -89,8 +86,7 @@ final class LiveMenuKeyEquivalentsTests: XCTestCase {
         XCTAssertEqual(found.chord, "cmd+opt+shift+v")
     }
 
-    // arrows and return arrive as function-key / control characters; rendering them raw would leave the
-    // key missing and stop the chord comparing against the action list.
+    // arrows and return arrive as function-key / control characters, not under their keymap names.
     func testNamedKeysRenderInKeymapVocabulary() {
         let file = menu("Navigate", [
             item("Previous Session", key: "\u{F700}", mods: [.command, .option]),

--- a/agtermTests/SessionNavRevealTests.swift
+++ b/agtermTests/SessionNavRevealTests.swift
@@ -34,12 +34,10 @@ final class SessionNavRevealTests: XCTestCase {
         try await super.tearDown()
     }
 
-    // A plain nav step that resolves to the session ALREADY selected must not run the pane reveal. `next`
-    // wraps within the filtered set, so a one-element set re-selects the current session, and
-    // `selectSession` does not short-circuit a same-target select — it still returns an indicator. Revealing
-    // on that indicator would clear `splitFocused` and pull the user onto the primary pane on a keystroke
-    // that moved nothing. An UNTAGGED `blocked` is the shape a plain `agtermctl session status blocked`
-    // sends and routes to the `.left`/nil arm, which is the arm that does the clearing.
+    // `next` wraps within the filtered set, so a one-element set re-selects the current session, and
+    // `selectSession` does not short-circuit a same-target select — it still returns an indicator, and
+    // revealing on it would clear `splitFocused` on a keystroke that moved nothing. An UNTAGGED `blocked`
+    // routes to the `.left`/nil arm, the arm that does the clearing.
     func testPlainNavThatMovesNothingKeepsSplitFocus() throws {
         let store = try XCTUnwrap(library.activeStore)
         let session = try XCTUnwrap(store.activeSession)
@@ -55,9 +53,8 @@ final class SessionNavRevealTests: XCTestCase {
                       "a nav step that moved nothing must leave the user on the split pane he was typing in")
     }
 
-    // The other direction, so the test above cannot pass by the reveal being dead everywhere: a step that
-    // DOES move still reveals the moved-to session's tagged pane. Same untagged `blocked` shape, so the
-    // same `.left`/nil arm runs — here it should clear `splitFocused`, targeting the primary pane.
+    // the other direction, so the test above cannot pass by the reveal being dead everywhere: the same
+    // untagged `blocked` shape runs the same `.left`/nil arm, which here must clear `splitFocused`.
     func testPlainNavThatMovesRunsTheReveal() throws {
         let store = try XCTUnwrap(library.activeStore)
         let first = try XCTUnwrap(store.activeSession)

--- a/agtermTests/UndoCloseShortcutTests.swift
+++ b/agtermTests/UndoCloseShortcutTests.swift
@@ -7,15 +7,10 @@ import agtermCore
 /// monitor. It lives here rather than in `agtermCoreTests` because the mapping reads `NSEvent` accessors
 /// an AppKit-free target cannot construct.
 ///
-/// Only the ASCII-capable-layout branch is reachable here. Which branch runs is decided by the LIVE
-/// input source (`KeyboardLayout.isASCIICapable`), which a test cannot set without changing the
-/// machine's keyboard, so these run on whatever the tester has — a Latin layout on any development
-/// machine and in CI. The non-Latin branch is covered deterministically in `KeybindTests`, where
-/// `chordKey(forKeyCode:produced:layoutIsASCIICapable:)` takes the layout as a parameter; keyCode 6 with
-/// a Cyrillic `я` and `layoutIsASCIICapable: false` resolves to `z`, which is this monitor's ⌘Z.
-///
-/// What is left here is still worth pinning: that the monitor feeds `chordKey` the right key code and
-/// the right character accessor, and that named keys win before it is consulted.
+/// Only the ASCII-capable-layout branch is reachable: the branch is chosen by the LIVE input source
+/// (`KeyboardLayout.isASCIICapable`), which a test cannot set without changing the machine's keyboard.
+/// The non-Latin branch is covered deterministically in `KeybindTests`, which takes the layout as a
+/// parameter.
 @MainActor
 final class UndoCloseShortcutTests: XCTestCase {
     private var stateDir: URL!
@@ -65,17 +60,15 @@ final class UndoCloseShortcutTests: XCTestCase {
         XCTAssertEqual(shortcut.chord(from: event), BuiltinAction.undoClose.defaultChord)
     }
 
-    // an alternative LATIN layout keeps its own letter positions: on Dvorak the physical Z position types
-    // ";", so ⌘Z follows the Z the user actually types rather than the ANSI Z position.
+    // on Dvorak the physical Z position (keyCode 6) types ";", so ⌘Z follows the Z the user actually types.
     func testAlternativeLatinLayoutKeepsItsOwnLetterPositions() throws {
         try skipUnlessLayoutIsASCIICapable()
         let event = try keyDown(";", keyCode: 6, flags: .command)
         XCTAssertEqual(shortcut.chord(from: event), Chord(mods: [.command], key: ";"))
     }
 
-    // the character accessor, not the key code, is what an ASCII-capable layout binds — pinning which of
-    // the two the monitor passes through. A remapped Latin layout typing a non-ASCII character keeps it
-    // and simply matches no chord, rather than being pulled onto the ANSI position.
+    // a remapped Latin layout typing a non-ASCII character keeps it and matches no chord, rather than
+    // being pulled onto the ANSI position of keyCode 6.
     func testASCIICapableLayoutBindsTheProducedCharacterNotThePosition() throws {
         try skipUnlessLayoutIsASCIICapable()
         let event = try keyDown("я", keyCode: 6, flags: .command)

--- a/agtermTests/WorkspaceFocusActionsTests.swift
+++ b/agtermTests/WorkspaceFocusActionsTests.swift
@@ -3,19 +3,15 @@ import XCTest
 @testable import agterm
 import agtermCore
 
-/// Hosted coverage for the workspace-focus entry points on `AppActions`
-/// (`AppActions+WorkspaceFocus.swift`) — the keyless ones the View menu, the ⌃⇧P palette and the
-/// `focus_workspace` keybind drive, which have no clicked sidebar row and so target the frontmost window's
-/// `AppStore.currentWorkspaceID`, plus the store-scoped workspace-row menu actions — Focus, Add to Focus,
-/// and Delete Workspace (the last from `AppActions.swift`), which must act on the window the clicked row
-/// belongs to. They live in the app-hosted target rather than `agtermUITests`
-/// because they reach `AppActions` directly through `@testable import agterm`, their whole outcome is
-/// MODEL state (the marked set plus the filter flag), and — unlike the XCUITest suite, which CI does not
-/// run — they run on every push via `scripts/test-app.sh`.
+/// Hosted coverage for the workspace-focus entry points on `AppActions` — the keyless View-menu / ⌃⇧P /
+/// `focus_workspace` ones, which have no clicked sidebar row and so target the frontmost window's
+/// `AppStore.currentWorkspaceID`, plus the store-scoped workspace-row menu actions, which must act on the
+/// window the clicked row belongs to. App-hosted rather than `agtermUITests` because the whole outcome is
+/// MODEL state and — unlike the XCUITest suite, which CI does not run — these run on every push via
+/// `scripts/test-app.sh`.
 ///
-/// The store-side semantics (replace-toggle, mark-only, the empty-set refusal) are pinned host-free in
-/// `AppStoreFocusTests`; what is proved HERE is the wiring: which store call each menu entry point makes,
-/// and its guard.
+/// The store-side semantics are pinned host-free in `AppStoreFocusTests`; what is proved HERE is the
+/// wiring: which store call each menu entry point makes, and its guard.
 @MainActor
 final class WorkspaceFocusActionsTests: XCTestCase {
     private var stateDir: URL!
@@ -42,10 +38,8 @@ final class WorkspaceFocusActionsTests: XCTestCase {
         try await super.tearDown()
     }
 
-    // View ▸ Focus Workspace (and the `focus_workspace` keybind / palette entry) zooms to the CURRENT
-    // workspace, and a second invocation — where the item reads "Unfocus Workspace" — clears the set. The
-    // menu's label is driven by `isCurrentWorkspaceSoleFocus`, so it is asserted alongside the state it
-    // describes: a label that disagreed with what the item does is exactly what this pins.
+    // the menu label is driven by `isCurrentWorkspaceSoleFocus`, so it is asserted alongside the state it
+    // describes — a label that disagrees with what the item does is what this pins.
     func testFocusActiveWorkspaceZoomsThenUnfocuses() throws {
         let store = try XCTUnwrap(library.activeStore)
         let current = try XCTUnwrap(store.currentWorkspaceID)
@@ -63,10 +57,8 @@ final class WorkspaceFocusActionsTests: XCTestCase {
         XCTAssertFalse(store.focusEnabled)
     }
 
-    // View ▸ Add Workspace to Focus MARKS the current workspace without applying the filter — the
-    // additive sibling of Focus Workspace, and the entry point that makes a working set buildable from the
-    // menu (a mark that applied would hide the rows still to be marked). Once marked, the item is disabled
-    // (`isCurrentWorkspaceFocusMember`), because a repeat would be a silent no-op.
+    // a mark that applied the filter would hide the rows still to be marked. Once marked the item is
+    // disabled (`isCurrentWorkspaceFocusMember`), because a repeat would be a silent no-op.
     func testAddActiveWorkspaceToFocusMarksWithoutApplyingTheFilter() throws {
         let store = try XCTUnwrap(library.activeStore)
         let first = try XCTUnwrap(store.currentWorkspaceID)
@@ -80,7 +72,6 @@ final class WorkspaceFocusActionsTests: XCTestCase {
         XCTAssertFalse(store.focusEnabled, "marking must never turn the filter on")
         XCTAssertTrue(store.isCurrentWorkspaceFocusMember, "the menu item should now be disabled")
 
-        // move the selection to the first workspace and mark it too: the set WIDENS, it is not replaced.
         let firstSession = try XCTUnwrap(store.workspaces.first { $0.id == first }?.sessions.first)
         store.selectSession(firstSession.id)
         actions.addActiveWorkspaceToFocus()
@@ -90,9 +81,7 @@ final class WorkspaceFocusActionsTests: XCTestCase {
         XCTAssertEqual(session.id, store.workspaces.first { $0.id == second.id }?.sessions.first?.id)
     }
 
-    // View ▸ Clear Focus empties the WHOLE marked set (and with it the filter) — distinct from Toggle
-    // Workspace Filter, which keeps the set and only stops applying it. The menu/palette item is the only
-    // driver of `clearFocus()`, so it has no accessibility-observable e2e.
+    // the menu/palette item is the only driver of `clearFocus()`, so it has no accessibility-observable e2e.
     func testClearFocusEmptiesTheWholeSet() throws {
         let store = try XCTUnwrap(library.activeStore)
         let first = try XCTUnwrap(store.currentWorkspaceID)
@@ -108,8 +97,7 @@ final class WorkspaceFocusActionsTests: XCTestCase {
         XCTAssertEqual(store.visibleWorkspaces.count, store.workspaces.count, "the whole tree should be back")
     }
 
-    // Toggle Workspace Filter suspends and re-applies WITHOUT touching the set — the menu twin of the
-    // bottom-bar grid button, and the reason Clear Focus is a separate item.
+    // the menu twin of the bottom-bar grid button — and the reason Clear Focus is a separate item.
     func testToggleFocusFilterKeepsTheMarkedSet() throws {
         let store = try XCTUnwrap(library.activeStore)
         let current = try XCTUnwrap(store.currentWorkspaceID)
@@ -125,8 +113,7 @@ final class WorkspaceFocusActionsTests: XCTestCase {
         XCTAssertEqual(store.focusedWorkspaceIDs, [current])
     }
 
-    // The empty-set state the store refuses to enable: the toggle is a no-op there (which is why the
-    // bottom-bar button renders disabled), and Clear Focus has nothing to clear.
+    // the store refuses to enable an empty set — which is why the bottom-bar button renders disabled.
     func testFilterEntryPointsAreNoOpsWithNothingMarked() throws {
         let store = try XCTUnwrap(library.activeStore)
 
@@ -136,9 +123,8 @@ final class WorkspaceFocusActionsTests: XCTestCase {
         XCTAssertTrue(store.focusedWorkspaceIDs.isEmpty && !store.focusEnabled)
     }
 
-    // The sidebar row menu's "Focus"/"Unfocus" is STORE-SCOPED: the clicked row belongs to one window, and
-    // a right-click opens the menu WITHOUT raising a background window, so routing through the frontmost
-    // store would read the row's own store (which built the label) and write another window's marked set.
+    // a right-click opens the row menu WITHOUT raising a background window, so routing through the
+    // frontmost store would read the row's own store and write another window's marked set.
     func testRowFocusTargetsItsOwnStoreNotTheFrontmostOne() throws {
         let (frontStore, otherStore) = try twoWindows()
         let clicked = try XCTUnwrap(otherStore.currentWorkspaceID)
@@ -156,10 +142,8 @@ final class WorkspaceFocusActionsTests: XCTestCase {
         XCTAssertFalse(otherStore.focusEnabled)
     }
 
-    // "Delete Workspace" carries the same routing requirement as the two focus items above: the row's
-    // enabled state comes from its own store's `canRemoveWorkspace`, so a background window's row must
-    // delete the workspace it was opened over. Routed through the frontmost store the id is absent, the
-    // lookup returns nil, and the item silently does nothing — no deletion, no error, no feedback.
+    // same routing requirement: routed through the frontmost store the id is absent, the lookup returns
+    // nil, and the item silently does nothing — no deletion, no error, no feedback.
     func testRowDeleteWorkspaceTargetsItsOwnStoreNotTheFrontmostOne() throws {
         let (frontStore, otherStore) = try twoWindows()
         let frontWorkspaces = frontStore.workspaces.map(\.id)
@@ -173,9 +157,8 @@ final class WorkspaceFocusActionsTests: XCTestCase {
         XCTAssertEqual(frontStore.workspaces.map(\.id), frontWorkspaces, "the frontmost window must not be mutated")
     }
 
-    // "Add to Focus"/"Remove from Focus" carries the same routing requirement, and additionally computes
-    // its own direction from the row's store — read and write must land on the SAME window, or the menu
-    // flips a membership it never read.
+    // this one also computes its own direction from the row's store — read and write must land on the
+    // SAME window, or the menu flips a membership it never read.
     func testRowMembershipTargetsItsOwnStoreNotTheFrontmostOne() throws {
         let (frontStore, otherStore) = try twoWindows()
         let clicked = try XCTUnwrap(otherStore.currentWorkspaceID)

--- a/agtermUITests/AppearanceFlipUITests.swift
+++ b/agtermUITests/AppearanceFlipUITests.swift
@@ -22,8 +22,8 @@ final class AppearanceFlipUITests: ControlAPITestCase {
         XCTAssertEqual(start["ok"] as? Bool, true, "debug.appearance should be accepted under a UI-test launch: \(start)")
         XCTAssertEqual((start["result"] as? [String: Any])?["text"] as? String, "light")
 
-        // follow the system appearance with both slots set — the flip precondition. This settings
-        // apply() reloads and records the light side as the last-applied one.
+        // both slots set plus syncing on is the flip precondition; this apply() records light as the
+        // last-applied side.
         let synced = try sendCommand(#"{"cmd":"theme.set","args":{"light":"Builtin Light","dark":"Builtin Dark"}}"#)
         XCTAssertEqual(synced["ok"] as? Bool, true, "theme.set --light --dark should succeed: \(synced)")
 
@@ -35,9 +35,8 @@ final class AppearanceFlipUITests: ControlAPITestCase {
         }
         var zoomed = try XCTUnwrap(pollFirstSessionFontSize(timeout: 8),
                                    "zooming should persist a per-session fontSize override")
-        // the per-session save is debounced (~0.3s), so under load the three increments can persist in
-        // steps; wait until two reads 0.5s apart agree so `zoomed` is the SETTLED override, not an
-        // intermediate one (which would make the steady-state assertion below fail spuriously).
+        // the per-session save is debounced (~0.3s), so the three increments can persist in steps; wait
+        // until two reads 0.5s apart agree, else the steady-state assertion below fails spuriously.
         let settleDeadline = Date().addingTimeInterval(8)
         while Date() < settleDeadline {
             usleep(500_000)
@@ -46,19 +45,13 @@ final class AppearanceFlipUITests: ControlAPITestCase {
             if let current { zoomed = current }
         }
 
-        // flip to dark: the response echoing the applied side proves the appearance change reached the
-        // app — which drives the debounced flip reload (the seam posts .agtermSystemAppearanceChanged,
-        // the same notification the production KVO observer posts).
         let flipped = try sendCommand(#"{"cmd":"debug.appearance","args":{"name":"dark"}}"#)
         XCTAssertEqual(flipped["ok"] as? Bool, true, "the flip should be accepted: \(flipped)")
         XCTAssertEqual((flipped["result"] as? [String: Any])?["text"] as? String, "dark")
 
-        // the persisted override must hold STEADY through the flip reload (debounced ~0.05s). The old
-        // behavior routed the flip through the zoom-CLEARING reload, which nils the persisted override
-        // — the surface's own size report then re-persists it ~0.4s later (update_config does not reset
-        // the runtime zoom on the current libghostty pin), so a single settled read would miss the
-        // wipe. Sampling continuously catches that nil blip: it IS the regression (a quit inside the
-        // window loses the zoom, and closed windows' snapshots are stripped for good).
+        // the zoom-CLEARING reload nils the persisted override and the surface's own size report
+        // re-persists it ~0.4s later (update_config does not reset the runtime zoom on the current
+        // libghostty pin), so a single settled read would miss the wipe — sampling catches the nil blip.
         let sampleDeadline = Date().addingTimeInterval(2.5)
         while Date() < sampleDeadline {
             let sampled = try XCTUnwrap(firstSessionFontSize(),
@@ -82,29 +75,19 @@ final class AppearanceFlipUITests: ControlAPITestCase {
         XCTAssertEqual(applied, "dark", "the flip must drive the config reload (last-applied side)")
     }
 
-    /// Regression: committing after a mid-preview appearance flip must NOT persist a value that was only
-    /// ever browsed into the off-screen slot. Open the picker in light while following, preview a theme
-    /// (writes the light slot), flip to dark, preview a DIFFERENT theme (writes the dark slot), Enter. Only
-    /// the dark slot — active at Enter-time — may commit; the light slot must revert to its pre-preview
-    /// value. The commit-side twin of the Esc-revert flip-safety the pair snapshot already covers.
     func testCommitAfterMidPreviewFlipDoesNotLeakUnconfirmedSlot() throws {
-        // pin a known starting side + a following pair with known slots.
         XCTAssertEqual(try sendCommand(#"{"cmd":"debug.appearance","args":{"name":"light"}}"#)["ok"] as? Bool, true)
         let synced = try sendCommand(#"{"cmd":"theme.set","args":{"light":"Builtin Light","dark":"Builtin Dark"}}"#)
         XCTAssertEqual(synced["ok"] as? Bool, true, "theme.set --light --dark should succeed: \(synced)")
 
-        // browse a theme in LIGHT mode: previews it into the light slot without committing.
         openThemePicker()
         previewInPalette("Dracula")
 
-        // flip to dark mid-preview (socket-driven, the picker stays open), then browse a DIFFERENT theme,
-        // which previews into the dark slot. Enter commits.
+        // the flip is socket-driven, so the picker stays open.
         XCTAssertEqual(try sendCommand(#"{"cmd":"debug.appearance","args":{"name":"dark"}}"#)["ok"] as? Bool, true)
         previewInPalette("Hot Dog", clearFirst: true) // top match: "Hot Dog Stand"
         app.typeKey(.return, modifierFlags: [])
 
-        // the dark slot (active at Enter) commits its preview; the light slot must be the pre-preview
-        // original, NOT the browsed-but-unconfirmed "Dracula". Poll until the commit lands.
         var light: String?
         var dark: String?
         let deadline = Date().addingTimeInterval(8)

--- a/agtermUITests/AttentionButtonUITests.swift
+++ b/agtermUITests/AttentionButtonUITests.swift
@@ -1,12 +1,10 @@
 import Darwin
 import XCTest
 
-/// End-to-end tests for the opt-in title-bar attention bell (Task 11). The bell exists only when the
-/// `attentionButtonEnabled` setting is on (seeded into the isolated `settings.json` before launch), and
-/// its three states (dimmed/disabled, plain enabled, filled-blocked) are derived from the window's
-/// `attentionSessions`. The bell↔bell.fill highlight isn't observable, so the test reads the
-/// `accessibilityValue` (none|attention|blocked) the button exposes (mirroring `StatusIconView`). Status
-/// is driven over the control socket (spoken directly, like `ControlAPIUITests`) via `session.status`.
+/// End-to-end tests for the opt-in title-bar attention bell. The bell exists only when the
+/// `attentionButtonEnabled` setting is on, seeded into the isolated `settings.json` before launch. The
+/// bell↔bell.fill highlight isn't observable, so the tests read the `accessibilityValue`
+/// (none|attention|blocked) the button exposes, and drive status over the control socket.
 @MainActor
 final class AttentionButtonUITests: XCTestCase {
     private var app: XCUIApplication!
@@ -30,16 +28,12 @@ final class AttentionButtonUITests: XCTestCase {
         if let socketPath { try? FileManager.default.removeItem(atPath: socketPath) }
     }
 
-    // with the toggle on, the bell tracks the window's attention state: idle → disabled "none", a
-    // non-blocked status → enabled "attention", a blocked status → enabled "blocked", back to idle →
-    // disabled "none". The accessibilityValue is the oracle for the otherwise-unobservable highlight.
     func testAttentionButtonStatesTrackSessionStatus() throws {
         launch(attentionEnabled: true)
         let seeded = try seededSessionID()
 
         let bell = app.buttons["attention-button"]
         XCTAssertTrue(bell.waitForExistence(timeout: 10), "the attention bell should exist with the toggle on")
-        // all sessions idle at launch: the bell is dimmed/disabled and reports "none".
         XCTAssertTrue(pollButton(bell, value: "none", enabled: false), "an all-idle window should disable the bell as none")
 
         try setStatus("active", target: seeded)
@@ -59,17 +53,14 @@ final class AttentionButtonUITests: XCTestCase {
                       "clearing the last attention session should disable the bell back to none")
     }
 
-    // clicking the bell opens the attention POPOVER (the mouse form; ⌃⇧I keeps the searchable palette),
-    // listing the blocked session as a row. The row click→select can't be driven from XCUITest (a synthesized
-    // click inside an NSPopover doesn't fire a SwiftUI button — see RecentSessionsButtonUITests), so this
-    // asserts the popover opens and lists exactly the attention session; the select is verified by hand and
-    // covered host-free by the selection APIs.
+    // a synthesized click inside an NSPopover doesn't fire a SwiftUI button (see
+    // RecentSessionsButtonUITests), so the row click→select is unreachable here: this asserts only that
+    // the popover opens and lists exactly the attention session.
     func testAttentionButtonOpensPopoverListingAttention() throws {
         launch(attentionEnabled: true)
         let seeded = try seededSessionID()
 
-        // block the seeded session, then add a SECOND (idle) session — `session.new` selects the new one, so
-        // only the seeded session needs attention. The bell lists it window-wide; the new one is not listed.
+        // `session.new` selects the new session, so only the seeded one needs attention.
         try setStatus("blocked", target: seeded)
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
         let createdResult = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
@@ -93,7 +84,6 @@ final class AttentionButtonUITests: XCTestCase {
                        "only the blocked session needs attention, so the popover lists exactly one row")
     }
 
-    // with the toggle off (the default — no seeded setting), the bell is absent from the title bar.
     func testAttentionButtonAbsentWhenToggleOff() throws {
         launch(attentionEnabled: false)
         // the sidebar toggle proves the custom title bar rendered, so the bell's absence is real, not a
@@ -102,10 +92,7 @@ final class AttentionButtonUITests: XCTestCase {
         XCTAssertFalse(app.buttons["attention-button"].exists, "the bell should be absent with the toggle off")
     }
 
-    // flipping the Settings toggle at runtime shows/hides the bell live (the .agtermAppearanceChanged
-    // refresh path) without a relaunch — every other test seeds settings.json before launch. launch
-    // WITHOUT the toggle (bell absent), open Settings (Cmd+,), flip the toggle on (bell appears), flip it
-    // back off (bell hides).
+    // the live .agtermAppearanceChanged refresh path — every other test seeds settings.json before launch.
     func testAttentionButtonTogglesLiveFromSettings() throws {
         launch(attentionEnabled: false)
         XCTAssertTrue(app.buttons["sidebar-toggle-button"].waitForExistence(timeout: 10), "the title bar should render")
@@ -113,10 +100,10 @@ final class AttentionButtonUITests: XCTestCase {
         XCTAssertFalse(bell.exists, "the bell should be absent before the toggle is flipped on")
 
         let toggle = settingsControl(tab: "Notifications", control: "settings-attention-button")
-        toggle.click() // turn it on (default off)
+        toggle.click() // default off
         XCTAssertTrue(bell.waitForExistence(timeout: 10), "flipping the toggle on should show the bell live")
 
-        toggle.click() // turn it back off
+        toggle.click()
         XCTAssertTrue(pollAbsent(bell), "flipping the toggle back off should hide the bell live")
     }
 
@@ -183,7 +170,7 @@ final class AttentionButtonUITests: XCTestCase {
             if tabButton.exists, tabButton.isHittable {
                 tabButton.click()
             } else {
-                app.typeKey(",", modifierFlags: .command) // settings not open yet (or lost) — (re)open
+                app.typeKey(",", modifierFlags: .command)
             }
             RunLoop.current.run(until: Date().addingTimeInterval(0.25))
         }

--- a/agtermUITests/AutoFollowUITests.swift
+++ b/agtermUITests/AutoFollowUITests.swift
@@ -8,18 +8,13 @@ import XCTest
 /// statuses are then driven over the socket — `session.new`/`session.status`/`session.select` do NOT count
 /// as user activity, so the setup never resets the per-window idle timer that fires the follow. The live
 /// `tree` node's `active` flag (= the window's selected session) is the selection oracle: it reflects
-/// `selectedSessionID` at query time, so it is immediate and has no snapshot-save debounce. Subclass of
-/// `ControlAPITestCase` for the socket harness. No keystrokes are typed, so the idle window elapses; the
-/// waits are generous per the ui-tests occlusion-timeout guidance.
+/// `selectedSessionID` at query time, so it has no snapshot-save debounce.
 @MainActor
 final class AutoFollowUITests: ControlAPITestCase {
-    // parked on a NON-blocked session with auto-follow armed at 5 s, a block landing on another session
-    // pulls the window's selection to it once the idle window elapses (no keystrokes reset the timer).
     func testAutoFollowJumpsToBlockedAfterIdle() throws {
         try relaunch(withSettings: #"{"autoFollowAttention":"s5"}"#)
 
-        // A = the restored seeded session; add B, then park the selection back on A (a non-blocked session,
-        // since session.new leaves the new session B selected).
+        // session.new leaves the new session B selected, so park the selection back on the non-blocked A.
         let sessionA = try activeSessionID()
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
         let sessionB = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "session.new should return an id")
@@ -28,16 +23,12 @@ final class AutoFollowUITests: ControlAPITestCase {
                        "selecting A should succeed")
         XCTAssertTrue(pollActiveNode(equals: sessionA, timeout: 10), "A should be the parked (non-blocked) selection")
 
-        // block B over the socket (does not note activity, so the idle timer keeps running); after the 5 s
-        // idle window the window auto-follows to the oldest blocked session, which is B.
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.status","target":"\#(sessionB)","args":{"status":"blocked"}}"#)["ok"] as? Bool,
                        true, "blocking B should succeed")
         XCTAssertTrue(pollActiveNode(equals: sessionB, timeout: 15),
                       "after the idle window the selection should auto-follow to the blocked session B")
     }
 
-    // parking the selection ON a blocked session suppresses the follow: even with an OLDER blocked session
-    // waiting elsewhere, the idle fire does not move away from the blocked session you are already on.
     func testAutoFollowSuppressedWhenParkedOnBlocked() throws {
         try relaunch(withSettings: #"{"autoFollowAttention":"s5"}"#)
 
@@ -46,8 +37,7 @@ final class AutoFollowUITests: ControlAPITestCase {
         let sessionB = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "session.new should return an id")
         XCTAssertTrue(pollSessionCount(2, timeout: 10), "the new session should land")
 
-        // block B FIRST so B is the OLDER blocked (a broken suppress would jump to it), then block A and park
-        // the selection on A — now A is both the selected AND a blocked session.
+        // block B FIRST so it is the OLDER blocked — a broken suppress would jump to it.
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.status","target":"\#(sessionB)","args":{"status":"blocked"}}"#)["ok"] as? Bool,
                        true, "blocking B should succeed")
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.status","target":"\#(sessionA)","args":{"status":"blocked"}}"#)["ok"] as? Bool,
@@ -56,7 +46,6 @@ final class AutoFollowUITests: ControlAPITestCase {
                        "selecting A should succeed")
         XCTAssertTrue(pollActiveNode(equals: sessionA, timeout: 10), "A should be the parked (blocked) selection")
 
-        // across the whole idle window the selection must stay on A and never jump to the older blocked B.
         assertActiveNodeStays(sessionA, never: sessionB, during: 12)
     }
 

--- a/agtermUITests/ClipboardPromptUITests.swift
+++ b/agtermUITests/ClipboardPromptUITests.swift
@@ -13,8 +13,8 @@ final class ClipboardPromptUITests: ControlAPITestCase {
     private var savedClipboard: String?
 
     override func setUp() async throws {
-        // best-effort save/restore of the developer's clipboard STRING around these tests (which read and
-        // write it). Non-string clipboard content (images, rich text) is not preserved.
+        // best-effort save/restore of the developer's clipboard STRING; non-string content (images, rich
+        // text) is not preserved.
         savedClipboard = NSPasteboard.general.string(forType: .string)
         try await super.setUp()
     }
@@ -94,7 +94,6 @@ final class ClipboardPromptUITests: ControlAPITestCase {
         setSystemClipboard(secret)
         let allow = try emitOSC52(printfBody: "\\033]52;c;?\\007", sheetButton: "Allow", target: id)
         allow.click()
-        // allow delivers the clipboard, so the shell echoes the OSC 52 response carrying its base64.
         let buffer = pollSessionText(target: id, timeout: 6) { $0.contains(self.base64(secret)) }
         XCTAssertNotNil(buffer, "an allowed read must deliver the clipboard base64 (\(base64(secret)))")
     }
@@ -116,7 +115,7 @@ final class ClipboardPromptUITests: ControlAPITestCase {
         setSystemClipboard("KEEP-THIS-VALUE")
         let deny = try emitOSC52(printfBody: "\\033]52;c;\(base64("SHOULD-NOT-STICK"))\\007", sheetButton: "Deny", target: id)
         deny.click()
-        // give the denied write a beat to (not) run, then confirm the clipboard is unchanged.
+        // a denial raises no event to poll for, so give the write a beat to (not) happen.
         usleep(500_000)
         XCTAssertEqual(NSPasteboard.general.string(forType: .string), "KEEP-THIS-VALUE", "a denied write must not change the clipboard")
     }

--- a/agtermUITests/ControlAPITestCase.swift
+++ b/agtermUITests/ControlAPITestCase.swift
@@ -38,20 +38,15 @@ class ControlAPITestCase: XCTestCase {
         markerDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("agterm-ctlmarker-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: markerDir, withIntermediateDirectories: true)
-        // socket path constraints: it must be (a) under the unix-socket sun_path ~104-byte limit and
-        // (b) inside the runner's sandbox grant. The per-test AGTERM_STATE_DIR subdir pushes the path to
-        // ~135 bytes (too long), and /tmp is outside the runner sandbox (connect → EPERM). The runner's
-        // own temp dir (NSTemporaryDirectory(), ~81 bytes) with a short filename satisfies both.
+        // the runner's own temp dir keeps the socket path under the sun_path ~104-byte limit AND inside
+        // the sandbox grant (the per-test AGTERM_STATE_DIR subdir is ~135 bytes; /tmp gives EPERM).
         socketPath = (NSTemporaryDirectory() as NSString)
             .appendingPathComponent("agtermc-\(UUID().uuidString.prefix(8)).sock")
         app = XCUIApplication()
         app.launchEnvironment["AGTERM_STATE_DIR"] = stateDir.path
         app.launchEnvironment["AGTERM_CONTROL_SOCKET"] = socketPath
-        // Pin the title-bar double-click action so the header gesture tests are hermetic regardless of
-        // the host's Desktop & Dock setting (the app honors this env override in
-        // performTitlebarDoubleClickAction; launch args can't carry it — FB11763863). Most tests never
-        // double-click, so the value is irrelevant to them; the no-op-case test opts into "None".
-        // (that test, testDoubleClickHeaderHonorsNoneSetting, now lives in ControlWindowUITests.)
+        // pin the title-bar double-click action so the header gesture tests are hermetic regardless of
+        // the host's Desktop & Dock setting; launch args can't carry it — FB11763863.
         app.launchEnvironment["AGTERM_UITEST_DOUBLECLICK_ACTION"] =
             name.contains("testDoubleClickHeaderHonorsNoneSetting") ? "None" : "Maximize"
         try seedSettingsIfNeeded()

--- a/agtermUITests/ControlAPIThemeUITests.swift
+++ b/agtermUITests/ControlAPIThemeUITests.swift
@@ -6,16 +6,13 @@ import XCTest
 @MainActor
 final class ControlAPIThemeUITests: ControlAPITestCase {
     func testThemeSyncWithSystemAppearance() throws {
-        // a positional name plus --light targets the same slot twice.
         let both = try sendCommand(#"{"cmd":"theme.set","args":{"name":"Dracula","light":"Builtin Light"}}"#)
         XCTAssertEqual(both["ok"] as? Bool, false, "name + --light should fail: \(both)")
 
-        // an unknown slot name is rejected, like the single form.
         let bad = try sendCommand(#"{"cmd":"theme.set","args":{"light":"NotARealTheme","dark":"agterm"}}"#)
         XCTAssertEqual(bad["ok"] as? Bool, false, "an unknown theme should fail: \(bad)")
 
-        // setting the dark slot alone starts syncing; the light side seeds from the current theme
-        // (the fresh-install agterm default).
+        // the light side seeds from the current theme — the fresh-install agterm default.
         let darkOnly = try sendCommand(#"{"cmd":"theme.set","args":{"dark":"Dracula"}}"#)
         XCTAssertEqual(darkOnly["ok"] as? Bool, true, "theme.set --dark should succeed: \(darkOnly)")
         let darkResult = try XCTUnwrap(darkOnly["result"] as? [String: Any])
@@ -24,24 +21,20 @@ final class ControlAPIThemeUITests: ControlAPITestCase {
         XCTAssertEqual(darkResult["dark"] as? String, "Dracula")
         XCTAssertNil(darkResult["theme"], "no plain theme while syncing")
 
-        // a plain name replaces the light slot and KEEPS the pair.
         let light = try sendCommand(#"{"cmd":"theme.set","args":{"name":"Builtin Light"}}"#)
         let lightResult = try XCTUnwrap(light["result"] as? [String: Any])
         XCTAssertEqual(lightResult["sync"] as? Bool, true, "a plain set keeps the pair")
         XCTAssertEqual(lightResult["light"] as? String, "Builtin Light")
         XCTAssertEqual(lightResult["dark"] as? String, "Dracula", "the dark side is untouched")
 
-        // theme.list reflects the same derived sync state.
         let listed = try sendCommand(#"{"cmd":"theme.list"}"#)
         XCTAssertEqual((listed["result"] as? [String: Any])?["sync"] as? Bool, true, "theme.list reports sync on")
 
-        // --dark none clears the dark slot: syncing off, the light side survives as the plain theme.
         let cleared = try sendCommand(#"{"cmd":"theme.set","args":{"dark":"none"}}"#)
         let clearedResult = try XCTUnwrap(cleared["result"] as? [String: Any])
         XCTAssertEqual(clearedResult["sync"] as? Bool, false, "--dark none turns syncing off")
         XCTAssertEqual(clearedResult["theme"] as? String, "Builtin Light", "the light side survives as the theme")
 
-        // the reserved `none` is case-insensitive: re-establish syncing, then clear with `--dark None`.
         let resynced = try sendCommand(#"{"cmd":"theme.set","args":{"dark":"Dracula"}}"#)
         XCTAssertEqual(resynced["ok"] as? Bool, true, "re-establishing the dark slot should succeed: \(resynced)")
         let clearedCaps = try sendCommand(#"{"cmd":"theme.set","args":{"dark":"None"}}"#)

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -8,7 +8,6 @@ import XCTest
 /// assert against the response and the `workspaces.json` file-polling oracle the sidebar tests use.
 @MainActor
 final class ControlAPIUITests: ControlAPITestCase {
-    // a `tree` request returns the seeded workspace and session with non-empty ids.
     func testTreeReturnsSeededWorkspaceAndSession() throws {
         let response = try sendCommand(#"{"cmd":"tree"}"#)
         XCTAssertEqual(response["ok"] as? Bool, true, "tree should succeed: \(response)")
@@ -26,8 +25,7 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertEqual(sessions[0]["active"] as? Bool, true, "the seeded session should be active")
     }
 
-    // the tree exposes a session's raw OSC title. Set one by typing a printf that emits OSC 2, held by
-    // `cat` so the local shell can't clear it at the next prompt (mirroring how a remote keeps its title).
+    // `cat` holds the foreground so the next prompt can't clear the title, as a remote session keeps it.
     func testTreeExposesOscTitle() throws {
         let text = "printf '\\033]2;CTL-OSC-TITLE\\007'; cat\n"
         let payload: [String: Any] = ["cmd": "session.type", "args": ["text": text]]
@@ -53,8 +51,7 @@ final class ControlAPIUITests: ControlAPITestCase {
         return sessions.first?["title"] as? String
     }
 
-    // tree exposes each session's LIVE foreground command: run a non-shell blocking process (`tee` opens
-    // its file on start, then blocks reading the pty) so the foreground is `tee`, not the shell prompt.
+    // `tee` opens its file on start then blocks on the pty, so the foreground is `tee`, not the prompt.
     func testTreeExposesForegroundProcess() throws {
         let marker = markerDir.appendingPathComponent("fg-\(UUID().uuidString)").path
         let payload: [String: Any] = ["cmd": "session.type", "args": ["text": "tee \(marker)\n"]]
@@ -79,8 +76,7 @@ final class ControlAPIUITests: ControlAPITestCase {
         return sessions.first?["foreground"] as? [String]
     }
 
-    // tree exposes each session's agent status: setting `blocked` surfaces `status: "blocked"` on that
-    // session's node, while a session left idle omits the key entirely (the read side of session.status).
+    // an idle session omits the status key entirely, which the second session is here to prove.
     func testTreeExposesAgentStatus() throws {
         let tree = try sendCommand(#"{"cmd":"tree"}"#)
         let treeResult = try XCTUnwrap(tree["result"] as? [String: Any], "tree should carry a result")
@@ -89,17 +85,14 @@ final class ControlAPIUITests: ControlAPITestCase {
         let sessions = try XCTUnwrap(workspaces.first?["sessions"] as? [[String: Any]], "workspace should list sessions")
         let seeded = try XCTUnwrap(sessions.first?["id"] as? String, "should have a seeded session id")
 
-        // a second session stays idle so its node can prove the status key is omitted when idle.
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
         let createdResult = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
         let idleID = try XCTUnwrap(createdResult["id"] as? String, "session.new should return the new id")
         XCTAssertTrue(pollSessionCount(2, timeout: 10), "the new session should land")
 
-        // baseline: every fresh session is idle, so the seeded node omits the status key.
         let before = try sendCommand(#"{"cmd":"tree"}"#)
         XCTAssertNil(sessionNode(before, id: seeded)?["status"], "an idle session should omit the status key")
 
-        // set blocked on the seeded session; its node now reports status "blocked".
         let set = try sendCommand(#"{"cmd":"session.status","target":"\#(seeded)","args":{"status":"blocked"}}"#)
         XCTAssertEqual(set["ok"] as? Bool, true, "session.status blocked should succeed: \(set)")
 
@@ -111,7 +104,6 @@ final class ControlAPIUITests: ControlAPITestCase {
         }
         XCTAssertEqual(seededStatus, "blocked", "tree should report the seeded session's blocked status")
 
-        // the untouched second session is still idle, so it omits the status key.
         let after = try sendCommand(#"{"cmd":"tree"}"#)
         XCTAssertNil(sessionNode(after, id: idleID)?["status"], "an idle session should omit the status key")
     }
@@ -130,15 +122,12 @@ final class ControlAPIUITests: ControlAPITestCase {
         return nil
     }
 
-    // restore.clear succeeds and the server keeps serving. The saved-command WIPE is only observable across
-    // a quit (the field is populated at quit, consumed at restore), so the cross-relaunch behavior is left
-    // to the arm's trivial nil+saveAllOpen logic plus the protocol round-trip + CLI parse tests.
+    // the WIPE itself is only observable across a quit, so this covers the arm, not the wipe.
     func testRestoreClearSucceeds() throws {
         let resp = try sendCommand(#"{"cmd":"restore.clear"}"#)
         XCTAssertEqual(resp["ok"] as? Bool, true, "restore.clear should succeed: \(resp)")
 
-        // the two verbs are easy to confuse: `restore clear` is app-global and CAPTURE-scoped, so it must
-        // leave a per-session `session.restore` override pinned.
+        // `restore clear` is app-global and CAPTURE-scoped, so a per-session override must survive it.
         let sessionID = try activeSessionID()
         XCTAssertEqual(try sendRestore(target: sessionID, mode: "set", command: "echo kept")["ok"] as? Bool, true,
                        "pinning an override should succeed")
@@ -147,9 +136,8 @@ final class ControlAPIUITests: ControlAPITestCase {
                        "restore.clear captures only — the per-session override must survive it")
     }
 
-    // the two `--pane-id` FALLBACK paths, the other half of the deliberate divergence from session.status:
-    // an EMPTY token counts as ABSENT (an older shell exporting no $AGTERM_PANE_ID), and an unresolvable
-    // token supplied WITH an explicit `--pane` falls back to that pane instead of erroring.
+    // an EMPTY token counts as ABSENT (an older shell exports none); an unresolvable one falls back to
+    // an explicit `--pane` rather than erroring.
     func testSessionRestorePaneIDFallsBackWhenEmptyOrUnresolvable() throws {
         let sessionID = try activeSessionID()
         let empty = try sendRestore(target: sessionID, mode: "set", command: "echo empty-token", paneID: "")
@@ -165,9 +153,7 @@ final class ControlAPIUITests: ControlAPITestCase {
                        "the explicit --pane is the intended fallback")
     }
 
-    // the read side of session.restore: a pinned command reads back verbatim, `--none` reads back as an
-    // EMPTY string (the key is present — the tri-state depends on it), and `--clear` omits the key.
-    // Whether the override actually RE-RUNS is a relaunch matter, covered by RestoreCommandUITests.
+    // the tri-state depends on presence: `--none` reads back as an EMPTY string, `--clear` omits the key.
     func testSessionRestoreReadsBackOnTree() throws {
         let sessionID = try activeSessionID()
         XCTAssertNil(try restoreNode(sessionID)["restoreCommand"], "a fresh session has no override pinned")
@@ -187,9 +173,7 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertNil(try restoreNode(sessionID)["restoreCommand"], "a cleared override omits the key entirely")
     }
 
-    // `--pane-id` addresses the pane's LIVE slot, which is the whole point of the token: after the MAIN
-    // pane exits, the split survivor is PROMOTED into the main slot, so its own $AGTERM_PANE_ID (baked
-    // when it was the right pane) must pin `restoreCommand`, not `splitRestoreCommand`.
+    // the survivor is PROMOTED into the main slot, so its right-pane token must pin `restoreCommand`.
     func testSessionRestorePaneIDFollowsPromotedPane() throws {
         let sessionID = try activeSessionID()
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.split","target":"\#(sessionID)","args":{"mode":"on"}}"#)["ok"] as? Bool,
@@ -197,15 +181,12 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertTrue(pollActiveSessionSplit(true, timeout: 10), "the session should report split:true")
         let rightToken = try readPaneToken(target: sessionID, pane: "right")
 
-        // prove the main pane's shell is READING keystrokes before sending `exit` — a dropped injection
-        // can't be retried here, since a second `exit` would land on the promoted survivor and close the
-        // session outright.
+        // prove the shell is READING before `exit`: a retry would land on the survivor and close the session.
         XCTAssertNotNil(try pollPaneText(target: sessionID, pane: "left", contains: "MAINRDY-42", retype: {
             _ = try self.sendCommand(self.typeRequest(text: "echo MAINRDY-$((6*7))\n", target: sessionID,
                                                       select: false, pane: "left"))
         }), "the main pane's shell should be reading keystrokes")
 
-        // exiting the main pane promotes the survivor into the main slot (session stays, split:false).
         _ = try sendCommand(typeRequest(text: "exit\n", target: sessionID, select: false, pane: "left"))
         XCTAssertTrue(pollActiveSessionSplit(false, timeout: 15), "the session should collapse to a single pane")
 
@@ -218,9 +199,7 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertNil(node["splitRestoreCommand"], "nothing may be pinned on the vacated split slot")
     }
 
-    // the pane-resolution rejections: a right pane that does not exist, a token that resolves to the
-    // scratch (never restored), and an unresolvable token with no `--pane` fallback — the last is where
-    // session.restore deliberately diverges from session.status, which would silently fall back to left.
+    // the last case is where session.restore diverges from session.status, which falls back to left.
     func testSessionRestoreRejectsUnrestorablePanes() throws {
         let sessionID = try activeSessionID()
         let noSplit = try sendRestore(target: sessionID, mode: "set", command: "echo x", pane: "right")
@@ -279,9 +258,7 @@ final class ControlAPIUITests: ControlAPITestCase {
         return String(text[try XCTUnwrap(Range(match.range(at: 1), in: text))])
     }
 
-    // session.reveal resolves the active session and drives the same focused-cwd Finder action as the
-    // main/context menus. Finder itself is outside the app's AX tree; success plus the returned id proves
-    // the command reached the platform action, while a missing target proves normal resolver errors remain.
+    // Finder is outside the AX tree, so the returned id is all that proves the action was reached.
     func testSessionRevealSucceedsAndResolvesTargets() throws {
         let activeID = try activeSessionID()
         let revealed = try sendCommand(#"{"cmd":"session.reveal","target":"active"}"#)
@@ -294,24 +271,20 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertTrue((missing["error"] as? String)?.contains("no such session") == true)
     }
 
-    // session.background sets a text watermark and clears it; bad input (missing image, invalid fit) is
-    // rejected and the server stays alive. The actual pixels are not AX-observable (Metal surface), so this
-    // covers the control round-trip + validation, like the other surface-state commands.
+    // the pixels are not AX-observable (Metal surface), so this covers the round-trip and validation only.
     func testSessionBackgroundSetClearAndValidation() throws {
         let sid = try activeSessionID()
 
         let text = try sendCommand(#"{"cmd":"session.background","target":"\#(sid)","args":{"mode":"text","text":"STAGING","opacity":0.2}}"#)
         XCTAssertEqual(text["ok"] as? Bool, true, "session.background text should succeed: \(text)")
 
-        // read-back: the watermark spec now rides the session's tree node (set/clear/query symmetry).
         let afterSet = try sendCommand(#"{"cmd":"tree"}"#)
         let setNode = try XCTUnwrap(sessionNode(afterSet, id: sid), "the session should appear in the tree")
         let bg = try XCTUnwrap(setNode["background"] as? [String: Any], "tree should expose the set watermark")
         XCTAssertEqual(bg["kind"] as? String, "text", "the watermark kind should read back")
         XCTAssertEqual(bg["text"] as? String, "STAGING", "the watermark text should read back")
 
-        // a solid background color reads back with kind "color" and the hex. The spec carries no opacity —
-        // a color honors the Settings window translucency at render time.
+        // the spec carries no opacity: a color honors the Settings translucency at render time.
         let colorSet = try sendCommand(##"{"cmd":"session.background","target":"\##(sid)","args":{"mode":"color","color":"#ff0000"}}"##)
         XCTAssertEqual(colorSet["ok"] as? Bool, true, "session.background color should succeed: \(colorSet)")
         let afterColor = try sendCommand(#"{"cmd":"tree"}"#)
@@ -323,8 +296,7 @@ final class ControlAPIUITests: ControlAPITestCase {
         let badColor = try sendCommand(#"{"cmd":"session.background","target":"\#(sid)","args":{"mode":"color","color":"red"}}"#)
         XCTAssertEqual(badColor["ok"] as? Bool, false, "a malformed color should be rejected")
 
-        // color mode with no color hits the "requires a color" guard (unreachable from the CLI, whose
-        // argument is required, so the raw-JSON e2e is the only cover for this arm).
+        // unreachable from the CLI, whose argument is required, so raw JSON is the only cover.
         let emptyColor = try sendCommand(#"{"cmd":"session.background","target":"\#(sid)","args":{"mode":"color"}}"#)
         XCTAssertEqual(emptyColor["ok"] as? Bool, false, "color mode with no color should be rejected")
         XCTAssertEqual(emptyColor["error"] as? String, "session.background color requires a color",
@@ -336,9 +308,8 @@ final class ControlAPIUITests: ControlAPITestCase {
         let badFit = try sendCommand(#"{"cmd":"session.background","target":"\#(sid)","args":{"mode":"image","path":"/no/such.png","fit":"fill"}}"#)
         XCTAssertEqual(badFit["ok"] as? Bool, false, "an invalid fit should be rejected")
 
-        // config-injection vector: a newline in the image path would smuggle an extra ghostty key into the
-        // per-surface overlay. The control-char guard runs BEFORE the format/existence checks, so its own
-        // error proves it (not fileExists) did the rejecting.
+        // a newline would smuggle an extra ghostty key in. The guard runs BEFORE the existence check, so
+        // its own error proves it did the rejecting.
         let injection = try sendCommand(#"{"cmd":"session.background","target":"\#(sid)","args":{"mode":"image","path":"x.png\nclipboard-read = allow\ny.png"}}"#)
         XCTAssertEqual(injection["ok"] as? Bool, false, "an image path with a control char must be rejected")
         XCTAssertEqual(injection["error"] as? String, "image path must not contain control characters",
@@ -347,7 +318,6 @@ final class ControlAPIUITests: ControlAPITestCase {
         let badOpacity = try sendCommand(#"{"cmd":"session.background","target":"\#(sid)","args":{"mode":"text","text":"X","opacity":5}}"#)
         XCTAssertEqual(badOpacity["ok"] as? Bool, false, "an out-of-range opacity should be rejected")
 
-        // an over-long text must be rejected at the boundary so the renderer never attempts a huge bitmap.
         let longText = String(repeating: "A", count: 5000)
         let tooLong = try sendCommand(#"{"cmd":"session.background","target":"\#(sid)","args":{"mode":"text","text":"\#(longText)"}}"#)
         XCTAssertEqual(tooLong["ok"] as? Bool, false, "an over-long watermark text should be rejected")
@@ -357,13 +327,10 @@ final class ControlAPIUITests: ControlAPITestCase {
 
         let tree = try sendCommand(#"{"cmd":"tree"}"#)
         XCTAssertEqual(tree["ok"] as? Bool, true, "the server should stay alive after background commands")
-        // read-back after clear: the background key is omitted from the node.
         let clearedNode = try XCTUnwrap(sessionNode(tree, id: sid), "the session should still appear in the tree")
         XCTAssertNil(clearedNode["background"], "a cleared watermark should be absent from the tree node")
     }
 
-    // a malformed JSON line returns ok:false with an error, and the server stays alive: a
-    // subsequent valid `tree` still succeeds.
     func testMalformedRequestErrorsAndServerStaysAlive() throws {
         let bad = try sendCommand("not json at all")
         XCTAssertEqual(bad["ok"] as? Bool, false, "malformed request should fail")
@@ -373,7 +340,6 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertEqual(good["ok"] as? Bool, true, "the server should still answer after a bad request")
     }
 
-    // session.new returns an id and the session appears in workspaces.json; session.close removes it.
     func testSessionNewAndClose() throws {
         XCTAssertTrue(pollSessionCount(1, timeout: 10), "should start with the one seeded session")
 
@@ -389,15 +355,10 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertTrue(pollSessionCount(1, timeout: 10), "closing the session should remove its row")
     }
 
-    // session.duplicate opens a fresh shell rooted at the source's cwd, inserted DIRECTLY AFTER the source
-    // in the same workspace, and focuses it. Read-back is `tree`: the new node follows its source carrying
-    // the source's cwd (the write-only command's own read-back point) and becomes the active session. Seeds
-    // the source with a real non-home directory so the cwd carry-over is a genuine assertion, not the shared
-    // new-session default.
+    // the source needs a real non-home directory, or the cwd carry-over matches the default and proves nothing.
     func testSessionDuplicate() throws {
         let sourceID = UUID(uuidString: "DD100000-0000-0000-0000-000000000001")!
-        // a real dir UNDER home (home is not a symlink, so the shell's OSC 7 report matches the seeded path
-        // verbatim — no /private canonicalization that a /tmp or NSTemporaryDirectory() seed would hit).
+        // under home, which is not a symlink: a /tmp seed would hit /private canonicalization.
         let cwd = NSHomeDirectory() + "/agterm-dup-\(UUID().uuidString)"
         try FileManager.default.createDirectory(atPath: cwd, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(atPath: cwd) }
@@ -424,20 +385,17 @@ final class ControlAPIUITests: ControlAPITestCase {
         let sessions = try XCTUnwrap(workspace["sessions"] as? [[String: Any]], "workspace should list sessions")
         XCTAssertEqual(sessions.count, 2, "the source and its duplicate")
 
-        // inserted DIRECTLY AFTER its source, not appended elsewhere.
         XCTAssertEqual((sessions[0]["id"] as? String)?.lowercased(), sourceID.uuidString.lowercased(),
                        "the source stays first")
         XCTAssertEqual((sessions[1]["id"] as? String)?.lowercased(), newID.lowercased(),
                        "the duplicate lands right after its source")
-        // carries the source's cwd (the read-back) and becomes the active session.
         XCTAssertEqual(sessions[1]["cwd"] as? String, sessions[0]["cwd"] as? String,
                        "the duplicate carries its source's cwd")
         XCTAssertEqual(sessions[1]["cwd"] as? String, cwd, "the duplicate opens in the source's specific directory")
         XCTAssertEqual(sessions[1]["active"] as? Bool, true, "the duplicate becomes the active session")
     }
 
-    // session.close with multiple targets is the control surface for the GUI batch close: one request
-    // hides all targeted sessions together (the save is deferred by the grace window, so assert via tree).
+    // the save is deferred by the grace window, so the assertion goes through `tree`, not the file.
     func testSessionCloseMultipleTargets() throws {
         let firstID = UUID(uuidString: "AA100000-0000-0000-0000-000000000001")!
         let secondID = UUID(uuidString: "AA200000-0000-0000-0000-000000000002")!
@@ -464,8 +422,7 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertNil(sessionNode(tree, id: thirdID.uuidString), "the third session should be hidden by the grouped close")
     }
 
-    // The control surface follows the GUI's grace setting. With grace disabled, batch close tears down and
-    // persists immediately instead of leaving the pre-close snapshot on disk for the undo window.
+    // with grace disabled the close persists immediately instead of leaving the pre-close snapshot on disk.
     func testSessionCloseMultipleTargetsHonorsDisabledGraceUndo() throws {
         let firstID = UUID(uuidString: "AB100000-0000-0000-0000-000000000001")!
         let secondID = UUID(uuidString: "AB200000-0000-0000-0000-000000000002")!
@@ -487,9 +444,7 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertTrue(pollSessionCount(1, timeout: 2), "grace-disabled close must persist both removals immediately")
     }
 
-    // Batch target resolution is all-or-nothing: a request naming a valid session alongside an unknown
-    // or ambiguous target must fail WHOLE, without closing the valid member — resolveBatchSessions
-    // errors before anything mutates.
+    // `resolveBatchSessions` errors before anything mutates, so the valid member must survive.
     func testSessionCloseBatchIsAllOrNothing() throws {
         let firstID = UUID(uuidString: "ABCD1111-0000-0000-0000-000000000001")!
         let secondID = UUID(uuidString: "ABCD2222-0000-0000-0000-000000000002")!
@@ -517,9 +472,7 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertNotNil(sessionNode(tree, id: thirdID.uuidString), "the valid batch member must stay open")
     }
 
-    // session.new --command runs the command AS the session's process (no shell echo): create a session
-    // whose command writes a marker file, then read it back — proof the command ran as the process, not
-    // typed into a shell. The session closes when the command exits (kitty-style).
+    // the marker file is the proof the command ran AS the process rather than being typed into a shell.
     func testSessionNewWithCommandRunsAsProcess() throws {
         let marker = NSTemporaryDirectory() + "agterm-cmd-\(UUID().uuidString).txt"
         let cmd = "printf RANCMD > \(marker)"
@@ -536,15 +489,12 @@ final class ControlAPIUITests: ControlAPITestCase {
         try? FileManager.default.removeItem(atPath: marker)
     }
 
-    // session.new --command --wait HOLDS the session open after the command exits (issue #254): the command
-    // `true` exits immediately, so WITHOUT --wait the session would vanish; WITH it the session stays on the
-    // press-any-key prompt and the tree reports commandWait=true (the read-back).
+    // `true` exits immediately, so without --wait the session would vanish (issue #254).
     func testSessionNewCommandWaitHoldsSessionAfterExit() throws {
         let created = try sendCommand(#"{"cmd":"session.new","args":{"command":"true","wait":true}}"#)
         XCTAssertEqual(created["ok"] as? Bool, true, "session.new --command --wait should succeed: \(created)")
         let newID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "session.new should return an id")
 
-        // let the command run and exit; the surface holds on the prompt rather than closing the session.
         RunLoop.current.run(until: Date().addingTimeInterval(2))
 
         let tree = try sendCommand(#"{"cmd":"tree"}"#)
@@ -552,24 +502,20 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertEqual(node["commandWait"] as? Bool, true, "the tree should report commandWait=true for a held session")
     }
 
-    // --wait holds a command surface, so it is meaningless without a command; the dispatcher rejects it
-    // SERVER-SIDE (a raw socket client can't bypass the CLI validate()).
+    // rejected SERVER-SIDE, since a raw socket client bypasses the CLI's own validate().
     func testSessionNewWaitWithoutCommandRejectedServerSide() throws {
         let resp = try sendCommand(#"{"cmd":"session.new","args":{"wait":true}}"#)
         XCTAssertEqual(resp["ok"] as? Bool, false, "--wait without --command must be rejected: \(resp)")
         XCTAssertEqual(resp["error"] as? String, "--wait requires --command")
     }
 
-    // a control session.new (frontmost window) FOCUSES the new session, so real keystrokes reach it: the
-    // command is `head -n1 > marker` (captures one typed line), and we type via the keyboard — the text
-    // only lands if the new session grabbed first responder. Guards the gate-command focus fix.
+    // `head -n1 > marker` plus REAL keystrokes: the text lands only if the new session took first responder.
     func testSessionNewWithCommandFocusesTheNewSession() throws {
         let marker = NSTemporaryDirectory() + "agterm-focus-\(UUID().uuidString).txt"
         let cmd = "head -n1 > \(marker)"
         let created = try sendCommand(#"{"cmd":"session.new","args":{"command":"\#(cmd)"}}"#)
         XCTAssertEqual(created["ok"] as? Bool, true, "session.new --command should succeed: \(created)")
 
-        // let the surface mount and grab first responder (focusActiveSession's bounded retry), then type.
         RunLoop.current.run(until: Date().addingTimeInterval(2))
         app.typeText("FOCUSED")
         app.typeKey(.return, modifierFlags: [])
@@ -584,16 +530,11 @@ final class ControlAPIUITests: ControlAPITestCase {
         try? FileManager.default.removeItem(atPath: marker)
     }
 
-    // promote → re-split keystroke-clear: after the primary exits and the split survivor is promoted into
-    // the main slot, then a fresh split opens, typing a REAL keystroke in the promoted MAIN pane must NOT
-    // clear a `.right` block owned by the fresh split — the promoted survivor is the main (`.left`) pane now.
-    // Before the role-aware wireStatusClear fix the survivor stayed statically `.right`-wired, so main-pane
-    // typing wrongly cleared the split's `.right` block. Real keystrokes (not session.type inject) drive the
-    // onUserInputClearsStatus path; the socket sets + reads the status. Guards the role-aware clear + re-tag.
+    // the promoted survivor is the MAIN pane now, so its keystrokes must not clear the fresh split's
+    // `.right` block. Real keystrokes are load-bearing: a session.type inject skips onUserInputClearsStatus.
     func testPromotedMainPaneDoesNotClearSplitRightStatus() throws {
         let sid = try activeSessionID()
 
-        // open a split, focus the primary (left), and exit its shell so the right pane PROMOTES to main.
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.split","target":"\#(sid)","args":{"mode":"on"}}"#)["ok"] as? Bool, true)
         RunLoop.current.run(until: Date().addingTimeInterval(1))
         app.typeKey(.leftArrow, modifierFlags: [.command, .option])
@@ -602,11 +543,9 @@ final class ControlAPIUITests: ControlAPITestCase {
         app.typeKey(.return, modifierFlags: [])
         RunLoop.current.run(until: Date().addingTimeInterval(2)) // shell exit + promotion + auto-focus
 
-        // re-split → a fresh right pane opens; block it (.right).
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.split","target":"\#(sid)","args":{"mode":"on"}}"#)["ok"] as? Bool, true)
         RunLoop.current.run(until: Date().addingTimeInterval(1))
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.status","target":"\#(sid)","args":{"status":"blocked","pane":"right"}}"#)["ok"] as? Bool, true)
-        // sanity: the block is set before we test that typing elsewhere doesn't clear it.
         var set = false
         for _ in 0..<10 {
             if (sessionNode(try sendCommand(#"{"cmd":"tree"}"#), id: sid)?["status"] as? String) == "blocked" { set = true; break }
@@ -614,7 +553,6 @@ final class ControlAPIUITests: ControlAPITestCase {
         }
         XCTAssertTrue(set, "the .right block should be set before the keystroke test")
 
-        // type a REAL keystroke in the promoted MAIN (left) pane — must NOT clear the split's .right block.
         app.typeKey(.leftArrow, modifierFlags: [.command, .option])
         RunLoop.current.run(until: Date().addingTimeInterval(0.5))
         app.typeText("x")
@@ -625,8 +563,6 @@ final class ControlAPIUITests: ControlAPITestCase {
                        "typing in the promoted main pane must not clear the split pane's .right block")
     }
 
-    // session.new --name seeds the new session's custom name at creation (open a session already labeled,
-    // without a follow-up rename). Verify the returned id carries the given name in the persisted snapshot.
     func testSessionNewWithName() throws {
         let created = try sendCommand(#"{"cmd":"session.new","args":{"name":"myhost"}}"#)
         XCTAssertEqual(created["ok"] as? Bool, true, "session.new --name should succeed: \(created)")
@@ -635,37 +571,29 @@ final class ControlAPIUITests: ControlAPITestCase {
                       "the new session should carry the given custom name")
     }
 
-    // session.new --workspace-name addresses a workspace by its sidebar label. Without --create-workspace
-    // a missing name errors (nothing created); with it, the workspace is created once and REUSED on the
-    // next call (idempotent), so two creates land two sessions in a single "servers" workspace.
+    // the reuse leg is what makes it idempotent: two creates must land two sessions in ONE workspace.
     func testSessionNewWorkspaceNameCreatesThenReuses() throws {
-        // no match + no create -> error, and nothing is created.
         let missing = try sendCommand(#"{"cmd":"session.new","args":{"workspaceName":"servers"}}"#)
         XCTAssertEqual(missing["ok"] as? Bool, false, "name target with no match and no create should fail: \(missing)")
         XCTAssertTrue((missing["error"] as? String ?? "").contains("no workspace named"),
                       "should report the missing workspace name: \(missing)")
         XCTAssertTrue(pollWorkspaceNames(["workspace 1"], timeout: 5), "the failed call must not create a workspace")
 
-        // create: the "servers" workspace is added and the session lands in it.
         let created = try sendCommand(#"{"cmd":"session.new","args":{"workspaceName":"servers","createWorkspace":true}}"#)
         XCTAssertEqual(created["ok"] as? Bool, true, "create-workspace should succeed: \(created)")
         XCTAssertTrue(pollWorkspaceNames(["workspace 1", "servers"], timeout: 10), "the servers workspace should be created")
 
-        // reuse: a second call with the same name does NOT create a duplicate; both sessions sit in servers.
         let reused = try sendCommand(#"{"cmd":"session.new","args":{"workspaceName":"servers","createWorkspace":true}}"#)
         XCTAssertEqual(reused["ok"] as? Bool, true, "the second create should reuse the workspace: \(reused)")
         XCTAssertTrue(pollWorkspaceNames(["workspace 1", "servers"], timeout: 10), "still exactly one servers workspace")
         XCTAssertTrue(pollSessionCounts([1, 2], timeout: 10), "both sessions should land in the single servers workspace")
 
-        // no-create name target of an EXISTING workspace succeeds and lands there (a third session).
         let existing = try sendCommand(#"{"cmd":"session.new","args":{"workspaceName":"servers"}}"#)
         XCTAssertEqual(existing["ok"] as? Bool, true, "no-create name target of an existing workspace should succeed: \(existing)")
         XCTAssertTrue(pollSessionCounts([1, 3], timeout: 10), "the no-create name target should land a third session in servers")
     }
 
-    // the ControlServer arm enforces the two addressing rules independently of the CLI validate() (a raw
-    // socket caller bypasses the CLI), and a blank name reports must-not-be-blank rather than a misleading
-    // --create-workspace suggestion.
+    // enforced SERVER-SIDE, since a raw socket caller bypasses the CLI's validate().
     func testSessionNewWorkspaceNameValidationErrors() throws {
         let both = try sendCommand(#"{"cmd":"session.new","args":{"workspace":"active","workspaceName":"servers"}}"#)
         XCTAssertEqual(both["ok"] as? Bool, false, "both --workspace and --workspace-name should fail: \(both)")
@@ -682,9 +610,6 @@ final class ControlAPIUITests: ControlAPITestCase {
                       "a blank name should report must-not-be-blank, not suggest --create-workspace: \(blank)")
     }
 
-    // session.new --no-select creates the session in the background: it is added (a second row appears and
-    // the returned id resolves in the tree) but the ORIGINAL session stays active, so the read-back `active`
-    // flag confirms the selection was not pulled to the new one.
     func testSessionNewNoSelectKeepsActiveSelection() throws {
         let original = try activeSessionID()
 
@@ -693,7 +618,6 @@ final class ControlAPIUITests: ControlAPITestCase {
         let newID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "session.new should return an id")
         XCTAssertNotEqual(newID.lowercased(), original.lowercased(), "the background session should be a new session")
 
-        // poll until the new session appears, then assert the ORIGINAL is still active and the new one is not.
         var confirmed = false
         for _ in 0..<20 {
             let tree = try sendCommand(#"{"cmd":"tree"}"#)
@@ -707,7 +631,6 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertTrue(confirmed, "the new session should exist while the original stays active (not the new one)")
     }
 
-    // workspace.new returns an id and the workspace appears; workspace.rename is reflected in json.
     func testWorkspaceNewAndRename() throws {
         let created = try sendCommand(#"{"cmd":"workspace.new","args":{"name":"control ws"}}"#)
         XCTAssertEqual(created["ok"] as? Bool, true, "workspace.new should succeed: \(created)")
@@ -722,7 +645,6 @@ final class ControlAPIUITests: ControlAPITestCase {
                       "the rename should be reflected in workspaces.json")
     }
 
-    // workspace.delete of the last workspace returns the keep-one error and leaves the workspace present.
     func testWorkspaceDeleteLastErrors() throws {
         XCTAssertTrue(pollWorkspaceNames(["workspace 1"], timeout: 10), "should start with the one seeded workspace")
 
@@ -730,11 +652,9 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertEqual(response["ok"] as? Bool, false, "deleting the last workspace should fail")
         XCTAssertEqual(response["error"] as? String, "cannot delete last workspace",
                        "should return the keep-one error: \(response)")
-        // the workspace must still be there a beat later.
         XCTAssertTrue(pollWorkspaceNames(["workspace 1"], timeout: 5), "the workspace should still be present")
     }
 
-    // a command with an unknown target returns a structured "no such …" error.
     func testUnknownTargetErrors() throws {
         let response = try sendCommand(#"{"cmd":"session.close","target":"deadbeef"}"#)
         XCTAssertEqual(response["ok"] as? Bool, false, "an unknown target should fail")
@@ -742,9 +662,7 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertTrue(error.hasPrefix("no such session"), "should report no such session, got: \(error)")
     }
 
-    // session.type without select into a visible, realized session writes its tty to a file — read it back
-    // (the split-test idiom: the surface's own shell is the oracle for "the text actually landed"). A new
-    // session is selected and shown on creation, so its surface is realized — the immediate-inject arm.
+    // the surface's own shell is the oracle for "the text actually landed".
     func testSessionTypeIntoActiveSession() throws {
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
         let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
@@ -752,8 +670,7 @@ final class ControlAPIUITests: ControlAPITestCase {
 
         let file = markerDir.appendingPathComponent("active")
         let command = "tty > '\(file.path)'\n"
-        // type-and-retry: a freshly-realized surface's shell may not be ready for the first keystrokes under
-        // full-suite load, so re-inject until the shell writes the marker (the deterministic readiness wait).
+        // a freshly-realized shell may drop the first keystrokes, so the marker is the readiness wait.
         XCTAssertNotNil(try typeUntilMarker(command, target: newID, file: file, select: false),
                         "the typed command should run in the visible session's shell")
     }
@@ -766,17 +683,14 @@ final class ControlAPIUITests: ControlAPITestCase {
 
         let file = markerDir.appendingPathComponent("realized")
         let command = "tty > '\(file.path)'\n"
-        // --select realizes the never-shown session; type-and-retry rides out the shell-readiness race so a
-        // dropped first injection under full-suite load doesn't fail the test (the marker is the readiness signal).
+        // --select realizes the never-shown session; the marker rides out the shell-readiness race.
         XCTAssertNotNil(try typeUntilMarker(command, target: newID, file: file, select: true),
                         "the typed command should run in the realized session's shell")
     }
 
-    // eager session realization means a restored-but-not-selected session is already live, so session.type
-    // without --select reaches it (there are no never-shown sessions left to error on).
+    // the eager deck realizes every restored session, so there are no never-shown ones left to error on.
     func testSessionTypeReachesEagerlyRealizedSession() throws {
-        // pre-seed two sessions with the FIRST selected and relaunch; the second is restored but never
-        // selected, yet the deck realizes every session at startup, so its shell is already running.
+        // the second is restored but never selected, yet its shell is already running.
         let selectedID = UUID()
         let otherID = UUID()
         let snapshot = """
@@ -787,14 +701,12 @@ final class ControlAPIUITests: ControlAPITestCase {
         """
         try relaunch(withSnapshot: snapshot)
 
-        // type WITHOUT --select into the non-selected session; the command must land in its shell.
         let file = markerDir.appendingPathComponent("eager")
         XCTAssertNotNil(try typeUntilMarker("tty > '\(file.path)'\n", target: otherID.uuidString, file: file, select: false),
                         "session.type without select reaches the eagerly-realized, non-selected session")
     }
 
-    // session.copy on a session with no selection returns the "no selection" error (a fresh session has
-    // none). The with-selection path needs a real text selection in the Metal surface, verified manually.
+    // the with-selection path needs a real Metal-surface selection, verified by hand.
     func testSessionCopyWithoutSelectionErrors() throws {
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
         let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
@@ -805,10 +717,7 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertEqual(response["error"] as? String, "no selection", "should report no selection: \(response)")
     }
 
-    // session.selectall selects the WHOLE buffer; session.copy is its read-back. Two markers are echoed on
-    // separate lines (separated by blank lines) and both must come back in one copied selection — a
-    // select_all that only grabbed the current line or the visible row would return just the second marker
-    // and fail. Polling for the LAST marker also proves both echoes rendered before the selection is taken.
+    // two markers on separate lines: a select_all grabbing only the current line returns just the second.
     func testSessionSelectAllThenCopyReturnsBuffer() throws {
         let id = try activeSessionID()
         let first = "SELECTALLMARKERONE", second = "SELECTALLMARKERTWO"
@@ -829,9 +738,7 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertTrue(text.contains(second), "selection should include the last marker, got: \(text)")
     }
 
-    // session.paste pastes the SYSTEM clipboard into the session (the socket analogue of ⌘V). Put a marker
-    // on NSPasteboard.general (shared across processes), paste it, and read the buffer back until the pasted
-    // text shows at the prompt.
+    // NSPasteboard.general is shared across processes, so the test process can seed it.
     func testSessionPasteInsertsClipboardText() throws {
         let id = try activeSessionID()
         let marker = "PASTECLIPMARKER"
@@ -844,10 +751,8 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertNotNil(found, "the pasted clipboard marker should appear in the buffer")
     }
 
-    // session.paste is UNGATED, unlike the Edit menu's Paste item (which validateMenuItem disables when the
-    // clipboard holds nothing pasteable). An empty clipboard is therefore `ok` with no buffer change, matching
-    // every other binding-action arm (font.*, search), which report success without consulting libghostty's
-    // return. Pinned so the GUI-gated / socket-ungated asymmetry can't drift unnoticed.
+    // UNGATED, unlike the Edit menu's Paste item: an empty clipboard is `ok` with no buffer change, as
+    // every other binding-action arm reports success without consulting libghostty's return.
     func testSessionPasteWithEmptyClipboardSucceedsWithoutChangingBuffer() throws {
         let id = try activeSessionID()
         seedPasteboard { _ in }  // cleared, nothing written
@@ -863,7 +768,6 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertEqual(beforeText, afterText, "an empty-clipboard paste must not change the buffer")
     }
 
-    // both new commands surface the resolver's error for an unknown target rather than silently no-opping.
     func testSessionPasteAndSelectAllRejectUnknownTarget() throws {
         for cmd in ["session.paste", "session.selectall"] {
             let response = try sendCommand(#"{"cmd":"\#(cmd)","target":"deadbeef"}"#)

--- a/agtermUITests/ControlOverlaySplitUITests.swift
+++ b/agtermUITests/ControlOverlaySplitUITests.swift
@@ -13,9 +13,7 @@ final class ControlOverlaySplitUITests: ControlAPITestCase {
         XCTAssertEqual(response["error"] as? String, "session.overlay.open requires a command", "\(response)")
     }
 
-    // session.overlay open/close lifecycle and the guards: a long-lived command (cat waits on stdin)
-    // keeps the overlay up, so a second open errors; after close, closing again errors. The overlay
-    // actually rendering and running a TUI is verified manually (the Metal surface is not in the tree).
+    // `cat` waits on stdin, which is what keeps the overlay up long enough to assert against.
     func testOverlayOpenCloseLifecycle() throws {
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
         let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
@@ -36,36 +34,28 @@ final class ControlOverlaySplitUITests: ControlAPITestCase {
         XCTAssertEqual(closeAgain["error"] as? String, "no overlay", "\(closeAgain)")
     }
 
-    // session.overlay.resize switches an open overlay between floating and full in place. Overlay geometry
-    // is a Metal surface (not in the AX tree), so this asserts the COMMAND PATH: resize succeeds while the
-    // overlay is up (a percent AND --full) and the overlay stays up across it, errors with no overlay, and
-    // the dispatcher rejects missing/conflicting/out-of-range size args server-side; a raw JSON client (like
-    // this test) skips the CLI's validate() entirely, so the dispatcher is the real enforcement boundary.
-    // The visual re-flow is verified manually.
+    // a raw JSON client skips the CLI's validate(), so the dispatcher is the real enforcement boundary.
+    // Geometry is a Metal surface, not in the AX tree, so only the command path is asserted.
     func testOverlayResizeSwitchesFloatingAndFull() throws {
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
         let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
         let id = try XCTUnwrap(result["id"] as? String, "session.new should return the new id")
 
-        // resizing with no overlay open errors.
         let noOverlay = try sendCommand(#"{"cmd":"session.overlay.resize","target":"\#(id)","args":{"sizePercent":60}}"#)
         XCTAssertEqual(noOverlay["ok"] as? Bool, false, "resize with no overlay should fail: \(noOverlay)")
         XCTAssertEqual(noOverlay["error"] as? String, "no overlay", "\(noOverlay)")
 
-        // open a full overlay (cat is long-lived), then resize it to floating and back to full.
         let open = try sendCommand(#"{"cmd":"session.overlay.open","target":"\#(id)","args":{"command":"cat"}}"#)
         XCTAssertEqual(open["ok"] as? Bool, true, "overlay open should succeed: \(open)")
         XCTAssertTrue(pollSessionOverlay(id: id, expected: true, timeout: 10), "the overlay should be up")
 
         let toFloating = try sendCommand(#"{"cmd":"session.overlay.resize","target":"\#(id)","args":{"sizePercent":60}}"#)
         XCTAssertEqual(toFloating["ok"] as? Bool, true, "resize to floating should succeed: \(toFloating)")
-        // the overlay stays up across the resize (in-place re-flow, never a re-spawn).
         XCTAssertTrue(pollSessionOverlay(id: id, expected: true, timeout: 5), "the overlay stays up after resize")
 
         let toFull = try sendCommand(#"{"cmd":"session.overlay.resize","target":"\#(id)","args":{"full":true}}"#)
         XCTAssertEqual(toFull["ok"] as? Bool, true, "resize back to full should succeed: \(toFull)")
 
-        // the dispatcher rejects the bad arg combos server-side.
         let neither = try sendCommand(#"{"cmd":"session.overlay.resize","target":"\#(id)"}"#)
         XCTAssertEqual(neither["ok"] as? Bool, false, "resize with neither arg should fail: \(neither)")
         let both = try sendCommand(#"{"cmd":"session.overlay.resize","target":"\#(id)","args":{"sizePercent":50,"full":true}}"#)
@@ -77,22 +67,18 @@ final class ControlOverlaySplitUITests: ControlAPITestCase {
         XCTAssertEqual(close["ok"] as? Bool, true, "overlay close should succeed: \(close)")
     }
 
-    // session.overlay.open --background-color: a valid #rrggbb opens the overlay (the colored surface is
-    // a Metal layer, not in the AX tree, so the color is verified manually — this asserts the arm accepts
-    // and applies it via the lifecycle), and a malformed color is rejected before the overlay opens.
+    // the colored surface is a Metal layer, not in the AX tree, so only the arm is asserted.
     func testOverlayOpenWithBackgroundColorAndRejectsBadColor() throws {
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
         let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
         let id = try XCTUnwrap(result["id"] as? String, "session.new should return the new id")
 
-        // a malformed color is rejected up front; no overlay opens.
         let bad = try sendCommand(#"{"cmd":"session.overlay.open","target":"\#(id)","args":{"command":"cat","color":"purple"}}"#)
         XCTAssertEqual(bad["ok"] as? Bool, false, "a malformed color should be rejected: \(bad)")
         XCTAssertEqual(bad["error"] as? String, "invalid color: purple (#rrggbb)", "\(bad)")
         XCTAssertTrue(pollSessionOverlay(id: id, expected: false, timeout: 5), "the rejected open must not open an overlay")
 
-        // a valid color opens the overlay (cat is long-lived so it stays up); close tears it down.
-        // ##"…"## delimiters so the "#2a1a3a" value's leading "# doesn't close a #"…"# raw string.
+        // ##"…"## delimiters: the value's leading `"#` would close a `#"…"#` raw string.
         let open = try sendCommand(##"{"cmd":"session.overlay.open","target":"\##(id)","args":{"command":"cat","color":"#2a1a3a"}}"##)
         XCTAssertEqual(open["ok"] as? Bool, true, "overlay open with a valid color should succeed: \(open)")
         XCTAssertTrue(pollSessionOverlay(id: id, expected: true, timeout: 10), "the colored overlay should be up")
@@ -101,9 +87,7 @@ final class ControlOverlaySplitUITests: ControlAPITestCase {
         XCTAssertEqual(close["ok"] as? Bool, true, "overlay close should succeed: \(close)")
     }
 
-    // the overlay auto-closes when its command exits (the SHOW_CHILD_EXITED path): open an overlay
-    // running a command that writes a marker then exits — the marker proves the command ran inside the
-    // overlay, and the tree's overlay flag clearing proves the overlay vanished with no key press.
+    // the marker proves the command ran INSIDE the overlay; the cleared flag proves it vanished unaided.
     func testOverlayAutoClosesWhenCommandExits() throws {
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
         let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
@@ -118,8 +102,6 @@ final class ControlOverlaySplitUITests: ControlAPITestCase {
                       "the overlay should auto-close when the command exits (no press-any-key prompt)")
     }
 
-    // session.overlay.result reports the overlay program's exit status once it exits (the --block path).
-    // while the program runs, result errors "overlay still running"; after exit it returns result.exitCode.
     func testOverlayResultReportsExitCode() throws {
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
         let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
@@ -128,7 +110,6 @@ final class ControlOverlaySplitUITests: ControlAPITestCase {
         let open = try sendCommand(#"{"cmd":"session.overlay.open","target":"\#(id)","args":{"command":"sh -c 'exit 7'"}}"#)
         XCTAssertEqual(open["ok"] as? Bool, true, "overlay open should succeed: \(open)")
 
-        // poll session.overlay.result (errors while running) until the program exits and the code is reported.
         var exitCode: Int?
         let deadline = Date().addingTimeInterval(15)
         while Date() < deadline {
@@ -142,14 +123,12 @@ final class ControlOverlaySplitUITests: ControlAPITestCase {
         XCTAssertEqual(exitCode, 7, "session.overlay.result should report the program's exit status")
     }
 
-    // session.overlay.result errors "overlay still running" while the program is up, and "no overlay
-    // result" after a force-close where the program never recorded a status (killed before the wrapper).
     func testOverlayResultStillRunningThenClosed() throws {
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
         let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
         let id = try XCTUnwrap(result["id"] as? String, "session.new should return the new id")
 
-        // cat with no input blocks indefinitely, so the overlay stays up.
+        // `cat` with no input blocks indefinitely, so the overlay stays up.
         let open = try sendCommand(#"{"cmd":"session.overlay.open","target":"\#(id)","args":{"command":"cat"}}"#)
         XCTAssertEqual(open["ok"] as? Bool, true, "overlay open should succeed: \(open)")
         XCTAssertTrue(pollSessionOverlay(id: id, expected: true, timeout: 10), "the overlay should be up")
@@ -162,17 +141,14 @@ final class ControlOverlaySplitUITests: ControlAPITestCase {
         XCTAssertEqual(closed["ok"] as? Bool, true, "overlay close should succeed: \(closed)")
         XCTAssertTrue(pollSessionOverlay(id: id, expected: false, timeout: 10), "the overlay should be gone")
 
-        // cat was killed before the wrapper's `echo $?`, so no status was recorded.
+        // killed before the wrapper's `echo $?`, so no status was recorded.
         let after = try sendCommand(#"{"cmd":"session.overlay.result","target":"\#(id)"}"#)
         XCTAssertEqual(after["ok"] as? Bool, false, "result should error when no status was recorded")
         XCTAssertEqual(after["error"] as? String, "no overlay result")
     }
 
-    // closing an overlay must hand keyboard focus back to the underlying session terminal. this test is
-    // DISCRIMINATING: it first proves the overlay actually grabbed keyboard focus (an overlay shell
-    // `read` captures a typed line), so the after-close assertion is meaningful — then proves the same
-    // keystrokes reach the underlying session shell once the overlay is gone. (overlay rendering/opacity
-    // is verified manually; this asserts the focus handoff, which is automatable.)
+    // DISCRIMINATING: the overlay shell's `read` first proves the overlay HELD focus, or the after-close
+    // assertion would pass vacuously.
     func testOverlayCloseReturnsFocusToSession() throws {
         let tree = try sendCommand(#"{"cmd":"tree"}"#)
         let treeResult = try XCTUnwrap(tree["result"] as? [String: Any], "tree should carry a result")
@@ -181,14 +157,13 @@ final class ControlOverlaySplitUITests: ControlAPITestCase {
         let sessions = try XCTUnwrap(workspaces.first?["sessions"] as? [[String: Any]], "workspace should list sessions")
         let id = try XCTUnwrap(sessions.first?["id"] as? String, "should have a seeded session id")
 
-        // the session's tty, captured by injecting into its surface directly (independent of focus).
+        // injected directly into the surface, so the capture is independent of focus.
         let sessionTTY = markerDir.appendingPathComponent("session-tty")
         XCTAssertEqual(try sendCommand(typeRequest(text: "tty > '\(sessionTTY.path)'\n", target: id, select: false))["ok"] as? Bool,
                        true, "typing tty into the session should succeed")
         let sessionTtyValue = try XCTUnwrap(pollMarker(sessionTTY, timeout: 12), "the session should report its tty")
 
-        // open an overlay whose shell captures one keyboard line, then stays alive (cat) so the overlay
-        // remains up until we close it. the captured line proves the overlay holds keyboard focus.
+        // the captured line proves the overlay holds keyboard focus.
         let ovlMarker = markerDir.appendingPathComponent("overlay-keys")
         let ovlCmd = "sh -c 'IFS= read -r x; printf %s \"$x\" > \(ovlMarker.path); cat'"
         let ovlJSON = try! JSONSerialization.data(withJSONObject:
@@ -197,8 +172,6 @@ final class ControlOverlaySplitUITests: ControlAPITestCase {
         XCTAssertEqual(open["ok"] as? Bool, true, "overlay open should succeed: \(open)")
         XCTAssertTrue(pollSessionOverlay(id: id, expected: true, timeout: 10), "the overlay should be up")
 
-        // type via the KEYBOARD while the overlay is up; the overlay shell's `read` should capture it,
-        // proving the overlay (not the session) holds first responder.
         usleep(800_000) // let the overlay surface attach, grab focus, and the shell reach `read`
         app.typeText("OVLFOCUS")
         app.typeKey(.return, modifierFlags: [])
@@ -209,34 +182,24 @@ final class ControlOverlaySplitUITests: ControlAPITestCase {
         XCTAssertEqual(close["ok"] as? Bool, true, "overlay close should succeed: \(close)")
         XCTAssertTrue(pollSessionOverlay(id: id, expected: false, timeout: 10), "the overlay should be gone")
 
-        // after the overlay tears down, type via the keyboard again: it must now reach the underlying
-        // session shell (same tty), proving focus returned. focus return is async (focusAfterReparent is a
-        // bounded makeFirstResponder retry that wins the teardown/re-host race over a few run-loop turns),
-        // so a single fixed-sleep keystroke burst can land before first responder is the session and be
-        // lost. re-type until the marker appears (same idiom as typeUntilMarker for surface-readiness):
-        // re-typing the tty line is idempotent — once focus is correct one burst writes the tty.
+        // focus return is async (a bounded makeFirstResponder retry), so a single burst can land before
+        // the session is first responder. Re-typing the tty line is idempotent.
         let afterTTY = markerDir.appendingPathComponent("after-close-tty")
         let afterValue = keyboardTypeUntilMarker("tty > '\(afterTTY.path)'", file: afterTTY)
         XCTAssertNotNil(afterValue, "after overlay close, keyboard focus should return to the session terminal")
         XCTAssertEqual(afterValue, sessionTtyValue, "focus should return to the SAME session terminal, not be lost")
     }
 
-    // a cover (overlay or scratch) is modal within its session: a sidebar click restores keyboard focus to
-    // the terminal (so the sidebar never keeps it), but it must restore focus to the cover ON TOP, not to
-    // the pane BEHIND it. clicking the covered session's own row otherwise hands first responder to the
-    // pane and the cover's program silently stops receiving input.
+    // a sidebar click must restore focus to the cover ON TOP, not the pane behind it — otherwise the
+    // cover's program silently stops receiving input.
     //
-    // each test captures TWO keyboard lines: the first, typed BEFORE the click, proves the cover already
-    // holds first responder (so the cover's own bounded auto-focus retry — 40 x 0.05s — has finished and
-    // cannot re-grab focus later and mask a steal). the second, typed after the click, is the assertion.
-    // without the pre-click line the test can pass on a buggy build: the click steals focus to the pane,
-    // then an auto-focus retry still in flight takes it back before the line is typed.
+    // the pre-click line is load-bearing: it proves the cover's own auto-focus retry has FINISHED, so a
+    // retry still in flight cannot take focus back and mask a steal.
     func testSidebarClickKeepsFocusOnOverlayNotPaneBehind() throws {
         let id = try activeSessionID()
         let pre = markerDir.appendingPathComponent("overlay-pre-click")
         let post = markerDir.appendingPathComponent("overlay-post-click")
-        // two blocking reads then `cat` to hold the shell; retyping is NOT idempotent (each `read`
-        // consumes exactly one line), so the markers are polled rather than re-typed.
+        // retyping is NOT idempotent here — each `read` consumes one line — so the markers are polled.
         let ovlCmd = "sh -c 'IFS= read -r a; printf %s \"$a\" > \(pre.path); " +
             "IFS= read -r b; printf %s \"$b\" > \(post.path); cat'"
         let ovlJSON = try! JSONSerialization.data(withJSONObject:

--- a/agtermUITests/ControlSidebarStatusUITests.swift
+++ b/agtermUITests/ControlSidebarStatusUITests.swift
@@ -5,9 +5,7 @@ import XCTest
 /// flag, agent-status glyph, and notification-badge behaviors. Subclass of `ControlAPITestCase`.
 @MainActor
 final class ControlSidebarStatusUITests: ControlAPITestCase {
-    // an OSC 9 desktop notification from an UNFOCUSED pane badges its sidebar row, and selecting the
-    // session clears it. Fire into the seeded session (realized at launch) after a new session takes
-    // focus, so suppression doesn't drop it and no --select (which would re-focus it) is needed.
+    // the pane must be UNFOCUSED or suppression drops the notification, and --select would re-focus it.
     func testUnfocusedNotificationBadgesRowAndClearsOnSelect() throws {
         let tree = try sendCommand(#"{"cmd":"tree"}"#)
         let treeResult = try XCTUnwrap(tree["result"] as? [String: Any], "tree should carry a result")
@@ -16,11 +14,9 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         let sessions = try XCTUnwrap(workspaces.first?["sessions"] as? [[String: Any]], "workspace should list sessions")
         let seeded = try XCTUnwrap(sessions.first?["id"] as? String, "should have a seeded session id")
 
-        // a second session takes focus, leaving the seeded one realized but unfocused.
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.new"}"#)["ok"] as? Bool, true)
         XCTAssertTrue(pollSessionCount(2, timeout: 10), "the new session should land")
 
-        // emit OSC 9 from the unfocused seeded session (printf interprets the octal escapes).
         let typed = try sendCommand(typeRequest(text: "printf '\\033]9;agterm test\\007'\n", target: seeded, select: false))
         XCTAssertEqual(typed["ok"] as? Bool, true, "typing into the realized seeded session should succeed: \(typed)")
 
@@ -32,9 +28,7 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
                       "selecting the session should clear its badge")
     }
 
-    // the `sidebar` control command shows/hides the custom sidebar (the custom split has no system
-    // toggle). hiding removes the session rows from the AX tree; showing restores them. mode is
-    // show|hide|toggle on the frontmost window, and an unknown mode is an error.
+    // the custom split has no system toggle, so hiding is observable as the rows leaving the AX tree.
     func testSidebarShowHideToggle() throws {
         XCTAssertTrue(app.staticTexts["session-row"].waitForExistence(timeout: 10), "sidebar should start visible")
 
@@ -52,13 +46,10 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         XCTAssertEqual(bad["ok"] as? Bool, false, "an invalid sidebar mode should error")
     }
 
-    // session.flag flags a session for the flagged working-set view; sidebar.mode flagged switches the
-    // sidebar to the flat list of just the flagged sessions (each labeled "session : workspace"), so an
-    // unflagged session's row is absent in flagged mode and returns when switched back to tree.
+    // flagged rows are labeled "session : workspace", which is how they are told apart from tree rows.
     func testSessionFlagAndSidebarModeFlagged() throws {
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 10), "seeded session row")
 
-        // name the seeded session and add a second one, so the two are distinguishable by name.
         let tree = try sendCommand(#"{"cmd":"tree"}"#)
         let result = try XCTUnwrap(tree["result"] as? [String: Any], "tree should carry a result")
         let t = try XCTUnwrap(result["tree"] as? [String: Any], "result should carry a tree")
@@ -72,28 +63,21 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.rename","target":"\#(newID)","args":{"name":"keepme"}}"#)["ok"] as? Bool,
                        true, "renaming the new session should succeed")
 
-        // both rows present in tree mode.
         XCTAssertTrue(pollSessionRowCount(2, timeout: 10), "both session rows should be present in tree mode")
 
-        // flag the seeded session.
         let flag = try sendCommand(#"{"cmd":"session.flag","target":"\#(seededID)","args":{"mode":"on"}}"#)
         XCTAssertEqual(flag["ok"] as? Bool, true, "session.flag on should succeed: \(flag)")
 
-        // switch to the flat flagged view: exactly one row, the flagged "flagme", labeled with its
-        // workspace; the unflagged "keepme" row is absent.
         let mode = try sendCommand(#"{"cmd":"sidebar.mode","args":{"mode":"flagged"}}"#)
         XCTAssertEqual(mode["ok"] as? Bool, true, "sidebar.mode flagged should succeed: \(mode)")
         XCTAssertTrue(pollSessionRowCount(1, timeout: 10), "flagged mode should show only the one flagged row")
         XCTAssertTrue(sessionRowValueExists(containing: "flagme"), "the flagged session's row should be present")
         XCTAssertFalse(sessionRowValueExists(containing: "keepme"), "the unflagged session's row should be absent")
 
-        // toggling back to the tree restores both rows.
         XCTAssertEqual(try sendCommand(#"{"cmd":"sidebar.mode","args":{"mode":"toggle"}}"#)["ok"] as? Bool, true,
                        "sidebar.mode toggle should succeed")
         XCTAssertTrue(pollSessionRowCount(2, timeout: 10), "toggling back to tree restores the full tree")
 
-        // session.flag clear unflags everything: flag BOTH, view the flat list (two rows), then clear → the
-        // flagged view empties (zero rows).
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.flag","target":"\#(newID)","args":{"mode":"on"}}"#)["ok"] as? Bool,
                        true, "flagging the second session should succeed")
         XCTAssertEqual(try sendCommand(#"{"cmd":"sidebar.mode","args":{"mode":"flagged"}}"#)["ok"] as? Bool, true,
@@ -102,23 +86,19 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         let cleared = try sendCommand(#"{"cmd":"session.flag","args":{"mode":"clear"}}"#)
         XCTAssertEqual(cleared["ok"] as? Bool, true, "session.flag clear should succeed: \(cleared)")
         XCTAssertTrue(pollSessionRowCount(0, timeout: 10), "clearing all flags empties the flagged view")
-        // back to the tree so the invalid-mode check below runs against the full tree.
         XCTAssertEqual(try sendCommand(#"{"cmd":"sidebar.mode","args":{"mode":"tree"}}"#)["ok"] as? Bool, true,
                        "switching back to tree should succeed")
         XCTAssertTrue(pollSessionRowCount(2, timeout: 10), "the sessions themselves are not closed by clear")
 
-        // an invalid mode errors rather than silently no-opping.
         let bad = try sendCommand(#"{"cmd":"sidebar.mode","args":{"mode":"bogus"}}"#)
         XCTAssertEqual(bad["ok"] as? Bool, false, "an invalid sidebar mode should error: \(bad)")
         XCTAssertTrue((bad["error"] as? String ?? "").contains("invalid sidebar mode"), "should report invalid mode: \(bad)")
     }
 
-    // workspace.focus on collapses the sidebar tree to a single workspace's subtree — the other workspaces'
-    // session rows leave the AX tree; unfocusing restores them. Orthogonal to the flagged view.
+    // orthogonal to the flagged view: the flat list ignores the marked set entirely.
     func testWorkspaceFocusHidesOtherWorkspaces() throws {
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 10), "seeded session row")
 
-        // capture the seeded workspace + session, name the session so it's findable by value.
         let tree = try sendCommand(#"{"cmd":"tree"}"#)
         let result = try XCTUnwrap(tree["result"] as? [String: Any], "tree should carry a result")
         let t = try XCTUnwrap(result["tree"] as? [String: Any], "result should carry a tree")
@@ -128,7 +108,6 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.rename","target":"\#(seededID)","args":{"name":"stay"}}"#)["ok"] as? Bool,
                        true, "renaming the seeded session should succeed")
 
-        // add a second workspace with its own session.
         let newWs = try sendCommand(#"{"cmd":"workspace.new","args":{"name":"second"}}"#)
         let secondWsID = try XCTUnwrap((newWs["result"] as? [String: Any])?["id"] as? String, "workspace.new should return an id")
         let created = try sendCommand(#"{"cmd":"session.new","args":{"workspace":"\#(secondWsID)"}}"#)
@@ -136,11 +115,9 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.rename","target":"\#(newSessID)","args":{"name":"hidden"}}"#)["ok"] as? Bool,
                        true, "renaming the new session should succeed")
 
-        // both rows present in the unfocused tree.
         XCTAssertTrue(pollSessionRowCount(2, timeout: 10), "both session rows should be present unfocused")
 
-        // select the first workspace's session (so the active session is inside the workspace we focus),
-        // then focus the FIRST workspace: the second workspace's session row disappears.
+        // the active session must be INSIDE the focused workspace, or the narrowing moves the selection.
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.select","target":"\#(seededID)"}"#)["ok"] as? Bool, true,
                        "selecting the seeded session should succeed")
         let focus = try sendCommand(#"{"cmd":"workspace.focus","target":"\#(firstWsID)","args":{"mode":"on"}}"#)
@@ -149,15 +126,13 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         XCTAssertTrue(sessionRowValueExists(containing: "stay"), "the focused workspace's session should remain")
         XCTAssertFalse(sessionRowValueExists(containing: "hidden"), "the other workspace's session should be hidden")
 
-        // workspace.focus off on a workspace that is NOT in the marked set is a no-op — it only drops that
-        // workspace from the set, so the mark on the first workspace must survive (the other's rows stay hidden).
+        // `off` on a NON-member only drops it from the set, so the first workspace's mark survives.
         XCTAssertEqual(try sendCommand(#"{"cmd":"workspace.focus","target":"\#(secondWsID)","args":{"mode":"off"}}"#)["ok"] as? Bool,
                        true, "workspace.focus off on a non-focused workspace should succeed (no-op)")
         XCTAssertTrue(pollSessionRowCount(1, timeout: 10), "the focus on the first workspace should be unchanged")
         XCTAssertTrue(sessionRowValueExists(containing: "stay"), "the focused workspace's session should still remain")
         XCTAssertFalse(sessionRowValueExists(containing: "hidden"), "the other workspace's session should still be hidden")
 
-        // unfocus restores the full tree.
         XCTAssertEqual(try sendCommand(#"{"cmd":"workspace.focus","target":"\#(firstWsID)","args":{"mode":"off"}}"#)["ok"] as? Bool,
                        true, "workspace.focus off should succeed")
         XCTAssertTrue(pollSessionRowCount(2, timeout: 10), "unfocusing should restore the full tree")
@@ -168,27 +143,19 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         XCTAssertTrue((bad["error"] as? String ?? "").contains("invalid focus mode"), "should report invalid mode: \(bad)")
     }
 
-    // workspace.focus add MARKS a workspace alongside the existing members instead of replacing them — the
-    // multi-workspace working set the single-id filter could not express. Three workspaces: `add` the third
-    // from an empty set (marks only, the filter stays off), `on` the first (only its row's session renders),
-    // `add` the second (both render, the third does not), `off` the second (back to one). The read-back is
-    // each tree node's `focused` flag, which now means SET MEMBERSHIP and is reported independently of
-    // whether the filter applies.
+    // `focused` reports SET MEMBERSHIP, independently of whether the filter applies.
     func testWorkspaceFocusAddBuildsAMultiWorkspaceSet() throws {
         let ids = try seedFocusWorkspaces([(workspace: "second", session: "hidden"),
                                            (workspace: "third", session: "buried")])
         let (first, second, third) = (ids[0], ids[1], ids[2])
 
-        // `add` NEVER turns the filter on — it only marks, which is what lets a script build a set with a
-        // run of adds and apply it with one `workspace.filter on` (and what keeps the GUI's row-by-row
-        // marking from hiding the rows still to be marked).
+        // `add` NEVER turns the filter on, or marking row by row would hide the rows still to be marked.
         XCTAssertEqual(try sendCommand(#"{"cmd":"workspace.focus","target":"\#(third)","args":{"mode":"add"}}"#)["ok"] as? Bool,
                        true, "workspace.focus add should succeed on an empty set")
         XCTAssertEqual(treeWorkspaceFilter(), false, "add must leave the filter off")
         XCTAssertEqual(try workspaceFocusedFlag(third), true, "the added workspace should read back focused")
         XCTAssertTrue(pollSessionRowCount(3, timeout: 10), "with the filter off every session row still renders")
 
-        // `on` replaces the set with the first workspace: only its session renders.
         let focus = try sendCommand(#"{"cmd":"workspace.focus","target":"\#(first)","args":{"mode":"on"}}"#)
         XCTAssertEqual(focus["ok"] as? Bool, true, "workspace.focus on should succeed: \(focus)")
         XCTAssertTrue(pollSessionRowCount(1, timeout: 10), "marking one workspace should hide the other two")
@@ -198,7 +165,6 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         XCTAssertNil(try workspaceFocusedFlag(third), "an unmarked workspace should omit focused")
         XCTAssertEqual(treeWorkspaceFilter(), true, "the filter should be on")
 
-        // `add` marks the second WITHOUT dropping the first: both sessions render, the third stays hidden.
         let added = try sendCommand(#"{"cmd":"workspace.focus","target":"\#(second)","args":{"mode":"add"}}"#)
         XCTAssertEqual(added["ok"] as? Bool, true, "workspace.focus add should succeed: \(added)")
         XCTAssertTrue(pollSessionRowCount(2, timeout: 10), "add should widen the filtered tree to both marked workspaces")
@@ -209,13 +175,11 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         XCTAssertEqual(try workspaceFocusedFlag(second), true, "the added workspace should read back focused")
         XCTAssertNil(try workspaceFocusedFlag(third), "the unmarked workspace should still omit focused")
 
-        // idempotent: adding an existing member changes nothing.
         XCTAssertEqual(try sendCommand(#"{"cmd":"workspace.focus","target":"\#(second)","args":{"mode":"add"}}"#)["ok"] as? Bool,
                        true, "re-adding an existing member should succeed")
         XCTAssertTrue(pollSessionRowCount(2, timeout: 10), "a repeat add should leave the set unchanged")
         XCTAssertEqual(try workspaceFocusedFlag(second), true, "a repeat add should keep the membership")
 
-        // `off` drops just that member; the other survives and the filter stays on.
         let removed = try sendCommand(#"{"cmd":"workspace.focus","target":"\#(second)","args":{"mode":"off"}}"#)
         XCTAssertEqual(removed["ok"] as? Bool, true, "workspace.focus off should succeed: \(removed)")
         XCTAssertTrue(pollSessionRowCount(1, timeout: 10), "off should narrow the tree back to the remaining member")
@@ -224,23 +188,17 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         XCTAssertEqual(treeWorkspaceFilter(), true, "a non-empty set keeps the filter on")
     }
 
-    // workspace.filter turns the marked-set filter on/off WITHOUT touching the set — the control half of the
-    // bottom-bar toggle, read back as the tree's top-level `workspaceFilter`. Two invariants: `on` with an
-    // EMPTY set is refused (so the filter term of the documented row-visibility contract — a workspace row
-    // renders iff sidebarVisible && sidebarMode == tree && (!workspaceFilter || focused) — can never lie), and
-    // once a workspace is marked the flag flips independently of membership — off restores the full tree
-    // while the member keeps reporting `focused`, and on filters back to exactly the same rows.
+    // `on` with an EMPTY set is refused, so the row-visibility contract's filter term
+    // (`!workspaceFilter || focused`) can never report true with nothing focused.
     func testWorkspaceFilterTogglesWithoutLosingTheSet() throws {
         let ids = try seedFocusWorkspaces([(workspace: "second", session: "hidden")])
         let first = ids[0]
 
-        // nothing marked yet: `on` succeeds having changed nothing, and the read-back stays false.
         let empty = try sendCommand(#"{"cmd":"workspace.filter","args":{"mode":"on"}}"#)
         XCTAssertEqual(empty["ok"] as? Bool, true, "workspace.filter on should succeed with an empty set: \(empty)")
         XCTAssertEqual(treeWorkspaceFilter(), false, "enabling an empty set must be refused — enabled + empty is unrepresentable")
         XCTAssertTrue(pollSessionRowCount(2, timeout: 10), "an empty set filters nothing")
 
-        // mark the first workspace, then suspend the filter: the full tree returns and the mark survives.
         XCTAssertEqual(try sendCommand(#"{"cmd":"workspace.focus","target":"\#(first)","args":{"mode":"on"}}"#)["ok"] as? Bool,
                        true, "workspace.focus on should succeed")
         XCTAssertTrue(pollSessionRowCount(1, timeout: 10), "marking one workspace should hide the other")
@@ -253,13 +211,11 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         XCTAssertEqual(try workspaceFocusedFlag(first), true,
                        "the mark must survive the filter being off — that is what makes re-enabling one call")
 
-        // re-enable: the SAME row set comes back with nothing re-marked.
         XCTAssertEqual(try sendCommand(#"{"cmd":"workspace.filter","args":{"mode":"on"}}"#)["ok"] as? Bool, true,
                        "workspace.filter on should succeed")
         XCTAssertTrue(pollSessionRowCount(1, timeout: 10), "re-enabling should apply the preserved set")
         XCTAssertTrue(pollWorkspaceFilter(true, timeout: 10), "the filter should read on again")
 
-        // toggle flips it in both directions.
         XCTAssertEqual(try sendCommand(#"{"cmd":"workspace.filter","args":{"mode":"toggle"}}"#)["ok"] as? Bool, true,
                        "workspace.filter toggle should succeed")
         XCTAssertTrue(pollSessionRowCount(2, timeout: 10), "toggle should suspend the filter")
@@ -277,11 +233,8 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         XCTAssertTrue(pollWorkspaceFilter(true, timeout: 10), "a rejected mode must leave the filter unchanged")
     }
 
-    // Creating a workspace while the filter is applied JOINS the marked set, so a foreground create is
-    // never hidden behind the filter (the GUI's New Workspace button does the same) — EXCEPT a
-    // `--collapsed` create, whose whole point is a quiet background build: it must not widen a working set
-    // a script carefully marked. Both polarities are asserted through the `focused` read-back, since the
-    // difference is invisible in the row count (a collapsed workspace's row shows either way).
+    // the difference is invisible in the row count — a collapsed workspace's row shows either way — so
+    // both polarities are asserted through the `focused` read-back.
     func testWorkspaceNewJoinsTheMarkedSetUnlessCollapsed() throws {
         let ids = try seedFocusWorkspaces([])
         let first = ids[0]
@@ -301,11 +254,8 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         XCTAssertTrue(pollWorkspaceFilter(true, timeout: 10), "neither create suspends the filter")
     }
 
-    // workspace.filter and workspace.focus resolve their target through `--window`, so they can drive a
-    // BACKGROUND window — the leg no single-window test can tell apart from "acts on the frontmost". A
-    // second window is created MINIMIZED so the seeded one stays frontmost: every command below names the
-    // background window explicitly, and an arm that ignored `--window` would land on the frontmost one,
-    // whose own filter is asserted to stay off throughout.
+    // the second window is MINIMIZED so the seeded one stays frontmost: an arm ignoring `--window` would
+    // land on the frontmost, whose filter is asserted to stay off throughout.
     func testWorkspaceFilterDrivesABackgroundWindow() throws {
         let frontID = try XCTUnwrap(try windowIDs().first, "the seeded window should have an id")
         let created = try sendCommand(#"{"cmd":"window.new","args":{"name":"parked","minimized":true}}"#)
@@ -313,7 +263,6 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         let backID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "window.new returns an id")
         XCTAssertTrue(pollWindowCount(2, timeout: 10), "the second window should register")
 
-        // mark a workspace in the BACKGROUND window and apply the filter there.
         let backWs = try XCTUnwrap(treeWorkspaces(window: backID).first?["id"] as? String,
                                    "the new window should have a seeded workspace")
         let focused = try sendCommand(#"{"cmd":"workspace.focus","target":"\#(backWs)","args":{"mode":"on","window":"\#(backID)"}}"#)
@@ -323,13 +272,11 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         XCTAssertEqual(treeWorkspaceFilter(window: frontID), false,
                        "the frontmost window's own filter must be untouched")
 
-        // suspend it — again by name, with the frontmost window still the default target.
         XCTAssertEqual(try sendCommand(#"{"cmd":"workspace.filter","args":{"mode":"off","window":"\#(backID)"}}"#)["ok"] as? Bool,
                        true, "workspace.filter off should succeed on a background window")
         XCTAssertTrue(pollWorkspaceFilter(false, window: backID, timeout: 10), "the background filter should read off")
         XCTAssertEqual(try workspaceFocusedFlag(backWs, window: backID), true, "suspending keeps the marked set")
 
-        // and re-apply, so the toggle is exercised in both directions against the background window.
         XCTAssertEqual(try sendCommand(#"{"cmd":"workspace.filter","args":{"mode":"toggle","window":"\#(backID)"}}"#)["ok"] as? Bool,
                        true, "workspace.filter toggle should succeed on a background window")
         XCTAssertTrue(pollWorkspaceFilter(true, window: backID, timeout: 10), "toggle should re-apply it")
@@ -401,10 +348,8 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         poll(until: treeWorkspaceFilter(window: window) == expected, timeout: timeout)
     }
 
-    // --no-select --create-workspace must not widen the workspace focus SET. A plain --create-workspace adds
-    // the new workspace to the set while the filter is on (addWorkspace's reveal, so a just-created workspace
-    // is visible); --no-select threads revealNewWorkspace:false so a background create leaves the set — and
-    // the current session selection — untouched.
+    // a plain --create-workspace joins the set (addWorkspace's reveal); --no-select threads
+    // revealNewWorkspace:false so a background create leaves it alone.
     func testSessionNewNoSelectCreateWorkspacePreservesFocus() throws {
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 10), "seeded session row")
 
@@ -413,12 +358,10 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
                                        "tree should carry workspaces")
         let firstWsID = try XCTUnwrap(workspaces.first?["id"] as? String, "seeded workspace id")
 
-        // focus the seeded workspace.
         XCTAssertEqual(try sendCommand(#"{"cmd":"workspace.focus","target":"\#(firstWsID)","args":{"mode":"on"}}"#)["ok"] as? Bool,
                        true, "workspace.focus on should succeed")
         XCTAssertTrue(workspaceFocused(firstWsID, timeout: 5), "the seeded workspace should be focused")
 
-        // background-create a session in a brand-new workspace: the marked set must survive untouched.
         let created = try sendCommand(#"{"cmd":"session.new","args":{"workspaceName":"bg","createWorkspace":true,"noSelect":true}}"#)
         XCTAssertEqual(created["ok"] as? Bool, true, "background create-workspace should succeed: \(created)")
         XCTAssertTrue(workspaceFocused(firstWsID, timeout: 5),
@@ -430,13 +373,9 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
                      "a background create must NOT widen the set — that reveal is the foreground path's job")
     }
 
-    // sidebar.collapse collapses every workspace except the active session's — the others' session rows
-    // leave the AX tree while the active workspace's stay; sidebar.expand re-expands every workspace and
-    // restores them.
     func testSidebarExpandCollapse() throws {
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 10), "seeded session row")
 
-        // capture the seeded workspace + session, name the session so it's findable by value.
         let tree = try sendCommand(#"{"cmd":"tree"}"#)
         let result = try XCTUnwrap(tree["result"] as? [String: Any], "tree should carry a result")
         let t = try XCTUnwrap(result["tree"] as? [String: Any], "result should carry a tree")
@@ -445,7 +384,6 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.rename","target":"\#(seededID)","args":{"name":"stay"}}"#)["ok"] as? Bool,
                        true, "renaming the seeded session should succeed")
 
-        // add a second workspace with its own session in a different workspace.
         let newWs = try sendCommand(#"{"cmd":"workspace.new","args":{"name":"second"}}"#)
         let secondWsID = try XCTUnwrap((newWs["result"] as? [String: Any])?["id"] as? String, "workspace.new should return an id")
         let created = try sendCommand(#"{"cmd":"session.new","args":{"workspace":"\#(secondWsID)"}}"#)
@@ -453,11 +391,9 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.rename","target":"\#(newSessID)","args":{"name":"hidden"}}"#)["ok"] as? Bool,
                        true, "renaming the new session should succeed")
 
-        // both rows present with both workspaces expanded (the sidebar expands all on launch).
         XCTAssertTrue(pollSessionRowCount(2, timeout: 10), "both session rows should be present expanded")
 
-        // select the seeded session so the ACTIVE workspace is the first one, then collapse: the second
-        // workspace folds away (its "hidden" row leaves the AX tree) while the active workspace stays open.
+        // the ACTIVE workspace is what stays open, so the selection decides which one folds.
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.select","target":"\#(seededID)"}"#)["ok"] as? Bool, true,
                        "selecting the seeded session should succeed")
         let collapse = try sendCommand(#"{"cmd":"sidebar.collapse"}"#)
@@ -466,7 +402,6 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         XCTAssertTrue(sessionRowValueExists(containing: "stay"), "the active workspace's session should remain")
         XCTAssertFalse(sessionRowValueExists(containing: "hidden"), "the collapsed workspace's session should be hidden")
 
-        // expand re-opens every workspace and restores both rows.
         let expand = try sendCommand(#"{"cmd":"sidebar.expand"}"#)
         XCTAssertEqual(expand["ok"] as? Bool, true, "sidebar.expand should succeed: \(expand)")
         XCTAssertTrue(pollSessionRowCount(2, timeout: 10), "expand should restore every workspace's rows")
@@ -480,8 +415,6 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
             .firstMatch.exists
     }
 
-    // session.status sets a session's agent indicator: a valid state returns ok + the resolved id, an
-    // unknown state returns the literal `invalid status` error, and an unknown target is not-found.
     func testSessionStatusSetsIndicator() throws {
         let tree = try sendCommand(#"{"cmd":"tree"}"#)
         let treeResult = try XCTUnwrap(tree["result"] as? [String: Any], "tree should carry a result")
@@ -490,19 +423,16 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         let sessions = try XCTUnwrap(workspaces.first?["sessions"] as? [[String: Any]], "workspace should list sessions")
         let seeded = try XCTUnwrap(sessions.first?["id"] as? String, "should have a seeded session id")
 
-        // a valid state with a blink flag succeeds and echoes the resolved id.
         let ok = try sendCommand(#"{"cmd":"session.status","target":"\#(seeded)","args":{"status":"active","blink":true}}"#)
         XCTAssertEqual(ok["ok"] as? Bool, true, "session.status active should succeed: \(ok)")
         let result = try XCTUnwrap(ok["result"] as? [String: Any], "session.status should carry a result")
         XCTAssertEqual((result["id"] as? String)?.lowercased(), seeded.lowercased(),
                        "session.status should return the resolved session id: \(ok)")
 
-        // an unknown state returns the literal guard string the arm emits.
         let bad = try sendCommand(#"{"cmd":"session.status","target":"\#(seeded)","args":{"status":"bogus"}}"#)
         XCTAssertEqual(bad["ok"] as? Bool, false, "an unknown status should fail: \(bad)")
         XCTAssertEqual(bad["error"] as? String, "invalid status", "should report invalid status: \(bad)")
 
-        // an unknown target is the structured not-found error (mirrors testUnknownTargetErrors).
         let unknown = try sendCommand(#"{"cmd":"session.status","target":"deadbeef","args":{"status":"active"}}"#)
         XCTAssertEqual(unknown["ok"] as? Bool, false, "an unknown target should fail: \(unknown)")
         let error = try XCTUnwrap(unknown["error"] as? String, "an unknown target should carry an error")
@@ -512,14 +442,11 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
     func testSessionStatusSoundValidatesName() throws {
         let seeded = try activeSessionID()
 
-        // reads the seeded session's current status from a fresh tree (nil when idle).
         func currentStatus() throws -> String? { try sessionNode(id: seeded)["status"] as? String }
 
-        // the default-beep keyword resolves and the command succeeds.
         let ok = try sendCommand(#"{"cmd":"session.status","target":"\#(seeded)","args":{"status":"active","sound":"default"}}"#)
         XCTAssertEqual(ok["ok"] as? Bool, true, "session.status --sound default should succeed: \(ok)")
 
-        // establish a known baseline, then try to set a DIFFERENT status with an unknown sound.
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.status","target":"\#(seeded)","args":{"status":"completed"}}"#)["ok"] as? Bool, true)
         XCTAssertEqual(try currentStatus(), "completed", "baseline status should be completed")
 
@@ -528,29 +455,23 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         let error = try XCTUnwrap(bad["error"] as? String, "an unknown sound should carry an error")
         XCTAssertTrue(error.hasPrefix("unknown sound: NoSuchSoundXYZ"), "should report the unknown sound, got: \(error)")
 
-        // the rejected call must NOT have changed the status — validation happens before the mutation.
+        // validation happens before the mutation, so the status must be unchanged.
         XCTAssertEqual(try currentStatus(), "completed", "an unknown sound must leave the status unchanged")
     }
 
-    // session.status --color sets a per-call glyph tint. The tint itself is NOT accessibility-observable
-    // (glyph color, like the cursor's solid/hollow state, isn't in the AX tree — covered host-free +
-    // manual), so this drives the command path end-to-end: a valid #rrggbb applies the status, and a
-    // malformed color is rejected before the mutation and leaves the status unchanged.
+    // the tint is NOT in the AX tree, so this drives the command path only; the color is verified by eye.
     func testSessionStatusColorValidatesHex() throws {
         let seeded = try activeSessionID()
 
         func currentStatus() throws -> String? { try sessionNode(id: seeded)["status"] as? String }
 
-        // a valid #rrggbb applies the status and shows the glyph. NOTE: the `"#ff0000"` value contains the
-        // `"#` sequence, which would close a `#"..."#` raw string early, so this line uses the `##"..."##`
-        // delimiter (and `\##(seeded)` interpolation) — the rest of the file's `#"..."#` JSON has no `#`.
+        // `"#ff0000"` contains `"#`, which closes a `#"..."#` raw string early — hence the `##"..."##` delimiter.
         let ok = try sendCommand(##"{"cmd":"session.status","target":"\##(seeded)","args":{"status":"blocked","color":"#ff0000"}}"##)
         XCTAssertEqual(ok["ok"] as? Bool, true, "session.status --color #ff0000 should succeed: \(ok)")
         XCTAssertEqual(try currentStatus(), "blocked", "the status should be applied")
         XCTAssertTrue(app.staticTexts["agent-status"].waitForExistence(timeout: 12),
                       "the status glyph should appear on the session's row")
 
-        // a malformed color is rejected before the mutation.
         let bad = try sendCommand(#"{"cmd":"session.status","target":"\#(seeded)","args":{"status":"active","color":"nope"}}"#)
         XCTAssertEqual(bad["ok"] as? Bool, false, "a malformed color should fail: \(bad)")
         XCTAssertEqual(bad["error"] as? String, "invalid color (expected #rrggbb)", "should report the invalid color: \(bad)")
@@ -559,16 +480,10 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         XCTAssertEqual(try currentStatus(), "blocked", "an invalid color must leave the status unchanged")
     }
 
-    // session.status --shape picks a per-call glyph silhouette. ASSERTION LIMIT, the same one --color has:
-    // the drawn shape is NOT accessibility-observable — `StatusIconView` exposes only the state NAME as its
-    // accessibility value — so no test can assert the rendered symbol (that is verified by eye on a dev
-    // instance). This drives the command path instead: a valid shape applies the status and reads back on
-    // the tree, an unknown shape is rejected before the mutation, and the next status without --shape
-    // discards the override.
+    // `StatusIconView` exposes only the state NAME to AX, so the drawn shape cannot be asserted here.
     func testSessionStatusShapeValidatesAndReadsBack() throws {
         let seeded = try activeSessionID()
 
-        // a valid shape applies the status and shows the glyph.
         let ok = try sendCommand(#"{"cmd":"session.status","target":"\#(seeded)","args":{"status":"blocked","shape":"triangle"}}"#)
         XCTAssertEqual(ok["ok"] as? Bool, true, "session.status --shape triangle should succeed: \(ok)")
         XCTAssertTrue(app.staticTexts["agent-status"].waitForExistence(timeout: 12),
@@ -576,12 +491,10 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         XCTAssertEqual(app.staticTexts["agent-status"].value as? String, "blocked",
                        "the glyph keeps reporting the state name — the silhouette is not accessibility-observable")
 
-        // the tree read-back carries the per-call shape alongside the status.
         var node = try sessionNode(id: seeded)
         XCTAssertEqual(node["status"] as? String, "blocked", "the status should be applied")
         XCTAssertEqual(node["statusShape"] as? String, "triangle", "the tree should report the per-call shape")
 
-        // an unknown shape is rejected with the allCases-derived message, before any mutation.
         let bad = try sendCommand(#"{"cmd":"session.status","target":"\#(seeded)","args":{"status":"active","shape":"hexagon"}}"#)
         XCTAssertEqual(bad["ok"] as? Bool, false, "an unknown shape should fail: \(bad)")
         XCTAssertEqual(bad["error"] as? String, "invalid shape: hexagon (circle|square|triangle|diamond|capsule|star)",
@@ -590,8 +503,7 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         XCTAssertEqual(node["status"] as? String, "blocked", "an invalid shape must leave the status unchanged")
         XCTAssertEqual(node["statusShape"] as? String, "triangle", "an invalid shape must leave the shape unchanged")
 
-        // the next status without --shape discards the override — the glyph falls back to the Settings
-        // shape (here the built-in circle) and the read-back drops the field.
+        // without --shape the override is discarded and the glyph falls back to the Settings shape.
         let cleared = try sendCommand(#"{"cmd":"session.status","target":"\#(seeded)","args":{"status":"active"}}"#)
         XCTAssertEqual(cleared["ok"] as? Bool, true, "session.status without --shape should succeed: \(cleared)")
         node = try sessionNode(id: seeded)
@@ -599,10 +511,7 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         XCTAssertNil(node["statusShape"], "a status set without --shape should clear the shape read-back")
     }
 
-    // the agent-status icon shows on every non-idle session, the selected one INCLUDED — there is no
-    // visibility gate. Set active on a non-selected session → the icon appears; select that session → it
-    // STAYS (active is keep-state); set completed --auto-reset on a non-selected session → it shows, then
-    // VISITING (selecting) it clears the auto-reset flash.
+    // there is no visibility gate: the icon shows on the selected session too.
     func testAgentStatusIconShowsRegardlessOfSelectionAndAutoResetClears() throws {
         let tree = try sendCommand(#"{"cmd":"tree"}"#)
         let treeResult = try XCTUnwrap(tree["result"] as? [String: Any], "tree should carry a result")
@@ -611,28 +520,25 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         let sessions = try XCTUnwrap(workspaces.first?["sessions"] as? [[String: Any]], "workspace should list sessions")
         let seeded = try XCTUnwrap(sessions.first?["id"] as? String, "should have a seeded session id")
 
-        // a second session takes focus, leaving the seeded one realized but non-selected.
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
         let createdResult = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
         let secondID = try XCTUnwrap(createdResult["id"] as? String, "session.new should return the new id")
         XCTAssertTrue(pollSessionCount(2, timeout: 10), "the new session should land")
 
-        // negative baseline: no status set yet, so no agent-status icon exists on any row.
         XCTAssertTrue(app.staticTexts["agent-status"].waitForNonExistence(timeout: 5),
                       "no agent-status icon should exist before any status is set")
 
-        // set active on the non-selected seeded session: the icon appears.
         let status = try sendCommand(#"{"cmd":"session.status","target":"\#(seeded)","args":{"status":"active"}}"#)
         XCTAssertEqual(status["ok"] as? Bool, true, "session.status active should succeed: \(status)")
         XCTAssertTrue(app.staticTexts["agent-status"].waitForExistence(timeout: 12),
                       "the status icon should appear on the session's row")
 
-        // selecting that session KEEPS the icon — active is keep-state and there is no visibility gate.
+        // `active` is keep-state, so selecting the session does not clear it.
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.select","target":"\#(seeded)"}"#)["ok"] as? Bool, true)
         XCTAssertTrue(app.staticTexts["agent-status"].waitForExistence(timeout: 5),
                       "the active status icon stays on the selected session (no visibility gate)")
 
-        // completed --auto-reset on the now non-selected session shows, then VISITING it clears it.
+        // an auto-reset flash clears on VISIT, unlike `active`.
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.select","target":"\#(secondID)"}"#)["ok"] as? Bool, true)
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.status","target":"\#(seeded)","args":{"status":"completed","autoReset":true}}"#)["ok"] as? Bool, true)
         XCTAssertTrue(app.staticTexts["agent-status"].waitForExistence(timeout: 12),
@@ -642,10 +548,8 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
                       "visiting a completed --auto-reset session should clear its icon")
     }
 
-    // typing into a session flagged for your attention (`blocked` or `completed`) clears the glyph — the
-    // input-driven clear. blocked covers the Esc-decline case Claude Code fires no hook for; completed clears
-    // the finished flash once you re-engage. wired off GhosttySurfaceView.keyDown, so it MUST be driven by the
-    // real keyboard: `session.type`/inject calls ghostty_surface_key directly, bypassing keyDown.
+    // wired off GhosttySurfaceView.keyDown, so it MUST be a real keystroke: `session.type` calls
+    // ghostty_surface_key directly and bypasses keyDown.
     func testTypingClearsBlockedOrCompletedStatus() throws {
         let tree = try sendCommand(#"{"cmd":"tree"}"#)
         let treeResult = try XCTUnwrap(tree["result"] as? [String: Any], "tree should carry a result")
@@ -654,8 +558,7 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         let sessions = try XCTUnwrap(workspaces.first?["sessions"] as? [[String: Any]], "workspace should list sessions")
         let seeded = try XCTUnwrap(sessions.first?["id"] as? String, "should have a seeded session id")
 
-        // press a real key into the focused terminal until the glyph clears. keyboard focus return can be
-        // async, so retry (mirrors the marker-poll retry idiom).
+        // keyboard focus return is async, so retry until the glyph clears.
         func typeUntilGlyphCleared() -> Bool {
             for _ in 0..<8 {
                 app.typeKey(.escape, modifierFlags: [])
@@ -664,7 +567,7 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
             return false
         }
 
-        // both attention states clear on a keystroke; active would NOT (agent still working), idle has no glyph.
+        // `active` would NOT clear — the agent is still working.
         for state in ["blocked", "completed"] {
             let set = try sendCommand(#"{"cmd":"session.status","target":"\#(seeded)","args":{"status":"\#(state)"}}"#)
             XCTAssertEqual(set["ok"] as? Bool, true, "session.status \(state) should succeed: \(set)")

--- a/agtermUITests/ControlSurfaceZoomUITests.swift
+++ b/agtermUITests/ControlSurfaceZoomUITests.swift
@@ -39,10 +39,8 @@ final class ControlSurfaceZoomUITests: ControlAPITestCase {
         XCTAssertTrue(pollSplitRatio(0.33, timeout: 10), "zoom round-trip must not change the split ratio")
     }
 
-    // A primary surface can exit while terminal zoom owns its host. When a live split exists, that exit
-    // promotes the split surface into the primary slot without changing the zoom target's semantic identity
-    // (`surface:<session>:left`). The zoom host must still replace its torn-down AppKit view and focus the
-    // promoted survivor; otherwise the zoom stays blank until the user exits it.
+    // promotion keeps the zoom target's semantic identity (`surface:<session>:left`), so the zoom host
+    // must replace its torn-down AppKit view itself or the zoom stays blank until the user exits it.
     func testZoomedPrimaryExitRehostsAndFocusesPromotedSurvivor() throws {
         let sessionID = try activeSessionID()
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.split","args":{"mode":"on"}}"#)["ok"] as? Bool, true,
@@ -84,8 +82,8 @@ final class ControlSurfaceZoomUITests: ControlAPITestCase {
         XCTAssertTrue(app.buttons["terminal-zoom-exit"].exists,
                       "promotion should keep the semantic primary target zoomed")
 
-        // Type without clicking or leaving zoom. A stale representable still hosts the torn-down primary
-        // and can never write this marker; a remounted survivor receives focus and runs it.
+        // typed without clicking or leaving zoom: a stale representable still hosting the torn-down
+        // primary can never write this marker.
         let afterPromotion = markerDir.appendingPathComponent("zoom-after-promotion")
         var promotedValue: String?
         for _ in 0..<4 where promotedValue == nil {
@@ -106,14 +104,11 @@ final class ControlSurfaceZoomUITests: ControlAPITestCase {
 
         let scratch = try sendCommand(#"{"cmd":"session.scratch","args":{"mode":"on"}}"#)
         XCTAssertEqual(scratch["ok"] as? Bool, true, "scratch on should succeed while zoomed: \(scratch)")
-        // the deck keeps realizing surfaces behind the zoom layer: the scratch must become readable
-        // (surface realized, shell spawned) without exiting zoom first.
         XCTAssertTrue(pollScratchReadable(timeout: 10),
                       "a control-opened scratch must realize its surface while the session is zoomed")
 
         XCTAssertEqual(try sendCommand(#"{"cmd":"surface.zoom","args":{"mode":"hide"}}"#)["ok"] as? Bool, true,
                        "zoom hide should succeed")
-        // hide is idempotent for explicit targets too: hiding an already-un-zoomed surface is an ok no-op.
         let rehide = try sendCommand(#"{"cmd":"surface.zoom","target":"\#(leftSurface)","args":{"mode":"hide"}}"#)
         XCTAssertEqual(rehide["ok"] as? Bool, true, "explicit-target hide should be idempotent: \(rehide)")
     }
@@ -127,13 +122,12 @@ final class ControlSurfaceZoomUITests: ControlAPITestCase {
         XCTAssertEqual((zoom["result"] as? [String: Any])?["id"] as? String, "quick",
                        "zooming with the quick terminal visible should target it: \(zoom)")
 
-        // the API must accept the address it just emitted: hide the zoom by its returned id.
         let hide = try sendCommand(#"{"cmd":"surface.zoom","target":"quick","args":{"mode":"hide"}}"#)
         XCTAssertEqual(hide["ok"] as? Bool, true,
                        "the id surface.zoom emitted must be accepted back as a target: \(hide)")
 
-        // zoom the quick terminal again and dismiss it with plain `quick hide`: dismissal must stay
-        // unconditional for scripts — a zoomed quick terminal exits its zoom first, never an error.
+        // `quick hide` must stay unconditional for scripts — a zoomed quick terminal exits its zoom
+        // first, never an error.
         XCTAssertEqual(try sendCommand(#"{"cmd":"surface.zoom","args":{"mode":"show"}}"#)["ok"] as? Bool, true,
                        "re-zooming the quick terminal should succeed")
         let quickHide = try sendCommand(#"{"cmd":"quick","args":{"mode":"hide"}}"#)
@@ -144,11 +138,8 @@ final class ControlSurfaceZoomUITests: ControlAPITestCase {
     }
 
     func testZoomedSurfaceTreeReadBackAndScopedErrorPaths() throws {
-        // unzoomed: the tree must OMIT zoomedSurface (nil closure result → key absent, not null).
         XCTAssertNil(try treeZoomedSurface(), "zoomedSurface should be absent while nothing is zoomed")
 
-        // zoom the active session's left surface and read the SAME id back from the tree top level —
-        // the record-then-restore leg of the write-only surface.zoom command.
         let leftSurface = try activeSurfaceID(kind: "left")
         let zoom = try sendCommand(#"{"cmd":"surface.zoom","target":"\#(leftSurface)","args":{"mode":"show"}}"#)
         XCTAssertEqual(zoom["ok"] as? Bool, true, "surface zoom show should succeed: \(zoom)")
@@ -159,18 +150,15 @@ final class ControlSurfaceZoomUITests: ControlAPITestCase {
                        "zoom hide should succeed")
         XCTAssertNil(try treeZoomedSurface(), "zoomedSurface should clear on zoom exit")
 
-        // error paths. a well-formed id whose session exists nowhere → no such surface.
         let ghost = "surface:00000000-0000-0000-0000-000000000000:left"
         let noSuch = try sendCommand(#"{"cmd":"surface.zoom","target":"\#(ghost)","args":{"mode":"show"}}"#)
         XCTAssertEqual(noSuch["ok"] as? Bool, false, "zooming an unknown surface should fail: \(noSuch)")
         XCTAssertEqual(noSuch["error"] as? String, "no such surface: \(ghost)")
 
-        // a malformed target → invalid surface.
         let invalid = try sendCommand(#"{"cmd":"surface.zoom","target":"not-a-surface","args":{"mode":"show"}}"#)
         XCTAssertEqual(invalid["ok"] as? Bool, false, "a malformed target should fail: \(invalid)")
         XCTAssertEqual(invalid["error"] as? String, "invalid surface: not-a-surface")
 
-        // a real surface addressed through a --window that does not own it → no such surface (scoped).
         let created = try sendCommand(#"{"cmd":"window.new","args":{"name":"zoom-err"}}"#)
         XCTAssertEqual(created["ok"] as? Bool, true, "window.new should succeed: \(created)")
         let otherWindow = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String,
@@ -181,7 +169,7 @@ final class ControlSurfaceZoomUITests: ControlAPITestCase {
                        "zooming a surface through a window that does not own it should fail: \(wrongWindow)")
         XCTAssertEqual(wrongWindow["error"] as? String, "no such surface: \(leftSurface)")
 
-        // a known-but-CLOSED window → window not open (the resolver knows the id; there is no live store).
+        // the resolver still knows the closed window's id; there is just no live store behind it.
         XCTAssertEqual(try sendCommand(#"{"cmd":"window.close","target":"\#(otherWindow)"}"#)["ok"] as? Bool, true,
                        "closing the helper window should succeed")
         let closed = try sendCommand(
@@ -191,26 +179,24 @@ final class ControlSurfaceZoomUITests: ControlAPITestCase {
     }
 
     func testZoomingBackgroundTargetEndsItsSearch() throws {
-        // open search on session A (session.search selects its target, so A is active with the bar up).
+        // session.search selects its target, so A ends up active with the bar up.
         let sessionA = try activeSessionID()
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.search","target":"\#(sessionA)","args":{"text":"login"}}"#)["ok"] as? Bool,
                        true, "opening search on session A should succeed")
         XCTAssertTrue(app.textFields["search-field"].waitForExistence(timeout: 10),
                       "the search bar should be up on session A")
 
-        // park the selection on a fresh session B, making A a BACKGROUND session with searchActive set.
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
         XCTAssertEqual(created["ok"] as? Bool, true, "creating session B should succeed: \(created)")
 
-        // zoom A's surface by explicit id — the addressable path that does NOT select A first — then exit.
+        // by explicit id — the addressable path that does NOT select A first, so A stays background.
         let zoom = try sendCommand(#"{"cmd":"surface.zoom","target":"surface:\#(sessionA):left","args":{"mode":"show"}}"#)
         XCTAssertEqual(zoom["ok"] as? Bool, true, "zooming background session A's surface should succeed: \(zoom)")
         XCTAssertTrue(app.buttons["terminal-zoom-exit"].waitForExistence(timeout: 10), "zoom should be active")
         XCTAssertEqual(try sendCommand(#"{"cmd":"surface.zoom","args":{"mode":"hide"}}"#)["ok"] as? Bool, true,
                        "zoom hide should succeed")
 
-        // zoom-enter must have ENDED A's search: re-selecting A shows no search bar (a surviving
-        // searchActive would re-mount it the moment A becomes the active session).
+        // a surviving searchActive would re-mount the bar the moment A becomes active again.
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.select","target":"\#(sessionA)"}"#)["ok"] as? Bool, true,
                        "re-selecting session A should succeed")
         XCTAssertTrue(app.textFields["search-field"].waitForNonExistence(timeout: 10),
@@ -218,7 +204,6 @@ final class ControlSurfaceZoomUITests: ControlAPITestCase {
     }
 
     func testBackgroundWindowZoomExitDoesNotStealFrontmostFocus() throws {
-        // zoom window A's left surface, then open window B on top: A becomes a BACKGROUND zoomed window.
         let windows = try XCTUnwrap(
             (try sendCommand(#"{"cmd":"window.list"}"#)["result"] as? [String: Any])?["windows"] as? [[String: Any]],
             "window.list should carry windows")
@@ -231,14 +216,12 @@ final class ControlSurfaceZoomUITests: ControlAPITestCase {
         XCTAssertEqual(created["ok"] as? Bool, true, "window.new should succeed: \(created)")
         let windowB = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String,
                                     "window.new should return the new window id")
-        // wait for the second window to MATERIALIZE in the AX tree before driving it — a control-created
-        // window can lag its window.list "active" flag (the multi-window suites' count-poll pattern).
+        // a control-created window can lag its window.list "active" flag, so wait for the AX tree.
         let appeared = Date().addingTimeInterval(10)
         while Date() < appeared, app.windows.count < 2 { usleep(200_000) }
         XCTAssertGreaterThanOrEqual(app.windows.count, 2, "the second window should materialize and take key")
         XCTAssertTrue(pollWindowActive(windowB, timeout: 12), "the new window should take key")
 
-        // put the keyboard into window B's search field and prove it owns the keystrokes.
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.search"}"#)["ok"] as? Bool, true,
                        "opening search in the frontmost window should succeed")
         let searchField = app.textFields["search-field"]
@@ -248,9 +231,8 @@ final class ControlSurfaceZoomUITests: ControlAPITestCase {
         XCTAssertTrue(pollFieldValue(searchField, equals: "ab", timeout: 8),
                       "the search field should own the keyboard before the background unzoom")
 
-        // un-zoom BACKGROUND window A over the socket. Its zoom-exit focus return is scoped to window A,
-        // so window B's field keeps the keyboard — a frontmost-targeted restore would steal it (the
-        // regression this pins). Give a stray restore its full retry window before typing on.
+        // A's zoom-exit focus return is scoped to window A; a frontmost-targeted restore would steal B's
+        // keyboard. The run-loop wait below gives such a stray restore its full retry window.
         XCTAssertEqual(try sendCommand(#"{"cmd":"surface.zoom","args":{"mode":"hide","window":"\#(windowA)"}}"#)["ok"] as? Bool,
                        true, "hiding the background window's zoom should succeed")
         RunLoop.current.run(until: Date().addingTimeInterval(1.0))

--- a/agtermUITests/ControlWindowUITests.swift
+++ b/agtermUITests/ControlWindowUITests.swift
@@ -8,12 +8,9 @@ import XCTest
 final class ControlWindowUITests: ControlAPITestCase {
     // MARK: - Window commands
 
-    // window.new opens a second window and window.list reflects it: the new window is present + open,
-    // and the list keeps the active-flag invariant (exactly one of the two windows is active). Which
-    // window is frontmost depends on AppKit key-window timing, so the test asserts the invariant rather
-    // than which one — `window.select` flipping the active flag is covered by the captured-id test.
+    // which window ends up frontmost depends on AppKit key-window timing, so this asserts the
+    // exactly-one-active invariant rather than which one.
     func testWindowNewAndList() throws {
-        // the seeded launch has exactly one window, and it's the active one.
         let initial = try windowList()
         XCTAssertEqual(initial.count, 1, "should start with the one seeded window: \(initial)")
         XCTAssertEqual(initial.first?["active"] as? Bool, true, "the seeded window should be active")
@@ -24,7 +21,6 @@ final class ControlWindowUITests: ControlAPITestCase {
         let result = try XCTUnwrap(created["result"] as? [String: Any], "window.new should carry a result")
         let newID = try XCTUnwrap(result["id"] as? String, "window.new should return the new id")
 
-        // poll until the list shows two windows, the new one present + open, with exactly one active.
         let settled = pollWindowList(timeout: 10) { list in
             guard list.count == 2 else { return false }
             guard let made = list.first(where: { ($0["id"] as? String)?.lowercased() == newID.lowercased() }) else { return false }
@@ -33,9 +29,8 @@ final class ControlWindowUITests: ControlAPITestCase {
         }
         XCTAssertTrue(settled, "the new window should appear open with exactly one active window in window.list")
 
-        // an ACTUAL on-screen window must materialize, not just the library JSON open flag — window.new
-        // pre-loads the new store (so window.list always shows open:true), but the spawned SwiftUI window
-        // self-dismisses if its claim is dropped. polling app.windows guards that regression.
+        // window.new pre-loads the store, so window.list shows open:true even when the spawned SwiftUI
+        // window self-dismisses on a dropped claim — only polling app.windows catches that.
         let appeared = pollAppWindows(atLeast: baselineWindows + 1, timeout: 10)
         XCTAssertTrue(appeared, "window.new must render a real on-screen window, got \(app.windows.count) (baseline \(baselineWindows))")
     }
@@ -50,7 +45,6 @@ final class ControlWindowUITests: ControlAPITestCase {
         return false
     }
 
-    // window.resize sets the active window's frame size; the on-screen window reflects it.
     func testWindowResize() throws {
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session")
         let window = app.windows.firstMatch
@@ -65,8 +59,7 @@ final class ControlWindowUITests: ControlAPITestCase {
         XCTFail("window did not resize to 1000x700, got \(window.frame.size)")
     }
 
-    // window.move repositions the active window; moving right+down shifts the on-screen origin right+down
-    // (a relative check, robust to screen-coordinate/menu-bar offsets).
+    // a relative right+down check, robust to screen-coordinate/menu-bar offsets.
     func testWindowMove() throws {
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session")
         let window = app.windows.firstMatch
@@ -84,9 +77,6 @@ final class ControlWindowUITests: ControlAPITestCase {
         XCTFail("window did not move right+down: first=\(first) now=\(window.frame.origin)")
     }
 
-    // window.zoom toggles the active window between its normal frame and a maximized (fill-screen) frame —
-    // the control half of the double-click-header gesture. From a known small frame the first zoom clearly
-    // enlarges; a second zoom restores it toward that frame.
     func testWindowZoom() throws {
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session")
         let window = app.windows.firstMatch
@@ -110,7 +100,6 @@ final class ControlWindowUITests: ControlAPITestCase {
         XCTAssertTrue(window.frame.size.width > normal.width + 50 || window.frame.size.height > normal.height + 50,
                       "window should grow after window.zoom: normal=\(normal) now=\(window.frame.size)")
 
-        // a second zoom restores the window toward its previous (normal) frame.
         XCTAssertEqual(try sendCommand(#"{"cmd":"window.zoom"}"#)["ok"] as? Bool, true)
         deadline = Date().addingTimeInterval(5)
         while Date() < deadline {
@@ -122,11 +111,7 @@ final class ControlWindowUITests: ControlAPITestCase {
                        "window should restore toward \(normal) after a second window.zoom, got \(window.frame.size)")
     }
 
-    // window.fullscreen toggles native macOS full screen for the active window — the control half of the
-    // View ▸ Toggle Full Screen menu item / the green traffic-light button. From a known small frame the
-    // first call fills the screen; a second call restores it. Asserts the command is wired end-to-end
-    // (socket -> dispatcher -> WindowRegistry -> NSWindow.toggleFullScreen) and always leaves the app OUT
-    // of full screen so it can't wedge later tests on a separate Space.
+    // must always leave the app OUT of full screen, or later tests wedge on a separate Space.
     func testWindowFullscreen() throws {
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session")
         let window = app.windows.firstMatch
@@ -140,7 +125,7 @@ final class ControlWindowUITests: ControlAPITestCase {
         let normal = window.frame.size
         XCTAssertEqual(normal.width, 800, accuracy: 8, "window should settle near 800 wide before fullscreen, got \(normal)")
 
-        // enter full screen — the window fills the display (the native transition animates ~1s).
+        // the native transition animates ~1s, hence the longer settle.
         XCTAssertEqual(try sendCommand(#"{"cmd":"window.fullscreen"}"#)["ok"] as? Bool, true)
         deadline = Date().addingTimeInterval(10)
         while Date() < deadline {
@@ -151,7 +136,6 @@ final class ControlWindowUITests: ControlAPITestCase {
         XCTAssertTrue(window.frame.size.width > normal.width + 50 || window.frame.size.height > normal.height + 50,
                       "window should fill the screen after window.fullscreen: normal=\(normal) now=\(window.frame.size)")
 
-        // exit full screen — restores toward the previous frame and leaves the app un-fullscreened.
         XCTAssertEqual(try sendCommand(#"{"cmd":"window.fullscreen"}"#)["ok"] as? Bool, true)
         deadline = Date().addingTimeInterval(10)
         while Date() < deadline {
@@ -163,14 +147,10 @@ final class ControlWindowUITests: ControlAPITestCase {
                        "window should restore toward \(normal) after exiting full screen, got \(window.frame.size)")
     }
 
-    // window.minimize puts the window in the Dock and brings it back, with `minimized` reading back on
-    // window.list. Everything is asserted through the control channel: a miniaturized window is off-screen,
-    // so any XCUIElement query against it hangs on event synthesis rather than failing. The restore rides
-    // `addTeardownBlock` (registered BEFORE the minimize) because `continueAfterFailure = false` unwinds
-    // through an ObjC exception that skips a Swift `defer`, which would leave the runner's screen with a
-    // Dock-parked window. A parked window stays parked because `bringForwardForUITests` latches on its
-    // first tick — the delay-0 block finds the window already on screen and disarms the rest of the
-    // schedule — so nothing deminiaturizes it out from under the assertions.
+    // asserted entirely over the control channel: a miniaturized window is off-screen, so an XCUIElement
+    // query against it hangs on event synthesis instead of failing. The restore rides `addTeardownBlock`
+    // (registered BEFORE the minimize) because `continueAfterFailure = false` unwinds through an ObjC
+    // exception that skips a Swift `defer`.
     func testWindowMinimizeAndRestore() throws {
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session")
         let id = try XCTUnwrap(try windowList().first?["id"] as? String, "the seeded window should have an id")
@@ -183,7 +163,6 @@ final class ControlWindowUITests: ControlAPITestCase {
         XCTAssertTrue(pollWindowList(timeout: 10) { $0.first?["minimized"] as? Bool == true },
                       "window.list should report minimized:true after window.minimize on")
 
-        // the payoff for a re-align script: a minimized window keeps reporting the frame it comes back to.
         // NSWindow.screen is nil while miniaturized, so this fails without the overlap-based screen fallback.
         let whileMinimized = try XCTUnwrap(try windowList().first?["geometry"] as? [String: Any],
                                            "a minimized window must still report its geometry")
@@ -192,30 +171,23 @@ final class ControlWindowUITests: ControlAPITestCase {
                            "\(key) should survive minimizing: before=\(before) now=\(whileMinimized)")
         }
 
-        // `on` again is a no-op, not a flip — the mode resolves against current state.
         XCTAssertEqual(try sendCommand(#"{"cmd":"window.minimize","args":{"mode":"on"}}"#)["ok"] as? Bool, true)
         XCTAssertEqual(try windowList().first?["minimized"] as? Bool, true, "a repeated `on` must stay minimized")
 
-        // window.select restores it too — `WindowRegistry.raise` deminiaturizes before making key, which is
-        // also what pulls a minimized window forward on a notification-banner reveal.
         XCTAssertEqual(try sendCommand(#"{"cmd":"window.select","target":"\#(id)"}"#)["ok"] as? Bool, true)
         XCTAssertTrue(pollWindowList(timeout: 10) { $0.first?["minimized"] as? Bool == false },
                       "window.select should un-minimize the window it raises")
 
-        // and the explicit restore is idempotent from there.
         XCTAssertEqual(try sendCommand(#"{"cmd":"window.minimize","target":"\#(id)","args":{"mode":"off"}}"#)["ok"] as? Bool,
                        true)
         XCTAssertEqual(try windowList().first?["minimized"] as? Bool, false)
-        // only now is the window back on screen, so element queries are safe again.
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 10),
                       "the restored window should be interactive again")
     }
 
-    // window.new --minimized creates the window already parked, so a script can build a set of project
-    // windows without each one flashing on screen and taking focus. The window must come up minimized and
-    // must NOT be left as the frontmost one — a window in the Dock would otherwise swallow every untargeted
-    // command. This also guards the ordering inside the command: WindowAccessor presents a new window on
-    // the next main-queue turn as well as synchronously, so parking it too early is silently undone.
+    // a parked window must not be left frontmost — one sitting in the Dock swallows every untargeted
+    // command. It also guards the ordering: WindowAccessor presents a new window on the next main-queue
+    // turn as well as synchronously, so parking it too early is silently undone.
     func testWindowNewMinimizedStaysParked() throws {
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session")
         let launchID = try XCTUnwrap(try windowList().first?["id"] as? String, "the seeded window should have an id")
@@ -233,17 +205,15 @@ final class ControlWindowUITests: ControlAPITestCase {
         XCTAssertEqual(list.first { ($0["id"] as? String)?.lowercased() == launchID.lowercased() }?["active"] as? Bool,
                        true, "the visible window should keep frontmost: \(list)")
 
-        // and it STAYS parked past WindowAccessor's deferred present and its UI-test schedule.
+        // the sleep outlasts WindowAccessor's deferred present and the UI-test schedule.
         usleep(1_500_000)
         XCTAssertEqual(try windowList().first { ($0["id"] as? String)?.lowercased() == newID.lowercased() }?["minimized"] as? Bool,
                        true, "the parked window must not be dragged back out of the Dock")
     }
 
-    // Parking the FRONTMOST window must hand frontmost to a window that is still visible. `activeWindowID`
-    // only falls back when the frontmost window's store is gone, and a minimized window keeps its store, so
-    // without the handoff every untargeted command keeps routing into a window sitting in the Dock — the
-    // exact state a park-all-but-one script produces. AppKit only keys another window while the app is
-    // active, so this cannot be left to it.
+    // `activeWindowID` only falls back when the frontmost window's store is gone, and a minimized window
+    // keeps its store; AppKit keys another window only while the app is active, so the handoff can be left
+    // to neither.
     func testMinimizingFrontmostHandsOffActive() throws {
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session")
         let launchID = try XCTUnwrap(try windowList().first?["id"] as? String, "the seeded window should have an id")
@@ -253,9 +223,8 @@ final class ControlWindowUITests: ControlAPITestCase {
         XCTAssertTrue(pollWindowList(timeout: 10) { list in
             list.first { ($0["id"] as? String)?.lowercased() == newID.lowercased() }?["active"] as? Bool == true
         }, "the new window should be frontmost before we park it")
-        // no wait is needed before parking: `bringForwardForUITests` latches on its delay-0 tick, which is
-        // enqueued inside the same `viewDidMoveToWindow` body that registers the window — so it has run
-        // long before `window.new` replies, and the later ticks are inert.
+        // no wait before parking: `bringForwardForUITests` latches on its delay-0 tick, enqueued in the
+        // same `viewDidMoveToWindow` that registers the window, so it has run before `window.new` replies.
         addTeardownBlock { _ = try? self.sendCommand(#"{"cmd":"window.minimize","target":"\#(newID)","args":{"mode":"off"}}"#) }
         XCTAssertEqual(try sendCommand(#"{"cmd":"window.minimize","target":"\#(newID)","args":{"mode":"on"}}"#)["ok"] as? Bool,
                        true)
@@ -270,11 +239,9 @@ final class ControlWindowUITests: ControlAPITestCase {
                       "minimizing the frontmost window should make the still-visible one active: \(finalList)")
     }
 
-    // AppKit's own Window ▸ Minimize (⌘M) mutates the state with no control command in play, so the
-    // read-back only stays honest because `ControlServer` observes NSWindow.didMiniaturize. This drives the
-    // menu item — the GUI half — and asserts the flag flips, which is the regression guard for those
-    // observers. The menu click happens while the window is still on screen, so no element query touches a
-    // miniaturized window; the teardown block restores it whatever happens.
+    // ⌘M mutates the state with no control command in play, so the read-back stays honest only because
+    // `ControlServer` observes NSWindow.didMiniaturize. The click happens while the window is still on
+    // screen, so no element query touches a miniaturized one.
     func testMenuMinimizeReadsBackOverControl() throws {
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session")
         XCTAssertEqual(try windowList().first?["minimized"] as? Bool, false, "should start un-minimized")
@@ -294,10 +261,7 @@ final class ControlWindowUITests: ControlAPITestCase {
     }
 
     // window.new must not reply until its NSWindow has attached: the store loads synchronously (so the
-    // library reports open:true at once) while the NSWindow lands two SwiftUI render passes later. Before
-    // the attach poll, an immediate window.resize on the returned id failed with "window not open", and the
-    // node cached right after window.new carried no geometry — with nothing on that path refreshing it
-    // afterwards, so window.list reported a geometry-less window indefinitely.
+    // library reports open:true at once) while the NSWindow lands two SwiftUI render passes later.
     func testWindowNewIsUsableImmediately() throws {
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session")
         let created = try sendCommand(#"{"cmd":"window.new","args":{"name":"immediate"}}"#)
@@ -305,8 +269,8 @@ final class ControlWindowUITests: ControlAPITestCase {
         let result = try XCTUnwrap(created["result"] as? [String: Any], "window.new should carry a result")
         let newID = try XCTUnwrap(result["id"] as? String, "window.new should return the new id")
 
-        // no polling and no intervening command: window.list is fast-path-served from the cache, so a node
-        // built before the attach would still be missing geometry here.
+        // no polling and no intervening command: window.list is served from the cache, so a node built
+        // before the attach would still be missing geometry here.
         let list = try windowList()
         let made = try XCTUnwrap(list.first { ($0["id"] as? String)?.lowercased() == newID.lowercased() },
                                  "the new window should be listed: \(list)")
@@ -317,19 +281,15 @@ final class ControlWindowUITests: ControlAPITestCase {
         XCTAssertEqual(resized["ok"] as? Bool, true, "resize right after window.new should succeed: \(resized)")
     }
 
-    // A point 14pt below the top edge, horizontally centred: clears the top resize strip, lands inside the
-    // titlebar band (compact 30 / normal 48), and sits in the empty header (a Spacer) — clear of the traffic
-    // lights on the left and the toolbar buttons on the right, so the click falls through the decorative
-    // regions' `.allowsHitTesting(false)` to the `WindowControlArea` layer behind the custom header.
-    // Re-resolved at each interaction, so it stays in the header even after a zoom grows the window.
+    // 14pt below the top edge, horizontally centred: clears the top resize strip, lands in the titlebar
+    // band (compact 30 / normal 48) and in the empty header Spacer — clear of the traffic lights and the
+    // toolbar buttons, so the click falls through to the `WindowControlArea` layer. Re-resolved at each
+    // interaction so it stays in the header after a zoom grows the window.
     private func emptyHeaderPoint(_ window: XCUIElement) -> XCUICoordinate {
         window.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0)).withOffset(CGVector(dx: 0, dy: 14))
     }
 
-    // The double-click-header GESTURE (the actual mouse event, not the window.zoom control command) must
-    // zoom the window. Mirrors testWindowZoom's settle logic but drives the real cursor: resize to a known
-    // small frame, double-click the empty header centre, assert the window grows, then double-click again
-    // and assert it restores.
+    // drives the real cursor, unlike testWindowZoom's control command.
     func testDoubleClickHeaderZoomsAndRestores() throws {
         let window = app.windows.firstMatch
         XCTAssertTrue(window.waitForExistence(timeout: 5), "window should exist")
@@ -362,10 +322,8 @@ final class ControlWindowUITests: ControlAPITestCase {
                        "a second header double-click should restore the window toward \(normal), got \(window.frame.size)")
     }
 
-    // Locks in that the gesture HONORS the system setting rather than hardcoding zoom: pinned to "None"
-    // (Desktop & Dock ▸ "Do Nothing") via setUp's env override, a header double-click must be a no-op —
-    // the window's frame must not change. The complement of testDoubleClickHeaderZoomsAndRestores.
-    // (the "None" pin is applied by ControlAPITestCase.setUp keyed on this test's name.)
+    // the "None" pin (Desktop & Dock ▸ "Do Nothing") is applied by ControlAPITestCase.setUp, keyed on
+    // this test's name.
     func testDoubleClickHeaderHonorsNoneSetting() throws {
         let window = app.windows.firstMatch
         XCTAssertTrue(window.waitForExistence(timeout: 5), "window should exist")
@@ -378,7 +336,7 @@ final class ControlWindowUITests: ControlAPITestCase {
         XCTAssertEqual(normal.width, 800, accuracy: 8, "window should settle near 800 wide before the gesture, got \(normal)")
 
         emptyHeaderPoint(window).doubleClick()
-        // give any (erroneous) zoom time to land, then assert the frame never changed.
+        // let any (erroneous) zoom land before asserting the frame never changed.
         RunLoop.current.run(until: Date().addingTimeInterval(2))
         XCTAssertEqual(window.frame.size.width, normal.width, accuracy: 8,
                        "with 'None' set, a header double-click must not zoom (width): normal=\(normal) now=\(window.frame.size)")
@@ -386,28 +344,23 @@ final class ControlWindowUITests: ControlAPITestCase {
                        "with 'None' set, a header double-click must not zoom (height): normal=\(normal) now=\(window.frame.size)")
     }
 
-    // The `WindowControlArea` drag/zoom layer sits BEHIND the header; the toolbar buttons render in front
-    // and must keep their own clicks. A double-click on the empty header must zoom (not reach a button);
-    // a click on quick-terminal-toggle must still open the quick terminal cover despite the layer behind.
+    // the `WindowControlArea` drag/zoom layer sits BEHIND the header; the toolbar buttons render in front
+    // and must keep their own clicks.
     func testHeaderButtonsStillReceiveClicksOverControlArea() throws {
         let window = app.windows.firstMatch
         XCTAssertTrue(window.waitForExistence(timeout: 5), "window should exist")
         let cover = app.descendants(matching: .any).matching(identifier: "quick-terminal").firstMatch
 
-        // double-clicking the empty header zooms the window; it must NOT open the quick terminal.
         emptyHeaderPoint(window).doubleClick()
         XCTAssertFalse(cover.waitForExistence(timeout: 2), "double-clicking the header must not open the quick terminal")
 
-        // the button itself still takes its click even though the control-area layer is behind the header.
         let button = app.buttons["quick-terminal-toggle"]
         XCTAssertTrue(button.waitForExistence(timeout: 5), "quick-terminal toolbar button should exist")
         button.click()
         XCTAssertTrue(cover.waitForExistence(timeout: 5), "clicking quick-terminal-toggle should open the quick terminal cover")
     }
 
-    // A single-click-drag anywhere on the full custom header moves the window (performDrag), not just the
-    // native top band. Resize + position to a known on-screen frame so the drag stays on screen and the
-    // delta is unambiguous, record the origin, drag the empty header, and assert the window's origin moved.
+    // the resize + move pin a known on-screen frame, so the drag stays on screen and the delta is unambiguous.
     func testDragHeaderMovesWindow() throws {
         let window = app.windows.firstMatch
         XCTAssertTrue(window.waitForExistence(timeout: 5), "window should exist")
@@ -432,24 +385,17 @@ final class ControlWindowUITests: ControlAPITestCase {
                       "dragging the header should move the window: origin=\(origin) now=\(moved)")
     }
 
-    // window.close marks the window closed, after which a session command targeting it returns the
-    // "window not open" error. (--window routing into the second window is exercised first to prove
-    // the round-trip, then the close flips it to the error path.)
     func testClosedWindowTargetingErrors() throws {
         let created = try sendCommand(#"{"cmd":"window.new"}"#)
         let result = try XCTUnwrap(created["result"] as? [String: Any], "window.new should carry a result")
         let windowB = try XCTUnwrap(result["id"] as? String, "window.new should return the new id")
         XCTAssertTrue(pollWindowList(timeout: 10) { $0.count == 2 }, "the second window should appear")
 
-        // routing into the still-open window B works.
         let openTree = try sendCommand(#"{"cmd":"tree","args":{"window":"\#(windowB)"}}"#)
         XCTAssertEqual(openTree["ok"] as? Bool, true, "tree --window B should succeed while open: \(openTree)")
 
-        // close window B, then wait until the index/list marks it closed. window.close drives AppKit's
-        // performClose → willCloseNotification → per-window surface teardown → library.closeWindow, a
-        // heavier round-trip than the other commands; under full-suite CPU contention the willClose handler
-        // can be delayed past a tight budget, so allow a longer settle (the open flag is the deterministic
-        // readiness signal — this waits for it, it isn't a blanket sleep).
+        // window.close drives performClose → willCloseNotification → surface teardown → library.closeWindow;
+        // under full-suite CPU contention that can be delayed, so the open flag gets a long settle.
         let closed = try sendCommand(#"{"cmd":"window.close","target":"\#(windowB)"}"#)
         XCTAssertEqual(closed["ok"] as? Bool, true, "window.close should succeed: \(closed)")
         let settled = pollWindowList(timeout: 30) { list in
@@ -457,15 +403,12 @@ final class ControlWindowUITests: ControlAPITestCase {
         }
         XCTAssertTrue(settled, "window B should be marked closed after window.close")
 
-        // a session command targeting the now-closed window returns the structured closed-window error.
         let response = try sendCommand(#"{"cmd":"tree","args":{"window":"\#(windowB)"}}"#)
         XCTAssertEqual(response["ok"] as? Bool, false, "targeting a closed window should fail: \(response)")
         XCTAssertEqual(response["error"] as? String, "window not open — window.select it first",
                        "should return the closed-window error: \(response)")
     }
 
-    // --window targeting routes session.new + tree to the right window: a session added to window B with
-    // --window lands in B's tree (now two sessions) and NOT in the frontmost (A) tree (still one).
     func testWindowTargetingRoutesToTheRightTree() throws {
         let initial = try windowList()
         let windowA = try XCTUnwrap(initial.first?["id"] as? String, "the seeded window id")
@@ -475,20 +418,15 @@ final class ControlWindowUITests: ControlAPITestCase {
         let windowB = try XCTUnwrap(result["id"] as? String, "window.new should return the new id")
         XCTAssertTrue(pollWindowList(timeout: 10) { $0.count == 2 }, "the second window should appear")
 
-        // add a session to window B by id.
         let added = try sendCommand(#"{"cmd":"session.new","args":{"window":"\#(windowB)"}}"#)
         XCTAssertEqual(added["ok"] as? Bool, true, "session.new --window B should succeed: \(added)")
 
-        // window B's tree now holds two sessions; window A's still holds one.
         XCTAssertTrue(pollTreeSessionCount(window: windowB, expected: 2, timeout: 10),
                       "the new session should land in window B's tree")
         XCTAssertTrue(pollTreeSessionCount(window: windowA, expected: 1, timeout: 5),
                       "window A's tree should be unchanged")
     }
 
-    // an id captured from one window resolves with no --window even while another window is frontmost:
-    // create window B + a session in it, raise window A to make it frontmost, then session.select the
-    // captured B-session id with no --window — it resolves cross-window and selects it in B's store.
     func testCapturedIDResolvesWhileAnotherWindowFrontmost() throws {
         let initial = try windowList()
         let windowA = try XCTUnwrap(initial.first?["id"] as? String, "the seeded window id")
@@ -498,47 +436,38 @@ final class ControlWindowUITests: ControlAPITestCase {
         let windowB = try XCTUnwrap(result["id"] as? String, "window.new should return the new id")
         XCTAssertTrue(pollWindowList(timeout: 10) { $0.count == 2 }, "the second window should appear")
 
-        // capture a session id created in window B.
         let added = try sendCommand(#"{"cmd":"session.new","args":{"window":"\#(windowB)"}}"#)
         let addedResult = try XCTUnwrap(added["result"] as? [String: Any], "session.new should carry a result")
         let sessionID = try XCTUnwrap(addedResult["id"] as? String, "session.new should return the new session id")
 
-        // raise window A so it becomes frontmost (window B was frontmost right after window.new).
+        // window B is frontmost right after window.new, so A has to be raised.
         XCTAssertTrue(selectWindowUntilActive(windowA, timeout: 15),
                       "window A should become active")
 
-        // select the B-session by id with NO --window: it resolves cross-window to window B's store.
         let selected = try sendCommand(#"{"cmd":"session.select","target":"\#(sessionID)"}"#)
         XCTAssertEqual(selected["ok"] as? Bool, true, "selecting the captured id with no --window should succeed: \(selected)")
         XCTAssertEqual((selected["result"] as? [String: Any])?["id"] as? String, sessionID,
                        "select should resolve to the captured B-session id: \(selected)")
 
-        // confirm it actually selected in window B's tree.
         XCTAssertTrue(pollTreeActiveSession(window: windowB, sessionID: sessionID, timeout: 10),
                       "the captured session should be active in window B's tree")
     }
 
-    // a WORKSPACE id captured from window B resolves cross-window with no --window even while window A
-    // is frontmost (exercises the cross-window workspace resolver arm, distinct from the session one).
     func testCapturedWorkspaceIDResolvesCrossWindow() throws {
         let created = try sendCommand(#"{"cmd":"window.new"}"#)
         let windowB = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "window.new should return the new id")
         XCTAssertTrue(pollWindowList(timeout: 10) { $0.count == 2 }, "the second window should appear")
 
-        // create a workspace in window B and capture its id.
         let madeWs = try sendCommand(#"{"cmd":"workspace.new","args":{"window":"\#(windowB)","name":"betaws"}}"#)
         let workspaceID = try XCTUnwrap((madeWs["result"] as? [String: Any])?["id"] as? String,
                                         "workspace.new should return the new workspace id")
 
-        // select the B-workspace by id with NO --window: it resolves cross-window to window B's store.
         let selected = try sendCommand(#"{"cmd":"workspace.select","target":"\#(workspaceID)"}"#)
         XCTAssertEqual(selected["ok"] as? Bool, true, "selecting the captured workspace id cross-window should succeed: \(selected)")
         XCTAssertEqual((selected["result"] as? [String: Any])?["id"] as? String, workspaceID,
                        "select should resolve to the captured B-workspace id: \(selected)")
     }
 
-    // an unknown id with no --window is searched across ALL open windows and, found nowhere, returns
-    // the structured not-found error (the cross-window resolver's miss path).
     func testCrossWindowUnknownIDErrors() throws {
         let created = try sendCommand(#"{"cmd":"window.new"}"#)
         _ = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "window.new should return the new id")
@@ -551,17 +480,13 @@ final class ControlWindowUITests: ControlAPITestCase {
                        "should return the cross-window not-found error: \(response)")
     }
 
-    // after closing the frontmost window, the remaining window becomes active — window.list reports
-    // exactly one open window and it is flagged active (the frontmost invariant survives a close).
     func testRemainingWindowBecomesActiveAfterClosingFrontmost() throws {
         let created = try sendCommand(#"{"cmd":"window.new"}"#)
         let windowB = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "window.new should return the new id")
         XCTAssertTrue(pollWindowList(timeout: 10) { $0.count == 2 }, "the second window should appear")
 
-        // close the just-created (frontmost) window B.
         XCTAssertEqual(try sendCommand(#"{"cmd":"window.close","target":"\#(windowB)"}"#)["ok"] as? Bool, true)
 
-        // exactly one window remains open, and the surviving (frontmost-or-first) window is active.
         let settled = pollWindowList(timeout: 30) { list in
             let open = list.filter { ($0["open"] as? Bool) == true }
             let active = list.filter { ($0["active"] as? Bool) == true }
@@ -581,11 +506,9 @@ final class ControlWindowUITests: ControlAPITestCase {
     }
 
     /// Re-issues `window.select` for `id` while polling `window.list` for that window's `active` flag.
-    /// `window.select` returns ok as soon as the window is OPEN, not when it has become key — and the
-    /// `active` flag flips only on the async `didBecomeKey`/`didBecomeMain`, which macOS can drop or
-    /// delay under XCUITest (a `makeKeyAndOrderFront` that doesn't take is never re-issued by a single
-    /// select). Re-selecting (idempotent: raises again) recovers a dropped activation; `app.activate()`
-    /// first so the app is the active application (a window can't become key while the app is inactive).
+    /// The flag flips only on the async `didBecomeKey`/`didBecomeMain`, which macOS can drop under
+    /// XCUITest; re-selecting recovers a dropped activation, and `app.activate()` comes first because a
+    /// window cannot become key while the app is inactive.
     private func selectWindowUntilActive(_ id: String, timeout: TimeInterval) -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {

--- a/agtermUITests/CustomCommandPaneTokenUITests.swift
+++ b/agtermUITests/CustomCommandPaneTokenUITests.swift
@@ -1,39 +1,25 @@
 import Foundation
 import XCTest
 
-// Verifies the `CustomCommandRunner` pane derivation that populates `{AGT_PANE}`/`$AGT_PANE`: a custom
-// command reports the pane it fired FROM — "left" (main), "right" (split), or "scratch" (the session's
-// scratch terminal). This is the only test that pins that logic. The keybind path derives the pane from
-// the focused SURFACE's identity (NOT the session's `splitFocused` flag), and the palette path from the
-// flag. The probe command writes `$AGT_PANE` to a marker file, which the test reads back. A
-// `ControlAPITestCase` subclass so it can split/focus/scratch panes over the control socket while firing
-// real keystrokes for the keybind path.
+// Pins the `CustomCommandRunner` pane derivation behind `{AGT_PANE}`/`$AGT_PANE`: the keybind path derives
+// the pane from the focused SURFACE's identity (NOT the session's `splitFocused` flag), the palette path
+// from the flag. The probe command writes `$AGT_PANE` to a marker file, which the test reads back.
 @MainActor
 final class CustomCommandPaneTokenUITests: ControlAPITestCase {
-    // keybind path: fire the SAME chord from the main pane (no split) and then from the split's focused
-    // right pane; $AGT_PANE must be "left" then "right", exercising both branches of `runFromKeybind`'s
-    // surface-identity derivation end-to-end through the real NSEvent monitor.
-    //
-    // NOTE: this does NOT isolate "surface identity" from "the splitFocused flag" — in both fired states
-    // the flag and the actual first responder AGREE (the surfaces' onFocusChange closures keep splitFocused
-    // synced to real focus), so a regression deriving the pane from splitFocused would pass here too. A
-    // flag-vs-focus divergence isn't deterministically reproducible: the only way to set the flag without a
-    // focus change is `session.split on` over the socket, after which the main surface is re-hosted into the
-    // HSplitView and holds no reliable first responder — so the chord's "a GhosttySurfaceView must hold
-    // first responder" gate can't be pinned. The surface-identity choice itself is covered by inspection
-    // (`CustomCommandRunner.runFromKeybind`) plus the promoted-survivor reasoning in keymap.md.
+    // NOTE: this does NOT isolate "surface identity" from "the splitFocused flag" — in both fired states the
+    // flag and the actual first responder AGREE, so a regression deriving the pane from splitFocused would
+    // pass here too. A divergence isn't deterministically reproducible: only `session.split on` over the
+    // socket sets the flag without a focus change, and the main surface is then re-hosted into the HSplitView
+    // holding no reliable first responder, so the chord's first-responder gate can't be pinned.
     func testAgtPaneKeybindReflectsFiredFromPane() throws {
         let marker = markerDir.appendingPathComponent("agt-pane-keybind")
-        // ⌘⇧E → write $AGT_PANE to the marker. The runner already wraps the line in `/bin/sh -c`, so
-        // `$AGT_PANE` expands from the exported env; no inner `sh -c` is needed.
+        // the runner already wraps the line in `/bin/sh -c`, so `$AGT_PANE` expands with no inner `sh -c`.
         try relaunch(withKeymap: "command \"Pane Probe\" cmd+shift+e printf %s \"$AGT_PANE\" > \"\(marker.path)\"\n")
 
-        // MAIN pane (no split yet): focus the seeded terminal, fire the chord → "left".
         focusMainTerminal()
         XCTAssertEqual(firePaneProbe(marker) { self.app.typeKey("e", modifierFlags: [.command, .shift]) }, "left",
                        "a chord fired from the main pane should report $AGT_PANE=left")
 
-        // SPLIT right pane: split on, move keyboard focus to the right pane, fire the SAME chord → "right".
         let split = try sendCommand(#"{"cmd":"session.split","target":"active","args":{"mode":"on"}}"#)
         XCTAssertEqual(split["ok"] as? Bool, true, "split on should succeed: \(split)")
         XCTAssertTrue(pollActiveSessionSplit(true, timeout: 10), "the active session should report split:true")
@@ -45,12 +31,8 @@ final class CustomCommandPaneTokenUITests: ControlAPITestCase {
                        "a chord fired from the split's right pane should report $AGT_PANE=right")
     }
 
-    // keybind path, SCRATCH: open the session's scratch terminal over the socket (it auto-focuses on
-    // show), then fire the SAME chord from it → "scratch". This is the app-side proof of
-    // `runFromSessionlessSurface`'s scratch branch: the scratch surface has no `view.session`, so the
-    // runner identifies it as the ACTIVE session's `scratchSurface` and reports `.scratch`, the read leg
-    // of the `$AGT_PANE` → `session type --pane scratch` round-trip. The host-free tests can't reach the
-    // runner. The quick terminal and overlays deliberately have no pane value (their state is on `tree`).
+    // the scratch surface has no `view.session`, so `runFromSessionlessSurface` must identify it as the ACTIVE
+    // session's `scratchSurface` — the read leg of the `$AGT_PANE` → `session type --pane scratch` round-trip.
     func testAgtPaneKeybindReportsScratch() throws {
         let marker = markerDir.appendingPathComponent("agt-pane-scratch")
         try relaunch(withKeymap: "command \"Pane Probe\" cmd+shift+e printf %s \"$AGT_PANE\" > \"\(marker.path)\"\n")
@@ -58,23 +40,20 @@ final class CustomCommandPaneTokenUITests: ControlAPITestCase {
         focusMainTerminal()
         let scratch = try sendCommand(#"{"cmd":"session.scratch","target":"active","args":{"mode":"on"}}"#)
         XCTAssertEqual(scratch["ok"] as? Bool, true, "scratch on should succeed: \(scratch)")
-        // wait for the scratch surface to realize (shell spawned, readable) so the focus it grabs is real.
         XCTAssertTrue(pollScratchRealized(timeout: 10), "the control-opened scratch should realize its surface")
         app.activate()
 
-        // the scratch auto-focuses on show, but that focus is async — retry the chord until it reports the
-        // scratch (a chord landing before the scratch grabs first responder reports the main pane).
+        // the scratch's auto-focus on show is async, so a chord landing before it grabs first responder
+        // reports the main pane — retry until it reports the scratch.
         XCTAssertEqual(fireUntil("scratch", marker: marker) { self.app.typeKey("e", modifierFlags: [.command, .shift]) },
                        "scratch", "a chord fired from the scratch terminal should report $AGT_PANE=scratch")
     }
 
-    // palette path: the runner's `run(_:)` (no fired-from surface to key off) derives the pane from the
-    // active session's `splitFocused` flag. Split on + focus right, then run the command from the Custom
-    // Commands palette; opening the menu doesn't touch `splitFocused`, so the flag stays true → "right".
+    // `run(_:)` has no fired-from surface to key off, so it derives the pane from `splitFocused`; opening the
+    // palette menu doesn't touch that flag, so it stays true across the run.
     func testAgtPanePaletteUsesFocusedPane() throws {
         let marker = markerDir.appendingPathComponent("agt-pane-palette")
-        // no chord → palette-only (the `printf` token is not a valid chord, so the whole remainder is the
-        // shell line).
+        // no chord, so the `printf` token is not read as one and the whole remainder is the shell line.
         try relaunch(withKeymap: "command \"Pane Probe\" printf %s \"$AGT_PANE\" > \"\(marker.path)\"\n")
 
         let split = try sendCommand(#"{"cmd":"session.split","target":"active","args":{"mode":"on"}}"#)
@@ -90,26 +69,21 @@ final class CustomCommandPaneTokenUITests: ControlAPITestCase {
                        "a command run from the palette while the right pane is focused should report $AGT_PANE=right")
     }
 
-    // palette path, default (no split): the seeded session has no split, so `run(_:)`'s
-    // `splitFocused ? .right : .left` takes the `.left` branch — the common case, and the half of that
-    // ternary the split+focus-right test above never exercises through the real runner. Pins that a
-    // swapped ternary or a hardcoded `.right` in the palette path would be caught.
+    // the `.left` half of `run(_:)`'s `splitFocused ? .right : .left`, which the split+focus-right test above
+    // never exercises — without it a swapped ternary or a hardcoded `.right` would go unnoticed.
     func testAgtPanePaletteDefaultsToLeftWithoutSplit() throws {
         let marker = markerDir.appendingPathComponent("agt-pane-palette-left")
         try relaunch(withKeymap: "command \"Pane Probe\" printf %s \"$AGT_PANE\" > \"\(marker.path)\"\n")
 
-        // no split on the seeded session → the active pane is the main pane, so the palette path reports left.
         try? FileManager.default.removeItem(at: marker)
         runFromCustomCommandsPalette("Pane Probe")
         XCTAssertEqual(pollMarker(marker, timeout: 5), "left",
                        "a command run from the palette with no split should report $AGT_PANE=left")
     }
 
-    // promoted single-pane: split on, then exit the PRIMARY (main/left) shell so `closePrimaryPane`
-    // promotes the survivor INTO the main slot (surface=survivor, splitSurface=nil, hasSplit=false,
-    // splitFocused=false — a plain single pane). {AGT_PANE} must report "left": the survivor is now the
-    // main pane, and `session.type --pane left` reaches it. Then prove the round-trip the token exists
-    // for: `session.type --pane <reported>` lands in the promoted pane's own buffer.
+    // exiting the PRIMARY shell makes `closePrimaryPane` promote the survivor INTO the main slot
+    // (splitSurface=nil, hasSplit=false, splitFocused=false), so the survivor must report "left" and
+    // `session.type --pane left` must reach it.
     func testAgtPanePromotedSurvivorReportsLeft() throws {
         let marker = markerDir.appendingPathComponent("agt-pane-promoted")
         try relaunch(withKeymap: "command \"Pane Probe\" printf %s \"$AGT_PANE\" > \"\(marker.path)\"\n")
@@ -119,10 +93,8 @@ final class CustomCommandPaneTokenUITests: ControlAPITestCase {
         XCTAssertTrue(pollActiveSessionSplit(true, timeout: 10), "the active session should report split:true")
         let activeID = try activeSessionID()
 
-        // a no-pane session.type injects into the main (left) surface regardless of focus, so `exit` closes
-        // the primary pane; with a live split pane, `closePrimaryPane` promotes the survivor rather than
-        // closing the session. Retry the exit until the split flag drops (the shell may not be at a prompt
-        // for the first keystrokes — the same readiness idiom the pane-text polls use).
+        // a no-pane session.type injects into the main surface regardless of focus, so this `exit` closes the
+        // primary pane. Retry it: the shell may not be at a prompt yet for the first keystrokes.
         var promoted = false
         for _ in 0..<5 {
             _ = try sendCommand(typeRequest(text: "exit\n", target: activeID, select: false))
@@ -130,15 +102,12 @@ final class CustomCommandPaneTokenUITests: ControlAPITestCase {
         }
         XCTAssertTrue(promoted, "exiting the primary pane should promote the survivor to a single (non-split) pane")
 
-        // palette path: the promoted survivor is now the main pane (splitSurface == nil, splitFocused ==
-        // false), so run() reports left.
         try? FileManager.default.removeItem(at: marker)
         runFromCustomCommandsPalette("Pane Probe")
         let reported = pollMarker(marker, timeout: 5)
         XCTAssertEqual(reported, "left", "a promoted split survivor is the main pane, so $AGT_PANE=left")
 
-        // round-trip: session.type --pane <reported> must reach THAT pane's buffer (the survivor). Typed as
-        // `$((6*7))` arithmetic so a match proves the survivor's shell RAN the line, not merely echoed it.
+        // typed as `$((6*7))` arithmetic so a match proves the survivor's shell RAN the line, not echoed it.
         let pane = try XCTUnwrap(reported)
         let tag = "PROMO-\(UUID().uuidString.prefix(8))"
         let text = try pollPaneText(target: activeID, pane: pane, contains: "\(tag)-42", retype: {

--- a/agtermUITests/DashboardUITests.swift
+++ b/agtermUITests/DashboardUITests.swift
@@ -16,8 +16,6 @@ import XCTest
 final class DashboardUITests: ControlAPITestCase {
     // MARK: - open / cell count / read-back
 
-    // opening a 3-session dashboard renders exactly three member cells and reports the members on `tree`;
-    // closing removes the overlay and clears every dashboard read-back.
     func testDashboardOpensWithMemberCellsAndClosesClean() throws {
         let ids = try prepareSessions(extra: 2) // 3 sessions → a 2x2 grid with three real cells + one filler
         XCTAssertEqual(ids.count, 3, "the seeded session plus two new ones")
@@ -35,16 +33,11 @@ final class DashboardUITests: ControlAPITestCase {
         XCTAssertNil(dashHighlighted(), "tree.dashboardHighlighted clears on close")
     }
 
-    // `dashboard --mru` populates the grid from the window's most-recently-used sessions (no explicit ids):
-    // a KNOWN recency order is seeded via explicit `session.select`s (the LAST selected is most-recent), then
-    // the mru members are asserted to equal that order exactly (recency is deterministic — the RecencyStack is
-    // pushed on every select), one cell per session (fewer than the 9-cell cap). Asserts ORDER, not just the
-    // set, since the switcher/recency behavior is deterministic.
+    // asserts ORDER, not just the set: RecencyStack is pushed on every select, so it is deterministic.
     func testDashboardMruOpensRecentSessions() throws {
         let ids = try prepareSessions(extra: 3) // 4 sessions total (seeded + three new)
         XCTAssertEqual(ids.count, 4)
 
-        // seed recency by selecting each session in a known sequence; most-recent-first is its reverse.
         let selectOrder = [ids[1], ids[3], ids[0], ids[2]]
         for id in selectOrder {
             XCTAssertEqual(try sendCommand(#"{"cmd":"session.select","target":"\#(id)"}"#)["ok"] as? Bool, true,
@@ -59,7 +52,7 @@ final class DashboardUITests: ControlAPITestCase {
 
         XCTAssertTrue(pollCellCount(4, timeout: 15), "mru renders one cell per recent session (≤9, fewer if fewer)")
         let members = try XCTUnwrap(dashMembers(), "tree carries the mru members while open")
-        // the sessions have no split, so each is a single primary-pane cell (`<id>:left`), in mru order.
+        // no split, so each session is a single `<id>:left` cell.
         XCTAssertEqual(members.map { $0.lowercased() }, expected.map { "\($0.lowercased()):left" },
                        "mru members are the window's sessions in most-recent-first order (each a primary pane cell)")
 
@@ -68,16 +61,11 @@ final class DashboardUITests: ControlAPITestCase {
         XCTAssertNil(dashMembers(), "the mru members read-back clears on close")
     }
 
-    // a SPLIT session opens as TWO cells — its primary AND its split pane — so tree.dashboardMembers carries
-    // BOTH `<id>:left` and `<id>:right`. Highlighting the split (right) cell and pressing Enter focuses the
-    // RIGHT pane, asserted via the tree `splitFocused` read-back (flips false → true). The focus routing is
-    // real behavior, not a weaker proxy: `splitFocused` is the same field `session.focus` reads back.
+    // `splitFocused` is the same field `session.focus` reads back, so this is real routing, not a proxy.
     func testSplitSessionOpensTwoCellsAndEnterFocusesSplitPane() throws {
         let ids = try prepareSessions(extra: 0) // just the seeded session
         let id = ids[0]
-        // give the session a split pane (both shells alive). `session.split on` shows it and focuses the new
-        // RIGHT pane, so move focus back to the LEFT pane first — that makes the split-cell Enter below flip
-        // splitFocused false → true, a real (non-vacuous) effect to assert.
+        // `split on` focuses the RIGHT pane, so move back to LEFT first or the Enter below asserts nothing.
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.split","target":"\#(id)","args":{"mode":"on"}}"#)["ok"] as? Bool,
                        true, "session.split on should succeed")
         XCTAssertTrue(try pollSplit(id, timeout: 10), "the session should report a split")
@@ -92,7 +80,6 @@ final class DashboardUITests: ControlAPITestCase {
                        Set(["\(id.lowercased()):left", "\(id.lowercased()):right"]),
                        "the two cells are the session's left and right panes")
 
-        // highlight the split (right) cell (right arrow: primary[0] → split[1]), then Enter.
         settle(0.5)
         app.typeKey(.rightArrow, modifierFlags: [])
         XCTAssertTrue(pollDashHighlightedRef("\(id):right", timeout: 8), "right arrow highlights the split pane cell")
@@ -104,21 +91,16 @@ final class DashboardUITests: ControlAPITestCase {
                       "Enter on the split cell focuses the RIGHT pane (splitFocused flips to true)")
     }
 
-    // regression: opening the dashboard over a session whose FOCUSED split pane holds first responder must
-    // hand the keyboard to the dashboard's key-catcher, not leave it with the reparented pane surface. The
-    // focused split surface carries first responder ACROSS the reparent into the view-only cell
-    // (`acceptsFirstResponder=false` blocks only NEW grabs, never a HELD one), so without the viewOnly resign
-    // it keeps the keyboard — a bare arrow goes to that pane (invisible) instead of walking the highlight.
-    // Deliberately does NOT use the `openDashboard` helper: its post-open cell click forces a key-catcher
-    // re-grab that would MASK this exact race (the test would then pass even on the broken code). Routing is
-    // established by the pre-open `row.click()` + `splitButton.click()` (the SplitUITests idiom) and persists
-    // into the socket-opened dashboard, so the bare arrow below is the real discriminator.
+    // `acceptsFirstResponder=false` blocks only NEW grabs, never a HELD one, so the focused split surface
+    // carries first responder across the reparent unless viewOnly resigns it.
+    // Deliberately does NOT use `openDashboard`: its post-open cell click forces a key-catcher re-grab that
+    // MASKS this race, so the test would pass on the broken code.
     func testDashboardOverFocusedSplitPaneGivesKeyboardToKeyCatcher() throws {
         let ids = try prepareSessions(extra: 0) // just the seeded session
         let id = ids[0]
 
-        // GUI click establishes XCUITest key routing AND focuses the seeded terminal; the split button then
-        // moves focus to the NEW right pane, so its surface holds first responder (SplitUITests idiom).
+        // the GUI click establishes XCUITest key routing; the split button then hands first responder to
+        // the new right pane (SplitUITests idiom).
         let row = app.staticTexts["session-row"]
         XCTAssertTrue(row.waitForExistence(timeout: 15), "the seeded row should exist")
         row.click()
@@ -129,25 +111,19 @@ final class DashboardUITests: ControlAPITestCase {
         XCTAssertTrue(try pollSplit(id, timeout: 10), "the session should report a split")
         XCTAssertTrue(try pollSplitFocused(id, expected: true, timeout: 10), "opening the split focuses the right pane")
 
-        // open the dashboard over the split session via the SOCKET, WITHOUT the masking cell click.
         let response = try sendCommand(#"{"cmd":"dashboard","args":{"targets":["\#(id)"]}}"#)
         XCTAssertEqual(response["ok"] as? Bool, true, "dashboard open should succeed: \(response)")
         XCTAssertTrue(dashboardOverlay.waitForExistence(timeout: 15), "the dashboard overlay should appear")
         XCTAssertTrue(pollCellCount(2, timeout: 15), "the split session opens as two pane cells")
         XCTAssertTrue(pollDashHighlightedRef("\(id):left", timeout: 8), "the highlight starts on the primary pane cell")
 
-        // a bare right arrow must WALK the highlight to the split cell — proving the key-catcher owns the
-        // keyboard. Without the viewOnly resign, the carried-in split surface swallows the arrow and the
-        // highlight never leaves the primary cell.
+        // a bare arrow is the discriminator: the carried-in split surface would swallow it instead.
         settle(0.5)
         app.typeKey(.rightArrow, modifierFlags: [])
         XCTAssertTrue(pollDashHighlightedRef("\(id):right", timeout: 8),
                       "a bare arrow walks the highlight — the key-catcher, not the reparented split pane, owns keys")
     }
 
-    // arrow keys walk the highlight between cells (observed via tree.dashboardHighlighted and the
-    // `dashboard-highlighted` marker), and Enter jumps into the highlighted session — closing the overlay AND
-    // moving the selection to that session.
     func testArrowMovesHighlightAndEnterSelectsClosingDashboard() throws {
         let ids = try prepareSessions(extra: 1) // [seeded, new1] → a 1x2 grid
         try openDashboard(members: ids)
@@ -156,25 +132,20 @@ final class DashboardUITests: ControlAPITestCase {
         XCTAssertEqual(refSession(initial), ids[0].lowercased(), "the highlight starts on the first member")
         XCTAssertTrue(highlightedMarker.waitForExistence(timeout: 10), "the highlighted cell renders its marker")
 
-        // give the AppKit key-catcher a beat to own first responder, then move the highlight right.
         settle(0.5)
         app.typeKey(.rightArrow, modifierFlags: [])
         let moved = pollDashHighlighted(changedFrom: ids[0], timeout: 8)
         XCTAssertEqual(moved.map(refSession), ids[1].lowercased(), "right arrow moves the highlight to the next cell")
 
-        // Enter selects the highlighted session and closes the dashboard.
         app.typeKey(.return, modifierFlags: [])
         XCTAssertTrue(dashboardOverlay.waitForNonExistence(timeout: 10), "Enter closes the dashboard")
         XCTAssertNil(dashMembers(), "the dashboard read-backs clear once it closes")
         XCTAssertTrue(pollSelectedSession(ids[1], timeout: 10), "Enter selects the highlighted session")
     }
 
-    // Esc dismisses the dashboard WITHOUT jumping in: the selection is whatever it was before opening, even
-    // though the highlight was moved onto a different session.
     func testEscapeClosesDashboardWithoutChangingSelection() throws {
         let ids = try prepareSessions(extra: 1)
-        // pin a known baseline selection distinct from the cell we will highlight (so a wrongly-selecting Esc
-        // would be observable as a change to ids[1]).
+        // the baseline must differ from the highlighted cell, or a wrongly-selecting Esc is unobservable.
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.select","target":"\#(ids[0])"}"#)["ok"] as? Bool, true,
                        "selecting the seeded session should succeed")
         XCTAssertTrue(pollSelectedSession(ids[0], timeout: 10), "the seeded session is selected before opening")
@@ -186,67 +157,47 @@ final class DashboardUITests: ControlAPITestCase {
 
         app.typeKey(.escape, modifierFlags: [])
         XCTAssertTrue(dashboardOverlay.waitForNonExistence(timeout: 10), "Esc closes the dashboard")
-        // give any (wrongly) armed selection change time to LAND and assert it never does — polling for the
-        // WRONG state's absence, rather than a fixed settle before one read that could pass vacuously.
+        // polls for the WRONG state's ABSENCE: a fixed settle then one read could pass vacuously.
         XCTAssertFalse(pollSelectedSession(ids[1], timeout: 3), "Esc must not select the highlighted session")
         XCTAssertEqual(selectedSessionID()?.lowercased(), ids[0].lowercased(),
                        "Esc leaves the pre-open selection in place")
     }
 
-    // while the view-only dashboard is open the full titlebar is swapped for a stripped bar (mirroring
-    // terminal zoom): its interactive session controls are GONE, so a stray click on one can no longer steal
-    // the key-catcher's first responder (which stranded Esc) or drive an action behind the grid. Only an exit
-    // button remains, and clicking it closes the dashboard.
+    // the controls are gone so a stray click cannot steal the key-catcher's first responder, which
+    // stranded Esc.
     func testDashboardTitlebarStripsInteractiveButtonsAndExitCloses() throws {
         let ids = try prepareSessions(extra: 1)
 
-        // baseline: the full titlebar's session controls exist before opening.
         XCTAssertTrue(app.buttons["split-toggle"].waitForExistence(timeout: 15),
                       "the split button renders in the normal titlebar")
 
         try openDashboard(members: ids)
 
-        // opening swaps in the stripped titlebar: every interactive session control is gone...
         for control in ["split-toggle", "sidebar-toggle-button", "scratch-toggle", "quick-terminal-toggle"] {
             XCTAssertTrue(app.buttons[control].waitForNonExistence(timeout: 10),
                           "\(control) must not render while the dashboard is open")
         }
-        // ...and only the exit button remains (the counterpart of terminal-zoom-exit).
         let exit = app.buttons["dashboard-exit"]
         XCTAssertTrue(exit.waitForExistence(timeout: 10), "the stripped dashboard titlebar shows an exit button")
 
-        // the exit button closes the dashboard (same close-and-refocus path as Esc)...
         exit.click()
         XCTAssertTrue(dashboardOverlay.waitForNonExistence(timeout: 10), "the exit button closes the dashboard")
-        // ...and the full titlebar returns once it is closed.
         XCTAssertTrue(app.buttons["split-toggle"].waitForExistence(timeout: 10),
                       "the full titlebar returns once the dashboard closes")
     }
 
-    // the correctness crux: while the dashboard is open it is VIEW-ONLY — a typed keystroke never reaches
-    // any terminal. Proven with a three-phase probe so the negative is not vacuous:
-    //   1. before opening, GUI typing DOES reach the focused terminal (a marker file is written);
-    //   2. while open, a typed sentinel is swallowed (it never echoes into the surface buffer) — a bare arrow
-    //      that walks the highlight proves the key pipeline drained PAST the sentinel first (a leaked
-    //      keystroke would already be in the buffer);
-    //   3. after closing, GUI typing reaches the terminal again — so the block in phase 2 was the dashboard,
-    //      not a dead terminal.
-    // A single mouse CLICK on a cell now ENTERS it — that mouse path is covered by
-    // testDashboardCellSingleClickEntersSession, which also proves a click is consumed by the dashboard's hit
-    // target rather than the terminal beneath it.
+    // three phases so the negative is not vacuous: typing works before, is swallowed while open, and works
+    // again after — proving phase 2 was the dashboard, not a dead terminal. The bare arrow in phase 2 proves
+    // the pipeline drained PAST the sentinel, since a leaked keystroke would already be in the buffer.
     func testDashboardIsViewOnlyKeystrokesDoNotReachTerminal() throws {
         let ids = try prepareSessions(extra: 1) // [seeded, new1]
 
-        // focus the seeded terminal via its sidebar row (row click → select + focus, the SplitUITests idiom).
         let seededRow = app.staticTexts.matching(identifier: "session-row").element(boundBy: 0)
         XCTAssertTrue(seededRow.waitForExistence(timeout: 15), "the seeded row should exist")
         seededRow.click()
         settle(0.8)
 
-        // PHASE 1 — GUI keystrokes reach the focused terminal (baseline that typing works at all). Retry the
-        // GUI type until the marker lands: a freshly focused terminal's pty may not be ready to read when the
-        // first keystrokes arrive (especially under full-suite CPU load), so a single type can be dropped —
-        // the GUI-input twin of the base typeUntilMarker readiness wait.
+        // PHASE 1 — a freshly focused pty may drop the first keystrokes, so retry until the marker lands.
         let beforeFile = markerDir.appendingPathComponent("before")
         XCTAssertNotNil(typeShellMarkerUntilFile(token: "DASHBEFORE7788", file: beforeFile),
                         "GUI keystrokes should reach the terminal before the dashboard opens")
@@ -254,7 +205,6 @@ final class DashboardUITests: ControlAPITestCase {
         try openDashboard(members: ids)
         settle(0.6)
 
-        // PHASE 2 — typing while open is swallowed by the key-catcher, so nothing echoes into the surface.
         // No Return: a Return would be consumed as Enter=select and close the overlay, so a leak is detected
         // by the sentinel appearing in the buffer, not by a marker file.
         app.typeText("LEAKSENTINEL9911")

--- a/agtermUITests/EditMenuUITests.swift
+++ b/agtermUITests/EditMenuUITests.swift
@@ -16,8 +16,7 @@ import XCTest
 /// So every clipboard-dependent assertion polls until the app catches up, and each "disabled" expectation is
 /// entered from a known-enabled state so a stale read cannot satisfy it.
 ///
-/// The runner is also SANDBOXED, which bounds what can be seeded at all — see the note above
-/// `testEditMenuLeavesCutAndUndoDisabledForTerminal`.
+/// The runner is also SANDBOXED, which bounds what can be seeded at all — see the file-URL NOTE below.
 @MainActor
 final class EditMenuUITests: ControlAPITestCase {
     /// Open the Edit menu, run `body` against it, then dismiss. Menu validation runs on open, so the
@@ -44,9 +43,7 @@ final class EditMenuUITests: ControlAPITestCase {
         return observed
     }
 
-    // Copy is gated on ghostty_surface_has_selection: disabled on a fresh session, enabled once
-    // session.selectall creates a selection. Select All is gated only on a realized surface, so it is
-    // always enabled while the terminal holds first responder.
+    // Copy is gated on ghostty_surface_has_selection; Select All only on a realized surface.
     func testEditMenuGatesCopyOnSelection() throws {
         let id = try activeSessionID()
 
@@ -62,8 +59,8 @@ final class EditMenuUITests: ControlAPITestCase {
                       "Copy should enable once the buffer is selected")
     }
 
-    // Paste is gated on the clipboard holding something the paste path can insert. Seeded text FIRST, so the
-    // later empty-clipboard expectation starts from a confirmed-enabled state and cannot pass on a stale read.
+    // text is seeded FIRST so the later empty-clipboard expectation starts from a confirmed-enabled state
+    // and cannot pass on a stale read.
     func testEditMenuGatesPasteOnClipboardText() throws {
         seedPasteboard { $0.setString("pasteable", forType: .string) }
         XCTAssertTrue(pollEditMenuItem("Paste", isEnabled: true),
@@ -74,33 +71,29 @@ final class EditMenuUITests: ControlAPITestCase {
                        "Paste should disable once the clipboard is emptied")
     }
 
-    // NOTE: the file-URL Paste case (a Finder copy, which carries no string representation) is NOT covered
-    // here and cannot be. The XCUITest runner is sandboxed (`com.apple.security.app-sandbox`), so a file URL
-    // it writes to `NSPasteboard.general` never becomes visible to the app process — instrumenting
-    // `hasPasteboardText` showed the app reading `types=[]` for the full 8 s of polling while the runner's own
-    // `canReadObject([NSURL])` returned true from its in-process cache. Such a test exercises the sandbox, not
-    // `validateMenuItem`. The invariant it would have pinned lives in the code instead: `hasPasteboardText`
-    // must mirror `pasteboardText`'s branches. See the Control API rule.
+    // NOTE: the file-URL Paste case (a Finder copy carries no string representation) can NOT be covered
+    // here: the runner is sandboxed (`com.apple.security.app-sandbox`), so a file URL it writes to
+    // `NSPasteboard.general` never becomes visible to the app process — the app reads `types=[]` while the
+    // runner's own `canReadObject([NSURL])` returns true from its in-process cache. Such a test exercises
+    // the sandbox, not `validateMenuItem`.
 
-    // Cut is deliberately NOT implemented on the surface, so AppKit leaves it disabled for the terminal.
-    // (It still works in a focused text field, whose field editor implements `cut:`.) It cannot be removed
-    // on its own: it shares SwiftUI's `.pasteboard` group with Copy/Paste/Select All.
+    // Cut is deliberately unimplemented on the surface (it still works in a focused text field, whose field
+    // editor implements `cut:`) and cannot be removed on its own — it shares SwiftUI's `.pasteboard` group
+    // with Copy/Paste/Select All.
     func testEditMenuLeavesCutDisabledForTerminal() throws {
         withEditMenu {
             XCTAssertFalse(app.menuItems["Cut"].isEnabled, "Cut should stay disabled for the terminal")
         }
     }
 
-    // Undo/Redo are removed outright (`CommandGroup(replacing: .undoRedo) {}`): agterm has no undo manager,
-    // and their ⌘Z is already owned by File ▸ Reopen Closed Item. Asserting NON-EXISTENCE rather than
-    // `isEnabled == false` matters — `isEnabled` on a missing element is also false, so a disabled-check
-    // would keep passing if the items ever came back.
+    // Undo/Redo are removed outright (`CommandGroup(replacing: .undoRedo) {}`); their ⌘Z belongs to File ▸
+    // Reopen Closed Item. Assert NON-EXISTENCE, not `isEnabled == false`: `isEnabled` is false for a missing
+    // element too, so a disabled-check would keep passing if the items came back.
     func testEditMenuHasNoUndoOrRedoItems() throws {
         withEditMenu {
             XCTAssertFalse(app.menuItems["Undo"].exists, "Undo should be gone from the Edit menu")
             XCTAssertFalse(app.menuItems["Redo"].exists, "Redo should be gone from the Edit menu")
         }
-        // ⌘Z belongs to File ▸ Reopen Closed Item, and nothing in Edit competes for it any more.
         app.menuBars.menuBarItems["File"].click()
         XCTAssertTrue(app.menuItems["Reopen Closed Item"].waitForExistence(timeout: 5),
                       "File should still own the ⌘Z action")

--- a/agtermUITests/FlaggedViewUITests.swift
+++ b/agtermUITests/FlaggedViewUITests.swift
@@ -17,8 +17,8 @@ final class FlaggedViewUITests: XCTestCase {
 
     override func setUp() async throws {
         continueAfterFailure = false
-        // hermetic state: a fresh temp dir per test so the app seeds exactly one "workspace 1" + one
-        // session, and we never touch the real workspaces.json.
+        // a fresh temp dir per test: the app seeds exactly one "workspace 1" + one session, and the real
+        // workspaces.json is never touched.
         stateDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("agterm-uitest-\(UUID().uuidString)", isDirectory: true)
         app = XCUIApplication()
@@ -31,10 +31,6 @@ final class FlaggedViewUITests: XCTestCase {
         if let stateDir { try? FileManager.default.removeItem(at: stateDir) }
     }
 
-    /// End-to-end flagged view: seed three sessions across two workspaces, flag one in each, flip to
-    /// the flat flagged list (exactly the two flagged rows, labeled `session : workspace`, the unflagged
-    /// row absent), confirm a flagged-row click selects that session and toggling back restores the tree,
-    /// then Clear Flagged empties the view back to the empty-state hint.
     func testFlaggedViewToggleSelectAndClear() throws {
         // workspace 1: alpha (flagged), beta (unflagged); workspace 2: gamma (flagged).
         seedThreeSessions()
@@ -44,18 +40,16 @@ final class FlaggedViewUITests: XCTestCase {
         XCTAssertTrue(pollFlagged("alpha", timeout: 8), "alpha should persist flagged == true")
         XCTAssertTrue(pollFlagged("gamma", timeout: 8), "gamma should persist flagged == true")
 
-        addWorkspace() // workspace 2
+        addWorkspace()
         XCTAssertTrue(app.staticTexts["workspace 2"].waitForExistence(timeout: 5), "second workspace should appear")
         moveSession(named: "gamma", toWorkspace: "workspace 2")
         XCTAssertTrue(pollSessionCount(workspace: "workspace 2", expected: 1, timeout: 8),
                       "gamma should land under workspace 2 (keeping its flag)")
 
-        // flip to the flat flagged list via the bottom-bar toggle.
         let toggle = app.buttons["flagged-view-toggle"]
         XCTAssertTrue(toggle.waitForHittable(timeout: 8), "flagged-view toggle should be hittable")
         toggle.click()
 
-        // exactly the two flagged rows, each labeled `session : workspace`; the unflagged row is absent.
         XCTAssertTrue(sessionRow(named: "alpha : workspace 1").waitForExistence(timeout: 8),
                       "the flagged list should show alpha labeled with its workspace")
         XCTAssertTrue(sessionRow(named: "gamma : workspace 2").waitForExistence(timeout: 8),
@@ -65,11 +59,8 @@ final class FlaggedViewUITests: XCTestCase {
         XCTAssertTrue(pollRowCount(2, timeout: 8),
                       "the flagged list should show exactly the two flagged rows")
 
-        // clicking a flagged row selects that session (observable side effect: the persisted selection).
         clickFlaggedRowSelectsItsSession()
 
-        // toggling back restores the full tree: the unflagged session returns and the `: workspace` label
-        // is gone.
         toggle.click()
         XCTAssertTrue(sessionRow(named: "beta").waitForExistence(timeout: 8),
                       "toggling back to tree mode should restore the unflagged session row")
@@ -78,8 +69,7 @@ final class FlaggedViewUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["workspace 1"].waitForExistence(timeout: 5), "the workspace tree should be back")
         XCTAssertTrue(app.staticTexts["workspace 2"].waitForExistence(timeout: 5), "both workspaces should be back")
 
-        // Clear Flagged empties the flagged view back to the empty-state hint.
-        toggle.click() // back to flagged mode
+        toggle.click()
         XCTAssertTrue(sessionRow(named: "alpha : workspace 1").waitForExistence(timeout: 8),
                       "flagged mode should again show the flagged rows before clearing")
         invokeViewMenuItem("Clear Flagged")
@@ -103,14 +93,12 @@ final class FlaggedViewUITests: XCTestCase {
         flagRow(named: "alpha")
         XCTAssertTrue(pollFlagged("alpha", timeout: 8), "alpha should persist flagged == true")
 
-        // flip to the flat flagged view: the row now shows the decorated `alpha : workspace 1` label.
         let toggle = app.buttons["flagged-view-toggle"]
         XCTAssertTrue(toggle.waitForHittable(timeout: 8), "flagged-view toggle should be hittable")
         toggle.click()
         let decorated = sessionRow(named: "alpha : workspace 1")
         XCTAssertTrue(decorated.waitForHittable(timeout: 8), "the flagged row should show the decorated label")
 
-        // enter inline rename via double-click.
         let field = app.descendants(matching: .any).matching(identifier: "edit-field").firstMatch
         var editing = false
         for _ in 0..<5 {
@@ -119,9 +107,8 @@ final class FlaggedViewUITests: XCTestCase {
         }
         XCTAssertTrue(editing, "rename did not enter edit mode in the flagged view (field never appeared)")
 
-        // the reporter's flow: edit WITHOUT clearing the seed. collapse the selection to the end of the
-        // pre-filled text (right arrow), append, and commit. the stored custom name must be the bare
-        // `alpha-x` — if the editor was seeded with the decorated label, it would bake in ` : workspace 1`.
+        // the reporter's flow: edit WITHOUT clearing the seed — the right arrow collapses to the end of the
+        // pre-filled text, so a decorated seed would bake ` : workspace 1` into the stored name.
         app.typeKey(.rightArrow, modifierFlags: [])
         app.typeText("-x\r")
         XCTAssertTrue(stateDir.pollSnapshot(equals: "alpha-x", timeout: 8) { obj in

--- a/agtermUITests/FocusReselectFocusUITests.swift
+++ b/agtermUITests/FocusReselectFocusUITests.swift
@@ -52,8 +52,7 @@ final class FocusReselectFocusUITests: ControlAPITestCase {
                           "keystrokes reaching the hidden session is the regression this guards")
     }
 
-    /// A visible quick terminal OWNS first responder, so a narrowing behind it must not pull focus into the
-    /// covered deck. Driven over the socket, since the bottom-bar toggle is under the cover.
+    /// Driven over the socket rather than the bottom-bar toggle, which sits under the quick terminal.
     func testNarrowingBehindTheQuickTerminalLeavesItsFocusAlone() throws {
         let hidden = try activeSessionID()
         let hiddenTTY = markerDir.appendingPathComponent("qt-hidden-tty")

--- a/agtermUITests/FocusWorkspaceUITests.swift
+++ b/agtermUITests/FocusWorkspaceUITests.swift
@@ -25,8 +25,7 @@ final class FocusWorkspaceUITests: XCTestCase {
 
     override func setUp() async throws {
         continueAfterFailure = false
-        // hermetic state: a fresh temp dir per test so the app seeds exactly one "workspace 1" + one
-        // session, and we never touch the real workspaces.json.
+        // hermetic state: a fresh temp dir per test, never the real workspaces.json.
         stateDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("agterm-uitest-\(UUID().uuidString)", isDirectory: true)
         app = XCUIApplication()
@@ -39,18 +38,10 @@ final class FocusWorkspaceUITests: XCTestCase {
         if let stateDir { try? FileManager.default.removeItem(at: stateDir) }
     }
 
-    /// End-to-end single-workspace focus (the set-of-one case every pre-set script and muscle memory
-    /// relies on): seed two workspaces (workspace 1 holding the visible session, workspace 2 empty), Focus
-    /// workspace 2 from its row's context menu — the OTHER workspace's row AND its session row leave the AX
-    /// tree while the toggle flips to `on` — then invoke the same item, which now reads "Unfocus", and
-    /// confirm the hidden workspace and its session row return with the toggle back to `off` AND disabled
-    /// (Unfocus clears the set, it does not merely suspend the filter).
-    ///
-    /// Focusing the (empty) other workspace is what makes a *visible* session row (workspace 1's, which is
-    /// expanded because it holds the selection) leave the AX tree — a non-focused workspace's own sessions
-    /// are collapsed, so only the focused-away workspace's rows are reliably observable as disappearing.
+    /// Focusing the (empty) OTHER workspace is what makes a *visible* session row (workspace 1's, which
+    /// is expanded because it holds the selection) leave the AX tree — a non-focused workspace's own
+    /// sessions are collapsed, so only the focused-away workspace's rows observably disappear.
     func testFocusWorkspaceHidesOthersAndUnfocusRestores() throws {
-        // workspace 1: [visible] (seeded, selected, expanded); workspace 2: empty.
         XCTAssertTrue(sessionRow().waitForExistence(timeout: 20), "seeded session should exist")
         let defaultName = (sessionRow().value as? String) ?? ""
         XCTAssertFalse(defaultName.isEmpty, "seeded session should expose a default name")
@@ -58,15 +49,11 @@ final class FocusWorkspaceUITests: XCTestCase {
         addWorkspace()
         XCTAssertTrue(workspaceRow(named: "workspace 2").waitForExistence(timeout: 5), "second workspace should appear")
 
-        // unfiltered: the visible session row and both workspace rows are present, and the toggle reads
-        // off + disabled because nothing is marked yet.
         XCTAssertTrue(sessionRow(named: "visible").waitForExistence(timeout: 8), "visible row should exist unfiltered")
         XCTAssertTrue(workspaceRow(named: "workspace 1").waitForExistence(timeout: 5), "workspace 1 row should exist")
         XCTAssertTrue(pollFilterToggle(value: "off", enabled: false, timeout: 8),
                       "with nothing marked the filter toggle should read off and be disabled")
 
-        // Focus workspace 2 via its row's context menu: workspace 1 (row + its visible session row) leaves
-        // the AX tree and the filter reports on.
         invokeWorkspaceMenuItem("Focus", onWorkspace: "workspace 2")
         XCTAssertTrue(sessionRow(named: "visible").waitForNonExistence(timeout: 8),
                       "the other workspace's session row should leave the AX tree while filtered")
@@ -77,8 +64,6 @@ final class FocusWorkspaceUITests: XCTestCase {
         XCTAssertTrue(pollFilterToggle(value: "on", enabled: true, timeout: 8),
                       "focusing a workspace should turn the filter on and enable the toggle")
 
-        // the item's label has flipped to "Unfocus" (the set is exactly this workspace AND the filter is
-        // on); invoking it clears the set, so the hidden workspace + its session row return.
         invokeWorkspaceMenuItem("Unfocus", onWorkspace: "workspace 2")
         XCTAssertTrue(sessionRow(named: "visible").waitForExistence(timeout: 8),
                       "Unfocus should restore the other workspace's session row")
@@ -88,10 +73,8 @@ final class FocusWorkspaceUITests: XCTestCase {
                       "Unfocus CLEARS the set (not just the flag), so the toggle goes back to off AND disabled")
     }
 
-    /// The multi-workspace working set: mark two of three workspaces via the row menu's "Add to Focus" and
-    /// confirm the tree renders exactly those two while the third stays out. This is what the set
-    /// generalization buys over the old one-or-all filter, and it is the only assertion that would catch
-    /// "Add to Focus" being wired to the replace-toggle by mistake (which would leave ONE row visible).
+    /// The only assertion that would catch "Add to Focus" being wired to the replace-toggle by mistake,
+    /// which would leave ONE row visible.
     func testAddToFocusKeepsBothMarkedWorkspacesVisible() throws {
         markFirstTwoOfThreeWorkspaces()
 
@@ -104,15 +87,10 @@ final class FocusWorkspaceUITests: XCTestCase {
         XCTAssertTrue(pollWorkspaceRowCount(2, timeout: 8), "exactly the two marked workspaces should render")
     }
 
-    /// The bottom-bar toggle SUSPENDS the filter without destroying the set: with two workspaces marked,
-    /// one click brings the whole tree back (and the toggle stays ENABLED, since the set is still there),
-    /// and a second click restores exactly the same two rows with nothing re-marked. That survival is the
-    /// point of splitting membership from the on/off flag — the old pill could only clear.
     func testFilterToggleSuspendsAndRestoresTheMarkedSet() throws {
         markFirstTwoOfThreeWorkspaces()
         XCTAssertTrue(pollWorkspaceRowCount(2, timeout: 8), "the filtered tree should start at the two marked workspaces")
 
-        // suspend: the whole tree returns, the toggle reads off but stays ENABLED — the set survives.
         filterToggle().click()
         XCTAssertTrue(pollFilterToggle(value: "off", enabled: true, timeout: 8),
                       "suspending should read off yet stay enabled — the marked set is untouched")
@@ -120,7 +98,6 @@ final class FocusWorkspaceUITests: XCTestCase {
         XCTAssertTrue(workspaceRow(named: "workspace 3").waitForExistence(timeout: 8),
                       "the unmarked workspace should be visible while the filter is suspended")
 
-        // re-enable: the SAME two rows come back with nothing re-marked, proving the set survived.
         filterToggle().click()
         XCTAssertTrue(pollFilterToggle(value: "on", enabled: true, timeout: 8), "re-enabling should read on")
         XCTAssertTrue(pollWorkspaceRowCount(2, timeout: 8), "re-enabling should filter back down to the marked set")
@@ -130,16 +107,8 @@ final class FocusWorkspaceUITests: XCTestCase {
                       "the unmarked workspace should be filtered out again")
     }
 
-    /// The toggle is DISABLED while nothing is marked and enabled once a workspace joins the set — the GUI
-    /// half of the "enabled + empty set is unrepresentable" invariant (the store refuses to enable an empty
-    /// set, so an enabled-but-inert button would misrepresent what a click does). Removing the last member
-    /// puts it back. `isEnabled` and `value` are both accessibility-observable, so this belongs in an e2e
-    /// rather than in the manual checks.
-    ///
-    /// It is also the direct read of the mark-only contract on the two accessibility-observable fields:
     /// "Add to Focus" moves `isEnabled` false → true while `value` stays `off`, so the two must be
-    /// asserted together — a marking add that also flipped `value` to `on` would pass an `isEnabled`-only
-    /// check.
+    /// asserted together — an add that also flipped `value` to `on` would pass an `isEnabled`-only check.
     func testFilterToggleIsDisabledUntilAWorkspaceIsMarked() throws {
         XCTAssertTrue(sessionRow().waitForExistence(timeout: 20), "seeded session should exist")
         let toggle = filterToggle()
@@ -152,8 +121,6 @@ final class FocusWorkspaceUITests: XCTestCase {
         XCTAssertTrue(pollFilterToggle(value: "off", enabled: true, timeout: 8),
                       "marking a workspace should enable the toggle WITHOUT turning the filter on")
 
-        // the item now reads "Remove from Focus"; taking the last member out empties the set, so the
-        // toggle must go back to disabled rather than sit enabled over an empty filter.
         invokeWorkspaceMenuItem("Remove from Focus", onWorkspace: "workspace 1")
         XCTAssertTrue(pollFilterToggle(value: "off", enabled: false, timeout: 8),
                       "removing the last member should empty the set and disable the toggle again")

--- a/agtermUITests/FontPaneUITests.swift
+++ b/agtermUITests/FontPaneUITests.swift
@@ -1,37 +1,28 @@
 import Foundation
 import XCTest
 
-// font --pane e2e: the font commands can target a specific pane (`left`|`right`|`scratch`), mirroring
-// `session type`/`session text`. The split pane's font is NOT persisted (its surface's onFontSizeChange is
-// unwired by design), so the persisted MAIN-pane size is the oracle: `font dec --pane right` must return ok
-// (proving it reached the realized split surface) while leaving the main pane's persisted size untouched,
-// and the default (no --pane) must still shrink the main pane. The error cases (no split, invalid pane) go
-// straight over the socket so the SERVER, not just the CLI `validate()`, enforces them. A `ControlAPITestCase`
-// subclass like `SessionTypePaneUITests`, reusing the shared harness.
+// the split pane's font is NOT persisted (its surface's onFontSizeChange is unwired by design), so the
+// persisted MAIN-pane size is the oracle for what the split did NOT touch. The error cases go straight over
+// the socket, so the SERVER — not just the CLI `validate()` — enforces them.
 @MainActor
 final class FontPaneUITests: ControlAPITestCase {
-    // font dec --pane right decrements the split surface, NOT the main/left one (the reported bug). Two
-    // oracles: the split pane's live font (read back via tree's splitFontSize) must DROP, proving the
-    // action landed on the split; and the main pane's persisted size must stay put, proving it didn't leak
-    // to the main. The default font dec then DOES shrink the main pane — so the panes are addressed
-    // independently.
+    // two oracles: the split's live font (tree `splitFontSize`) must DROP, and the main pane's persisted
+    // size must stay put — the bug was that font always hit the main/left surface.
     func testFontPaneRightTargetsSplitNotMain() throws {
         let split = try sendCommand(#"{"cmd":"session.split","target":"active","args":{"mode":"on"}}"#)
         XCTAssertEqual(split["ok"] as? Bool, true, "split on should succeed: \(split)")
         XCTAssertTrue(pollActiveSessionSplit(true, timeout: 10), "the active session should report split:true")
         let id = try activeSessionID()
 
-        // baseline captured AFTER the split is shown, so any post-split reflow of the main pane already
-        // settled — its point size doesn't change with pane width, so this stays constant hereafter.
+        // captured AFTER the split is shown so any post-split reflow already settled; point size does not
+        // track pane width, so it stays constant hereafter.
         let baseline = try XCTUnwrap(pollFirstSessionFontSize(timeout: 10),
                                      "the main pane should report a persisted font size on launch")
-        // the split pane's live font baseline, read back from the tree once the split surface realizes.
         let splitBaseline = try XCTUnwrap(pollSplitFontSize(target: id, timeout: 10),
                                           "the split pane should report a live font size once realized")
 
-        // ride out split-surface realization: a freshly shown split may not be realized for the first
-        // request, which returns "session not realized" (continueAfterFailure = false forbids asserting in
-        // the retry loop, so fontUntilOk swallows the transient failures and returns the settled response).
+        // a freshly shown split may not be realized for the first request; continueAfterFailure = false
+        // forbids asserting inside a retry loop, so fontUntilOk swallows the transient failures.
         let firstRight = try fontUntilOk(cmd: "font.dec", target: id, pane: "right")
         XCTAssertEqual(firstRight["ok"] as? Bool, true,
                        "font dec --pane right should reach the realized split surface: \(firstRight)")
@@ -40,21 +31,16 @@ final class FontPaneUITests: ControlAPITestCase {
             XCTAssertEqual(response["ok"] as? Bool, true, "font dec --pane right should stay ok: \(response)")
         }
 
-        // POSITIVE proof the action landed on the split: its live font (tree read-back) dropped below its
-        // baseline. This is what the main-pane-only oracle couldn't show.
         let splitAfter = try XCTUnwrap(pollSplitFontSize(target: id, below: splitBaseline - 0.5, timeout: 8),
                                        "font --pane right should shrink the split pane's live font size")
         XCTAssertLessThan(splitAfter, splitBaseline)
 
-        // the main pane's persisted size must be untouched by the split-pane changes — the bug was that
-        // font always hit the main/left surface. Wait past the debounced save, then assert no drift (a
-        // buggy 4-point drop would fail; the split's font simply isn't persisted, so it can't move).
+        // wait past the debounced save before asserting the main pane did not drift.
         RunLoop.current.run(until: Date().addingTimeInterval(1.5))
         let afterRight = try XCTUnwrap(firstSessionFontSize(), "the main pane size should still be readable")
         XCTAssertEqual(afterRight, baseline, accuracy: 0.5,
                        "font --pane right must not change the main pane's persisted size")
 
-        // the default (no --pane) still targets the main pane, so its persisted size drops below baseline.
         for _ in 0..<4 {
             let response = try sendCommand(fontRequest(cmd: "font.dec", target: id, pane: nil))
             XCTAssertEqual(response["ok"] as? Bool, true, "default font dec should hit the main pane: \(response)")
@@ -65,8 +51,6 @@ final class FontPaneUITests: ControlAPITestCase {
         XCTAssertLessThan(decreased, baseline)
     }
 
-    // font --pane right on a non-split session errors. Sent straight over the socket (bypassing the CLI), so
-    // the SERVER itself rejects it — mirroring session.type/session.text.
     func testFontPaneRightWithoutSplitErrors() throws {
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
         let newID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "session.new should return the new id")
@@ -76,10 +60,7 @@ final class FontPaneUITests: ControlAPITestCase {
         XCTAssertEqual(response["error"] as? String, "session has no split pane", "should report no split pane: \(response)")
     }
 
-    // font --pane scratch on a session with no scratch terminal opened errors. The scratch is lazily
-    // spawned on first show, so a fresh session's scratchSurface is nil — deterministic, mirroring
-    // testFontPaneRightWithoutSplitErrors. This is the only e2e over the font scratch arm (the success
-    // path shares fontUntilOk's realized-surface proof with the split case).
+    // the scratch is lazily spawned on first show, so a fresh session's scratchSurface is nil.
     func testFontPaneScratchWithoutScratchErrors() throws {
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
         let newID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "session.new should return the new id")
@@ -90,21 +71,15 @@ final class FontPaneUITests: ControlAPITestCase {
                        "should report no scratch terminal: \(response)")
     }
 
-    // pane validation is enforced SERVER-SIDE, not only in the CLI `validate()`: a raw socket client bypasses
-    // the CLI, so an unknown pane value must error here too (sendCommand is that raw client).
     func testFontRejectsInvalidPaneServerSide() throws {
         let response = try sendCommand(#"{"cmd":"font.dec","target":"active","args":{"pane":"middle"}}"#)
         XCTAssertEqual(response["ok"] as? Bool, false, "font pane:middle should fail server-side: \(response)")
         XCTAssertEqual(response["error"] as? String, "invalid pane: middle", "should report the invalid pane: \(response)")
     }
 
-    // the DEFAULT (and `--pane left`) font target follows a promoted split survivor. When the primary
-    // pane's shell exits while a split is shown, closePrimaryPane tears the primary surface down (surface
-    // == nil) and promotes the split shell to a single session. The default font WRITE resolves
-    // addressableSurface (= surface ?? splitSurface), so it hits the survivor — and the tree's fontSize
-    // read-back must resolve the SAME addressableSurface. This is the app-level guard for the read-side
-    // wiring: a regression to reading bare `surface` would OMIT fontSize here, because the primary surface
-    // is gone (the host-free AppStorePaneTests can't exercise ControlServer.buildTree's closure).
+    // when the primary pane's shell exits, closePrimaryPane tears the primary surface down (surface == nil)
+    // and promotes the split shell. Both the default WRITE and the tree's fontSize read-back must resolve
+    // addressableSurface (= surface ?? splitSurface): a read off bare `surface` would OMIT fontSize here.
     func testFontDefaultTargetsPromotedSplitSurvivor() throws {
         let id = try activeSessionID()
 
@@ -115,24 +90,18 @@ final class FontPaneUITests: ControlAPITestCase {
         _ = try XCTUnwrap(pollSplitFontSize(target: id, timeout: 10),
                           "the split pane should report a live font size once realized")
 
-        // exit the primary -> onExit fires closePrimaryPane, promoting the split survivor to a single session.
         XCTAssertTrue(try promoteSurvivorByExitingPrimary(target: id, timeout: 25),
                       "exiting the primary should promote the split survivor (session survives, split -> false)")
 
-        // fontSize MUST read the promoted survivor via addressableSurface: the primary surface is torn down,
-        // so a read off bare `surface` would omit this field. Its presence proves the addressableSurface wiring.
         let baseline = try XCTUnwrap(pollMainFontSize(target: id, timeout: 8),
                                      "fontSize must read the promoted survivor via addressableSurface (surface is nil)")
 
-        // the DEFAULT font dec (no --pane) targets addressableSurface = the survivor.
         for _ in 0..<4 {
             let response = try sendCommand(fontRequest(cmd: "font.dec", target: id, pane: nil))
             XCTAssertEqual(response["ok"] as? Bool, true, "default font dec should reach the promoted survivor: \(response)")
             RunLoop.current.run(until: Date().addingTimeInterval(0.25))
         }
 
-        // the survivor's live font dropped, read back through fontSize — the default write and its read-back
-        // both track the promoted survivor.
         let dropped = try XCTUnwrap(pollMainFontSize(target: id, below: baseline - 0.5, timeout: 8),
                                     "the default font dec must shrink the promoted survivor's fontSize read-back")
         XCTAssertLessThan(dropped, baseline)

--- a/agtermUITests/FontSizeUITests.swift
+++ b/agtermUITests/FontSizeUITests.swift
@@ -29,10 +29,8 @@ final class FontSizeUITests: XCTestCase {
         row.click()
         usleep(800_000)
 
-        // baseline: the surface reports its size on first render, so a value should appear.
         let baseline = try XCTUnwrap(pollFontSize(timeout: 8), "the terminal should report a font size on launch")
 
-        // increase the font a few times (cmd +); the persisted size must grow.
         for _ in 0..<4 {
             app.typeKey("=", modifierFlags: .command)
             usleep(250_000)
@@ -41,7 +39,6 @@ final class FontSizeUITests: XCTestCase {
                                       "increasing the font (cmd +) should grow the persisted size")
         XCTAssertGreaterThan(increased, baseline)
 
-        // relaunch with the same state dir; the increased size must be restored.
         app.terminate()
         app = XCUIApplication()
         app.launchEnvironment["AGTERM_STATE_DIR"] = stateDir.path

--- a/agtermUITests/KeymapArrowRebindUITests.swift
+++ b/agtermUITests/KeymapArrowRebindUITests.swift
@@ -7,9 +7,8 @@ import XCTest
 /// `ControlAPITestCase` (the `KeymapUITests` base can't reach the socket).
 @MainActor
 final class KeymapArrowRebindUITests: ControlAPITestCase {
-    // map `next_session` (one of the four reported arrow-bound actions) to a parseable chord and prove the
-    // chord actually navigates. two sessions so a single forward step never wraps to self, and the
-    // selection starts on the first so the step lands on the second (forward, unambiguous).
+    // two sessions so a single forward step never wraps to self, and the selection starts on the first so
+    // the step lands on the second.
     func testMapArrowNavActionFiresWhenSeededAtLaunch() throws {
         try relaunch(withKeymap: "map cmd+shift+a next_session\n")
         let sessionA = try activeSessionID()
@@ -21,7 +20,6 @@ final class KeymapArrowRebindUITests: ControlAPITestCase {
         _ = try sendCommand(#"{"cmd":"session.select","target":"\#(sessionA)"}"#)
         XCTAssertTrue(pollSelectedSession(sessionA, timeout: 10), "A should be selected before the chord")
 
-        // the mapped chord ⌘⇧A must fire next_session and move the selection A -> B.
         app.typeKey("a", modifierFlags: [.command, .shift])
         XCTAssertTrue(pollSelectedSession(sessionB, timeout: 10),
                       "the mapped chord ⌘⇧A should fire next_session and select B (issue #219)")
@@ -35,9 +33,8 @@ final class KeymapArrowRebindUITests: ControlAPITestCase {
                       "session.go next over the socket should select B (proves navigation is alive)")
     }
 
-    // the #278 case: rebind a built-in to an ARROW chord and prove the arrow key actually fires it. This
-    // covers the menu half of arrow support (Chord "left" -> KeyEquivalent.leftArrow in `toShortcut`);
-    // the runner half is covered by `KeymapUITests.testCustomCommandArrowChordFires`.
+    // issue #278: the MENU half of arrow support (Chord "left" -> KeyEquivalent.leftArrow in `toShortcut`);
+    // the runner half is `KeymapUITests.testCustomCommandArrowChordFires`.
     func testMapToAnArrowChordFires() throws {
         try relaunch(withKeymap: "map cmd+shift+left next_session\n")
         let sessionA = try activeSessionID()
@@ -54,13 +51,11 @@ final class KeymapArrowRebindUITests: ControlAPITestCase {
                       "the mapped arrow chord ⌘⇧← should fire next_session and select B (issue #278)")
     }
 
-    // `UndoCloseShortcut` is the OTHER app-side NSEvent→Chord site, and the only KEYBOARD path to
-    // undo_close — File ▸ Reopen Closed Item ships no key equivalent, so native text undo keeps working
-    // in the rename/palette/Settings fields. Its arrow support arrived with the shared
-    // `namedKey(forKeyCode:)`, so an arrow chord bound there must actually fire.
-    // Two constraints shape this test: a SINGLE-target control close takes the hard path and never arms
-    // the grace window, so it closes TWO sessions in one command; and the grace is 3 s
-    // (`AppStore.pendingCloseGraceInterval`), so nothing may poll or wait between the close and the chord.
+    // `UndoCloseShortcut` is the other app-side NSEvent→Chord site and the only KEYBOARD path to undo_close
+    // — File ▸ Reopen Closed Item ships no key equivalent. Two constraints: a SINGLE-target control close
+    // takes the hard path and never arms the grace window, so TWO sessions are closed in one command; and
+    // the grace is 3 s (`AppStore.pendingCloseGraceInterval`), so nothing may poll or wait between the
+    // close and the chord.
     func testMapToAnArrowChordFiresUndoClose() throws {
         try relaunch(withKeymap: "map cmd+shift+up undo_close\n")
 
@@ -77,9 +72,8 @@ final class KeymapArrowRebindUITests: ControlAPITestCase {
                       "the mapped arrow chord ⌘⇧↑ should fire undo_close and restore the closed group")
     }
 
-    // the same rebind but applied via a LIVE `keymap.reload` (the exact path issue #219 used —
-    // `agtermctl keymap reload` while running), not seeded at launch. The menu items start with their
-    // shipped arrow defaults, and reload must RE-REGISTER the mapped chord onto them.
+    // the live `keymap.reload` path issue #219 used, not a launch seed: the menu items start with their
+    // shipped arrow defaults, and the reload must RE-REGISTER the mapped chord onto them.
     func testMapArrowNavActionFiresAfterLiveReload() throws {
         let sessionA = try activeSessionID()
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
@@ -102,16 +96,14 @@ final class KeymapArrowRebindUITests: ControlAPITestCase {
                       "session.go next over the socket should select B (proves navigation is alive)")
     }
 
-    // control for the live-reload path: a DEFAULT-chord action (new_session, ships ⌘N) rebound via the
-    // SAME live reload. If this fires but the arrow action above does not, the failure is specific to the
-    // arrow-bound actions' menu key-equivalent update; if both fail, live reload never re-registers a
-    // built-in menu shortcut at all.
+    // control for the live-reload path: if this fires but the arrow action above does not, the failure is
+    // specific to the arrow-bound actions' menu key-equivalent update; if both fail, live reload never
+    // re-registers a built-in menu shortcut at all.
     func testRebindDefaultChordActionFiresAfterLiveReload() throws {
         XCTAssertTrue(pollSessionRowCount(1, timeout: 10), "starts with the one seeded session")
 
         writeKeymapAndReload("map cmd+shift+y new_session\n")
 
-        // ⌘⇧Y must now fire new_session (a second row appears).
         app.typeKey("y", modifierFlags: [.command, .shift])
         XCTAssertTrue(pollSessionRowCount(2, timeout: 10),
                       "the live-reloaded chord ⌘⇧Y should fire new_session and add a session")

--- a/agtermUITests/KeymapUITests.swift
+++ b/agtermUITests/KeymapUITests.swift
@@ -1,9 +1,8 @@
 import XCTest
 
 /// End-to-end tests for the user-editable keymap (`<stateDir>/config/keymap.conf`). Seeded via the
-/// isolated `AGTERM_STATE_DIR` before launch so `SettingsModel` parses it at init. The palette case
-/// asserts a custom command shows the `custom` badge in the action palette and runs from it, using
-/// the branch's observable-side-effect pattern (the command `touch`es a tempfile that the test polls).
+/// isolated `AGTERM_STATE_DIR` before launch so `SettingsModel` parses it at init. A custom command's
+/// effect is observed as a side effect: it `touch`es a tempfile the test polls for.
 @MainActor
 final class KeymapUITests: XCTestCase {
     private var app: XCUIApplication!
@@ -28,7 +27,6 @@ final class KeymapUITests: XCTestCase {
     }
 
     func testCustomCommandShowsBadgeInPaletteAndRuns() throws {
-        // a palette-only custom command (no chord) that touches a marker file when run.
         let marker = markerDir.appendingPathComponent("touched")
         seedKeymap("command \"Touch File\" touch '\(marker.path)'\n")
         app.launchForUITest()
@@ -37,19 +35,16 @@ final class KeymapUITests: XCTestCase {
         openPalette("Command Palette")
         typeIntoPalette("Touch File")
 
-        // the custom badge identifies the row as a keymap command; assert it surfaced.
         let badge = app.descendants(matching: .any).matching(identifier: "palette-badge").firstMatch
         XCTAssertTrue(badge.waitForExistence(timeout: 5), "the custom command should show the `custom` badge in the palette")
 
-        // run the selected (top) match and assert the command actually executed.
         app.typeKey(.return, modifierFlags: [])
         XCTAssertTrue(poll { FileManager.default.fileExists(atPath: marker.path) },
                       "running the custom command from the palette should touch the marker file")
     }
 
-    // the Custom Commands palette (Navigate ▸ Custom Commands, ⌃⇧O) lists ONLY custom commands and drops
-    // the `custom` badge — every row is already custom. Seed one custom command, open the palette, and
-    // assert: the custom row appears, a built-in action (New Session) does NOT, no badge shows, and it runs.
+    // the Custom Commands palette (Navigate ▸ Custom Commands, ⌃⇧O) drops the `custom` badge — every row
+    // in it is already custom.
     func testCustomCommandsPaletteShowsCustomOnlyWithoutBadge() throws {
         let marker = markerDir.appendingPathComponent("custom-only")
         seedKeymap("command \"Touch File\" touch '\(marker.path)'\n")
@@ -59,22 +54,18 @@ final class KeymapUITests: XCTestCase {
         openPalette("Custom Commands")
         XCTAssertTrue(app.staticTexts["Touch File"].waitForExistence(timeout: 5),
                       "the custom command should appear in the Custom Commands palette")
-        // built-in actions are excluded — this palette is custom-only.
         XCTAssertFalse(app.staticTexts["New Session"].exists, "built-in actions must not appear in the Custom Commands palette")
-        // the `custom` badge is suppressed here (the whole list is custom).
         XCTAssertFalse(app.descendants(matching: .any).matching(identifier: "palette-badge").firstMatch.exists,
                        "the Custom Commands palette should not show the `custom` badge")
 
-        // filter to the command (also focuses the field), then run it and assert it executed.
         typeIntoPalette("Touch File")
         app.typeKey(.return, modifierFlags: [])
         XCTAssertTrue(poll { FileManager.default.fileExists(atPath: marker.path) },
                       "running a custom command from the Custom Commands palette should touch the marker file")
     }
 
-    // the Increase Font Size palette hint must NOT show the unparseable kitty string `cmd++` (its
-    // default chord's key is `+`, a grammar separator, so `displayString` renders `cmd++`). The
-    // palette-hint path falls back to a readable ⌘+ glyph for separator-key chords instead.
+    // the default chord's key is `+`, a grammar separator, so `displayString` renders the unparseable
+    // `cmd++`; the palette hint falls back to a readable ⌘+ glyph for separator-key chords.
     func testIncreaseFontSizePaletteHintIsNotBroken() throws {
         app.launchForUITest()
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session should exist")
@@ -82,41 +73,32 @@ final class KeymapUITests: XCTestCase {
         openPalette("Command Palette")
         typeIntoPalette("Increase Font Size")
 
-        // the row appears (its title is the static text the palette renders)…
         XCTAssertTrue(app.staticTexts["Increase Font Size"].waitForExistence(timeout: 5),
                       "the Increase Font Size palette item should appear")
-        // …and the broken `cmd++` hint must NOT be present anywhere in the palette.
         XCTAssertFalse(app.staticTexts["cmd++"].exists, "the palette hint must not render the unparseable `cmd++`")
     }
 
-    // a `map` override moves a built-in's key: bind new_session to ⌘⇧Y. new_session is the most
-    // reliably observable built-in — each new session is a countable `session-row` element. Pressing
-    // the OVERRIDE chord adds a row; pressing the OLD default (⌘N) does NOT, proving the key moved.
-    // (Built-ins fire via the menu key-equivalent, so no terminal focus is needed.)
+    // new_session is the most reliably observable built-in — each new session is a countable `session-row`
+    // element. Built-ins fire via the menu key-equivalent, so no terminal focus is needed.
     func testBuiltinOverrideMovesKey() throws {
         seedKeymap("map cmd+shift+y new_session\n")
         app.launchForUITest()
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session should exist")
         XCTAssertTrue(poll { self.sessionRowCount() == 1 }, "should start with the one seeded session")
 
-        // the override chord ⌘⇧Y now triggers new_session → a second row appears.
         app.typeKey("y", modifierFlags: [.command, .shift])
         XCTAssertTrue(poll { self.sessionRowCount() == 2 }, "the override chord ⌘⇧Y should create a new session")
 
-        // the OLD default ⌘N must no longer trigger new_session (the key moved) → the count stays at 2.
         app.typeKey("n", modifierFlags: .command)
         XCTAssertFalse(poll { self.sessionRowCount() == 3 }, "the old default ⌘N must no longer create a session")
         XCTAssertEqual(sessionRowCount(), 2, "no extra session should have been created by the moved-away default")
 
-        // positive control: the OVERRIDE chord ⌘⇧Y is still bound, so it MUST still create a session.
-        // this makes the negative above meaningful — it distinguishes "⌘N is correctly inert" from
-        // "key dispatch is dead/slow" (which would also make this still-bound chord fail).
+        // positive control: ⌘⇧Y is still bound, which distinguishes "⌘N is correctly inert" from "key
+        // dispatch is dead/slow" — the latter would fail here too.
         app.typeKey("y", modifierFlags: [.command, .shift])
         XCTAssertTrue(poll { self.sessionRowCount() == 3 }, "the still-bound override ⌘⇧Y should keep creating sessions")
     }
 
-    // a custom command bound to a single chord fires from a focused terminal: bind ⌘⇧E to `touch
-    // <file>`, focus the terminal, press the chord, assert the file appears (observable-side-effect).
     func testCustomCommandSingleChordFires() throws {
         let marker = markerDir.appendingPathComponent("single")
         seedKeymap("command \"Touch A\" cmd+shift+e touch '\(marker.path)'\n")
@@ -127,15 +109,11 @@ final class KeymapUITests: XCTestCase {
                       "the custom single chord ⌘⇧E should run its command and touch the marker file")
     }
 
-    // a custom command still fires when the window has NO sessions — the SSH-disconnect / "all my
-    // terminals closed" state, where every session's shell exited and no terminal surface holds first
-    // responder. bind ⌘⇧E to `touch <file>`, exit the only session so the window's tree is empty, then
-    // press the chord and assert it fires. regression guard for the empty-window first-responder gate in
-    // `CustomCommandRunner.handleKeyDown` (the runner used to fire ONLY with a focused terminal surface).
+    // the SSH-disconnect state: every session's shell exited, so no terminal surface holds first responder
+    // and the empty-window arm of `CustomCommandRunner.handleKeyDown` is the only path left.
     func testCustomCommandFiresWhenWindowHasNoSessions() throws {
-        // bind a command that expands {AGT_WINDOW_ID} into the touched filename: a file named
-        // `win-<uuid>` proves BOTH that the chord fired from the empty window AND that sessionlessContext()
-        // populated the window id — a degenerate empty context would create a bare `win-`.
+        // the touched filename embeds {AGT_WINDOW_ID}: a `win-<uuid>` proves sessionlessContext() populated
+        // the window id, a bare `win-` would mean a degenerate empty context.
         seedKeymap("command \"Touch E\" cmd+shift+e touch '\(markerDir.path)/win-{AGT_WINDOW_ID}'\n")
         app.launchForUITest()
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session should exist")
@@ -148,11 +126,8 @@ final class KeymapUITests: XCTestCase {
                              "sessionlessContext() should populate {AGT_WINDOW_ID}; got bare \"\(created ?? "nil")\"")
     }
 
-    // a bound chord must NOT fire while a text field has focus — the runner's `responder is NSText` guard
-    // (Settings editor, inline rename, palette search). Without it, the terminal-window firing path would
-    // eat a keystroke meant for the field. Seed ⌘⇧E, open the action palette (its search field is a text
-    // field hosted IN the agterm window, so this also proves the NSText check wins over the
-    // WindowRegistry.contains terminal-window path), press the chord, assert the marker never appears.
+    // the palette's search field is a text field hosted IN the agterm terminal window, so this proves the
+    // runner's `responder is NSText` guard wins over its `WindowRegistry.contains` fire-anyway path.
     func testCustomCommandDoesNotFireWhileTextFieldFocused() throws {
         let marker = markerDir.appendingPathComponent("textfield-guard")
         seedKeymap("command \"Touch F\" cmd+shift+e touch '\(marker.path)'\n")
@@ -167,18 +142,15 @@ final class KeymapUITests: XCTestCase {
         XCTAssertFalse(poll({ FileManager.default.fileExists(atPath: marker.path) }, timeout: 3),
                        "a bound chord must not fire while a text field has focus")
 
-        // positive control (same launch): close the palette so the field yields focus, then the SAME
-        // chord must fire — proving the binding was live and the negative assertion above wasn't vacuous.
+        // positive control: the same chord must fire once the field yields focus, so the negative above
+        // cannot pass on a dead binding.
         app.typeKey(.escape, modifierFlags: [])
         XCTAssertTrue(chordFiresMarker(marker) { app.typeKey("e", modifierFlags: [.command, .shift]) },
                       "after the palette closes, the same chord should fire (binding was live)")
     }
 
-    // a custom command bound to a SHIFTED-SYMBOL key fires: bind `shift+/` (the `?` key) to `touch
-    // <file>`, focus the terminal, press Shift+/ (which types `?`), assert the file appears. Regression
-    // guard for the base-key derivation in `CustomCommandRunner.chord(from:)`: the runner must normalize
-    // a shifted symbol to its BASE key (shift+/ → key "/", matching the `shift+/` binding), not to the
-    // shifted glyph "?" — a parser↔runtime mismatch the host-free tests structurally can't reach.
+    // `CustomCommandRunner.chord(from:)` must normalize a shifted symbol to its BASE key (shift+/ → key
+    // "/") rather than the shifted glyph "?" — a parser↔runtime mismatch the host-free tests can't reach.
     func testCustomCommandShiftedSymbolFires() throws {
         let marker = markerDir.appendingPathComponent("shifted")
         seedKeymap("command \"Touch Q\" shift+/ touch '\(marker.path)'\n")
@@ -189,11 +161,9 @@ final class KeymapUITests: XCTestCase {
                       "a custom command bound to shift+/ should fire when Shift+/ (the ? key) is pressed")
     }
 
-    // a custom command bound to an ARROW chord fires. This is the path the host-free tests structurally
-    // cannot reach: the parser accepting `cmd+shift+left` means nothing unless the runner's NSEvent→Chord
-    // mapping produces key "left" for keyCode 123. Without the keyCode entry the event falls through to
-    // the character branch, which yields the private-use arrow character — a valid Chord no keymap line
-    // can spell, so the binding registers and silently never fires (the shifted-symbol failure mode).
+    // the parser accepting `cmd+shift+left` means nothing unless the runner's NSEvent→Chord mapping yields
+    // key "left" for keyCode 123: without that entry the event falls to the character branch and produces
+    // the private-use arrow glyph — a valid Chord no keymap line can spell, so the binding never fires.
     func testCustomCommandArrowChordFires() throws {
         let marker = markerDir.appendingPathComponent("arrow")
         seedKeymap("command \"Touch Arrow\" cmd+shift+left touch '\(marker.path)'\n")
@@ -204,28 +174,21 @@ final class KeymapUITests: XCTestCase {
                       "a custom command bound to cmd+shift+left should fire when ⌘⇧← is pressed (issue #278)")
     }
 
-    // a custom command bound to a LEADER sequence fires: bind `ctrl+a>g` to `touch <file>`, focus the
-    // terminal, press ctrl+a then g (two key events), assert the file appears. ctrl+a normally moves to
-    // the line start in the shell, but the runner arms on it and consumes the sequence.
+    // ctrl+a normally moves to the shell's line start; the runner arms on it and consumes the sequence.
     func testCustomCommandLeaderFires() throws {
         let marker = markerDir.appendingPathComponent("leader")
         seedKeymap("command \"Touch B\" ctrl+a>g touch '\(marker.path)'\n")
         app.launchForUITest()
         focusTerminal()
 
-        // chordFiresMarker may press the ctrl+a>g burst several times before the marker appears. This is
-        // safe only because the matcher re-arms on each fresh leader (ctrl+a): a dropped first burst
-        // leaves the matcher in a clean state, so the next ctrl+a starts the sequence over rather than
-        // the retry colliding with a half-consumed leader.
+        // chordFiresMarker's retried burst is safe only because the matcher re-arms on each fresh ctrl+a:
+        // a dropped burst leaves a clean state instead of a half-consumed leader for the retry to collide with.
         XCTAssertTrue(chordFiresMarker(marker) {
             app.typeKey("a", modifierFlags: .control)
             app.typeKey("g", modifierFlags: [])
         }, "the custom leader ctrl+a>g should run its command and touch the marker file")
     }
 
-    // "Reload Keymap" re-reads keymap.conf: launch with ⌘⇧J bound to touch fileC1, then rewrite the
-    // file so ⌘⇧J touches fileC2 instead, invoke Reload Keymap (File menu), and assert the POST-reload
-    // chord touches fileC2 — proving the reload picked up the rewritten file.
     func testReloadKeymapPicksUpRewrittenFile() throws {
         let before = markerDir.appendingPathComponent("reload-before")
         let after = markerDir.appendingPathComponent("reload-after")
@@ -233,42 +196,30 @@ final class KeymapUITests: XCTestCase {
         app.launchForUITest()
         focusTerminal()
 
-        // the pre-reload binding fires (sanity: the seeded file is in effect).
         XCTAssertTrue(chordFiresMarker(before) { app.typeKey("j", modifierFlags: [.command, .shift]) },
                       "the pre-reload binding ⌘⇧J should touch the first marker")
 
-        // rewrite keymap.conf so the same chord now touches a DIFFERENT file.
         seedKeymap("command \"Touch C\" cmd+shift+j touch '\(after.path)'\n")
 
-        // invoke Reload Keymap from the File menu.
         app.menuBars.menuBarItems["File"].click()
         let reload = app.menuItems["Reload Keymap"]
         XCTAssertTrue(reload.waitForExistence(timeout: 5), "File menu should offer Reload Keymap")
         reload.click()
 
-        // after the reload the chord must touch the NEW file (the rewritten binding is in effect).
         focusTerminal()
         XCTAssertTrue(chordFiresMarker(after) { app.typeKey("j", modifierFlags: [.command, .shift]) },
                       "after Reload Keymap the rewritten binding should touch the second marker")
     }
 
-    // the Key Mapping settings tab renders the parse diagnostics and its Reload button re-reads the
-    // file: seed a broken line, open Settings ▸ Key Mapping, assert the diagnostic surfaces; then
-    // rewrite the file clean, click the tab's Reload, assert the diagnostics clear to "No issues.".
     func testKeyMappingSettingsTabShowsDiagnosticsAndReloads() throws {
         seedKeymap("bogus line here\n")
         app.launchForUITest()
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session should exist")
 
-        // open the tab (retrying the click) and confirm the diagnostics list renders the broken line.
-        // a SwiftUI container with an accessibilityIdentifier combines its child Texts into the
-        // container's own label, so match the broken-line message anywhere in the diagnostics subtree
-        // OR in the app's static texts.
         settingsControl(tab: "Key Mapping", control: "settings-keymap-diagnostics")
         XCTAssertTrue(poll { self.diagnosticsContain("unknown verb") },
                       "the diagnostics list should render the broken line")
 
-        // rewrite the file clean, then Reload from the tab; the diagnostics must clear to "No issues.".
         seedKeymap("# all comments, nothing to parse\n")
         let reload = app.descendants(matching: .any).matching(identifier: "settings-keymap-reload").firstMatch
         XCTAssertTrue(reload.waitForHittable(timeout: 5), "the Reload button should be hittable")
@@ -314,30 +265,25 @@ final class KeymapUITests: XCTestCase {
     }
 
     // issue #296: moving close_session OFF ⌘W lets SwiftUI's stock File ▸ Close claim the chord, and
-    // putting close_session BACK on ⌘W does not reclaim it — SwiftUI unbinds its own item instead, so ⌘W
-    // closed the whole window until the app was relaunched. Drive the reported sequence through RELOAD
-    // (never a relaunch): start with the override, remove it, reload, then press ⌘W and assert a session
-    // closed and the window survived. The existing keymap coverage only ever seeds the file at LAUNCH, so
-    // the reload path this regressed on had no test at all.
+    // putting it BACK does not reclaim it — SwiftUI unbinds its own item instead. The sequence must run
+    // through RELOAD, never a relaunch: seeding keymap.conf at LAUNCH does not exercise that path.
     func testCloseSessionReclaimsCommandWAfterReload() throws {
         seedKeymap("map cmd+e close_session\n")
         app.launchForUITest()
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session should exist")
         XCTAssertTrue(poll { self.sessionRowCount() == 1 }, "should start with the one seeded session")
 
-        // a second session, so closing one leaves the window populated (an emptied window legitimately
-        // closes on ⌘W, which would make the assertion below ambiguous).
+        // a second session, so closing one leaves the window populated — an emptied window legitimately
+        // closes on ⌘W, which would make the assertion below ambiguous.
         app.typeKey("n", modifierFlags: .command)
         XCTAssertTrue(poll { self.sessionRowCount() == 2 }, "⌘N should add a second session")
 
-        // remove the override so close_session falls back to its shipped ⌘W, then reload — no relaunch.
         seedKeymap("")
         reloadKeymapFromMenu()
 
         app.typeKey("w", modifierFlags: .command)
         XCTAssertTrue(poll({ self.sessionRowCount() == 1 }, timeout: 10),
                       "⌘W should close a session once the override is gone; the stock File ▸ Close must not keep the chord")
-        // the window-close confirmation is the pre-fix symptom — it must not have appeared.
         XCTAssertFalse(app.sheets.firstMatch.exists, "⌘W must not raise the close-window confirmation")
         XCTAssertEqual(app.state, .runningForeground, "the window must survive")
     }
@@ -370,9 +316,6 @@ final class KeymapUITests: XCTestCase {
         let row = app.staticTexts["session-row"].firstMatch
         XCTAssertTrue(row.waitForHittable(timeout: 20), "seeded session should be hittable")
         row.click()
-        // drain the run loop until the row reports selected, so the responder bounce
-        // (mouseDown → focusActiveTerminal) settles before a chord is pressed — a wait-for-condition
-        // rather than a fixed sleep. chordFiresMarker retries anyway, so a slow settle is not fatal.
         let deadline = Date().addingTimeInterval(2)
         while Date() < deadline, row.isSelected == false {
             RunLoop.current.run(until: Date().addingTimeInterval(0.05))

--- a/agtermUITests/MenuUITests.swift
+++ b/agtermUITests/MenuUITests.swift
@@ -68,10 +68,8 @@ final class MenuUITests: XCTestCase {
         app.typeKey(.escape, modifierFlags: [])
     }
 
-    // agterm ships its OWN rebindable "Toggle Full Screen" (⌃⌘F) View item so full screen is drivable from
-    // the keymap / palette / control channel. AppKit would otherwise ALSO auto-add its native "Enter Full
-    // Screen" (Globe+F) item — a duplicate. AppDelegate strips the native one, so the View menu must show
-    // agterm's item and NOT the native "Enter Full Screen".
+    // AppKit auto-adds its own native "Enter Full Screen" item next to agterm's rebindable one, so
+    // AppDelegate strips it — the menu must carry agterm's item alone.
     func testViewMenuHasSingleFullScreenItem() throws {
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session should exist")
         app.menuBars.menuBarItems["View"].click()

--- a/agtermUITests/MultiWindowUITests.swift
+++ b/agtermUITests/MultiWindowUITests.swift
@@ -2,37 +2,30 @@ import Darwin
 import XCTest
 
 /// End-to-end tests for the multi-window scene: seed `AGTERM_STATE_DIR` with a `windows.json` index +
-/// two per-window snapshot files, launch the real app, and assert both windows open on screen and
-/// stay recorded open in the index. Closing one window drops the on-screen count and marks that
-/// window closed.
+/// per-window snapshot files, launch the real app, and assert on two oracles — the live window count
+/// (`app.windows`) and the persisted index.
 ///
-/// Assertions use two oracles: the live window count (`app.windows`) and the persisted
-/// `windows.json` index (the launch reopen-all + the quit-time flush keep both windows recorded
-/// open). Per-window sidebar content isn't asserted across BOTH windows — the test-only
-/// force-sidebar fixup reliably expands only the key window's sidebar — so the per-window-store
-/// resolution is proven by at least one seeded workspace rendering plus the two-window count.
+/// Per-window sidebar content isn't asserted across BOTH windows — the test-only force-sidebar fixup
+/// reliably expands only the key window's sidebar — so per-window-store resolution is proven by one
+/// seeded workspace rendering plus the two-window count.
 ///
-/// The seed is written as raw JSON (the UI-test target doesn't link `agtermCore`) matching the
-/// `WindowsIndex` and `Snapshot` Codable shapes.
+/// The seed is raw JSON (the UI-test target doesn't link `agtermCore`) matching the `WindowsIndex` and
+/// `Snapshot` Codable shapes.
 @MainActor
 final class MultiWindowUITests: XCTestCase {
     private var app: XCUIApplication!
     private var stateDir: URL!
-    /// The control socket the app binds, for tests that drive a command (e.g. `quick`). Kept short and
-    /// inside the runner sandbox (NSTemporaryDirectory) so it fits `sun_path`'s ~104-byte limit, like
-    /// `ControlAPIUITests`.
+    /// The control socket the app binds. Kept under NSTemporaryDirectory so it fits `sun_path`'s
+    /// ~104-byte limit, like `ControlAPIUITests`.
     private var socketPath: String!
-    /// A short temp dir the spawned shell writes env-probe marker files into (kept under
-    /// NSTemporaryDirectory so paths stay short, like the socket).
+    /// A temp dir the spawned shell writes env-probe marker files into, short-pathed like the socket.
     private var markerDir: URL!
     private var windowAID = UUID()
     private var windowBID = UUID()
-    /// The selected session id seeded into each window's snapshot, by window id — set by
-    /// `seedTwoWindowsWithSelection`, asserted by the reopen-all test.
+    /// The selected session id seeded per window by `seedTwoWindowsWithSelection`.
     private var selectedByWindow: [UUID: UUID] = [:]
-    /// The single session id seeded into each window's snapshot, by window id — set by
-    /// `seedTwoWindowsWithKnownSessions`, used by the distinct-store test to target each window's
-    /// own session over the control socket.
+    /// The single session id seeded per window by `seedTwoWindowsWithKnownSessions`, used by the
+    /// distinct-store test to target each window's own session over the control socket.
     private var sessionByWindow: [UUID: UUID] = [:]
 
     override func setUp() async throws {
@@ -214,9 +207,8 @@ final class MultiWindowUITests: XCTestCase {
         app.launchForUITest()
     }
 
-    /// Simulate a quit/relaunch cycle: terminate the running app (its `applicationWillTerminate` flushes
-    /// every open store + the index) and relaunch against the SAME state dir + socket, so the persisted
-    /// open-set + per-window selection drive the relaunch reopen.
+    /// Simulate a quit/relaunch cycle: terminate the running app and relaunch against the SAME state dir
+    /// + socket, so the persisted open-set + per-window selection drive the relaunch reopen.
     private func relaunch() {
         app?.terminate()
         launch()
@@ -263,33 +255,23 @@ final class MultiWindowUITests: XCTestCase {
 
     // MARK: - Tests
 
-    // the seeded index reopens both windows on launch; both are on screen and recorded open, and each
-    // window binds its OWN store. The distinct-store proof is the load-bearing assertion: a probe typed
-    // into each window's own seeded session writes that window's $AGTERM_WINDOW_ID, and the two values must
-    // be DIFFERENT (each == its own window's id). Under the reopen-all duplicate-store collision the two
-    // on-screen windows would both bind one store, so the un-rendered window's session never realizes and
-    // its probe never writes — catching the bug definitively (the index open-flags alone would not).
+    // the distinct-store probe is the load-bearing assertion: under a duplicate-store collision both
+    // on-screen windows bind one store, so the un-rendered window's session never realizes and its probe
+    // never writes. The index open-flags alone would not catch that.
     func testReopensTwoSeededWindows() throws {
         try seedTwoWindowsWithKnownSessions()
         launch()
 
-        // both windows resolve a store and render their seeded workspace (the OR is fine here — the
-        // distinct-store assertion below is what proves the two stores are actually distinct).
+        // the OR is fine here — the distinct-store assertion below is what proves the stores differ.
         let alpha = app.staticTexts["alpha-ws"]
         let beta = app.staticTexts["beta-ws"]
         XCTAssertTrue(alpha.waitForExistence(timeout: 30) || beta.waitForExistence(timeout: 30),
                       "a seeded window's workspace should render")
 
-        // two on-screen windows materialize (the launch window claims the frontmost id, the reopen-all
-        // opens the second).
         XCTAssertTrue(pollWindowCount(atLeast: 2, timeout: 10), "two windows should open, got \(app.windows.count)")
         XCTAssertTrue(pollIndexOpenState([windowAID: true, windowBID: true], timeout: 10),
                       "both seeded windows should be marked open in windows.json")
 
-        // the definitive distinct-store oracle: type a probe into EACH window's own seeded session and
-        // read back the $AGTERM_WINDOW_ID its shell saw. Each must equal that window's id, and the two must
-        // differ — impossible if the two windows shared one store (the un-rendered window's session would
-        // never realize, so its probe would never write).
         let aSession = try XCTUnwrap(sessionByWindow[windowAID], "window A's seeded session id")
         let bSession = try XCTUnwrap(sessionByWindow[windowBID], "window B's seeded session id")
         let aValue = try readWindowEnv(windowID: windowAID, sessionID: aSession, fileName: "win-a-env")
@@ -307,8 +289,7 @@ final class MultiWindowUITests: XCTestCase {
     /// value back, lowercased. The window/session scoping routes the inject to the owning store, so a
     /// shared-store collision shows up as the un-rendered window's session never realizing (no write).
     private func readWindowEnv(windowID: UUID, sessionID: UUID, fileName: String) throws -> String {
-        // raise the window so its selected session's surface is the one rendered (surfaces realize when
-        // their detail pane is shown), then inject into that window's session by id.
+        // surfaces realize only when their detail pane is shown, so raise the window before injecting.
         XCTAssertEqual(try sendCommand(#"{"cmd":"window.select","target":"\#(windowID.uuidString)"}"#)["ok"] as? Bool, true,
                        "selecting window \(windowID) should succeed")
         let file = markerDir.appendingPathComponent(fileName)
@@ -318,17 +299,12 @@ final class MultiWindowUITests: XCTestCase {
         return value.lowercased()
     }
 
-    // reopen-all after a simulated quit: seed two open windows each with a known selected session, launch
-    // (the first reopen), then terminate (the quit-time flush) and relaunch. Both windows must come back
-    // open and each window's selected session id must survive the round-trip — the launch reopen-all + the
-    // per-window store flush restore both the open-set and the selection.
     func testReopenAllAfterSimulatedQuitRestoresOpenSetAndSelection() throws {
         try seedTwoWindowsWithSelection()
         let expectedSelection = selectedByWindow
 
         launch()
 
-        // first reopen: both seeded windows open + recorded open, and each window's seeded selection is intact.
         let alpha = app.staticTexts["alpha-ws"]
         let beta = app.staticTexts["beta-ws"]
         XCTAssertTrue(alpha.waitForExistence(timeout: 30) || beta.waitForExistence(timeout: 30),
@@ -341,8 +317,6 @@ final class MultiWindowUITests: XCTestCase {
         XCTAssertEqual(windowSelectedSessionID(windowBID), expectedSelection[windowBID],
                        "window B's seeded selection should be intact after launch")
 
-        // simulate a real quit + relaunch: terminate (flushes every open store + the index), then relaunch
-        // the same state dir. The reopen-all must bring both windows back open with the same selections.
         relaunch()
 
         XCTAssertTrue(app.staticTexts["alpha-ws"].waitForExistence(timeout: 30)
@@ -358,8 +332,6 @@ final class MultiWindowUITests: XCTestCase {
                        "window B's selected session should survive the simulated quit/relaunch")
     }
 
-    // closing one of the two windows marks exactly that window closed in the index, leaving the other
-    // open (proves the per-window close path tears down + records only the closed window).
     /// Clicks a button labelled `label` in a confirmation sheet/dialog (the close-confirm alert),
     /// searching sheets, then dialogs, then any matching button. Returns whether it was clicked.
     private func clickConfirmButton(_ label: String, timeout: TimeInterval) -> Bool {
@@ -376,7 +348,6 @@ final class MultiWindowUITests: XCTestCase {
         try seedTwoWindows()
         launch()
 
-        // wait for a seeded sidebar to render so the window tree is populated, then both open.
         let alpha = app.staticTexts["alpha-ws"]
         let beta = app.staticTexts["beta-ws"]
         XCTAssertTrue(alpha.waitForExistence(timeout: 30) || beta.waitForExistence(timeout: 30),
@@ -384,19 +355,15 @@ final class MultiWindowUITests: XCTestCase {
         XCTAssertTrue(pollIndexOpenState([windowAID: true, windowBID: true], timeout: 10),
                       "both windows should start open")
 
-        // close the seeded window "win-a", targeted by title. Targeting matters: SwiftUI restores an
-        // extra empty stray window from its OWN restoration state (NSUserDefaults, not isolated by
-        // AGTERM_STATE_DIR) under the test's launch — the app's dedup mostly dismisses it, but it can sit
-        // frontmost, so a generic firstMatch / File-menu Close hits THAT empty window, not a seeded
-        // one. The targeted window has a running session, so a confirm sheet appears; Close proceeds.
+        // targeting by title matters: SwiftUI restores an extra empty stray window from its OWN
+        // restoration state (NSUserDefaults, not isolated by AGTERM_STATE_DIR), and it can sit frontmost,
+        // so a generic firstMatch / File-menu Close hits THAT window instead of a seeded one.
         let target = app.windows.matching(NSPredicate(format: "title CONTAINS %@", "win-a")).firstMatch
         XCTAssertTrue(target.waitForExistence(timeout: 10), "seeded window win-a should be on screen")
         target.buttons[XCUIIdentifierCloseWindow].click()
         XCTAssertTrue(clickConfirmButton("Close", timeout: 10), "a close-confirmation sheet should appear; clicking Close proceeds")
 
-        // win-a is now marked closed in the index, win-b stays open. The per-window close path
-        // (performClose → willClose → teardown → closeWindow → index save) can be delayed under load,
-        // so allow a generous settle; the index is the deterministic readiness signal.
+        // the close path can lag under load, so the settle is generous; the index is the readiness signal.
         let deadline = Date().addingTimeInterval(30)
         var settled = false
         while Date() < deadline {
@@ -409,48 +376,35 @@ final class MultiWindowUITests: XCTestCase {
         XCTAssertTrue(settled, "win-a should be marked closed and win-b open, got \(String(describing: indexOpenState()))")
     }
 
-    // the quick terminal is per-window: with two windows open, driving `quick show` over the control
-    // socket toggles only the frontmost window's quick terminal (exactly one `quick-terminal` element
-    // appears), and `quick hide` clears it. Proves each window owns its own controller and the control
-    // arm acts on the frontmost window.
     func testQuickTerminalIsPerWindow() throws {
         try seedTwoWindows()
         launch()
 
-        // both windows are up (a seeded sidebar rendered + two on-screen windows).
         let alpha = app.staticTexts["alpha-ws"]
         let beta = app.staticTexts["beta-ws"]
         XCTAssertTrue(alpha.waitForExistence(timeout: 30) || beta.waitForExistence(timeout: 30),
                       "a seeded window should render")
         XCTAssertTrue(pollWindowCount(atLeast: 2, timeout: 10), "two windows should open, got \(app.windows.count)")
 
-        // no quick terminal is showing in any window yet.
         let quick = app.descendants(matching: .any).matching(identifier: "quick-terminal")
         XCTAssertEqual(quick.count, 0, "no quick terminal should be visible before showing one")
 
-        // show the frontmost window's quick terminal via the control socket.
         let shown = try sendCommand(#"{"cmd":"quick","args":{"mode":"show"}}"#)
         XCTAssertEqual(shown["ok"] as? Bool, true, "quick show should succeed: \(shown)")
         XCTAssertTrue(quick.firstMatch.waitForExistence(timeout: 10), "the frontmost quick terminal should appear")
-        // exactly ONE window's quick terminal showed — not both — so the controller is per-window.
         XCTAssertEqual(quick.count, 1, "only the frontmost window's quick terminal should show, got \(quick.count)")
 
-        // hide it again; it disappears.
         let hidden = try sendCommand(#"{"cmd":"quick","args":{"mode":"hide"}}"#)
         XCTAssertEqual(hidden["ok"] as? Bool, true, "quick hide should succeed: \(hidden)")
         XCTAssertTrue(waitForCount(quick, equals: 0, timeout: 10), "the quick terminal should hide")
     }
 
-    // the spawned shell sees the AGTERM_* env: create a session over the control socket (so its surface
-    // is realized after the socket bound, and AGTERM_SOCKET is populated), then type `echo "$AGTERM_WINDOW_ID"`
-    // / `echo "$AGTERM_SESSION_ID"` into it and read the written files back (the split-test write-to-file
-    // idiom). AGTERM_WINDOW_ID must equal the owning (frontmost) window's id and AGTERM_SESSION_ID the new
-    // session's id — proof the factory injects the right per-surface env.
+    // the session is created over the socket so its surface realizes AFTER the bind, which is what
+    // populates AGTERM_SOCKET in the spawned shell's env.
     func testSpawnedShellSeesWindowAndSessionEnv() throws {
         try seedTwoWindows()
         launch()
 
-        // both windows are up.
         let alpha = app.staticTexts["alpha-ws"]
         let beta = app.staticTexts["beta-ws"]
         XCTAssertTrue(alpha.waitForExistence(timeout: 30) || beta.waitForExistence(timeout: 30),
@@ -458,17 +412,12 @@ final class MultiWindowUITests: XCTestCase {
         XCTAssertTrue(pollWindowCount(atLeast: 2, timeout: 10), "two windows should open, got \(app.windows.count)")
         XCTAssertTrue(pollIndexOpenState([windowAID: true, windowBID: true], timeout: 10), "both windows should be open")
 
-        // create a new session in the frontmost window; it's selected + shown, so its surface realizes
-        // (and was created after the control socket bound, so AGTERM_SOCKET is set).
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
         let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
         let newSessionID = try XCTUnwrap(result["id"] as? String, "session.new should return the new id")
 
-        // the owning window is the frontmost one, which the index records.
         let frontmost = try XCTUnwrap(pollIndexFrontmost(timeout: 10), "windows.json should record a frontmost id")
 
-        // echo $AGTERM_WINDOW_ID into a file and read it back: it must equal the frontmost window's id. The
-        // type-and-retry guards the freshly-realized surface's shell-readiness race under full-suite load.
         let windowFile = markerDir.appendingPathComponent("window-id")
         let windowCmd = "echo \"$AGTERM_WINDOW_ID\" > '\(windowFile.path)'\n"
         let readWindowID = try XCTUnwrap(try typeUntilMarker(windowCmd, target: newSessionID, file: windowFile),
@@ -476,7 +425,6 @@ final class MultiWindowUITests: XCTestCase {
         XCTAssertEqual(readWindowID.lowercased(), frontmost.lowercased(),
                        "AGTERM_WINDOW_ID should equal the owning (frontmost) window's id")
 
-        // echo $AGTERM_SESSION_ID into a file and read it back: it must equal the new session's id.
         let sessionFile = markerDir.appendingPathComponent("session-id")
         let sessionCmd = "echo \"$AGTERM_SESSION_ID\" > '\(sessionFile.path)'\n"
         let readSessionID = try XCTUnwrap(try typeUntilMarker(sessionCmd, target: newSessionID, file: sessionFile),
@@ -485,9 +433,6 @@ final class MultiWindowUITests: XCTestCase {
                        "AGTERM_SESSION_ID should equal the spawning session's id")
     }
 
-    // a session created in (and shown in) window B sees AGTERM_WINDOW_ID == window B's id, NOT the
-    // initially-frontmost window A — proof surfaceEnv resolves the owning window per surface, not the
-    // frontmost window at creation time.
     func testSessionEnvBindsToOwningWindowB() throws {
         try seedTwoWindows()
         launch()
@@ -498,18 +443,16 @@ final class MultiWindowUITests: XCTestCase {
         XCTAssertTrue(pollWindowCount(atLeast: 2, timeout: 10), "two windows should open, got \(app.windows.count)")
         XCTAssertTrue(pollIndexOpenState([windowAID: true, windowBID: true], timeout: 10), "both windows should be open")
 
-        // raise window B so its new session is shown (surfaces are lazy — they realize when displayed).
+        // surfaces are lazy — they realize only when displayed, so window B has to be raised first.
         XCTAssertEqual(try sendCommand(#"{"cmd":"window.select","target":"\#(windowBID.uuidString)"}"#)["ok"] as? Bool, true,
                        "selecting window B should succeed")
 
-        // create a session in window B by id and select it so its surface realizes after the socket bound.
         let created = try sendCommand(#"{"cmd":"session.new","args":{"window":"\#(windowBID.uuidString)"}}"#)
         let newSessionID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String,
                                          "session.new --window B should return the new id")
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.select","target":"\#(newSessionID)","args":{"window":"\#(windowBID.uuidString)"}}"#)["ok"] as? Bool,
                        true, "selecting the new B-session should succeed")
 
-        // the B-session's shell must see AGTERM_WINDOW_ID == window B's id.
         let windowFile = markerDir.appendingPathComponent("window-b-id")
         let windowCmd = "echo \"$AGTERM_WINDOW_ID\" > '\(windowFile.path)'\n"
         let readWindowID = try XCTUnwrap(try typeUntilMarker(windowCmd, target: newSessionID, file: windowFile),
@@ -520,8 +463,6 @@ final class MultiWindowUITests: XCTestCase {
 
     // MARK: - File-menu window actions (Task 9)
 
-    // File ▸ New Window opens a second on-screen window and adds an open entry to the index (proving
-    // the menu drives library.newWindow + the scene's openWindow opener).
     func testNewWindowMenuOpensSecondWindow() throws {
         try seedOneWindow()
         launch()
@@ -539,7 +480,6 @@ final class MultiWindowUITests: XCTestCase {
                       "the index should record two open windows, got \(String(describing: indexWindows()))")
     }
 
-    // File ▸ Delete Window is disabled when only one window remains (keep-at-least-one).
     func testDeleteWindowMenuDisabledForLastWindow() throws {
         try seedOneWindow()
         launch()
@@ -552,8 +492,6 @@ final class MultiWindowUITests: XCTestCase {
         XCTAssertFalse(item.isEnabled, "Delete Window should be disabled with only one window")
     }
 
-    // File ▸ New Window then File ▸ Delete Window removes the extra window: the confirm alert fires
-    // (the new window has a session), clicking Delete drops it back to one window in the index.
     func testDeleteWindowMenuRemovesExtraWindow() throws {
         try seedOneWindow()
         launch()
@@ -561,19 +499,17 @@ final class MultiWindowUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["alpha-ws"].waitForExistence(timeout: 30), "the seeded window should render")
         XCTAssertTrue(pollIndexWindows(timeout: 10) { $0.count == 1 }, "one window to start")
 
-        // create a second window via the menu; it becomes frontmost (the delete target).
         app.menuBars.menuBarItems["File"].click()
         app.menuItems["New Window"].click()
         XCTAssertTrue(pollIndexWindows(timeout: 10) { $0.count == 2 }, "two windows after New Window")
 
-        // delete the frontmost (the just-created) window; it has a session, so confirm fires.
+        // the just-created window is frontmost and has a session, so the delete confirm fires.
         app.menuBars.menuBarItems["File"].click()
         let delete = app.menuItems["Delete Window"]
         XCTAssertTrue(delete.waitForExistence(timeout: 5), "File menu should offer Delete Window")
         XCTAssertTrue(delete.isEnabled, "Delete Window should be enabled with two windows")
         delete.click()
 
-        // the confirm alert's Delete button — accept it.
         let confirm = app.dialogs.buttons["Delete"].firstMatch
         if confirm.waitForExistence(timeout: 5) {
             confirm.click()
@@ -583,13 +519,11 @@ final class MultiWindowUITests: XCTestCase {
             fallback.click()
         }
 
-        // back to exactly one window in the index.
         XCTAssertTrue(pollIndexWindows(timeout: 10) { $0.count == 1 },
                       "deleting the extra window should leave one, got \(String(describing: indexWindows()))")
     }
 
-    // Rename is verified on the control path (the File-menu alert is system UI not driven in XCUI):
-    // window.rename updates the index entry's name.
+    // the File-menu rename alert is system UI XCUITest can't drive, so this verifies the control path.
     func testRenameWindowViaControlUpdatesIndex() throws {
         try seedOneWindow()
         launch()
@@ -642,20 +576,17 @@ final class MultiWindowUITests: XCTestCase {
         return nil
     }
 
-    /// Type a `session.type` command at `file` and wait for the shell to write it back, retrying the inject
-    /// if the marker hasn't appeared yet. A freshly-realized surface's shell/pty may not be ready to read
-    /// when the first keystrokes land (especially under full-suite CPU load), so a single injection can be
-    /// dropped — re-injecting once the shell has had time to spawn is the deterministic readiness wait. The
-    /// marker file is the readiness signal: when it's non-empty the command actually ran. Returns the marker
-    /// contents, or nil if it never appeared across all attempts. Asserts each type request returns ok.
+    /// Type a `session.type` command at `file` and wait for the shell to write it back, retrying the
+    /// inject if the marker hasn't appeared yet. A freshly-realized surface's shell/pty may not be ready
+    /// to read when the first keystrokes land (especially under full-suite CPU load), so a single
+    /// injection can be dropped; the non-empty marker file is the readiness signal. Returns the marker
+    /// contents, or nil if it never appeared across all attempts.
     private func typeUntilMarker(_ command: String, target: String, file: URL, window: String? = nil,
                                  attempts: Int = 4, perAttempt: TimeInterval = 4) throws -> String? {
         for attempt in 0..<attempts {
-            // clear any marker a prior attempt's late injection may have written, so a stale value
-            // can't be read as this attempt's success.
+            // a prior attempt's late injection must not be read as this attempt's success.
             try? FileManager.default.removeItem(at: file)
-            // first attempt realizes a never-shown surface (select:true); retries re-inject once it's
-            // realized — a window-scoped target stays in its own store across attempts.
+            // select:true so the first attempt realizes a never-shown surface.
             let typed = try sendCommand(typeRequest(text: command, target: target, select: true, window: window))
             XCTAssertEqual(typed["ok"] as? Bool, true, "typing the probe (attempt \(attempt)) should succeed: \(typed)")
             if let value = pollMarker(file, timeout: perAttempt) { return value }

--- a/agtermUITests/NewSessionDirectoryUITests.swift
+++ b/agtermUITests/NewSessionDirectoryUITests.swift
@@ -1,12 +1,9 @@
 import Foundation
 import XCTest
 
-// e2e for the "New sessions open in" setting. Split out of ControlAPIUITests so that file stays under
-// the swiftlint file_length limit; this is an extension over the SAME test class, reusing its socket
-// harness (sendCommand / activeSessionID / typeRequest / app), so no scaffolding is duplicated.
+// e2e for the "New sessions open in" setting. An extension over the SAME class as ControlAPIUITests
+// (reusing its socket harness) so that file stays under the swiftlint file_length limit.
 extension ControlAPIUITests {
-    // with "Current session's directory" chosen, File ▸ New Session opens the new session in the ACTIVE
-    // session's cwd, not home.
     func testNewSessionInheritsCurrentSessionDirectory() throws {
         let (seededID, marker, markerName) = try armCurrentSessionMode()
         defer { try? FileManager.default.removeItem(at: marker) }
@@ -19,9 +16,8 @@ extension ControlAPIUITests {
         assertNewSessionInherited(seededID: seededID, markerName: markerName)
     }
 
-    // the workspace-row right-click "New Session" is a SEPARATE entry point (WorkspaceSidebar.menuNewSession,
-    // not AppActions.newSession) — it must honor the setting too. Regression guard: without the shared
-    // resolvedNewSessionCwd() it hardcoded home and ignored the picker.
+    // the workspace-row right-click "New Session" is a SEPARATE entry point
+    // (WorkspaceSidebar.menuNewSession, not AppActions.newSession).
     func testWorkspaceRowNewSessionInheritsCurrentSessionDirectory() throws {
         let (seededID, marker, markerName) = try armCurrentSessionMode()
         defer { try? FileManager.default.removeItem(at: marker) }
@@ -48,8 +44,7 @@ extension ControlAPIUITests {
 
         chooseCurrentSessionDirectoryMode()
 
-        // cd the seeded session into the marker dir (over the socket, no GUI focus needed), then wait for
-        // the tree to report the new cwd (OSC 7 fires on the next prompt after cd).
+        // the tree's cwd only catches up on the next prompt after the cd (OSC 7).
         let seededID = try activeSessionID()
         _ = try sendCommand(typeRequest(text: "cd \(marker.path)\n", target: seededID, select: true))
         XCTAssertTrue(poll(timeout: 15) {

--- a/agtermUITests/NotifyBannersUITests.swift
+++ b/agtermUITests/NotifyBannersUITests.swift
@@ -1,10 +1,8 @@
 import XCTest
 
-// `notify` with the "Show notification banners" toggle OFF. The command still succeeds and the unseen
-// badge still tracks, but nothing is handed to macOS — so it answers `ok` WITH an advisory note in
-// `result.text` rather than a bare `ok`, which would be indistinguishable from a broken notification
-// path (issue #286: a user read the bare `ok` plus a silent log as "notify never delivers").
-// Launches with `notificationsEnabled: false` pre-seeded, since there is no `settings.*` control command.
+// `notify` with the "Show notification banners" toggle OFF still succeeds, so it answers `ok` WITH an
+// advisory note in `result.text`; a bare `ok` is indistinguishable from a broken notification path
+// (issue #286). Launches with `notificationsEnabled: false` pre-seeded — there is no `settings.*` command.
 final class NotifyBannersOffUITests: ControlAPITestCase {
     override var seededSettings: [String: Any]? { ["notificationsEnabled": false] }
 
@@ -19,14 +17,13 @@ final class NotifyBannersOffUITests: ControlAPITestCase {
                        "badge updated, but \"Show notification banners\" is off, so no banner was posted",
                        "banners-off notify should explain why no banner appeared: \(result)")
 
-        // the badge is independent of the banner toggle, so the unseen count still rises.
         XCTAssertTrue(poll(timeout: 10) { try self.unseen(ofSession: seeded) == 1 },
                       "the unseen badge should still track with banners off")
     }
 }
 
-// The same command with banners ON (stock defaults) — the note must be ABSENT, so a caller can treat
-// its presence as "no banner was posted" rather than boilerplate on every call.
+// with banners ON the note must be ABSENT, so a caller can read its presence as "no banner was posted"
+// rather than boilerplate on every call.
 final class NotifyBannersOnUITests: ControlAPITestCase {
     func testNotifyWithBannersOnReturnsNoNote() throws {
         let seeded = try seededSessionID()

--- a/agtermUITests/PaletteUITests.swift
+++ b/agtermUITests/PaletteUITests.swift
@@ -56,7 +56,6 @@ final class PaletteUITests: XCTestCase {
         XCTAssertTrue(poll { self.firstSessionName() == "zeta" })
         let first = try XCTUnwrap(firstSessionID())
 
-        // add a second session; it becomes selected.
         app.menuBars.menuBarItems["File"].click()
         app.menuItems["New Session"].click()
         XCTAssertTrue(poll { self.sessionCount() == 2 }, "a second session should be added")
@@ -69,16 +68,13 @@ final class PaletteUITests: XCTestCase {
     }
 
     func testThemePickerCommitsOnEnterAndRevertsOnEsc() throws {
-        // commit: open the picker, filter to a non-default theme, Enter persists it to settings.json
-        // (the live color change is a Metal-surface visual, verified manually; the persistence is the
-        // observable contract here). "Dracula" differs from the seeded agterm default, so it proves a change.
+        // the live recolor is a Metal-surface visual, so settings.json is the oracle; "Dracula" differs
+        // from the seeded agterm default, so persisting it proves a change.
         openThemePicker()
         typeIntoPalette("Dracula")
         app.typeKey(.return, modifierFlags: [])
         XCTAssertTrue(poll { self.settingsTheme() == "Dracula" }, "Enter on a theme should persist it to settings.json")
 
-        // revert: open again, filter to a different theme (which previews it live), Esc. The preview is
-        // never persisted, so settings.json keeps the previously committed theme.
         openThemePicker()
         typeIntoPalette("Nord")
         app.typeKey(.escape, modifierFlags: [])
@@ -87,16 +83,14 @@ final class PaletteUITests: XCTestCase {
     }
 
     func testThemePickerAutoFocusesFieldFromActionPaletteLauncher() throws {
-        // open the picker the way a keyboard user does: the action palette → "Select Theme…" → Enter.
-        // that path closes the action palette (whose close-restore re-grabs terminal focus) and opens the
-        // .themes picker a tick later; the picker must AUTO-FOCUS its field so typing filters it.
+        // the action-palette launcher closes that palette (whose close-restore re-grabs terminal focus)
+        // and opens the picker a tick later, so the picker has to auto-focus its own field.
         openPalette("Command Palette")
         typeIntoPalette("Select Theme") // clicking the ACTION-palette field is fine — not the focus under test
         app.typeKey(.return, modifierFlags: [])
 
-        // the picker is open; type WITHOUT clicking its field. If focus stayed on the terminal behind it
-        // (the bug), this text would reach the shell, the selection would stay on the current theme, and
-        // Enter would commit the wrong one — so the commit assertion is the focus oracle.
+        // typing WITHOUT clicking the field is the point: had focus stayed on the terminal behind it, the
+        // text would reach the shell and Enter would commit the unfiltered theme, so the commit is the oracle.
         XCTAssertTrue(app.textFields.firstMatch.waitForExistence(timeout: 5), "the theme picker field should appear")
         app.typeText("agterm")
         app.typeKey(.return, modifierFlags: [])
@@ -105,17 +99,15 @@ final class PaletteUITests: XCTestCase {
     }
 
     func testFreshLaunchAppliesAgtermDefaultThemeWithoutAnyChange() throws {
-        // a fresh install must apply the seeded agterm default at LAUNCH, not only after a settings change
-        // triggers a config rewrite. SettingsModel.init writes the ghostty config before GhosttyApp boots,
-        // so <stateDir>/ghostty-settings.conf carries the theme with NO interaction.
+        // SettingsModel.init writes the ghostty config before GhosttyApp boots, so the theme must be in
+        // <stateDir>/ghostty-settings.conf with NO interaction at all.
         XCTAssertTrue(poll { self.appliedGhosttyTheme()?.contains("agterm") == true },
                       "a fresh launch should write the agterm default into the live ghostty config")
     }
 
     func testThemePickerPreviewsTopMatchOnFilterWithoutNavigating() throws {
-        // typing to filter must preview the new top match live — even with no arrow navigation. The live
-        // preview writes the applied theme into <stateDir>/ghostty-settings.conf, so that file is the
-        // oracle (the Metal recolor itself isn't observable). No Enter, no arrows.
+        // the Metal recolor isn't observable, so the applied theme in <stateDir>/ghostty-settings.conf is
+        // the oracle. No Enter, no arrows.
         openThemePicker()
         typeIntoPalette("Hot Dog") // top match: the vivid "Hot Dog Stand" theme
         XCTAssertTrue(poll { self.appliedGhosttyTheme()?.contains("Hot Dog Stand") == true },

--- a/agtermUITests/PaneAwareStatusUITests.swift
+++ b/agtermUITests/PaneAwareStatusUITests.swift
@@ -2,34 +2,20 @@ import Foundation
 import XCTest
 
 /// Control-channel e2e for pane-aware agent status: a `blocked` status tagged with the pane that set it
-/// (`session.status --pane left|right|scratch`) must (1) survive foreground typing in a DIFFERENT pane and
-/// (2) make every user-initiated GUI selection (attention navigation, a sidebar row click, the attention
-/// command palette) reveal and land on the pane that actually blocked — a split (right) pane, a hidden
-/// split, or a scratch terminal — instead of the session's plain focused pane. Subclass of
-/// `ControlAPITestCase` for the socket harness (isolated `AGTERM_STATE_DIR` + short socket path).
+/// (`session.status --pane left|right|scratch`) must survive typing in a DIFFERENT pane, and every
+/// user-initiated GUI selection must reveal the pane that actually blocked.
 ///
-/// Reveal oracle (deterministic, race-free): the reveal step (`AppActions.revealActiveBlockedPane`) sets the
-/// MODEL flags `splitFocused` / `scratchActive` synchronously, and `Session.onScreenSurface` follows those
-/// flags — so `session.text` with NO `--pane` (the on-screen surface) reflects the reveal immediately,
-/// independent of the best-effort AppKit `makeFirstResponder` retry the reveal also fires. Each pane is
-/// pre-seeded with a distinct echo marker; after nav, the no-pane read returns the REVEALED pane's marker
-/// and not the other's. The primary trigger is the GUI attention-nav shortcut ⌃⌥↓ (Navigate ▸ Next
-/// Attention Session → `AppActions.selectNextAttentionSession` → `revealActiveBlockedPane`); the SAME reveal
-/// also fires on a plain GUI selection — a sidebar row click (`outlineViewSelectionDidChange`) and the
-/// ⌃P/attention command palette's run closure, each covered below — since the reveal now runs on every
-/// user-initiated selection. Only the control `session.go next-attention` stays reveal-free (it drives
-/// `AppStore.navigateSession` directly), so a menu key-equivalent / click / palette pick is the way to
-/// exercise it (as `SessionNavUITests` drives ⌥⌘↓).
+/// Reveal oracle: the reveal sets the MODEL flags `splitFocused` / `scratchActive` synchronously and
+/// `Session.onScreenSurface` follows them, so `session.text` with NO `--pane` reflects the reveal
+/// immediately, independent of the best-effort AppKit `makeFirstResponder` retry. Each pane carries a
+/// distinct echo marker, so the no-pane read tells the panes apart. The control `session.go
+/// next-attention` is reveal-free, so only a menu key-equivalent / click / palette pick exercises it.
 ///
-/// Clear oracle (survival / self-clear): the pane-scoped keystroke-clear is wired off the real `keyDown`
-/// (each surface factory owns the decision for its own pane), so it MUST be driven by the synthesized
-/// keyboard — `session.type` injects via `ghostty_surface_key` and bypasses `keyDown`. The sidebar glyph
-/// (`agent-status`) is the observable, as in `ControlSidebarStatusUITests.testTypingClearsBlockedOrCompletedStatus`.
+/// Clear oracle: the pane-scoped keystroke-clear is wired off the real `keyDown`, so it MUST be driven by
+/// the synthesized keyboard — `session.type` injects via `ghostty_surface_key` and bypasses `keyDown`.
+/// The sidebar glyph (`agent-status`) is the observable.
 @MainActor
 final class PaneAwareStatusUITests: ControlAPITestCase {
-    // a `right`-tagged block on a SHOWN split: parked on another session, ⌃⌥↓ jumps to the blocked session
-    // AND flips the on-screen pane from the main (left) pane — where focus was parked — to the split (right)
-    // pane that set the status. Without the pane tag, nav would keep focus on the main pane.
     func testAttentionNavRevealsBlockedSplitPane() throws {
         let sessionA = try activeSessionID()
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.split","target":"\#(sessionA)","args":{"mode":"on"}}"#)["ok"] as? Bool,
@@ -41,14 +27,11 @@ final class PaneAwareStatusUITests: ControlAPITestCase {
         try seedPaneMarker(target: sessionA, pane: "left", tag: leftTag)
         try seedPaneMarker(target: sessionA, pane: "right", tag: rightTag)
 
-        // move focus to the main (left) pane so the split (right) pane is NOT the on-screen one — the state a
-        // background pane block starts from.
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.focus","target":"\#(sessionA)","args":{"pane":"left"}}"#)["ok"] as? Bool,
                        true, "focusing the left pane should succeed")
         XCTAssertTrue(try pollOnScreen(target: sessionA, contains: "\(leftTag)-42"),
                       "with the left pane focused, the on-screen surface should be the main pane")
 
-        // the split (right) pane's agent blocks; park the selection on a fresh non-blocked session.
         try blockPane("right", target: sessionA)
         XCTAssertEqual(try statusPane(of: sessionA), "right", "the block should be tagged right")
         let sessionB = try parkOnNewSession()
@@ -63,9 +46,8 @@ final class PaneAwareStatusUITests: ControlAPITestCase {
         XCTAssertNotEqual(sessionB, sessionA, "sanity: the parked session is distinct")
     }
 
-    // A sole attention session is already selected, so both attention-nav directions are selection no-ops:
-    // `navigateSession` returns nil after wrapping back to the current row. They must still read the live
-    // indicator and reveal its tagged pane instead of falling back to the currently focused main pane.
+    // both directions are selection no-ops here — `navigateSession` returns nil after wrapping back onto the
+    // current row — so the reveal has to come from the live indicator instead.
     func testAttentionNavRevealsTaggedPaneWhenSoleAttentionSessionIsAlreadySelected() throws {
         let sessionA = try activeSessionID()
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.split","target":"\#(sessionA)","args":{"mode":"on"}}"#)["ok"] as? Bool,
@@ -103,12 +85,8 @@ final class PaneAwareStatusUITests: ControlAPITestCase {
                       "previous-attention should reveal the selected session's tagged right pane")
     }
 
-    // The INVERSE of the test above, and the reason plain nav and attention nav must not share a fallback:
-    // a PLAIN ⌥⌘↓ that resolves to the session already selected must leave the user's pane alone. In a
-    // one-element filtered set (flagged mode, a single flag) `next` wraps back onto the current session, so
-    // `navigateSession` re-selects it and — since `selectSession` does not short-circuit a same-target select
-    // — still hands back an indicator. Revealing on that would clear `splitFocused` and drop the user onto
-    // the primary pane on a keystroke that moved nothing.
+    // the inverse of the test above: `selectSession` does not short-circuit a same-target select, so a plain
+    // nav that moved nothing still hands back an indicator — revealing on it would clear `splitFocused`.
     func testPlainNavNoOpKeepsTheFocusedSplitPane() throws {
         let sessionA = try activeSessionID()
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.split","target":"\#(sessionA)","args":{"mode":"on"}}"#)["ok"] as? Bool,
@@ -120,13 +98,12 @@ final class PaneAwareStatusUITests: ControlAPITestCase {
         try seedPaneMarker(target: sessionA, pane: "left", tag: leftTag)
         try seedPaneMarker(target: sessionA, pane: "right", tag: rightTag)
 
-        // the user is working in the split (right) pane while the agent blocks in the MAIN pane. An UNTAGGED
-        // block is treated as `left`, which is what a plain `agtermctl session status blocked` sends, and a
-        // left-scoped block is not cleared by typing in the right pane, so the state persists into the nav.
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.focus","target":"\#(sessionA)","args":{"pane":"right"}}"#)["ok"] as? Bool,
                        true, "focusing the right pane should succeed")
         XCTAssertTrue(try pollOnScreen(target: sessionA, contains: "\(rightTag)-42"),
                       "the split pane should be the on-screen surface before nav")
+        // an UNTAGGED block (what a plain `agtermctl session status blocked` sends) is treated as `left`, so
+        // it survives the user working in the right pane.
         try blockPane("blocked", pane: nil, target: sessionA)
 
         // narrow the navigable set to this one session so ⌥⌘↓ wraps onto it instead of moving elsewhere.
@@ -145,9 +122,6 @@ final class PaneAwareStatusUITests: ControlAPITestCase {
                       "the split pane the user was working in should still be the on-screen surface")
     }
 
-    // a `right`-tagged block on a HIDDEN split: nav reveals it by swapping which pane shows MAXIMIZED (the
-    // split stays hidden — split:false — but the right pane is now the on-screen one), not by re-showing the
-    // two panes side-by-side.
     func testAttentionNavRevealsHiddenSplit() throws {
         let sessionA = try activeSessionID()
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.split","target":"\#(sessionA)","args":{"mode":"on"}}"#)["ok"] as? Bool,
@@ -159,7 +133,6 @@ final class PaneAwareStatusUITests: ControlAPITestCase {
         try seedPaneMarker(target: sessionA, pane: "left", tag: leftTag)
         try seedPaneMarker(target: sessionA, pane: "right", tag: rightTag)
 
-        // focus the main pane, then HIDE the split (keep-alive) — the main pane shows maximized.
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.focus","target":"\#(sessionA)","args":{"pane":"left"}}"#)["ok"] as? Bool,
                        true, "focusing the left pane should succeed")
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.split","target":"\#(sessionA)","args":{"mode":"off"}}"#)["ok"] as? Bool,
@@ -180,15 +153,12 @@ final class PaneAwareStatusUITests: ControlAPITestCase {
                        "the split stays hidden after the reveal — the right pane is shown maximized, not side-by-side")
     }
 
-    // a `scratch`-tagged block with the scratch HIDDEN: nav shows the scratch (the toggleScratch reveal path,
-    // which has no notification PaneRole) and makes it the on-screen surface.
     func testAttentionNavRevealsHiddenScratch() throws {
         let sessionA = try activeSessionID()
         let mainTag = "PAWSM-\(UUID().uuidString.prefix(8))"
         let scratchTag = "PAWSS-\(UUID().uuidString.prefix(8))"
         try seedPaneMarker(target: sessionA, pane: "left", tag: mainTag)
 
-        // open the scratch, seed its buffer, then HIDE it (keep-alive) — the main pane is on-screen again.
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.scratch","target":"\#(sessionA)","args":{"mode":"on"}}"#)["ok"] as? Bool,
                        true, "scratch on should succeed")
         XCTAssertTrue(try pollScratch(id: sessionA, equals: true, timeout: 10), "the scratch should be shown")
@@ -213,10 +183,8 @@ final class PaneAwareStatusUITests: ControlAPITestCase {
         XCTAssertFalse(onScreen.contains("\(mainTag)-42"), "the revealed scratch must not carry the main pane's marker")
     }
 
-    // the inverse of the hidden-scratch reveal: a `right`-tagged block on the split with the scratch ALREADY
-    // SHOWN (covering the panes). Without hiding the cover, both focus paths resolve to the scratch and nav
-    // never reaches the blocked pane; the reveal must HIDE the covering scratch first, then surface the right
-    // pane. The scratch is a background cover here — the block was set by the split behind it.
+    // with the scratch covering the panes both focus paths resolve to it, so the reveal has to HIDE the
+    // covering scratch before the blocked right pane can surface.
     func testAttentionNavRevealsSplitBehindShownScratch() throws {
         let sessionA = try activeSessionID()
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.split","target":"\#(sessionA)","args":{"mode":"on"}}"#)["ok"] as? Bool,
@@ -228,14 +196,12 @@ final class PaneAwareStatusUITests: ControlAPITestCase {
         try seedPaneMarker(target: sessionA, pane: "left", tag: leftTag)
         try seedPaneMarker(target: sessionA, pane: "right", tag: rightTag)
 
-        // focus the main (left) pane, then SHOW the scratch so it covers both panes.
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.focus","target":"\#(sessionA)","args":{"pane":"left"}}"#)["ok"] as? Bool,
                        true, "focusing the left pane should succeed")
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.scratch","target":"\#(sessionA)","args":{"mode":"on"}}"#)["ok"] as? Bool,
                        true, "scratch on should succeed")
         XCTAssertTrue(try pollScratch(id: sessionA, equals: true, timeout: 10), "the scratch should cover the panes")
 
-        // the split (right) pane's agent blocks behind the covering scratch; park on a fresh session.
         try blockPane("right", target: sessionA)
         XCTAssertEqual(try statusPane(of: sessionA), "right", "the block should be tagged right")
         _ = try parkOnNewSession()
@@ -251,21 +217,14 @@ final class PaneAwareStatusUITests: ControlAPITestCase {
         XCTAssertFalse(onScreen.contains("\(leftTag)-42"), "the revealed right pane must not carry the main pane's marker")
     }
 
-    // the core fix: typing in the MAIN pane must NOT clear a block tagged `right` or `scratch` (a background
-    // pane set it). The positive control at the end proves the SAME keystrokes DO reach the main pane's
-    // keyDown and clear a `left`-tagged block — so the survivals above are real pane-scoping, not lost keys.
     func testMainPaneTypingSurvivesBackgroundPaneBlock() throws {
         let sessionA = try activeSessionID()
         // put first responder in the main pane so the synthesized Escape reaches its keyDown.
         app.staticTexts["session-row"].firstMatch.click()
         usleep(800_000)
 
-        // the `right` case needs a LIVE split. `setAgentIndicator` coerces a `.right` tag to `.left` on a
-        // session with no split (the promoted-survivor normalization, pinned host-free by
-        // AppStorePaneTests.setAgentIndicatorCoercesRightToLeftWithoutLiveSplit), which would hand the block
-        // to the very pane this test types into and let the Escape clear it — a `right` tag is only a
-        // BACKGROUND pane once the right pane really exists. Opening the split focuses the NEW right pane,
-        // so hand focus back to the main pane before typing.
+        // the `right` case needs a LIVE split: without one `setAgentIndicator` coerces a `.right` tag to
+        // `.left`, handing the block to the very pane this test types into, and the Escape would clear it.
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.split","target":"\#(sessionA)","args":{"mode":"on"}}"#)["ok"] as? Bool,
                        true, "session.split on should succeed")
         XCTAssertTrue(try pollSplit(sessionA, timeout: 10), "the split should be live before tagging the right pane")
@@ -275,7 +234,6 @@ final class PaneAwareStatusUITests: ControlAPITestCase {
                       "focus should be back on the main pane before typing")
         usleep(800_000)
 
-        // a right- or scratch-tagged block survives Escape typed into the main pane.
         for tag in ["right", "scratch"] {
             try blockPane("blocked", pane: tag, target: sessionA)
             XCTAssertTrue(app.staticTexts["agent-status"].waitForExistence(timeout: 12),
@@ -291,34 +249,27 @@ final class PaneAwareStatusUITests: ControlAPITestCase {
             XCTAssertTrue(app.staticTexts["agent-status"].waitForNonExistence(timeout: 12), "idle should hide the glyph")
         }
 
-        // positive control: a left-tagged block IS cleared by the same Escape in the main pane, proving the
-        // keystrokes actually reach the main pane's keyDown (so the survivals above weren't false passes).
+        // positive control: the same Escape DOES clear a left-tagged block, so the survivals above are real
+        // pane-scoping and not lost keystrokes.
         try blockPane("blocked", pane: "left", target: sessionA)
         XCTAssertTrue(app.staticTexts["agent-status"].waitForExistence(timeout: 12), "a left-tagged block should show the glyph")
         XCTAssertTrue(typeUntilGlyphCleared(), "typing in the main pane SHOULD clear a left-tagged block (its own pane)")
     }
 
-    // self-clear parity (the Task 8 scratch-factory closure): typing in the SCRATCH clears a `scratch`-tagged
-    // block — the scratch surface owns its own pane-scoped keystroke-clear, so its own keystrokes clear its
-    // own block, mirroring the main/split panes.
     func testScratchTypingClearsScratchBlock() throws {
         let sessionA = try activeSessionID()
         try blockPane("scratch", target: sessionA)
         XCTAssertTrue(app.staticTexts["agent-status"].waitForExistence(timeout: 12), "a scratch-tagged block should show the glyph")
 
-        // show the scratch — its autoFocus grabs first responder, so synthesized keys reach the scratch's keyDown.
+        // the scratch's autoFocus grabs first responder, so synthesized keys reach the scratch's keyDown.
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.scratch","target":"\#(sessionA)","args":{"mode":"on"}}"#)["ok"] as? Bool,
                        true, "scratch on should succeed")
         XCTAssertTrue(try pollScratch(id: sessionA, equals: true, timeout: 10), "the scratch should be shown")
-        usleep(800_000) // let the scratch's autoFocus settle first responder onto it
+        usleep(800_000)
 
         XCTAssertTrue(typeUntilGlyphCleared(), "typing in the scratch SHOULD clear its own scratch-tagged block")
     }
 
-    // a `right`-tagged block revealed by a SIDEBAR ROW CLICK: with the selection parked on another session,
-    // clicking the blocked session's row selects it AND flips the on-screen pane from the main (left) pane —
-    // where focus was parked — to the split (right) pane that set the status. The reveal now fires on a plain
-    // GUI selection, not only attention-nav; without the pane tag the click would keep focus on the main pane.
     func testSidebarClickRevealsBlockedSplitPane() throws {
         let sessionA = try activeSessionID()
         // rename the blocked session so its sidebar row is matchable by value, distinct from the parked one.
@@ -335,18 +286,15 @@ final class PaneAwareStatusUITests: ControlAPITestCase {
         try seedPaneMarker(target: sessionA, pane: "left", tag: leftTag)
         try seedPaneMarker(target: sessionA, pane: "right", tag: rightTag)
 
-        // focus the main (left) pane so the split (right) pane is NOT the on-screen one.
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.focus","target":"\#(sessionA)","args":{"pane":"left"}}"#)["ok"] as? Bool,
                        true, "focusing the left pane should succeed")
         XCTAssertTrue(try pollOnScreen(target: sessionA, contains: "\(leftTag)-42"),
                       "with the left pane focused, the on-screen surface should be the main pane")
 
-        // the split (right) pane's agent blocks; park the selection on a fresh session so A is NOT selected.
         try blockPane("right", target: sessionA)
         XCTAssertEqual(try statusPane(of: sessionA), "right", "the block should be tagged right")
         _ = try parkOnNewSession()
 
-        // click the blocked session's row: selecting it should reveal its blocked (right) pane.
         clickSessionRow(named: rowName)
 
         XCTAssertTrue(try pollActiveNode(equals: sessionA, timeout: 12), "clicking the row should select the blocked session")
@@ -356,10 +304,7 @@ final class PaneAwareStatusUITests: ControlAPITestCase {
         XCTAssertFalse(onScreen.contains("\(leftTag)-42"), "the revealed right pane must not carry the main pane's marker")
     }
 
-    // a `right`-tagged block revealed by the ATTENTION COMMAND PALETTE: opening Navigate ▸ Go to Attention…
-    // and choosing the blocked session selects it AND flips the on-screen pane to the split (right) pane that
-    // set the status. The palette-run reveal is dispatched async (after the palette closes and its own
-    // focus-restore), so it lands on the waiting pane, mirroring attention-nav and the sidebar click.
+    // the palette-run reveal is dispatched async, after the palette closes and its own focus-restore.
     func testAttentionPaletteRevealsBlockedSplitPane() throws {
         let sessionA = try activeSessionID()
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.split","target":"\#(sessionA)","args":{"mode":"on"}}"#)["ok"] as? Bool,
@@ -376,15 +321,12 @@ final class PaneAwareStatusUITests: ControlAPITestCase {
         XCTAssertTrue(try pollOnScreen(target: sessionA, contains: "\(leftTag)-42"),
                       "with the left pane focused, the on-screen surface should be the main pane")
 
-        // block the right pane, then park on a fresh IDLE session so the blocked A is the ONLY attention row.
+        // park on a fresh IDLE session so the blocked A is the ONLY attention row and Return picks it.
         try blockPane("right", target: sessionA)
         XCTAssertEqual(try statusPane(of: sessionA), "right", "the block should be tagged right")
         _ = try parkOnNewSession()
 
         openAttentionPalette()
-        // A is the only non-idle session, so Return on the top match selects it; re-send Return each tick
-        // since a menu-opened palette can settle field focus a beat after it mounts (the pollReturnSelects
-        // idiom from AttentionButtonUITests).
         XCTAssertTrue(try pollReturnSelects(sessionA, timeout: 12), "choosing the attention row should select the blocked session")
 
         XCTAssertTrue(try pollOnScreen(target: sessionA, contains: "\(rightTag)-42"),
@@ -393,11 +335,6 @@ final class PaneAwareStatusUITests: ControlAPITestCase {
         XCTAssertFalse(onScreen.contains("\(leftTag)-42"), "the revealed right pane must not carry the main pane's marker")
     }
 
-    // regression: selecting a session that merely has its scratch SHOWN — with NO agent status (idle) — must
-    // LEAVE the scratch shown. Before the idle-gate, `revealActiveBlockedPane` hid the scratch whenever
-    // `statusPane` was nil (`nil != .scratch` is true) on EVERY selection, so a plain sidebar click to an idle
-    // session dismissed its scratch. Now an idle session is a pure no-op. A stay-shown poll (not a single
-    // read) is used so the async reveal can't false-pass by hiding the scratch a beat after the first check.
     func testSelectingIdleSessionKeepsShownScratch() throws {
         let sessionA = try activeSessionID()
         let rowName = "PAWIDLE-\(UUID().uuidString.prefix(8))"
@@ -408,21 +345,18 @@ final class PaneAwareStatusUITests: ControlAPITestCase {
         let scratchTag = "PAWIS-\(UUID().uuidString.prefix(8))"
         try seedPaneMarker(target: sessionA, pane: "left", tag: mainTag)
 
-        // show the scratch and seed it; leave it SHOWN. the session stays IDLE (no session.status at all).
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.scratch","target":"\#(sessionA)","args":{"mode":"on"}}"#)["ok"] as? Bool,
                        true, "scratch on should succeed")
         XCTAssertTrue(try pollScratch(id: sessionA, equals: true, timeout: 10), "the scratch should be shown")
         try seedPaneMarker(target: sessionA, pane: "scratch", tag: scratchTag)
         XCTAssertNil(try statusPane(of: sessionA), "sanity: an idle session carries no status pane")
 
-        // park the selection on a fresh session, then click BACK to the idle session's row — a GUI selection
-        // that runs the reveal, which must be a no-op for the idle session and NOT hide its scratch.
         _ = try parkOnNewSession()
         clickSessionRow(named: rowName)
         XCTAssertTrue(try pollActiveNode(equals: sessionA, timeout: 12), "clicking the row should select the idle session")
 
-        // the sidebar-click reveal is dispatched async; poll across its window and require the scratch stays
-        // shown on EVERY tick (a single read could catch it before the pre-fix reveal hid it).
+        // the reveal is async, so require the scratch stays shown on EVERY tick — a single read could sample
+        // before a wrongly-firing reveal hid it.
         var stayedShown = true
         for _ in 0..<8 {
             usleep(250_000)
@@ -435,11 +369,8 @@ final class PaneAwareStatusUITests: ControlAPITestCase {
         XCTAssertFalse(onScreen.contains("\(mainTag)-42"), "the idle-session selection must not dismiss the scratch to the main pane")
     }
 
-    // #199 end-to-end: `session.status --pane-id <token>` resolves the surface's LIVE slot and overrides a
-    // stale `--pane` role. Read the MAIN pane's real `$AGTERM_PANE_ID` from its shell (the exact value the
-    // agent-status hook forwards), then set a status carrying that main-slot token but the WRONG role
-    // (--pane right) — the promoted-survivor shape. The tree read-back must report `left` (the token won),
-    // and an unknown token must fall back to the baked `--pane right`.
+    // #199: the token read from the MAIN pane's shell is paired with the WRONG role (--pane right) — the
+    // promoted-survivor shape — so `left` in the read-back can only come from the token winning.
     func testPaneIDOverridesStaleRoleThenFallsBack() throws {
         let sessionA = try activeSessionID()
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.split","target":"\#(sessionA)","args":{"mode":"on"}}"#)["ok"] as? Bool,
@@ -449,13 +380,11 @@ final class PaneAwareStatusUITests: ControlAPITestCase {
         let mainToken = try readPaneToken(target: sessionA, pane: "left")
         XCTAssertFalse(mainToken.isEmpty, "the main pane's shell should expose a non-empty AGTERM_PANE_ID")
 
-        // --pane-id resolves to the main slot and OVERRIDES the stale --pane right → statusPane reads left.
         XCTAssertEqual(try sendStatus(target: sessionA, pane: "right", paneID: mainToken)["ok"] as? Bool, true,
                        "session.status with --pane-id should succeed")
         XCTAssertEqual(try statusPane(of: sessionA), "left",
                        "a main-slot --pane-id must override the stale --pane right (#199)")
 
-        // an UNKNOWN token resolves to nothing and falls back to the baked --pane right (pre-token behavior).
         XCTAssertEqual(try sendStatus(target: sessionA, pane: "right", paneID: "not-a-real-token")["ok"] as? Bool, true,
                        "session.status with a bogus --pane-id should still succeed")
         XCTAssertEqual(try statusPane(of: sessionA), "right",

--- a/agtermUITests/QuickTerminalUITests.swift
+++ b/agtermUITests/QuickTerminalUITests.swift
@@ -36,40 +36,32 @@ final class QuickTerminalUITests: XCTestCase {
     func testCloseSessionShortcutHidesQuickTerminalInsteadOfClosingSession() throws {
         let (mainTTY, _) = try openQuickTerminalRecordingTTYs()
 
-        // ⌘W with the quick terminal up must DISMISS it, NOT close the session underneath.
         app.typeKey("w", modifierFlags: .command)
         usleep(900_000)
 
-        // the session survives (the bug closed the session behind the quick terminal instead).
         XCTAssertTrue(app.staticTexts["session-row"].exists, "⌘W must not close the session behind the quick terminal")
         XCTAssertEqual(app.staticTexts.matching(identifier: "session-row").count, 1, "no session should be closed")
 
-        // focus returned to the original session (the quick terminal hid), so its tty matches the main shell.
         let afterTTY = ttyAfterCommand(named: "after")
         XCTAssertEqual(afterTTY, mainTTY, "⌘W hid the quick terminal and refocused the session")
     }
 
-    // ⌘W must dismiss the quick terminal even when the window has NO active session (the cover guard lives
-    // in closeActiveSession, not the menu gate). Regression for the bug where the menu's old
-    // `if activeSession != nil` gate fell through to performClose and closed the window with the cover up.
+    // the cover guard lives in closeActiveSession, not the menu gate.
     func testCloseSessionShortcutWithNoSessionKeepsWindowAndDismissesQuickTerminal() throws {
         let row = app.staticTexts["session-row"]
         XCTAssertTrue(row.waitForExistence(timeout: 20), "seeded session should exist")
         row.click()
         usleep(500_000)
 
-        // ⌘W with no cover closes the only session, emptying the window to zero sessions (no-cover fall-through).
         app.typeKey("w", modifierFlags: .command)
         XCTAssertTrue(row.waitForNonExistence(timeout: 10), "⌘W with no cover should close the only session")
 
-        // open the quick terminal over the now session-less window; the cover element proves it is shown.
         let button = app.buttons["quick-terminal-toggle"]
         XCTAssertTrue(button.waitForExistence(timeout: 5), "quick-terminal toolbar button should exist")
         button.click()
         let cover = app.descendants(matching: .any).matching(identifier: "quick-terminal").firstMatch
         XCTAssertTrue(cover.waitForExistence(timeout: 5), "the quick terminal cover should be shown")
 
-        // ⌘W must DISMISS the quick terminal (cover gone) and NOT close the (last) window (toolbar survives).
         app.typeKey("w", modifierFlags: .command)
         XCTAssertTrue(cover.waitForNonExistence(timeout: 10), "⌘W should dismiss the quick terminal cover")
         XCTAssertTrue(app.buttons["quick-terminal-toggle"].waitForExistence(timeout: 10),

--- a/agtermUITests/RecentSessionsButtonUITests.swift
+++ b/agtermUITests/RecentSessionsButtonUITests.swift
@@ -2,19 +2,15 @@ import XCTest
 
 /// End-to-end tests for the title-bar recent-sessions button — the mouse equivalent of the Ctrl-Tab
 /// switcher. It opens a popover of the window's most-recently-used sessions; clicking a row commits the
-/// switch. The button is disabled until there are at least two sessions to switch between. Subclasses the
-/// shared control harness for the isolated launch + socket (`session.new`/`session.rename`) and the
-/// `selectedSessionID` snapshot oracle.
+/// switch. The button is disabled until there are at least two sessions to switch between.
 ///
 /// SCOPE NOTE: the row CLICK → session switch cannot be driven from XCUITest — a synthesized click (element
 /// OR coordinate) on a SwiftUI `Button` inside an `NSPopover` does not fire the button's action (confirmed
-/// by instrumenting the row action: the marker never wrote). A real mouse click works because it makes the
-/// popover key. So these tests cover the button's enable/disable and that the popover OPENS and LISTS the
-/// correct previous session; the click → `selectSession` glue (already unit-tested in agtermCore) is verified
-/// by hand in the app, like other non-AX-observable behaviors (see ui-tests.md).
+/// by instrumenting the row action: the marker never wrote), while a real mouse click does, because it makes
+/// the popover key. So these tests cover the enable/disable state and that the popover OPENS and LISTS the
+/// correct previous session; the click → `selectSession` glue is verified by hand (see ui-tests.md).
 @MainActor
 final class RecentSessionsButtonUITests: ControlAPITestCase {
-    // one session at launch → the button is present but disabled; adding a second session enables it live.
     func testRecentButtonEnablesWithSecondSession() throws {
         let button = app.buttons["recent-sessions-button"]
         XCTAssertTrue(button.waitForExistence(timeout: 10), "the recent-sessions button should render in the title bar")
@@ -24,8 +20,7 @@ final class RecentSessionsButtonUITests: ControlAPITestCase {
         XCTAssertTrue(pollEnabled(button, true, timeout: 8), "a second session should enable the recent-sessions button")
     }
 
-    // with two sessions, clicking the button opens the popover; it lists the previously-selected session as
-    // the clickable jump row (identified by a unique rename). The current session is omitted (not a jump target).
+    // the previous session gets a unique rename so its jump row can be told apart by label.
     func testRecentButtonPopoverListsPreviousSession() throws {
         let seeded = try activeSessionID()
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.rename","target":"\#(seeded)","args":{"name":"prevsession"}}"#)["ok"] as? Bool,
@@ -42,7 +37,6 @@ final class RecentSessionsButtonUITests: ControlAPITestCase {
         XCTAssertTrue(jumpRow.exists, "clicking the button should open the popover with the previous session as a jump row")
         XCTAssertTrue(jumpRow.label.contains("prevsession"),
                       "the jump row should be the previously-selected (renamed) session, got label: \(jumpRow.label)")
-        // the current (new) session is NOT listed — it isn't a jump target, so the only row is the previous one.
         XCTAssertEqual(app.buttons.matching(identifier: "recent-session-row").count, 1,
                        "the popover should list only the single other session, not the current one")
     }

--- a/agtermUITests/ReorderUITests.swift
+++ b/agtermUITests/ReorderUITests.swift
@@ -11,8 +11,8 @@ final class ReorderUITests: XCTestCase {
 
     override func setUp() async throws {
         continueAfterFailure = false
-        // hermetic state: a fresh temp dir per test so the app seeds exactly one
-        // "workspace 1" + one session, and we never touch the real workspaces.json.
+        // a fresh temp dir per test seeds exactly one "workspace 1" + one session and keeps the real
+        // workspaces.json untouched.
         stateDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("agterm-uitest-\(UUID().uuidString)", isDirectory: true)
         app = XCUIApplication()
@@ -25,10 +25,8 @@ final class ReorderUITests: XCTestCase {
         if let stateDir { try? FileManager.default.removeItem(at: stateDir) }
     }
 
-    // Drag a session UP onto a higher sibling and confirm the persisted order changed through the
-    // full sidebar drop path (validateDrop → acceptDrop → moveSessions). Three sessions are seeded with
-    // aaa/bbb/ccc custom names so the persisted order is an unambiguous oracle. Dropping ccc ON
-    // aaa's row inserts ccc just after aaa: [aaa, bbb, ccc] → [aaa, ccc, bbb].
+    // the aaa/bbb/ccc custom names make the persisted order an unambiguous oracle; dropping ON a row
+    // inserts just AFTER it, so ccc onto aaa gives [aaa, ccc, bbb].
     func testReorderSessionUp() throws {
         try relaunchWithSessions(["aaa", "bbb", "ccc"])
         dragRow(named: "ccc", onto: "aaa")
@@ -36,10 +34,8 @@ final class ReorderUITests: XCTestCase {
                       "dragging ccc up onto aaa should reorder to [aaa, ccc, bbb]")
     }
 
-    // Drag a session DOWN onto a lower sibling. Dropping bbb ON ccc's row inserts bbb just after
-    // ccc: [aaa, bbb, ccc] → [aaa, ccc, bbb]. The downward path exercises the same-workspace
-    // `childIndex - 1` post-removal adjustment in `acceptDrop` (sourceIndex 1 < dropChildIndex 3)
-    // that the up-move does not.
+    // the downward path exercises the same-workspace `childIndex - 1` post-removal adjustment in
+    // `acceptDrop` (sourceIndex 1 < dropChildIndex 3) that the up-move does not.
     func testReorderSessionDown() throws {
         try relaunchWithSessions(["aaa", "bbb", "ccc"])
         dragRow(named: "bbb", onto: "ccc")
@@ -47,11 +43,8 @@ final class ReorderUITests: XCTestCase {
                       "dragging bbb down onto ccc should reorder to [aaa, ccc, bbb]")
     }
 
-    // Drag a session DOWN onto a MIDDLE row (not the last). With four sessions [aaa, bbb, ccc, ddd],
-    // dragging aaa onto ccc's row inserts aaa just after ccc → [bbb, ccc, aaa, ddd]. This discriminates
-    // the same-workspace downward `childIndex - 1` post-removal adjustment: WITH it the session lands at
-    // index 2 ([bbb, ccc, aaa, ddd]); WITHOUT it the append-clamp would push it to the END
-    // ([bbb, ccc, ddd, aaa]) — the two outcomes differ only because the drop is NOT onto the last row.
+    // the drop must NOT be onto the last row, or the two outcomes coincide: with the `childIndex - 1`
+    // post-removal adjustment aaa lands at index 2, without it the append-clamp pushes it to the END.
     func testReorderSessionDownPastMiddle() throws {
         try relaunchWithSessions(["aaa", "bbb", "ccc", "ddd"])
         dragRow(named: "aaa", onto: "ccc")
@@ -59,10 +52,8 @@ final class ReorderUITests: XCTestCase {
                       "dragging aaa down onto the middle row ccc should land it between ccc and ddd")
     }
 
-    // Shift-click creates a range, Command-click toggles one row out, and right-clicking inside the
-    // remaining multi-selection must keep it for batch context-menu actions. Right-clicking outside the
-    // selection should narrow to that clicked row. The oracle is the persisted flag state because AppKit's
-    // transient outline multi-selection is not serialized.
+    // the oracle is the persisted flag state because AppKit's transient outline multi-selection is not
+    // serialized.
     func testMultiSelectContextMenuKeepsAndNarrowsSelection() throws {
         try relaunchWithSessions(["aaa", "bbb", "ccc", "ddd"])
 
@@ -85,9 +76,7 @@ final class ReorderUITests: XCTestCase {
                       "outside right-click should flag only the clicked row")
     }
 
-    // Dragging from any selected row should move the whole selected block, not just the row under the
-    // pointer. Dropping bbb/ccc onto ddd inserts the block after ddd:
-    // [aaa, bbb, ccc, ddd, eee] -> [aaa, ddd, bbb, ccc, eee].
+    // the block inserts after ddd, so [aaa, bbb, ccc, ddd, eee] -> [aaa, ddd, bbb, ccc, eee].
     func testDragSelectedSessionsMovesBlock() throws {
         try relaunchWithSessions(["aaa", "bbb", "ccc", "ddd", "eee"])
         sessionRow(named: "bbb").click()
@@ -98,8 +87,6 @@ final class ReorderUITests: XCTestCase {
                       "dragging a selected block onto ddd should move bbb+ccc together after ddd")
     }
 
-    // The primary batch-drag workflow is cross-workspace: the AppKit pasteboard must carry every selected
-    // id, resolve the destination row's owning workspace, and persist the ordered block there.
     func testDragSelectedSessionsAcrossWorkspacesMovesBlock() throws {
         try relaunchWithWorkspaces([
             (name: "one", sessions: ["aaa", "bbb"]),
@@ -120,8 +107,7 @@ final class ReorderUITests: XCTestCase {
         ], timeout: 10), "the selected block should move after ccc in workspace two")
     }
 
-    // Confirmation is normally bypassed in XCUITests. This test opts in narrowly and verifies the exact
-    // batch-close regression: one alert names the selected count, and Cancel leaves every session intact.
+    // XCUITest launches suppress the close modal; `confirmClose: true` opts this one test back into it.
     func testMultiSessionCloseRequiresOneConfirmation() throws {
         try relaunchWithWorkspaces([
             (name: "workspace 1", sessions: ["aaa", "bbb", "ccc"]),
@@ -143,10 +129,6 @@ final class ReorderUITests: XCTestCase {
                       "cancelling the batch confirmation must leave every session open")
     }
 
-    // Drag a workspace UP above a higher sibling and confirm the persisted order changed through the
-    // full sidebar drop path (validateDrop → acceptDrop → moveWorkspace). Three workspaces are created
-    // (workspace 1/2/3). Dropping "workspace 3" near the TOP edge of "workspace 1" lands a top-level
-    // between-rows drop above it: [workspace 1, workspace 2, workspace 3] → [workspace 3, workspace 1, workspace 2].
     func testReorderWorkspace() throws {
         seedThreeWorkspaces()
         dragWorkspaceRow(named: "workspace 3", toTopOf: "workspace 1")
@@ -154,14 +136,10 @@ final class ReorderUITests: XCTestCase {
                       "dragging workspace 3 above workspace 1 should reorder to [workspace 3, workspace 1, workspace 2]")
     }
 
-    // Drop a workspace onto a SESSION row that belongs to another workspace — the realistic case the
-    // edge-sliver test misses. With workspaces expanded (each holding sessions, like the real app), the
-    // space between workspace rows is filled with session rows, so a dragged workspace lands ON a session
-    // (or workspace) row, which AppKit proposes as `item != nil`. The original `guard item == nil` rejected
-    // every such drop (the reported "can't drag workspaces" bug). Dropping workspace 3 onto workspace 1's
-    // session row reorders it just after its owning workspace: [w1, w2, w3] → [w1, w3, w2].
+    // with workspaces expanded their session rows fill the space between workspace rows, so a dragged
+    // workspace lands ON a row, which AppKit proposes as `item != nil` rather than a root between-rows slot.
     func testReorderWorkspaceOntoSessionRow() throws {
-        seedThreeWorkspaces() // workspace 1 keeps the seeded session; 2 and 3 are empty
+        seedThreeWorkspaces()
         dragWorkspaceOntoSessionRow(named: "workspace 3")
         XCTAssertTrue(pollWorkspaceNames(["workspace 1", "workspace 3", "workspace 2"], timeout: 10),
                       "dropping workspace 3 onto workspace 1's session row should land it after workspace 1 → [w1, w3, w2]")
@@ -258,7 +236,6 @@ final class ReorderUITests: XCTestCase {
         from.click()
         RunLoop.current.run(until: Date().addingTimeInterval(0.2))
         let start = from.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
-        // the top sliver of the target → NSOutlineView proposes a drop above it at the top level.
         let end = to.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.05))
         start.click(forDuration: 0.7, thenDragTo: end, withVelocity: 180, thenHoldForDuration: 0.25)
     }
@@ -295,8 +272,7 @@ final class ReorderUITests: XCTestCase {
         let to = sessionRow(named: target)
         XCTAssertTrue(from.waitForHittable(timeout: 10), "\(source) row should be hittable to drag")
         XCTAssertTrue(to.waitForHittable(timeout: 10), "\(target) row should be hittable as a drop target")
-        // select the source row first: the outline only begins a drag from the selected row, so an
-        // unselected source (e.g. a middle row that wasn't the last one touched) never starts a drag.
+        // the outline only begins a drag from the SELECTED row, so an unselected source never starts one.
         from.click()
         RunLoop.current.run(until: Date().addingTimeInterval(0.2))
         let start = from.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))

--- a/agtermUITests/RestoreCommandUITests.swift
+++ b/agtermUITests/RestoreCommandUITests.swift
@@ -25,8 +25,7 @@ final class RestoreCommandUITests: XCTestCase {
         app = XCUIApplication()
         app.launchEnvironment["AGTERM_STATE_DIR"] = stateDir.path
         // short socket path in the runner's temp dir: under the ~104-byte sun_path limit AND inside the
-        // runner sandbox (the long per-test stateDir subdir + /tmp both fail); used to create a --command
-        // session over the control channel.
+        // runner sandbox (the long per-test stateDir subdir + /tmp both fail).
         socketPath = (NSTemporaryDirectory() as NSString)
             .appendingPathComponent("agtermr-\(UUID().uuidString.prefix(8)).sock")
         app.launchEnvironment["AGTERM_CONTROL_SOCKET"] = socketPath
@@ -43,7 +42,6 @@ final class RestoreCommandUITests: XCTestCase {
         app.launchForUITest()
         runTeeMarker()
 
-        // delete the marker, quit (applicationWillTerminate captures the foreground `tee`), relaunch.
         try FileManager.default.removeItem(at: marker)
         gracefulQuit()
         app.launchForUITest()
@@ -61,7 +59,6 @@ final class RestoreCommandUITests: XCTestCase {
         gracefulQuit()
         app.launchForUITest()
 
-        // flag off → nothing captured at quit → `tee` is not re-run → the marker stays gone.
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "session restored")
         RunLoop.current.run(until: Date().addingTimeInterval(2)) // give any (incorrect) re-run a chance to fire
         XCTAssertFalse(FileManager.default.fileExists(atPath: marker.path),
@@ -69,11 +66,9 @@ final class RestoreCommandUITests: XCTestCase {
     }
 
     func testRestoreReRunsShellScriptWrapper() throws {
-        // a shell RUNNING a command (argv0 a shell WITH a payload arg) must be captured, not skipped as an
-        // idle prompt. The real `cld` claude-code launcher is a `#!/bin/sh` wrapper whose foreground is
-        // `/bin/sh <script>`; this uses `sh -c 'tee …; true'` (a compound list, so sh stays the foreground
-        // with a payload arg) because the XCUITest runner can't drop an executable script the sandboxed app
-        // is allowed to run. Same isIdleShell path: a shell with a payload is captured.
+        // the real `cld` launcher is a `#!/bin/sh` wrapper whose foreground is `/bin/sh <script>`. This
+        // stands in with `sh -c 'tee …; true'` (a compound list keeps sh the foreground, with a payload
+        // arg) because the XCUITest runner cannot drop an executable script the sandboxed app may run.
         seedRestoreFlag(true)
         app.launchForUITest()
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session row")
@@ -92,8 +87,7 @@ final class RestoreCommandUITests: XCTestCase {
     func testRestoreSkipsIdleShellPane() throws {
         seedRestoreFlag(true)
         app.launchForUITest()
-        // leave the pane at its prompt (no command run), then quit. Capture runs (flag on), but the idle
-        // login shell — argv0 `-/bin/zsh`, recognized by isKnownShell — must NOT be captured as a command.
+        // the idle login shell (argv0 `-/bin/zsh`) must not be captured even with the flag on
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session")
         RunLoop.current.run(until: Date().addingTimeInterval(1))
         gracefulQuit()
@@ -101,10 +95,8 @@ final class RestoreCommandUITests: XCTestCase {
                       "an idle login-shell pane must not be captured as a foreground command, got \(capturedForegroundCommands())")
     }
 
-    // A `session.new --command` session persists its command and re-runs it via the EXEC path on restore
-    // when the feature is on — the command-session analogue of the foreground path. `tee <marker>` as the
-    // command exec-replaces the shell (so libghostty reports no foreground and NOTHING is captured), which
-    // proves the restore comes from the persisted `initialCommand`, not a captured foreground.
+    // `tee <marker>` as the command exec-replaces the shell, so libghostty reports no foreground and
+    // NOTHING is captured — the re-run can only come from the persisted `initialCommand`.
     func testRestoreReRunsCommandSession() throws {
         seedRestoreFlag(true)
         app.launchForUITest()
@@ -132,7 +124,6 @@ final class RestoreCommandUITests: XCTestCase {
         try FileManager.default.removeItem(at: marker)
         gracefulQuit()
         app.launchForUITest()
-        // flag off → a restored --command session comes back a plain shell → tee is not re-run → marker gone.
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "session restored")
         RunLoop.current.run(until: Date().addingTimeInterval(2)) // give any (incorrect) re-run a chance to fire
         XCTAssertFalse(FileManager.default.fileExists(atPath: marker.path),
@@ -141,9 +132,8 @@ final class RestoreCommandUITests: XCTestCase {
 
     // MARK: - session.restore override
 
-    // A pinned override wins over the pane's captured foreground command. BOTH markers are deleted before
-    // quitting, so the proof is two-sided: the override's marker reappears and the captured command's does
-    // not (testRestoreReRunsForegroundCommand proves the capture would otherwise re-run).
+    // BOTH markers are deleted before quitting, so the proof is two-sided: the override's marker reappears
+    // and the captured command's does not (testRestoreReRunsForegroundCommand proves it would otherwise).
     func testRestoreOverrideBeatsCapturedCommand() throws {
         seedRestoreFlag(true)
         app.launchForUITest()
@@ -161,9 +151,8 @@ final class RestoreCommandUITests: XCTestCase {
                        "the captured foreground command must not run when an override is pinned")
     }
 
-    // Stickiness: the override is consumed from a TRANSIENT payload, never off the persisted field, so it
-    // fires again on the NEXT launch with no re-pinning. A single relaunch cannot prove this — it passes
-    // even against an implementation that nils the persisted field on consume — so this runs two.
+    // one relaunch cannot prove stickiness — it passes even against an implementation that nils the
+    // persisted field on consume — so this runs two.
     func testRestoreOverrideStaysPinnedAcrossTwoRelaunches() throws {
         seedRestoreFlag(true)
         app.launchForUITest()
@@ -174,8 +163,7 @@ final class RestoreCommandUITests: XCTestCase {
         XCTAssertTrue(poll { FileManager.default.fileExists(atPath: self.overrideMarker.path) },
                       "the pinned override should fire on the first relaunch")
 
-        // relaunch AGAIN without re-pinning. `touch` exits, leaving an idle shell, so the quit captures
-        // nothing — only the sticky persisted override can recreate the marker.
+        // `touch` exits, so this quit captures nothing — only the sticky override can recreate the marker
         try FileManager.default.removeItem(at: overrideMarker)
         gracefulQuit()
         XCTAssertTrue(capturedForegroundCommands().isEmpty,
@@ -185,8 +173,6 @@ final class RestoreCommandUITests: XCTestCase {
                       "the override must fire again on the second relaunch — it is sticky, not consumed")
     }
 
-    // `--none` pins the pane to nothing: the captured foreground command is suppressed and the pane comes
-    // back a plain shell.
     func testRestoreOverrideNonePinsPlainShell() throws {
         seedRestoreFlag(true)
         app.launchForUITest()
@@ -203,7 +189,6 @@ final class RestoreCommandUITests: XCTestCase {
                        "a pane pinned to nothing must restore a plain shell, not the captured command")
     }
 
-    // `--clear` drops the override, so the pane goes back to restoring its captured foreground command.
     func testRestoreOverrideClearRestoresCapture() throws {
         seedRestoreFlag(true)
         app.launchForUITest()
@@ -222,8 +207,7 @@ final class RestoreCommandUITests: XCTestCase {
                        "a cleared override must not run")
     }
 
-    // The override obeys the global restore-running-command setting: with it off the pane is a plain
-    // shell, and the response says so up front (a hook author would otherwise see a silent no-op).
+    // the response says the setting is off up front; a hook author would otherwise see a silent no-op.
     func testRestoreOverrideDoesNotFireWithRestoreOff() throws {
         seedRestoreFlag(false)
         app.launchForUITest()
@@ -240,9 +224,8 @@ final class RestoreCommandUITests: XCTestCase {
                        "with the restore setting off, a pinned override must not run")
     }
 
-    // The split pane has its own override slot and its own restore path (`makeSplitSurface` bypasses
-    // `restorePlan` entirely). With a SHOWN split, the right pane's override must beat the right pane's
-    // capture while the MAIN pane, which has neither an override nor a change, still restores its own.
+    // the split pane has its own override slot and its own restore path — `makeSplitSurface` bypasses
+    // `restorePlan` entirely. The main pane, pinned to nothing, still restores its own capture.
     func testRestoreOverrideOnSplitPane() throws {
         seedRestoreFlag(true)
         app.launchForUITest()
@@ -268,10 +251,9 @@ final class RestoreCommandUITests: XCTestCase {
                       "the main pane is unaffected: its own captured command still restores")
     }
 
-    // A split HIDDEN at quit is not rebuilt, so its override describes a pane that no longer exists: it is
-    // dropped on the restore (`tree` stops reporting it), nothing is armed for it, and a fresh ⌘D split is
-    // a plain shell. The SECOND relaunch is what proves the drop: quitting with that fresh split SHOWN
-    // would otherwise re-arm the stale pin into an unrelated pane's shell.
+    // a split HIDDEN at quit is not rebuilt, so its override describes a pane that no longer exists. The
+    // SECOND relaunch is what proves the drop: quitting with the fresh split SHOWN would otherwise re-arm
+    // the stale pin into an unrelated pane's shell.
     func testRestoreOverrideHiddenSplitDoesNotFireOnFreshSplit() throws {
         seedRestoreFlag(true)
         app.launchForUITest()
@@ -289,14 +271,11 @@ final class RestoreCommandUITests: XCTestCase {
         XCTAssertNil(try firstSessionNode()["splitRestoreCommand"],
                      "the split is gone, so its override is dropped rather than left unclearable on `tree`")
 
-        // ⌘D opens a FRESH split, which must be a plain shell.
         openFreshSplit()
         RunLoop.current.run(until: Date().addingTimeInterval(3)) // give any (incorrect) fire a chance
         XCTAssertFalse(FileManager.default.fileExists(atPath: overrideMarker.path),
                        "a split opened mid-session must be a plain shell — the pinned override must not fire")
 
-        // quit with the FRESH split SHOWN and relaunch: that split IS rebuilt, so a stale pin surviving
-        // the first restore would arm here and type a dead pane's command into an unrelated shell.
         gracefulQuit()
         app.launchForUITest()
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 30), "session restored")
@@ -306,9 +285,8 @@ final class RestoreCommandUITests: XCTestCase {
         XCTAssertNil(try firstSessionNode()["splitRestoreCommand"], "and it must still read back as unpinned")
     }
 
-    // The split pane's DEFAULT path: with no override pinned, the right pane restores its own captured
-    // foreground command. `makeSplitSurface` bypasses `restorePlan` and decides with `restoreInput` alone,
-    // so the nil-override branch needs its own guard — the override tests all exercise the other one.
+    // `makeSplitSurface` decides with `restoreInput` alone, so the nil-override branch needs its own
+    // guard — the override tests all exercise the other one.
     func testSplitPaneRestoresCapturedCommandWithoutOverride() throws {
         seedRestoreFlag(true)
         app.launchForUITest()
@@ -326,9 +304,8 @@ final class RestoreCommandUITests: XCTestCase {
                       "with no override pinned, the split pane re-runs its captured foreground command")
     }
 
-    // Reopening a CLOSED WINDOW mid-process reloads its store through the same `restore(from:)` the
-    // bootstrap uses, but must NOT arm anything: overrides fire on an app launch only. Arming here would
-    // execute every sticky override the moment a user closes and reopens a window.
+    // a window reopen reloads its store through the same `restore(from:)` the bootstrap uses, but must NOT
+    // arm: that would execute every sticky override the moment a user closes and reopens a window.
     func testWindowReopenDoesNotArmTheOverride() throws {
         seedRestoreFlag(true)
         app.launchForUITest()
@@ -345,14 +322,12 @@ final class RestoreCommandUITests: XCTestCase {
         assertOverrideHasNotFired("a mid-process window reopen is not a launch restore, so nothing may fire")
     }
 
-    // `setRestoreCommand` persists eagerly, so a hook's write survives a force quit. `terminate()` is
-    // SIGKILL — no `applicationWillTerminate`, so neither the capture nor the quit-flush runs, and only
-    // that immediate `save()` can carry the override to the next launch.
+    // `terminate()` is SIGKILL — no `applicationWillTerminate`, so neither the capture nor the quit-flush
+    // runs, and only `setRestoreCommand`'s eager `save()` can carry the override to the next launch.
     func testRestoreOverrideSurvivesForceQuit() throws {
         seedRestoreFlag(true)
         app.launchForUITest()
         try pinRestore(mode: "set", command: touchLine(overrideMarker))
-        // without this the test cannot tell a restore-time fire from an immediate one at pin time.
         assertOverrideHasNotFired("the pin must not run in the live session")
 
         app.terminate()
@@ -464,10 +439,8 @@ final class RestoreCommandUITests: XCTestCase {
 
     /// Type `tee <marker>` into the focused terminal and confirm it created the marker (so it is the live
     /// foreground process — `tee` opens its output file on start, then blocks reading the terminal).
-    /// The injection is RETRIED (the `typeUntilMarker` idiom): a freshly realized surface's shell may not
-    /// be reading yet when the first keystrokes land — a slow launch under full-class load drops them and
-    /// leaves the pane at its prompt with nothing to capture. ⌃U clears the line editor before a retry so
-    /// a half-typed line can't concatenate into a bogus path.
+    /// The injection is RETRIED: a freshly realized surface's shell may not be reading yet when the first
+    /// keystrokes land. ⌃U clears the line editor first so a half-typed line can't build a bogus path.
     private func runTeeMarker() {
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session row")
         for attempt in 0..<3 {

--- a/agtermUITests/SearchUITests.swift
+++ b/agtermUITests/SearchUITests.swift
@@ -2,10 +2,8 @@ import XCTest
 
 /// End-to-end test for the in-terminal search bar. The terminal surface is a Metal
 /// `GhosttySurfaceView` with no readable accessibility text, so the oracle is the bar's
-/// `search-counter` StaticText: pressing ⌘F sends `start_search`, typing a needle sends
-/// `search:<needle>`, and the START_SEARCH/SEARCH_TOTAL callbacks populate the counter. A
-/// non-empty "N of M" / "M matches" counter therefore confirms the libghostty binding-action
-/// strings actually fire end-to-end (the deferred empirical check Task 5 could not run headlessly).
+/// `search-counter` StaticText, populated by the START_SEARCH/SEARCH_TOTAL callbacks — a non-empty
+/// "N of M" / "M matches" counter is what confirms the libghostty binding-action strings fire.
 @MainActor
 final class SearchUITests: XCTestCase {
     private var app: XCUIApplication!
@@ -25,87 +23,63 @@ final class SearchUITests: XCTestCase {
         if let stateDir { try? FileManager.default.removeItem(at: stateDir) }
     }
 
-    // ⌘F opens the bar; typing a needle that appears repeatedly on screen (the echoed command line
-    // plus its output both carry the token) round-trips through start_search + search:<needle> and the
-    // SEARCH_TOTAL callback, so the counter reports matches — which confirms the binding strings fire.
     func testSearchBarOpensTypesAndCounts() throws {
         selectSeededSession()
 
-        // put a known, repeated token on screen: the typed command line AND its echoed output both
-        // contain "agtermFINDME", guaranteeing at least two matches in the scrollback.
+        // the typed command line AND its echoed output both carry the token, so there are ≥2 matches.
         app.typeText("echo agtermFINDME agtermFINDME")
         app.typeKey(.return, modifierFlags: [])
 
-        // ⌘F opens the search bar over the focused pane.
         app.typeKey("f", modifierFlags: .command)
         let field = app.textFields["search-field"]
         XCTAssertTrue(field.waitForExistence(timeout: 5), "⌘F should open the search bar with a search-field")
 
-        // type the needle; the bar's binding drives search:<needle> on each keystroke. the echoed line
-        // render + the async SEARCH_TOTAL callback can lag, so re-send the needle until a real match
-        // count settles (NOT "no matches", which the echo-not-yet-rendered case would briefly show). the
-        // counter StaticText is empty (absent from the AX tree) until a count lands, so it's looked up
-        // INSIDE the poll, only after the needle is sent.
         let label = waitForMatchLabel(field: field, needle: "agtermFINDME", timeout: 12)
         let resolved = try XCTUnwrap(label, "the search counter should report a match count (binding strings fired)")
         XCTAssertTrue(resolved.contains("of") || resolved.contains("matches"),
                       "counter should read 'N of M' or 'M matches', got '\(resolved)'")
     }
 
-    // While the quick terminal covers the session, ⌘F must NOT open the search bar over the hidden pane
-    // (a covered, focus-stealing bar). The OPEN is gated when a covering surface is up; the search-field
-    // must NOT appear.
     func testSearchDoesNotOpenWhileQuickTerminalCovers() throws {
         selectSeededSession()
 
-        // open the quick terminal — a window-level cover over the session.
         let qtButton = app.buttons["quick-terminal-toggle"]
         XCTAssertTrue(qtButton.waitForExistence(timeout: 5), "quick-terminal toolbar button should exist")
         qtButton.click()
         // drain the run loop so the panel is up before ⌘F.
         RunLoop.current.run(until: Date().addingTimeInterval(0.9))
 
-        // ⌘F goes through the Find menu key-equivalent; it must no-op while the cover is up.
         app.typeKey("f", modifierFlags: .command)
         let field = app.textFields["search-field"]
         XCTAssertFalse(field.waitForExistence(timeout: 3),
                        "⌘F while the quick terminal covers the session must NOT open a hidden search bar")
     }
 
-    // Search works IN the scratch terminal: with the scratch shown, ⌘F opens the bar over the scratch
-    // surface (not the hidden pane underneath), and typing a needle that appears in the scratch's
-    // scrollback round-trips through start_search + search:<needle> so the counter reports matches.
     func testSearchOpensOverScratch() throws {
         selectSeededSession()
 
-        // open the scratch terminal — a full-coverage layer over the session; autoFocus puts first
-        // responder in the scratch shell, so typeText goes to it.
         let scratchButton = app.buttons["scratch-toggle"]
         XCTAssertTrue(scratchButton.waitForExistence(timeout: 5), "scratch toolbar button should exist")
         scratchButton.click()
         RunLoop.current.run(until: Date().addingTimeInterval(0.9))
 
-        // put a known, repeated token in the SCRATCH scrollback: the typed line and its echoed output
-        // both carry "scratchFINDME", guaranteeing at least two matches.
+        // the scratch's autoFocus takes first responder, so this lands in the scratch shell; the typed line
+        // and its echo both carry the token, so the scratch scrollback holds ≥2 matches.
         app.typeText("echo scratchFINDME scratchFINDME")
         app.typeKey(.return, modifierFlags: [])
 
-        // ⌘F now opens the bar over the scratch (the cover gate no longer blocks it for the scratch).
         app.typeKey("f", modifierFlags: .command)
         let field = app.textFields["search-field"]
         XCTAssertTrue(field.waitForExistence(timeout: 5),
                       "⌘F while the scratch terminal is shown SHOULD open the search bar over the scratch")
 
-        // the needle matches against the SCRATCH content, confirming search targets the scratch surface.
         let label = waitForMatchLabel(field: field, needle: "scratchFINDME", timeout: 12)
         let resolved = try XCTUnwrap(label, "the search counter should report a match against the scratch content")
         XCTAssertTrue(resolved.contains("of") || resolved.contains("matches"),
                       "counter should read 'N of M' or 'M matches', got '\(resolved)'")
     }
 
-    // Esc closes the bar: the close path sends end_search, the END_SEARCH callback clears the fields
-    // and hides the bar, so the search-field leaves the accessibility tree. Fresh launch (one reliable
-    // keyboard-driven interaction per launch is the norm for these tests).
+    // the END_SEARCH callback hides the bar, so the search-field leaves the accessibility tree.
     func testSearchBarCloses() throws {
         selectSeededSession()
 
@@ -145,9 +119,8 @@ final class SearchUITests: XCTestCase {
                 field.typeText(needle)
                 first = false
             } else {
-                // re-seed: clear the field to empty (sends search:"") then retype the needle, so the
-                // binding genuinely changes value and re-fires search:<needle> after a late render — typing
-                // the identical string over itself would not change the binding and would not re-evaluate.
+                // typing the identical string over itself would not change the binding, so clear the
+                // field first to make the re-typed needle re-fire search:<needle> after a late render.
                 field.click()
                 field.typeKey("a", modifierFlags: .command)
                 field.typeKey(.delete, modifierFlags: [])

--- a/agtermUITests/SessionNavUITests.swift
+++ b/agtermUITests/SessionNavUITests.swift
@@ -33,14 +33,12 @@ final class SessionNavUITests: XCTestCase {
     func testSessionNavigationFollowsFocus() throws {
         let firstRow = app.staticTexts["session-row"]
         XCTAssertTrue(firstRow.waitForExistence(timeout: 20), "seeded session should exist")
-        // click the row to put first responder in its terminal (the row click bounces focus into
-        // the surface), then record the first session's shell tty.
+        // the row click bounces first responder into the surface, which the tty oracle needs.
         firstRow.click()
         usleep(800_000)
         let firstTTY = ttyAfterCommand(named: "first")
         XCTAssertNotNil(firstTTY, "first session shell should write its tty (terminal must be focused)")
 
-        // add a second session via the bottom-bar add-session menu.
         let add = app.descendants(matching: .any).matching(identifier: "add-session").firstMatch
         XCTAssertTrue(add.waitForExistence(timeout: 5), "bottom-bar add-session menu should exist")
         add.click()
@@ -48,8 +46,7 @@ final class SessionNavUITests: XCTestCase {
         XCTAssertTrue(newItem.waitForExistence(timeout: 5), "New Session menu item should appear")
         newItem.click()
 
-        // two session rows now; click the second to focus its terminal and record its tty. (the menu
-        // interaction can leave focus off the surface, so a deterministic row click establishes it.)
+        // the menu interaction can leave focus off the surface, so a row click re-establishes it.
         let rows = app.staticTexts.matching(identifier: "session-row")
         XCTAssertTrue(waitForCount(rows, 2, timeout: 8), "a second session row should appear")
         let secondRow = rows.element(boundBy: 1)
@@ -59,12 +56,10 @@ final class SessionNavUITests: XCTestCase {
         XCTAssertNotNil(secondTTY, "second session shell should write its tty")
         XCTAssertNotEqual(secondTTY, firstTTY, "the second session is a separate shell")
 
-        // 3. ⌥⌘↑ (Previous Session) steps back to the first session — focus follows.
         app.typeKey(.upArrow, modifierFlags: [.command, .option])
         usleep(500_000)
         XCTAssertEqual(ttyAfterCommand(named: "prev"), firstTTY, "Opt+Cmd+Up selects the previous session")
 
-        // 4. ⌥⌘↓ (Next Session) steps forward to the second session.
         app.typeKey(.downArrow, modifierFlags: [.command, .option])
         usleep(500_000)
         XCTAssertEqual(ttyAfterCommand(named: "next"), secondTTY, "Opt+Cmd+Down selects the next session")

--- a/agtermUITests/SessionSubtitleUITests.swift
+++ b/agtermUITests/SessionSubtitleUITests.swift
@@ -40,8 +40,7 @@ final class SessionSubtitleUITests: XCTestCase {
 
         emitOscTitle("REMOTE-DEMO-TITLE")
 
-        // the palette list is snapshotted on open, so reopen until the OSC title has landed; capture the
-        // value that satisfied it for the negative assertion.
+        // the palette list is snapshotted on open, so reopen until the OSC title has landed.
         var subtitle = ""
         XCTAssertTrue(poll(timeout: 10) {
             subtitle = self.currentPaletteSubtitle()
@@ -50,15 +49,13 @@ final class SessionSubtitleUITests: XCTestCase {
         }, "a named session's second line should show the OSC title; got \(subtitle)")
         XCTAssertFalse(subtitle.contains(cwdMarker), "the second line should drop the stale local path; got \(subtitle)")
 
-        // line 1 stays the custom name — the title only ever changes the second line.
         XCTAssertTrue(rowValueEquals("session-row", "demo-host"), "the OSC title must not override the custom name")
     }
 
     func testUnnamedSessionKeepsCwdOnSecondLine() throws {
         emitOscTitle("UNNAMED-DEMO-TITLE")
 
-        // unnamed → the OSC title drives the sidebar label (line 1); waiting on this also confirms the
-        // title has been captured before the palette is opened.
+        // waiting on line 1 also confirms the title was captured before the palette is opened.
         XCTAssertTrue(rowValueEquals("session-row", "UNNAMED-DEMO-TITLE", timeout: 10),
                       "an unnamed session's line 1 should become the OSC title")
 

--- a/agtermUITests/SessionSwitcherUITests.swift
+++ b/agtermUITests/SessionSwitcherUITests.swift
@@ -27,14 +27,13 @@ final class SessionSwitcherUITests: XCTestCase {
     func testCtrlTabSwitchesToPreviousSession() throws {
         let first = try XCTUnwrap(firstSessionID())
 
-        // add a second session; it becomes selected (so [second, first] is the MRU order).
+        // the new session becomes selected, making the MRU order [second, first].
         app.menuBars.menuBarItems["File"].click()
         app.menuItems["New Session"].click()
         XCTAssertTrue(poll { self.sessionCount() == 2 }, "a second session should be added")
         let second = try XCTUnwrap(selectedID())
         XCTAssertNotEqual(second, first, "the new session should be selected after add")
 
-        // Ctrl+Tab → switch to the previously visited (first) session.
         app.typeKey("\t", modifierFlags: .control)
         XCTAssertTrue(poll { self.selectedID() == first }, "Ctrl+Tab should switch to the previously visited session")
 

--- a/agtermUITests/SessionTextUITests.swift
+++ b/agtermUITests/SessionTextUITests.swift
@@ -1,22 +1,18 @@
 import Foundation
 import XCTest
 
-// session.text UI e2e. A `ControlAPITestCase` subclass (was an extension over `ControlAPIUITests`), so
-// it reuses the shared harness helpers (sendCommand / typeRequest / app / pollActiveSessionSplit /
-// activeSessionID) without duplicating scaffolding.
+// session.text UI e2e; the `ControlAPITestCase` base supplies the socket/app harness helpers.
 @MainActor
 final class SessionTextUITests: ControlAPITestCase {
-    // session.text returns the session's terminal buffer in result.text. Type a command whose OUTPUT (not
-    // the echoed command line) is a unique marker — `echo <tag>-$((6*7))` prints `<tag>-42`, a string the
-    // typed line itself does NOT contain (it has `$((6*7))`) — so a match proves command output was
-    // captured, not merely the typed input echoed back. Poll until the rendered output lands (async).
+    // the marker is the OUTPUT, not the typed line: `echo <tag>-$((6*7))` prints `<tag>-42`, a string the
+    // typed line does NOT contain, so a match cannot be the echoed input.
     func testSessionTextReturnsBuffer() throws {
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
         let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
         let newID = try XCTUnwrap(result["id"] as? String, "session.new should return the new id")
 
         let tag = "AGTERM-TEXT-\(UUID().uuidString.prefix(8))"
-        let output = "\(tag)-42" // the shell evaluates $((6*7)); this string is absent from the typed line
+        let output = "\(tag)-42"
         let typed = try sendCommand(typeRequest(text: "echo \(tag)-$((6*7))\n", target: newID, select: true))
         XCTAssertEqual(typed["ok"] as? Bool, true, "session.type should succeed: \(typed)")
 
@@ -33,10 +29,6 @@ final class SessionTextUITests: ControlAPITestCase {
         XCTAssertNotNil(text, "session.text should return a buffer containing the command OUTPUT \(output)")
     }
 
-    // session.text --lines N keeps only the LAST N lines of the full buffer (the GhosttySurfaceView trim:
-    // strip one trailing newline, split on \n, suffix(N)). Print 50 distinctly-tagged numbered lines, then
-    // read --lines 5: assert exactly 5 lines come back, the LAST printed line (tag-50) is present, and an
-    // EARLY line (tag-1) is NOT — proving the suffix trim, which no other test exercises.
     func testSessionTextLinesReturnsLastN() throws {
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
         let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
@@ -63,10 +55,6 @@ final class SessionTextUITests: ControlAPITestCase {
         XCTAssertFalse(t.contains("\(tag)-1-X"), "an early line must be trimmed away by --lines 5: \(t)")
     }
 
-    // session.text --all reads the whole SCREEN (visible + scrollback); the default read is the VIEWPORT
-    // only. Print far more lines than fit on screen, then assert --all returns an EARLY line that scrolled
-    // out of the viewport while the default read does NOT — a swapped VIEWPORT/SCREEN region would fail this
-    // (the default read is never otherwise distinguished from --all over the socket).
     func testSessionTextAllIncludesScrollback() throws {
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
         let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
@@ -77,7 +65,6 @@ final class SessionTextUITests: ControlAPITestCase {
         let typed = try sendCommand(typeRequest(text: "printf '\(tag)-%s-X\\n' $(seq 1 400)\n", target: newID, select: true))
         XCTAssertEqual(typed["ok"] as? Bool, true, "session.type should succeed: \(typed)")
 
-        // poll --all until the last printed line lands (proves the output fully rendered to scrollback).
         var allText: String?
         for _ in 0..<60 {
             let response = try sendCommand(#"{"cmd":"session.text","target":"\#(newID)","args":{"all":true}}"#)
@@ -98,27 +85,20 @@ final class SessionTextUITests: ControlAPITestCase {
         XCTAssertTrue(viewport.contains("\(tag)-400-X"), "the default (VIEWPORT) read should still show the most recent line")
     }
 
-    // session.text --pane left|right reads the matching pane of a split. The LEFT marker goes in over the
-    // socket (a no-pane session.type injects into the main pane); the RIGHT pane is fed via the real
-    // keyboard after focusing it — deliberately NOT via `session.type --pane right` (that route has its own
-    // e2e in SessionTypePaneUITests), so this test also proves the focus→keyboard first-responder routing.
-    // Assert each pane read returns its OWN marker and NOT the other's — the --pane success mappings
-    // (left→surface, right→splitSurface) are otherwise only hit on the error path.
+    // the right pane is fed via the real keyboard, deliberately NOT `session.type --pane right` (covered by
+    // SessionTypePaneUITests), so this also proves the focus→keyboard first-responder routing.
     func testSessionTextPaneSelectsCorrectPane() throws {
         let split = try sendCommand(#"{"cmd":"session.split","target":"active","args":{"mode":"on"}}"#)
         XCTAssertEqual(split["ok"] as? Bool, true, "split on should succeed: \(split)")
         XCTAssertTrue(pollActiveSessionSplit(true, timeout: 10), "the active session should report split:true")
         let activeID = try activeSessionID()
 
-        // LEFT (main) pane: a no-pane session.type injects into session.surface (the main pane), so this
-        // marker lands in the left pane regardless of which pane holds focus.
+        // a no-pane session.type always injects into the main pane, whichever pane holds focus.
         let leftMarker = "LEFT-\(UUID().uuidString.prefix(8))"
         XCTAssertNotNil(try pollPaneText(target: activeID, pane: "left", contains: leftMarker, retype: {
             _ = try self.sendCommand(self.typeRequest(text: "echo \(leftMarker)\n", target: activeID, select: false))
         }), "--pane left should read the marker typed into the main pane")
 
-        // RIGHT (split) pane: focus it and type via the real keyboard, which routes to the focused pane's
-        // first responder.
         let rightMarker = "RIGHT-\(UUID().uuidString.prefix(8))"
         XCTAssertEqual(try sendCommand(#"{"cmd":"session.focus","target":"\#(activeID)","args":{"pane":"right"}}"#)["ok"] as? Bool,
                        true, "focus right should succeed")
@@ -128,7 +108,6 @@ final class SessionTextUITests: ControlAPITestCase {
             self.app.typeKey(.return, modifierFlags: [])
         }), "--pane right should read the marker typed into the split pane")
 
-        // cross-check: each pane read carries ONLY its own marker (the two reads hit different surfaces).
         let leftText = try XCTUnwrap((try sendCommand(#"{"cmd":"session.text","target":"\#(activeID)","args":{"pane":"left"}}"#)["result"] as? [String: Any])?["text"] as? String)
         let rightText = try XCTUnwrap((try sendCommand(#"{"cmd":"session.text","target":"\#(activeID)","args":{"pane":"right"}}"#)["result"] as? [String: Any])?["text"] as? String)
         XCTAssertTrue(leftText.contains(leftMarker), "--pane left should contain the left marker: \(leftText)")
@@ -137,8 +116,7 @@ final class SessionTextUITests: ControlAPITestCase {
         XCTAssertFalse(rightText.contains(leftMarker), "--pane right must NOT contain the left pane's marker: \(rightText)")
     }
 
-    // session.text --pane right on a non-split session errors. `right` is a valid pane value so it passes
-    // the CLI validate() and the request reaches the server, which rejects it (no split pane to read).
+    // `right` is a valid pane value, so the CLI validate() passes and the SERVER is what rejects it.
     func testSessionTextSplitPaneWithoutSplitErrors() throws {
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
         let result = try XCTUnwrap(created["result"] as? [String: Any], "session.new should carry a result")
@@ -149,10 +127,7 @@ final class SessionTextUITests: ControlAPITestCase {
         XCTAssertEqual(response["error"] as? String, "session has no split pane", "should report no split pane: \(response)")
     }
 
-    // session.text arg validation is enforced SERVER-SIDE, not only in the CLI `validate()`: a raw socket
-    // client bypasses the CLI, so `lines <= 0` and `all` + `lines` together must error here too (an unchecked
-    // `lines: 0` would otherwise fall through to the full buffer). sendCommand speaks raw JSON, so it is the
-    // bypassing client.
+    // sendCommand speaks raw JSON, so it IS the CLI-bypassing client this server-side validation guards.
     func testSessionTextRejectsInvalidArgsServerSide() throws {
         let zero = try sendCommand(#"{"cmd":"session.text","target":"active","args":{"lines":0}}"#)
         XCTAssertEqual(zero["ok"] as? Bool, false, "session.text lines:0 should fail server-side: \(zero)")
@@ -166,14 +141,13 @@ final class SessionTextUITests: ControlAPITestCase {
         XCTAssertEqual(both["error"] as? String, "use either --all or --lines, not both", "should report mutual exclusion: \(both)")
     }
 
-    // A genuinely BLANK screen reads ok with an EMPTY string, not an error (readScreenText returns "" for an
-    // empty read, nil only for a failed one). `session new --command "sleep 300"` execs sleep directly — no
-    // shell, so no prompt and no output — leaving the viewport blank; session.text returns ok + "".
+    // `--command "sleep 300"` execs sleep directly — no shell, no prompt, no output — so the viewport is
+    // genuinely blank.
     func testSessionTextBlankScreenReturnsOkEmpty() throws {
         let created = try sendCommand(#"{"cmd":"session.new","args":{"command":"sleep 300"}}"#)
         let newID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "session.new should return the new id")
 
-        // poll for the surface to realize (a never-shown session realizes a beat after create).
+        // a never-shown session realizes a beat after create, hence the poll.
         var response: [String: Any] = [:]
         for _ in 0..<40 {
             response = try sendCommand(#"{"cmd":"session.text","target":"\#(newID)"}"#)
@@ -185,10 +159,7 @@ final class SessionTextUITests: ControlAPITestCase {
         XCTAssertTrue(text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty, "a blank screen should read as empty, got: \(text)")
     }
 
-    // `--pane scratch` reads (and `session.type --pane scratch` writes) the scratch terminal whether or not
-    // it is on screen, since its surface is kept alive when hidden. Open the scratch, echo a marker into it,
-    // read it back, then HIDE it and prove the buffer is still readable AND still writable via --pane scratch.
-    // The arithmetic ($((6*7)) -> 42) proves the scratch's own shell RAN the line, not merely echoed it.
+    // the arithmetic ($((6*7)) → 42) proves the scratch's own shell RAN the line rather than echoing it.
     func testSessionScratchPaneReadsAndWritesEvenWhenHidden() throws {
         let activeID = try activeSessionID()
 
@@ -202,13 +173,11 @@ final class SessionTextUITests: ControlAPITestCase {
         })
         XCTAssertNotNil(shown, "session.text --pane scratch should read the scratch's own buffer while it is shown")
 
-        // hide the scratch (keep-alive) and confirm its buffer is STILL readable via --pane scratch.
         let off = try sendCommand(#"{"cmd":"session.scratch","target":"\#(activeID)","args":{"mode":"off"}}"#)
         XCTAssertEqual(off["ok"] as? Bool, true, "session.scratch off should succeed: \(off)")
         let hidden = try XCTUnwrap((try sendCommand(#"{"cmd":"session.text","target":"\#(activeID)","args":{"pane":"scratch","all":true}}"#)["result"] as? [String: Any])?["text"] as? String)
         XCTAssertTrue(hidden.contains("\(tag)-42"), "a hidden scratch's buffer must still be readable via --pane scratch, got: \(hidden)")
 
-        // and it must still be WRITABLE while hidden: type a fresh marker via --pane scratch and read it back.
         let tag2 = "HIDDEN-\(UUID().uuidString.prefix(8))"
         let afterHiddenWrite = try pollPaneText(target: activeID, pane: "scratch", contains: "\(tag2)-42", retype: {
             _ = try self.sendCommand(self.typeRequest(text: "echo \(tag2)-$((6*7))\n", target: activeID,
@@ -217,7 +186,6 @@ final class SessionTextUITests: ControlAPITestCase {
         XCTAssertNotNil(afterHiddenWrite, "session.type --pane scratch must reach the scratch even while it is hidden")
     }
 
-    // --pane scratch on a session that never opened a scratch errors on both read and write, server-side.
     func testSessionScratchPaneWithoutScratchErrors() throws {
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
         let newID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "session.new should return the new id")

--- a/agtermUITests/SessionTypePaneUITests.swift
+++ b/agtermUITests/SessionTypePaneUITests.swift
@@ -1,16 +1,12 @@
 import Foundation
 import XCTest
 
-// session.type --pane UI e2e: pane-addressed text injection into a split. A `ControlAPITestCase`
-// subclass like `SessionTextUITests`, reusing the shared harness (sendCommand / typeRequest /
-// pollActiveSessionSplit / activeSessionID). The read-back oracle is `session.text --pane`, whose own
-// pane routing is proven independently in `SessionTextUITests.testSessionTextPaneSelectsCorrectPane`.
+// the read-back oracle is `session.text --pane`, whose own pane routing is proven independently in
+// `SessionTextUITests.testSessionTextPaneSelectsCorrectPane`.
 @MainActor
 final class SessionTypePaneUITests: ControlAPITestCase {
-    // session.type --pane right injects into the SPLIT pane's pty while the default (no pane) keeps
-    // injecting into the main pane — each marker must come back from its own pane's buffer and NOT the
-    // other's, proving the two injections hit different surfaces. Markers are echo OUTPUT tags typed as
-    // `$((6*7))` arithmetic so a match proves the shell in that pane RAN the line, not merely echoed it.
+    // the markers are echo OUTPUT tags typed as `$((6*7))` arithmetic, so a match proves the shell in that
+    // pane RAN the line rather than merely echoing it.
     func testSessionTypePaneRightReachesSplitPane() throws {
         let split = try sendCommand(#"{"cmd":"session.split","target":"active","args":{"mode":"on"}}"#)
         XCTAssertEqual(split["ok"] as? Bool, true, "split on should succeed: \(split)")
@@ -20,34 +16,29 @@ final class SessionTypePaneUITests: ControlAPITestCase {
         let leftTag = "TYPEL-\(UUID().uuidString.prefix(8))"
         let rightTag = "TYPER-\(UUID().uuidString.prefix(8))"
 
-        // default (no pane) lands in the main pane; --pane right lands in the split pane. Re-inject per
-        // attempt: a freshly-spawned pane's shell may not be ready for its first keystrokes (the
-        // typeUntilMarker readiness idiom), and an `echo` line is idempotent.
+        // re-inject per attempt: a freshly-spawned pane's shell may not be ready for its first keystrokes,
+        // and an `echo` line is idempotent.
         let leftText = try pollPaneText(target: activeID, pane: "left", contains: "\(leftTag)-42", retype: {
             _ = try self.sendCommand(self.typeRequest(text: "echo \(leftTag)-$((6*7))\n", target: activeID, select: false))
         })
         XCTAssertNotNil(leftText, "the default (no pane) injection should land in the main pane")
 
-        // NB: no inner `ok == true` assert here (unlike a one-shot check) — the base class sets
-        // continueAfterFailure = false, so a transient ok:false on a not-yet-ready split would abort the
-        // whole test instead of letting the retry loop ride it out. Success is asserted once, below, via
-        // the marker actually landing (the left closure omits the inner assert for the same reason).
+        // no inner `ok == true` assert in either closure: the base class sets continueAfterFailure = false,
+        // so a transient ok:false on a not-yet-ready split would abort the whole test instead of letting the
+        // retry loop ride it out. Success is asserted below, via the marker landing.
         let rightText = try pollPaneText(target: activeID, pane: "right", contains: "\(rightTag)-42", retype: {
             _ = try self.sendCommand(self.typeRequest(text: "echo \(rightTag)-$((6*7))\n",
                                                       target: activeID, select: false, pane: "right"))
         })
         XCTAssertNotNil(rightText, "--pane right should land in the split pane")
 
-        // cross-check: each pane's buffer carries ONLY its own marker.
         XCTAssertFalse(try XCTUnwrap(leftText).contains("\(rightTag)-42"),
                        "the main pane must NOT contain the split pane's marker: \(leftText ?? "")")
         XCTAssertFalse(try XCTUnwrap(rightText).contains("\(leftTag)-42"),
                        "the split pane must NOT contain the main pane's marker: \(rightText ?? "")")
     }
 
-    // session.type --pane right on a non-split session errors. The request is sent directly over the socket
-    // (sendCommand bypasses the CLI entirely), so the SERVER itself rejects it (no split pane to type into)
-    // — mirroring session.text.
+    // sendCommand bypasses the CLI entirely, so the SERVER itself is what rejects the request.
     func testSessionTypePaneRightWithoutSplitErrors() throws {
         let created = try sendCommand(#"{"cmd":"session.new"}"#)
         let newID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "session.new should return the new id")
@@ -57,8 +48,6 @@ final class SessionTypePaneUITests: ControlAPITestCase {
         XCTAssertEqual(response["error"] as? String, "session has no split pane", "should report no split pane: \(response)")
     }
 
-    // pane validation is enforced SERVER-SIDE, not only in the CLI `validate()`: a raw socket client
-    // bypasses the CLI, so an unknown pane value must error here too (sendCommand is that raw client).
     func testSessionTypeRejectsInvalidPaneServerSide() throws {
         let response = try sendCommand(#"{"cmd":"session.type","target":"active","args":{"text":"x","pane":"middle"}}"#)
         XCTAssertEqual(response["ok"] as? Bool, false, "session.type pane:middle should fail server-side: \(response)")

--- a/agtermUITests/SettingsUITests.swift
+++ b/agtermUITests/SettingsUITests.swift
@@ -25,12 +25,10 @@ final class SettingsUITests: XCTestCase {
     func testSettingsWindowHasSixTabsAndThemePersists() throws {
         app.typeKey(",", modifierFlags: .command)
 
-        // the six tabs are reachable.
         for tab in ["General", "Appearance", "Interface", "Notifications", "Agent Status", "Key Mapping"] {
             XCTAssertTrue(app.buttons[tab].firstMatch.waitForHittable(timeout: 12), "Settings should have a \(tab) tab")
         }
 
-        // pick a known theme from the theme picker and confirm it lands in settings.json.
         let themePicker = settingsControl(tab: "Appearance", control: "settings-theme")
         themePicker.click()
         let choice = app.menuItems["Alabaster"]
@@ -60,7 +58,6 @@ final class SettingsUITests: XCTestCase {
     func testDockBouncePickerPersists() throws {
         let picker = settingsControl(tab: "Notifications", control: "settings-dock-bounce")
 
-        // Until focused → dockBounce="untilFocused".
         picker.click()
         let untilFocused = app.menuItems["Until focused"]
         XCTAssertTrue(untilFocused.waitForExistence(timeout: 5), "the dock-bounce picker should offer 'Until focused'")
@@ -68,7 +65,6 @@ final class SettingsUITests: XCTestCase {
         XCTAssertTrue(poll { self.settingsValue("dockBounce") == "untilFocused" },
                       "selecting 'Until focused' should persist dockBounce=untilFocused to settings.json")
 
-        // Once → dockBounce="once".
         picker.click()
         let once = app.menuItems["Once"]
         XCTAssertTrue(once.waitForExistence(timeout: 5), "the dock-bounce picker should offer 'Once'")
@@ -76,7 +72,6 @@ final class SettingsUITests: XCTestCase {
         XCTAssertTrue(poll { self.settingsValue("dockBounce") == "once" },
                       "selecting 'Once' should persist dockBounce=once to settings.json")
 
-        // None → the default, mapped back to nil, so the key is REMOVED.
         picker.click()
         let none = app.menuItems["None"]
         XCTAssertTrue(none.waitForExistence(timeout: 5), "the dock-bounce picker should offer 'None'")
@@ -88,7 +83,6 @@ final class SettingsUITests: XCTestCase {
     func testNotificationSoundPickerPersists() throws {
         let picker = settingsControl(tab: "Notifications", control: "settings-notification-sound")
 
-        // Glass → notificationSoundName="Glass".
         picker.click()
         let glass = app.menuItems["Glass"]
         XCTAssertTrue(glass.waitForExistence(timeout: 5), "the notification-sound picker should offer 'Glass'")
@@ -96,7 +90,6 @@ final class SettingsUITests: XCTestCase {
         XCTAssertTrue(poll { self.settingsValue("notificationSoundName") == "Glass" },
                       "selecting 'Glass' should persist notificationSoundName=Glass to settings.json")
 
-        // None → the default, mapped back to nil, so the key is REMOVED.
         picker.click()
         let none = app.menuItems["None"]
         XCTAssertTrue(none.waitForExistence(timeout: 5), "the notification-sound picker should offer 'None'")
@@ -105,20 +98,18 @@ final class SettingsUITests: XCTestCase {
                       "selecting None (the default) should remove the notificationSoundName key from settings.json")
     }
 
-    // the row geometry and the option list, split off the persistence flow below: these are the most
-    // fragile assertions (they move with any Form-style, font or OS-metric change) and running them in
-    // the same test would mask every persistence leg behind a layout failure.
+    // split off the persistence flow deliberately: a layout failure here would otherwise mask every
+    // persistence leg.
     func testAgentStatusShapePickerRowLayoutAndOptions() throws {
         let picker = settingsControl(tab: "Agent Status", control: "settings-status-shape-blocked")
 
-        // the Sound section's picker is the flush-right reference: every sibling section's trailing
-        // control ends at the tab's right margin, so a glyph row that floats inboard is a ragged edge.
+        // the Sound picker is the flush-right reference: every sibling section's trailing control ends
+        // at the tab's right margin.
         let soundPicker = settingsControl(tab: "Agent Status", control: "settings-status-blocked-sound")
         assertGlyphRowsLineUp(against: soundPicker, context: "default shapes")
 
-        // the same geometry with the rows showing DIFFERENT silhouettes: a menu button sizes to the glyph
-        // it shows and the six shapes differ by a few points, so the widest one is what a reserved column
-        // that is too narrow (or aligned anywhere but trailing) knocks out of line.
+        // Capsule is the widest silhouette and a menu button sizes to its glyph, so a too-narrow or
+        // non-trailing column only knocks the row out of line here.
         picker.click()
         let capsuleOption = app.menuItems["Capsule"]
         XCTAssertTrue(capsuleOption.waitForExistence(timeout: 5), "the shape picker should offer 'Capsule'")
@@ -127,12 +118,11 @@ final class SettingsUITests: XCTestCase {
                       "selecting 'Capsule' should reach the Blocked row before its geometry is measured")
         assertGlyphRowsLineUp(against: soundPicker, context: "Blocked row on the widest silhouette")
 
-        // everything below still fits the fixed-size window, so the tab needs no scrolling.
         XCTAssertTrue(app.buttons["settings-status-reset"].firstMatch.waitForHittable(timeout: 5),
                       "the Reset button should stay reachable without scrolling")
 
-        // the options are symbols only, but each keeps its shape name for VoiceOver (and for this test);
-        // the six shapes are the whole list, since an unset shape now renders the plain circle.
+        // the options are symbols only; each keeps its shape name for VoiceOver, which is what these
+        // menu-item lookups match on.
         picker.click()
         let triangle = app.menuItems["Triangle"]
         XCTAssertTrue(triangle.waitForExistence(timeout: 5), "the shape picker should offer 'Triangle'")
@@ -148,7 +138,6 @@ final class SettingsUITests: XCTestCase {
         let picker = settingsControl(tab: "Agent Status", control: "settings-status-shape-blocked")
         let activeShape = settingsControl(tab: "Agent Status", control: "settings-status-shape-active")
 
-        // Triangle → blockedStatusShape="triangle".
         picker.click()
         let triangle = app.menuItems["Triangle"]
         XCTAssertTrue(triangle.waitForExistence(timeout: 5), "the shape picker should offer 'Triangle'")
@@ -156,8 +145,8 @@ final class SettingsUITests: XCTestCase {
         XCTAssertTrue(poll { self.settingsValue("blockedStatusShape") == "triangle" },
                       "selecting 'Triangle' should persist blockedStatusShape=triangle to settings.json")
 
-        // a SECOND status through the same flow: each row must write its OWN key, so a copy-pasted
-        // binding that drove the wrong status shows up here rather than passing on the blocked row alone.
+        // a second status through the same flow: a copy-pasted binding driving the wrong status only
+        // shows up once two rows are exercised.
         activeShape.click()
         let star = app.menuItems["Star"]
         XCTAssertTrue(star.waitForExistence(timeout: 5), "the active shape picker should offer 'Star'")
@@ -166,7 +155,6 @@ final class SettingsUITests: XCTestCase {
                       "selecting 'Star' on the Active row should persist activeStatusShape=star to settings.json")
         XCTAssertEqual(settingsValue("blockedStatusShape"), "triangle", "the Active row must not rewrite the Blocked shape")
 
-        // both choices survive a relaunch: the pickers read them back from the same isolated state dir.
         app.terminate()
         app.launchForUITest()
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForHittable(timeout: 20), "seeded session should be hittable")
@@ -177,7 +165,6 @@ final class SettingsUITests: XCTestCase {
         XCTAssertTrue(poll { (restoredActive.value as? String) == "Star" },
                       "after a relaunch the Active picker should show the stored Star, got \(String(describing: restoredActive.value))")
 
-        // Circle is the built-in default and maps back to nil, so picking it REMOVES that row's key only.
         restored.click()
         let fallback = app.menuItems["Circle"]
         XCTAssertTrue(fallback.waitForExistence(timeout: 5), "the shape picker should offer 'Circle'")
@@ -186,8 +173,7 @@ final class SettingsUITests: XCTestCase {
                       "selecting Circle (the default) should remove the blockedStatusShape key from settings.json")
         XCTAssertEqual(settingsValue("activeStatusShape"), "star", "clearing the Blocked shape must leave the Active one alone")
 
-        // Reset to defaults clears the remaining shape too — the leg that would otherwise ship green
-        // with the three shape-clearing lines missing from resetAgentStatus().
+        // without this leg, a resetAgentStatus() missing its three shape-clearing lines ships green.
         let reset = app.buttons["settings-status-reset"].firstMatch
         XCTAssertTrue(reset.waitForHittable(timeout: 5), "the Reset button should be clickable")
         reset.click()
@@ -198,11 +184,9 @@ final class SettingsUITests: XCTestCase {
     }
 
     func testToolbarModePickerPersists() throws {
-        // the Toolbar dropdown offers Normal/Compact/Hidden. compact is the default and maps back to nil;
-        // Normal/Hidden write a stable key.
+        // compact is the default and maps back to nil; Normal/Hidden write a stable key.
         let picker = settingsControl(tab: "Appearance", control: "settings-toolbar-mode")
 
-        // Hidden → toolbarMode="hidden".
         picker.click()
         let hidden = app.menuItems["Hidden"]
         XCTAssertTrue(hidden.waitForExistence(timeout: 5), "the toolbar dropdown should offer a Hidden item")
@@ -210,7 +194,6 @@ final class SettingsUITests: XCTestCase {
         XCTAssertTrue(poll { self.settingsValue("toolbarMode") == "hidden" },
                       "selecting Hidden should persist toolbarMode=hidden to settings.json")
 
-        // Compact → the default, mapped back to nil, so the key is REMOVED (the nil-mapping branch).
         picker.click()
         let compact = app.menuItems["Compact"]
         XCTAssertTrue(compact.waitForExistence(timeout: 5), "the toolbar dropdown should offer a Compact item")
@@ -218,7 +201,6 @@ final class SettingsUITests: XCTestCase {
         XCTAssertTrue(poll { self.settingsValue("toolbarMode") == nil },
                       "selecting Compact (the default) should remove the toolbarMode key from settings.json")
 
-        // Normal → toolbarMode="normal".
         picker.click()
         let normal = app.menuItems["Normal"]
         XCTAssertTrue(normal.waitForExistence(timeout: 5), "the toolbar dropdown should offer a Normal item")
@@ -263,14 +245,13 @@ final class SettingsUITests: XCTestCase {
     }
 
     func testInterfaceElementTogglePersists() throws {
-        // the Interface tab's toggles are default-on (element visible); turning one off adds its raw name
-        // to hiddenInterfaceElements, and turning it back on empties the set so the key is removed.
+        // the Interface tab's toggles are default-on (element visible).
         let toggle = settingsControl(tab: "Interface", control: "settings-interface-split")
-        toggle.click() // hide the Split view element (default shown)
+        toggle.click()
         XCTAssertTrue(poll { self.settingsStringArray("hiddenInterfaceElements")?.contains("split") == true },
                       "hiding the Split view element should persist \"split\" into hiddenInterfaceElements")
 
-        toggle.click() // show it again → the set empties
+        toggle.click()
         XCTAssertTrue(poll { self.settingsObject()?["hiddenInterfaceElements"] == nil },
                       "re-showing the last hidden element should remove hiddenInterfaceElements from settings.json")
     }

--- a/agtermUITests/SidebarUITests.swift
+++ b/agtermUITests/SidebarUITests.swift
@@ -17,8 +17,7 @@ final class SidebarUITests: XCTestCase {
 
     override func setUp() async throws {
         continueAfterFailure = false
-        // hermetic state: a fresh temp dir per test so the app seeds exactly one
-        // "workspace 1" + one session, and we never touch the real workspaces.json.
+        // a fresh temp dir per test seeds exactly one "workspace 1" + one session.
         stateDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("agterm-uitest-\(UUID().uuidString)", isDirectory: true)
         markerDir = FileManager.default.temporaryDirectory
@@ -102,8 +101,7 @@ final class SidebarUITests: XCTestCase {
         let rename = app.menuItems["Rename"]
         XCTAssertTrue(rename.waitForExistence(timeout: 5), "Rename menu item should appear")
         rename.click()
-        // the field appears keyboard-focused (the rename fix); type into it. it
-        // surfaces as a TextField (session rows) or StaticText (workspace headers),
+        // the field surfaces as a TextField (session rows) or StaticText (workspace headers),
         // so match by identifier across element types.
         let field = app.descendants(matching: .any).matching(identifier: "edit-field").firstMatch
         XCTAssertTrue(field.waitForExistence(timeout: 5), "rename did not enter edit mode (field never appeared)")
@@ -111,7 +109,6 @@ final class SidebarUITests: XCTestCase {
         app.typeText("\(newName)\r")
     }
 
-    // The reported bug: renaming a session did nothing.
     func testRenameSession() throws {
         let row = sessionRow()
         rename(row, to: "renamed-session")
@@ -126,8 +123,7 @@ final class SidebarUITests: XCTestCase {
                       "workspace header should show the new name after rename")
     }
 
-    // clicking anywhere on a workspace row (not just the disclosure triangle) toggles its expansion.
-    // the toggle is deferred by the double-click interval so a rename double-click can cancel it, so the
+    // the toggle is deferred by the double-click interval (so a rename double-click can cancel it), so the
     // child session hides/returns a beat after the click rather than instantly.
     func testClickWorkspaceRowTogglesExpansion() throws {
         let ws = app.staticTexts["workspace 1"]
@@ -135,24 +131,20 @@ final class SidebarUITests: XCTestCase {
         let session = sessionRow()
         XCTAssertTrue(session.waitForExistence(timeout: 20), "seeded session row should be visible while expanded")
 
-        // click the row body → collapse → the child session row disappears.
         ws.click()
         XCTAssertTrue(session.waitForNonExistence(timeout: 5), "collapsing the workspace should hide its session row")
 
-        // click again → expand → the session row comes back.
         ws.click()
         XCTAssertTrue(session.waitForExistence(timeout: 5), "expanding the workspace should show its session row again")
     }
 
-    /// A workspace's collapsed state persists per window and restores on relaunch. Collapse a workspace
-    /// whose session is NOT the selected one (so the launch-time reveal of the active session can't
-    /// re-expand it), confirm the snapshot records it, then relaunch and confirm it comes back collapsed.
+    // collapses a workspace whose session is NOT the selected one, so the launch-time reveal of the
+    // active session cannot re-expand it.
     func testWorkspaceCollapsePersistsAcrossRelaunch() throws {
         XCTAssertTrue(app.staticTexts["workspace 1"].waitForExistence(timeout: 20), "seeded workspace should exist")
         XCTAssertTrue(pollSessionRowCount(1, timeout: 10), "seeded session A should be visible")
 
-        // add a second workspace and give it its own session B (created via the workspace-row menu so it
-        // lands in workspace 2); B becomes the selected/active session.
+        // session B goes in via the workspace-row menu so it lands in workspace 2 and becomes active.
         app.buttons["New Workspace"].click()
         let ws2 = app.staticTexts["workspace 2"]
         XCTAssertTrue(ws2.waitForExistence(timeout: 5), "second workspace should appear")
@@ -160,7 +152,6 @@ final class SidebarUITests: XCTestCase {
         presentedMenuItem("New Session").click()
         XCTAssertTrue(pollSessionRowCount(2, timeout: 10), "workspace 2 should now show its own session B")
 
-        // collapse workspace 1 (NOT the active workspace) → its session A hides, leaving only B.
         app.staticTexts["workspace 1"].click()
         XCTAssertTrue(pollSessionRowCount(1, timeout: 8), "collapsing workspace 1 should hide session A")
         XCTAssertTrue(stateDir.pollSnapshot(equals: true, timeout: 8) { snapshot in
@@ -168,9 +159,8 @@ final class SidebarUITests: XCTestCase {
                 .first(where: { $0["name"] as? String == "workspace 1" })?["collapsed"] as? Bool
         }, "collapsing workspace 1 should persist collapsed=true")
 
-        // relaunch with the same state dir: workspace 1 must restore COLLAPSED. The active session B's
-        // workspace (2) is revealed on launch, so exactly one session row (B) shows; A stays hidden under
-        // the restored-collapsed workspace 1.
+        // the active session B's workspace is revealed on launch, so exactly one row (B) shows; A stays
+        // hidden under the restored-collapsed workspace 1.
         app.terminate()
         app = XCUIApplication()
         app.launchEnvironment["AGTERM_STATE_DIR"] = stateDir.path
@@ -179,27 +169,22 @@ final class SidebarUITests: XCTestCase {
         XCTAssertTrue(pollSessionRowCount(1, timeout: 10),
                       "workspace 1 should restore collapsed (session A hidden); only the active session B shows")
 
-        // expanding workspace 1 again brings A back and clears the persisted collapse.
         app.staticTexts["workspace 1"].click()
         XCTAssertTrue(pollSessionRowCount(2, timeout: 8), "expanding workspace 1 should reveal session A again")
     }
 
-    /// Collapsing the workspace that OWNS the active session must persist that collapse even though the
-    /// active session is force-revealed on relaunch: the reveal shows the session but is a view action, so
-    /// it must NOT re-persist the workspace as expanded. Guards the reveal-must-not-burn-collapse fix.
+    // the relaunch force-reveal of the active session is a view action, so it must not re-persist that
+    // session's workspace as expanded.
     func testActiveWorkspaceCollapsePersistsDespiteReveal() throws {
         XCTAssertTrue(app.staticTexts["workspace 1"].waitForExistence(timeout: 20), "seeded workspace should exist")
         XCTAssertTrue(pollSessionRowCount(1, timeout: 10), "seeded active session should be visible")
 
-        // collapse the active session's own workspace → its row hides, snapshot records collapsed=true.
         app.staticTexts["workspace 1"].click()
         XCTAssertTrue(pollSessionRowCount(0, timeout: 8), "collapsing the active workspace should hide its session row")
         XCTAssertTrue(stateDir.pollSnapshot(equals: true, timeout: 8) { snapshot in
             (snapshot["workspaces"] as? [[String: Any]])?.first?["collapsed"] as? Bool
         }, "collapsing the active workspace should persist collapsed=true")
 
-        // relaunch: the active session is revealed (its row shows again), but the persisted collapse must
-        // survive — the reveal must not have flipped the snapshot back to expanded.
         app.terminate()
         app = XCUIApplication()
         app.launchEnvironment["AGTERM_STATE_DIR"] = stateDir.path
@@ -210,12 +195,11 @@ final class SidebarUITests: XCTestCase {
         }, "the launch reveal must not re-persist the workspace as expanded (still collapsed=true)")
     }
 
-    /// Collapse Workspaces while a workspace is FOCUSED must still collapse the focus-hidden workspaces,
-    /// not just the one visible row. Guards the focused-mode collapseOthers fix (it reduces the tracked set
-    /// to the active workspace across ALL workspaces, so hidden ones are persisted collapsed too).
+    // the focus filter hides workspace 1, so this only passes if Collapse Workspaces reaches past the
+    // visible rows.
     func testCollapseWorkspacesWhileFocusedCollapsesHiddenWorkspaces() throws {
         XCTAssertTrue(app.staticTexts["workspace 1"].waitForExistence(timeout: 20), "seeded workspace should exist")
-        // give workspace 2 its own session B (via its row menu) so it becomes the active workspace.
+        // session B goes in via the workspace-row menu so workspace 2 becomes the active one.
         app.buttons["New Workspace"].click()
         let ws2 = app.staticTexts["workspace 2"]
         XCTAssertTrue(ws2.waitForExistence(timeout: 5), "second workspace should appear")
@@ -223,12 +207,10 @@ final class SidebarUITests: XCTestCase {
         presentedMenuItem("New Session").click()
         XCTAssertTrue(pollSessionRowCount(2, timeout: 10), "workspace 2 should show its own active session B")
 
-        // focus workspace 2 → workspace 1 (holding the non-active session A) is now hidden from the tree.
         ws2.rightClick()
         presentedMenuItem("Focus").click()
         XCTAssertTrue(pollSessionRowCount(1, timeout: 8), "focusing workspace 2 should hide workspace 1's session")
 
-        // Collapse Workspaces (View menu) must collapse workspace 1 even though it is hidden by the focus.
         app.menuBars.menuBarItems["View"].click()
         let collapse = app.menuItems["Collapse Workspaces"]
         XCTAssertTrue(collapse.waitForExistence(timeout: 5), "Collapse Workspaces menu item should appear")
@@ -239,17 +221,14 @@ final class SidebarUITests: XCTestCase {
         }, "Collapse Workspaces must persist the focus-hidden workspace 1 as collapsed")
     }
 
-    /// Moving the active session into a freshly created workspace must keep it visible: a runtime-added
-    /// workspace defaults expanded, so its rows show without a manual expand. The move does not change the
-    /// selection, so nothing reveals the workspace — only the model-expanded-default (picked up by the
-    /// rebuild's formUnion) renders it open. Guards that fix.
+    // the move does not change the selection, so nothing reveals workspace 2 — it renders open only from
+    // the model's expanded-by-default state.
     func testMovingActiveSessionIntoNewWorkspaceKeepsItVisible() throws {
         let row = sessionRow()
         XCTAssertTrue(row.waitForExistence(timeout: 20), "seeded active session should exist")
         app.buttons["New Workspace"].click()
         XCTAssertTrue(app.staticTexts["workspace 2"].waitForExistence(timeout: 5), "second workspace should appear")
 
-        // move the active session into the new (never-revealed) workspace 2 via its context menu.
         row.rightClick()
         let moveTo = app.menuItems["Move to"]
         XCTAssertTrue(moveTo.waitForExistence(timeout: 5), "Move to submenu should appear")
@@ -258,8 +237,6 @@ final class SidebarUITests: XCTestCase {
         XCTAssertTrue(target.waitForExistence(timeout: 5), "target workspace in submenu should appear")
         target.click()
 
-        // the moved session stays selected (no reveal fires), so it only shows if workspace 2 renders
-        // expanded from its isExpanded=true default; without that it would be hidden under a collapsed row.
         XCTAssertTrue(pollSessionRowCount(1, timeout: 8),
                       "the active session should stay visible in the new workspace (rendered expanded by default)")
     }
@@ -278,17 +255,14 @@ final class SidebarUITests: XCTestCase {
         app.typeKey("a", modifierFlags: .command)
         app.typeText("should-be-discarded")
         app.typeKey(XCUIKeyboardKey.escape, modifierFlags: [])
-        // edit mode closes: on restore the field's identifier reverts from edit-field to session-row.
+        // on restore the field's identifier reverts from edit-field to session-row.
         XCTAssertTrue(field.waitForNonExistence(timeout: 5), "Esc should close rename edit mode")
-        // and the name is unchanged: the rename was discarded, not committed.
         XCTAssertEqual(sessionRow().value as? String, original, "Esc should discard the rename")
-        // focus returns to the terminal: the sidebar must not keep focus after the rename ends.
         usleep(800_000)
         XCTAssertTrue(terminalReceivedTyping(named: "after-esc"),
                       "Esc should return focus to the session terminal, not keep it on the sidebar")
     }
 
-    // ending a rename with Return must also hand focus back to the terminal (not keep it on the sidebar).
     func testRenameSessionCommitReturnsFocus() throws {
         let row = sessionRow()
         rename(row, to: "renamed-focus")
@@ -344,13 +318,12 @@ final class SidebarUITests: XCTestCase {
         app.typeKey("n", modifierFlags: [.command, .shift])
         XCTAssertTrue(app.staticTexts["workspace 2"].waitForExistence(timeout: 5), "New Workspace should add workspace 2")
 
-        // delete workspace 1 — it still holds the seeded session, so a confirm alert appears.
         app.staticTexts["workspace 1"].rightClick()
         let delete = presentedMenuItem("Delete Workspace")
         XCTAssertTrue(delete.waitForExistence(timeout: 5), "Delete Workspace menu item should appear")
         delete.click()
-        // the confirm alert is an app-modal dialog; scope the Delete button to it (menu-bar items
-        // also surface in the app-wide button query).
+        // scope the Delete button to the modal dialog — menu-bar items also surface in the app-wide
+        // button query.
         let alert = app.dialogs.firstMatch
         XCTAssertTrue(alert.waitForExistence(timeout: 5), "a non-empty workspace should prompt to confirm")
         alert.buttons["Delete"].firstMatch.click()
@@ -361,8 +334,7 @@ final class SidebarUITests: XCTestCase {
 
     func testRowsShowKindIcons() throws {
         XCTAssertTrue(sessionRow().waitForExistence(timeout: 20), "seeded session should exist")
-        // the leading row icons (folder for a workspace, terminal for a session) carry stable
-        // identifiers on their image views; match across element types like the other rows do.
+        // the row icons carry their identifiers on image views, so match across element types.
         let workspaceIcon = app.descendants(matching: .any).matching(identifier: "workspace-icon").firstMatch
         XCTAssertTrue(workspaceIcon.waitForExistence(timeout: 5), "workspace row should show its folder icon")
         let sessionIcon = app.descendants(matching: .any).matching(identifier: "session-icon").firstMatch
@@ -371,8 +343,7 @@ final class SidebarUITests: XCTestCase {
 
     func testNewSessionButton() throws {
         XCTAssertTrue(sessionRow().waitForExistence(timeout: 20), "seeded session should exist")
-        // bottom-bar add-session menu (a SwiftUI Menu may surface as a popup, not a
-        // plain button), matched by identifier across element types.
+        // a SwiftUI Menu may surface as a popup rather than a plain button, so match across element types.
         let add = app.descendants(matching: .any).matching(identifier: "add-session").firstMatch
         XCTAssertTrue(add.waitForExistence(timeout: 5), "bottom-bar add-session menu should exist")
         add.click()
@@ -383,16 +354,14 @@ final class SidebarUITests: XCTestCase {
                       "workspace 1 should have 2 sessions after add-session -> New Session")
     }
 
-    /// The inline "+" button on a workspace row adds a session to that workspace —
-    /// the same action as right-click "New Session" on the row. The button is hover-revealed
-    /// (hidden at zero width on an idle row), so the row must be hovered before it is hittable.
+    // the "+" is hover-revealed (zero width on an idle row), so the row must be hovered to make it hittable.
     func testInlineAddSessionButtonCreatesSession() throws {
         XCTAssertTrue(sessionRow().waitForExistence(timeout: 20), "seeded session should exist")
         let ws = app.staticTexts["workspace 1"]
         XCTAssertTrue(ws.waitForExistence(timeout: 5), "seeded workspace should exist")
         let addBtn = app.descendants(matching: .any).matching(identifier: "workspace-add-session").firstMatch
-        // hover the row to reveal the button; retry — the first synthesized move can land before
-        // the window is key, and .activeInKeyWindow tracking swallows it.
+        // retry the hover: the first synthesized move can land before the window is key, and
+        // .activeInKeyWindow tracking swallows it.
         let deadline = Date().addingTimeInterval(8)
         while !addBtn.isHittable, Date() < deadline {
             ws.hover()
@@ -404,9 +373,8 @@ final class SidebarUITests: XCTestCase {
                       "workspace 1 should have 2 sessions after clicking the inline '+' button")
     }
 
-    // Verifies the "Open Directory…" wiring: the menu item presents the native
-    // folder picker. (The picker is system UI; choosing a directory and the
-    // resulting addSession(cwd:) are covered at the model level by AppStoreTests.)
+    // the picker is system UI, so only its presentation is checked here; the resulting addSession(cwd:)
+    // is covered at the model level by AppStoreTests.
     func testOpenDirectoryShowsPicker() throws {
         let add = app.descendants(matching: .any).matching(identifier: "add-session").firstMatch
         XCTAssertTrue(add.waitForExistence(timeout: 20), "bottom-bar add-session menu should exist")
@@ -414,8 +382,7 @@ final class SidebarUITests: XCTestCase {
         let open = presentedMenuItem("Open Directory…")
         XCTAssertTrue(open.waitForExistence(timeout: 5), "Open Directory… menu item should appear")
         open.click()
-        // the native folder picker appears (app-modal); confirm via its Cancel button, then
-        // dismiss with Escape (there can be more than one "Cancel" in the tree, so don't click by label).
+        // more than one "Cancel" can exist in the tree, so dismiss with Escape rather than by label.
         XCTAssertTrue(app.buttons["Cancel"].firstMatch.waitForExistence(timeout: 5),
                       "Open Directory… should present a folder picker")
         app.typeKey(XCUIKeyboardKey.escape, modifierFlags: [])
@@ -454,23 +421,19 @@ final class SidebarUITests: XCTestCase {
         return false
     }
 
-    /// Sidebar visibility persists per-window: hiding it records `sidebarVisible=false` in the snapshot,
-    /// it survives a relaunch (the sidebar restores hidden, so no `session-row`s show), and showing it
-    /// again records `true` and reveals the restored session. Width and split ratio are geometric (no AX
-    /// value, the divider has no queryable element), so those stay on the host-free `AppStore` round-trip
-    /// tests; visibility is observable here in both the snapshot file and the rows' presence.
+    // width and split ratio have no AX value (the divider has no queryable element), so they stay on the
+    // host-free AppStore round-trip tests; only visibility is observable here.
     func testSidebarVisibilityPersistsAcrossRelaunch() throws {
         XCTAssertTrue(sessionRow().firstMatch.waitForExistence(timeout: 20), "seeded session should exist")
 
-        // hide via the title-bar toggle; the toggle's save() must record sidebarVisible=false.
         let toggle = app.buttons["sidebar-toggle-button"]
         XCTAssertTrue(toggle.waitForHittable(timeout: 8), "sidebar toggle should be hittable")
         toggle.click()
         XCTAssertTrue(stateDir.pollSnapshot(equals: false, timeout: 8) { $0["sidebarVisible"] as? Bool },
                       "hiding should persist sidebarVisible=false")
 
-        // relaunch with the same state dir; the sidebar must restore HIDDEN. The toggle is present either
-        // way (proves the window rendered); the rows stay absent because the sidebar is hidden.
+        // the toggle is present either way, so it only proves the window rendered; the absent rows are
+        // the real signal.
         app.terminate()
         app = XCUIApplication()
         app.launchEnvironment["AGTERM_STATE_DIR"] = stateDir.path
@@ -480,7 +443,6 @@ final class SidebarUITests: XCTestCase {
         XCTAssertFalse(sessionRow().firstMatch.waitForExistence(timeout: 3),
                        "the sidebar should restore hidden (no session rows)")
 
-        // showing it again reveals the restored session and persists sidebarVisible=true.
         toggleAfter.click()
         XCTAssertTrue(sessionRow().firstMatch.waitForExistence(timeout: 8),
                       "the restored session appears when the sidebar is shown again")

--- a/agtermUITests/SplitUITests.swift
+++ b/agtermUITests/SplitUITests.swift
@@ -33,15 +33,12 @@ final class SplitUITests: XCTestCase {
     func testSplitFocusKeyboardNavAndCollapse() throws {
         let row = app.staticTexts["session-row"]
         XCTAssertTrue(row.waitForExistence(timeout: 20), "seeded session should exist")
-        // ensure the primary terminal holds focus before typing.
         row.click()
         usleep(800_000)
 
-        // 1. record the primary shell's tty.
         let primaryTTY = ttyAfterCommand(named: "primary")
         XCTAssertNotNil(primaryTTY, "primary shell should write its tty (terminal must be focused)")
 
-        // 2. open the split — focus MOVES to the new (right) pane, a separate shell.
         let splitButton = app.buttons["split-toggle"]
         XCTAssertTrue(splitButton.waitForExistence(timeout: 5), "split toolbar button should exist")
         splitButton.click()
@@ -50,28 +47,22 @@ final class SplitUITests: XCTestCase {
         XCTAssertNotNil(rightTTY, "right shell should write its tty")
         XCTAssertNotEqual(rightTTY, primaryTTY, "opening the split moves focus to the new (right) pane")
 
-        // 3. Cmd+Opt+Left focuses the primary pane again.
         app.typeKey(.leftArrow, modifierFlags: [.command, .option])
         usleep(500_000)
         let leftTTY = ttyAfterCommand(named: "left")
         XCTAssertEqual(leftTTY, primaryTTY, "Cmd+Opt+Left focuses the primary shell")
 
-        // 4. Cmd+Opt+Right focuses the right pane (the same separate shell) again.
         app.typeKey(.rightArrow, modifierFlags: [.command, .option])
         usleep(500_000)
         let rightAgainTTY = ttyAfterCommand(named: "right")
         XCTAssertEqual(rightAgainTTY, rightTTY, "Cmd+Opt+Right focuses the separate right shell")
 
-        // 5. with focus on the right pane, close the split — the focused (right) pane is kept
-        // maximized, its shell alive, not the primary.
         splitButton.click()
         usleep(800_000)
         let collapsedTTY = ttyAfterCommand(named: "collapsed")
         XCTAssertEqual(collapsedTTY, rightTTY, "closing the split keeps the focused (right) pane, not the primary")
     }
 
-    // Ctrl-1 / Ctrl-2 focus the primary / split pane directly (a faster alias for ⌘⌥←/→). Verified
-    // with the same tty oracle: the command lands in whichever pane the shortcut focused.
     func testCtrlNumberFocusesPaneDirectly() throws {
         let row = app.staticTexts["session-row"]
         XCTAssertTrue(row.waitForExistence(timeout: 20), "seeded session should exist")
@@ -81,7 +72,6 @@ final class SplitUITests: XCTestCase {
         let primaryTTY = ttyAfterCommand(named: "primary")
         XCTAssertNotNil(primaryTTY, "primary shell should write its tty")
 
-        // open the split — focus moves to the new (right) pane.
         let splitButton = app.buttons["split-toggle"]
         XCTAssertTrue(splitButton.waitForExistence(timeout: 5), "split toolbar button should exist")
         splitButton.click()
@@ -90,21 +80,17 @@ final class SplitUITests: XCTestCase {
         XCTAssertNotNil(rightTTY, "right shell should write its tty")
         XCTAssertNotEqual(rightTTY, primaryTTY, "opening the split moves focus to the new (right) pane")
 
-        // Ctrl-1 focuses the primary pane.
         app.typeKey("1", modifierFlags: .control)
         usleep(500_000)
         XCTAssertEqual(ttyAfterCommand(named: "ctrl1"), primaryTTY, "Ctrl-1 focuses the primary pane")
 
-        // Ctrl-2 focuses the split (right) pane.
         app.typeKey("2", modifierFlags: .control)
         usleep(500_000)
         XCTAssertEqual(ttyAfterCommand(named: "ctrl2"), rightTTY, "Ctrl-2 focuses the split pane")
     }
 
-    // Ctrl-1 / Ctrl-2 are reserved app shortcuts: in a non-split session they must be consumed (no-op),
-    // never leaking a literal "1"/"2" into the shell. Verified by typing them, then running the tty
-    // oracle on the SAME line — a leaked "1"/"2" would prefix the command ("12tty …"), so the command
-    // fails and the marker file stays empty (ttyAfterCommand returns nil).
+    // a leaked "1"/"2" would prefix the tty command on the SAME line ("12tty …"), so it fails and the
+    // marker file stays empty — which is why a non-nil read proves nothing leaked.
     func testCtrlNumberDoesNotLeakIntoNonSplitTerminal() throws {
         let row = app.staticTexts["session-row"]
         XCTAssertTrue(row.waitForExistence(timeout: 20), "seeded session should exist")
@@ -118,10 +104,8 @@ final class SplitUITests: XCTestCase {
                         "Ctrl-1/Ctrl-2 must not leak characters into a non-split shell")
     }
 
-    // hiding the split (the toolbar toggle / ⌘D) keeps both shells alive, so re-showing must restore
-    // the SAME panes — the re-parent that swaps the surface between the HSplitView and a standalone host
-    // must never tear a surface down. Verified by tty identity across a full hide → show cycle: a
-    // destroyed-and-recreated pane would report a different tty.
+    // the re-parent between the HSplitView and a standalone host must never tear a surface down; a
+    // destroyed-and-recreated pane would report a different tty across the hide → show cycle.
     func testSplitSurvivesHideShow() throws {
         let row = app.staticTexts["session-row"]
         XCTAssertTrue(row.waitForExistence(timeout: 20), "seeded session should exist")
@@ -131,7 +115,6 @@ final class SplitUITests: XCTestCase {
         let splitButton = app.buttons["split-toggle"]
         XCTAssertTrue(splitButton.waitForExistence(timeout: 5), "split toolbar button should exist")
 
-        // open the split and record the right pane's shell tty.
         splitButton.click()
         usleep(800_000)
         app.typeKey(.rightArrow, modifierFlags: [.command, .option])
@@ -139,23 +122,19 @@ final class SplitUITests: XCTestCase {
         let rightTTY = ttyAfterCommand(named: "right-before")
         XCTAssertNotNil(rightTTY, "right shell should write its tty")
 
-        // hide the split (keep-alive), then show it again.
         splitButton.click() // hide
         usleep(800_000)
         splitButton.click() // show
         usleep(800_000)
 
-        // focus the right pane and re-record its tty — the same shell must have survived the cycle.
         app.typeKey(.rightArrow, modifierFlags: [.command, .option])
         usleep(500_000)
         let rightTTYAfter = ttyAfterCommand(named: "right-after")
         XCTAssertEqual(rightTTYAfter, rightTTY, "hiding then showing the split keeps the same right shell alive")
     }
 
-    // pane navigation must keep working when the split is HIDDEN (maximized): with one pane shown,
-    // ⌃1/⌃2 (and ⌘⌥←/→) swap WHICH pane is shown maximized — gated on hasSplit, not isSplit. Before
-    // the fix these no-op'd while hidden. Verified with the tty oracle: after hiding, the focus
-    // shortcut swaps which shell receives the keystrokes.
+    // pane nav is gated on hasSplit, not isSplit: while the split is hidden, ⌃1/⌃2 (and ⌘⌥←/→) swap
+    // WHICH pane is shown maximized.
     func testHiddenSplitPaneNavigationSwapsShownPane() throws {
         let row = app.staticTexts["session-row"]
         XCTAssertTrue(row.waitForExistence(timeout: 20), "seeded session should exist")
@@ -165,7 +144,6 @@ final class SplitUITests: XCTestCase {
         let primaryTTY = ttyAfterCommand(named: "primary")
         XCTAssertNotNil(primaryTTY, "primary shell should write its tty")
 
-        // open the split — focus moves to the new (right) pane.
         let splitButton = app.buttons["split-toggle"]
         XCTAssertTrue(splitButton.waitForExistence(timeout: 5), "split toolbar button should exist")
         splitButton.click()
@@ -174,30 +152,24 @@ final class SplitUITests: XCTestCase {
         XCTAssertNotNil(rightTTY, "right shell should write its tty")
         XCTAssertNotEqual(rightTTY, primaryTTY, "opening the split moves focus to the new (right) pane")
 
-        // hide the split — the focused (right) pane stays shown maximized, both shells alive.
         splitButton.click()
         usleep(800_000)
         XCTAssertEqual(ttyAfterCommand(named: "hidden-right"), rightTTY, "the hidden split shows the focused (right) pane")
 
-        // Ctrl-1 while hidden swaps the shown pane to the primary (the bug: it used to no-op when hidden).
         app.typeKey("1", modifierFlags: .control)
         usleep(800_000)
         XCTAssertEqual(ttyAfterCommand(named: "hidden-ctrl1"), primaryTTY,
                        "Ctrl-1 swaps the hidden split to the primary pane")
 
-        // Ctrl-2 while hidden swaps the shown pane back to the right pane.
         app.typeKey("2", modifierFlags: .control)
         usleep(800_000)
         XCTAssertEqual(ttyAfterCommand(named: "hidden-ctrl2"), rightTTY,
                        "Ctrl-2 swaps the hidden split back to the right pane")
     }
 
-    // the split toolbar glyph encodes the split state via its accessibilityValue (the symbol name is not
-    // observable): none for a non-split session, both while shown side-by-side, and left/right when
-    // collapsed to a single pane — whichever pane is currently shown. Also pins the design choice that a
-    // SHOWN split stays "both" regardless of which pane holds focus (only a collapsed split distinguishes
-    // left vs right). Ctrl-1's effect is proven by the later "left" assertion: had it not registered,
-    // focus would still be on the right pane and the hide would collapse to "right", failing that check.
+    // the glyph's symbol name is not observable, so the state rides its accessibilityValue
+    // (none/both/left/right). Ctrl-1's effect is proven by the later "left" assertion: had it not
+    // registered, focus would still be on the right pane and the hide would collapse to "right".
     func testSplitButtonGlyphReflectsState() throws {
         let row = app.staticTexts["session-row"]
         XCTAssertTrue(row.waitForExistence(timeout: 20), "seeded session should exist")
@@ -207,41 +179,31 @@ final class SplitUITests: XCTestCase {
         let splitButton = app.buttons["split-toggle"]
         XCTAssertTrue(splitButton.waitForExistence(timeout: 5), "split toolbar button should exist")
 
-        // non-split session → outline glyph.
         XCTAssertTrue(waitSplitValue(splitButton, "none"), "a non-split session shows the outline glyph")
 
-        // open the split (both panes shown) → both halves filled.
         splitButton.click()
         XCTAssertTrue(waitSplitValue(splitButton, "both"), "a shown split fills both panes")
 
-        // a shown split stays "both" regardless of focus: focusing the primary must NOT flip the glyph.
         app.typeKey("1", modifierFlags: .control)
         usleep(500_000)
         XCTAssertTrue(waitSplitValue(splitButton, "both"), "a shown split ignores which pane is focused")
 
-        // hide the split while the primary (left) pane is focused → collapsed to the left pane.
         splitButton.click()
         XCTAssertTrue(waitSplitValue(splitButton, "left"), "collapsed to the primary pane fills the left half")
 
-        // Ctrl-2 swaps the shown pane to the right → right half filled.
         app.typeKey("2", modifierFlags: .control)
         XCTAssertTrue(waitSplitValue(splitButton, "right"), "collapsed to the split pane fills the right half")
 
-        // re-showing the collapsed split fills both panes again (isSplit true).
         splitButton.click()
         XCTAssertTrue(waitSplitValue(splitButton, "both"), "re-showing a collapsed split fills both panes again")
 
-        // closing the split (exit the right pane's shell) collapses to a single non-split session → outline.
-        app.typeKey(.rightArrow, modifierFlags: [.command, .option]) // put terminal focus on the right pane
+        app.typeKey(.rightArrow, modifierFlags: [.command, .option])
         usleep(500_000)
         app.typeText("exit")
         app.typeKey(.return, modifierFlags: [])
         XCTAssertTrue(waitSplitValue(splitButton, "none"), "closing the split returns the glyph to the no-split outline")
     }
 
-    // exiting one pane of a split must keep the session alive (collapsed to the survivor) AND focus
-    // the surviving pane, so typing reaches it without a click. Verified by exiting the primary, then
-    // typing WITHOUT focusing and checking the command landed in the surviving right shell.
     func testExitPrimaryPaneKeepsSessionAndFocusesSurvivor() throws {
         let row = app.staticTexts["session-row"]
         XCTAssertTrue(row.waitForExistence(timeout: 20), "seeded session should exist")
@@ -251,7 +213,6 @@ final class SplitUITests: XCTestCase {
         let splitButton = app.buttons["split-toggle"]
         XCTAssertTrue(splitButton.waitForExistence(timeout: 5), "split toolbar button should exist")
 
-        // open the split, focus the right pane, record its tty (the survivor when the primary exits).
         splitButton.click()
         usleep(800_000)
         app.typeKey(.rightArrow, modifierFlags: [.command, .option])
@@ -259,25 +220,22 @@ final class SplitUITests: XCTestCase {
         let rightTTY = ttyAfterCommand(named: "right")
         XCTAssertNotNil(rightTTY, "right shell should write its tty")
 
-        // focus the primary (left) pane and exit its shell.
         app.typeKey(.leftArrow, modifierFlags: [.command, .option])
         usleep(500_000)
         app.typeText("exit")
         app.typeKey(.return, modifierFlags: [])
         usleep(1_500_000) // shell exit + collapse + auto-focus retry
 
-        // the session survives (collapsed to the surviving right pane).
         XCTAssertTrue(row.waitForExistence(timeout: 5), "exiting the primary pane must keep the session")
 
-        // type WITHOUT focusing — the survivor must already hold focus, so the command reaches its shell.
+        // typed WITHOUT focusing, so this only lands if the survivor already holds focus.
         let survivorTTY = ttyAfterCommand(named: "survivor")
         XCTAssertEqual(survivorTTY, rightTTY, "after exiting the primary, the surviving right pane is focused")
     }
 
-    // Regression for #303: when the split is hidden with the PRIMARY shown, exiting that primary promotes
-    // the live right pane into the primary slot without changing the surrounding SwiftUI branch. The
-    // terminal host must therefore remount for the promoted surface, or the visible pane remains the dead
-    // primary while the live survivor is stranded off-screen. Verify by typing WITHOUT focusing after exit.
+    // Regression for #303: promotion into the primary slot does not change the surrounding SwiftUI
+    // branch, so the terminal host must remount for the promoted surface or the visible pane stays the
+    // dead primary while the live survivor is stranded off-screen.
     func testExitPrimaryPaneWhileSplitHiddenHostsAndFocusesSurvivor() throws {
         let row = app.staticTexts["session-row"]
         XCTAssertTrue(row.waitForExistence(timeout: 20), "seeded session should exist")
@@ -287,37 +245,29 @@ final class SplitUITests: XCTestCase {
         let splitButton = app.buttons["split-toggle"]
         XCTAssertTrue(splitButton.waitForExistence(timeout: 5), "split toolbar button should exist")
 
-        // Open the split and record the right pane's tty — this is the survivor that will be promoted.
         splitButton.click()
         usleep(800_000)
         let rightTTY = ttyAfterCommand(named: "hidden-survivor")
         XCTAssertNotNil(rightTTY, "right shell should write its tty")
 
-        // Show only the primary pane while keeping the right shell alive off-screen.
         app.typeKey("1", modifierFlags: .control)
         usleep(500_000)
         splitButton.click()
         XCTAssertTrue(waitSplitValue(splitButton, "left"), "the hidden split should show the primary pane")
 
-        // Exit the shown primary. The hidden right pane must promote into the visible host and take focus.
         app.typeText("exit")
         app.typeKey(.return, modifierFlags: [])
         XCTAssertTrue(waitSplitValue(splitButton, "none"), "promotion should leave a regular non-split session")
         XCTAssertTrue(row.waitForExistence(timeout: 5), "exiting the hidden primary must keep the session")
 
-        // Type WITHOUT focusing — this fails if SwiftUI kept hosting the torn-down primary surface.
+        // typed WITHOUT focusing — this fails if SwiftUI kept hosting the torn-down primary surface.
         XCTAssertEqual(ttyAfterCommand(named: "after-hidden-promotion"), rightTTY,
                        "the promoted hidden survivor should be visible and focused")
     }
 
-    // promote → re-split → exit-main: the round-1 zombie scenario, driven through the REAL pane-exit
-    // routing (typing `exit`, not calling closePrimaryPane directly like the host-free test). After the
-    // primary exits, the right pane promotes into the sole/main slot; a fresh split then opens a new right
-    // pane; exiting the promoted MAIN pane must route through closePrimaryPane (dispatched on the surface's
-    // LIVE role, now primary) and collapse onto the FRESH right pane — not through the survivor's stale
-    // split onExit, which would tear the fresh right down and strand the dead main. The tell: the final
-    // command reaches the fresh right shell. This is the only test that guards the role-aware dispatch;
-    // reverting it strands the session, failing the last assertion.
+    // exiting the promoted main pane must dispatch on the surface's LIVE role (primary after promotion)
+    // and collapse onto the FRESH right pane; the survivor's stale split onExit would tear that pane
+    // down and strand the dead main. The only test guarding the role-aware dispatch.
     func testPromoteThenResplitThenExitMainCollapsesToFreshSplit() throws {
         let row = app.staticTexts["session-row"]
         XCTAssertTrue(row.waitForExistence(timeout: 20), "seeded session should exist")
@@ -327,7 +277,6 @@ final class SplitUITests: XCTestCase {
         let splitButton = app.buttons["split-toggle"]
         XCTAssertTrue(splitButton.waitForExistence(timeout: 5), "split toolbar button should exist")
 
-        // open the split, focus the right pane, record its tty — this is the survivor that promotes.
         splitButton.click()
         usleep(800_000)
         app.typeKey(.rightArrow, modifierFlags: [.command, .option])
@@ -335,7 +284,6 @@ final class SplitUITests: XCTestCase {
         let promotedTTY = ttyAfterCommand(named: "promoted")
         XCTAssertNotNil(promotedTTY, "right shell should write its tty")
 
-        // exit the primary (left) shell → the right pane promotes into the sole/main pane and holds focus.
         app.typeKey(.leftArrow, modifierFlags: [.command, .option])
         usleep(500_000)
         app.typeText("exit")
@@ -345,16 +293,12 @@ final class SplitUITests: XCTestCase {
         XCTAssertEqual(ttyAfterCommand(named: "after-promote"), promotedTTY,
                        "the promoted survivor is the session's sole pane and holds focus")
 
-        // split AGAIN → a fresh right pane opens and takes focus (a separate shell from the promoted main).
         splitButton.click()
         usleep(800_000)
         let freshRightTTY = ttyAfterCommand(named: "fresh-right")
         XCTAssertNotNil(freshRightTTY, "the re-split's fresh right shell should write its tty")
         XCTAssertNotEqual(freshRightTTY, promotedTTY, "re-split opens a fresh right pane, distinct from the promoted main")
 
-        // focus the promoted MAIN (left) pane and exit its shell. Its exit must route through
-        // closePrimaryPane (live role = primary after promotion) and collapse onto the FRESH right pane —
-        // NOT closeSplitPane, which would tear the fresh right down and strand the dead main (round-1 bug).
         app.typeKey(.leftArrow, modifierFlags: [.command, .option])
         usleep(500_000)
         app.typeText("exit")
@@ -362,14 +306,11 @@ final class SplitUITests: XCTestCase {
         usleep(1_500_000)
 
         XCTAssertTrue(row.waitForExistence(timeout: 5), "exiting the promoted main pane must keep the session")
-        // type WITHOUT focusing — the fresh right pane must be the survivor and hold focus, so the command
-        // reaches its shell (a torn-down fresh right / stranded dead main would fail this).
+        // typed WITHOUT focusing — a torn-down fresh right or a stranded dead main fails here.
         XCTAssertEqual(ttyAfterCommand(named: "final"), freshRightTTY,
                        "exiting the promoted main collapses onto the fresh right pane, not tears it down")
     }
 
-    // mirror of the above for exiting the split (right) pane: the session survives, collapsed to the
-    // primary, and the primary holds focus.
     func testExitSplitPaneKeepsSessionAndFocusesSurvivor() throws {
         let row = app.staticTexts["session-row"]
         XCTAssertTrue(row.waitForExistence(timeout: 20), "seeded session should exist")
@@ -379,11 +320,9 @@ final class SplitUITests: XCTestCase {
         let splitButton = app.buttons["split-toggle"]
         XCTAssertTrue(splitButton.waitForExistence(timeout: 5), "split toolbar button should exist")
 
-        // record the primary tty (the survivor when the split exits).
         let primaryTTY = ttyAfterCommand(named: "primary")
         XCTAssertNotNil(primaryTTY, "primary shell should write its tty")
 
-        // open the split, focus the right pane, exit its shell.
         splitButton.click()
         usleep(800_000)
         app.typeKey(.rightArrow, modifierFlags: [.command, .option])
@@ -398,7 +337,6 @@ final class SplitUITests: XCTestCase {
         XCTAssertEqual(survivorTTY, primaryTTY, "after exiting the split, the surviving primary pane is focused")
     }
 
-    // exiting a non-split session closes it: the only session disappears from the sidebar.
     func testExitNonSplitSessionClosesIt() throws {
         let row = app.staticTexts["session-row"]
         XCTAssertTrue(row.waitForExistence(timeout: 20), "seeded session should exist")


### PR DESCRIPTION
Applies the two rules added in `f4f082c` to the surfaces they name: comments and docs are liabilities kept short, and comments in tests are rare and one line.

**19243 comment and prose lines become 11956.**

| surface | files | before | after |
|---|---|---|---|
| tests | 135 | 4704 | 2894 |
| Swift sources | 154 | 9660 | 7138 |
| rules + `CLAUDE.md` | 14 | 6080 | 1924 |

What goes is restatement: a comment repeating the test name, step narration through arrange/act/expect, an assertion annotated with what it asserts, an enumeration spelled out at three call sites, a contract stated in four files instead of owned by one.

What stays is the part the code cannot say, compressed rather than deleted. A six-line note stating three constraints becomes two lines stating three constraints. FB11763863, the CoreGraphics Release-WMO deserialization crash, the Metal drawable invalidated by the split re-parent, the 104-byte `sun_path` cap, `isReleasedWhenClosed` over-release, the pinned pre-regression libghostty SHA, the renamed-branch snag after a squash merge - all intact.

**Four comments were removed for being wrong, not verbose.** `WindowRegistry`'s type doc said `close(_:)` runs `performClose`, contradicting the method's own doc that it deliberately calls `window.close()` to bypass the confirm proxy. The Dock menu doc claimed New Window "is always enabled" against its own `enabled: actions != nil`. The recent-sessions popover named a type that does not exist. `WorkspaceSidebar` described the agent-status indicator as gated behind a frontmost-selected hide - `effectiveIndicator` is a plain pass-through, `effectiveUnseen`'s doc says the glyph is not gated, and `ControlSidebarStatusUITests` asserts it shows on the selected session too.

**Verification.** The claim to check is that nothing but comments moved, so it is checked four ways.

- A Swift lexer strips comments from both revisions and compares the code: 233 files, zero differences. It handles nested block comments, escapes, multiline strings and raw strings at any `#` depth, and self-checks that it still catches a deliberate mutation.
- The same comparison with indentation significant, closing the gap that the first one normalizes leading whitespace away: zero differences.
- `swiftc -frontend -dump-parse` on both revisions, normalized for pointers, source ranges and paths. All 233 files parse and every tree is byte-identical. This one is independent of my own code.
- Markdown has no comments, so the question there is whether anything machine-consumed moved: every fenced code block and every YAML frontmatter block is byte-identical, and every `paths:` glob count is unchanged, so rule scoping is untouched.

247 files changed, all modifications - nothing added, deleted or renamed. 2485 test declarations before and after.

`swift test` 2042 passing, `make test-app` 73 passing, `build-for-testing` and `swiftlint --strict` clean. The XCUITest suite is left to CI; the test bundle compiles here, and running it locally drives the screen for eight minutes.

*Not included: `README.md`, `site/*.html` and the bundled agent skill. Those are published docs where brevity trades against completeness, so they are a separate decision.*

*The verification scripts sit untracked at `.claude/verify-comment-only.sh` and `.claude/strip_swift_comments.py`. Worth keeping on their own merit, but committing them is a separate call.*
