### PR TITLE
fix(palette): clip the panel to its own rounded corners

### DIFF
--- a/agterm/Views/Palette.swift
+++ b/agterm/Views/Palette.swift
@@ -240,6 +240,10 @@ struct CommandPalette: View {
             results
         }
         .background { PalettePanelBackground() }
+        // the rounded background is drawn, not enforced: a selected or hovered bottom row fills its full
+        // square bounds and paints over the corner arc without this. the clip stays above `.shadow`, which
+        // would otherwise be clipped away with everything else outside the shape.
+        .clipShape(RoundedRectangle(cornerRadius: 12))
         .overlay(RoundedRectangle(cornerRadius: 12).strokeBorder(.white.opacity(0.1)))
         .shadow(radius: 24)
         .accessibilityIdentifier(explicitItems == nil ? "command-palette" : "pick-palette")


### PR DESCRIPTION
the palette panel drew a `RoundedRectangle(cornerRadius: 12)` background and a radius-12 stroked overlay but never clipped to either, so a selected row was free to fill its full square bounds. When the selection sat on the bottom row, `Color.accentColor.opacity(0.25)` painted straight over the corner arc and squared it off.

`results` is the panel VStack's last child with no bottom padding, and its `.frame(maxHeight:)` always fills, so the scroll bottom edge is the panel bottom edge. The `pick` free-text path shows it every time: when nothing matches, `filtered` becomes one synthetic row that is always both selected and last.

fix is the chain the rest of the app already uses - background, clip, stroke, shadow - as at `WindowContentView.swift:568`, `WindowContentView+Detail.swift:218` and `DashboardView.swift:128`. `Palette.swift` was that chain with the clip line missing. It covers both mount points, the command palette and caller-supplied pickers, and any future filled content that reaches a corner.

Rounding the row background instead would not fix it. A radius-6 row corner still sits outside a radius-12 panel arc unless the panel also gains padding, which is what `SessionSwitcher` does with its 6pt inset - a different look, not a fix for this.

one accepted side effect: the overlay scroller's bottom tip is now shaved by the corner radius. That is what clipping does.

not verified visually - SwiftUI views do not render in hosted tests and there are no snapshot tests, so this rests on the modifier chain and the three sites it copies. Worth an eyeball on key-repeat scrolling under translucency, since `Palette.swift:281-283` records an earlier compositing flash in this view (its cause, an animated center-anchored `scrollTo`, was removed).

Fix #409
