### PR TITLE
fix(window): apply the titlebar blend in native fullscreen

### DIFF
--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -97,6 +97,12 @@ paths:
   `CGSSetWindowBackgroundBlurRadius`; absence is a no-op. `ghosttyConfigLines()` pins renderer opacity and
   blur to 0. At opacity 1, restore opaque rendering. Reduce Transparency temporarily forces opaque,
   unblurred windows/panels without changing saved settings or config.
+- In native fullscreen AppKit relocates the chrome into an `NSToolbarFullScreenWindow` child window, so the
+  window's own view tree holds no `NSTitlebarContainerView` and the whole blend is skipped.
+  Hidden toolbar mode falls back to that child, or `NSTitlebarBackgroundView` paints a hairline across the
+  top edge of the full-bleed terminal. Other modes keep AppKit's own fullscreen rendering.
+  Key the `_NSTitlebarDecorationView` suppression off the mode, never the traffic-light flag, whose
+  fullscreen carve-out would un-hide what AppKit hides there itself.
 - On macOS 26, find the wrapping `NSContainerConcentricGlassEffectView` by walking from
   `agterm-sidebar-scroll`; for translucent windows use clear style plus terminal tint. Its Liquid Glass
   blur is not pixel-identical to CGS blur. Reapply on key/main/fullscreen and appearance changes.

--- a/agterm/Views/WindowAppearance.swift
+++ b/agterm/Views/WindowAppearance.swift
@@ -64,7 +64,7 @@ enum WindowAppearance {
         syncSidebarBackground(in: window)
 
         // the title/terminal separator is drawn in the detail pane, so it ends at the sidebar edge.
-        guard let container = titlebarContainer(in: window) else { return }
+        guard let container = titlebarContainer(in: window, toolbarMode: chrome.toolbarMode) else { return }
         if let titlebarView = container.firstDescendant(withClassName: "NSTitlebarView") {
             titlebarView.wantsLayer = true
             titlebarView.layer?.backgroundColor = NSColor.clear.cgColor
@@ -73,9 +73,10 @@ enum WindowAppearance {
         // .hiddenTitleBar doesn't hold (the XCUITest reopen path), it paints a dark strip above the header.
         container.firstDescendant(withClassName: "NSTitlebarBackgroundView")?.isHidden = true
         // hidden mode must also suppress `_NSTitlebarDecorationView` — a full-width titlebar-height sibling
-        // of NSTitlebarView painting a vibrancy material band (macOS 26). tall/compact cover it with the
-        // custom row; hidden mode (traffic lights gone, row collapsed to the 3px drag strip) leaves it bare.
-        container.firstDescendant(withClassName: "_NSTitlebarDecorationView")?.isHidden = hideButtons
+        // of NSTitlebarView painting a vibrancy material band (macOS 26). normal/compact cover it with the
+        // custom row; hidden mode collapses that row to the 3px drag strip and leaves the band bare.
+        // Keyed off the mode, never `hideButtons`, whose fullscreen carve-out would un-hide it there.
+        container.firstDescendant(withClassName: "_NSTitlebarDecorationView")?.isHidden = chrome.toolbarMode == .hidden
     }
 
     /// Keeps the sidebar see-through — opaque terminal color at full opacity, translucent tinted background
@@ -125,8 +126,20 @@ enum WindowAppearance {
         for subview in view.subviews { forceVisualEffectsActive(in: subview) }
     }
 
-    /// The `NSTitlebarContainerView` for `window`, found from the window's root theme frame.
-    private static func titlebarContainer(in window: NSWindow) -> NSView? {
+    /// The `NSTitlebarContainerView` governing `window`'s chrome, falling back to the fullscreen child
+    /// window AppKit relocates it into, as `.claude/rules/settings.md` requires. The fallback is apply-only:
+    /// leaving hidden mode while still in fullscreen does not undo the suppression, because the other
+    /// modes decline the fallback and so write nothing back. Exiting fullscreen restores it.
+    private static func titlebarContainer(in window: NSWindow, toolbarMode: ToolbarMode) -> NSView? {
+        if let container = titlebarContainer(inHierarchyOf: window) { return container }
+        guard toolbarMode == .hidden, window.styleMask.contains(.fullScreen) else { return nil }
+        return window.childWindows?
+            .first { String(describing: type(of: $0)) == "NSToolbarFullScreenWindow" }
+            .flatMap(titlebarContainer(inHierarchyOf:))
+    }
+
+    /// The `NSTitlebarContainerView` inside `window`'s own root theme frame, if it hosts one.
+    private static func titlebarContainer(inHierarchyOf window: NSWindow) -> NSView? {
         guard let contentView = window.contentView else { return nil }
         var root: NSView = contentView
         while let parent = root.superview { root = parent }


### PR DESCRIPTION
with the toolbar set to Hidden, a 1px light hairline is drawn across the full top edge of the window in native fullscreen. Reported in #368 with pixel measurements: exactly 1 logical px, full window width, background plus a constant ~8% white.

the cause is not the hairline itself. In native fullscreen AppKit relocates window chrome into an `NSToolbarFullScreenWindow` child window, so `titlebarContainer(in:)` - which only walked the window's own view tree - returned nil and `WindowAppearance.sync` hit its `guard ... else { return }`. **none** of its titlebar treatments ran in fullscreen. What shows is AppKit's own `NSTitlebarBackgroundView`, left unsuppressed. In windowed hidden mode that same view is hidden, which is why the bug is fullscreen-only.

confirmed with a runtime probe against a live fullscreen instance, not inferred:

```
--- sync mode=hidden fullscreen=true
    containerFound=false
    children=["NSToolbarFullScreenWindow"]
    win NSToolbarFullScreenWindow visible=true frame=(0, 1588, 2880, 32)
        NSTitlebarBackgroundView[hidden=false]
```

worth noting the first plausible fix, keying the decoration-view suppression off the toolbar mode instead of the traffic-light flag, would have been a no-op. The code never reached that line in fullscreen.

**what changed**

`titlebarContainer` falls back to the `NSToolbarFullScreenWindow` child when the window's own hierarchy has no container. Scoped to hidden mode: normal/compact are visually clean in fullscreen today and keep AppKit's own rendering.

the `_NSTitlebarDecorationView` suppression is now keyed off the toolbar mode rather than `hideButtons`. That flag carves out fullscreen for the traffic lights, and reusing it there would un-hide a view AppKit hides itself.

the fallback is apply-only, and the doc comment says so: leaving hidden mode while still in fullscreen takes no container and writes nothing back, so the suppression stands until fullscreen exits. Restoring it properly means writing guessed defaults into private AppKit views with no test able to cover them, which is not worth it for something that self-heals on exit.

**verification**

no test added. `WindowAppearance` has no existing coverage and this is private-AppKit-view manipulation the project verifies by eye, per the fullscreen and cursor conventions already in `.claude/rules`.

confirmed by eye in an isolated fullscreen Debug instance, before and after. `swift test` 2357 passed, `make test-app` 155 passed, `make lint` clean.

Related to #368
