### PR TITLE
fix: mute a pane overlay on the unfocused split pane

### DIFF
--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -97,6 +97,10 @@ paths:
 - Because those two leave a live terminal around the panel, their tap-catcher also paints the
   `inactivePaneMuteStrength` wash. Fill the existing catcher; never add a sibling scrim. Suppress `paneDim`
   while a backdrop wash is up or the covered inactive pane takes both.
+- Anything that HIDES a pane in place takes the wash with it, so the cover must carry `paneDim` itself:
+  `paneOverlayPanel` washes an overlay opened on the unfocused pane, or split focus stops reading.
+  Wash a cover against ITS OWN background, not `washColor(for:)`. An overlay surface is sessionless and
+  never inherits the session background, so the session color would shift the background it blends into.
 - The wash is neutral only at full window opacity. Below it the wash color is opaque while the backing is
   not, so the body rises to `m + p(1-m)` against a title bar left at `p`; scaling by the rendered opacity
   shrinks that gap but no fill closes it. Scale by what the window actually renders at, not the saved

--- a/agterm/Views/WindowContentView+Detail.swift
+++ b/agterm/Views/WindowContentView+Detail.swift
@@ -168,7 +168,7 @@ extension WindowContentView {
                 Color.clear
                     .id("\(session.id.uuidString)-\(pane == .left ? "primary" : "split")-placeholder")
             }
-            paneOverlayPanel(session: session, pane: pane,
+            paneOverlayPanel(session: session, pane: pane, focused: focused,
                              isActive: gates.focusable && !gates.overlaid && focused, deckVisible: gates.visible)
         }
     }
@@ -223,7 +223,9 @@ extension WindowContentView {
     /// `isActive` is the FOCUSED-pane gate (auto-focus, first responder), `deckVisible` the on-screen one
     /// (drag types, mouse cursor, clicks): an overlay on the unfocused pane stays visible and clickable —
     /// clicking it moves focus through the surface's own `onFocusChange` — without grabbing focus on open.
-    @ViewBuilder private func paneOverlayPanel(session: Session, pane: OverlayPane, isActive: Bool,
+    /// It therefore carries `focused`'s `paneDim` too: the overlay replaces the pane the wash would have
+    /// marked, so without it the unfocused side of a split reads as live.
+    @ViewBuilder private func paneOverlayPanel(session: Session, pane: OverlayPane, focused: Bool, isActive: Bool,
                                                deckVisible: Bool) -> some View {
         let active = session.paneOverlay(pane) != nil
             && deckHostsSurface(session: session, surface: pane.zoomSurface)
@@ -235,6 +237,7 @@ extension WindowContentView {
                     TerminalView(session: session, surfaceKeyPath: pane.surfaceSlot,
                                  makeSurface: { makeOverlaySurface($0, pane) },
                                  isActive: isActive, deckVisible: deckVisible)
+                        .overlay { paneDim(!focused, session: session, color: overlayWashColor(session, pane: pane)) }
                         .id("\(session.id.uuidString)-overlay-\(pane.rawValue)")
                 }
             }
@@ -244,15 +247,27 @@ extension WindowContentView {
         .allowsHitTesting(deckVisible && active)
     }
 
-    /// Mutes the inactive split pane's TEXT without darkening the background: a translucent wash of the
-    /// terminal background, so background pixels blend bg→bg and text pixels text→bg. Strength 0 renders
-    /// nothing; clicks pass through, so it stays focusable. Suppressed while a floating panel washes the
-    /// whole backdrop, which already covers this pane — the two would stack to a stronger mute here than on
-    /// the pane beside it.
-    @ViewBuilder private func paneDim(_ dimmed: Bool, session: Session) -> some View {
+    /// Mutes the inactive split pane — or the overlay covering it — by fading its TEXT without darkening the
+    /// background: a translucent wash of the terminal background, so background pixels blend bg→bg and text
+    /// pixels text→bg. Strength 0 renders nothing; clicks pass through, so it stays focusable. Suppressed
+    /// while a floating panel washes the whole backdrop, which already covers this pane — the two would
+    /// stack to a stronger mute here than on the pane beside it. `color` overrides the blend target for a
+    /// surface that does not render the session's background; the pane itself takes the default.
+    @ViewBuilder private func paneDim(_ dimmed: Bool, session: Session, color: Color? = nil) -> some View {
         if dimmed, muteWashOpacity > 0, !backdropWashActive(session: session) {
-            washColor(for: session).opacity(muteWashOpacity).allowsHitTesting(false)
+            (color ?? washColor(for: session)).opacity(muteWashOpacity).allowsHitTesting(false)
         }
+    }
+
+    /// The blend target for a PANE OVERLAY's wash: its own `--background-color` when it set one, else the
+    /// theme. An overlay surface is sessionless and never inherits the session's background — only the
+    /// scratch does, through `watermarkSession` — so `washColor(for:)` would blend bg→OTHER-bg and shift
+    /// the background instead of fading the text. Gated on the renderer's own hex predicate, so the wash
+    /// tracks exactly what `applyOverlayBackgroundColor` painted rather than a value it rejected.
+    private func overlayWashColor(_ session: Session, pane: OverlayPane) -> Color {
+        guard let hex = session.paneOverlay(pane)?.backgroundColor, WatermarkConfig.isValidColorHex(hex),
+              let nsColor = NSColor(agtermHex: hex) else { return terminalColor }
+        return Color(nsColor: nsColor)
     }
 
     /// Whether a floating panel is washing the whole backdrop of this session's detail pane.


### PR DESCRIPTION
a pane overlay opened on the unfocused side of a split rendered at full brightness, so both panes read
as live and the split focus cue was gone.

the wash that mutes an inactive split pane (`paneDim`) is drawn on that pane's `TerminalView`.
`PaneOverlayCover` sets the covered pane's opacity to 0, which took the wash down with it, and
`paneOverlayPanel` drew its own `TerminalView` without one. `paneOverlayPanel` now takes `focused` and
carries the same wash.

the wash blends against the overlay's OWN background, not the session's. An overlay surface is
sessionless and never inherits the session background (`GhosttySurfaceView+Config.swift:20-22`), so
`washColor(for:)` would have shifted the background instead of fading the text, both for an overlay
opened with `--background-color` and for a plain one over a session that set its own color. New
`overlayWashColor` resolves the overlay's color, falling back to the theme, gated on the same hex
predicate `applyOverlayBackgroundColor` uses.

`paneDim` keeps its `allowsHitTesting(false)`, so clicking a muted overlay still moves focus to it, and
the `backdropWashActive` suppression covers the new call site too, so a floating session overlay or the
quick terminal can't stack two washes on one pane. Everything stays inside `deckPane`'s ZStack, which is
inside the arranged subview, so the constant-shape rule holds and the `NSSplitView` is not re-hosted.

no automated coverage: SwiftUI view output has no test surface here, `AppSettings.muteOpacity` is the
only unit-tested piece. Verified by eye in an isolated Debug instance, overlay on the unfocused pane
washed and on the focused pane not.

known trade-off, same one the existing backdrop wash makes: under window translucency the overlay is
chromeless, so the wash paints over the window backing and reads more as a tint than a text mute.
`muteWashOpacity` scales by the rendered window opacity, which shrinks the gap without closing it.

Related to #343.
