### PR TITLE
docs(cookbook): add annotate-pane-output recipe

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -34,6 +34,7 @@ its *needs* column, so searching this page for `claude` or `kiro` finds those di
 | recipe | what it does | needs |
 |---|---|---|
 | [annotate-claude-replies](annotate-claude-replies/) | mark up Claude's answers in revdiff and send the notes back | 0.13.0, revdiff, python3, Claude Code |
+| [annotate-pane-output](annotate-pane-output/) | mark up what the pane just printed in revdiff and send the notes back to whatever is running there | 0.13.0, revdiff, python3 |
 | [claude-clear](claude-clear/) | one chord sends /clear to the pane's Claude Code run, and nothing when it is not running | 0.13.0, python3, Claude Code |
 | [claude-conversation-picker](claude-conversation-picker/) | pick a past Claude Code conversation by what it was about and resume it in the pane | 0.21.0, python3, Claude Code |
 | [claude-recap](claude-recap/) | one key lists what the Claude Code run in a session was working on | 0.10.0, zsh, jq, Claude Code |

--- a/cookbook/annotate-pane-output/README.md
+++ b/cookbook/annotate-pane-output/README.md
@@ -1,0 +1,89 @@
+# Annotate pane output
+
+Mark up whatever the pane just printed in [revdiff](https://github.com/umputun/revdiff), and get your notes back at the prompt with the lines they point at.
+
+The sibling [annotate-claude-replies](../annotate-claude-replies/) recipe does the same for a Claude Code answer, and does it better where it applies: it reads Claude's own transcript, so it gets every reply of the exchange in full, formatted, however far it has scrolled. This one reads the terminal instead. That costs the transcript's fidelity — you get the visible screen, wrapped and truncated as the terminal drew it — and buys everything else: any agent, any program, any command output, and no hook to install.
+
+## What it does
+
+One chord takes the text in front of you, opens it in revdiff inside an overlay on that session, and waits. You put a note on any line you want to ask about. On quit the notes are pasted at that session's prompt, unsent.
+
+What gets captured is whatever you selected, or the pane's last 50 lines when nothing is selected. So it works on an agent's answer, but equally on a stack trace, a failing test run, a `terraform plan`, or a config someone just `cat`-ed.
+
+Each note comes back with the line it hangs on, quoted above it:
+
+```
+> ERROR failed to open /var/lib/thing/state.db: permission denied
+
+which user is it running as?
+
+> retrying in 30s (attempt 4/5)
+
+why is it retrying a permission error at all?
+```
+
+Two lines of yours in that example, in the order they were made, each next to what it is about. The paste is not submitted, so you read it, edit it, add a sentence, and send when it says what you meant.
+
+## Requirements
+
+- agterm 0.13.0 or later. That is where `$AGT_PANE` began reporting which pane a custom command fired from, which is how the capture and the paste stay on the right half of a split. Everything else it uses is older: `session paste` shipped in 0.11.0, `session text` in 0.5.0, and `session overlay open --block` and `notify` before either.
+- [revdiff](https://github.com/umputun/revdiff)
+- `python3`, which macOS ships
+- macOS `pbcopy` and `pbpaste`, which the reply goes through
+
+## Setup
+
+Copy `annotate-pane.py` somewhere on your machine, say `~/.local/bin/`, and make it executable:
+
+```sh
+chmod +x annotate-pane.py
+```
+
+Bind it in `~/.config/agterm/keymap.conf`, with the full path to wherever you put it:
+
+```
+command "Annotate" ctrl+a>k ~/.local/bin/annotate-pane.py
+```
+
+Then **View ▸ Reload Keymap**, or `agtermctl keymap reload`.
+
+Nothing is passed on that line: the script reads `$AGT_SESSION_ID`, `$AGT_PANE`, `$AGT_SELECTION` and `$AGT_SOCKET` from the environment the runner gives it, and opens its own overlay.
+
+A custom command runs under the app's `PATH`, not your shell's. That is the launchd default — `/usr/local/bin` plus the system directories, with no `/opt/homebrew/bin` and nothing your profile adds. `python3` resolves from `/usr/bin` and `agtermctl` from `/usr/local/bin`, where **Help ▸ Install Command Line Tool…** symlinks it. `revdiff` usually resolves from neither, so the script also tries `/opt/homebrew/bin/revdiff` and `~/go/bin/revdiff`; set `REVDIFF` to the full path when yours is somewhere else. `AGTERMCTL` overrides the CLI the same way.
+
+Two knobs at the top of the script: `CAPTURE_LINES`, how much of the pane to take when nothing is selected, and `OVERLAY_PERCENT` with `OVERLAY_TINT`, the size and color of the panel.
+
+## Usage
+
+Press the chord. Either select the lines you care about first, or press it on whatever is on screen.
+
+In revdiff: move to a line, press `a` to write a note, `Ctrl+E` while typing it to open `$EDITOR` for a long one, `A` for a note about the output as a whole, `d` to delete the one under the cursor, `q` to quit and send what you wrote, `Q` to throw it all away. Quitting with no notes does nothing at all — no paste, no empty line at the prompt.
+
+Run it from a shell with `--print` to see the reply on stdout instead of pasting it, which is the way to check the formatting without a prompt catching it. A session's shell is given `AGTERM_*`, while the script expects the `AGT_*` a custom command gets, so map them across:
+
+```sh
+AGT_SESSION_ID=$AGTERM_SESSION_ID AGT_PANE=$AGTERM_PANE AGT_SOCKET=$AGTERM_SOCKET \
+    ~/.local/bin/annotate-pane.py --print
+```
+
+## How it works
+
+The capture is `session text --lines 50 --pane <pane>`, or `$AGT_SELECTION` when a selection exists. `--pane` is passed explicitly because the pane the chord fired from and the focused pane are not the same thing: a chord pressed in a split's right half while focus sits left would otherwise capture the wrong side. Whitespace does not count as a selection — a stray drag leaves one, and reviewing it would open an empty buffer instead of the screen you meant.
+
+The text goes to a scratch file and revdiff opens on it with `--only`, which is its no-VCS mode: the file is shown in full as context, no `+`/`-` gutter, annotations working normally. The overlay is opened with `--block`, so the script sits there until you quit. `--exit-code-on-annotations` makes revdiff exit `10` when it wrote notes and `0` when you quit without any, which is how the script knows there is nothing to paste without reading the file.
+
+Blank tail lines are trimmed from the pane capture but never from a selection. `session text` returns the whole screen, so a pane holding six lines hands over a screenful of padding and revdiff opens on the emptiness below the content. Only the tail is trimmed: dropping leading blanks would shift every line number the annotations come back with.
+
+The reply goes through the **clipboard**, saved and restored around the paste. That is not a shortcut. `session type` sends real keystrokes, so a multi-line reply submits itself one line at a time — the first line goes as a command and the rest land wherever that left you. `session paste` is the only bracketed-paste path the control API exposes, and it reads the system clipboard. Against a pty with DECSET 2004 on, `type` produced bare lines and `paste` produced one `^[[200~…^[[201~` block. So the reply arrives whole and unsent. The clipboard is put back the way it was found, so using the chord never costs you what you were carrying.
+
+## Limits
+
+Nothing is closed, deleted, or killed. The reply is pasted, never submitted; the only thing it touches outside the session is the clipboard, which it restores.
+
+What you can capture is what the terminal drew. A wrapped line comes back wrapped, a box-drawing TUI comes back as box-drawing characters, and anything above the top of the screen is gone — `session text` without `--all` does not reach into scrollback, and raising `CAPTURE_LINES` past the pane height gains nothing. When the pane holds a long agent answer that has scrolled, select what you want before pressing the chord, or use [annotate-claude-replies](../annotate-claude-replies/) if it is Claude Code.
+
+A note lands on one line. revdiff has no visual range select, and its one range mechanism — the word "hunk" in the note text, which expands the header to the surrounding hunk — needs a real diff and does nothing here, where every line is context. So a point about six consecutive lines is either six notes or one note on the first of them. Notes themselves can be as long as you like: `Ctrl+E` opens `$EDITOR` and the whole file becomes the note, newlines included. A file-level note (`A`) comes back with no quoted line above it, which is the way to say something about the output as a whole.
+
+Only one at a time per session. The chord blocks on the overlay, and pressing it again while the overlay is up opens a second one over the first.
+
+macOS only, for `pbcopy` and `pbpaste` — which agterm is anyway.

--- a/cookbook/annotate-pane-output/README.md
+++ b/cookbook/annotate-pane-output/README.md
@@ -72,7 +72,7 @@ The capture is `session text --lines 50 --pane <pane>`, or `$AGT_SELECTION` when
 
 The text goes to a scratch file and revdiff opens on it with `--only`, which is its no-VCS mode: the file is shown in full as context, no `+`/`-` gutter, annotations working normally. The overlay is opened with `--block`, so the script sits there until you quit. `--exit-code-on-annotations` makes revdiff exit `10` when it wrote notes and `0` when you quit without any, which is how the script knows there is nothing to paste without reading the file.
 
-The reply goes through the **clipboard**, saved and restored around the paste. That is not a shortcut. `session type` sends real keystrokes, so a multi-line reply submits itself one line at a time — the first line goes as a command and the rest land wherever that left you. `session paste` is the only bracketed-paste path the control API exposes, and it reads the system clipboard. Against a pty with DECSET 2004 on, `type` produced bare lines and `paste` produced one `^[[200~…^[[201~` block. So the reply arrives whole and unsent. The plain text that was on the clipboard is put back afterwards.
+The reply goes through the **clipboard**, saved and restored around the paste. That is not a shortcut. `session type` sends real keystrokes, so a multi-line reply submits itself one line at a time — the first line goes as a command and the rest land wherever that left you. `session paste` is the only bracketed-paste path the control API exposes, and it reads the system clipboard. Against a pty with DECSET 2004 on, `type` produced bare lines and `paste` produced one `^[[200~…^[[201~` block. So the reply arrives whole and unsent — with the caveat in *Limits*. The plain text that was on the clipboard is put back afterwards.
 
 `session paste` takes no `--pane`. It runs on the session's main surface, so a chord fired from a split's right pane or from the scratch would drop the notes at a different prompt than the one you annotated. Those two panes get the notes on the clipboard and a banner saying so, for a manual ⌘V. The capture side has no such limit: `session text` does take `--pane`, so what you annotate is always the pane you pressed in.
 
@@ -80,7 +80,9 @@ A nonzero exit from the overlay call is ambiguous — agtermctl can refuse befor
 
 ## Limits
 
-Nothing is closed, deleted, or killed. The reply is pasted, never submitted. Three things are touched outside the session: the clipboard, restored afterwards; the run log at `$TMPDIR/agterm-annotate.log`; and revdiff's own annotation history, which it auto-saves under `~/.config/revdiff/history/` for any review you quit with `q`, so a durable copy of your notes outlives the temp file the script deletes.
+Nothing is closed, deleted, or killed. Three things are touched outside the session: the clipboard, restored afterwards; the run log at `$TMPDIR/agterm-annotate.log`; and revdiff's own annotation history, which it auto-saves under `~/.config/revdiff/history/` for any review you quit with `q`, so a durable copy of your notes outlives the temp file the script deletes.
+
+The reply arrives unsent against a program with bracketed paste on, which is what an agent CLI, a readline shell prompt and any full-screen editor turn on. Bracketed paste is the program's mode, not a property of the paste, so a destination with it off — macOS `/bin/sh`, a `read` loop, a bare REPL — takes the newlines as Return and runs the lines. That is what a manual ⌘V of the same notes would do there, and nothing in the control API can ask which mode a program is in, so the chord cannot check first.
 
 The clipboard restore is plain text only. Copy an image or a file in Finder, press the chord, and what comes back afterwards is the empty string — `pbpaste` cannot carry a pasteboard's non-text flavors.
 

--- a/cookbook/annotate-pane-output/README.md
+++ b/cookbook/annotate-pane-output/README.md
@@ -2,11 +2,11 @@
 
 Mark up whatever the pane just printed in [revdiff](https://github.com/umputun/revdiff), and get your notes back at the prompt with the lines they point at.
 
-The sibling [annotate-claude-replies](../annotate-claude-replies/) recipe does the same for a Claude Code answer, and does it better where it applies: it reads Claude's own transcript, so it gets every reply of the exchange in full, formatted, however far it has scrolled. This one reads the terminal instead. That costs the transcript's fidelity — you get the visible screen, wrapped and truncated as the terminal drew it — and buys everything else: any agent, any program, any command output, and no hook to install.
+The sibling [annotate-claude-replies](../annotate-claude-replies/) recipe does the same for a Claude Code answer, and does it better where it applies: it reads Claude's own transcript, so it gets every reply of the exchange in full, formatted, however far it has scrolled. This one reads the terminal instead. That costs the transcript's fidelity — you get the screen as the terminal drew it, wrapped where it wrapped — and buys everything else: any agent, any program, any command output, and no hook to install.
 
 ## What it does
 
-One chord takes the text in front of you, opens it in revdiff inside an overlay on that session, and waits. You put a note on any line you want to ask about. On quit the notes are pasted at that session's prompt, unsent.
+One chord takes the text in front of you, opens it in revdiff inside an overlay on that session, and waits. You put a note on any line you want to ask about. On quit the notes are pasted at that session's prompt, unsent — or left on the clipboard when the chord came from a split's right pane or the scratch, which `session paste` cannot address.
 
 What gets captured is whatever you selected, or the pane's last 50 lines when nothing is selected. So it works on an agent's answer, but equally on a stack trace, a failing test run, a `terraform plan`, or a config someone just `cat`-ed.
 
@@ -26,7 +26,7 @@ Two lines of yours in that example, in the order they were made, each next to wh
 
 ## Requirements
 
-- agterm 0.13.0 or later. That is where `$AGT_PANE` began reporting which pane a custom command fired from, which is how the capture and the paste stay on the right half of a split. Everything else it uses is older: `session paste` shipped in 0.11.0, `session text` in 0.5.0, and `session overlay open --block` and `notify` before either.
+- agterm 0.13.0 or later. That is where `$AGT_PANE` began reporting which pane a custom command fired from, which is how the capture stays on the half of a split you pressed in. Everything else it uses is older: `session paste` shipped in 0.11.0 and `session text` in 0.5.0.
 - [revdiff](https://github.com/umputun/revdiff)
 - `python3`, which macOS ships
 - macOS `pbcopy` and `pbpaste`, which the reply goes through
@@ -49,9 +49,9 @@ Then **View ▸ Reload Keymap**, or `agtermctl keymap reload`.
 
 Nothing is passed on that line: the script reads `$AGT_SESSION_ID`, `$AGT_PANE`, `$AGT_SELECTION` and `$AGT_SOCKET` from the environment the runner gives it, and opens its own overlay.
 
-A custom command runs under the app's `PATH`, not your shell's. That is the launchd default — `/usr/local/bin` plus the system directories, with no `/opt/homebrew/bin` and nothing your profile adds. `python3` resolves from `/usr/bin` and `agtermctl` from `/usr/local/bin`, where **Help ▸ Install Command Line Tool…** symlinks it. `revdiff` usually resolves from neither, so the script also tries `/opt/homebrew/bin/revdiff` and `~/go/bin/revdiff`; set `REVDIFF` to the full path when yours is somewhere else. `AGTERMCTL` overrides the CLI the same way.
+A custom command runs under the app's `PATH`, not your shell's, and which `PATH` that is depends on the version. From 0.22.0 it is the system directories plus the app bundle's own CLI directory in front and `/usr/local/bin` and `/opt/homebrew/bin` behind, so `agtermctl` and a Homebrew `revdiff` both resolve. Before 0.22.0 it is launchd's bare `/usr/bin:/bin:/usr/sbin:/sbin` — which does not include the `/usr/local/bin` that **Help ▸ Install Command Line Tool…** writes to, so nothing but `python3` resolves. The script covers both: it falls back to `/usr/local/bin/agtermctl`, and for revdiff to `/opt/homebrew/bin` then `~/go/bin`. Set `REVDIFF` or `AGTERMCTL` to a full path when yours is somewhere else; both are checked first.
 
-Two knobs at the top of the script: `CAPTURE_LINES`, how much of the pane to take when nothing is selected, and `OVERLAY_PERCENT` with `OVERLAY_TINT`, the size and color of the panel.
+Two knobs at the top of the script: `CAPTURE_LINES`, how much of the pane to take when nothing is selected, and `OVERLAY_PERCENT` with `OVERLAY_TINT`, the size and color of the panel. `ANNOTATE_LOG` moves the run log, which is `$TMPDIR/agterm-annotate.log` by default and is where a chord that appears to do nothing explains itself.
 
 ## Usage
 
@@ -72,18 +72,22 @@ The capture is `session text --lines 50 --pane <pane>`, or `$AGT_SELECTION` when
 
 The text goes to a scratch file and revdiff opens on it with `--only`, which is its no-VCS mode: the file is shown in full as context, no `+`/`-` gutter, annotations working normally. The overlay is opened with `--block`, so the script sits there until you quit. `--exit-code-on-annotations` makes revdiff exit `10` when it wrote notes and `0` when you quit without any, which is how the script knows there is nothing to paste without reading the file.
 
-Blank tail lines are trimmed from the pane capture but never from a selection. `session text` returns the whole screen, so a pane holding six lines hands over a screenful of padding and revdiff opens on the emptiness below the content. Only the tail is trimmed: dropping leading blanks would shift every line number the annotations come back with.
+The reply goes through the **clipboard**, saved and restored around the paste. That is not a shortcut. `session type` sends real keystrokes, so a multi-line reply submits itself one line at a time — the first line goes as a command and the rest land wherever that left you. `session paste` is the only bracketed-paste path the control API exposes, and it reads the system clipboard. Against a pty with DECSET 2004 on, `type` produced bare lines and `paste` produced one `^[[200~…^[[201~` block. So the reply arrives whole and unsent. The plain text that was on the clipboard is put back afterwards.
 
-The reply goes through the **clipboard**, saved and restored around the paste. That is not a shortcut. `session type` sends real keystrokes, so a multi-line reply submits itself one line at a time — the first line goes as a command and the rest land wherever that left you. `session paste` is the only bracketed-paste path the control API exposes, and it reads the system clipboard. Against a pty with DECSET 2004 on, `type` produced bare lines and `paste` produced one `^[[200~…^[[201~` block. So the reply arrives whole and unsent. The clipboard is put back the way it was found, so using the chord never costs you what you were carrying.
+`session paste` takes no `--pane`. It runs on the session's main surface, so a chord fired from a split's right pane or from the scratch would drop the notes at a different prompt than the one you annotated. Those two panes get the notes on the clipboard and a banner saying so, for a manual ⌘V. The capture side has no such limit: `session text` does take `--pane`, so what you annotate is always the pane you pressed in.
+
+A nonzero exit from the overlay call is ambiguous — agtermctl can refuse before revdiff ever starts — so the script carries agtermctl's own sentence out rather than reporting the status as revdiff's.
 
 ## Limits
 
-Nothing is closed, deleted, or killed. The reply is pasted, never submitted; the only thing it touches outside the session is the clipboard, which it restores.
+Nothing is closed, deleted, or killed. The reply is pasted, never submitted. Three things are touched outside the session: the clipboard, restored afterwards; the run log at `$TMPDIR/agterm-annotate.log`; and revdiff's own annotation history, which it auto-saves under `~/.config/revdiff/history/` for any review you quit with `q`, so a durable copy of your notes outlives the temp file the script deletes.
 
-What you can capture is what the terminal drew. A wrapped line comes back wrapped, a box-drawing TUI comes back as box-drawing characters, and anything above the top of the screen is gone — `session text` without `--all` does not reach into scrollback, and raising `CAPTURE_LINES` past the pane height gains nothing. When the pane holds a long agent answer that has scrolled, select what you want before pressing the chord, or use [annotate-claude-replies](../annotate-claude-replies/) if it is Claude Code.
+The clipboard restore is plain text only. Copy an image or a file in Finder, press the chord, and what comes back afterwards is the empty string — `pbpaste` cannot carry a pasteboard's non-text flavors.
+
+What you can capture is what the terminal drew. A wrapped line comes back wrapped and a box-drawing TUI comes back as box-drawing characters. Scrollback is reachable, though: `--lines N` reads the whole screen buffer rather than the viewport, so raising `CAPTURE_LINES` past the pane height picks up lines that have scrolled off. For a long agent answer, select what you want before pressing the chord, or use [annotate-claude-replies](../annotate-claude-replies/) if it is Claude Code — it reads the transcript and gets the replies formatted rather than as the terminal drew them.
 
 A note lands on one line. revdiff has no visual range select, and its one range mechanism — the word "hunk" in the note text, which expands the header to the surrounding hunk — needs a real diff and does nothing here, where every line is context. So a point about six consecutive lines is either six notes or one note on the first of them. Notes themselves can be as long as you like: `Ctrl+E` opens `$EDITOR` and the whole file becomes the note, newlines included. A file-level note (`A`) comes back with no quoted line above it, which is the way to say something about the output as a whole.
 
-Only one at a time per session. The chord blocks on the overlay, and pressing it again while the overlay is up opens a second one over the first.
+Only one at a time per session. The overlay slot holds one occupant, so a second press is refused with `overlay already open` and the banner says exactly that; the review already up is untouched.
 
 macOS only, for `pbcopy` and `pbpaste` — which agterm is anyway.

--- a/cookbook/annotate-pane-output/annotate-pane.py
+++ b/cookbook/annotate-pane-output/annotate-pane.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Annotate what the pane just printed and hand the notes back to it as an unsent paste.
 
-Runs as an agterm keymap custom command, so the runner exports $AGT_* and the app spawns it with
-launchd's PATH and stdout on /dev/null.
+Runs as an agterm keymap custom command, so the runner exports $AGT_* and the app spawns it with a
+PATH of its own choosing and stdout on /dev/null.
 
     text selected    -> that selection is what you annotate
     nothing selected -> the pane's last CAPTURE_LINES lines
@@ -17,6 +17,10 @@ a time, while `session paste` is the only bracketed-paste path agterm exposes an
 system clipboard. Measured against a pty with DECSET 2004 on: type produced bare lines, paste
 produced one `^[[200~...^[[201~` block. So the reply lands whole and unsent, for you to read and
 send.
+
+`session paste` takes no --pane and always runs on the session's main surface, so from a split's
+right pane or the scratch it would deliver to the wrong prompt. Those panes keep the notes on the
+clipboard and say so instead.
 
 Usage: annotate-pane.py [--print]
     --print  write the reply to stdout instead of pasting it, for checking the formatting
@@ -33,8 +37,8 @@ import tempfile
 import time
 from pathlib import Path
 
-# how much of the pane to offer when nothing is selected. The pane's visible screen is the ceiling
-# anyway - `session text` without --all does not reach into scrollback
+# how much of the pane to offer when nothing is selected. `session text --lines N` reads the whole
+# screen buffer, scrollback included, so raising this reaches back past the visible pane
 CAPTURE_LINES = 50
 
 # a floating panel rather than the full pane, so the session it asks about stays visible behind it,
@@ -42,7 +46,6 @@ CAPTURE_LINES = 50
 OVERLAY_PERCENT = 80
 OVERLAY_TINT = "#3a2c1e"
 
-AGTERMCTL = os.environ.get("AGTERMCTL") or "agtermctl"
 LOG = Path(os.environ.get("ANNOTATE_LOG") or (Path(tempfile.gettempdir()) / "agterm-annotate.log"))
 
 # `## path:line (type)` and `## path:line-end (type)`, the record header revdiff writes. The path is
@@ -71,16 +74,48 @@ def fail(message: str, agt: Agt | None = None) -> None:
 
 
 def find_revdiff() -> str:
-    """Resolve revdiff absolutely: a custom command gets launchd's PATH, not a shell's.
+    """Resolve revdiff absolutely: a custom command gets the app's PATH, not a shell's.
 
-    That PATH is /usr/local/bin plus the system directories, so a revdiff installed by Homebrew or
-    `go install` is not on it. Set REVDIFF to its full path when neither fallback below matches.
+    Nothing a profile adds is on it, so a revdiff installed anywhere but Homebrew's prefix or
+    `go install`'s needs REVDIFF set to its full path.
     """
     for candidate in (os.environ.get("REVDIFF") or "", shutil.which("revdiff") or "",
                       "/opt/homebrew/bin/revdiff", str(Path.home() / "go/bin/revdiff")):
         if candidate and os.access(candidate, os.X_OK):
             return candidate
     return ""
+
+
+def find_agtermctl() -> str:
+    """Resolve the CLI, falling back to the install target when the bare name does not resolve.
+
+    Before 0.22.0 a custom command ran with launchd's bare `/usr/bin:/bin:/usr/sbin:/sbin`, which
+    does not contain the `/usr/local/bin` that Help > Install Command Line Tool writes to, so a bare
+    `agtermctl` exited 127 before anything happened. From 0.22.0 the app widens PATH and the lookup
+    above succeeds. Returning the bare name last keeps the failure legible rather than silent.
+    """
+    for candidate in (os.environ.get("AGTERMCTL") or "", shutil.which("agtermctl") or "",
+                      "/usr/local/bin/agtermctl"):
+        if candidate and os.access(candidate, os.X_OK):
+            return candidate
+    return "agtermctl"
+
+
+AGTERMCTL = find_agtermctl()
+
+
+def cli_error(res: subprocess.CompletedProcess[str]) -> str:
+    """Pull agtermctl's own sentence out of a failed call, falling back to the exit status."""
+    for stream in (res.stderr, res.stdout):
+        line = (stream or "").strip().splitlines()
+        if line:
+            return line[-1]
+    return f"agtermctl exited {res.returncode}"
+
+
+def copy_clipboard(text: str) -> None:
+    """Put text on the system clipboard, which is what `session paste` reads."""
+    subprocess.run(["pbcopy"], input=text, text=True, check=False)
 
 
 class Agt:
@@ -92,51 +127,72 @@ class Agt:
         self.pane = os.environ.get("AGT_PANE") or ""
 
     def run(self, *args: str) -> subprocess.CompletedProcess[str]:
-        """Invoke agtermctl against the instance the chord came from, never raising on a nonzero exit."""
+        """Invoke agtermctl against the instance the chord came from, never raising on a nonzero exit.
+
+        An unresolvable binary is turned into a 127 rather than a FileNotFoundError: the traceback
+        would go to a stdout the runner pins to /dev/null, and the chord would appear to do nothing.
+        """
         cmd = [AGTERMCTL, *args]
         if self.socket:
             cmd += ["--socket", self.socket]
-        return subprocess.run(cmd, capture_output=True, text=True, check=False)
+        try:
+            return subprocess.run(cmd, capture_output=True, text=True, check=False)
+        except OSError as err:
+            return subprocess.CompletedProcess(cmd, 127, "", f"{AGTERMCTL}: {err}")
 
     def notify(self, message: str) -> None:
         """Post a desktop banner, the one channel a keybinding has when it cannot paste."""
         self.run("notify", message, "--title", "annotate")
 
-    def pane_text(self) -> str:
-        """Read the pane the chord fired from, not whichever pane happens to be focused.
+    def pane_text(self) -> tuple[str, str]:
+        """Read the pane the chord fired from, returning (text, error). A blank pane is not an error.
 
-        --pane is passed explicitly because the two can differ: a chord fired in a split's right pane
-        while focus sits left would otherwise capture the wrong half.
+        --pane is passed explicitly because the pane the chord fired from and the focused pane can
+        differ: a chord pressed in a split's right half while focus sits left would otherwise capture
+        the wrong side. The error is kept apart from an empty read so a refused call is not
+        diagnosed as an empty screen.
         """
         args = ["session", "text", "--target", self.sid, "--lines", str(CAPTURE_LINES)]
         if self.pane in ("left", "right", "scratch"):
             args += ["--pane", self.pane]
         res = self.run(*args)
-        return res.stdout if res.returncode == 0 else ""
+        if res.returncode != 0:
+            return "", cli_error(res)
+        return res.stdout, ""
 
-    def review(self, revdiff: str, src: Path, out: Path) -> int:
-        """Open revdiff over this session and block, returning its exit status.
+    def review(self, revdiff: str, src: Path, out: Path) -> tuple[int, str]:
+        """Open revdiff over this session and block, returning (exit status, agtermctl error).
 
-        10 means annotations were written, 0 that the review was quit without any.
+        10 means annotations were written, 0 that the review was quit without any. A nonzero status
+        is ambiguous on its own: agtermctl can refuse before revdiff ever runs, "overlay already
+        open" being the one a second press produces, so its own message is carried out with it.
         """
         command = f"{revdiff} --only={src} -o {out} --exit-code-on-annotations --wrap"
-        return self.run("session", "overlay", "open", command, "--block",
-                        "--size-percent", str(OVERLAY_PERCENT),
-                        "--background-color", OVERLAY_TINT,
-                        "--target", self.sid).returncode
+        res = self.run("session", "overlay", "open", command, "--block",
+                       "--size-percent", str(OVERLAY_PERCENT),
+                       "--background-color", OVERLAY_TINT,
+                       "--target", self.sid)
+        return res.returncode, cli_error(res)
 
-    def paste(self, text: str) -> bool:
-        """Deliver text as one bracketed paste, leaving the clipboard as it was found.
+    def deliver(self, text: str) -> str:
+        """Put the notes where the chord came from, returning "" on success or what went wrong.
 
-        The save-and-restore is what makes the clipboard route free: without it, using this command
-        would silently cost whatever you were carrying.
+        Only the main pane can be pasted into: `session paste` takes no --pane and runs on the
+        session's main surface, so pasting from a split's right pane or the scratch would drop the
+        notes at another prompt. Those panes keep the text on the clipboard for a manual paste,
+        which is why the restore below is skipped for them.
         """
+        if self.pane in ("right", "scratch"):
+            copy_clipboard(text)
+            self.notify(f"notes copied to the clipboard - paste them into the {self.pane} pane")
+            return ""
         saved = subprocess.run(["pbpaste"], capture_output=True, text=True, check=False).stdout
         try:
-            subprocess.run(["pbcopy"], input=text, text=True, check=False)
-            return self.run("session", "paste", "--target", self.sid).returncode == 0
+            copy_clipboard(text)
+            res = self.run("session", "paste", "--target", self.sid)
+            return "" if res.returncode == 0 else cli_error(res)
         finally:
-            subprocess.run(["pbcopy"], input=saved, text=True, check=False)
+            copy_clipboard(saved)
 
 
 def captured(selection: str, pane: str) -> str:
@@ -145,10 +201,9 @@ def captured(selection: str, pane: str) -> str:
     Whitespace does not count as a selection - a stray drag leaves one, and reviewing it would show
     an empty buffer instead of the screen you meant.
 
-    Blank tail lines are dropped from the PANE only. `session text` returns the whole screen, so a
-    pane holding a few lines hands over a screenful of padding, and revdiff opens on the emptiness
-    below the content rather than on the content. A selection is taken exactly as made. Only the tail
-    is trimmed: dropping leading blanks would shift every line number an annotation comes back with.
+    The pane's trailing newline is dropped so revdiff does not open on an empty last line; `--lines`
+    has already trimmed blank grid rows server-side. A selection is taken exactly as made. Only the
+    tail is touched: dropping leading blanks would shift every line number a note comes back with.
     """
     if selection.strip():
         return selection
@@ -210,7 +265,11 @@ def main(argv: list[str]) -> int:
     if not revdiff:
         fail("revdiff not found: set REVDIFF to its full path", agt)
 
-    text = captured(os.environ.get("AGT_SELECTION") or "", agt.pane_text())
+    selection = os.environ.get("AGT_SELECTION") or ""
+    pane, err = agt.pane_text()
+    if err and not selection.strip():
+        fail(f"could not read the pane: {err}", agt)
+    text = captured(selection, pane)
     if not text.strip():
         fail("nothing to annotate: no selection and the pane read empty", agt)
 
@@ -218,9 +277,9 @@ def main(argv: list[str]) -> int:
     src, out = room / "session.txt", room / "notes.md"
     src.write_text(text)
     try:
-        code = agt.review(revdiff, src, out)
+        code, err = agt.review(revdiff, src, out)
         if code not in (0, 10):
-            fail(f"revdiff exited {code}", agt)
+            fail(err or f"revdiff exited {code}", agt)
         if code == 0 or not out.exists():
             log("quit without annotations")
             return 0
@@ -234,8 +293,8 @@ def main(argv: list[str]) -> int:
     if "--print" in argv:
         print(reply)
         return 0
-    if not agt.paste(reply):
-        fail("could not paste the reply into the session", agt)
+    if failure := agt.deliver(reply):
+        fail(f"could not deliver the notes: {failure}", agt)
     return 0
 
 

--- a/cookbook/annotate-pane-output/annotate-pane.py
+++ b/cookbook/annotate-pane-output/annotate-pane.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Annotate what the pane just printed and hand the notes back to it as an unsent paste.
+
+Runs as an agterm keymap custom command, so the runner exports $AGT_* and the app spawns it with
+launchd's PATH and stdout on /dev/null.
+
+    text selected    -> that selection is what you annotate
+    nothing selected -> the pane's last CAPTURE_LINES lines
+
+The text goes into a scratch file, revdiff opens on it in a blocking overlay, and every annotation
+comes back as the line it was attached to plus what was written about it. That pair is the whole
+point: a note like "why this one?" is unreadable on its own once the pane has scrolled on.
+
+The reply is delivered through the CLIPBOARD, saved and restored around the paste. This is not a
+convenience - `session type` sends real keystrokes, so a multi-line reply submits itself one line at
+a time, while `session paste` is the only bracketed-paste path agterm exposes and it reads the
+system clipboard. Measured against a pty with DECSET 2004 on: type produced bare lines, paste
+produced one `^[[200~...^[[201~` block. So the reply lands whole and unsent, for you to read and
+send.
+
+Usage: annotate-pane.py [--print]
+    --print  write the reply to stdout instead of pasting it, for checking the formatting
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+# how much of the pane to offer when nothing is selected. The pane's visible screen is the ceiling
+# anyway - `session text` without --all does not reach into scrollback
+CAPTURE_LINES = 50
+
+# a floating panel rather than the full pane, so the session it asks about stays visible behind it,
+# tinted dark enough that revdiff's syntax colors still read against it
+OVERLAY_PERCENT = 80
+OVERLAY_TINT = "#3a2c1e"
+
+AGTERMCTL = os.environ.get("AGTERMCTL") or "agtermctl"
+LOG = Path(os.environ.get("ANNOTATE_LOG") or (Path(tempfile.gettempdir()) / "agterm-annotate.log"))
+
+# `## path:line (type)` and `## path:line-end (type)`, the record header revdiff writes. The path is
+# non-greedy so a colon inside it cannot eat the line number
+HEADER_RE = re.compile(r"^##\s+(?P<path>.+?):(?P<start>\d+)(?:-(?P<end>\d+))?\s+\((?P<kind>[^)]*)\)\s*$")
+# the file-level form carries no line at all, so it quotes nothing
+FILE_HEADER_RE = re.compile(r"^##\s+(?P<path>.+?)\s+\((?P<kind>[^)]*)\)\s*$")
+
+
+def log(message: str) -> None:
+    """Append a line to the run log; a keybinding has no stdout anyone reads."""
+    try:
+        with LOG.open("a") as fh:
+            fh.write(f"{time.strftime('%F %T')}  {message}\n")
+    except OSError:
+        pass
+
+
+def fail(message: str, agt: Agt | None = None) -> None:
+    """Report through the only channels a keybinding has, then exit."""
+    log(message)
+    print(f"annotate-pane: {message}", file=sys.stderr)
+    if agt:
+        agt.notify(message)
+    sys.exit(1)
+
+
+def find_revdiff() -> str:
+    """Resolve revdiff absolutely: a custom command gets launchd's PATH, not a shell's.
+
+    That PATH is /usr/local/bin plus the system directories, so a revdiff installed by Homebrew or
+    `go install` is not on it. Set REVDIFF to its full path when neither fallback below matches.
+    """
+    for candidate in (os.environ.get("REVDIFF") or "", shutil.which("revdiff") or "",
+                      "/opt/homebrew/bin/revdiff", str(Path.home() / "go/bin/revdiff")):
+        if candidate and os.access(candidate, os.X_OK):
+            return candidate
+    return ""
+
+
+class Agt:
+    """The agterm control channel: agtermctl plus this session's addressing."""
+
+    def __init__(self) -> None:
+        self.socket = os.environ.get("AGT_SOCKET") or ""
+        self.sid = os.environ.get("AGT_SESSION_ID") or ""
+        self.pane = os.environ.get("AGT_PANE") or ""
+
+    def run(self, *args: str) -> subprocess.CompletedProcess[str]:
+        """Invoke agtermctl against the instance the chord came from, never raising on a nonzero exit."""
+        cmd = [AGTERMCTL, *args]
+        if self.socket:
+            cmd += ["--socket", self.socket]
+        return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+    def notify(self, message: str) -> None:
+        """Post a desktop banner, the one channel a keybinding has when it cannot paste."""
+        self.run("notify", message, "--title", "annotate")
+
+    def pane_text(self) -> str:
+        """Read the pane the chord fired from, not whichever pane happens to be focused.
+
+        --pane is passed explicitly because the two can differ: a chord fired in a split's right pane
+        while focus sits left would otherwise capture the wrong half.
+        """
+        args = ["session", "text", "--target", self.sid, "--lines", str(CAPTURE_LINES)]
+        if self.pane in ("left", "right", "scratch"):
+            args += ["--pane", self.pane]
+        res = self.run(*args)
+        return res.stdout if res.returncode == 0 else ""
+
+    def review(self, revdiff: str, src: Path, out: Path) -> int:
+        """Open revdiff over this session and block, returning its exit status.
+
+        10 means annotations were written, 0 that the review was quit without any.
+        """
+        command = f"{revdiff} --only={src} -o {out} --exit-code-on-annotations --wrap"
+        return self.run("session", "overlay", "open", command, "--block",
+                        "--size-percent", str(OVERLAY_PERCENT),
+                        "--background-color", OVERLAY_TINT,
+                        "--target", self.sid).returncode
+
+    def paste(self, text: str) -> bool:
+        """Deliver text as one bracketed paste, leaving the clipboard as it was found.
+
+        The save-and-restore is what makes the clipboard route free: without it, using this command
+        would silently cost whatever you were carrying.
+        """
+        saved = subprocess.run(["pbpaste"], capture_output=True, text=True, check=False).stdout
+        try:
+            subprocess.run(["pbcopy"], input=text, text=True, check=False)
+            return self.run("session", "paste", "--target", self.sid).returncode == 0
+        finally:
+            subprocess.run(["pbcopy"], input=saved, text=True, check=False)
+
+
+def captured(selection: str, pane: str) -> str:
+    """Pick what gets reviewed: the selection when there is one, else the pane text.
+
+    Whitespace does not count as a selection - a stray drag leaves one, and reviewing it would show
+    an empty buffer instead of the screen you meant.
+
+    Blank tail lines are dropped from the PANE only. `session text` returns the whole screen, so a
+    pane holding a few lines hands over a screenful of padding, and revdiff opens on the emptiness
+    below the content rather than on the content. A selection is taken exactly as made. Only the tail
+    is trimmed: dropping leading blanks would shift every line number an annotation comes back with.
+    """
+    if selection.strip():
+        return selection
+    return "\n".join(pane.splitlines()).rstrip()
+
+
+def parse_annotations(text: str) -> list[tuple[int, int, str]]:
+    """Read revdiff's output into (start, end, note) triples, 0 for file-level.
+
+    A body line beginning with `## ` arrives space-prefixed, revdiff's own guard against a comment
+    being read as the next record; that space is taken back off here.
+    """
+    found: list[tuple[int, int, str]] = []
+    start = end = 0
+    body: list[str] = []
+    open_record = False
+
+    def flush() -> None:
+        note = "\n".join(body).strip()
+        if open_record and note:
+            found.append((start, end, note))
+
+    for line in text.splitlines():
+        header = HEADER_RE.match(line)
+        if not header and line.startswith("## "):
+            header = FILE_HEADER_RE.match(line)
+        if header:
+            flush()
+            groups = header.groupdict()
+            start = int(groups.get("start") or 0)
+            end = int(groups.get("end") or 0) or start
+            body, open_record = [], True
+            continue
+        if open_record:
+            body.append(line[1:] if line.startswith(" ## ") else line)
+    flush()
+    return found
+
+
+def reply_text(lines: list[str], annotations: list[tuple[int, int, str]]) -> str:
+    """Render each annotation as the line it hangs on, quoted, then the note.
+
+    Line numbers are 1-based into the captured text. One out of range quotes nothing rather than
+    dropping the note: a question is still worth asking without its referent.
+    """
+    blocks = []
+    for start, end, note in annotations:
+        quoted = [f"> {lines[n - 1]}" for n in range(start, end + 1) if 1 <= n <= len(lines)]
+        blocks.append("\n".join(quoted + ["", note]) if quoted else note)
+    return "\n\n".join(blocks)
+
+
+def main(argv: list[str]) -> int:
+    """Capture, review, and paste the notes back into the session."""
+    agt = Agt()
+    if not agt.sid:
+        fail("no $AGT_SESSION_ID: run this as an agterm custom command")
+    revdiff = find_revdiff()
+    if not revdiff:
+        fail("revdiff not found: set REVDIFF to its full path", agt)
+
+    text = captured(os.environ.get("AGT_SELECTION") or "", agt.pane_text())
+    if not text.strip():
+        fail("nothing to annotate: no selection and the pane read empty", agt)
+
+    room = Path(tempfile.mkdtemp(prefix="agterm-annotate-"))
+    src, out = room / "session.txt", room / "notes.md"
+    src.write_text(text)
+    try:
+        code = agt.review(revdiff, src, out)
+        if code not in (0, 10):
+            fail(f"revdiff exited {code}", agt)
+        if code == 0 or not out.exists():
+            log("quit without annotations")
+            return 0
+        annotations = parse_annotations(out.read_text())
+    finally:
+        shutil.rmtree(room, ignore_errors=True)
+
+    if not annotations:
+        return 0
+    reply = reply_text(text.splitlines(), annotations)
+    if "--print" in argv:
+        print(reply)
+        return 0
+    if not agt.paste(reply):
+        fail("could not paste the reply into the session", agt)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv[1:]))
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/cookbook/annotate-pane-output/annotate-pane.py
+++ b/cookbook/annotate-pane-output/annotate-pane.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -168,7 +169,10 @@ class Agt:
         is ambiguous on its own: agtermctl can refuse before revdiff ever runs, "overlay already
         open" being the one a second press produces, so its own message is carried out with it.
         """
-        command = f"{revdiff} --only={src} -o {out} --exit-code-on-annotations --wrap"
+        # the overlay runs this string through a shell, so a REVDIFF path with a space in it would
+        # otherwise split into two words
+        command = (f"{shlex.quote(revdiff)} --only={shlex.quote(str(src))} -o {shlex.quote(str(out))}"
+                   " --exit-code-on-annotations --wrap")
         res = self.run("session", "overlay", "open", command, "--block",
                        "--size-percent", str(OVERLAY_PERCENT),
                        "--background-color", OVERLAY_TINT,
@@ -203,12 +207,14 @@ def captured(selection: str, pane: str) -> str:
     an empty buffer instead of the screen you meant.
 
     The pane's trailing newline is dropped so revdiff does not open on an empty last line; `--lines`
-    has already trimmed blank grid rows server-side. A selection is taken exactly as made. Only the
-    tail is touched: dropping leading blanks would shift every line number a note comes back with.
+    has already trimmed blank grid rows server-side. Newlines ONLY - a bare rstrip would eat trailing
+    spaces off the last line of a prompt or an ASCII layout, changing what is annotated. A selection
+    is taken exactly as made, and leading blanks stay: dropping them would shift every line number a
+    note comes back with.
     """
     if selection.strip():
         return selection
-    return "\n".join(pane.splitlines()).rstrip()
+    return "\n".join(pane.splitlines()).rstrip("\n")
 
 
 def parse_annotations(text: str) -> list[tuple[int, int, str]]:

--- a/cookbook/annotate-pane-output/annotate-pane.py
+++ b/cookbook/annotate-pane-output/annotate-pane.py
@@ -13,10 +13,11 @@ point: a note like "why this one?" is unreadable on its own once the pane has sc
 
 The reply is delivered through the CLIPBOARD, saved and restored around the paste. This is not a
 convenience - `session type` sends real keystrokes, so a multi-line reply submits itself one line at
-a time, while `session paste` is the only bracketed-paste path agterm exposes and it reads the
-system clipboard. Measured against a pty with DECSET 2004 on: type produced bare lines, paste
-produced one `^[[200~...^[[201~` block. So the reply lands whole and unsent, for you to read and
-send.
+a time whatever is reading, while `session paste` is the only bracketed-paste path agterm exposes
+and it reads the system clipboard. Measured against a pty with DECSET 2004 on: type produced bare
+lines, paste produced one `^[[200~...^[[201~` block, so the reply lands whole and unsent. 2004 is
+the PROGRAM's mode, not a property of the route: against one with it off the newlines submit, the
+same as any manual paste. There is no way to ask over the control API which it is.
 
 `session paste` takes no --pane and always runs on the session's main surface, so from a split's
 right pane or the scratch it would deliver to the wrong prompt. Those panes keep the notes on the


### PR DESCRIPTION
a cookbook recipe for a keymap chord I run here. It takes what you selected, or the pane's last 50 lines when nothing is selected, opens it in revdiff inside an overlay on that session, and pastes your notes back at the prompt when you quit, each one quoting the line it hangs on.

Select the three lines you want to argue with, or press it on whatever is on screen. So it works on an agent's answer, but equally on a stack trace, a failing test run or a `terraform plan`.

`annotate-claude-replies` already does this for Claude Code, and does it better where it applies: it reads Claude's own transcript, so it gets every reply of the exchange in full, however far it has scrolled. This one reads the terminal instead, which costs that fidelity and buys any agent, any program, and no hook to install. Both READMEs point at each other.

The reply goes through the clipboard, saved and restored around the paste. `session type` sends real keystrokes, so a multi-line reply submits itself one line at a time; `session paste` is the only bracketed-paste path the control API exposes and it reads the system clipboard. So the notes arrive whole and unsent.

Minimum 0.13.0, for `$AGT_PANE`. Nothing else is new: `session paste` shipped in 0.11.0 and `session text` in 0.5.0.

Index row goes in Agent status and workflows, next to `annotate-claude-replies`.
