### PR TITLE
fix: use a bindable chord in keymap.conf's starter examples

### DIFF
--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -108,10 +108,11 @@ paths:
   bare tokens, but bind as `shift+=`/`shift+.`. `increase_font_size`'s stored `Chord(key:"+")` cannot
   round-trip and prints `(not expressible)` in the starter file. Ctrl-Tab and Ctrl-1/2 are reserved,
   monitor-driven, and not rebindable. Palette custom hints use raw kitty syntax, not macOS glyphs.
-- The starter file's `map` examples are literal chords that rot when a new built-in claims one, as
-  `dashboard` did to the shipped `cmd+shift+d` (issue #405). Keep
-  `ConfigPathsTests.starterKeymapMapExamplesApplyWhenUncommented`, which uncomments every example and
-  requires it to parse clean and bind.
+- The starter file's `map` and `command` examples are literal chords that rot when a new built-in claims
+  one, as `dashboard` did to the shipped `cmd+shift+d` (issue #405). Keep
+  `ConfigPathsTests.starterKeymapExamplesApplyWhenUncommented`, which uncomments every example and
+  requires it to parse clean and bind; both verbs rot, `validateCommands` clearing a custom shortcut a
+  built-in has claimed just as `resolveBuiltinOverrides` drops the colliding `map`.
 - **`{AGT_X}` interpolation is intentionally raw and unquoted.** Selection, OSC title, OSC 7 pwd, and the
   session/workspace/window names and `--cwd` a caller supplies over control or the GUI can all inject
   visible shell metacharacters. `TerminalText.sanitized` strips control characters, not `;`,

--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -108,6 +108,10 @@ paths:
   bare tokens, but bind as `shift+=`/`shift+.`. `increase_font_size`'s stored `Chord(key:"+")` cannot
   round-trip and prints `(not expressible)` in the starter file. Ctrl-Tab and Ctrl-1/2 are reserved,
   monitor-driven, and not rebindable. Palette custom hints use raw kitty syntax, not macOS glyphs.
+- The starter file's `map` examples are literal chords that rot when a new built-in claims one, as
+  `dashboard` did to the shipped `cmd+shift+d` (issue #405). Keep
+  `ConfigPathsTests.starterKeymapMapExamplesApplyWhenUncommented`, which uncomments every example and
+  requires it to parse clean and bind.
 - **`{AGT_X}` interpolation is intentionally raw and unquoted.** Selection, OSC title, OSC 7 pwd, and the
   session/workspace/window names and `--cwd` a caller supplies over control or the GUI can all inject
   visible shell metacharacters. `TerminalText.sanitized` strips control characters, not `;`,

--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -110,9 +110,10 @@ paths:
   monitor-driven, and not rebindable. Palette custom hints use raw kitty syntax, not macOS glyphs.
 - The starter file's `map` and `command` examples are literal chords that rot when a new built-in claims
   one, as `dashboard` did to the shipped `cmd+shift+d` (issue #405). Keep
-  `ConfigPathsTests.starterKeymapExamplesApplyWhenUncommented`, which uncomments every example and
-  requires it to parse clean and bind; both verbs rot, `validateCommands` clearing a custom shortcut a
-  built-in has claimed just as `resolveBuiltinOverrides` drops the colliding `map`.
+  `ConfigPathsTests.starterKeymapExamplesApplyWhenUncommented`, which uncomments every example, requires
+  it to parse clean, and counts the chords that survive.
+  Both verbs rot: `validateCommands` clears a custom shortcut a built-in has claimed just as
+  `resolveBuiltinOverrides` drops the colliding `map`.
 - **`{AGT_X}` interpolation is intentionally raw and unquoted.** Selection, OSC title, OSC 7 pwd, and the
   session/workspace/window names and `--cwd` a caller supplies over control or the GUI can all inject
   visible shell metacharacters. `TerminalText.sanitized` strips control characters, not `;`,

--- a/agtermCore/Sources/agtermCore/ConfigPaths.swift
+++ b/agtermCore/Sources/agtermCore/ConfigPaths.swift
@@ -39,17 +39,18 @@ public enum ConfigPaths {
         return """
         # agterm keymap — a kitty-flavored config for rebinding built-in shortcuts and defining
         # custom shell commands. Edit this file and run File ▸ Reload Keymap (or `agtermctl keymap
-        # reload`) to apply. Blank lines and lines starting with `#` are ignored.
+        # reload`) to apply. Blank lines and lines starting with `#` are ignored. A line that is
+        # rejected or skipped is reported in Settings ▸ Key Mapping and by `agtermctl keymap list`.
         #
         # Two verbs:
         #
         #   map <chord> <action>
         #       Rebind a built-in action to a single chord (no leader sequences for built-ins).
-        #       Chords use kitty syntax: mods joined by `+`, e.g. `cmd+shift+d`, `ctrl+\\``.
+        #       Chords use kitty syntax: mods joined by `+`, e.g. `cmd+shift+l`, `ctrl+\\``.
         #       Mods: ctrl, cmd, opt, shift. A Shift-typed symbol is shift+<base key>
         #       (shift+/ for ?, shift+= for +, shift+5 for %). Example:
         #
-        #           map cmd+shift+d  toggle_split
+        #           map cmd+shift+l  toggle_split
         #
         #   command "<name>" [chord] <shell...>
         #       Define a custom command, shown in the action palette marked `custom`. The quoted
@@ -86,7 +87,7 @@ public enum ConfigPaths {
         # environment variable, QUOTED, e.g. "$AGT_SELECTION".
         #
         # Uncomment and edit a line below to start.
-        # map cmd+shift+d toggle_split
+        # map cmd+shift+l toggle_split
 
         """
     }

--- a/agtermCore/Tests/agtermCoreTests/ConfigPathsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ConfigPathsTests.swift
@@ -80,6 +80,23 @@ struct ConfigPathsTests {
         #expect(parsed.diagnostics.isEmpty)
     }
 
+    // issue #405: the shipped example was `map cmd+shift+d toggle_split`, a chord `dashboard` later took,
+    // so uncommenting the starter's own suggestion silently bound nothing.
+    @Test func starterKeymapMapExamplesApplyWhenUncommented() {
+        let examples = ConfigPaths.starterKeymapConf().split(separator: "\n").compactMap { line -> String? in
+            let text = line.drop { $0 == "#" || $0 == " " }
+            // `<` skips the `map <chord> <action>` syntax line, which is a grammar, not an example.
+            guard text.hasPrefix("map "), !text.contains("<") else { return nil }
+            return String(text)
+        }
+        #expect(!examples.isEmpty)
+        for example in examples {
+            let (keymap, diagnostics) = parseKeymap(example)
+            #expect(diagnostics.isEmpty, "starter example '\(example)' is skipped: \(diagnostics.map(\.message))")
+            #expect(keymap.builtinOverrides.count == 1, "starter example '\(example)' bound nothing")
+        }
+    }
+
     @Test func ghosttyConfigPathIsGhosttyConfInDir() {
         let dir = URL(fileURLWithPath: "/Users/test/.config/agterm")
         #expect(ConfigPaths.ghosttyConfigPath(configDirectory: dir).path == "/Users/test/.config/agterm/ghostty.conf")

--- a/agtermCore/Tests/agtermCoreTests/ConfigPathsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ConfigPathsTests.swift
@@ -81,19 +81,23 @@ struct ConfigPathsTests {
     }
 
     // issue #405: the shipped example was `map cmd+shift+d toggle_split`, a chord `dashboard` later took,
-    // so uncommenting the starter's own suggestion silently bound nothing.
-    @Test func starterKeymapMapExamplesApplyWhenUncommented() {
+    // so uncommenting the starter's own suggestion silently bound nothing. A `command` example rots the
+    // same way, `validateCommands` dropping a custom shortcut a built-in has since claimed.
+    @Test func starterKeymapExamplesApplyWhenUncommented() {
         let examples = ConfigPaths.starterKeymapConf().split(separator: "\n").compactMap { line -> String? in
-            let text = line.drop { $0 == "#" || $0 == " " }
-            // `<` skips the `map <chord> <action>` syntax line, which is a grammar, not an example.
-            guard text.hasPrefix("map "), !text.contains("<") else { return nil }
+            let text = line.drop { $0 == "#" || $0.isWhitespace }
+            let verb = text.prefix { !$0.isWhitespace }
+            // `<` skips the two verb-syntax lines, which state a grammar rather than an example.
+            guard verb == "map" || verb == "command", !text.contains("<") else { return nil }
             return String(text)
         }
-        #expect(!examples.isEmpty)
+        // an example silently dropped from the guard must fail here: two `map` lines and three `command`.
+        #expect(examples.count == 5)
         for example in examples {
             let (keymap, diagnostics) = parseKeymap(example)
             #expect(diagnostics.isEmpty, "starter example '\(example)' is skipped: \(diagnostics.map(\.message))")
-            #expect(keymap.builtinOverrides.count == 1, "starter example '\(example)' bound nothing")
+            #expect(keymap.builtinOverrides.count + keymap.commands.count == 1,
+                    "starter example '\(example)' bound nothing")
         }
     }
 

--- a/agtermCore/Tests/agtermCoreTests/ConfigPathsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ConfigPathsTests.swift
@@ -93,12 +93,16 @@ struct ConfigPathsTests {
         }
         // an example silently dropped from the guard must fail here: two `map` lines and three `command`.
         #expect(examples.count == 5)
+        var bound = 0
         for example in examples {
             let (keymap, diagnostics) = parseKeymap(example)
             #expect(diagnostics.isEmpty, "starter example '\(example)' is skipped: \(diagnostics.map(\.message))")
-            #expect(keymap.builtinOverrides.count + keymap.commands.count == 1,
-                    "starter example '\(example)' bound nothing")
+            // an unparseable command chord is absorbed as shell text without a diagnostic, so count the
+            // shortcuts that survived rather than the commands that parsed.
+            bound += keymap.builtinOverrides.count + keymap.commands.filter { !$0.shortcut.isEmpty }.count
         }
+        // both `map` examples and the two chorded `command` ones; `Deploy` is palette-only by design.
+        #expect(bound == 4)
     }
 
     @Test func ghosttyConfigPathIsGhosttyConfInDir() {


### PR DESCRIPTION
the starter `keymap.conf` told the user to uncomment `map cmd+shift+d toggle_split`, and that line can never apply. `cmd+shift+d` is `BuiltinAction.dashboard`'s default, so `resolveBuiltinOverrides` drops the override with `chord conflicts with built-in 'dashboard'; map skipped`. The example was fine when it was written and rotted when `dashboard` claimed the chord.

it is not a reserved chord, despite what the issue infers from `strings`: `isReservedMonitorChord` covers only Ctrl-Tab and Ctrl-1/2. The symptom is as reported, the cause is a plain built-in collision.

changes:

- both `map` examples in `ConfigPaths.starterKeymapConf()` now use `cmd+shift+l`, the chord README already uses
- one header sentence points at where a skipped line is reported, Settings ▸ Key Mapping and `agtermctl keymap list`
- `ConfigPathsTests.starterKeymapExamplesApplyWhenUncommented` uncomments every starter `map` and `command` example, requires each to parse without diagnostics, and pins the number of surviving chords at 4. `command` examples rot the same way: `validateCommands` clears a custom shortcut a built-in has claimed
- `.claude/rules/keymap.md` notes the rot class and the test that pins it

the guard was checked against all three failure shapes: the shipped `cmd+shift+d`, a built-in stealing a `command` example's chord, and an unparseable command chord (`parseCommandLine` absorbs that one as shell text with no diagnostic, so the test counts surviving shortcuts rather than parsed commands).

on the second half of the issue, the diagnostic text is already reachable. `agtermctl keymap list` prints every diagnostic with its line number, Settings ▸ Key Mapping lists them, and a reload posts a banner. Putting them in `keymap.reload`'s own JSON is a control-API response change with skill and site mirrors, so it is not in this PR.

Fix #405
