### PR TITLE
docs(cookbook): add the flagged-dashboard recipe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,15 @@ concurrency before changing the bridge.
   Set only a short `/tmp` `AGTERM_STATE_DIR` so app and inherited CLI derive the same socket.
   Prepend the Debug app's `Contents/MacOS` to PATH for custom commands; login shells may restore the
   deployed CLI, so manual commands should use the Debug binary's full path.
+- A fresh isolated state dir reads as a first launch and opens the welcome alert.
+  `mkdir -p "$AGTERM_STATE_DIR/windows"` before launching to skip it: `FirstRunWelcome.hasPriorState`
+  looks for `settings.json`, `workspaces.json`, or `windows` before the app writes anything.
+  Leave the marker out only when the welcome itself is under test.
+- The control socket binds from the window scene's task, so a backgrounded `open -n -g` can leave the app
+  running with no socket until a window renders. Activate the instance when the socket never appears.
+- `agtermctl` never reads `AGTERM_SOCKET`; it resolves `--socket`, then `AGTERM_STATE_DIR`, then
+  `~/Library/Application Support/agterm`. A shell inside the live terminal therefore defaults onto the
+  live socket, and exporting a short `AGTERM_STATE_DIR` is what keeps inherited commands off it.
 - After launching an instance for manual testing, do not touch it. For an assisted experiment, announce
   every action. Ask before acting when unclear.
 - Put nontrivial work in an isolated worktree and remove it after merge. See the build section for artifact

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -23,6 +23,7 @@ Recipes come from other people as well as the maintainer. Every one is reviewed 
 | [claude-recap](claude-recap/) | one key lists what the Claude Code run in a session was working on | 0.10.0, zsh, jq, Claude Code |
 | [new-session-in-workspace](new-session-in-workspace/) | pick a workspace with fzf and start a session in it | 0.8.0, jq, fzf |
 | [project-launcher](project-launcher/) | pick a project anywhere — or type "project + prompt" — and get a session in its workspace | 0.19.0, jq |
+| [flagged-dashboard](flagged-dashboard/) | grid the flagged panes that are running something, one chord to show and dismiss | 0.20.0, jq |
 
 Most recipes need `agtermctl` on your PATH; **Help ▸ Install Command Line Tool…** puts it there. The three session-resume recipes are shell functions that read the environment agterm gives a session and never call the CLI. Some recipes also need `jq`, `fzf`, or a particular shell, and each recipe's *Requirements* section says which, along with the minimum agterm version it needs. Recipes are snapshots rather than a maintained surface: the control API grows by addition, so they rarely break, and one that does gets fixed when it is reported.
 

--- a/cookbook/flagged-dashboard/README.md
+++ b/cookbook/flagged-dashboard/README.md
@@ -1,0 +1,80 @@
+# Flagged dashboard
+
+Grid the flagged panes that are actually running something, one chord, and dismiss them with the same key.
+
+## What it does
+
+Flagging marks the sessions you care about right now, and the flagged sidebar view lists them by name. This recipe shows that set as live terminals instead, minus the panes that have nothing to show: `agt-flagged-dashboard.sh` takes the flagged sessions, keeps only the panes running a foreground command, and opens the dashboard grid over those. Flag the three agents you are babysitting, press the chord, and watch all three at once; arrow keys move the highlight, Enter drops into one and closes the grid.
+
+The unit is a pane, not a session, which is what makes the filter worth having. A split session whose left pane sits at a prompt while its right pane runs a build contributes one cell, not two, so the cells go to work you are waiting on rather than to idle shells. A pane whose split is hidden still counts: if it is running something, it earns a cell, and the grid becomes the only place you can see it.
+
+Pressing the chord while the grid already shows that same set closes it, so the key both opens and dismisses. Start something in another flagged pane first and the same press reopens the grid with it included.
+
+⌘⇧D already grids a window's most-recently-used sessions, which is a different question. Recency is what you touched last, not what is working: a build you started twenty minutes ago and have not typed in since is exactly the thing that falls off the recent list while still being the thing you want on screen.
+
+## Requirements
+
+- agterm 0.20.0 or later. The grid itself is older, but naming one pane of a session with an `<id>:left` / `<id>:right` suffix shipped in 0.20.0, and skipping the idle half of a split is the whole point here.
+- `jq`
+
+## Setup
+
+Copy the script somewhere on your `PATH` and make it executable:
+
+```sh
+mkdir -p ~/bin
+cp agt-flagged-dashboard.sh ~/bin/
+chmod +x ~/bin/agt-flagged-dashboard.sh
+```
+
+Then add an entry to `~/.config/agterm/keymap.conf`:
+
+```
+command "Flagged dashboard" ctrl+shift+g ~/bin/agt-flagged-dashboard.sh
+```
+
+Apply the file with File ▸ Reload Keymap or `agtermctl keymap reload`. Any free chord works; ⌃⇧G collides with no built-in. Leave the chord out entirely and the entry is palette-only.
+
+Nothing else needs configuring, because the recipe has no list to maintain: flagging is the configuration. ⌘⇧F flags and unflags the selected session out of the box, and View ▸ Flag Session does the same from the menu.
+
+Fired from a chord or the palette, the script runs under the app's `PATH` rather than your shell's. That is the launchd default: `/usr/local/bin` plus the system directories, with no `/opt/homebrew/bin` and nothing else your profile adds. `agtermctl` normally resolves there, because **Help ▸ Install Command Line Tool…** symlinks it into `/usr/local/bin`. `jq` resolves only if it is a system one; recent macOS ships `/usr/bin/jq`, but a Homebrew `jq` is out of reach and needs its absolute path written into the script. Set `AGTERMCTL` to the binary's full path if yours sits somewhere unusual.
+
+## Usage
+
+Flag a few sessions with ⌘⇧F, then press the chord. Press it again to dismiss the grid, or Esc, which closes it the same way.
+
+```sh
+agt-flagged-dashboard.sh
+```
+
+Run it from a shell when the grid looks wrong. It prints nothing on success and sends its complaints to stderr, so a shell is where you see that nothing flagged is running, or that the set was too big to fit and got trimmed. A chord throws both away.
+
+## How it works
+
+One read and one write. `agtermctl tree --json` returns the frontmost window's tree, and every session node carries what the selection needs: `flagged`, plus `foreground` and `splitForeground`, the live foreground command of the main and split panes. A pane sitting at its shell prompt reports no foreground at all, so `select(.flagged)` combined with a presence test on those two fields is the entire rule — there is no process inspection to do, and no list of "interesting" commands to maintain.
+
+Each surviving pane becomes an `<id>:left` or `<id>:right` reference, and `agtermctl dashboard <ref> <ref> … --auto-size` opens the grid over exactly those. Passing a bare session id instead would take every pane of the session, idle ones included, which is the behavior this recipe exists to avoid.
+
+One `tree` read answers every question the script has. Reading twice would let a command finish in between and produce a decision that matches neither state.
+
+The toggle is a set comparison against the tree's top-level `dashboardMembers`, which reports the grid's cells in the same `<id>:left` / `<id>:right` form the script writes, so the two round-trip without any translation. Equal sets mean the grid is already the one this chord would build, so the chord closes it instead.
+
+A full grid needs a second rule. The grid holds nine cells and drops the rest, so once the set overflows, what is on screen can never equal what the script would open, and a plain equality test would leave the chord unable to ever close it. A grid holding nine cells that are all cells the script wants therefore counts as a match too. Unflagging something that is on screen still fails that test, which is what keeps the refresh working.
+
+`--auto-size` sizes the cells relative to your Settings font, shrinking them as the grid grows. It is what ⌘⇧D uses, so a flagged grid and a recent-sessions grid look alike. Swap in `--font-size N` for an absolute size in points if you would rather the cells stay put whatever the count.
+
+## Limits
+
+Nothing here closes a session, kills a shell, or changes a flag. The grid is an overlay that comes and goes, and everything it shows keeps running whether it is on screen or not.
+
+A pane counts as busy only when agterm can read its foreground command, and there are cases where it cannot. A session started with `session new --command` runs its program under `login` and reports no foreground, so it is treated as idle and left off the grid even while it works. The same applies to a setuid or setgid program such as `sudo` or `top`, whose argv macOS will not expose. Start the program by typing it in a session, or from a shell wrapper, and it reports normally.
+
+Membership is fixed when the grid opens. A command that finishes while you are watching leaves its pane on the grid, now sitting at a prompt, and a pane that starts working is not added. Press the chord again to rebuild the set.
+
+The grid holds nine cells. Past that the extra panes are dropped, the script reports the trim on stderr, and a chord discards it, so the visible symptom is a grid that is short. Overflowing also costs the toggle one press: with the set trimmed, flagging or starting something new leaves the chord closing the grid rather than refreshing it, so seeing the new arrangement takes a second press.
+
+Everything is scoped to the frontmost window. The script reads `tree` and calls `dashboard` without a window selector, so flagged sessions in another window are not part of the set and need a run in that window.
+
+The toggle recognises the set, not who opened it. A ⌘⇧D recent-sessions grid that happens to hold exactly these panes will be closed by the chord rather than reopened.
+
+The grid is view-only, so no cell takes keyboard input. Opening and closing it does resize each pane's pty to its cell, so a full-screen program may redraw as the grid appears and again as it goes.

--- a/cookbook/flagged-dashboard/agt-flagged-dashboard.sh
+++ b/cookbook/flagged-dashboard/agt-flagged-dashboard.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# agt-flagged-dashboard.sh - grid the flagged panes that are actually running something.
+#
+# The flagged sidebar view as live terminals instead of names, minus the panes
+# sitting at a prompt: flag what you are babysitting, press the chord, watch it.
+# Pressing the chord while the grid already shows that same set closes it, so one
+# key both opens and dismisses. Nothing is closed and no shell is killed; only the
+# grid overlay comes and goes.
+set -e
+
+AGTERMCTL=${AGTERMCTL:-agtermctl}
+
+# The grid's pane limit. Only used to tell a grid trimmed by the cap from one
+# that is short because the flags changed; raise it if a later agterm does.
+CAP=9
+
+# One read answers every question: which panes are flagged and busy, which are on
+# the grid, and how many cells it holds. Two reads could disagree if a command
+# finished between them.
+snapshot=$("$AGTERMCTL" tree --json)
+
+# A pane earns a cell when its session is flagged AND it reports a foreground
+# command. `foreground`/`splitForeground` are omitted for a pane at its shell
+# prompt, which is exactly the pane worth leaving off the grid.
+panes=$(printf '%s' "$snapshot" | jq -r '
+	.result.tree.workspaces[].sessions[]
+	| select(.flagged)
+	| (if .foreground then "\(.id):left" else empty end),
+	  (if .splitForeground then "\(.id):right" else empty end)')
+
+if [ -z "$panes" ]; then
+	echo "${0##*/}: no flagged session is running anything" >&2
+	exit 1
+fi
+
+# The grid is mine when it holds exactly the panes I would open. A full grid
+# holding nothing but those panes counts too, because at the cap it CANNOT hold
+# the whole set and demanding equality would leave the chord unable to close it.
+verdict=$(printf '%s' "$snapshot" | jq -r --argjson cap "$CAP" '
+	. as $root
+	| ($root.result.tree.dashboardMembers // [] | unique) as $onscreen
+	| ([$root.result.tree.workspaces[].sessions[]
+	    | select(.flagged)
+	    | (if .foreground then "\(.id):left" else empty end),
+	      (if .splitForeground then "\(.id):right" else empty end)] | unique) as $wanted
+	| if ($onscreen | length) == 0 then "open"
+	  elif $onscreen == $wanted then "close"
+	  elif ($onscreen | length) >= $cap and (($onscreen - $wanted) | length) == 0 then "close"
+	  else "open"
+	  end')
+
+if [ "$verdict" = close ]; then
+	"$AGTERMCTL" dashboard --close >/dev/null
+	exit 0
+fi
+
+# Pane refs collected as positional parameters rather than an unquoted variable,
+# so the expansion stays explicit and shellcheck has nothing to complain about.
+set --
+for ref in $panes; do
+	set -- "$@" "$ref"
+done
+
+# The grid caps at nine panes and says so in the response when it trims. Fired
+# from a chord that goes nowhere; run the script from a shell to read it.
+note=$("$AGTERMCTL" dashboard "$@" --auto-size --json | jq -r '.result.text // empty')
+[ -n "$note" ] && echo "${0##*/}: $note" >&2
+
+exit 0


### PR DESCRIPTION
adds a cookbook recipe that grids the flagged sessions' panes that are running something, on one chord.

flagging already marks the sessions you care about, and the flagged sidebar view lists them by name. This shows the same set as live terminals instead, minus the panes with nothing to show. The unit is a pane, so a split whose left pane sits at a prompt while its right runs a build contributes one cell, not two, and a pane whose split is hidden still counts if it is working. `⌘⇧D` answers a different question: recency is what you touched last, not what is running.

selection is `select(.flagged)` plus a presence test on `foreground`/`splitForeground`, so there is no list of interesting commands to maintain. Each surviving pane becomes an `<id>:left` / `<id>:right` ref, which is why the recipe needs 0.20.0.

pressing the chord again closes the grid. That is a set comparison against the tree's `dashboardMembers`, which reports the same pane-ref form the script writes. A full grid holding only wanted panes counts as a match too, otherwise the nine-cell cap would leave the chord unable to ever close.

**verified against an isolated debug instance**, never the default socket. 6 flagged sessions with 2 busy panes opened 2 cells, correctly excluding the idle left half of a split. The toggle closes, a newly busy pane reopens with 3, a hidden-but-running split gets a cell, and both empty cases exit 1. The cap branch is covered by fixtures.

one limitation worth calling out in case it is news: a session started with `session new --command` reports no foreground at all. It runs as `-sleep 900` under `/usr/bin/login`, so this filter treats it as idle. Commands typed into a shell report fine, including in background sessions. Documented under *Limits*; I did not trace why `foregroundPid()` comes back empty for that process shape, so I am not claiming it is a bug.

second commit is unrelated to the recipe: three dev-instance notes for `CLAUDE.md`. A fresh isolated state dir reads as a first launch and opens the welcome alert, the control socket binds from the window scene's task so a backgrounded launch can sit there with no socket, and `agtermctl` ignores `AGTERM_SOCKET`.
