### PR TITLE
fix: keep the injected environment on surfaces created by a dark launch

### DIFF
--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -22,6 +22,12 @@ paths:
 - Pass `theme = light:X,dark:Y` raw. Pinned libghostty `4dcb09ada` supports conditional themes, but
   `set_color_scheme` only changes conditional state and emits an unhandled soft reload. agterm must set
   app and surface schemes, then call `update_config`.
+- A dark launch must re-side the app config through `update_config` BEFORE the first surface exists;
+  `GhosttyApp.syncLaunchColorScheme`, called from `applicationDidFinishLaunching`, owns that.
+  `Surface.init` rebuilds a surface config whose conditional state differs from the app's, keeps only
+  `working-directory`, and drops the per-surface env, `initial_input` and `command` (#260).
+  A host-built config always resolves light, and `GhosttyApp` is built before `NSApp` exists, so its own
+  appearance read is always light; the KVO reload is debounced and lands after the launch restore.
 - Observe app-level `NSApplication.effectiveAppearance` through KVO, not per-view appearance,
   `AppleInterfaceStyle`, or the early distributed notification. Post the KVO-delivered settled `isDark`
   and thread it through `reloadConfigPreservingSessionZoom`; do not use `apply`, whose unchanged text skips

--- a/agterm/AppDelegate.swift
+++ b/agterm/AppDelegate.swift
@@ -55,7 +55,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         } else {
             NSApp.activate()
         }
-        // boot libghostty: init, config, app_new.
+        // libghostty is already booted: `SettingsModel.init` touches `GhosttyApp.shared` during App.init,
+        // before NSApp exists. This keeps the dependency explicit ahead of the re-side below.
         _ = GhosttyApp.shared
         // then re-side the config to the launch appearance, while NSApp exists and no scene has mounted —
         // a dark launch otherwise strips the env, restore replay and command off every restored surface.

--- a/agterm/AppDelegate.swift
+++ b/agterm/AppDelegate.swift
@@ -33,6 +33,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // no native window tabs: this strips AppKit's injected "Show Tab Bar" / "Show All Tabs" / "Move Tab
         // to New Window" items and the tab affordances. Must be set before any window is created.
         NSWindow.allowsAutomaticWindowTabbing = false
+        applyUITestAppearanceOverride()
         // do NOT set NSApp.applicationIconImage: the adaptive Icon Composer `AppIcon.icon` is rendered LIVE
         // per appearance (light/dark/clear/tinted, Liquid Glass), and a STATIC NSImage would freeze the Dock
         // to one flat rendering. The unseen badge draws over it via `UNUserNotificationCenter.setBadgeCount`.
@@ -56,6 +57,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         // boot libghostty: init, config, app_new.
         _ = GhosttyApp.shared
+        // then re-side the config to the launch appearance, while NSApp exists and no scene has mounted —
+        // a dark launch otherwise strips the env, restore replay and command off every restored surface.
+        GhosttyApp.shared.syncLaunchColorScheme()
         scheduleRestoredWindowReconciliation(reason: "did-finish-launching")
         // AppKit auto-adds its own "Enter Full Screen" item (Globe+F / ⌃⌘F) to the View menu and RE-INJECTS
         // it whenever the menu opens, duplicating agterm's rebindable "Toggle Full Screen" (what makes full
@@ -72,6 +76,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NotificationCenter.default.addObserver(self, selector: #selector(keymapChanged),
                                                name: .agtermKeymapChanged, object: nil)
         reconcileCloseSessionChord()
+    }
+
+    /// XCUITest-only seam: pin the LAUNCH appearance from `AGTERM_UITEST_FORCE_APPEARANCE` (`light`/`dark`).
+    ///
+    /// The dark-launch config re-siding (`GhosttyApp.syncLaunchColorScheme`) runs in
+    /// `applicationDidFinishLaunching`, so a test covering it must decide the side before that — and
+    /// XCUITest cannot: it inherits the machine's appearance, and `-AppleInterfaceStyle` would have to ride
+    /// launch ARGUMENTS, which hit FB11763863 here. `NSApp.appearance` moves `effectiveAppearance`, which is
+    /// what `currentIsDark()` reads. Ignored outside an isolated UI-test launch, like `debug.appearance`,
+    /// and exempt from the control keep-in-sync for the same reason: it is test scaffolding, not a feature.
+    private func applyUITestAppearanceOverride() {
+        guard ContentView.isUITestLaunch,
+              let side = ProcessInfo.processInfo.environment["AGTERM_UITEST_FORCE_APPEARANCE"],
+              side == "light" || side == "dark" else { return }
+        NSApp.appearance = NSAppearance(named: side == "dark" ? .darkAqua : .aqua)
     }
 
     @objc private func appDidBecomeActive(_: Notification) {

--- a/agterm/Ghostty/GhosttyApp.swift
+++ b/agterm/Ghostty/GhosttyApp.swift
@@ -152,6 +152,27 @@ final class GhosttyApp {
         ghostty_app_tick(app)
     }
 
+    /// Re-side the APP config to the launch appearance, BEFORE the first surface is created.
+    ///
+    /// `Surface.init` rebuilds a surface's config whenever the app's conditional state differs from the
+    /// config's, and that rebuild replays the config FILES only: it carries `working-directory` over and
+    /// drops the per-surface `env_vars`, `initial_input` and `command` the host set on the struct. A
+    /// host-built config always resolves LIGHT, so on a dark launch with a dual `theme = light:,dark:`
+    /// every surface created before the first re-feed spawns with no `AGTERM_*`, no restore replay and no
+    /// `session.new --command` (#260). Only the `update_config` round trip re-sides the stored app config
+    /// — after it the states match and surfaces keep what they were built with. The KVO appearance reload
+    /// does the same thing but is debounced, so it lands well after the launch restore.
+    ///
+    /// Must run where `NSApp` exists (`GhosttyApp` is built before that, so its own read is always light)
+    /// and before any scene mounts, which is why `applicationDidFinishLaunching` calls it.
+    func syncLaunchColorScheme() {
+        guard let app, Self.currentIsDark(), let config else { return }
+        ghostty_app_set_color_scheme(app, GHOSTTY_COLOR_SCHEME_DARK)
+        ghostty_app_update_config(app, config)
+        // the reply carries the config libghostty APPLIED; take and free it so the box holds no stale clone.
+        if let derived = callbacks.takeDerivedAppConfig() { ghostty_config_free(derived) }
+    }
+
     /// Set the window translucency the chrome applies. `SettingsModel` calls this and every setter below at
     /// launch and on each change; the window re-syncs on `.agtermAppearanceChanged`.
     func setWindowTranslucency(opacity: Double, blurRadius: Int) {

--- a/agtermUITests/RestoreCommandUITests.swift
+++ b/agtermUITests/RestoreCommandUITests.swift
@@ -65,6 +65,10 @@ final class RestoreCommandUITests: XCTestCase {
 
         app.launchForUITest()
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "restored session row")
+        // the assertions below pass on a LIGHT launch too (no conditional mismatch, so no surface rebuild),
+        // so confirm the forced side actually took or the test proves nothing. The bare `debug.appearance`
+        // reads `lastAppliedIsDark`, which the dark launch's own seeding reload flips — debounced, so poll.
+        XCTAssertTrue(poll { self.appliedAppearance() == "dark" }, "the launch under test must be dark")
         let probe = try XCTUnwrap(writeEnvProbe(), "the restored pane's shell should answer the env probe")
         let fields = probe.split(separator: "|", omittingEmptySubsequences: false).map(String.init)
         XCTAssertEqual(fields.first, "agterm", "a restored pane must keep agterm's TERM_PROGRAM identity")
@@ -562,14 +566,24 @@ final class RestoreCommandUITests: XCTestCase {
         try? Data(json.utf8).write(to: stateDir.appendingPathComponent("settings.json"))
     }
 
+    /// The side the app last applied, from the XCUITest-only bare `debug.appearance`, nil when unreadable.
+    private func appliedAppearance() -> String? {
+        guard let response = try? sendCommand(#"{"cmd":"debug.appearance"}"#) else { return nil }
+        return (response["result"] as? [String: Any])?["text"] as? String
+    }
+
     /// Type a probe writing the focused shell's agterm identity + session id into `envProbe`, retried like
-    /// `runTeeMarker` because a freshly realized surface's shell may not be reading yet.
+    /// `runTeeMarker` because a freshly realized surface's shell may not be reading yet. Polls the CONTENT
+    /// the caller asserts on, not the path: `> file` truncates before `printf` writes, so an existence poll
+    /// can return an empty file — and on a retry it would return the previous attempt's file instantly.
     private func writeEnvProbe() -> String? {
         for attempt in 0..<3 {
+            try? FileManager.default.removeItem(at: envProbe)
             RunLoop.current.run(until: Date().addingTimeInterval(1))
             if attempt > 0 { app.typeKey("u", modifierFlags: .control) }
             app.typeText("printf '%s|%s' \"$TERM_PROGRAM\" \"$AGTERM_SESSION_ID\" > \(envProbe.path)\n")
-            if poll({ FileManager.default.fileExists(atPath: self.envProbe.path) }, timeout: 6) {
+            if poll({ (try? String(contentsOf: self.envProbe, encoding: .utf8))?.contains("|") == true },
+                    timeout: 6) {
                 return try? String(contentsOf: envProbe, encoding: .utf8)
             }
         }

--- a/agtermUITests/RestoreCommandUITests.swift
+++ b/agtermUITests/RestoreCommandUITests.swift
@@ -12,6 +12,7 @@ final class RestoreCommandUITests: XCTestCase {
     private var marker: URL!
     private var splitMarker: URL!
     private var overrideMarker: URL!
+    private var envProbe: URL!
     private var socketPath: String!
 
     override func setUp() async throws {
@@ -22,6 +23,7 @@ final class RestoreCommandUITests: XCTestCase {
         marker = stateDir.appendingPathComponent("restore-marker")
         splitMarker = stateDir.appendingPathComponent("restore-split-marker")
         overrideMarker = stateDir.appendingPathComponent("restore-override-marker")
+        envProbe = stateDir.appendingPathComponent("env-probe")
         app = XCUIApplication()
         app.launchEnvironment["AGTERM_STATE_DIR"] = stateDir.path
         // short socket path in the runner's temp dir: under the ~104-byte sun_path limit AND inside the
@@ -48,6 +50,25 @@ final class RestoreCommandUITests: XCTestCase {
 
         XCTAssertTrue(poll { FileManager.default.fileExists(atPath: self.marker.path) },
                       "restore should re-run the captured foreground `tee` command and recreate the marker")
+    }
+
+    /// #260: on a DARK launch a conditional `theme = light:,dark:` made libghostty rebuild each surface's
+    /// config from the config files alone, dropping the injected `AGTERM_*` and agterm's `TERM_PROGRAM`
+    /// identity (and, on a restored pane, the replay). A fresh session made later was unaffected, which is
+    /// why this asserts on the RESTORED one.
+    func testDarkLaunchWithDualThemeKeepsRestoredPaneEnvironment() throws {
+        seedDualTheme()
+        app.launchEnvironment["AGTERM_UITEST_FORCE_APPEARANCE"] = "dark"
+        app.launchForUITest()
+        XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session row")
+        gracefulQuit()
+
+        app.launchForUITest()
+        XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "restored session row")
+        let probe = try XCTUnwrap(writeEnvProbe(), "the restored pane's shell should answer the env probe")
+        let fields = probe.split(separator: "|", omittingEmptySubsequences: false).map(String.init)
+        XCTAssertEqual(fields.first, "agterm", "a restored pane must keep agterm's TERM_PROGRAM identity")
+        XCTAssertFalse(fields.last?.isEmpty ?? true, "a restored pane must keep its injected AGTERM_SESSION_ID")
     }
 
     func testRestoreOffDoesNotReRun() throws {
@@ -531,6 +552,28 @@ final class RestoreCommandUITests: XCTestCase {
     private func seedRestoreFlag(_ on: Bool) {
         let json = #"{"restoreRunningCommand":\#(on)}"#
         try? Data(json.utf8).write(to: stateDir.appendingPathComponent("settings.json"))
+    }
+
+    /// Seed both theme slots + following, which makes `ghosttyConfigLines()` emit the CONDITIONAL
+    /// `theme = light:,dark:` — the config shape that triggers the surface-config rebuild.
+    private func seedDualTheme() {
+        let json = #"{"restoreRunningCommand":true,"theme":"Builtin Light","darkTheme":"agterm","#
+            + #""followSystemAppearance":true}"#
+        try? Data(json.utf8).write(to: stateDir.appendingPathComponent("settings.json"))
+    }
+
+    /// Type a probe writing the focused shell's agterm identity + session id into `envProbe`, retried like
+    /// `runTeeMarker` because a freshly realized surface's shell may not be reading yet.
+    private func writeEnvProbe() -> String? {
+        for attempt in 0..<3 {
+            RunLoop.current.run(until: Date().addingTimeInterval(1))
+            if attempt > 0 { app.typeKey("u", modifierFlags: .control) }
+            app.typeText("printf '%s|%s' \"$TERM_PROGRAM\" \"$AGTERM_SESSION_ID\" > \(envProbe.path)\n")
+            if poll({ FileManager.default.fileExists(atPath: self.envProbe.path) }, timeout: 6) {
+                return try? String(contentsOf: envProbe, encoding: .utf8)
+            }
+        }
+        return nil
     }
 
     /// Type `tee <marker>` into the focused terminal and confirm it created the marker (so it is the live


### PR DESCRIPTION
a dark launch with a conditional `theme = light:X,dark:Y` spawned every restored surface with no `AGTERM_*`, no restore replay and no `session.new --command`. Only the cwd survived.

libghostty's `Surface.init` rebuilds a surface's config whenever the app's conditional state differs from the config's, and that rebuild replays the config files alone: it carries `working-directory` over and drops the per-surface `env_vars`, `initial_input` and `command` the host set on the struct. A host-built config always resolves light, and the app scheme is set to dark before the first surface is created, so at launch the two disagree. Only an `update_config` round trip re-sides the stored app config, and the KVO appearance reload that does it is debounced until after the launch restore. Sessions created later match and were always fine, which is why this looked like a restore-specific bug.

`GhosttyApp.syncLaunchColorScheme`, called from `applicationDidFinishLaunching`, re-sides the config before any scene mounts. No patch to ghostty, `GHOSTTY_REV` unchanged.

`AGTERM_UITEST_FORCE_APPEARANCE` is an XCUITest-only seam alongside the existing `AGTERM_UITEST_*` ones, because XCUITest inherits the machine's appearance and `-AppleInterfaceStyle` would have to ride launch arguments, which hit FB11763863 here.

verified by reproducing it first: an isolated instance with both theme slots and a dark launch lost the env and the pinned restore override, the same instance with a single `theme =` line kept both. `testDarkLaunchWithDualThemeKeepsRestoredPaneEnvironment` fails with `ghostty` instead of `agterm` when the fix is reverted, and fails at its dark precondition when the appearance is forced light, so neither the test nor its guard is vacuous.

Fix #260
