### PR TITLE
feat(split): restore an even split on a divider double-click

### DIFF
--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -94,6 +94,14 @@ paths:
 - Persist each pane cwd and the 0...1 left-pane `splitRatio`. `SplitRatioAccessor` is an unconditional
   background representable on primary, introspects `NSSplitView`, retries until width exists, observes
   `didResizeSubviews`, and debounces save by about 0.4 seconds. Regular saves and quit flush also persist it.
+- Double-clicking the divider restores `splitRatioDefault`. AppKit offers no hook: `NSSplitView`'s own
+  double-click collapses a pane through the delegate SwiftUI owns. One app-wide `SplitProbeView` monitor,
+  never one per probe, sees the second click after the first one's drag-tracking loop ends, so dragging is
+  unaffected; consume that press and its release so neither starts a drag nor reports a phantom button-up.
+  `clickCount == 2` also matches a re-grab after a nudge-drag, so require the divider not to have moved
+  since the previous press. Claimants are the probes whose panes are on screen AND uncovered: the deck's
+  `visible` stays true under a floating overlay, whose terminal passes `terminalOwnsHit`. Host-free
+  `SplitDividerBand` owns the band arithmetic and already excludes the masked titlebar strip.
 - `SplitRatioAccessor` masks only the compact-titlebar divider overrun. At 30pt compact height, SwiftUI
   padding lies inside the safe-area band and AppKit expands `NSSplitView` full height; normal 48px mode is
   already bounded. Compute the live overrun and apply a CALayer mask, removing it at zero.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ agterm arranges terminals into a small hierarchy. These are the only terms you n
 
 **Session.** A session is one running shell with a name, a working directory, and its own scrollback. It is the unit you work in and the row you see in the sidebar. A new session takes its name from the basename of its directory; rename it to pin a custom name, clear the name to go back to the basename. New sessions open in your home directory by default, or in the current session's directory, or in a fixed folder (set in Settings). A session runs until you close it or its shell exits, and it comes back on the next launch with its directory, font size, and split state restored.
 
-**Panes.** A session can split into two shells side by side. Both panes are part of the same session and share one sidebar row; a split is one session with two terminals, not two sessions. One pane is focused at a time, and the divider position is remembered.
+**Panes.** A session can split into two shells side by side. Both panes are part of the same session and share one sidebar row; a split is one session with two terminals, not two sessions. One pane is focused at a time, and the divider position is remembered — drag the divider to resize the panes, and double-click it to snap back to an even split.
 
 **Scratch terminal.** Every session has an extra shell, the scratch terminal, that you toggle on over the session and hide again without killing it. It opens in the session's directory and is for a quick aside next to your main work. It belongs to that one session and is not restored across launches.
 

--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -271,7 +271,8 @@ extension ControlServer: ControlActions {
         }
     }
 
-    /// Resize a split's divider (control-native — the GUI only drags it). `ratio` is an absolute left-pane
+    /// Resize a split's divider (control-native — the GUI only drags it, or double-clicks it for an even
+    /// split). `ratio` is an absolute left-pane
     /// fraction, `delta` a signed nudge (positive grows the left pane) on the current fraction (0.5 when
     /// never moved); exactly one must be set. `applySplitRatio` clamps + persists, then
     /// `.agtermApplySplitRatio` pokes the session's `SplitProbeView` to move the live divider — a no-op

--- a/agterm/Ghostty/GhosttySurfaceView+Tracking.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+Tracking.swift
@@ -1,6 +1,17 @@
 import AppKit
 import GhosttyKit
 
+/// Issue #324's ownership rule: hit-test `point` (window coordinates) against the window content view and
+/// decline for CHROME only — the sidebar's grab handle, an `NSSplitView` divider, a floating overlay's
+/// margin. `host` itself, any descendant, and a sibling pane stacked at the same frame in the eager deck all
+/// count as owned, so a hit test that cannot see through the deck can never silence the visible terminal.
+/// Shared by the pane cursor writers (`ownsPointer`) and the split-divider gesture, which must answer the
+/// same question about the same pixel.
+func terminalOwnsHit(_ point: NSPoint, host: NSView) -> Bool {
+    guard let hit = host.window?.contentView?.hitTest(point) else { return true }
+    return hit.isDescendant(of: host) || hit is GhosttySurfaceView
+}
+
 extension GhosttySurfaceView {
     /// Only the on-screen deck pane tracks the pointer. Every session's surface is eagerly realized, and
     /// AppKit tracking areas ignore SwiftUI's `.opacity(0)` and sibling overlap exactly like drag-destination
@@ -44,15 +55,9 @@ extension GhosttySurfaceView {
     /// re-asserts its shape into the process-global `NSCursor` on every move — beating chrome that sets the
     /// cursor once on hover entry (issue #324). Hit-testing resolves ownership the same way the drag that
     /// starts in that band already does, so no per-divider width has to be guessed and later chrome is
-    /// covered without touching this file.
-    ///
-    /// Declines for chrome ONLY: a hit landing on any surface — this one, a descendant, or a sibling pane
-    /// stacked at the same frame in the eager deck — keeps the pre-#324 behavior, so a hit test that cannot
-    /// see through the deck can never silence the visible terminal.
+    /// covered without touching this file. `terminalOwnsHit` owns the rule itself.
     func ownsPointer(at point: NSPoint) -> Bool {
-        guard let hit = window?.contentView?.hitTest(point) else { return true }
-        if hit === self || hit.isDescendant(of: self) { return true }
-        return hit is GhosttySurfaceView
+        terminalOwnsHit(point, host: self)
     }
 
     /// `ownsPointer(at:)` for the callers with no event in hand (`applyMouseShape`, activation), reading the

--- a/agterm/Views/SplitRatioAccessor.swift
+++ b/agterm/Views/SplitRatioAccessor.swift
@@ -3,15 +3,21 @@ import AppKit
 import SwiftUI
 
 /// Bridges to the AppKit `NSSplitView` under SwiftUI's `HSplitView` to (1) persist and restore the split
-/// divider ratio — no public SwiftUI API exposes the divider position — and (2) clip the split's divider
-/// out of the titlebar strip. Attached as a `.background` on the primary pane so its `NSView` lives inside
-/// the split's view tree without becoming a third arranged pane.
+/// divider ratio — no public SwiftUI API exposes the divider position — (2) reset it to an even split on a
+/// divider double-click, and (3) clip the split's divider out of the titlebar strip. Attached as a
+/// `.background` on the primary pane so its `NSView` lives inside the split's view tree without becoming a
+/// third arranged pane.
 ///
 /// (1) Once the split has a real width it restores `session.splitRatio` via `setPosition`; on each divider
 /// resize it writes the current left-pane fraction back to the session, which the next `save()` (or the
 /// quit-flush) persists, like a live cwd change.
 ///
-/// (2) In COMPACT mode the SwiftUI `.padding(.top, titlebarHeight)` (30px) lands inside the window's
+/// (2) A drag can't land exactly on 50/50, and `NSSplitView`'s own double-click gesture only collapses a
+/// pane through the delegate SwiftUI owns. So the reset is recognized from ONE app-wide mouse monitor
+/// (`installClickMonitorIfNeeded`) instead: it sees the second click after the first one's divider-drag
+/// tracking loop ends, leaving dragging intact.
+///
+/// (3) In COMPACT mode the SwiftUI `.padding(.top, titlebarHeight)` (30px) lands inside the window's
 /// safe-area band, so the AppKit `NSSplitView` ignores it and grows to the FULL window height (verified:
 /// its frame + both arranged panes span pt 0..windowHeight); the panes' top strip is then empty
 /// terminal-bg (invisible against the window bg), but the divider draws BLACK through it — a streak up
@@ -24,6 +30,10 @@ struct SplitRatioAccessor: NSViewRepresentable {
     let session: Session
     let titlebarHeight: CGFloat
     let suspended: Bool
+    /// This session's panes are the ones on screen AND nothing covers them, so divider clicks are this
+    /// probe's to answer. The deck's `visible` alone is not enough: it stays true under a FLOATING overlay,
+    /// whose own terminal would then pass the chrome hit test and hand the gesture a click meant for it.
+    let dividerEligible: Bool
     let onPersist: () -> Void
 
     func makeNSView(context _: Context) -> SplitProbeView {
@@ -31,12 +41,14 @@ struct SplitRatioAccessor: NSViewRepresentable {
         view.onPersist = onPersist
         view.titlebarHeight = titlebarHeight
         view.suspended = suspended
+        view.dividerEligible = dividerEligible
         return view
     }
     func updateNSView(_ nsView: SplitProbeView, context _: Context) {
         nsView.onPersist = onPersist
         nsView.titlebarHeight = titlebarHeight // re-clip on a toolbar-mode change (changes titlebarHeight)
         nsView.suspended = suspended
+        nsView.dividerEligible = dividerEligible
     }
 
     final class SplitProbeView: NSView {
@@ -52,12 +64,30 @@ struct SplitRatioAccessor: NSViewRepresentable {
                 needsLayout = true
             }
         }
+        var dividerEligible: Bool = false {
+            didSet {
+                guard dividerEligible != oldValue else { return }
+                if dividerEligible { Self.claimants.add(self) } else { Self.claimants.remove(self) }
+            }
+        }
+        /// Grab slop each side of the divider gap, so the double-click target matches the band AppKit already
+        /// lets you start a drag in rather than the 1pt line.
+        private static let dividerGrabSlop: CGFloat = 3
+        /// The probes currently answering divider clicks — one per window with an uncovered split on screen.
+        /// Weak, so a torn-down probe drops out on its own: `NSEvent.removeMonitor` in a nonisolated `deinit`
+        /// has no main-thread guarantee, and the shared monitor below is never removed anyway.
+        private static let claimants = NSHashTable<SplitProbeView>.weakObjects()
+        private static var clickMonitor: Any?
         nonisolated(unsafe) private var resizeObserver: NSObjectProtocol?
         nonisolated(unsafe) private var applyObserver: NSObjectProtocol?
         nonisolated(unsafe) private var saveWorkItem: DispatchWorkItem?
         private weak var splitView: NSSplitView?
         private var dividerClipMask: CALayer?
         private var restored = false
+        /// Left-pane width at the previous in-band press, nil when that press missed the band.
+        private var lastPressLeftWidth: CGFloat?
+        /// A press was swallowed and its release is still to come.
+        private var swallowedPress = false
 
         init(session: Session) {
             self.session = session
@@ -98,6 +128,68 @@ struct SplitRatioAccessor: NSViewRepresentable {
                 forName: .agtermApplySplitRatio, object: session, queue: .main) { [weak self] _ in
                 MainActor.assumeIsolated { self?.applyRatio() }
             }
+            Self.installClickMonitorIfNeeded()
+        }
+
+        /// ONE monitor for the whole app, like `PaneShortcuts` — never one per probe, which would run N
+        /// predicates per click and leak a monitor on every re-attach. It outlives every probe (a torn-down
+        /// one simply leaves `claimants`), so it is installed once and never removed.
+        private static func installClickMonitorIfNeeded() {
+            guard clickMonitor == nil else { return }
+            clickMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .leftMouseUp]) { event in
+                for probe in claimants.allObjects where probe.consumes(event) { return nil }
+                return event
+            }
+        }
+
+        /// Whether this probe takes the event: a double-click on its divider, which restores the even split,
+        /// or the release pairing with a press it already took — an unpaired release would otherwise reach
+        /// the surface under the swallowed press and report a phantom button-up to a mouse-reporting TUI.
+        ///
+        /// A press counts as a double-click only if the divider has not MOVED since the previous one: macOS
+        /// reports `clickCount == 2` for a re-grab that lands close enough in time and space to the last
+        /// press, so fine-tuning the divider with a nudge-drag and grabbing it again would otherwise throw
+        /// the adjustment away and eat the second drag.
+        private func consumes(_ event: NSEvent) -> Bool {
+            guard !suspended, let split = splitView, event.window === split.window else { return false }
+            if event.type == .leftMouseUp {
+                defer { swallowedPress = false }
+                return swallowedPress
+            }
+            guard split.arrangedSubviews.count == 2, let band = dividerBand(of: split) else { return false }
+            let leftWidth = split.arrangedSubviews[0].frame.width
+            let point = split.convert(event.locationInWindow, from: nil)
+            let onDivider = band.contains(x: Double(point.x), y: Double(point.y))
+                && terminalOwnsHit(event.locationInWindow, host: split)
+            defer { lastPressLeftWidth = onDivider ? leftWidth : nil }
+            guard onDivider, event.clickCount == 2,
+                  let previous = lastPressLeftWidth, abs(previous - leftWidth) < 1 else { return false }
+            resetToEvenSplit()
+            swallowedPress = true
+            return true
+        }
+
+        /// Where a click counts as landing on the divider, nil while the split has no window to measure
+        /// against. `terminalOwnsHit` then rejects chrome drawn over it, and the masked titlebar strip is
+        /// already outside the band.
+        private func dividerBand(of split: NSSplitView) -> SplitDividerBand? {
+            guard let clipped = titlebarOverrun(of: split) else { return nil }
+            return SplitDividerBand(leftPaneMaxX: Double(split.arrangedSubviews[0].frame.maxX),
+                                    rightPaneMinX: Double(split.arrangedSubviews[1].frame.minX),
+                                    dividerThickness: Double(split.dividerThickness),
+                                    grabSlop: Double(Self.dividerGrabSlop),
+                                    visibleTop: Double(split.isFlipped ? clipped : 0),
+                                    visibleHeight: Double(split.bounds.height - clipped))
+        }
+
+        /// Restore the even split, reusing the `session.resize` path so the model and the live divider move
+        /// exactly as they do for a control-driven ratio. Persist straight away: this is one discrete action,
+        /// not the drag stream `capture()` debounces.
+        private func resetToEvenSplit() {
+            session.splitRatio = AppStore.splitRatioDefault
+            applyRatio()
+            saveWorkItem?.cancel()
+            onPersist?()
         }
 
         /// Move the live divider to the session's stored `splitRatio` (set by `session.resize` just before
@@ -119,12 +211,10 @@ struct SplitRatioAccessor: NSViewRepresentable {
         /// split spans the full window) and 0 in normal (already bounded at the content top, where clipping
         /// a fixed strip would eat real terminal rows). A layer mask, not a frame change, so panes never reflow.
         private func updateDividerClip() {
-            guard let split = splitView, let contentH = split.window?.contentView?.bounds.height else { return }
+            // an off-window split cannot be measured; leave any installed mask alone rather than dropping it
+            // and streaking the divider through the titlebar until the next layout pass re-installs it.
+            guard let split = splitView, let overrun = titlebarOverrun(of: split) else { return }
             split.wantsLayer = true
-            // split's top edge measured in points DOWN from the content top (window base coords, AppKit
-            // origin bottom-left, so the top edge is maxY); then how far it rises above the titlebar boundary.
-            let splitTopFromContentTop = contentH - split.convert(split.bounds, to: nil).maxY
-            let overrun = max(0, titlebarHeight - splitTopFromContentTop)
             // no overrun (normal mode, or any state where the split is already bounded at the content top) →
             // no clip: drop the mask so the split composites untouched, like a single pane.
             guard overrun > 0 else {
@@ -147,6 +237,14 @@ struct SplitRatioAccessor: NSViewRepresentable {
                 dividerClipMask = mask
             }
             split.layer?.mask = mask // re-assert (SwiftUI may rebuild the split's layer)
+        }
+
+        /// How far the split rises above the titlebar boundary — the strip whose divider is masked away —
+        /// or nil with no window to measure against. Measure the split's top edge in points DOWN from the
+        /// content top (window base coords, AppKit origin bottom-left, so the top edge is maxY).
+        private func titlebarOverrun(of split: NSSplitView) -> CGFloat? {
+            guard let contentH = split.window?.contentView?.bounds.height else { return nil }
+            return max(0, titlebarHeight - (contentH - split.convert(split.bounds, to: nil).maxY))
         }
 
         /// Record the current left-pane fraction onto the session, skipping no-op and degenerate values so

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -468,10 +468,15 @@ struct WindowContentView: View {
                                     .id("\(session.id.uuidString)-primary-placeholder")
                             }
                         }
-                        // persists/restores the divider ratio and clips the NSSplitView out of the titlebar
-                        // strip; a background on the stable wrapper (not a third pane, not inside the swapped
-                        // content), so ONE probe survives zoom and suspend/resume flips in place.
-                        .background { SplitRatioAccessor(session: session, titlebarHeight: titlebarHeight, suspended: !deckInteractive, onPersist: { store.save() }) }
+                        // persists/restores the divider ratio, resets it on a divider double-click, and clips
+                        // the NSSplitView out of the titlebar strip; a background on the stable wrapper (not a
+                        // third pane, not inside the swapped content), so ONE probe survives zoom and
+                        // suspend/resume flips in place.
+                        .background {
+                            SplitRatioAccessor(session: session, titlebarHeight: titlebarHeight,
+                                               suspended: !deckInteractive, dividerEligible: visible && !overlaid,
+                                               onPersist: { store.save() })
+                        }
                         ZStack {
                             if deckHostsSurface(session: session, surface: .split) {
                                 TerminalView(session: session, surfaceKeyPath: \.splitSurface, makeSurface: makeSplitSurface,

--- a/agtermCore/Sources/agtermCore/SplitDividerBand.swift
+++ b/agtermCore/Sources/agtermCore/SplitDividerBand.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// The area a split's divider answers clicks in, in the split view's own coordinate space: horizontally the
+/// gap between the two panes widened by the pointer's grab slop, vertically only the part that is on screen
+/// (a compact titlebar masks the divider's top strip away, and a click up there belongs to the title bar).
+public struct SplitDividerBand: Equatable, Sendable {
+    public let minX: Double
+    public let maxX: Double
+    public let minY: Double
+    public let maxY: Double
+
+    /// A hairline divider lays its panes out edge to edge, so the gap can be narrower than the divider
+    /// itself; `dividerThickness` is the floor. Slop widens the band into both panes because the 1pt line is
+    /// not a clickable target — keep it no wider than the band AppKit already starts a drag in, or the extra
+    /// columns steal double-clicks from the terminal text beside the divider.
+    public init(leftPaneMaxX: Double, rightPaneMinX: Double, dividerThickness: Double, grabSlop: Double,
+                visibleTop: Double, visibleHeight: Double) {
+        minX = leftPaneMaxX - grabSlop
+        maxX = leftPaneMaxX + max(rightPaneMinX - leftPaneMaxX, dividerThickness) + grabSlop
+        minY = visibleTop
+        maxY = visibleTop + max(0, visibleHeight)
+    }
+
+    public func contains(x: Double, y: Double) -> Bool {
+        x >= minX && x <= maxX && y >= minY && y <= maxY
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/SplitDividerBandTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SplitDividerBandTests.swift
@@ -1,0 +1,53 @@
+import Testing
+@testable import agtermCore
+
+struct SplitDividerBandTests {
+    private func band(leftPaneMaxX: Double = 300, rightPaneMinX: Double = 301, dividerThickness: Double = 1,
+                      grabSlop: Double = 3, visibleTop: Double = 0,
+                      visibleHeight: Double = 500) -> SplitDividerBand {
+        SplitDividerBand(leftPaneMaxX: leftPaneMaxX, rightPaneMinX: rightPaneMinX,
+                         dividerThickness: dividerThickness, grabSlop: grabSlop,
+                         visibleTop: visibleTop, visibleHeight: visibleHeight)
+    }
+
+    @Test func spansTheGapPlusSlopOnBothSides() {
+        let hairline = band()
+        #expect(hairline.contains(x: 300.5, y: 250))
+        #expect(hairline.contains(x: 297, y: 250))
+        #expect(hairline.contains(x: 304, y: 250))
+        #expect(!hairline.contains(x: 296.9, y: 250))
+        #expect(!hairline.contains(x: 304.1, y: 250))
+    }
+
+    @Test func panesLaidOutEdgeToEdgeStillLeaveTheDividerClickable() {
+        let noGap = band(rightPaneMinX: 300, dividerThickness: 1)
+        #expect(noGap.contains(x: 300.5, y: 250))
+        #expect(noGap.maxX == 304)
+    }
+
+    @Test func aThickDividerWidensTheBandByItsOwnGap() {
+        let thick = band(rightPaneMinX: 309, dividerThickness: 9)
+        #expect(thick.contains(x: 308, y: 250))
+        #expect(!thick.contains(x: 312.1, y: 250))
+    }
+
+    @Test func zeroSlopLeavesOnlyTheDividerItself() {
+        let bare = band(grabSlop: 0)
+        #expect(bare.contains(x: 300.5, y: 250))
+        #expect(!bare.contains(x: 299.9, y: 250))
+    }
+
+    @Test func theMaskedTitlebarStripIsOutsideTheBand() {
+        let compact = band(visibleTop: 30, visibleHeight: 470)
+        #expect(!compact.contains(x: 300.5, y: 29))
+        #expect(compact.contains(x: 300.5, y: 30))
+        #expect(compact.contains(x: 300.5, y: 500))
+        #expect(!compact.contains(x: 300.5, y: 501))
+    }
+
+    @Test func aFullyMaskedDividerAnswersNothing() {
+        let collapsed = band(visibleTop: 30, visibleHeight: -10)
+        #expect(!collapsed.contains(x: 300.5, y: 25))
+        #expect(!collapsed.contains(x: 300.5, y: 31))
+    }
+}

--- a/agtermUITests/SplitUITests.swift
+++ b/agtermUITests/SplitUITests.swift
@@ -349,6 +349,40 @@ final class SplitUITests: XCTestCase {
                       "exiting a non-split session closes it")
     }
 
+    /// The divider is the one part of the split with a real AX element (`NSSplitView` publishes a
+    /// Splitter), so the gesture is driven with real mouse events and read back from the persisted
+    /// left-pane fraction — which only moves when the LIVE divider does.
+    func testDoubleClickDividerRestoresEvenSplit() throws {
+        let row = app.staticTexts["session-row"]
+        XCTAssertTrue(row.waitForExistence(timeout: 20), "seeded session should exist")
+        row.click()
+        usleep(800_000)
+        let splitButton = app.buttons["split-toggle"]
+        XCTAssertTrue(splitButton.waitForExistence(timeout: 5), "split toolbar button should exist")
+        splitButton.click()
+
+        let divider = app.splitters.firstMatch
+        XCTAssertTrue(divider.waitForExistence(timeout: 8), "the split should publish a divider")
+        let start = divider.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+        start.click(forDuration: 0.7, thenDragTo: start.withOffset(CGVector(dx: 120, dy: 0)),
+                    withVelocity: 180, thenHoldForDuration: 0.25)
+        XCTAssertTrue(poll(until: (splitRatio() ?? 0.5) > 0.55, timeout: 8),
+                      "dragging the divider right should grow the left pane: \(String(describing: splitRatio()))")
+
+        divider.doubleClick()
+        XCTAssertTrue(poll(until: abs((splitRatio() ?? 0) - 0.5) < 0.01, timeout: 8),
+                      "double-clicking the divider should restore the even split: \(String(describing: splitRatio()))")
+    }
+
+    /// The persisted left-pane fraction of the single seeded session, nil until one is stored.
+    private func splitRatio() -> Double? {
+        guard let data = try? Data(contentsOf: stateDir.windowSnapshotFile()),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let workspaces = obj["workspaces"] as? [[String: Any]],
+              let sessions = workspaces.first?["sessions"] as? [[String: Any]] else { return nil }
+        return sessions.first?["splitRatio"] as? Double
+    }
+
     /// Types `tty > <markerDir>/<name>` into the focused terminal and returns the tty the
     /// shell wrote (trimmed), or nil if nothing was written within the timeout.
     private func ttyAfterCommand(named name: String) -> String? {

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -260,8 +260,9 @@ omitted when expanded).
   --command` (respawns the scratch if one is open). Target your own session with
   `--target "$AGTERM_SESSION_ID"` (see Addressing).
 - `focus [left|right|other]` — move focus between split panes.
-- `resize --split-ratio R | --grow-left D | --grow-right D` — move the split divider (no GUI/keymap
-  equivalent — bind it via a `command "agtermctl session resize …"` custom action). `--split-ratio` sets
+- `resize --split-ratio R | --grow-left D | --grow-right D` — move the split divider (the GUI only drags
+  it, or double-clicks it for an even split — bind other fractions via a
+  `command "agtermctl session resize …"` custom action). `--split-ratio` sets
   the absolute left-pane fraction (0..1, clamped to 0.05..0.95); `--grow-left`/`--grow-right` nudge it by
   a fraction. Prints the applied (clamped) fraction.
 - `status <idle|active|completed|blocked> [--blink] [--auto-reset] [--sound NAME] [--color #rrggbb] [--shape SHAPE] [--pane left|right|scratch] [--pane-id TOKEN]` — set the sidebar agent glyph (`--sound default` or a system sound name plays a one-shot sound; `--color` tints the glyph for this call only, reverting on the next status set without it; `--shape` (`circle`, `square`, `triangle`, `diamond`, `capsule`, `star`) picks its silhouette for this call only and reverts the same way, read back as the tree `statusShape` field; `--pane` records which pane set it — `left`=main, `right`=split, `scratch` — so foreground typing in another pane won't clear it and any user-initiated GUI selection (auto-follow, attention-nav ⌃⌥↑/↓, plain session nav, the command palettes, a Dock-menu session, a sidebar row click) reveals that pane when the status needs attention (`blocked`/`completed`); `active` preserves the existing pane selection; the pane reads back as the tree `statusPane` field; the socket `session go next-attention` only steps the selection, it does not itself reveal the pane; `--pane-id` is the hook-forwarded stable surface token (`$AGTERM_PANE_ID`) that resolves the pane's live slot and overrides a stale `--pane` after a promote + re-split — scripts set `--pane` directly and leave `--pane-id` to the hook).

--- a/plugins/agterm/skills/agterm/examples.md
+++ b/plugins/agterm/skills/agterm/examples.md
@@ -183,8 +183,9 @@ after/before placement, not `--to up|down|top|bottom`.
 
 ## Resize the split divider from a keybinding
 
-The divider is otherwise mouse-drag only — there is no built-in resize action, so bind keys to the CLI
-with `command "<name>" <chord> <shell…>` custom actions in `keymap.conf` (then `agtermctl keymap reload`):
+The mouse can only drag the divider (or double-click it for an even split) — there is no built-in resize
+action, so bind keys to the CLI with `command "<name>" <chord> <shell…>` custom actions in `keymap.conf`
+(then `agtermctl keymap reload`):
 
 ```conf
 # grow/shrink the left pane by 5% per press; cmd+ctrl+0 resets to an even split

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -395,8 +395,9 @@ All twelve are read-only projections of GUI state.
   split panes (`other` toggles, the default). Errors when the session has no split. Works whether the
   split is shown side-by-side or hidden (maximized) — when hidden, focusing a pane swaps which one shows.
 - `session resize (--split-ratio R | --grow-left D | --grow-right D) [--target] [--window W]` — move the
-  split DIVIDER (the divider is otherwise mouse-drag only; there is no GUI/menu/keymap action, so bind a
-  key by mapping a `command "agtermctl session resize …"` custom action). Provide exactly one form:
+  split DIVIDER (the mouse can only drag it, or double-click it for an even split; there is no GUI/menu/
+  keymap action for an arbitrary fraction, so bind a key by mapping a
+  `command "agtermctl session resize …"` custom action). Provide exactly one form:
   `--split-ratio` sets the absolute left-pane fraction (`0..1`); `--grow-left D` / `--grow-right D` nudge
   it by the fraction `D` (grow-left shrinks the right pane and vice-versa). The result is clamped to
   `0.05..0.95` and persisted, and the applied (clamped) fraction is printed (and returned as `result.ratio`

--- a/site/commands.html
+++ b/site/commands.html
@@ -1135,7 +1135,8 @@
                 split.
               </p>
               <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
-                Control-native: the divider is otherwise mouse-drag only, with no GUI, menu, or keymap action — bind a key by mapping
+                Control-native: the mouse can only drag the divider (or double-click it for an even split), and there is no menu or
+                keymap action for an arbitrary fraction — bind a key by mapping
                 a <span style="font-family: &quot;JetBrains Mono&quot;, monospace">command "agtermctl session resize …"</span> custom
                 action. Resizing a hidden split updates the stored fraction, applied when it is next shown.
               </p>

--- a/site/docs.html
+++ b/site/docs.html
@@ -662,7 +662,8 @@
                 </div>
                 <p style="font-size: 15px; line-height: 1.6; color: #949ba4; margin: 0">
                   A session can split into two shells side by side. Both panes share one sidebar row — a split is one session with
-                  two terminals, not two sessions. One pane is focused at a time and the divider position is remembered.
+                  two terminals, not two sessions. One pane is focused at a time and the divider position is remembered — drag
+                  the divider to resize the panes, and double-click it to snap back to an even split.
                 </p>
               </div>
               <div


### PR DESCRIPTION
Double-clicking a split's divider snaps it back to 50/50. A drag can never land exactly on an even split, and `NSSplitView`'s own double-click only collapses a pane through a delegate SwiftUI owns, so the gesture is recognized from one app-wide mouse monitor that sees the second click after the first one's drag-tracking loop ends — dragging is untouched.

The claimants are the probes whose panes are on screen and uncovered (the deck's `visible` stays true under a floating overlay, whose terminal would otherwise pass the chrome hit test), and a press only counts as a double-click if the divider has not moved since the previous one, so fine-tuning with a nudge-drag and re-grabbing does not throw the adjustment away. This is a GUI shortcut for an existing capability — `session resize --split-ratio 0.5` already did it over the control channel — so no new protocol command.

Also here: the issue #324 ownership rule now lives once as `terminalOwnsHit(_:host:)` with `ownsPointer` calling it, and the band arithmetic moved to host-free `SplitDividerBand` in `agtermCore`.

## Test plan

- `swift test` — 2104 tests pass, including 6 new `SplitDividerBandTests` covering hairline gaps, thick dividers, zero slop and the masked titlebar strip.
- `SplitUITests.testDoubleClickDividerRestoresEvenSplit` drives a real drag then a real double-click and reads back the persisted fraction. Verified against a negative control: with the gesture disabled the test fails at the reset assertion (ratio stays 0.675).
- `SplitUITests.testSplitFocusKeyboardNavAndCollapse` still passes; Debug and Release build clean; `swiftlint --strict` reports zero findings.
- Not automated: the floating-overlay and compact-titlebar paths, and the cursor behaviour around the extracted `terminalOwnsHit` (manual per the libghostty rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
