### PR TITLE
fix(split): dismiss the scratch instead of splitting behind it

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ agterm arranges terminals into a small hierarchy. These are the only terms you n
 
 **Panes.** A session can split into two shells side by side. Both panes are part of the same session and share one sidebar row; a split is one session with two terminals, not two sessions. One pane is focused at a time, and the divider position is remembered — drag the divider to resize the panes, double-click it to snap back to an even split.
 
-**Scratch terminal.** Every session has an extra shell, the scratch terminal, that you toggle on over the session and hide again without killing it. It opens in the session's directory and is for a quick aside next to your main work. It belongs to that one session and is not restored across launches.
+**Scratch terminal.** Every session has an extra shell, the scratch terminal, that you toggle on over the session and hide again without killing it. It opens in the session's directory and is for a quick aside next to your main work. It belongs to that one session and is not restored across launches. While it covers the session, ⌘D and the split button hide it rather than rearrange the panes beneath, so either one takes you back to the panes exactly as you left them.
 
 **Quick terminal.** The quick terminal is a single throwaway shell per window, not tied to any session. It drops over whatever session is active, for a command unrelated to what you are working on, and hiding it keeps the shell alive. It is not restored across launches.
 

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -666,9 +666,18 @@ final class AppActions {
     /// closing only HIDES it (both shells stay alive) and maximizes the focused pane, so reopening restores
     /// both in their original positions with the SAME pane focused — focus follows `splitFocused`, which
     /// `AppStore.toggleSplit` moves only for a genuinely new split.
+    ///
+    /// A session-wide cover hides the panes, so rearranging them behind it would only be seen once the cover
+    /// goes — the layout the user left is silently different. A shown scratch is DISMISSED instead, ⌘W's
+    /// cover-first rule, making this the way back to the panes as they were; hiding is keep-alive, so the
+    /// scratch shell survives. A full overlay runs a caller's program that must not be closed under it, so
+    /// the press is inert. Control's `session.split` keeps acting on the deck behind either cover.
     func toggleSplit() {
         guard uiActionsEnabled else { return }
         guard let store, let session = store.activeSession else { return }
+        guard !session.fullOverlayActive else { return }
+        // the deck's `scratchActive` onChange reclaims first responder for the pane, as it does for ⌘J.
+        if session.scratchActive { store.toggleScratch(session.id); return }
         store.toggleSplit(session.id)
         focusSplitPane(session, wantSplit: session.splitFocused)
     }

--- a/agtermTests/SplitToggleCoverTests.swift
+++ b/agtermTests/SplitToggleCoverTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+@testable import agterm
+import agtermCore
+
+/// Hosted coverage for `AppActions.toggleSplit`'s cover rung — ⌘D / the toolbar button / View ▸ Split /
+/// the palette all funnel through it. Lives here rather than in `agtermUITests` for the same reasons as
+/// `SessionNavRevealTests`: it reaches `AppActions` through `@testable import agterm`, observes MODEL flags
+/// (`isSplit`, `scratchActive`) that need no terminal surface, and runs on every push via `scripts/test-app.sh`.
+@MainActor
+final class SplitToggleCoverTests: XCTestCase {
+    private var stateDir: URL!
+    private var library: WindowLibrary!
+    private var actions: AppActions!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        await MainActor.run {
+            stateDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("agterm-split-cover-tests-\(UUID().uuidString)", isDirectory: true)
+            library = WindowLibrary(directory: stateDir)
+            actions = AppActions(library: library)
+        }
+    }
+
+    override func tearDown() async throws {
+        await MainActor.run {
+            actions = nil
+            library = nil
+            try? FileManager.default.removeItem(at: stateDir)
+            stateDir = nil
+        }
+        try await super.tearDown()
+    }
+
+    private func activeSession() throws -> Session {
+        let store = try XCTUnwrap(library.activeStore)
+        return try XCTUnwrap(store.activeSession)
+    }
+
+    func testUncoveredSessionStillSplits() throws {
+        let session = try activeSession()
+
+        actions.toggleSplit()
+
+        XCTAssertTrue(session.isSplit, "the cover rung must not disarm the ordinary split toggle")
+        XCTAssertTrue(session.hasSplit)
+    }
+
+    func testShownScratchIsDismissedInsteadOfSplitting() throws {
+        let session = try activeSession()
+        session.scratchActive = true
+
+        actions.toggleSplit()
+
+        XCTAssertFalse(session.scratchActive, "⌘D over the scratch is the way back to the panes")
+        XCTAssertFalse(session.hasSplit, "no split may be created behind the cover")
+    }
+
+    // the layout the user left must be the one he comes back to: a shown split stays shown.
+    func testDismissingTheScratchLeavesAShownSplitAlone() throws {
+        let session = try activeSession()
+        actions.toggleSplit()
+        session.scratchActive = true
+
+        actions.toggleSplit()
+
+        XCTAssertFalse(session.scratchActive)
+        XCTAssertTrue(session.isSplit, "the split must survive the press that dismissed the scratch")
+    }
+
+    // a second press, now uncovered, is an ordinary toggle again — so the rung is a detour, not a swap.
+    func testPressAfterTheScratchIsGoneSplits() throws {
+        let session = try activeSession()
+        session.scratchActive = true
+
+        actions.toggleSplit()
+        actions.toggleSplit()
+
+        XCTAssertFalse(session.scratchActive)
+        XCTAssertTrue(session.isSplit)
+    }
+
+    func testFullOverlayMakesThePressInert() throws {
+        let session = try activeSession()
+        session.overlayActive = true
+        session.overlaySizePercent = nil
+        session.scratchActive = true
+
+        actions.toggleSplit()
+
+        XCTAssertTrue(session.scratchActive, "a full overlay hides the scratch too, so it is not what ⌘D dismisses")
+        XCTAssertFalse(session.hasSplit, "the panes are invisible under a full overlay and must not be rearranged")
+    }
+
+    func testFloatingOverlayLeavesThePanesReachable() throws {
+        let session = try activeSession()
+        session.overlayActive = true
+        session.overlaySizePercent = 40
+
+        actions.toggleSplit()
+
+        XCTAssertTrue(session.isSplit, "a floating panel leaves the panes on screen, so the toggle is visible")
+    }
+
+    // a HUD is a message, not a cover: `fullOverlayActive` excludes it even with no size percent.
+    func testHudLeavesThePanesReachable() throws {
+        let session = try activeSession()
+        session.overlayActive = true
+        session.overlaySizePercent = nil
+        session.hudSpec = HudSpec(message: "gathering options…", position: .center)
+
+        actions.toggleSplit()
+
+        XCTAssertTrue(session.isSplit)
+    }
+}

--- a/site/docs.html
+++ b/site/docs.html
@@ -691,7 +691,8 @@
                 </div>
                 <p style="font-size: 15px; line-height: 1.6; color: #949ba4; margin: 0">
                   An extra shell belonging to one session, for a quick aside next to your main work. It covers the session
-                  full-screen and hides again without killing it. Opens in the session's directory; not restored across launches.
+                  full-screen and hides again without killing it. While it is up, ⌘D and the split button hide it rather than
+                  rearrange the panes beneath. Opens in the session's directory; not restored across launches.
                 </p>
               </div>
               <div


### PR DESCRIPTION
⌘D, the title-bar split button, View ▸ Split and the palette all funnel through `AppActions.toggleSplit`, which gates only on `uiActionsEnabled` (zoom, dashboard, pending pick). The scratch is not in that gate, so with the scratch up the press flipped `isSplit` behind the cover and persisted it: the screen could not change, but the split glyph moved and the layout you came back to was not the one you left.

A shown scratch is dismissed instead, the same cover-first rule ⌘W already uses for closing. Hiding is keep-alive so the scratch shell survives, and the deck's `scratchActive` onChange puts first responder back on the pane, exactly as ⌘J does. A second press then splits as usual.

A full program overlay makes the press inert rather than rearranging panes nobody can see. A floating overlay or a HUD leaves the panes on screen, so the toggle stays visible and behaves as before.

Control `session.split` goes through `ControlServer` and is untouched, so scripts keep their exact semantics.

`agtermTests/SplitToggleCoverTests.swift` pins seven cases: the scratch dismissed instead of split, a shown split surviving that press, the next press splitting, full overlay inert, floating overlay and HUD reachable, and an uncovered session still splitting. README and its `site/docs.html` mirror get the behavior in the scratch paragraph.
