### PR TITLE
docs(cookbook): add the project-launcher recipe

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -22,6 +22,7 @@ Recipes come from other people as well as the maintainer. Every one is reviewed 
 | [kimi-agent-status](kimi-agent-status/) | Kimi Code sessions report agent status onto their sidebar row | 0.3.1, Kimi Code |
 | [claude-recap](claude-recap/) | one key lists what the Claude Code run in a session was working on | 0.10.0, zsh, jq, Claude Code |
 | [new-session-in-workspace](new-session-in-workspace/) | pick a workspace with fzf and start a session in it | 0.8.0, jq, fzf |
+| [project-launcher](project-launcher/) | pick a project anywhere — or type "project + prompt" — and get a session in its workspace | 0.19.0, jq |
 
 Most recipes need `agtermctl` on your PATH; **Help ▸ Install Command Line Tool…** puts it there. The three session-resume recipes are shell functions that read the environment agterm gives a session and never call the CLI. Some recipes also need `jq`, `fzf`, or a particular shell, and each recipe's *Requirements* section says which, along with the minimum agterm version it needs. Recipes are snapshots rather than a maintained surface: the control API grows by addition, so they rarely break, and one that does gets fixed when it is reported.
 

--- a/cookbook/project-launcher/README.md
+++ b/cookbook/project-launcher/README.md
@@ -1,0 +1,104 @@
+# Project launcher
+
+Press one key anywhere, pick a project from the native fuzzy picker, and get a new session in that project's workspace — created on the spot when it does not exist yet. With a command configured, typing a prompt after the project's name hands it to that command, so one line starts an agent already working.
+
+## What it does
+
+Press the key and the picker agterm draws for its own palettes opens over the current window, listing your projects: every direct subdirectory of the roots you name. Type a few letters, press Return, and a new session opens in that project's directory, inside a workspace named after the project. The workspace is created if the sidebar does not have it yet and reused if it does, so pressing the key twice for the same project stacks a second session into the same workspace rather than making a second workspace.
+
+It closes the gap between "I am somewhere" and "I want a shell in that project". The built-in ⌘N opens a session where you already are, and reaching a different project through the sidebar means finding its workspace first — or creating one, naming it, and setting the directory by hand when it is a project you have not opened this week. Here the starting point does not matter: any session, any workspace, one key, no typing beyond the filter.
+
+Two recipes in this cookbook sit close by. [`native-dir-picker`](../native-dir-picker/) is the same enumeration feeding the same picker; the difference is the last line, which types the chosen path into the shell you are in, where this one opens a session there. It also walks deep with `fd`, while this recipe stays one level down — so run that one to reach an arbitrary directory, this one to reach a project. [`new-session-in-workspace`](../new-session-in-workspace/) also creates a workspace from a picker, but a workspace is all it makes: you type its name rather than pick a directory, and the session's `--cwd` is not set, because nothing in it maps workspaces to places on disk.
+
+The session runs your login shell by default. Set one variable and it runs something else instead — a coding agent is the obvious candidate, so that the key becomes "new agent in any project" — but nothing in the recipe assumes one.
+
+With that command set, the same picker line can carry the work itself: keep typing past the project's name — `api fix the failing render test` — and Return opens the session with everything after the first word handed to the command as its first argument. For an agent, that is the prompt, and the gap this closes is the round trip: without it you launch, wait for the agent to come up, and type the request you already had in your head when you pressed the key. The first word needs only to identify the project — any unambiguous piece of its name works, resolved exact-first, so `gate` reaches `gateway` and `api` means the project named `api` even when `api-gateway` sits beside it.
+
+## Requirements
+
+- agterm 0.19.0 or later. The floor comes from `agtermctl pick`, which shipped in 0.19.0: it reads choices on stdin, shows them in the native fuzzy picker, and prints the chosen one back as JSON — including, with `--allow-custom`, a line of free text that matches no row, which is what the prompt flow rides on. Everything else the script calls — `session new` with `--workspace-name`, `--create-workspace`, `--cwd`, `--command`, `--window`, and `notify` — is older than that.
+- `jq`, to build the picker's items.
+- `/bin/sh`. The script is POSIX shell and does not need a particular one.
+
+## Setup
+
+Copy the script somewhere and make it executable:
+
+```sh
+mkdir -p ~/bin
+cp project-launcher.sh ~/bin/
+chmod +x ~/bin/project-launcher.sh
+```
+
+Add an entry to `~/.config/agterm/keymap.conf`:
+
+```
+command "Launch Project" cmd+shift+g zsh -lc "$HOME/bin/project-launcher.sh"
+```
+
+Apply it with File ▸ Reload Keymap or `agtermctl keymap reload`. ⌘⇧G is free in agterm's shipped defaults, so nothing is shadowed by taking it; any chord with a modifier works, and leaving the chord out makes the entry palette-only.
+
+`zsh -lc` is there for `PATH`. A custom command inherits the app's environment, which is the launchd default and has no `/opt/homebrew/bin` in it, so a bare `jq` inside the script fails. A login shell sources your profile first and gives the script the `PATH` you normally have.
+
+Two variables configure it, both read from the environment the script runs in:
+
+- `AGT_PROJECT_ROOTS` — colon-separated directories whose direct children are your projects, defaulting to `$HOME/src`. This is the one you almost certainly need to set.
+- `AGT_PROJECT_COMMAND` — a command to run as the new session's process instead of your login shell, and the receiver of a typed prompt. Leave it unset for a plain shell. The script wraps it in a login shell itself, so a bare `claude` resolves from your normal `PATH`.
+
+Put the exports in `.zshenv` or `.zprofile` — the keymap entry runs the script under `zsh -lc`, a non-interactive login shell, which reads those two and skips `.zshrc` entirely. Setting them on the keymap line itself works too, and keeps them out of your shell:
+
+```
+command "Launch Project" cmd+shift+g zsh -lc "AGT_PROJECT_ROOTS=$HOME/src:$HOME/work AGT_PROJECT_COMMAND=claude $HOME/bin/project-launcher.sh"
+```
+
+If `agtermctl` is not on your `PATH`, set `AGTERMCTL` to its full path. **Help ▸ Install Command Line Tool…** normally puts it in `/usr/local/bin`.
+
+## Usage
+
+Press ⌘⇧G. Type to filter, Return to launch, Esc to cancel and launch nothing.
+
+Each row shows the project's name with its path underneath, `$HOME` written as `~`, so two projects that share a name in different roots stay distinguishable in the list. The new session is selected when it opens, and its workspace appears in the sidebar under the project's name if it was not already there.
+
+To launch with a prompt, type the project's name — or any unambiguous piece of it — then a space and the request: `api fix the failing render test`, Return. The picker shows the whole line as its free-text row once it stops matching a project row; Return accepts it, the session opens in `api`, and the command receives everything after the first word as its first argument. A first word that matches nothing raises a banner naming the problem; one that matches several projects raises a banner listing them, so a wrong guess costs a keypress, not a session in the wrong repo. One kind of line defeats the flow entirely — when one project's row still fuzzy-matches every word you typed, Return opens that project without the prompt; Limits describes the shape and the escape.
+
+The sidebar row takes its label from the session the usual way — the shell's title when it sets one, the directory's basename when it does not. Nothing here pins a name, so agents or scripts that retitle their session keep working.
+
+## How it works
+
+The script does three things over the control socket: it hands the project list to `agtermctl pick`, opens the session with `agtermctl session new`, and reports its own failures with `agtermctl notify`.
+
+It runs as the custom command's own process rather than inside an overlay, which is what keeps it short — no second pty, no fzf, nothing to install. The runner exports `$AGT_WINDOW_ID` and `$AGT_SOCKET` into the process, so the script reads its targets out of the environment instead of taking `{AGT_X}` tokens as arguments.
+
+The project list is a plain directory listing, one glob per root, not a filesystem walk. That is a deliberate difference from a finder-based picker: roots-with-children is how people actually keep projects (`~/src/*`), it needs no `fd`, and it stays far from the picker's 1000-item cap where a recursive walk gets there quickly.
+
+Choices go to `pick` as JSON objects rather than plain lines because id, label, and subtitle differ: the id is the absolute path `session new` needs, the label is the basename you filter on, and the subtitle is the path so you can tell twins apart. `pick` blocks until the picker is answered and prints one JSON line — `{"result":"picked","id":...}` at exit 0, `{"result":"cancelled"}` at exit 2. Cancelling is an ordinary way out rather than an error, so the script treats exit 2 as success and stops. `--window` pins the picker to the window the key was pressed in; without it the picker opens in the frontmost window, which is the wrong one as soon as you have two.
+
+The prompt flow is one picker doing two jobs, and it leans on how the free-text row behaves. `--allow-custom` adds a "Use …" row only while the query matches **no** project row, and the palette's filter is fuzzy: every whitespace-separated word of the query has to match a row, but a scattered subsequence counts as matching. A line therefore usually stops matching everything the moment a real prompt word follows the project, and arrives back whole as `{"result":"custom","query":...}` — usually, not always; the case where a row keeps matching is in Limits. The script splits a custom result on the first space: the first word resolves against the project names (exact match first, then unique prefix, then unique substring, case-insensitive), the rest is the prompt. Picking a row the ordinary way still means "no prompt", so the plain flow is untouched.
+
+The prompt reaches the command by temp file, not by splicing. `--command` is tokenized argv-style with no shell in between, and quoting arbitrary text into a shell line inside a JSON argument is exactly the kind of construction that breaks on the first apostrophe. The script writes the prompt to a `mktemp` file instead and builds `zsh -lc 'p=$(cat <file>); rm -f <file>; <command> "$p"'` — the session's own shell reads the file, deletes it, and passes the text as one argument, whatever is in it. This is also why `AGT_PROJECT_COMMAND` itself may not contain a single quote: the command line is spliced into that single-quoted token, and the script refuses at startup rather than truncating it silently.
+
+`--workspace-name` plus `--create-workspace` is the pair that makes the workspace half automatic: the name is looked up first, created only when missing, reused otherwise. Reuse-not-duplicate is `--create-workspace`'s documented behavior, and it is what turns the recipe from "session factory" into "take me to that project".
+
+`session new` carries `--window` for the same reason `pick` does, and it matters twice here: the session must land in the window the picker showed in, and the workspace-name lookup itself is scoped to the target window — an unpinned call matches, or creates, against whatever window is frontmost by the time the pick lands, which after a moment of window-switching is not necessarily where you pressed the key.
+
+A keybinding's command runs with stdout and stderr on `/dev/null`, and a non-zero exit raises only a bare "exit N" banner with no detail. Anything the reader has to see is therefore posted with `agtermctl notify`, which is the one channel that reaches a script whose output goes nowhere.
+
+## Limits
+
+Picking a project **creates** a workspace when none has its name yet. Nothing is closed or deleted anywhere in this recipe, but every launch into a fresh project leaves a real workspace in the sidebar that you remove by hand when you are done with it.
+
+The workspace is found by name, within the window the key was pressed in. A workspace you named after something other than its project will not match, so the launcher makes a second workspace beside it; a matching workspace in one of your *other* windows does not count either, so each window grows its own copy of a project you launch in both. Two same-named workspaces in one window take the first match. And two projects with the same basename under different roots — distinguishable in the picker by their subtitle — land in the same workspace, because the name is all `session new` gets.
+
+Only direct children of the roots are offered. A project nested two levels down needs its parent added to `AGT_PROJECT_ROOTS`; the recipe deliberately does not walk the tree.
+
+With `AGT_PROJECT_COMMAND` set, the session runs that command instead of a shell and **closes when it exits**, including when it fails to start. A command that dies instantly — a typo, a binary not on the launchd `PATH` — looks like the key doing nothing; the script's own login-shell wrapper covers `PATH`, but the command still has to exist. Unset the variable to get an ordinary shell that stays.
+
+A typed prompt needs that command: with `AGT_PROJECT_COMMAND` unset there is nothing to hand it to, so the script says so in a banner and opens the plain shell rather than losing the text silently. The command also may not contain a single quote — the script refuses at startup with a banner rather than mangling it.
+
+The single-line flow can silently lose a typed prompt. The free-text row exists only while the query matches nothing, and the palette's matcher is generous: every word of the query must match, but a scattered subsequence counts — `api ga` still matches `api-gateway`, and a long project name can absorb several short words letter-by-letter. On 0.19.0 and 0.19.1 a row's subtitle — here the project's path — is matched as well, which widens the net further. As long as one row survives every word of the line, no free-text row appears and Return is an ordinary pick: the session opens plainly and the rest of the line is gone, with no banner, because the script only ever sees a picked row. A colon on the project word (`api: ga`) matches no label, forces the free-text row, and is stripped before resolving — when the prompt matters, glance for the "Use …" row before pressing Return, or make the colon a habit. And since the matcher is palette UI rather than control API, a release can retune its scoring without anything in this recipe failing loudly — it has already narrowed once since 0.19.1 — so the colon, not a mental model of the scoring, is the reliable escape.
+
+The prompt crosses to the new session through a file in `$TMPDIR`, which is per-user and closed to other users on macOS — the question is the file's lifetime, not who can read it. The session's shell deletes it as its first act, and the script deletes it itself when `session new` fails, so both ordinary outcomes remove it within the session's startup. What leaks is the in-between: a session that opens and then dies before its shell runs leaves the file behind, holding the prompt's text until macOS's periodic temp cleanup collects it. Fine for a work request; still not the place for a secret.
+
+The picker holds at most 1000 items and rejects a longer list outright instead of truncating it. The script counts first and posts a banner explaining the number, so an over-long list is refused with a reason rather than cut short.
+
+Only one picker can be open per window. Pressing the key while one is already open in that window fails with `pick already pending`, which arrives as a failure banner.

--- a/cookbook/project-launcher/project-launcher.sh
+++ b/cookbook/project-launcher/project-launcher.sh
@@ -1,0 +1,165 @@
+#!/bin/sh
+# pick a project in agterm's native picker and open a new session in it, creating the
+# project's workspace when it does not exist yet. With a command configured, typing a
+# prompt after the project's name hands it to that command as its first argument.
+#
+# takes no arguments: it runs as a keymap custom command, and the runner exports the
+# window and socket as $AGT_* environment variables.
+#
+# project roots come from $AGT_PROJECT_ROOTS (colon-separated, default $HOME/src); every
+# direct subdirectory of a root is a project. $AGT_PROJECT_COMMAND, when set, is a shell
+# line run in the new session in place of your login shell.
+set -eu
+
+AGTERMCTL=${AGTERMCTL:-agtermctl}
+ROOTS=${AGT_PROJECT_ROOTS:-$HOME/src}
+CMD=${AGT_PROJECT_COMMAND:-}
+LIMIT=1000
+tilde='~'  # shortens $HOME in a row subtitle; a display string, never expanded as a path
+
+# carry the socket when the session names one, so the recipe also works in a second instance
+agt() {
+    if [ -n "${AGT_SOCKET:-}" ]; then
+        "$AGTERMCTL" "$@" --socket "$AGT_SOCKET"
+    else
+        "$AGTERMCTL" "$@"
+    fi
+}
+
+# a keybinding runs with stdout and stderr on /dev/null, so anything the reader must see is a banner
+fail() {
+    agt notify "$1" --title "Launch Project" >/dev/null 2>&1 || true
+    exit 1
+}
+
+command -v jq >/dev/null 2>&1 || fail "jq is not on PATH"
+
+# the command line is spliced into a single-quoted token below, where a single quote
+# would end the token early and run the rest outside it
+case $CMD in *\'*) fail "AGT_PROJECT_COMMAND must not contain single quotes" ;; esac
+
+# one TSV line per project: the directory the picker returns, the name the row shows,
+# and the path as the row's second line
+candidates() {
+    old_ifs=$IFS
+    IFS=:
+    # shellcheck disable=SC2086  # deliberate split of the colon-separated root list
+    set -- $ROOTS
+    IFS=$old_ifs
+    for root in "$@"; do
+        root=${root%/}  # a trailing slash in the roots list would double up in every path
+        [ -d "$root" ] || continue
+        for dir in "$root"/*/; do
+            [ -d "$dir" ] || continue
+            dir=${dir%/}
+            case $dir in
+                "$HOME"/*) printf '%s\t%s\t%s/%s\n' "$dir" "${dir##*/}" "$tilde" "${dir#"$HOME"/}" ;;
+                *) printf '%s\t%s\t%s\n' "$dir" "${dir##*/}" "$dir" ;;
+            esac
+        done
+    done
+}
+
+LIST=$(candidates)
+[ -n "$LIST" ] || fail "no projects under $ROOTS. Set AGT_PROJECT_ROOTS"
+
+# the picker rejects a list longer than its limit, so count first and explain rather than fail opaquely
+COUNT=$(printf '%s\n' "$LIST" | wc -l | tr -d ' ')
+if [ "$COUNT" -gt "$LIMIT" ]; then
+    fail "$COUNT projects is over the picker's $LIMIT-item limit. Narrow AGT_PROJECT_ROOTS"
+fi
+
+ITEMS=$(printf '%s\n' "$LIST" |
+    jq -R -s 'split("\n") | map(select(length > 0) | split("\t")) |
+              map({id: .[0], label: .[1], subtitle: .[2]})')
+
+set +e
+CHOICE=$(printf '%s' "$ITEMS" | agt pick --prompt "project — or project + prompt" \
+    --allow-custom --window "${AGT_WINDOW_ID:-active}")
+rc=$?
+set -e
+case $rc in
+    0) ;;
+    2) exit 0 ;;  # cancelled at the picker, which is a normal way out
+    *) fail "picker failed (exit $rc)" ;;
+esac
+
+# a picked row is a project alone; a free-text answer splits into a project word and a
+# prompt. The free-text row only exists while the query matches no row — which a line
+# with prompt words after the project usually is, but not always: see Limits in the README.
+PROMPT=''
+RESULT=$(printf '%s' "$CHOICE" | jq -r '.result' 2>/dev/null) || exit 0
+case $RESULT in
+    picked)
+        DIR=$(printf '%s' "$CHOICE" | jq -r '.id')
+        ;;
+    custom)
+        QUERY=$(printf '%s' "$CHOICE" | jq -r '.query')
+        word=$(printf '%s\n' "$QUERY" | awk '{print $1}')
+        word=${word%:}  # "api: ga" forces the prompt path when "api ga" would still match a row
+        PROMPT=$(printf '%s\n' "$QUERY" | sed 's/^[[:space:]]*[^[:space:]]*[[:space:]]*//')
+        [ -n "$word" ] || exit 0
+        # resolve the word against the project names: exact, then prefix, then substring,
+        # unique at each tier. Ambiguity prints the contenders and refuses.
+        set +e
+        MATCH=$(printf '%s\n' "$LIST" | awk -F'\t' -v w="$word" '
+            BEGIN { w = tolower(w) }
+            { n = tolower($2)
+              if (n == w)              { er[++ne] = $0; en[ne] = $2 }
+              else if (index(n, w) == 1) { pr[++np] = $0; pn[np] = $2 }
+              else if (index(n, w) > 1)  { sr[++ns] = $0; sn[ns] = $2 } }
+            END {
+                if (ne == 1) { print er[1]; exit }
+                if (ne > 1)  { for (i = 1; i <= ne; i++) printf "%s%s", (i > 1 ? ", " : ""), en[i]; exit 3 }
+                if (np == 1) { print pr[1]; exit }
+                if (np > 1)  { for (i = 1; i <= np; i++) printf "%s%s", (i > 1 ? ", " : ""), pn[i]; exit 3 }
+                if (ns == 1) { print sr[1]; exit }
+                if (ns > 1)  { for (i = 1; i <= ns; i++) printf "%s%s", (i > 1 ? ", " : ""), sn[i]; exit 3 }
+                exit 4 }')
+        mrc=$?
+        set -e
+        case $mrc in
+            0) DIR=$(printf '%s\n' "$MATCH" | cut -f1) ;;
+            3) fail "\"$word\" is ambiguous: $MATCH" ;;
+            *) fail "no project matches \"$word\"" ;;
+        esac
+        ;;
+    *) exit 0 ;;
+esac
+
+[ -n "$DIR" ] || exit 0
+WS=${DIR##*/}
+
+# a prompt with nothing to receive it would vanish silently; say so, then open plain
+if [ -n "$PROMPT" ] && [ -z "$CMD" ]; then
+    agt notify "AGT_PROJECT_COMMAND is not set, so the prompt went nowhere" \
+        --title "Launch Project" >/dev/null 2>&1 || true
+    PROMPT=''
+fi
+
+# the command runs through a login shell so it resolves from your normal PATH. A prompt
+# travels by temp file: --command is tokenized argv-style with no shell, so splicing
+# arbitrary text into it is a quoting problem, while a file the session's own shell
+# reads and deletes carries any text.
+launch=''
+if [ -n "$CMD" ]; then
+    if [ -n "$PROMPT" ]; then
+        PF=$(mktemp "${TMPDIR:-/tmp}/agt-launch-prompt.XXXXXX") || fail "mktemp failed"
+        printf '%s' "$PROMPT" > "$PF"
+        launch="zsh -lc 'p=\$(cat \"$PF\"); rm -f \"$PF\"; $CMD \"\$p\"'"
+    else
+        launch="zsh -lc '$CMD'"
+    fi
+fi
+
+# --window twice over: the session must land in the window the picker showed in, and the
+# workspace-name lookup itself is scoped to the target window's store, so an unpinned call
+# matches (or creates) against whatever window happens to be frontmost by then.
+if [ -n "$launch" ]; then
+    out=$(agt session new --window "${AGT_WINDOW_ID:-active}" --workspace-name "$WS" \
+        --create-workspace --cwd "$DIR" --command "$launch" 2>&1) \
+        || { [ -n "$PROMPT" ] && rm -f "$PF"; fail "session new failed: $out"; }
+else
+    out=$(agt session new --window "${AGT_WINDOW_ID:-active}" --workspace-name "$WS" \
+        --create-workspace --cwd "$DIR" 2>&1) || fail "session new failed: $out"
+fi


### PR DESCRIPTION
The recipe from #348, both halves, with your corrections folded in:

- **new-session-in-workspace**: corrected — it does create workspaces (the ＋ New workspace… entry, `--create-workspace`), so the README now claims only the narrower gap: no `--cwd`, and nothing that maps a workspace to a project on disk. **native-dir-picker** is named in *What it does* as the nearest neighbor — same enumeration feeding the same picker, last line swapped — with a sentence on what each buys you: deep walk that types a path into the shell you're in, versus one-level roots that open a session there.
- **The collision case is rewritten as what it is: silent prompt loss.** *Limits* opens with that sentence, then the mechanism: the free-text row exists only at zero matches, the matcher counts a scattered subsequence, subtitles are matched too on 0.19.0/0.19.1, so a long project name can absorb several short words and one surviving row means Return is an ordinary pick and the rest of the line is gone with no banner. The "one real prompt word guarantees" claim is dropped everywhere, including the script comment. *Limits* also says the scoring is palette tuning rather than control API — it has already narrowed once on master (#339) — so the colon escape, not a mental model of the scoring, is the thing to rely on.
- **Temp file**: the visibility caveat was overstated — `$TMPDIR` is per-user on macOS — so the paragraph is now about lifetime. The session's shell deletes the file as its first act, the script deletes it itself when `session new` fails, and the leftover case is named: a session that opens and then dies before its shell runs leaves the prompt text sitting there until the periodic temp cleanup collects it.
- **Version floor** worked out from what the script calls, kimi-recipe style: `pick` shipped in 0.19.0 (with `--allow-custom` from the start), and everything else — `session new --workspace-name/--create-workspace/--cwd/--command/--window`, `notify` — predates it, so 0.19.0 is the floor and the *Requirements* line says where it comes from.

On the two-picker shape: I kept the one-line parse, on the tiebreak you set — it's the one I actually run daily. It would also be a floor question: an itemless `pick --allow-custom` is #339 behavior, so the second-picker variant needs master today. Happy to move the recipe onto it once that's in a release, if you'd rather this collision class not exist at all.

Index row included; shellcheck clean; executable bit set.
