### PR TITLE
fix: animate the workspace row-click expand/collapse

### DIFF
--- a/.claude/rules/sidebar.md
+++ b/.claude/rules/sidebar.md
@@ -43,7 +43,10 @@ paths:
   toggle. This click routing is keep-in-sync exempt. `GhosttyApp.workspaceRowClickExpands` (default on)
   gates the whole-row target only; the disclosure triangle toggles natively and stays unconditional.
   The deferred item re-reads that mirror when it fires, so turning the setting off inside the deferral
-  window cancels the pending toggle. Control expansion instead persists through
+  window cancels the pending toggle. Route the row-click toggle through `outline.animator()` so it animates
+  like the triangle; a bare `expandItem`/`collapseItem` silently drops the animation. Do not gate that on
+  Reduce Motion — both hit targets reach the same AppKit animation, so a gate would re-split them. Every
+  other expand/collapse site stays unanimated: bulk or programmatic. Control expansion instead persists through
   `AppActions.setWorkspaceExpanded`, then posts `.agtermSetWorkspaceExpanded` to synchronize a live outline.
 - A session-row click selects, then asynchronously calls `revealActiveBlockedPane` with the captured
   pre-reset indicator. Blocked/completed pane tags reveal split, scratch, or primary; idle and active use

--- a/agterm/Views/WorkspaceSidebar+ContextMenu.swift
+++ b/agterm/Views/WorkspaceSidebar+ContextMenu.swift
@@ -48,9 +48,8 @@ extension WorkspaceSidebar.Coordinator {
     }
 
     /// Animated to match the disclosure triangle; `.claude/rules/sidebar.md` owns why, why it is not gated on
-    /// Reduce Motion, and which sites stay unanimated. The proxy flips expansion and fires
-    /// didExpand/didCollapse synchronously, so the persist write-back is unaffected and the
-    /// `suppressExpansionPersist` bracketing the other sites wrap their calls in still holds.
+    /// Reduce Motion, and which sites stay unanimated. The proxy fires didExpand/didCollapse synchronously, so
+    /// the persist write-back still runs and the other sites' `suppressExpansionPersist` brackets still hold.
     private func toggleExpansion(of node: SidebarNode, in outline: NSOutlineView) {
         let proxy = outline.animator()
         if outline.isItemExpanded(node) { proxy.collapseItem(node) } else { proxy.expandItem(node) }

--- a/agterm/Views/WorkspaceSidebar+ContextMenu.swift
+++ b/agterm/Views/WorkspaceSidebar+ContextMenu.swift
@@ -47,8 +47,14 @@ extension WorkspaceSidebar.Coordinator {
         renameController.beginEditing(node: node)
     }
 
+    /// Animated to match the disclosure triangle, which toggles the same row through AppKit's own animation —
+    /// two hit targets for one action must not render differently. Deliberately NOT gated on Reduce Motion
+    /// like the app's own pulses: both paths reach the same AppKit animation, so gating here would restore
+    /// the divergence. The proxy still flips expansion and fires didExpand/didCollapse synchronously, so the
+    /// persist write-back is unaffected. Every other call site stays unanimated — bulk or programmatic.
     private func toggleExpansion(of node: SidebarNode, in outline: NSOutlineView) {
-        if outline.isItemExpanded(node) { outline.collapseItem(node) } else { outline.expandItem(node) }
+        let proxy = outline.animator()
+        if outline.isItemExpanded(node) { proxy.collapseItem(node) } else { proxy.expandItem(node) }
     }
 
     /// Builds the per-row context menu, resolving the clicked row lazily so one menu serves every row.

--- a/agterm/Views/WorkspaceSidebar+ContextMenu.swift
+++ b/agterm/Views/WorkspaceSidebar+ContextMenu.swift
@@ -47,11 +47,10 @@ extension WorkspaceSidebar.Coordinator {
         renameController.beginEditing(node: node)
     }
 
-    /// Animated to match the disclosure triangle, which toggles the same row through AppKit's own animation —
-    /// two hit targets for one action must not render differently. Deliberately NOT gated on Reduce Motion
-    /// like the app's own pulses: both paths reach the same AppKit animation, so gating here would restore
-    /// the divergence. The proxy still flips expansion and fires didExpand/didCollapse synchronously, so the
-    /// persist write-back is unaffected. Every other call site stays unanimated — bulk or programmatic.
+    /// Animated to match the disclosure triangle; `.claude/rules/sidebar.md` owns why, why it is not gated on
+    /// Reduce Motion, and which sites stay unanimated. The proxy flips expansion and fires
+    /// didExpand/didCollapse synchronously, so the persist write-back is unaffected and the
+    /// `suppressExpansionPersist` bracketing the other sites wrap their calls in still holds.
     private func toggleExpansion(of node: SidebarNode, in outline: NSOutlineView) {
         let proxy = outline.animator()
         if outline.isItemExpanded(node) { proxy.collapseItem(node) } else { proxy.expandItem(node) }

--- a/docs/backlog/workspace-row-toggle-deferral-drops-clicks.md
+++ b/docs/backlog/workspace-row-toggle-deferral-drops-clicks.md
@@ -1,0 +1,33 @@
+---
+worth: later
+where: agterm/Views/WorkspaceSidebar+ContextMenu.swift:15
+added: 2026-08-09
+---
+# the deferred workspace-row toggle drops one click and fires another under the wrong row
+
+`handleSingleClick` parks the toggle in a single `pendingRowToggle` slot for `NSEvent.doubleClickInterval`
+so a rename double-click can cancel it. Two consequences fall out of the guard ordering, both reachable
+with ordinary clicking:
+
+- **A click on a second workspace row eats the first.** The `pendingRowToggle?.cancel()` at line 28 is
+  unconditional and the slot holds one item, so clicking workspace A's row and then workspace B's inside
+  the interval cancels A and toggles only B. A's click is gone with nothing on screen to say so.
+- **A session-row click does not disarm a pending workspace toggle.** The guard at lines 17-18 returns for
+  `node.kind == .session` before reaching that cancel, so clicking workspace A and then a session in
+  another workspace selects the session immediately and then, a beat later, expands A underneath it and
+  shifts every row below.
+
+Both are worse than they look because a workspace row is not selectable
+(`WorkspaceSidebar+RowRendering.swift:14-17` returns `shouldSelectItem` only for sessions), so the whole
+deferral window carries no feedback at all - no pill, no press state, no disclosure movement. The click
+reads as dropped either way.
+
+Not fixed alongside #407's animation because the fix is a behavior decision, not a rendering one. #407
+itself names the two candidates for the delay - toggle optimistically and reverse on a double-click, or
+move workspace rename off double-click - and either would settle these two as a side effect, while
+patching them in isolation (per-node pending toggles, or hoisting the cancel above the guards) preserves
+a half-second of silent latency that is itself the complaint.
+
+Worth weighing that workspace rename already has five other entry points - the row context menu, the
+Workspace menu, the `rename_workspace` built-in, the command palette, and `workspace.rename` - so the
+deferral protects a sixth path to something already well covered.

--- a/docs/backlog/workspace-row-toggle-deferral-drops-clicks.md
+++ b/docs/backlog/workspace-row-toggle-deferral-drops-clicks.md
@@ -18,7 +18,7 @@ with ordinary clicking:
   shifts every row below.
 
 Both are worse than they look because a workspace row is not selectable
-(`WorkspaceSidebar+RowRendering.swift:14-17` returns `shouldSelectItem` only for sessions), so the whole
+(`WorkspaceSidebar+RowRendering.swift:15-18` returns `shouldSelectItem` only for sessions), so the whole
 deferral window carries no feedback at all - no pill, no press state, no disclosure movement. The click
 reads as dropped either way.
 
@@ -28,6 +28,6 @@ move workspace rename off double-click - and either would settle these two as a 
 patching them in isolation (per-node pending toggles, or hoisting the cancel above the guards) preserves
 a half-second of silent latency that is itself the complaint.
 
-Worth weighing that workspace rename already has five other entry points - the row context menu, the
-Workspace menu, the `rename_workspace` built-in, the command palette, and `workspace.rename` - so the
-deferral protects a sixth path to something already well covered.
+Worth weighing that workspace rename already has five other entry points - the row context menu, the File
+menu's Workspace section, the `rename_workspace` built-in, the command palette, and `workspace.rename` -
+so the deferral protects a sixth path to something already well covered.

--- a/docs/backlog/workspace-row-toggle-deferral-drops-clicks.md
+++ b/docs/backlog/workspace-row-toggle-deferral-drops-clicks.md
@@ -22,6 +22,13 @@ Both are worse than they look because a workspace row is not selectable
 deferral window carries no feedback at all - no pill, no press state, no disclosure movement. The click
 reads as dropped either way.
 
+Three approaches were weighed and none taken: drop double-click rename on workspace rows (rejected -
+double-click rename is the discoverable path and the macOS convention, whatever the other entry points);
+toggle optimistically and invert on double-click (rejected - trades a dead pause for a visible flicker on
+rename); and keep the deferral but add press feedback (rejected - a custom-drawn disclosure triangle or a
+transient row pill is too much machinery for the size of the defect). Revisit only if the delay starts
+costing more than it looks like it does.
+
 Not fixed alongside #407's animation because the fix is a behavior decision, not a rendering one. #407
 itself names the two candidates for the delay - toggle optimistically and reverse on a double-click, or
 move workspace rename off double-click - and either would settle these two as a side effect, while


### PR DESCRIPTION
a workspace row has two hit targets for one toggle and they rendered differently. The disclosure triangle goes through AppKit's native path and animates; clicking anywhere else on the row called `expandItem`/`collapseItem` directly, which do not animate, so the sessions just appeared and disappeared.

routing the row-click toggle through `outline.animator()` makes both paths render the same.

the animator proxy is not documented for expand/collapse, so I checked it before committing:

- it does animate. Row frames are mid-flight right after the call, settling to their final positions ~0.25s later, with a live CA animation on the parent row. The plain call jumps straight to the end state.
- `outlineViewItemDidExpand`/`DidCollapse` still fire synchronously and `isItemExpanded`/`numberOfRows` update immediately, which is what keeps the `suppressExpansionPersist` bracketing at the other call sites intact. `testWorkspaceCollapsePersistsAcrossRelaunch` and `testActiveWorkspaceCollapsePersistsDespiteReveal` both collapse from a row click and assert the state reaches disk, so that leg is pinned.

no Reduce Motion gate here, unlike the app's own pulses. Both hit targets reach the same AppKit animation, so gating this one would split them again.

scope is the row-click path only. The other expand/collapse sites stay unanimated, being either bulk (Expand/Collapse Workspaces, rebuild re-apply) or programmatic (selection reveal, drag spring-load).

**what this does not fix**: the row click still waits out `NSEvent.doubleClickInterval` before toggling, so it reads as a pause and then motion. Getting rid of that means dropping double-click rename on workspace rows, or toggling optimistically and inverting on a double-click, or adding press feedback during the wait. None of the three is worth its cost for a defect this size, so the delay stays.

it is written up in `docs/backlog/workspace-row-toggle-deferral-drops-clicks.md` with the rejected approaches, along with two real defects in the same deferral: a second workspace-row click inside the interval cancels the first one's pending toggle, and a session-row click returns before the cancel so a pending workspace toggle still fires under it.

Fix #407
