### PR TITLE
feat: nested (child) sessions

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -83,14 +83,14 @@ paths:
 
 ## Public catalog
 
-There are 74 public commands:
+There are 76 public commands:
 
 - `tree`, `events.read`
 - `workspace.new`, `.rename`, `.delete`, `.select`, `.move`, `.focus`, `.filter`, `.collapse`, `.expand`
 - `session.new`, `.duplicate`, `.close`, `.select`, `.rename`, `.reveal`, `.move`, `.type`, `.split`,
   `.scratch`, `.focus`, `.resize`, `.go`, `.copy`, `.paste`, `.selectall`, `.text`, `.search`, `.status`,
-  `.flag`, `.seen`, `.restore`, `.background`, `.overlay.open`, `.overlay.close`, `.overlay.resize`,
-  `.overlay.result`, `.hud.open`, `.hud.update`, `.hud.close`
+  `.flag`, `.seen`, `.collapse`, `.expand`, `.restore`, `.background`, `.overlay.open`, `.overlay.close`,
+  `.overlay.resize`, `.overlay.result`, `.hud.open`, `.hud.update`, `.hud.close`
 - `surface.zoom`, `dashboard`, `pick.open`, `pick.result`, `pick.cancel`
 - `quick`, `quick.type`, `quick.text`
 - `sidebar`, `sidebar.mode`, `sidebar.expand`, `sidebar.collapse`, `notify`
@@ -111,11 +111,27 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   one grouped undo/reopen record, and returns actual `affected`; selecting any recent group member restores
   the group and selects that member.
 - `session.move` accepts exactly one placement intent:
-  - `--to up|down|top|bottom` reorders one session in its workspace.
+  - `--to up|down|top|bottom` reorders one session in its sibling group (carrying its subtree).
   - workspace relocates and appends.
-  - `--after`/`--before` resolves an anchor across the store, carrying destination workspace.
+  - `--after`/`--before` resolves an anchor across the store, carrying destination workspace AND the
+    anchor's `parentID` — a placed session ADOPTS the anchor's parent, so `--after <child>` nests it as a
+    sibling child. A subtree-bearing session carries its whole block, then `repairContiguity` restores
+    preorder (the placed session keeps its positional slot among the anchor's siblings).
+  - `--parent <sid>` reparents the target under that session (last child); `--unparent` promotes it to
+    top-level. Single target only; mutually exclusive with each other and with `--to`/`--after`/`--before`/
+    a workspace. Cross-workspace parents are rejected (a subtree can't straddle workspaces).
   Relative placement uses host-free `SidebarDrop.resolveRelative`; batches use tree-order remove-first
   `resolveSessions`. Reject batch `--to`. Count only actual moves. A one-member batch uses singular behavior.
+- Nested sessions: `Session.parentID` (nil = top-level) is an adjacency list; `Workspace.sessions` stays a
+  flat array whose CONTIGUITY invariant (a parent immediately followed by its whole subtree, depth-first
+  preorder) makes array order equal visual tree order. `session.new --parent <sid|active>` creates a child;
+  the sidebar's "New Child Session" is the GUI twin. Closing a parent CASCADES — its whole subtree closes
+  as one grouped undo/reopen record (the `removeWorkspace` precedent). Host-free math lives in
+  `SessionTree`; store ops in `AppStore+Nesting.swift`; drag-reparent in `SidebarDrop.resolveReparent`.
+- `session.collapse`/`.expand` fold/unfold a single parent session's subtree, the per-session analogue of
+  `workspace.collapse`/`.expand`. Persist `Session.isExpanded` on the store first (the `collapsed`
+  read-back source of truth, so it works with the sidebar hidden), then post an object-scoped notification
+  for the live outline. Read omitted/true `collapsed`.
 - Sidebar batch Flag computes one uniform value: flag all unless all are already flagged. This is not
   equivalent to repeated toggle; scripts read state then loop on/off. Batch Clear Status is equivalent to
   repeated `session.status idle` and needs no batch command.
@@ -145,9 +161,12 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
 - `session.new` chooses one mutually exclusive destination:
   - workspace ID/prefix/active;
   - exact-trimmed workspace name, optionally create-or-reuse;
-  - `--after`/`--before` anchor, which supplies workspace and insertion index.
-  Reject both anchors, placement plus workspace, name plus ID, create without name, and missing name without
-  create. Insert indices are clamped.
+  - `--after`/`--before` anchor, which supplies workspace, insertion index AND the anchor's parent (the new
+    session inherits `parentID`, so `--after <child>` creates a sibling child);
+  - `--parent <sid|active>` nests the new session as that session's last child.
+  Reject both anchors, `--parent` plus a placement anchor or a workspace, placement plus workspace, name
+  plus ID, create without name, and missing name without create. Insert indices are clamped; an unknown or
+  cross-workspace parent is ignored (the session appends top-level) rather than failing creation.
 - `--command` becomes raw libghostty `config.command`, not shell input. Ghostty quote-splits into argv and
   executes directly, so operators, expansion, redirection, and globs require an explicit `sh -c` or
   `zsh -lc`. GUI launch PATH lacks `/opt/homebrew/bin`; missing binaries exit 127, so use absolute paths
@@ -428,7 +447,9 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
 ## Tree and window read-back
 
 - Session nodes include foreground/split foreground argv, background spec, overlay size, pane overlays,
-  split ratio, split focus, status fields, flag, unseen, restore pins, and surfaces. Foreground shares the
+  split ratio, split focus, status fields, flag, unseen, restore pins, `parentID` (the nesting parent,
+  omitted when top-level — reconstructs the tree client-side), `collapsed` (true only, the read side of
+  `session.collapse`/`.expand`), and surfaces. Foreground shares the
   restore capture's pid/sysctl/host-free extraction but adds one step the capture must never take.
   libghostty's foreground pid is `tcgetpgrp`, a process GROUP id, and a pane with no job-control shell
   leaves its program in the group led by setuid-root `login`, whose argv `KERN_PROCARGS2` refuses. The tree

--- a/.claude/rules/sidebar.md
+++ b/.claude/rules/sidebar.md
@@ -179,3 +179,33 @@ paths:
   every member after tree changes would undo deliberate collapses and diverge from `tree` read-back.
   Revealing a session may expand visually without changing disk state; launch still reveals the active
   session, and its row may re-collapse next launch.
+
+## Nested sessions
+
+- A session may nest under another via `Session.parentID` (nil = top-level). `Workspace.sessions` stays a
+  flat ordered array whose CONTIGUITY invariant — a parent immediately followed by its whole subtree in
+  depth-first preorder — makes array order equal visual tree order, so every flat consumer (navigation,
+  flagged view, focus filter, persistence, recency, reorder) is unchanged. Pure math is `SessionTree`;
+  store ops are `AppStore+Nesting.swift`. The confining change is the sidebar tree-build plus block moves.
+- `rebuildAndReload` builds a NESTED `SidebarNode` tree from each workspace's `parentID`s (not one flat
+  child list). `isItemExpandable` is a workspace OR a session with children. `TreeShape` carries each
+  session's `parentID`, so a promote that keeps linear order but changes depth still rebuilds. Track parent
+  expansion in `expandedSessionIDs` (the workspace-set twin, one level deeper): seed from
+  `Session.isExpanded`, re-apply after `reloadData` top-down via `reapplySessionExpansion`, and on a genuine
+  toggle persist through `setSessionExpanded`. `syncSelection` expands the FULL ancestor chain
+  (`SessionTree.ancestorIDs` + owner workspace) so a nested selection resolves to a row.
+- A COLLAPSED parent rolls its hidden subtree up onto its own row: `rowUnseen` sums the subtree's unseen
+  badges and `rowIndicator` shows the most-urgent descendant status (`AgentStatus.attentionRank`). Both
+  feed `RowContent` so a hidden descendant's change reloads the collapsed parent. An expanded parent or a
+  leaf shows only its own.
+- Drag-to-reparent: dropping onto a session row nests (last child); dropping in a top-level gap un-nests;
+  cross-workspace clears `parentID` (a subtree can't straddle workspaces). AppKit's `proposedChildIndex`
+  counts DIRECT outline children, not the flat array, so the drop resolves in (parentID, sibling-index)
+  space via `SidebarDrop.resolveReparent` + `AppStore.reparentSession(_:to:at:)`, cycle-guarded. `session
+  new --parent` / `session move --parent|--unparent` and the row's "New Child Session" are the non-drag
+  surfaces; `session.collapse`/`.expand` fold a parent over control.
+- Closing a parent CASCADES its whole subtree as one grouped soft/hard close (the `removeWorkspace`
+  precedent); the GUI confirms with the descendant count (`confirmDelete`, like Delete Workspace) and
+  `closeSessionSubtree`/`softCloseSessions` record ONE undo/reopen. `Session.isExpanded`/`parentID` are
+  optional snapshot fields (`collapsed` inverse, emitted only when non-default) — a legacy `workspaces.json`
+  decodes every session top-level and expanded, and a non-nested tree serializes byte-identically.

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ The theme picker (View ▸ Select Theme…, or the action palette) previews each
 
 To open a terminal at a directory without the CLI, `open -a agterm <path>` — or right-click a folder in Finder and choose **Open With ▸ agterm**. agterm adds a session in that directory to the last-active window. This works when agterm is already running (its usual state); if it isn't, launch agterm first, then run the command. The socket equivalent, and the way to place the session precisely, is `agtermctl session new --cwd <path>`.
 
-The sections below cover the common cases. All 74 commands, with every argument, return value, and error, are documented in the **[Command reference](https://agterm.com/commands)**.
+The sections below cover the common cases. All 76 commands, with every argument, return value, and error, are documented in the **[Command reference](https://agterm.com/commands)**.
 
 The app bundles `agtermctl` inside `agterm.app`. The easiest way to put it on your PATH is **Help ▸ Install Command Line Tool…**, which symlinks the bundled binary into `/usr/local/bin` (the first entry in macOS's default PATH). When that directory is user-writable it installs silently; otherwise it asks once for an administrator password.
 
@@ -266,7 +266,8 @@ agtermctl session new --command "sh -c 'clear; ssh user@host'"  # --command is a
 agtermctl session new --command "zsh -lc 'make test'" --wait  # hold the session open after the command exits (press any key to close) so its final output stays readable; --wait needs --command
 agtermctl session new --name "myhost" --command "ssh user@host"  # pre-name the session (sidebar label set at creation)
 agtermctl session new --workspace-name servers --create-workspace --name "myhost"  # open in the "servers" workspace, creating it if absent (idempotent)
-agtermctl session new --after active             # create right after the current session (--before to precede it); the anchor's workspace is used
+agtermctl session new --after active             # create right after the current session (--before to precede it); the anchor's workspace AND nesting parent are used, so --after a child makes a sibling child
+agtermctl session new --parent "$AGTERM_SESSION_ID"   # nest a new session under the calling one as its last child (the sidebar's "New Child Session"; --parent active also works); unknown/cross-workspace parent appends top-level
 agtermctl session new --cwd ~/src/agterm --no-select  # create in the background without switching to it (the current session stays active)
 agtermctl session duplicate --target 9f3c        # a second plain shell in that session's workspace and cwd, right after it (only the directory carries over)
 agtermctl session type --target 9f3c $'make test\n'      # inject text into a session by id prefix
@@ -274,7 +275,9 @@ echo 'make test' | agtermctl session type --target active --stdin
 agtermctl session go --to next                   # step to the next session (next|prev|first|last; wraps at the ends, within the visible set)
 agtermctl session move --to up                   # reorder the active session within its workspace (up|down|top|bottom)
 agtermctl session move "$ws"                      # relocate the active session to another workspace (appends)
-agtermctl session move --after 9f3c              # place the active session right after another (--before to precede it); relocates cross-workspace if the anchor lives elsewhere
+agtermctl session move --after 9f3c              # place the active session right after another (--before to precede it); relocates cross-workspace if the anchor lives elsewhere, and adopts the anchor's nesting parent
+agtermctl session move --parent 9f3c --target abcd  # reparent abcd under session 9f3c as its last child (--unparent promotes it back to top-level; you can also drag a sidebar row onto another to nest it)
+agtermctl session collapse --target 9f3c         # fold a parent session's subtree in the sidebar (session expand unfolds it); closing a parent closes its whole subtree as one undo
 agtermctl session move "$ws" --target 9f3c --target abcd  # move a batch as one ordered block; --after/--before also accept repeated --target
 agtermctl session close --target 9f3c --target abcd       # close a batch with one grace-period undo
 agtermctl workspace move --to top                # reorder a workspace among its siblings (up|down|top|bottom)

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -125,6 +125,26 @@ final class AppActions {
         focusActiveSession()
     }
 
+    /// Create a new session as a CHILD of `parentSessionID`, nesting it under that session (last child) in the
+    /// sidebar. Store-scoped like the other row actions so a background window's row acts on its own store;
+    /// resolves the parent's workspace, then selects + focuses the child exactly as `newSession` does.
+    func newChildSession(of parentSessionID: UUID, in store: AppStore) {
+        guard let workspace = store.workspace(forSession: parentSessionID),
+              let session = store.addSession(toWorkspace: workspace.id, cwd: resolvedNewSessionCwd(),
+                                             parentID: parentSessionID)
+        else { return }
+        store.noteUserActivity()
+        store.selectSession(session.id)
+        focusActiveSession()
+    }
+
+    /// Create a child of the ACTIVE session — the menu-bar / palette "New Child Session". Frontmost-scoped
+    /// and gated like `newSession`; a no-op without a selected session.
+    func newChildActiveSession() {
+        guard uiActionsEnabled, let store, let parentID = store.selectedSessionID else { return }
+        newChildSession(of: parentID, in: store)
+    }
+
     /// The cwd for a new session: the new-session-directory setting (home / the current session's cwd / a
     /// fixed custom dir) resolved against the active session's focused-pane cwd, home when `settingsModel`
     /// isn't wired. Read as the `addSession` argument, so it captures the cwd BEFORE the new session exists.
@@ -234,7 +254,7 @@ final class AppActions {
         // does not intercept — that pane stays live and ⌘W keeps its ordinary meaning.
         if let pane = session.focusedOverlayPane { store.closePaneOverlay(session.id, pane: pane); return true }
         // handled either way — returning true on cancel keeps the File menu from closing the whole window.
-        guard confirmCloseSession(session) else { return true }
+        guard confirmSessionClose(session, in: store) else { return true }
         closeSessionAfterConfirmation(session.id, in: store)
         focusActiveSession()
         return true
@@ -265,7 +285,7 @@ final class AppActions {
     func closeSession(_ id: UUID, in store: AppStore) {
         guard uiActionsEnabled else { return }
         guard let session = store.session(withID: id) else { return }
-        guard confirmCloseSession(session) else { return }
+        guard confirmSessionClose(session, in: store) else { return }
         closeSessionAfterConfirmation(id, in: store)
     }
 
@@ -294,6 +314,17 @@ final class AppActions {
 
     func clearRecentClosedItems() {
         library.clearRecentClosedItems()
+    }
+
+    /// Confirms a session close, adapting to whether it parents a subtree. A PARENT always confirms — closing
+    /// it cascades to its whole subtree as one grouped close — showing the descendant count, mirroring the
+    /// workspace-delete confirm. A childless session keeps the per-session `confirmCloseSession` (gated by the
+    /// Settings toggle, bypassed under XCUITest). The cascade confirm is NOT bypassed, matching Delete
+    /// Workspace, so the Task 12 UI test can drive it; no existing test closes a parent session.
+    private func confirmSessionClose(_ session: Session, in store: AppStore) -> Bool {
+        let subtreeCount = store.sessionSubtreeIDs(session.id).count
+        guard subtreeCount > 1 else { return confirmCloseSession(session) }
+        return confirmDelete(name: session.displayName, sessionCount: subtreeCount)
     }
 
     /// A native warning confirm before closing `session`, gated by `AppSettings.confirmCloseSession`. Returns
@@ -532,6 +563,19 @@ final class AppActions {
         NotificationCenter.default.post(
             name: .agtermSetWorkspaceExpanded, object: store,
             userInfo: [WorkspaceSidebar.Coordinator.workspaceIDUserInfoKey: id,
+                       WorkspaceSidebar.Coordinator.expandedUserInfoKey: expanded])
+    }
+
+    /// The session analogue of `setWorkspaceExpanded` — `session.collapse`/`.expand`. Persists
+    /// `Session.isExpanded` DIRECTLY on the store (source of truth for the `collapsed` read-back,
+    /// delta-guarded), THEN posts a store-scoped notification so that window's Coordinator folds/unfolds the
+    /// row and updates its tracked set. The persist must NOT ride the notification: with the sidebar hidden
+    /// the Coordinator is unmounted, so a notification-only write would drop and leave the read-back stale.
+    func setSessionExpanded(_ id: UUID, expanded: Bool, in store: AppStore) {
+        store.setSessionExpanded(id, expanded: expanded)
+        NotificationCenter.default.post(
+            name: .agtermSetSessionExpanded, object: store,
+            userInfo: [WorkspaceSidebar.Coordinator.sessionIDUserInfoKey: id,
                        WorkspaceSidebar.Coordinator.expandedUserInfoKey: expanded])
     }
 

--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -123,13 +123,31 @@ extension ControlServer: ControlActions {
     /// name, there is nothing to create by id. cwd/command/name are applied in `makeSessionResponse`.
     func createSession(_ options: ControlSessionCreateOptions) -> ControlResponse {
         resolver.resolvePlacementStore(options.window) { store in
+            // parent nesting: the parent sid self-identifies its workspace, bypassing `--workspace`/
+            // `--workspace-name`. The child appends as the parent's LAST child (`at: nil` → `addSession`
+            // computes the last-child slot from the parentID), mutually exclusive with placement above.
+            if let parent = options.parent {
+                return resolveSessionAcrossStore(parent, in: store) { parentID in
+                    guard let location = store.sessionLocation(ofSession: parentID) else {
+                        return ControlResponse(ok: false, error: "no such session")
+                    }
+                    return makeSessionResponse(in: store, workspaceID: location.workspace, options: options,
+                                               parentID: parentID, at: nil)
+                }
+            }
             // anchor-relative placement: the anchor names its own workspace, bypassing `--workspace`/
             // `--workspace-name`. `before` takes the anchor's slot, `after` the next (clamped in `addSession`).
+            // The new session INHERITS the anchor's parent, so it lands as a sibling at any depth.
             if let anchor = options.after ?? options.before {
                 let placeBefore = options.before != nil
                 return resolveAnchorLocation(anchor, in: store) { location in
                     let index = placeBefore ? location.index : location.index + 1
-                    return makeSessionResponse(in: store, workspaceID: location.workspace, options: options, at: index)
+                    let response = makeSessionResponse(in: store, workspaceID: location.workspace,
+                                                       options: options, parentID: location.parentID, at: index)
+                    // `--after` a subtree-bearing anchor inserts between it and its children; restore preorder
+                    // (identity for a flat/childless anchor, so plain placements stay byte-identical).
+                    store.repairContiguity(inWorkspace: location.workspace)
+                    return response
                 }
             }
             // name addressing: reuse-or-create with `createWorkspace`, else require an existing match.
@@ -156,17 +174,35 @@ extension ControlServer: ControlActions {
         }
     }
 
+    /// Resolve a session address (id / unique prefix / `active`) across ALL of `store`'s workspaces to its
+    /// id — the shared spelling of the anchor/parent candidate set, so `--after`/`--before`/`--parent` all
+    /// resolve identically. Unresolved/ambiguous yields the shared resolver error.
+    private func resolveSessionAcrossStore(_ address: String, in store: AppStore,
+                                           _ body: (UUID) -> ControlResponse) -> ControlResponse {
+        resolver.resolve(address, candidates: store.workspaces.flatMap { $0.sessions.map(\.id) },
+                       active: store.selectedSessionID, noun: "session", body)
+    }
+
+    /// An `--after`/`--before` anchor's placement: its workspace, index, and workspace session count, plus
+    /// the anchor's own `parentID` so a placed or created sibling can INHERIT it (nesting at any depth).
+    private struct AnchorLocation {
+        let workspace: UUID
+        let index: Int
+        let count: Int
+        let parentID: UUID?
+    }
+
     /// Resolve an `--after`/`--before` anchor across all workspaces (so it names its own destination) and
-    /// hand its `(workspace, index, count)` to `body`. Unresolved/ambiguous yields the shared resolver
-    /// error; the location guard is defense-in-depth — the id came from the store's own list.
+    /// hand its `AnchorLocation` to `body`. Unresolved/ambiguous yields the shared resolver error; the
+    /// location guard is defense-in-depth — the id came from the store's own list.
     private func resolveAnchorLocation(_ anchor: String, in store: AppStore,
-                                       _ body: ((workspace: UUID, index: Int, count: Int)) -> ControlResponse) -> ControlResponse {
-        resolver.resolve(anchor, candidates: store.workspaces.flatMap { $0.sessions.map(\.id) },
-                       active: store.selectedSessionID, noun: "session") { anchorID in
+                                       _ body: (AnchorLocation) -> ControlResponse) -> ControlResponse {
+        resolveSessionAcrossStore(anchor, in: store) { anchorID in
             guard let location = store.sessionLocation(ofSession: anchorID) else {
                 return ControlResponse(ok: false, error: "no such session")
             }
-            return body(location)
+            return body(AnchorLocation(workspace: location.workspace, index: location.index,
+                                       count: location.count, parentID: store.session(withID: anchorID)?.parentID))
         }
     }
 
@@ -476,6 +512,19 @@ extension ControlServer: ControlActions {
         }
     }
 
+    /// Collapse (`expanded: false`) / expand (`expanded: true`) a SINGLE parent session's subtree in a
+    /// window's sidebar — the per-session analogue of `workspace.collapse`/`.expand`. Resolves the session
+    /// (honoring `--window`), then `AppActions.setSessionExpanded` persists `Session.isExpanded` on the store
+    /// directly (source of truth for the `collapsed` read-back, so it works with the sidebar hidden) and posts
+    /// a store-scoped notification for the live outline sync. Idempotent; returns the session id — a leaf just
+    /// records the state (no subtree to fold).
+    func setSessionExpansion(_ target: String?, window: String?, expanded: Bool) -> ControlResponse {
+        resolver.resolveSession(target, window: window) { store, id in
+            actions.setSessionExpanded(id, expanded: expanded, in: store)
+            return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
+        }
+    }
+
     /// Mode-bearing `session.move`: `to` (`up`|`down`|`top`|`bottom`) reorders within the session's own
     /// workspace, `workspace` relocates to another one (appending), `place` relocates + positions against an
     /// anchor session (which carries its own workspace). Exactly one form, enforced in the dispatcher.
@@ -497,12 +546,25 @@ extension ControlServer: ControlActions {
             }
         case .place(let anchor, let after):
             return placeSession(target, window: window, anchor: anchor, after: after)
+        case .parent(let anchor):
+            // `--parent`/`--unparent`: reparent the target within its own workspace. nil anchor (`--unparent`)
+            // promotes to top-level; a non-nil anchor nests under it (resolved in the target's store).
+            return resolver.resolveSession(target, window: window) { store, sessionID in
+                guard let anchor else {
+                    store.reparentSession(sessionID, to: nil)
+                    return ControlResponse(ok: true, result: ControlResult(id: sessionID.uuidString))
+                }
+                return resolveSessionAcrossStore(anchor, in: store) { anchorID in
+                    store.reparentSession(sessionID, to: anchorID)
+                    return ControlResponse(ok: true, result: ControlResult(id: sessionID.uuidString))
+                }
+            }
         }
     }
 
     func moveSessions(_ targets: [String], window: String?, move: ControlSessionMove) -> ControlResponse {
         switch move {
-        case .reorder:
+        case .reorder, .parent:
             return ControlResponse(ok: false, error: "session.move --target can be repeated only with a workspace or --after/--before")
         case .workspace(let workspace):
             return resolveBatchSessions(targets, window: window) { store, ids in
@@ -531,6 +593,12 @@ extension ControlServer: ControlActions {
                     placeAfter: after) {
                     store.moveSession(sessionID, toWorkspace: resolution.workspace, at: resolution.destination)
                 }
+                // adopt the anchor's parent so `--after`/`--before` nests as a sibling at any depth; a no-op
+                // (same parent, e.g. both top-level) leaves the positional move above as the only effect.
+                store.reparentSession(sessionID, to: anchorLoc.parentID)
+                // the flat positional splice can split the ANCHOR's own subtree, which reparentSession's
+                // parent-unchanged no-op would not repair; re-establish preorder unconditionally.
+                store.repairContiguity(inWorkspace: anchorLoc.workspace)
                 return ControlResponse(ok: true, result: ControlResult(id: sessionID.uuidString))
             }
         }

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -340,7 +340,7 @@ final class ControlServer {
                 .workspaceNew, .workspaceSelect, .workspaceRename, .workspaceDelete, .workspaceMove, .workspaceFocus,
                 .workspaceFilter, .workspaceCollapse, .workspaceExpand,
                 .sessionSplit, .sessionScratch, .sessionFocus, .sessionResize, .surfaceZoom,
-                .sessionStatus, .sessionFlag, .sessionSeen, .sessionRestore, .notify,
+                .sessionStatus, .sessionFlag, .sessionSeen, .sessionCollapse, .sessionExpand, .sessionRestore, .notify,
                 .fontInc, .fontDec, .fontReset, .keymapReload, .keymapList, .configReload, .themeSet, .themeList,
                 .sidebar, .sidebarMode, .sidebarExpand, .sidebarCollapse, .sessionType, .sessionCopy,
                 .sessionPaste, .sessionSelectAll,
@@ -555,11 +555,13 @@ final class ControlServer {
     /// `--after`/`--before` slot (clamped in `AppStore`), nil appends; `options.noSelect` creates in the
     /// background, selection and focus untouched.
     func makeSessionResponse(in store: AppStore, workspaceID: UUID,
-                             options: ControlSessionCreateOptions, at index: Int? = nil) -> ControlResponse {
+                             options: ControlSessionCreateOptions, parentID: UUID? = nil,
+                             at index: Int? = nil) -> ControlResponse {
         let cwd = options.cwd ?? FileManager.default.homeDirectoryForCurrentUser.path
         guard let session = store.addSession(toWorkspace: workspaceID, cwd: cwd,
                                              command: options.command, name: options.name,
-                                             wait: options.wait ?? false, at: index, select: !options.noSelect) else {
+                                             wait: options.wait ?? false, at: index, select: !options.noSelect,
+                                             parentID: parentID) else {
             return ControlResponse(ok: false, error: "could not create session")
         }
         if !options.noSelect, store === library.activeStore { actions.focusActiveSession() }

--- a/agterm/Views/WorkspaceSidebar+ContextMenu.swift
+++ b/agterm/Views/WorkspaceSidebar+ContextMenu.swift
@@ -87,6 +87,16 @@ extension WorkspaceSidebar.Coordinator {
                 duplicate.target = self
                 duplicate.representedObject = node
                 menu.addItem(duplicate)
+                // create a child session nested under this row — the GUI twin of `session new --parent`.
+                let newChild = NSMenuItem(title: "New Child Session", action: #selector(menuNewChildSession(_:)), keyEquivalent: "")
+                newChild.target = self
+                newChild.representedObject = node
+                menu.addItem(newChild)
+                let newChildDir = NSMenuItem(title: "New Child (Open Directory…)",
+                                             action: #selector(menuNewChildOpenSession(_:)), keyEquivalent: "")
+                newChildDir.target = self
+                newChildDir.representedObject = node
+                menu.addItem(newChildDir)
             }
             let targets = store.workspaces.filter { workspace in
                 sessionTargets.contains { ownerWorkspaceID(ofSession: $0) != workspace.id }
@@ -223,6 +233,18 @@ extension WorkspaceSidebar.Coordinator {
         addSession(toWorkspace: node.id, cwd: actions.resolvedNewSessionCwd())
     }
 
+    @objc private func menuNewChildSession(_ sender: NSMenuItem) {
+        guard let node = sender.representedObject as? SidebarNode else { return }
+        // this sidebar's window-local store, like Duplicate/Close — a background window nests under its own row.
+        actions.newChildSession(of: node.id, in: store)
+    }
+
+    @objc private func menuNewChildOpenSession(_ sender: NSMenuItem) {
+        guard let node = sender.representedObject as? SidebarNode,
+              let workspace = store.workspace(forSession: node.id) else { return }
+        openDirectoryAndAddSession(toWorkspace: workspace.id, parentID: node.id)
+    }
+
     /// Inline "+" button on a workspace row, the right-click "New Session" action. The button carries no
     /// workspace id, so it is derived from the outline row at click time — reused cells target the right one.
     @objc func addSessionButtonClicked(_ sender: NSButton) {
@@ -262,9 +284,9 @@ extension WorkspaceSidebar.Coordinator {
         openDirectoryAndAddSession(toWorkspace: node.id)
     }
 
-    /// Adds a session to `workspaceID` at `cwd` and selects it.
-    private func addSession(toWorkspace workspaceID: UUID, cwd: String) {
-        if let session = store.addSession(toWorkspace: workspaceID, cwd: cwd) {
+    /// Adds a session to `workspaceID` at `cwd` and selects it; `parentID` nests it under that session.
+    private func addSession(toWorkspace workspaceID: UUID, cwd: String, parentID: UUID? = nil) {
+        if let session = store.addSession(toWorkspace: workspaceID, cwd: cwd, parentID: parentID) {
             // creating + selecting from the sidebar context menu is a user-initiated selection on THIS
             // window's store: note activity so it buys the full idle grace before auto-follow pulls away.
             store.noteUserActivity()
@@ -273,7 +295,7 @@ extension WorkspaceSidebar.Coordinator {
         }
     }
 
-    private func openDirectoryAndAddSession(toWorkspace workspaceID: UUID) {
+    private func openDirectoryAndAddSession(toWorkspace workspaceID: UUID, parentID: UUID? = nil) {
         let panel = NSOpenPanel()
         panel.canChooseDirectories = true
         panel.canChooseFiles = false
@@ -282,6 +304,6 @@ extension WorkspaceSidebar.Coordinator {
         panel.prompt = "Open"
         panel.message = "Choose a directory for the new session"
         guard panel.runModal() == .OK, let url = panel.url else { return }
-        addSession(toWorkspace: workspaceID, cwd: url.path)
+        addSession(toWorkspace: workspaceID, cwd: url.path, parentID: parentID)
     }
 }

--- a/agterm/Views/WorkspaceSidebar+DragDrop.swift
+++ b/agterm/Views/WorkspaceSidebar+DragDrop.swift
@@ -38,12 +38,15 @@ extension WorkspaceSidebar.Coordinator {
             return .move
         }
         if !draggedSessionIDs(from: info).isEmpty {
-            guard let move = resolveSessionMove(from: info, item: item, childIndex: index) else {
+            guard let plan = resolveSessionDrop(from: info, item: item, childIndex: index) else {
                 cancelSpringLoadedExpansion()
                 return []
             }
-            outlineView.setDropItem(workspaceNode(forID: move.workspace), dropChildIndex: move.dropChildIndex)
-            scheduleSpringLoadedExpansion(of: move.workspace, in: outlineView)
+            // nest-under-session drops highlight the target session row; top-level drops highlight the
+            // workspace row (both fall back to the workspace when the parent node isn't cached).
+            let highlight = plan.parentID.flatMap(sessionNode(forID:)) ?? workspaceNode(forID: plan.workspace)
+            outlineView.setDropItem(highlight, dropChildIndex: plan.highlightChildIndex)
+            scheduleSpringLoadedExpansion(of: plan.workspace, in: outlineView)
             return .move
         }
         guard let drop = resolveDirectoryDrop(from: info, item: item) else {
@@ -71,8 +74,8 @@ extension WorkspaceSidebar.Coordinator {
             return true
         }
         if !draggedSessionIDs(from: info).isEmpty {
-            guard let move = resolveSessionMove(from: info, item: item, childIndex: index) else { return false }
-            store.moveSessions(move.sessionIDs, toWorkspace: move.workspace, at: move.destination)
+            guard let plan = resolveSessionDrop(from: info, item: item, childIndex: index) else { return false }
+            applySessionDrop(plan)
             dropSucceeded = true
             return true
         }
@@ -108,42 +111,79 @@ extension WorkspaceSidebar.Coordinator {
         let exceedsLimit: Bool
     }
 
-    /// The resolved session drop. `dropChildIndex` is the PRE-removal slot to highlight; `destination`
-    /// is the POST-removal index `moveSessions` expects.
-    private struct SessionMove {
-        let sessionIDs: [UUID]
+    /// A resolved session drop. A SAME-workspace drop reparents the dragged roots (nest under `parentID`, or
+    /// top-level when nil), carrying each subtree and positioning at `destination` among the new siblings. A
+    /// CROSS-workspace drop always lands at the target workspace's top level (a subtree can't straddle
+    /// workspaces) at flat index `destination`. `highlightChildIndex` drives `setDropItem`.
+    private struct SessionDropPlan {
+        let roots: [UUID]
         let workspace: UUID
-        let dropChildIndex: Int
+        let parentID: UUID?
         let destination: Int
+        let crossWorkspace: Bool
+        let highlightChildIndex: Int
     }
 
-    /// Resolves a proposed session drop into the move it would perform, nil when the drop is invalid or a
-    /// no-op, so `validateDrop` and `acceptDrop` agree exactly. Reads the pasteboard + store to map dragged
-    /// sessions and the drop-target row to indices, then defers the index arithmetic (drop-on-row redirect,
-    /// post-removal insertion slot, no-op detection) to the host-free `SidebarDrop.resolveSessions`.
-    private func resolveSessionMove(from info: NSDraggingInfo, item: Any?, childIndex index: Int) -> SessionMove? {
-        let sessionIDs = draggedSessionIDs(from: info)
-        guard !sessionIDs.isEmpty, let node = item as? SidebarNode else { return nil }
+    /// Resolves a proposed session drop into the reparent/move it would perform, nil when invalid or a
+    /// no-op, so `validateDrop` and `acceptDrop` agree exactly. The drop target's `item` names the parent:
+    /// a workspace row → the workspace top level (parentID nil), a session row → nest under that session.
+    /// Same-workspace drops defer the sibling-index arithmetic + cycle guard to `SidebarDrop.resolveReparent`;
+    /// cross-workspace drops force top-level placement (no cross-workspace nesting) via `flatChildInsertIndex`.
+    private func resolveSessionDrop(from info: NSDraggingInfo, item: Any?, childIndex index: Int) -> SessionDropPlan? {
+        let dragged = draggedSessionIDs(from: info)
+        guard !dragged.isEmpty, let node = item as? SidebarNode else { return nil }
+        // reduce a mixed selection to its topmost roots — a dragged child rides along inside its dragged
+        // parent's subtree, so moving it independently would double-handle it.
+        let draggedSet = Set(dragged)
+        let roots = dragged.filter { store.session(withID: $0)?.parentID.map { !draggedSet.contains($0) } ?? true }
+        guard !roots.isEmpty else { return nil }
 
-        let target: SidebarDrop.SessionDropTarget
+        let targetWorkspace: UUID
+        let parentID: UUID?
         switch node.kind {
         case .workspace:
-            let count = store.workspaces.first(where: { $0.id == node.id })?.sessions.count ?? 0
-            target = .workspaceRow(id: node.id, sessionCount: count)
+            targetWorkspace = node.id
+            parentID = nil
         case .session:
-            guard let drop = store.sessionLocation(ofSession: node.id) else { return nil }
-            target = .sessionRow(workspace: drop.workspace, sessionIndex: drop.index, sessionCount: drop.count)
+            guard let workspace = store.workspace(forSession: node.id)?.id else { return nil }
+            targetWorkspace = workspace
+            parentID = node.id
         }
+        let order = store.workspaces.first(where: { $0.id == targetWorkspace })?
+            .sessions.map { SessionTree.Node(id: $0.id, parentID: $0.parentID) } ?? []
 
-        let sources = sessionIDs.compactMap { id -> SidebarDrop.SessionSource? in
-            guard let source = store.sessionLocation(ofSession: id) else { return nil }
-            return SidebarDrop.SessionSource(workspace: source.workspace, index: source.index)
+        let allSameWorkspace = roots.allSatisfy { store.workspace(forSession: $0)?.id == targetWorkspace }
+        if allSameWorkspace {
+            guard let reparent = SidebarDrop.resolveReparent(order: order, sourceIDs: roots,
+                                                             parentID: parentID, childIndex: index) else { return nil }
+            return SessionDropPlan(roots: roots, workspace: targetWorkspace, parentID: reparent.parentID,
+                                   destination: reparent.destination, crossWorkspace: false, highlightChildIndex: index)
         }
-        guard sources.count == sessionIDs.count,
-              let move = SidebarDrop.resolveSessions(sources: sources, target: target, childIndex: index)
-        else { return nil }
-        return SessionMove(sessionIDs: sessionIDs, workspace: move.workspace,
-                           dropChildIndex: move.dropChildIndex, destination: move.destination)
+        // cross-workspace: nesting isn't allowed, so land at the target's top level — dropped ON a row appends.
+        let topChildIndex = node.kind == .workspace ? index : SidebarDrop.onItemIndex
+        let flat = SidebarDrop.flatChildInsertIndex(order: order, parent: nil,
+                                                    childDestination: topChildIndex == SidebarDrop.onItemIndex ? nil : topChildIndex)
+        return SessionDropPlan(roots: roots, workspace: targetWorkspace, parentID: nil,
+                               destination: flat, crossWorkspace: true, highlightChildIndex: topChildIndex)
+    }
+
+    /// Applies a resolved drop. A same-workspace single root repositions with its sibling index; a batch
+    /// appends each root under the new parent in drag order. A cross-workspace drop moves each root's whole
+    /// subtree to the target's top level (`moveSession` nils the root's parentID and carries descendants),
+    /// advancing the insert slot past each moved block so drag order is preserved.
+    private func applySessionDrop(_ plan: SessionDropPlan) {
+        if plan.crossWorkspace {
+            var index = plan.destination
+            for root in plan.roots {
+                let blockSize = store.sessionSubtreeIDs(root).count
+                store.moveSession(root, toWorkspace: plan.workspace, at: index)
+                index += blockSize
+            }
+        } else if plan.roots.count == 1 {
+            store.reparentSession(plan.roots[0], to: plan.parentID, at: plan.destination)
+        } else {
+            for root in plan.roots { store.reparentSession(root, to: plan.parentID, at: nil) }
+        }
     }
 
     /// Resolves a Finder drop to existing directory URLs and a destination workspace: a workspace row adds

--- a/agterm/Views/WorkspaceSidebar+RowRendering.swift
+++ b/agterm/Views/WorkspaceSidebar+RowRendering.swift
@@ -64,8 +64,10 @@ extension WorkspaceSidebar.Coordinator {
             field.setAccessibilityIdentifier("session-row")
             field.setAccessibilityLabel(nil)
             let session = store.session(withID: node.id)
-            applyBadge(toCell: cell, count: effectiveUnseen(session?.unseenCount ?? 0))
-            cell.statusIcon.apply(effectiveIndicator(forSession: node.id))
+            // a collapsed parent session rolls its hidden subtree's badge + most-urgent status onto its own
+            // row (rowUnseen/rowIndicator); an expanded parent or a leaf shows only its own.
+            applyBadge(toCell: cell, count: session.map { rowUnseen(forSession: $0) } ?? 0)
+            cell.statusIcon.apply(session.map { rowIndicator(forSession: $0) } ?? AgentIndicator())
             // the split-rectangle icon (matching the toolbar split button) shows in BOTH modes so a split
             // stays distinguishable at a glance, and `hasSplit` keeps it while merely hidden. Only the
             // filled `flagged` variant is tree-mode only — every row in the flat flagged view is flagged,

--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -98,7 +98,9 @@ struct WorkspaceSidebar: NSViewRepresentable {
         // reload; a touch inside viewFor wouldn't register it. The badge-visibility toggle
         // (GhosttyApp.notificationBadgeEnabled) is NOT observable and drives a re-reconcile via
         // .agtermAppearanceChanged, like toolbarMode.
-        _ = store.workspaces.map { ($0.id, $0.name, $0.unseenCount, $0.sessions.map { ($0.id, $0.displayName, $0.hasSplit, $0.unseenCount, $0.agentIndicator, $0.flagged) }) }
+        // parentID/isExpanded ride the observed read so a reparent (order + depth) or a parent collapse
+        // reconciles, and each session's unseen/status feeds a collapsed parent's rolled-up badge/glyph.
+        _ = store.workspaces.map { ($0.id, $0.name, $0.unseenCount, $0.sessions.map { ($0.id, $0.displayName, $0.hasSplit, $0.unseenCount, $0.agentIndicator, $0.flagged, $0.parentID, $0.isExpanded) }) }
         _ = store.selectedSessionID
         _ = store.sidebarSelectionIDs
         // sidebarMode flips the whole data source (tree ↔ flat flagged list), so a mode change must rebuild.
@@ -138,6 +140,11 @@ struct WorkspaceSidebar: NSViewRepresentable {
         /// truth for restoring expansion on rebuild: NSOutlineView discards its own expansion state for
         /// items it no longer renders, and the flagged-mode reload drops every workspace node.
         private var expandedWorkspaceIDs = Set<UUID>()
+        /// Session ids the user has left expanded — the same source-of-truth pattern as
+        /// `expandedWorkspaceIDs`, one level deeper: NSOutlineView drops expansion for items it stops
+        /// rendering, so `rebuildAndReload` re-applies this set to the nested session nodes. Every session
+        /// defaults `isExpanded == true`, so a parent renders open until the user collapses it.
+        private var expandedSessionIDs = Set<UUID>()
         /// Set true around PROGRAMMATIC `expandItem`/`collapseItem` (the launch/rebuild re-apply, the
         /// `syncSelection` reveal, the focus force-expand): the didExpand/DidCollapse callbacks still update
         /// the visual `expandedWorkspaceIDs` but SKIP the persist write-back, so a view-only reveal never
@@ -168,6 +175,9 @@ struct WorkspaceSidebar: NSViewRepresentable {
         /// `UUID` and the desired `Bool` state, written by `AppActions.setWorkspaceExpanded(_:expanded:in:)`.
         static let workspaceIDUserInfoKey = "agterm.workspaceID"
         static let expandedUserInfoKey = "agterm.expanded"
+        /// `userInfo` key for the `.agtermSetSessionExpanded` per-session poke (the target session `UUID`);
+        /// the `Bool` rides `expandedUserInfoKey`, shared with the workspace poke.
+        static let sessionIDUserInfoKey = "agterm.sessionID"
 
         /// Last-seen visible content (label, split icon, badge) per session and workspace id, so a
         /// reconcile reloads only the rows whose content changed. An absent key ≠ any real content.
@@ -206,6 +216,8 @@ struct WorkspaceSidebar: NSViewRepresentable {
             // the per-workspace collapse/expand poke (workspace.collapse/expand) is store-scoped the same way.
             NotificationCenter.default.addObserver(self, selector: #selector(setWorkspaceExpandedNotified(_:)),
                                                    name: .agtermSetWorkspaceExpanded, object: store)
+            NotificationCenter.default.addObserver(self, selector: #selector(setSessionExpandedNotified(_:)),
+                                                   name: .agtermSetSessionExpanded, object: store)
             // a theme change (new terminal foreground) re-tints the visible rows in place.
             NotificationCenter.default.addObserver(self, selector: #selector(appearanceChanged),
                                                    name: .agtermAppearanceChanged, object: nil)
@@ -283,8 +295,9 @@ struct WorkspaceSidebar: NSViewRepresentable {
             guard let outline = outlineView else { return }
             for row in 0 ..< outline.numberOfRows {
                 guard let node = outline.item(atRow: row) as? SidebarNode, node.kind == .session,
+                      let session = store.session(withID: node.id),
                       let cell = outline.view(atColumn: 0, row: row, makeIfNecessary: false) as? SidebarCellView else { continue }
-                cell.statusIcon.apply(effectiveIndicator(forSession: node.id))
+                cell.statusIcon.apply(rowIndicator(forSession: session))
             }
         }
 
@@ -327,14 +340,44 @@ struct WorkspaceSidebar: NSViewRepresentable {
             suppressExpansionPersist = false
         }
 
+        /// Sync the sidebar to a SINGLE parent session's collapse/expand (`session.collapse`/`.expand`), the
+        /// one-level-deeper twin of `setWorkspaceExpandedNotified`. `AppActions.setSessionExpanded` has already
+        /// persisted `Session.isExpanded`, so this only keeps the tracked `expandedSessionIDs` in step and
+        /// folds/unfolds the live row (suppressing its re-persist). A leaf or off-screen row updates the set
+        /// alone; on expand the newly revealed subtree re-applies its own tracked expansion.
+        @objc private func setSessionExpandedNotified(_ notification: Notification) {
+            guard let id = notification.userInfo?[Self.sessionIDUserInfoKey] as? UUID,
+                  let expanded = notification.userInfo?[Self.expandedUserInfoKey] as? Bool else { return }
+            if expanded { expandedSessionIDs.insert(id) } else { expandedSessionIDs.remove(id) }
+            guard store.sidebarMode == .tree, let outline = outlineView,
+                  let node = nodeCache[id], node.kind == .session, !node.children.isEmpty,
+                  outline.row(forItem: node) >= 0 else { return }
+            suppressExpansionPersist = true
+            if expanded {
+                outline.expandItem(node)
+                reapplySessionExpansion(under: node, outline: outline)
+            } else {
+                outline.collapseItem(node)
+            }
+            suppressExpansionPersist = false
+        }
+
         // MARK: - Model rebuild
 
-        /// The tree SHAPE: a workspace's id and its ordered session ids. Equal shapes mean no
-        /// add/remove/move/reorder, so a content change takes a targeted per-row reload. Row TEXT is NOT
-        /// here: a cwd-driven `displayName` change must not `reloadData` + re-expand, which jitters labels.
+        /// The tree SHAPE: a workspace's id and its ordered sessions as (id, parentID) pairs. Equal shapes
+        /// mean no add/remove/move/reorder AND no depth change, so a content change takes a targeted per-row
+        /// reload. Carrying `parentID` (not just the id) makes a promote/reparent that keeps linear order but
+        /// changes nesting (e.g. `[A, A/b]` → `[A, b]`) still count as a shape change and rebuild the nested
+        /// outline. Row TEXT is NOT here: a cwd-driven `displayName` change must not `reloadData` + re-expand.
         private struct TreeShape: Equatable {
             let workspaceID: UUID
-            let sessionIDs: [UUID]
+            let sessions: [SessionShape]
+        }
+
+        /// One session's identity in a `TreeShape`: its id plus the `parentID` that places it in the tree.
+        private struct SessionShape: Equatable {
+            let id: UUID
+            let parentID: UUID?
         }
 
         /// A row's visible content: label (workspace name or session `displayName`), split-rectangle icon,
@@ -354,18 +397,36 @@ struct WorkspaceSidebar: NSViewRepresentable {
             let focusMember: Bool
         }
 
-        /// The session's own agent-status indicator (`.idle` for an unknown id / workspace row). Shown
-        /// regardless of selection — `completed --auto-reset` clears itself on `selectSession`, so a
-        /// visited session drops its glyph without a render-time gate.
-        func effectiveIndicator(forSession id: UUID) -> AgentIndicator {
-            store.session(withID: id)?.agentIndicator ?? AgentIndicator()
-        }
-
         /// The unseen count after the badge-visibility gate: 0 when the Settings toggle is off. Render-only
         /// — `unseenCount` keeps tracking, so re-enabling instantly shows current counts. The agent-status
         /// glyph is NOT gated by this.
         func effectiveUnseen(_ count: Int) -> Int {
             GhosttyApp.shared.notificationBadgeEnabled ? count : 0
+        }
+
+        /// Whether `session` currently rolls its subtree up onto its own row: a COLLAPSED parent with at
+        /// least one descendant. When true its row stands in for the hidden block, aggregating their badge
+        /// and surfacing their most-urgent status; an expanded parent or a leaf shows only its own.
+        private func rollsUpDescendants(_ session: Session) -> Bool {
+            !session.isExpanded && store.sessionSubtreeIDs(session.id).count > 1
+        }
+
+        /// The gated unseen count a session ROW shows: its own, or — for a collapsed parent — the sum across
+        /// its whole subtree (itself + hidden descendants), so a notification folded under it stays visible.
+        func rowUnseen(forSession session: Session) -> Int {
+            guard rollsUpDescendants(session) else { return effectiveUnseen(session.unseenCount) }
+            let total = store.sessionSubtreeIDs(session.id).reduce(0) { $0 + (store.session(withID: $1)?.unseenCount ?? 0) }
+            return effectiveUnseen(total)
+        }
+
+        /// The status glyph a session ROW shows: its own indicator, or — for a collapsed parent — the
+        /// most-urgent non-idle indicator across its whole subtree (`AgentStatus.attentionRank`, blocked
+        /// first), so a blocked/active session folded beneath it still draws for attention.
+        func rowIndicator(forSession session: Session) -> AgentIndicator {
+            guard rollsUpDescendants(session) else { return session.agentIndicator }
+            return store.sessionSubtreeIDs(session.id)
+                .compactMap { store.session(withID: $0)?.agentIndicator }
+                .min { $0.status.attentionRank < $1.status.attentionRank } ?? session.agentIndicator
         }
 
         /// Decides between a full rebuild (a SHAPE change: add/move/close/reorder) and a targeted per-row
@@ -391,9 +452,14 @@ struct WorkspaceSidebar: NSViewRepresentable {
         private func currentShape() -> [TreeShape] {
             switch store.sidebarMode {
             case .tree:
-                return store.visibleWorkspaces.map { TreeShape(workspaceID: $0.id, sessionIDs: $0.sessions.map(\.id)) }
+                return store.visibleWorkspaces.map { workspace in
+                    TreeShape(workspaceID: workspace.id,
+                              sessions: workspace.sessions.map { SessionShape(id: $0.id, parentID: $0.parentID) })
+                }
             case .flagged:
-                return [TreeShape(workspaceID: Self.flaggedShapeID, sessionIDs: store.flaggedSessions.map(\.id))]
+                // flagged mode is a flat list; every row is a top-level (nil-parent) shape entry.
+                return [TreeShape(workspaceID: Self.flaggedShapeID,
+                                  sessions: store.flaggedSessions.map { SessionShape(id: $0.id, parentID: nil) })]
             }
         }
 
@@ -440,8 +506,8 @@ struct WorkspaceSidebar: NSViewRepresentable {
         /// `workspaceName` in, so the label needs no per-session lookup and the reconcile stays linear.
         private func rowContent(forSession session: Session, workspaceName: String) -> RowContent {
             RowContent(label: rowLabel(for: session, workspaceName: workspaceName), hasSplit: session.hasSplit,
-                       unseen: effectiveUnseen(session.unseenCount),
-                       indicator: effectiveIndicator(forSession: session.id), flagged: session.flagged,
+                       unseen: rowUnseen(forSession: session),
+                       indicator: rowIndicator(forSession: session), flagged: session.flagged,
                        focusMember: false)
         }
 
@@ -455,7 +521,9 @@ struct WorkspaceSidebar: NSViewRepresentable {
                 var seen = Set<UUID>()
                 roots = store.flaggedSessions.map { session in
                     seen.insert(session.id)
-                    return node(for: session.id, kind: .session)
+                    let node = node(for: session.id, kind: .session)
+                    node.children = [] // a cached node may carry tree-mode children; the flat view has none
+                    return node
                 }
                 nodeCache = nodeCache.filter { seen.contains($0.key) }
                 outline.reloadData()
@@ -469,10 +537,7 @@ struct WorkspaceSidebar: NSViewRepresentable {
             for workspace in store.visibleWorkspaces {
                 let wsNode = node(for: workspace.id, kind: .workspace)
                 seen.insert(workspace.id)
-                wsNode.children = workspace.sessions.map { session in
-                    seen.insert(session.id)
-                    return node(for: session.id, kind: .session)
-                }
+                wsNode.children = sessionNodes(under: nil, in: workspace, seen: &seen)
                 newRoots.append(wsNode)
             }
             nodeCache = nodeCache.filter { seen.contains($0.key) }
@@ -484,6 +549,15 @@ struct WorkspaceSidebar: NSViewRepresentable {
             // already-present id are undisturbed (formUnion only adds).
             expandedWorkspaceIDs.formIntersection(Set(store.workspaces.map(\.id)))
             expandedWorkspaceIDs.formUnion(store.workspaces.filter(\.isExpanded).map(\.id))
+
+            // same re-sync one level deeper for parent sessions: a session created or reparented at RUNTIME
+            // was never in `expandedSessionIDs` (that set is seeded once at launch), so without this a freshly
+            // nested subtree would render under a collapsed parent. Drop closed ids, then pick up every
+            // session the model reports expanded (default true, incl. a leaf just turned parent); a
+            // user-collapsed one stays collapsed since formUnion only adds.
+            let allSessionIDs = store.workspaces.flatMap(\.sessions)
+            expandedSessionIDs.formIntersection(Set(allSessionIDs.map(\.id)))
+            expandedSessionIDs.formUnion(allSessionIDs.filter(\.isExpanded).map(\.id))
 
             // restore expansion from the tracked set, not the live outline state, which forgets across a
             // flagged-mode reload. A filter applied to a SINGLE marked workspace also force-expands it — a
@@ -497,9 +571,36 @@ struct WorkspaceSidebar: NSViewRepresentable {
             let forceExpanded = store.soleFocusedWorkspaceID
             for node in roots where expandedWorkspaceIDs.contains(node.id) || forceExpanded == node.id {
                 outline.expandItem(node)
+                reapplySessionExpansion(under: node, outline: outline)
             }
             suppressExpansionPersist = false
             updateEmptyState()
+        }
+
+        /// Builds the nested session nodes directly under `parentID` (nil = the workspace's top-level
+        /// sessions) in array order, recursing into each session's own children — so the flat, contiguous
+        /// `workspace.sessions` array becomes the outline's nested tree. Reuses cached nodes by id and marks
+        /// each `seen` so `rebuildAndReload`'s cache prune keeps them.
+        private func sessionNodes(under parentID: UUID?, in workspace: Workspace, seen: inout Set<UUID>) -> [SidebarNode] {
+            workspace.sessions.filter { $0.parentID == parentID }.map { session in
+                seen.insert(session.id)
+                let node = node(for: session.id, kind: .session)
+                node.children = sessionNodes(under: session.id, in: workspace, seen: &seen)
+                return node
+            }
+        }
+
+        /// Re-applies the tracked session expansion to `parent`'s now-visible session descendants, top-down:
+        /// AppKit expanding one item does not restore its children's expansion, so after expanding a workspace
+        /// (or a parent session in `didExpand`) each child parent that the user left open is re-expanded, then
+        /// recursed into. A collapsed child is skipped — its own subtree stays folded until it is expanded,
+        /// at which point this runs again for it. Caller owns `suppressExpansionPersist`.
+        private func reapplySessionExpansion(under parent: SidebarNode, outline: NSOutlineView) {
+            for child in parent.children where child.kind == .session && !child.children.isEmpty {
+                guard expandedSessionIDs.contains(child.id) else { continue }
+                outline.expandItem(child)
+                reapplySessionExpansion(under: child, outline: outline)
+            }
         }
 
         /// Adds the flagged-mode empty-state hint below the safe-area inset so it clears the titlebar, as a
@@ -532,10 +633,12 @@ struct WorkspaceSidebar: NSViewRepresentable {
             label.textColor = (GhosttyApp.shared.terminalForegroundColor ?? .secondaryLabelColor).withAlphaComponent(0.6)
         }
 
-        /// Seeds the tracked expansion set from the persisted `Workspace.isExpanded`. Sets only the tracked
-        /// set — `rebuildAndReload` applies it to the outline. Called once from `makeNSView`.
+        /// Seeds the tracked expansion sets from the persisted `Workspace.isExpanded` and `Session.isExpanded`.
+        /// Sets only the tracked sets — `rebuildAndReload` applies them to the outline. Called once from
+        /// `makeNSView`.
         func seedExpansionFromModel() {
             expandedWorkspaceIDs = Set(store.workspaces.filter(\.isExpanded).map(\.id))
+            expandedSessionIDs = Set(store.workspaces.flatMap(\.sessions).filter(\.isExpanded).map(\.id))
         }
 
         /// Expands every workspace row — the "Expand Workspaces" user action. Seeds the tracked expansion
@@ -546,7 +649,10 @@ struct WorkspaceSidebar: NSViewRepresentable {
             guard let outline = outlineView else { return }
             for workspace in store.workspaces { expandedWorkspaceIDs.insert(workspace.id) }
             suppressExpansionPersist = true
-            for node in roots where node.kind == .workspace { outline.expandItem(node) }
+            for node in roots where node.kind == .workspace {
+                outline.expandItem(node)
+                reapplySessionExpansion(under: node, outline: outline)
+            }
             suppressExpansionPersist = false
             store.setWorkspacesExpanded(expandedWorkspaceIDs)
         }
@@ -564,6 +670,7 @@ struct WorkspaceSidebar: NSViewRepresentable {
             for node in roots where node.kind == .workspace {
                 if node.id == keepID {
                     if !outline.isItemExpanded(node) { outline.expandItem(node) }
+                    reapplySessionExpansion(under: node, outline: outline)
                 } else if outline.isItemExpanded(node) {
                     outline.collapseItem(node)
                 }
@@ -578,20 +685,38 @@ struct WorkspaceSidebar: NSViewRepresentable {
         }
 
         func outlineViewItemDidExpand(_ notification: Notification) {
-            guard let node = notification.userInfo?[Self.outlineItemUserInfoKey] as? SidebarNode,
-                  node.kind == .workspace else { return }
-            expandedWorkspaceIDs.insert(node.id)
+            guard let node = notification.userInfo?[Self.outlineItemUserInfoKey] as? SidebarNode else { return }
             // persist ONLY a genuine user expand: a programmatic reveal or rebuild re-apply sets
             // suppressExpansionPersist, updating the visual set above without burning the persisted intent.
-            if !suppressExpansionPersist { store.setWorkspaceExpanded(node.id, expanded: true) }
+            switch node.kind {
+            case .workspace:
+                expandedWorkspaceIDs.insert(node.id)
+                if !suppressExpansionPersist { store.setWorkspaceExpanded(node.id, expanded: true) }
+            case .session:
+                expandedSessionIDs.insert(node.id)
+                if !suppressExpansionPersist { store.setSessionExpanded(node.id, expanded: true) }
+                // the newly-revealed children may themselves be expanded parents; AppKit won't restore that,
+                // so re-apply the tracked expansion to this node's subtree (a view action, so suppress it).
+                if let outline = outlineView {
+                    let wasSuppressed = suppressExpansionPersist
+                    suppressExpansionPersist = true
+                    reapplySessionExpansion(under: node, outline: outline)
+                    suppressExpansionPersist = wasSuppressed
+                }
+            }
         }
 
         func outlineViewItemDidCollapse(_ notification: Notification) {
-            guard let node = notification.userInfo?[Self.outlineItemUserInfoKey] as? SidebarNode,
-                  node.kind == .workspace else { return }
-            expandedWorkspaceIDs.remove(node.id)
+            guard let node = notification.userInfo?[Self.outlineItemUserInfoKey] as? SidebarNode else { return }
             // persist only a genuine user collapse; programmatic collapses are suppressed (see didExpand).
-            if !suppressExpansionPersist { store.setWorkspaceExpanded(node.id, expanded: false) }
+            switch node.kind {
+            case .workspace:
+                expandedWorkspaceIDs.remove(node.id)
+                if !suppressExpansionPersist { store.setWorkspaceExpanded(node.id, expanded: false) }
+            case .session:
+                expandedSessionIDs.remove(node.id)
+                if !suppressExpansionPersist { store.setSessionExpanded(node.id, expanded: false) }
+            }
         }
 
         private func node(for id: UUID, kind: SidebarNode.Kind) -> SidebarNode {
@@ -618,13 +743,13 @@ struct WorkspaceSidebar: NSViewRepresentable {
             // and scrolling into view — only fires on a real selection change, so unrelated cwd/title/badge
             // updates leave a user-collapsed workspace and a user-moved scroll position alone.
             let selectionChanged = selectedID != lastRevealedSelection
-            // a session selected by keyboard nav may live in a collapsed workspace, whose row is -1 until
-            // expanded; expand its owner first so the row resolves. A VIEW action, so suppress the persist:
-            // navigating into a deliberately collapsed workspace shows the session without un-collapsing it
-            // on disk.
-            if selectionChanged, let owner = ownerWorkspaceNode(ofSession: selectedID), !outline.isItemExpanded(owner) {
+            // a session selected by keyboard nav may live in a collapsed workspace and/or under collapsed
+            // parent sessions, whose row is -1 until every ancestor is expanded; expand the whole chain first
+            // so the row resolves. A VIEW action, so suppress the persist: navigating into a deliberately
+            // collapsed owner shows the session without un-collapsing it on disk.
+            if selectionChanged {
                 suppressExpansionPersist = true
-                outline.expandItem(owner)
+                revealAncestors(ofSession: selectedID, in: outline)
                 suppressExpansionPersist = false
             }
             var rows = IndexSet()
@@ -646,9 +771,18 @@ struct WorkspaceSidebar: NSViewRepresentable {
             lastRevealedSelection = selectedID
         }
 
-        /// The workspace node whose `children` hold `sessionID` — used to expand a collapsed owner first.
-        private func ownerWorkspaceNode(ofSession sessionID: UUID) -> SidebarNode? {
-            roots.first { $0.children.contains { $0.id == sessionID } }
+        /// Expands every collapsed ancestor of `sessionID` — its owner workspace and each ancestor session,
+        /// outermost first — so a selection nested under collapsed parents resolves to a real row. Caller owns
+        /// `suppressExpansionPersist`, so revealing a deliberately-collapsed owner does not persist it open.
+        private func revealAncestors(ofSession sessionID: UUID, in outline: NSOutlineView) {
+            guard let workspace = store.workspace(forSession: sessionID) else { return }
+            if let wsNode = nodeCache[workspace.id], !outline.isItemExpanded(wsNode) { outline.expandItem(wsNode) }
+            let nodes = workspace.sessions.map { SessionTree.Node(id: $0.id, parentID: $0.parentID) }
+            // ancestorIDs is nearest-first; expand outermost-first so each parent's row exists before its child.
+            for ancestorID in SessionTree.ancestorIDs(of: sessionID, in: nodes).reversed() {
+                guard let node = nodeCache[ancestorID], !outline.isItemExpanded(node) else { continue }
+                outline.expandItem(node)
+            }
         }
 
         func outlineViewSelectionDidChange(_ notification: Notification) {
@@ -718,7 +852,9 @@ struct WorkspaceSidebar: NSViewRepresentable {
 
         func outlineView(_ outlineView: NSOutlineView, isItemExpandable item: Any) -> Bool {
             guard let node = item as? SidebarNode else { return false }
-            return node.kind == .workspace
+            // a workspace always shows a disclosure triangle (even when empty, as before); a session shows one
+            // only when it parents a subtree.
+            return node.kind == .workspace || !node.children.isEmpty
         }
 
         /// Leading row icons as monochrome template symbols. A flagged SESSION swaps to its base glyph's
@@ -750,6 +886,13 @@ struct WorkspaceSidebar: NSViewRepresentable {
 
         func workspaceNode(forID id: UUID) -> SidebarNode? {
             roots.first(where: { $0.id == id })
+        }
+
+        /// The cached SESSION node for `id`, at any depth — the drag-and-drop code (a different file, so it
+        /// can't read the private `nodeCache`) uses it to highlight a nest-under-session drop target.
+        func sessionNode(forID id: UUID) -> SidebarNode? {
+            guard let node = nodeCache[id], node.kind == .session else { return nil }
+            return node
         }
     }
 }
@@ -798,6 +941,9 @@ extension Notification.Name {
     /// Posted by the `workspace.collapse`/`workspace.expand` control arm for a SINGLE workspace, with the
     /// target window's `AppStore` as the object and the workspace id + desired state in `userInfo`.
     static let agtermSetWorkspaceExpanded = Notification.Name("agterm.setWorkspaceExpanded")
+    /// Posted by the `session.collapse`/`session.expand` control arm for a SINGLE parent session, with the
+    /// target window's `AppStore` as the object and the session id + desired state in `userInfo`.
+    static let agtermSetSessionExpanded = Notification.Name("agterm.setSessionExpanded")
     /// Posted by the `session.resize` control arm after storing a new split-divider fraction, with the
     /// target `Session` as the object so only that session's `SplitProbeView` (in `ContentView`) moves its
     /// live divider to `Session.splitRatio`.

--- a/agterm/agtermApp+Menus.swift
+++ b/agterm/agtermApp+Menus.swift
@@ -102,6 +102,8 @@ extension agtermApp {
                 Button("New Session") { actions.newSession() }
                     .keyboardShortcut(shortcut(for: .newSession))
                     .disabled(modalActive)
+                Button("New Child Session") { actions.newChildActiveSession() }
+                    .disabled(library.activeStore?.activeSession == nil || modalActive)
                 Button("Open Directory…") { actions.openDirectory() }
                     .keyboardShortcut(shortcut(for: .openDirectory))
                     .disabled(modalActive)

--- a/agtermCore/Sources/agtermCore/AppStore+Nesting.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Nesting.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+/// Nested-session tree operations bridging observed `Session`/`Workspace` state to the host-free
+/// `SessionTree` math: create-child placement (in `addSession`), reparent, subtree lookup, expand/collapse,
+/// and the cascade-close helpers `closeSession`/`softCloseSession(s)` hook into. Kept out of
+/// `AppStore.swift` to stay under its source line limit.
+extension AppStore {
+    /// Flat `SessionTree.Node`s for a workspace, in array order (bridges `Session` → pure tree math).
+    /// Empty for an unknown workspace id.
+    func sessionNodes(inWorkspace workspaceID: UUID) -> [SessionTree.Node] {
+        guard let workspace = workspaces.first(where: { $0.id == workspaceID }) else { return [] }
+        return workspace.sessions.map { SessionTree.Node(id: $0.id, parentID: $0.parentID) }
+    }
+
+    /// `sessionID` plus every descendant, in tree order — the whole cascade-close block, and the input
+    /// `reparentSession`'s cycle guard and `expandedSubtreeIDs` build on. Empty for an unknown id.
+    public func sessionSubtreeIDs(_ sessionID: UUID) -> [UUID] {
+        guard let workspace = workspace(forSession: sessionID) else { return [] }
+        let nodes = sessionNodes(inWorkspace: workspace.id)
+        guard let range = SessionTree.subtreeRange(of: sessionID, in: nodes) else { return [] }
+        return range.map { nodes[$0].id }
+    }
+
+    /// Reparents `sessionID` (and its subtree, riding along untouched) under `newParentID` within its OWN
+    /// workspace, appended as that parent's last child. The control `--parent` verb: an already-matching
+    /// parent is a no-op (position is not disturbed), otherwise it delegates to the positioned form below.
+    /// No-ops (no write) on an unknown id, a `newParentID` outside the same workspace, a cycle, or an
+    /// already-matching parent.
+    public func reparentSession(_ sessionID: UUID, to newParentID: UUID?) {
+        guard let session = session(withID: sessionID), session.parentID != newParentID else { return }
+        reparentSession(sessionID, to: newParentID, at: nil)
+    }
+
+    /// Reparents `sessionID` (subtree riding along) under `newParentID` (nil = top-level) within its OWN
+    /// workspace and inserts it as that parent's child number `destination` (nil / out of range = last
+    /// child), then repairs the workspace to `SessionTree.preorder` so contiguity holds. The primitive the
+    /// sidebar drag needs — unlike the control verb it CAN reposition among the current siblings (a top-level
+    /// or same-parent reorder), so its no-op guard is order-and-parent, not parent alone. No-ops (no write)
+    /// on an unknown id, a `newParentID` in another workspace, a cycle (`newParentID` is `sessionID` or one
+    /// of its descendants), or when neither the parent nor the resulting order would change.
+    public func reparentSession(_ sessionID: UUID, to newParentID: UUID?, at destination: Int?) {
+        guard let loc = location(ofSession: sessionID) else { return }
+        let wsIndex = loc.workspaceIndex
+        let nodes = sessionNodes(inWorkspace: workspaces[wsIndex].id)
+        if let newParentID {
+            guard let parentLoc = location(ofSession: newParentID), parentLoc.workspaceIndex == wsIndex,
+                  !SessionTree.isSelfOrDescendant(newParentID, of: sessionID, in: nodes) else { return }
+        }
+        guard let range = SessionTree.subtreeRange(of: sessionID, in: nodes) else { return }
+        // compute the resulting id order on pure Node values: drop the moved block, retarget the root's
+        // parent, reinsert at the sibling slot, then normalize to preorder.
+        let block = nodes[range].map { $0.id == sessionID ? SessionTree.Node(id: $0.id, parentID: newParentID) : $0 }
+        var remaining = nodes
+        remaining.removeSubrange(range)
+        let insertAt = SidebarDrop.flatChildInsertIndex(order: remaining, parent: newParentID, childDestination: destination)
+        remaining.insert(contentsOf: block, at: insertAt)
+        let order = SessionTree.preorder(remaining)
+        let parentUnchanged = workspaces[wsIndex].sessions[loc.sessionIndex].parentID == newParentID
+        guard order != nodes.map(\.id) || !parentUnchanged else { return }
+        var byID: [UUID: Session] = [:]
+        for session in workspaces[wsIndex].sessions { byID[session.id] = session }
+        byID[sessionID]?.parentID = newParentID
+        // reparenting INTO a session reveals that new parent, so the just-nested subtree is visible rather
+        // than hidden under a collapsed row — the expected result of "drop this onto that to nest it".
+        if let newParentID { byID[newParentID]?.isExpanded = true }
+        workspaces[wsIndex].sessions = order.compactMap { byID[$0] }
+        scheduleTreeChanged()
+        save()
+    }
+
+    /// Reorders one workspace's sessions into canonical `SessionTree.preorder` so the contiguity invariant
+    /// (a parent immediately followed by its whole subtree) holds again. The anchor-relative placement paths
+    /// need this UNCONDITIONALLY: a flat positional splice can split the anchor's own subtree, and
+    /// `reparentSession` skips its preorder repair when the parent is unchanged (the placed session already
+    /// shares the anchor's parent), so nothing else fixes it. Preorder preserves sibling input order — so a
+    /// placed session stays exactly where the positional move put it among its siblings — and is the identity
+    /// on a flat/non-nested workspace, keeping childless placements byte-identical. No-op (no write) on an
+    /// unknown workspace or when the order already matches.
+    public func repairContiguity(inWorkspace workspaceID: UUID) {
+        guard let wsIndex = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return }
+        let before = workspaces[wsIndex].sessions.map(\.id)
+        let order = SessionTree.preorder(sessionNodes(inWorkspace: workspaceID))
+        guard order != before else { return }
+        var byID: [UUID: Session] = [:]
+        for session in workspaces[wsIndex].sessions { byID[session.id] = session }
+        workspaces[wsIndex].sessions = order.compactMap { byID[$0] }
+        scheduleTreeChanged()
+        save()
+    }
+
+    /// Sets one session's expand/collapse state and persists it; mirrors `setWorkspaceExpanded`. Clean
+    /// no-op (no write) for an unknown id or when unchanged.
+    public func setSessionExpanded(_ sessionID: UUID, expanded: Bool) {
+        guard let session = session(withID: sessionID), session.isExpanded != expanded else { return }
+        session.isExpanded = expanded
+        save()
+    }
+
+    /// Expands every id in `ids` to its own subtree, dedups, and keeps tree order per input entry — the
+    /// shared cascade-expansion `softCloseSession`/`softCloseSessions` feed into the existing batch-close
+    /// machinery, so a parent anywhere in the input always closes with its whole subtree under the one
+    /// grace timer and one undo the batch already groups.
+    func expandedSubtreeIDs(_ ids: [UUID]) -> [UUID] {
+        var seen: Set<UUID> = []
+        var result: [UUID] = []
+        for id in ids {
+            for member in sessionSubtreeIDs(id) where seen.insert(member).inserted {
+                result.append(member)
+            }
+        }
+        return result
+    }
+
+    /// Cascades `closeSession` over `root`'s whole subtree as ONE operation when it has descendants: one
+    /// grouped `.sessionGroup` Recent Closed record (so a single Reopen restores the whole subtree, tree
+    /// order and nesting intact — `recordRecentClosedSessionGroup`), then the same per-session
+    /// teardown `closeSession` performs for a single session, looped over the contiguous subtree block, with
+    /// ONE reselection computed from the root's original slot — mirroring `removeWorkspace`'s
+    /// cascade-teardown precedent (one teardown loop, then one reselect). Returns false (a no-op) for an
+    /// unknown id or a childless session, so `closeSession` falls through unchanged to its original
+    /// single-session path, which still records the legacy single `.session` item.
+    @discardableResult
+    func closeSessionSubtree(_ root: UUID) -> Bool {
+        guard let location = location(ofSession: root) else { return false }
+        let workspace = workspaces[location.workspaceIndex]
+        let nodes = sessionNodes(inWorkspace: workspace.id)
+        guard let range = SessionTree.subtreeRange(of: root, in: nodes), range.count > 1 else { return false }
+
+        let removed = Array(workspaces[location.workspaceIndex].sessions[range])
+        workspaces[location.workspaceIndex].sessions.removeSubrange(range)
+        let wasActive = selectedSessionID.map { id in removed.contains { $0.id == id } } ?? false
+        recordRecentClosedSessionGroup(removed, workspaceID: workspace.id, workspaceName: workspace.name,
+                                       location: location, selectedSessionID: removed.first?.id)
+        for session in removed {
+            emitSessionClosed(session, workspace: workspace.id)
+            session.surface?.teardown()
+            session.splitSurface?.teardown()
+            session.overlaySurface?.teardown()
+            session.teardownPaneOverlays()
+            session.scratchSurface?.teardown()
+            session.discardHudBody() // a HUD whose surface never realized has no teardown to delete its body file
+            WatermarkStorage.removeRenderedText(sessionID: session.id) // drop any rendered .text PNG; the session is gone
+            removeFromRecency(session.id)
+        }
+        if wasActive {
+            selectedSessionID = closeReselectionTarget(after: location)
+            replaceSidebarSelection(with: selectedSessionID)
+            disableFocusIfSelectionOutsideSet(selectedSessionID) // the reselected session may live outside the marked set
+            recordRecency()
+        } else {
+            pruneSidebarSelection()
+        }
+        save()
+        return true
+    }
+}

--- a/agtermCore/Sources/agtermCore/AppStore+PendingClose.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+PendingClose.swift
@@ -53,9 +53,14 @@ extension AppStore {
     public static let pendingCloseGraceInterval: TimeInterval = 3
 
     /// Hide a session from the visible tree but keep its surfaces alive for a short undo window.
-    /// If the grace expires, `finalizePendingClose` performs the same teardown as `closeSession`.
+    /// If the grace expires, `finalizePendingClose` performs the same teardown as `closeSession`. A session
+    /// with descendants cascades: the whole subtree soft-closes as one `softCloseSessions` batch, under the
+    /// one grace timer and one undo that call already groups; this method's single-session path below
+    /// resumes unchanged for a childless one.
     @discardableResult
     public func softCloseSession(_ sessionID: UUID, grace: TimeInterval = AppStore.pendingCloseGraceInterval) -> Bool {
+        let subtreeIDs = sessionSubtreeIDs(sessionID)
+        if subtreeIDs.count > 1 { return softCloseSessions(subtreeIDs, grace: grace) }
         guard let location = location(ofSession: sessionID) else { return false }
         let workspace = workspaces[location.workspaceIndex]
         let wasActive = selectedSessionID == sessionID
@@ -96,13 +101,16 @@ extension AppStore {
         return true
     }
 
-    /// Hide multiple sessions as one undoable operation. The removed sessions keep their surfaces alive
-    /// until the one shared grace timer finalizes, and a single undo restores every session in the group.
+    /// Hide multiple sessions as one undoable operation. Any parent in `sessionIDs` expands to its whole
+    /// subtree first (deduped, tree order), so closing a session with children always cascades to them too.
+    /// The removed sessions keep their surfaces alive until the one shared grace timer finalizes, and a
+    /// single undo restores every session in the group.
     @discardableResult
     public func softCloseSessions(_ sessionIDs: [UUID], grace: TimeInterval = AppStore.pendingCloseGraceInterval) -> Bool {
-        let targetIDs = Set(sessionIDs)
+        let expandedIDs = expandedSubtreeIDs(sessionIDs)
+        let targetIDs = Set(expandedIDs)
         guard targetIDs.count > 1 else {
-            guard let id = sessionIDs.first else { return false }
+            guard let id = expandedIDs.first else { return false }
             return softCloseSession(id, grace: grace)
         }
 

--- a/agtermCore/Sources/agtermCore/AppStore+RecentClosed.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+RecentClosed.swift
@@ -56,6 +56,35 @@ extension AppStore {
             }
             save()
             return true
+        case .sessionGroup:
+            guard let recent = item.sessionGroup else { return false }
+            if restoreOrSelectExistingRecentSessionGroup(recent) { return true }
+            let index: Int
+            if let existing = workspaces.firstIndex(where: { $0.id == recent.workspaceID }) {
+                index = existing
+            } else {
+                let insertAt = max(0, min(recent.workspaceIndex, workspaces.count))
+                workspaces.insert(rebuiltWorkspaceShell(id: recent.workspaceID, name: recent.workspaceName), at: insertAt)
+                index = insertAt
+            }
+            // as in the `.workspace` case above: a snapshot whose id is already live or held by a pending
+            // close is skipped rather than duplicated under a shared id.
+            let taken = Set(workspaces.flatMap(\.sessions).map(\.id)).union(pendingHeldSessionIDs())
+            let sessions = recent.snapshots.filter { !taken.contains($0.id) }.map { session(from: $0) }
+            guard !sessions.isEmpty else { return false }
+            let insertAt = max(0, min(recent.sessionIndex, workspaces[index].sessions.count))
+            workspaces[index].sessions.insert(contentsOf: sessions, at: insertAt)
+            for session in sessions { emitSessionCreated(session, workspace: workspaces[index].id) }
+            let target = recent.selectedSessionID.flatMap { id in sessions.contains { $0.id == id } ? id : nil }
+                ?? sessions.first?.id
+            if let target {
+                selectedSessionID = target
+                replaceSidebarSelection(with: target)
+                disableFocusIfSelectionOutsideSet(target)
+                recordRecency()
+            }
+            save()
+            return true
         }
     }
 
@@ -65,6 +94,19 @@ extension AppStore {
         }
         guard session(withID: recent.snapshot.id) != nil else { return false }
         selectSession(recent.snapshot.id)
+        return true
+    }
+
+    /// Mirrors `restoreOrSelectExistingRecentSession` for the group's root: the hard-close cascade that
+    /// produces a `.sessionGroup` record has no grace/pending state of its own, so `pendingCloseID` only
+    /// matters here if the root was independently re-closed (soft) after being reopened once already.
+    private func restoreOrSelectExistingRecentSessionGroup(_ recent: RecentClosedSessionGroup) -> Bool {
+        guard let rootID = recent.snapshots.first?.id else { return false }
+        if let pendingID = pendingCloseID(containingSessionID: rootID) {
+            return undoPendingClose(pendingID, selecting: rootID)
+        }
+        guard session(withID: rootID) != nil else { return false }
+        selectSession(rootID)
         return true
     }
 
@@ -161,6 +203,32 @@ extension AppStore {
                                          workspaceIndex: workspaceIndex,
                                          sessionIndex: sessionIndex,
                                          snapshot: sessionSnapshot(session))
+        ))
+        recentClosedDidChange?()
+        return id
+    }
+
+    /// Records a closed session SUBTREE as ONE item, so a single Reopen restores the whole group — the hard
+    /// `closeSession` cascade's counterpart to `recordRecentClosedSession`. `sessions` must be in tree order
+    /// (root first); `sessions.first` supplies the title and the group's dedupe identity.
+    @discardableResult
+    func recordRecentClosedSessionGroup(_ sessions: [Session],
+                                        workspaceID: UUID,
+                                        workspaceName: String,
+                                        location: (workspaceIndex: Int, sessionIndex: Int),
+                                        selectedSessionID: UUID?,
+                                        id: UUID = UUID()) -> UUID? {
+        guard let recentClosedStore, let root = sessions.first else { return nil }
+        recentClosedStore.record(RecentClosedItem(
+            id: id,
+            kind: .sessionGroup,
+            title: root.displayName,
+            subtitle: "\(sessions.count) sessions",
+            sessionGroup: RecentClosedSessionGroup(workspaceID: workspaceID, workspaceName: workspaceName,
+                                                   workspaceIndex: location.workspaceIndex,
+                                                   sessionIndex: location.sessionIndex,
+                                                   snapshots: sessions.map(sessionSnapshot),
+                                                   selectedSessionID: selectedSessionID)
         ))
         recentClosedDidChange?()
         return id

--- a/agtermCore/Sources/agtermCore/AppStore+Snapshot.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Snapshot.swift
@@ -37,7 +37,9 @@ extension AppStore {
                         initialCommand: session.initialCommand, commandWait: session.commandWait ? true : nil,
                         backgroundWatermark: session.backgroundWatermark,
                         restoreCommand: session.restoreCommand,
-                        splitRestoreCommand: session.splitRestoreCommand)
+                        splitRestoreCommand: session.splitRestoreCommand,
+                        parentID: session.parentID,
+                        collapsed: session.isExpanded ? nil : true)
     }
 
     func workspaceSnapshot(_ workspace: Workspace) -> WorkspaceSnapshot {
@@ -73,6 +75,8 @@ extension AppStore {
         session.backgroundWatermark = snapshot.backgroundWatermark
         session.restoreCommand = snapshot.restoreCommand
         session.splitRestoreCommand = session.isSplit ? snapshot.splitRestoreCommand : nil
+        session.parentID = snapshot.parentID
+        session.isExpanded = !(snapshot.collapsed ?? false)
         if launchRestore {
             // into the TRANSIENT slots, leaving the persisted fields nil: `snapshot()` serializes those, so
             // arming them would let any save before the surface spawns rewrite the argv the launch strip

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -284,7 +284,9 @@ public final class AppStore {
                                           fontSize: fontSize(session),
                                           splitFontSize: splitFontSize(session),
                                           scratchFontSize: scratchFontSize(session),
-                                          surfaces: surfaces)
+                                          surfaces: surfaces,
+                                          parentID: session.parentID?.uuidString,
+                                          collapsed: session.isExpanded ? nil : true)
             }
             return ControlWorkspaceNode(id: workspace.id.uuidString, name: workspace.name,
                                         active: workspace.id == activeWorkspaceID,
@@ -362,11 +364,15 @@ public final class AppStore {
     /// Creates a session in the given workspace and selects it when `select` (the default); `select: false`
     /// appends it in the background, leaving selection/focus/recency untouched (`session.new --no-select`).
     /// `name` seeds `customName` (trimmed; blank = the auto basename, matching `renameSession`). `at` nil
-    /// appends, else inserts at the clamped index (`0...count`), backing `--after`/`--before`. Nil if no
-    /// workspace matches.
+    /// appends after `parentID`'s last existing child (top-level end when `parentID` is nil), else inserts
+    /// at the clamped index (`0...count`), backing `--after`/`--before` — an explicit index always wins, and
+    /// the caller is expected to pass the anchor's own `parentID` alongside it. `parentID` outside
+    /// `workspaceID` (unknown or belonging to another workspace) is ignored — the session still creates,
+    /// top-level. Nil if no workspace matches.
     @discardableResult
     public func addSession(toWorkspace workspaceID: UUID, cwd: String, command: String? = nil,
-                           name: String? = nil, wait: Bool = false, at index: Int? = nil, select: Bool = true) -> Session? {
+                           name: String? = nil, wait: Bool = false, at index: Int? = nil, select: Bool = true,
+                           parentID: UUID? = nil) -> Session? {
         guard let wsIndex = workspaces.firstIndex(where: { $0.id == workspaceID }) else { return nil }
         // cwd feeds {AGT_SESSION_PWD} through initialCwd → effectiveCwd until OSC 7 reports; name feeds
         // {AGT_SESSION_NAME}. See TerminalText.
@@ -374,11 +380,18 @@ public final class AppStore {
                               customName: name.map(TerminalText.sanitized)?.trimmedOrNil)
         session.initialCommand = command
         session.commandWait = wait
+        // an unknown/cross-workspace parent is ignored rather than failing the create — matches
+        // `appendChildIndex`'s own nil-parent fallback below, so the two can't disagree.
+        let resolvedParentID = parentID.flatMap { pid in
+            workspaces[wsIndex].sessions.contains { $0.id == pid } ? pid : nil
+        }
+        session.parentID = resolvedParentID
         if let index {
             let destination = max(0, min(index, workspaces[wsIndex].sessions.count))
             workspaces[wsIndex].sessions.insert(session, at: destination)
         } else {
-            workspaces[wsIndex].sessions.append(session)
+            let destination = SessionTree.appendChildIndex(parent: resolvedParentID, in: sessionNodes(inWorkspace: workspaceID))
+            workspaces[wsIndex].sessions.insert(session, at: destination)
         }
         if select {
             selectedSessionID = session.id
@@ -438,7 +451,10 @@ public final class AppStore {
 
     /// Removes a session, tears down its surface, and — if it was active — reselects the most-recently-active
     /// surviving session in scope (`closeReselectionTarget(after:)`), falling back to the positional neighbor.
+    /// A session with descendants cascades: `closeSessionSubtree` closes the whole subtree as one operation,
+    /// and this method's single-session path below resumes unchanged for a childless one.
     public func closeSession(_ sessionID: UUID) {
+        if closeSessionSubtree(sessionID) { return }
         guard let location = location(ofSession: sessionID) else { return }
         let wasActive = selectedSessionID == sessionID
         let workspace = workspaces[location.workspaceIndex]
@@ -505,22 +521,34 @@ public final class AppStore {
         save()
     }
 
-    /// Moves a session to another workspace (or reorders within one), keeping the **same** `Session` instance
-    /// so its attached surface and live shell survive. `index` is the destination position **after** the
-    /// move's removal (clamped); nil appends. `selectedSessionID` is unaffected — the id is stable. No-ops on
-    /// an unknown session or target workspace, and a same-workspace move to the current slot leaves order
-    /// unchanged. Moving the **active** session out of the marked set suspends the focus filter while KEEPING
-    /// the set (the auto-reveal contract: the active session must stay inside the visible set); a non-active
-    /// session leaves the filter intact.
+    /// Moves a session to another workspace (or reorders within one), keeping the **same** `Session` instances
+    /// so attached surfaces and live shells survive. A session with descendants carries its whole subtree as
+    /// one contiguous block (inner order preserved); a childless session moves exactly as before. `index` is
+    /// the destination position **after** the move's removal (clamped); nil appends. `selectedSessionID` is
+    /// unaffected — the id is stable. No-ops on an unknown session or target workspace, and a same-workspace
+    /// move to the current slot leaves order unchanged. A subtree can't straddle workspaces, so a
+    /// cross-workspace move nils the moved root's `parentID`; descendants keep theirs and ride along. Moving
+    /// the **active** session (root or a descendant) out of the marked set suspends the focus filter while
+    /// KEEPING the set (the auto-reveal contract: the active session must stay inside the visible set); a
+    /// non-active session leaves the filter intact.
     public func moveSession(_ sessionID: UUID, toWorkspace targetID: UUID, at index: Int? = nil) {
         guard let source = location(ofSession: sessionID) else { return }
         guard let targetIndex = workspaces.firstIndex(where: { $0.id == targetID }) else { return }
+        let sourceWorkspaceID = workspaces[source.workspaceIndex].id
+        guard let range = SessionTree.subtreeRange(of: sessionID, in: sessionNodes(inWorkspace: sourceWorkspaceID)) else { return }
         let before = workspaces.map { $0.sessions.map(\.id) }
 
-        let session = workspaces[source.workspaceIndex].sessions.remove(at: source.sessionIndex)
-        let destination = max(0, min(index ?? workspaces[targetIndex].sessions.count, workspaces[targetIndex].sessions.count))
-        workspaces[targetIndex].sessions.insert(session, at: destination)
-        if sessionID == selectedSessionID { disableFocusIfSelectionOutsideSet(sessionID) }
+        let block = Array(workspaces[source.workspaceIndex].sessions[range])
+        workspaces[source.workspaceIndex].sessions.removeSubrange(range)
+        if sourceWorkspaceID != targetID {
+            block.first?.parentID = nil // a subtree can't straddle workspaces; descendants keep their parentIDs
+        }
+        let destinationCount = workspaces[targetIndex].sessions.count
+        let destination = max(0, min(index ?? destinationCount, destinationCount))
+        workspaces[targetIndex].sessions.insert(contentsOf: block, at: destination)
+        if let selectedSessionID, block.contains(where: { $0.id == selectedSessionID }) {
+            disableFocusIfSelectionOutsideSet(selectedSessionID)
+        }
         pruneSidebarSelection()
         if before != workspaces.map({ $0.sessions.map(\.id) }) { scheduleTreeChanged() }
         save()
@@ -560,13 +588,21 @@ public final class AppStore {
         return moving.count
     }
 
-    /// Reorders a session one step within its own workspace (`up`/`down`/`top`/`bottom`) via `moveSession`.
+    /// Reorders a session one step (`up`/`down`/`top`/`bottom`) WITHIN its own sibling group (sessions
+    /// sharing its parentID), carrying its subtree so the contiguity invariant holds even for a nested row.
     /// No-op (no write) on an unknown id or when the move would leave order unchanged (already at that end).
     public func reorderSession(_ id: UUID, _ direction: ReorderDirection) {
         guard let loc = location(ofSession: id) else { return }
-        let count = workspaces[loc.workspaceIndex].sessions.count
-        guard let dest = direction.destinationIndex(from: loc.sessionIndex, count: count) else { return }
-        moveSession(id, toWorkspace: workspaces[loc.workspaceIndex].id, at: dest)
+        let wsIndex = loc.workspaceIndex
+        let nodes = sessionNodes(inWorkspace: workspaces[wsIndex].id)
+        guard let order = SessionTree.reorderSibling(id, direction, in: nodes) else { return }
+        let before = workspaces[wsIndex].sessions.map(\.id)
+        guard order != before else { return }
+        var byID: [UUID: Session] = [:]
+        for session in workspaces[wsIndex].sessions { byID[session.id] = session }
+        workspaces[wsIndex].sessions = order.compactMap { byID[$0] }
+        scheduleTreeChanged()
+        save()
     }
 
     /// Moves a workspace to `index` among its siblings, mirroring `moveSession`'s remove/clamp/insert/save

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -29,6 +29,9 @@ public protocol ControlActions {
     func setWorkspaceExpansion(_ target: String?, window: String?, expanded: Bool) -> ControlResponse
     func setSessionFlag(_ target: String?, window: String?, mode: String?) -> ControlResponse
     func markSessionSeen(_ target: String?, window: String?) -> ControlResponse
+    /// Collapse/expand a single parent session's subtree in the sidebar — the session analogue of
+    /// `setWorkspaceExpansion`. The host persists `Session.isExpanded` and syncs the live outline.
+    func setSessionExpansion(_ target: String?, window: String?, expanded: Bool) -> ControlResponse
     func setSessionStatus(_ target: String?, window: String?, update: ControlSessionStatusUpdate) -> ControlResponse
     /// Write a pane's PERSISTED restore-command override (consumed on the NEXT launch, never this run).
     /// The host resolves the target session and the live pane slot, then stores the tri-state value; it
@@ -171,7 +174,8 @@ public struct ControlDispatcher {
         case .eventsRead:
             return dispatchEventsRead(request)
         case .sessionNew, .sessionDuplicate, .sessionSelect, .sessionGo, .sessionClose, .sessionRename,
-                .sessionReveal, .sessionMove, .sessionFlag, .sessionSeen, .sessionStatus, .sessionRestore:
+                .sessionReveal, .sessionMove, .sessionFlag, .sessionSeen, .sessionCollapse, .sessionExpand,
+                .sessionStatus, .sessionRestore:
             return dispatchSessionCommand(request)
         case .sessionSplit, .sessionScratch, .sessionFocus, .sessionResize, .surfaceZoom, .sessionType,
                 .sessionCopy, .sessionPaste, .sessionSelectAll, .sessionSearch, .sessionOverlayOpen,
@@ -243,6 +247,13 @@ public struct ControlDispatcher {
         switch request.cmd {
         case .sessionNew:
             let args = request.args
+            // `--parent` self-identifies the destination workspace, so it's mutually exclusive with every
+            // other placement/workspace form.
+            if args?.parent != nil,
+               args?.after != nil || args?.before != nil || args?.workspace != nil || args?.workspaceName != nil {
+                return ControlResponse(ok: false,
+                                       error: "session.new takes --parent, --after/--before, or a workspace, not more than one")
+            }
             if args?.after != nil, args?.before != nil {
                 return ControlResponse(ok: false, error: "use either --after or --before, not both")
             }
@@ -271,6 +282,7 @@ public struct ControlDispatcher {
                 name: args?.name,
                 after: args?.after,
                 before: args?.before,
+                parent: args?.parent,
                 noSelect: args?.noSelect == true
             ))
         case .sessionDuplicate:
@@ -300,49 +312,15 @@ public struct ControlDispatcher {
         case .sessionReveal:
             return actions.revealSession(request.target, window: request.args?.window)
         case .sessionMove:
-            let args = request.args
-            if args?.after != nil, args?.before != nil {
-                return ControlResponse(ok: false, error: "use either --after or --before, not both")
-            }
-            // Placement mode: the anchor sid self-identifies the destination workspace, so it's
-            // mutually exclusive with --to and with a workspace parameter.
-            if let anchor = args?.after ?? args?.before {
-                if args?.to != nil {
-                    return ControlResponse(ok: false, error: "session.move takes --after/--before or --to, not both")
-                }
-                if args?.workspace != nil {
-                    return ControlResponse(ok: false, error: "session.move takes --after/--before or a workspace, not both")
-                }
-                let move = ControlSessionMove.place(anchor: anchor, after: args?.after != nil)
-                if let targets = args?.targets {
-                    return dispatchSessionMove(targets: targets, window: args?.window, move: move)
-                }
-                return actions.moveSession(request.target, window: args?.window, move: move)
-            }
-            if args?.to != nil && args?.workspace != nil {
-                return ControlResponse(ok: false, error: "session.move takes either --to or a workspace, not both")
-            }
-            if let to = args?.to {
-                guard let direction = ReorderDirection(rawValue: to) else {
-                    return ControlResponse(ok: false, error: "session.move --to must be up|down|top|bottom")
-                }
-                if args?.targets != nil {
-                    return ControlResponse(ok: false, error: "session.move --target can be repeated only with a workspace or --after/--before")
-                }
-                return actions.moveSession(request.target, window: args?.window, move: .reorder(direction))
-            }
-            guard let workspace = args?.workspace else {
-                return ControlResponse(ok: false, error: "session.move requires --to or a workspace")
-            }
-            let move = ControlSessionMove.workspace(workspace)
-            if let targets = args?.targets {
-                return dispatchSessionMove(targets: targets, window: args?.window, move: move)
-            }
-            return actions.moveSession(request.target, window: args?.window, move: move)
+            return dispatchSessionMoveCommand(request)
         case .sessionFlag:
             return actions.setSessionFlag(request.target, window: request.args?.window, mode: request.args?.mode)
         case .sessionSeen:
             return actions.markSessionSeen(request.target, window: request.args?.window)
+        case .sessionCollapse:
+            return actions.setSessionExpansion(request.target, window: request.args?.window, expanded: false)
+        case .sessionExpand:
+            return actions.setSessionExpansion(request.target, window: request.args?.window, expanded: true)
         case .sessionStatus:
             guard let status = AgentStatus(rawValue: request.args?.status ?? "") else {
                 return ControlResponse(ok: false, error: "invalid status")
@@ -442,6 +420,66 @@ public struct ControlDispatcher {
     /// being no scratch pane to cover.
     private func parseOverlayPane(_ raw: String?) -> PaneSelection<OverlayPane> {
         parsePane(raw, error: PaneOverlayError.invalidPane) { OverlayPane(controlName: $0) }
+    }
+
+    /// `session.move` parsing/validation, extracted from the `dispatchSessionCommand` switch so that switch
+    /// stays under the cyclomatic limit. Accepts exactly one placement intent: `--parent`/`--unparent`
+    /// (reparent), `--after`/`--before` (anchor-relative), `--to` (reorder), or a workspace (relocate).
+    private func dispatchSessionMoveCommand(_ request: ControlRequest) -> ControlResponse {
+        let args = request.args
+        if args?.parent != nil, args?.unparent == true {
+            return ControlResponse(ok: false, error: "use either --parent or --unparent, not both")
+        }
+        // `--parent`/`--unparent` self-identify the destination (or top-level), so they take no other
+        // placement form and, like the anchor forms, no batch of more than one target.
+        if args?.parent != nil || args?.unparent == true {
+            if args?.to != nil || args?.after != nil || args?.before != nil || args?.workspace != nil {
+                return ControlResponse(ok: false, error: "session.move takes --parent/--unparent alone")
+            }
+            if (args?.targets?.count ?? 0) > 1 {
+                return ControlResponse(ok: false, error: "session.move --parent takes a single --target")
+            }
+            let anchor = args?.unparent == true ? nil : args?.parent
+            return actions.moveSession(request.target, window: args?.window, move: .parent(anchor: anchor))
+        }
+        if args?.after != nil, args?.before != nil {
+            return ControlResponse(ok: false, error: "use either --after or --before, not both")
+        }
+        // Placement mode: the anchor sid self-identifies the destination workspace, so it's
+        // mutually exclusive with --to and with a workspace parameter.
+        if let anchor = args?.after ?? args?.before {
+            if args?.to != nil {
+                return ControlResponse(ok: false, error: "session.move takes --after/--before or --to, not both")
+            }
+            if args?.workspace != nil {
+                return ControlResponse(ok: false, error: "session.move takes --after/--before or a workspace, not both")
+            }
+            let move = ControlSessionMove.place(anchor: anchor, after: args?.after != nil)
+            if let targets = args?.targets {
+                return dispatchSessionMove(targets: targets, window: args?.window, move: move)
+            }
+            return actions.moveSession(request.target, window: args?.window, move: move)
+        }
+        if args?.to != nil && args?.workspace != nil {
+            return ControlResponse(ok: false, error: "session.move takes either --to or a workspace, not both")
+        }
+        if let to = args?.to {
+            guard let direction = ReorderDirection(rawValue: to) else {
+                return ControlResponse(ok: false, error: "session.move --to must be up|down|top|bottom")
+            }
+            if args?.targets != nil {
+                return ControlResponse(ok: false, error: "session.move --target can be repeated only with a workspace or --after/--before")
+            }
+            return actions.moveSession(request.target, window: args?.window, move: .reorder(direction))
+        }
+        guard let workspace = args?.workspace else {
+            return ControlResponse(ok: false, error: "session.move requires --to or a workspace")
+        }
+        let move = ControlSessionMove.workspace(workspace)
+        if let targets = args?.targets {
+            return dispatchSessionMove(targets: targets, window: args?.window, move: move)
+        }
+        return actions.moveSession(request.target, window: args?.window, move: move)
     }
 
     private func dispatchSessionMove(targets: [String], window: String?, move: ControlSessionMove) -> ControlResponse {

--- a/agtermCore/Sources/agtermCore/ControlModes.swift
+++ b/agtermCore/Sources/agtermCore/ControlModes.swift
@@ -114,6 +114,9 @@ public enum ControlSessionMove: Equatable, Sendable {
     /// Relocate relative to an anchor session (id / prefix / `active`); `after == false` places before it.
     /// The anchor carries its own workspace, so this form never reads the workspace parameter.
     case place(anchor: String, after: Bool)
+    /// Nest under `anchor` (id / prefix / `active`), or detach to top-level when `anchor` is nil (the
+    /// `--unparent` form). The anchor carries its own workspace, same as `place`.
+    case parent(anchor: String?)
 }
 
 /// Parsed resize request for `session.resize`.
@@ -138,12 +141,16 @@ public struct ControlSessionCreateOptions: Equatable, Sendable {
     public let after: String?
     /// Anchor session to place the new session right BEFORE, the mirror of `after`.
     public let before: String?
+    /// Parent session (id / prefix / `active`) to nest the new session under, the parent naming its own
+    /// workspace. Mutually exclusive with `after`/`before` and `workspace`/`workspaceName`.
+    public let parent: String?
     /// Create in the background (`--no-select`): skip select+focus, leaving the current selection untouched.
     public let noSelect: Bool
 
     public init(window: String?, cwd: String?, workspace: String?, workspaceName: String?,
                 createWorkspace: Bool?, command: String?, wait: Bool? = nil, name: String?,
-                after: String? = nil, before: String? = nil, noSelect: Bool = false) {
+                after: String? = nil, before: String? = nil, parent: String? = nil,
+                noSelect: Bool = false) {
         self.window = window
         self.cwd = cwd
         self.workspace = workspace
@@ -154,6 +161,7 @@ public struct ControlSessionCreateOptions: Equatable, Sendable {
         self.name = name
         self.after = after
         self.before = before
+        self.parent = parent
         self.noSelect = noSelect
     }
 }

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -24,6 +24,8 @@ public enum Command: String, Codable, Sendable {
     case sessionStatus = "session.status"
     case sessionFlag = "session.flag"
     case sessionSeen = "session.seen"
+    case sessionCollapse = "session.collapse"
+    case sessionExpand = "session.expand"
     case sessionRestore = "session.restore"
     case sessionBackground = "session.background"
     case sessionSplit = "session.split"
@@ -192,6 +194,13 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     public var after: String?
     /// Anchor session to place a session right BEFORE, the mirror of `after` (mutually exclusive with it).
     public var before: String?
+    /// Parent session (id / prefix / `active`) for `session.new`/`session.move`: nests the session as a
+    /// child, the parent naming its own workspace. Mutually exclusive with `after`/`before`, a workspace
+    /// param, and (on `session.move`) `unparent`.
+    public var parent: String?
+    /// For `session.move`: detach the target to top-level, dropping any parent. Mutually exclusive with
+    /// `parent` and every other placement form.
+    public var unparent: Bool?
     /// App-run UUID paired with `after` for `events.read`. Both fields are omitted for a bootstrap read.
     public var run: String?
     /// Raw event-kind filters for `events.read`. Validation happens in the dispatcher so unknown future
@@ -296,7 +305,8 @@ public struct ControlArgs: Codable, Sendable, Equatable {
                 items: [ControlPickItem]? = nil, prompt: String? = nil,
                 query: String? = nil, allowCustom: Bool? = nil, window: String? = nil,
                 pane: String? = nil, paneID: String? = nil, to: String? = nil,
-                after: String? = nil, before: String? = nil, run: String? = nil,
+                after: String? = nil, before: String? = nil, parent: String? = nil, unparent: Bool? = nil,
+                run: String? = nil,
                 kinds: [String]? = nil, limit: Int? = nil,
                 title: String? = nil, body: String? = nil,
                 width: Int? = nil, height: Int? = nil, x: Int? = nil, y: Int? = nil, display: Int? = nil,
@@ -337,6 +347,8 @@ public struct ControlArgs: Codable, Sendable, Equatable {
         self.to = to
         self.after = after
         self.before = before
+        self.parent = parent
+        self.unparent = unparent
         self.run = run
         self.kinds = kinds
         self.limit = limit
@@ -542,6 +554,13 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
     /// Addressable terminal surfaces owned by this session; nil/omitted against a server predating
     /// `surface.zoom`. Hidden-but-alive surfaces are included, so a client can zoom them without unhiding.
     public let surfaces: [ControlSurfaceNode]?
+    /// The id of this session's PARENT in the nesting tree; nil/omitted for a top-level session. Sessions
+    /// list in depth-first preorder, so a child always appears right after its parent's own row. The read
+    /// side of `session.new --parent`, `session.move --parent`, and `--unparent`.
+    public let parentID: String?
+    /// Whether this session is COLLAPSED in the sidebar tree, hiding its descendant rows; nil/omitted when
+    /// expanded (the default), so a non-collapsed tree omits it — matching `SessionSnapshot.collapsed`.
+    public let collapsed: Bool?
 
     public init(id: String, name: String, cwd: String, title: String? = nil, active: Bool, split: Bool,
                 splitRatio: Double? = nil, splitFocused: Bool? = nil,
@@ -554,7 +573,8 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
                 statusShape: String? = nil,
                 background: BackgroundWatermark? = nil, unseen: Int? = nil,
                 fontSize: Double? = nil, splitFontSize: Double? = nil, scratchFontSize: Double? = nil,
-                surfaces: [ControlSurfaceNode]? = nil) {
+                surfaces: [ControlSurfaceNode]? = nil,
+                parentID: String? = nil, collapsed: Bool? = nil) {
         self.id = id
         self.name = name
         self.cwd = cwd
@@ -585,6 +605,8 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
         self.splitFontSize = splitFontSize
         self.scratchFontSize = scratchFontSize
         self.surfaces = surfaces
+        self.parentID = parentID
+        self.collapsed = collapsed
     }
 }
 

--- a/agtermCore/Sources/agtermCore/RecentClosed.swift
+++ b/agtermCore/Sources/agtermCore/RecentClosed.swift
@@ -3,6 +3,12 @@ import Foundation
 public enum RecentClosedKind: String, Codable, Sendable {
     case session
     case workspace
+    /// A closed session SUBTREE (a parent plus every descendant), recorded as one item so a single Reopen
+    /// restores the whole group — the nested-session analog of `.workspace`. Only the hard `closeSession`
+    /// cascade produces this; a childless close still records the legacy `.session` shape, and the
+    /// grace-timer soft-close path keeps recording one `.session` item per member (its own undo already
+    /// groups the batch in memory).
+    case sessionGroup
 }
 
 public struct RecentClosedItem: Codable, Identifiable, Equatable, Sendable {
@@ -13,10 +19,13 @@ public struct RecentClosedItem: Codable, Identifiable, Equatable, Sendable {
     public let closedAt: Date
     public let session: RecentClosedSession?
     public let workspace: RecentClosedWorkspace?
+    /// OPTIONAL for the same reason `session`/`workspace` are: a file written before `.sessionGroup` existed
+    /// has no such key, and a required key would fail the whole decode — see `RecentClosedStore.load()`.
+    public let sessionGroup: RecentClosedSessionGroup?
 
     public init(id: UUID = UUID(), kind: RecentClosedKind, title: String, subtitle: String?,
                 closedAt: Date = Date(), session: RecentClosedSession? = nil,
-                workspace: RecentClosedWorkspace? = nil) {
+                workspace: RecentClosedWorkspace? = nil, sessionGroup: RecentClosedSessionGroup? = nil) {
         self.id = id
         self.kind = kind
         self.title = title
@@ -24,6 +33,7 @@ public struct RecentClosedItem: Codable, Identifiable, Equatable, Sendable {
         self.closedAt = closedAt
         self.session = session
         self.workspace = workspace
+        self.sessionGroup = sessionGroup
     }
 }
 
@@ -60,6 +70,32 @@ public struct RecentClosedWorkspace: Codable, Equatable, Sendable {
         self.snapshot = snapshot
         self.selectedSessionID = selectedSessionID
         self.focusMember = focusMember
+    }
+}
+
+/// A closed session subtree: the root (the session the user actually closed) plus every descendant, in
+/// TREE ORDER (root first) with `parentID`/`collapsed` intact on each snapshot, so restoring rebuilds both
+/// the nesting and the sidebar's contiguity invariant (parent immediately followed by its whole subtree) in
+/// one insert. `workspaceID`/`workspaceName`/`workspaceIndex` rebuild a missing workspace shell exactly like
+/// `RecentClosedSession`; `sessionIndex` is the root's original slot, the whole group's reinsertion point.
+public struct RecentClosedSessionGroup: Codable, Equatable, Sendable {
+    public let workspaceID: UUID
+    public let workspaceName: String
+    public let workspaceIndex: Int
+    public let sessionIndex: Int
+    public let snapshots: [SessionSnapshot]
+    /// The session to reselect on restore — the root the user closed, when it is still present after any
+    /// live-id filtering.
+    public let selectedSessionID: UUID?
+
+    public init(workspaceID: UUID, workspaceName: String, workspaceIndex: Int, sessionIndex: Int,
+                snapshots: [SessionSnapshot], selectedSessionID: UUID?) {
+        self.workspaceID = workspaceID
+        self.workspaceName = workspaceName
+        self.workspaceIndex = workspaceIndex
+        self.sessionIndex = sessionIndex
+        self.snapshots = snapshots
+        self.selectedSessionID = selectedSessionID
     }
 }
 
@@ -106,6 +142,9 @@ public struct RecentClosedStore: Sendable {
                 return existing.session?.snapshot.id == item.session?.snapshot.id
             case (.workspace, .workspace):
                 return existing.workspace?.snapshot.id == item.workspace?.snapshot.id
+            case (.sessionGroup, .sessionGroup):
+                // keyed on the root (first, tree order) snapshot's id, the group's own identity.
+                return existing.sessionGroup?.snapshots.first?.id == item.sessionGroup?.snapshots.first?.id
             default:
                 return false
             }

--- a/agtermCore/Sources/agtermCore/Session.swift
+++ b/agtermCore/Sources/agtermCore/Session.swift
@@ -118,6 +118,14 @@ public final class Session: Identifiable {
     /// flagged view with a filled row icon. Persisted, surviving a relaunch and a workspace move.
     public var flagged: Bool = false
 
+    /// The parent session this one nests under, nil at the workspace's top level. Observed, so a reparent
+    /// reloads the sidebar. Persisted.
+    public var parentID: UUID?
+
+    /// Whether this session's children are shown in the sidebar tree; meaningless with no children.
+    /// Observed, so a collapse reloads the sidebar. Persisted as the INVERSE, like `Workspace.isExpanded`.
+    public var isExpanded: Bool = true
+
     /// Changes only when one live primary-slot surface replaces another; SwiftUI hosts fold it into their
     /// identity, so lazy nil→first creation stays at zero while split-survivor promotion remounts the view.
     @ObservationIgnored public private(set) var primarySurfaceHostRevision = 0

--- a/agtermCore/Sources/agtermCore/SessionTree.swift
+++ b/agtermCore/Sources/agtermCore/SessionTree.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// Pure tree math over a flat ordered session list obeying the contiguity invariant: a parent is
+/// immediately followed by its whole subtree in depth-first preorder. Operates on the lightweight `Node`
+/// value type (not `Session`) so it is unit-testable without `@MainActor`. Later reparent/drag work builds
+/// on `preorder` to repair contiguity after a move; everything else reads the existing order as-is.
+public enum SessionTree {
+    /// A minimal id/parentID pair mirroring `Session.id`/`Session.parentID` for tree math.
+    public struct Node: Equatable, Sendable {
+        public let id: UUID
+        public let parentID: UUID?
+
+        public init(id: UUID, parentID: UUID?) {
+            self.id = id
+            self.parentID = parentID
+        }
+    }
+
+    /// Half-open index range of `id`'s node plus its entire subtree (the contiguous block), or nil if the
+    /// id is absent. The block starts at the node itself.
+    public static func subtreeRange(of id: UUID, in order: [Node]) -> Range<Int>? {
+        guard let start = order.firstIndex(where: { $0.id == id }) else { return nil }
+        var idsInBlock: Set<UUID> = [id]
+        var end = start + 1
+        while end < order.count, let parentID = order[end].parentID, idsInBlock.contains(parentID) {
+            idsInBlock.insert(order[end].id)
+            end += 1
+        }
+        return start..<end
+    }
+
+    /// Ids of every descendant of `id` (excludes `id`), in tree order.
+    public static func descendantIDs(of id: UUID, in order: [Node]) -> [UUID] {
+        guard let range = subtreeRange(of: id, in: order) else { return [] }
+        return range.dropFirst().map { order[$0].id }
+    }
+
+    /// True if `candidate` is `ancestor` or a descendant of it — the reparent cycle guard.
+    public static func isSelfOrDescendant(_ candidate: UUID, of ancestor: UUID, in order: [Node]) -> Bool {
+        candidate == ancestor || descendantIDs(of: ancestor, in: order).contains(candidate)
+    }
+
+    /// The array index just past the last element of `parent`'s subtree — the insert slot for a new
+    /// last-child. For a nil parent (top-level append) returns `order.count`.
+    public static func appendChildIndex(parent: UUID?, in order: [Node]) -> Int {
+        guard let parent else { return order.count }
+        return subtreeRange(of: parent, in: order)?.upperBound ?? order.count
+    }
+
+    /// The chain of ancestor ids from the direct parent up to the root (nearest first), for expand-reveal.
+    public static func ancestorIDs(of id: UUID, in order: [Node]) -> [UUID] {
+        var byID: [UUID: Node] = [:]
+        for node in order { byID[node.id] = node }
+        var result: [UUID] = []
+        var current = byID[id]?.parentID
+        while let parentID = current {
+            result.append(parentID)
+            current = byID[parentID]?.parentID
+        }
+        return result
+    }
+
+    /// Reorders `id` one step (`up`/`down`/`top`/`bottom`) WITHIN its own sibling group (the nodes sharing
+    /// its parentID), carrying its whole subtree, and returns the repaired full preorder of ids. A flat
+    /// index move would let a nested row cross into a neighbouring subtree and break contiguity; scoping to
+    /// siblings keeps the invariant. Nil (no change) when `id` is absent or already at that group's end.
+    public static func reorderSibling(_ id: UUID, _ direction: ReorderDirection, in order: [Node]) -> [UUID]? {
+        guard let node = order.first(where: { $0.id == id }) else { return nil }
+        let siblings = order.filter { $0.parentID == node.parentID }.map(\.id)
+        guard let index = siblings.firstIndex(of: id),
+              let destination = direction.destinationIndex(from: index, count: siblings.count) else { return nil }
+        var reordered = siblings
+        reordered.remove(at: index)
+        reordered.insert(id, at: destination)
+        // the sibling subtree blocks tile one contiguous region (all of the parent's subtree bar the parent
+        // itself, or the whole array for top-level roots); reorder the blocks and splice the region back.
+        guard let first = siblings.first, let last = siblings.last,
+              let firstRange = subtreeRange(of: first, in: order),
+              let lastRange = subtreeRange(of: last, in: order) else { return nil }
+        var blocks: [UUID: [UUID]] = [:]
+        for sibling in siblings {
+            guard let range = subtreeRange(of: sibling, in: order) else { return nil }
+            blocks[sibling] = range.map { order[$0].id }
+        }
+        var result = order[..<firstRange.lowerBound].map(\.id)
+        for sibling in reordered { result.append(contentsOf: blocks[sibling] ?? []) }
+        result.append(contentsOf: order[lastRange.upperBound...].map(\.id))
+        return result
+    }
+
+    /// Reorders `order` into canonical depth-first preorder given each node's parentID, preserving the
+    /// existing relative order of siblings. Used to REPAIR contiguity after a reparent/move builds the new
+    /// parentID set; returns ids in the corrected order. Roots keep their current relative order.
+    public static func preorder(_ order: [Node]) -> [UUID] {
+        var childrenByParent: [UUID?: [Node]] = [:]
+        for node in order { childrenByParent[node.parentID, default: []].append(node) }
+        var result: [UUID] = []
+        func visit(_ node: Node) {
+            result.append(node.id)
+            for child in childrenByParent[node.id] ?? [] { visit(child) }
+        }
+        for root in childrenByParent[nil] ?? [] { visit(root) }
+        return result
+    }
+}

--- a/agtermCore/Sources/agtermCore/SidebarDrop.swift
+++ b/agtermCore/Sources/agtermCore/SidebarDrop.swift
@@ -165,6 +165,65 @@ public enum SidebarDrop {
         return visibleIndices[min(slot, visibleIndices.count) - 1] + 1
     }
 
+    /// The reparent a sidebar session drop resolves to within ONE workspace: the dragged block's new
+    /// `parentID` (nil = the workspace's top level) and the destination index among that parent's DIRECT
+    /// children AFTER the dragged roots are removed from the group. `AppStore.reparentSession(_:to:at:)`
+    /// consumes it.
+    public struct Reparent: Equatable, Sendable {
+        public let parentID: UUID?
+        public let destination: Int
+
+        public init(parentID: UUID?, destination: Int) {
+            self.parentID = parentID
+            self.destination = destination
+        }
+    }
+
+    /// Resolves a same-workspace session drop into a reparent. `parentID` is the drop's resolved parent — a
+    /// session row the block nests under, or nil for a workspace-row / top-level-gap drop; `childIndex` is
+    /// AppKit's proposed index among that parent's direct children (`onItemIndex` = dropped ON the row →
+    /// last child). Returns nil for an ILLEGAL drop (the target is a dragged root or a descendant of one — a
+    /// cycle) or a NO-OP (a single dragged root already parented here and landing back in its own slot).
+    /// `order` is the workspace's flat session list (contiguity-valid); `sourceIDs` the dragged roots in
+    /// drag order.
+    public static func resolveReparent(order: [SessionTree.Node], sourceIDs: [UUID], parentID: UUID?,
+                                       childIndex: Int) -> Reparent? {
+        guard !sourceIDs.isEmpty else { return nil }
+        let sources = Set(sourceIDs)
+        if let parentID {
+            guard order.contains(where: { $0.id == parentID }) else { return nil }
+            // a cycle: the new parent is a dragged root, or nested inside one of them.
+            for source in sourceIDs where SessionTree.isSelfOrDescendant(parentID, of: source, in: order) {
+                return nil
+            }
+        }
+        let directChildren = order.filter { $0.parentID == parentID }.map(\.id)
+        let rawDestination = childIndex == onItemIndex ? directChildren.count
+            : max(0, min(childIndex, directChildren.count))
+        // dragged roots already in the target group shift the destination left by however many sit above it.
+        let removedBefore = directChildren.enumerated().count { sources.contains($0.element) && $0.offset < rawDestination }
+        let destination = rawDestination - removedBefore
+
+        // no-op: a single dragged root already parented here, landing back in its own slot.
+        if sourceIDs.count == 1, let only = sourceIDs.first, let slot = directChildren.firstIndex(of: only) {
+            let landed = max(0, min(destination, directChildren.count - 1))
+            if landed == slot { return nil }
+        }
+        return Reparent(parentID: parentID, destination: destination)
+    }
+
+    /// The flat index in `order` (the node list AFTER the moved block was removed) at which to insert that
+    /// block so its root becomes `parent`'s child number `childDestination` (nil / out-of-range = last
+    /// child). A nil `parent` positions among the top-level roots. Pure arithmetic over the contiguity
+    /// invariant: a child's slot is just before the `childDestination`-th sibling's own subtree, or past the
+    /// parent's whole subtree when appending.
+    public static func flatChildInsertIndex(order: [SessionTree.Node], parent: UUID?, childDestination: Int?) -> Int {
+        let children = order.filter { $0.parentID == parent }.map(\.id)
+        let dest = childDestination.map { max(0, min($0, children.count)) } ?? children.count
+        guard dest < children.count else { return SessionTree.appendChildIndex(parent: parent, in: order) }
+        return SessionTree.subtreeRange(of: children[dest], in: order)?.lowerBound ?? order.count
+    }
+
     /// Resolves a top-level workspace reorder (validity — a between-rows root drop — is the caller's
     /// to enforce). `count` is the pre-removal workspace count.
     public static func resolveWorkspace(sourceIndex: Int, count: Int, childIndex: Int) -> WorkspaceResolution? {

--- a/agtermCore/Sources/agtermCore/Snapshot.swift
+++ b/agtermCore/Sources/agtermCore/Snapshot.swift
@@ -173,13 +173,19 @@ public struct SessionSnapshot: Codable, Equatable, Sendable {
     public var restoreCommand: String?
     /// The split (right) pane's restore-command override, the split analogue of `restoreCommand`.
     public var splitRestoreCommand: String?
+    /// The parent session this one nests under; nil at the workspace's top level.
+    public var parentID: UUID?
+    /// The INVERSE of `Session.isExpanded`, so missing → expanded (the default) and only a collapsed
+    /// session writes it — a non-nested, non-collapsed tree serializes byte-identically to before nesting.
+    public var collapsed: Bool?
 
     public init(id: UUID, customName: String?, cwd: String, isSplit: Bool? = nil, fontSize: Double? = nil,
                 splitCwd: String? = nil, splitRatio: Double? = nil, flagged: Bool? = nil,
                 foregroundCommand: [String]? = nil, splitForegroundCommand: [String]? = nil,
                 initialCommand: String? = nil, commandWait: Bool? = nil,
                 backgroundWatermark: BackgroundWatermark? = nil,
-                restoreCommand: String? = nil, splitRestoreCommand: String? = nil) {
+                restoreCommand: String? = nil, splitRestoreCommand: String? = nil,
+                parentID: UUID? = nil, collapsed: Bool? = nil) {
         self.id = id
         self.customName = customName
         self.cwd = cwd
@@ -195,12 +201,14 @@ public struct SessionSnapshot: Codable, Equatable, Sendable {
         self.backgroundWatermark = backgroundWatermark
         self.restoreCommand = restoreCommand
         self.splitRestoreCommand = splitRestoreCommand
+        self.parentID = parentID
+        self.collapsed = collapsed
     }
 
     enum CodingKeys: String, CodingKey {
         case id, customName, cwd, isSplit, fontSize, splitCwd, splitRatio, flagged
         case foregroundCommand, splitForegroundCommand, initialCommand, commandWait, backgroundWatermark
-        case restoreCommand, splitRestoreCommand
+        case restoreCommand, splitRestoreCommand, parentID, collapsed
     }
 
     /// Custom decode so every optional is LOSSY, matching `Snapshot.init(from:)`: an unknown
@@ -227,5 +235,7 @@ public struct SessionSnapshot: Codable, Equatable, Sendable {
         backgroundWatermark = (try? c.decodeIfPresent(BackgroundWatermark.self, forKey: .backgroundWatermark)) ?? nil
         restoreCommand = (try? c.decodeIfPresent(String.self, forKey: .restoreCommand)) ?? nil
         splitRestoreCommand = (try? c.decodeIfPresent(String.self, forKey: .splitRestoreCommand)) ?? nil
+        parentID = (try? c.decodeIfPresent(UUID.self, forKey: .parentID)) ?? nil
+        collapsed = (try? c.decodeIfPresent(Bool.self, forKey: .collapsed)) ?? nil
     }
 }

--- a/agtermCore/Sources/agtermctlKit/SessionCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/SessionCommands.swift
@@ -20,11 +20,11 @@ struct Session: ParsableCommand {
         subcommands: [New.self, Duplicate.self, Close.self, Select.self, Go.self, Rename.self, Reveal.self, Move.self, TypeText.self,
                       Split.self, Scratch.self, Focus.self, Resize.self, Copy.self, Paste.self, SelectAll.self,
                       Text.self, Status.self, Restore.self, FlagCommand.self,
-                      Seen.self, Search.self, Background.self, Overlay.self, Hud.self]
+                      Seen.self, Collapse.self, Expand.self, Search.self, Background.self, Overlay.self, Hud.self]
     )
 
     struct New: RequestCommand {
-        static let configuration = CommandConfiguration(abstract: "Create a session.")
+        static let configuration = CommandConfiguration(abstract: "Create a session, optionally nested under a parent.")
         @Option(name: .long, help: "Working directory (defaults to $HOME).") var cwd: String?
         @Option(name: .long, help: "Target workspace by id/prefix/active (defaults to the current one). Mutually exclusive with --workspace-name.") var workspace: String?
         @Option(name: .long, help: "Target workspace by name; errors if not found unless --create-workspace. Mutually exclusive with --workspace.") var workspaceName: String?
@@ -34,11 +34,21 @@ struct Session: ParsableCommand {
         @Option(name: .long, help: "Initial session name (defaults to the auto basename).") var name: String?
         @Option(name: .long, help: "Place the new session right AFTER this anchor session (id/prefix/active); the anchor carries its own workspace, replacing --workspace.") var after: String?
         @Option(name: .long, help: "Place the new session right BEFORE this anchor session (id/prefix/active); mirror of --after.") var before: String?
+        @Option(name: .long, help: """
+            Create the session as a CHILD of this anchor session (id/prefix/active); it nests under the \
+            parent in the sidebar. Mutually exclusive with --workspace/--workspace-name and --after/--before.
+            """)
+        var parent: String?
         @Flag(name: .long, help: "Create the session in the background without selecting or focusing it (leaves the current selection untouched).") var noSelect = false
         @OptionGroup var options: ClientOptions
         var echoesResultID: Bool { true }
 
         func validate() throws {
+            // `--parent` self-identifies the destination workspace, so it's mutually exclusive with every
+            // other placement/workspace form.
+            if parent != nil, after != nil || before != nil || workspace != nil || workspaceName != nil {
+                throw ValidationError("session.new takes --parent, --after/--before, or a workspace, not more than one")
+            }
             if after != nil, before != nil {
                 throw ValidationError("use either --after or --before, not both")
             }
@@ -61,7 +71,7 @@ struct Session: ParsableCommand {
             ControlRequest(cmd: .sessionNew, args: options.withWindow(
                 ControlArgs(name: name, cwd: cwd, workspace: workspace, workspaceName: workspaceName,
                             createWorkspace: createWorkspace ? true : nil, noSelect: noSelect ? true : nil,
-                            command: command, wait: wait ? true : nil, after: after, before: before)))
+                            command: command, wait: wait ? true : nil, after: after, before: before, parent: parent)))
         }
     }
 
@@ -135,18 +145,35 @@ struct Session: ParsableCommand {
 
     struct Move: RequestCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Move a session: to another workspace, reorder with --to, or place relative to an anchor with --after/--before.")
-        @Argument(help: "Destination workspace id/prefix (relocate). Omit with --to or --after/--before.") var workspace: String?
+            abstract: "Move a session: to another workspace, reorder with --to, place relative to an anchor with "
+                + "--after/--before, or reparent with --parent/--unparent.")
+        @Argument(help: "Destination workspace id/prefix (relocate). Omit with --to, --after/--before, or --parent/--unparent.") var workspace: String?
         @Option(name: .long, help: "Reorder within the workspace: up, down, top, or bottom.") var to: String?
         @Option(name: .long, help: "Place right AFTER this anchor session (id/prefix/active); the anchor carries its own workspace (relocates + positions in one shot).") var after: String?
         @Option(name: .long, help: "Place right BEFORE this anchor session (id/prefix/active); mirror of --after.") var before: String?
+        @Option(name: .long, help: "Reparent the session under this anchor session (id/prefix/active).") var parent: String?
+        @Flag(name: .long, help: "Promote the session to top-level (remove its parent).") var unparent = false
         @OptionGroup var target: BatchTargetOptions
         @OptionGroup var options: ClientOptions
 
         // exactly one placement intent among {workspace positional (relocate), --to (reorder), --after/--before
-        // (anchor-relative)}; reject empty/conflicting cases at parse time as a clean usage error, unit-testable
-        // without a socket. the anchor carries its own workspace, so placement excludes --to and a workspace.
+        // (anchor-relative), --parent/--unparent (reparent)}; reject empty/conflicting cases at parse time as a
+        // clean usage error, unit-testable without a socket. the anchor carries its own workspace, so placement
+        // excludes --to and a workspace; --parent/--unparent self-identify the destination and take no other
+        // placement form, operating on a single --target.
         func validate() throws {
+            if parent != nil, unparent {
+                throw ValidationError("use either --parent or --unparent, not both")
+            }
+            if parent != nil || unparent {
+                if to != nil || after != nil || before != nil || workspace != nil {
+                    throw ValidationError("session.move takes --parent/--unparent alone")
+                }
+                if target.targets.count > 1 {
+                    throw ValidationError("session.move --parent takes a single --target")
+                }
+                return
+            }
             if after != nil, before != nil {
                 throw ValidationError("use either --after or --before, not both")
             }
@@ -171,7 +198,11 @@ struct Session: ParsableCommand {
 
         func makeRequest() throws -> ControlRequest {
             let args: ControlArgs
-            if let after {
+            if let parent {
+                args = ControlArgs(parent: parent)
+            } else if unparent {
+                args = ControlArgs(unparent: true)
+            } else if let after {
                 args = ControlArgs(after: after)
             } else if let before {
                 args = ControlArgs(before: before)
@@ -466,6 +497,26 @@ struct Session: ParsableCommand {
 
         func makeRequest() throws -> ControlRequest {
             ControlRequest(cmd: .sessionSeen, target: target.target, args: options.withWindow())
+        }
+    }
+
+    struct Collapse: RequestCommand {
+        static let configuration = CommandConfiguration(abstract: "Collapse a parent session's subtree in the sidebar tree.")
+        @OptionGroup var target: TargetOptions
+        @OptionGroup var options: ClientOptions
+
+        func makeRequest() throws -> ControlRequest {
+            ControlRequest(cmd: .sessionCollapse, target: target.target, args: options.withWindow())
+        }
+    }
+
+    struct Expand: RequestCommand {
+        static let configuration = CommandConfiguration(abstract: "Expand a parent session's subtree in the sidebar tree.")
+        @OptionGroup var target: TargetOptions
+        @OptionGroup var options: ClientOptions
+
+        func makeRequest() throws -> ControlRequest {
+            ControlRequest(cmd: .sessionExpand, target: target.target, args: options.withWindow())
         }
     }
 

--- a/agtermCore/Tests/agtermCoreTests/AppStoreNestingTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreNestingTests.swift
@@ -1,0 +1,540 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+/// `AppStore` nesting operations: create-child placement, `sessionSubtreeIDs`, `reparentSession`,
+/// `setSessionExpanded`, subtree-aware `moveSession`, and cascade close (hard `closeSession` and the
+/// grace-timer `softCloseSession`/`softCloseSessions`).
+@MainActor
+struct AppStoreNestingTests {
+    @Test func addSessionWithParentInsertsAtLastChildSlotPreservingContiguity() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let a = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        let b = try #require(store.addSession(toWorkspace: ws.id, cwd: "/b"))
+        #expect(store.workspaces[0].sessions.map(\.id) == [a.id, b.id])
+
+        let c = try #require(store.addSession(toWorkspace: ws.id, cwd: "/c", parentID: a.id))
+        #expect(c.parentID == a.id)
+        // c is a's only child so far: it lands immediately after a, ahead of the unrelated top-level b.
+        #expect(store.workspaces[0].sessions.map(\.id) == [a.id, c.id, b.id])
+
+        let d = try #require(store.addSession(toWorkspace: ws.id, cwd: "/d", parentID: a.id))
+        #expect(d.parentID == a.id)
+        // d joins as a's LAST child: after c (a's existing child), still ahead of b.
+        #expect(store.workspaces[0].sessions.map(\.id) == [a.id, c.id, d.id, b.id])
+    }
+
+    @Test func addSessionWithParentNestsAGrandchildAtTheGrandparentSlot() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let a = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        let c = try #require(store.addSession(toWorkspace: ws.id, cwd: "/c", parentID: a.id))
+        let d = try #require(store.addSession(toWorkspace: ws.id, cwd: "/d", parentID: a.id))
+
+        let e = try #require(store.addSession(toWorkspace: ws.id, cwd: "/e", parentID: c.id))
+        #expect(e.parentID == c.id)
+        // e nests under c (a's first child), landing right after it — ahead of a's other child d.
+        #expect(store.workspaces[0].sessions.map(\.id) == [a.id, c.id, e.id, d.id])
+        #expect(store.sessionSubtreeIDs(a.id) == [a.id, c.id, e.id, d.id])
+    }
+
+    @Test func addSessionWithUnknownParentIgnoresItAndAppendsTopLevel() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let a = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        let b = try #require(store.addSession(toWorkspace: ws.id, cwd: "/b", parentID: UUID()))
+        #expect(b.parentID == nil)
+        #expect(store.workspaces[0].sessions.map(\.id) == [a.id, b.id])
+    }
+
+    @Test func addSessionWithCrossWorkspaceParentIgnoresItAndAppendsTopLevel() throws {
+        let store = makeStore()
+        let ws1 = store.addWorkspace(name: "one")
+        let ws2 = store.addWorkspace(name: "two")
+        let a = try #require(store.addSession(toWorkspace: ws1.id, cwd: "/a"))
+        let b = try #require(store.addSession(toWorkspace: ws2.id, cwd: "/b", parentID: a.id))
+        #expect(b.parentID == nil)
+        #expect(store.workspaces[1].sessions.map(\.id) == [b.id])
+    }
+
+    @Test func sessionSubtreeIDsReturnsTreeOrder() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let a = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        let a1 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a1", parentID: a.id))
+        let a2 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a2", parentID: a1.id))
+        _ = try #require(store.addSession(toWorkspace: ws.id, cwd: "/b"))
+
+        #expect(store.sessionSubtreeIDs(a.id) == [a.id, a1.id, a2.id])
+        #expect(store.sessionSubtreeIDs(a1.id) == [a1.id, a2.id])
+        #expect(store.sessionSubtreeIDs(a2.id) == [a2.id])
+    }
+
+    @Test func sessionSubtreeIDsUnknownIDIsEmpty() {
+        let store = makeStore()
+        #expect(store.sessionSubtreeIDs(UUID()) == [])
+    }
+
+    @Test func reparentSessionMovesSubtreeBlockAndRepairsPreorder() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let a = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        let a1 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a1", parentID: a.id))
+        let a2 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a2", parentID: a1.id))
+        let b = try #require(store.addSession(toWorkspace: ws.id, cwd: "/b"))
+        #expect(store.workspaces[0].sessions.map(\.id) == [a.id, a1.id, a2.id, b.id])
+
+        store.reparentSession(a1.id, to: b.id)
+        #expect(a1.parentID == b.id)
+        #expect(a2.parentID == a1.id) // descendant untouched
+        // a1's whole subtree (a1, a2) relocates under b, preorder-repaired: a keeps its now-childless slot.
+        #expect(store.workspaces[0].sessions.map(\.id) == [a.id, b.id, a1.id, a2.id])
+    }
+
+    @Test func reparentSessionToNilMovesSubtreeToTopLevel() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let a = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        let a1 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a1", parentID: a.id))
+
+        store.reparentSession(a1.id, to: nil)
+        #expect(a1.parentID == nil)
+        #expect(store.workspaces[0].sessions.map(\.id) == [a.id, a1.id])
+    }
+
+    @Test func reparentSessionCycleUnderItsOwnDescendantIsNoOp() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let a = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        let a1 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a1", parentID: a.id))
+        let a2 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a2", parentID: a1.id))
+        let order = store.workspaces[0].sessions.map(\.id)
+
+        store.reparentSession(a.id, to: a2.id) // a2 is a's own grandchild
+        #expect(a.parentID == nil)
+        #expect(store.workspaces[0].sessions.map(\.id) == order)
+
+        store.reparentSession(a.id, to: a.id) // self-parent, also a cycle
+        #expect(a.parentID == nil)
+    }
+
+    @Test func reparentSessionAcrossWorkspacesIsNoOp() throws {
+        let store = makeStore()
+        let ws1 = store.addWorkspace(name: "one")
+        let ws2 = store.addWorkspace(name: "two")
+        let a = try #require(store.addSession(toWorkspace: ws1.id, cwd: "/a"))
+        let b = try #require(store.addSession(toWorkspace: ws2.id, cwd: "/b"))
+
+        store.reparentSession(a.id, to: b.id)
+        #expect(a.parentID == nil)
+        #expect(store.workspaces[0].sessions.map(\.id) == [a.id])
+        #expect(store.workspaces[1].sessions.map(\.id) == [b.id])
+    }
+
+    @Test func reparentSessionUnknownIDIsNoOp() {
+        let store = makeStore()
+        store.addWorkspace(name: "work")
+        store.reparentSession(UUID(), to: nil) // must not crash
+        #expect(store.workspaces[0].sessions.isEmpty)
+    }
+
+    @Test func reparentingIntoACollapsedParentRevealsIt() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let p = try #require(store.addSession(toWorkspace: ws.id, cwd: "/p"))
+        _ = try #require(store.addSession(toWorkspace: ws.id, cwd: "/c", parentID: p.id))
+        store.setSessionExpanded(p.id, expanded: false)
+        #expect(p.isExpanded == false)
+
+        let d = try #require(store.addSession(toWorkspace: ws.id, cwd: "/d"))
+        store.reparentSession(d.id, to: p.id) // drop d onto the collapsed parent p
+        #expect(d.parentID == p.id)
+        #expect(p.isExpanded == true, "nesting a child into p must reveal p so the child is visible")
+    }
+
+    @Test func moveSessionCarriesSubtreeAsOneContiguousBlock() throws {
+        let store = makeStore()
+        let ws1 = store.addWorkspace(name: "one")
+        let ws2 = store.addWorkspace(name: "two")
+        let a = try #require(store.addSession(toWorkspace: ws1.id, cwd: "/a"))
+        let a1 = try #require(store.addSession(toWorkspace: ws1.id, cwd: "/a1", parentID: a.id))
+        let a2 = try #require(store.addSession(toWorkspace: ws1.id, cwd: "/a2", parentID: a.id))
+        let b = try #require(store.addSession(toWorkspace: ws1.id, cwd: "/b"))
+
+        store.moveSession(a.id, toWorkspace: ws2.id)
+        #expect(store.workspaces[0].sessions.map(\.id) == [b.id]) // source keeps only the unrelated session
+        #expect(store.workspaces[1].sessions.map(\.id) == [a.id, a1.id, a2.id]) // whole block, inner order kept
+    }
+
+    @Test func moveSessionCrossWorkspaceNilsMovedRootParentIDButKeepsDescendants() throws {
+        let store = makeStore()
+        let ws1 = store.addWorkspace(name: "one")
+        let ws2 = store.addWorkspace(name: "two")
+        let p = try #require(store.addSession(toWorkspace: ws1.id, cwd: "/p"))
+        let a = try #require(store.addSession(toWorkspace: ws1.id, cwd: "/a", parentID: p.id))
+        let a1 = try #require(store.addSession(toWorkspace: ws1.id, cwd: "/a1", parentID: a.id))
+        #expect(a.parentID == p.id)
+
+        store.moveSession(a.id, toWorkspace: ws2.id)
+        #expect(a.parentID == nil) // a subtree can't straddle workspaces: the moved root becomes top-level
+        #expect(a1.parentID == a.id) // the descendant rides along, parentID untouched
+        #expect(store.workspaces[0].sessions.map(\.id) == [p.id])
+        #expect(store.workspaces[1].sessions.map(\.id) == [a.id, a1.id])
+    }
+
+    @Test func moveSessionWithinWorkspaceKeepsChildlessFastPathIdentical() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let a = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        let b = try #require(store.addSession(toWorkspace: ws.id, cwd: "/b"))
+        let c = try #require(store.addSession(toWorkspace: ws.id, cwd: "/c"))
+
+        store.moveSession(a.id, toWorkspace: ws.id, at: 2)
+        #expect(store.workspaces[0].sessions.map(\.id) == [b.id, c.id, a.id])
+    }
+
+    @Test func setSessionExpandedFlipsAndPersists() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("agterm-tests-\(UUID().uuidString)")
+        let persistence = PersistenceStore(directory: dir)
+        let store = AppStore(persistence: persistence)
+        let ws = store.addWorkspace(name: "work")
+        let a = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        #expect(a.isExpanded)
+
+        store.setSessionExpanded(a.id, expanded: false)
+        #expect(!a.isExpanded)
+        let loaded = persistence.load()
+        #expect(loaded.workspaces[0].sessions[0].collapsed == true)
+    }
+
+    @Test func setSessionExpandedUnknownOrUnchangedIsNoOp() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let a = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        store.setSessionExpanded(UUID(), expanded: false) // unknown id
+        #expect(a.isExpanded)
+        store.setSessionExpanded(a.id, expanded: true) // already expanded
+        #expect(a.isExpanded)
+    }
+
+    @Test func closeSessionCascadesWholeSubtree() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let a = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        let a1 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a1", parentID: a.id))
+        let a2 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a2", parentID: a1.id))
+        let z = try #require(store.addSession(toWorkspace: ws.id, cwd: "/z"))
+
+        store.closeSession(a.id)
+        #expect(store.workspaces[0].sessions.map(\.id) == [z.id])
+        #expect(store.session(withID: a.id) == nil)
+        #expect(store.session(withID: a1.id) == nil) // children torn down, not orphaned
+        #expect(store.session(withID: a2.id) == nil)
+    }
+
+    @Test func closeSessionChildlessBehavesExactlyAsBefore() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let a = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        let b = try #require(store.addSession(toWorkspace: ws.id, cwd: "/b"))
+        store.selectSession(b.id)
+
+        store.closeSession(b.id)
+        #expect(store.workspaces[0].sessions.map(\.id) == [a.id])
+        #expect(store.selectedSessionID == a.id) // unchanged reselection behavior
+    }
+
+    @Test func closeSessionCascadeRecordsOneGroupedRecentClosedItem() throws {
+        let (store, recentClosed, _) = makeStoreWithRecentClosed()
+        let ws = store.addWorkspace(name: "work")
+        let a = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        let a1 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a1", parentID: a.id))
+        let a2 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a2", parentID: a1.id))
+        _ = try #require(store.addSession(toWorkspace: ws.id, cwd: "/z"))
+
+        store.closeSession(a.id)
+
+        let items = recentClosed.load()
+        #expect(items.count == 1) // ONE record for the whole subtree, not three
+        #expect(items[0].kind == .sessionGroup)
+        #expect(items[0].sessionGroup?.snapshots.map(\.id) == [a.id, a1.id, a2.id]) // tree order preserved
+        #expect(items[0].sessionGroup?.snapshots[1].parentID == a.id)
+        #expect(items[0].sessionGroup?.snapshots[2].parentID == a1.id)
+        #expect(items[0].sessionGroup?.selectedSessionID == a.id)
+        #expect(items[0].subtitle == "3 sessions")
+    }
+
+    @Test func closeSessionCascadeReopenRestoresWholeSubtreeWithContiguityAndSelection() throws {
+        let (store, recentClosed, _) = makeStoreWithRecentClosed()
+        let ws = store.addWorkspace(name: "work")
+        let a = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        let a1 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a1", parentID: a.id))
+        let a2 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a2", parentID: a1.id))
+        let z = try #require(store.addSession(toWorkspace: ws.id, cwd: "/z"))
+        store.selectSession(z.id)
+
+        store.closeSession(a.id)
+        let item = try #require(recentClosed.load().first { $0.kind == .sessionGroup })
+
+        #expect(store.restoreRecentClosed(item))
+        // one Reopen restores the whole subtree, contiguous and in its original relative order.
+        #expect(store.workspaces[0].sessions.map(\.id) == [a.id, a1.id, a2.id, z.id])
+        let restoredA1 = try #require(store.session(withID: a1.id))
+        let restoredA2 = try #require(store.session(withID: a2.id))
+        #expect(restoredA1.parentID == a.id)
+        #expect(restoredA2.parentID == a1.id)
+        #expect(store.selectedSessionID == a.id) // reselects the root the user closed
+    }
+
+    @Test func closeSessionChildlessStillRecordsTheLegacySingleSessionItem() throws {
+        let (store, recentClosed, _) = makeStoreWithRecentClosed()
+        let ws = store.addWorkspace(name: "work")
+        let a = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+
+        store.closeSession(a.id)
+
+        let items = recentClosed.load()
+        #expect(items.count == 1)
+        #expect(items[0].kind == .session) // not wrapped in the new grouped kind
+        #expect(items[0].session?.snapshot.id == a.id)
+        #expect(items[0].sessionGroup == nil)
+    }
+
+    @Test func softCloseSessionCascadesWholeSubtreeUnderOneUndo() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let a = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        let a1 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a1", parentID: a.id))
+        let a2 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a2", parentID: a1.id))
+        let z = try #require(store.addSession(toWorkspace: ws.id, cwd: "/z"))
+
+        let closed = store.softCloseSession(a.id, grace: 999)
+        #expect(closed)
+        #expect(store.workspaces[0].sessions.map(\.id) == [z.id])
+        #expect(store.pendingCloseSummary?.kind == .sessions)
+        #expect(store.pendingCloseSummary?.title == "3 sessions")
+
+        let undone = store.undoPendingClose()
+        #expect(undone)
+        // one undo restores the whole subtree, in its original contiguous order.
+        #expect(store.workspaces[0].sessions.map(\.id) == [a.id, a1.id, a2.id, z.id])
+        #expect(store.pendingCloseSummary == nil)
+    }
+
+    @Test func softCloseSessionChildlessStaysASingleSessionRecord() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let a = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+
+        #expect(store.softCloseSession(a.id, grace: 999))
+        #expect(store.pendingCloseSummary?.kind == .session)
+        #expect(store.pendingCloseSummary?.title == a.displayName)
+    }
+
+    @Test func softCloseSessionsExpandsAnyParentInTheBatchToItsSubtree() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let a = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        let a1 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a1", parentID: a.id))
+        let b = try #require(store.addSession(toWorkspace: ws.id, cwd: "/b"))
+
+        #expect(store.softCloseSessions([a.id, b.id], grace: 999))
+        #expect(store.workspaces[0].sessions.isEmpty)
+        #expect(store.pendingCloseSummary?.kind == .sessions)
+        #expect(store.pendingCloseSummary?.title == "3 sessions") // a, a1 (expanded in), b
+
+        #expect(store.undoPendingClose())
+        #expect(store.workspaces[0].sessions.map(\.id) == [a.id, a1.id, b.id])
+    }
+
+    // --to on a NESTED session reorders it within its sibling group carrying its subtree, never breaking
+    // the contiguity invariant (a flat index move would strand the moved row inside a neighbour's subtree).
+    @Test func reorderSessionOnNestedSessionKeepsTreeContiguous() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let a = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        let a1 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a1", parentID: a.id))
+        let a1x = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a1x", parentID: a1.id))
+        let a2 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a2", parentID: a.id))
+        #expect(store.workspaces[0].sessions.map(\.id) == [a.id, a1.id, a1x.id, a2.id])
+
+        // move a2 UP past its sibling a1 (which carries grandchild a1x): the whole a1 subtree stays contiguous.
+        store.reorderSession(a2.id, .up)
+        #expect(store.workspaces[0].sessions.map(\.id) == [a.id, a2.id, a1.id, a1x.id])
+        #expect(a2.parentID == a.id) // still a's child, only reordered among siblings
+        #expect(store.sessionSubtreeIDs(a.id) == [a.id, a2.id, a1.id, a1x.id]) // preorder == array order
+
+        // a child can't escape its parent: moving a2 to the TOP of its sibling group is the furthest it goes.
+        store.reorderSession(a1.id, .bottom)
+        #expect(store.workspaces[0].sessions.map(\.id) == [a.id, a2.id, a1.id, a1x.id]) // a1 already last child, no-op
+    }
+
+    @Test func controlTreeReportsParentIDAndCollapsed() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let a = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        let a1 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a1", parentID: a.id))
+
+        var nodes = store.controlTree().workspaces[0].sessions
+        let parentNode = try #require(nodes.first { $0.id == a.id.uuidString })
+        let childNode = try #require(nodes.first { $0.id == a1.id.uuidString })
+        #expect(parentNode.parentID == nil) // top-level session omits parentID
+        #expect(childNode.parentID == a.id.uuidString)
+        #expect(parentNode.collapsed == nil) // expanded by default, omitted
+
+        store.setSessionExpanded(a.id, expanded: false)
+        nodes = store.controlTree().workspaces[0].sessions
+        #expect(try #require(nodes.first { $0.id == a.id.uuidString }).collapsed == true)
+    }
+
+    // Regression: `session.move --after` an anchor that ALREADY shares the target's parent AND has its own
+    // subtree used to leave a non-contiguous tree — the flat splice split the anchor's subtree and
+    // reparentSession's parent-unchanged no-op never repaired it. repairContiguity now restores preorder.
+    @Test func placeAfterSiblingWithSubtreeKeepsContiguity() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let p = try #require(store.addSession(toWorkspace: ws.id, cwd: "/p"))
+        let c1 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/c1", parentID: p.id))
+        let c1x = try #require(store.addSession(toWorkspace: ws.id, cwd: "/c1x", parentID: c1.id))
+        let c2 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/c2", parentID: p.id))
+        #expect(store.workspaces[0].sessions.map(\.id) == [p.id, c1.id, c1x.id, c2.id])
+
+        placeSessionHostFree(store, move: c2.id, relativeTo: c1.id, after: true)
+        #expect(store.workspaces[0].sessions.map(\.id) == [p.id, c1.id, c1x.id, c2.id]) // c2 after c1's subtree
+        #expect(c2.parentID == p.id)
+        #expect(SessionTree.subtreeRange(of: c1.id, in: store.sessionNodes(inWorkspace: ws.id)) == 1..<3) // c1 + c1x
+    }
+
+    @Test func placeBeforeSiblingWithSubtreeKeepsContiguity() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let p = try #require(store.addSession(toWorkspace: ws.id, cwd: "/p"))
+        let c1 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/c1", parentID: p.id))
+        let c1x = try #require(store.addSession(toWorkspace: ws.id, cwd: "/c1x", parentID: c1.id))
+        let c2 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/c2", parentID: p.id))
+
+        placeSessionHostFree(store, move: c2.id, relativeTo: c1.id, after: false)
+        #expect(store.workspaces[0].sessions.map(\.id) == [p.id, c2.id, c1.id, c1x.id]) // c2 before c1's subtree
+        #expect(c2.parentID == p.id)
+        #expect(SessionTree.subtreeRange(of: c1.id, in: store.sessionNodes(inWorkspace: ws.id)) == 2..<4) // c1 + c1x
+    }
+
+    // The create counterpart: `session.new --after` a subtree-bearing anchor inserts a childless session
+    // between the anchor and its children; repairContiguity lands it after the anchor's whole subtree.
+    @Test func createAfterSiblingWithSubtreeKeepsContiguity() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let p = try #require(store.addSession(toWorkspace: ws.id, cwd: "/p"))
+        let c1 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/c1", parentID: p.id))
+        _ = try #require(store.addSession(toWorkspace: ws.id, cwd: "/c1x", parentID: c1.id))
+        let loc = try #require(store.sessionLocation(ofSession: c1.id))
+
+        let new = try #require(store.addSession(toWorkspace: ws.id, cwd: "/new",
+                                                at: loc.index + 1, parentID: store.session(withID: c1.id)?.parentID))
+        store.repairContiguity(inWorkspace: ws.id)
+        #expect(store.workspaces[0].sessions.map(\.id).last == new.id) // lands after c1's whole subtree
+        #expect(new.parentID == p.id)
+        #expect(SessionTree.subtreeRange(of: c1.id, in: store.sessionNodes(inWorkspace: ws.id)) == 1..<3)
+    }
+
+    @Test func reparentSessionAtPositionNestsAtAGivenChildSlot() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let p = try #require(store.addSession(toWorkspace: ws.id, cwd: "/p"))
+        let c1 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/c1", parentID: p.id))
+        let c2 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/c2", parentID: p.id))
+        let d = try #require(store.addSession(toWorkspace: ws.id, cwd: "/d"))
+        #expect(store.workspaces[0].sessions.map(\.id) == [p.id, c1.id, c2.id, d.id])
+
+        store.reparentSession(d.id, to: p.id, at: 1) // between c1 and c2
+        #expect(d.parentID == p.id)
+        #expect(store.workspaces[0].sessions.map(\.id) == [p.id, c1.id, d.id, c2.id])
+    }
+
+    @Test func reparentSessionAtPositionReordersTopLevelCarryingSubtree() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let a = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        let a1 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a1", parentID: a.id))
+        let b = try #require(store.addSession(toWorkspace: ws.id, cwd: "/b"))
+        #expect(store.workspaces[0].sessions.map(\.id) == [a.id, a1.id, b.id])
+
+        // move top-level `a` (with child a1) to the last top-level slot; parentID stays nil, subtree rides.
+        store.reparentSession(a.id, to: nil, at: 1)
+        #expect(a.parentID == nil)
+        #expect(store.workspaces[0].sessions.map(\.id) == [b.id, a.id, a1.id])
+    }
+
+    @Test func reparentSessionAtPositionFirstChildLandsRightAfterParent() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let p = try #require(store.addSession(toWorkspace: ws.id, cwd: "/p"))
+        let c1 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/c1", parentID: p.id))
+        let d = try #require(store.addSession(toWorkspace: ws.id, cwd: "/d"))
+
+        store.reparentSession(d.id, to: p.id, at: 0) // become p's FIRST child
+        #expect(store.workspaces[0].sessions.map(\.id) == [p.id, d.id, c1.id])
+    }
+
+    @Test func reparentSessionAtPositionCycleIsNoOp() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let a = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        let a1 = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a1", parentID: a.id))
+        let order = store.workspaces[0].sessions.map(\.id)
+
+        store.reparentSession(a.id, to: a1.id, at: 0) // parent under its own child
+        #expect(a.parentID == nil)
+        #expect(store.workspaces[0].sessions.map(\.id) == order)
+    }
+
+    // The CONTIGUITY invariant (a parent immediately followed by its whole subtree, depth-first preorder)
+    // must survive EVERY structural op. It holds iff the flat array already equals its own preorder.
+    @Test func contiguityInvariantSurvivesEveryStructuralOp() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let other = store.addWorkspace(name: "other")
+        let a = try #require(store.addSession(toWorkspace: ws.id, cwd: "/a"))
+        let b = try #require(store.addSession(toWorkspace: ws.id, cwd: "/b"))
+        let c = try #require(store.addSession(toWorkspace: ws.id, cwd: "/c", parentID: a.id))
+        _ = try #require(store.addSession(toWorkspace: ws.id, cwd: "/d", parentID: c.id))
+        assertContiguous(store, ws.id, "create-child + grandchild")
+
+        store.reparentSession(b.id, to: a.id)
+        assertContiguous(store, ws.id, "reparent (last child)")
+        store.reparentSession(c.id, to: nil, at: 0) // promote c (carrying d) to top-level, positioned
+        assertContiguous(store, ws.id, "positioned reparent to top-level")
+        store.reorderSession(a.id, .bottom)
+        assertContiguous(store, ws.id, "sibling reorder")
+        store.moveSession(c.id, toWorkspace: other.id)
+        assertContiguous(store, ws.id, "source after cross-workspace move")
+        assertContiguous(store, other.id, "destination after cross-workspace move")
+        _ = store.closeSessionSubtree(a.id)
+        assertContiguous(store, ws.id, "cascade close")
+    }
+
+    /// Asserts a workspace's flat session array already equals its own depth-first preorder — the contiguity
+    /// invariant. Any op that split a subtree would leave the array out of preorder.
+    private func assertContiguous(_ store: AppStore, _ workspaceID: UUID, _ note: String) {
+        guard let workspace = store.workspaces.first(where: { $0.id == workspaceID }) else { return }
+        let nodes = workspace.sessions.map { SessionTree.Node(id: $0.id, parentID: $0.parentID) }
+        #expect(workspace.sessions.map(\.id) == SessionTree.preorder(nodes), "contiguity broken after \(note)")
+    }
+
+    /// The host-free core of `ControlServer.placeSession`: the drop math + positional move, parent adoption,
+    /// then the UNCONDITIONAL contiguity repair. Mirrors the app arm so the invariant is proven without a host.
+    private func placeSessionHostFree(_ store: AppStore, move sessionID: UUID, relativeTo anchorID: UUID, after: Bool) {
+        guard let source = store.sessionLocation(ofSession: sessionID),
+              let anchor = store.sessionLocation(ofSession: anchorID) else { return }
+        let anchorParent = store.session(withID: anchorID)?.parentID
+        if let resolution = SidebarDrop.resolveRelative(
+            source: (workspace: source.workspace, index: source.index),
+            anchor: (workspace: anchor.workspace, index: anchor.index, count: anchor.count),
+            placeAfter: after) {
+            store.moveSession(sessionID, toWorkspace: resolution.workspace, at: resolution.destination)
+        }
+        store.reparentSession(sessionID, to: anchorParent)
+        store.repairContiguity(inWorkspace: anchor.workspace)
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -253,6 +253,51 @@ struct ControlDispatcherTests {
         #expect(actions.calls.isEmpty)
     }
 
+    @Test func sessionNewRoutesParentOption() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextSessionNewResponse = ControlResponse(ok: true, result: ControlResult(id: "child-session"))
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionNew,
+            args: ControlArgs(parent: "active")
+        ))
+
+        let options = ControlSessionCreateOptions(window: nil, cwd: nil, workspace: nil, workspaceName: nil,
+                                                  createWorkspace: nil, command: nil, name: nil, parent: "active")
+        #expect(response == ControlResponse(ok: true, result: ControlResult(id: "child-session")))
+        #expect(actions.calls == [.sessionNew(options)])
+    }
+
+    @Test func sessionNewRejectsParentCombinedWithOtherPlacementForms() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let parentAndAfter = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionNew,
+            args: ControlArgs(after: "a", parent: "b")
+        ))
+        let parentAndBefore = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionNew,
+            args: ControlArgs(before: "a", parent: "b")
+        ))
+        let parentAndWorkspace = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionNew,
+            args: ControlArgs(workspace: "dest", parent: "b")
+        ))
+        let parentAndWorkspaceName = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionNew,
+            args: ControlArgs(workspaceName: "servers", parent: "b")
+        ))
+
+        let expectedError = "session.new takes --parent, --after/--before, or a workspace, not more than one"
+        #expect(parentAndAfter == ControlResponse(ok: false, error: expectedError))
+        #expect(parentAndBefore == ControlResponse(ok: false, error: expectedError))
+        #expect(parentAndWorkspace == ControlResponse(ok: false, error: expectedError))
+        #expect(parentAndWorkspaceName == ControlResponse(ok: false, error: expectedError))
+        #expect(actions.calls.isEmpty)
+    }
+
     @Test func sessionMoveRoutesPlacementForms() async {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)
@@ -301,6 +346,78 @@ struct ControlDispatcherTests {
             ok: false, error: "session.move takes --after/--before or --to, not both"))
         #expect(anchorAndWorkspace == ControlResponse(
             ok: false, error: "session.move takes --after/--before or a workspace, not both"))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test func sessionMoveRoutesParentAndUnparentForms() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let parent = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionMove,
+            target: "session",
+            args: ControlArgs(window: "win", parent: "anchor")
+        ))
+        let unparent = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionMove,
+            target: "session",
+            args: ControlArgs(unparent: true)
+        ))
+
+        #expect(parent == ControlResponse(ok: true))
+        #expect(unparent == ControlResponse(ok: true))
+        #expect(actions.calls == [
+            .sessionMove(target: "session", window: "win", .parent(anchor: "anchor")),
+            .sessionMove(target: "session", window: nil, .parent(anchor: nil))
+        ])
+    }
+
+    @Test func sessionMoveRejectsConflictingParentAndUnparentForms() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let both = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionMove,
+            target: "active",
+            args: ControlArgs(parent: "a", unparent: true)
+        ))
+        let parentAndTo = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionMove,
+            target: "active",
+            args: ControlArgs(to: "up", parent: "a")
+        ))
+        let parentAndAfter = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionMove,
+            target: "active",
+            args: ControlArgs(after: "b", parent: "a")
+        ))
+        let parentAndBefore = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionMove,
+            target: "active",
+            args: ControlArgs(before: "b", parent: "a")
+        ))
+        let parentAndWorkspace = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionMove,
+            target: "active",
+            args: ControlArgs(workspace: "dest", parent: "a")
+        ))
+        let unparentAndWorkspace = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionMove,
+            target: "active",
+            args: ControlArgs(workspace: "dest", unparent: true)
+        ))
+        let unparentBatch = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionMove,
+            args: ControlArgs(targets: ["a", "b"], unparent: true)
+        ))
+
+        #expect(both == ControlResponse(ok: false, error: "use either --parent or --unparent, not both"))
+        #expect(parentAndTo == ControlResponse(ok: false, error: "session.move takes --parent/--unparent alone"))
+        #expect(parentAndAfter == ControlResponse(ok: false, error: "session.move takes --parent/--unparent alone"))
+        #expect(parentAndBefore == ControlResponse(ok: false, error: "session.move takes --parent/--unparent alone"))
+        #expect(parentAndWorkspace == ControlResponse(ok: false, error: "session.move takes --parent/--unparent alone"))
+        #expect(unparentAndWorkspace == ControlResponse(ok: false, error: "session.move takes --parent/--unparent alone"))
+        #expect(unparentBatch == ControlResponse(ok: false, error: "session.move --parent takes a single --target"))
         #expect(actions.calls.isEmpty)
     }
 
@@ -567,6 +684,25 @@ struct ControlDispatcherTests {
         #expect(actions.calls == [
             .workspaceExpansion(target: "workspace", window: "win", expanded: false),
             .workspaceExpansion(target: "active", window: nil, expanded: true)
+        ])
+    }
+
+    @Test func sessionCollapseAndExpandRouteExpandedFlag() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let collapsed = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionCollapse, target: "sess", args: ControlArgs(window: "win")
+        ))
+        let expanded = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionExpand, target: "active"
+        ))
+
+        #expect(collapsed == ControlResponse(ok: true))
+        #expect(expanded == ControlResponse(ok: true))
+        #expect(actions.calls == [
+            .sessionExpansion(target: "sess", window: "win", expanded: false),
+            .sessionExpansion(target: "active", window: nil, expanded: true)
         ])
     }
 

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -604,6 +604,28 @@ struct ControlProtocolTests {
         #expect(!json.contains("foreground"), "a nil foreground must be omitted from the JSON; got \(json)")
     }
 
+    @Test func treeSessionNodeRoundTripsWithParentIDAndCollapsed() throws {
+        let session = ControlSessionNode(id: "s2", name: "child", cwd: "/tmp", active: false, split: false,
+                                         parentID: "s1", collapsed: true)
+        let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(
+            workspaces: [ControlWorkspaceNode(id: "w1", name: "work", active: true, sessions: [session])])))
+        let decoded = try roundTrip(response)
+        #expect(decoded == response)
+        let node = decoded.result?.tree?.workspaces.first?.sessions.first
+        #expect(node?.parentID == "s1")
+        #expect(node?.collapsed == true)
+    }
+
+    @Test func treeSessionNodeOmitsParentIDAndCollapsedWhenNil() throws {
+        let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false)
+        let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
+        #expect(!json.contains("parentID"), "a nil parentID must be omitted from the JSON; got \(json)")
+        #expect(!json.contains("collapsed"), "a nil collapsed must be omitted from the JSON; got \(json)")
+        let decoded = try JSONDecoder().decode(ControlSessionNode.self, from: Data(json.utf8))
+        #expect(decoded.parentID == nil)
+        #expect(decoded.collapsed == nil)
+    }
+
     @Test func treeSessionNodeRoundTripsWithFontSizes() throws {
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: true,
                                          fontSize: 13, splitFontSize: 9.5, scratchFontSize: 11)
@@ -1310,6 +1332,35 @@ struct ControlProtocolTests {
         #expect(decoded == request)
         #expect(decoded.args?.before == "1a2b")
         #expect(decoded.args?.after == nil)
+    }
+
+    @Test func sessionNewRoundTripsWithParent() throws {
+        let request = ControlRequest(cmd: .sessionNew, args: ControlArgs(parent: "active"))
+        let decoded = try roundTrip(request)
+        #expect(decoded == request)
+        #expect(decoded.args?.parent == "active")
+        #expect(decoded.args?.after == nil)
+        #expect(decoded.args?.before == nil)
+        #expect(decoded.args?.workspace == nil)
+    }
+
+    @Test func sessionMoveRoundTripsWithParent() throws {
+        let request = ControlRequest(cmd: .sessionMove, target: "9f3c", args: ControlArgs(parent: "1a2b"))
+        let decoded = try roundTrip(request)
+        #expect(decoded == request)
+        #expect(decoded.args?.parent == "1a2b")
+        #expect(decoded.args?.unparent == nil)
+        #expect(decoded.args?.after == nil)
+        #expect(decoded.args?.before == nil)
+        #expect(decoded.args?.to == nil)
+    }
+
+    @Test func sessionMoveRoundTripsWithUnparent() throws {
+        let request = ControlRequest(cmd: .sessionMove, target: "9f3c", args: ControlArgs(unparent: true))
+        let decoded = try roundTrip(request)
+        #expect(decoded == request)
+        #expect(decoded.args?.unparent == true)
+        #expect(decoded.args?.parent == nil)
     }
 
     @Test func workspaceMoveRoundTripsWithDirection() throws {

--- a/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
+++ b/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
@@ -31,6 +31,7 @@ final class MockControlActions: ControlActions {
         case workspaceExpansion(target: String?, window: String?, expanded: Bool)
         case sessionFlag(target: String?, window: String?, String?)
         case markSessionSeen(target: String?, window: String?)
+        case sessionExpansion(target: String?, window: String?, expanded: Bool)
         case sessionStatus(target: String?, window: String?, ControlSessionStatusUpdate)
         case sessionRestore(target: String?, window: String?, ControlSessionRestoreUpdate)
         case sessionSplit(target: String?, window: String?, String?)
@@ -263,6 +264,11 @@ final class MockControlActions: ControlActions {
 
     func markSessionSeen(_ target: String?, window: String?) -> ControlResponse {
         calls.append(.markSessionSeen(target: target, window: window))
+        return ControlResponse(ok: true)
+    }
+
+    func setSessionExpansion(_ target: String?, window: String?, expanded: Bool) -> ControlResponse {
+        calls.append(.sessionExpansion(target: target, window: window, expanded: expanded))
         return ControlResponse(ok: true)
     }
 

--- a/agtermCore/Tests/agtermCoreTests/PersistenceTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/PersistenceTests.swift
@@ -536,6 +536,62 @@ final class PersistenceTests {
         #expect(app.workspaces[0].isExpanded)
     }
 
+    @Test func sessionParentAndCollapsedRoundTripThroughDisk() throws {
+        let parent = UUID()
+        let child = UUID()
+        let original = Snapshot(workspaces: [
+            WorkspaceSnapshot(id: UUID(), name: "work", sessions: [
+                SessionSnapshot(id: parent, customName: nil, cwd: "/a"),
+                SessionSnapshot(id: child, customName: nil, cwd: "/b", parentID: parent, collapsed: true),
+            ]),
+        ])
+        try store.save(original)
+        let decoded = store.load()
+        #expect(decoded == original)
+        #expect(decoded.workspaces[0].sessions[1].parentID == parent)
+        #expect(decoded.workspaces[0].sessions[1].collapsed == true)
+    }
+
+    @Test func sessionWithoutParentOrCollapsedRoundTripsThroughDisk() throws {
+        let original = Snapshot(workspaces: [
+            WorkspaceSnapshot(id: UUID(), name: "work", sessions: [
+                SessionSnapshot(id: UUID(), customName: nil, cwd: "/a"),
+            ]),
+        ])
+        try store.save(original)
+        let decoded = store.load()
+        #expect(decoded == original)
+        #expect(decoded.workspaces[0].sessions[0].parentID == nil)
+        #expect(decoded.workspaces[0].sessions[0].collapsed == nil)
+    }
+
+    @Test func legacySessionWithoutParentOrCollapsedDecodesTopLevelExpanded() throws {
+        // a file written before nesting existed has neither key; it must decode rather than wipe the tree.
+        let ws = UUID()
+        let session = UUID()
+        let json = #"{ "version": 1, "workspaces": "# +
+            #"[ { "id": "\#(ws.uuidString)", "name": "work", "sessions": [ { "id": "\#(session.uuidString)", "customName": null, "cwd": "/a" } ] } ] }"#
+        try Data(json.utf8).write(to: fileURL)
+        let loaded = store.load()
+        #expect(loaded.workspaces.map(\.id) == [ws])
+        #expect(loaded.workspaces[0].sessions[0].parentID == nil)
+        #expect(loaded.workspaces[0].sessions[0].collapsed == nil)
+
+        let app = AppStore(persistence: store)
+        app.restore(from: loaded)
+        #expect(app.workspaces[0].sessions[0].parentID == nil)
+        #expect(app.workspaces[0].sessions[0].isExpanded == true)
+    }
+
+    @Test func nonNestedExpandedTreeEncodesWithoutParentOrCollapsedKeys() throws {
+        let app = AppStore(persistence: store)
+        let work = app.addWorkspace(name: "work")
+        _ = app.addSession(toWorkspace: work.id, cwd: "/a")
+        let written = try String(contentsOf: fileURL, encoding: .utf8)
+        #expect(!written.contains("\"parentID\""))
+        #expect(!written.contains("\"collapsed\""))
+    }
+
     @Test func selectSessionPersistsSelectionToDisk() {
         let app = AppStore(persistence: store)
         let work = app.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/RecentClosedTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/RecentClosedTests.swift
@@ -81,6 +81,47 @@ final class RecentClosedTests {
         #expect(loaded[0].workspace?.focusMember == nil)
     }
 
+    @Test func sessionGroupEntryRoundTripsThroughPersistence() throws {
+        let store = RecentClosedStore(directory: directory)
+        let parentID = UUID()
+        let childID = UUID()
+        let item = sessionGroupItem(rootID: parentID, childID: childID, title: "parent")
+
+        store.record(item)
+
+        let loaded = try #require(RecentClosedStore(directory: directory).load().first)
+        #expect(loaded.kind == .sessionGroup)
+        #expect(loaded.sessionGroup?.snapshots.map(\.id) == [parentID, childID]) // tree order preserved
+        #expect(loaded.sessionGroup?.snapshots[1].parentID == parentID) // nesting preserved
+        #expect(loaded.sessionGroup?.selectedSessionID == parentID)
+        #expect(loaded.subtitle == "2 sessions")
+    }
+
+    @Test func recordDedupesSessionGroupsByRootSnapshotID() {
+        let store = RecentClosedStore(directory: directory)
+        let rootID = UUID()
+
+        store.record(sessionGroupItem(id: UUID(), rootID: rootID, childID: UUID(), title: "old"))
+        store.record(sessionGroupItem(id: UUID(), rootID: rootID, childID: UUID(), title: "new"))
+
+        let loaded = store.load()
+        #expect(loaded.count == 1)
+        #expect(loaded[0].title == "new")
+    }
+
+    @Test func legacyListWithoutSessionGroupKeyStillDecodes() throws {
+        // an OLD store file predates `.sessionGroup` entirely: every item is legacy `.session`/`.workspace`
+        // shape with no "sessionGroup" key at all. `load()` must not drop the list on the upgrade.
+        let data = try JSONEncoder().encode(RecentClosedState(items: [sessionItem(title: "s"), workspaceItem(title: "w")]))
+        let json = String(decoding: data, as: UTF8.self)
+        #expect(!json.contains("sessionGroup"))
+        try data.write(to: fileURL)
+
+        let loaded = RecentClosedStore(directory: directory).load()
+        #expect(loaded.count == 2)
+        #expect(loaded.allSatisfy { $0.sessionGroup == nil })
+    }
+
     @Test func workspaceEntryWithALegacyFocusEnabledKeyStillDecodes() throws {
         // the other direction of the same rule: a DROPPED key must not fail the decode either.
         // `focusEnabled` was one — the reopen leg marks only, so nothing reads a stored filter flag.
@@ -131,6 +172,26 @@ final class RecentClosedTests {
                 workspaceIndex: 0,
                 sessionIndex: 0,
                 snapshot: SessionSnapshot(id: snapshotID, customName: title, cwd: "/tmp")
+            )
+        )
+    }
+
+    private func sessionGroupItem(id: UUID = UUID(), rootID: UUID, childID: UUID, title: String) -> RecentClosedItem {
+        RecentClosedItem(
+            id: id,
+            kind: .sessionGroup,
+            title: title,
+            subtitle: "2 sessions",
+            sessionGroup: RecentClosedSessionGroup(
+                workspaceID: UUID(),
+                workspaceName: "work",
+                workspaceIndex: 0,
+                sessionIndex: 0,
+                snapshots: [
+                    SessionSnapshot(id: rootID, customName: title, cwd: "/tmp"),
+                    SessionSnapshot(id: childID, customName: "child", cwd: "/tmp", parentID: rootID),
+                ],
+                selectedSessionID: rootID
             )
         )
     }

--- a/agtermCore/Tests/agtermCoreTests/SessionTreeTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SessionTreeTests.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+struct SessionTreeTests {
+    // Fixture: [A, A/b, A/b/c, A/d, E] — a 3-level tree plus an unrelated root, in canonical preorder.
+    private static let idA = UUID()
+    private static let idB = UUID()
+    private static let idC = UUID()
+    private static let idD = UUID()
+    private static let idE = UUID()
+
+    private static var fixture: [SessionTree.Node] {
+        [
+            SessionTree.Node(id: idA, parentID: nil),
+            SessionTree.Node(id: idB, parentID: idA),
+            SessionTree.Node(id: idC, parentID: idB),
+            SessionTree.Node(id: idD, parentID: idA),
+            SessionTree.Node(id: idE, parentID: nil),
+        ]
+    }
+
+    @Test func subtreeRangeCoversRootAndWholeSubtree() {
+        #expect(SessionTree.subtreeRange(of: Self.idA, in: Self.fixture) == 0..<4)
+    }
+
+    @Test func subtreeRangeCoversMidLevelNodeAndItsChild() {
+        #expect(SessionTree.subtreeRange(of: Self.idB, in: Self.fixture) == 1..<3)
+    }
+
+    @Test func subtreeRangeOfLeafIsSingleElement() {
+        #expect(SessionTree.subtreeRange(of: Self.idC, in: Self.fixture) == 2..<3)
+    }
+
+    @Test func subtreeRangeUnknownIDIsNil() {
+        #expect(SessionTree.subtreeRange(of: UUID(), in: Self.fixture) == nil)
+    }
+
+    @Test func subtreeRangeEmptyOrderIsNil() {
+        #expect(SessionTree.subtreeRange(of: Self.idA, in: []) == nil)
+    }
+
+    @Test func descendantIDsExcludesSelfInTreeOrder() {
+        #expect(SessionTree.descendantIDs(of: Self.idA, in: Self.fixture) == [Self.idB, Self.idC, Self.idD])
+    }
+
+    @Test func descendantIDsOfLeafIsEmpty() {
+        #expect(SessionTree.descendantIDs(of: Self.idC, in: Self.fixture) == [])
+    }
+
+    @Test func descendantIDsUnknownIDIsEmpty() {
+        #expect(SessionTree.descendantIDs(of: UUID(), in: Self.fixture) == [])
+    }
+
+    @Test func isSelfOrDescendantTrueForDescendant() {
+        #expect(SessionTree.isSelfOrDescendant(Self.idC, of: Self.idA, in: Self.fixture))
+    }
+
+    @Test func isSelfOrDescendantTrueForSelf() {
+        #expect(SessionTree.isSelfOrDescendant(Self.idA, of: Self.idA, in: Self.fixture))
+    }
+
+    @Test func isSelfOrDescendantFalseForAncestor() {
+        #expect(!SessionTree.isSelfOrDescendant(Self.idA, of: Self.idC, in: Self.fixture))
+    }
+
+    @Test func isSelfOrDescendantFalseForUnrelatedNode() {
+        #expect(!SessionTree.isSelfOrDescendant(Self.idE, of: Self.idA, in: Self.fixture))
+    }
+
+    @Test func appendChildIndexUnderParentIsPastItsSubtree() {
+        #expect(SessionTree.appendChildIndex(parent: Self.idA, in: Self.fixture) == 4)
+    }
+
+    @Test func appendChildIndexTopLevelIsOrderCount() {
+        #expect(SessionTree.appendChildIndex(parent: nil, in: Self.fixture) == 5)
+    }
+
+    @Test func appendChildIndexUnknownParentIsOrderCount() {
+        #expect(SessionTree.appendChildIndex(parent: UUID(), in: Self.fixture) == 5)
+    }
+
+    @Test func ancestorIDsNearestFirstUpToRoot() {
+        #expect(SessionTree.ancestorIDs(of: Self.idC, in: Self.fixture) == [Self.idB, Self.idA])
+    }
+
+    @Test func ancestorIDsOfRootIsEmpty() {
+        #expect(SessionTree.ancestorIDs(of: Self.idA, in: Self.fixture) == [])
+    }
+
+    @Test func ancestorIDsUnknownIDIsEmpty() {
+        #expect(SessionTree.ancestorIDs(of: UUID(), in: Self.fixture) == [])
+    }
+
+    @Test func preorderRepairsScrambledButValidParentIDs() {
+        // Same nodes as the fixture, listed out of contiguity order; parentIDs alone must drive the repair.
+        let scrambled = [
+            SessionTree.Node(id: Self.idE, parentID: nil),
+            SessionTree.Node(id: Self.idD, parentID: Self.idA),
+            SessionTree.Node(id: Self.idC, parentID: Self.idB),
+            SessionTree.Node(id: Self.idA, parentID: nil),
+            SessionTree.Node(id: Self.idB, parentID: Self.idA),
+        ]
+        #expect(SessionTree.preorder(scrambled) == [Self.idE, Self.idA, Self.idD, Self.idB, Self.idC])
+    }
+
+    @Test func preorderEmptyOrderIsEmpty() {
+        #expect(SessionTree.preorder([]) == [])
+    }
+
+    // fixture roots are A (with subtree A/b/c, A/d) and E. Moving E up swaps the two ROOTS, carrying A's
+    // whole subtree — a flat index move would strand E inside A's subtree and break contiguity.
+    @Test func reorderSiblingRootUpCarriesTheNeighbourSubtree() {
+        #expect(SessionTree.reorderSibling(Self.idE, .up, in: Self.fixture)
+            == [Self.idE, Self.idA, Self.idB, Self.idC, Self.idD])
+    }
+
+    // b and d are both children of A; moving d up past b keeps A's subtree contiguous (d, d has no kids;
+    // b carries c).
+    @Test func reorderSiblingChildUpStaysWithinTheParentSubtree() {
+        #expect(SessionTree.reorderSibling(Self.idD, .up, in: Self.fixture)
+            == [Self.idA, Self.idD, Self.idB, Self.idC, Self.idE])
+    }
+
+    @Test func reorderSiblingChildToBottomIsAlreadyLastIsNil() {
+        // d is already A's last child, so `bottom`/`down` are no-ops within the sibling group.
+        #expect(SessionTree.reorderSibling(Self.idD, .bottom, in: Self.fixture) == nil)
+        #expect(SessionTree.reorderSibling(Self.idD, .down, in: Self.fixture) == nil)
+    }
+
+    @Test func reorderSiblingRootToBottom() {
+        #expect(SessionTree.reorderSibling(Self.idA, .bottom, in: Self.fixture)
+            == [Self.idE, Self.idA, Self.idB, Self.idC, Self.idD])
+    }
+
+    @Test func reorderSiblingUnknownIDIsNil() {
+        #expect(SessionTree.reorderSibling(UUID(), .up, in: Self.fixture) == nil)
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/SidebarDropTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SidebarDropTests.swift
@@ -309,4 +309,78 @@ struct SidebarDropTests {
         let insert = SidebarDrop.workspaceInsertIndex(visibleIndices: [1, 3], slot: 1)
         #expect(SidebarDrop.resolveWorkspace(sourceIndex: 1, count: 4, childIndex: insert) == nil)
     }
+
+    // MARK: - Nested-session reparent
+
+    // Fixture tree (flat, contiguity-valid): top-level p and e; p parents c1 and c2; c1 parents c1x.
+    private static let p = UUID(), c1 = UUID(), c1x = UUID(), c2 = UUID(), e = UUID()
+    private static var nestedOrder: [SessionTree.Node] {
+        [.init(id: p, parentID: nil), .init(id: c1, parentID: p), .init(id: c1x, parentID: c1),
+         .init(id: c2, parentID: p), .init(id: e, parentID: nil)]
+    }
+
+    @Test func reparentDroppingOntoASessionRowNestsAsItsLastChild() {
+        // drop e ONTO p's row (onItemIndex): appends after p's existing children c1, c2 → child index 2.
+        #expect(SidebarDrop.resolveReparent(order: Self.nestedOrder, sourceIDs: [Self.e],
+                                            parentID: Self.p, childIndex: Self.onItem)
+                == SidebarDrop.Reparent(parentID: Self.p, destination: 2))
+    }
+
+    @Test func reparentBetweenAParentsChildrenTakesThatSlot() {
+        #expect(SidebarDrop.resolveReparent(order: Self.nestedOrder, sourceIDs: [Self.e],
+                                            parentID: Self.p, childIndex: 1)
+                == SidebarDrop.Reparent(parentID: Self.p, destination: 1))
+    }
+
+    @Test func reparentToTopLevelUnNestsAChild() {
+        // drop c1 (currently under p) into the top-level gap after p (childIndex 1 among roots [p, e]).
+        #expect(SidebarDrop.resolveReparent(order: Self.nestedOrder, sourceIDs: [Self.c1],
+                                            parentID: nil, childIndex: 1)
+                == SidebarDrop.Reparent(parentID: nil, destination: 1))
+    }
+
+    @Test func reparentOntoADescendantIsACycleAndRejected() {
+        // dropping p onto c1x (p's own grandchild) would nest a node inside its own subtree.
+        #expect(SidebarDrop.resolveReparent(order: Self.nestedOrder, sourceIDs: [Self.p],
+                                            parentID: Self.c1x, childIndex: Self.onItem) == nil)
+    }
+
+    @Test func reparentOntoItselfIsRejected() {
+        #expect(SidebarDrop.resolveReparent(order: Self.nestedOrder, sourceIDs: [Self.c1],
+                                            parentID: Self.c1, childIndex: Self.onItem) == nil)
+    }
+
+    @Test func reparentIntoTheSameParentAtTheSameSlotIsANoOp() {
+        // c1 is already p's child at index 0; dropping it there changes nothing.
+        #expect(SidebarDrop.resolveReparent(order: Self.nestedOrder, sourceIDs: [Self.c1],
+                                            parentID: Self.p, childIndex: 0) == nil)
+    }
+
+    @Test func reparentToAnUnknownParentIsRejected() {
+        #expect(SidebarDrop.resolveReparent(order: Self.nestedOrder, sourceIDs: [Self.e],
+                                            parentID: UUID(), childIndex: Self.onItem) == nil)
+    }
+
+    // MARK: - flatChildInsertIndex
+
+    @Test func flatChildInsertIndexAppendsPastAParentsWholeSubtree() {
+        // p's subtree is [p, c1, c1x, c2] (indices 0..<4); appending a new last child lands at 4.
+        #expect(SidebarDrop.flatChildInsertIndex(order: Self.nestedOrder, parent: Self.p, childDestination: nil) == 4)
+        #expect(SidebarDrop.flatChildInsertIndex(order: Self.nestedOrder, parent: Self.p, childDestination: 9) == 4)
+    }
+
+    @Test func flatChildInsertIndexFirstChildLandsRightAfterTheParent() {
+        #expect(SidebarDrop.flatChildInsertIndex(order: Self.nestedOrder, parent: Self.p, childDestination: 0) == 1)
+    }
+
+    @Test func flatChildInsertIndexSecondChildLandsBeforeThatSiblingsSubtree() {
+        // p's second direct child is c2 at flat index 3 (c1's own child c1x sits between them).
+        #expect(SidebarDrop.flatChildInsertIndex(order: Self.nestedOrder, parent: Self.p, childDestination: 1) == 3)
+    }
+
+    @Test func flatChildInsertIndexTopLevelPositions() {
+        #expect(SidebarDrop.flatChildInsertIndex(order: Self.nestedOrder, parent: nil, childDestination: nil) == 5)
+        #expect(SidebarDrop.flatChildInsertIndex(order: Self.nestedOrder, parent: nil, childDestination: 0) == 0)
+        #expect(SidebarDrop.flatChildInsertIndex(order: Self.nestedOrder, parent: nil, childDestination: 1) == 4)
+    }
 }

--- a/agtermCore/Tests/agtermCoreTests/SkillInstallTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SkillInstallTests.swift
@@ -23,7 +23,7 @@ struct SkillInstallTests {
         let reference = try String(contentsOf: skillDirectory.appendingPathComponent("reference.md"), encoding: .utf8)
         let examples = try String(contentsOf: skillDirectory.appendingPathComponent("examples.md"), encoding: .utf8)
 
-        #expect(skill.contains("Command summary (74 commands)"))
+        #expect(skill.contains("Command summary (76 commands)"))
         #expect(skill.contains("`keymap list`"))
         #expect(reference.contains("`agtermctl keymap list`"))
         #expect(examples.contains("agtermctl keymap list"))

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -137,6 +137,15 @@ struct CommandsTests {
         #expect(try request(["workspace", "expand", "--window", "win"]) == expected)
     }
 
+    @Test func sessionCollapseDefaultsActive() throws {
+        #expect(try request(["session", "collapse"]) == ControlRequest(cmd: .sessionCollapse, target: "active"))
+    }
+
+    @Test func sessionExpandWithTargetAndWindow() throws {
+        let expected = ControlRequest(cmd: .sessionExpand, target: "9f3c", args: ControlArgs(window: "win"))
+        #expect(try request(["session", "expand", "--target", "9f3c", "--window", "win"]) == expected)
+    }
+
     @Test func sessionNewWithCwdAndWorkspace() throws {
         let expected = ControlRequest(cmd: .sessionNew, args: ControlArgs(cwd: "/tmp", workspace: "ws1"))
         #expect(try request(["session", "new", "--cwd", "/tmp", "--workspace", "ws1"]) == expected)
@@ -198,6 +207,21 @@ struct CommandsTests {
     @Test func sessionNewRejectsBeforeAndWorkspaceName() {
         #expect(validationMessage(["session", "new", "--before", "a", "--workspace-name", "servers"])
             == "session.new takes --after/--before or a workspace, not both")
+    }
+
+    @Test func sessionNewParent() throws {
+        let expected = ControlRequest(cmd: .sessionNew, args: ControlArgs(parent: "p1"))
+        #expect(try request(["session", "new", "--parent", "p1"]) == expected)
+    }
+
+    @Test func sessionNewRejectsParentAndAfter() {
+        #expect(validationMessage(["session", "new", "--parent", "p1", "--after", "a"])
+            == "session.new takes --parent, --after/--before, or a workspace, not more than one")
+    }
+
+    @Test func sessionNewRejectsParentAndWorkspace() {
+        #expect(validationMessage(["session", "new", "--parent", "p1", "--workspace", "ws1"])
+            == "session.new takes --parent, --after/--before, or a workspace, not more than one")
     }
 
     @Test func sessionDuplicateTargetsExplicitSession() throws {
@@ -295,6 +319,31 @@ struct CommandsTests {
     @Test func sessionMoveRejectsAfterAndWorkspace() {
         #expect(validationMessage(["session", "move", "ws2", "--after", "a"])
             == "session.move takes --after/--before or a workspace, not both")
+    }
+
+    @Test func sessionMoveParent() throws {
+        let expected = ControlRequest(cmd: .sessionMove, target: "s1", args: ControlArgs(parent: "p1"))
+        #expect(try request(["session", "move", "--parent", "p1", "--target", "s1"]) == expected)
+    }
+
+    @Test func sessionMoveUnparent() throws {
+        let expected = ControlRequest(cmd: .sessionMove, target: "s1", args: ControlArgs(unparent: true))
+        #expect(try request(["session", "move", "--unparent", "--target", "s1"]) == expected)
+    }
+
+    @Test func sessionMoveRejectsParentAndUnparent() {
+        #expect(validationMessage(["session", "move", "--parent", "p1", "--unparent", "--target", "s1"])
+            == "use either --parent or --unparent, not both")
+    }
+
+    @Test func sessionMoveRejectsParentAndTo() {
+        #expect(validationMessage(["session", "move", "--parent", "p1", "--to", "up", "--target", "s1"])
+            == "session.move takes --parent/--unparent alone")
+    }
+
+    @Test func sessionMoveRejectsParentAndWorkspace() {
+        #expect(validationMessage(["session", "move", "ws2", "--parent", "p1", "--target", "s1"])
+            == "session.move takes --parent/--unparent alone")
     }
 
     @Test func sessionTypeWithText() throws {

--- a/agtermUITests/NestedSessionsUITests.swift
+++ b/agtermUITests/NestedSessionsUITests.swift
@@ -1,0 +1,225 @@
+import XCTest
+
+/// End-to-end coverage for nested sessions over the control channel: `session.new --parent` creates a
+/// child, `session.move --parent`/`--unparent` reparents/promotes, `session.new --after` inherits the
+/// anchor's parent, and the mutually-exclusive placement guards. Asserts the new `tree` `parentID`
+/// read-back plus the persisted session order (which must stay in depth-first preorder).
+@MainActor
+final class NestedSessionsUITests: ControlAPITestCase {
+    private let home = NSHomeDirectory()
+
+    // session.new --parent nests the new session as the parent's last child, right after it and ahead of an
+    // unrelated top-level sibling; the tree node reports parentID.
+    func testSessionNewParentCreatesChild() throws {
+        let parentID = UUID(uuidString: "F1110000-0000-0000-0000-000000000001")!
+        let siblingID = UUID(uuidString: "F2220000-0000-0000-0000-000000000002")!
+        try relaunch(withSnapshot: """
+        {"version":1,"selectedSessionID":"\(parentID.uuidString)","workspaces":[\
+        {"id":"\(UUID().uuidString)","name":"workspace 1","sessions":[\
+        {"id":"\(parentID.uuidString)","customName":null,"cwd":"\(home)"},\
+        {"id":"\(siblingID.uuidString)","customName":null,"cwd":"\(home)"}]}]}
+        """)
+        XCTAssertTrue(pollSessionOrder([parentID, siblingID], timeout: 10), "should start in seeded order")
+
+        let resp = try sendCommand(#"{"cmd":"session.new","args":{"parent":"\#(parentID.uuidString)"}}"#)
+        XCTAssertEqual(resp["ok"] as? Bool, true, "session.new --parent should succeed: \(resp)")
+        let childID = try XCTUnwrap(((resp["result"] as? [String: Any])?["id"] as? String).flatMap(UUID.init(uuidString:)),
+                                    "session.new should return the new id: \(resp)")
+        XCTAssertTrue(pollParentID(of: childID, equals: parentID.uuidString, timeout: 10),
+                      "the tree node should report the child's parentID")
+        XCTAssertTrue(pollSessionOrder([parentID, childID, siblingID], timeout: 10),
+                      "the child should land as the parent's last child, ahead of the sibling")
+    }
+
+    // session.move --parent reparents a top-level session under another, moving it to the parent's last-child
+    // slot (right after the parent) in preorder.
+    func testSessionMoveParentReparents() throws {
+        let parentID = UUID(uuidString: "F3330000-0000-0000-0000-000000000001")!
+        let siblingID = UUID(uuidString: "F4440000-0000-0000-0000-000000000002")!
+        let movedID = UUID(uuidString: "F5550000-0000-0000-0000-000000000003")!
+        try relaunch(withSnapshot: """
+        {"version":1,"selectedSessionID":"\(parentID.uuidString)","workspaces":[\
+        {"id":"\(UUID().uuidString)","name":"workspace 1","sessions":[\
+        {"id":"\(parentID.uuidString)","customName":null,"cwd":"\(home)"},\
+        {"id":"\(siblingID.uuidString)","customName":null,"cwd":"\(home)"},\
+        {"id":"\(movedID.uuidString)","customName":null,"cwd":"\(home)"}]}]}
+        """)
+        XCTAssertTrue(pollSessionOrder([parentID, siblingID, movedID], timeout: 10), "should start in seeded order")
+
+        let resp = try sendCommand(#"{"cmd":"session.move","target":"\#(movedID.uuidString)","args":{"parent":"\#(parentID.uuidString)"}}"#)
+        XCTAssertEqual(resp["ok"] as? Bool, true, "session.move --parent should succeed: \(resp)")
+        XCTAssertTrue(pollParentID(of: movedID, equals: parentID.uuidString, timeout: 10),
+                      "the moved session should now report the new parentID")
+        XCTAssertTrue(pollSessionOrder([parentID, movedID, siblingID], timeout: 10),
+                      "the reparented session should land right after its new parent, preorder-repaired")
+    }
+
+    // session.move --unparent promotes a nested session back to top-level: parentID drops off the tree node.
+    func testSessionMoveUnparentPromotesToTopLevel() throws {
+        let parentID = UUID(uuidString: "F6660000-0000-0000-0000-000000000001")!
+        let childID = UUID(uuidString: "F7770000-0000-0000-0000-000000000002")!
+        try relaunch(withSnapshot: """
+        {"version":1,"selectedSessionID":"\(parentID.uuidString)","workspaces":[\
+        {"id":"\(UUID().uuidString)","name":"workspace 1","sessions":[\
+        {"id":"\(parentID.uuidString)","customName":null,"cwd":"\(home)"},\
+        {"id":"\(childID.uuidString)","customName":null,"cwd":"\(home)","parentID":"\(parentID.uuidString)"}]}]}
+        """)
+        XCTAssertTrue(pollParentID(of: childID, equals: parentID.uuidString, timeout: 10),
+                      "the seeded child should start nested under the parent")
+
+        let resp = try sendCommand(#"{"cmd":"session.move","target":"\#(childID.uuidString)","args":{"unparent":true}}"#)
+        XCTAssertEqual(resp["ok"] as? Bool, true, "session.move --unparent should succeed: \(resp)")
+        XCTAssertTrue(pollParentID(of: childID, equals: nil, timeout: 10),
+                      "the promoted session's tree node should omit parentID")
+        XCTAssertTrue(pollSessionOrder([parentID, childID], timeout: 10), "both sessions remain, now top-level")
+    }
+
+    // session.new --after a NESTED anchor inherits the anchor's parent, landing as a sibling right after it.
+    func testSessionNewAfterChildInheritsParent() throws {
+        let parentID = UUID(uuidString: "F8880000-0000-0000-0000-000000000001")!
+        let childID = UUID(uuidString: "F9990000-0000-0000-0000-000000000002")!
+        try relaunch(withSnapshot: """
+        {"version":1,"selectedSessionID":"\(parentID.uuidString)","workspaces":[\
+        {"id":"\(UUID().uuidString)","name":"workspace 1","sessions":[\
+        {"id":"\(parentID.uuidString)","customName":null,"cwd":"\(home)"},\
+        {"id":"\(childID.uuidString)","customName":null,"cwd":"\(home)","parentID":"\(parentID.uuidString)"}]}]}
+        """)
+        XCTAssertTrue(pollParentID(of: childID, equals: parentID.uuidString, timeout: 10),
+                      "the seeded child should start nested under the parent")
+
+        let resp = try sendCommand(#"{"cmd":"session.new","args":{"after":"\#(childID.uuidString)"}}"#)
+        XCTAssertEqual(resp["ok"] as? Bool, true, "session.new --after should succeed: \(resp)")
+        let newID = try XCTUnwrap(((resp["result"] as? [String: Any])?["id"] as? String).flatMap(UUID.init(uuidString:)),
+                                  "session.new should return the new id: \(resp)")
+        XCTAssertTrue(pollParentID(of: newID, equals: parentID.uuidString, timeout: 10),
+                      "the new session should INHERIT the anchor child's parent")
+        XCTAssertTrue(pollSessionOrder([parentID, childID, newID], timeout: 10),
+                      "the new session should land right after the anchor child")
+    }
+
+    // session.move --after an anchor that already shares the target's parent AND has its own subtree must
+    // keep the tree contiguous: the moved session lands after the anchor's WHOLE subtree, not between the
+    // anchor and its children (regression — the flat splice used to orphan the anchor's descendants).
+    func testSessionMoveAfterSubtreeBearingSiblingStaysContiguous() throws {
+        let p = UUID(uuidString: "FA100000-0000-0000-0000-000000000001")!
+        let c1 = UUID(uuidString: "FA200000-0000-0000-0000-000000000002")!
+        let c1x = UUID(uuidString: "FA300000-0000-0000-0000-000000000003")!
+        let c2 = UUID(uuidString: "FA400000-0000-0000-0000-000000000004")!
+        try relaunch(withSnapshot: """
+        {"version":1,"selectedSessionID":"\(p.uuidString)","workspaces":[\
+        {"id":"\(UUID().uuidString)","name":"workspace 1","sessions":[\
+        {"id":"\(p.uuidString)","customName":null,"cwd":"\(home)"},\
+        {"id":"\(c1.uuidString)","customName":null,"cwd":"\(home)","parentID":"\(p.uuidString)"},\
+        {"id":"\(c1x.uuidString)","customName":null,"cwd":"\(home)","parentID":"\(c1.uuidString)"},\
+        {"id":"\(c2.uuidString)","customName":null,"cwd":"\(home)","parentID":"\(p.uuidString)"}]}]}
+        """)
+        XCTAssertTrue(pollSessionOrder([p, c1, c1x, c2], timeout: 10), "should start in seeded preorder")
+
+        let resp = try sendCommand(#"{"cmd":"session.move","target":"\#(c2.uuidString)","args":{"after":"\#(c1.uuidString)"}}"#)
+        XCTAssertEqual(resp["ok"] as? Bool, true, "session.move --after should succeed: \(resp)")
+        XCTAssertTrue(pollSessionOrder([p, c1, c1x, c2], timeout: 10),
+                      "c2 must land after c1's whole subtree, keeping [p, c1, c1x, c2] contiguous")
+        XCTAssertTrue(pollParentID(of: c1x, equals: c1.uuidString, timeout: 10),
+                      "c1's child must stay under c1 (subtree not orphaned by the move)")
+        XCTAssertTrue(pollParentID(of: c2, equals: p.uuidString, timeout: 10),
+                      "c2 keeps its parent p (sibling of c1)")
+    }
+
+    // --parent self-identifies the destination, so it is mutually exclusive with a workspace and with a
+    // placement anchor; and on session.move it cannot combine with --unparent.
+    func testNestingPlacementGuards() throws {
+        let withWorkspace = try sendCommand(#"{"cmd":"session.new","args":{"parent":"active","workspace":"active"}}"#)
+        XCTAssertEqual(withWorkspace["ok"] as? Bool, false, "--parent + a workspace should fail")
+        XCTAssertEqual(withWorkspace["error"] as? String,
+                       "session.new takes --parent, --after/--before, or a workspace, not more than one",
+                       "should return the exclusivity guard: \(withWorkspace)")
+
+        let withAfter = try sendCommand(#"{"cmd":"session.new","args":{"parent":"active","after":"active"}}"#)
+        XCTAssertEqual(withAfter["ok"] as? Bool, false, "--parent + --after should fail")
+        XCTAssertEqual(withAfter["error"] as? String,
+                       "session.new takes --parent, --after/--before, or a workspace, not more than one",
+                       "should return the exclusivity guard: \(withAfter)")
+
+        let parentAndUnparent = try sendCommand(#"{"cmd":"session.move","target":"active","args":{"parent":"active","unparent":true}}"#)
+        XCTAssertEqual(parentAndUnparent["ok"] as? Bool, false, "--parent + --unparent should fail")
+        XCTAssertEqual(parentAndUnparent["error"] as? String, "use either --parent or --unparent, not both",
+                       "should return the either/or guard: \(parentAndUnparent)")
+    }
+
+    // session.collapse/.expand fold a parent's subtree; the tree node's `collapsed` read-back reflects the
+    // persisted Session.isExpanded (true only when collapsed), independent of a visible sidebar.
+    func testSessionCollapseAndExpandReflectInTree() throws {
+        let parentID = UUID(uuidString: "FB100000-0000-0000-0000-000000000001")!
+        let childID = UUID(uuidString: "FB200000-0000-0000-0000-000000000002")!
+        try relaunch(withSnapshot: """
+        {"version":1,"selectedSessionID":"\(parentID.uuidString)","workspaces":[\
+        {"id":"\(UUID().uuidString)","name":"workspace 1","sessions":[\
+        {"id":"\(parentID.uuidString)","customName":null,"cwd":"\(home)"},\
+        {"id":"\(childID.uuidString)","customName":null,"cwd":"\(home)","parentID":"\(parentID.uuidString)"}]}]}
+        """)
+        XCTAssertTrue(pollParentID(of: childID, equals: parentID.uuidString, timeout: 10), "child starts nested")
+        XCTAssertTrue(pollCollapsed(of: parentID, equals: nil, timeout: 10), "parent starts expanded (key omitted)")
+
+        let collapse = try sendCommand(#"{"cmd":"session.collapse","target":"\#(parentID.uuidString)"}"#)
+        XCTAssertEqual(collapse["ok"] as? Bool, true, "session.collapse should succeed: \(collapse)")
+        XCTAssertTrue(pollCollapsed(of: parentID, equals: true, timeout: 10), "the collapsed parent reports collapsed:true")
+
+        let expand = try sendCommand(#"{"cmd":"session.expand","target":"\#(parentID.uuidString)"}"#)
+        XCTAssertEqual(expand["ok"] as? Bool, true, "session.expand should succeed: \(expand)")
+        XCTAssertTrue(pollCollapsed(of: parentID, equals: nil, timeout: 10), "the re-expanded parent omits collapsed")
+    }
+
+    // GUI: the nested outline renders a child as its own row, and collapsing the parent FOLDS the descendant
+    // row away (the row count drops), then expanding brings it back — proving Task 7's nested render + fold in
+    // the real sidebar, not just the tree read-back.
+    func testCollapseFoldsDescendantRowInSidebar() throws {
+        let parentID = UUID(uuidString: "FC100000-0000-0000-0000-000000000001")!
+        let childID = UUID(uuidString: "FC200000-0000-0000-0000-000000000002")!
+        let siblingID = UUID(uuidString: "FC300000-0000-0000-0000-000000000003")!
+        try relaunch(withSnapshot: """
+        {"version":1,"selectedSessionID":"\(siblingID.uuidString)","workspaces":[\
+        {"id":"\(UUID().uuidString)","name":"workspace 1","sessions":[\
+        {"id":"\(parentID.uuidString)","customName":"parent","cwd":"\(home)"},\
+        {"id":"\(childID.uuidString)","customName":"child","cwd":"\(home)","parentID":"\(parentID.uuidString)"},\
+        {"id":"\(siblingID.uuidString)","customName":"sibling","cwd":"\(home)"}]}]}
+        """)
+        XCTAssertTrue(pollSessionRowCount(3, timeout: 15), "the nested child renders as its own row (parent, child, sibling)")
+
+        let collapse = try sendCommand(#"{"cmd":"session.collapse","target":"\#(parentID.uuidString)"}"#)
+        XCTAssertEqual(collapse["ok"] as? Bool, true, "session.collapse should succeed: \(collapse)")
+        XCTAssertTrue(pollSessionRowCount(2, timeout: 15), "collapsing the parent folds the child row away")
+
+        let expand = try sendCommand(#"{"cmd":"session.expand","target":"\#(parentID.uuidString)"}"#)
+        XCTAssertEqual(expand["ok"] as? Bool, true, "session.expand should succeed: \(expand)")
+        XCTAssertTrue(pollSessionRowCount(3, timeout: 15), "expanding the parent brings the child row back")
+    }
+
+    /// Polls the live `tree` until the (present) session's `parentID` read-back equals `expected` (nil = the
+    /// key is omitted, i.e. top-level). An absent session never matches, so it keeps polling until timeout.
+    private func pollParentID(of id: UUID, equals expected: String?, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        let want = expected?.lowercased()
+        while true {
+            if let node = (try? sessionNodeIfPresent(id: id.uuidString)) ?? nil,
+               (node["parentID"] as? String)?.lowercased() == want {
+                return true
+            }
+            if Date() >= deadline { return false }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        }
+    }
+
+    /// Polls the live `tree` until the (present) session's `collapsed` read-back equals `expected` (nil =
+    /// the key is omitted, i.e. expanded — the byte-compatible default). An absent session never matches.
+    private func pollCollapsed(of id: UUID, equals expected: Bool?, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while true {
+            if let node = (try? sessionNodeIfPresent(id: id.uuidString)) ?? nil,
+               (node["collapsed"] as? Bool) == expected {
+                return true
+            }
+            if Date() >= deadline { return false }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        }
+    }
+}

--- a/docs/plans/completed/20260806-nested-sessions.md
+++ b/docs/plans/completed/20260806-nested-sessions.md
@@ -1,0 +1,581 @@
+# Nested (child) sessions
+
+> **For agentic workers:** implement task-by-task, host-free `agtermCore` first. Every task ends green:
+> `cd agtermCore && swift test`, `make build`, `make test-app` where relevant, and `make lint`
+> (`swiftlint --strict`, zero findings) all pass before the next task starts. Steps use `- [x]` checkboxes.
+> This project's maintainer commits — do NOT run `git commit`/`git add`.
+
+## Overview
+
+Let a session be created **as a child of another session** and rendered as an indented sub-tree under its
+parent in the sidebar, at arbitrary depth. The headline case is agent-driven: a skill running inside a
+session spawns a helper session and stacks it under the caller
+(`agtermctl session new --parent "$AGTERM_SESSION_ID"`, or `--parent active`), so related work groups
+visually instead of scattering as flat siblings.
+
+- **Problem:** every session today is a flat leaf under its workspace. A skill that spawns N helper
+  sessions produces N ungrouped rows with no visible parent/child relationship.
+- **Solution:** an **adjacency-list** model — one new `Session.parentID: UUID?` (nil = top-level = today).
+  `Workspace.sessions` stays a **flat ordered array**; the parent→child tree is *derived* for display.
+  The confining invariant is **contiguity**: a parent is immediately followed by its whole subtree
+  (depth-first preorder), so **array order == visual tree order** and every subtree is a contiguous block.
+  This keeps every existing flat consumer (navigation, flagged view, focus filter, persistence, recency,
+  reorder) working unchanged, and confines the real change to the sidebar tree-build plus a few
+  block-move operations.
+- **Why adjacency, not `Session.children: [Session]`:** nested storage forces navigation, flagged view,
+  focus, persistence, recency, and close to all recurse — the opposite of the maintainer's "minimal,
+  clean, structural" bar. Adjacency adds one optional field and one invariant.
+- **Close semantics (decided):** closing a parent **cascades** — its whole subtree closes together, with a
+  confirm showing the descendant count and one grouped grace-undo / Reopen record. This reuses the exact
+  pattern `removeWorkspace` already uses for a workspace full of sessions (see `AppStore.removeWorkspace`,
+  `AppStore.swift:475`), so it is not new machinery.
+- **Parenting surface (decided): creation-time AND drag-to-reparent.**
+  - Create: `session.new --parent <sid|active>` and a sidebar **New Child Session** context item.
+    `--after`/`--before` **inherit the anchor's `parentID`**, so `session new --after active` from inside a
+    child session creates a *sibling child* — the agent idiom keeps working at any depth.
+  - Reparent: drop a session onto another in the sidebar (child), or drag it out to top-level; plus control
+    parity via `session move --parent <sid>` / `session move --unparent`.
+- **Maintainer approval:** the use case is pre-approved (this reverses the general "no extra tree depth"
+  stance in [discussion #293](https://github.com/umputun/agterm/discussions/293) specifically for
+  agent-spawned session grouping). The bar is a top-notch, minimal, structural implementation.
+
+### Prior art reused (do NOT reinvent)
+
+- **`docs/plans/completed/20260705-session-placement-flags.md`** — the `--after`/`--before` feature is the
+  near-exact template: optional field on `ControlArgs` + `ControlSessionCreateOptions`, a
+  `ControlSessionMove` case, `SidebarDrop.resolveRelative` + `AppStore.addSession(at:)`, dispatcher
+  mutual-exclusion guards, and the test harnesses (`ControlProtocolTests`, `SidebarDropTests`,
+  `ControlDispatcherTests`, `agtermctlKitTests/CommandsTests`, `ControlAPIUITests` with
+  `relaunch(withSnapshot:)` / `pollSessionOrder` / `pollSessionCounts`).
+- **`docs/plans/completed/20260626-sidebar-flagged-and-focus.md`** — how the outline data source
+  (`numberOfChildrenOfItem`/`child`/`isItemExpandable`) and the `TreeShape`/`RowContent` reconcile split
+  were extended for a second rendering shape. Nesting extends the same three methods + `TreeShape`.
+- **`docs/plans/completed/20260621-session-navigation.md`** — `WorkspaceSidebar.syncSelection()` already
+  expands a collapsed owner workspace and `scrollRowToVisible`s a selected off-screen row
+  (`expandItem(owner)`); generalize from workspace-owner to the full ancestor chain.
+
+## Context (from discovery — exact hook points)
+
+Host-free model / persistence (`agtermCore`):
+- `Session.swift:82` — `Session` fields + `init(id:initialCwd:customName:)` at `:370`.
+- `Workspace.swift:6` — `Workspace { id, name, sessions: [Session], isExpanded }`; the `isExpanded` pattern
+  to mirror for sessions.
+- `Snapshot.swift` — `SessionSnapshot` (fields `:139-175`, `CodingKeys` `:200-204`, memberwise init
+  `:177-198`, custom `init(from:)` `:213-230`, all non-key fields lossy `(try? decodeIfPresent) ?? nil`);
+  `WorkspaceSnapshot` (`collapsed: Bool?` is the inverse of `isExpanded`, `:105-134`);
+  `Snapshot.currentVersion = 1` (`:12`) — **not bumped** (new fields are optional).
+- `AppStore+Snapshot.swift:30` `sessionSnapshot(_:)` (capture), `:62` `session(from:launchRestore:)`
+  (restore), `:13` `snapshot()` (workspace `collapsed: isExpanded ? nil : true`).
+- `AppStore.swift:368` `addSession(...at:select:)`; `:441` `closeSession(_:)`; `:475` `removeWorkspace(_:)`
+  (the cascade-teardown precedent); `:515` `moveSession(_:toWorkspace:at:)`; `:700` `setWorkspaceExpanded`;
+  `:709` `setWorkspacesExpanded`; `sessionLocation(ofSession:)` (returns `(workspace, index, count)`);
+  `session(withID:)`.
+- `AppStore+PendingClose.swift:58` `softCloseSession(_:grace:)`, `:102` `softCloseSessions(_:grace:)`
+  (grouped grace-undo — the cascade-close vehicle); `AppStore+RecentClosed.swift` (undo records).
+- `AppStore+Events.swift:22` `emitSessionCreated(_:workspace:)` → `ControlEventPayload(name:)`
+  (`ControlEvents.swift:14`).
+- `SidebarDrop.swift` — `resolveSession`, `resolveSessions` (batch block move), `resolveRelative` (the
+  anchor→index reuse). Extend with subtree-block awareness + a cycle guard.
+
+Control (host-free protocol + app effects):
+- `ControlProtocol.swift:10` `sessionNew`, `:17` `sessionMove`; `ControlSessionNode` (`:458-557`, synthesized
+  Codable, optional lets omit nil).
+- `ControlModes.swift:126` `ControlSessionCreateOptions`; `:111` `ControlSessionMove` enum;
+  `ControlArgs` (in `ControlProtocol.swift`, carries `after`/`before`/`to`/`workspace`/`targets`).
+- `ControlDispatcher.swift:10/22-23` `ControlActions.createSession`/`moveSession`/`moveSessions`;
+  `.sessionNew` arm `:244-275`; `.sessionMove` arm `:302-341`; `dispatchSessionMove` `:447`.
+- `agterm/Control/ControlServer+SessionActions.swift:124` `createSession`, `:162` `resolveAnchorLocation`;
+  `agterm/Control/ControlServer.swift:557` `makeSessionResponse(in:workspaceID:options:at:)`;
+  `moveSession`/`placeSession` in the same file (`:482-568`).
+- `agtermctlKit/SessionCommands.swift:26` `struct New`, `:136` `struct Move`.
+
+App-side sidebar (AppKit `NSOutlineView`):
+- `Views/WorkspaceSidebar.swift:116` `Coordinator`; data source `:709-722`
+  (`numberOfChildrenOfItem`/`child`/`isItemExpandable`); expand/collapse delegates `:580-595`;
+  `expandedWorkspaceIDs` `:140`, `suppressExpansionPersist` `:145`; `reconcile()` `:374`,
+  `currentShape()` `:391`, `TreeShape` `:335`, `RowContent` `:343`; `rebuildAndReload()` `:450`
+  (SidebarNode build + expansion re-apply `:485-501`); `syncSelection()` `:608` (collapsed-owner reveal).
+- `Views/SidebarRowViews.swift:268` `SidebarNode { enum Kind { case workspace, session }; id; children }`.
+- `Views/WorkspaceSidebar+RowRendering.swift` — cell builder (`:28`), `iconForSession` (`:97`),
+  `applyBadge` (`:90`), `rowLabel(forSession:)` (`:220`).
+- `Views/WorkspaceSidebar+ContextMenu.swift:266` `addSession(toWorkspace:cwd:)`, row menu `:131`,
+  inline "+" `:228`; `Views/WorkspaceSidebar+DragDrop.swift` (drop validate/accept).
+- `AppActions.swift:117` `newSession()`; `agtermApp+Menus.swift` (session menu items).
+
+Environment (already present — the parent handle a skill passes):
+- `SurfaceEnvironment.swift:17` injects `AGTERM_SESSION_ID`, `:24` `AGTERM_WORKSPACE_ID` into every shell.
+
+Docs / keep-in-sync:
+- `plugins/agterm/skills/agterm/` (`SKILL.md` "Command summary (74 commands)" `:151`, `reference.md`,
+  `examples.md`, `troubleshooting.md`); `.claude/rules/sidebar.md`, `control-api.md`; `README.md:187`
+  ("74 commands"); `site/docs.html`, `site/commands.html` (count on `:9,21,33,240`), `site/index.html`.
+
+## Global constraints (HARD — verify against every task)
+
+- **`agtermCore` stays host-free:** no `import GhosttyKit`/`AppKit`/`Metal`/CoreGraphics (no
+  `CGSize`/`CGPoint`/`CGRect`/`CGFloat`). Pure model / index math / dispatcher / CLI parse live here; the
+  app target is the thin side-effect adapter.
+- **Backward compatible, no version bump:** `Session.parentID`/`isExpanded` snapshot fields are OPTIONAL;
+  a legacy `workspaces.json` / `windows/<id>.json` must decode with every session top-level and expanded,
+  and a non-nested tree must serialize byte-identically to today (emit `parentID`/`collapsed` only when
+  non-default). `Snapshot.currentVersion` stays `1`.
+- **Contiguity invariant (load-bearing):** within one `Workspace.sessions` array, a parent is immediately
+  followed by its entire subtree in depth-first preorder. Every structural op (create-child, reparent,
+  reorder, cross-workspace move, cascade close) preserves it. Same-workspace parent only — a child and its
+  parent always live in one workspace.
+- **No cycles:** a session may not be reparented under itself or any of its descendants.
+- **Green tree after every task:** `swift test`, `make build`, `make test-app` (when app code changed),
+  `make lint --strict` all clean.
+- **File sizes:** source < 1000 lines, tests < 2000. New pure logic goes in NEW files (`SessionTree.swift`)
+  rather than growing `AppStore.swift`/`Session.swift`; if a touched file nears the limit, stop and ask —
+  never bump the swiftlint limit.
+- **Cross-surface contract:** a new user-facing action isn't done until it is drivable from the control
+  socket with dispatcher + CLI + round-trip/e2e tests, and the bundled skill + rules + README + site are
+  updated. State-setting commands expose read-back on `ControlSessionNode`.
+- **`CHANGELOG.md` is release-only — do NOT touch it here.**
+- **Protect the live terminal:** all manual verification uses a separate `open -n` Debug instance with an
+  isolated `AGTERM_STATE_DIR` + short socket; never drive the default socket, never quit/relaunch the
+  deployed app.
+
+## Development approach
+
+- **Testing: regular (code first, then tests in the SAME task)** — the maintainer's chosen cadence; every
+  code task lists its tests as explicit checklist items and they pass before the next task starts.
+- Bottom-up: host-free model + tree math + AppStore ops (unit-tested with `swift test`) → control protocol
+  + dispatcher + CLI → app-side effects + read-back → sidebar rendering → drag-reparent → GUI affordances →
+  docs → verify.
+- Small, focused changes; keep this plan in sync (`➕` new task, `⚠️` blocker) if scope shifts.
+
+## Open decision (confirm at review)
+
+**Task 10 — `session.collapse`/`session.expand` control commands** for folding a parent session's subtree.
+Collapsing a parent IS a new user action, and the CLAUDE.md control-parity contract plus the exact
+`workspace.collapse`/`.expand` precedent argue it should be control-drivable (74 → 76 commands). The
+minimal alternative is GUI-only collapse with `tree` read-back (`ControlSessionNode.collapsed`) and no new
+command (stays 74). This plan **includes** Task 10 by default as the consistent choice; the reviewer may
+cut it, in which case the command-count doc bumps in Task 11 are dropped and `collapsed` stays a read-back
+of a GUI-only toggle.
+
+---
+
+## Implementation Steps
+
+### Task 1: Model + persistence fields (`agtermCore`)
+
+**Files:**
+- Modify: `agtermCore/Sources/agtermCore/Session.swift` (fields near `:119`; init `:370`)
+- Modify: `agtermCore/Sources/agtermCore/Snapshot.swift` (`SessionSnapshot` `:138-231`)
+- Modify: `agtermCore/Sources/agtermCore/AppStore+Snapshot.swift` (`sessionSnapshot` `:30`, `session(from:)` `:62`)
+- Test: `agtermCore/Tests/agtermCoreTests/PersistenceTests.swift`
+
+**Interfaces produced:**
+- `Session.parentID: UUID?` (observed, default nil), `Session.isExpanded: Bool` (observed, default true).
+- `SessionSnapshot.parentID: UUID?`, `SessionSnapshot.collapsed: Bool?` (inverse of `isExpanded`).
+
+- [x] `Session.swift`: add `public var parentID: UUID?` and `public var isExpanded: Bool = true` beside
+      `flagged` (`:119`); both observed (NOT `@ObservationIgnored`) so a reparent / collapse reloads the
+      sidebar. Do NOT add them to `init` params (set post-construction like `initialCommand`).
+- [x] `Snapshot.swift`: add `public var parentID: UUID?` and `public var collapsed: Bool?` to
+      `SessionSnapshot`; extend the memberwise `init` (both defaulting nil, appended after
+      `splitRestoreCommand` to keep call-site diffs minimal), the `CodingKeys` enum (`case parentID,
+      collapsed`), and the custom `init(from:)` with the same lossy pattern:
+      `parentID = (try? c.decodeIfPresent(UUID.self, forKey: .parentID)) ?? nil` and likewise `collapsed`.
+      No `encode(to:)` (synthesized `encodeIfPresent` omits nil). Do NOT bump `currentVersion`.
+- [x] `AppStore+Snapshot.swift` `sessionSnapshot(_:)`: pass `parentID: session.parentID` and
+      `collapsed: session.isExpanded ? nil : true` (emit `collapsed` only when collapsed, mirroring the
+      workspace rule, so a non-collapsed session stays byte-identical).
+- [x] `AppStore+Snapshot.swift` `session(from:launchRestore:)`: set `session.parentID = snapshot.parentID`
+      and `session.isExpanded = !(snapshot.collapsed ?? false)`.
+- [x] Tests (`PersistenceTests`): round-trip a session with `parentID` set + `collapsed` true; round-trip
+      with both unset; decode a legacy `SessionSnapshot` JSON literal WITHOUT the keys → `parentID == nil`,
+      `isExpanded == true`; assert a non-nested/expanded tree encodes without `parentID`/`collapsed` keys
+      (byte-compat — encode and grep the JSON for absence).
+- [x] `cd agtermCore && swift test` — green before Task 2.
+
+### Task 2: Host-free tree math — `SessionTree` (`agtermCore`)
+
+**Files:**
+- Create: `agtermCore/Sources/agtermCore/SessionTree.swift`
+- Create: `agtermCore/Tests/agtermCoreTests/SessionTreeTests.swift`
+
+**Interfaces produced** (all pure, operate on a flat ordered `[Node]` obeying the contiguity invariant;
+`Node = (id: UUID, parentID: UUID?)` so it is testable without `Session`/`@MainActor`):
+```swift
+public enum SessionTree {
+    public struct Node: Equatable, Sendable { public let id: UUID; public let parentID: UUID?
+        public init(id: UUID, parentID: UUID?) }
+    /// Half-open index range of `parentID`'s node plus its entire subtree (the contiguous block),
+    /// or nil if the id is absent. The block starts at the node itself.
+    public static func subtreeRange(of id: UUID, in order: [Node]) -> Range<Int>?
+    /// Ids of every descendant of `id` (excludes `id`), in tree order.
+    public static func descendantIDs(of id: UUID, in order: [Node]) -> [UUID]
+    /// True if `candidate` is `ancestor` or a descendant of it — the reparent cycle guard.
+    public static func isSelfOrDescendant(_ candidate: UUID, of ancestor: UUID, in order: [Node]) -> Bool
+    /// The array index just past the last element of `parentID`'s subtree — the insert slot for a new
+    /// last-child. For a nil parent (top-level append) returns `order.count`.
+    public static func appendChildIndex(parent: UUID?, in order: [Node]) -> Int
+    /// The chain of ancestor ids from the direct parent up to the root (nearest first), for expand-reveal.
+    public static func ancestorIDs(of id: UUID, in order: [Node]) -> [UUID]
+    /// Reorders `order` into canonical depth-first preorder given each node's parentID, preserving the
+    /// existing relative order of siblings. Used to REPAIR contiguity after a reparent/move builds the
+    /// new parentID set; returns ids in the corrected order. Roots keep their current relative order.
+    public static func preorder(_ order: [Node]) -> [UUID]
+}
+```
+
+- [x] Implement `SessionTree` with the signatures above. `subtreeRange`: find the node's index `i`, then
+      walk forward while the running set of "ids seen inside the block" contains each node's `parentID`
+      (i.e. it is a descendant), stopping at the first node whose parentID is outside the block — correct
+      because the invariant guarantees contiguity. `isSelfOrDescendant`: `candidate == ancestor ||
+      descendantIDs(of: ancestor).contains(candidate)`. `preorder`: build children-by-parent buckets
+      preserving input order, then DFS from roots (parentID nil, in input order).
+- [x] Tests (`SessionTreeTests`, `@Test`/`#expect`): a 3-level fixture `[A, A/b, A/b/c, A/d, E]` — assert
+      `subtreeRange(A) == 0..<4`, `subtreeRange(b) == 1..<3`, `descendantIDs(A) == [b,c,d]`,
+      `isSelfOrDescendant(c, of: A) == true`, `isSelfOrDescendant(A, of: c) == false`,
+      `appendChildIndex(A) == 4`, `appendChildIndex(nil) == 5`, `ancestorIDs(c) == [b, A]`; `preorder` of a
+      deliberately-scrambled-but-valid parentID set returns canonical order; empty input → empty results;
+      unknown id → nil range / `[]`.
+- [x] `cd agtermCore && swift test` — green before Task 3.
+
+### Task 3: `AppStore` operations — create-child, reparent, collapse, subtree move, cascade close (`agtermCore`)
+
+**Files:**
+- Modify: `agtermCore/Sources/agtermCore/AppStore.swift` (`addSession` `:368`, `moveSession` `:515`,
+  `closeSession` `:441`); new extension `agtermCore/Sources/agtermCore/AppStore+Nesting.swift`
+- Modify: `agtermCore/Sources/agtermCore/AppStore+PendingClose.swift` (cascade subtree in soft close)
+- Test: `agtermCore/Tests/agtermCoreTests/AppStoreNestingTests.swift`
+
+**Interfaces consumed:** `SessionTree.*` (Task 2), `SessionSnapshot`/`Session.parentID` (Task 1).
+**Interfaces produced:**
+```swift
+extension AppStore {
+    /// Flat `SessionTree.Node`s for a workspace, in array order (bridges Session → pure tree math).
+    func sessionNodes(inWorkspace: UUID) -> [SessionTree.Node]
+    /// The id + every descendant id, in tree order (for cascade close / confirm count).
+    public func sessionSubtreeIDs(_ sessionID: UUID) -> [UUID]
+    /// Reparent `sessionID` (and its subtree) under `newParentID` (nil = top-level) within its OWN
+    /// workspace, appended as last child, then repaired to preorder. No-ops on unknown id, a cross-workspace
+    /// parent, or a cycle. Persists.
+    public func reparentSession(_ sessionID: UUID, to newParentID: UUID?)
+    /// Collapse/expand a parent session; mirrors setWorkspaceExpanded. No-op on unknown/unchanged. Persists.
+    public func setSessionExpanded(_ sessionID: UUID, expanded: Bool)
+}
+```
+
+- [x] `addSession(...)`: add `parentID: UUID? = nil`. When non-nil, validate the parent exists in
+      `workspaceID` (else ignore the parent, append top-level — do NOT fail creation); set
+      `session.parentID`; when `at index` is nil, insert at `SessionTree.appendChildIndex(parent: parentID,
+      in: sessionNodes(inWorkspace: workspaceID))` instead of appending. An explicit `at index` (from
+      `--after`/`--before`) still wins and the caller sets `parentID` to the anchor's parent (Task 5).
+- [x] `AppStore+Nesting.swift`: implement `sessionNodes`, `sessionSubtreeIDs` (map `SessionTree.subtreeRange`
+      back to ids), `reparentSession` (guard same workspace via `sessionLocation`; guard
+      `!SessionTree.isSelfOrDescendant(newParentID, of: sessionID, ...)` when newParentID non-nil; set
+      parentID; rebuild the workspace's `sessions` array to `SessionTree.preorder(...)` order; `save()`),
+      and `setSessionExpanded` (mirror `setWorkspaceExpanded` `:700`).
+- [x] `moveSession(_:toWorkspace:at:)`: when the moved session has descendants, move the whole subtree
+      block (use `SessionTree.subtreeRange`) preserving inner order, and — for a cross-workspace move —
+      set the moved root's `parentID = nil` (a subtree can't straddle workspaces; descendants keep their
+      parentIDs and ride along). Keep the single-session fast path unchanged for a childless session.
+- [x] Cascade close: in the GUI/close path, closing a session with descendants closes the subtree. Add the
+      subtree expansion at the `softCloseSessions`/`closeSession` call sites (Task 9 GUI wires the confirm);
+      here, make `softCloseSessions(_:)` and the hard `closeSession` accept the subtree id list and record
+      ONE grouped undo (they already group a batch — feed `sessionSubtreeIDs(id)` in tree order). Ensure a
+      promoted/closed parent's children are torn down, not orphaned.
+- [x] Tests (`AppStoreNestingTests`, `@MainActor`): create child inserts at last-child slot preserving
+      contiguity; nested grandchild; `reparentSession` moves a subtree block and repairs preorder; reparent
+      cycle (parent under its own child) is a no-op; cross-workspace parent is a no-op; `moveSession` of a
+      parent carries its subtree and nils the root parentID cross-workspace; `sessionSubtreeIDs` returns
+      tree order; cascade close removes the whole subtree and a single undo restores it; `setSessionExpanded`
+      flips + saves, unknown id no-ops.
+- [x] `cd agtermCore && swift test` — green before Task 4.
+
+### Task 4: Control protocol + dispatcher — `--parent` on new/move (`agtermCore`)
+
+**Files:**
+- Modify: `agtermCore/Sources/agtermCore/ControlProtocol.swift` (`ControlArgs` + `init`)
+- Modify: `agtermCore/Sources/agtermCore/ControlModes.swift` (`ControlSessionCreateOptions` `:126`,
+  `ControlSessionMove` `:111`)
+- Modify: `agtermCore/Sources/agtermCore/ControlDispatcher.swift` (`.sessionNew` `:244`, `.sessionMove` `:302`)
+- Test: `agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift`,
+  `agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift`
+
+**Interfaces produced:**
+- `ControlArgs.parent: String?`, `ControlArgs.unparent: Bool?`.
+- `ControlSessionCreateOptions.parent: String?` (threaded through its `init`).
+- `ControlSessionMove.parent(anchor: String?)` — `anchor` nil = unparent to top-level.
+- `.place(anchor:after:)` semantics extended: the placed session ADOPTS the anchor's `parentID` (Task 5).
+
+- [x] `ControlProtocol.swift`: add `public var parent: String?` and `public var unparent: Bool?` to
+      `ControlArgs` and its `init` (both optional, default nil — keeps existing call sites / old JSON).
+- [x] `ControlModes.swift`: add `public let parent: String?` to `ControlSessionCreateOptions` + its `init`
+      (default nil); add `case parent(anchor: String?)` to `ControlSessionMove`.
+- [x] `.sessionNew` arm: reject `--parent` combined with `--after`/`--before` (single placement intent) and
+      with `--workspace`/`--workspace-name` (the parent names the workspace):
+      `"session.new takes --parent, --after/--before, or a workspace, not more than one"`. Thread
+      `parent: args?.parent` into `ControlSessionCreateOptions`. Leave the existing after/before/workspace
+      guards intact.
+- [x] `.sessionMove` arm: before the after/before branch, handle `--parent`/`--unparent`: reject both
+      together (`"use either --parent or --unparent, not both"`) and either combined with
+      `--to`/`--after`/`--before`/workspace (`"session.move takes --parent/--unparent alone"`), then route
+      `actions.moveSession(request.target, window:, move: .parent(anchor: args?.unparent == true ? nil :
+      args?.parent))` (single target only — reject `targets.count > 1` with `.parent`:
+      `"session.move --parent takes a single --target"`).
+- [x] Tests: `ControlProtocolTests` round-trip `session.new`/`session.move` carrying `parent`/`unparent`
+      (fields survive, others nil); `ControlDispatcherTests` (mock `ControlActions`) assert each new error
+      string, and that valid `--parent`/`--unparent` hand the right `ControlSessionMove.parent` /
+      `ControlSessionCreateOptions.parent` to the mock.
+- [x] `cd agtermCore && swift test` — green before Task 5.
+
+### Task 5: App-side `ControlActions` + tree read-back (`agtermCore` + app)
+
+**Files:**
+- Modify: `agterm/Control/ControlServer+SessionActions.swift` (`createSession` `:124`,
+  `resolveAnchorLocation` `:162`, `moveSession`)
+- Modify: `agterm/Control/ControlServer.swift` (`makeSessionResponse` `:557`; tree builder)
+- Modify: `agtermCore/Sources/agtermCore/ControlProtocol.swift` (`ControlSessionNode`) + the app-side
+  session-node builder that populates it
+- Test: `agtermUITests/ControlAPIUITests.swift`
+
+**Interfaces produced:** `ControlSessionNode.parentID: String?`, `ControlSessionNode.collapsed: Bool?`
+(both omitted when nil/expanded).
+
+- [x] `ControlProtocol.swift`: add `public let parentID: String?` and `public let collapsed: Bool?` to
+      `ControlSessionNode` + its memberwise init (synthesized Codable already omits nil).
+- [x] The session-node builder (where `ControlSessionNode(...)` is constructed for `tree`): set
+      `parentID: session.parentID?.uuidString` and `collapsed: session.isExpanded ? nil : true`.
+- [x] `resolveAnchorLocation` (`:162`): also surface the anchor session's `parentID` to callers — change its
+      `body` tuple to `(workspace: UUID, index: Int, count: Int, parentID: UUID?)` (read via
+      `store.session(withID: anchorID)?.parentID`).
+- [x] `createSession` (`:124`): add a `--parent` branch BEFORE the after/before branch — resolve the parent
+      sid across the store (reuse `resolveAnchorLocation`), then
+      `makeSessionResponse(in: store, workspaceID: parentLocation.workspace, options: options,
+      parentID: parentSessionID)` with `at: nil` (last-child insert handled in `addSession`, Task 3). In the
+      existing after/before branch, pass `parentID: location.parentID` so the placed session INHERITS the
+      anchor's parent (sibling placement at any depth).
+- [x] `makeSessionResponse` (`:557`): add `parentID: UUID? = nil`; forward it into
+      `store.addSession(..., parentID: parentID)`.
+- [x] `moveSession` app action: handle `.parent(anchor:)` — resolve `--target`; if anchor non-nil resolve it
+      across the store and call `store.reparentSession(targetID, to: anchorID)`; if nil call
+      `store.reparentSession(targetID, to: nil)`. Handle `.place(anchor:after:)` (existing) so it ALSO
+      adopts the anchor's parentID: after the positional move, call `store.reparentSession(targetID, to:
+      anchorParentID)` (or fold parent-adoption into the move to avoid a double reload — implementer's call,
+      but the end state must be: placed session's parentID == anchor's parentID). Return `result.id`.
+- [x] E2E (`ControlAPIUITests`, isolated `.debug` bundle + `AGTERM_STATE_DIR`/socket, `relaunch(withSnapshot:)`
+      + `pollSessionOrder`/`pollSessionCounts`, mirror `testSessionNewPlaceRelativeToAnchor`):
+      `session new --parent <sid>` creates a child (assert `tree` node `parentID`); `session move --parent`
+      reparents; `session move --unparent` promotes to top-level; `session new --after <child>` inherits the
+      child's parent; error guards (`--parent` + `--workspace`, `--parent` + `--after`,
+      `--parent`+`--unparent`).
+- [x] `make build` + `make lint` + the new e2e cases pass — green before Task 6.
+
+### Task 6: CLI — `session new --parent`, `session move --parent`/`--unparent` (`agtermctlKit`)
+
+**Files:**
+- Modify: `agtermCore/Sources/agtermctlKit/SessionCommands.swift` (`struct New` `:26`, `struct Move` `:136`)
+- Test: `agtermCore/Tests/agtermctlKitTests/CommandsTests.swift`
+
+- [x] `struct New`: add `@Option(name: .long, help: "Create the session as a CHILD of this anchor session
+      (id/prefix/active); it nests under the parent in the sidebar. Mutually exclusive with
+      --workspace/--workspace-name and --after/--before.") var parent: String?`. In `validate()`: reject
+      `parent` with `after`/`before` and with `workspace`/`workspaceName`. In `makeRequest()`, thread
+      `parent` into `ControlArgs(...)`.
+- [x] `struct Move`: add `@Option(name: .long, help: "Reparent the session under this anchor session
+      (id/prefix/active).") var parent: String?` and `@Flag(name: .long, help: "Promote the session to
+      top-level (remove its parent).") var unparent = false`. In `validate()`: reject `parent`+`unparent`
+      together, and either with `to`/`after`/`before`/positional `workspace`; require a single `--target`.
+      In `makeRequest()`, build `ControlArgs(parent:)` / `ControlArgs(unparent: true)`.
+- [x] Tests (`CommandsTests`): `session new --parent <sid>` maps to `ControlArgs.parent`; `session move
+      --parent <sid> --target <sid>` and `--unparent --target <sid>` map correctly; `validate()` rejection
+      messages for each new conflict (mirror `sessionMoveRejectsWorkspaceAndTo`).
+- [x] `cd agtermCore && swift test` — green before Task 7.
+
+### Task 7: Sidebar — nested outline, expansion, reveal, roll-up (app)
+
+**Files:**
+- Modify: `agterm/Views/WorkspaceSidebar.swift` (data source `:709-722`; `TreeShape` `:335`, `RowContent`
+  `:343`, `currentShape` `:391`; `rebuildAndReload` `:450`; expand/collapse delegates `:580-595`;
+  `syncSelection` `:608`; `expandedWorkspaceIDs` `:140` → add `expandedSessionIDs`)
+- Modify: `agterm/Views/WorkspaceSidebar+RowRendering.swift` (roll-up badge/status on collapsed parents)
+- Modify: `agterm/Views/SidebarRowViews.swift` (`SidebarNode` build helper if needed)
+- Test: host-free coverage rides Task 2/3; sidebar wiring is verified by the Task 12 XCUITest (no app unit host).
+
+- [x] `rebuildAndReload` SidebarNode build: instead of one flat `session` child list per workspace, build a
+      **nested** `SidebarNode` tree from each workspace's sessions using `parentID` (a session node's
+      `children` are its direct children in array order). Reuse the id-keyed `nodeCache` so identity/expansion
+      survive reloads.
+- [x] Data source: `isItemExpandable` returns true for a workspace node OR a session node with non-empty
+      `children`. `numberOfChildrenOfItem`/`child` already read `node.children`, so they work unchanged once
+      the nested tree is built.
+- [x] `TreeShape`: change `sessionIDs: [UUID]` to carry parent structure — `sessions: [(id: UUID, parentID:
+      UUID?)]` (or a parallel `parentIDs: [UUID?]`). REQUIRED: a promote that preserves linear order but
+      changes depth (e.g. `[A, A/b]` → `[A, b]`) must still count as a shape change and rebuild.
+- [x] `expandedSessionIDs: Set<UUID>` beside `expandedWorkspaceIDs`; seed from `store.workspaces.flatMap
+      { $0.sessions }.filter(\.isExpanded)` (parent sessions only), re-apply after `reloadData()` in
+      `rebuildAndReload` (expand session nodes in `expandedSessionIDs`, under `suppressExpansionPersist`).
+- [x] Expand/collapse delegates (`:580-595`): handle `node.kind == .session` too — update
+      `expandedSessionIDs` and, unless suppressed, `store.setSessionExpanded(node.id, expanded:)`.
+- [x] `syncSelection` (`:608`): before the `row(forItem:)` lookup, expand the FULL ancestor chain of the
+      selected session (`SessionTree.ancestorIDs` over the workspace's nodes → `expandItem` each ancestor
+      session node and the owner workspace) so selecting a collapsed descendant reveals it, then
+      `scrollRowToVisible`. Generalizes the existing collapsed-workspace reveal.
+- [x] `RowContent`: add `rolledUpUnseen: Int` and `rolledUpAttention: Bool` (a collapsed parent shows the
+      aggregate of its hidden descendants; an expanded parent or a leaf uses its own values). Fold each
+      session's `parentID`/`isExpanded`/descendant unseen+status into the `updateNSView` observed read so a
+      hidden descendant's badge/status change reloads the collapsed parent row.
+- [x] `WorkspaceSidebar+RowRendering.swift`: when a session node is collapsed and has descendants, render the
+      rolled-up unseen badge + attention glyph (reuse `applyBadge`/`StatusIconView`); expanded parents render
+      their own values as today. Row icon/label unchanged (native disclosure triangle indicates children).
+- [x] `make build` + `make test-app` + `make lint` — green before Task 8.
+
+### Task 8: Drag-to-reparent (app + `agtermCore`)
+
+**Files:**
+- Modify: `agterm/Views/WorkspaceSidebar+DragDrop.swift` (validate/accept drop)
+- Modify: `agtermCore/Sources/agtermCore/SidebarDrop.swift` (subtree-aware helper + cycle guard)
+- Test: `agtermCore/Tests/agtermCoreTests/SidebarDropTests.swift`; wiring via Task 12 XCUITest
+
+**Interfaces produced:**
+```swift
+extension SidebarDrop {
+    /// Resolves a drop of `sourceIDs` (a dragged block) ONTO a session row (→ become its children) or
+    /// between rows at a target depth, into (newParentID, destinationIndex) within one workspace, or nil
+    /// for a no-op / illegal (cross-workspace, or a cycle — dropping a parent onto its own descendant).
+    public static func resolveReparent(order: [SessionTree.Node], sourceIDs: [UUID],
+                                       onto targetID: UUID?, workspace: UUID) -> (parentID: UUID?, destination: Int)?
+}
+```
+
+- [x] `SidebarDrop.resolveReparent`: reject when `targetID` is the source or any of its descendants
+      (`SessionTree.isSelfOrDescendant`); compute the new parentID (the drop target, or nil for a top-level
+      gap) and the post-removal destination index using the existing block-move arithmetic; nil for a no-op
+      (same parent + same slot).
+- [x] `WorkspaceSidebar+DragDrop.swift`: in `validateDrop`, when AppKit's proposed `item` is a session node
+      accept it as `.move` (nest) — NSOutlineView's outline drop already hands the intended parent item; in
+      `acceptDrop`, map pasteboard ids → source ids, call `resolveReparent`, then
+      `store.reparentSession(sourceRoot, to: resolved.parentID)` (single) or the batch equivalent. Keep the
+      existing workspace-row and cross-workspace drops working (a cross-workspace drop clears parentID via
+      the Task 3 `moveSession` rule).
+- [x] Tests (`SidebarDropTests`): drop a leaf onto a session → parentID set, correct slot; drop a parent
+      onto an outside node → whole block moves; drop a parent onto its own child → nil (cycle); drop a child
+      to a top-level gap → parentID nil; same-parent same-slot → nil no-op.
+- [x] `cd agtermCore && swift test` + `make build` + `make lint` — green before Task 9.
+
+### Task 9: GUI affordances — New Child Session + cascade-close confirm (app)
+
+**Files:**
+- Modify: `agterm/Views/WorkspaceSidebar+ContextMenu.swift` (`:131` row menu; `addSession` `:266`)
+- Modify: `agterm/AppActions.swift` (`:117` `newSession`; add `newChildSession`)
+- Modify: `agterm/agtermApp+Menus.swift` (session menu)
+- Modify: the active-session close path / `AppActions` delete-confirm (reuse `confirmDelete(name:sessionCount:)`)
+- Test: Task 12 XCUITest
+
+- [x] `AppActions`: add `newChildSession(of parentSessionID: UUID)` — resolve the parent's workspace via
+      `store.sessionLocation`, call `store.addSession(toWorkspace:cwd: resolvedNewSessionCwd(), parentID:
+      parentSessionID)`, then select + focus (matching `newSession`).
+- [x] `WorkspaceSidebar+ContextMenu.swift`: add a **New Child Session** item (and **New Child (Open
+      Directory…)**) to the SESSION row menu, wired to `newChildSession`. Accessibility id `new-child-session`.
+- [x] `agtermApp+Menus.swift`: add "New Child Session" to the session actions group (gated on a selected
+      session), sharing the `AppActions` seam.
+- [x] Cascade-close confirm: where a session close is initiated with descendants present, confirm via the
+      existing `confirmDelete(name:sessionCount:)` showing the descendant count, then close
+      `store.sessionSubtreeIDs(id)` as one grouped soft/hard close (Task 3). A childless session closes with
+      no prompt, exactly as today.
+- [x] `make build` + `make test-app` + `make lint` — green before Task 10.
+
+### Task 10: (OPEN — see "Open decision") `session.collapse`/`.expand` control commands
+
+**Files:**
+- Modify: `agtermCore/Sources/agtermCore/ControlProtocol.swift` (`Command` enum: `sessionCollapse =
+  "session.collapse"`, `sessionExpand = "session.expand"`)
+- Modify: `agtermCore/Sources/agtermCore/ControlDispatcher.swift` (`ControlActions` + arms)
+- Modify: `agterm/Control/ControlServer+SessionActions.swift` (effects → `store.setSessionExpanded`)
+- Modify: `agtermCore/Sources/agtermctlKit/SessionCommands.swift` (`Collapse`/`Expand` subcommands)
+- Test: `ControlDispatcherTests`, `CommandsTests`, `ControlAPIUITests`
+
+- [x] Add `Command.sessionCollapse`/`.sessionExpand` mirroring `workspace.collapse`/`.expand`; dispatcher
+      arms resolve a single session target and route to `actions.setSessionExpanded(target, expanded:)`
+      (new `ControlActions` method). App effect calls `store.setSessionExpanded`, then posts the
+      object-scoped live-outline sync notification (mirror `setWorkspaceExpandedNotified`).
+- [x] CLI `session collapse <id>` / `session expand <id>`; register under the `Session` subcommands list.
+- [x] Tests: dispatcher target validation + routing; CLI parse; e2e collapse/expand reflected in `tree`
+      node `collapsed`.
+- [x] `cd agtermCore && swift test` + `make build` + `make lint` — green before Task 11.
+- [x] ⚠️ If the reviewer cuts this task: drop it entirely, keep `ControlSessionNode.collapsed` as a
+      GUI-only read-back (Task 5), and DO NOT bump the command count in Task 11 (stays 74).
+
+### Task 11: Keep-in-sync docs
+
+**Files:**
+- Modify: `plugins/agterm/skills/agterm/SKILL.md`, `reference.md`, `examples.md`, `troubleshooting.md`
+- Modify: `.claude/rules/sidebar.md`, `.claude/rules/control-api.md`
+- Modify: `README.md`; `site/docs.html`, `site/index.html`, `site/commands.html`
+
+- [x] `reference.md`: document `session.new --parent`, `--after`/`--before` parent-inheritance,
+      `session.move --parent`/`--unparent`, the cascade-close semantics, the `tree` node `parentID`/
+      `collapsed` read-back, and (if Task 10 kept) `session.collapse`/`.expand`.
+- [x] `SKILL.md`: update the `session.new`/`session.move` summary lines; bump "Command summary (74 commands)"
+      → **76** ONLY if Task 10 is kept (else leave 74).
+- [x] `examples.md`: add the headline recipe `agtermctl session new --parent "$AGTERM_SESSION_ID"` and a
+      drag/`session move --parent` note.
+- [x] `.claude/rules/sidebar.md`: add a "nested sessions" note (adjacency model, contiguity invariant,
+      cascade close, expand/collapse of parent sessions, roll-up badge). `.claude/rules/control-api.md`:
+      update the `session.new`/`session.move` catalog lines and the command count (74 → 76 iff Task 10).
+- [x] `README.md` + `site/docs.html`: add `--parent`/nesting to the `agtermctl` session examples; update the
+      count on `README.md:187` and `site/commands.html` (`:9,21,33,240`) iff Task 10; `site/index.html`
+      feature list + `softwareVersion` if this ships in a version bump.
+- [x] Verify the documented command count matches the dispatch catalog (grep the `Command` cases).
+
+### Task 12: Verify acceptance criteria + XCUITest e2e
+
+**Files:**
+- Modify: `agtermUITests/SidebarUITests.swift` (or a new `NestedSessionsUITests.swift`)
+
+- [x] XCUITest (isolated `.debug` state/socket, `mkdir windows` to skip the welcome): drive
+      `agtermctl session new --parent <sid>` → assert a nested `session-row`; drag a row onto another →
+      reparent; collapse the parent (disclosure triangle) → descendant rows hidden and the parent shows the
+      rolled-up badge; cascade-close the parent → confirm dialog with count, subtree gone; Reopen Closed Item
+      → subtree restored. Scope with `-only-testing:agtermUITests/NestedSessionsUITests`.
+- [x] Verify all Overview requirements: create-as-child (control + GUI); arbitrary depth (grandchild);
+      `--after`/`--before` inherit parent; drag-reparent + drag-out; cascade close with grouped undo;
+      collapse/expand persists across relaunch; legacy snapshot decodes flat; non-nested tree byte-identical.
+- [x] Verify invariants held: contiguity after every op (a host-free assertion helper in
+      `AppStoreNestingTests`), no cycles, no cross-workspace subtree.
+- [x] Full `cd agtermCore && swift test` green; `make build` clean; `make test-app` green; `make lint`
+      (`--strict`) zero findings; the targeted XCUITest passes.
+- [x] Verify no source file crossed 1000 lines from these edits; new logic lives in `SessionTree.swift` /
+      `AppStore+Nesting.swift`.
+
+### Task 13: Finalize
+
+- [x] Final accuracy pass over `README.md` / site / skill.
+- [x] Add a `.claude/rules/*.md` cross-reference if the nesting contract warrants its own owned note.
+- [x] Move this plan to `docs/plans/completed/`.
+
+## Technical details
+
+- **Contiguity vs. reparent:** `reparentSession` sets the new `parentID` then re-derives the whole
+  workspace order via `SessionTree.preorder`, which is the single place that restores the invariant. All
+  other ops (create-child last-slot insert, subtree block move, cascade close block remove) preserve it
+  without a full re-sort.
+- **`--after`/`--before` parent-inheritance** is what makes reparent-by-move fall out for free: because the
+  placed session adopts the anchor's `parentID`, `session move --after <child>` both positions AND nests,
+  so the only genuinely new move verbs are `--parent`/`--unparent` (last-child / top-level).
+- **Cascade close** feeds `sessionSubtreeIDs(id)` (tree order) into the existing grouped
+  `softCloseSessions`/batch `closeSession`, so one grace timer and one Reopen record cover the subtree —
+  identical to how `removeWorkspace` closes a workspace's sessions.
+- **Read-back:** `ControlSessionNode.parentID` (nil omitted) reconstructs the tree client-side; `collapsed`
+  (true only) mirrors the workspace convention. No new top-level tree field.
+- **Wire (unchanged shape):** `{"cmd":"session.new","args":{"parent":"active"}}`,
+  `{"cmd":"session.move","target":"<sid>","args":{"parent":"<sid>"}}`,
+  `{"cmd":"session.move","target":"<sid>","args":{"unparent":true}}`. `result.id` = new/moved session id.
+
+## Post-Completion
+*Manual, no checkboxes — informational.*
+
+- **Manual smoke (isolated Debug instance only):** `open -n --env AGTERM_STATE_DIR=<tmp> --env
+  AGTERM_CONTROL_SOCKET=/tmp/agterm-nest.sock <Debug>/agterm.app` (after `mkdir -p "$tmp/windows"`); from a
+  shell inside a session run `agtermctl --socket /tmp/agterm-nest.sock session new --parent active` and watch
+  it nest; drag rows to reparent; collapse; cascade-close and Reopen. Do NOT touch the deployed app.
+- **PR:** reference discussion #293's agent-spawned-session use case; keep the description short and
+  goal-first; confirm the four keep-in-sync surfaces (protocol/CLI/e2e/skill+rules+site) before review.
+  No changelog edit (release-only).

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -148,7 +148,7 @@ prompt concatenates with yours, and the program starts on the merged line. (`--n
 focus, but the newline and shared-buffer hazards of `type`-as-launcher remain — `--command` is still the
 rule.) After `--command`, confirm in `tree --json` that the new node's `foreground` shows your program running, not a bare shell prompt.
 
-## Command summary (74 commands)
+## Command summary (76 commands)
 
 Run `agtermctl <area> <cmd> --help` for exact flags. Full detail in **reference.md**; recipes in
 **examples.md**.
@@ -186,7 +186,11 @@ session that has a split — shown or hidden; omitted when there's no split or t
 the default 0.5) —
 the read side of `session resize`, record it to restore the exact divider), `splitFocused`
 (which pane holds focus in a session that has a split — `true` = split/right, `false` = main/left; omitted
-when there's no split; the read side of `session focus`, record it to restore focus), and `surfaces`
+when there's no split; the read side of `session focus`, record it to restore focus), `parentID`
+(the id of this session's PARENT when it is nested under another — omitted when top-level; reconstructs the
+tree client-side, the read side of `session new --parent` / `session move --parent`), `collapsed`
+(`true` when this parent session's subtree is folded in the sidebar, omitted when expanded — the read side
+of `session collapse`/`expand`), and `surfaces`
 (`id`, `kind`, `active`, `visible`) for `surface zoom`. The tree top level carries `zoomedSurface`
 (the control id of the currently zoomed surface, omitted when nothing is zoomed — the read side of
 `surface zoom`, so a script can check the zoom state and record-then-restore). It also carries the read
@@ -226,7 +230,7 @@ read the open/closed state back from the tree workspace node's `collapsed` flag,
 omitted when expanded).
 
 **session**
-- `new [--cwd DIR] [--workspace W] [--workspace-name NAME] [--create-workspace] [--command CMD] [--wait] [--name NAME] [--after SID | --before SID] [--no-select]` —
+- `new [--cwd DIR] [--workspace W] [--workspace-name NAME] [--create-workspace] [--command CMD] [--wait] [--name NAME] [--after SID | --before SID] [--parent SID] [--no-select]` —
   create (and focus) a session. Target the workspace by id/prefix (`--workspace`) OR by name
   (`--workspace-name`, mutually exclusive); add `--create-workspace` to reuse-or-create the named
   workspace when absent. `--command` runs that program as the session process instead of a login shell
@@ -237,8 +241,12 @@ omitted when expanded).
   overlay's live-only wait; read back on `tree`'s `commandWait`);
   `--name` seeds the sidebar label (default: the auto basename). `--after`/`--before` place it directly
   after/before an anchor session (id/prefix/`active`) instead of appending — the anchor carries its own
-  workspace, so it's mutually exclusive with `--workspace`/`--workspace-name`. `new --after active` =
-  create right after the current session. `--no-select` creates the session in the BACKGROUND — it is
+  workspace AND its parent, so the new session INHERITS the anchor's nesting (`new --after <child>` makes a
+  sibling child); mutually exclusive with `--workspace`/`--workspace-name`. `new --after active` =
+  create right after the current session. `--parent SID` instead NESTS the new session as that session's
+  last child (the headline agent idiom `session new --parent "$AGTERM_SESSION_ID"`), rendered indented
+  under the parent in the sidebar; mutually exclusive with `--after`/`--before` and with a workspace, and an
+  unknown/cross-workspace parent is ignored (appends top-level) rather than failing. `--no-select` creates the session in the BACKGROUND — it is
   added to the sidebar but NOT selected or focused, leaving the current selection untouched (the new node
   is not `active` in `tree`); omit it for the default select-and-focus behavior.
 - `duplicate [--target]` — create a fresh session (a plain login shell) in the target's workspace, right
@@ -252,11 +260,14 @@ omitted when expanded).
   grace-period undo.
 - `select` · `rename <name>` · `reveal` (select the focused pane's cwd in Finder).
 - `go --to next|prev|first|last|next-attention|prev-attention` — move the selection between sessions.
-- `move <workspace>` (relocate) or `move --to up|down|top|bottom` (reorder within the workspace) or
-  `move --after SID | --before SID` (place after/before an anchor session; the anchor carries its own
-  workspace, so this relocates + positions in one shot, even cross-workspace). For workspace and
-  after/before placement, repeat `--target` to move several sessions as one ordered block. Do not repeat
-  `--target` with `--to up|down|top|bottom`.
+- `move <workspace>` (relocate) or `move --to up|down|top|bottom` (reorder within the sibling group,
+  carrying the subtree) or `move --after SID | --before SID` (place after/before an anchor session; the
+  anchor carries its own workspace AND parent, so the moved session ADOPTS the anchor's nesting — relocate +
+  position + reparent in one shot, even cross-workspace) or `move --parent SID | --unparent` (reparent under
+  a session as its last child, or promote to top-level). `--parent`/`--unparent` take a SINGLE `--target`
+  and are mutually exclusive with each other and with `--to`/`--after`/`--before`/a workspace; a
+  cross-workspace parent is rejected. For workspace and after/before placement, repeat `--target` to move
+  several sessions as one ordered block. Do not repeat `--target` with `--to up|down|top|bottom`.
 - `type <text> [--stdin] [--select] [--pane left|right|scratch]` — inject keystrokes (real typing, Enter
   included) into the main pane, the split pane with `--pane right`, or the scratch terminal (even hidden)
   with `--pane scratch`. Pass `--target "$AGTERM_SESSION_ID"` to type into YOUR session, not the user's
@@ -287,6 +298,11 @@ omitted when expanded).
   selection or focus (the focus-free counterpart to `notify`, which raises the badge). Idempotent — a
   no-op when already zero. Read the current count from the tree node's `unseen` field. Use it so an
   orchestrator can acknowledge a driven session's notifications without pulling focus to it.
+- `collapse [--target] [--window W]` · `expand [--target] [--window W]` — fold/unfold a PARENT session's
+  subtree in the sidebar (the per-session twin of `workspace collapse`/`expand`). A collapsed parent hides
+  its descendant rows and rolls their unseen badge + most-urgent status onto its own row. Idempotent; a leaf
+  just records the state. Read it back from the tree node's `collapsed` flag (`true` when collapsed, omitted
+  when expanded). Closing a parent instead CASCADES — the whole subtree closes together under one undo.
 - `restore ("cmd" | --none | --clear) [--pane left|right] [--pane-id TOKEN]` — pin what a pane re-runs on
   the NEXT launch, overriding the captured foreground command. A `"cmd"` shell line pins it, `--none` pins
   nothing (a plain shell), `--clear` drops the override back to auto-capture. Written now, consumed on the

--- a/plugins/agterm/skills/agterm/examples.md
+++ b/plugins/agterm/skills/agterm/examples.md
@@ -181,6 +181,41 @@ agtermctl session close --target "$server" --target "$logs"
 workspace — the anchor already picks the workspace. Repeated `--target` is only for workspace and
 after/before placement, not `--to up|down|top|bottom`.
 
+## Nest a session under another (a helper under the calling one)
+
+Sessions can nest: a session's children render indented under it in the sidebar. `session new --parent`
+creates the new session as that parent's LAST CHILD. The headline agent idiom is a skill spawning a
+helper nested under the session it runs in, so the two read as one unit:
+
+```bash
+# spawn a helper nested under the calling session (the parent is a session address; `active` also works)
+agtermctl session new --parent "$AGTERM_SESSION_ID" --name "helper"
+child=$(agtermctl session new --parent active --json | jq -r '.result.id')
+```
+
+An unknown or cross-workspace `--parent` is ignored (the session appends top-level), never an error.
+`session new --after <child>` also nests — it inherits the anchor's parent, creating a sibling child at
+the same depth. Reparent or promote an existing session with `session move`, or drag a sidebar row onto
+another to nest it (drag it out to top-level):
+
+```bash
+agtermctl session move --parent "$AGTERM_SESSION_ID" --target 3f2a   # reparent 3f2a under this session
+agtermctl session move --unparent --target 3f2a                      # promote it back to top-level
+```
+
+Fold a parent's subtree with `session collapse` (the per-session twin of `workspace collapse`); a
+collapsed parent hides its descendant rows and rolls their unseen badge + most-urgent status onto its own
+row. Closing a parent CASCADES — the whole subtree closes as one grouped undo/reopen record:
+
+```bash
+agtermctl session collapse --target "$AGTERM_SESSION_ID"   # fold the subtree; session expand unfolds it
+collapsed=$(agtermctl tree --json | jq -r --arg s "$child" '.result.tree.workspaces[].sessions[] | select(.id==$s) | .collapsed // false')
+agtermctl session close --target "$AGTERM_SESSION_ID"      # closes the parent AND its whole subtree, one undo
+```
+
+Read the shape back off `tree`: each session node carries `parentID` (its nesting parent, omitted when
+top-level) and `collapsed` (`true` only when its subtree is folded).
+
 ## Resize the split divider from a keybinding
 
 The divider is otherwise mouse-only — drag it, or double-click it for an even split. There is no built-in

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -157,7 +157,12 @@ when zero), `fontSize`/`splitFontSize`/`scratchFontSize` (the LIVE font size in 
 the read side of `font --pane`; each omitted when that pane isn't realized. `fontSize` tracks the
 default/left target (the main pane, or the promoted split survivor once the primary exits — the same pane
 `font --pane left` writes); only the main pane's size survives a relaunch, so the split/scratch sizes and a
-promoted survivor are live-only — read them back here rather than from the snapshot), and `surfaces` (array
+promoted survivor are live-only — read them back here rather than from the snapshot), `parentID` (the id of
+this session's nesting PARENT — the read side of `session new --parent` / `session move --parent`; OMITTED
+when the session is top-level, so a client reconstructs the subtree by linking each node to its parent),
+`collapsed` (`true` ONLY when this PARENT session's subtree is folded in the sidebar — the read side of
+`session collapse`/`session expand`; omitted when expanded or a leaf, so an all-expanded tree carries no
+session `collapsed` keys), and `surfaces` (array
 of `{id, kind, active, visible}` where `kind` is
 `left`|`right`|`scratch`|`overlay`|`overlay-left`|`overlay-right`).
 The surface `id` is the address for `surface zoom`; hidden-but-alive split/scratch surfaces are included
@@ -282,7 +287,7 @@ All twelve are read-only projections of GUI state.
 
 ## session
 
-- `session new [--cwd DIR] [--workspace W] [--workspace-name NAME] [--create-workspace] [--command CMD] [--wait] [--name NAME] [--after SID | --before SID] [--no-select] [--window W]`
+- `session new [--cwd DIR] [--workspace W] [--workspace-name NAME] [--create-workspace] [--command CMD] [--wait] [--name NAME] [--after SID | --before SID] [--parent SID] [--no-select] [--window W]`
   — create a session and focus it; returns the new id. `--cwd` sets the start directory (default
   `$HOME`). The destination workspace is addressed one of two mutually-exclusive ways: `--workspace`
   (id / unique prefix / `active`, the default) or `--workspace-name` (the sidebar label) — the latter
@@ -306,10 +311,17 @@ All twelve are read-only projections of GUI state.
   equivalent to a `session rename` right after create. `--after SID` / `--before SID` place the new
   session directly after / before an anchor session instead of appending at the end (the anchor is a
   session address — id / unique prefix / `active`). The anchor CARRIES ITS OWN WORKSPACE (resolved
-  across all workspaces), so it names the destination workspace itself — `--after`/`--before` are
+  across all workspaces) AND ITS OWN NESTING PARENT, so it names the destination workspace itself and the
+  new session ADOPTS the anchor's `parentID` — `--after <child>` therefore creates a SIBLING CHILD at the
+  anchor's depth, not a top-level row. `--after`/`--before` are
   therefore mutually exclusive with each other and with `--workspace`/`--workspace-name` (the anchor
   already picks the workspace). `agtermctl session new --after active` is the headline case: create
-  right after the current session in one round-trip. `--no-select` creates the session in the BACKGROUND:
+  right after the current session in one round-trip. `--parent SID` instead nests the new session as that
+  session's LAST CHILD (`SID` is a session address — id / unique prefix / `active`), the control twin of
+  the sidebar's **New Child Session**. `agtermctl session new --parent "$AGTERM_SESSION_ID"` is the
+  headline agent idiom: spawn a helper nested under the calling session. It is mutually exclusive with
+  `--after`/`--before` and with `--workspace`/`--workspace-name`; an unknown or cross-workspace parent is
+  IGNORED (the session appends top-level) rather than erroring. `--no-select` creates the session in the BACKGROUND:
   it is added to the sidebar but NOT selected or focused, so the current selection and focus are left
   untouched (the new node is not `active` in `tree` — that flag is the read-back); omit it for the default
   select-and-focus behavior. Every other addressing/placement option composes with it, and a background
@@ -333,7 +345,11 @@ All twelve are read-only projections of GUI state.
   (single-selection only).
 - `session close [--target T ...] [--window W]` — close one session, or repeat `--target` to close
   several sessions in the same window/store. Batch close honors the GUI grace-undo setting: one grouped
-  undo/reopen record when enabled, immediate close when disabled. Returns `result.affected`.
+  undo/reopen record when enabled, immediate close when disabled. Closing a PARENT session CASCADES: its
+  whole subtree closes with it as ONE grouped undo/reopen record (the same pattern as deleting a workspace
+  full of sessions), so a later reopen restores the parent and every descendant together, and the GUI
+  confirm shows the descendant count. Returns `result.affected` (every session actually closed,
+  descendants included).
 - `session select [--target] [--window W]`.
 - `session rename <name> [--target] [--window W]`.
 - `session reveal [--target] [--window W]` — select the target session's focused-pane working
@@ -345,13 +361,20 @@ All twelve are read-only projections of GUI state.
   first→last); first/last jump to the ends of that set; next-attention/prev-attention step only through the filtered
   sessions needing attention (status blocked/completed), wrapping. Returns the newly selected id.
 - `session move <workspace> [--target] [--window W]` — relocate the session to another workspace
-  (appends). OR `session move --to up|down|top|bottom [--target]` — reorder within its workspace. OR
+  (appends). OR `session move --to up|down|top|bottom [--target]` — reorder within its SIBLING GROUP,
+  carrying its subtree. OR
   `session move --after SID | --before SID [--target]` — place the session directly after / before an
   anchor session (id / unique prefix / `active`). The anchor CARRIES ITS OWN WORKSPACE (resolved across
-  all workspaces), so it relocates + positions in one shot, wherever the anchor lives — cross-workspace
-  placement falls out for free. Exactly one placement intent is required among {positional workspace,
-  `--to`, `--after`/`--before`}; `--after`/`--before` are mutually exclusive with each other, with `--to`,
-  and with a destination workspace (the anchor already names the workspace).
+  all workspaces) AND ITS OWN NESTING PARENT, so it relocates + positions + ADOPTS the anchor's parent in
+  one shot, wherever the anchor lives — cross-workspace placement and `--after <child>` slotting the
+  session as a sibling child both fall out for free. OR `session move --parent SID [--target]` reparents
+  the session under `SID` as its LAST CHILD, and `session move --unparent [--target]` promotes it back to
+  top-level. Exactly one placement intent is required among {positional workspace,
+  `--to`, `--after`/`--before`, `--parent`/`--unparent`}; `--after`/`--before` are mutually exclusive with
+  each other, with `--to`,
+  and with a destination workspace (the anchor already names the workspace). `--parent` and `--unparent`
+  are mutually exclusive with each other and with every other placement intent, take a SINGLE `--target`
+  only, and reject a cross-workspace parent (a subtree can't straddle workspaces).
   Repeat `--target` for a batch move with the workspace and after/before placement forms; the sessions
   move as one ordered block after all sources are removed. Repeated `--target` is rejected with
   `--to up|down|top|bottom` because relative reorder is per-session. Batch moves return `result.affected`,
@@ -476,6 +499,15 @@ All twelve are read-only projections of GUI state.
   session. Idempotent — a no-op when the badge is already zero. Read the current count from the tree node's
   `unseen` field. This lets an orchestrator acknowledge a driven session's notifications over the socket
   while keeping the badge a real attention signal on the sessions a human tends.
+- `session collapse [--target] [--window W]` — fold ONE parent session's subtree in the sidebar tree
+  (hide its descendant rows); returns the session id. The per-session counterpart of `workspace collapse`.
+  A collapsed parent hides every descendant row and rolls their unseen badge and most-urgent agent status
+  up onto its own row, so an agent working in a folded child still shows attention. Idempotent — a leaf
+  just records the state. Persisted. Read back from the tree session node's `collapsed` flag.
+- `session expand [--target] [--window W]` — unfold ONE parent session's subtree (show its descendant
+  rows); returns the session id. The inverse of `session collapse`, and the per-session counterpart of
+  `workspace expand`. Idempotent. To TOGGLE, read the node's `collapsed` flag off `tree` first, then call
+  `expand` or `collapse`.
 - `session restore (<command> | --none | --clear) [--pane left|right] [--pane-id TOKEN] [--target] [--window W]`
   — pin the command a pane re-runs on the NEXT launch, overriding the captured foreground. Provide exactly
   one of: a `<command>` shell line to pin, `--none` to pin nothing (the pane restores a plain shell,

--- a/site/commands.html
+++ b/site/commands.html
@@ -6,7 +6,7 @@
     <title>Command reference — agterm | agtermctl control API</title>
     <meta
       name="description"
-      content="Complete agtermctl reference: all 74 control commands for agterm, including sessions, workspaces, windows, overlays, the native picker, the quick terminal, sidebar, agent status, themes, and keymaps, with arguments and return values."
+      content="Complete agtermctl reference: all 76 control commands for agterm, including sessions, workspaces, windows, overlays, the native picker, the quick terminal, sidebar, agent status, themes, and keymaps, with arguments and return values."
     />
     <meta
       name="keywords"
@@ -18,7 +18,7 @@
     <meta property="og:title" content="Command reference — agterm" />
     <meta
       property="og:description"
-      content="All 74 agtermctl control commands with arguments, return values, and errors."
+      content="All 76 agtermctl control commands with arguments, return values, and errors."
     />
     <meta property="og:url" content="https://agterm.com/commands" />
     <meta property="og:image" content="https://agterm.com/assets/agterm-og.png" />
@@ -30,7 +30,7 @@
     <meta name="twitter:title" content="Command reference — agterm" />
     <meta
       name="twitter:description"
-      content="All 74 agtermctl control commands with arguments, return values, and errors."
+      content="All 76 agtermctl control commands with arguments, return values, and errors."
     />
     <meta name="twitter:image" content="https://agterm.com/assets/agterm-og.png" />
     <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
@@ -237,7 +237,7 @@
             Command reference
           </h1>
           <p style="font-size: 19px; line-height: 1.6; color: #bfbab0; margin: 0 0 8px">
-            All 74 commands of the agterm control API, with arguments and return values. Every one is reachable from the
+            All 76 commands of the agterm control API, with arguments and return values. Every one is reachable from the
             <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl</span> CLI and from the local
             control socket.
           </p>
@@ -464,8 +464,16 @@
                 restore override, omitted when none and an empty string when pinned to nothing),
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">commandWait</span> (a held
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--command</span> session created with
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">session new --wait</span>; omitted otherwise), and
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">unseen</span>.
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">session new --wait</span>; omitted otherwise),
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">unseen</span>,
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">parentID</span> (this session's nesting parent — the
+                read side of <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">session new --parent</span> /
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">session move --parent</span>; omitted
+                when top-level, so a client rebuilds the subtree by linking each node to its parent), and
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">collapsed</span> (the read side of
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">session collapse</span>/<span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">expand</span>;
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">true</span> only when this parent's subtree is folded,
+                omitted otherwise).
               </p>
               <p style="font-size: 14px; line-height: 1.65; color: #949ba4; margin: 8px 0 0">
                 <strong style="color: #bfbab0">Workspace node:</strong>
@@ -791,7 +799,7 @@
             <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
                 agtermctl session new [--cwd DIR] [--workspace W | --workspace-name NAME [--create-workspace]] [--command CMD] [--wait]
-                [--name NAME] [--after SID | --before SID] [--no-select] [--window W]
+                [--name NAME] [--after SID | --before SID] [--parent SID] [--no-select] [--window W]
               </div>
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">session.new</div>
               <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
@@ -811,11 +819,24 @@
               <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">--after SID</span> /
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">--before SID</span> place the new session directly
-                after or before an anchor session instead of appending. The anchor carries its own workspace, so it names the
-                destination itself — these are mutually exclusive with each other and with
+                after or before an anchor session instead of appending. The anchor carries its own workspace <em>and</em> nesting
+                parent, so it names the destination itself and the new session adopts the anchor's parent —
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">--after &lt;child&gt;</span> therefore
+                creates a sibling child at the anchor's depth. These are mutually exclusive with each other and with
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--workspace</span> /
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--workspace-name</span>. The headline case:
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #f2b45c; white-space: nowrap">session new --after active</span>.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--parent SID</span> nests the new session as that
+                session's <strong style="color: #bfbab0">last child</strong> — the control twin of the sidebar's
+                <strong style="color: #bfbab0">New Child Session</strong>. The headline agent idiom is
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #f2b45c; white-space: nowrap">session new --parent "$AGTERM_SESSION_ID"</span>,
+                spawning a helper nested under the calling session. It is mutually exclusive with
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--after</span> /
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--before</span> and with the workspace options; an
+                unknown or cross-workspace parent is ignored (the session appends top-level) rather than erroring. Read the nesting
+                back from the session node's <span style="font-family: &quot;JetBrains Mono&quot;, monospace">parentID</span>.
               </p>
               <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--command</span> runs a program as the session's
@@ -890,6 +911,12 @@
                 to close a batch as one grouped undo when close grace is enabled, or immediately when it is disabled. Batch output
                 reports the number of sessions actually closed.
               </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                Closing a <strong style="color: #bfbab0">parent</strong> session cascades: its whole subtree closes with it as one
+                grouped undo/reopen record (the same pattern as deleting a workspace full of sessions), so a later reopen restores
+                the parent and every descendant together, and the GUI confirm shows the descendant count. The count includes the
+                descendants.
+              </p>
             </div>
 
             <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
@@ -924,21 +951,32 @@
 
             <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
-                agtermctl session move &lt;workspace&gt; | --to up|down|top|bottom | --after SID | --before SID [--target T ...] [--window W]
+                agtermctl session move &lt;workspace&gt; | --to up|down|top|bottom | --after SID | --before SID | --parent SID | --unparent [--target T ...] [--window W]
               </div>
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">session.move</div>
               <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
-                Three mutually-exclusive placement intents, exactly one required. A positional
+                Mutually-exclusive placement intents, exactly one required. A positional
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">&lt;workspace&gt;</span> relocates the session there
                 (appending). <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--to</span> reorders it within its own
-                workspace. <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--after</span> /
+                sibling group, carrying its subtree. <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--after</span> /
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--before</span> place it directly after or before an
-                anchor session — the anchor carries its own workspace, so cross-workspace placement falls out for free. Repeat
+                anchor session — the anchor carries its own workspace <em>and</em> nesting parent, so cross-workspace placement and
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">--after &lt;child&gt;</span> making it
+                a sibling child both fall out for free. Repeat
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--target</span> with a workspace or
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--after</span> /
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--before</span> to move an ordered batch atomically;
                 batch relative reorder via <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--to</span> is not supported.
                 Batch output reports the number of sessions actually moved.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--parent SID</span> reparents the target under that
+                session as its <strong style="color: #bfbab0">last child</strong>;
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--unparent</span> promotes it back to top-level. Both
+                take a single <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--target</span> only, are mutually
+                exclusive with each other and with every other placement intent, and reject a cross-workspace parent (a subtree
+                can't straddle workspaces). Dragging a sidebar row onto another does the same nesting; read the result back from the
+                session node's <span style="font-family: &quot;JetBrains Mono&quot;, monospace">parentID</span>.
               </p>
             </div>
 
@@ -1254,6 +1292,45 @@
               <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
                 Lets an orchestrator acknowledge a driven session's notifications over the socket, keeping the badge a real attention
                 signal on the sessions a human tends.
+              </p>
+            </div>
+
+            <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
+                agtermctl session collapse [--target T] [--window W]
+              </div>
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">session.collapse</div>
+              <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
+                Fold a parent session's subtree in the sidebar tree, hiding its descendant rows — the per-session counterpart of
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">workspace collapse</span>. Idempotent
+                (a leaf just records the state) and persisted. <strong style="color: #bfbab0">Returns</strong>
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">result.id</span>.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                A collapsed parent rolls its descendants' unseen badge and most-urgent agent status up onto its own row, so an agent
+                working in a folded child still shows attention. Read the fold state back via the session node's
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">collapsed</span> field
+                (<span style="font-family: &quot;JetBrains Mono&quot;, monospace">true</span> when folded, omitted when expanded).
+              </p>
+            </div>
+
+            <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
+                agtermctl session expand [--target T] [--window W]
+              </div>
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">session.expand</div>
+              <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
+                Unfold a parent session's subtree, showing its descendant rows — the inverse of
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">session collapse</span> and the
+                per-session counterpart of <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">workspace expand</span>.
+                Idempotent and persisted. <strong style="color: #bfbab0">Returns</strong>
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">result.id</span>.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                To toggle, read the session node's <span style="font-family: &quot;JetBrains Mono&quot;, monospace">collapsed</span> field
+                off <span style="font-family: &quot;JetBrains Mono&quot;, monospace">tree</span> first, then call
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">expand</span> or
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">collapse</span>.
               </p>
             </div>
 

--- a/site/docs.html
+++ b/site/docs.html
@@ -1147,7 +1147,7 @@
               "
             >
               <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 0">
-                Looking for the full list? All 74 commands, with every argument, return value, and error, live on the
+                Looking for the full list? All 76 commands, with every argument, return value, and error, live on the
                 <a href="/commands" style="color: #6d82f3; font-weight: 500">Command reference →</a>
               </p>
             </div>
@@ -1294,12 +1294,18 @@
               <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;# reorder: up|down|top|bottom</span><br />agtermctl session move
               <span style="color: #f2b45c">"$ws"</span> <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;&nbsp;# relocate to a workspace</span
               ><br />agtermctl session new --after active
-              <span style="color: #6b727a">&nbsp;&nbsp;# create right after the current session (--before to precede)</span
+              <span style="color: #6b727a">&nbsp;&nbsp;# create right after the current session (--before to precede); --after a child makes a sibling child</span
+              ><br />agtermctl session new --parent <span style="color: #f2b45c">"$AGTERM_SESSION_ID"</span>
+              <span style="color: #6b727a">&nbsp;&nbsp;# nest a new session under the calling one as its last child (the sidebar's "New Child Session"; --parent active also works)</span
               ><br />agtermctl session new --cwd ~/src/agterm --no-select
               <span style="color: #6b727a">&nbsp;&nbsp;# create in the background without switching to it</span
               ><br />agtermctl session duplicate --target <span style="color: #f2b45c">9f3c</span>
               <span style="color: #6b727a">&nbsp;&nbsp;# a fresh shell in that session's workspace and cwd, right after it</span><br />agtermctl session move --after
-              <span style="color: #f2b45c">9f3c</span> <span style="color: #6b727a">&nbsp;&nbsp;# place after an anchor (its workspace is used; relocates cross-workspace)</span
+              <span style="color: #f2b45c">9f3c</span> <span style="color: #6b727a">&nbsp;&nbsp;# place after an anchor (its workspace and nesting parent are used; relocates cross-workspace)</span
+              ><br />agtermctl session move --parent <span style="color: #f2b45c">9f3c</span> --target <span style="color: #f2b45c">abcd</span>
+              <span style="color: #6b727a">&nbsp;&nbsp;# reparent abcd under 9f3c as its last child (--unparent promotes back to top-level; or drag a row onto another)</span
+              ><br />agtermctl session collapse --target <span style="color: #f2b45c">9f3c</span>
+              <span style="color: #6b727a">&nbsp;&nbsp;# fold a parent's subtree (session expand unfolds it); closing a parent closes its whole subtree as one undo</span
               ><br />agtermctl session move <span style="color: #f2b45c">"$ws"</span> --target 9f3c --target abcd
               <span style="color: #6b727a">&nbsp;&nbsp;# move a batch as one ordered block</span
               ><br />agtermctl session close --target 9f3c --target abcd


### PR DESCRIPTION
Lets a session be created as a child of another and stacked as an indented
sub-tree under its parent in the sidebar, at arbitrary depth. Headline case is
agent-driven: `agtermctl session new --parent "$AGTERM_SESSION_ID"` groups a
skill's helper sessions instead of scattering them as flat siblings. Reverses
the "no extra tree depth" stance in discussion #293 for this use case.

- Adjacency model (`Session.parentID`) + contiguity invariant → array order ==
  visual tree order, so every flat consumer (navigation, flagged view, focus,
  persistence, recency, reorder) is unchanged. `SessionTree` math,
  `AppStore+Nesting` ops.
- Control/CLI: `session new --parent`, `session move --parent/--unparent`,
  `--after/--before` parent inheritance, `session collapse/expand`; `tree`
  `parentID`/`collapsed` read-back. 74 → 76 commands.
- GUI: nested outline with collapse/fold + roll-up badge/status on a collapsed
  parent, drag-to-reparent (auto-expands the new parent), New Child Session
  menus, cascade-close confirm with descendant count and grouped undo/Reopen.
- Backward compatible: optional snapshot fields, no version bump, non-nested
  trees serialize byte-identically.

Keep-in-sync surfaces updated alongside the code:
- Bundled agterm skill — `plugins/agterm/skills/agterm/` `SKILL.md`,
  `reference.md`, `examples.md` (the source the Help ▸ Install bakes into the
  installed Claude/Codex copy): `--parent`/`--unparent`, `collapse`/`expand`,
  `parentID`/`collapsed` read-back, cascade close, and the command count.
- Engineering rules — `.claude/rules/control-api.md`, `.claude/rules/sidebar.md`.
- `README.md` and `site/commands.html` + `site/docs.html` (count 74 → 76 and the
  new commands/args).

`swift test`, `make build`, `make test-app`, `make lint`, and
`NestedSessionsUITests` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
