### PR TITLE
feat(split): restore an even split on a divider double-click

### DIFF
--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -100,7 +100,9 @@ paths:
 - Double-clicking the divider restores `splitRatioDefault` through the same `applyRatio` path as
   `session.resize`, persisting immediately rather than through the drag debounce. AppKit offers no hook:
   `NSSplitView`'s own double-click collapses a pane through the delegate SwiftUI owns. One shared
-  `SplitProbeView` monitor, installed with the first split and removed with the last, sees the second click
+  `SplitProbeView` monitor, installed with the first split and removed once the last probe leaves its window
+  (a probe freed without that callback leaves it installed, passing every event through an empty weak
+  claimant table), sees the second click
   after the first one's drag-tracking loop ends, so dragging is unaffected; consume that press and its
   release so neither starts a drag nor reports a phantom button-up. The target is `dividerOwns`, the band
   already used for the resize cursor, so the gesture claims no pixel that could have selected a word.

--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -97,6 +97,15 @@ paths:
 - Persist each pane cwd and the 0...1 left-pane `splitRatio`. `SplitRatioAccessor` is an unconditional
   background representable on primary, introspects `NSSplitView`, retries until width exists, observes
   `didResizeSubviews`, and debounces save by about 0.4 seconds. Regular saves and quit flush also persist it.
+- Double-clicking the divider restores `splitRatioDefault` through the same `applyRatio` path as
+  `session.resize`, persisting immediately rather than through the drag debounce. AppKit offers no hook:
+  `NSSplitView`'s own double-click collapses a pane through the delegate SwiftUI owns. One shared
+  `SplitProbeView` monitor, installed with the first split and removed with the last, sees the second click
+  after the first one's drag-tracking loop ends, so dragging is unaffected; consume that press and its
+  release so neither starts a drag nor reports a phantom button-up. The target is `dividerOwns`, the band
+  already used for the resize cursor, so the gesture claims no pixel that could have selected a word.
+  `clickCount == 2` also matches a re-grab after a nudge-drag, so require the divider not to have moved
+  since the previous press.
 - `SplitRatioAccessor` masks only the compact-titlebar divider overrun. At 30pt compact height, SwiftUI
   padding lies inside the safe-area band and AppKit expands `NSSplitView` full height; normal 48px mode is
   already bounded. Compute the live overrun and apply a CALayer mask, removing it at zero.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ agterm arranges terminals into a small hierarchy. These are the only terms you n
 
 **Session.** A session is one running shell with a name, a working directory, and its own scrollback. It is the unit you work in and the row you see in the sidebar. A new session takes its name from the basename of its directory; rename it to pin a custom name, clear the name to go back to the basename. New sessions open in your home directory by default, or in the current session's directory, or in a fixed folder (set in Settings). A session runs until you close it or its shell exits, and it comes back on the next launch with its directory, font size, and split state restored.
 
-**Panes.** A session can split into two shells side by side. Both panes are part of the same session and share one sidebar row; a split is one session with two terminals, not two sessions. One pane is focused at a time, and the divider position is remembered.
+**Panes.** A session can split into two shells side by side. Both panes are part of the same session and share one sidebar row; a split is one session with two terminals, not two sessions. One pane is focused at a time, and the divider position is remembered — drag the divider to resize the panes, double-click it to snap back to an even split.
 
 **Scratch terminal.** Every session has an extra shell, the scratch terminal, that you toggle on over the session and hide again without killing it. It opens in the session's directory and is for a quick aside next to your main work. It belongs to that one session and is not restored across launches.
 

--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -294,7 +294,8 @@ extension ControlServer: ControlActions {
         }
     }
 
-    /// Resize a split's divider (control-native — the GUI only drags it). `ratio` is an absolute left-pane
+    /// Resize a split's divider (control-native — the GUI only drags it, or double-clicks it for an even
+    /// split). `ratio` is an absolute left-pane
     /// fraction, `delta` a signed nudge (positive grows the left pane) on the current fraction (0.5 when
     /// never moved); exactly one must be set. `applySplitRatio` clamps + persists, then
     /// `.agtermApplySplitRatio` pokes the session's `SplitProbeView` to move the live divider — a no-op

--- a/agterm/Views/SplitRatioAccessor.swift
+++ b/agterm/Views/SplitRatioAccessor.swift
@@ -191,9 +191,12 @@ struct SplitRatioAccessor: NSViewRepresentable {
         }
 
         /// Join the probes the click monitor asks, installing that monitor with the first split and dropping
-        /// it with the last, so a window with no split has no app-wide mouse monitor at all. ONE monitor for
-        /// the whole app, like `PaneShortcuts` — never one per probe, which would run N predicates per click
-        /// and leak a monitor on every re-attach. Adding is idempotent; `layout()` re-claims after a re-host.
+        /// it once the last probe leaves its window, so an app that never splits installs none. ONE monitor
+        /// for the whole app, like `PaneShortcuts` — never one per probe, which would run N predicates per
+        /// click and leak a monitor on every re-attach. Adding is idempotent; `layout()` re-claims after a
+        /// re-host. A probe freed without `viewWillMove(toWindow:)` leaves the monitor installed, which costs
+        /// nothing: `claimants` is weak, so the handler finds it empty and passes every event through
+        /// untouched. Removing it from inside its own dispatch is not worth that.
         private static func addClaimant(_ probe: SplitProbeView) {
             claimants.add(probe)
             guard clickMonitor == nil else { return }

--- a/agterm/Views/SplitRatioAccessor.swift
+++ b/agterm/Views/SplitRatioAccessor.swift
@@ -17,9 +17,9 @@ extension NSView {
 
 /// Bridges to the AppKit `NSSplitView` under SwiftUI's `HSplitView` to (1) persist and restore the split
 /// divider ratio — no public SwiftUI API exposes the divider position — (2) clip the split's divider out
-/// of the titlebar strip, and (3) paint the divider's own resize cursor, which nothing else writes.
-/// Attached as a `.background` on the primary pane so its `NSView` lives inside the split's view tree
-/// without becoming a third arranged pane.
+/// of the titlebar strip, (3) paint the divider's own resize cursor, which nothing else writes, and
+/// (4) restore an even split on a divider double-click. Attached as a `.background` on the primary pane so
+/// its `NSView` lives inside the split's view tree without becoming a third arranged pane.
 ///
 /// (1) Once the split has a real width it restores `session.splitRatio` via `setPosition`; on each divider
 /// resize it writes the current left-pane fraction back to the session, which the next `save()` (or the
@@ -34,13 +34,18 @@ extension NSView {
 /// reflowing the terminal grid (a SwiftUI `.mask`/`.clipped()` here scrolled the top row away), the empty
 /// strip is harmless to clip, and it composes with translucency (revealing the window backing, never an
 /// opaque color over the titlebar).
+///
+/// (4) A drag can't land exactly on 50/50, and `NSSplitView`'s own double-click gesture only collapses a
+/// pane through the delegate SwiftUI owns, so the reset is recognized from a shared mouse monitor instead.
+/// It sees the second click after the first one's divider-drag tracking loop ends, leaving dragging intact.
 struct SplitRatioAccessor: NSViewRepresentable {
     let session: Session
     let titlebarHeight: CGFloat
     let suspended: Bool
     /// On screen and uncovered: the deck's `visible` minus any overlay or scratch over the panes. Gates (3)
-    /// alone — a background session's split is still laid out at the full frame with its tracking area
-    /// armed, so its divider column would paint over whatever session IS on screen.
+    /// and (4) — a background session's split is still laid out at the full frame with its tracking area
+    /// armed, so its divider column would paint over, and answer clicks meant for, whatever session IS on
+    /// screen.
     let deckVisible: Bool
     let onPersist: () -> Void
 
@@ -73,6 +78,10 @@ struct SplitRatioAccessor: NSViewRepresentable {
                 needsLayout = true
             }
         }
+        /// The probes a divider click is offered to, weak so a torn-down one drops out on its own. Every
+        /// attached probe joins; `dividerOwns` then decides which single one actually holds that pixel.
+        private static let claimants = NSHashTable<SplitProbeView>.weakObjects()
+        private static var clickMonitor: Any?
         nonisolated(unsafe) private var resizeObserver: NSObjectProtocol?
         nonisolated(unsafe) private var applyObserver: NSObjectProtocol?
         nonisolated(unsafe) private var saveWorkItem: DispatchWorkItem?
@@ -80,6 +89,10 @@ struct SplitRatioAccessor: NSViewRepresentable {
         private var dividerClipMask: CALayer?
         private var dividerTracking: NSTrackingArea?
         private var restored = false
+        /// Left-pane width at the previous in-band press, nil when that press missed the band.
+        private var lastPressLeftWidth: CGFloat?
+        /// A press was swallowed and its release is still to come.
+        private var swallowedPress = false
 
         init(session: Session) {
             self.session = session
@@ -90,11 +103,13 @@ struct SplitRatioAccessor: NSViewRepresentable {
         required init?(coder _: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
         /// Hand the tracking area back before the split outlives this probe: `NSTrackingArea` does not retain
-        /// its owner, so a stale one would message a freed view on the next move. `layout()` reinstalls it if
-        /// the probe is re-hosted.
+        /// its owner, so a stale one would message a freed view on the next move. `layout()` reinstalls it,
+        /// and re-claims divider clicks, if the probe is re-hosted.
         override func viewWillMove(toWindow newWindow: NSWindow?) {
             super.viewWillMove(toWindow: newWindow)
-            guard newWindow == nil, let dividerTracking else { return }
+            guard newWindow == nil else { return }
+            Self.dropClaimant(self)
+            guard let dividerTracking else { return }
             splitView?.removeTrackingArea(dividerTracking)
             self.dividerTracking = nil
         }
@@ -103,6 +118,7 @@ struct SplitRatioAccessor: NSViewRepresentable {
             super.layout()
             attachIfNeeded()
             updateDividerTracking()
+            Self.addClaimant(self)
             updateDividerClip() // keep the titlebar-strip clip sized to the current split bounds
             guard !suspended else { return }
             guard !restored, let split = splitView else { return }
@@ -172,6 +188,63 @@ struct SplitRatioAccessor: NSViewRepresentable {
             guard split.hitTest(parent.convert(pointInWindow, from: nil)) === split else { return false }
             guard let hit = split.window?.contentView?.hitTest(pointInWindow) else { return true }
             return hit === split || hit.isDescendant(of: split) || hit is GhosttySurfaceView || hit is NSSplitView
+        }
+
+        /// Join the probes the click monitor asks, installing that monitor with the first split and dropping
+        /// it with the last, so a window with no split has no app-wide mouse monitor at all. ONE monitor for
+        /// the whole app, like `PaneShortcuts` — never one per probe, which would run N predicates per click
+        /// and leak a monitor on every re-attach. Adding is idempotent; `layout()` re-claims after a re-host.
+        private static func addClaimant(_ probe: SplitProbeView) {
+            claimants.add(probe)
+            guard clickMonitor == nil else { return }
+            clickMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .leftMouseUp]) { event in
+                for claimant in claimants.allObjects where claimant.consumes(event) { return nil }
+                return event
+            }
+        }
+
+        private static func dropClaimant(_ probe: SplitProbeView) {
+            claimants.remove(probe)
+            guard claimants.allObjects.isEmpty, let monitor = clickMonitor else { return }
+            NSEvent.removeMonitor(monitor)
+            clickMonitor = nil
+        }
+
+        /// Whether this probe takes the event: a double-click on its divider, which restores the even split,
+        /// or the release pairing with a press it already took — an unpaired release would otherwise reach
+        /// whatever sits under the swallowed press.
+        ///
+        /// The target is `dividerOwns`, the same band the resize cursor is painted over and the same one the
+        /// split's own drag already starts in, so the gesture takes no pixel the terminal could have used for
+        /// a word selection. A press counts as a double-click only if the divider has not MOVED since the
+        /// previous one: macOS reports `clickCount == 2` for a re-grab that lands close enough in time and
+        /// space to the last press, so fine-tuning with a nudge-drag and grabbing again would otherwise throw
+        /// the adjustment away and eat the second drag.
+        func consumes(_ event: NSEvent) -> Bool {
+            guard let split = splitView, event.window === split.window else { return false }
+            if event.type == .leftMouseUp {
+                defer { swallowedPress = false }
+                return swallowedPress
+            }
+            guard split.arrangedSubviews.count == 2 else { return false }
+            let onDivider = dividerOwns(event.locationInWindow)
+            let leftWidth = split.arrangedSubviews[0].frame.width
+            defer { lastPressLeftWidth = onDivider ? leftWidth : nil }
+            guard onDivider, event.clickCount == 2,
+                  let previous = lastPressLeftWidth, abs(previous - leftWidth) < 1 else { return false }
+            resetToEvenSplit()
+            swallowedPress = true
+            return true
+        }
+
+        /// Restore the even split through the `session.resize` path, so the model and the live divider move
+        /// exactly as they do for a control-driven ratio. Persist straight away: this is one discrete action,
+        /// not the drag stream `capture()` debounces.
+        private func resetToEvenSplit() {
+            session.splitRatio = AppStore.splitRatioDefault
+            applyRatio()
+            saveWorkItem?.cancel()
+            onPersist?()
         }
 
         /// Move the live divider to the session's stored `splitRatio` (set by `session.resize` just before

--- a/agtermTests/SplitRatioAccessorTests.swift
+++ b/agtermTests/SplitRatioAccessorTests.swift
@@ -8,6 +8,7 @@ import XCTest
 final class SplitRatioAccessorTests: XCTestCase {
     private var window: NSWindow!
     private var split: NSSplitView!
+    private var session: Session!
     private var probe: SplitRatioAccessor.SplitProbeView!
 
     override func setUp() async throws {
@@ -21,7 +22,8 @@ final class SplitRatioAccessorTests: XCTestCase {
             split.addArrangedSubview(NSView(frame: NSRect(x: 0, y: 0, width: 200, height: 200)))
             split.addArrangedSubview(NSView(frame: NSRect(x: 201, y: 0, width: 199, height: 200)))
             window.contentView?.addSubview(split)
-            probe = SplitRatioAccessor.SplitProbeView(session: Session(initialCwd: NSTemporaryDirectory()))
+            session = Session(initialCwd: NSTemporaryDirectory())
+            probe = SplitRatioAccessor.SplitProbeView(session: session)
             split.arrangedSubviews[0].addSubview(probe)
         }
     }
@@ -29,6 +31,7 @@ final class SplitRatioAccessorTests: XCTestCase {
     override func tearDown() async throws {
         await MainActor.run {
             probe = nil
+            session = nil
             split = nil
             window.orderOut(nil)
             window = nil
@@ -128,5 +131,116 @@ final class SplitRatioAccessorTests: XCTestCase {
         NSCursor.arrow.set()
         try moveOverDivider()
         XCTAssertEqual(NSCursor.current, NSCursor.arrow)
+    }
+
+    private func press(atX x: CGFloat, count: Int, y: CGFloat = 100, windowNumber: Int? = nil) throws -> Bool {
+        let event = try XCTUnwrap(NSEvent.mouseEvent(with: .leftMouseDown, location: NSPoint(x: x, y: y),
+                                                     modifierFlags: [], timestamp: 0,
+                                                     windowNumber: windowNumber ?? window.windowNumber,
+                                                     context: nil, eventNumber: 0, clickCount: count, pressure: 1))
+        return probe.consumes(event)
+    }
+
+    private func dividerX() throws -> CGFloat {
+        try XCTUnwrap(split.arrangedSubviews.first).frame.maxX + split.dividerThickness / 2
+    }
+
+    private func doubleClickDivider() throws -> Bool {
+        _ = try press(atX: dividerX(), count: 1)
+        return try press(atX: dividerX(), count: 2)
+    }
+
+    private func leftWidth() -> CGFloat { split.arrangedSubviews[0].frame.width }
+
+    /// Off-center starting point for the gesture, standing in for a user's drag.
+    private func offsetDivider(to position: CGFloat) {
+        split.setPosition(position, ofDividerAt: 0)
+        split.layoutSubtreeIfNeeded()
+        probe.layout()
+    }
+
+    func testDoubleClickOnTheDividerRestoresTheEvenSplit() throws {
+        probe.layout()
+        offsetDivider(to: 300)
+        XCTAssertTrue(try doubleClickDivider())
+        XCTAssertEqual(leftWidth(), 200, accuracy: 1)
+        XCTAssertEqual(try XCTUnwrap(session.splitRatio), AppStore.splitRatioDefault, accuracy: 0.01)
+    }
+
+    func testSingleClickOnTheDividerIsLeftToTheSplitsOwnDrag() throws {
+        probe.layout()
+        offsetDivider(to: 300)
+        XCTAssertFalse(try press(atX: dividerX(), count: 1))
+        XCTAssertEqual(leftWidth(), 300, accuracy: 1)
+    }
+
+    func testDoubleClickOverAPaneIsLeftToTheTerminal() throws {
+        probe.layout()
+        offsetDivider(to: 300)
+        _ = try press(atX: 50, count: 1)
+        XCTAssertFalse(try press(atX: 50, count: 2))
+        XCTAssertEqual(leftWidth(), 300, accuracy: 1)
+    }
+
+    /// macOS reports `clickCount == 2` for a re-grab close enough in time and space to the last press, so
+    /// nudging the divider and grabbing it again must keep the adjustment instead of throwing it away.
+    func testRegrabAfterANudgeDragKeepsTheAdjustment() throws {
+        probe.layout()
+        offsetDivider(to: 300)
+        _ = try press(atX: dividerX(), count: 1)
+        offsetDivider(to: 320) // the nudge-drag that first press started
+        XCTAssertFalse(try press(atX: dividerX(), count: 2))
+        XCTAssertEqual(leftWidth(), 320, accuracy: 1)
+    }
+
+    func testLeavesDividerClicksAloneWhileOffScreen() throws {
+        probe.layout()
+        offsetDivider(to: 300)
+        probe.deckVisible = false
+        XCTAssertFalse(try doubleClickDivider())
+        XCTAssertEqual(leftWidth(), 300, accuracy: 1)
+    }
+
+    func testLeavesDividerClicksAloneUnderChrome() throws {
+        probe.layout()
+        offsetDivider(to: 300)
+        window.contentView?.addSubview(NSView(frame: NSRect(x: 0, y: 0, width: 400, height: 200)))
+        XCTAssertFalse(try doubleClickDivider())
+        XCTAssertEqual(leftWidth(), 300, accuracy: 1)
+    }
+
+    func testLeavesDividerClicksAloneWhileSuspended() throws {
+        probe.layout()
+        offsetDivider(to: 300)
+        probe.suspended = true
+        XCTAssertFalse(try doubleClickDivider())
+        XCTAssertEqual(leftWidth(), 300, accuracy: 1)
+    }
+
+    /// Compact toolbar mode: the split spans the full window height and its divider is masked out of the top
+    /// strip, which the titlebar row's own full-width `WindowControlArea` covers. A press up there belongs to
+    /// the titlebar, while the divider below the strip still resets — the band is partly covered, not gone.
+    func testCompactTitlebarStripDeclinesWhileTheRestOfTheDividerResets() throws {
+        probe.titlebarHeight = 30
+        probe.layout()
+        offsetDivider(to: 300)
+        window.contentView?.addSubview(NSView(frame: NSRect(x: 0, y: 170, width: 400, height: 30)))
+
+        _ = try press(atX: dividerX(), count: 1, y: 185)
+        XCTAssertFalse(try press(atX: dividerX(), count: 2, y: 185))
+        XCTAssertEqual(leftWidth(), 300, accuracy: 1)
+
+        XCTAssertTrue(try doubleClickDivider())
+        XCTAssertEqual(leftWidth(), 200, accuracy: 1)
+    }
+
+    /// The monitor is shared by every split in the app, so a probe must decline an event that did not come
+    /// from its own split's window.
+    func testDeclinesAnEventFromAnotherWindow() throws {
+        probe.layout()
+        offsetDivider(to: 300)
+        XCTAssertFalse(try press(atX: dividerX(), count: 1, windowNumber: 0))
+        XCTAssertFalse(try press(atX: dividerX(), count: 2, windowNumber: 0))
+        XCTAssertEqual(leftWidth(), 300, accuracy: 1)
     }
 }

--- a/agtermUITests/ControlOverlaySplitUITests.swift
+++ b/agtermUITests/ControlOverlaySplitUITests.swift
@@ -640,6 +640,24 @@ final class ControlOverlaySplitUITests: ControlAPITestCase {
         XCTAssertEqual(empty["ok"] as? Bool, false, "resize with no fraction should fail: \(empty)")
     }
 
+    // the GUI half of session.resize. Real mouse events are the point: the gesture is recognized from a
+    // shared local event monitor, which only sees the second press once the first one's divider-drag
+    // tracking loop has ended, and nothing below the app can stand in for that.
+    func testDoubleClickOnDividerRestoresEvenSplit() throws {
+        let split = try sendCommand(#"{"cmd":"session.split","target":"active","args":{"mode":"on"}}"#)
+        XCTAssertEqual(split["ok"] as? Bool, true, "split on should succeed: \(split)")
+        XCTAssertTrue(pollActiveSessionSplit(true, timeout: 10), "the active session should report split:true")
+
+        let offset = try sendCommand(#"{"cmd":"session.resize","target":"active","args":{"ratio":0.7}}"#)
+        XCTAssertEqual(offset["ok"] as? Bool, true, "absolute resize should succeed: \(offset)")
+        XCTAssertTrue(pollSplitRatio(0.7, timeout: 10), "the divider should start off center")
+
+        let divider = app.splitters.firstMatch
+        XCTAssertTrue(divider.waitForExistence(timeout: 8), "the split should publish a divider")
+        divider.doubleClick()
+        XCTAssertTrue(pollSplitRatio(0.5, timeout: 10), "double-clicking the divider should restore the even split")
+    }
+
     // the divider-normalize regression guard. A pane overlay renders INSIDE the NSSplitView's arranged
     // subview, so mounting or freeing one must never re-lay-out the split. `splitRatio` in the tree is
     // captured off the LIVE NSSplitView by `SplitRatioAccessor`, so a normalize surfaces here as 0.5.

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -264,8 +264,9 @@ omitted when expanded).
   --command` (respawns the scratch if one is open). Target your own session with
   `--target "$AGTERM_SESSION_ID"` (see Addressing).
 - `focus [left|right|other]` — move focus between split panes.
-- `resize --split-ratio R | --grow-left D | --grow-right D` — move the split divider (no GUI/keymap
-  equivalent — bind it via a `command "agtermctl session resize …"` custom action). `--split-ratio` sets
+- `resize --split-ratio R | --grow-left D | --grow-right D` — move the split divider (the GUI only drags
+  it, or double-clicks it for an even split; bind any other fraction via a
+  `command "agtermctl session resize …"` custom action). `--split-ratio` sets
   the absolute left-pane fraction (0..1, clamped to 0.05..0.95); `--grow-left`/`--grow-right` nudge it by
   a fraction. Prints the applied (clamped) fraction.
 - `status <idle|active|completed|blocked> [--blink] [--auto-reset] [--sound NAME] [--color #rrggbb] [--shape SHAPE] [--pane left|right|scratch] [--pane-id TOKEN]` — set the sidebar agent glyph (`--sound default` or a system sound name plays a one-shot sound; `--color` tints the glyph for this call only, reverting on the next status set without it; `--shape` (`circle`, `square`, `triangle`, `diamond`, `capsule`, `star`) picks its silhouette for this call only and reverts the same way, read back as the tree `statusShape` field; `--pane` records which pane set it — `left`=main, `right`=split, `scratch` — so foreground typing in another pane won't clear it and any user-initiated GUI selection (auto-follow, attention-nav ⌃⌥↑/↓, plain session nav, the command palettes, a Dock-menu session, a sidebar row click) reveals that pane when the status needs attention (`blocked`/`completed`); `active` preserves the existing pane selection; the pane reads back as the tree `statusPane` field; the socket `session go next-attention` only steps the selection, it does not itself reveal the pane; `--pane-id` is the hook-forwarded stable surface token (`$AGTERM_PANE_ID`) that resolves the pane's live slot and overrides a stale `--pane` after a promote + re-split — scripts set `--pane` directly and leave `--pane-id` to the hook).

--- a/plugins/agterm/skills/agterm/examples.md
+++ b/plugins/agterm/skills/agterm/examples.md
@@ -183,7 +183,8 @@ after/before placement, not `--to up|down|top|bottom`.
 
 ## Resize the split divider from a keybinding
 
-The divider is otherwise mouse-drag only — there is no built-in resize action, so bind keys to the CLI
+The divider is otherwise mouse-only — drag it, or double-click it for an even split. There is no built-in
+resize action for any other fraction, so bind keys to the CLI
 with `command "<name>" <chord> <shell…>` custom actions in `keymap.conf` (then `agtermctl keymap reload`):
 
 ```conf

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -403,8 +403,9 @@ All twelve are read-only projections of GUI state.
   split panes (`other` toggles, the default). Errors when the session has no split. Works whether the
   split is shown side-by-side or hidden (maximized) — when hidden, focusing a pane swaps which one shows.
 - `session resize (--split-ratio R | --grow-left D | --grow-right D) [--target] [--window W]` — move the
-  split DIVIDER (the divider is otherwise mouse-drag only; there is no GUI/menu/keymap action, so bind a
-  key by mapping a `command "agtermctl session resize …"` custom action). Provide exactly one form:
+  split DIVIDER (the divider is otherwise mouse-only: drag it, or double-click it for an even split. No
+  GUI/menu/keymap action reaches any other fraction, so bind a key by mapping a
+  `command "agtermctl session resize …"` custom action). Provide exactly one form:
   `--split-ratio` sets the absolute left-pane fraction (`0..1`); `--grow-left D` / `--grow-right D` nudge
   it by the fraction `D` (grow-left shrinks the right pane and vice-versa). The result is clamped to
   `0.05..0.95` and persisted, and the applied (clamped) fraction is printed (and returned as `result.ratio`

--- a/site/commands.html
+++ b/site/commands.html
@@ -1142,7 +1142,8 @@
                 split.
               </p>
               <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
-                Control-native: the divider is otherwise mouse-drag only, with no GUI, menu, or keymap action — bind a key by mapping
+                Control-native: the divider is otherwise mouse-only — drag it, or double-click it for an even split. No GUI, menu, or
+                keymap action reaches any other fraction — bind a key by mapping
                 a <span style="font-family: &quot;JetBrains Mono&quot;, monospace">command "agtermctl session resize …"</span> custom
                 action. Resizing a hidden split updates the stored fraction, applied when it is next shown.
               </p>

--- a/site/docs.html
+++ b/site/docs.html
@@ -664,7 +664,8 @@
                 </div>
                 <p style="font-size: 15px; line-height: 1.6; color: #949ba4; margin: 0">
                   A session can split into two shells side by side. Both panes share one sidebar row — a split is one session with
-                  two terminals, not two sessions. One pane is focused at a time and the divider position is remembered.
+                  two terminals, not two sessions. One pane is focused at a time and the divider position is remembered —
+                  drag the divider to resize the panes, double-click it to snap back to an even split.
                 </p>
               </div>
               <div


### PR DESCRIPTION
Double-clicking a split's divider snaps it back to 50/50. A drag can never land exactly on an even split, and `NSSplitView`'s own double-click only collapses a pane through a delegate SwiftUI owns, so the gesture is recognized from a local mouse monitor that sees the second press after the first one's drag-tracking loop ends. Dragging is untouched.

This is the feature from #341, rebuilt on the band `dividerOwns` already owns. Both of the reasons that PR was passed on are addressed rather than tuned:

**the grab band.** #341 invented its own, 3pt of slop either side of the divider gap, computed by a new host-free `SplitDividerBand`. That band was terminal text, so it cost word selection. This one asks `NSSplitView.hitTest` instead, through the same `dividerOwns` the resize cursor has painted over since #344 - the pixels where the split already swallows the press for its own drag. Nothing the terminal could have used is taken, no slop constant exists, and the `agtermCore` type is gone.

**the monitor.** Still a mouse monitor, but installed with the first split and removed with the last, so a session with no split has none. It returns the event untouched unless a claimant owns the pixel and `clickCount == 2`.

A press counts as a double-click only if the divider has not moved since the previous one, because macOS reports `clickCount == 2` for a re-grab that arrives close enough in time and space to the last press. Fine-tuning with a nudge-drag and grabbing it again would otherwise throw the adjustment away.

No new protocol command: this is a GUI alias for one fraction of `session.resize`, which already reaches 0.5, and it reuses that command's apply path.

**Tests**

11 new hosted tests in `SplitRatioAccessorTests`, covering the reset, single click, a press over a pane, the nudge-drag re-grab, off-screen and suspended probes, chrome over the band, a foreign window, and the compact-titlebar strip. `ControlOverlaySplitUITests.testDoubleClickOnDividerRestoresEvenSplit` drives a real double-click against the launched app, which is the only thing that can show the monitor receives the second press at all.

Three negative controls, each failing at the expected assertion: dropping the divider-moved guard breaks the re-grab test, stubbing out the reset breaks the XCUITest, and the compact-titlebar case was checked against the view tree before the test was written.

`swift test`, `make test-app`, `make lint` and both builds are clean.
