### PR TITLE
fix: highlight the palette row under the pointer

### DIFF
--- a/agterm/Views/Palette.swift
+++ b/agterm/Views/Palette.swift
@@ -335,6 +335,17 @@ private struct PaletteRow: View {
     let item: PaletteItem
     let isSelected: Bool
     let metrics: InterfaceMetrics
+    @State private var hovering = false
+
+    /// A neutral wash rather than a weaker accent: hover and the accent-tinted selection can sit on different
+    /// rows at once, so the same hue at two strengths would read as a second selection. It also has to hold up
+    /// over both panel backings, `.regularMaterial` and the opaque Reduce Transparency one.
+    private static let hoverTint = Color.primary.opacity(0.04)
+
+    private var rowTint: Color {
+        if isSelected { return Color.accentColor.opacity(0.25) }
+        return hovering ? Self.hoverTint : .clear
+    }
 
     var body: some View {
         HStack {
@@ -370,8 +381,9 @@ private struct PaletteRow: View {
         .padding(.horizontal, metrics.scaled(12))
         .padding(.vertical, metrics.scaled(6))
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(isSelected ? Color.accentColor.opacity(0.25) : Color.clear)
+        .background(rowTint)
         .contentShape(Rectangle())
+        .onHover { hovering = $0 }
         .accessibilityIdentifier("palette-item-\(item.id)")
     }
 }


### PR DESCRIPTION
palette rows have been full-width click targets since they were built, but nothing painted under the pointer. Only the keyboard-selected row was tinted, so there was no way to tell what a click would run until you clicked it.

the title-bar popover rows already highlight on hover through `SessionPopoverRow`, and README documents that behavior, so the palette was the one clickable list in the app with no pointer feedback. The Ctrl-Tab switcher is the opposite case and stays as it is: same accent selection, no hover, and its rows are not clickable.

**what changed**

- `PaletteRow` gets its own `@State hovering` and `.onHover`, so the diffing boundary the struct exists for is unchanged.
- hover paints a neutral wash, `Color.primary.opacity(0.04)`, not a weaker accent. Hover and the accent-tinted selection can sit on different rows at once, so the same hue at two strengths would read as a second selection. It also has to hold up over both panel backings, `.regularMaterial` and the opaque Reduce Transparency one.
- selection wins on the row that has it, so the two never stack.
- hover is visual only. It does not move the keyboard cursor, which would fire `onSelect` and thrash the theme palette's live preview on every mouse move across the list.

covers the action, session, theme, attention and control-API `pick` palettes, since they all render through `PaletteRow`.

**not included**

the issue also lists sidebar row tinting and the eight `.plain`/`.borderless` buttons. Left alone here, per the reporter's own offer to split them.

**testing**

no automated test. Hover is private view state painting a background color, so there is no host-free surface and XCUITest cannot assert it. Same as `SessionPopoverRow`, which has no hover test either. Verified by running it, plus `ControlPickUITests` row click and `PaletteUITests` arrow navigation to confirm the hit target and AX tree are unchanged.

Fix #408
