### PR TITLE
fix: cap the substring band under the subsequence floor (#371)

### DIFF
--- a/agtermCore/Sources/agtermCore/Fuzzy.swift
+++ b/agtermCore/Sources/agtermCore/Fuzzy.swift
@@ -2,8 +2,10 @@
 /// The query splits on whitespace into terms (`"cap dev"` is two); EVERY term must match `target` and the
 /// score is their sum, so term order is irrelevant — `"cap dev"` and `"dev cap"` both match `caprica-dev`.
 /// An empty or whitespace-only query matches everything at `0`, keeping the unfiltered list's natural
-/// order. Case-insensitive. Per term: an exact prefix is `0`, a substring `5 +` its start offset, a
-/// scattered subsequence `40 +` the length gap.
+/// order. Case-insensitive. Per term: an exact prefix is `0`, a substring `5 + min(offset, 34)`, a
+/// scattered subsequence `40 +` the length gap. The cap keeps a single term's literal match (`39` at
+/// worst) ahead of any subsequence-only match; substrings starting at or past offset `34` tie and fall
+/// to the caller's tie-break. Summed multi-term scores can still cross bands.
 public func fuzzyScore(query: String, target: String) -> Int? {
     let terms = query.lowercased().split(whereSeparator: \.isWhitespace).map(String.init)
     guard !terms.isEmpty else { return 0 }
@@ -41,7 +43,8 @@ public func fuzzyRank<Item>(query: String, items: [Item], keys: (Item) -> [Strin
 private func termScore(_ term: String, in target: String) -> Int? {
     if target.hasPrefix(term) { return 0 }
     if let range = target.range(of: term) {
-        return 5 + target.distance(from: target.startIndex, to: range.lowerBound)
+        // 39 max — the substring band must stay under the subsequence floor of 40.
+        return 5 + min(target.distance(from: target.startIndex, to: range.lowerBound), 34)
     }
     // subsequence: every term char appears in order, not necessarily adjacent.
     var ti = term.startIndex

--- a/agtermCore/Tests/agtermCoreTests/FuzzyTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/FuzzyTests.swift
@@ -30,6 +30,21 @@ struct FuzzyTests {
         #expect(fuzzyScore(query: "xyz", target: "New Session") == nil)
     }
 
+    @Test func substringInOneTargetRanksAboveSubsequenceInAnother() {
+        // Regression for #371: unclamped, the literal "stem" at offset 43 scored 48 and ranked
+        // below /opt/steam's scattered subsequence at 46 — a real match lost to a non-match.
+        let stems = "~/Music/Ableton/Exports/2026/album/bounces/stems"
+
+        #expect(fuzzyRank(query: "stem", items: ["/opt/steam", stems], keys: { [$0] })
+            == [stems, "/opt/steam"])
+    }
+
+    @Test func substringBandCapsAtThirtyNine() {
+        // Substrings starting at or past offset 34 tie at 39, under the subsequence floor of 40.
+        #expect(fuzzyScore(query: "z", target: String(repeating: "a", count: 40) + "z") == 39)
+        #expect(fuzzyScore(query: "z", target: String(repeating: "a", count: 80) + "z") == 39)
+    }
+
     @Test func prefixBeatsSubstringBeatsSubsequence() {
         let prefix = fuzzyScore(query: "ne", target: "New Session")!
         let substring = fuzzyScore(query: "ew", target: "New Session")!


### PR DESCRIPTION
Fixes #371.

`termScore`'s substring band was unbounded (`5 + offset`), so a literal substring in a long target could score past the subsequence floor of 40 and rank below a scattered match on another row. Clamped to `5 + min(offset, 34)` as discussed — a substring now lands at 39 at worst, under any subsequence score.

Per your notes on the issue: the `fuzzyScore` doc comment now states the cap, the tie at 39 for substrings starting at or past offset 34 (falling to the caller's tie-break), and scopes the guarantee per term — summed multi-term scores can still cross bands, and the doc no longer implies otherwise.

Two tests: the cross-target regression drives `fuzzyRank` with the probe pair from the report (`/opt/steam` against a literal `stem` at offset 43) and asserts the ranking — unclamped it fails with the report's exact 48-vs-46 scores; a second test pins the 39 tie for deep offsets.

Full suite (2405 tests) + `make lint` strict green.