### PR TITLE
fix(tests): stop AppKit rewriting the uppercase-key-equivalent fixture

### DIFF
--- a/agtermTests/LiveMenuKeyEquivalentsTests.swift
+++ b/agtermTests/LiveMenuKeyEquivalentsTests.swift
@@ -78,8 +78,13 @@ final class LiveMenuKeyEquivalentsTests: XCTestCase {
 
     // AppKit matches an uppercase key equivalent against the SHIFTED chord even with shift absent from
     // the mask, so lowercasing without adding shift would name a chord the item can never fire.
+    //
+    // The title must NOT be one AppKit recognises as a standard menu item ("Paste and Match Style" was,
+    // and is why this used to fail): `NSMenu.addItem` rewrites such an item to the system-standard
+    // equivalent, turning ⌥⌘V into ⇧⌘V before the code under test ever sees it — a fixture that
+    // silently stops testing what it says. The rewrite keys off the title alone, not the chord.
     func testUppercaseKeyEquivalentReportsImpliedShift() throws {
-        let file = menu("Edit", [item("Paste and Match Style", key: "V", mods: [.command, .option])])
+        let file = menu("Edit", [item("Vendor Paste Special", key: "V", mods: [.command, .option])])
 
         let found = try XCTUnwrap(ControlServer.collectKeyEquivalents(in: file, menu: "Edit").first)
 


### PR DESCRIPTION
`make test-app` fails on `LiveMenuKeyEquivalentsTests.testUppercaseKeyEquivalentReportsImpliedShift()`:

```
XCTAssertEqual failed: ("cmd+shift+v") is not equal to ("cmd+opt+shift+v")
```

Product code is fine — the fixture is mutated before the code under test runs.

## Cause

The test builds its item with the title `"Paste and Match Style"`. AppKit recognises that as a **standard** menu item and, on `NSMenu.addItem`, rewrites it to the system-standard equivalent — so `"V"` + `[.command, .option]` becomes `"v"` + `[.command, .shift]`. `collectKeyEquivalents` then correctly reports `cmd+shift+v` for the item it was actually handed, and the assertion compares that against the `cmd+opt+shift+v` the test believed it built.

The rewrite keys off the **title alone**. Measured on macOS 26.5.2:

| fixture | after `addItem` |
|---|---|
| title `"Paste and Match Style"`, key `"V"`, mask `[cmd, opt]` | key `"v"`, mask `[cmd, shift]` |
| title `"Totally Custom Title"`, key `"V"`, mask `[cmd, opt]` | key `"V"`, mask `[cmd, opt]` — untouched |
| title `"Paste and Match Style"`, key `"Q"`, mask `[cmd, opt]` | key `"v"`, mask `[cmd, shift]` |

The third row is the telling one: a completely different key equivalent is still replaced with ⇧⌘V, because the title is what AppKit matches on. Before `addItem` the item holds exactly what the test set, so the rewrite happens at insertion.

It is not key-equivalent localization — `allowsAutomaticKeyEquivalentLocalization = false` makes no difference — and it is not the chord logic, which never sees the original values.

## Fix

Rename the fixture item to a non-stock title, and record why in a comment so it does not get "corrected" back to a realistic-looking stock name. One line of test data; `chordSyntax` is untouched.

After: `make test-app` reports **TEST SUCCEEDED**, and `swiftlint --strict` stays at 0 violations across 326 files.

## Why it presumably passes in CI

I did not confirm this, so treat it as a guess: the rewrite depends on AppKit's standard-item table, so a different macOS version — or a different system language, since the match is against localized standard titles — would not fire it. Reproduced here on macOS 26.5.2 / Xcode 26, where it fails identically on unmodified `master` (`4155ed9`).

Split out of #398, which ran into it.
