### PR TITLE
fix(control): poll for realization when session.type runs without --select

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -165,8 +165,10 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
 ## Surface input, output, and search
 
 - `session.type --pane left|right|scratch` defaults to main for compatibility, not focused/on-screen.
-  Hidden live scratch is addressable; missing panes error. Main alone may select and bounded-poll a newly
-  unrealized session.
+  Hidden live scratch is addressable; missing panes error. Main alone bounded-polls (12 × 30ms) a newly
+  unrealized session, with or without `select`, so `session.new --no-select` plus an immediate type does
+  not race the mount+layout gap (#349). The probe precedes every sleep, so a realized session pays nothing
+  and `select` moves selection only when the surface was not ready. `right`/`scratch` still fail fast.
 - `inject` emits Ghostty key events and Return keycode 36 for newline/CR/CRLF. Never replace it with
   `ghostty_surface_text`, whose bracketed paste suppresses Return and can expose `\e[200~`/`\e[201~`
   markers under rapid use.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,10 @@ concurrency before changing the bridge.
   files, and 800-line types; test configs raise file/type limits to 2000 and inherit all other rules.
   Disabled/tuned rules reflect deliberate conventions. Zero findings are required.
 - Every change must build, pass `swift test`, `make test-app`, and `make lint`.
+- Run each gate ONCE, at the end, and scope everything else to what changed: a new or changed test runs
+  via `-only-testing:<Target>/<Class>/<test>`. Never re-run a whole XCUITest suite to verify a narrow
+  change; `agtermUITests/ControlAPIUITests` alone is about 7 minutes and tells you nothing the targeted
+  run did not.
 - For maintainer work, ask before splitting a touched long file and do not raise limits reflexively.
   Contributors need not refactor preexisting length; mention it without blocking or suggesting a limit bump.
 

--- a/README.md
+++ b/README.md
@@ -350,11 +350,11 @@ By default an overlay opens on its `--target` without switching the active sessi
 
 By default the overlay fills the pane, drawn translucent, hiding the session beneath it. Pass `--size-percent N` (1–100) for a *floating* variant instead: an opaque, framed panel sized to N% of the pane in both dimensions and centered in it, with the session still visible around it. Useful for a small auxiliary program (a picker, a monitor) that you want floating over — not replacing — the terminal you're working in. It composes with `--block` (a blocking floating overlay). Like a full overlay it opens in the background and runs even when the target is not active; pass `--follow` to switch the user to the target as it opens.
 
-A session's terminal surface is created lazily — it does not exist until the session has been shown at least once. Injecting text into a never-shown session therefore fails with `session not realized` unless you pass `--select`, which selects the session (realizing its surface) before injecting:
+Every session's terminal is mounted whether or not it has been shown, so `session type` reaches a background session without selecting it. A session created a moment ago is the one exception: its surface needs a layout pass before it can take input, so `session type` waits briefly for it rather than failing, and a script can create and type back to back. Pass `--select` to select the session first — it only moves your selection when the surface is not ready yet — and `session not realized` is left for a surface that never comes up:
 
 ```sh
-id=$(agtermctl session new --cwd ~/src/agterm)
-agtermctl session type --target "$id" --select $'echo hello\n'
+id=$(agtermctl session new --cwd ~/src/agterm --no-select)
+agtermctl session type --target "$id" $'echo hello\n'   # no focus change
 ```
 
 `agtermctl window` drives the named windows. `window list` prints `id  name  [open]  [active]` (raw with `--json`); the other subcommands take a window id, a unique prefix, or `active` (the frontmost):

--- a/agterm/Control/ControlServer+SurfaceIO.swift
+++ b/agterm/Control/ControlServer+SurfaceIO.swift
@@ -291,18 +291,25 @@ extension ControlServer {
                                                                count: session.searchTotal))
     }
 
-    /// Injects `text` into session `id`'s surface. A surface is created lazily (deferred until it has a
-    /// non-zero backing size, so a never-shown session has `surface == nil`). `inject(text:)` sends the text
-    /// as `ghostty_surface_key` keystrokes (NOT `ghostty_surface_text` — see its doc for why), which write to
-    /// the child pty; the kernel buffers the pty, so text is never lost even before the first prompt.
+    /// Injects `text` into session `id`'s surface. The deck mounts every session, but realization still
+    /// needs a SwiftUI pass plus an AppKit layout pass (`createSurface` defers on a zero backing size), so a
+    /// session created moments ago is briefly unrealized whether or not it is selected. `inject(text:)` sends
+    /// the text as `ghostty_surface_key` keystrokes (NOT `ghostty_surface_text` — see its doc for why), which
+    /// write to the child pty; the kernel buffers the pty, so text is never lost even before the first prompt.
     /// `pane` follows `session.text` (`left`|`right`|`scratch`, no `other`): omitted/`left` is the main pane,
     /// NOT the focused one — the pre-pane behavior, so existing automation is unaffected; `scratch` is
     /// typable while hidden since its surface is kept alive. Selecting never creates a split pane, so the
     /// realize/select path below is main-pane only and `right`/`scratch` inject or error.
-    /// - already realized → inject immediately, ok.
-    /// - never realized, `select:true` → select it, then poll (bounded: 12 × 0.03 s, the `focusSplitPane`
-    ///   idiom) and inject on the first realized attempt; still unrealized → error, never a false ok.
-    /// - never realized, no select → an immediate "use select" error.
+    /// - already realized → inject immediately, ok, and `select` does NOT move the user's selection.
+    /// - unrealized → optionally select, then poll (bounded: 12 × 0.03 s, the `focusSplitPane` idiom) and
+    ///   inject on the first realized attempt; still unrealized → error, never a false ok.
+    ///
+    /// The poll runs WITHOUT `select` too (#349): a background `session.new --no-select` replies from a
+    /// synchronous store mutation, so a back-to-back `session.type` raced the mount and failed, and the
+    /// documented workaround (select, then re-select) tears down the workspace focus filter, consumes the
+    /// previous session's auto-reset indicator, and rewrites recency. `quick.type` polls after `quick show`
+    /// for the same reason. A call that succeeds on the first probe pays no wait at all; the sleeps below are
+    /// only reached once that probe has already failed.
     func injectText(_ text: String, into id: UUID, store: AppStore, select: Bool, pane: String?) async -> ControlResponse {
         switch pane {
         case nil, "left":
@@ -332,18 +339,16 @@ extension ControlServer {
             return ControlResponse(ok: false, error: "invalid pane: \(value)")
         }
         // main pane: inject if realized; a false return (view exists, libghostty surface not up yet) falls
-        // through to the select/poll path rather than returning a silent-drop false ok.
+        // through to the poll rather than returning a silent-drop false ok. This probe precedes the select
+        // below, so `--select` on a realized session leaves the user's selection alone.
         if let surface = store.session(withID: id)?.surface as? GhosttySurfaceView, surface.inject(text: text) {
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
         }
-        guard select else {
-            return ControlResponse(ok: false, error: "session not realized; use select")
-        }
-        store.selectSession(id)
+        if select { store.selectSession(id) }
         for _ in 0..<12 {
             try? await Task.sleep(nanoseconds: 30_000_000)
-            // poll for the surface AND its realization (a false inject keeps polling), so a just-selected
-            // session isn't reported ok before its libghostty surface is up.
+            // poll for the surface AND its realization (a false inject keeps polling), so a just-created or
+            // just-selected session isn't reported ok before its libghostty surface is up.
             if let surface = store.session(withID: id)?.surface as? GhosttySurfaceView, surface.inject(text: text) {
                 return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
             }

--- a/agterm/Ghostty/GhosttySurfaceView+IO.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+IO.swift
@@ -12,8 +12,9 @@ extension GhosttySurfaceView {
     /// suppresses command execution and leaks `\e[200~`/`\e[201~` markers when fired rapidly. Every line ending
     /// (`\n`, `\r`, `\r\n`) becomes a real Return keypress, so a trailing newline submits and a multi-line
     /// payload runs line by line; `withCString` means no buffer outlives the call. Returns `false` when the
-    /// surface is not created yet, so a caller injecting into a pane with no realize/select path
-    /// (`right`/`scratch`) reports `session not realized`, not a false ok; the main pane realizes via select+poll.
+    /// surface is not created yet, so a caller injecting into a pane with no realize path
+    /// (`right`/`scratch`) reports `session not realized`, not a false ok; the main pane instead feeds this
+    /// false return into a bounded poll, selecting only when `select` was passed.
     @discardableResult
     func inject(text: String) -> Bool {
         guard let surface else { return false }

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -114,7 +114,8 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     public var noSelect: Bool?
     /// Text to inject for `session.type` / `quick.type`; the search needle for `session.search`.
     public var text: String?
-    /// Whether `session.type` may select a never-shown session to realize its surface.
+    /// Whether `session.type` may select the session first when its surface is not ready (main pane only).
+    /// Realization itself no longer depends on it: the main pane polls with or without `select`.
     public var select: Bool?
     /// Mode for `session.split` (`on|off|toggle`), `quick`/`surface.zoom` (`show|hide|toggle`),
     /// `session.flag` (`on|off|toggle|clear`), `sidebar.mode` (`tree|flagged|toggle`),

--- a/agtermCore/Sources/agtermctlKit/SessionCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/SessionCommands.swift
@@ -191,7 +191,7 @@ struct Session: ParsableCommand {
         static let configuration = CommandConfiguration(commandName: "type", abstract: "Inject text into a session.")
         @Argument(help: "Text to inject (omit with --stdin).") var text: String?
         @Flag(name: .long, help: "Read the text from stdin instead of an argument.") var stdin = false
-        @Flag(name: .long, help: "Select (and realize) a never-shown session before injecting (main pane only; a split pane must already exist).") var select = false
+        @Flag(name: .long, help: "Select the session first if its surface is not ready (main pane only; a split pane must already exist).") var select = false
         @Option(name: .long, help: "Which pane to type into: left (main), right (split), or scratch (the session's scratch terminal, even when hidden). Defaults to the left pane.") var pane: String?
         @OptionGroup var target: TargetOptions
         @OptionGroup var options: ClientOptions

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -1190,7 +1190,7 @@ struct ControlDispatcherTests {
     @Test func sessionTypeRoutesParsedOptionsAndEchoesActionResponse() async {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)
-        actions.nextSessionTypeResponse = ControlResponse(ok: false, error: "session not realized; use select")
+        actions.nextSessionTypeResponse = ControlResponse(ok: false, error: "session not realized")
 
         let response = await dispatcher.dispatch(ControlRequest(
             cmd: .sessionType,
@@ -1198,7 +1198,7 @@ struct ControlDispatcherTests {
             args: ControlArgs(text: "ls\n", select: true, window: "win", pane: "scratch")
         ))
 
-        #expect(response == ControlResponse(ok: false, error: "session not realized; use select"))
+        #expect(response == ControlResponse(ok: false, error: "session not realized"))
         #expect(actions.calls == [
             .sessionType(target: "session", window: "win",
                          ControlSessionTypeOptions(text: "ls\n", select: true, pane: "scratch"))

--- a/agtermTests/ControlServerSessionActionsTests.swift
+++ b/agtermTests/ControlServerSessionActionsTests.swift
@@ -88,6 +88,44 @@ final class ControlServerSessionActionsTests: XCTestCase {
         XCTAssertEqual(store.currentWorkspaceID, owner)
     }
 
+    // pins #349. A store-only session never gets a view, so its surface stays nil and the poll always runs
+    // to exhaustion — which is what makes this deterministic where the e2e version is not. The pre-#349 code
+    // returned "session not realized; use select" immediately; both the wire string and the elapsed time
+    // discriminate, so restoring the `guard select` fails on the string and dropping the sleep fails on time.
+    // The target is created unselected and a SECOND session holds the selection, so making the select
+    // unconditional fails the last assertion; the companion below pins the other side of that branch.
+    func testTypeWithoutSelectPollsInsteadOfDemandingSelect() async throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let owner = try XCTUnwrap(store.currentWorkspaceID)
+        let target = try XCTUnwrap(store.addSession(toWorkspace: owner, cwd: NSHomeDirectory(), select: false))
+        let other = try XCTUnwrap(store.addSession(toWorkspace: owner, cwd: NSHomeDirectory()))
+        store.selectSession(other.id)
+
+        let started = Date()
+        let response = await server.injectText("ls\n", into: target.id, store: store, select: false, pane: nil)
+        let elapsed = Date().timeIntervalSince(started)
+
+        XCTAssertFalse(response.ok, "a surface that never comes up must not report a false ok")
+        XCTAssertEqual(response.error, "session not realized", "the no-select path no longer tells callers to select")
+        XCTAssertGreaterThan(elapsed, 0.3, "it should ride out the full 12 x 30ms realize poll, not fast-fail")
+        XCTAssertEqual(store.selectedSessionID, other.id, "typing without select must leave the selection where it was")
+    }
+
+    // the true side of that branch: deleting the body of `if select` leaves every other test green while
+    // `--select` silently stops selecting, so this asserts the move itself rather than the typed text.
+    func testTypeWithSelectStillSelectsWhenTheSurfaceIsNotReady() async throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let owner = try XCTUnwrap(store.currentWorkspaceID)
+        let target = try XCTUnwrap(store.addSession(toWorkspace: owner, cwd: NSHomeDirectory(), select: false))
+        let other = try XCTUnwrap(store.addSession(toWorkspace: owner, cwd: NSHomeDirectory()))
+        store.selectSession(other.id)
+
+        let response = await server.injectText("ls\n", into: target.id, store: store, select: true, pane: nil)
+
+        XCTAssertFalse(response.ok, "a store-only session never realizes, so the poll still runs out")
+        XCTAssertEqual(store.selectedSessionID, target.id, "--select must select the target when its surface is not up")
+    }
+
     // the two pane rejections come back from the store as an enum this arm maps to wire strings; without
     // asserting both here, swapping the arms of `paneOverlayFailure` leaves every other test green.
     func testPaneOverlayOpenReportsEachRejectionByItsOwnError() throws {

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -706,6 +706,22 @@ final class ControlAPIUITests: ControlAPITestCase {
                         "session.type without select reaches the eagerly-realized, non-selected session")
     }
 
+    // #349 end to end: create in the background, then type once with no retry. This does NOT discriminate
+    // the realize poll — over two socket round-trips the surface has always come up by the time the type
+    // lands, so it stays green against the pre-#349 fast-fail too. `ControlServerSessionActionsTests`
+    // .testTypeWithoutSelectPollsInsteadOfDemandingSelect is what pins the poll.
+    func testSessionTypeAfterNoSelectCreateLands() throws {
+        let created = try sendCommand(#"{"cmd":"session.new","args":{"noSelect":true}}"#)
+        XCTAssertEqual(created["ok"] as? Bool, true, "session.new --no-select should succeed: \(created)")
+        let id = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String,
+                               "session.new should carry the new id")
+
+        let file = markerDir.appendingPathComponent("noselect-race")
+        let typed = try sendCommand(typeRequest(text: "tty > '\(file.path)'\n", target: id, select: false))
+        XCTAssertEqual(typed["ok"] as? Bool, true, "session.type into a background session should land: \(typed)")
+        XCTAssertNotNil(pollMarker(file, timeout: 8), "the typed command should run in the new session")
+    }
+
     // the with-selection path needs a real Metal-surface selection, verified by hand.
     func testSessionCopyWithoutSelectionErrors() throws {
         let created = try sendCommand(#"{"cmd":"session.new"}"#)

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -346,8 +346,11 @@ All twelve are read-only projections of GUI state.
   counting only sessions whose position/workspace changed.
 - `session type <text> [--stdin] [--select] [--pane left|right|scratch] [--target] [--window W]` — inject text
   as real keystrokes (printable runs plus Return for each newline; no bracketed-paste markers).
-  `--stdin` reads the text from stdin instead of the argument. `--select` selects (and realizes) a
-  never-shown session before injecting. Any realized session is normally typable without `--select`.
+  `--stdin` reads the text from stdin instead of the argument. Any session is typable without `--select`,
+  including a background one and one created moments ago: the main pane bounded-polls (12 × 30ms) for the
+  surface, so `session new --no-select` followed straight away by `session type` does not race the mount.
+  `--select` selects the session first, and only when its surface is not ready — a realized session is typed
+  into without moving the user's selection. A surface that never comes up → `session not realized`.
   `--pane left` types into the main pane (the default when omitted), `--pane right` into the split pane
   (errors with `session has no split pane` when the session has no split), `--pane scratch` into the
   session's scratch terminal even while it is hidden (`session has no scratch terminal` when none opened);

--- a/site/commands.html
+++ b/site/commands.html
@@ -969,8 +969,11 @@
                 Inject text as real keystrokes — printable runs plus a Return for each newline, with no bracketed-paste markers. So a
                 trailing newline submits the command.
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--stdin</span> reads the text from stdin instead of the
-                argument. <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--select</span> selects and realizes a
-                never-shown session first (the main pane only); any realized session is normally typable without it.
+                argument. Any session is typable without
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--select</span>, including one created moments ago: the main
+                pane waits briefly for its surface, so creating and typing back to back does not race.
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--select</span> selects the session first, and only when its
+                surface is not ready yet.
               </p>
               <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">--pane left</span> is the main pane (the default),

--- a/site/docs.html
+++ b/site/docs.html
@@ -1343,8 +1343,8 @@
                 ># route to a pane: left (default) | right (split) | scratch (even when hidden)</span
               ><br />agtermctl session type --pane right <span style="color: #f2b45c">$'ls\n'</span><br /><br /><span
                 style="color: #6b727a"
-                ># a never-shown session needs --select to realize its surface first</span
-              ><br />agtermctl session type --target <span style="color: #f2b45c">"$id"</span> --select
+                ># type into a background session without changing focus</span
+              ><br />agtermctl session type --target <span style="color: #f2b45c">"$id"</span>
               <span style="color: #f2b45c">$'echo hi\n'</span><br /><br /><span style="color: #6b727a"
                 ># read a pane's selection (does not touch the clipboard) or its output</span
               ><br /><span style="color: #6d82f3">sel</span>=$(agtermctl session copy --target 9f3c)<br />agtermctl session text


### PR DESCRIPTION
`session new --no-select` replies from a synchronous store mutation, so a script typing straight after it raced the mount and layout gap and got `session not realized; use select`. The documented workaround, select then re-select, tears down the workspace focus filter, consumes the previous session's auto-reset indicator and rewrites recency, which is exactly what `--no-select` exists to avoid.

The main pane now runs the same bounded 12x30ms poll with or without select, the way `quick.type` already polls after `quick show`. The probe precedes every sleep, so a realized session pays nothing and only an already-failing call ever waits. `--select` now selects solely when the surface is not ready.

Two hosted cases pin both sides of that branch. A store-only session never realizes, so the poll always runs to exhaustion and the wire string and the elapsed time both discriminate, which the e2e version cannot do. Both mutations were run against the tree: making the select unconditional fails the first case, deleting it fails the second.

Also refreshes the README paragraph describing the lazy surface lifecycle, which `ad7021e` made false over a year ago, plus the matching wording in the bundled skill, `site/commands.html`, `site/docs.html`, `.claude/rules/control-api.md` and the CLI flag help.

Fix #349
