### PR TITLE
feat(cookbook): add fish port of claude-session-resume

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -16,7 +16,7 @@ Recipes come from other people as well as the maintainer. Every one is reviewed 
 | [native-dir-picker](native-dir-picker/) | pick a directory in the native picker and type it into the shell | 0.19.0, fd, jq |
 | [overlay-and-split](overlay-and-split/) | keymap lines: a stateful split toggle and TUI overlays | 0.10.0, jq |
 | [status-announcer](status-announcer/) | demo: speak agent status changes from a dedicated session | 0.16.0, jq |
-| [claude-session-resume](claude-session-resume/) | each tab reopens its own Claude Code conversation after a restart | 0.3.1, zsh, Claude Code |
+| [claude-session-resume](claude-session-resume/) | each tab reopens its own Claude Code conversation after a restart | 0.3.1, zsh or fish, Claude Code |
 | [codex-session-resume](codex-session-resume/) | each tab reopens its own codex conversation after a restart | 0.3.1, zsh, Codex CLI |
 | [opencode-session-resume](opencode-session-resume/) | each tab reopens its own opencode conversation after a restart | 0.3.1, zsh, opencode |
 | [kimi-agent-status](kimi-agent-status/) | Kimi Code sessions report agent status onto their sidebar row | 0.3.1, Kimi Code |

--- a/cookbook/claude-session-resume/README.md
+++ b/cookbook/claude-session-resume/README.md
@@ -2,7 +2,7 @@
 
 After a restart each tab reopens its own Claude Code conversation instead of a shared most-recent one.
 
-Contributed by [@ssgreg](https://github.com/ssgreg), from [discussion #71](https://github.com/umputun/agterm/discussions/71).
+Contributed by [@ssgreg](https://github.com/ssgreg), from [discussion #71](https://github.com/umputun/agterm/discussions/71). Fish port by [@Arelav](https://github.com/Arelav).
 
 ## What it does
 
@@ -12,15 +12,17 @@ Keep several Claude Code sessions open at once, and after the terminal restarts 
 - Zero state: the conversation id **is** the tab's uuid (`AGTERM_SESSION_ID`). No mapping file to keep in sync or let go stale.
 - Idempotent: the first launch pins the conversation to the tab (`--session-id`); later launches continue it (`--resume`), and it flips automatically.
 - Stays out of the way: `claude mcp`, `-p`, an explicit `claude --resume <other-id>`, and any launch outside agterm pass through untouched.
-- Small, dependency-free, pure zsh; options are function-local (`emulate -L`), so nothing leaks into your interactive shell.
+- Small, dependency-free, pure shell; options are function-local (zsh's `emulate -L`, fish's implicit function scoping), so nothing leaks into your interactive shell.
 
 ## Requirements
 
 - agterm 0.3.1 or later, with **Restore running commands on restart** turned on under Settings ▸ General ▸ Sessions. Both `AGTERM_SESSION_ID` and that setting predate the repository's earliest tagged release, so 0.3.1 is the first version that can be named, not the version the behavior arrived in.
-- `zsh`
+- `zsh`, or `fish`
 - Claude Code, with its conversations in the default `~/.claude/projects/`
 
 ## Setup
+
+### zsh
 
 The function has to be defined in `~/.zshrc`, the config your interactive login zsh reads. That matters: agterm feeds the restored command into that shell, so `.zshenv` and `.zprofile` are too early to intercept it.
 
@@ -44,6 +46,23 @@ Turn on **Restore running commands on restart** in Settings ▸ General, under S
 New tabs and shells pick the function up on their own. In an already-open shell, run `source ~/.zshrc`.
 
 To remove it, delete the function block, or the `source` line, from `~/.zshrc`.
+
+### fish
+
+Drop `claude-resume.fish` into fish's autoload directory, under the name the function is defined with:
+
+```sh
+mkdir -p ~/.config/fish/functions
+cp claude-resume.fish ~/.config/fish/functions/claude.fish
+```
+
+Fish autoloads a function from that directory by filename on first call, in any shell, interactive or not, so there is no config file to source and no restart to arrange. This file too is sourced by fish's autoloader, never run, so it does not need the executable bit and is committed without one.
+
+Turn on **Restore running commands on restart** in Settings ▸ General, under Sessions. Without it agterm brings a tab back as a plain shell and there is nothing for the function to intercept.
+
+New tabs and shells pick the function up on their own; an already-open shell does too, since fish resolves `claude` against the autoload path on next call.
+
+To remove it, delete `~/.config/fish/functions/claude.fish`.
 
 ## Usage
 
@@ -70,5 +89,5 @@ On the agterm side that replay is a foreground-process capture. At quit agterm r
 - **One conversation per tab.** Since conversation id equals tab id, two live `claude` processes in the same tab collide with `Session ID ... is already in use`. A split pane, a scratch pane and any overlay all run under the same `AGTERM_SESSION_ID` as the main pane, so a second `claude` in any of them hits this.
 - **It shadows the `claude` command** with a shell function. Passthrough is handled, but the list of subcommands and flags that must not be touched has to be kept current if the CLI grows new ones.
 - **It knows Claude Code's on-disk layout** (`~/.claude/projects/*/<id>.jsonl`). If that storage location changes, the "does this conversation exist" check breaks: it would always create, then hit "already in use" on restart. A one-line fix, but worth knowing.
-- **zsh only** (`${:l}`, the `(N)` glob qualifier, `emulate`). Bash needs a rewrite.
+- **zsh or fish only** (the zsh version uses `${:l}`, the `(N)` glob qualifier, and `emulate`; the fish version uses fish-only syntax throughout). Bash needs a rewrite.
 - **Existing conversations are not bound to tabs.** After you install this, the first launch in a tab starts a new conversation pinned to that tab; it does not adopt an arbitrary earlier one.

--- a/cookbook/claude-session-resume/claude-resume.fish
+++ b/cookbook/claude-session-resume/claude-resume.fish
@@ -1,0 +1,38 @@
+#!/usr/bin/env fish
+# Sourced, not executed: put this function in a fish autoload file, e.g.
+# ~/.config/fish/functions/claude.fish, or source this file from ~/.config/fish/config.fish.
+# See README.md.
+
+# Claude Code: per-agterm-tab session resume.
+# Binds each tab's Claude Code session id to the tab's own uuid (AGTERM_SESSION_ID),
+# so restoring the terminal resumes that tab's own conversation instead of starting fresh.
+# Requires: agterm (exports AGTERM_SESSION_ID, restores running commands) + fish.
+function claude --description 'Per-agterm-tab Claude Code session resume'
+    set -l sid (string lower -- "$AGTERM_SESSION_ID")
+    if test -z "$sid"
+        command claude $argv                                    # not in an agterm tab -> passthrough
+        return
+    end
+
+    set -l args $argv
+
+    if contains -- "$argv[1]" --session-id -r --resume
+        and test (string lower -- "$argv[2]") = "$sid"
+        set args $argv[3..-1]                                    # restore replayed our own flag -> re-decide below
+    else
+        for a in $argv                                           # user steering a session/subcommand/headless?
+            switch $a
+                case -r --resume --session-id '--resume=*' '--session-id=*' '-r=*' -c --continue -p --print -v --version -h --help mcp update doctor config install migrate-installer setup-token
+                    command claude $argv                          # -> hand off untouched
+                    return
+            end
+        end
+    end
+
+    set -l existing ~/.claude/projects/*/$sid.jsonl               # does this tab's session already exist?
+    if test (count $existing) -gt 0
+        command claude --resume "$sid" $args                      # yes -> continue it
+    else
+        command claude --session-id "$sid" $args                  # no  -> create it with this fixed id
+    end
+end


### PR DESCRIPTION
## Summary

- Adds `claude-resume.fish`, a fish port of the existing `claude-resume.zsh` per-tab Claude Code session resume recipe, next to it in `cookbook/claude-session-resume/`.
- fish's own autoload mechanism makes setup simpler than zsh's `source ~/.zshrc` step: drop the file in `~/.config/fish/functions/claude.fish` and it's picked up automatically, no restart or explicit sourcing needed.
- Updates the recipe README's Requirements, Setup, and Limits sections to cover both shells, and the cookbook index row.

Per CONTRIBUTING.md, `.fish` isn't one of the linted extensions (`.sh`/`.zsh`/`.py`), so nothing gates it in CI — flagging that here for review.

## Test plan

- [x] `fish --no-execute cookbook/claude-session-resume/claude-resume.fish` — parses clean
- [x] Live agterm tab: pin with `--session-id`, resume after restart with `--resume` — confirmed working
