### PR TITLE
fix: decode sidebarMode lossily so an unknown value can't wipe the persisted tree (#360)

### DIFF
--- a/agtermCore/Sources/agtermCore/Snapshot.swift
+++ b/agtermCore/Sources/agtermCore/Snapshot.swift
@@ -55,10 +55,12 @@ public struct Snapshot: Codable, Equatable, Sendable {
         case focusedWorkspaceID
     }
 
-    /// Custom decode so `sessionRecency` is LOSSY: a present-but-invalid list (a malformed UUID, a wrong
-    /// JSON type after a hand edit) drops to nil. `Optional` alone tolerates only a MISSING key, so one bad
-    /// MRU entry would fail the whole `Snapshot` and `PersistenceStore.load` would start fresh, wiping every
-    /// workspace and session over a non-essential field. Mirrors `backgroundWatermark` below; others strict.
+    /// Custom decode so `sessionRecency` and `sidebarMode` are LOSSY: a present-but-invalid value (a
+    /// malformed UUID, an unknown enum raw value from a newer build or a hand edit) drops to nil.
+    /// `Optional` alone tolerates only a MISSING key, so one bad value would fail the whole `Snapshot` and
+    /// `PersistenceStore.load` would start fresh, wiping every workspace and session over a non-essential
+    /// field. Mirrors `backgroundWatermark` below; the remaining optionals stay strict — primitives and
+    /// UUIDs can't gain a value a newer build writes.
     ///
     /// Also migrates the legacy `focusedWorkspaceID`: its presence implied the filter was on, so it becomes
     /// a one-member ENABLED set. Neither key present decodes to nil/nil — an empty, disabled filter.
@@ -69,7 +71,7 @@ public struct Snapshot: Codable, Equatable, Sendable {
         workspaces = try c.decode([WorkspaceSnapshot].self, forKey: .workspaces)
         sidebarWidth = try c.decodeIfPresent(Double.self, forKey: .sidebarWidth)
         sidebarVisible = try c.decodeIfPresent(Bool.self, forKey: .sidebarVisible)
-        sidebarMode = try c.decodeIfPresent(SidebarMode.self, forKey: .sidebarMode)
+        sidebarMode = (try? c.decodeIfPresent(SidebarMode.self, forKey: .sidebarMode)) ?? nil
         let legacyContainer = try decoder.container(keyedBy: LegacyCodingKeys.self)
         let legacyFocus = try legacyContainer.decodeIfPresent(UUID.self, forKey: .focusedWorkspaceID)
         let ids = try c.decodeIfPresent([UUID].self, forKey: .focusedWorkspaceIDs)

--- a/agtermCore/Tests/agtermCoreTests/PersistenceTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/PersistenceTests.swift
@@ -230,6 +230,22 @@ final class PersistenceTests {
         #expect(app.sidebarMode == .tree)
     }
 
+    @Test func malformedSidebarModeDropsToNilKeepingTree() throws {
+        // an invalid sidebarMode (an unknown raw value from a newer build, a wrong JSON type) must drop
+        // to nil lossily, never fail the whole Snapshot decode and wipe the tree on the next save.
+        let ws = UUID()
+        let session = UUID()
+        let tree = #""selectedSessionID": "\#(session.uuidString)", "workspaces": "# +
+            #"[ { "id": "\#(ws.uuidString)", "name": "work", "sessions": [ { "id": "\#(session.uuidString)", "cwd": "/a" } ] } ]"#
+        for bad in [#""sidebarMode": "hologram""#, #""sidebarMode": 42"#] {
+            try Data(#"{ "version": 1, \#(bad), \#(tree) }"#.utf8).write(to: fileURL)
+            let loaded = store.load()
+            #expect(loaded.workspaces.map(\.id) == [ws])
+            #expect(loaded.selectedSessionID == session)
+            #expect(loaded.sidebarMode == nil)
+        }
+    }
+
     @Test func focusedWorkspacePersistsAndRestores() {
         let app = AppStore(persistence: store)
         let work = app.addWorkspace(name: "work")


### PR DESCRIPTION
Fixes #360.

`sidebarMode` was the one enum in `Snapshot` still decoded strictly, so an unrecognized raw value in `workspaces.json` (written by a newer build, or a hand edit) failed the whole `Snapshot` decode — and `load()` recovers from a throw by starting fresh, wiping every workspace and session over a non-essential display field.

This applies the same `try?` guard `sessionRecency` and `backgroundWatermark` already have, scoped to `sidebarMode` only: the remaining strict optionals are primitives and can't gain a value a newer build writes, so strict stays correct for them.

Also adds the missing test case: `PersistenceTests` covered a bad `sessionRecency` value and a *missing* `sidebarMode` key, but not a bad `sidebarMode` value. New `malformedSidebarModeDropsToNilKeepingTree` mirrors `malformedRecencyDropsToNilKeepingTree` (unknown raw value + wrong JSON type, tree survives, field drops to nil).

Full suite (2341 tests) + `make lint` strict green.