### PR TITLE
docs(cookbook): add the kimi-session-resume recipe

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -19,6 +19,7 @@ Recipes come from other people as well as the maintainer. Every one is reviewed 
 | [claude-session-resume](claude-session-resume/) | each tab reopens its own Claude Code conversation after a restart | 0.3.1, zsh or fish, Claude Code |
 | [codex-session-resume](codex-session-resume/) | each tab reopens its own codex conversation after a restart | 0.3.1, zsh, Codex CLI |
 | [opencode-session-resume](opencode-session-resume/) | each tab reopens its own opencode conversation after a restart | 0.3.1, zsh, opencode |
+| [kimi-session-resume](kimi-session-resume/) | each tab reopens its own Kimi Code conversation after a restart | 0.16.0, Kimi Code, python3 |
 | [kimi-agent-status](kimi-agent-status/) | Kimi Code sessions report agent status onto their sidebar row | 0.3.1, Kimi Code |
 | [claude-recap](claude-recap/) | one key lists what the Claude Code run in a session was working on | 0.10.0, zsh, jq, Claude Code |
 | [new-session-in-workspace](new-session-in-workspace/) | pick a workspace with fzf and start a session in it | 0.8.0, jq, fzf |
@@ -28,7 +29,7 @@ Recipes come from other people as well as the maintainer. Every one is reviewed 
 | [claude-clear](claude-clear/) | one chord sends /clear to the pane's Claude Code run, and nothing when it is not running | 0.13.0, python3, Claude Code |
 | [claude-conversation-picker](claude-conversation-picker/) | pick a past Claude Code conversation by what it was about and resume it in the pane | 0.21.0, python3, Claude Code |
 
-Most recipes need `agtermctl` on your PATH; **Help ▸ Install Command Line Tool…** puts it there. The three session-resume recipes are shell functions that read the environment agterm gives a session and never call the CLI. Some recipes also need `jq`, `fzf`, or a particular shell, and each recipe's *Requirements* section says which, along with the minimum agterm version it needs. Recipes are snapshots rather than a maintained surface: the control API grows by addition, so they rarely break, and one that does gets fixed when it is reported.
+Most recipes need `agtermctl` on your PATH; **Help ▸ Install Command Line Tool…** puts it there. Three of the four session-resume recipes are shell functions that read the environment agterm gives a session and never call the CLI; the Kimi one is a lifecycle hook that pins its tab's restore command through `agtermctl`. Some recipes also need `jq`, `fzf`, or a particular shell, and each recipe's *Requirements* section says which, along with the minimum agterm version it needs. Recipes are snapshots rather than a maintained surface: the control API grows by addition, so they rarely break, and one that does gets fixed when it is reported.
 
 ## Contributing a recipe
 

--- a/cookbook/kimi-session-resume/README.md
+++ b/cookbook/kimi-session-resume/README.md
@@ -1,0 +1,61 @@
+# Kimi Code per-tab session resume
+
+After a restart each tab reopens its own Kimi Code conversation instead of a fresh one.
+
+## What it does
+
+Same idea as the other session-resume recipes: each tab reopens its own conversation after a restart.
+
+The mechanism differs from all of them. Kimi Code has lifecycle hooks of its own (`[[hooks]]` in `~/.kimi-code/config.toml`), and its SessionStart hook receives the new conversation's `session_id` on stdin — so instead of a shell function wrapping the launch, a hook script pins the tab's restore command directly with `agtermctl session restore "kimi -r <id>"`. No mapping file, no wrapper: the pin is rewritten on every kimi start, so it always points at the tab's current conversation, and `kimi` itself is never shadowed.
+
+The hook also carries the `-m` model flag of the running kimi process into the pinned command, so a session launched against a specific model route resumes on the same one. The pinned line is shell code, so a model name outside a safe character set is dropped rather than quoted in.
+
+## Requirements
+
+- agterm 0.16.0 or later (`session restore` with `--pane-id` and the sticky per-pane override shipped in 0.16.0), with **Restore running commands on restart** turned on under Settings ▸ General ▸ Sessions.
+- Kimi Code with `[[hooks]]` support in `~/.kimi-code/config.toml` (SessionStart event delivering JSON on stdin; tested on kimi-code 0.31.0).
+- `python3` (ships with macOS command line tools) for the one-line JSON read.
+
+## Setup
+
+Copy the script somewhere stable and make it executable:
+
+```sh
+mkdir -p ~/bin
+cp kimi-pin-resume.sh ~/bin/
+chmod +x ~/bin/kimi-pin-resume.sh
+```
+
+Add the hook to `~/.kimi-code/config.toml`:
+
+```toml
+[[hooks]]
+event = "SessionStart"
+command = "$HOME/bin/kimi-pin-resume.sh"
+```
+
+Turn on **Restore running commands on restart** in Settings ▸ General, under Sessions.
+
+To remove it, delete the `[[hooks]]` block and the script.
+
+## Usage
+
+Run `kimi` the way you always do. Every start (and every resume) re-pins the tab to that conversation; after agterm restarts, the tab relaunches `kimi -r <that conversation>`.
+
+To detach a tab from its conversation, run `agtermctl session restore --clear` in it, or just start a new `kimi` — the pin follows the newest start.
+
+## How it works
+
+Kimi's SessionStart hook fires with `{"session_id": "session_…", …}` on stdin inside the session's shell environment, where agterm's `AGTERM_SESSION_ID`, `AGTERM_PANE_ID`, and `AGTERM_SOCKET` are already exported. The script reads the id, walks up the process tree to find the owning `kimi` process and lift its `-m` flag, and writes the pane's restore override over the control socket. agterm consumes the override on the next launch — it never touches the running session.
+
+The gotcha that matters in agent setups: a kimi run spawned *by* another agent (a Claude Code session driving kimi as a worker) fires the same hook in the same pane, and would steal the pane's pin from the conversation that actually owns it. The script detects that case via `CLAUDE_CODE_SESSION_ID` in the environment and skips the pin.
+
+## Limits
+
+Nothing destructive: the script only writes a restore override; it never closes sessions or touches kimi state.
+
+- The pin is sticky and follows the *newest* kimi start in the tab. If you run a quick throwaway `kimi -p "…"` in a tab that hosts a long-lived conversation, the throwaway becomes the pin. Restart kimi on the conversation you care about (or `session restore --clear`) to fix it.
+- The restore override is one slot per pane, shared with anything else that sets one — a pin you set by hand in that tab is overwritten on the next kimi start.
+- Inside the scratch terminal the hook is a silent no-op: the scratch terminal is never restored, and `session restore` rejects its pane id.
+- The child-session guard only knows Claude Code (`CLAUDE_CODE_SESSION_ID`). A kimi worker spawned by some other orchestrator will still take the pin.
+- The pinned command is stored in the window's state file in plain text, like every restore override; it carries only the session id and model name.

--- a/cookbook/kimi-session-resume/kimi-pin-resume.sh
+++ b/cookbook/kimi-session-resume/kimi-pin-resume.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# kimi-code SessionStart hook: pin this agterm tab's restore command to
+# `kimi -r <session_id>`, so restoring the terminal resumes the tab's own
+# conversation. Installed via a [[hooks]] block in ~/.kimi-code/config.toml;
+# see README.md. Outside agterm it is a silent no-op.
+
+[ -n "$AGTERM_SESSION_ID" ] || exit 0
+[ -n "$AGTERM_SOCKET" ] || exit 0
+
+# A kimi run spawned by a Claude Code session (a worker inside an agent
+# pipeline) shares the pane with its parent: the pane's pin belongs to the
+# Claude conversation, not the child. Skip those.
+[ -n "$CLAUDE_CODE_SESSION_ID" ] && exit 0
+
+AGTERMCTL=${AGTERMCTL:-agtermctl}
+command -v "$AGTERMCTL" >/dev/null 2>&1 || exit 0
+
+# kimi hooks deliver JSON on stdin; SessionStart carries the session id.
+session_id=$(python3 -c 'import sys,json;print(json.load(sys.stdin).get("session_id",""))' 2>/dev/null)
+[ -n "$session_id" ] || exit 0
+
+# Carry the -m model flag of the owning kimi process into the resume, so a
+# lane launched against a specific route comes back on the same one. Hooks
+# run under an intermediate shell, so walk up the process tree to find it.
+flags=""
+pid=$$
+for _ in 1 2 3 4 5 6; do
+  pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+  { [ -n "$pid" ] && [ "$pid" -gt 1 ]; } 2>/dev/null || break
+  parent_cmd=$(ps -o command= -p "$pid" 2>/dev/null)
+  case "$parent_cmd" in
+    kimi\ *|*/kimi\ *|kimi-code*|*/kimi-code*)
+      # First standalone -m token. The value lands in shell code (the pinned
+      # restore line), so anything outside a safe charset is dropped, not quoted.
+      model=$(printf '%s' "$parent_cmd" |
+        awk '{for (i = 1; i < NF; i++) if ($i == "-m") { print $(i + 1); exit }}')
+      case $model in
+        *[!A-Za-z0-9._:@/-]*) ;;
+        ?*) flags=" -m $model";;
+      esac
+      break;;
+  esac
+done
+
+pane_flag=""
+[ -n "$AGTERM_PANE_ID" ] && pane_flag="--pane-id $AGTERM_PANE_ID"
+
+# shellcheck disable=SC2086  # pane_flag is deliberately word-split
+"$AGTERMCTL" session restore "kimi${flags} -r $session_id" \
+  --target "$AGTERM_SESSION_ID" $pane_flag \
+  --socket "$AGTERM_SOCKET" >/dev/null 2>&1 || true
+exit 0


### PR DESCRIPTION
Adds the missing member of the session-resume family: each tab reopens its own Kimi Code conversation after a restart.

The mechanism differs from the three existing recipes. Kimi Code has lifecycle hooks of its own, and its SessionStart hook receives the new conversation's `session_id` on stdin — so instead of a shell function wrapping the launch, a hook script pins the tab's restore command with `agtermctl session restore "kimi -r <id>"`. No wrapper, no mapping file, `kimi` itself is never shadowed; the pin is rewritten on every start, so it always points at the tab's current conversation. That makes the index sentence about session-resume recipes never calling the CLI wrong by one — reworded to scope it to the three shell-function ones.

The script guards the agent-pipeline case — a kimi worker spawned by a Claude Code session in the same pane would steal the pane's pin from the conversation that owns it, detected via `CLAUDE_CODE_SESSION_ID` and skipped — and carries the owning process's `-m` model flag into the pinned line, validated against a safe character set rather than quoted, since the pinned line is shell code.

Floor is 0.16.0: `session restore` including `--pane-id` and the sticky per-pane override shipped there (#271). Tested on kimi-code 0.31.0. The committed script is the sanitized twin of the copy that has been driving my own sessions.

shellcheck clean; the cookbook layout/index/headings check passes locally.