### PR TITLE
fix: remove agterm's full screen menu item, duplicated by AppKit's

### DIFF
--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -63,8 +63,10 @@ paths:
   disjoint without relying on dispatch order. Standard menu items such as ⌘Q/⌘C/⌘, remain AppKit's
   responsibility.
 - `BuiltinAction.defaultChord` is the sole built-in default. Every menu item resolves
-  override-or-default, including the six arrow actions. `undo_close` is the one keyed action delivered
-  by `UndoCloseShortcut`, not a menu equivalent, so native text undo still works.
+  override-or-default, including the six arrow actions. Two keyed actions are delivered by a monitor
+  rather than a menu equivalent: `undo_close` through `UndoCloseShortcut`, so native text undo still
+  works, and `toggle_fullscreen` through `CustomCommandRunner`, because agterm ships no full screen menu
+  item for it to ride — see [[windows]]. Both are absent from `keymap list`'s `menu` by design.
 - Write shifted symbols as `shift+<base>`: `shift+/` for `?`, `shift+=` for `+`, `shift+5` for `%`, and
   `shift+.` for `>`. `CustomCommandRunner` uses `characters(byApplyingModifiers: [])` to recover that
   base; keep `KeymapUITests.testCustomCommandShiftedSymbolFires`.

--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -56,8 +56,8 @@ paths:
   Expand/Collapse Workspaces alone are disabled outside tree mode, in both menu and palette.
 - Dashboard uses Command-Shift-D, `BuiltinAction.dashboard`, and `toggleDashboard`; it toggles an MRU,
   auto-sized grid unless terminal zoom is active. Share `dashboardMembers` with control.
-- Remove AppKit's reinjected fullscreen item as described in [[windows]]. agterm's own
-  `toggle_fullscreen` remains rebindable and control-drivable.
+- The View menu carries no fullscreen item of agterm's own, and `toggle_fullscreen` rides the key monitor
+  rather than a menu shortcut; see [[windows]]. It remains rebindable and control-drivable.
 - Font shortcuts call libghostty binding actions on the key window's first-responder surface, falling back
   to the active session. Persistence still flows from cell-size callbacks.
 - `shortcutGlyph` delegates to host-free `Keymap.glyphHint`. Use it for palette hints and the ten built-in

--- a/.claude/rules/windows.md
+++ b/.claude/rules/windows.md
@@ -98,9 +98,9 @@ session drag are out of scope.
   `AppleActionOnDoubleClick`: Zoom/Fill zooms, Minimize miniaturizes, Do Nothing does nothing, and an absent
   key defaults to Zoom. `AGTERM_UITEST_DOUBLECLICK_ACTION` overrides via environment because launch
   arguments hit FB11763863. Decorative titlebar regions disable hit testing; buttons remain above them.
-- `window.fullscreen` uses `toggleFullScreen`, a distinct native Space. GUI surfaces are View > Toggle Full
-  Screen, palette, `BuiltinAction.toggleFullscreen` with Ctrl-Command-F, and the green button. Control
-  resolves an open ID; read back the `.fullScreen` style mask.
+- `window.fullscreen` uses `toggleFullScreen`, a distinct native Space. GUI surfaces are the palette,
+  `BuiltinAction.toggleFullscreen` with Ctrl-Command-F through the key monitor, AppKit's own injected
+  View menu item, and the green button. Control resolves an open ID; read back the `.fullScreen` style mask.
 - agterm ships NO full screen menu item. AppKit appends its own "Enter Full Screen" (`toggleFullScreen:`,
   Globe+F) to the View menu as it is prepared for display, so any item of agterm's own is a visible
   duplicate. All of these were measured and none suppresses it: removing the injected item on

--- a/.claude/rules/windows.md
+++ b/.claude/rules/windows.md
@@ -101,9 +101,21 @@ session drag are out of scope.
 - `window.fullscreen` uses `toggleFullScreen`, a distinct native Space. GUI surfaces are View > Toggle Full
   Screen, palette, `BuiltinAction.toggleFullscreen` with Ctrl-Command-F, and the green button. Control
   resolves an open ID; read back the `.fullScreen` style mask.
-- AppKit reinjects its own `toggleFullScreen:` menu item whenever View opens. Remove only that selector at
-  launch and every `NSMenu.didBeginTrackingNotification`; do not install a menu delegate that would replace
-  SwiftUI updates. `testViewMenuHasSingleFullScreenItem` pins this.
+- agterm ships NO full screen menu item. AppKit appends its own "Enter Full Screen" (`toggleFullScreen:`,
+  Globe+F) to the View menu as it is prepared for display, so any item of agterm's own is a visible
+  duplicate. All of these were measured and none suppresses it: removing the injected item on
+  `NSMenu.didBeginTrackingNotification` (posted once per ROOT tracking session, before the injection);
+  removing it deferred one runloop turn (too late — the displayed menu is already snapshotted, so the model
+  loses the item while the duplicate stays on screen); registering `NSFullScreenMenuItemEverywhere` false,
+  which macOS 26 ignores; and giving agterm's own item the `toggleFullScreen:` selector, which AppKit
+  injects past anyway. Do not install a menu delegate, which would replace SwiftUI updates.
+- `toggle_fullscreen` therefore has no menu item to carry its equivalent, and is matched in
+  `CustomCommandRunner`'s key monitor instead — the one built-in that does not ride a SwiftUI shortcut.
+  A half-typed leader sequence still wins. The menu affordance and Globe+F are AppKit's item.
+- `testViewMenuHasSingleFullScreenItem` asserts the item COUNT and matches on TITLE. Matching by
+  identifier silently fails to find the injected item, which is why the assertion it replaced passed for
+  months while the duplicate was on screen. Never trust the AX tree alone here: it reflects the menu model,
+  which a removal can change without changing the pixels. Verify a menu fix by opening the menu and looking.
 - `window.minimize` accepts `on`, `off`, or `toggle` through `ControlToggleMode`, defaulting to toggle.
   Deterministic modes support park-all-but-one. GUI Command-M, yellow button, and titlebar preference use
   AppKit directly, so observe `didMiniaturize`/`didDeminiaturize` to keep control read-back current.

--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ Open the file in your editor with **File ▸ Edit Keymap…** or the ⌃⇧P pal
 
 After editing the file, apply it with **File ▸ Reload Keymap**, the action palette (⌃⇧P → "Reload Keymap"), or `agtermctl keymap reload`. A malformed line never discards the rest of the file — it surfaces in the diagnostics list in Settings ▸ Key Mapping (and `keymap.reload` returns the diagnostic count) while the good lines still apply.
 
-To check what is actually bound, `agtermctl keymap list` prints every built-in with the chord it resolved to, the custom commands, each diagnostic in full, and the key equivalents the menu bar is really carrying. If a binding will not fire, compare the last two: an action whose chord no menu item holds is usually a menu problem, not a keymap one. The one deliberate exception is `undo_close` (⌘Z), which is delivered by a key monitor rather than a menu item so it never appears under the menu list.
+To check what is actually bound, `agtermctl keymap list` prints every built-in with the chord it resolved to, the custom commands, each diagnostic in full, and the key equivalents the menu bar is really carrying. If a binding will not fire, compare the last two: an action whose chord no menu item holds is usually a menu problem, not a keymap one. Two deliberate exceptions never appear under the menu list, because a key monitor delivers them rather than a menu item: `undo_close` (⌘Z) and `toggle_fullscreen` (⌃⌘F).
 
 v1 limitations:
 

--- a/README.md
+++ b/README.md
@@ -449,6 +449,8 @@ select_theme       toggle_fullscreen  toggle_terminal_zoom
 dashboard
 ```
 
+`toggle_fullscreen` is the one action with no menu item of its own. macOS adds an "Enter Full Screen" item to the View menu whenever that menu is drawn, and nothing suppresses it, so an item of agterm's own would sit beside it as a duplicate. The binding (⌃⌘F by default) is handled directly instead, which is why the menu entry advertises the system's Globe+F rather than your chord. Both work, and rebinding `toggle_fullscreen` changes the chord as usual — it just won't show up next to that menu item.
+
 The shell line of a `command` may use these `{AGT_X}` tokens, expanded at fire time (the same values are also exported as `$AGT_X` environment variables on the spawned process):
 
 ```

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -757,7 +757,9 @@ final class AppActions {
     }
 
     /// Toggle native macOS full screen for the key window: the green traffic-light behavior, moving the window
-    /// to its own Space; a second invocation exits. Shared by ⌃⌘F, the palette, `toggle_fullscreen`, `window.fullscreen`.
+    /// to its own Space; a second invocation exits. The palette's entry alone — `toggle_fullscreen`'s chord
+    /// calls `NSWindow.toggleFullScreen` from the key monitor and `window.fullscreen` through
+    /// `WindowRegistry`, so neither routes here.
     func toggleFullscreen() { NSApp.keyWindow?.toggleFullScreen(nil) }
 
     // MARK: - Font (on the focused terminal)

--- a/agterm/AppDelegate.swift
+++ b/agterm/AppDelegate.swift
@@ -62,11 +62,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // a dark launch otherwise strips the env, restore replay and command off every restored surface.
         GhosttyApp.shared.syncLaunchColorScheme()
         scheduleRestoredWindowReconciliation(reason: "did-finish-launching")
-        // AppKit auto-adds its own "Enter Full Screen" item (Globe+F / ⌃⌘F) to the View menu and RE-INJECTS
-        // it whenever the menu opens, duplicating agterm's rebindable "Toggle Full Screen" (what makes full
-        // screen drivable from keymap, palette and control). Strip the native one on every menu-tracking
-        // start — a launch-time one-shot does NOT stick.
-        AppDelegate.removeNativeFullScreenMenuItem()
         NotificationCenter.default.addObserver(self, selector: #selector(menuBeganTracking),
                                                name: NSMenu.didBeginTrackingNotification, object: nil)
         // SwiftUI defers its menu rebuild to the next app ACTIVATION, and that rebuild is what lets the
@@ -96,7 +91,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func appDidBecomeActive(_: Notification) {
         DispatchQueue.main.async { [weak self] in
-            MainActor.assumeIsolated { self?.reconcileCloseSessionChord() }
+            MainActor.assumeIsolated {
+                self?.reconcileCloseSessionChord()
+            }
         }
     }
 
@@ -106,7 +103,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func menuBeganTracking(_: Notification) {
         MainActor.assumeIsolated {
-            AppDelegate.removeNativeFullScreenMenuItem()
             reconcileCloseSessionChord()
         }
     }
@@ -161,19 +157,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// The File-menu title of agterm's own close-the-session item, matched by `applyCloseSessionChord`.
     static let closeSessionItemTitle = "Close Session"
     private static let commandW = Chord(mods: [.command], key: "w")
-
-    /// Remove AppKit's auto-injected fullscreen item (action `toggleFullScreen:`); agterm's own is a SwiftUI
-    /// closure action, so only the native one matches. Finds the submenu by content, not a localized title.
-    @MainActor
-    private static func removeNativeFullScreenMenuItem() {
-        let selector = #selector(NSWindow.toggleFullScreen(_:))
-        for topItem in NSApp.mainMenu?.items ?? [] {
-            guard let submenu = topItem.submenu else { continue }
-            for item in submenu.items where item.action == selector {
-                submenu.removeItem(item)
-            }
-        }
-    }
 
     /// `open -a agterm /path` (the OS "open terminal here" integration): each URL resolves to a directory
     /// (folder → itself, file → its parent, via `OpenPathResolver`), queued and drained into a new session

--- a/agterm/Commands/CustomCommandRunner.swift
+++ b/agterm/Commands/CustomCommandRunner.swift
@@ -78,14 +78,14 @@ final class CustomCommandRunner {
     private static let escapeKeyCode: UInt16 = 53
 
     /// Feed one key event to the matcher; returns whether it was consumed (so the caller drops it). Esc while
-    /// armed resets, `.fired` runs, `.armed` arms the leader timer — all consumed; `.unmatched` passes through.
+    /// armed resets, `.fired` runs, `.armed` arms the leader timer, and `toggle_fullscreen`'s chord toggles
+    /// full screen without reaching the matcher at all — all consumed; `.unmatched` passes through.
     ///
     /// Acts when the key window's first responder is a terminal surface (context from that surface), or when
     /// the key window is an agterm terminal window whose focus is NOT on a text field — including one emptied
     /// to zero sessions. Passes through for a focused text field (Settings editor, inline rename, palette
     /// search) so a bound chord never eats those keystrokes, and for an auxiliary window focused off a text
     /// field. A key repeat is ignored, so a held-down shortcut spawns one process, not one per OS repeat.
-    ///
     private func handleKeyDown(_ event: NSEvent) -> Bool {
         guard let keyWindow = NSApp.keyWindow else { return false }
         return handleKeyDown(event, in: keyWindow)

--- a/agterm/Commands/CustomCommandRunner.swift
+++ b/agterm/Commands/CustomCommandRunner.swift
@@ -91,9 +91,10 @@ final class CustomCommandRunner {
         return handleKeyDown(event, in: keyWindow)
     }
 
-    /// The half above the key-window lookup, so a test can supply the window: a hosted test's own window
-    /// never becomes `NSApp.keyWindow` (the app is not active), which would make every guard here pass
-    /// vacuously. Internal for that reason alone, like `ControlServer.collectKeyEquivalents`.
+    /// Everything after the key-window lookup, split out so a test can supply the window: a hosted test's
+    /// own window never becomes `NSApp.keyWindow` (the app is not active), so `handleKeyDown(_:)` returns at
+    /// that guard and none of this runs. Internal for that reason alone, like
+    /// `ControlServer.collectKeyEquivalents`.
     func handleKeyDown(_ event: NSEvent, in keyWindow: NSWindow) -> Bool {
         guard !event.isARepeat else { return false }
         let responder = keyWindow.firstResponder

--- a/agterm/Commands/CustomCommandRunner.swift
+++ b/agterm/Commands/CustomCommandRunner.swift
@@ -85,9 +85,17 @@ final class CustomCommandRunner {
     /// to zero sessions. Passes through for a focused text field (Settings editor, inline rename, palette
     /// search) so a bound chord never eats those keystrokes, and for an auxiliary window focused off a text
     /// field. A key repeat is ignored, so a held-down shortcut spawns one process, not one per OS repeat.
+    ///
     private func handleKeyDown(_ event: NSEvent) -> Bool {
-        guard !event.isARepeat else { return false }
         guard let keyWindow = NSApp.keyWindow else { return false }
+        return handleKeyDown(event, in: keyWindow)
+    }
+
+    /// The half above the key-window lookup, so a test can supply the window: a hosted test's own window
+    /// never becomes `NSApp.keyWindow` (the app is not active), which would make every guard here pass
+    /// vacuously. Internal for that reason alone, like `ControlServer.collectKeyEquivalents`.
+    func handleKeyDown(_ event: NSEvent, in keyWindow: NSWindow) -> Bool {
+        guard !event.isARepeat else { return false }
         let responder = keyWindow.firstResponder
         // a focused text field is the window's NSText field editor and must keep its keystrokes: drop the
         // half-typed leader, pass through.
@@ -118,6 +126,14 @@ final class CustomCommandRunner {
         guard let chord = chord(from: event) else {
             // a key with no usable base (e.g. a bare modifier) can't advance; while armed, keep waiting.
             return false
+        }
+        // `toggle_fullscreen` is the one built-in with no menu item to carry its equivalent: AppKit appends
+        // the only full screen item there is, at menu-display time, and an item of agterm's own beside it is
+        // the duplicate this avoids. So the rebindable chord is matched here instead. A half-typed leader
+        // sequence still wins, exactly as it does over a custom command sharing its first chord.
+        if !commandEngine.isArmed, chord == settings.keymap.equivalent(for: .toggleFullscreen) {
+            keyWindow.toggleFullScreen(nil)
+            return true
         }
         switch commandEngine.advance(chord) {
         case .fired(let command):

--- a/agterm/Control/ControlServer+WindowCommands.swift
+++ b/agterm/Control/ControlServer+WindowCommands.swift
@@ -138,7 +138,7 @@ extension ControlServer {
     }
 
     /// Toggle native macOS full screen on the resolved window; a closed one errors. The control half of
-    /// View ▸ Toggle Full Screen / the green traffic-light button.
+    /// ⌃⌘F, AppKit's own View ▸ Enter/Exit Full Screen item, and the green traffic-light button.
     func windowFullscreen(_ target: String?) -> ControlResponse {
         return resolver.resolveWindowID(target) { id in
             guard WindowRegistry.shared.fullscreen(id) else {

--- a/agterm/agtermApp+Menus.swift
+++ b/agterm/agtermApp+Menus.swift
@@ -184,8 +184,8 @@ extension agtermApp {
                 Button { actions.reloadGhosttyConfig() } label: { Label("Reload Config", systemImage: "arrow.clockwise") }
             }
             // View: font zoom (on the focused terminal), the status-bar toggle, split / quick terminal /
-            // palettes. Every custom item needs an SF Symbol — the system "Enter Full Screen" item reserves
-            // an icon column, so an iconless one renders as a blank, indented slot.
+            // palettes. Every item needs an SF Symbol: one iconless item renders as a blank, indented slot
+            // beside the icon column its neighbours reserve.
             CommandGroup(after: .toolbar) {
                 // the File group's modal gate, mirrored.
                 let zoomed = actions.terminalZoomActive
@@ -287,12 +287,13 @@ extension agtermApp {
                 Button { actions.toggleTerminalZoom() } label: { Label("Toggle Terminal Zoom", systemImage: "arrow.up.left.and.arrow.down.right") }
                     .keyboardShortcut(shortcut(for: .toggleTerminalZoom))
                 Divider()
-                // native macOS full screen for the key window (⌃⌘F default, rebindable); a second invocation
-                // exits. the green traffic-light button drives the same NSWindow.toggleFullScreen.
-                Button { actions.toggleFullscreen() } label: {
-                    Label("Toggle Full Screen", systemImage: "arrow.up.left.and.arrow.down.right")
-                }
-                .keyboardShortcut(shortcut(for: .toggleFullscreen))
+                // NO full screen item: AppKit appends its own "Enter Full Screen" (`toggleFullScreen:`,
+                // Globe+F) below this menu whenever it is displayed, and nothing suppresses it — removal
+                // before the injection is undone and afterwards changes only the model, since the menu is
+                // already snapshotted for display; `NSFullScreenMenuItemEverywhere` is ignored on macOS 26;
+                // and adopting the selector on an item of our own does not stop it either. An item here is
+                // therefore a visible duplicate. The rebindable `toggle_fullscreen` chord is matched in
+                // `CustomCommandRunner` instead, and the action palette still offers Toggle Full Screen.
             }
             // a dedicated Navigate menu keeps the View menu scannable: selection/focus movement between
             // sessions and split panes lives here, driving the SAME AppActions the View menu does, with the

--- a/agtermTests/FullScreenChordTests.swift
+++ b/agtermTests/FullScreenChordTests.swift
@@ -15,6 +15,7 @@ final class FullScreenChordTests: XCTestCase {
     private var library: WindowLibrary!
     private var runner: CustomCommandRunner!
     private var window: RecordingWindow!
+    private var windowID: WindowInfo.ID!
 
     /// Records `toggleFullScreen` instead of performing it: the real call opens a Space and animates, which
     /// a unit test must not do to the machine running it.
@@ -38,12 +39,16 @@ final class FullScreenChordTests: XCTestCase {
                                      styleMask: [.titled, .closable], backing: .buffered, defer: false)
             window.isReleasedWhenClosed = false
             // the monitor fires only for an agterm terminal window, which the registry is what decides.
-            WindowRegistry.shared.register(UUID(), window: window)
+            // `WindowRegistry.shared` is process-global, so the id is retained for tearDown to unregister.
+            windowID = UUID()
+            WindowRegistry.shared.register(windowID, window: window)
         }
     }
 
     override func tearDown() async throws {
         await MainActor.run {
+            WindowRegistry.shared.unregister(windowID)
+            windowID = nil
             window.orderOut(nil)
             window = nil
             runner = nil
@@ -85,6 +90,28 @@ final class FullScreenChordTests: XCTestCase {
         XCTAssertTrue(window.makeFirstResponder(text), "the text view should take first responder")
         XCTAssertFalse(runner.handleKeyDown(controlCommandF, in: window))
         XCTAssertEqual(window.toggleCount, 0)
+    }
+
+    // The other side of the `!commandEngine.isArmed` guard: a half-typed leader outranks the built-in, so
+    // ctrl+a then ⌃⌘F must fire the custom command rather than toggle full screen. Seeded through a real
+    // keymap.conf in an isolated config directory, since the matcher is built from the parsed keymap.
+    func testHalfTypedLeaderOutranksTheFullScreenChord() throws {
+        let configDir = stateDir.appendingPathComponent("config", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        let marker = stateDir.appendingPathComponent("leader-fired")
+        try "command \"Leader\" ctrl+a>ctrl+cmd+f touch \(marker.path)\n"
+            .write(to: ConfigPaths.keymapPath(configDirectory: configDir), atomically: true, encoding: .utf8)
+        let settings = SettingsModel(library: library, settingsStore: SettingsStore(directory: stateDir))
+        settings.setConfigDirectory(configDir.path)
+        let leaderRunner = CustomCommandRunner(library: library, settings: settings, socketProvider: { "" })
+        leaderRunner.start()
+        defer { leaderRunner.stop() }
+
+        let leader = keyDown("a", keyCode: 0, mods: [.control])
+        XCTAssertTrue(leaderRunner.handleKeyDown(leader, in: window), "ctrl+a should arm the leader")
+        XCTAssertTrue(leaderRunner.handleKeyDown(controlCommandF, in: window),
+                      "the second chord completes the sequence and is consumed")
+        XCTAssertEqual(window.toggleCount, 0, "an armed leader must outrank the full screen chord")
     }
 
     func testKeyRepeatDoesNotToggleTwice() throws {

--- a/agtermTests/FullScreenChordTests.swift
+++ b/agtermTests/FullScreenChordTests.swift
@@ -1,0 +1,98 @@
+import AppKit
+import XCTest
+@testable import agterm
+import agtermCore
+
+/// Coverage for `toggle_fullscreen` riding `CustomCommandRunner`'s key monitor.
+///
+/// It is the one built-in with no SwiftUI menu item to carry its equivalent: AppKit appends the only full
+/// screen item there is as the View menu is prepared for display, and an item of agterm's own beside it is
+/// a visible duplicate that nothing suppresses. So the chord is matched in the monitor, which means it must
+/// also honour the monitor's guards — a text field keeps its keystrokes.
+@MainActor
+final class FullScreenChordTests: XCTestCase {
+    private var stateDir: URL!
+    private var library: WindowLibrary!
+    private var runner: CustomCommandRunner!
+    private var window: RecordingWindow!
+
+    /// Records `toggleFullScreen` instead of performing it: the real call opens a Space and animates, which
+    /// a unit test must not do to the machine running it.
+    private final class RecordingWindow: NSWindow {
+        var toggleCount = 0
+        override func toggleFullScreen(_ sender: Any?) { toggleCount += 1 }
+    }
+
+    override func setUp() async throws {
+        try await super.setUp()
+        await MainActor.run {
+            stateDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("agterm-fullscreen-chord-\(UUID().uuidString)", isDirectory: true)
+            library = WindowLibrary(directory: stateDir)
+            runner = CustomCommandRunner(library: library,
+                                         settings: SettingsModel(library: library,
+                                                                 settingsStore: SettingsStore(directory: stateDir)),
+                                         socketProvider: { "" })
+            // `NSWindow` defaults isReleasedWhenClosed to true; see the hosted-test rule in ui-tests.md.
+            window = RecordingWindow(contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+                                     styleMask: [.titled, .closable], backing: .buffered, defer: false)
+            window.isReleasedWhenClosed = false
+            // the monitor fires only for an agterm terminal window, which the registry is what decides.
+            WindowRegistry.shared.register(UUID(), window: window)
+        }
+    }
+
+    override func tearDown() async throws {
+        await MainActor.run {
+            window.orderOut(nil)
+            window = nil
+            runner = nil
+            library = nil
+            try? FileManager.default.removeItem(at: stateDir)
+            stateDir = nil
+        }
+        try await super.tearDown()
+    }
+
+    private func keyDown(_ key: String, keyCode: UInt16, mods: NSEvent.ModifierFlags) -> NSEvent {
+        NSEvent.keyEvent(with: .keyDown, location: .zero, modifierFlags: mods, timestamp: 0,
+                         windowNumber: window.windowNumber, context: nil,
+                         characters: key, charactersIgnoringModifiers: key, isARepeat: false, keyCode: keyCode)!
+    }
+
+    private var controlCommandF: NSEvent { keyDown("f", keyCode: 3, mods: [.control, .command]) }
+
+    func testShippedChordTogglesFullScreenAndIsConsumed() throws {
+        XCTAssertTrue(runner.handleKeyDown(controlCommandF, in: window), "the chord must be consumed, not passed to the terminal")
+        XCTAssertEqual(window.toggleCount, 1)
+    }
+
+    func testUnboundChordIsIgnored() throws {
+        XCTAssertFalse(runner.handleKeyDown(keyDown("g", keyCode: 5, mods: [.control, .command]), in: window))
+        XCTAssertEqual(window.toggleCount, 0)
+    }
+
+    func testBareKeyIsIgnored() throws {
+        XCTAssertFalse(runner.handleKeyDown(keyDown("f", keyCode: 3, mods: []), in: window),
+                       "an unmodified f is terminal input")
+        XCTAssertEqual(window.toggleCount, 0)
+    }
+
+    // the guard that keeps a rename field or the palette search usable: NSText first responder passes through.
+    func testFocusedTextFieldKeepsTheChord() throws {
+        let text = NSTextView(frame: NSRect(x: 0, y: 0, width: 200, height: 40))
+        window.contentView?.addSubview(text)
+        XCTAssertTrue(window.makeFirstResponder(text), "the text view should take first responder")
+        XCTAssertFalse(runner.handleKeyDown(controlCommandF, in: window))
+        XCTAssertEqual(window.toggleCount, 0)
+    }
+
+    func testKeyRepeatDoesNotToggleTwice() throws {
+        let repeated = NSEvent.keyEvent(with: .keyDown, location: .zero, modifierFlags: [.control, .command],
+                                        timestamp: 0, windowNumber: window.windowNumber, context: nil,
+                                        characters: "f", charactersIgnoringModifiers: "f",
+                                        isARepeat: true, keyCode: 3)!
+        XCTAssertFalse(runner.handleKeyDown(repeated, in: window), "a held-down chord toggles once, on the first press")
+        XCTAssertEqual(window.toggleCount, 0)
+    }
+}

--- a/agtermUITests/MenuUITests.swift
+++ b/agtermUITests/MenuUITests.swift
@@ -68,15 +68,18 @@ final class MenuUITests: XCTestCase {
         app.typeKey(.escape, modifierFlags: [])
     }
 
-    // AppKit auto-adds its own native "Enter Full Screen" item next to agterm's rebindable one, so
-    // AppDelegate strips it — the menu must carry agterm's item alone.
+    // AppKit's injected item must be the only one — agterm ships none, because nothing suppresses the
+    // injection. Match on TITLE, not by identifier: the subscript form never matched the injected item,
+    // which is why the assertion this replaces passed while the duplicate was on screen.
     func testViewMenuHasSingleFullScreenItem() throws {
         XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 20), "seeded session should exist")
         app.menuBars.menuBarItems["View"].click()
-        let toggle = app.menuItems["Toggle Full Screen"]
-        XCTAssertTrue(toggle.waitForExistence(timeout: 5), "View menu should offer agterm's Toggle Full Screen")
-        XCTAssertFalse(app.menuItems["Enter Full Screen"].exists,
-                       "AppKit's native Enter Full Screen item should be stripped so there's no duplicate")
+        XCTAssertTrue(app.menuItems["Toggle Terminal Zoom"].waitForExistence(timeout: 5), "View menu should be open")
+        // scoped to the View menu: the Window menu carries a system full screen item of its own.
+        let viewMenu = app.menuBars.menuBarItems["View"].menus.firstMatch
+        let fullScreen = viewMenu.menuItems.matching(NSPredicate(format: "title ENDSWITH %@", "Full Screen"))
+        let titles = fullScreen.allElementsBoundByIndex.map(\.title)
+        XCTAssertEqual(fullScreen.count, 1, "the View menu should carry one full screen item, got \(titles)")
         app.typeKey(.escape, modifierFlags: [])
     }
 

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -701,7 +701,7 @@ shell (no controlling terminal — `/dev/tty` errors). See examples.md for usage
   control-native, but `zoom` mirrors a GUI action.
 - `window fullscreen <id>` — toggle NATIVE macOS full screen (a separate Space, auto-hidden menu bar),
   via `NSWindow.toggleFullScreen`. A second call exits. The window must be open. This is the control half
-  of the View ▸ Toggle Full Screen menu item (⌃⌘F, rebindable as `toggle_fullscreen`) and the green
+  of ⌃⌘F (rebindable as `toggle_fullscreen`), View ▸ Enter/Exit Full Screen, and the green
   traffic-light button — distinct from `zoom`, which only maximizes the frame in the same Space.
 - `window minimize <id> [on|off|toggle]` — minimize the window to the Dock, or restore it, via
   `NSWindow.miniaturize`/`deminiaturize`. The mode resolves against the window's current state, so `on` and

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -966,9 +966,10 @@ end up holding a chord an action claims. If a keybinding "does not work" while `
 compare the two lists: find the action's `chord`, then look for that chord in `menu` and check which
 item carries it.
 
-One built-in is legitimately absent from `menu`: `undo_close` (⌘Z by default) is delivered by a key
-monitor, not a menu item, so native text undo keeps working in the rename, palette and Settings fields.
-Its missing menu entry is expected and not a fault.
+Two built-ins are legitimately absent from `menu`, both delivered by a key monitor rather than a menu
+item: `undo_close` (⌘Z by default), so native text undo keeps working in the rename, palette and Settings
+fields, and `toggle_fullscreen` (⌃⌘F by default), because agterm ships no full screen menu item — macOS
+adds its own, carrying `fn+f`. Their missing menu entries are expected and not a fault.
 
 Menu chords use the same vocabulary as the file (`cmd+opt+up`, `cmd+shift+return`), so the two lists
 compare as plain strings. One exception: the globe/fn modifier prints as `fn+`, which no `keymap.conf`

--- a/plugins/agterm/skills/agterm/troubleshooting.md
+++ b/plugins/agterm/skills/agterm/troubleshooting.md
@@ -19,8 +19,8 @@ You are inside agterm (`AGTERM_ENABLED=1`). Use:
   key equivalents the menu bar is actually dispatching. If the action's `chord` looks right but no `menu`
   entry carries it (or a different item does), the keymap is fine and the menu is the problem: SwiftUI
   rebuilds the menu only on the next app activation, so switch to another app and back, then relaunch if it
-  persists. Exception: `undo_close` (⌘Z) is delivered by a key monitor rather than a menu item, so it never
-  appears under `menu` and its absence there means nothing.
+  persists. Exceptions: `undo_close` (⌘Z) and `toggle_fullscreen` (⌃⌘F) are delivered by a key monitor
+  rather than a menu item, so they never appear under `menu` and their absence there means nothing.
 - **Ghostty settings** - `agtermctl config reload` re-reads the ghostty config and prints the diagnostic
   count (`0` = clean). The count covers every config source, not just `ghostty.conf` (libghostty does not
   record which file a diagnostic came from), so check the Console log for the offending line. `ghostty.conf`

--- a/site/commands.html
+++ b/site/commands.html
@@ -1772,7 +1772,7 @@
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">window.fullscreen</div>
               <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
                 Toggle native macOS full screen — a separate Space with an auto-hidden menu bar. A second call exits. The window must
-                be open. The control half of View ▸ Toggle Full Screen (⌃⌘F) and the green traffic-light button; distinct from
+                be open. The control half of ⌃⌘F, View ▸ Enter/Exit Full Screen, and the green traffic-light button; distinct from
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">zoom</span>. Read back via
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">window list</span>'s
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">fullscreen</span>.

--- a/site/docs.html
+++ b/site/docs.html
@@ -1867,6 +1867,15 @@
             >
               new_window&nbsp;&nbsp;&nbsp;rename_window&nbsp;&nbsp;&nbsp;delete_window<br />new_workspace&nbsp;&nbsp;&nbsp;rename_workspace&nbsp;&nbsp;&nbsp;delete_workspace<br />new_session&nbsp;&nbsp;&nbsp;open_directory&nbsp;&nbsp;&nbsp;rename_session&nbsp;&nbsp;&nbsp;duplicate_session<br />close_session&nbsp;&nbsp;&nbsp;reopen_recent&nbsp;&nbsp;&nbsp;undo_close&nbsp;&nbsp;&nbsp;clear_status<br />increase_font_size&nbsp;&nbsp;&nbsp;decrease_font_size&nbsp;&nbsp;&nbsp;reset_font_size<br />toggle_split&nbsp;&nbsp;&nbsp;toggle_scratch&nbsp;&nbsp;&nbsp;toggle_search<br />toggle_sidebar&nbsp;&nbsp;&nbsp;toggle_flag&nbsp;&nbsp;&nbsp;toggle_flagged_view<br />focus_left_pane&nbsp;&nbsp;&nbsp;focus_right_pane&nbsp;&nbsp;&nbsp;focus_workspace&nbsp;&nbsp;&nbsp;toggle_workspace_filter<br />previous_session&nbsp;&nbsp;&nbsp;next_session&nbsp;&nbsp;&nbsp;first_session&nbsp;&nbsp;&nbsp;last_session<br />previous_attention_session&nbsp;&nbsp;&nbsp;next_attention_session<br />quick_terminal&nbsp;&nbsp;&nbsp;session_palette&nbsp;&nbsp;&nbsp;command_palette<br />custom_command_palette&nbsp;&nbsp;&nbsp;show_attention<br />select_theme&nbsp;&nbsp;&nbsp;toggle_fullscreen&nbsp;&nbsp;&nbsp;toggle_terminal_zoom<br />dashboard
             </div>
+            <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">toggle_fullscreen</span> is the one
+              action with no menu item of its own. macOS adds an "Enter Full Screen" item to the View menu whenever that menu is
+              drawn, and nothing suppresses it, so an item of agterm's own would sit beside it as a duplicate. The binding (⌃⌘F by
+              default) is handled directly instead, which is why the menu entry advertises the system's Globe+F rather than your
+              chord. Both work, and rebinding
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">toggle_fullscreen</span> changes the
+              chord as usual — it just won't show up next to that menu item.
+            </p>
 
             <h3
               style="

--- a/site/docs.html
+++ b/site/docs.html
@@ -1983,9 +1983,10 @@
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl keymap list</span> prints every
               built-in with the chord it resolved to, the custom commands, each diagnostic in full, and the key equivalents the menu
               bar is really carrying. If a binding will not fire, compare the last two: an action whose chord no menu item holds is
-              usually a menu problem, not a keymap one. The one deliberate exception is
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">undo_close</span> (⌘Z), delivered by a
-              key monitor rather than a menu item, so it never appears in the menu list.
+              usually a menu problem, not a keymap one. Two deliberate exceptions never appear in the menu list, because a key
+              monitor delivers them rather than a menu item:
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">undo_close</span> (⌘Z) and
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">toggle_fullscreen</span> (⌃⌘F).
             </p>
             <h3
               style="


### PR DESCRIPTION
the View menu showed two full screen items: agterm's own "Toggle Full Screen" and AppKit's "Enter Full Screen" right below it. Both also carried the same icon as Toggle Terminal Zoom.

AppKit appends its item as the View menu is prepared for display, and nothing stops it. Four mechanisms were tried and measured on macOS 26.5, all fail:

- stripping the injected item on `NSMenu.didBeginTrackingNotification` - that fires before the injection. This is what the code did before, and it never worked; the test that pinned it matched by AX identifier, which never matches the injected item, so it passed while the duplicate was on screen
- stripping it one runloop turn later - too late. The displayed menu is already snapshotted, so the item leaves the model and stays on the pixels
- registering `NSFullScreenMenuItemEverywhere` false, the documented opt-out - ignored on macOS 26. Verified with the default registered and the item injected anyway
- giving agterm's own item the `toggleFullScreen:` selector so AppKit finds an equivalent - it injects past that too

so agterm now ships no full screen menu item and AppKit's is the only one. `toggle_fullscreen` keeps its rebindable ⌃⌘F by matching in `CustomCommandRunner`'s existing key monitor, behind the same text-field and window guards custom commands use. A half-typed leader still outranks it. The palette entry and `window.fullscreen` are untouched, and Globe+F works because the item is the system's own.

the visible trade: the menu entry reads "Enter/Exit Full Screen" and advertises Globe+F rather than your chord, since the shortcut no longer lives on that item. Documented in README and the site mirror.

second commit is a revmux review sweep: a test for the leader-sequence side of the new guard, an unregister for a window the test leaked into the process-global `WindowRegistry`, and the doc surfaces the removal made stale - `windows.md` was asserting both that the menu item exists and that it does not, and five places still named `undo_close` as the only action no menu item carries.
