### PR TITLE
fix(cookbook): passthrough non-interactive fish claude calls

### DIFF
--- a/cookbook/claude-session-resume/README.md
+++ b/cookbook/claude-session-resume/README.md
@@ -56,7 +56,7 @@ mkdir -p ~/.config/fish/functions
 cp claude-resume.fish ~/.config/fish/functions/claude.fish
 ```
 
-Fish autoloads a function from that directory by filename on first call, in any shell, interactive or not, so there is no config file to source and no restart to arrange. This file too is sourced by fish's autoloader, never run, so it does not need the executable bit and is committed without one.
+Fish autoloads a function from that directory by filename on first call, in any shell, interactive or not, so there is no config file to source and no restart to arrange. This file too is sourced by fish's autoloader, never run, so it does not need the executable bit and is committed without one. Unlike the zsh version — which a non-interactive shell never sources at all — the function checks `status is-interactive` itself and passes non-interactive calls straight through, so a script invoking `claude` from inside a tab isn't intercepted.
 
 Turn on **Restore running commands on restart** in Settings ▸ General, under Sessions. Without it agterm brings a tab back as a plain shell and there is nothing for the function to intercept.
 

--- a/cookbook/claude-session-resume/claude-resume.fish
+++ b/cookbook/claude-session-resume/claude-resume.fish
@@ -8,6 +8,11 @@
 # so restoring the terminal resumes that tab's own conversation instead of starting fresh.
 # Requires: agterm (exports AGTERM_SESSION_ID, restores running commands) + fish.
 function claude --description 'Per-agterm-tab Claude Code session resume'
+    if not status is-interactive
+        command claude $argv                                    # non-interactive (script/subshell) -> passthrough
+        return
+    end
+
     set -l sid (string lower -- "$AGTERM_SESSION_ID")
     if test -z "$sid"
         command claude $argv                                    # not in an agterm tab -> passthrough


### PR DESCRIPTION
## Summary

Follow-up to #365. Fish autoloads `claude.fish` for scripts too, unlike zsh's `.zshrc`-only sourcing (the zsh version never sees a non-interactive shell). Concretely: Claude Code's own Bash tool calling `claude` from inside an already-running agterm tab hit the resume logic and could collide on the tab's session id (`Session ID ... is already in use`) instead of passing through untouched.

- `claude-resume.fish`: guard the top of the function with `status is-interactive`, passthrough otherwise.
- `README.md`: note the zsh/fish difference and the guard in the Setup section.

## Test plan

- [x] `fish --no-execute cookbook/claude-session-resume/claude-resume.fish` — parses clean
- [x] Verified manually: non-interactive `claude` call from a script inside a tab now passes through untouched instead of hitting the resume logic