### PR TITLE
fix(control): report foreground for panes with no job-control shell

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -342,8 +342,13 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
 ## Tree and window read-back
 
 - Session nodes include foreground/split foreground argv, background spec, overlay size, pane overlays,
-  split ratio, split focus, status fields, flag, unseen, restore pins, and surfaces. Foreground uses the
-  same pid/sysctl/host-free command extraction as restore capture.
+  split ratio, split focus, status fields, flag, unseen, restore pins, and surfaces. Foreground shares the
+  restore capture's pid/sysctl/host-free extraction but adds one step the capture must never take.
+  libghostty's foreground pid is `tcgetpgrp`, a process GROUP id, and a pane with no job-control shell
+  leaves its program in the group led by setuid-root `login`, whose argv `KERN_PROCARGS2` refuses. The tree
+  read (`ForegroundProcess.running`) descends the group to the first readable member, so a `--command` pane
+  reports what it runs; the capture (`.command`) stays leader-only, because a non-nil capture sets
+  `hadForeground`, which preempts `initialCommand` in `restorePlan` and would drop the exec path.
 - Top-level tree includes idle/auto-follow, live sidebar visibility/mode, workspace filter, quick
   visibility, zoom, dashboard, and picker state. Prefer live tree sidebar state over cached window list.
 - Window nodes include open/active, open-store sidebar/auto-follow, geometry, fullscreen, zoomed, minimized.

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -346,9 +346,11 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   restore capture's pid/sysctl/host-free extraction but adds one step the capture must never take.
   libghostty's foreground pid is `tcgetpgrp`, a process GROUP id, and a pane with no job-control shell
   leaves its program in the group led by setuid-root `login`, whose argv `KERN_PROCARGS2` refuses. The tree
-  read (`ForegroundProcess.running`) descends the group to the first readable member, so a `--command` pane
-  reports what it runs; the capture (`.command`) stays leader-only, because a non-nil capture sets
-  `hadForeground`, which preempts `initialCommand` in `restorePlan` and would drop the exec path.
+  read (`ForegroundProcess.running`) descends to the leader's own CHILDREN, lowest pid first, so a
+  `--command` pane reports what it runs while a pipeline sibling under `sudo` and a post-pid-wrap
+  grandchild stay out; a group whose leader already exited has no parentage to test, so every survivor
+  qualifies. The capture (`.command`) stays leader-only, because a non-nil capture sets `hadForeground`,
+  which preempts `initialCommand` in `restorePlan` and would drop the exec path.
 - Top-level tree includes idle/auto-follow, live sidebar visibility/mode, workspace filter, quick
   visibility, zoom, dashboard, and picker state. Prefer live tree sidebar state over cached window list.
 - Window nodes include open/active, open-store sidebar/auto-follow, geometry, fullscreen, zoomed, minimized.

--- a/.claude/rules/ui-tests.md
+++ b/.claude/rules/ui-tests.md
@@ -100,7 +100,10 @@ These run inside the app, so a mistake can kill the host instead of failing an a
 - Dismiss Settings by the close button of `app.windows.containing(.any, identifier: <a control on the
   tab>)`, never ⌘W: that reaches the app's Close Session command and takes the seeded session with it,
   which a session-row-count oracle reads as a collapse rather than as a closed session.
-- `ghostty_surface_foreground_pid` returns the actual foreground process. Restore skips only a known idle
+- `ghostty_surface_foreground_pid` is `tcgetpgrp`, so it returns the foreground process GROUP id. Under a
+  job-control shell that leader IS the program; a `--command` pane has no such shell and its leader is
+  unreadable setuid-root `login`, which is why the tree read descends to the leader's children and the
+  restore capture does not (see [[control-api]]). Restore skips only a known idle
   shell with no payload arguments except flags; shell scripts and `sh -c` payloads are captured. Use
   blocking `tee <file>` as the e2e marker and prove relaunch by delete/recreate.
   `RestoreCommandUITests.testRestoreReRunsShellScriptWrapper` uses `sh -c 'tee ...; true'` so `sh` remains

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -501,12 +501,12 @@ final class ControlServer {
         return store.controlTree(
             foreground: { session in
                 (session.surface as? GhosttySurfaceView).flatMap {
-                    ForegroundProcess.command(for: $0, shellBasename: shellBasename)
+                    ForegroundProcess.running(for: $0, shellBasename: shellBasename)
                 }
             },
             splitForeground: { session in
                 (session.splitSurface as? GhosttySurfaceView).flatMap {
-                    ForegroundProcess.command(for: $0, shellBasename: shellBasename)
+                    ForegroundProcess.running(for: $0, shellBasename: shellBasename)
                 }
             },
             fontSize: { ($0.addressableSurface as? GhosttySurfaceView)?.currentFontSize() },

--- a/agterm/Ghostty/ForegroundProcess.swift
+++ b/agterm/Ghostty/ForegroundProcess.swift
@@ -66,20 +66,26 @@ enum ForegroundProcess {
     }
 
     /// Every member of `pgid`'s process group via `sysctl(KERN_PROC_PGRP)`, with each one's parent; empty
-    /// on any syscall failure. The count comes from the second call, because the group can change between
-    /// the two: a shrink leaves fewer entries than the buffer holds, and a growth past the first call's
-    /// margin returns ENOMEM with the buffer full of whole, valid entries — the kernel never copies a
-    /// partial one — so ENOMEM keeps what landed instead of discarding the whole read and reporting the
-    /// pane as idle.
+    /// on any syscall failure. The count comes from the second call, because the group can shrink between
+    /// the two and leave fewer entries than the buffer holds.
+    ///
+    /// A group that GROWS past the sizing call's slop (a fixed handful of entries) returns ENOMEM, and
+    /// macOS reports `oldlen` 0 there, so nothing can be salvaged from the buffer however full it is.
+    /// Retry with a widening margin instead, rather than reporting a busy pane as idle.
     private static func processGroup(pgid: pid_t) -> [CommandRestore.ProcessGroupMember] {
         var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PGRP, pgid]
-        var size = 0
-        guard sysctl(&mib, u_int(mib.count), nil, &size, nil, 0) == 0, size > 0 else { return [] }
         let stride = MemoryLayout<kinfo_proc>.stride
-        var procs = [kinfo_proc](repeating: kinfo_proc(), count: size / stride)
-        guard !procs.isEmpty else { return [] }
-        size = procs.count * stride
-        guard sysctl(&mib, u_int(mib.count), &procs, &size, nil, 0) == 0 || errno == ENOMEM else { return [] }
-        return procs.prefix(size / stride).map { .init(pid: $0.kp_proc.p_pid, ppid: $0.kp_eproc.e_ppid) }
+        for margin in [0, 32, 256] {
+            var size = 0
+            guard sysctl(&mib, u_int(mib.count), nil, &size, nil, 0) == 0, size > 0 else { return [] }
+            var procs = [kinfo_proc](repeating: kinfo_proc(), count: size / stride + margin)
+            guard !procs.isEmpty else { return [] }
+            size = procs.count * stride
+            if sysctl(&mib, u_int(mib.count), &procs, &size, nil, 0) == 0 {
+                return procs.prefix(size / stride).map { .init(pid: $0.kp_proc.p_pid, ppid: $0.kp_eproc.e_ppid) }
+            }
+            if errno != ENOMEM { return [] }
+        }
+        return []
     }
 }

--- a/agterm/Ghostty/ForegroundProcess.swift
+++ b/agterm/Ghostty/ForegroundProcess.swift
@@ -31,9 +31,11 @@ enum ForegroundProcess {
     /// job in its own group, so the leader IS the program. A pane with no job-control shell (a
     /// `--command` session) runs its program as a child of setuid-root `login`, whose argv
     /// `KERN_PROCARGS2` refuses for a non-root caller — so without the descent every such pane reads as
-    /// idle. A setuid leader under a job-control shell (`top`, `sudo`) still reads as idle, because the
-    /// descent takes only the leader's own children: `sudo`'s child runs as root and stays unreadable,
-    /// and a pipeline's other elements are children of the shell rather than of the leader.
+    /// idle. A setuid leader under a job-control shell (`top`, `sudo`) still reads as idle while it is
+    /// alive, because the descent takes only the leader's own children: `sudo`'s child runs as root and
+    /// stays unreadable, and a pipeline's other elements are children of the shell rather than of the
+    /// leader. Once the leader is reaped there is no parentage to test and every survivor qualifies, so a
+    /// pipeline that outlives its `sudo` does report — see `groupDescentCandidates`.
     @MainActor
     static func running(for view: GhosttySurfaceView, shellBasename: String?) -> [String]? {
         guard let pgid = view.foregroundPid() else { return nil }

--- a/agterm/Ghostty/ForegroundProcess.swift
+++ b/agterm/Ghostty/ForegroundProcess.swift
@@ -29,10 +29,11 @@ enum ForegroundProcess {
     ///
     /// libghostty's `foreground_pid` is `tcgetpgrp`, a process GROUP id. An interactive shell puts each
     /// job in its own group, so the leader IS the program. A pane with no job-control shell (a
-    /// `--command` session) leaves its program in the group led by setuid-root `login`, whose argv
+    /// `--command` session) runs its program as a child of setuid-root `login`, whose argv
     /// `KERN_PROCARGS2` refuses for a non-root caller — so without the descent every such pane reads as
-    /// idle. A leader running setuid under a job-control shell (`top`, `sudo`) still reads as idle: it is
-    /// alone in its group, so there is nothing to descend to.
+    /// idle. A setuid leader under a job-control shell (`top`, `sudo`) still reads as idle, because the
+    /// descent takes only the leader's own children: `sudo`'s child runs as root and stays unreadable,
+    /// and a pipeline's other elements are children of the shell rather than of the leader.
     @MainActor
     static func running(for view: GhosttySurfaceView, shellBasename: String?) -> [String]? {
         guard let pgid = view.foregroundPid() else { return nil }
@@ -64,15 +65,21 @@ enum ForegroundProcess {
         return CommandRestore.parseProcArgs(Data(buffer[0..<size]))
     }
 
-    /// Every pid in `pgid`'s process group via `sysctl(KERN_PROC_PGRP)`; empty on any syscall failure. The
-    /// size is re-read from the second call because the group can shrink between the two.
-    private static func processGroup(pgid: pid_t) -> [Int32] {
+    /// Every member of `pgid`'s process group via `sysctl(KERN_PROC_PGRP)`, with each one's parent; empty
+    /// on any syscall failure. The count comes from the second call, because the group can change between
+    /// the two: a shrink leaves fewer entries than the buffer holds, and a growth past the first call's
+    /// margin returns ENOMEM with the buffer full of whole, valid entries — the kernel never copies a
+    /// partial one — so ENOMEM keeps what landed instead of discarding the whole read and reporting the
+    /// pane as idle.
+    private static func processGroup(pgid: pid_t) -> [CommandRestore.ProcessGroupMember] {
         var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PGRP, pgid]
         var size = 0
         guard sysctl(&mib, u_int(mib.count), nil, &size, nil, 0) == 0, size > 0 else { return [] }
         let stride = MemoryLayout<kinfo_proc>.stride
         var procs = [kinfo_proc](repeating: kinfo_proc(), count: size / stride)
-        guard sysctl(&mib, u_int(mib.count), &procs, &size, nil, 0) == 0 else { return [] }
-        return procs.prefix(size / stride).map(\.kp_proc.p_pid)
+        guard !procs.isEmpty else { return [] }
+        size = procs.count * stride
+        guard sysctl(&mib, u_int(mib.count), &procs, &size, nil, 0) == 0 || errno == ENOMEM else { return [] }
+        return procs.prefix(size / stride).map { .init(pid: $0.kp_proc.p_pid, ppid: $0.kp_eproc.e_ppid) }
     }
 }

--- a/agterm/Ghostty/ForegroundProcess.swift
+++ b/agterm/Ghostty/ForegroundProcess.swift
@@ -3,23 +3,58 @@ import Darwin
 import Foundation
 import agtermCore
 
-/// Reads the argv of a pane's foreground process for the restore-running-command capture. The libghostty
-/// pid lookup lives on `GhosttySurfaceView.foregroundPid()`; this owns the macOS `sysctl(KERN_PROCARGS2)`
-/// syscall and defers every judgement (parse, shell-detection) to the host-free `CommandRestore`.
+/// Reads the argv of a pane's foreground process. The libghostty pid lookup lives on
+/// `GhosttySurfaceView.foregroundPid()`; this owns the macOS `sysctl` syscalls and defers every judgement
+/// (parse, shell-detection, dash-stripping) to the host-free `CommandRestore`.
+///
+/// Two entry points, because the restore capture and the `tree` read-side ask different questions. See
+/// `running(for:shellBasename:)` for why only one of them descends into the process group.
 enum ForegroundProcess {
-    /// The foreground command (full argv) of `view`'s pane, or nil when the pane is at its shell prompt
-    /// (the foreground process is a login shell), the surface isn't realized, or the syscall fails.
+    /// The pane's foreground command for the RESTORE capture: the process-group leader's argv only, or nil
+    /// when the pane is at its shell prompt, the surface isn't realized, or the syscall fails.
     /// `shellBasename` is the user's `$SHELL` basename so a non-standard login shell is recognized too.
+    ///
+    /// Deliberately does NOT descend the group. A non-nil capture sets `hadForeground`, which preempts
+    /// `initialCommand` in `CommandRestore.restorePlan` — so a descending capture would restore a
+    /// `--command` session by typing its command into a login shell instead of taking the exec path,
+    /// losing the `--wait` hold and the close-on-exit shape.
     @MainActor
     static func command(for view: GhosttySurfaceView, shellBasename: String?) -> [String]? {
-        guard let pid = view.foregroundPid(), let argv = procArgs(pid: pid), !argv.isEmpty else { return nil }
-        // skip a shell ONLY when it's idle at its prompt (no script/command argument); a shell running a
-        // script (a #!/bin/sh wrapper like cld) is a real foreground process to restore.
-        if CommandRestore.isIdleShell(argv: argv, extra: shellBasename) { return nil }
-        return argv
+        guard let pid = view.foregroundPid(), let argv = procArgs(pid: pid) else { return nil }
+        return usable(argv, shellBasename: shellBasename)
     }
 
-    /// Fetch and parse a process's argv via `sysctl(KERN_PROCARGS2)`; nil on any syscall failure.
+    /// The pane's foreground command for the `tree` read-side: as `command`, plus a descent into the
+    /// process group when the leader's argv is unreadable.
+    ///
+    /// libghostty's `foreground_pid` is `tcgetpgrp`, a process GROUP id. An interactive shell puts each
+    /// job in its own group, so the leader IS the program. A pane with no job-control shell (a
+    /// `--command` session) leaves its program in the group led by setuid-root `login`, whose argv
+    /// `KERN_PROCARGS2` refuses for a non-root caller — so without the descent every such pane reads as
+    /// idle. A leader running setuid under a job-control shell (`top`, `sudo`) still reads as idle: it is
+    /// alone in its group, so there is nothing to descend to.
+    @MainActor
+    static func running(for view: GhosttySurfaceView, shellBasename: String?) -> [String]? {
+        guard let pgid = view.foregroundPid() else { return nil }
+        if let argv = procArgs(pid: pgid) { return usable(argv, shellBasename: shellBasename) }
+        let members = CommandRestore.groupDescentCandidates(pgid: pgid, members: processGroup(pgid: pgid))
+        for pid in members {
+            if let argv = procArgs(pid: pid) { return usable(argv, shellBasename: shellBasename) }
+        }
+        return nil
+    }
+
+    /// Normalize a raw argv and drop it when it is an idle shell: a shell is skipped ONLY at its prompt (no
+    /// script/command argument); a shell running a script (a `#!/bin/sh` wrapper like `cld`) is a real
+    /// foreground process to report.
+    private static func usable(_ argv: [String], shellBasename: String?) -> [String]? {
+        guard !argv.isEmpty else { return nil }
+        if CommandRestore.isIdleShell(argv: argv, extra: shellBasename) { return nil }
+        return CommandRestore.stripLoginDash(argv)
+    }
+
+    /// Fetch and parse a process's argv via `sysctl(KERN_PROCARGS2)`; nil on any syscall failure, which is
+    /// what a process owned by another user (setuid `login`, `sudo`) returns.
     private static func procArgs(pid: pid_t) -> [String]? {
         var mib: [Int32] = [CTL_KERN, KERN_PROCARGS2, pid]
         var size = 0
@@ -27,5 +62,17 @@ enum ForegroundProcess {
         var buffer = [UInt8](repeating: 0, count: size)
         guard sysctl(&mib, u_int(mib.count), &buffer, &size, nil, 0) == 0 else { return nil }
         return CommandRestore.parseProcArgs(Data(buffer[0..<size]))
+    }
+
+    /// Every pid in `pgid`'s process group via `sysctl(KERN_PROC_PGRP)`; empty on any syscall failure. The
+    /// size is re-read from the second call because the group can shrink between the two.
+    private static func processGroup(pgid: pid_t) -> [Int32] {
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PGRP, pgid]
+        var size = 0
+        guard sysctl(&mib, u_int(mib.count), nil, &size, nil, 0) == 0, size > 0 else { return [] }
+        let stride = MemoryLayout<kinfo_proc>.stride
+        var procs = [kinfo_proc](repeating: kinfo_proc(), count: size / stride)
+        guard sysctl(&mib, u_int(mib.count), &procs, &size, nil, 0) == 0 else { return [] }
+        return procs.prefix(size / stride).map(\.kp_proc.p_pid)
     }
 }

--- a/agtermCore/Sources/agtermCore/CommandRestore.swift
+++ b/agtermCore/Sources/agtermCore/CommandRestore.swift
@@ -47,12 +47,28 @@ public enum CommandRestore {
         return result
     }
 
-    /// The pids to try when a process group's LEADER argv is unreadable, lowest pid first. A pane with no
-    /// job-control shell (a `--command` session) leaves its program in the group led by setuid-root
-    /// `login`, whose argv `KERN_PROCARGS2` refuses for a non-root caller, so the program one hop down is
-    /// the real answer. The leader itself is dropped: it is the pid that already failed.
-    public static func groupDescentCandidates(pgid: Int32, members: [Int32]) -> [Int32] {
-        members.filter { $0 != pgid && $0 > 0 }.sorted()
+    /// One process-group member as `KERN_PROC_PGRP` reports it: its own pid and its parent's.
+    public struct ProcessGroupMember: Equatable, Sendable {
+        public let pid: Int32
+        public let ppid: Int32
+        public init(pid: Int32, ppid: Int32) {
+            self.pid = pid
+            self.ppid = ppid
+        }
+    }
+
+    /// The pids to try when a process group's LEADER argv is unreadable: the leader's own children, lowest
+    /// pid first. A pane with no job-control shell (a `--command` session) runs its program as a child of
+    /// setuid-root `login`, whose argv `KERN_PROCARGS2` refuses for a non-root caller, so that child is the
+    /// real answer.
+    ///
+    /// Only DIRECT children qualify, and parentage rather than pid order is what decides. A pipeline under
+    /// a job-control shell puts every element in one group led by the first, while parenting them all to
+    /// the shell — so `sudo tail … | grep …` must not report `grep`, which is a sibling of the leader
+    /// rather than its child. Ordering on pid alone would also pick the wrong process once macOS recycles
+    /// pids past 99999, where a freshly forked grandchild sorts below the program that spawned it.
+    public static func groupDescentCandidates(pgid: Int32, members: [ProcessGroupMember]) -> [Int32] {
+        members.filter { $0.ppid == pgid && $0.pid != pgid && $0.pid > 0 }.map(\.pid).sorted()
     }
 
     /// Whether a captured argv should be re-run on restore: false for an empty argv or one whose

--- a/agtermCore/Sources/agtermCore/CommandRestore.swift
+++ b/agtermCore/Sources/agtermCore/CommandRestore.swift
@@ -37,6 +37,24 @@ public enum CommandRestore {
         return !argv.dropFirst().contains { !$0.hasPrefix("-") }
     }
 
+    /// Drop the leading `-` macOS dash-marks a login process's argv[0] with, so the argv names a program
+    /// that can actually be rendered and re-run (`-sleep` → `sleep`). Only argv[0] carries the mark, and
+    /// only the mark is removed: a path form (`-/bin/zsh`) keeps the rest of the path.
+    public static func stripLoginDash(_ argv: [String]) -> [String] {
+        guard let first = argv.first, first.hasPrefix("-") else { return argv }
+        var result = argv
+        result[0] = String(first.dropFirst())
+        return result
+    }
+
+    /// The pids to try when a process group's LEADER argv is unreadable, lowest pid first. A pane with no
+    /// job-control shell (a `--command` session) leaves its program in the group led by setuid-root
+    /// `login`, whose argv `KERN_PROCARGS2` refuses for a non-root caller, so the program one hop down is
+    /// the real answer. The leader itself is dropped: it is the pid that already failed.
+    public static func groupDescentCandidates(pgid: Int32, members: [Int32]) -> [Int32] {
+        members.filter { $0 != pgid && $0 > 0 }.sorted()
+    }
+
     /// Whether a captured argv should be re-run on restore: false for an empty argv or one whose
     /// `argv[0]` basename is in `denylist`, true otherwise. The denylist is the user-editable
     /// `restore-denylist.conf` (no built-in entries) — `parseDenylist` builds it.

--- a/agtermCore/Sources/agtermCore/CommandRestore.swift
+++ b/agtermCore/Sources/agtermCore/CommandRestore.swift
@@ -62,13 +62,20 @@ public enum CommandRestore {
     /// setuid-root `login`, whose argv `KERN_PROCARGS2` refuses for a non-root caller, so that child is the
     /// real answer.
     ///
-    /// Only DIRECT children qualify, and parentage rather than pid order is what decides. A pipeline under
-    /// a job-control shell puts every element in one group led by the first, while parenting them all to
-    /// the shell — so `sudo tail … | grep …` must not report `grep`, which is a sibling of the leader
-    /// rather than its child. Ordering on pid alone would also pick the wrong process once macOS recycles
-    /// pids past 99999, where a freshly forked grandchild sorts below the program that spawned it.
+    /// Only DIRECT children qualify while the leader is alive, and parentage rather than pid order is what
+    /// decides. A pipeline under a job-control shell puts every element in one group led by the first,
+    /// while parenting them all to the shell — so `sudo tail … | grep …` must not report `grep`, which is
+    /// a sibling of the leader rather than its child. Ordering on pid alone would also pick the wrong
+    /// process once macOS recycles pids past 99999, where a freshly forked grandchild sorts below the
+    /// program that spawned it.
+    ///
+    /// A leader that has already EXITED is the exception: `cat f | less` keeps the group id of the reaped
+    /// `cat`, so no survivor is its child and the parentage test would report a live pane as idle. With no
+    /// leader in the group there is nothing to check parentage against, so every survivor qualifies.
     public static func groupDescentCandidates(pgid: Int32, members: [ProcessGroupMember]) -> [Int32] {
-        members.filter { $0.ppid == pgid && $0.pid != pgid && $0.pid > 0 }.map(\.pid).sorted()
+        let others = members.filter { $0.pid != pgid && $0.pid > 0 }
+        guard members.contains(where: { $0.pid == pgid }) else { return others.map(\.pid).sorted() }
+        return others.filter { $0.ppid == pgid }.map(\.pid).sorted()
     }
 
     /// Whether a captured argv should be re-run on restore: false for an empty argv or one whose

--- a/agtermCore/Sources/agtermCore/Session.swift
+++ b/agtermCore/Sources/agtermCore/Session.swift
@@ -167,9 +167,9 @@ public final class Session: Identifiable {
 
     /// A command to run as the session's process instead of the login shell (kitty's `launch <cmd>`, ghostty's
     /// `command`), set via `session.new --command`. The surface factory reads it once; the session closes when
-    /// the command exits. Persisted, so a command session — e.g. an `ssh …` shortcut, which exec-replaces the
-    /// shell and so escapes the foreground-pid capture — re-runs it on restore when `restoreRunningCommand` is
-    /// on (via `wasRestored`); a fresh session always runs it.
+    /// the command exits. Persisted, so a command session — e.g. an `ssh …` shortcut, which escapes the
+    /// foreground-pid capture because that pane's group is led by unreadable setuid-root `login` — re-runs it
+    /// on restore when `restoreRunningCommand` is on (via `wasRestored`); a fresh session always runs it.
     @ObservationIgnored public var initialCommand: String?
 
     /// Whether a `--command` session HOLDS its surface after the command exits — libghostty's "press any key

--- a/agtermCore/Sources/agtermCore/Snapshot.swift
+++ b/agtermCore/Sources/agtermCore/Snapshot.swift
@@ -125,9 +125,10 @@ public struct SessionSnapshot: Codable, Equatable, Sendable {
     public var foregroundCommand: [String]?
     /// The split (right) pane's foreground command (full argv), the split analogue of `foregroundCommand`.
     public var splitForegroundCommand: [String]?
-    /// The command the session was created with (`session.new --command`); it exec-replaces the login shell
-    /// and so is invisible to libghostty's foreground pid, hence persisted separately so a command session
-    /// re-runs it on restore instead of coming back a plain shell. A live `foregroundCommand` wins.
+    /// The command the session was created with (`session.new --command`); the quit-time capture cannot see
+    /// it — the pane's foreground process GROUP is led by setuid-root `login`, whose argv is unreadable, and
+    /// the capture deliberately does not descend — hence persisted separately so a command session re-runs
+    /// it on restore instead of coming back a plain shell. A live `foregroundCommand` wins.
     public var initialCommand: String?
     /// Whether a `--command` session holds its surface after the command exits (`--wait`), so a restored
     /// command session holds again instead of vanishing. nil (missing key) decodes as false.

--- a/agtermCore/Tests/agtermCoreTests/CommandRestoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/CommandRestoreTests.swift
@@ -67,8 +67,11 @@ struct CommandRestoreTests {
         // the setuid leader is not the pane's foreground.
         #expect(CommandRestore.groupDescentCandidates(pgid: 100, members: [m(100, 9), m(101, 9)]).isEmpty)
         // a grandchild that took a low pid after the 99999 wrap must not outrank its own parent.
-        #expect(CommandRestore.groupDescentCandidates(pgid: 100, members: [m(99500, 100), m(500, 99500)])
+        #expect(CommandRestore.groupDescentCandidates(pgid: 100, members: [m(100, 9), m(99500, 100), m(500, 99500)])
             == [99500])
+        // a reaped leader (`cat f | less`) leaves nothing to check parentage against, so survivors qualify.
+        #expect(CommandRestore.groupDescentCandidates(pgid: 100, members: [m(101, 9)]) == [101])
+        #expect(CommandRestore.groupDescentCandidates(pgid: 100, members: [m(102, 9), m(101, 9)]) == [101, 102])
     }
 
     @Test func isIdleShellSkipsBarePromptButNotScripts() {

--- a/agtermCore/Tests/agtermCoreTests/CommandRestoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/CommandRestoreTests.swift
@@ -46,6 +46,22 @@ struct CommandRestoreTests {
         #expect(!CommandRestore.isKnownShell("", extra: ""))
     }
 
+    @Test func stripLoginDashDropsOnlyTheMark() {
+        #expect(CommandRestore.stripLoginDash(["-sleep", "900"]) == ["sleep", "900"])
+        #expect(CommandRestore.stripLoginDash(["-/bin/zsh"]) == ["/bin/zsh"])
+        #expect(CommandRestore.stripLoginDash(["sleep", "900"]) == ["sleep", "900"])
+        #expect(CommandRestore.stripLoginDash(["git", "-C", "/tmp", "status"]) == ["git", "-C", "/tmp", "status"])
+        #expect(CommandRestore.stripLoginDash([]) == [])
+        #expect(CommandRestore.stripLoginDash(["-"]) == [""])
+    }
+
+    @Test func groupDescentCandidatesDropTheLeader() {
+        #expect(CommandRestore.groupDescentCandidates(pgid: 100, members: [100, 102, 101]) == [101, 102])
+        #expect(CommandRestore.groupDescentCandidates(pgid: 100, members: [100]).isEmpty)
+        #expect(CommandRestore.groupDescentCandidates(pgid: 100, members: []).isEmpty)
+        #expect(CommandRestore.groupDescentCandidates(pgid: 100, members: [0, -1, 100, 101]) == [101])
+    }
+
     @Test func isIdleShellSkipsBarePromptButNotScripts() {
         #expect(CommandRestore.isIdleShell(argv: ["-zsh"]))
         #expect(CommandRestore.isIdleShell(argv: ["/bin/zsh"]))

--- a/agtermCore/Tests/agtermCoreTests/CommandRestoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/CommandRestoreTests.swift
@@ -55,11 +55,20 @@ struct CommandRestoreTests {
         #expect(CommandRestore.stripLoginDash(["-"]) == [""])
     }
 
-    @Test func groupDescentCandidatesDropTheLeader() {
-        #expect(CommandRestore.groupDescentCandidates(pgid: 100, members: [100, 102, 101]) == [101, 102])
-        #expect(CommandRestore.groupDescentCandidates(pgid: 100, members: [100]).isEmpty)
+    @Test func groupDescentCandidatesKeepOnlyTheLeadersChildren() {
+        func m(_ pid: Int32, _ ppid: Int32) -> CommandRestore.ProcessGroupMember { .init(pid: pid, ppid: ppid) }
+        #expect(CommandRestore.groupDescentCandidates(pgid: 100, members: [m(100, 9), m(102, 100), m(101, 100)])
+            == [101, 102])
+        #expect(CommandRestore.groupDescentCandidates(pgid: 100, members: [m(100, 9)]).isEmpty)
         #expect(CommandRestore.groupDescentCandidates(pgid: 100, members: []).isEmpty)
-        #expect(CommandRestore.groupDescentCandidates(pgid: 100, members: [0, -1, 100, 101]) == [101])
+        #expect(CommandRestore.groupDescentCandidates(pgid: 100, members: [m(0, 100), m(-1, 100), m(101, 100)])
+            == [101])
+        // a pipeline parents every element to the SHELL while the group leads on the first, so a sibling of
+        // the setuid leader is not the pane's foreground.
+        #expect(CommandRestore.groupDescentCandidates(pgid: 100, members: [m(100, 9), m(101, 9)]).isEmpty)
+        // a grandchild that took a low pid after the 99999 wrap must not outrank its own parent.
+        #expect(CommandRestore.groupDescentCandidates(pgid: 100, members: [m(99500, 100), m(500, 99500)])
+            == [99500])
     }
 
     @Test func isIdleShellSkipsBarePromptButNotScripts() {

--- a/agtermUITests/ControlAPIUITests.swift
+++ b/agtermUITests/ControlAPIUITests.swift
@@ -108,6 +108,24 @@ final class ControlAPIUITests: ControlAPITestCase {
         XCTAssertNil(sessionNode(after, id: idleID)?["status"], "an idle session should omit the status key")
     }
 
+    // a --command pane has no job-control shell, so its process GROUP is led by setuid-root `login` and only
+    // the descent to login's own child can name the program. Pins the `.running` wiring: reverting the tree
+    // to `ForegroundProcess.command` reports null here while every other gate stays green.
+    func testTreeExposesForegroundOfCommandSession() throws {
+        let marker = markerDir.appendingPathComponent("cmdfg-\(UUID().uuidString)").path
+        let created = try sendCommand(#"{"cmd":"session.new","args":{"command":"tee \#(marker)"}}"#)
+        XCTAssertEqual(created["ok"] as? Bool, true, "session.new --command should succeed: \(created)")
+        let newID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "should return an id")
+
+        var fg: [String]?
+        for _ in 0..<40 {
+            let resp = try sendCommand(#"{"cmd":"tree"}"#)
+            if let f = sessionNode(resp, id: newID)?["foreground"] as? [String], f.first == "tee" { fg = f; break }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+        }
+        XCTAssertEqual(fg, ["tee", marker], "tree should expose a --command session's live foreground")
+    }
+
     /// The session node matching `id` (case-insensitive) anywhere in a `tree` response, or nil.
     private func sessionNode(_ response: [String: Any], id: String) -> [String: Any]? {
         guard let result = response["result"] as? [String: Any],

--- a/agtermUITests/RestoreCommandUITests.swift
+++ b/agtermUITests/RestoreCommandUITests.swift
@@ -95,8 +95,10 @@ final class RestoreCommandUITests: XCTestCase {
                       "an idle login-shell pane must not be captured as a foreground command, got \(capturedForegroundCommands())")
     }
 
-    // `tee <marker>` as the command exec-replaces the shell, so libghostty reports no foreground and
-    // NOTHING is captured — the re-run can only come from the persisted `initialCommand`.
+    // the quit-time capture reads the pane's process-GROUP leader, which for a command session is unreadable
+    // setuid-root `login`, so NOTHING is captured and the re-run can only come from `initialCommand`. This
+    // does not pin that split on its own: were the capture to descend, it would type `tee <marker>` into the
+    // login shell, recreating the marker this asserts on.
     func testRestoreReRunsCommandSession() throws {
         seedRestoreFlag(true)
         app.launchForUITest()

--- a/cookbook/flagged-dashboard/README.md
+++ b/cookbook/flagged-dashboard/README.md
@@ -67,7 +67,7 @@ A full grid needs a second rule. The grid holds nine cells and drops the rest, s
 
 Nothing here closes a session, kills a shell, or changes a flag. The grid is an overlay that comes and goes, and everything it shows keeps running whether it is on screen or not.
 
-A pane counts as busy only when agterm can read its foreground command, and there are cases where it cannot. A session started with `session new --command` runs its program under `login` and reports no foreground, so it is treated as idle and left off the grid even while it works. The same applies to a setuid or setgid program such as `sudo` or `top`, whose argv macOS will not expose. Start the program by typing it in a session, or from a shell wrapper, and it reports normally.
+A pane counts as busy only when agterm can read its foreground command, and a setuid or setgid program such as `sudo` or `top` will not expose its argv to be read. A pane running one of those is treated as idle and left off the grid even while it works.
 
 Membership is fixed when the grid opens. A command that finishes while you are watching leaves its pane on the grid, now sitting at a prompt, and a pane that starts working is not added. Press the chord again to rebuild the set.
 


### PR DESCRIPTION
a pane started with `session new --command` always read as idle in `tree --json`. Its `foreground` was omitted however hard the program was working, so nothing driving the control API could tell a busy agent session from an empty shell.

**the cause**

libghostty's `ghostty_surface_foreground_pid` is `tcgetpgrp`, a process GROUP id rather than a pid. An interactive shell does job control and puts each command in its own group, so the leader is the program and reading its argv works. A `--command` pane has no such shell: `login` forks the program, the program inherits `login`'s group, and the group leader is therefore setuid-root `/usr/bin/login`, whose argv `KERN_PROCARGS2` refuses to a non-root caller. Measured, rather than inferred:

```
root     77233 ... 77233  /usr/bin/login -q -flp umputun ... exec -l sleep 777
umputun  77235 77233 77233  -sleep 777          <- PID 77235, PGID 77233
```

`KERN_PROCARGS2(77233)` fails; `(77235)` returns `["-sleep","777"]`.

**the fix**

`ForegroundProcess` gets two entry points, because its two callers ask different questions. `running` (the `tree` read) descends to the leader's own children when the leader's argv is unreadable. `command` (the quit-time restore capture) stays leader-only and is unchanged.

that split is not tidiness. A non-nil capture sets `hadForeground`, which preempts `initialCommand` in `restorePlan`, so a descending capture would restore a `--command` session by typing into a login shell instead of taking the exec path, losing the `--wait` hold and close-on-exit.

selection keys on parentage rather than pid order: a pipeline puts every element in the leader's group while parenting them to the shell, so `sudo tail | grep` must not report `grep`, and macOS recycles pids past 99999, so a grandchild forked after the wrap sorts below the program that spawned it. A reaped leader is the exception, since there is nothing to test parentage against and `cat f | less` would otherwise report nothing.

reading the group is a bounded retry at a widening margin rather than a single sized call. An undersized `KERN_PROC_PGRP` returns ENOMEM with `oldlen` 0 on macOS, so a partly-filled buffer cannot be salvaged and a group that grows between the two calls would otherwise report the pane as idle again.

`testTreeExposesForegroundOfCommandSession` is the regression test, and I checked it fails on the reverted wiring (`nil` vs `["tee", …]`) rather than only that it passes.

**note for the release**

`cookbook/flagged-dashboard/README.md` loses its claim that `--command` panes read as idle. The recipe is already on master and pins 0.20.0, so that sentence describes behavior only in the release carrying this fix.
