### PR TITLE
fix: stop ⌘C/⌘V/⌘A leaking a key report into the program

### DIFF
--- a/agterm/Resources/ghostty-defaults.conf
+++ b/agterm/Resources/ghostty-defaults.conf
@@ -30,16 +30,20 @@ cursor-click-to-move = false
 # the character the active layout produces — so on a Russian/Greek/etc. layout the
 # physical V key yields `м`/etc. and the bind never fires. these physical-key
 # triggers match by keycode (the physical position) regardless of the produced
-# character, so they work on any layout. performable: keeps ghostty's default
-# fall-through (e.g. ⌘C does nothing when there is no selection). a Latin alternative
-# layout (Dvorak/Colemak) that wants its own letter positions can re-bind these in
-# ~/.config/agterm/ghostty.conf.
+# character, so they work on any layout. a Latin alternative layout (Dvorak/Colemak)
+# that wants its own letter positions can re-bind these in ~/.config/agterm/ghostty.conf.
 #
 # these are the FALLBACK layer: agterm's standard Edit menu carries ⌘C/⌘V/⌘A as menu
 # key equivalents, which AppKit matches against the produced CHARACTER and consumes
-# before the terminal sees the key. on a non-Latin layout no equivalent matches, the
-# event reaches keyDown, and these keycode binds fire. select_all needs one too, or
-# ⌘A silently does nothing on a Cyrillic/Greek layout.
-keybind = performable:super+key_c=copy_to_clipboard
-keybind = performable:super+key_v=paste_from_clipboard
-keybind = performable:super+key_a=select_all
+# before the terminal sees the key. the event reaches keyDown and these keycode binds
+# fire in two cases: a non-Latin layout, where no equivalent matches, and a DISABLED item
+# on any layout — Copy without a selection, Paste with nothing pasteable. select_all needs
+# a bind too, or ⌘A silently does nothing on a Cyrillic/Greek layout.
+#
+# deliberately NOT `performable:`. that prefix consumes the key only when the action ran,
+# so the disabled-item case fell through to key encoding: invisible under legacy encoding,
+# which drops ⌘ chords on macOS, but the kitty keyboard protocol reports them and any TUI
+# enabling it renders the key report as text.
+keybind = super+key_c=copy_to_clipboard
+keybind = super+key_v=paste_from_clipboard
+keybind = super+key_a=select_all

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -107,6 +107,8 @@ The full ghostty key reference is at <https://ghostty.org/docs/config>.
 
 The reason is that ghostty's own copy/paste binds match the produced character: on a Russian layout the physical V key yields `м`, so the built-in `super+v` bind never fires. The bundled agterm defaults add physical-key binds (`super+key_c`, `super+key_v`) that match by position instead.
 
+Those binds always consume the key, even when there is nothing to act on: ⌘C with no selection does nothing at all, rather than reaching the running program. That is deliberate. The Edit menu disables Copy without a selection and Paste without pasteable content — on every layout — so those presses fall to the terminal's own bind, and a bind that declined them would let the chord through to key encoding. A plain shell shows nothing either way, but under the kitty keyboard protocol, which Claude Code and other TUIs turn on, the program receives the chord as a key report and renders it as text — a stray `с` or `^[[1089;9u` in the prompt. If you rebind copy or paste yourself, do not add ghostty's `performable:` prefix for the same reason.
+
 The same distinction lets you remap any shortcut for your layout:
 
 - A physical key name (`key_c`, `key_v`, `key_a`, and so on) matches the key's position, whatever character it prints.

--- a/plugins/agterm/skills/agterm/troubleshooting.md
+++ b/plugins/agterm/skills/agterm/troubleshooting.md
@@ -83,8 +83,12 @@ agterm's bundled ghostty defaults are the **fallback**, binding all three to the
 (`super+key_c`/`super+key_v`/`super+key_a`), matched by keycode regardless of the character the layout
 prints. They fire whenever the menu equivalent does not: on a Russian/Greek/etc. layout the physical C key
 yields `с`, so the menu's ⌘C never matches and the keycode bind runs instead; likewise a ⌘C with no
-selection leaves the menu item disabled, so the key falls through (and ghostty's `performable:` prefix makes
-it a no-op). This is why copy, paste, and select-all all keep working on a non-Latin layout. (ghostty's own
+selection, or a ⌘V with nothing pasteable, leaves the menu item disabled and reaches the bind on ANY
+layout. The three binds deliberately omit ghostty's `performable:` prefix so they always consume the key,
+and one that cannot act simply does nothing. With that prefix the unperformed press fell through to key
+encoding — invisible under legacy encoding, which drops ⌘ chords on macOS, but the kitty keyboard protocol
+reports them and the program renders a stray `^[[…u` as text. This is why copy, paste, and select-all all
+keep working on a non-Latin layout. (ghostty's own
 `super+c`/`super+v`/`super+a` match the produced CHARACTER, so alone they would miss there — `super+key_a`
 in particular exists because without it ⌘A would silently do nothing on a Cyrillic layout.)
 


### PR DESCRIPTION
⌘C with nothing selected typed a stray key report into the running program. Reported in #373 with a clean repro and the right diagnosis.

**cause.** the bundled ghostty defaults marked the three physical-key clipboard binds `performable:`, which consumes the key only when the action actually ran. The Edit menu disables Copy without a selection and Paste with nothing pasteable, so those presses reach the bind, fail to perform, and fall through to key encoding. Legacy encoding drops ⌘ chords on macOS, which is why this was invisible until now, but the kitty keyboard protocol reports them. Claude Code and other TUIs turn that protocol on, so the chord renders as text in the prompt.

it is not layout-specific, contrary to how the report scoped it. The menu item is disabled on any layout, so a US layout leaks `^[[99;9u` exactly like a Russian one leaks `^[[1089;9u`. Only ⌘A is immune, its menu item being enabled whenever a surface is live.

**fix.** drop `performable:` from all three binds so they always consume. The only case that changes was already a no-op. `Binding.Set.getEvent` resolves the physical trigger before the unicode one, so ghostty's built-in `super+c`/`super+v`/`super+a` are never reached and nothing falls back to them. No native macOS terminal sends a ⌘ chord to the program.

checked both ways in a debug instance: with the prefix restored through a `ghostty.conf` override, ⌘C emits `^[[99;9u`; without it, nothing at all. Copy, paste and select-all still work, on the Russian layout too, which is what #30 originally fixed.

**docs.** two places called the fall-through a no-op and are corrected: the bundled skill's `troubleshooting.md` and `docs/troubleshooting.md`.

Fix #373
