### PR TITLE
cookbook: annotate Claude's replies in revdiff and send the notes back

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -22,6 +22,7 @@ Recipes come from other people as well as the maintainer. Every one is reviewed 
 | [kimi-agent-status](kimi-agent-status/) | Kimi Code sessions report agent status onto their sidebar row | 0.3.1, Kimi Code |
 | [claude-recap](claude-recap/) | one key lists what the Claude Code run in a session was working on | 0.10.0, zsh, jq, Claude Code |
 | [new-session-in-workspace](new-session-in-workspace/) | pick a workspace with fzf and start a session in it | 0.8.0, jq, fzf |
+| [annotate-claude-replies](annotate-claude-replies/) | mark up Claude's answers in revdiff and send the notes back | 0.13.0, revdiff, python3, Claude Code |
 | [project-launcher](project-launcher/) | pick a project anywhere — or type "project + prompt" — and get a session in its workspace | 0.19.0, jq |
 | [flagged-dashboard](flagged-dashboard/) | grid the flagged panes that are running something, one chord to show and dismiss | 0.20.0, jq |
 

--- a/cookbook/annotate-claude-replies/README.md
+++ b/cookbook/annotate-claude-replies/README.md
@@ -1,0 +1,126 @@
+# Annotate Claude's replies
+
+Mark up a long Claude Code answer the way you would mark up a diff, and send the notes back to the prompt you are sitting at.
+
+## What it does
+
+One chord opens everything Claude has said since your last prompt in [revdiff](https://github.com/umputun/revdiff), inside an overlay on the session you pressed it in. You put a note on any line you do not follow or disagree with. On quit the notes are put at that session's prompt and sent, so annotating and quitting is the whole interaction.
+
+A long answer is the case this is for. Quoting the parts you want to argue with is slow, and "the third paragraph" is worse.
+
+One exchange usually produces several replies, because Claude writes, runs a tool, then writes again. They all go into one markdown file, each under its own heading, and revdiff builds its sidebar from those headings. The prompt that started the exchange opens the file, and the replies follow in the order they happened:
+
+```
+10:52 · what you asked
+10:58 · reply 1
+11:04 · reply 2, the one you just read
+```
+
+The notes that come back are not only your comments. Each one quotes the lines it points at and names the reply it landed on, so the answer you get is about the sentences you marked:
+
+```
+## Note 1 — 11:04 · the reply you just read, line 12
+> the launcher already opens revdiff in an agterm overlay
+which launcher? I never set this up
+```
+
+## Requirements
+
+- agterm 0.13.0 or later. That is where `{AGT_PANE}` began reporting the pane a custom command fired from, which is how the notes get routed back into the right half of a split. Everything else it uses is older: `session overlay open --block` and `notify` shipped in 0.3.1, `session type --pane` in 0.7.0.
+- [revdiff](https://github.com/umputun/revdiff), on your `PATH`
+- Claude Code. The recipe reads Claude Code's own session transcripts, so no other agent will work without being ported.
+- `python3`, which macOS ships
+
+`AGTERMCTL`, `REVDIFF` and `PYTHON` at the top of the script take an absolute path if any of them is somewhere unusual. `REVDIFF` is worth knowing about if you keep more than one build: the script resolves whatever `revdiff` the widened `PATH` finds first, which is not necessarily the one your interactive shell picks.
+
+## Setup
+
+Copy the four files somewhere on your machine, say `~/.local/bin/agterm-annotate/`, and make them executable:
+
+```sh
+chmod +x annotate-replies.sh annotate-extract.py annotate-render.py save-transcript-path.py
+```
+
+The three helpers must sit **beside** `annotate-replies.sh`; it looks for them in its own directory.
+
+Register the Stop hook by adding an entry to the `Stop` array in `~/.claude/settings.json`, alongside anything already there:
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.local/bin/agterm-annotate/save-transcript-path.py",
+            "timeout": 5,
+            "async": true
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Then add the keybinding to `~/.config/agterm/keymap.conf` and apply it with File ▸ Reload Keymap or `agtermctl keymap reload`:
+
+```
+command "Annotate replies"  cmd+ctrl+e  ~/.local/bin/agterm-annotate/annotate-replies.sh "{AGT_SESSION_ID}" "{AGT_PANE}"
+```
+
+Pick a chord that is free in your own keymap. A custom command cannot shadow a built-in, so one that collides is quietly demoted to palette-only and the chord appears to do nothing. On 0.19.0 and later `agtermctl keymap list` shows what every chord resolved to; before that, read `keymap.conf` and the commented list of built-in defaults at the top of it. Either way the command is always reachable by name from the action palette, which is the quickest way to tell a bad chord from a broken script.
+
+Two settings, read from the environment. Put them in front of the script in the keymap line, or change the defaults at the top of the script — a keymap change needs a reload before it takes effect, an edit to the script does not:
+
+- `AGTERM_ANNOTATE_SUBMIT=0` leaves the notes at the prompt for you to read over and send yourself. The default sends them, so quitting revdiff is the whole interaction.
+- `AGTERM_ANNOTATE_PROMPTS=2` reaches back a further exchange, and so on. The default of 1 is everything since your last prompt.
+`AGTERM_ANNOTATE_REVDIFF_FLAGS` replaces the flags handed to revdiff, which default to `--wrap --wrap-indent=2`. Wrapping is on because a reply is prose rather than code, and the indent stops a wrapped bullet from reading as a new one. Adding `--tree-width=1` shrinks the side panel to its narrowest.
+
+Two further flags are added automatically, but only when the binary advertises them, so a revdiff without them is never handed an unknown flag. `--no-tree` starts with the side panel hidden, which a single reply has no use for; it is in revdiff `master` but not in v1.12.0, so a released build simply will not get it yet. `--preview` starts in rendered markdown rather than source: annotations are placed in the source view, so the flow is read the rendered reply, toggle to source, mark it up. Setting `AGTERM_ANNOTATE_REVDIFF_FLAGS` yourself turns the probe off entirely and uses exactly what you give it.
+
+Every setting can also live in `~/.config/agterm-annotate/config`, a plain shell file sourced on each run. That is the better place for anything machine-specific: it takes effect on the next press, while a keymap line needs a reload first, and it keeps the script itself identical to the published one. `AGTERM_ANNOTATE_REVDIFF_NAMES` belongs there — it lists the binary names to try in order, so a local build under its own name is a config line rather than an edit.
+
+## Usage
+
+Ask Claude something. When the answer lands, press the chord.
+
+revdiff opens over the session. The sidebar lists what you asked and then each reply in the order it came, so the one you were reading is last and the earlier ones are a keypress away. Mark the lines you want to argue with, then quit.
+
+The notes are sent as soon as you quit, so annotating and quitting is the whole interaction. Set `AGTERM_ANNOTATE_SUBMIT=0` if you would rather they waited at the prompt for you to read over and add to. Quitting with no annotations sends nothing either way.
+
+`AGTERM_ANNOTATE_INLINE=0` sends a one-line pointer to the notes file instead of the notes themselves. That is also what happens automatically in a split or scratch pane, for the reason below.
+
+A pane only becomes annotatable once a turn has finished in it, because that is when the hook runs. Pressing the chord in a plain shell says so and does nothing else.
+
+## How it works
+
+The hook records `transcript_path`, which is the one thing that cannot be worked out afterwards. A project directory holds one transcript per session, so picking the newest by modification time opens whichever session was busiest, not the one you are sitting in. It keys the record by session **and** pane, because a split session shares one session id while running an agent in each half.
+
+The reply itself is read from the transcript when the chord fires, not copied by the hook. A hook only runs when a turn ends, so anything it copies is stale the moment it misses one, and it does miss them — across an app restart, or in a pane you have not returned to. The stored message survives only as the fallback for a transcript rotated by a resume.
+
+A transcript keeps one content block per line, and the blocks of one reply share `message.id`. An exchange boundary is a user record whose content is a plain string, or an array carrying no `tool_result` block; that is what separates something you typed from a tool result Claude Code feeds back as a user record. Sidechain records are subagents and are skipped. At most 12 replies are written, so one very long exchange cannot fill the sidebar, and the opening prompt is truncated at 4000 characters so a pasted wall of text cannot bury the replies it opened.
+
+Sections run oldest first, the order the exchange happened in, with the prompt at the top so the replies have something to be answers to. Every heading inside a section body is pushed down one level, because a reply — and especially a pasted prompt — can carry its own `#` heading, which would otherwise sit beside the section titles in the contents and read as another turn. Headings inside fenced code are left alone; a `#` there is a comment, not a heading.
+
+Two things cost an hour each:
+
+An overlay's command runs through `sh -c` with the app's **GUI** `PATH`, which has neither `/opt/homebrew/bin` nor `~/.local/bin`. A bare `revdiff` there exits 127 and the overlay flashes shut, so the script resolves it to an absolute path first. The same trap applies to the script itself, which agterm runs detached in a small-`PATH` `/bin/sh` with stdio on `/dev/null`. That is why it widens `PATH` at the top and logs to `/tmp/agterm-annotate.log` instead of printing.
+
+`session overlay open --block` exits with the program's own status, so a non-zero code can equally mean agterm refused before revdiff ever ran. Reading only the code turns "overlay already open" into a meaningless "exited with 1", so the script reads the reply text as well.
+
+Putting the notes at the prompt needs `session paste`, because `session type` sends a real Return for every newline and multi-line text would submit itself line by line. `session paste` reads the system clipboard, so the script saves what is on it, pastes, and puts it back. It also has no `--pane` and always targets the session's main pane, so a note taken in a split or scratch pane falls back to typing a one-line pointer at the notes file instead.
+
+## Limits
+
+- **It types into your session and sends.** The notes are injected at the prompt of the session you pressed the chord in and submitted for you, so the agent acts on them without you seeing them first. `AGTERM_ANNOTATE_SUBMIT=0` stops at the prompt instead.
+- **It uses the clipboard.** Pasting is the only way to land multi-line text at a prompt without submitting it. What was on the clipboard is saved and put back, but only if it was plain text — an image or rich content is lost. `AGTERM_ANNOTATE_INLINE=0` avoids the clipboard entirely.
+- **A promoted pane can open the wrong replies.** The record is keyed on the pane the agent's shell was started in, but the chord reports the pane it fires from now, and those diverge after a promote: closing the left half of a split promotes the right one, so a chord in the survivor can open the replies of the pane that closed. There is no `{AGT_PANE_ID}` keymap token to reconcile the two from a script.
+- **The hook writes to `~/.cache/agterm-annotate/` on every finished turn**, in every agterm pane, whether or not you ever press the chord. Each file holds that pane's last reply in full, and `last-notes.md` holds the last set of notes. Delete the directory to clear them; nothing prunes it.
+- **It reads your Claude Code transcripts**, and copies the replies into a file under `TMPDIR`. Anything in an answer is in that file, in the clear.
+- Nothing under `${TMPDIR}/agterm-annotate/` is ever deleted. Old replies and notes stay until the system clears the directory.
+- Claude Code only. No other agent hands a hook the transcript path.
+- One reply set per pane at a time. Pressing the chord again while revdiff is open is dropped rather than stacking a second overlay.
+- A session that already has an overlay open cannot take another, so the chord says so and stops. Close the overlay first.
+- The `--only` view is read-only. Annotating a reply changes nothing but the note you send.

--- a/cookbook/annotate-claude-replies/annotate-extract.py
+++ b/cookbook/annotate-claude-replies/annotate-extract.py
@@ -148,7 +148,7 @@ def demote_headings(body: str) -> list[str]:
     out, fenced = [], False
     for line in body.splitlines():
         stripped = line.lstrip()
-        if stripped.startswith("```") or stripped.startswith("~~~"):
+        if stripped.startswith(("```", "~~~")):
             fenced = not fenced
         elif not fenced and stripped.startswith("#"):
             hashes = len(stripped) - len(stripped.lstrip("#"))

--- a/cookbook/annotate-claude-replies/annotate-extract.py
+++ b/cookbook/annotate-claude-replies/annotate-extract.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Write out every answer Claude gave in an agterm pane since the last thing the person typed.
+
+The Stop hook records where the transcript is; this reads it at the moment the chord fires. That is the
+whole point of the split. The hook only runs when a turn ends, so anything it copies out goes stale the
+moment it misses one, while the transcript is whatever Claude has actually written.
+
+A transcript holds one content block per line, and the blocks of a single reply share `message.id`. One
+exchange often produces several such replies — text, then tool calls, then more text — and only the
+last is on screen when the chord fires. Each becomes its own file so revdiff can show them as a tree.
+
+They go into ONE markdown file, each under its own heading, because revdiff builds a table of contents
+from a markdown file's headings. A section heading can say "11:04, the reply you just read" where a
+filename could only say `11-04.md`. Oldest first, opening with the prompt that started the exchange.
+
+Usage: annotate-extract.py <pointer.json> <outdir> <slug> [prompts-back]
+Prints the file path. Exits 1 when there is nothing to show.
+"""
+
+import json
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+MAX_ANSWERS = 12
+# Records the agent injects into the user side of the transcript: peer sessions, background task
+# notifications, slash-command output. They are user records, but nobody typed them, so treating one
+# as the start of an exchange puts the boundary in the wrong place and hides everything before it.
+INJECTED = re.compile(
+    r"<(teammate-message|agent-message|task-notification|task-name"
+    r"|local-command-stdout|local-command-caveat)\b"
+)
+# Appended to a real prompt rather than being one, so strip it from what is shown instead of rejecting.
+REMINDER = re.compile(r"<system-reminder>.*?</system-reminder>", re.DOTALL)
+# A pasted wall of text as the prompt would bury the replies it opened.
+PROMPT_LIMIT = 4000
+
+
+def load_pointer(path: Path) -> dict:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def is_typed_prompt(record: dict) -> bool:
+    """A turn the person actually typed.
+
+    Three things masquerade as one. Tool results come back as user records. So do messages from peer
+    sessions and background task notifications. And `isMeta` marks some injected records but not all —
+    it was false on a real `<teammate-message>` — so the tag has to be checked as well.
+
+    Bias towards rejecting: a wrongly accepted record cuts the exchange short and hides replies, while a
+    wrongly rejected one only reaches further back than asked.
+    """
+    if record.get("type") != "user" or record.get("isSidechain") or record.get("isMeta"):
+        return False
+    content = (record.get("message") or {}).get("content")
+    if isinstance(content, list) and any(b.get("type") == "tool_result" for b in content):
+        return False
+    text = prompt_text(record)
+    return bool(text) and not INJECTED.search(text[:4000])
+
+
+def prompt_text(record: dict) -> str:
+    """What the person actually typed, whether the record stores it as a string or as text blocks."""
+    content = (record.get("message") or {}).get("content")
+    if isinstance(content, str):
+        raw = content
+    elif isinstance(content, list):
+        raw = "\n".join(b.get("text") or "" for b in content if b.get("type") == "text")
+    else:
+        return ""
+    return REMINDER.sub("", raw).strip()
+
+
+def exchange_since(transcript: Path, prompts_back: int) -> tuple[tuple[str, str], list[tuple[str, str]]]:
+    """The typed prompt that opened the exchange, and every reply after it, oldest first."""
+    groups: dict[str, list[str]] = {}
+    stamps: dict[str, str] = {}
+    order: list[str] = []
+    boundaries: list[int] = []
+    prompts: list[tuple[str, str]] = []
+
+    with transcript.open(encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except ValueError:
+                continue
+
+            if is_typed_prompt(record):
+                boundaries.append(len(order))
+                prompts.append((prompt_text(record), record.get("timestamp") or ""))
+                continue
+            if record.get("type") != "assistant" or record.get("isSidechain"):
+                continue
+
+            message = record.get("message") or {}
+            key = message.get("id")
+            if not key:
+                continue
+            for block in message.get("content") or []:
+                if block.get("type") != "text":
+                    continue
+                text = block.get("text") or ""
+                if not text.strip():
+                    continue
+                if key not in groups:
+                    groups[key] = []
+                    order.append(key)
+                groups[key].append(text)
+                stamps[key] = record.get("timestamp") or stamps.get(key, "")
+
+    if not order:
+        return ("", ""), []
+    start = boundaries[-prompts_back] if len(boundaries) >= prompts_back else 0
+    opening = prompts[-prompts_back] if len(prompts) >= prompts_back else ("", "")
+    # No fallback to an earlier reply. A prompt Claude has not answered yet would otherwise be paired
+    # with the previous exchange's answer, which reads as a reply to the wrong question.
+    picked = order[start:]
+    if not picked:
+        return ("", ""), []
+    replies = [("".join(groups[k]).strip(), stamps.get(k, "")) for k in picked][-MAX_ANSWERS:]
+    return opening, replies
+
+
+def local_time(raw: str) -> datetime:
+    """Transcript times are UTC. A person reads the filename, so it goes in their own clock."""
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone()
+    except ValueError:
+        return datetime.now().astimezone()
+
+
+def demote_headings(body: str) -> list[str]:
+    """Push every heading down one level so only the section titles are h1.
+
+    A reply, and especially a pasted prompt, can carry its own `#` heading. Left alone it would sit
+    beside the section titles in the contents and read as another turn. Fenced code is left alone: a
+    `#` there is a comment or a shell prompt, not a heading.
+    """
+    out, fenced = [], False
+    for line in body.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            fenced = not fenced
+        elif not fenced and stripped.startswith("#"):
+            hashes = len(stripped) - len(stripped.lstrip("#"))
+            if 1 <= hashes <= 5 and stripped[hashes:hashes + 1] in (" ", ""):
+                line = line.replace("#" * hashes, "#" * (hashes + 1), 1)
+        out.append(line)
+    return out
+
+
+def shape(position: int, total: int) -> str:
+    """What to call a reply in the contents. Sections run oldest first, so the last one is on screen."""
+    last = position == total - 1
+    if total == 1:
+        return "the reply you just read"
+    if last:
+        return f"reply {position + 1}, the one you just read"
+    return f"reply {position + 1}"
+
+
+def slugify(text: str) -> str:
+    import re
+
+    return re.sub(r"[^A-Za-z0-9]+", "-", text).strip("-")[:40] or "replies"
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) not in (4, 5):
+        print(__doc__, file=sys.stderr)
+        return 2
+    pointer, outdir, slug = Path(argv[1]), Path(argv[2]), argv[3]
+    prompts_back = max(1, int(argv[4])) if len(argv) == 5 else 1
+
+    info = load_pointer(pointer)
+    transcript = info.get("transcript_path")
+    answers: list[tuple[str, str]] = []
+
+    opening = ("", "")
+    readable = bool(transcript) and Path(transcript).is_file()
+    if readable:
+        opening, answers = exchange_since(Path(transcript), prompts_back)
+
+    # The hook also carries the message it saw, but it is only right when the transcript could not be
+    # read -- rotated by a resume, or never recorded. When the transcript IS readable and this exchange
+    # has no reply yet, that stored message is the PREVIOUS exchange's answer, and pairing it with the
+    # new question reads as a reply to the wrong thing. Show nothing instead.
+    if not answers and not readable:
+        fallback = (info.get("last_assistant_message") or "").strip()
+        if fallback:
+            answers = [(fallback, info.get("updated") or "")]
+    if not answers:
+        return 1
+
+    outdir.mkdir(parents=True, exist_ok=True)
+    # Earlier versions wrote a file per reply. Clear them so a stale one cannot be mistaken for a source.
+    for stale in outdir.glob("*.md"):
+        if stale.name not in ("notes.md", "description.md"):
+            stale.unlink()
+
+    # Oldest first, the order the exchange happened in. The prompt that started it opens the file, so
+    # the replies have something to be answers to.
+    moments = [local_time(raw) for _, raw in answers]
+    spans_days = len({m.date() for m in moments}) > 1
+    fmt = "%m-%d %H:%M" if spans_days else "%H:%M"
+
+    lines: list[str] = []
+    manifest: list[dict] = []
+
+    def section(title: str, body: str, clock: str) -> None:
+        # Sections open at h1 so a body's own ## and ### nest under them in the contents.
+        manifest.append({"title": title, "when": clock, "line": len(lines) + 1})
+        lines.append(f"# {title}")
+        lines.append("")
+        lines.extend(demote_headings(body))
+        lines.append("")
+
+    if opening[0]:
+        clock = local_time(opening[1]).strftime(fmt)
+        section(f"{clock} · what you asked", opening[0][:PROMPT_LIMIT], clock)
+
+    for position, ((text, _), moment) in enumerate(zip(answers, moments)):
+        clock = moment.strftime(fmt)
+        section(f"{clock} · {shape(position, len(answers))}", text, clock)
+
+    path = outdir / f"{slugify(slug)}.md"
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+    (outdir / "replies.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/cookbook/annotate-claude-replies/annotate-render.py
+++ b/cookbook/annotate-claude-replies/annotate-render.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Turn revdiff's annotation output into a notes file that reads on its own.
+
+revdiff reports `## <file>:<line>[-<end>] (<type>)` followed by the comment. On its own that tells the
+agent a line number in a file it never saw, so each note here carries the quoted source line with it.
+All the replies sit in one markdown file under their own headings, so a line number alone does not say
+which reply was marked. replies.json records where each section starts, which turns a note into
+"11:04, the reply you just read" instead.
+
+Usage: annotate-render.py <replies-dir> <notes.raw> <notes.md>
+Exits 1 when the raw file holds no parseable annotation, which the caller treats as "nothing to send".
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+HEADER = re.compile(r"^##\s+(?P<file>.+?):(?P<start>\d+)(?:-(?P<end>\d+))?\s+\((?P<kind>[^)]*)\)\s*$")
+
+
+def parse(raw: str) -> list[dict]:
+    notes: list[dict] = []
+    current: dict | None = None
+    for line in raw.splitlines():
+        match = HEADER.match(line)
+        if match:
+            current = {
+                "file": Path(match.group("file")).name,
+                "start": int(match.group("start")),
+                "end": int(match.group("end") or match.group("start")),
+                "body": [],
+            }
+            notes.append(current)
+            continue
+        if current is not None:
+            current["body"].append(line)
+    for note in notes:
+        note["body"] = "\n".join(note["body"]).strip()
+    return [n for n in notes if n["body"]]
+
+
+def section_for(line: int, sections: list[dict]) -> str:
+    """The last section starting at or before this line is the one the note landed in."""
+    found = ""
+    for entry in sections:
+        if entry.get("line", 1) <= line:
+            found = entry.get("title", "")
+        else:
+            break
+    return found
+
+
+def render(notes: list[dict], sources: dict[str, list[str]], sections: list[dict]) -> str:
+    count = len(notes)
+    plural = "note" if count == 1 else "notes"
+    out = [
+        "# Notes on your replies",
+        "",
+        f"{count} {plural}. Each one quotes the lines I marked, then says what I want from you.",
+        "",
+    ]
+    for index, note in enumerate(notes, start=1):
+        start, end = note["start"], note["end"]
+        span = f"line {start}" if start == end else f"lines {start}-{end}"
+        where = section_for(start, sections)
+        out.append(f"## Note {index} — {where or note['file']}, {span}")
+        out.append("")
+        source = sources.get(note["file"], [])
+        quoted = source[start - 1 : end] or ["(line not found in the saved reply)"]
+        out.extend(f"> {line}" if line.strip() else ">" for line in quoted)
+        out.append("")
+        out.append(note["body"])
+        out.append("")
+    return "\n".join(out)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 4:
+        print(__doc__, file=sys.stderr)
+        return 2
+    replies, raw, dest = (Path(p) for p in argv[1:])
+
+    notes = parse(raw.read_text(encoding="utf-8", errors="replace"))
+    if not notes:
+        return 1
+
+    sources = {
+        path.name: path.read_text(encoding="utf-8", errors="replace").splitlines()
+        for path in replies.glob("*.md")
+        if path.name not in ("notes.md", "description.md")
+    }
+    try:
+        sections = json.loads((replies / "replies.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        sections = []
+    dest.write_text(render(notes, sources, sections), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/cookbook/annotate-claude-replies/annotate-replies.sh
+++ b/cookbook/annotate-claude-replies/annotate-replies.sh
@@ -1,0 +1,253 @@
+#!/bin/sh
+# Open my last Claude response in revdiff, annotate it, hand the notes back to the same prompt.
+#
+# Bound to a chord in ~/.config/agterm/keymap.conf. agterm runs a custom command detached, in a
+# non-interactive /bin/sh with a small PATH and stdio on /dev/null, so the PATH is widened here and
+# progress goes to the log instead of a terminal.
+#
+#   $1  agterm session id, from {AGT_SESSION_ID}
+#   $2  pane, from {AGT_PANE} (left, right or scratch)
+#
+# Which transcript to read comes from save-transcript-path.py, the Stop hook beside this script.
+# Without it there is nothing to open.
+set -eu
+
+PATH=$PATH:/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin
+export PATH
+
+# Everything below can be set in a config file instead of edited here, so one machine's quirks never
+# become a change to the script. A setting takes effect on the next press; a keymap line would need a
+# reload first, which is a trap when the chord keeps working with the old value and says nothing.
+CONFIG=${AGTERM_ANNOTATE_CONFIG:-$HOME/.config/agterm-annotate/config}
+if [ -r "$CONFIG" ]; then
+    # shellcheck source=/dev/null
+    . "$CONFIG"
+fi
+
+AGTERMCTL=${AGTERMCTL:-agtermctl}
+PYTHON=${PYTHON:-python3}
+# Binary names to try, in order. A local build under its own name belongs in the config file rather
+# than here: AGTERM_ANNOTATE_REVDIFF_NAMES="my-revdiff revdiff".
+REVDIFF_NAMES=${AGTERM_ANNOTATE_REVDIFF_NAMES:-revdiff}
+# An absolute path, because the overlay runs its command under the app's GUI PATH, which has neither
+# Homebrew nor ~/.local/bin. A bare name there exits 127 and the overlay flashes shut.
+if [ -z "${REVDIFF:-}" ]; then
+    for candidate in $REVDIFF_NAMES; do
+        found=$(command -v "$candidate" 2>/dev/null || true)
+        if [ -n "$found" ]; then
+            REVDIFF=$found
+            break
+        fi
+    done
+fi
+REVDIFF=${REVDIFF:-}
+CACHE_DIR=${AGTERM_ANNOTATE_DIR:-$HOME/.cache/agterm-annotate}
+LOG=${AGTERM_ANNOTATE_LOG:-/tmp/agterm-annotate.log}
+# 1 sends the Return for you, so quitting revdiff is the whole interaction. Set here rather than in the
+# keymap line: a keymap change needs a reload to take effect, and this script is read fresh every run.
+SUBMIT=${AGTERM_ANNOTATE_SUBMIT:-1}
+# 1 pastes the notes at the prompt; 0 types a one-line pointer to the file instead. Pasting needs the
+# clipboard, which is saved and put back around the paste.
+INLINE=${AGTERM_ANNOTATE_INLINE:-1}
+# Flags handed to revdiff. Wrapping is on because a reply is prose, not code, and --wrap-indent keeps a
+# wrapped bullet from reading as a new one. Add --tree-width=1 to shrink the side panel; there is no
+# flag to collapse it outright.
+REVDIFF_FLAGS=${AGTERM_ANNOTATE_REVDIFF_FLAGS:---wrap --wrap-indent=2}
+# How far back to gather. 1 is everything Claude said since your last prompt; 2 adds the exchange
+# before it, and so on. Each reply becomes a section of the file revdiff opens.
+PROMPTS_BACK=${AGTERM_ANNOTATE_PROMPTS:-1}
+
+exec >>"$LOG" 2>&1
+
+session=${1:-}
+pane=${2:-left}
+# Resolve through symlinks, so the helpers are found beside the real script rather than beside
+# whatever name it was installed under.
+here=$("$PYTHON" -c 'import os, sys; print(os.path.dirname(os.path.realpath(sys.argv[1])))' "$0")
+render=$here/annotate-render.py
+extract=$here/annotate-extract.py
+
+echo "--- $(date '+%F %T') session=$session pane=$pane"
+echo "revdiff=$REVDIFF"
+
+notify() {
+    "$AGTERMCTL" notify "$1" --title "Annotate response" --target "$session" >/dev/null || true
+}
+
+if [ -z "$session" ]; then
+    echo "no session id given; the keymap line must pass {AGT_SESSION_ID}"
+    exit 1
+fi
+
+# Not every build has these, and an unknown flag makes the overlay flash shut with a usage error
+# instead of opening, so ask the binary rather than assume. One --help, not one per flag. Skipped when
+# the flags were overridden, because an explicit set is a deliberate one.
+#   --no-tree  hides the side panel, which a single reply has no use for
+#   --preview  opens in rendered markdown; the toggle switches to source to place annotations
+if [ -z "${AGTERM_ANNOTATE_REVDIFF_FLAGS:-}" ] && [ -x "$REVDIFF" ]; then
+    revdiff_help=$("$REVDIFF" --help 2>&1 || true)
+    for probe in --no-tree --preview; do
+        case $revdiff_help in
+        *"$probe"*) REVDIFF_FLAGS="$REVDIFF_FLAGS $probe" ;;
+        esac
+    done
+fi
+
+if [ ! -x "$REVDIFF" ]; then
+    echo "revdiff not found on PATH; set REVDIFF to its absolute path"
+    notify "revdiff is not on the PATH this script sees. Set REVDIFF in it."
+    exit 1
+fi
+
+pointer=$CACHE_DIR/$session.$pane.json
+if [ ! -s "$pointer" ]; then
+    echo "no pointer at $pointer"
+    notify "This pane has no Claude transcript on record yet. It registers when Claude finishes a reply."
+    exit 0
+fi
+
+work=${TMPDIR:-/tmp}/agterm-annotate/$session.$pane
+mkdir -p "$work"
+
+# One run per pane. mkdir is atomic, so a second press while revdiff is still open is dropped instead
+# of stacking another overlay on the same session.
+if ! mkdir "$work/lock" 2>/dev/null; then
+    echo "already open for this pane, ignoring"
+    exit 0
+fi
+trap 'rmdir "$work/lock" 2>/dev/null || true' EXIT INT TERM
+
+# The session name goes in every reply's filename, because revdiff prints the path across the top and
+# lists them in its tree. A stale or foreign answer is then obvious on sight.
+# Two answers from one read: the session's name, and whether anything is running in the addressed
+# pane. A pane whose agent has exited reports no foreground, and pasting there would hand the notes to
+# a shell -- every quoted line starts with "> ", which a shell reads as a redirect and acts on.
+probe=$("$AGTERMCTL" tree --json 2>/dev/null | "$PYTHON" -c '
+import json, re, sys
+want, pane = sys.argv[1], sys.argv[2]
+try:
+    tree = json.load(sys.stdin)["result"]["tree"]
+except Exception:
+    sys.exit(0)
+for workspace in tree.get("workspaces", []):
+    for node in workspace.get("sessions", []):
+        if node.get("id") != want:
+            continue
+        slug = re.sub(r"[^A-Za-z0-9]+", "-", node.get("name") or "").strip("-")[:40]
+        # No read-back exposes the foreground of a scratch pane, so it reports unknown and is
+        # treated as live; it never takes the paste path anyway.
+        key = {"left": "foreground", "right": "splitForeground"}.get(pane)
+        busy = "unknown" if key is None else ("yes" if node.get(key) else "no")
+        print(slug)
+        print(busy)
+' "$session" "$pane") || probe=""
+name=$(printf '%s\n' "$probe" | sed -n 1p)
+pane_busy=$(printf '%s\n' "$probe" | sed -n 2p)
+[ -n "$pane_busy" ] || pane_busy=unknown
+
+# Read the replies out of the transcript now, rather than trusting whatever the hook last copied. The
+# hook only fires when a turn ends, so its copy goes stale as soon as it misses one.
+replies=$("$PYTHON" "$extract" "$pointer" "$work" "${name:-replies}" "$PROMPTS_BACK") || replies=""
+if [ -z "$replies" ]; then
+    echo "no replies found through $pointer"
+    notify "No answer to annotate in this pane yet."
+    exit 0
+fi
+echo "resolved name=${name:-?} file=$(basename "$replies")"
+
+# One file. revdiff builds its sidebar from a markdown file's headings, so each reply is a section and
+# the contents can name them in words, running oldest first from the prompt that started it.
+only_flags=" --only='$replies'"
+: >"$work/notes.raw"
+
+{
+    printf '# Annotate the replies\n\n'
+    printf 'Session **%s**, every reply since your last prompt.\n\n' "${name:-this pane}"
+    cat <<'EOF'
+The sidebar lists them oldest first, starting with what you asked. A note can land on an earlier reply as easily as on the one
+that was on screen.
+
+Put a note on any line you do not follow or disagree with. Quit when you are done and the notes go
+back to the prompt in the session behind this overlay.
+
+Quitting without a note sends nothing.
+EOF
+} >"$work/description.md"
+
+# The overlay's command runs through `sh -c` with the app's GUI PATH, which has no /opt/homebrew/bin
+# and no ~/.local/bin, so revdiff needs its absolute path here or the overlay flashes shut with 127.
+overlay_cmd="'$REVDIFF' $REVDIFF_FLAGS$only_flags -o '$work/notes.raw' --description-file='$work/description.md'"
+
+# --block makes agtermctl exit with revdiff's own status, so a non-zero rc is ambiguous: it can come
+# from agtermctl refusing before revdiff ever ran. The reply text is what tells the two apart.
+rc=0
+# No --follow. The chord fires from the session you are looking at, so following is a no-op when the
+# target is right and silently drags you elsewhere when it is not.
+opened=$("$AGTERMCTL" session overlay open "$overlay_cmd" --target "$session" --block 2>&1) || rc=$?
+echo "${opened:-(no reply)}"
+echo "revdiff exit=$rc"
+if [ "$rc" -ne 0 ] && [ "$rc" -ne 10 ]; then
+    case $opened in
+    *"overlay already open"*)
+        notify "This session already has an overlay open. Close it, then press the chord again."
+        ;;
+    *"not realized"* | *"no such session"*)
+        notify "This session is not on screen yet. Visit it once, then press the chord again."
+        ;;
+    *)
+        notify "Could not open revdiff (exit $rc). See $LOG."
+        ;;
+    esac
+    exit 0
+fi
+
+# Quitting without marking anything is a normal outcome, so it stays silent. A banner here would raise
+# the session's unseen badge and make you clear a red dot for a non-event.
+if ! "$PYTHON" "$render" "$work" "$work/notes.raw" "$work/notes.md"; then
+    echo "no annotations"
+    exit 0
+fi
+
+# `session paste` is the only way to land multi-line text at the prompt without submitting it, because
+# `session type` sends a real Return for every newline. It reads the system clipboard and has no
+# --pane, always targeting the main pane, so a split or scratch pane falls back to the pointer.
+# Nothing is typed into a pane whose agent has gone. The notes stay on disk instead.
+if [ "$pane_busy" = "no" ]; then
+    echo "nothing running in pane $pane; not sending"
+    notify "No agent running in this pane, so the notes were not sent. They are in $work/notes.md."
+    exit 0
+fi
+
+pasted=0
+if [ "$INLINE" = "1" ] && [ "$pane" = "left" ] &&
+    command -v pbcopy >/dev/null 2>&1 && command -v pbpaste >/dev/null 2>&1; then
+    held=$(pbpaste 2>/dev/null || true)
+    if pbcopy <"$work/notes.md" && "$AGTERMCTL" session paste --target "$session" >/dev/null; then
+        pasted=1
+        echo "pasted the notes inline"
+    else
+        echo "paste failed, using the pointer instead"
+    fi
+    # Put back whatever was on the clipboard. Plain text only; an image would already be gone.
+    printf '%s' "$held" | pbcopy 2>/dev/null || true
+fi
+
+if [ "$pasted" -eq 0 ]; then
+    ask="Read $work/notes.md and address every note in it. Each note quotes the lines of the replies I marked."
+    "$AGTERMCTL" session type "$ask" --target "$session" --pane "$pane"
+fi
+
+if [ "$SUBMIT" = "1" ]; then
+    # `session paste` returns once libghostty has run the paste, but the program on the other side of
+    # the pty is still reading those bytes. A Return sent immediately can land before a long paste has
+    # been ingested and submit half a message, so give it a moment to settle first.
+    [ "$pasted" -eq 1 ] && sleep "${AGTERM_ANNOTATE_SETTLE:-0.4}"
+    printf '\n' | "$AGTERMCTL" session type --stdin --target "$session" --pane "$pane"
+    echo "submitted"
+fi
+
+# A blind Return is not safe: the agent's TUI decides what Enter does from its own focus, and an
+# artifact or attachment chip can take it instead of the input, dropping the pasted text. Nothing here
+# can see that focus, so keep a fixed recovery copy rather than pretend it cannot happen.
+cp "$work/notes.md" "$CACHE_DIR/last-notes.md" 2>/dev/null || true
+echo "sent, notes at $work/notes.md (copy: $CACHE_DIR/last-notes.md)"

--- a/cookbook/annotate-claude-replies/save-transcript-path.py
+++ b/cookbook/annotate-claude-replies/save-transcript-path.py
@@ -32,7 +32,7 @@ def main() -> int:
 
     try:
         payload = json.load(sys.stdin)
-    except Exception:
+    except Exception:  # noqa: BLE001 - a Stop hook must never fail a turn, whatever arrives on stdin
         return 0
     if not isinstance(payload, dict):
         return 0

--- a/cookbook/annotate-claude-replies/save-transcript-path.py
+++ b/cookbook/annotate-claude-replies/save-transcript-path.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Claude Code Stop hook: record where an agterm pane's Claude transcript lives.
+
+The transcript path is the valuable part. A hook only runs when a turn ends, so a copy of the message
+is stale the moment one is missed, while the transcript keeps whatever Claude actually wrote —
+`annotate-extract.py` reads it fresh when the chord fires. The message is stored too, as the
+fallback for a transcript that was rotated by a resume or never recorded.
+
+The file is keyed by session AND pane because a split session shares one session id while running an
+agent in each pane.
+
+A hook that raises shows an error in the session, so every failure here is swallowed.
+"""
+
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def cache_dir() -> Path:
+    override = os.environ.get("AGTERM_ANNOTATE_DIR")
+    return Path(override) if override else Path.home() / ".cache" / "agterm-annotate"
+
+
+def main() -> int:
+    session = os.environ.get("AGTERM_SESSION_ID")
+    if not session:
+        return 0
+    pane = os.environ.get("AGTERM_PANE") or "left"
+
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+
+    message = payload.get("last_assistant_message") or ""
+    transcript = payload.get("transcript_path") or ""
+    if not isinstance(message, str):
+        message = ""
+    if not message.strip() and not transcript:
+        return 0
+
+    # Only what is read back. The transcript path is the point of the hook; the message is the fallback
+    # for a transcript rotated by a resume. Nothing needs the session id or the working directory, and
+    # this file already holds enough of a conversation without them.
+    record = {
+        "transcript_path": transcript,
+        "last_assistant_message": message,
+        "updated": datetime.now().astimezone().isoformat(timespec="seconds"),
+    }
+
+    try:
+        target = cache_dir()
+        target.mkdir(parents=True, exist_ok=True)
+        (target / f"{session}.{pane}.json").write_text(
+            json.dumps(record, indent=2), encoding="utf-8"
+        )
+    except OSError:
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds `cookbook/annotate-claude-replies/`: a chord that opens everything Claude Code has said since your last prompt in revdiff, on the session you pressed it in, and puts your notes back at that session's prompt.

The gap it fills is composition rather than a new command. Several recipes run a TUI in an overlay, and `examples.md` shows `overlay open --block` reading a program's output file, but nothing yet takes that output and feeds it back into the session it came from. This does that end to end.

### What it looks like

One exchange usually produces several replies, because Claude writes, runs a tool, then writes again. They go into one markdown file under per-reply headings, so revdiff's sidebar becomes a table of contents that can name them in words. The prompt that started the exchange opens the file and the replies follow in order:

```
10:52 · what you asked
10:58 · reply 1
11:04 · reply 2, the one you just read
```

Notes come back with the lines they point at already quoted, and are sent as soon as you quit:

```
## Note 1 — 11:04 · reply 2, the one you just read, line 12
> the launcher already opens revdiff in an agterm overlay
which launcher? I never set this up
```

### Commands used

`session overlay open --block`, `session paste`, `session type --pane`, `notify`, `tree --json`, plus the `{AGT_SESSION_ID}` and `{AGT_PANE}` keymap tokens.

### Minimum version

**0.13.0**, from `{AGT_PANE}` reporting the pane a custom command fired from (#210) — that is how a note taken in a split gets routed back to the right half. Everything else is older: `session overlay open --block` and `notify` shipped in 0.3.1, `session type --pane` in 0.7.0.

### Behaviour worth reviewing

Three things a reader should agree to before running it, all stated in *Limits*:

- It injects text at the prompt of the session the chord fired in **and sends it**, so the agent acts on the notes without you seeing them first. `AGTERM_ANNOTATE_SUBMIT=0` stops at the prompt. Sending is the default because annotating and quitting being the whole interaction is the point of binding it to a chord, but it is the setting most worth a second opinion.
- It uses the system clipboard, because `session paste` is the only way to land multi-line text at a prompt without submitting it. The prior clipboard is saved and restored, but only if it was plain text. `AGTERM_ANNOTATE_INLINE=0` avoids the clipboard entirely.
- It reads Claude Code's session transcripts and copies replies into a file under `TMPDIR`. The recipe never deletes them; macOS `dirhelper` purges `/var/folders/…/T` by access time after 3 days, so they persist until then.

It closes no sessions, deletes no workspaces, and kills no shells.

### Three API details the README records

`session overlay open --block` exits with the program's own status, so a non-zero code can equally mean agterm refused before the program ever ran. Reading only the code turns `overlay already open` into a meaningless "exited with 1".

An overlay's command runs under the app's GUI `PATH`, which has neither `/opt/homebrew/bin` nor `~/.local/bin`, so a bare binary name there exits 127 and the overlay flashes shut. The script resolves an absolute path first. The same trap applies to the script itself, which agterm runs detached in a small-`PATH` `/bin/sh` with stdio on `/dev/null` — hence the log under `/tmp` rather than printed output.

`session paste` takes no `--pane` and always targets the main pane, so a chord fired from a split or scratch pane falls back to typing a one-line pointer at the notes file.

### Two things the transcript format forces

A hook only runs when a turn ends, so any copy of the message it makes is stale the moment it misses one. The hook therefore records `transcript_path`, and the reply is read live when the chord fires. A project directory holds one transcript per session, so picking the newest by modification time would open whichever session was busiest rather than the one you are in — that pairing cannot be worked out afterwards, which is why the hook exists at all.

Peer-session messages, background task notifications and slash-command output all arrive as *user* records. Treating one as a typed prompt puts the exchange boundary in the wrong place and hides replies. `userType` is `external` on genuine prompts too, and `isMeta` was false on a real `<teammate-message>`, so the tags are matched as well.

### Checks

`shellcheck` clean across all cookbook scripts, `sh -n` clean, six headings present, index row added, shebangs and executable bits set. Exercised under `env -i` with the stripped `PATH` agterm gives a detached custom command, covering the overlay-busy, no-transcript, repeat-press, split-pane, clipboard-restore, injected-boundary and optional-flag paths, and against real transcripts rather than only fixtures.

Optional revdiff flags (`--no-tree`, `--preview`) are added only when the binary advertises them, so a released revdiff gets `--wrap --wrap-indent=2` and is never handed an unknown flag.

### Open questions for you

Two things I would rather you decide than me: whether sending on quit should be the default, and whether a recipe that needs a Claude Code hook belongs in the cookbook at all, given the rest are pure `agtermctl`.

Happy to split, rename, or drop any part of it.
