### PR TITLE
fix the Toolbar Hidden hairline at the window top edge

### DIFF
--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -19,6 +19,8 @@ paths:
 - Theme slots and following are owned by the theme-picker rule. `ToolbarMode` is
   `normal|compact|hidden`, stored raw; nil defaults compact. Normal adds cwd, hidden removes titlebar and
   traffic lights but leaves an invisible roughly 3-point drag strip above the first row at padding 6.
+  Hidden also drops the title/terminal hairline both columns draw: `titlebarHeight` is 0 there, so the line
+  would sit on the window's top edge separating nothing and read as a rendering artifact.
   `effectiveToolbarMode` falls back through legacy `compactToolbar` (`false` = normal, nil/true = compact);
   writing a mode clears the legacy field.
 - Default-on nil fields are `notificationsEnabled`, `notificationBadgeEnabled`, `rightClickPaste`, and

--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -97,12 +97,6 @@ paths:
   `CGSSetWindowBackgroundBlurRadius`; absence is a no-op. `ghosttyConfigLines()` pins renderer opacity and
   blur to 0. At opacity 1, restore opaque rendering. Reduce Transparency temporarily forces opaque,
   unblurred windows/panels without changing saved settings or config.
-- In native fullscreen AppKit relocates the chrome into an `NSToolbarFullScreenWindow` child window, so the
-  window's own view tree holds no `NSTitlebarContainerView` and the whole blend is skipped.
-  Hidden toolbar mode falls back to that child, or `NSTitlebarBackgroundView` paints a hairline across the
-  top edge of the full-bleed terminal. Other modes keep AppKit's own fullscreen rendering.
-  Key the `_NSTitlebarDecorationView` suppression off the mode, never the traffic-light flag, whose
-  fullscreen carve-out would un-hide what AppKit hides there itself.
 - On macOS 26, find the wrapping `NSContainerConcentricGlassEffectView` by walking from
   `agterm-sidebar-scroll`; for translucent windows use clear style plus terminal tint. Its Liquid Glass
   blur is not pixel-identical to CGS blur. Reapply on key/main/fullscreen and appearance changes.

--- a/agterm/Views/DashboardView.swift
+++ b/agterm/Views/DashboardView.swift
@@ -31,6 +31,9 @@ struct DashboardView: View {
     let pillTextColor: Color
     /// False while a control picker is above the dashboard, so its key catcher cannot steal focus.
     let focusAllowed: Bool
+    /// Whether to restore the title-bar hairline the opaque backdrop covers. False in hidden toolbar mode,
+    /// which draws no such line and insets the overlay by nothing, so it would sit on the window's top edge.
+    let showsTopHairline: Bool
     /// A single click on a cell: the wiring flashes the active frame, then enters after a brief delay, so the
     /// click is visibly acknowledged before the grid closes.
     let onClick: (DashboardMember) -> Void
@@ -68,9 +71,11 @@ struct DashboardView: View {
         // the margins, deliberately dropping window translucency/blur. Not a black scrim — over the
         // translucent backing that read as near-black.
         .background(captionBackground)
-        // restores the hairline the opaque backdrop covers — the same 1px themed line `detailColumn` draws
-        // under the title bar.
-        .overlay(alignment: .top) { Rectangle().fill(highlightColor.opacity(0.1)).frame(height: 1) }
+        // restores the hairline the opaque backdrop covers, matching `WindowContentView.titlebarHairline`,
+        // which likewise draws nothing in hidden toolbar mode.
+        .overlay(alignment: .top) {
+            if showsTopHairline { Rectangle().fill(highlightColor.opacity(0.1)).frame(height: 1) }
+        }
         // behind the cells so it never intercepts their click hit targets.
         .background {
             DashboardKeyCatcher(

--- a/agterm/Views/DashboardView.swift
+++ b/agterm/Views/DashboardView.swift
@@ -133,7 +133,8 @@ struct DashboardView: View {
                               lineWidth: isHighlighted ? Self.highlightLineWidth : 1)
         }
         // the caption rides the cell's BOTTOM frame line: an overlay OUTSIDE the clip, so its lower half
-        // survives. Layered AFTER the ring so the frame line never crosses the name.
+        // survives. Layered after the ring, and the pill paints its own opaque backing — ordering alone
+        // leaves the ring showing through a translucent fill.
         .overlay(alignment: .bottom) {
             caption(for: member, session: session, isHighlighted: isHighlighted)
                 .offset(y: Self.captionBottomOffset)
@@ -185,7 +186,8 @@ struct DashboardView: View {
             DashboardCaptionPill(text: session.displayName + paneIndicator(for: member, session: session),
                                  indicator: session.agentIndicator, isHighlighted: isHighlighted,
                                  idleFill: pillColor, idleText: pillTextColor,
-                                 unselectedTextOpacity: Self.unselectedCaptionTextOpacity)
+                                 unselectedTextOpacity: Self.unselectedCaptionTextOpacity,
+                                 backing: captionBackground)
         }
         .padding(.horizontal, 6)
         .allowsHitTesting(false)
@@ -224,6 +226,9 @@ private struct DashboardCaptionPill: View {
     let idleFill: Color
     let idleText: Color
     let unselectedTextOpacity: Double
+    /// The opaque backing painted under the fill — the cell's own background, so a translucent fill never
+    /// lets the cell frame line show through the capsule.
+    let backing: Color
 
     /// peak opacity of the pulsing wash. Deep on purpose: on a large opaque capsule a shallow value reads as
     /// faint dimming rather than a blink (the small sidebar glyph needs less).
@@ -259,8 +264,14 @@ private struct DashboardCaptionPill: View {
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
             .background {
+                // `backing` under the fill: the idle fill falls back to a translucent wash on themes with no
+                // selection color, and the pill overhangs the cell's frame line, so a bare fill lets the
+                // highlight ring read through the capsule and cross the name.
                 Capsule()
-                    .fill(fill)
+                    .fill(backing)
+                    .overlay {
+                        Capsule().fill(fill)
+                    }
                     .overlay {
                         Capsule().fill(washColor)
                             .opacity(shouldAnimatePulse && pulsed ? Self.washPeakOpacity : 0)

--- a/agterm/Views/WindowAppearance.swift
+++ b/agterm/Views/WindowAppearance.swift
@@ -63,7 +63,8 @@ enum WindowAppearance {
         // clearing the glass keeps the color constant across key/non-key — visible only with multiple windows.
         syncSidebarBackground(in: window)
 
-        // the title/terminal separator is drawn in the detail pane, so it ends at the sidebar edge.
+        // the title/terminal separator is SwiftUI's (`WindowContentView.titlebarHairline`), drawn full width
+        // by both columns and omitted in hidden mode. Nothing below draws it.
         guard let container = titlebarContainer(in: window) else { return }
         if let titlebarView = container.firstDescendant(withClassName: "NSTitlebarView") {
             titlebarView.wantsLayer = true

--- a/agterm/Views/WindowAppearance.swift
+++ b/agterm/Views/WindowAppearance.swift
@@ -64,7 +64,7 @@ enum WindowAppearance {
         syncSidebarBackground(in: window)
 
         // the title/terminal separator is drawn in the detail pane, so it ends at the sidebar edge.
-        guard let container = titlebarContainer(in: window, toolbarMode: chrome.toolbarMode) else { return }
+        guard let container = titlebarContainer(in: window) else { return }
         if let titlebarView = container.firstDescendant(withClassName: "NSTitlebarView") {
             titlebarView.wantsLayer = true
             titlebarView.layer?.backgroundColor = NSColor.clear.cgColor
@@ -73,10 +73,9 @@ enum WindowAppearance {
         // .hiddenTitleBar doesn't hold (the XCUITest reopen path), it paints a dark strip above the header.
         container.firstDescendant(withClassName: "NSTitlebarBackgroundView")?.isHidden = true
         // hidden mode must also suppress `_NSTitlebarDecorationView` — a full-width titlebar-height sibling
-        // of NSTitlebarView painting a vibrancy material band (macOS 26). normal/compact cover it with the
-        // custom row; hidden mode collapses that row to the 3px drag strip and leaves the band bare.
-        // Keyed off the mode, never `hideButtons`, whose fullscreen carve-out would un-hide it there.
-        container.firstDescendant(withClassName: "_NSTitlebarDecorationView")?.isHidden = chrome.toolbarMode == .hidden
+        // of NSTitlebarView painting a vibrancy material band (macOS 26). tall/compact cover it with the
+        // custom row; hidden mode (traffic lights gone, row collapsed to the 3px drag strip) leaves it bare.
+        container.firstDescendant(withClassName: "_NSTitlebarDecorationView")?.isHidden = hideButtons
     }
 
     /// Keeps the sidebar see-through — opaque terminal color at full opacity, translucent tinted background
@@ -126,20 +125,8 @@ enum WindowAppearance {
         for subview in view.subviews { forceVisualEffectsActive(in: subview) }
     }
 
-    /// The `NSTitlebarContainerView` governing `window`'s chrome, falling back to the fullscreen child
-    /// window AppKit relocates it into, as `.claude/rules/settings.md` requires. The fallback is apply-only:
-    /// leaving hidden mode while still in fullscreen does not undo the suppression, because the other
-    /// modes decline the fallback and so write nothing back. Exiting fullscreen restores it.
-    private static func titlebarContainer(in window: NSWindow, toolbarMode: ToolbarMode) -> NSView? {
-        if let container = titlebarContainer(inHierarchyOf: window) { return container }
-        guard toolbarMode == .hidden, window.styleMask.contains(.fullScreen) else { return nil }
-        return window.childWindows?
-            .first { String(describing: type(of: $0)) == "NSToolbarFullScreenWindow" }
-            .flatMap(titlebarContainer(inHierarchyOf:))
-    }
-
-    /// The `NSTitlebarContainerView` inside `window`'s own root theme frame, if it hosts one.
-    private static func titlebarContainer(inHierarchyOf window: NSWindow) -> NSView? {
+    /// The `NSTitlebarContainerView` for `window`, found from the window's root theme frame.
+    private static func titlebarContainer(in window: NSWindow) -> NSView? {
         guard let contentView = window.contentView else { return nil }
         var root: NSView = contentView
         while let parent = root.superview { root = parent }

--- a/agterm/Views/WindowContentView+Dashboard.swift
+++ b/agterm/Views/WindowContentView+Dashboard.swift
@@ -110,6 +110,7 @@ extension WindowContentView {
                 pillColor: dashboardPillColor,
                 pillTextColor: dashboardPillTextColor,
                 focusAllowed: pick.pending == nil,
+                showsTopHairline: toolbarMode != .hidden,
                 onClick: { clickDashboardMember($0) },
                 onSelect: { selectDashboardMember($0) },
                 onClose: { closeDashboardFromKeyboard() }

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -266,6 +266,18 @@ struct WindowContentView: View {
         }
     }
 
+    /// The separator between the custom titlebar row and the content below it, themed (`chromeText` at low
+    /// opacity) so it stays visible on light themes. Both columns draw it so the line runs full width.
+    /// Hidden mode draws nothing: `titlebarHeight` is 0 there, so with no row above it the line would sit
+    /// on the window's top edge separating nothing, which reads as a rendering artifact (#368).
+    @ViewBuilder private var titlebarHairline: some View {
+        if toolbarMode != .hidden {
+            Rectangle()
+                .fill(chromeText.opacity(0.1))
+                .frame(height: 1)
+        }
+    }
+
     /// A plain `HStack` (sidebar + themed draggable divider + terminal) instead of `NavigationSplitView`, so
     /// macOS 26 can't impose Liquid-Glass sidebar chrome (inset panel, toggle capsule) or the toolbar style.
     @ViewBuilder private var splitRoot: some View {
@@ -305,10 +317,7 @@ struct WindowContentView: View {
 
     private var sidebarColumn: some View {
         VStack(spacing: 0) {
-            // matches the detail pane's hairline so the line runs full width under the title bar.
-            Rectangle()
-                .fill(chromeText.opacity(0.1))
-                .frame(height: 1)
+            titlebarHairline
             WorkspaceSidebar(store: store, actions: actions)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         }
@@ -388,11 +397,7 @@ struct WindowContentView: View {
 
     @ViewBuilder private var detailColumn: some View {
         VStack(spacing: 0) {
-            // hairline between the title bar and the terminal; in the detail pane so it starts at the
-            // sidebar's right edge, themed (chromeText, low opacity) so it stays visible on light themes.
-            Rectangle()
-                .fill(chromeText.opacity(0.1))
-                .frame(height: 1)
+            titlebarHairline
             detailPane
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 // the overlay renders in-deck inside `sessionDetail` (`overlayPanel`), not at this level.


### PR DESCRIPTION
the hairline in #368 is drawn by agterm, not AppKit. `sidebarColumn` and `detailColumn` each drew a 1px
`chromeText.opacity(0.1)` separator between the custom titlebar row and the content below it, and
`titlebarHeight` is 0 in hidden mode, so the line sat on the window's top edge with no row above it. 10%
`chromeText` on a dark theme is white at 10%, which composites to exactly the `#3E4147` and `#34353A` the
reporter measured.

most obvious in native fullscreen on a notched display, where the window sits below the notch and the line
separates the black band from the terminal. Both copies now come from one `titlebarHairline` that renders
nothing in hidden mode. `DashboardView` takes the same gate: it draws its own copy to restore what its opaque
backdrop covers, and `windowOverlayLayer` is inset by `titlebarHeight` as well, so it put the line back at the
top edge whenever the dashboard opened.

**also reverts e962e84.** That commit redirected the titlebar lookup into the `NSToolbarFullScreenWindow`
child to suppress a hairline it attributed to `NSTitlebarBackgroundView`, so it could never have worked. Its
lookup also raced the child window's creation: instrumenting the view hierarchy shows the child does not exist
when `sync` runs one main-queue hop after `didEnterFullScreen`, and nothing re-applies afterwards. When it won
that race it hid the reveal strip's background, which is why the reporter saw the traffic lights drawn over
the first sidebar row with no strip behind them.

verified by eye in an isolated fullscreen instance with Toolbar hidden: line gone, traffic lights back on a
normal strip, and the dashboard's own top edge clean. SwiftUI views do not render in hosted tests, so there is
no unit coverage for either path.

Fix #368
