### PR TITLE
fix(agtermctl): survive oversized requests instead of dying on SIGPIPE

### DIFF
--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -73,9 +73,9 @@ final class ControlServer {
         }
     }
 
-    /// 1 MiB cap on a request line, far above any realistic `session.type` payload; over it the line is
-    /// rejected and the connection closed, so a bad client can't grow the buffer unbounded.
-    nonisolated private static let maxLineBytes = 1 << 20
+    /// Cap on a request line, shared with the client via `ControlWire` so the two sides can't drift; over
+    /// it the line is rejected and the connection closed, so a bad client can't grow the buffer unbounded.
+    nonisolated private static let maxLineBytes = ControlWire.maxRequestLineBytes
 
     /// Seconds a blocking client read may stall before timing out (EAGAIN → connection closed), so a stalled
     /// client can't park the serial accept loop forever.

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -336,12 +336,11 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     }
 }
 
-/// Wire-level limits both ends of the control socket share. The server rejects a request line over
-/// `maxRequestLineBytes` and closes the connection; the client checks the same cap before writing, so an
-/// oversized request fails with a readable error instead of a write to a closing peer.
+/// 1 MiB cap on a request line (newline excluded), far above any realistic `session.type` payload. Over it
+/// the server rejects the line and closes the connection, so a bad client can't grow the buffer unbounded;
+/// the client checks the same cap before writing, so an oversized request fails with a readable error
+/// instead of a write to a closing peer. Shared so the two sides cannot drift.
 public enum ControlWire {
-    /// 1 MiB cap on a request line (newline excluded); over it the server rejects the line and closes the
-    /// connection, so a bad client can't grow the buffer unbounded.
     public static let maxRequestLineBytes = 1 << 20
 }
 

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -336,6 +336,15 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     }
 }
 
+/// Wire-level limits both ends of the control socket share. The server rejects a request line over
+/// `maxRequestLineBytes` and closes the connection; the client checks the same cap before writing, so an
+/// oversized request fails with a readable error instead of a write to a closing peer.
+public enum ControlWire {
+    /// 1 MiB cap on a request line (newline excluded); over it the server rejects the line and closes the
+    /// connection, so a bad client can't grow the buffer unbounded.
+    public static let maxRequestLineBytes = 1 << 20
+}
+
 /// One control request: a command, an optional target (session or workspace id / `active` / prefix),
 /// and an optional args bag. One request per connection, newline-delimited JSON.
 public struct ControlRequest: Codable, Sendable, Equatable {

--- a/agtermCore/Sources/agtermctlKit/SocketClient.swift
+++ b/agtermCore/Sources/agtermctlKit/SocketClient.swift
@@ -68,8 +68,8 @@ struct SocketClient {
 
         // a write after the server closes the connection (e.g. it rejected an oversized request) would
         // raise the default-fatal SIGPIPE and kill the process with no output; SO_NOSIGPIPE turns it into
-        // a normal EPIPE write error, mirroring the server side of the socket. Darwin-only (Glibc has no
-        // SO_NOSIGPIPE), and the Glibc build only serves the test suite, which never writes to a dead peer.
+        // a normal EPIPE write error, mirroring the server side of the socket. Darwin-only — Glibc has no
+        // SO_NOSIGPIPE.
         #if canImport(Darwin)
         var noSigPipe: Int32 = 1
         setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, socklen_t(MemoryLayout<Int32>.size))

--- a/agtermCore/Sources/agtermctlKit/SocketClient.swift
+++ b/agtermCore/Sources/agtermctlKit/SocketClient.swift
@@ -26,11 +26,20 @@ struct SocketClient {
 
     /// Connect, send `request` as one newline-terminated JSON line, read the response line, decode it.
     func send(_ request: ControlRequest) throws -> ControlResponse {
+        var data = try JSONEncoder().encode(request)
+        // the server rejects a request line over the shared cap (newline excluded, matching this count)
+        // and closes the connection; check before writing so the caller gets this error instead of a
+        // write failure against the closing peer.
+        guard data.count <= ControlWire.maxRequestLineBytes else {
+            throw SocketClientError(
+                "request too large (\(data.count) bytes, cap \(ControlWire.maxRequestLineBytes)) — "
+                    + "split the input into smaller requests")
+        }
+        data.append(UInt8(ascii: "\n"))
+
         let fd = try connect()
         defer { close(fd) }
 
-        var data = try JSONEncoder().encode(request)
-        data.append(UInt8(ascii: "\n"))
         try Self.writeAll(fd, data)
 
         guard let line = Self.readLine(fd) else {
@@ -56,6 +65,15 @@ struct SocketClient {
         let fd = socket(AF_UNIX, Int32(SOCK_STREAM.rawValue), 0)
         #endif
         guard fd >= 0 else { throw SocketClientError("socket() failed: \(String(cString: strerror(errno)))") }
+
+        // a write after the server closes the connection (e.g. it rejected an oversized request) would
+        // raise the default-fatal SIGPIPE and kill the process with no output; SO_NOSIGPIPE turns it into
+        // a normal EPIPE write error, mirroring the server side of the socket. Darwin-only (Glibc has no
+        // SO_NOSIGPIPE), and the Glibc build only serves the test suite, which never writes to a dead peer.
+        #if canImport(Darwin)
+        var noSigPipe: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, socklen_t(MemoryLayout<Int32>.size))
+        #endif
 
         addr.sun_family = sa_family_t(AF_UNIX)
         let pathBytes = path.utf8CString

--- a/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
@@ -78,6 +78,42 @@ struct SocketClientTests {
         #expect(throws: SocketClientError.self) { try client.send(ControlRequest(cmd: .tree)) }
     }
 
+    @Test func oversizedRequestFailsBeforeConnecting() {
+        let missing = NSTemporaryDirectory() + "agterm-missing-\(UUID().uuidString.prefix(8)).sock"
+        let big = String(repeating: "x", count: ControlWire.maxRequestLineBytes + 1)
+        let client = SocketClient(path: missing)
+
+        do {
+            _ = try client.send(ControlRequest(cmd: .sessionType, target: "active", args: ControlArgs(text: big)))
+            Issue.record("expected an oversized request to fail")
+        } catch let error as SocketClientError {
+            // the size check must fire before connect: a connect error would say "is agterm running?"
+            #expect(error.description.hasPrefix("request too large"))
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
+    // the server hangs up mid-request when it rejects an oversized line; without SO_NOSIGPIPE the
+    // client's next write raises the default-fatal SIGPIPE and the process dies with no output.
+    @Test func writeToHungUpPeerThrowsInsteadOfDying() throws {
+        let server = HangUpStubServer()
+        try server.start()
+        defer { server.stop() }
+        // under the request cap but far over the socket buffer, so writeAll is mid-write when the close lands
+        let payload = String(repeating: "x", count: 900_000)
+        let client = SocketClient(path: server.path)
+
+        do {
+            _ = try client.send(ControlRequest(cmd: .sessionType, target: "active", args: ControlArgs(text: payload)))
+            Issue.record("expected the write to a hung-up peer to fail")
+        } catch let error as SocketClientError {
+            #expect(error.description.hasPrefix("write failed"))
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
     @Test func socketPathLimitMatchesPlatformCapacity() {
         let addr = sockaddr_un()
         let capacity = MemoryLayout.size(ofValue: addr.sun_path)
@@ -848,6 +884,62 @@ private final class StubServer: @unchecked Sendable {
         lock.lock(); stopped = true; lock.unlock()
         wakeAccept(path)                        // unblock a pending accept() so the loop observes `stopped`
         _ = finished.wait(timeout: .now() + 2)  // join the accept loop before freeing the fd
+        close(listenFD); listenFD = -1
+        unlink(path)
+    }
+}
+
+/// A server that accepts one connection and closes it immediately without reading the request — the
+/// shape of the real server rejecting an oversized line. A client mid-write on that connection gets
+/// EPIPE, which is the SIGPIPE hazard `SO_NOSIGPIPE` exists to defuse.
+private final class HangUpStubServer: @unchecked Sendable {
+    let path: String
+    private var listenFD: Int32 = -1
+    private let queue = DispatchQueue(label: "hangup.stub.server")
+    private let finished = DispatchSemaphore(value: 0)
+
+    init() {
+        self.path = NSTemporaryDirectory() + "agterm-hangup-\(UUID().uuidString.prefix(8)).sock"
+    }
+
+    func start() throws {
+        let fd = systemSocket()
+        guard fd >= 0 else { throw SocketClientError("stub socket() failed") }
+        unlink(path)
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = path.utf8CString
+        withUnsafeMutablePointer(to: &addr.sun_path) { dst in
+            dst.withMemoryRebound(to: CChar.self, capacity: pathBytes.count) { buf in
+                pathBytes.withUnsafeBufferPointer { src in buf.update(from: src.baseAddress!, count: src.count) }
+            }
+        }
+        let bound = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+                bind(fd, sa, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bound == 0 else {
+            close(fd)
+            throw SocketClientError("stub bind failed: \(String(cString: strerror(errno)))")
+        }
+        guard listen(fd, 1) == 0 else {
+            close(fd)
+            throw SocketClientError("stub listen failed")
+        }
+        listenFD = fd
+        queue.async { [self] in
+            let conn = systemAccept(fd)
+            if conn >= 0 { close(conn) }
+            finished.signal()
+        }
+    }
+
+    func stop() {
+        guard listenFD >= 0 else { unlink(path); return }
+        wakeAccept(path)                        // unblock a still-pending accept() so it can finish
+        _ = finished.wait(timeout: .now() + 2)  // join the accept before freeing the fd
         close(listenFD); listenFD = -1
         unlink(path)
     }


### PR DESCRIPTION
Fixes #338.

A request over the server's 1 MiB line cap made the server close the connection mid-write; the client fd had no `SO_NOSIGPIPE` (the server side sets it, with a comment naming this exact hazard), so agtermctl died on signal 13 — exit 141, zero output.

Two changes, both needed — the signal fix alone still loses the server's "request too large" message, because `writeAll` throws on EPIPE before `readLine` ever runs:

- `SO_NOSIGPIPE` on the client fd right after `socket()`, mirroring the server. Darwin-only guard so the Glibc test build (7de50a4) keeps compiling — Glibc has no `SO_NOSIGPIPE`, and that build only serves the test suite.
- The encoded request is checked against the cap before connecting, so an oversized request fails with a readable error naming the size and the cap. The newline is appended after the check, matching the server's newline-excluded count in `readLine`.
- The cap moves into agtermCore as `ControlWire.maxRequestLineBytes` and `ControlServer` reads it from there, so the two sides can't drift.

Tests: an oversized request throws before connecting (error prefix pinned, so a connect failure can't satisfy it); a hang-up stub server proves a mid-write peer close surfaces as a thrown `write failed` error rather than killing the process — removing the `setsockopt` makes the test runner die on signal 13, so the test has teeth.

Verified: `swift test` (2114 tests green), `make build`, `make test-app`, `swiftlint --strict` clean; live repro before/after — the 3 MB `--stdin` payload from the issue went from exit 141 with no output to exit 1 with `request too large (3000078 bytes, cap 1048576)`, and a just-under-cap payload still goes through.
