### PR TITLE
docs(cookbook): add the claude-recap recipe

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -20,6 +20,7 @@ Recipes come from other people as well as the maintainer. Every one is reviewed 
 | [codex-session-resume](codex-session-resume/) | each tab reopens its own codex conversation after a restart | 0.3.1, zsh, Codex CLI |
 | [opencode-session-resume](opencode-session-resume/) | each tab reopens its own opencode conversation after a restart | 0.3.1, zsh, opencode |
 | [kimi-agent-status](kimi-agent-status/) | Kimi Code sessions report agent status onto their sidebar row | 0.3.1, Kimi Code |
+| [claude-recap](claude-recap/) | one key lists what the Claude Code run in a session was working on | 0.10.0, zsh, jq, Claude Code |
 | [new-session-in-workspace](new-session-in-workspace/) | pick a workspace with fzf and start a session in it | 0.8.0, jq, fzf |
 
 Most recipes need `agtermctl` on your PATH; **Help ▸ Install Command Line Tool…** puts it there. The three session-resume recipes are shell functions that read the environment agterm gives a session and never call the CLI. Some recipes also need `jq`, `fzf`, or a particular shell, and each recipe's *Requirements* section says which, along with the minimum agterm version it needs. Recipes are snapshots rather than a maintained surface: the control API grows by addition, so they rarely break, and one that does gets fixed when it is reported.

--- a/cookbook/claude-recap/README.md
+++ b/cookbook/claude-recap/README.md
@@ -1,0 +1,105 @@
+# Claude recap
+
+One keypress answers "what was this session doing?" from its Claude Code transcript, instead of scrolling the scrollback.
+
+## What it does
+
+You come back to a session, either one you left hours ago or one an agent has been driving while you were elsewhere, and you need to know where it got to. ⌃A then C reads that session's Claude Code transcript and lists the last few pieces of work in a floating overlay, newest first.
+
+Each item is a relative age, an eight-word title, a one-sentence detail, and a status of done, in progress, blocked or abandoned. The header carries the directory and how long ago the session was last active, so a recap from yesterday does not read like a running one. Any key closes it.
+
+## Requirements
+
+- agterm 0.10.0 or later, which shipped the `{AGT_PANE}` keymap token and `session overlay open --background-color`. The overlay itself works from 0.8.0.
+- `zsh`, for the script
+- `jq`, for reading the transcript
+- Claude Code CLI, for the summary. Tested with 2.1.220. The flags it depends on (`--safe-mode`, `--json-schema`, `--tools`, `--no-session-persistence`) are less stable than agterm's own API, so a much newer or older CLI may need the invocation adjusted.
+
+## Setup
+
+Put the script somewhere on disk, make it executable, and bind it. The example uses `~/.config/agterm/scripts`; anywhere works as long as the keymap line points at it.
+
+```bash
+mkdir -p ~/.config/agterm/scripts
+cp claude-recap.zsh ~/.config/agterm/scripts/
+chmod +x ~/.config/agterm/scripts/claude-recap.zsh
+```
+
+Add the line to `~/.config/agterm/keymap.conf` and apply it with File ▸ Reload Keymap or `agtermctl keymap reload`:
+
+```
+# ctrl+a>c: recap the claude code session running in this agterm session.
+# {AGT_SESSION_ID} is passed twice: --target opens the overlay on THIS session, and the script
+# argument lets it resolve the session's cwd, because a fresh overlay pty cannot read $AGT_*.
+# zsh -c so the login shell puts jq and claude on PATH.
+command "Claude Recap" ctrl+a>c agtermctl session overlay open 'zsh -c "$HOME/.config/agterm/scripts/claude-recap.zsh {AGT_SESSION_ID} {AGT_PANE}"' --size-percent 60 --background-color "#2e3a2e" --target {AGT_SESSION_ID}
+```
+
+### The pane map
+
+Without this part the recap finds the transcript by working directory, which picks the wrong run for a split working in one repository and for a session whose Claude Code moved into a git worktree. Claude Code's status line is what fixes it: the command receives the live `transcript_path` on stdin, and it runs as a child of the pane's shell, so it knows which pane it is in.
+
+If you already have a status line, paste these lines into it, after it has read stdin into `$input`:
+
+```bash
+# record which transcript is live in this agterm pane, for claude-recap
+if [ -n "$AGTERM_SESSION_ID" ]; then
+    transcript_path=$(echo "$input" | jq -r '.transcript_path // empty' 2>/dev/null)
+    if [ -n "$transcript_path" ]; then
+        mkdir -p /tmp/claude/panes 2>/dev/null
+        printf '%s\n' "$transcript_path" > "/tmp/claude/panes/${AGTERM_SESSION_ID}.${AGTERM_PANE:-left}"
+    fi
+fi
+```
+
+If you have none, `pane-map-statusline.sh` in this directory is a minimal status line that does only this and prints the model name. Install it and point Claude Code at it in `~/.claude/settings.json`:
+
+```bash
+cp pane-map-statusline.sh ~/.claude/scripts/
+chmod +x ~/.claude/scripts/pane-map-statusline.sh
+```
+
+```json
+{ "statusLine": { "type": "command", "command": "~/.claude/scripts/pane-map-statusline.sh" } }
+```
+
+Claude Code takes one `statusLine` command, so this is an either/or: extend the one you have, or install this one.
+
+### Environment variables
+
+All optional:
+
+- `CLAUDE_BIN`, the Claude Code binary, default `claude`
+- `RECAP_MODEL`, the summarizing model, default `claude-haiku-4-5-20251001`
+- `CLAUDE_DIRS`, space-separated Claude Code config dirs to search, default `$HOME/.claude`. Set it if you run more than one config dir.
+- `PANE_MAP_DIR`, where the status line records each pane's transcript path, default `/tmp/claude/panes`. Change it in both places or neither.
+
+## Usage
+
+Press ⌃A then C in a session that has, or recently had, a Claude Code run in it. The overlay draws a spinner while it resolves the session, reads the transcript and summarizes, then renders the list. Any key closes it, and nothing is left behind.
+
+It works on a session an agent is driving right now, and on one whose Claude Code has already exited, as long as the transcript is still on disk.
+
+## How it works
+
+The overlay is a real pty and does not inherit `$AGT_*`, which is why the session id and pane are passed as arguments. With the id, the script asks `agtermctl tree --json` for that session's working directory.
+
+Claude Code files transcripts under a slug of the working directory, so the obvious lookup is the newest `.jsonl` under the slug for this cwd. It picks the wrong run twice: two panes of one split in the same repository share a cwd and so share a slug, and a run that moves into a git worktree files its transcript under the worktree while the pane's shell stays put. The per-pane record is the reliable source, so the script reads `$PANE_MAP_DIR/<session-id>.<pane>` first and falls back to the slug lookup only for a pane that never rendered a status line.
+
+The summary is a second Claude Code invocation, not an API call, so it runs on the same subscription. Two flags make it usable: `MAX_THINKING_TOKENS=0`, without which the model spends thousands of thinking tokens on six one-line items and the wait grows from seconds to a minute and a half, and `--safe-mode`, which drops CLAUDE.md, rules, skills, plugins, hooks and MCP so the request carries a few hundred tokens of harness context instead of tens of thousands. `--json-schema` pins the output shape; `--tools ""` and `--no-session-persistence` keep the run from touching anything.
+
+The transcript is condensed with `jq` first: user prompts in full, assistant replies cut to 400 characters, tool traffic dropped, each prompt tagged with a relative age so the model dates an item without arithmetic. Only the last 120 KB is kept.
+
+Rendering is by hand rather than through a markdown pager, which does not keep the two-line item shape. The list is sorted by parsing the age strings back into seconds, because the model ignores "newest first" often enough that the ordering has to be mechanical.
+
+## Limits
+
+Read-only. It opens an overlay, reads a transcript and closes; no session, pane or file is changed.
+
+Each press sends up to 120 KB of the transcript to the model. That is your prompts and the assistant's replies, which on a work machine may include source, paths and anything else the session discussed. Nothing is written anywhere, but the data does leave the machine.
+
+Skip the pane map and the recap can name the wrong run: both panes of a split working in one repository resolve to the same transcript, and a Claude Code run that moved into a git worktree is filed under the worktree rather than the pane's directory.
+
+The pane map itself has one hole. A `claude` started under tmux, or under any daemon that outlives the shell, inherits the `AGTERM_*` of whichever session started that server, so its transcript is recorded against that session instead of its own. The recap then falls back to the working-directory lookup.
+
+The summary is a model's reading of a condensed transcript. It is a signpost for picking work back up, not a record: statuses in particular are inferred from what the transcript shows, and a piece of work concluded outside the session reads as unfinished.

--- a/cookbook/claude-recap/claude-recap.zsh
+++ b/cookbook/claude-recap/claude-recap.zsh
@@ -1,0 +1,245 @@
+#!/usr/bin/env zsh
+# claude-recap.zsh — recap what the Claude Code session in an agterm session was working on.
+#
+# resolves the target session's cwd, finds the newest Claude Code transcript for that directory,
+# condenses it to user prompts plus trimmed assistant replies, and asks a small model for a short
+# newest-first list of what was done.
+#
+# usage: claude-recap.zsh [agterm-session-id] [pane]
+# meant to run inside an agterm overlay: the arguments are needed because a fresh overlay pty does
+# not inherit $AGT_*.
+
+set -u
+
+CLAUDE_BIN="${CLAUDE_BIN:-claude}"
+# full id, not the "haiku" alias — that is not a recognized alias and silently falls back to the
+# session's default model, which is far slower and dearer for what is six one-line items
+RECAP_MODEL="${RECAP_MODEL:-claude-haiku-4-5-20251001}"
+# Claude Code config dirs to search for transcripts, space separated. add a second one here if you
+# run more than one config dir
+CLAUDE_DIRS="${CLAUDE_DIRS:-$HOME/.claude}"
+# where a status-line hook records the transcript path per pane; see Limits in the README
+PANE_MAP_DIR="${PANE_MAP_DIR:-/tmp/claude/panes}"
+MAX_DIGEST_BYTES=120000   # ~30k tokens of transcript fed to the model
+ASSISTANT_TRIM=400        # per-reply cut, enough to show the outcome without the reasoning
+
+bold=$'\033[1m'; dim=$'\033[2m'; age_c=$'\033[38;5;108m'; rst=$'\033[0m'
+
+# the whole run is a few seconds of waiting, so the wait gets a spinner naming the current step.
+# the phase lives in a file because the spinner runs in a background subshell that cannot see later
+# assignments in this one
+phase_file=$(mktemp /tmp/claude-recap.XXXXXX)
+spinner_pid=""
+
+cleanup() {
+    [ -n "$spinner_pid" ] && kill "$spinner_pid" 2>/dev/null
+    rm -f "$phase_file"
+    printf '\033[?25h'   # cursor back, whatever the exit path
+}
+trap cleanup EXIT INT TERM
+
+phase() {
+    printf '%s' "$1" > "$phase_file"
+    [ -n "$spinner_pid" ] && return
+    (
+        frames=(⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏)
+        i=1
+        while :; do
+            printf '\r\033[2K  %s%s%s %s%s ...%s' \
+                "$age_c" "$frames[i]" "$rst" "$dim" "$(cat "$phase_file")" "$rst"
+            i=$(( i % $#frames + 1 ))
+            sleep 0.08
+        done
+    ) &
+    spinner_pid=$!
+}
+
+phase_stop() {
+    [ -n "$spinner_pid" ] && kill "$spinner_pid" 2>/dev/null
+    spinner_pid=""
+    printf '\r\033[2K'
+}
+
+die() {
+    phase_stop
+    printf "\n  %s\n\n" "$1"
+    read -k1 -s -r "?Press any key to close..."
+    exit 0
+}
+
+printf '\033[?25l'
+printf '\n  %sclaude recap%s\n\n' "$bold" "$rst"
+phase "resolving session"
+
+# session cwd: ask agterm for the focused pane's directory, fall back to the overlay's own cwd
+sid="${1:-}"
+pane="${2:-left}"
+cwd=""
+if [ -n "$sid" ] && command -v agtermctl >/dev/null 2>&1; then
+    cwd=$(agtermctl tree --json 2>/dev/null | \
+        jq -r --arg id "$sid" '.result.tree.workspaces[].sessions[] | select(.id==$id) | .cwd' 2>/dev/null | head -1)
+fi
+[ -n "$cwd" ] || cwd="$PWD"
+
+# the exact transcript, recorded per pane by a status-line hook. this is the only source that
+# survives a worktree: claude moves its transcript to the worktree's project dir while the pane's
+# shell stays put, and two panes on the same repo have identical cwds
+transcript=""
+pane_map="$PANE_MAP_DIR/${sid}.${pane}"
+[ -n "$sid" ] && [ -r "$pane_map" ] && transcript=$(head -1 "$pane_map")
+[ -n "$transcript" ] && [ -f "$transcript" ] || transcript=""
+
+# fallback with no pane map: newest transcript filed under the cwd, which Claude Code slugs by
+# replacing every non-alphanumeric char with a dash
+if [ -z "$transcript" ]; then
+    slug=$(printf '%s' "$cwd" | sed 's/[^a-zA-Z0-9]/-/g')
+    candidates=()
+    for dir in ${=CLAUDE_DIRS}; do
+        candidates+=("$dir/projects/$slug"/*.jsonl(N))
+    done
+    [ ${#candidates} -gt 0 ] && transcript=$(ls -t -- "${candidates[@]}" 2>/dev/null | head -1)
+fi
+[ -n "$transcript" ] && [ -f "$transcript" ] || die "no claude code session found for $cwd"
+
+phase "reading transcript"
+now_epoch=$(date +%s)
+
+# shared by the digest and the header — an iso timestamp to a relative age
+ago_def='def ago: (try ($now - (sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601)) catch null)
+       | if . == null then "?"
+         elif . < 60 then "just now"
+         elif . < 3600 then "\(./60|floor)m ago"
+         elif . < 86400 then "\(./3600|floor)h ago"
+         else "\(./86400|floor)d ago" end;'
+
+# last timestamp and last cwd, in one pass. the cwd is claude's own, which is the worktree it moved
+# into rather than the pane's shell directory — report what the session was actually working in
+meta=$(jq -r 'select(.timestamp or .cwd) | [(.timestamp // ""), (.cwd // "")] | @tsv' "$transcript" 2>/dev/null)
+last_ts=$(printf '%s\n' "$meta" | cut -f1 | grep -v '^$' | tail -1)
+last_cwd=$(printf '%s\n' "$meta" | cut -f2 | grep -v '^$' | tail -1)
+[ -n "$last_cwd" ] && cwd="$last_cwd"
+
+# how stale the recap is — the header states it outright instead of claiming a present tense the
+# transcript cannot support
+last_age=$(printf '%s' "$last_ts" | jq -Rr --argjson now "$now_epoch" "$ago_def"' ago' 2>/dev/null)
+
+# condense the transcript: human prompts in full, assistant replies trimmed, tool traffic dropped.
+# prompts carry a relative-age tag so the model can date each item without doing the arithmetic
+digest=$(jq -rj --argjson trim "$ASSISTANT_TRIM" --argjson now "$now_epoch" "$ago_def"'
+    def strip: gsub("(?s)<system-reminder>.*?</system-reminder>"; "")
+             | gsub("(?s)<local-command-caveat>.*?</local-command-caveat>"; "")
+             | gsub("^[[:space:]]+|[[:space:]]+$"; "");
+
+    if .type=="user" and (.message.content|type=="string") then
+        (.message.content|strip) as $t
+        | if ($t|length) == 0 or ($t|startswith("[Request interrupted")) then empty
+          else "\n[" + (.timestamp // "" | ago) + "] USER: " + $t + "\n" end
+    elif .type=="assistant" and (.message.content|type=="array") then
+        ((.message.content | map(select(.type=="text").text) | join(" ") | strip)) as $t
+        | if ($t|length) == 0 then empty else "CLAUDE: " + $t[0:$trim] + "\n" end
+    else empty end
+' "$transcript" 2>/dev/null)
+
+[ -n "$digest" ] || die "transcript has no readable conversation: $transcript"
+
+# keep the tail — the recent work is what the user is coming back to
+digest=$(printf '%s' "$digest" | tail -c "$MAX_DIGEST_BYTES")
+
+prompt='Below is a condensed Claude Code session transcript (oldest first) from the directory '"$cwd"'.
+Summarize what was worked on so the user can pick the task back up.
+
+Each user prompt is tagged with how long ago it was sent, e.g. "[3h ago] USER: ...".
+
+Rules:
+- split the session into distinct pieces of work, NEWEST FIRST, and cover ALL of it
+- every distinct piece of work gets its own item — never merge unrelated work into one item, and
+  never merge an investigation with the separate fix, review or merge that followed it
+- 6 items maximum: if the session holds more, keep the 6 NEWEST and drop the older ones. produce
+  fewer than 6 only when the session genuinely contains fewer distinct pieces of work
+- "age" is the tag of the most recent prompt in that group, without its square brackets (e.g. "3h ago")
+- "title" is at most 8 words
+- "detail" is one sentence, at most 25 words, and never states the status
+- "status" is judged from the WHOLE transcript, not from that group alone:
+    done        the work reached a conclusion anywhere later in the transcript — committed,
+                merged, pushed, verified, or a question answered. ALSO done when a later group
+                continues it and that one concluded: an investigation whose fix was merged is done
+    in progress no conclusion anywhere after it. normally only the newest group can be this
+    blocked     it stopped on something unresolved and nothing after it resolved that
+    abandoned   dropped with no conclusion and no later work on it
+- when unsure between done and in progress, choose done — most work in a finished session concluded
+- no markdown, no backticks, no quotes around names, lowercase prose throughout
+
+Transcript:
+'
+
+schema='{"type":"object","properties":{
+  "items":{"type":"array","maxItems":6,"items":{"type":"object","properties":{
+    "age":{"type":"string"},"title":{"type":"string"},"detail":{"type":"string"},
+    "status":{"type":"string","enum":["done","in progress","blocked","abandoned"]}},
+    "required":["age","title","detail","status"]}}},
+  "required":["items"]}'
+
+phase "summarizing"
+# MAX_THINKING_TOKENS=0 is the difference between seconds and a minute and a half: without it the
+# model spends thousands of thinking tokens on what is six one-line items. --safe-mode drops
+# CLAUDE.md, rules, skills, plugins, hooks and MCP, leaving a few hundred input tokens of harness
+# context (--bare would go further but never reads OAuth or the keychain, so it cannot authenticate
+# a subscription)
+summary=$(printf '%s%s' "$prompt" "$digest" | \
+    MAX_THINKING_TOKENS=0 "$CLAUDE_BIN" -p --model "$RECAP_MODEL" --safe-mode \
+        --no-session-persistence --tools "" \
+        --system-prompt "You summarize development session transcripts. Be terse and concrete. Write in lowercase prose. Never exceed a stated length limit." \
+        --json-schema "$schema" 2>&1)
+
+phase_stop
+[ -n "$summary" ] || die "summary failed (empty response from claude)"
+printf '%s' "$summary" | jq -e '.items' >/dev/null 2>&1 || die "unexpected response: $summary"
+
+# render by hand rather than through a markdown pager: the two-line item shape (bold age + title,
+# indented wrapped detail) is not something a markdown renderer keeps
+width=${COLUMNS:-100}
+[ "$width" -gt 110 ] && width=110
+[ "$width" -lt 46 ] && width=46
+body=$((width - 8))
+
+# right-align the staleness against the header, dropping to its own line when they collide
+stale="last active ${last_age:-?}"
+head_left="claude recap  $cwd"
+gap=$((width - 4 - ${#head_left} - ${#stale}))
+
+clear
+if [ "$gap" -ge 2 ]; then
+    printf '\n  %sclaude recap%s  %s%s%*s%s%s\n' \
+        "$bold" "$rst" "$dim" "$cwd" "$gap" '' "$stale" "$rst"
+else
+    printf '\n  %sclaude recap%s  %s%s%s\n  %s%s%s\n' \
+        "$bold" "$rst" "$dim" "$cwd" "$rst" "$dim" "$stale" "$rst"
+fi
+printf '  %s%s%s\n\n' "$dim" "$(printf '%*s' $((width - 4)) '' | sed 's/ /─/g')" "$rst"
+
+# sort here rather than trusting the model's "newest first" — it silently emits oldest-first often
+# enough that the ordering has to be mechanical. the age string is parsed back into seconds
+printf '%s' "$summary" | jq -r '
+    def secs: if test("just now") then 0
+              elif test("[0-9]+ *m") then (capture("(?<n>[0-9]+) *m").n | tonumber) * 60
+              elif test("[0-9]+ *h") then (capture("(?<n>[0-9]+) *h").n | tonumber) * 3600
+              elif test("[0-9]+ *d") then (capture("(?<n>[0-9]+) *d").n | tonumber) * 86400
+              else 9999999999 end;
+    .items
+    | map(.age |= gsub("[\\[\\]]"; ""))
+    | sort_by(.age | secs)
+    | .[] | [.age, .title, .detail, (.status // "")] | @tsv' | \
+while IFS=$'\t' read -r age title detail st; do
+    case "$st" in
+        done)          st_c=$'\033[38;5;108m' ;;
+        "in progress") st_c=$'\033[38;5;179m' ;;
+        blocked)       st_c=$'\033[38;5;167m' ;;
+        *)             st_c="$dim" ;;
+    esac
+    printf '  %s%s%s %s—%s %s%s%s  %s%s%s\n' \
+        "$age_c" "$age" "$rst" "$dim" "$rst" "$bold" "$title" "$rst" "$st_c" "$st" "$rst"
+    printf '%s\n' "$detail" | fold -s -w "$body" | sed 's/^/      /'
+    printf '\n'
+done
+
+read -k1 -s -r "?Press any key to close..."

--- a/cookbook/claude-recap/pane-map-statusline.sh
+++ b/cookbook/claude-recap/pane-map-statusline.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# pane-map-statusline.sh — a minimal Claude Code status line that records which transcript is live
+# in which agterm pane, so claude-recap.zsh can find the exact session.
+#
+# only for readers who have no status line of their own: Claude Code runs exactly one, so anyone who
+# already has one pastes the recording block into it instead (see the recipe README).
+#
+# the pane's shell never enters a worktree Claude Code moved into, so cwd alone cannot identify the
+# transcript, and two panes of a split rooted at the same repository are indistinguishable without
+# this. the status line runs as a child of claude, which is a child of the pane's shell, so it
+# inherits AGTERM_SESSION_ID and AGTERM_PANE.
+
+set -f
+
+input=$(cat)
+[ -n "$input" ] || { printf 'Claude'; exit 0; }
+
+if [ -n "${AGTERM_SESSION_ID:-}" ]; then
+    transcript_path=$(echo "$input" | jq -r '.transcript_path // empty' 2>/dev/null)
+    if [ -n "$transcript_path" ]; then
+        pane_map_dir="${PANE_MAP_DIR:-/tmp/claude/panes}"
+        mkdir -p "$pane_map_dir" 2>/dev/null
+        printf '%s\n' "$transcript_path" > "$pane_map_dir/${AGTERM_SESSION_ID}.${AGTERM_PANE:-left}"
+    fi
+fi
+
+printf '%s' "$(echo "$input" | jq -r '.model.display_name // "Claude"' 2>/dev/null)"


### PR DESCRIPTION
⌃A then C over a session lists what the Claude Code run inside it was working on, newest first, in a floating overlay. Each item is a relative age, a short title, a one-sentence detail and a status of done, in progress, blocked or abandoned.

**What ships**

`claude-recap.zsh` resolves the session's directory through `agtermctl tree --json`, finds that session's transcript, condenses it with `jq`, and asks a second Claude Code invocation on haiku for the list, pinned to a json schema.

`pane-map-statusline.sh` is the other half. Claude Code files transcripts under a slug of the working directory, which names the wrong run twice: two panes of a split in one repository share a cwd, and a run that moves into a git worktree is filed under the worktree while the pane's shell stays put. The status line receives the live `transcript_path` and runs as a child of the pane's shell, so it can record which transcript belongs to which pane. Claude Code takes exactly one `statusLine` command, so the README gives both the block to paste into an existing status line and this minimal one for readers who have none.

**Worth knowing**

Two flags decide whether the summary is usable. `MAX_THINKING_TOKENS=0` keeps the model from spending thousands of thinking tokens on six one-line items, which is the difference between seconds and a minute and a half. `--safe-mode` drops CLAUDE.md, rules, skills, plugins, hooks and MCP, leaving a few hundred tokens of harness context instead of tens of thousands.

The list is sorted by parsing the age strings back into seconds rather than trusting the model's "newest first", which it ignores often enough that the ordering has to be mechanical.

**Limits, stated in the README**

Read-only, but each press sends up to 120 KB of transcript to the model. Without the pane map the recap can name the wrong run, and the map itself misses a `claude` started under tmux, which inherits the `AGTERM_*` of whichever session started that server.

Requirements are agterm 0.10.0 or later, for `{AGT_PANE}` and `overlay open --background-color`, plus zsh, jq and the Claude Code CLI.
