### PR TITLE
fix(sidebar): keep the status blink running across row reloads

### DIFF
--- a/agterm/Views/WorkspaceSidebar+RowRendering.swift
+++ b/agterm/Views/WorkspaceSidebar+RowRendering.swift
@@ -36,10 +36,8 @@ extension WorkspaceSidebar.Coordinator {
         field.isEditable = false
         field.isBordered = false
         field.drawsBackground = false
-        // a recycled cell may carry the prior row's badge/hover state; reset before use. The status glyph is
-        // NOT reset here: both branches below assign it in full, and the idle round-trip would tear down and
-        // re-add the blink animation on every reload, restarting the fade at full opacity — a row whose
-        // terminal title animates (a spinner in the title) then strobes instead of pulsing.
+        // a recycled cell may carry the prior row's badge/hover state; reset before use. NOT the status
+        // glyph: each branch assigns it in full, and an idle round-trip restarts the blink on reload.
         applyBadge(toCell: cell, count: 0)
         cell.setAddButtonVisible(false)
         switch node.kind {
@@ -67,7 +65,6 @@ extension WorkspaceSidebar.Coordinator {
             field.setAccessibilityLabel(nil)
             let session = store.session(withID: node.id)
             applyBadge(toCell: cell, count: effectiveUnseen(session?.unseenCount ?? 0))
-            // gate the agent-status glyph: hidden for the frontmost window's selected session.
             cell.statusIcon.apply(effectiveIndicator(forSession: node.id))
             // the split-rectangle icon (matching the toolbar split button) shows in BOTH modes so a split
             // stays distinguishable at a glance, and `hasSplit` keeps it while merely hidden. Only the

--- a/agterm/Views/WorkspaceSidebar+RowRendering.swift
+++ b/agterm/Views/WorkspaceSidebar+RowRendering.swift
@@ -36,13 +36,17 @@ extension WorkspaceSidebar.Coordinator {
         field.isEditable = false
         field.isBordered = false
         field.drawsBackground = false
-        // a recycled cell may carry the prior row's badge/status/hover state; reset before use
+        // a recycled cell may carry the prior row's badge/hover state; reset before use. The status glyph is
+        // NOT reset here: both branches below assign it in full, and the idle round-trip would tear down and
+        // re-add the blink animation on every reload, restarting the fade at full opacity — a row whose
+        // terminal title animates (a spinner in the title) then strobes instead of pulsing.
         applyBadge(toCell: cell, count: 0)
-        cell.statusIcon.apply(AgentIndicator())
         cell.setAddButtonVisible(false)
         switch node.kind {
         case .workspace:
             let workspace = store.workspaces.first(where: { $0.id == node.id })
+            // workspaces carry no agent status; the idle apply collapses the glyph slot
+            cell.statusIcon.apply(AgentIndicator())
             field.stringValue = workspace?.name ?? ""
             field.font = .systemFont(ofSize: GhosttyApp.shared.sidebarFontSize, weight: .medium)
             field.setAccessibilityIdentifier("workspace-row")

--- a/agtermTests/SidebarStatusBlinkTests.swift
+++ b/agtermTests/SidebarStatusBlinkTests.swift
@@ -3,10 +3,8 @@ import XCTest
 @testable import agterm
 import agtermCore
 
-/// Hosted coverage for the sidebar status glyph's blink surviving a row reload. A terminal title change
-/// moves `displayName`, which reloads just that row; the row builder must not tear the blink animation
-/// down and re-add it, or an animated title (Codex CLI's ~10Hz braille spinner) restarts the 0.5s fade
-/// before it leaves full opacity and the glyph strobes instead of pulsing.
+/// Hosted coverage for the sidebar status glyph's blink surviving a per-row reload: a title change moves
+/// `displayName`, which reloads the row, and the row builder must not tear the animation down and re-add it.
 @MainActor
 final class SidebarStatusBlinkTests: XCTestCase {
     private var stateDir: URL!
@@ -76,8 +74,27 @@ final class SidebarStatusBlinkTests: XCTestCase {
 
         session.agentIndicator = AgentIndicator(status: .active, blink: true)
         coordinator.reconcile()
-        let (_, blink) = try renderedStatus(forSession: session.id)
-        XCTAssertNotNil(blink)
+        _ = try renderedStatus(forSession: session.id)
+    }
+
+    func testClearingOnlyTheBlinkFlagStopsTheAnimation() throws {
+        try XCTSkipIf(NSWorkspace.shared.accessibilityDisplayShouldReduceMotion,
+                      "Reduce Motion suppresses the blink this test pins")
+        let store = try XCTUnwrap(library.activeStore)
+        let session = try XCTUnwrap(store.activeSession)
+        buildSidebar(for: store)
+
+        session.agentIndicator = AgentIndicator(status: .active, blink: true)
+        coordinator.reconcile()
+        _ = try renderedStatus(forSession: session.id)
+
+        session.agentIndicator = AgentIndicator(status: .active, blink: false)
+        coordinator.reconcile()
+        let (_, cell) = try renderedRow(forSession: session.id)
+
+        XCTAssertNil(cell.statusIcon.layer?.animation(forKey: Self.blinkKey),
+                     "dropping the blink flag must stop the animation, not only going idle")
+        XCTAssertFalse(cell.statusIcon.isHidden, "a still-active status keeps its glyph on screen")
     }
 
     func testClearingBlinkStopsTheAnimation() throws {

--- a/agtermTests/SidebarStatusBlinkTests.swift
+++ b/agtermTests/SidebarStatusBlinkTests.swift
@@ -3,8 +3,8 @@ import XCTest
 @testable import agterm
 import agtermCore
 
-/// Hosted coverage for the sidebar status glyph's blink surviving a per-row reload: a title change moves
-/// `displayName`, which reloads the row, and the row builder must not tear the animation down and re-add it.
+/// Hosted coverage for the sidebar status glyph's blink lifecycle: it starts and stops with the indicator,
+/// and survives a per-row reload, which a terminal title change triggers through `displayName`.
 @MainActor
 final class SidebarStatusBlinkTests: XCTestCase {
     private var stateDir: URL!

--- a/agtermTests/SidebarStatusBlinkTests.swift
+++ b/agtermTests/SidebarStatusBlinkTests.swift
@@ -1,0 +1,149 @@
+import AppKit
+import XCTest
+@testable import agterm
+import agtermCore
+
+/// Hosted coverage for the sidebar status glyph's blink surviving a row reload. A terminal title change
+/// moves `displayName`, which reloads just that row; the row builder must not tear the blink animation
+/// down and re-add it, or an animated title (Codex CLI's ~10Hz braille spinner) restarts the 0.5s fade
+/// before it leaves full opacity and the glyph strobes instead of pulsing.
+@MainActor
+final class SidebarStatusBlinkTests: XCTestCase {
+    private var stateDir: URL!
+    private var library: WindowLibrary!
+    private var actions: AppActions!
+    private var window: NSWindow!
+    private var outline: SidebarOutlineView!
+    private var coordinator: WorkspaceSidebar.Coordinator!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        await MainActor.run {
+            stateDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("agterm-status-blink-tests-\(UUID().uuidString)", isDirectory: true)
+            library = WindowLibrary(directory: stateDir)
+            actions = AppActions(library: library)
+        }
+    }
+
+    override func tearDown() async throws {
+        await MainActor.run {
+            window?.orderOut(nil)
+            window = nil
+            outline = nil
+            coordinator = nil
+            actions = nil
+            library = nil
+            try? FileManager.default.removeItem(at: stateDir)
+            stateDir = nil
+        }
+        try await super.tearDown()
+    }
+
+    func testTitleChangeDoesNotRestartTheStatusBlink() throws {
+        try XCTSkipIf(NSWorkspace.shared.accessibilityDisplayShouldReduceMotion,
+                      "Reduce Motion suppresses the blink this test pins")
+        let store = try XCTUnwrap(library.activeStore)
+        let session = try XCTUnwrap(store.activeSession)
+        buildSidebar(for: store)
+
+        session.agentIndicator = AgentIndicator(status: .active, blink: true)
+        coordinator.reconcile()
+        let (firstCell, firstBlink) = try renderedStatus(forSession: session.id)
+
+        session.oscTitle = "spin 1"
+        coordinator.reconcile()
+        let (secondCell, secondBlink) = try renderedStatus(forSession: session.id)
+
+        XCTAssertTrue(firstCell === secondCell,
+                      "a per-row reload must recycle the cell, or a surviving animation proves nothing")
+        XCTAssertTrue(firstBlink === secondBlink,
+                      "the blink must ride through the reload; a fresh animation restarts the fade at full opacity")
+    }
+
+    func testStatusChangeStillStartsTheBlink() throws {
+        try XCTSkipIf(NSWorkspace.shared.accessibilityDisplayShouldReduceMotion,
+                      "Reduce Motion suppresses the blink this test pins")
+        let store = try XCTUnwrap(library.activeStore)
+        let session = try XCTUnwrap(store.activeSession)
+        buildSidebar(for: store)
+
+        session.agentIndicator = AgentIndicator(status: .active, blink: false)
+        coordinator.reconcile()
+        let (_, cell) = try renderedRow(forSession: session.id)
+        XCTAssertNil(cell.statusIcon.layer?.animation(forKey: Self.blinkKey),
+                     "a non-blinking status must not animate")
+
+        session.agentIndicator = AgentIndicator(status: .active, blink: true)
+        coordinator.reconcile()
+        let (_, blink) = try renderedStatus(forSession: session.id)
+        XCTAssertNotNil(blink)
+    }
+
+    func testClearingBlinkStopsTheAnimation() throws {
+        try XCTSkipIf(NSWorkspace.shared.accessibilityDisplayShouldReduceMotion,
+                      "Reduce Motion suppresses the blink this test pins")
+        let store = try XCTUnwrap(library.activeStore)
+        let session = try XCTUnwrap(store.activeSession)
+        buildSidebar(for: store)
+
+        session.agentIndicator = AgentIndicator(status: .active, blink: true)
+        coordinator.reconcile()
+        _ = try renderedStatus(forSession: session.id)
+
+        session.agentIndicator = AgentIndicator(status: .idle)
+        coordinator.reconcile()
+        let (_, cell) = try renderedRow(forSession: session.id)
+
+        XCTAssertNil(cell.statusIcon.layer?.animation(forKey: Self.blinkKey),
+                     "going idle must remove the animation, not leave a hidden view pulsing")
+    }
+
+    /// Mirrors `StatusIconView.blinkKey`, which is private; the non-nil assertions below fail loudly if the
+    /// two ever drift, so a renamed key cannot make these tests pass vacuously.
+    private static let blinkKey = "agent-status-blink"
+
+    private func buildSidebar(for store: AppStore) {
+        outline = SidebarOutlineView()
+        coordinator = WorkspaceSidebar.Coordinator(store: store, actions: actions)
+        outline.dataSource = coordinator
+        outline.delegate = coordinator
+        outline.headerView = nil
+        outline.rowSizeStyle = .custom
+        outline.rowHeight = AppSettings.sidebarRowHeight(fontSize: GhosttyApp.shared.sidebarFontSize)
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("main"))
+        column.resizingMask = .autoresizingMask
+        outline.addTableColumn(column)
+        outline.outlineTableColumn = column
+
+        let scroll = NSScrollView(frame: NSRect(x: 0, y: 0, width: 240, height: 400))
+        scroll.documentView = outline
+        window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 240, height: 400),
+                          styleMask: [.titled], backing: .buffered, defer: false)
+        // over-releases a window the registry may still hold, crashing the host at autorelease-pool pop
+        window.isReleasedWhenClosed = false
+        window.contentView = scroll
+
+        coordinator.outlineView = outline
+        coordinator.renameController.outlineView = outline
+        coordinator.seedExpansionFromModel()
+        coordinator.reconcile()
+    }
+
+    private func renderedRow(forSession id: UUID) throws -> (row: Int, cell: SidebarCellView) {
+        outline.layoutSubtreeIfNeeded()
+        let row = try XCTUnwrap((0..<outline.numberOfRows).first { index in
+            guard let node = outline.item(atRow: index) as? SidebarNode else { return false }
+            return node.kind == .session && node.id == id
+        }, "the session row should be visible in the outline")
+        let cell = try XCTUnwrap(outline.view(atColumn: 0, row: row, makeIfNecessary: true) as? SidebarCellView)
+        return (row, cell)
+    }
+
+    private func renderedStatus(forSession id: UUID) throws -> (cell: SidebarCellView, blink: CAAnimation) {
+        let (_, cell) = try renderedRow(forSession: id)
+        let blink = try XCTUnwrap(cell.statusIcon.layer?.animation(forKey: Self.blinkKey),
+                                  "a blinking status should have installed the opacity animation")
+        return (cell, blink)
+    }
+}


### PR DESCRIPTION
a session's blinking status glyph strobed instead of pulsing when its terminal title updated
rapidly. Codex CLI rewrites the title every ~100ms while working, so the affected row never got
past the first fifth of the 0.5s fade.

the row builder reset every recycled cell with an idle indicator before the per-kind branch
re-applied the real one (`WorkspaceSidebar+RowRendering.swift:41`). On a session row that idle
round trip removed the blink `CABasicAnimation` and the re-apply added a fresh one, restarting the
fade at full opacity. A title change moves `displayName`, which reloads just that row, so the
teardown ran at the title-update rate.

it is not layer recreation, which the issue guessed. The cell is recycled and its layer survives:
on the unfixed code the new test's `firstCell === secondCell` assertion passes while the animation
identity check fails.

the reset now sits in the workspace branch, the only one that needs it. The session branch already
assigns the glyph in full.

three tests in `agtermTests/SidebarStatusBlinkTests.swift`: the regression pin, one that the blink
still starts on a status change, and one that going idle still stops it.

Fix #333
