### PR TITLE
cookbook: add keymap-cheatsheet recipe, a shortcut sheet kept in sync with keymap.conf

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -47,6 +47,7 @@ its *needs* column, so searching this page for `claude` or `kiro` finds those di
 |---|---|---|
 | [flagged-dashboard](flagged-dashboard/) | grid the flagged panes that are running something, one chord to show and dismiss | 0.20.0, jq |
 | [fzf-path-picker](fzf-path-picker/) | pick a path with fzf and type it into the shell | 0.8.0, fzf, fd, zsh |
+| [keymap-cheatsheet](keymap-cheatsheet/) | your own shortcut sheet in an overlay, and a drafted row for every chord you bound but never wrote down | >0.21.0, python3, glow, Claude Code |
 | [native-dir-picker](native-dir-picker/) | pick a directory in the native picker and type it into the shell | 0.19.0, fd, jq |
 | [overlay-and-split](overlay-and-split/) | keymap lines: a stateful split toggle and TUI overlays | 0.10.0, jq |
 | [same-dir](same-dir/) | sync working directory to target split pane | 0.10.0, jq, zsh |

--- a/cookbook/keymap-cheatsheet/README.md
+++ b/cookbook/keymap-cheatsheet/README.md
@@ -1,0 +1,135 @@
+# Keymap cheat sheet
+
+One chord shows your own keyboard cheat sheet in an overlay, and a chord you bound but never wrote down gets a drafted row before the sheet opens.
+
+## What it does
+
+Press the chord and the sheet you wrote about your own keymap renders over the session, in a floating overlay. `q` closes it.
+
+The sheet is a markdown file you write and keep, not generated output. That is the point: an action name says what the code does, and the thing you forget is why you reach for a chord. `previous_attention_session` does not tell you that the chord walks the sessions waiting on you and skips the ones still working. A sentence you wrote does.
+
+So a sentence you wrote is never rewritten. What the recipe does instead, on the press after you bind something new, is draft a row for the chord the sheet has never heard of and append it to a holding section at the end. You move it into the right table and put it in your own words. The chord is documented from the moment it is bound rather than whenever you next remember.
+
+One case does write inside your tables, and only one: a chord that keeps its key and changes its command leaves a row naming the right chord and describing the wrong thing. If the words in it are still the model's, they are replaced with a fresh description. If you have rewritten that cell yourself, it is left alone and named in a banner instead.
+
+A progress panel sits over the session while the model is out, so a press that takes three seconds does not look like a press that did nothing.
+
+With no model available, or with drafting turned off, the sheet still opens and a banner above it names what is undocumented:
+
+```
+> This sheet has drifted from keymap.conf.
+>
+> Bound but not documented: cmd+ctrl+m, cmd+ctrl+shift+m
+```
+
+With no sheet at all, the first run writes the whole thing: every bound chord, described and grouped into sections by the model, in about fifteen seconds behind the progress panel. That is the one time it writes a whole file, because there is nothing to preserve yet. With no model available the first sheet is a plain table of chord and action name instead.
+
+## Requirements
+
+- agterm > 0.21.0, for the `PATH` a custom command is spawned with. The fix is `babc760`, on master and unreleased as this is written, so put the real number here when it ships. Up to and including 0.21.0 the runner handed a custom command launchd's own `PATH` — `/usr/bin:/bin:/usr/sbin:/sbin` — and a bare `agtermctl` exited 127 with nothing on screen (#393). This recipe relies on the fix rather than working around it, which is what keeps the opener free of hardcoded directories. `session hud`, the progress panel over a model call, needs 0.21.0; `session overlay open --follow` and `--size-percent` are 0.8.0.
+- Python 3.7 or later, which every supported macOS ships. Standard library only.
+- [glow](https://github.com/charmbracelet/glow), to render the markdown. Not found, and the overlay falls back to `less -R` and raw markdown rather than failing. `AGTERM_CHEATSHEET_PAGER='less -R'` drops the dependency deliberately.
+- [Claude Code](https://github.com/anthropics/claude-code), for the drafting. Optional in the sense that everything else works without it: with no `claude` found, the recipe falls back to the drift banner, silently and with no delay. Nothing else here calls a model.
+
+`AGTERMCTL`, `CLAUDE_BIN` and `PYTHON` take an absolute path for a binary in a prefix the runner's `PATH` does not reach.
+
+## Setup
+
+Copy the three files somewhere on your machine, say `~/.local/bin/agterm-cheatsheet/`, and make them executable:
+
+```sh
+chmod +x keymap-cheatsheet.sh render-cheatsheet.sh cheatsheet.py
+```
+
+The two helpers must sit **beside** `keymap-cheatsheet.sh`; it looks for both in its own directory.
+
+Add the keybinding to `~/.config/agterm/keymap.conf` and apply it with File ▸ Reload Keymap or `agtermctl keymap reload`:
+
+```
+command "Cheat sheet"  cmd+ctrl+shift+/  ~/.local/bin/agterm-cheatsheet/keymap-cheatsheet.sh "{AGT_SESSION_ID}"
+```
+
+Pick a chord that is free in your own keymap. A custom command cannot shadow a built-in, so one that collides is quietly demoted to palette-only and the chord appears to do nothing. On 0.19.0 and later `agtermctl keymap list` shows what every chord resolved to. Either way the command is reachable by name from the action palette, which is the quickest way to tell a bad chord from a broken script.
+
+Press it once. With no sheet at `~/.config/agterm/SHORTCUTS.md` the first press writes one and shows it, so the overlay comes up with your real chords already described. Then edit it into something worth reading — it is yours from that moment and nothing regenerates it.
+
+Settings, read from the environment. Put them in front of the script in the keymap line, or change the defaults at the top of the scripts — a keymap change needs a reload before it takes effect, an edit to a script does not:
+
+The first four are forwarded into the overlay on its command line, because an overlay program is spawned from the app's environment and an exported variable would not reach it. The rest are read before the overlay opens.
+
+- `AGTERM_CHEATSHEET` is the sheet, `~/.config/agterm/SHORTCUTS.md` by default.
+- `AGTERM_KEYMAP` is the file the chords are read from, `~/.config/agterm/keymap.conf` by default. `AGTERM_CONFIG_DIR` moves both at once.
+- `AGTERM_CHEATSHEET_DRAFT=0` turns the model off. The banner is then the whole mechanism.
+- `AGTERM_CHEATSHEET_MODEL` is the model, `claude-haiku-4-5-20251001` by default. Write the full id: the short `haiku` alias is not recognized here and falls back to the default model, which is a slower and dearer way to write one table row.
+- `AGTERM_CHEATSHEET_TIMEOUT` is how long the model gets, 45 seconds by default. On expiry the call is killed and the banner takes over.
+- `AGTERM_CHEATSHEET_STAMP` is where the last-checked marker lives, under `~/.cache/agterm/` by default.
+- `AGTERM_CHEATSHEET_PAGER` replaces `glow -p -`, and `AGTERM_CHEATSHEET_SIZE` is the overlay size in percent, 90 by default.
+
+## Usage
+
+Press the chord. Read. Press `q`.
+
+After you bind something new, the next press takes a few seconds and comes back with a row for it at the end of the sheet. Move that row into the table it belongs in and rewrite it. The draft is a placeholder that keeps the chord from being forgotten, not the final wording — a model can read `next_attention_session` and the script it calls, and it cannot know why *you* bound it.
+
+## How it works
+
+The keymap line runs `keymap-cheatsheet.sh`, which does two things in order: a maintenance pass, then the overlay.
+
+The maintenance pass runs **before** the overlay opens, and that is forced rather than chosen. A session has one overlay slot, and the progress panel and the cheat sheet overlay both want it, so a panel posted from inside the overlay would have nowhere to go. Running the pass from the custom command also means it has `{AGT_SESSION_ID}` and `AGT_SOCKET` in its environment, which the panel needs to address the session.
+
+The gate is two stages, because a press that needs nothing has to cost nothing:
+
+1. Compare `keymap.conf`'s modification time against a stamp file. Unchanged, and the pass returns immediately — one `stat`, about 40ms including python startup. This is every press but a handful.
+2. Changed, so compare the chord sets. Every chord bound in `keymap.conf` has to appear somewhere in the sheet. Nothing missing — a comment edit, a chord you already documented — and the stamp moves forward with no model call.
+
+Only a chord the sheet has never mentioned reaches the model. It gets the keymap lines themselves, not just the chords, so it can read the action name and the script path. It answers against a JSON schema, and the rows are appended under a `## Recently bound, drafted` heading at the end of the sheet.
+
+The first run is the exception: every binding goes in one call, and the schema asks for a section per row as well as a description, so the sheet arrives grouped rather than as one long table. A long answer can quietly come back one row short, so any chord the model skipped is added afterwards with the label the mechanical starter would have used.
+
+Appending, rather than inserting into the right section, is deliberate. Cheat sheets are hand-arranged: the one this was written for pairs two related chords per row across four columns. A generic inserter aiming for the right table would eventually corrupt the thing it is trying to keep current. A holding section at the end is a worse-looking sheet and a safe one.
+
+Everything about the model call fails soft. No `claude` found, a non-zero exit, a timeout, unparseable output, or an answer naming a chord nobody asked about — each returns nothing, the stamp is left alone so the next press tries again, and the sheet opens with the banner. The sheet is written through a temp file and renamed, so a killed run cannot leave you with half of one.
+
+A partial answer is the one case that does not retry: three chords missing and one row back means that row is appended and the stamp moves on, so the other two wait for the next keymap edit. The banner keeps naming them in the meantime. Retrying instead would mean a model call on every press for as long as the model refuses to describe one particular chord, which is the worse failure.
+
+Neither script hardcodes a `PATH`, and the two halves get there differently.
+
+The opener is a custom command, so the runner hands it a `PATH` carrying the bundled `agtermctl`, `/usr/local/bin` and `/opt/homebrew/bin`. That is why *Requirements* starts at the release with that fix: an earlier build gives a custom command launchd's bare `PATH`, and a bare `agtermctl` exits 127 with nothing on screen.
+
+The overlay half is not covered by that fix and never will be, because an overlay program is launched by the terminal rather than by the custom command. It gets the app's own `PATH` and nothing the opener exported, so it can resolve neither `glow` nor `python3` for itself.
+
+The answer is not to guess a prefix inside the overlay script, and not to run the reader's shell profile to find one. The opener already has a working `PATH`, so it resolves both and passes them across as absolute paths on the command line, which is the only channel into an overlay. The overlay's command string is `eval`ed by `sh` on the other side, so each word is single-quoted going in; a path containing a single quote is the one case that does not survive. If `glow` is not there, the opener sends `/usr/bin/less -R` instead: raw markdown, but visible, where a failed pipeline would close the overlay at once and look exactly like a chord that never fired.
+
+There are two scripts rather than one because agterm spawns the overlay program itself. Nothing the opener exports reaches it, so the second script takes everything it needs as arguments — which is also why it has no environment override for the sheet script: one set in the opener would never arrive.
+
+The drift check reads `keymap.conf` for two line shapes: `map <chord> <action>`, and `command "<name>" <chord> <shell...>` where the chord is optional. A command with no chord is palette-only and has nothing to document, and requiring a modifier prefix on that second capture is what separates the two cases, since the shell word after a chordless command never begins with `ctrl+`, `cmd+`, `opt+` or `shift+`. Each chord is then looked for in the sheet with its markdown intact. Stripping the backticks first is the obvious move and it breaks the one chord whose key is a backtick, which would shrink to a bare `cmd+ctrl+` and match almost any row. Written either way — `` `cmd+ctrl+j` `` or ```` ``cmd+ctrl+` `` ```` — the row contains the chord as a literal substring, and the boundary rule does the rest.
+
+A chord can also stay bound while its binding changes underneath it, which leaves a row naming the right chord and describing the wrong thing. The chord-set check cannot see that, so a second file beside the stamp records what each chord was bound to as of the last time the sheet was current. A documented chord whose keymap line has changed since is named in a banner of its own — it says the row is suspect and leaves the sentence to you, like everything else here.
+
+That check needs no acknowledgement. It compares against the sheet's own modification time: edit the sheet and every chord is taken as described correctly again, leave it and the same chords are named on every press until you do.
+
+Only one direction is checked. The reverse — the sheet naming a chord that is no longer bound — is almost entirely deliberate: the macOS chords you did not touch, the reserved ones, the ones a sheet lists as freed. Flagging those buries the real finding in noise.
+
+## Limits
+
+A new chord costs one model call on the next press, a few seconds with the default model, and so does a rebound chord whose row the recipe owns. A press that follows neither never calls a model, and a row left for you to reword never calls one again. Set `AGTERM_CHEATSHEET_DRAFT=0` if you would rather it never did.
+
+Drafted rows land in a holding section at the end, not in the table where they belong. Filing them is yours to do, and until you do, the sheet has a slightly untidy tail.
+
+The drafted wording is a first pass written from the action name and the script path. It is usually right about what the binding does and it cannot be right about why you wanted it.
+
+**One case writes inside your own tables.** A chord that keeps its key and changes its command has its description replaced, and only when the words there are still the model's — proved by the row sitting in the holding section, or by the cell matching what was recorded when the model wrote it. A cell you have reworded is never touched; it is named in a banner and left for you. Nothing else is ever rewritten: new rows are appended, and an existing sheet is never replaced by a generated one.
+
+Writes go to `~/.config/agterm/SHORTCUTS.md` and to two small files under `~/.cache/agterm/` — the stamp and the record of what each chord was bound to — creating both directories if needed. Each write goes through a `.tmp` sibling that exists for the length of the write and is renamed over the target, carrying the original's permission bits. Shelling out to `claude` also lets that tool keep its own state under `~/.claude/`, which is not this recipe's doing but is not nothing either. No session, workspace or window is closed or changed: the only control commands here are `session hud open|update|close` and `session overlay open`.
+
+A drafted row is one line the model wrote, put into a table in your file, so its text is flattened to a single line and any `|` in it is escaped. Without that, one stray pipe splits the row into extra columns and one stray newline ends the table and leaves the rest of your sheet as loose prose — neither repairable by hand without knowing what the file looked like before.
+
+A chord counts as documented when it appears in a **table row**, and only there. Two rules make that work, and both come from a sheet in daily use.
+
+A chord is matched as a whole chord rather than as a substring, so `cmd+ctrl+shift+s` is not satisfied by a row documenting `cmd+ctrl+shift+space`.
+
+And prose does not count. A sheet says two different things about a chord: "this is what it does", which is an entry, and "this one is still free", which is a note. Both name the chord, so searching the whole file lets the second stand in for the first — and a "still free" line written a year ago then hides a chord someone bound last month. Searching the tables only is what separates them. A sheet with no table at all falls back to the whole text, since reporting every chord as missing helps nobody who writes in paragraphs.
+
+Leader chords like `ctrl+a>a` are matched the same way and work, as long as the sheet writes them exactly as `keymap.conf` does. A custom command bound to a chord with no modifier, which agterm accepts, is not read as a binding here and so is never documented or reported.
+
+The sheet is markdown, and glow renders it. A table wider than the overlay wraps badly rather than scrolling, so keep the right-hand column to a line. `AGTERM_CHEATSHEET_SIZE=100` buys some width back.

--- a/cookbook/keymap-cheatsheet/cheatsheet.py
+++ b/cookbook/keymap-cheatsheet/cheatsheet.py
@@ -1,0 +1,692 @@
+#!/usr/bin/env python3
+"""The keyboard cheat sheet: keep it level with keymap.conf, then print it.
+
+Two modes. `--sync` is the maintenance pass, run by the custom command before the
+overlay opens. With no arguments the sheet goes to stdout, which is what runs
+inside the overlay.
+
+The sheet is hand-written, because what a chord is *for* is not in its action
+name: `previous_attention_session` says what the code does, not that the chord
+walks the sessions waiting on you and skips the ones still working. So nothing
+here rewrites the sheet. The maintenance pass only ever appends a row for a
+chord the sheet has no line about at all, and a model drafts that row so the
+chord is documented from the moment it is bound rather than whenever you next
+remember.
+
+The gate is two-stage on purpose. The modification time is cheap and wrong on
+its own: a comment edit in keymap.conf moves it, and it says nothing about which
+chords changed. So the timestamp decides whether to look, and the chord set
+decides whether to act. A press that follows no keymap change costs one stat.
+"""
+
+import json
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+CONFIG = pathlib.Path(
+    os.environ.get("AGTERM_CONFIG_DIR") or pathlib.Path.home() / ".config/agterm"
+)
+KEYMAP = pathlib.Path(os.environ.get("AGTERM_KEYMAP") or CONFIG / "keymap.conf")
+SHEET = pathlib.Path(os.environ.get("AGTERM_CHEATSHEET") or CONFIG / "SHORTCUTS.md")
+STAMP = pathlib.Path(
+    os.environ.get("AGTERM_CHEATSHEET_STAMP")
+    or pathlib.Path.home() / ".cache/agterm/keymap-cheatsheet/stamp"
+)
+
+# Beside the stamp: chord -> the keymap line that bound it, as of the last time the sheet
+# was current. What the chord-set check cannot see is a chord that stayed bound while its
+# binding changed underneath, which leaves a row that names the right chord and describes
+# the wrong thing.
+BINDINGS = STAMP.with_name("bindings.json")
+
+AGTERMCTL = os.environ.get("AGTERMCTL") or "agtermctl"
+# Resolved rather than assumed, because this decides whether drafting happens at all:
+# an unresolvable name has to mean "fall back to the banner", not "fail mid-press".
+CLAUDE_BIN = os.environ.get("CLAUDE_BIN") or shutil.which("claude") or ""
+# The full id, not the "haiku" alias: the alias is not recognized here and falls back
+# to the default model, which is a slower and dearer way to write one table row.
+MODEL = os.environ.get("AGTERM_CHEATSHEET_MODEL", "claude-haiku-4-5-20251001")
+DRAFT = os.environ.get("AGTERM_CHEATSHEET_DRAFT", "1") != "0"
+def _seconds(value, fallback):
+    """A timeout that will not parse falls back rather than raising at import.
+
+    This module is also what the overlay runs, and an exception there means an empty stream,
+    a pager with nothing to show and an overlay that closes on the spot — the very symptom
+    the recipe exists to avoid.
+    """
+    try:
+        return max(1, int(value))
+    except (TypeError, ValueError):
+        return fallback
+
+
+TIMEOUT = _seconds(os.environ.get("AGTERM_CHEATSHEET_TIMEOUT"), 45)
+
+DRAFT_HEADING = "## Recently bound, drafted"
+DRAFT_INTRO = (
+    "Rows a model wrote when the chord appeared in `keymap.conf`. Move each one into the"
+    " section it belongs in and put it in your own words; this is a holding area, not a"
+    " section of the sheet."
+)
+
+SYSTEM_PROMPT = (
+    "You document keyboard shortcuts for a terminal. For each binding you are given, write"
+    " what pressing it does, from the point of view of someone reaching for it. At most 12"
+    " words, no trailing period, no chord repeated back, no marketing. Read the action name"
+    " and any script path for what the binding actually does. Say plainly when you cannot"
+    " tell: 'runs <script name>' beats an invention."
+)
+
+SCHEMA = json.dumps({
+    "type": "object",
+    "properties": {
+        "rows": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {"chord": {"type": "string"}, "does": {"type": "string"}},
+                "required": ["chord", "does"],
+            },
+        }
+    },
+    "required": ["rows"],
+})
+
+SHEET_PROMPT = (
+    "You write the first draft of someone's keyboard cheat sheet for a terminal. For each"
+    " binding you are given, say what pressing it does, from the point of view of someone"
+    " reaching for it: at most 12 words, no trailing period, no chord repeated back, no"
+    " marketing. Read the action name and any script path for what the binding actually"
+    " does, and say plainly when you cannot tell — 'runs <script name>' beats an invention."
+    " Also put each binding in a section, so related chords sit together: a handful of short"
+    " section names in plain English, reused exactly across the rows that belong together,"
+    " ordered from what someone reaches for most often to what they reach for least."
+)
+
+SHEET_SCHEMA = json.dumps({
+    "type": "object",
+    "properties": {
+        "rows": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {"chord": {"type": "string"}, "section": {"type": "string"},
+                               "does": {"type": "string"}},
+                "required": ["chord", "section", "does"],
+            },
+        }
+    },
+    "required": ["rows"],
+})
+
+# `map <chord> <action>`, and `command "<name>" [chord] <shell...>` where the chord is
+# optional: a command with no chord is palette-only and has none to document. Requiring
+# a modifier prefix is what tells the two apart, since the shell word that follows a
+# chordless command never starts with a modifier and a `+`.
+#
+# Leading whitespace is allowed because agterm's parser trims the line before reading the
+# verb, so an indented binding is a live binding. Every modifier spelling agterm accepts is
+# listed, and the match is case-insensitive, for the same reason: `alt+k` and `Control+K`
+# bind real chords, and a chord this misses is a chord that is never documented.
+MODS = r"ctrl|control|cmd|command|opt|option|alt|shift"
+MAP_LINE = re.compile(r"^[ \t]*map\s+(\S+)\s+(\S+)", re.MULTILINE)
+COMMAND_LINE = re.compile(r'^[ \t]*command\s+"([^"]*)"\s+((?:' + MODS + r')\+\S*)',
+                          re.MULTILINE | re.IGNORECASE)
+
+STARTER_HEAD = """# Keyboard shortcuts
+
+Generated from `keymap.conf` on the first run, as a starting point. Rewrite the
+right-hand column in your own words: an action name says what the code does, not
+why you reach for the chord.
+
+| chord | does |
+|---|---|
+"""
+
+GENERATED_HEAD = """# Keyboard shortcuts
+
+Written from `keymap.conf` on the first run, by a model reading each binding. Treat it as a
+draft in someone else's words: it knows what a chord does and it cannot know why you bound
+it. Rewrite as you go, and it will never be regenerated over you.
+
+"""
+
+
+def bindings(keymap):
+    """Chord and label for every chord-carrying binding, `map` lines first."""
+    pairs = [(chord, action.replace("_", " ")) for chord, action in MAP_LINE.findall(keymap)]
+    pairs += [(chord, name) for name, chord in COMMAND_LINE.findall(keymap)]
+    # A chord bound by both a map line and a command line is one chord, and one row.
+    seen, unique = set(), []
+    for chord, label in pairs:
+        if chord not in seen:
+            seen.add(chord)
+            unique.append((chord, label))
+    return unique
+
+
+def chord_md(chord):
+    """A chord as markdown code. The one whose key is a backtick needs the other fence."""
+    return f"``{chord} ``" if "`" in chord else f"`{chord}`"
+
+
+def starter(pairs):
+    rows = "".join(f"| {chord_md(chord)} | {label} |\n" for chord, label in pairs)
+    return STARTER_HEAD + rows
+
+
+def generated(rows):
+    """A first sheet from the model's rows, grouped under the sections it chose."""
+    order, grouped = [], {}
+    for row in rows:
+        section = row.get("section") or "Shortcuts"
+        if section not in grouped:
+            order.append(section)
+            grouped[section] = []
+        grouped[section].append(row)
+    out = [GENERATED_HEAD]
+    for section in order:
+        out.append(f"## {section}\n\n| chord | does |\n|---|---|\n")
+        for row in grouped[section]:
+            out.append(f"| {chord_md(row['chord'])} | {cell(row['does'])} |\n")
+        out.append("\n")
+    return "".join(out)
+
+
+def documented(chord, flat):
+    """Is this chord named in the sheet, as a whole chord rather than as a prefix?
+
+    A plain substring test is what you reach for first and it is wrong in a way that shows
+    up immediately: `cmd+ctrl+shift+s` is a substring of `cmd+ctrl+shift+space`, so binding
+    the first while the sheet documents the second reports it as already written up. The
+    boundaries below are what a chord can be continued by — a word character, `+`, or the
+    `>` of a leader sequence. `>` is in both of them: a row for `ctrl+x>ctrl+a` documents
+    that sequence, not the bare `ctrl+a` it happens to end with.
+    """
+    pattern = r"(?<![\w+>])" + re.escape(chord) + r"(?![\w+>])"
+    return re.search(pattern, flat) is not None
+
+
+def searchable(sheet):
+    """The part of the sheet a chord has to be found in: its table rows.
+
+    Prose does not count, and that is the point. A sheet says two different things about a
+    chord — "this is what it does", which is an entry, and "this one is still free", which
+    is a note. Both name the chord, so a whole-file search accepts the second as
+    documentation of the first, and a stale "still free" line then hides a chord someone
+    bound months ago. Entries live in tables here, so the tables are what is searched.
+
+    A sheet with no table at all falls back to the whole text, because reporting every
+    chord as missing is not a useful thing to tell someone who writes in paragraphs.
+    """
+    rows = [line for line in sheet.splitlines() if line.lstrip().startswith("|")]
+    return "\n".join(rows) if rows else sheet
+
+
+def undocumented(pairs, sheet):
+    # The sheet is searched with its markdown intact. Stripping the backticks first is the
+    # obvious move and it breaks the one chord whose key IS a backtick: `cmd+ctrl+`` would
+    # shrink to a bare `cmd+ctrl+` and match almost any row. Left in place, a chord written
+    # the markdown way — `cmd+ctrl+j`, or ``cmd+ctrl+` `` for the awkward one — contains the
+    # chord as a literal substring either way, and the boundary rule below does the rest.
+    flat = searchable(sheet)
+    return sorted({chord for chord, _ in pairs if not documented(chord, flat)})
+
+
+def normalise(line):
+    """A binding line reduced to what it actually does.
+
+    agterm strips an inline comment and tokenizes before binding anything, so neither a
+    trailing note nor the column padding people use to line a file up changes the chord's
+    behaviour. Comparing raw lines makes re-aligning the keymap read as a rebind of every
+    chord in it, which is a normal edit and a very loud false alarm.
+    """
+    return " ".join(line.split("#")[0].split())
+
+
+def binding_lines(keymap):
+    """Chord -> what its keymap line does, normalised."""
+    lines = {}
+    for line in keymap.splitlines():
+        stripped = line.strip()
+        for match in (MAP_LINE.match(stripped), COMMAND_LINE.match(stripped)):
+            if match:
+                chord = match.group(1) if match.re is MAP_LINE else match.group(2)
+                lines[chord] = normalise(stripped)
+    return lines
+
+
+def sheet_is_current():
+    """Was the sheet touched after both the baseline and the last keymap change?
+
+    That is the reader saying it describes what is bound now. Both comparisons are needed:
+    newer than the baseline alone also swallows a rebind that happened after they last
+    touched the sheet, which is the case worth reporting.
+    """
+    try:
+        sheet_at = SHEET.stat().st_mtime_ns
+        return sheet_at > BINDINGS.stat().st_mtime_ns and sheet_at > KEYMAP.stat().st_mtime_ns
+    except OSError:
+        return False
+
+
+def rebound(keymap, sheet):
+    """Documented chords whose binding changed since the sheet was last touched.
+
+    The comparison is against the sheet's own modification time, so it needs no
+    acknowledgement: edit the sheet and every chord is taken as described correctly again,
+    leave it alone and the same chords are named on every press until you do.
+    """
+    if not BINDINGS.exists():
+        return []
+    before = stored()["bound"]
+    if sheet_is_current():
+        return []
+    flat = searchable(sheet)
+    return sorted(chord for chord, line in binding_lines(keymap).items()
+                  if chord in before and before[chord] != line and documented(chord, flat))
+
+
+def source_lines(keymap, chords):
+    """The keymap lines binding these chords, which is what the model reads."""
+    wanted = set(chords)
+    out = []
+    for line in keymap.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith(("map ", "command ")):
+            continue
+        for chord in wanted:
+            if re.search(r"(?<![^\s])" + re.escape(chord) + r"(?!\S)", stripped):
+                out.append(stripped)
+                break
+    return out
+
+
+class Hud:
+    """The progress panel, posted over the session while the model is out.
+
+    A session holds one overlay slot, and a HUD and a program overlay compete for it. So
+    this only works before the cheat sheet overlay opens, which is why the maintenance
+    pass runs from the custom command rather than from inside the overlay.
+
+    Every failure here is swallowed. A panel that will not post must never be the reason
+    a keypress shows no cheat sheet.
+    """
+
+    def __init__(self):
+        self.sid = os.environ.get("AGT_SESSION_ID", "")
+        self.socket = os.environ.get("AGT_SOCKET", "")
+        self.up = False
+
+    def _run(self, *args):
+        cmd = [AGTERMCTL, *args]
+        if self.socket:
+            cmd += ["--socket", self.socket]
+        try:
+            return subprocess.run(cmd, capture_output=True, text=True, check=False)
+        except OSError:
+            return None
+
+    def show(self, detail):
+        if not self.sid:
+            return
+        res = self._run("session", "hud", "update" if self.up else "open", "cheat sheet",
+                        "--detail", detail, "--spinner-style", "braille", "--target", self.sid)
+        self.up = self.up or (res is not None and res.returncode == 0)
+
+    def close(self):
+        if self.up:
+            self._run("session", "hud", "close", "--target", self.sid)
+            self.up = False
+
+
+def draft(lines, chords, hud, whole_sheet=False, restating=False):
+    """Ask the model for one row per binding. None on any failure, so the sheet still opens.
+
+    `whole_sheet` is the first run, where there is nothing to preserve: every binding is sent
+    at once and the model groups them into sections as well as describing them.
+    """
+    if not CLAUDE_BIN:
+        return None
+    wanted = set(chords)
+    prompt, schema = (SHEET_PROMPT, SHEET_SCHEMA) if whole_sheet else (SYSTEM_PROMPT, SCHEMA)
+    body = "Document these agterm keybindings:\n\n" + "\n".join(lines)
+
+    # Output goes to a temp file rather than a pipe. Nothing reads a pipe until the poll
+    # loop below ends, so a child that writes more than the buffer holds would block on its
+    # next write and leave the press sitting under the spinner for the whole timeout.
+    with tempfile.TemporaryFile("w+") as out:
+        try:
+            proc = subprocess.Popen(
+                [CLAUDE_BIN, "-p", "--model", MODEL, "--safe-mode", "--no-session-persistence",
+                 # No tools, and no hooks: a SessionStart hook that prints anything lands in
+                 # this output, and a headless one-shot has no use for either.
+                 "--tools", "", "--settings", '{"hooks":{}}',
+                 "--output-format", "json", "--system-prompt", prompt,
+                 "--json-schema", schema, body],
+                stdout=out, stderr=subprocess.DEVNULL, text=True,
+                env={**os.environ, "MAX_THINKING_TOKENS": "0"})
+        except (OSError, subprocess.SubprocessError):
+            return None
+
+        started = time.monotonic()
+        while proc.poll() is None:
+            elapsed = int(time.monotonic() - started)
+            if elapsed > TIMEOUT:
+                proc.kill()
+                return None
+            what = "writing the sheet" if whole_sheet else (
+                "rewriting what changed" if restating else "drafting")
+            plural = "" if len(lines) == 1 else "s"
+            hud.show(f"{what}, {len(lines)} chord{plural} · {elapsed}s")
+            time.sleep(0.7)
+
+        try:
+            out.seek(0)
+            payload = json.loads(out.read())
+            result = payload.get("result", payload)
+            rows = (json.loads(result) if isinstance(result, str) else result).get("rows", [])
+            # Only rows for chords that were actually asked about. A model answering
+            # `Cmd+Ctrl+M` to a requested `cmd+ctrl+m` would otherwise add a row that never
+            # satisfies the check, and add it again on every keymap edit, for ever.
+            kept = [r for r in rows if r.get("chord") in wanted and r.get("does")]
+        except (json.JSONDecodeError, AttributeError, TypeError):
+            return None
+    return kept or None
+
+
+def cell(text):
+    """Make a string safe to sit in a markdown table cell.
+
+    The model is asked for one short line and normally sends one, but its answer is written
+    into the reader's own file: a stray `|` would split the row into extra columns and a
+    newline would end the table and leave the rest as loose prose. Neither is recoverable by
+    hand without knowing what the file looked like before.
+    """
+    flat = " ".join(str(text).split())
+    return flat.replace("|", "\\|")
+
+
+def append_rows(sheet, rows):
+    """Add the drafted rows to the holding section, creating it at the end when absent.
+
+    Only ever an append. The sheet's own tables are hand-arranged — one of them pairs two
+    chords per row across four columns — so a generic inserter aiming for the right
+    section would corrupt the thing it is trying to keep current.
+    """
+    body = "".join(f"| {chord_md(r['chord'])} | {cell(r['does'])} |\n" for r in rows)
+    if DRAFT_HEADING in sheet:
+        return sheet.rstrip("\n") + "\n" + body
+    return (sheet.rstrip("\n") + "\n\n" + DRAFT_HEADING + "\n\n" + DRAFT_INTRO
+            + "\n\n| chord | does |\n|---|---|\n" + body)
+
+
+def write(path, text):
+    """Write through a temp file in the same directory, so a killed run leaves no half file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    mode = path.stat().st_mode & 0o777 if path.exists() else None
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(text, encoding="utf-8")
+    # The replace swaps the inode, so a sheet the reader chmodded would come back at the
+    # umask default. Carry its bits over rather than quietly widening them.
+    if mode is not None:
+        tmp.chmod(mode)
+    tmp.replace(path)
+
+
+def snapshot(keymap, wrote=None, unresolved=()):
+    """Record what each chord is bound to now, as the baseline `rebound` compares against.
+
+    `wrote` carries the descriptions the model just produced, kept alongside so a later pass
+    can tell its own draft from a sentence the reader has since written. Anything recorded
+    before is kept, so a row drafted three edits ago is still recognisable as a draft.
+    """
+    before = stored() if BINDINGS.exists() else {"bound": {}, "drafted": {}}
+    was, previously_bound = before["drafted"], before["bound"]
+    was.update(wrote or {})
+
+    bound = binding_lines(keymap)
+    # A chord whose row could not be brought up to date keeps its OLD line here, so it is
+    # still reported next time. Recording the new one would mean the pass had quietly
+    # accepted a row it knows is wrong.
+    for chord in unresolved:
+        if chord in previously_bound:
+            bound[chord] = previously_bound[chord]
+
+    write(BINDINGS, json.dumps({"bound": bound, "drafted": was}, sort_keys=True, indent=1))
+
+
+def stored():
+    """The baseline file, as {bound, drafted}.
+
+    An earlier version of this recipe wrote the bare chord-to-line map at the top level. It
+    is read as `bound` rather than discarded, because discarding it would silently answer
+    "nothing has changed" for every chord until the next keymap edit reseeded the file.
+    """
+    try:
+        raw = json.loads(BINDINGS.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"bound": {}, "drafted": {}}
+    if "bound" not in raw:
+        return {"bound": {k: v for k, v in raw.items() if isinstance(v, str)}, "drafted": {}}
+    return {"bound": raw.get("bound", {}), "drafted": raw.get("drafted", {})}
+
+
+def drafted_text(chord):
+    """What the model last wrote for this chord, or None if it never did."""
+    return stored()["drafted"].get(chord)
+
+
+def first_sheet(keymap, pairs):
+    """The sheet a machine with none gets, and the descriptions the model wrote for it.
+
+    Nothing is being preserved here, so this is the one place the model writes the whole
+    file. Every later run only ever appends.
+    """
+    chords = [chord for chord, _ in pairs]
+    if not DRAFT or not chords:
+        return starter(pairs), {}
+    hud = Hud()
+    try:
+        rows = draft(source_lines(keymap, chords), chords, hud, whole_sheet=True)
+    finally:
+        hud.close()
+    if not rows:
+        return starter(pairs), {}
+
+    # A 41-row answer can quietly come back with 40. The drift banner would catch it on the
+    # next press, but an incomplete first sheet is a poor first impression when the missing
+    # rows can simply be added with the label the mechanical starter would have used.
+    described = {row["chord"] for row in rows}
+    rows += [{"chord": chord, "section": "Also bound", "does": label}
+             for chord, label in pairs if chord not in described]
+    # Every row here is the model's, and saying so is what lets a later pass rewrite one when
+    # its chord is rebound. Returning only the text threw that away, which left the rewrite
+    # dead on exactly the machines where the whole sheet is the model's work.
+    return generated(rows), {row["chord"]: row["does"] for row in rows}
+
+
+def is_chord_cell(text, chord):
+    """Is this cell the chord itself, rather than prose that happens to mention it?
+
+    The distinction is what keeps the replacement on the right cell. "mark, the opposite of
+    `cmd+ctrl+n`" names a chord and is somebody's description; a cell that is nothing but the
+    chord is a column entry, and the one after it is what describes it.
+    """
+    return text.replace("`", "").strip() == chord
+
+
+def owns(sheet, chord):
+    """Is the description beside this chord the model's words rather than the reader's?
+
+    Two proofs. The row still sits under the holding heading, which is what that heading
+    means. Or the cell still holds exactly what was recorded when the model wrote it. Without
+    one of them the words are the reader's, and rewriting those is not this recipe's to do.
+    """
+    mine = drafted_text(chord)
+    in_holding = False
+    for line in sheet.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            in_holding = stripped == DRAFT_HEADING
+        if not stripped.startswith("|"):
+            continue
+        cells = stripped.split("|")
+        for i, one in enumerate(cells[:-1]):
+            if is_chord_cell(one, chord):
+                return in_holding or (mine is not None and cells[i + 1].strip() == cell(mine))
+    return False
+
+
+def restate(sheet, chord, text):
+    """Replace the description beside `chord`, leaving the rest of the row alone.
+
+    The cell is the one after the cell that IS the chord, which is what makes this safe in a
+    hand-arranged table: a row holding two chords across four columns has the right one
+    rewritten and the other pair untouched, and a description mentioning some other chord is
+    not mistaken for a column entry.
+    """
+    out, replaced = [], False
+    for line in sheet.splitlines(keepends=True):
+        stripped = line.rstrip("\n")
+        indent = stripped[:len(stripped) - len(stripped.lstrip())]
+        body = stripped.strip()
+        if not replaced and body.startswith("|"):
+            cells = body.split("|")
+            for i, one in enumerate(cells[:-1]):
+                if is_chord_cell(one, chord):
+                    cells[i + 1] = f" {cell(text)} "
+                    line = indent + "|".join(cells) + "\n"
+                    replaced = True
+                    break
+        out.append(line)
+    return "".join(out), replaced
+
+
+def sync(keymap):
+    """The maintenance pass: draft rows for chords the sheet has never heard of."""
+    # Seeding happens BEFORE the gate. On an existing install the stamp is already current,
+    # so anything after the gate would wait for the next keymap edit — and that edit is
+    # exactly the one that could rebind a chord with no baseline to notice it against.
+    if SHEET.exists() and not BINDINGS.exists():
+        snapshot(keymap)
+
+    mtime = str(KEYMAP.stat().st_mtime_ns)
+    # The timestamp says nothing new since the last pass, and that is true of the chord SET.
+    # It is not true of a row an earlier pass left out of date: the keymap change that caused
+    # it is already stamped, so the timestamp alone would never look at it again.
+    unchanged = STAMP.exists() and STAMP.read_text(encoding="utf-8") == mtime
+    if unchanged and not (SHEET.exists() and rebound(keymap, SHEET.read_text(encoding="utf-8"))):
+        # Nothing to do, but a sheet edited since the baseline was written is the reader
+        # saying it describes what is bound now. Recording that here is what stops the next
+        # unrelated keymap edit from reporting a row they already fixed.
+        if SHEET.exists() and BINDINGS.exists() and sheet_is_current():
+            snapshot(keymap)
+        return
+
+    pairs = bindings(keymap)
+    if not SHEET.exists():
+        text, wrote = first_sheet(keymap, pairs)
+        write(SHEET, text)
+        write(STAMP, mtime)
+        snapshot(keymap, wrote)
+        return
+
+    # A sheet edited after the last keymap change describes what is bound now, so it becomes
+    # the baseline.
+    if sheet_is_current():
+        snapshot(keymap)
+
+    sheet = SHEET.read_text(encoding="utf-8")
+    missing = undocumented(pairs, sheet)
+    # A chord that kept its key and changed its command: the row names it and describes
+    # something else. Whose words those are decides what happens, and it is asked HERE,
+    # before the model is called — asking afterwards meant a call per press whose answer was
+    # thrown away, for as long as the reader left their own row in place.
+    stale = rebound(keymap, sheet)
+    ours = [chord for chord in stale if owns(sheet, chord)]
+    theirs = [chord for chord in stale if chord not in ours]
+    if not missing and not stale:
+        write(STAMP, mtime)
+        return
+    if not DRAFT:
+        write(STAMP, mtime)
+        return
+
+    hud = Hud()
+    try:
+        rows = draft(source_lines(keymap, missing), missing, hud) if missing else []
+        redone = draft(source_lines(keymap, ours), ours, hud, restating=True) if ours else []
+    finally:
+        hud.close()
+    if not rows and not redone:
+        if stale:
+            snapshot(keymap, unresolved=stale)
+        return
+
+    if rows:
+        sheet = append_rows(sheet, rows)
+    wrote = {row["chord"]: row["does"] for row in rows or []}
+    fixed = set()
+    for row in redone or []:
+        sheet, replaced = restate(sheet, row["chord"], row["does"])
+        if replaced:
+            wrote[row["chord"]] = row["does"]
+            fixed.add(row["chord"])
+    write(SHEET, sheet)
+    write(STAMP, mtime)
+    snapshot(keymap, wrote, unresolved=[c for c in stale if c not in fixed] + theirs)
+
+
+def render(keymap):
+    """Print the sheet, with a banner naming anything still undocumented."""
+    pairs = bindings(keymap)
+    if not SHEET.exists():
+        write(SHEET, starter(pairs))
+        print(f"> **Generated `{SHEET}` from your keymap.**")
+        print(">")
+        print("> Rewrite it in your own words. This run shows what was written.")
+        print()
+
+    sheet = SHEET.read_text(encoding="utf-8")
+    missing = undocumented(pairs, sheet)
+    if missing:
+        print(f"> **This sheet has drifted from `{KEYMAP.name}`.**")
+        print(">")
+        print("> Bound but not documented: " + ", ".join(f"`{c}`" for c in missing))
+        print()
+
+    # Normally the maintenance pass has already rewritten these. What reaches here is what
+    # it could not: no model available, or a call that failed.
+    changed = rebound(keymap, sheet)
+    if changed:
+        print("> **Bound to something else now, so the row is out of date:** "
+              + ", ".join(f"`{c}`" for c in changed))
+        print(">")
+        print("> These are yours to reword — the ones written by a model were already"
+              " brought up to date.")
+        print()
+
+    sys.stdout.write(sheet)
+
+
+def main():
+    try:
+        keymap = KEYMAP.read_text(encoding="utf-8")
+    except OSError as err:
+        sys.exit(f"cannot read {KEYMAP}: {err}")
+
+    if "--sync" in sys.argv[1:]:
+        sync(keymap)
+        return
+    render(keymap)
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbook/keymap-cheatsheet/keymap-cheatsheet.sh
+++ b/cookbook/keymap-cheatsheet/keymap-cheatsheet.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# Bring the cheat sheet level with keymap.conf, then show it in an overlay.
+#
+# $1 = session id, from {AGT_SESSION_ID} in the keymap line.
+#
+# No PATH handling here. A custom command is spawned with a widened PATH that
+# carries the bundled agtermctl, /usr/local/bin and /opt/homebrew/bin, so the
+# names below resolve. See Requirements for the version that starts at.
+set -eu
+
+SESSION=${1:-}
+
+AGTERMCTL=${AGTERMCTL:-agtermctl}
+DIR=$(dirname "$0")
+SHEET_SCRIPT=${AGTERM_CHEATSHEET_SCRIPT:-$DIR/cheatsheet.py}
+RENDER=${AGTERM_CHEATSHEET_RENDER:-$DIR/render-cheatsheet.sh}
+SIZE=${AGTERM_CHEATSHEET_SIZE:-90}
+
+export AGTERMCTL
+
+# Resolve the overlay's tools HERE and pass them across as absolute paths. The
+# overlay program is spawned by the terminal from the app's own environment, so
+# it inherits neither this PATH nor anything exported below, and its command
+# line is the only channel into it.
+PYTHON=$(command -v "${PYTHON:-python3}" || true)
+[ -n "$PYTHON" ] || PYTHON=/usr/bin/python3
+
+# The pager is a command with its flags, so it has to word-split.
+# shellcheck disable=SC2086
+set -- ${AGTERM_CHEATSHEET_PAGER:-glow -p -}
+PAGER_BIN=$(command -v "$1" || true)
+if [ -n "$PAGER_BIN" ]; then
+  shift
+  set -- "$PAGER_BIN" "$@"
+else
+  # glow is not installed, or is somewhere this PATH does not reach. Raw markdown
+  # in less beats an overlay that flashes shut with nothing in it, which is
+  # indistinguishable from a chord that never fired. less is on every mac.
+  set -- /usr/bin/less -R
+fi
+
+# The overlay command is `eval`ed by sh on the other side, so each word is quoted
+# here. A path containing a single quote is the one case this does not survive.
+#
+# The three path settings ride along for the same reason the binaries do: an overlay
+# program is spawned from the app's environment, so anything exported here would be
+# lost, and the render half would fall back to the default sheet and show the wrong
+# file. Empty values are passed as empty and ignored on the other side.
+COMMAND="'$RENDER' '${AGTERM_CONFIG_DIR:-}' '${AGTERM_KEYMAP:-}' '${AGTERM_CHEATSHEET:-}'"
+COMMAND="$COMMAND '${AGTERM_CHEATSHEET_STAMP:-}'"
+COMMAND="$COMMAND '$PYTHON'"
+for word do
+  COMMAND="$COMMAND '$word'"
+done
+
+# The maintenance pass runs BEFORE the overlay, because a session has one overlay
+# slot and its progress panel needs it. It returns at once unless keymap.conf
+# changed since the last press. A failure inside it is not a reason to withhold
+# the sheet, so its exit status is dropped.
+"$PYTHON" "$SHEET_SCRIPT" --sync || true
+
+# With no id, the overlay lands on the active session, which is the same one in
+# practice. Passing an empty --target is not the same thing and is rejected.
+if [ -n "$SESSION" ]; then
+  exec "$AGTERMCTL" session overlay open "$COMMAND" \
+    --target "$SESSION" --size-percent "$SIZE" --follow
+fi
+
+exec "$AGTERMCTL" session overlay open "$COMMAND" --size-percent "$SIZE"

--- a/cookbook/keymap-cheatsheet/render-cheatsheet.sh
+++ b/cookbook/keymap-cheatsheet/render-cheatsheet.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Runs inside the overlay: render the cheat sheet and hold the pager open.
+#
+# Everything arrives on the command line because nothing else can reach here. agterm
+# spawns an overlay program from the app's own environment, so it has the app's PATH
+# and none of what the opener exported. The opener has both, so it resolves the
+# binaries and forwards the settings, and this script puts them back.
+#
+#   $1     AGTERM_CONFIG_DIR, or empty
+#   $2     AGTERM_KEYMAP, or empty
+#   $3     AGTERM_CHEATSHEET, or empty
+#   $4     AGTERM_CHEATSHEET_STAMP, or empty
+#   $5     python
+#   $6...  the pager and its flags
+set -eu
+
+[ -n "$1" ] && export AGTERM_CONFIG_DIR="$1"
+[ -n "$2" ] && export AGTERM_KEYMAP="$2"
+[ -n "$3" ] && export AGTERM_CHEATSHEET="$3"
+[ -n "$4" ] && export AGTERM_CHEATSHEET_STAMP="$4"
+PYTHON=$5
+shift 5
+
+SHEET_SCRIPT=$(dirname "$0")/cheatsheet.py
+
+# The pager quits on q, which is what closes the overlay.
+"$PYTHON" "$SHEET_SCRIPT" | "$@"


### PR DESCRIPTION
One chord renders a hand-written shortcut sheet in an overlay. A chord you bound but never wrote down gets a drafted row before the sheet opens.

The sheet is a markdown file the reader writes and keeps, not generated output. That is the premise: the chord is the only half a machine knows, and the half worth documenting is why you reach for it. `previous_attention_session` is accurate and useless; "previous session wanting you, and a session still working is deliberately not included" is the sentence you actually want three months later. So nothing here rewrites the sheet.

What it does instead, on the press after you bind something new, is ask a model what the binding does and append one row to a holding section at the end. You move it into the right table and put it in your own words. The chord is documented from the moment it is bound rather than whenever you next remember, and the prose you wrote is never touched.

## The gate

A cheat sheet you press several times a day cannot afford a model call, so two stages decide:

1. `keymap.conf`'s modification time against a stamp file. Unchanged and the pass returns — about 40ms including python startup. This is every press but a handful.
2. Changed, so compare the chord sets. Nothing missing, which is what a comment edit or an already-documented chord looks like, and the stamp moves on with no model call.

Only a chord the sheet has never mentioned reaches the model. Measured on real files: 50ms for no change, 36ms for a comment-only edit, 3.6s to draft two new chords, and `AGTERM_CHEATSHEET_DRAFT=0` falls back to a plain drift banner.

The maintenance pass runs from the custom command, before the overlay opens. That is forced rather than chosen: a session has one overlay slot, and the progress panel and the cheat sheet both want it.

## Matching a chord

A chord matches as a whole chord, not as a substring, so a row for `cmd+ctrl+shift+space` does not document `cmd+ctrl+shift+s`, and a row for `ctrl+x>ctrl+a` does not document `ctrl+a`.

Only table rows are searched. A sheet names a chord in two senses — "this is what it does", which is an entry, and "this one is still free", which is a note — and searching the whole file lets the second stand in for the first, so a stale "still free" line hides a chord bound long after it was written. A sheet with no table at all falls back to the whole text.

Chords are read from `keymap.conf` allowing leading whitespace, since the parser trims the line before reading the verb, and accepting every modifier spelling agterm takes, case-insensitively.

## Noticing a row that went stale

A chord set answers "is this chord written down anywhere", which says nothing about a chord that kept its key and got a different command. That leaves a row naming the right chord and describing the wrong thing, and it is the failure the sheet this was written for actually hit — a respawn-pane chord became a conversation picker and the row went on describing the pane.

So a second file beside the stamp records what each chord was bound to as of the last time the sheet was current, and a documented chord whose line has changed since gets a banner of its own:

```
> Bound to something else now, so the row may be stale: cmd+ctrl+shift+r
>
> Edit the sheet and this clears itself.
```

Nothing is rewritten. It says the row is suspect and leaves the sentence to the reader, like everything else here. The comparison is against the sheet's own modification time, so there is no acknowledgement to click: edit the sheet and every chord counts as described correctly again; leave it and the same chords are named on every press.

Seeding runs before the modification-time gate. On an existing install the stamp is already current, so anything after the gate would wait for the next keymap edit — and that edit is exactly the one that could rebind a chord with no baseline to notice it against.

## Files

- `keymap-cheatsheet.sh` — what the keymap line calls: the maintenance pass, then the overlay
- `render-cheatsheet.sh` — runs inside the overlay, the sheet piped into the pager. Separate because agterm spawns the overlay program from its own environment, so nothing the opener exports reaches it; it takes python and the pager as arguments for the same reason
- `cheatsheet.py` — the gate, the drafting, the starter sheet. Standard library only
- `README.md`, and the index row under *Panes, pickers and input*

## The model call

`claude-haiku-4-5-20251001`, written as the full id because the short `haiku` alias is not recognized by `claude -p` and falls back to the default model — the picker recipe's finding, and its comment is kept. `AGTERM_CHEATSHEET_MODEL` overrides it.

```
claude -p --model claude-haiku-4-5-20251001 --safe-mode --no-session-persistence
       --tools "" --settings '{"hooks":{}}' --output-format json
       --system-prompt ... --json-schema ...
```

with `MAX_THINKING_TOKENS=0`. No tools, no hooks, nothing persisted, and the answer constrained to `{chord, does}` rows. Three to seven seconds for one or two rows.

It writes one thing: the right-hand column of a drafted row. Two things it does not touch are worth separating out, because "a model keeps my cheat sheet" would be the wrong impression to take from this recipe:

- The starter sheet, written on a machine that has no `SHORTCUTS.md` yet, is generated mechanically from `keymap.conf` — chord plus action name, underscores turned to spaces. No call.
- The reader's own sheet. Every table and paragraph in it is hand-written and never rewritten. Drafted rows land in a holding section at the end and stay there until the reader files them.

Regenerating the sheet was the other way to do all this, and it is the wrong one: it would replace the tier tables, the explanations and the groupings — everything a model cannot write — to fix a couple of cells, and you would reach for it exactly when the sheet has the most hand-written value to lose.

Everything about the call fails soft: no `claude` found, a non-zero exit, a timeout, unparseable output, or an answer naming a chord nobody asked about — each returns nothing, the stamp is left alone so the next press tries again, and the sheet opens with the drift banner. Output goes to a temp file rather than a pipe, so a large answer cannot block the child while the poll loop runs. Cells are flattened to one line with `|` escaped, because a drafted row is written into the reader's own table. The sheet is written through a temp sibling and renamed, carrying the original's permission bits.

## PATH

Neither script hardcodes a directory, and the two halves get there differently.

**The opener** is a custom command, so it takes the `PATH` the runner hands it — bundled `agtermctl`, `/usr/local/bin`, `/opt/homebrew/bin`.

**The overlay half** is not covered by that and cannot be: an overlay program is launched by the terminal, not by the custom command, so it gets the app's own `PATH` and nothing the opener exported. It can resolve neither `glow` nor `python3` for itself.

So the opener resolves both and passes them across as absolute paths on the command line, which is the only channel into an overlay. `OverlayCapture.shellLine` `eval`s the command string, so each word is single-quoted going in; a path containing a single quote is the one case that does not survive. With no `glow` reachable the opener sends `/usr/bin/less -R`, so the reader gets raw markdown rather than an overlay that closes on the spot and looks exactly like a chord that never fired.

Checked three ways: the command string the opener builds with and without `glow` on the `PATH`, and a round-trip through the app's own wrapper — `env -i` plus `eval "$AGTERM_OVL_CMD"` renders the sheet and exits 0.

⚠️ Relying on the runner's `PATH` means requiring it, so *Requirements* reads "the first release after 0.21.0". The fix is `babc760` and unreleased as this is written, so the version number is left blank for you to fill when it ships — say the word if you would rather the recipe carried a workaround and stayed usable on 0.21.0.

## Checks

`shellcheck` on both scripts, `ruff check --ignore EXE001`, the six headings, the shebangs, the index in both directions — all clean locally, and Cookbook checks pass on CI.

Behavior exercised against throwaway files in a temp `AGTERM_CONFIG_DIR`, with a stub in place of `claude`: starter sheet on first run, silent second run, a comment-only keymap edit costing no model call, drafting after a new binding, an existing sheet never replaced, a hostile cell escaped, a renamed chord dropped, an oversized answer not stalling the press, file permissions surviving the write, and the stale-row check across its four states: seeded quiet, named after a rebind, still named on the next press, cleared by an edit to the sheet.
