### PR TITLE
feat(help): point first-run users at the Help menu extras

### DIFF
--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -145,5 +145,11 @@ paths:
   sidebars, even when frontmost id was pre-set. Enabling applies immediately. While on, manual hide is
   transient and refocus shows it; turning off leaves current hidden states. Persisted visibility changes
   already refresh the window-list cache.
+- `welcomeShown` records that the first-run Help-extras alert has been shown; the launch that shows it
+  writes true before running any installer. `FirstRunWelcome.isDue` also requires no prior-launch state
+  (`settings.json`, `workspaces.json`, `windows/`) in the state directory, so an upgrading user whose
+  settings predate the flag never sees it. Decide it in `agtermApp.init()`: the first launch saves its own
+  window within a second of the scene appearing, which would read back as prior state.
+  `WelcomeAlert` suppresses itself under XCUITest unless `AGTERM_UITEST_SHOW_WELCOME` is set.
 - These settings are GUI-only unless the control catalog explicitly says otherwise. Do not add settings
   commands merely to mirror chrome; user actions already have control coverage.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Download the latest `.dmg` from the [releases page](https://github.com/umputun/a
 
 ### Optional Help-menu installers
 
-The app's **Help** menu has three one-time installers. None are needed to use agterm as a terminal; each connects it to a wider workflow, and you can run any of them later.
+The app's **Help** menu has three one-time installers. None are needed to use agterm as a terminal; each connects it to a wider workflow, and you can run any of them later. The first launch on a machine points them out in a welcome dialog, which offers the skill and the status hooks and never appears again.
 
 - **Install Command Line Tool…** puts the bundled `agtermctl` on your `PATH` (a symlink in `/usr/local/bin`) so you can script the app from a shell. The Homebrew cask already installs it, so cask users can skip this one. See [Scripting agterm](#scripting-agterm).
 - **Install Agent Status Hooks…** lets a coding agent (Claude Code, Codex, Pi, OpenCode, or others) report its state onto its session's sidebar row, so you can tell at a glance which of several running agents is active, blocked, or finished. See [Agent status](#agent-status).

--- a/agterm/SettingsModel.swift
+++ b/agterm/SettingsModel.swift
@@ -262,6 +262,8 @@ final class SettingsModel {
     func setConfirmCloseSession(_ value: Bool?) { settings.confirmCloseSession = value; try? settingsStore.save(settings) }
     /// Persist whether GUI closes use the short undo grace period. nil = on; false = close immediately.
     func setCloseGraceUndoEnabled(_ value: Bool?) { settings.closeGraceUndoEnabled = value; try? settingsStore.save(settings) }
+    /// Persist that the first-run welcome has been shown, so it never appears again on this state directory.
+    func setWelcomeShown(_ value: Bool?) { settings.welcomeShown = value; try? settingsStore.save(settings) }
     /// Persist the user-idle auto-follow timeout (nil = off) and push it into every open window's `AppStore`
     /// (a newly opened window seeds itself via `applyAutoFollow(to:)`).
     func setAutoFollowAttention(_ value: String?) {

--- a/agterm/WelcomeAlert.swift
+++ b/agterm/WelcomeAlert.swift
@@ -1,0 +1,103 @@
+import AppKit
+import agtermCore
+
+/// The first-launch alert pointing at the Help menu extras, with buttons for the two a Homebrew install
+/// does not provide. Host-free copy and the due-decision are `agtermCore.FirstRunWelcome`.
+@MainActor
+enum WelcomeAlert {
+    private static var presented = false
+
+    /// Suppressed under XCUITest, since every test launches on a fresh isolated state directory and would
+    /// otherwise open a modal before its first assertion. `WelcomeUITests` opts back in.
+    static var isSuppressedForUITest: Bool {
+        ContentView.isUITestLaunch && ProcessInfo.processInfo.environment["AGTERM_UITEST_SHOW_WELCOME"] == nil
+    }
+
+    /// Show the welcome once per process, marking it shown before any installer runs so a cancelled or
+    /// failed install cannot bring it back on the next launch.
+    static func presentOnce(settingsModel: SettingsModel) {
+        guard !presented, !isSuppressedForUITest else { return }
+        presented = true
+        settingsModel.setWelcomeShown(true)
+        // hop out of the caller's Task before the nested modal loop: started from inside the scene's
+        // `.task`, `runModal()` returns `.abort` immediately and nothing is ever drawn.
+        DispatchQueue.main.async { present() }
+    }
+
+    private static func present() {
+        let built = makeAlert()
+        guard built.alert.runModal() == .alertFirstButtonReturn else { return }
+        // each installer runs its own result alert, so they queue behind one another
+        if built.skill.state == .on { SkillInstaller.run() }
+        if built.hooks.state == .on { AgentHooksInstaller.run() }
+    }
+
+    /// The alert and its two option checkboxes, laid out and aligned. Split out of `present()` so a hosted
+    /// test can check the layout without running a modal.
+    static func makeAlert() -> (alert: NSAlert, skill: NSButton, hooks: NSButton) {
+        let skill = checkbox(title: FirstRunWelcome.skillOption, identifier: "welcome-skill-checkbox")
+        let hooks = checkbox(title: FirstRunWelcome.hooksOption, identifier: "welcome-hooks-checkbox")
+        let stack = NSStackView(views: [skill, hooks])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 4
+        stack.frame = NSRect(origin: .zero, size: stack.fittingSize)
+        let container = NSView(frame: stack.frame)
+        container.addSubview(stack)
+
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = FirstRunWelcome.title
+        alert.informativeText = FirstRunWelcome.message
+        alert.accessoryView = container
+        alert.addButton(withTitle: "Install")
+        alert.addButton(withTitle: "Later")
+        alert.buttons.first?.setAccessibilityIdentifier("welcome-install")
+        alert.buttons.last?.setAccessibilityIdentifier("welcome-later")
+        alert.layout()
+        indentOptions(stack, container: container, reference: skill, in: alert)
+        return (alert, skill, hooks)
+    }
+
+    private static func checkbox(title: String, identifier: String) -> NSButton {
+        let button = NSButton(checkboxWithTitle: title, target: nil, action: nil)
+        button.state = .on
+        button.setAccessibilityIdentifier(identifier)
+        return button
+    }
+
+    /// Move the checkboxes under the alert's text column. AppKit parks an accessory view narrower than the
+    /// alert at the window's left margin, which is the icon column, so without this the boxes hang left of
+    /// every line of text. Measured after `layout()` because the text column's x is not knowable before it,
+    /// then corrected against the checkbox itself: a stack positions its views by alignment rect, and a
+    /// checkbox's differs from a text field's by a couple of points.
+    private static func indentOptions(_ stack: NSStackView, container: NSView, reference: NSView, in alert: NSAlert) {
+        guard let content = alert.window.contentView,
+              let text = messageLabel(in: content, matching: alert.messageText) else { return }
+        let textX = leadingX(of: text, in: content)
+        let indent = textX - leadingX(of: container, in: content)
+        guard indent > 0 else { return }
+        stack.setFrameOrigin(NSPoint(x: indent, y: stack.frame.origin.y))
+        container.setFrameSize(NSSize(width: indent + stack.frame.width, height: container.frame.height))
+        alert.layout()
+        let residual = leadingX(of: reference, in: content) - textX
+        guard abs(residual) > 0.5 else { return }
+        stack.setFrameOrigin(NSPoint(x: stack.frame.origin.x - residual, y: stack.frame.origin.y))
+        alert.layout()
+    }
+
+    /// A view's visible left edge in `content` coordinates: the frame inset by the alignment rect, which is
+    /// what AppKit lines controls up by and what the eye reads as the edge.
+    private static func leadingX(of view: NSView, in content: NSView) -> CGFloat {
+        view.convert(NSPoint.zero, to: content).x + view.alignmentRectInsets.left
+    }
+
+    /// The alert's title label, the leftmost element of its text column.
+    private static func messageLabel(in view: NSView, matching title: String) -> NSView? {
+        for subview in view.subviews {
+            if let field = subview as? NSTextField, field.stringValue == title { return field }
+            if let found = messageLabel(in: subview, matching: title) { return found }
+        }
+        return nil
+    }
+}

--- a/agterm/agtermApp+Menus.swift
+++ b/agterm/agtermApp+Menus.swift
@@ -339,7 +339,7 @@ extension agtermApp {
             }
             CommandGroup(replacing: .help) {
                 Button("Developer Documentation…") {
-                    if let url = URL(string: "https://github.com/umputun/agterm#scripting-agterm") {
+                    if let url = URL(string: "https://agterm.com/docs#agtermctl") {
                         NSWorkspace.shared.open(url)
                     }
                 }

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -21,6 +21,11 @@ struct agtermApp: App {
     @State private var appearanceObserver: SystemAppearanceObserver
     @State private var accessibilityObserver: SystemAccessibilityObserver
 
+    /// Whether this launch owes the user the first-run welcome. Decided in `init()`, because the first
+    /// launch writes its own window snapshot moments after the scene appears and that write would read back
+    /// as prior state.
+    private let welcomeDue: Bool
+
     /// The plain `WindowGroup`'s scene id, used by `openWindow(id:)` to spawn additional windows.
     private static let windowGroupID = "terminal"
 
@@ -35,16 +40,22 @@ struct agtermApp: App {
     }
 
     init() {
+        let stateDirectory = ProcessInfo.processInfo.environment["AGTERM_STATE_DIR"]
+            .map { URL(fileURLWithPath: $0, isDirectory: true) } ?? PersistenceStore.defaultDirectory
+        // FIRST, before anything reads or writes the state directory: `WindowLibrary`'s bootstrap seeds a
+        // window and saves it, which a later read would see as evidence of an earlier launch.
+        let hadPriorState = FirstRunWelcome.hasPriorState(in: stateDirectory)
         let library = agtermApp.restoredLibrary()
         _library = State(initialValue: library)
         let actions = AppActions(library: library)
         _actions = State(initialValue: actions)
         // settings persist alongside the workspace snapshot (same AGTERM_STATE_DIR override); built before the
         // control server so it can drive `keymap.reload`, safe since both need only the library.
-        let settingsStore = ProcessInfo.processInfo.environment["AGTERM_STATE_DIR"]
-            .map { SettingsStore(directory: URL(fileURLWithPath: $0, isDirectory: true)) } ?? SettingsStore()
+        let settingsStore = SettingsStore(directory: stateDirectory)
         let settingsModel = SettingsModel(library: library, settingsStore: settingsStore)
         _settingsModel = State(initialValue: settingsModel)
+        welcomeDue = FirstRunWelcome.isDue(welcomeShown: settingsModel.settings.welcomeShown,
+                                           hasPriorState: hadPriorState)
         let controlServer = ControlServer(library: library, actions: actions, settingsModel: settingsModel)
         _controlServer = State(initialValue: controlServer)
         _sessionSwitcher = State(initialValue: SessionSwitcher(library: library, canSwitch: { actions.uiActionsEnabled }))
@@ -163,6 +174,9 @@ struct agtermApp: App {
                         appearanceObserver.start()
                         // consumers read current accessibility values at first render; this handles live flips.
                         accessibilityObserver.start()
+                        // last: a modal here blocks the rest of the task, and the window behind it should be
+                        // fully wired before it opens. `presentOnce` latches, so the per-window .task is safe.
+                        if welcomeDue { WelcomeAlert.presentOnce(settingsModel: settingsModel) }
                     }
             }
         }

--- a/agtermCore/Sources/agtermCore/AppSettings.swift
+++ b/agtermCore/Sources/agtermCore/AppSettings.swift
@@ -253,6 +253,9 @@ public struct AppSettings: Codable, Equatable, Sendable {
     /// collapses its own; nil = off. Visibility then follows window focus, so a manual per-window hide is
     /// transient — the frontmost window re-shows its sidebar on refocus.
     public var autoHideSidebarInactiveWindows: Bool?
+    /// Whether the first-launch pointer at the Help menu extras has been shown; nil/false = not yet.
+    /// Written once, by the launch that shows it. See `FirstRunWelcome`.
+    public var welcomeShown: Bool?
 
     public init(fontFamily: String? = nil, fontSize: Double? = nil, theme: String? = nil,
                 darkTheme: String? = nil, followSystemAppearance: Bool? = nil,
@@ -273,7 +276,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
                 autoFollowAttention: String? = nil,
                 autoFollowStayOnActive: Bool? = nil, sidebarFontSize: Double? = nil,
                 hiddenInterfaceElements: [String]? = nil,
-                autoHideSidebarInactiveWindows: Bool? = nil) {
+                autoHideSidebarInactiveWindows: Bool? = nil, welcomeShown: Bool? = nil) {
         self.fontFamily = fontFamily
         self.fontSize = fontSize
         self.theme = theme
@@ -312,6 +315,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.sidebarFontSize = sidebarFontSize
         self.hiddenInterfaceElements = hiddenInterfaceElements
         self.autoHideSidebarInactiveWindows = autoHideSidebarInactiveWindows
+        self.welcomeShown = welcomeShown
     }
 
     /// The hidden chrome elements, unknown (future-written) raw names dropped. The single read point.

--- a/agtermCore/Sources/agtermCore/FirstRunWelcome.swift
+++ b/agtermCore/Sources/agtermCore/FirstRunWelcome.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// The one-time pointer at the optional extras under the Help menu, shown on a first launch only. Owns the
+/// due-decision and the copy; the AppKit alert and the installers it runs live app-side.
+public enum FirstRunWelcome {
+    /// Files a previous launch leaves behind. The control socket is excluded: it is bound before the scene
+    /// task runs, so its presence says nothing about earlier launches.
+    static let priorStateNames = ["settings.json", "workspaces.json", "windows"]
+
+    public static let title = "Welcome to agterm"
+
+    public static let message = """
+    agterm ships optional extras. These two install from here, and all of them from the Help menu at any time:
+
+    The agent skill teaches Claude Code and Codex to drive agterm over its control socket.
+
+    The agent status hooks make an agent session report active, blocked or completed in the sidebar.
+
+    The command line tool puts agtermctl on your PATH. A Homebrew install already has it, so that one is \
+    only for a direct download.
+    """
+
+    public static let skillOption = "Install the agent skill"
+
+    public static let hooksOption = "Install the agent status hooks"
+
+    /// Whether any prior-launch state exists in `directory`. Must be read before the app writes anything,
+    /// since the first launch seeds a session and saves its window within a second of the scene appearing.
+    public static func hasPriorState(in directory: URL) -> Bool {
+        priorStateNames.contains { FileManager.default.fileExists(atPath: directory.appendingPathComponent($0).path) }
+    }
+
+    /// Whether to show the welcome: never twice, and never to a user who has run agterm before. The two
+    /// terms answer different questions, so both are needed. `welcomeShown` covers a state directory that
+    /// carries the flag, and `hasPriorState` covers everyone who upgraded into this feature, whose settings
+    /// predate the flag and would otherwise read as a fresh install.
+    public static func isDue(welcomeShown: Bool?, hasPriorState: Bool) -> Bool {
+        welcomeShown != true && !hasPriorState
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/FirstRunWelcomeTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/FirstRunWelcomeTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+struct FirstRunWelcomeTests {
+    private func makeTempDirectory() throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("first-run-welcome-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    @Test func isDueOnAFreshStateDirectory() {
+        #expect(FirstRunWelcome.isDue(welcomeShown: nil, hasPriorState: false))
+    }
+
+    @Test func isNotDueOnceShown() {
+        #expect(!FirstRunWelcome.isDue(welcomeShown: true, hasPriorState: false))
+    }
+
+    @Test func isNotDueForAnUpgradingUserWhoseSettingsPredateTheFlag() {
+        #expect(!FirstRunWelcome.isDue(welcomeShown: nil, hasPriorState: true))
+    }
+
+    @Test func falseFlagStillShows() {
+        #expect(FirstRunWelcome.isDue(welcomeShown: false, hasPriorState: false))
+    }
+
+    @Test func emptyDirectoryHasNoPriorState() throws {
+        let dir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        #expect(!FirstRunWelcome.hasPriorState(in: dir))
+    }
+
+    @Test func missingDirectoryHasNoPriorState() {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("first-run-welcome-absent-\(UUID().uuidString)", isDirectory: true)
+        #expect(!FirstRunWelcome.hasPriorState(in: dir))
+    }
+
+    @Test(arguments: FirstRunWelcome.priorStateNames)
+    func anySavedStateFileCountsAsPriorState(name: String) throws {
+        let dir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try Data().write(to: dir.appendingPathComponent(name))
+        #expect(FirstRunWelcome.hasPriorState(in: dir))
+    }
+
+    @Test func aWindowsDirectoryCountsAsPriorState() throws {
+        let dir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try FileManager.default.createDirectory(at: dir.appendingPathComponent("windows", isDirectory: true),
+                                                withIntermediateDirectories: true)
+        #expect(FirstRunWelcome.hasPriorState(in: dir))
+    }
+
+    /// The socket is bound before the scene task reads prior state, so counting it would suppress the
+    /// welcome on the very launch that owes it.
+    @Test func theControlSocketIsNotPriorState() throws {
+        let dir = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try Data().write(to: dir.appendingPathComponent("agterm.sock"))
+        #expect(!FirstRunWelcome.hasPriorState(in: dir))
+    }
+
+    @Test func messageNamesEveryHelpMenuInstaller() {
+        #expect(FirstRunWelcome.message.contains("agent skill"))
+        #expect(FirstRunWelcome.message.contains("agent status hooks"))
+        #expect(FirstRunWelcome.message.contains("command line tool"))
+    }
+
+    /// The CLI has no checkbox: a Homebrew install already links `agtermctl`, so the alert only mentions it.
+    @Test func onlyTheTwoInstallableExtrasAreOffered() {
+        #expect(FirstRunWelcome.skillOption.contains("agent skill"))
+        #expect(FirstRunWelcome.hooksOption.contains("agent status hooks"))
+    }
+}

--- a/agtermTests/WelcomeAlertTests.swift
+++ b/agtermTests/WelcomeAlertTests.swift
@@ -1,0 +1,44 @@
+import agtermCore
+import XCTest
+@testable import agterm
+
+/// AppKit parks an accessory view narrower than the alert at the window's left margin, under the icon, so
+/// the option checkboxes need an explicit indent to line up with the text they belong to.
+@MainActor
+final class WelcomeAlertTests: XCTestCase {
+    func testOptionCheckboxesAlignWithTheAlertTextColumn() throws {
+        let built = WelcomeAlert.makeAlert()
+        let content = try XCTUnwrap(built.alert.window.contentView)
+        let title = try XCTUnwrap(firstTextField(in: content, matching: FirstRunWelcome.title),
+                                  "the alert should carry its title in a text field")
+
+        let titleX = leadingX(of: title, in: content)
+        XCTAssertEqual(leadingX(of: built.skill, in: content), titleX, accuracy: 1,
+                       "the skill checkbox should start at the text column, not the icon column")
+        XCTAssertEqual(leadingX(of: built.hooks, in: content), titleX, accuracy: 1,
+                       "the hooks checkbox should share that edge")
+    }
+
+    private func leadingX(of view: NSView, in content: NSView) -> CGFloat {
+        view.convert(NSPoint.zero, to: content).x + view.alignmentRectInsets.left
+    }
+
+    func testBothOptionsStartChecked() {
+        let built = WelcomeAlert.makeAlert()
+        XCTAssertEqual(built.skill.state, .on)
+        XCTAssertEqual(built.hooks.state, .on)
+    }
+
+    func testInstallIsTheDefaultAndLaterIsPresent() {
+        let built = WelcomeAlert.makeAlert()
+        XCTAssertEqual(built.alert.buttons.map(\.title), ["Install", "Later"])
+    }
+
+    private func firstTextField(in view: NSView, matching value: String) -> NSTextField? {
+        for subview in view.subviews {
+            if let field = subview as? NSTextField, field.stringValue == value { return field }
+            if let found = firstTextField(in: subview, matching: value) { return found }
+        }
+        return nil
+    }
+}

--- a/agtermUITests/WelcomeUITests.swift
+++ b/agtermUITests/WelcomeUITests.swift
@@ -1,0 +1,56 @@
+import XCTest
+
+/// The first-launch welcome alert. Every UI test launches on a fresh isolated state directory, so the
+/// alert is suppressed under XCUITest unless `AGTERM_UITEST_SHOW_WELCOME` opts back in, which is what
+/// this class does.
+@MainActor
+final class WelcomeUITests: XCTestCase {
+    private var app: XCUIApplication!
+    private var stateDir: URL!
+
+    override func setUp() async throws {
+        continueAfterFailure = false
+        stateDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agterm-uitest-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    override func tearDown() async throws {
+        app?.terminate()
+        if let stateDir { try? FileManager.default.removeItem(at: stateDir) }
+    }
+
+    private func launch(showWelcome: Bool) {
+        app = XCUIApplication()
+        app.launchEnvironment["AGTERM_STATE_DIR"] = stateDir.path
+        if showWelcome { app.launchEnvironment["AGTERM_UITEST_SHOW_WELCOME"] = "1" }
+        app.launchForUITest()
+    }
+
+    func testWelcomeShowsOnFirstLaunchAndNotOnTheNextOne() throws {
+        launch(showWelcome: true)
+        let later = app.buttons["welcome-later"]
+        XCTAssertTrue(later.waitForExistence(timeout: 20), "first launch should show the welcome alert")
+        let skill = app.checkBoxes["welcome-skill-checkbox"]
+        let hooks = app.checkBoxes["welcome-hooks-checkbox"]
+        XCTAssertTrue(skill.exists, "the skill option should be offered")
+        XCTAssertTrue(hooks.exists, "the status hooks option should be offered")
+        XCTAssertEqual(skill.value as? Int, 1, "the skill option should start checked")
+        XCTAssertEqual(hooks.value as? Int, 1, "the status hooks option should start checked")
+        // Later, never Install: clicking Install here would really install into the running user's config
+        later.click()
+        XCTAssertTrue(app.staticTexts["session-row"].waitForExistence(timeout: 20),
+                      "dismissing the welcome should leave a usable window")
+        app.terminate()
+        XCTAssertTrue(app.wait(for: .notRunning, timeout: 20), "app should quit before the relaunch")
+
+        launch(showWelcome: true)
+        XCTAssertTrue(app.staticTexts["session-row"].waitForExistence(timeout: 20), "relaunch should reach the window")
+        XCTAssertFalse(app.buttons["welcome-later"].exists, "the welcome must not return on a later launch")
+    }
+
+    func testWelcomeIsSuppressedForOrdinaryUITestLaunches() throws {
+        launch(showWelcome: false)
+        XCTAssertTrue(app.staticTexts["session-row"].waitForExistence(timeout: 20), "launch should reach the window")
+        XCTAssertFalse(app.buttons["welcome-later"].exists, "a UI test launch without the opt-in must see no alert")
+    }
+}

--- a/site/docs.html
+++ b/site/docs.html
@@ -439,7 +439,9 @@
               Optional Help-menu installers
             </h3>
             <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 0 0 14px">
-              None are needed to use agterm as a terminal; each connects it to a wider workflow, and you can run any of them later.
+              None are needed to use agterm as a terminal; each connects it to a wider workflow, and you can run any of them later. The
+              first launch on a machine points them out in a welcome dialog, which offers the skill and the status hooks and never
+              appears again.
             </p>
             <ul style="list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 12px">
               <li style="font-size: 15px; line-height: 1.6; color: #cbc6bc; padding-left: 22px; position: relative">


### PR DESCRIPTION
a first launch on a machine now opens a welcome alert naming the Help menu extras, because a new user has no way to learn they exist. Two checkboxes, both checked, install the agent skill and the agent status hooks in one pass; the command line tool is described but has no checkbox, since a Homebrew install already links `agtermctl` and only a direct download needs it.

**When it shows**

`FirstRunWelcome.isDue` needs two things: the `welcomeShown` settings flag is not set, and the state directory holds no `settings.json`, `workspaces.json` or `windows/`. The flag alone is not enough, because an existing user's settings predate it and would read as a fresh install. The flag is written before any installer runs, so a cancelled or failed install cannot bring the alert back.

The decision is taken at the top of `agtermApp.init()`. `WindowLibrary`'s bootstrap seeds a window and saves it within a second of launch, so anything measuring prior state later sees the current launch's own writes. That is what the first version did, and it never showed the alert.

**Two things AppKit forced**

`runModal()` called from inside the scene's `.task` returns `.abort` immediately and draws nothing, so the alert hops to the main queue first.

An accessory view narrower than the alert is parked at the window's left margin, under the icon, leaving the checkboxes hanging left of every line of text. They are indented to the text column after `layout()`, then corrected against the checkbox's own alignment rect, which sits 2 points off a text field's.

**Also**

Help ▸ Developer Documentation opened `github.com/umputun/agterm#scripting-agterm`; it now opens `agterm.com/docs#agtermctl`.

**Tests**

`FirstRunWelcomeTests` covers the due-decision and prior-state detection, including that the control socket is not prior state (it is bound before the check reads). `WelcomeAlertTests` pins the checkbox alignment against the alert's text column and fails on the pre-fix geometry with 94 against 92. `WelcomeUITests` drives the real alert on a fresh state directory and asserts it does not return on the next launch, plus that an ordinary UI test launch never sees it; every other UI test launches on a fresh isolated state directory, so the alert is suppressed under XCUITest unless `AGTERM_UITEST_SHOW_WELCOME` opts in.

2200 host-free tests, hosted tests, both new UI tests, `make lint` clean.

**Not included**

No control command and no Settings entry to re-show it: this is chrome, and every extra it points at is already reachable from the Help menu.
