### PR TITLE
cookbook: annotate-claude-replies keeps revdiff file-level notes instead of dropping them

### DIFF
--- a/cookbook/annotate-claude-replies/annotate-render.py
+++ b/cookbook/annotate-claude-replies/annotate-render.py
@@ -17,6 +17,9 @@ import sys
 from pathlib import Path
 
 HEADER = re.compile(r"^##\s+(?P<file>.+?):(?P<start>\d+)(?:-(?P<end>\d+))?\s+\((?P<kind>[^)]*)\)\s*$")
+# A file-level note (`A` in revdiff) carries no line part: `## <file> (file-level)`. It lands on
+# the whole reply set, so it renders without a quoted source line or a section attribution.
+FILE_HEADER = re.compile(r"^##\s+(?P<file>.+?)\s+\(file-level\)\s*$")
 
 
 def parse(raw: str) -> list[dict]:
@@ -29,6 +32,16 @@ def parse(raw: str) -> list[dict]:
                 "file": Path(match.group("file")).name,
                 "start": int(match.group("start")),
                 "end": int(match.group("end") or match.group("start")),
+                "body": [],
+            }
+            notes.append(current)
+            continue
+        fmatch = FILE_HEADER.match(line)
+        if fmatch:
+            current = {
+                "file": Path(fmatch.group("file")).name,
+                "start": None,
+                "end": None,
                 "body": [],
             }
             notes.append(current)
@@ -61,6 +74,12 @@ def render(notes: list[dict], sources: dict[str, list[str]], sections: list[dict
         "",
     ]
     for index, note in enumerate(notes, start=1):
+        if note["start"] is None:
+            out.append(f"## Note {index} — on the whole reply set")
+            out.append("")
+            out.append(note["body"])
+            out.append("")
+            continue
         start, end = note["start"], note["end"]
         span = f"line {start}" if start == end else f"lines {start}-{end}"
         where = section_for(start, sections)


### PR DESCRIPTION
`annotate-render.py` parses revdiff's output with a header regex that requires a `:line` part, but a file-level note — `A` in revdiff, stored at the top of the diff — is emitted without one (revdiff's own "Output Format" docs show `## handler.go (file-level)`):

```
## /var/folders/.../support.md (file-level)
то ти legacy workflow додав, як я розумію?
```

Two failure modes follow:

- mixed with line notes, the file-level note's header matches nothing, so its lines belong to no note and vanish from `notes.md` — the reply the agent gets is quietly missing one of the notes;
- when it is the **only** annotation, `parse` finds nothing, the render exits on the "no annotations" path, and the whole interaction ends with nothing sent — annotate, quit, and the note is gone.

Hit both in real use on the first day of running the recipe.

The fix adds a second header regex for the file-level form and renders such a note as "on the whole reply set", with no quoted source line and no section attribution — it points at the whole file, so there is nothing narrower to quote. Line-note parsing is untouched: the new regex only matches the literal `(file-level)` kind, which a line header never carries.

Tested against the real `notes.raw` that lost the note (one file-level + two line notes: all three render, emitted order preserved) and against a raw file holding only a file-level note (previously "nothing to send", now one note goes back).
