### PR TITLE
docs(cookbook): fix the mapping path and the passthrough claim

### DIFF
--- a/cookbook/opencode-session-resume/README.md
+++ b/cookbook/opencode-session-resume/README.md
@@ -10,7 +10,7 @@ Same idea as the Claude Code and codex recipes next door: each tab reopens its o
 
 The mechanism follows the codex one, because opencode is also unable to take a session id at launch: the function maps tab id to opencode session id in `~/.local/state/opencode/agterm/<tab-id>` and resumes that. The difference is where the session id comes from. opencode keeps conversations in sqlite rather than one file per conversation, so there is nothing to glob for; the function asks `opencode session list --format json` instead. That list holds the current project's top-level sessions, while `--session` is not scoped at all and takes any session that exists, so everything the list offers is something a resume will accept.
 
-Subcommands, an explicit `--session`/`--continue`, and any launch outside agterm pass through untouched.
+Subcommands, `--continue`, and any launch outside agterm pass through untouched, and so does an explicit `--session` — unless the id is the one this tab already owns, which the function takes back and decides on again, so that it resumes only a conversation it has just seen listed.
 
 ## Requirements
 
@@ -41,7 +41,7 @@ Turn on **Restore running commands on restart** in Settings ▸ General, under S
 
 New tabs and shells pick the functions up on their own. In an already-open shell, run `source ~/.zshrc`.
 
-To remove it, delete the two function blocks, or the `source` line, from `~/.zshrc`, and `~/.local/state/opencode/agterm/` with it.
+To remove it, delete the two function blocks, or the `source` line, from `~/.zshrc`, and `${XDG_STATE_HOME:-~/.local/state}/opencode/agterm/` with it.
 
 ## Usage
 
@@ -49,7 +49,7 @@ Run `opencode` the way you always do. Start it, send at least one message, quit 
 
 The first message matters. opencode writes the session only once there is something in it, so a tab where you started opencode and typed nothing has nothing to remember and comes back empty-handed.
 
-Mappings live one file per tab under `~/.local/state/opencode/agterm/`, each holding a single opencode session id. Deleting one unbinds that tab, and the next `opencode` you type in it starts fresh — though a tab restored as `opencode --session <id>` still reopens that conversation while it exists, since an explicit id passes through untouched.
+Mappings live one file per tab under `${XDG_STATE_HOME:-~/.local/state}/opencode/agterm/`, each holding a single opencode session id. Deleting one unbinds that tab, and the next `opencode` you type in it starts fresh — though a tab restored as `opencode --session <id>` still reopens that conversation while it exists: with no mapping left there is nothing for the function to recognise, so the explicit id passes through untouched.
 
 ## How it works
 


### PR DESCRIPTION
Follow-up to #328, the two nits from your review.

The removal step and the Usage paragraph named `~/.local/state/opencode/agterm/` flat while the function honors `$XDG_STATE_HOME` (`opencode-resume.zsh:29`), so a reader with a custom state home cleans the wrong directory and leaves his bindings behind. Both now name `${XDG_STATE_HOME:-~/.local/state}/opencode/agterm/`. The mention in Requirements keeps the plain default, since the same sentence explains the variable.

The passthrough sentence claimed more than the code does. An explicit `--session` goes through untouched except when the id is the one the tab already owns, which the replay branch takes back. Reworded; the check is unchanged.

On what that exception actually costs, from re-running the four cases against a stub `opencode`:

| typed | tab's conversation in the project list | reaches opencode as |
|---|---|---|
| `--session <mapped-id> --fork` | yes | `--session <mapped-id> --fork`, forks fine |
| `--session <mapped-id> --fork` | no | `--fork`, rejected by opencode's own `--fork requires --continue or --session` |
| `--session <mapped-id>` | no | nothing — a fresh conversation, though opencode itself would have opened that session |
| `--session <other-id> --fork` | — | untouched |

So the fresh conversation is the third row rather than the fork case.
