### PR TITLE
fix: sanitize control chars in names and --cwd on the control/GUI paths (#347)

### DIFF
--- a/agtermCore/Sources/agtermCore/AppStore+Naming.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Naming.swift
@@ -6,7 +6,9 @@ extension AppStore {
     /// Sets a session's custom name, with a blank value restoring its automatic display name.
     public func renameSession(_ sessionID: UUID, to name: String) {
         guard let session = session(withID: sessionID) else { return }
-        let renamed = name.trimmedOrNil
+        // customName reaches {AGT_SESSION_NAME}, which expands unquoted into /bin/sh -c, so strip control
+        // characters (a newline is a statement separator there) as the OSC path does. See TerminalText.
+        let renamed = TerminalText.sanitized(name).trimmedOrNil
         guard session.customName != renamed else { return }
         session.customName = renamed
         scheduleTreeChanged()
@@ -15,7 +17,8 @@ extension AppStore {
 
     /// Renames a workspace. Blank and same-value names are structural no-ops.
     public func renameWorkspace(_ workspaceID: UUID, to name: String) {
-        guard let trimmed = name.trimmedOrNil,
+        // {AGT_WORKSPACE_NAME} expands unquoted into /bin/sh -c; strip control chars as the OSC path does (TerminalText).
+        guard let trimmed = TerminalText.sanitized(name).trimmedOrNil,
               let index = workspaces.firstIndex(where: { $0.id == workspaceID }),
               workspaces[index].name != trimmed else { return }
         workspaces[index].name = trimmed

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -352,7 +352,11 @@ public final class AppStore {
     public func addSession(toWorkspace workspaceID: UUID, cwd: String, command: String? = nil,
                            name: String? = nil, wait: Bool = false, at index: Int? = nil, select: Bool = true) -> Session? {
         guard let wsIndex = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return nil }
-        let session = Session(initialCwd: cwd, customName: name?.trimmedOrNil)
+        // Both seed values reach a custom-command token that expands unquoted into /bin/sh -c: cwd via
+        // initialCwd → effectiveCwd → {AGT_SESSION_PWD} until OSC 7 reports, and name via customName →
+        // {AGT_SESSION_NAME}. Strip control characters the same way the OSC path does. See TerminalText.
+        let session = Session(initialCwd: TerminalText.sanitized(cwd),
+                              customName: name.map(TerminalText.sanitized)?.trimmedOrNil)
         session.initialCommand = command
         session.commandWait = wait
         if let index {

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -317,7 +317,8 @@ public final class AppStore {
     /// false leaves the target where it is. `ensureWorkspace(named:revealNewWorkspace:)` forwards both.
     @discardableResult
     public func addWorkspace(name: String, collapsed: Bool = false, revealNewWorkspace: Bool = true) -> Workspace {
-        let workspace = Workspace(name: name, isExpanded: !collapsed)
+        // {AGT_WORKSPACE_NAME} expands unquoted into /bin/sh -c; strip control chars as the OSC path does (TerminalText).
+        let workspace = Workspace(name: TerminalText.sanitized(name), isExpanded: !collapsed)
         workspaces.append(workspace)
         if revealNewWorkspace {
             revealNewFocusMember(workspace.id)
@@ -331,7 +332,9 @@ public final class AppStore {
     /// The first workspace whose name exactly equals `name` (case-sensitive, trimmed); nil when none matches
     /// or `name` is blank. Backs `session.new --workspace-name` (addressing by sidebar label, not id).
     public func workspace(named name: String) -> Workspace? {
-        guard let needle = name.trimmedOrNil else { return nil }
+        // sanitize the needle like the stored names, so a raw control-char lookup still finds its workspace
+        // (session.new --workspace-name without --create-workspace calls this directly).
+        guard let needle = TerminalText.sanitized(name).trimmedOrNil else { return nil }
         return workspaces.first { $0.name == needle }
     }
 
@@ -339,7 +342,9 @@ public final class AppStore {
     /// is forwarded to `addWorkspace` on the create path. Nil only when blank. Backs `--workspace-name --create-workspace`.
     @discardableResult
     public func ensureWorkspace(named name: String, revealNewWorkspace: Bool = true) -> Workspace? {
-        guard let needle = name.trimmedOrNil else { return nil }
+        // sanitize before the blank check: a control-char-only name must read as blank, not create an
+        // unmatchable empty-named workspace on every call.
+        guard let needle = TerminalText.sanitized(name).trimmedOrNil else { return nil }
         return workspace(named: needle) ?? addWorkspace(name: needle, revealNewWorkspace: revealNewWorkspace)
     }
 

--- a/agtermCore/Sources/agtermCore/WindowLibrary.swift
+++ b/agtermCore/Sources/agtermCore/WindowLibrary.swift
@@ -317,7 +317,8 @@ public final class WindowLibrary {
     /// Defaults the name to "window N".
     @discardableResult
     public func newWindow(name: String? = nil) -> WindowInfo {
-        let info = WindowInfo(name: name?.trimmedOrNil ?? defaultWindowName)
+        // {AGT_WINDOW_NAME} expands unquoted into /bin/sh -c; strip control chars as the OSC path does (TerminalText).
+        let info = WindowInfo(name: name.map(TerminalText.sanitized)?.trimmedOrNil ?? defaultWindowName)
         let store = makeStore(for: info.id, persistence: persistenceStore(for: info.id))
         let workspace = store.addWorkspace(name: "workspace 1")
         store.addSession(toWorkspace: workspace.id, cwd: FileManager.default.homeDirectoryForCurrentUser.path)

--- a/agtermCore/Sources/agtermCore/WindowLibrary.swift
+++ b/agtermCore/Sources/agtermCore/WindowLibrary.swift
@@ -397,7 +397,8 @@ public final class WindowLibrary {
 
     /// Renames a window; the name lives only in the index. An empty/whitespace-only name is ignored.
     public func renameWindow(_ id: UUID, to name: String) {
-        guard let trimmed = name.trimmedOrNil, let index = windows.firstIndex(where: { $0.id == id }) else { return }
+        // {AGT_WINDOW_NAME} expands unquoted into /bin/sh -c; strip control chars as the OSC path does (TerminalText).
+        guard let trimmed = TerminalText.sanitized(name).trimmedOrNil, let index = windows.firstIndex(where: { $0.id == id }) else { return }
         guard windows[index].name != trimmed else { return }
         windows[index].name = trimmed
         scheduleTreeChanged(for: id)

--- a/agtermCore/Tests/agtermCoreTests/AppStoreNameSanitizeTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreNameSanitizeTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+/// Control-character sanitizing on every store arm whose value reaches a `{AGT_*}` custom-command token —
+/// those expand unquoted into `/bin/sh -c`, so an interior newline is a statement separator (#347).
+/// Split out of `AppStoreTests` for the line budget.
+@MainActor
+struct AppStoreNameSanitizeTests {
+    @Test func addSessionStripsInteriorControlCharactersFromNameAndCwd() {
+        // name → {AGT_SESSION_NAME} and cwd → {AGT_SESSION_PWD} both expand unquoted into /bin/sh -c.
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = try! #require(store.addSession(toWorkspace: ws.id,
+                                                     cwd: "/work\ntouch /tmp/pwned",
+                                                     name: "demo\ntouch /tmp/pwned"))
+        #expect(session.customName == "demotouch /tmp/pwned")
+        #expect(session.initialCwd == "/worktouch /tmp/pwned")
+        #expect(session.effectiveCwd == "/worktouch /tmp/pwned")
+    }
+
+    @Test func renameSessionStripsInteriorControlCharacters() {
+        // customName reaches {AGT_SESSION_NAME}, unquoted into /bin/sh -c; surrounding whitespace still trims.
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        store.renameSession(session.id, to: "  demo\ntouch /tmp/pwned  ")
+        #expect(session.customName == "demotouch /tmp/pwned")
+    }
+
+    @Test func addWorkspaceStripsInteriorControlCharacters() {
+        // {AGT_WORKSPACE_NAME} expands unquoted into /bin/sh -c; `workspace new --name` must not store the newline.
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "prod\ntouch /tmp/pwned")
+        #expect(ws.name == "prodtouch /tmp/pwned")
+    }
+
+    @Test func renameWorkspaceStripsInteriorControlCharacters() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        store.renameWorkspace(ws.id, to: "prod\ntouch /tmp/pwned")
+        #expect(store.workspaces[0].name == "prodtouch /tmp/pwned")
+    }
+
+    @Test func workspaceNamedSanitizesTheNeedle() {
+        // the lookup must match the sanitized stored name, or `session.new --workspace-name` (without
+        // --create-workspace) reads back as "workspace not found" against a name the caller just created.
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "prod\ntouch /tmp/pwned")
+        #expect(store.workspace(named: "prod\ntouch /tmp/pwned")?.id == ws.id)
+    }
+
+    @Test func ensureWorkspaceWithControlCharacterNameStaysIdempotent() {
+        // needle and stored name sanitize alike, so the second call reuses instead of appending a twin.
+        let store = makeStore()
+        let first = try! #require(store.ensureWorkspace(named: "prod\ntouch /tmp/pwned"))
+        let second = try! #require(store.ensureWorkspace(named: "prod\ntouch /tmp/pwned"))
+        #expect(second.id == first.id)
+        #expect(store.workspaces.filter { $0.name == "prodtouch /tmp/pwned" }.count == 1)
+        // a control-char-only name sanitizes to blank BEFORE the blank gate — nil, not an
+        // unmatchable empty-named workspace appended on every call.
+        #expect(store.ensureWorkspace(named: "\u{07}") == nil)
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -93,18 +93,6 @@ struct AppStoreTests {
         #expect(plain.customName == nil)
     }
 
-    @Test func addSessionStripsInteriorControlCharactersFromNameAndCwd() {
-        // name → {AGT_SESSION_NAME} and cwd → {AGT_SESSION_PWD} both expand unquoted into /bin/sh -c.
-        let store = makeStore()
-        let ws = store.addWorkspace(name: "work")
-        let session = try! #require(store.addSession(toWorkspace: ws.id,
-                                                     cwd: "/work\ntouch /tmp/pwned",
-                                                     name: "demo\ntouch /tmp/pwned"))
-        #expect(session.customName == "demotouch /tmp/pwned")
-        #expect(session.initialCwd == "/worktouch /tmp/pwned")
-        #expect(session.effectiveCwd == "/worktouch /tmp/pwned")
-    }
-
     @Test func addSessionToUnknownWorkspaceReturnsNil() {
         let store = makeStore()
         #expect(store.addSession(toWorkspace: UUID(), cwd: "/tmp") == nil)
@@ -1412,15 +1400,6 @@ struct AppStoreTests {
         #expect(session.customName == "build")
     }
 
-    @Test func renameSessionStripsInteriorControlCharacters() {
-        // customName reaches {AGT_SESSION_NAME}, unquoted into /bin/sh -c; surrounding whitespace still trims.
-        let store = makeStore()
-        let ws = store.addWorkspace(name: "work")
-        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
-        store.renameSession(session.id, to: "  demo\ntouch /tmp/pwned  ")
-        #expect(session.customName == "demotouch /tmp/pwned")
-    }
-
     @Test func renameWorkspaceSetsName() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
@@ -1433,13 +1412,6 @@ struct AppStoreTests {
         let ws = store.addWorkspace(name: "work")
         store.renameWorkspace(ws.id, to: "   ")
         #expect(store.workspaces[0].name == "work")
-    }
-
-    @Test func renameWorkspaceStripsInteriorControlCharacters() {
-        let store = makeStore()
-        let ws = store.addWorkspace(name: "work")
-        store.renameWorkspace(ws.id, to: "prod\ntouch /tmp/pwned")
-        #expect(store.workspaces[0].name == "prodtouch /tmp/pwned")
     }
 
     @Test func setBackgroundWatermarkReportsWhetherChanged() {

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -93,6 +93,18 @@ struct AppStoreTests {
         #expect(plain.customName == nil)
     }
 
+    @Test func addSessionStripsInteriorControlCharactersFromNameAndCwd() {
+        // name → {AGT_SESSION_NAME} and cwd → {AGT_SESSION_PWD} both expand unquoted into /bin/sh -c.
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = try! #require(store.addSession(toWorkspace: ws.id,
+                                                     cwd: "/work\ntouch /tmp/pwned",
+                                                     name: "demo\ntouch /tmp/pwned"))
+        #expect(session.customName == "demotouch /tmp/pwned")
+        #expect(session.initialCwd == "/worktouch /tmp/pwned")
+        #expect(session.effectiveCwd == "/worktouch /tmp/pwned")
+    }
+
     @Test func addSessionToUnknownWorkspaceReturnsNil() {
         let store = makeStore()
         #expect(store.addSession(toWorkspace: UUID(), cwd: "/tmp") == nil)
@@ -1400,6 +1412,15 @@ struct AppStoreTests {
         #expect(session.customName == "build")
     }
 
+    @Test func renameSessionStripsInteriorControlCharacters() {
+        // customName reaches {AGT_SESSION_NAME}, unquoted into /bin/sh -c; surrounding whitespace still trims.
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        store.renameSession(session.id, to: "  demo\ntouch /tmp/pwned  ")
+        #expect(session.customName == "demotouch /tmp/pwned")
+    }
+
     @Test func renameWorkspaceSetsName() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
@@ -1412,6 +1433,13 @@ struct AppStoreTests {
         let ws = store.addWorkspace(name: "work")
         store.renameWorkspace(ws.id, to: "   ")
         #expect(store.workspaces[0].name == "work")
+    }
+
+    @Test func renameWorkspaceStripsInteriorControlCharacters() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        store.renameWorkspace(ws.id, to: "prod\ntouch /tmp/pwned")
+        #expect(store.workspaces[0].name == "prodtouch /tmp/pwned")
     }
 
     @Test func setBackgroundWatermarkReportsWhetherChanged() {

--- a/agtermCore/Tests/agtermCoreTests/WindowLibraryTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/WindowLibraryTests.swift
@@ -463,6 +463,14 @@ final class WindowLibraryTests {
         #expect(library.windows[0].name == "personal")
     }
 
+    @Test func renameWindowStripsInteriorControlCharacters() {
+        // {AGT_WINDOW_NAME} expands unquoted into /bin/sh -c; an interior newline must not survive the index.
+        let library = WindowLibrary(directory: directory)
+        let id = library.windows[0].id
+        library.renameWindow(id, to: "prod\ntouch /tmp/pwned")
+        #expect(library.windows[0].name == "prodtouch /tmp/pwned")
+    }
+
     @Test func removeWindowDropsEntryStoreAndFile() throws {
         let library = WindowLibrary(directory: directory)
         let extra = library.newWindow(name: "extra")

--- a/agtermCore/Tests/agtermCoreTests/WindowLibraryTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/WindowLibraryTests.swift
@@ -454,6 +454,13 @@ final class WindowLibraryTests {
         #expect(info.name == "window 2")
     }
 
+    @Test func newWindowStripsInteriorControlCharactersFromName() {
+        // {AGT_WINDOW_NAME} expands unquoted into /bin/sh -c; `window new --name` must not store the newline.
+        let library = WindowLibrary(directory: directory)
+        let info = library.newWindow(name: "prod\ntouch /tmp/pwned")
+        #expect(info.name == "prodtouch /tmp/pwned")
+    }
+
     @Test func renameWindowUpdatesNameAndIgnoresBlank() {
         let library = WindowLibrary(directory: directory)
         let id = library.windows[0].id


### PR DESCRIPTION
Fixes #347.

An interior newline in a session/workspace/window **name** or a session **`--cwd`** survives into the stored value and, when a custom command fires, expands unquoted into the `/bin/sh -c` line via the `{AGT_SESSION_NAME}` / `{AGT_SESSION_PWD}` / `{AGT_WORKSPACE_NAME}` / `{AGT_WINDOW_NAME}` tokens — where a newline is a statement separator. The OSC path already closes this with `TerminalText.sanitized`; the control-socket and GUI rename paths ran the value through `trimmedOrNil` only, which strips *surrounding* whitespace but leaves an interior newline intact.

### Placement

Sanitizing lives in the four `agtermCore` store methods — `renameSession` / `renameWorkspace` (`AppStore+Naming.swift`), `renameWindow` (`WindowLibrary.swift`), `addSession` (`AppStore.swift`). This is the option you leaned to: it covers the control arms, the GUI rename (`SidebarRenameController` → `renameSession`/`renameWorkspace`, `AppActions` → `renameWindow`) and whatever calls these next, and the tests stay host-free. I didn't argue an alternative — the boundary-reader cost (the control arm shows nothing) is paid down with a one-line comment at each store method naming the token and the sink.

`--cwd` is folded in as you asked: it seeds `initialCwd`, which feeds `effectiveCwd` → `{AGT_SESSION_PWD}` until OSC 7 reports, so `addSession` sanitizes both the name and the cwd.

Scope is the invisible control-character vector only — visible shell metacharacters in a name/path stay the caller's concern via the quoted `$AGT_X` env form, consistent with `TerminalText`'s doc-comment.

### Tests

One per arm pinning that an interior newline does not survive the store (`addSession` covers both the name and the cwd arm), with the existing blank/trim cases kept.

### Verification

- `./scripts/test.sh` — 2204 tests in 86 suites pass.
- `swiftlint lint --strict` — clean.