### PR TITLE
docs(cookbook): add the opencode-session-resume recipe

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -18,9 +18,10 @@ Recipes come from other people as well as the maintainer. Every one is reviewed 
 | [status-announcer](status-announcer/) | demo: speak agent status changes from a dedicated session | 0.16.0, jq |
 | [claude-session-resume](claude-session-resume/) | each tab reopens its own Claude Code conversation after a restart | 0.3.1, zsh, Claude Code |
 | [codex-session-resume](codex-session-resume/) | each tab reopens its own codex conversation after a restart | 0.3.1, zsh, Codex CLI |
+| [opencode-session-resume](opencode-session-resume/) | each tab reopens its own opencode conversation after a restart | 0.3.1, zsh, opencode |
 | [new-session-in-workspace](new-session-in-workspace/) | pick a workspace with fzf and start a session in it | 0.8.0, jq, fzf |
 
-Most recipes need `agtermctl` on your PATH; **Help ▸ Install Command Line Tool…** puts it there. The two session-resume recipes are shell functions that read the environment agterm gives a session and never call the CLI. Some recipes also need `jq`, `fzf`, or a particular shell, and each recipe's *Requirements* section says which, along with the minimum agterm version it needs. Recipes are snapshots rather than a maintained surface: the control API grows by addition, so they rarely break, and one that does gets fixed when it is reported.
+Most recipes need `agtermctl` on your PATH; **Help ▸ Install Command Line Tool…** puts it there. The three session-resume recipes are shell functions that read the environment agterm gives a session and never call the CLI. Some recipes also need `jq`, `fzf`, or a particular shell, and each recipe's *Requirements* section says which, along with the minimum agterm version it needs. Recipes are snapshots rather than a maintained surface: the control API grows by addition, so they rarely break, and one that does gets fixed when it is reported.
 
 ## Contributing a recipe
 

--- a/cookbook/opencode-session-resume/README.md
+++ b/cookbook/opencode-session-resume/README.md
@@ -1,0 +1,82 @@
+# opencode per-tab session resume
+
+After a restart each tab reopens its own opencode conversation instead of starting a fresh one.
+
+Contributed by [@cherkale](https://github.com/cherkale), from [discussion #71](https://github.com/umputun/agterm/discussions/71#discussioncomment-17845561).
+
+## What it does
+
+Same idea as the Claude Code and codex recipes next door: each tab reopens its own conversation after a restart.
+
+The mechanism follows the codex one, because opencode is also unable to take a session id at launch: the function maps tab id to opencode session id in `~/.local/state/opencode/agterm/<tab-id>` and resumes that. The difference is where the session id comes from. opencode keeps conversations in sqlite rather than one file per conversation, so there is nothing to glob for; the function asks `opencode session list --format json` instead. That list holds the current project's top-level sessions, while `--session` is not scoped at all and takes any session that exists, so everything the list offers is something a resume will accept.
+
+Subcommands, an explicit `--session`/`--continue`, and any launch outside agterm pass through untouched.
+
+## Requirements
+
+- agterm 0.3.1 or later, with **Restore running commands on restart** turned on under Settings ▸ General ▸ Sessions. Both `AGTERM_SESSION_ID` and that setting predate the repository's earliest tagged release, so 0.3.1 is the first version that can be named, not the version the behavior arrived in.
+- `zsh`
+- opencode 1.18.10 or later, the version its `session list --format json` output shape and `--session` validation were checked against. The function creates `~/.local/state/opencode/agterm/` for its own mapping files, next to opencode's own state directory (`$XDG_STATE_HOME` is honored if you set it).
+
+## Setup
+
+The functions have to be defined in `~/.zshrc`, the config your interactive login zsh reads. That matters: agterm feeds the restored command into that shell, so `.zshenv` and `.zprofile` are too early to intercept it.
+
+Either paste both functions from `opencode-resume.zsh` into `~/.zshrc`, or keep the file and source it from there:
+
+```sh
+mkdir -p ~/.zsh
+cp opencode-resume.zsh ~/.zsh/
+```
+
+then add to `~/.zshrc`:
+
+```sh
+source ~/.zsh/opencode-resume.zsh
+```
+
+The file is sourced, never run, so it does not need the executable bit and is committed without one. Its shebang is there to name the shell it is written for.
+
+Turn on **Restore running commands on restart** in Settings ▸ General, under Sessions. Without it agterm brings a tab back as a plain shell and there is nothing for the function to intercept.
+
+New tabs and shells pick the functions up on their own. In an already-open shell, run `source ~/.zshrc`.
+
+To remove it, delete the two function blocks, or the `source` line, from `~/.zshrc`, and `~/.local/state/opencode/agterm/` with it.
+
+## Usage
+
+Run `opencode` the way you always do. Start it, send at least one message, then restart agterm: the tab comes back to that conversation, and `ps` shows `opencode --session ses_…`.
+
+The first message matters. opencode writes the session only once there is something in it, so a tab where you started opencode and typed nothing has nothing to remember and comes back empty-handed.
+
+Mappings live one file per tab under `~/.local/state/opencode/agterm/`, each holding a single opencode session id. Deleting one unbinds that tab, and the next `opencode` you type in it starts fresh — though a tab restored as `opencode --session <id>` still reopens that conversation while it exists, since an explicit id passes through untouched.
+
+## How it works
+
+agterm can remember the command running in a tab and re-run it on restart. It re-runs that command verbatim, and `opencode` with no arguments is a new conversation rather than a continuation.
+
+Every agterm tab has a stable identifier, `AGTERM_SESSION_ID`, that survives a restart. Claude Code can be handed a session id at launch and so needs no state at all. opencode cannot: `--session` is validated against existing sessions, and an id that is not there makes opencode print an error and exit instead of starting. So, like the codex recipe, this one keeps a file named after the tab holding the session id that tab owns — and, unlike it, never passes an id it has not just seen in the session list.
+
+On each `opencode` the function reads `~/.local/state/opencode/agterm/<tab-id>` and lists the current project's sessions. If the mapped id is among them it runs `opencode --session <id>` and is done. Otherwise it runs opencode plainly and, when that returns, lists again: the first id that was not in the "before" list is the conversation this run created, and it goes into the mapping file for next time. The list comes back most recently updated first, which is why the first new id is the right one to take.
+
+Two things about opencode shaped this. Conversations moved into `~/.local/share/opencode/opencode.db`, so the recipe reads them through the CLI rather than through the database — the schema is internal, `session list` is not. And the session row appears only when the first message is sent, not when the TUI starts, so the id cannot be captured right after launch; it has to be adopted after the run.
+
+The restored command line is `opencode --session <id>`, which the function recognizes as its own: it drops the flag and decides again from scratch, so a tab whose conversation was deleted in the meantime comes back to a fresh opencode rather than to an error message.
+
+On the agterm side the replay is a foreground-process capture. At quit agterm records the argv of whatever the pane was running, and on relaunch it types that line back into the tab's fresh login shell with each argument single-quoted. Quoting suppresses alias expansion but not function lookup, which is why a shell function named `opencode` still catches the replayed line and an alias would not.
+
+## Limits
+
+- **agterm-specific.** It needs a stable per-tab identifier and relies on agterm feeding the restored command back through the login shell, which is how the function intercepts it. It will not work as-is in another terminal; you would adapt it to that terminal's equivalent.
+- **Rests on restore behavior that is verified empirically, not documented.** It could change between agterm versions.
+- **The mapping is written only after opencode exits.** A terminal restart while opencode is still running kills the shell before that line is reached, so a tab that has never exited opencode cleanly comes back to a fresh conversation. From the first clean exit onward the tab is mapped, and after that a restart is covered twice over, by the mapping file and by the replayed `--session` line.
+- **One conversation per tab.** A split pane, a scratch pane and any overlay all run under the same `AGTERM_SESSION_ID` as the main pane, so a second opencode started in one of them reads and overwrites the same mapping file as the first.
+- **The tab keeps the conversation it first adopted.** Switching to another session inside the TUI does not move the mapping, so the next launch reopens the adopted one.
+- **A busy neighbor can be adopted by mistake.** The session list is shared across every tab in the project, so if another tab starts a conversation while this one is running, this one can adopt that id on exit. Outside a git repository the project is `global`, which spans every non-repository directory on the machine, so there the neighbor can be a tab working somewhere else entirely.
+- **It shadows the `opencode` command** with a shell function. Passthrough is handled, but the list of subcommands and flags that must not be touched has to be kept current if the CLI grows new ones.
+- **It reads the shape of `session list --format json`** — one field per line, ids as `"id": "ses_…"`. If that output becomes single-line JSON the parse finds nothing, no mapping is written and every tab starts fresh. It fails toward a new conversation rather than toward the wrong one.
+- **It costs a `session list` call per launch**, the better part of a second, plus a second one after a run that created a conversation. The TUI appears that much later.
+- **`opencode <path>` is not mapped.** The session list is taken in the shell's own directory, so a conversation started in another project is never seen there and that tab stays unmapped. A tab that already owns a conversation keeps it, since the path is simply passed along with the `--session` it resumes.
+- **The binding follows the project.** The "does it still exist" check is project-scoped, so running `opencode` from the same tab in a different repository starts a fresh conversation there and the mapping moves to it. The tab owns one conversation at a time, not one per project.
+- **zsh only** (`${:l}`, `${(f)}`, the `(Ie)` subscript flag, `emulate`). Bash needs a rewrite.
+- **Existing conversations are not bound to tabs.** After you install this, the first run in a tab adopts the conversation that run creates; it does not adopt an arbitrary earlier one.

--- a/cookbook/opencode-session-resume/README.md
+++ b/cookbook/opencode-session-resume/README.md
@@ -45,7 +45,7 @@ To remove it, delete the two function blocks, or the `source` line, from `~/.zsh
 
 ## Usage
 
-Run `opencode` the way you always do. Start it, send at least one message, then restart agterm: the tab comes back to that conversation, and `ps` shows `opencode --session ses_…`.
+Run `opencode` the way you always do. Start it, send at least one message, quit it, then start it again in the same tab — `ps` shows `opencode --session ses_…`. Restart agterm and the tab comes back to that conversation.
 
 The first message matters. opencode writes the session only once there is something in it, so a tab where you started opencode and typed nothing has nothing to remember and comes back empty-handed.
 

--- a/cookbook/opencode-session-resume/opencode-resume.zsh
+++ b/cookbook/opencode-session-resume/opencode-resume.zsh
@@ -1,0 +1,61 @@
+#!/usr/bin/env zsh
+# Sourced, not executed: paste both functions into ~/.zshrc, or source this file from there.
+# See README.md.
+
+# opencode: per-agterm-tab session resume.
+# Maps the tab's own uuid (AGTERM_SESSION_ID) to an opencode session id under
+# ~/.local/state/opencode/agterm/, so restoring the terminal resumes that tab's own
+# conversation instead of starting fresh.
+# Requires: agterm (exports AGTERM_SESSION_ID, restores running commands) + zsh.
+
+# Session ids of the current project, most recently updated first.
+# opencode keeps sessions in sqlite, so the CLI is the only supported way to ask. The list is
+# scoped to the project while --session is not scoped at all, so anything listed is resumable.
+_agterm_opencode_sessions() {
+  emulate -L zsh
+  local line
+  command opencode session list --format json 2>/dev/null | while read -r line; do
+    [[ $line == '"id": "ses_'* ]] || continue      # one field per line, so a title cannot fake an id line
+    line=${line#*: \"}
+    print -r -- ${line%%\"*}
+  done
+}
+
+opencode() {
+  emulate -L zsh
+  local sid=${AGTERM_SESSION_ID:l}
+  [[ -z $sid ]] && { command opencode "$@"; return; }              # not in an agterm tab -> passthrough
+
+  local mapf=${XDG_STATE_HOME:-$HOME/.local/state}/opencode/agterm/$sid
+  local cid; [[ -f $mapf ]] && cid=$(<$mapf)
+
+  if [[ $1 == (-s|--session) && -n $cid && $2 == $cid ]]; then
+    shift 2                                                        # restore replayed our own flag -> re-decide below
+  else
+    local a
+    for a in "$@"; do                                              # user steering a session/subcommand?
+      case $a in
+        -s|--session|--session=*|-c|--continue|--fork|-h|--help|-v|--version|\
+        run|attach|serve|web|acp|mcp|models|stats|export|import|session|plugin|plug|db|\
+        debug|agent|providers|auth|github|pr|upgrade|uninstall|completion)
+          command opencode "$@"; return ;;                         # -> hand off untouched
+      esac
+    done
+  fi
+
+  local -a before=( ${(f)"$(_agterm_opencode_sessions)"} )         # what existed before this run
+  if [[ -n $cid ]] && (( ${before[(Ie)$cid]} )); then
+    command opencode --session $cid "$@"                           # this tab's session is still there -> continue it
+    return
+  fi
+
+  command opencode "$@"                                            # nothing to resume -> plain run, then adopt what it made
+  local rc=$? id
+  for id in ${(f)"$(_agterm_opencode_sessions)"}; do
+    [[ -n $id ]] || continue
+    (( ${before[(Ie)$id]} )) && continue                           # was already there -> not this run's
+    command mkdir -p ${mapf:h} && print -r -- $id > $mapf
+    break
+  done
+  return $rc
+}


### PR DESCRIPTION
Third session-resume recipe, next to `claude-session-resume` and `codex-session-resume`: each agterm tab reopens its own opencode conversation after a restart. From [discussion #71](https://github.com/umputun/agterm/discussions/71#discussioncomment-17845561).

opencode will not take a session id at launch either, so the function maps tab id to session id the way the codex one does. It cannot glob for the conversation, though: sessions live in sqlite, so the id comes from `opencode session list --format json`, which lists the current project's top-level sessions while `--session` is not scoped at all — so everything the list offers is something a resume will accept, and a subagent's child session, which the list leaves out, can never be mapped by mistake. The session row also appears only once the first message is sent, not when the TUI starts, so the id is adopted after the run instead of captured at launch.

What the shape follows: one `.zsh` holding both functions, committed without the executable bit; README in the six-heading template with the byline; index row in the same change; Requirements naming agterm 0.3.1 or later, `zsh`, and opencode 1.18.10 as the version this was checked against.

Verified against the real CLI at 1.18.10:

- an unknown `--session` id makes opencode print `Session not found` and exit instead of starting, which is why the function never passes an id it has not just seen listed
- a mapped id reopens exactly that conversation, with `ps` showing `opencode --session ses_…`
- the parse returns precisely the ids `session list` prints, and a subagent's child session is in the database but absent from the list
- a TUI left open without a message creates no session row at all

Verified against a stub `opencode`, for the branches that need many runs: passthrough of subcommands and of an explicit `--session`, adopting the conversation a run creates, resuming a mapped one, the replayed `--session` line being re-decided rather than doubled, a deleted conversation falling back to a fresh run and re-adopting, two tabs keeping separate mappings, and the exit code passing through.

The cookbook gates were run locally: index in both directions, the six headings, kebab-case, shebang, `zsh -n`. The function is installed in my own `~/.zshrc` and drives my opencode tabs.

Limits keeps the two you called out — the `session list --format json` shape and adopting another tab's id — plus the mapping-written-only-after-exit one the codex recipe shares. Two entries are new since the thread, both from re-checking scoping afterwards: outside a git repository the project is `global`, which spans every non-repository directory on the machine, so the neighbour whose id can be adopted may be a tab working somewhere else entirely; and the existence check being project-scoped means a tab used in another repository starts a fresh conversation there and the mapping moves with it. That same re-check corrected what the thread post claimed — that the list and `--session` are scoped alike. They are not: the list is per project, `--session` takes any session that exists. The recipe only needs the list to be a subset of what a resume accepts, which it is.
