### PR TITLE
fix: sessions created while the display is asleep never start

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -203,6 +203,10 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   scratch addresses that pane, including hidden scratch. Default reads viewport; `--all` includes
   scrollback; `--lines N` returns last content lines after trimming blank grid rows. All and lines are
   exclusive; N must be positive and dispatcher-validated. Blank returns empty success; API failure errors.
+  An UNREALIZED pane answers `session not realized`, not `failed to read surface buffer`, whether its slot
+  is empty or holds a view whose libghostty surface never came up — one state to a caller, and the reading
+  never happened. `failed to read surface buffer` is left to a real read failure on a realized surface.
+  `quick.text` keeps its own vocabulary and still reports that string for an unrealized quick surface.
   Output is plain text because pinned Ghostty exposes no styled-cell read.
 - `session.search` selects and realizes the target, then searches its focused surface. Text opens/updates;
   to next/prev navigates; close ends; no arguments opens empty UI. Poll async SEARCH_TOTAL and return count

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -457,7 +457,15 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
 ## Tree and window read-back
 
 - Session nodes include foreground/split foreground argv, background spec, overlay size, pane overlays,
-  split ratio, split focus, status fields, flag, unseen, restore pins, and surfaces. Foreground shares the
+  split ratio, split focus, status fields, flag, unseen, restore pins, surfaces, and `realized`.
+- `realized` reports the MAIN pane's `TerminalSurface.isRealized`, populated host-free in
+  `AppStore.controlTree` (no app closure — `isRealized` is on the protocol) and false for an empty slot, so
+  only a server predating the field omits it. It exists because `session.new` answers `ok` for a model
+  insert while libghostty refuses to create a surface with the display asleep, leaving a scheduled job's
+  session unrealized until the displays wake (#416). It is the main pane because that is what `--command`
+  spawns on and what `session.type`/`session.text` address by default; per-pane liveness stays with the
+  `fontSize`/`splitFontSize`/`scratchFontSize` triple, so do not add a second per-pane spelling.
+  `agtermctl tree` tags the row `(not realized)`, beside `(split hidden)`. Foreground shares the
   restore capture's pid/sysctl/host-free extraction but adds one step the capture must never take.
   libghostty's foreground pid is `tcgetpgrp`, a process GROUP id, and a pane with no job-control shell
   leaves its program in the group led by setuid-root `login`, whose argv `KERN_PROCARGS2` refuses. The tree

--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -72,7 +72,9 @@ paths:
   a session a scheduled job creates overnight realized no surface and never ran its `--command`, while
   `session.new` had already answered `ok` (#416). `SystemWakeObserver` posts `.agtermScreensDidWake` and
   `GhosttySurfaceView.retryCreationAfterWake` re-attempts, bounded, because creation can still fail for a
-  second or two after the notification.
+  second or two after the notification. A failed create also re-arms `pendingSurfaceCreation`, so the
+  layout path retries as well: the wake hook makes recovery TIMELY, not possible, and a view first
+  mounted inside that residual window registered its observer too late for the wake that just fired.
 - `working_directory`, `initial_input`, and environment strdup buffers must outlive
   `ghostty_surface_new`; retain them until destruction.
 - Reparenting invalidates the drawable while leaving terminal buffer intact. `set_size` with an unchanged

--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -64,6 +64,15 @@ paths:
   nil every store-capturing callback to break the store/session/surface/closure cycle.
 - Create surfaces only with nonzero backing size; otherwise Metal stays blank. Defer through
   `pendingSurfaceCreation` until `setFrameSize`.
+- `ghostty_surface_new` returns NULL for as long as the DISPLAY is asleep, with a valid backing size —
+  measured 21 consecutive failures over 40s, then success within ~2s of wake while the screen was still
+  LOCKED. Unlock is irrelevant; display wake is the earliest moment creation can succeed, so retrying
+  during sleep is pure spin. Nothing in the deck re-attempts on its own: every other retry path rides
+  SwiftUI layout, which does not run for an off-display window, so `updateNSView` never fires. That is why
+  a session a scheduled job creates overnight realized no surface and never ran its `--command`, while
+  `session.new` had already answered `ok` (#416). `SystemWakeObserver` posts `.agtermScreensDidWake` and
+  `GhosttySurfaceView.retryCreationAfterWake` re-attempts, bounded, because creation can still fail for a
+  second or two after the notification.
 - `working_directory`, `initial_input`, and environment strdup buffers must outlive
   `ghostty_surface_new`; retain them until destruction.
 - Reparenting invalidates the drawable while leaving terminal buffer intact. `set_size` with an unchanged

--- a/agterm/Control/ControlServer+SurfaceIO.swift
+++ b/agterm/Control/ControlServer+SurfaceIO.swift
@@ -172,6 +172,14 @@ extension ControlServer {
             guard let surface = chosen as? GhosttySurfaceView else {
                 return ControlResponse(ok: false, error: "session not realized")
             }
+            // a view parked in the slot whose libghostty surface never came up is UNREALIZED, not a failed
+            // read — the deck installs the view before `createSurface`, and creation is refused outright
+            // while the display sleeps (#416). Without this the same state answered `failed to read surface
+            // buffer` here and `session not realized` from every other command, naming a cause that did not
+            // happen: nothing failed to read, there was nothing to read from.
+            guard surface.isRealized else {
+                return ControlResponse(ok: false, error: "session not realized")
+            }
             guard let text = surface.readScreenText(all: all, lines: lines) else {
                 return ControlResponse(ok: false, error: "failed to read surface buffer")
             }

--- a/agterm/Ghostty/GhosttyApp.swift
+++ b/agterm/Ghostty/GhosttyApp.swift
@@ -629,6 +629,13 @@ extension Notification.Name {
     static let agtermAccessibilityDisplayOptionsChanged =
         Notification.Name("agterm.accessibilityDisplayOptionsChanged")
 
+    /// Posted by `SystemWakeObserver` when the displays wake. `ghostty_surface_new` returns NULL while the
+    /// display is asleep, and `createSurface` clears `pendingSurfaceCreation` before it attempts, so a session
+    /// created in that window realizes no surface and nothing retries it — the `--command` never runs and every
+    /// later call reports `session not realized` (#416). Surfaces re-attempt creation here; an already-realized
+    /// one re-pushes its size to force a repaint, the drawable being invalidated by sleep like a reparent.
+    static let agtermScreensDidWake = Notification.Name("agterm.screensDidWake")
+
     /// Posted when a window becomes frontmost (async, via the window's didBecomeKey), so the control server can
     /// refresh its cached `window.list` — its `active` flag would otherwise stay stale until the next command.
     static let agtermWindowFrontmostChanged = Notification.Name("agterm.windowFrontmostChanged")

--- a/agterm/Ghostty/GhosttyApp.swift
+++ b/agterm/Ghostty/GhosttyApp.swift
@@ -630,10 +630,10 @@ extension Notification.Name {
         Notification.Name("agterm.accessibilityDisplayOptionsChanged")
 
     /// Posted by `SystemWakeObserver` when the displays wake. `ghostty_surface_new` returns NULL while the
-    /// display is asleep, and `createSurface` clears `pendingSurfaceCreation` before it attempts, so a session
-    /// created in that window realizes no surface and nothing retries it — the `--command` never runs and every
-    /// later call reports `session not realized` (#416). Surfaces re-attempt creation here; an already-realized
-    /// one re-pushes its size to force a repaint, the drawable being invalidated by sleep like a reparent.
+    /// display is asleep, so a session created in that window realizes no surface — the `--command` never runs
+    /// and every later call reports `session not realized` (#416). Nothing re-attempts on a schedule, because
+    /// the deck's retries all ride SwiftUI layout, which does not run for an off-display window. UNREALIZED
+    /// surfaces re-attempt creation here; a realized one is left alone.
     static let agtermScreensDidWake = Notification.Name("agterm.screensDidWake")
 
     /// Posted when a window becomes frontmost (async, via the window's didBecomeKey), so the control server can

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -599,9 +599,12 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         }
         guard let surface else {
             // libghostty declines to build a surface while the display is asleep. Silence here is what made
-            // #416 undiagnosable from outside: `session.new` had already answered ok. `.agtermScreensDidWake`
-            // drives the re-attempt; nothing else will, so a lost wake means a permanently empty pane.
-            logger.notice("surface creation failed (display asleep?); retrying when the displays wake")
+            // #416 undiagnosable from outside: `session.new` had already answered ok. Re-arm the deferred-create
+            // flag so the layout path retries too — `.agtermScreensDidWake` is what makes recovery TIMELY, not
+            // what makes it possible, and a view first mounted inside the residual post-wake window registers
+            // its observer too late for the wake that just fired.
+            pendingSurfaceCreation = true
+            logger.notice("surface creation failed (display asleep?); retrying on the next wake or layout pass")
             return
         }
         // record the same scheme on the surface itself, so a later `update_config` re-resolves its side.

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -3,7 +3,10 @@
 import agtermCore
 import AppKit
 import GhosttyKit
+import os
 import QuartzCore
+
+private let logger = Logger(subsystem: "com.umputun.agterm", category: "GhosttySurfaceView")
 
 /// A Metal-backed NSView hosting one libghostty surface (one shell). Conforms to `TerminalSurface` so the
 /// host-free `Session` can own it without importing GhosttyKit/AppKit.
@@ -318,6 +321,34 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         setupTrackingArea()
         observeKeyWindowChanges()
         observeWindowVisibilityChanges()
+        observeDisplayWake()
+    }
+
+    /// Re-attempt creation when the displays wake. `ghostty_surface_new` returns NULL for as long as the
+    /// display is asleep, and the deck's own retries all ride SwiftUI layout, which does not run for an
+    /// off-display window — so a session a scheduled job created in that window stays dead with its
+    /// `--command` unrun until something incidental re-lays it out (#416). `object: nil` and a token in
+    /// `focusObservers` match the sibling observers, including their `NotificationCenter.default` teardown.
+    private func observeDisplayWake() {
+        let token = NotificationCenter.default.addObserver(
+            forName: .agtermScreensDidWake, object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.retryCreationAfterWake() }
+        }
+        focusObservers.append(token)
+    }
+
+    /// Bounded re-attempts after a display wake: creation was measured still failing for a second or two
+    /// past `screensDidWake`, so one shot at the notification is not enough, and an unbounded retry would
+    /// spin forever against a surface that fails for some other reason. A realized surface costs nothing —
+    /// the first guard returns immediately.
+    private func retryCreationAfterWake(attempt: Int = 1) {
+        guard !isDestroyed, surface == nil else { return }
+        createSurface()
+        guard surface == nil, attempt < 10 else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+            self?.retryCreationAfterWake(attempt: attempt + 1)
+        }
     }
 
     /// Watch every window's key transitions and re-evaluate focus on each. No filtering to my own window:
@@ -566,8 +597,13 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
                 return ghostty_surface_new(app, &config)
             }
         }
-        guard let surface else { return }
-
+        guard let surface else {
+            // libghostty declines to build a surface while the display is asleep. Silence here is what made
+            // #416 undiagnosable from outside: `session.new` had already answered ok. `.agtermScreensDidWake`
+            // drives the re-attempt; nothing else will, so a lost wake means a permanently empty pane.
+            logger.notice("surface creation failed (display asleep?); retrying when the displays wake")
+            return
+        }
         // record the same scheme on the surface itself, so a later `update_config` re-resolves its side.
         ghostty_surface_set_color_scheme(surface, isDark ? GHOSTTY_COLOR_SCHEME_DARK : GHOSTTY_COLOR_SCHEME_LIGHT)
 

--- a/agterm/SystemWakeObserver.swift
+++ b/agterm/SystemWakeObserver.swift
@@ -1,0 +1,41 @@
+import AppKit
+import Foundation
+
+/// Bridges the macOS display-wake notification into agterm's app-local notification center, the way
+/// `SystemAccessibilityObserver` bridges accessibility changes: AppKit posts it on
+/// `NSWorkspace.notificationCenter`, not the default center surfaces observe.
+///
+/// Why any of this exists: `ghostty_surface_new` returns NULL for the whole time the display is asleep
+/// (measured: 21 consecutive failures over 40s), so a session created by a scheduled job in that window
+/// realizes no surface and its `--command` never runs. Nothing retries, because SwiftUI runs no layout for
+/// an off-display window — `updateNSView` never fires — so the pane stays dead long after the machine is
+/// usable again (#416). Creation starts succeeding the instant the displays wake, with the screen still
+/// LOCKED, so wake is the earliest correct moment to re-attempt and no unlock hook is needed.
+@MainActor
+final class SystemWakeObserver {
+    private var wakeObserver: NSObjectProtocol?
+
+    /// Register once for the process — the scene `.task` runs for every window, so this must be idempotent
+    /// like `SystemAccessibilityObserver.start()`.
+    func start() {
+        guard wakeObserver == nil else { return }
+        let workspace = NSWorkspace.shared
+        wakeObserver = workspace.notificationCenter.addObserver(
+            forName: NSWorkspace.screensDidWakeNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            // NotificationCenter's callback is @Sendable even on a main queue; hop explicitly to stay correct
+            // under Swift 6 isolation, matching SystemAccessibilityObserver's convention.
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(name: .agtermScreensDidWake, object: nil)
+            }
+        }
+    }
+
+    isolated deinit {
+        if let wakeObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(wakeObserver)
+        }
+    }
+}

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -20,6 +20,7 @@ struct agtermApp: App {
     @State private var customCommandRunner: CustomCommandRunner
     @State private var appearanceObserver: SystemAppearanceObserver
     @State private var accessibilityObserver: SystemAccessibilityObserver
+    @State private var wakeObserver: SystemWakeObserver
 
     /// Whether this launch owes the user the first-run welcome. Decided in `init()`, because the first
     /// launch writes its own window snapshot moments after the scene appears and that write would read back
@@ -70,6 +71,9 @@ struct agtermApp: App {
         // follows Reduce Motion / Reduce Transparency via NSWorkspace's accessibility-display notification,
         // fanning live changes to AppKit consumers; SwiftUI ones use Environment.
         _accessibilityObserver = State(initialValue: SystemAccessibilityObserver())
+        // re-attempts surface creation on display wake: libghostty refuses to create one while the display
+        // sleeps, which leaves a scheduled job's session realized-never and its --command unrun (#416).
+        _wakeObserver = State(initialValue: SystemWakeObserver())
     }
 
     var body: some Scene {
@@ -175,6 +179,7 @@ struct agtermApp: App {
                         appearanceObserver.start()
                         // consumers read current accessibility values at first render; this handles live flips.
                         accessibilityObserver.start()
+                        wakeObserver.start()
                         // last: a modal here blocks the rest of the task, and the window behind it should be
                         // fully wired before it opens. `presentOnce` latches, so the per-window .task is safe.
                         if welcomeDue { WelcomeAlert.presentOnce(settingsModel: settingsModel) }

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -285,7 +285,11 @@ public final class AppStore {
                                           fontSize: fontSize(session),
                                           splitFontSize: splitFontSize(session),
                                           scratchFontSize: scratchFontSize(session),
-                                          surfaces: surfaces)
+                                          surfaces: surfaces,
+                                          // host-free: `isRealized` is on `TerminalSurface`, so this needs
+                                          // no app-side closure like the font sizes above. An empty slot is
+                                          // false, not omitted — "no terminal" either way to a caller.
+                                          realized: session.surface?.isRealized ?? false)
             }
             return ControlWorkspaceNode(id: workspace.id.uuidString, name: workspace.name,
                                         active: workspace.id == activeWorkspaceID,

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -564,6 +564,18 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
     /// Addressable terminal surfaces owned by this session; nil/omitted against a server predating
     /// `surface.zoom`. Hidden-but-alive surfaces are included, so a client can zoom them without unhiding.
     public let surfaces: [ControlSurfaceNode]?
+    /// Whether the MAIN pane's terminal exists — the libghostty surface created and its program spawned —
+    /// as opposed to the session merely being in the model. False means `session.type`/`session.text` will
+    /// report `session not realized` and a `--command` has not run yet. nil/omitted only against a server
+    /// predating the field; this one always reports it.
+    ///
+    /// `session.new` answers `ok` for a model insert, which is honest but says nothing about the terminal:
+    /// libghostty refuses to create a surface while the display is asleep, so a session a scheduled job
+    /// creates overnight sits unrealized until the displays wake (#416). This is the field that tells them
+    /// apart. It reports the main pane because that is what `--command` spawns on and what the input/read
+    /// commands address by default; per-pane liveness is `fontSize`/`splitFontSize`/`scratchFontSize`,
+    /// each omitted when its pane is unrealized.
+    public let realized: Bool?
 
     public init(id: String, name: String, cwd: String, title: String? = nil, active: Bool, split: Bool,
                 hasSplit: Bool? = nil, splitRatio: Double? = nil, splitFocused: Bool? = nil,
@@ -576,7 +588,7 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
                 statusShape: String? = nil,
                 background: BackgroundWatermark? = nil, unseen: Int? = nil,
                 fontSize: Double? = nil, splitFontSize: Double? = nil, scratchFontSize: Double? = nil,
-                surfaces: [ControlSurfaceNode]? = nil) {
+                surfaces: [ControlSurfaceNode]? = nil, realized: Bool? = nil) {
         self.id = id
         self.name = name
         self.cwd = cwd
@@ -608,6 +620,7 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
         self.splitFontSize = splitFontSize
         self.scratchFontSize = scratchFontSize
         self.surfaces = surfaces
+        self.realized = realized
     }
 }
 

--- a/agtermCore/Sources/agtermctlKit/SocketClient.swift
+++ b/agtermCore/Sources/agtermctlKit/SocketClient.swift
@@ -288,7 +288,10 @@ struct SocketClient {
                 // a hidden split still owns a live pane, so it needs a tag of its own: without one it
                 // reads exactly like a session that has no split at all.
                 let splitTag = session.split ? " (split)" : (session.hasSplit == true ? " (split hidden)" : "")
-                let tags = splitTag + (session.overlay ? " (overlay)" : "")
+                // a session whose main pane has no terminal looks identical to a working one here, which is
+                // the whole complaint in #416 — it is listed, named, and does nothing.
+                let realizedTag = session.realized == false ? " (not realized)" : ""
+                let tags = splitTag + realizedTag + (session.overlay ? " (overlay)" : "")
                     + (session.scratch ? " (scratch)" : "")
                 let titleSuffix = session.title.map { "  title: \($0)" } ?? ""
                 lines.append("  \(smark) \(session.name)\(tags)  [\(session.id)]  \(session.cwd)\(titleSuffix)")

--- a/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
@@ -143,6 +143,26 @@ struct AppStorePaneTests {
         #expect(session.addressableSurface === split)
     }
 
+    // #416: `session.new` answers ok for a model insert, and libghostty refuses to build a surface while
+    // the display sleeps, so this is the field that separates a working session from an empty one.
+    @Test func controlTreeReportsMainPaneRealization() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+
+        func realized() -> Bool? { store.controlTree().workspaces.first?.sessions.first?.realized }
+
+        #expect(realized() == false, "an empty surface slot has no terminal, so it is not realized")
+
+        let parked = SpySurface()
+        parked.isRealized = false
+        session.surface = parked
+        #expect(realized() == false, "a parked view whose libghostty surface never came up is not realized")
+
+        parked.isRealized = true
+        #expect(realized() == true)
+    }
+
     @Test func addressableSurfaceIsTheMainPaneUntilThePrimaryExits() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -1458,7 +1458,9 @@ struct AppStoreTests {
                                surfaces: [
                                 ControlSurfaceNode(id: TerminalSurfaceID(sessionID: a.id, surface: .primary).rawValue,
                                                    kind: "left", active: true, visible: true),
-                               ])
+                               ],
+                               // store-only session: a surface slot with nothing in it has no terminal
+                               realized: false)
         ])
         #expect(tree.workspaces[1].sessions == [
             ControlSessionNode(id: b.id.uuidString, name: "remote:~/b", cwd: "/live/b",
@@ -1476,7 +1478,8 @@ struct AppStoreTests {
                                                    kind: "scratch", active: false, visible: false),
                                 ControlSurfaceNode(id: TerminalSurfaceID(sessionID: b.id, surface: .overlay).rawValue,
                                                    kind: "overlay", active: true, visible: true),
-                               ])
+                               ],
+                               realized: false)
         ])
     }
 

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -625,6 +625,31 @@ struct ControlProtocolTests {
         #expect(!json.contains("FontSize"), "splitFontSize/scratchFontSize must be omitted when nil; got \(json)")
     }
 
+    @Test func treeSessionNodeRoundTripsWithRealized() throws {
+        let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false,
+                                         realized: false)
+        let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(
+            workspaces: [ControlWorkspaceNode(id: "w1", name: "work", active: true, sessions: [session])])))
+        let decoded = try roundTrip(response)
+        #expect(decoded == response)
+        #expect(decoded.result?.tree?.workspaces.first?.sessions.first?.realized == false)
+    }
+
+    @Test func treeSessionNodeEncodesRealizedFalseRatherThanOmittingIt() throws {
+        let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false,
+                                         realized: false)
+        let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
+        // false is the answer a caller needs most - a session with no terminal - so it must not be dropped
+        // the way a nil optional is. Omission means "server predates the field", which is a different thing.
+        #expect(json.contains("\"realized\":false"), "realized:false must survive encoding; got \(json)")
+    }
+
+    @Test func treeSessionNodeOmitsRealizedWhenNil() throws {
+        let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false)
+        let json = String(data: try JSONEncoder().encode(session), encoding: .utf8) ?? ""
+        #expect(!json.contains("realized"), "a nil realized must be omitted from the JSON; got \(json)")
+    }
+
     @Test func treeSessionNodeRoundTripsWithStatus() throws {
         let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false, status: "blocked")
         let response = ControlResponse(ok: true, result: ControlResult(tree: ControlTree(

--- a/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
@@ -715,6 +715,26 @@ struct SocketClientTests {
         #expect(lines[1] == "  * shell (split hidden)  [s1]  /tmp")
     }
 
+    @Test func formatTreeTagsAnUnrealizedSession() {
+        let session = ControlSessionNode(id: "s1", name: "shell", cwd: "/tmp", active: true, split: false,
+                                         realized: false)
+        let workspace = ControlWorkspaceNode(id: "w1", name: "work", active: true, sessions: [session])
+        let tree = ControlTree(workspaces: [workspace])
+        let out = SocketClient.formatResponse(ControlResponse(ok: true, result: ControlResult(tree: tree)), json: false)
+        let lines = out.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        #expect(lines[1] == "  * shell (not realized)  [s1]  /tmp")
+    }
+
+    @Test func formatTreeLeavesARealizedSessionUntagged() {
+        let session = ControlSessionNode(id: "s2", name: "shell", cwd: "/tmp", active: true, split: false,
+                                         realized: true)
+        let workspace = ControlWorkspaceNode(id: "w2", name: "work", active: true, sessions: [session])
+        let tree = ControlTree(workspaces: [workspace])
+        let out = SocketClient.formatResponse(ControlResponse(ok: true, result: ControlResult(tree: tree)), json: false)
+        let lines = out.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        #expect(lines[1] == "  * shell  [s2]  /tmp", "only the failing state earns a tag; nil must stay quiet too")
+    }
+
     @Test func formatTreeShowsScratchTag() {
         let session = ControlSessionNode(id: "s3", name: "shell", cwd: "/tmp", active: true, split: false,
                                          overlay: false, scratch: true)

--- a/agtermTests/ControlServerSessionActionsTests.swift
+++ b/agtermTests/ControlServerSessionActionsTests.swift
@@ -111,6 +111,25 @@ final class ControlServerSessionActionsTests: XCTestCase {
         XCTAssertEqual(store.selectedSessionID, other.id, "typing without select must leave the selection where it was")
     }
 
+    // a pane parked in the slot with no libghostty surface is the state a display-asleep create leaves
+    // behind (#416). It used to answer `failed to read surface buffer`, naming a cause that never happened,
+    // while every sibling command called the same state `session not realized`.
+    func testTextOnAnUnrealizedPaneReportsNotRealizedRatherThanAReadFailure() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let owner = try XCTUnwrap(store.currentWorkspaceID)
+        let target = try XCTUnwrap(store.addSession(toWorkspace: owner, cwd: NSHomeDirectory()))
+        let parked = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+        target.surface = parked
+        XCTAssertFalse(parked.isRealized, "a detached view never runs createSurface, which is the point here")
+
+        let response = server.readSessionText(target.id.uuidString, window: nil,
+                                              options: ControlSessionTextOptions(pane: nil, all: false, lines: nil))
+
+        XCTAssertFalse(response.ok)
+        XCTAssertEqual(response.error, "session not realized",
+                       "an empty slot and a parked-but-unrealized view are one state to a caller")
+    }
+
     // the true side of that branch: deleting the body of `if select` leaves every other test green while
     // `--select` silently stops selecting, so this asserts the move itself rather than the typed text.
     func testTypeWithSelectStillSelectsWhenTheSurfaceIsNotReady() async throws {

--- a/agtermTests/SystemWakeObserverTests.swift
+++ b/agtermTests/SystemWakeObserverTests.swift
@@ -28,10 +28,16 @@ final class SystemWakeObserverTests: XCTestCase {
                                                           queue: .main) { _ in reposts += 1 }
         defer { NotificationCenter.default.removeObserver(token) }
 
-        let settled = expectation(description: "repost delivered")
+        // wait on the repost itself, not on one main-queue turn: the observer reposts from its own
+        // `DispatchQueue.main.async` while the workspace notification arrives via `OperationQueue.main`, and
+        // nothing orders those two, so a turn-based wait can assert before the first repost lands.
+        let arrived = expectation(forNotification: .agtermScreensDidWake, object: nil, notificationCenter: .default)
         NSWorkspace.shared.notificationCenter.post(name: NSWorkspace.screensDidWakeNotification, object: nil)
-        DispatchQueue.main.async { settled.fulfill() }
-        wait(for: [settled], timeout: 2)
+        wait(for: [arrived], timeout: 2)
+        // then drain, so a second and third repost from the duplicate starts would be counted rather than missed.
+        let drained = expectation(description: "any further reposts delivered")
+        DispatchQueue.main.async { DispatchQueue.main.async { drained.fulfill() } }
+        wait(for: [drained], timeout: 2)
 
         XCTAssertEqual(reposts, 1, "the scene .task starts this per window, so repeated starts must not fan out")
     }

--- a/agtermTests/SystemWakeObserverTests.swift
+++ b/agtermTests/SystemWakeObserverTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import agterm
+
+/// `ghostty_surface_new` returns NULL for as long as the display is asleep, so a session a scheduled job
+/// creates in that window realizes no surface and its `--command` never runs. Nothing else re-attempts —
+/// SwiftUI runs no layout for an off-display window — so this bridge is the only thing that revives the
+/// pane (#416). Measured: creation starts succeeding at display wake, with the screen still locked.
+@MainActor
+final class SystemWakeObserverTests: XCTestCase {
+    func testDisplayWakeIsRepostedOnTheAppNotificationCenter() {
+        let observer = SystemWakeObserver()
+        observer.start()
+
+        let reposted = expectation(forNotification: .agtermScreensDidWake, object: nil, notificationCenter: .default)
+        NSWorkspace.shared.notificationCenter.post(name: NSWorkspace.screensDidWakeNotification, object: nil)
+
+        wait(for: [reposted], timeout: 2)
+    }
+
+    func testStartIsIdempotentSoOneWakeStaysOneRepost() {
+        let observer = SystemWakeObserver()
+        observer.start()
+        observer.start()
+        observer.start()
+
+        var reposts = 0
+        let token = NotificationCenter.default.addObserver(forName: .agtermScreensDidWake, object: nil,
+                                                          queue: .main) { _ in reposts += 1 }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        let settled = expectation(description: "repost delivered")
+        NSWorkspace.shared.notificationCenter.post(name: NSWorkspace.screensDidWakeNotification, object: nil)
+        DispatchQueue.main.async { settled.fulfill() }
+        wait(for: [settled], timeout: 2)
+
+        XCTAssertEqual(reposts, 1, "the scene .task starts this per window, so repeated starts must not fan out")
+    }
+}

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -181,6 +181,11 @@ them never has to know the defaults; `spinner` names the STYLE, so `none` is wha
 turn one off. While a HUD is up the node's `overlay` reads `false` and `overlaySizePercent` is omitted, so a
 poll for "is a program covering this session" cannot mistake a message for one; HUD state is poll-only,
 no event announces it),
+`realized` (whether the session's MAIN pane has a live terminal; `false` means no shell was spawned and
+`session type`/`session text` will answer `session not realized`. `session new` returns `ok` for a model
+entry, which is weaker — libghostty will not create a surface while the display is asleep, so a session
+created by a scheduled job overnight stays unrealized until the displays wake and then recovers itself.
+Poll this after an unattended create),
 `hasSplit` (whether a second pane exists at all, shown or hidden; omitted when there is none — read this
 rather than `split`, which is false for a split hidden with ⌘D even though its pane is still alive),
 `splitRatio` (the left-pane divider fraction 0.05–0.95 of a

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -104,6 +104,12 @@ SIGTERM use normal process behavior.
 `id`, `name`, `cwd`, `title` (the raw OSC terminal title — e.g. a remote host over SSH — omitted
 when none reported; distinct from `name`, the derived sidebar label), `active` (selected),
 `split` (split SHOWN side by side, the read side of `session split on|off`),
+`realized` (whether the session's MAIN pane has a live terminal — `false` means no shell was spawned, a
+`--command` has not run, and `session type`/`session text` will answer `session not realized`. `session
+new` returns `ok` for a session that exists in the model, which is not the same thing: libghostty refuses
+to create a surface while the DISPLAY is asleep, so a session a scheduled job creates overnight stays
+unrealized until the displays wake, at which point it recovers on its own. Poll this after creating a
+session unattended; `agtermctl tree` also tags the row `(not realized)`),
 `hasSplit` (whether a second pane exists at all, shown or hidden with ⌘D; omitted when there is none —
 read THIS to decide whether a session has a split, because a hidden split reports `split: false` while
 its pane stays alive, and it is present exactly when `splitRatio`/`splitFocused` can be),

--- a/site/commands.html
+++ b/site/commands.html
@@ -434,6 +434,12 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">title</span> (raw OSC terminal title, omitted when
                 none), <span style="font-family: &quot;JetBrains Mono&quot;, monospace">active</span>,
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">split</span> (the split is SHOWN side by side),
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">realized</span> (the session's main pane has a live
+                terminal; <span style="font-family: &quot;JetBrains Mono&quot;, monospace">false</span> means no shell was spawned and
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">session type</span>/<span style="font-family: &quot;JetBrains Mono&quot;, monospace">session text</span>
+                answer <span style="font-family: &quot;JetBrains Mono&quot;, monospace">session not realized</span>. A surface cannot be
+                created while the display is asleep, so a session made by a scheduled job overnight stays unrealized until the
+                displays wake, then recovers on its own — poll this after an unattended create),
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">hasSplit</span> (a second pane exists at all, shown or
                 hidden, omitted when there is none — read this rather than
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">split</span> to tell whether a session has a split),


### PR DESCRIPTION
sessions created while the display is asleep never realize a surface, so a scheduled job's `--command` never runs while `session new` has already answered `ok`. Measured cause: `ghostty_surface_new` returns NULL for as long as the display sleeps, 21 consecutive failures over 40s with a valid backing size, and nothing re-attempts because the deck's retries all ride SwiftUI layout, which does not run for an off-display window.

creation starts succeeding within ~2s of display wake with the screen still LOCKED, so unlock is not involved and a machine with no lock set behaves the same.

**what changed**

- `SystemWakeObserver` bridges `NSWorkspace.screensDidWakeNotification` into `.agtermScreensDidWake`, and `GhosttySurfaceView.retryCreationAfterWake` re-attempts creation there, bounded, since creation can still fail for a second or two past the notification. A failed create now also re-arms `pendingSurfaceCreation` and logs instead of failing silently.
- `session text` reports `session not realized` for an unrealized pane instead of `failed to read surface buffer`. One state, and six other call sites already used the first string. `quick text` keeps its own four-state vocabulary.
- new `tree` field `realized` on the session node, the main pane's `TerminalSurface.isRealized`, populated host-free in `AppStore.controlTree`. `agtermctl tree` tags the row `(not realized)`. Mirrored into the bundled skill, `site/commands.html` and the rules files.

**verification**

reproduced three times before the fix: with the display asleep, `session new --no-select --command` returns `ok:true`, the marker file the command would write never appears, `session text` and `session type` both fail, and `screensDidWake` alone recovers nothing across 25s of awake-but-locked sampling. After the fix, a clean-room run with nobody touching the machine had the session heal itself about 2s after wake, screen still locked.

`realized` reports the main pane because that is what `--command` spawns on and what `session type`/`session text` address by default. Per-pane liveness stays with the `fontSize`/`splitFontSize`/`scratchFontSize` triple rather than growing a second spelling.

Fix #416
