### PR TITLE
fix: keep cmd+w on the Settings window instead of the session behind it

### DIFF
--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -124,6 +124,14 @@ paths:
   does not intercept). Only then close the active session. If no cover or session exists, the menu performs
   window close. Keep the cover check inside `closeActiveSession`, since a sessionless window can still show
   quick terminal.
+- The menu item diverts to a plain `performClose` when the key window is not an agterm terminal window —
+  Settings, the About panel, an open/save panel — because `applyCloseSessionChord` takes ⌘W off the stock
+  File ▸ Close item and nothing else would close them (issue #401). `WindowRegistry.contains` is the
+  predicate, as in `CustomCommandRunner`. A `nil` key window still runs the deck sequence: with every
+  window minimized the equivalent still dispatches, and `performClose` on nothing would make ⌘W silently
+  no-op. The divert is gated on `close_session` still holding ⌘W, the same condition
+  `applyCloseSessionChord` splits on: rebound off it, the stock item takes the chord back and the
+  auxiliary window closes itself, so the new chord keeps its labelled meaning.
 - All active-session close paths use host-free `closeReselectionTarget` (Discussion #147). Prefer the most
   recent survivor in three widening scopes: same workspace intersected with `navigableSessions`, all
   navigable sessions, then the whole tree. Build scopes from the post-removal tree; soft close retains

--- a/.claude/rules/ui-tests.md
+++ b/.claude/rules/ui-tests.md
@@ -98,8 +98,10 @@ These run inside the app, so a mistake can kill the host instead of failing an a
   quit-confirm modal. `MultiWindowUITests` survives hard termination only because structural saves
   already persist the open set. Use a temp file, not unreliable `NSLog`, to instrument the callback.
 - Dismiss Settings by the close button of `app.windows.containing(.any, identifier: <a control on the
-  tab>)`, never ⌘W: that reaches the app's Close Session command and takes the seeded session with it,
-  which a session-row-count oracle reads as a collapse rather than as a closed session.
+  tab>)`. ⌘W also closes it and leaves the deck alone (issue #401, pinned by
+  `SettingsUITests.testCommandWClosesTheSettingsWindowNotTheSession`), but only while Settings is KEY —
+  the reopen path above can leave it open and non-key, where ⌘W reaches the terminal window behind it
+  and takes a session with it.
 - `ghostty_surface_foreground_pid` is `tcgetpgrp`, so it returns the foreground process GROUP id. Under a
   job-control shell that leader IS the program; a `--command` pane has no such shell and its leader is
   unreadable setuid-root `login`, which is why the tree read descends to the leader's children and the

--- a/agterm/agtermApp+Menus.swift
+++ b/agterm/agtermApp+Menus.swift
@@ -34,6 +34,12 @@ extension agtermApp {
         return KeyboardShortcut(key, modifiers: modifiers)
     }
 
+    /// Whether `close_session` currently holds ⌘W, read live rather than off the deferred menu equivalent.
+    /// `AppDelegate.applyCloseSessionChord` splits the chord on the same condition.
+    private var closeSessionOwnsCommandW: Bool {
+        settingsModel.keymap.equivalent(for: .closeSession) == Chord(mods: [.command], key: "w")
+    }
+
     private func recentTitle(_ item: RecentClosedItem) -> String {
         guard let subtitle = item.subtitle, !subtitle.isEmpty else { return item.title }
         return "\(item.title) - \(subtitle)"
@@ -142,6 +148,18 @@ extension agtermApp {
                 Button("Reveal in Finder") { actions.revealActiveSessionInFinder() }
                     .disabled(!actions.canRevealActiveSessionInFinder)
                 Button("Close Session") {
+                    // an auxiliary key window — Settings, the About panel, an open/save panel — is not part of
+                    // any terminal deck, so ⌘W there keeps its standard meaning and closes THAT window. It can
+                    // only come from here: `applyCloseSessionChord` strips ⌘W off the stock File ▸ Close item
+                    // while close_session owns the chord, so without this rung the keystroke falls through to
+                    // the deck behind the panel and takes a session with it (issue #401). Same predicate as
+                    // `CustomCommandRunner`'s no-surface gate. A nil key window keeps the deck behavior.
+                    // Gated on close_session still holding ⌘W: rebound off it, the stock item takes the chord
+                    // back and an auxiliary window closes itself, so the new chord means only what it says.
+                    if closeSessionOwnsCommandW, let key = NSApp.keyWindow, !WindowRegistry.shared.contains(key) {
+                        key.performClose(nil)
+                        return
+                    }
                     // closeActiveSession dismisses any cover (quick terminal / overlay / scratch) or closes the
                     // active session; only when it handled nothing (no cover, no session) fall back to the window.
                     if !actions.closeActiveSession() { NSApp.keyWindow?.performClose(nil) }

--- a/agtermUITests/SettingsUITests.swift
+++ b/agtermUITests/SettingsUITests.swift
@@ -264,6 +264,20 @@ final class SettingsUITests: XCTestCase {
                       "re-showing the last hidden element should remove hiddenInterfaceElements from settings.json")
     }
 
+    func testCommandWClosesTheSettingsWindowNotTheSession() throws {
+        // #401: close_session owns ⌘W app-wide, so ⌘W over Settings reached the deck behind it.
+        app.typeKey("n", modifierFlags: .command)
+        XCTAssertTrue(poll { self.sessionRowCount() == 2 }, "⌘N should add a second session")
+
+        let control = settingsControl(tab: "General", control: "settings-confirm-close-session")
+
+        app.typeKey("w", modifierFlags: .command)
+
+        XCTAssertTrue(poll({ !control.exists }, timeout: 10), "⌘W should close the Settings window")
+        // both rows still readable is also the window-survival oracle: they render inside it.
+        XCTAssertEqual(sessionRowCount(), 2, "⌘W over Settings must leave the terminal sessions alone")
+    }
+
     // MARK: - Helpers
 
     /// Opens the Settings window (Cmd+,) if needed, switches to `tab`, and returns the control with
@@ -316,6 +330,10 @@ final class SettingsUITests: XCTestCase {
             XCTAssertEqual(edge, wellLeadingEdges[0], accuracy: 1,
                            "the color wells should stack in one column (\(context))", file: file, line: line)
         }
+    }
+
+    private func sessionRowCount() -> Int {
+        app.staticTexts.matching(identifier: "session-row").count
     }
 
     private func poll(_ condition: () -> Bool, timeout: TimeInterval = 5) -> Bool {


### PR DESCRIPTION
cmd+w with the Settings window open closed the active terminal session instead of Settings. Same for the About panel and the Open Directory panel.

`AppDelegate.applyCloseSessionChord` strips cmd+w off the stock File > Close item while `close_session` owns the chord, and File > Close Session is a main-menu item with no window scoping. So the keystroke reached the terminal deck no matter which window was key, and nothing was left that could close Settings.

**The fix.** The menu action diverts to a plain `performClose` when the key window is not a registered agterm terminal window. `WindowRegistry.contains` is the predicate, the same one `CustomCommandRunner` already uses for its no-surface gate ("never Settings"). A nil key window still runs the deck sequence: with every window minimized the equivalent still dispatches, and `performClose` on nothing would make cmd+w silently do nothing.

`SettingsUITests.testCommandWClosesTheSettingsWindowNotTheSession` pins it, verified red without the fix. The terminal-window path stays covered by `KeymapUITests.testCloseSessionReclaimsCommandWAfterReload`.

Also corrects the `.claude/rules/ui-tests.md` bullet that told test authors never to dismiss Settings with cmd+w, keeping the key-window precondition that still matters there.

Fix #401
