### PR TITLE
fix: add missing TCC resource-access entitlements and usage strings

### DIFF
--- a/agterm/Info.plist
+++ b/agterm/Info.plist
@@ -62,6 +62,8 @@
 	<string>Command-line tools you run inside agterm request access to your reminders through agterm.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>Command-line tools you run inside agterm request speech recognition through agterm.</string>
+	<key>NSSystemAdministrationUsageDescription</key>
+	<string>Command-line tools you run inside agterm (for example, dscl editing a directory record) request permission to change system configuration through agterm.</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>

--- a/agterm/Info.plist
+++ b/agterm/Info.plist
@@ -38,6 +38,8 @@
 	<string>Command-line tools you run inside agterm (for example, an osascript one-liner or a build script) request permission to control other apps through agterm.</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Command-line tools you run inside agterm request Bluetooth access through agterm.</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>Command-line tools you run inside agterm request access to your calendars through agterm.</string>
 	<key>NSCalendarsUsageDescription</key>
 	<string>Command-line tools you run inside agterm request access to your calendars through agterm.</string>
 	<key>NSCameraUsageDescription</key>
@@ -46,14 +48,18 @@
 	<string>Command-line tools you run inside agterm request access to your contacts through agterm.</string>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Command-line tools you run inside agterm (for example, connecting to a .local host) request local network access through agterm.</string>
-	<key>NSLocationUsageDescription</key>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>Command-line tools you run inside agterm request your location through agterm.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Command-line tools you run inside agterm request your location through agterm.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Command-line tools you run inside agterm (for example, voice dictation in Claude Code) request microphone access through agterm.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Command-line tools you run inside agterm (for example, a script importing a screenshot) request permission to add to your photo library through agterm.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Command-line tools you run inside agterm (for example, osxphotos) request access to your photo library through agterm.</string>
+	<key>NSRemindersFullAccessUsageDescription</key>
+	<string>Command-line tools you run inside agterm request access to your reminders through agterm.</string>
 	<key>NSRemindersUsageDescription</key>
 	<string>Command-line tools you run inside agterm request access to your reminders through agterm.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>

--- a/agterm/Info.plist
+++ b/agterm/Info.plist
@@ -34,8 +34,30 @@
 	<string>public.app-category.developer-tools</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2026 Umputun</string>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>Command-line tools you run inside agterm (for example, an osascript one-liner or a build script) request permission to control other apps through agterm.</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Command-line tools you run inside agterm request Bluetooth access through agterm.</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>Command-line tools you run inside agterm request access to your calendars through agterm.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Command-line tools you run inside agterm (for example, ffmpeg capturing video) request camera access through agterm.</string>
+	<key>NSContactsUsageDescription</key>
+	<string>Command-line tools you run inside agterm request access to your contacts through agterm.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Command-line tools you run inside agterm (for example, connecting to a .local host) request local network access through agterm.</string>
+	<key>NSLocationUsageDescription</key>
+	<string>Command-line tools you run inside agterm request your location through agterm.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Command-line tools you run inside agterm request your location through agterm.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Command-line tools you run inside agterm (for example, voice dictation in Claude Code) request microphone access through agterm.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Command-line tools you run inside agterm (for example, osxphotos) request access to your photo library through agterm.</string>
+	<key>NSRemindersUsageDescription</key>
+	<string>Command-line tools you run inside agterm request access to your reminders through agterm.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Command-line tools you run inside agterm request speech recognition through agterm.</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>

--- a/agterm/Info.plist
+++ b/agterm/Info.plist
@@ -42,20 +42,18 @@
 	<string>Command-line tools you run inside agterm request access to your calendars through agterm.</string>
 	<key>NSCalendarsUsageDescription</key>
 	<string>Command-line tools you run inside agterm request access to your calendars through agterm.</string>
+	<key>NSCalendarsWriteOnlyAccessUsageDescription</key>
+	<string>Command-line tools you run inside agterm request permission to add events to your calendars through agterm.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Command-line tools you run inside agterm (for example, ffmpeg capturing video) request camera access through agterm.</string>
 	<key>NSContactsUsageDescription</key>
 	<string>Command-line tools you run inside agterm request access to your contacts through agterm.</string>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Command-line tools you run inside agterm (for example, connecting to a .local host) request local network access through agterm.</string>
-	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>Command-line tools you run inside agterm request your location through agterm.</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
+	<key>NSLocationUsageDescription</key>
 	<string>Command-line tools you run inside agterm request your location through agterm.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Command-line tools you run inside agterm (for example, voice dictation in Claude Code) request microphone access through agterm.</string>
-	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>Command-line tools you run inside agterm (for example, a script importing a screenshot) request permission to add to your photo library through agterm.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Command-line tools you run inside agterm (for example, osxphotos) request access to your photo library through agterm.</string>
 	<key>NSRemindersFullAccessUsageDescription</key>

--- a/agterm/agterm.entitlements
+++ b/agterm/agterm.entitlements
@@ -8,7 +8,19 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
 	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+	<key>com.apple.security.personal-information.addressbook</key>
+	<true/>
+	<key>com.apple.security.personal-information.calendars</key>
+	<true/>
+	<key>com.apple.security.personal-information.location</key>
+	<true/>
+	<key>com.apple.security.personal-information.photos-library</key>
 	<true/>
 </dict>
 </plist>

--- a/project.yml
+++ b/project.yml
@@ -148,9 +148,12 @@ targets:
           # can't be clobbered by Xcode's own final code-sign, which also adds the required timestamp).
           codesign --force --options runtime --sign - "$dest"
           # re-seal the whole app: this phase can run AFTER Xcode's own code-sign on incremental
-          # builds, so adding the helper would otherwise break the seal. --deep re-signs every nested
-          # Mach-O too (the Debug agterm.debug.dylib, the helper).
-          codesign --force --deep --options runtime --entitlements "$SRCROOT/agterm/agterm.entitlements" --sign - "$CODESIGNING_FOLDER_PATH"
+          # builds, so adding the helper would otherwise break the seal. Deliberately NOT --deep:
+          # --deep re-signs every nested Mach-O with the app's --entitlements, which stamps the
+          # bundled agtermctl -- a standalone CLI the user puts on their PATH -- with every TCC
+          # entitlement the app declares. The helper is signed on its own line above, entitlement-
+          # free, so this seals inside-out exactly as scripts/release.sh does for Developer ID.
+          codesign --force --options runtime --entitlements "$SRCROOT/agterm/agterm.entitlements" --sign - "$CODESIGNING_FOLDER_PATH"
     dependencies:
       - framework: GhosttyKit.xcframework
         embed: false

--- a/project.yml
+++ b/project.yml
@@ -147,12 +147,19 @@ targets:
           # releases is done authoritatively by scripts/release.sh AFTER xcodebuild returns (so it
           # can't be clobbered by Xcode's own final code-sign, which also adds the required timestamp).
           codesign --force --options runtime --sign - "$dest"
+          # sign every other nested Mach-O too. On a CLEAN build this phase can run BEFORE Xcode
+          # signs them, so the seal below would fail with "code object is not signed at all" on
+          # agterm.debug.dylib; on an incremental build they are already signed and this is a
+          # no-op re-sign. Entitlements are deliberately not passed: a library never carries its
+          # own: the process takes the main executable's.
+          find "$CODESIGNING_FOLDER_PATH/Contents/MacOS" -name '*.dylib' -type f -print0 |
+            xargs -0 -I{} codesign --force --options runtime --sign - {}
           # re-seal the whole app: this phase can run AFTER Xcode's own code-sign on incremental
           # builds, so adding the helper would otherwise break the seal. Deliberately NOT --deep:
-          # --deep re-signs every nested Mach-O with the app's --entitlements, which stamps the
+          # --deep re-signs every nested Mach-O with the app's --entitlements, which stamped the
           # bundled agtermctl -- a standalone CLI the user puts on their PATH -- with every TCC
-          # entitlement the app declares. The helper is signed on its own line above, entitlement-
-          # free, so this seals inside-out exactly as scripts/release.sh does for Developer ID.
+          # entitlement the app declares. Everything nested is signed above, so this seals
+          # inside-out exactly as scripts/release.sh does for Developer ID builds.
           codesign --force --options runtime --entitlements "$SRCROOT/agterm/agterm.entitlements" --sign - "$CODESIGNING_FOLDER_PATH"
     dependencies:
       - framework: GhosttyKit.xcframework

--- a/project.yml
+++ b/project.yml
@@ -147,19 +147,12 @@ targets:
           # releases is done authoritatively by scripts/release.sh AFTER xcodebuild returns (so it
           # can't be clobbered by Xcode's own final code-sign, which also adds the required timestamp).
           codesign --force --options runtime --sign - "$dest"
-          # sign every other nested Mach-O too. On a CLEAN build this phase can run BEFORE Xcode
-          # signs them, so the seal below would fail with "code object is not signed at all" on
-          # agterm.debug.dylib; on an incremental build they are already signed and this is a
-          # no-op re-sign. Entitlements are deliberately not passed: a library never carries its
-          # own: the process takes the main executable's.
-          find "$CODESIGNING_FOLDER_PATH/Contents/MacOS" -name '*.dylib' -type f -print0 |
-            xargs -0 -I{} codesign --force --options runtime --sign - {}
           # re-seal the whole app: this phase can run AFTER Xcode's own code-sign on incremental
-          # builds, so adding the helper would otherwise break the seal. Deliberately NOT --deep:
-          # --deep re-signs every nested Mach-O with the app's --entitlements, which stamped the
-          # bundled agtermctl -- a standalone CLI the user puts on their PATH -- with every TCC
-          # entitlement the app declares. Everything nested is signed above, so this seals
-          # inside-out exactly as scripts/release.sh does for Developer ID builds.
+          # builds, so adding the helper would otherwise break the seal. --deep because a clean
+          # build can reach here before Xcode has signed agterm.debug.dylib or the injected XCTest
+          # frameworks. Entitlements come in a SECOND pass instead: --deep applies them to every
+          # nested binary, and agtermctl is a standalone CLI on the user's PATH, not a library.
+          codesign --force --deep --options runtime --sign - "$CODESIGNING_FOLDER_PATH"
           codesign --force --options runtime --entitlements "$SRCROOT/agterm/agterm.entitlements" --sign - "$CODESIGNING_FOLDER_PATH"
     dependencies:
       - framework: GhosttyKit.xcframework


### PR DESCRIPTION
Fixes #396. Same mechanism as #142, one layer down: that was a missing usage string, these are missing hardened-runtime entitlements.

agterm is signed with hardened runtime, under which Apple gates seven **resource-access** entitlements. agterm carried one (`device.audio-input`). For the other six, `tccd` refuses to *prompt* and records nothing — so a tool run inside a session cannot obtain the permission, and the user cannot grant it by hand either, because with no TCC record agterm never appears in the relevant Privacy & Security pane. Grants agterm already holds keep working, which is why this went unnoticed: only *new* grants are impossible.

## Changes

**`agterm/agterm.entitlements`** — the six missing resource-access entitlements:

```
automation.apple-events   device.camera   personal-information.addressbook
personal-information.calendars   personal-information.location   personal-information.photos-library
```

**`agterm/Info.plist`** — usage strings for the services with a real command-line path, worded to match the existing microphone string: AppleEvents, Camera, Contacts, Calendars (+ full-access, + write-only), Reminders (+ full-access), PhotoLibrary, Location, Bluetooth, LocalNetwork, SpeechRecognition.

Every key was checked against Apple's documented platform availability rather than copied from other terminals — that caught three keys iTerm2/Ghostty/kitty ship which are **iOS/iPadOS/visionOS only** and do nothing on macOS (`NSLocationWhenInUseUsageDescription`, `NSLocationAlwaysAndWhenInUseUsageDescription`, `NSPhotoLibraryAddUsageDescription`). The macOS key is `NSLocationUsageDescription` — 10.14+, not deprecated there.

The deprecated `NSCalendarsUsageDescription` / `NSRemindersUsageDescription` are kept deliberately. Both are deprecated at macOS 14, but agterm is the responsible app for third-party tools of unknown SDK vintage, and one linked against a pre-14 SDK still resolves against the legacy key.

**`project.yml`** — the reseal applied `--deep --entitlements`, which stamped the app's entitlement set onto the bundled `agtermctl`, a standalone CLI on the user's `PATH`. Measured before the fix, the helper carried all six TCC entitlements. Now `--deep` signs without entitlements and a second non-deep pass applies them to the app alone. Shipped artifacts were never affected — `release.sh` re-signs the helper itself — only `make build` / `make deploy` output.

## Verification

Each service was exercised from a CLI inside agterm 0.20.2 / macOS 26.5.2, against the **released build** — the failures this PR fixes, reproduced per service:

| Service | Result | `tccd` |
|---|---|---|
| Apple Events | `-1743`, no prompt | `kTCCServiceAppleEvents requires entitlement …automation.apple-events but it is missing` |
| Camera | denied | `kTCCServiceCamera requires …device.camera…` |
| Contacts | denied | `kTCCServiceAddressBook requires …addressbook…` |
| Calendars | denied | `kTCCServiceCalendar requires …calendars…` |
| Photos | denied | `kTCCServicePhotos requires …photos-library…` |
| Location | `notDetermined`, no prompt | none — handled by `locationd`, not `tccd` |

All carry `promptPolicy = 4` and `responsible={com.umputun.agterm}`.

**That the entitlements are the cure** was then shown with two minimal apps identical except for the entitlements passed to `codesign` — same binary, same usage strings, both `flags=0x10002(adhoc,runtime)`, distinct bundle ids:

| | no entitlements | with entitlements |
|---|---|---|
| Apple Events | `-1743`, no prompt | prompt → granted |
| Camera | denied, no prompt | prompt → granted |
| Location | `notDetermined` | prompt → `authorizedAlways` |

`tccd` un-entitled: `Policy disallows prompt … denied`. Entitled: `AUTHREQ_PROMPTING`, all three dialogs confirmed on screen. This also settles location, which produces no `tccd` line of its own.

Build: `make build` and the signing phase pass from an empty `DerivedData`, with `agtermctl` carrying no entitlements, the app all six, and `codesign --verify --deep --strict` clean.

## ✅ Resolved — `NSSystemAdministrationUsageDescription`

> **Decision reached and addressed.** Approved in review; the key is in the diff as of b5f641c. The
> follow-up asked alongside it — whether a missing purpose string terminates the process rather than
> denying — was checked: it denies. Details in the review thread.
>
> Original question kept below for the record.

**I think this should go in, and I'd like to add it.** It is not in the diff because you asked me to leave it out, and I'm not going to include it over that without checking first — but I don't think the reason it was excluded holds up:

1. **The exclusion tested a different subsystem.** It was ruled out because `CLIInstaller.elevatedSymlink` already elevates without it. That path is `do shell script … with administrator privileges` — Authorization Services, not TCC. This key gates a TCC service, so the installer working says nothing either way about it.
2. **Apple documents it as macOS-only and required.** macOS 10.14+, not deprecated: *"A message in macOS that tells people why the app is requesting to manipulate the system configuration"*, *"This key is required if your app uses APIs that manipulate the system configuration"*, naming `ODRecordSetValue` — the OpenDirectory API behind `dscl`. A tool running `dscl . -create` in a session lands exactly here, with agterm responsible.
3. **It is the same class as every other key here, and all three peers ship it.** Leaving this one out makes agterm the lone outlier for no mechanical reason, and the failure mode is the silent one this whole PR exists to remove.

~~One word and I'll push it.~~

**Still deliberately out of scope:** the Files & Folders family (`NSDesktopFolderUsageDescription` and friends). Those prompts already work — the keys would only replace Apple's generic wording with agterm's — so that is a copy improvement, not a fix, and belongs in its own change.

## ✅ Resolved — local `make test-app` failure

> **Decision reached and addressed.** Already fixed on master by 16d8cbc; this branch is rebased onto it
> and `make test-app` is green. The diagnosis below was wrong — see #400, which is closed as redundant.
>
> Original note kept below for the record.

~~`make test-app` fails locally on `LiveMenuKeyEquivalentsTests.testUppercaseKeyEquivalentReportsImpliedShift()`, on unmodified `master` too. Unrelated to this PR and fixed separately in #400 — the fixture uses the title "Paste and Match Style", which AppKit recognises as a standard item and rewrites to ⇧⌘V on `addItem`, before the code under test runs.~~

