### PR TITLE
fix: hold the resize cursor over the sidebar and split dividers

### DIFF
--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -166,10 +166,17 @@ paths:
 - On didBecomeKey, `reassertCursorOnActivation` for a visible, key-window, pointer-in-bounds surface because
   AppKit does not update the visible cursor automatically. Every `deckVisible` expression must exclude full
   overlay, scratch, and persistent quick terminal coverage.
-- Known limitations: a floating overlay shares pane-visible margins, and transient SwiftUI palette/switcher
-  overlays are absent from this boolean. One terminal may affect cursor over those regions; do not expand
-  the predicate without a more precise geometry model. Reproduce manually with stacked sessions and
-  `printf '\033]22;crosshair\007'`.
+- `deckVisible` answers "am I the on-screen pane?", never "do I own this pixel?". Chrome drawn over a pane
+  — the sidebar grab handle, an `NSSplitView` divider, a floating overlay's margin — still gets the pane's
+  per-move `NSCursor.set`, which beats chrome setting the cursor on hover entry alone (#324). All four
+  writers also gate on `ownsPointer`, a hit test against the window content view; it declines for chrome
+  only, treating a hit on any surface as ownership so a hit test that cannot see through the eager deck
+  can never silence the visible terminal. Do not replace either gate with the other.
+- Chrome that paints its own cursor must re-assert per move and per drag tick, then again on the next
+  runloop turn re-reading live hover state: a replacement lands after a synchronous `.set()` returns, and a
+  deferred pass that captured hover instead strands the shape over live terminal.
+- Reproduce manually with stacked sessions and `printf '\033]22;crosshair\007'`. Cursor shape has no
+  automated coverage; verify by eye.
 
 ## OSC 52 clipboard
 

--- a/agterm/Ghostty/GhosttySurfaceView+Input.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Input.swift
@@ -200,10 +200,12 @@ extension GhosttySurfaceView {
     /// Re-assert the libghostty-requested cursor on every move: `cursorUpdate` fires only on tracking-area
     /// entry, and SwiftUI (which owns the hosted view's cursor) can reset it on any move, so without this
     /// the pointing hand reverts to the arrow along a link. Gated on `deckVisible` so a background deck
-    /// surface never paints its shape over the visible terminal via the process-global cursor (issue #225).
+    /// surface never paints its shape over the visible terminal via the process-global cursor (issue #225),
+    /// and on `ownsPointer` so it stops at the chrome drawn over this pane (issue #324). The position report
+    /// stays ungated — libghostty tracks the pointer across the whole surface either way.
     override func mouseMoved(with event: NSEvent) {
         reportMousePos(from: event)
-        guard deckVisible else { return }
+        guard deckVisible, ownsPointer(at: event.locationInWindow) else { return }
         Self.nsCursor(for: mouseShape).set()
     }
 
@@ -407,15 +409,17 @@ extension GhosttySurfaceView: @preconcurrency NSTextInputClient {
     // MARK: - Mouse cursor shape + link opening
 
     /// Applies the cursor shape libghostty requested (`GHOSTTY_ACTION_MOUSE_SHAPE`). No-ops when unchanged,
-    /// else sets the cursor at once, but only while this is the on-screen pane (`deckVisible`) and the
-    /// pointer is inside: a background deck surface must not paint its shape over the visible terminal
-    /// (issue #225), and a revert delivered after the pointer left (the I-beam libghostty emits once
-    /// `mouseExited` reports `-1, -1`) must not paint the terminal cursor onto the sidebar. Setting it here
-    /// is what makes a stationary shape change (⌘ over a link without moving) take effect immediately.
+    /// else sets the cursor at once, but only while this is the on-screen pane (`deckVisible`), the pointer
+    /// is inside, and no chrome covers it (`ownsPointer`): a background deck surface must not paint its
+    /// shape over the visible terminal (issue #225), a revert delivered after the pointer left (the I-beam
+    /// libghostty emits once `mouseExited` reports `-1, -1`) must not paint the terminal cursor onto the
+    /// sidebar, and a shape change arriving while the pointer rests on a divider must not repaint it
+    /// (issue #324). Setting it here is what makes a stationary shape change (⌘ over a link without moving)
+    /// take effect immediately.
     func applyMouseShape(_ shape: ghostty_action_mouse_shape_e) {
         guard shape != mouseShape else { return }
         mouseShape = shape
-        if deckVisible, pointerInside { Self.nsCursor(for: shape).set() }
+        if deckVisible, pointerInside, ownsPointer() { Self.nsCursor(for: shape).set() }
     }
 
     /// AppKit's `.cursorUpdate` tracking-area callback (NOT cursor rectangles): paint the whole surface with
@@ -423,9 +427,10 @@ extension GhosttySurfaceView: @preconcurrency NSTextInputClient {
     /// resetting it as the mouse moves, so `addCursorRect`/`resetCursorRects` never take hold here — the
     /// link still underlines (libghostty draws it) but the pointing hand is dropped; upstream Ghostty.app
     /// drives the cursor through SwiftUI for the same reason. Gated on `deckVisible`: AppKit still delivers
-    /// a `cursorUpdate` to a hidden deck surface on window activation (issue #225 refocus).
+    /// a `cursorUpdate` to a hidden deck surface on window activation (issue #225 refocus), and on
+    /// `ownsPointer` because entry can land in the band a divider's grab handle covers (issue #324).
     override func cursorUpdate(with event: NSEvent) {
-        guard deckVisible else { return }
+        guard deckVisible, ownsPointer(at: event.locationInWindow) else { return }
         Self.nsCursor(for: mouseShape).set()
     }
 
@@ -433,11 +438,12 @@ extension GhosttySurfaceView: @preconcurrency NSTextInputClient {
     /// on bare activation, so a reactivating click leaves the OS arrow until the next move. Gated on
     /// `deckVisible` + `isKeyWindow` + pointer-in-bounds — read fresh from
     /// `mouseLocationOutsideOfEventStream`, since `pointerInside` can be stale on a no-move activation — so
-    /// it never paints over the sidebar/titlebar or a background window.
+    /// it never paints over the sidebar/titlebar or a background window, nor over a divider parked inside
+    /// this pane's bounds (issue #324).
     func reassertCursorOnActivation() {
         guard deckVisible, let window, window.isKeyWindow else { return }
-        let pointInView = convert(window.mouseLocationOutsideOfEventStream, from: nil)
-        guard bounds.contains(pointInView) else { return }
+        let pointInWindow = window.mouseLocationOutsideOfEventStream
+        guard bounds.contains(convert(pointInWindow, from: nil)), ownsPointer(at: pointInWindow) else { return }
         Self.nsCursor(for: mouseShape).set()
     }
 

--- a/agterm/Ghostty/GhosttySurfaceView+Tracking.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Tracking.swift
@@ -36,4 +36,29 @@ extension GhosttySurfaceView {
         super.updateTrackingAreas()
         setupTrackingArea()
     }
+
+    /// Whether this pane owns the pixel under `point` (window coordinates) — no sibling chrome is drawn over
+    /// it there. `deckVisible` answers "am I the on-screen pane?", which is a different question: tracking
+    /// areas ignore sibling overlap (see `updatePointerTracking`), so a pane keeps receiving `mouseMoved`
+    /// under the sidebar's grab handle, an `NSSplitView` divider, or a floating overlay's margin, and
+    /// re-asserts its shape into the process-global `NSCursor` on every move — beating chrome that sets the
+    /// cursor once on hover entry (issue #324). Hit-testing resolves ownership the same way the drag that
+    /// starts in that band already does, so no per-divider width has to be guessed and later chrome is
+    /// covered without touching this file.
+    ///
+    /// Declines for chrome ONLY: a hit landing on any surface — this one, a descendant, or a sibling pane
+    /// stacked at the same frame in the eager deck — keeps the pre-#324 behavior, so a hit test that cannot
+    /// see through the deck can never silence the visible terminal.
+    func ownsPointer(at point: NSPoint) -> Bool {
+        guard let hit = window?.contentView?.hitTest(point) else { return true }
+        if hit === self || hit.isDescendant(of: self) { return true }
+        return hit is GhosttySurfaceView
+    }
+
+    /// `ownsPointer(at:)` for the callers with no event in hand (`applyMouseShape`, activation), reading the
+    /// pointer live rather than from possibly-stale state.
+    func ownsPointer() -> Bool {
+        guard let window else { return true }
+        return ownsPointer(at: window.mouseLocationOutsideOfEventStream)
+    }
 }

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -59,6 +59,9 @@ struct WindowContentView: View {
     @State var toolbarMode: ToolbarMode = WindowContentView.resolvedToolbarMode()
     /// How strongly `paneDim` mutes the inactive split pane's text (0...10).
     @State private var inactivePaneMute: Int = WindowContentView.resolvedInactivePaneMute()
+    /// Live pointer/drag state for `sidebarDivider`'s grab handle, read by its deferred cursor re-assert.
+    @State private var dividerHovered = false
+    @State private var dividerDragging = false
     /// How much lighter/darker the sidebar background is than the terminal (0...10, 5 = neutral). Drives
     /// `sidebarTintWash`.
     @State var sidebarShift: Int = WindowContentView.resolvedSidebarShift()
@@ -317,20 +320,52 @@ struct WindowContentView: View {
                 Color.clear
                     .frame(width: 12)
                     .contentShape(Rectangle())
-                    .onHover { inside in
-                        if inside { NSCursor.resizeLeftRight.set() } else { NSCursor.arrow.set() }
+                    // per MOVE, not just on entry: the handle overhangs the terminal, whose surface re-asserts
+                    // its own shape on every move, and one set on entry cannot hold against it (issue #324).
+                    .onContinuousHover { phase in
+                        switch phase {
+                        case .active:
+                            dividerHovered = true
+                            setDividerCursor()
+                        case .ended:
+                            dividerHovered = false
+                            // a drag past the width clamp leaves the handle under the pointer; the drag's own
+                            // re-assert owns the cursor until release.
+                            if !dividerDragging { NSCursor.arrow.set() }
+                        }
                     }
                     .gesture(
                         // width comes from the absolute cursor X, NOT accumulated translation: the divider
                         // moves with the width, so translation feeds back on itself and the line flickers.
                         DragGesture(minimumDistance: 1, coordinateSpace: .global)
                             .onChanged { value in
+                                dividerDragging = true
                                 store.sidebarWidth = min(AppStore.sidebarWidthMax, max(AppStore.sidebarWidthMin, Double(value.location.x)))
+                                // past the clamp the divider stops following the pointer, which ends up over
+                                // live terminal with no hover event left to repaint ↔.
+                                setDividerCursor()
                             }
                             // persist the new width once, on release, not on every drag tick.
-                            .onEnded { _ in store.save() }
+                            .onEnded { _ in
+                                dividerDragging = false
+                                if !dividerHovered { NSCursor.arrow.set() }
+                                store.save()
+                            }
                     )
             }
+    }
+
+    /// Paint ↔ for the sidebar handle, then once more on the next runloop turn: a cursor replacement still
+    /// lands after this synchronous `.set()` returns — SwiftUI hosts the terminal surface and resets the
+    /// cursor as the mouse moves (see `GhosttySurfaceView.cursorUpdate`) — so a single set loses the race.
+    /// The deferred pass re-reads `dividerHovered` rather than capturing it, so a re-assert arriving after
+    /// the pointer left cannot strand ↔ over live terminal text.
+    private func setDividerCursor() {
+        NSCursor.resizeLeftRight.set()
+        DispatchQueue.main.async {
+            guard dividerHovered || dividerDragging else { return }
+            NSCursor.resizeLeftRight.set()
+        }
     }
 
     @ViewBuilder private var detailColumn: some View {

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -130,6 +130,12 @@ struct WindowContentView: View {
         .onChange(of: store.sidebarVisible) { _, visible in
             if visible {
                 DispatchQueue.main.async { NotificationCenter.default.post(name: .agtermAppearanceChanged, object: nil) }
+            } else {
+                // hiding mid-drag (⌘⌃S, the palette, `sidebar hide`, inactive-window auto-hide) removes the
+                // divider and cancels its gesture without `onEnded`, so these would stay latched on this
+                // view: ↔ would survive the next hover exit and the arrow would never be restored.
+                dividerHovered = false
+                dividerDragging = false
             }
         }
         // on quick-terminal hide refocus the active session, unless this window's zoom owns focus: zoom-enter

--- a/agtermTests/GhosttySurfaceViewTrackingTests.swift
+++ b/agtermTests/GhosttySurfaceViewTrackingTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import agterm
+
+/// Content view whose hit resolution the test supplies directly, standing in for the real window
+/// hierarchy: `ownsPointer` only asks who owns a point, so the geometry that would produce the answer is
+/// beside the point here.
+private final class StubContentView: NSView {
+    var hitResult: NSView?
+    override func hitTest(_ point: NSPoint) -> NSView? { hitResult }
+}
+
+/// Pins the chrome-versus-surface split that keeps the resize cursor over the dividers (issue #324).
+/// Returning true for chrome puts the flicker back; returning false for a sibling pane silences the
+/// visible terminal's own cursor instead. Neither shows up in any other test.
+@MainActor
+final class GhosttySurfaceViewTrackingTests: XCTestCase {
+    private var window: NSWindow!
+    private var content: StubContentView!
+    private var surface: GhosttySurfaceView!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        await MainActor.run {
+            window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
+                styleMask: [.titled],
+                backing: .buffered,
+                defer: false
+            )
+            window.isReleasedWhenClosed = false
+            content = StubContentView(frame: NSRect(x: 0, y: 0, width: 320, height: 200))
+            window.contentView = content
+            // both surfaces stay at their zero init frame, so `viewDidMoveToWindow` parks in
+            // `pendingSurfaceCreation` instead of spawning a libghostty surface and a shell.
+            surface = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+            content.addSubview(surface)
+        }
+    }
+
+    override func tearDown() async throws {
+        await MainActor.run {
+            surface.removeFromSuperview()
+            surface = nil
+            window.orderOut(nil)
+            window = nil
+            content = nil
+        }
+        try await super.tearDown()
+    }
+
+    func testDeclinesWhenChromeOwnsThePoint() {
+        content.hitResult = NSView(frame: NSRect(x: 0, y: 0, width: 12, height: 200))
+        XCTAssertFalse(surface.ownsPointer(at: NSPoint(x: 10, y: 100)))
+    }
+
+    func testOwnsThePointWhenTheHitIsItself() {
+        content.hitResult = surface
+        XCTAssertTrue(surface.ownsPointer(at: NSPoint(x: 10, y: 100)))
+    }
+
+    func testOwnsThePointWhenTheHitIsItsOwnDescendant() {
+        let child = NSView(frame: .zero)
+        surface.addSubview(child)
+        content.hitResult = child
+        XCTAssertTrue(surface.ownsPointer(at: NSPoint(x: 10, y: 100)))
+    }
+
+    /// The eager deck stacks every session at one frame, so a hit can resolve to a sibling pane. That is
+    /// `deckVisible`'s question, not this one: keeping it "owned" degrades to the pre-#324 behavior rather
+    /// than leaving the visible terminal with no cursor writer at all.
+    func testOwnsThePointWhenTheHitIsASiblingSurface() {
+        let sibling = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+        content.addSubview(sibling)
+        content.hitResult = sibling
+        XCTAssertTrue(surface.ownsPointer(at: NSPoint(x: 10, y: 100)))
+        sibling.removeFromSuperview()
+    }
+
+    func testOwnsThePointWhenNothingIsHit() {
+        content.hitResult = nil
+        XCTAssertTrue(surface.ownsPointer(at: NSPoint(x: 10, y: 100)))
+    }
+
+    func testOwnsThePointWhenDetachedFromAnyWindow() {
+        let detached = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+        XCTAssertTrue(detached.ownsPointer(at: NSPoint(x: 10, y: 100)))
+        XCTAssertTrue(detached.ownsPointer())
+    }
+}


### PR DESCRIPTION
Hovering either divider only flashed the resize cursor, which then alternated with the terminal's I-beam on every mouse move. Dragging worked; only the pointer feedback was broken.

`NSCursor` is process-global, and over a divider two writers set it for the same event. The pane's tracking area covers its full bounds and ignores sibling overlap, which #225 depends on, so a pane keeps receiving `mouseMoved` under the chrome drawn on top of it and re-asserts its own shape there. Meanwhile the sidebar handle set the resize cursor once on hover entry, and AppKit owns the split divider. One set on entry cannot hold against a writer that runs on every move.

Regression from #207, which replaced cursor rectangles with a per-move `NSCursor.set`. The handle's hover code is unchanged since before that commit.

**The fix**

`deckVisible` answers "am I the on-screen pane?", not "do I own this pixel?". All four cursor writers now also gate on `ownsPointer`, a hit test against the window content view, so a pane stops painting exactly where a grab handle starts. Hit-testing already resolves ownership correctly in both places, which is why the drags work today.

It declines for chrome only: a hit resolving to any surface, including a sibling pane stacked at the same frame in the eager deck, counts as ownership. A hit test that cannot see through the deck degrades to the old behavior rather than silencing the visible terminal.

A fixed geometric band was the obvious alternative and is worse: the width has to be guessed per divider, and a band wider than the handle leaves a resize cursor over live terminal text where a press does not resize.

The sidebar handle re-asserts per move and per drag tick, then once more on the next runloop turn re-reading live hover state, since a cursor replacement arrives after the synchronous set returns. Hiding the sidebar mid-drag cancels the gesture without `onEnded`, so both flags reset on that edge.

**Notes**

`deckVisible` stays as the outer gate everywhere; `ownsPointer` is an additional AND, never a replacement. The tracking-area half of #225 is untouched. `reportMousePos` stays ungated, so mouse-reporting TUIs and selection drags see no change.

This also covers the floating overlay and palette regions `.claude/rules/libghostty.md` listed as open limitations, since both are hit-testable chrome above a pane.

Verified by hand on a Debug build: both dividers hold, the terminal keeps its own shapes including the pointing hand on a command-hovered link, and dragging past the width clamp keeps the resize cursor.

Fix #324
