### PR TITLE
docs(cookbook): add backlog-picker recipe

### DIFF
--- a/cookbook/CONTRIBUTING.md
+++ b/cookbook/CONTRIBUTING.md
@@ -8,7 +8,7 @@ These rules cover recipes. The project-wide rules for everything else are in [CO
 
 ## Layout
 
-One directory per recipe, kebab-case, named after what the recipe does rather than after its script (`park-and-resume`, not `agt-park`). It holds a `README.md` and the scripts, nothing else.
+One directory per recipe, kebab-case, named after what the recipe does rather than after its script (`park-and-resume`, not `agt-park`). It holds a `README.md` and the scripts, nothing else — with one exception: a recipe whose chord hands work to a coding agent may ship the agent skill it needs, as `SKILL.md` beside the scripts, and *Setup* says where to copy it. The skill is part of the recipe and is read the same way, so keep it to what this recipe needs rather than shipping your whole configuration.
 
 Name scripts by their language, because the extension decides what CI does with them:
 

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -35,6 +35,7 @@ its *needs* column, so searching this page for `claude` or `kiro` finds those di
 |---|---|---|
 | [annotate-claude-replies](annotate-claude-replies/) | mark up Claude's answers in revdiff and send the notes back | 0.13.0, revdiff, python3, Claude Code |
 | [annotate-pane-output](annotate-pane-output/) | mark up what the pane just printed in revdiff and send the notes back to whatever is running there | 0.13.0, revdiff, python3 |
+| [backlog-picker](backlog-picker/) | pick one of the repo's written-down deferred items and hand it to the agent in the pane | 0.20.2, python3, Claude Code |
 | [claude-clear](claude-clear/) | one chord sends /clear to the pane's Claude Code run, and nothing when it is not running | 0.13.0, python3, Claude Code |
 | [claude-conversation-picker](claude-conversation-picker/) | pick a past Claude Code conversation by what it was about and resume it in the pane | 0.21.0, python3, Claude Code |
 | [claude-recap](claude-recap/) | one key lists what the Claude Code run in a session was working on | 0.10.0, zsh, jq, Claude Code |

--- a/cookbook/backlog-picker/README.md
+++ b/cookbook/backlog-picker/README.md
@@ -34,7 +34,7 @@ Set `AGTERMCTL` if your binary is somewhere unusual; the script otherwise finds 
 Copy the script somewhere on your machine, say `~/bin/`, and make it executable:
 
 ```sh
-chmod +x backlog-picker.py
+mkdir -p ~/bin && cp backlog-picker.py ~/bin/ && chmod +x ~/bin/backlog-picker.py
 ```
 
 Install the skill by copying `SKILL.md` to `~/.claude/skills/backlog/SKILL.md`:
@@ -53,10 +53,10 @@ command "Backlog ›" ctrl+a>b ~/bin/backlog-picker.py
 
 The name ends in `›` so the palette shows it opens something rather than doing something. Any chord works, and a `command` line with no chord at all is palette-only.
 
-If your Claude Code launcher is a wrapper rather than `claude` itself, tell the script what its argv looks like, or every pick will type a shell command into a running agent:
+If your Claude Code launcher is a wrapper rather than `claude` itself, it takes two variables, and both matter. `BACKLOG_FG_MATCH` is how the script recognises the wrapper already running in the pane, without which every pick types a shell command into a live agent; `BACKLOG_CLAUDE_CMD` is what it types at a bare prompt, without which it starts plain `claude` rather than your wrapper:
 
 ```
-command "Backlog ›" ctrl+a>b BACKLOG_FG_MATCH='(^|/)(claude|mywrapper)$' ~/bin/backlog-picker.py
+command "Backlog ›" ctrl+a>b BACKLOG_FG_MATCH='(^|/)(claude|mywrapper)$' BACKLOG_CLAUDE_CMD=mywrapper ~/bin/backlog-picker.py
 ```
 
 `BACKLOG_DIR` moves the item directory, relative to the repo root, if yours is not `docs/backlog`.
@@ -79,7 +79,7 @@ The script also carries its own tests, which is what to run after editing the pa
 ./backlog-picker.py --test
 ```
 
-Two failure modes are reported as desktop notifications, because a keybinding has no stdout anyone reads: no items in the directory, and the picker itself failing. Everything else lands in `/tmp/backlog-picker.log`, or wherever `BACKLOG_PICKER_LOG` points.
+Every failure exits nonzero, and agterm banners that by itself as `Backlog › (exit 1)`, because a keybinding has no stdout anyone reads. Four of them post a second banner naming what went wrong: no items in the directory, the picker failing, the picker returning an item that is not there, and the typing failing. A failure with no `agtermctl` to talk to — the binary missing, or an `AGTERMCTL` that is not executable — can only be the bare one. Everything else is in `/tmp/backlog-picker.log`, or wherever `BACKLOG_PICKER_LOG` points: a file skipped for its name, an unreadable file, and a `tree` read that failed are logged there and nowhere else.
 
 ## How it works
 
@@ -98,11 +98,13 @@ Body prose: repro, what was tried, the review that surfaced it.
 
 The H1 is the row's label and the three fields become its subtitle. All of them are optional and a missing one costs that field only, so a plain markdown note with no frontmatter still lists, under its H1 or its file name. `added` is never rewritten, which is what lets the subtitle show an item's age honestly; a year-old entry says something its title does not.
 
-Items are sorted by `added` and then by mtime, newest first, because a day's granularity cannot separate two items written in one session. That order is handed to `agtermctl pick` on stdin as JSON and shown as-is.
+Items are sorted by `added` and then by mtime, newest first, because a day's granularity cannot separate two items written in one session. That order is handed to `agtermctl pick` on stdin as JSON and shown as-is. `added` being the sort key is why a value that is not an ISO date is dropped rather than kept: `2026-8-5` compares above every well-formed `2026-…` and would park a typo at the top of the list with no age beside it to explain why.
 
-The pane's live foreground argv comes from `tree --json`: `foreground` for the left pane, `splitForeground` for the right. Any argv element matching `BACKLOG_FG_MATCH` means Claude Code is running there, which is what decides between typing a slash command and typing a launcher. A scratch pane always reads as a shell, because the tree reports the main and split panes only.
+The file name is treated as hostile, because in a repo you cloned it is someone else's. The bare-prompt line is quoted with `shlex`, so `a"; id; :"b.md` reaches the shell as one argument rather than as a second statement, and a name carrying a control character is refused outright and logged — a newline in a slug would otherwise submit a line of its own to whatever is running in the pane. The row shows the H1 while the file name carries the slug, so nothing about such an item looks wrong at the moment you pick it.
 
-Finding `agtermctl` is the part that cost an hour. Existence is not enough: several installs coexist easily, and a PATH lookup can land on an old **Install Command Line Tool…** symlink pointing at an app that is not the one holding the socket, so a `pick` call fails against a binary that looks perfectly fine. The script asks the running app's own bundle first — read out of the process list, since `pgrep` does not see GUI apps from a keybinding's environment — then falls back through `$GHOSTTY_BIN_DIR`, the usual install paths and `PATH`, probing each candidate's `--help` for a `pick` subcommand rather than trusting a version string. `AGTERMCTL` skips the whole search.
+The pane's live foreground argv comes from `tree --json --window`: `foreground` for the left pane, `splitForeground` for the right. Any argv element matching `BACKLOG_FG_MATCH` means Claude Code is running there, which is what decides between typing a slash command and typing a launcher. A scratch pane always reads as a shell, because the tree reports the main and split panes only, and so does a read that failed — a session closed while the picker was open, say — which is logged rather than guessed at.
+
+Finding `agtermctl` is the part that cost an hour. Existence is not enough: several installs coexist easily, and a PATH lookup can land on an old **Install Command Line Tool…** symlink pointing at an app that is not the one holding the socket, so a `pick` call fails against a binary that looks perfectly fine. The script asks the running app's own bundle first — read out of the process list, since `pgrep` does not see GUI apps from a keybinding's environment — then falls back through `$GHOSTTY_BIN_DIR`, the usual install paths and `PATH`, probing each candidate's `--help` for a `pick` subcommand rather than trusting a version string. `AGTERMCTL` skips the whole search and is used as given, without the probe: a wrapper script that adds a default `--socket` is exactly what the override is for, and it does not reproduce the help layout the probe reads. Being executable is all that is asked of it, and a path that is not stops the run saying so.
 
 Everything the script needs about where it is comes from the environment agterm exports to a custom command: `AGT_SESSION_PWD` for the repo, `AGT_SESSION_ID` and `AGT_PANE` for where to type, `AGT_WINDOW_ID` for which window shows the picker, and `AGT_SOCKET` for the instance to talk to. The repo root itself is `git rev-parse --show-toplevel` from that directory, so the chord works from a subdirectory.
 

--- a/cookbook/backlog-picker/README.md
+++ b/cookbook/backlog-picker/README.md
@@ -1,0 +1,117 @@
+# Backlog picker
+
+Pick one of the repo's written-down deferred items in the native picker and hand it to the Claude Code run sitting in the pane.
+
+## What it does
+
+A backlog is a directory of markdown files at the repo root, `docs/backlog/`, one file per item: a defect a change did not introduce, drift with no user-visible symptom, a fix whose blast radius exceeded its value. Writing an item down is cheap. Coming back to it is not, because by then you have to find it, read it, decide whether it still applies, and then explain it to the agent.
+
+One chord does all of that. The picker lists this repo's items newest first, each row showing the triage call, how old the item is and where it lives:
+
+```
+reopen fallback ignores the last-frontmost window
+worth fixing later · 6d · internal/store/reopen.go:537
+
+palette hover tint goes stale under a parked pointer
+worth fixing · 3mo · internal/ui/palette.go:212
+```
+
+Choosing one types `/backlog <slug>` into the pane you pressed the chord in, so the agent reads that single item, checks its `where` still says what the item claims, and comes back with fix-or-drop. At a bare shell prompt it types `claude "/backlog <slug>"` instead, which starts Claude Code on that item.
+
+The repo is whichever one the session sits in, so the same chord in another tab lists that project's backlog.
+
+## Requirements
+
+- agterm 0.20.2 or later. `pick` itself shipped in 0.19.0; 0.20.0 is where a caller-supplied picker stopped re-sorting an empty query alphabetically and stopped matching typed text against subtitles, both of which this recipe depends on — newest-first is the order it hands over, and a query must not match the `where` path in a row's subtitle. 0.20.2 is where `tree --json` began reporting `foreground` for a pane started with `session new --command`, which is what keeps the recipe from typing a shell command into a running agent. `{AGT_PANE}`, which routes the typing back into the half of the split you pressed the chord in, shipped in 0.13.0.
+- Python 3.9 or later, which macOS ships as `/usr/bin/python3`
+- Claude Code, plus the `backlog` skill in this directory. The skill is what makes `/backlog <slug>` mean anything; without it the slash command is typed into a Claude that does not know it.
+- `docs/backlog/` in the repos you use it in. The format is in the skill and in *How it works* below.
+
+Set `AGTERMCTL` if your binary is somewhere unusual; the script otherwise finds one itself, described under *How it works*.
+
+## Setup
+
+Copy the script somewhere on your machine, say `~/bin/`, and make it executable:
+
+```sh
+chmod +x backlog-picker.py
+```
+
+Install the skill by copying `SKILL.md` to `~/.claude/skills/backlog/SKILL.md`:
+
+```sh
+mkdir -p ~/.claude/skills/backlog && cp SKILL.md ~/.claude/skills/backlog/SKILL.md
+```
+
+It is an ordinary Claude Code skill, so a project copy under `.claude/skills/backlog/` works the same way if you want it in one repo only. Read it before you install it: it tells the agent when to write items, when to leave them alone, and to never commit one on its own.
+
+Add an entry to `~/.config/agterm/keymap.conf` and apply it with File ▸ Reload Keymap or `agtermctl keymap reload`:
+
+```
+command "Backlog ›" ctrl+a>b ~/bin/backlog-picker.py
+```
+
+The name ends in `›` so the palette shows it opens something rather than doing something. Any chord works, and a `command` line with no chord at all is palette-only.
+
+If your Claude Code launcher is a wrapper rather than `claude` itself, tell the script what its argv looks like, or every pick will type a shell command into a running agent:
+
+```
+command "Backlog ›" ctrl+a>b BACKLOG_FG_MATCH='(^|/)(claude|mywrapper)$' ~/bin/backlog-picker.py
+```
+
+`BACKLOG_DIR` moves the item directory, relative to the repo root, if yours is not `docs/backlog`.
+
+## Usage
+
+Press the chord in any session sitting in a repo that has a backlog. Type to filter, Return to pick, Escape to cancel — cancelling types nothing.
+
+Check what the picker will show without opening it:
+
+```sh
+./backlog-picker.py --list
+```
+
+It prints one line per item, slug first, then the count and the directory it read. This is the first thing to run when the picker says the backlog is empty and you know it is not: the path it prints is the repo root it resolved.
+
+The script also carries its own tests, which is what to run after editing the parser:
+
+```sh
+./backlog-picker.py --test
+```
+
+Two failure modes are reported as desktop notifications, because a keybinding has no stdout anyone reads: no items in the directory, and the picker itself failing. Everything else lands in `/tmp/backlog-picker.log`, or wherever `BACKLOG_PICKER_LOG` points.
+
+## How it works
+
+An item is `docs/backlog/<slug>.md`, and the slug — the file name without its extension — is the identifier the whole recipe passes around. Three optional frontmatter fields carry the triage:
+
+```markdown
+---
+worth: later
+where: internal/store/reopen.go:537
+added: 2026-08-05
+---
+# reopen fallback ignores the last-frontmost window
+
+Body prose: repro, what was tried, the review that surfaced it.
+```
+
+The H1 is the row's label and the three fields become its subtitle. All of them are optional and a missing one costs that field only, so a plain markdown note with no frontmatter still lists, under its H1 or its file name. `added` is never rewritten, which is what lets the subtitle show an item's age honestly; a year-old entry says something its title does not.
+
+Items are sorted by `added` and then by mtime, newest first, because a day's granularity cannot separate two items written in one session. That order is handed to `agtermctl pick` on stdin as JSON and shown as-is.
+
+The pane's live foreground argv comes from `tree --json`: `foreground` for the left pane, `splitForeground` for the right. Any argv element matching `BACKLOG_FG_MATCH` means Claude Code is running there, which is what decides between typing a slash command and typing a launcher. A scratch pane always reads as a shell, because the tree reports the main and split panes only.
+
+Finding `agtermctl` is the part that cost an hour. Existence is not enough: several installs coexist easily, and a PATH lookup can land on an old **Install Command Line Tool…** symlink pointing at an app that is not the one holding the socket, so a `pick` call fails against a binary that looks perfectly fine. The script asks the running app's own bundle first — read out of the process list, since `pgrep` does not see GUI apps from a keybinding's environment — then falls back through `$GHOSTTY_BIN_DIR`, the usual install paths and `PATH`, probing each candidate's `--help` for a `pick` subcommand rather than trusting a version string. `AGTERMCTL` skips the whole search.
+
+Everything the script needs about where it is comes from the environment agterm exports to a custom command: `AGT_SESSION_PWD` for the repo, `AGT_SESSION_ID` and `AGT_PANE` for where to type, `AGT_WINDOW_ID` for which window shows the picker, and `AGT_SOCKET` for the instance to talk to. The repo root itself is `git rev-parse --show-toplevel` from that directory, so the chord works from a subdirectory.
+
+## Limits
+
+Picking an item types a line and sends Return into the pane. If something other than an agent or a shell prompt is sitting there — a pager, a TUI, a program waiting on input — that line goes into it instead. The recipe never checks what it is typing into beyond the Claude-or-not test.
+
+The typed instruction is where it stops. What happens next is the agent's, and the skill tells it to ask before fixing anything and never to commit on its own, but it is an instruction and not a guarantee.
+
+A session whose repo has no `docs/backlog/` gets a notification saying so, not an empty picker. The recipe never creates the directory.
+
+The picker lists one repo, the session's own. There is no cross-repo view here.

--- a/cookbook/backlog-picker/SKILL.md
+++ b/cookbook/backlog-picker/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: backlog
+description: Read, work, and maintain a repo's deferred-work items in docs/backlog/, one file per item. Use when the user says "backlog", "check backlog", "what's on my backlog", "work the backlog", "address the backlog", "add to backlog", "clean up backlog", or when a review or task produced items that are real but not being fixed now. Owns the item format, the create-then-delete lifecycle.
+allowed-tools: Read, Edit, Write, Bash, Grep, Glob, AskUserQuestion
+---
+
+# Backlog
+
+`docs/backlog/` at a repo root holds work that is real but not being done now: a defect a change did not
+introduce, drift with no user-visible symptom, a fix whose blast radius exceeded its value, an idea worth
+keeping. One file per item. It is the maintainer's own list — it never gates anything and never reaches a
+contributor.
+
+## Item format
+
+`docs/backlog/<slug>.md`. The slug names the defect, not the file it lives in
+(`reopen-fallback-ignores-frontmost.md`), so it can be cited from a commit and dedupe is a filename check.
+
+```markdown
+---
+worth: later
+where: internal/store/reopen.go:537
+added: 2026-08-05
+---
+# reopen fallback ignores the last-frontmost window
+
+`reopen`'s fallback ignores which window was last frontmost once `frontmost` is nil, so a multi-window
+user's last-window capture replays only when the exited window happened to be `windows.first`. Surfaced
+reviewing PR #370; the fix touches restore ordering, which is why it was deferred rather than done inline.
+```
+
+Three frontmatter fields, written once and not rewritten afterwards:
+
+- **`worth: yes | no | later`** — the honest triage call. **`no` is a valid answer**: a real item not worth
+  the edit still belongs here, because writing it down is what stops it being rediscovered every review.
+- **`where: path:line`** — omit when the item is not anchored to one place. The dedupe key alongside the slug.
+- **`added: YYYY-MM-DD`** — never updated, so it reads as age. A year-old item is itself information.
+
+The H1 is the title. The body below it is free — repro, what was tried, the review that surfaced it, links,
+a snippet. No required sections: a two-line item stays two lines, a gnarly one gets a page.
+
+## Lifecycle
+
+Create the file. When the work lands, `git rm` it in the commit that lands the fix — not a separate cleanup
+commit. There is no checkbox, no in-progress marker: the staged deletion is the state. Dropping an item
+decided against is the same operation with a different reason.
+
+## A slug as the argument
+
+`/backlog <slug>` names one item: `docs/backlog/<slug>.md`, the file name without its extension. Read
+that file alone, verify its `where` the same way step 2 below does, and go straight to the fix-or-drop
+question for it — skip the listing, which is not what was asked for. A slug matching no file is a
+mistake worth saying plainly: report it and list what is there instead of guessing at the nearest name.
+
+The picker types this form, so the argument arrives already matching a real file name.
+
+## Reading and working the list
+
+1. Glob `docs/backlog/*.md` from the repo root and read each file's frontmatter and H1. If the directory
+   does not exist, say so plainly and offer to start one — do not create it empty.
+2. **Verify before reporting.** `where` goes stale when a file is renamed or a line moves. Check each
+   item's location still exists and still says what the item claims; report a stale item as stale rather
+   than as work.
+3. Report every item, one line each — `yes` first, then `later`, then `no`, oldest `added` first within
+   each group. Include `where`. Do not editorialize; the item already carries its reasoning.
+4. Offer concrete actions with **AskUserQuestion**, never prose, with a recommendation first:
+   - **fix a named item now** — name the specific item in the option label, not "fix something";
+   - **file one as an issue** — for an item that wants tracking rather than doing;
+   - **drop a named item** — a `no` that has stopped being worth carrying;
+   - **leave it** — report only, nothing changes.
+
+   With more than four items, group them across several questions rather than truncating the list.
+5. On "fix it now": do the work under the usual gates — tests, formatters, linters — and `git rm` the file
+   in the same commit. Never auto-commit.
+
+## Appending
+
+When a run produces deferred items, offer to append them; never write silently.
+
+**Never write into a branch this session did not create.** An item is repo-wide notes; dropped into
+someone else's in-progress branch it gets swept into that branch's diff or vanishes with it. Check
+`git branch --show-current` first:
+
+- the default branch, or a branch this session created — write in place;
+- any other branch — write it against the default branch instead, from a throwaway checkout or worktree
+  outside this one. Never switch the current checkout's branch to do it.
+
+**Dedupe before writing**, on `where` first and the slug second. A pre-existing defect surfaces in every
+review that touches its file, so the same item arrives repeatedly. If it is already there, say so and leave
+it alone. If the new sighting sharpens the description or changes the `worth` call, edit that file in place
+rather than adding a second one.
+
+Create `docs/backlog/` if it does not exist.
+
+When the files are written, offer the next step with **AskUserQuestion**, staging the `docs/backlog/` files
+only — an item bundled with the run's other changes violates the rule below. Never commit without that
+answer.
+
+- **written in place** — commit now, or leave it uncommitted.
+- **written from a separate checkout or worktree** — that tree is disposable, so a local commit leaves the
+  item somewhere the user will not go looking. Offer **commit and push** first, and remove the worktree
+  once it is pushed. Never end the run with an unpushed commit in a temp path as the only result.
+
+## Rules
+
+- **Never post a backlog item to a PR or issue thread** unless the user explicitly asks. These are the
+  maintainer's cleanup notes; surfacing them on a contributor's change reads as scope pressure.
+- **Never auto-commit** an item file, and never commit it alongside unrelated work.
+- **Do not fix an item without being asked.** Reading the backlog is not permission to work it.
+- **Prefer deleting to demoting.** An item nobody will ever do is noise; say so and offer to drop it.

--- a/cookbook/backlog-picker/SKILL.md
+++ b/cookbook/backlog-picker/SKILL.md
@@ -29,12 +29,14 @@ user's last-window capture replays only when the exited window happened to be `w
 reviewing PR #370; the fix touches restore ordering, which is why it was deferred rather than done inline.
 ```
 
-Three frontmatter fields, written once and not rewritten afterwards:
+Three frontmatter fields, written once and rewritten only when a later sighting of the same item
+sharpens it, which is the one case **Appending** below allows:
 
 - **`worth: yes | no | later`** — the honest triage call. **`no` is a valid answer**: a real item not worth
   the edit still belongs here, because writing it down is what stops it being rediscovered every review.
 - **`where: path:line`** — omit when the item is not anchored to one place. The dedupe key alongside the slug.
 - **`added: YYYY-MM-DD`** — never updated, so it reads as age. A year-old item is itself information.
+  Zero-pad it: a reader sorting on this field has nothing to fall back on when the value is not an ISO date.
 
 The H1 is the title. The body below it is free — repro, what was tried, the review that surfaced it, links,
 a snippet. No required sections: a two-line item stays two lines, a gnarly one gets a page.

--- a/cookbook/backlog-picker/backlog-picker.py
+++ b/cookbook/backlog-picker/backlog-picker.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""Pick a backlog item of THIS session's repo and hand it to the Claude Code run in the pane.
+
+Runs as an agterm keymap custom command, so the runner exports $AGT_* and the app spawns it with
+launchd's PATH and stdout on /dev/null.
+
+    claude already running in the pane -> types "/backlog <slug>" into the TUI
+    bare shell prompt                  -> types "claude \\"/backlog <slug>\\""
+
+Items are docs/backlog/*.md at the repo root, one file per item, newest first. The slug is the file
+name, which is what the backlog skill takes as its argument.
+
+Whether claude is running here is read from the pane's live foreground argv, so a wrapper counts as
+long as BACKLOG_FG_MATCH matches it.
+
+Environment:
+    AGTERMCTL           agtermctl to use, when the one on PATH is not the right one
+    BACKLOG_DIR         item directory relative to the repo root (default docs/backlog)
+    BACKLOG_CLAUDE_CMD  launcher typed at a bare prompt (default claude)
+    BACKLOG_FG_MATCH    argv pattern that means "claude runs here" (default (^|/)claude$)
+    BACKLOG_PICKER_LOG  run log (default /tmp/backlog-picker.log)
+
+Usage: backlog-picker.py [--list] [--test]
+    --list  print the parsed items and exit, without opening the picker
+    --test  run the self-tests
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+import unittest
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, NamedTuple
+
+BACKLOG_DIR = os.environ.get("BACKLOG_DIR", "docs/backlog")
+CLAUDE_CMD = os.environ.get("BACKLOG_CLAUDE_CMD", "claude")
+FG_MATCH = re.compile(os.environ.get("BACKLOG_FG_MATCH", r"(^|/)claude$"))
+LOG = Path(os.environ.get("BACKLOG_PICKER_LOG", "/tmp/backlog-picker.log"))
+
+FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
+FIELD_RE = re.compile(r"^(\w+):\s*(.*)$", re.MULTILINE)
+H1_RE = re.compile(r"^#\s+(.+?)\s*$", re.MULTILINE)
+# `worth` is the triage call, so it leads the subtitle. It orders nothing: the skill reports
+# yes-then-later-then-no, while this picker is newest-first. The bare frontmatter value reads as
+# nothing in a subtitle ("yes" answers a question the row does not ask), so spell it out; an
+# unrecognized value passes through verbatim rather than being dropped.
+WORTH_LABELS = {"yes": "worth fixing", "later": "worth fixing later", "no": "not worth fixing"}
+
+
+class Item(NamedTuple):
+    """Item is one docs/backlog/<slug>.md file."""
+
+    slug: str
+    title: str
+    worth: str
+    where: str
+    added: str   # the frontmatter date verbatim, "" when absent or unparseable
+    mtime: float
+
+
+def log(message: str) -> None:
+    """log appends a line to the run log; a keybinding has no stdout anyone reads."""
+    try:
+        with LOG.open("a") as fh:
+            fh.write(f"{time.strftime('%F %T')}  {message}\n")
+    except OSError:
+        pass
+
+
+def parse_item(path: Path, text: str, mtime: float) -> Item:
+    """parse_item reads one item file; a missing field costs that field, never the item.
+
+    The backlog format writes its three fields once and never rewrites them, so a file that predates
+    a field or omits `where` for an unanchored item is normal input, not an error. A plain markdown
+    note with no frontmatter at all still lists, under its H1 or its file name.
+    """
+    fields: dict[str, str] = {}
+    front = FRONTMATTER_RE.match(text)
+    if front:
+        fields = {m.group(1): m.group(2).strip() for m in FIELD_RE.finditer(front.group(1))}
+    title = H1_RE.search(text)
+    return Item(slug=path.stem,
+                title=title.group(1) if title else path.stem,
+                worth=fields.get("worth", ""),
+                where=fields.get("where", ""),
+                added=fields.get("added", ""),
+                mtime=mtime)
+
+
+def age_label(added: str, today: date) -> str:
+    """age_label turns the `added` date into how old the item is; "" when there is no usable date.
+
+    An item's age is information the skill relies on - a year-old entry says something the title does
+    not - and the frontmatter date is never updated, so this is honest.
+    """
+    try:
+        when = date.fromisoformat(added)
+    except ValueError:
+        return ""
+    days = (today - when).days
+    if days <= 0:
+        return "today"
+    if days < 31:
+        return f"{days}d"
+    if days < 365:
+        return f"{days // 31}mo"
+    return f"{days // 365}y"
+
+
+def local_today() -> date:
+    """local_today is today in the machine's own zone; an item's age is read in local terms."""
+    return datetime.now(timezone.utc).astimezone().date()
+
+
+def load_items(root: Path) -> list[Item]:
+    """load_items reads the repo's backlog newest first.
+
+    Sorted by the `added` date and then by mtime, because a day's granularity cannot separate two
+    items written in one session and the newest is what the user is coming back to.
+    """
+    directory = root / BACKLOG_DIR
+    items: list[Item] = []
+    try:
+        paths = sorted(directory.glob("*.md"))
+    except OSError as err:
+        fail(f"cannot read {directory}: {err}")
+    for path in paths:
+        try:
+            items.append(parse_item(path, path.read_text(errors="replace"), path.stat().st_mtime))
+        except OSError as err:
+            log(f"skipped {path}: {err}")
+    return sorted(items, key=lambda i: (i.added, i.mtime), reverse=True)
+
+
+def items_of(items: list[Item], today: date) -> list[dict[str, str]]:
+    """items_of renders the picker rows: the triage call, the age, then where the item lives."""
+    rows = []
+    for item in items:
+        worth = WORTH_LABELS.get(item.worth, item.worth)
+        parts = [p for p in (worth, age_label(item.added, today), item.where) if p]
+        rows.append({"id": item.slug, "label": item.title, "subtitle": " · ".join(parts)})
+    return rows
+
+
+class Agt:
+    """Agt is the agterm control channel: the resolved agtermctl plus this session's addressing."""
+
+    def __init__(self) -> None:
+        self.bin = self.resolve_bin()
+        self.socket = os.environ.get("AGT_SOCKET", "")
+        self.sid = os.environ.get("AGT_SESSION_ID", "")
+        self.window = os.environ.get("AGT_WINDOW_ID", "active")
+
+    @staticmethod
+    def resolve_bin() -> str:
+        """resolve_bin finds an agtermctl carrying `pick`, preferring the app actually running.
+
+        Existence is not enough. Several installs can coexist, and a PATH lookup can land on an old
+        "Install Command Line Tool..." symlink pointing at an app that is not the one holding the
+        socket. So the running app's own bundle is asked first and the rest are probed for the
+        subcommand rather than trusted by version, since two builds can report the same version and
+        differ in what they carry. Set AGTERMCTL to skip all of it.
+        """
+        candidates = [os.environ.get("AGTERMCTL", ""), running_app_ctl(),
+                      f"{os.environ.get('GHOSTTY_BIN_DIR', '')}/agtermctl",
+                      "/usr/local/bin/agtermctl",
+                      "/Applications/agterm.app/Contents/MacOS/agtermctl",
+                      str(Path.home() / "Applications/agterm.app/Contents/MacOS/agtermctl"),
+                      shutil.which("agtermctl") or ""]
+        for candidate in candidates:
+            if candidate and os.access(candidate, os.X_OK) and probe(candidate, "pick"):
+                return candidate
+        return ""
+
+    def run(self, *args: str, stdin: str | None = None) -> subprocess.CompletedProcess[str]:
+        """run invokes agtermctl with the socket appended, never raising on a nonzero exit."""
+        cmd = [self.bin, *args]
+        if self.socket:
+            cmd += ["--socket", self.socket]
+        return subprocess.run(cmd, input=stdin, capture_output=True, text=True, check=False)
+
+    def foreground(self, pane: str) -> list[str]:
+        """foreground returns the pane's live argv; the tree reports main and split only, so a
+        scratch pane reads as a shell."""
+        field = {"left": "foreground", "right": "splitForeground"}.get(pane, "")
+        if not field or not self.sid:
+            return []
+        try:
+            tree = json.loads(self.run("tree", "--json").stdout)["result"]["tree"]
+        except (ValueError, KeyError):
+            return []
+        for workspace in tree.get("workspaces", []):
+            for session in workspace.get("sessions", []):
+                if session.get("id") == self.sid:
+                    return [str(part) for part in (session.get(field) or [])]
+        return []
+
+    def pick(self, rows: list[dict[str, str]]) -> str:
+        """pick opens the native picker and returns the chosen slug, "" when cancelled."""
+        res = self.run("pick", "--prompt", "backlog", "--window", self.window, stdin=json.dumps(rows))
+        if res.returncode == 2:
+            return ""
+        if res.returncode != 0:
+            fail(f"picker failed (exit {res.returncode})", self)
+        try:
+            choice = json.loads(res.stdout)
+        except ValueError:
+            return ""
+        return str(choice.get("id", "")) if choice.get("result") == "picked" else ""
+
+    def type_line(self, line: str, pane: str) -> None:
+        """type_line sends the command into the pane the chord fired from, Return included."""
+        self.run("session", "type", line + "\n", "--target", self.sid or "active", "--pane", pane)
+
+    def notify(self, message: str) -> None:
+        """notify is the only channel a keybinding has: its stdout goes to /dev/null."""
+        if self.bin:
+            self.run("notify", message, "--title", "Backlog")
+
+
+def probe(binary: str, subcommand: str) -> bool:
+    """probe reports whether the binary's top-level help offers the named subcommand."""
+    try:
+        res = subprocess.run([binary, "--help"], capture_output=True, text=True, timeout=5, check=False)
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return any(line.startswith(f"  {subcommand}") for line in (res.stdout + res.stderr).splitlines())
+
+
+def running_app_ctl() -> str:
+    """running_app_ctl returns the agtermctl of the agterm process actually running, "" when none.
+
+    pgrep is blind to GUI apps from here, so the process list is read directly.
+    """
+    try:
+        res = subprocess.run(["ps", "-axo", "comm="], capture_output=True, text=True, timeout=5,
+                             check=False)
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    for line in res.stdout.splitlines():
+        if line.endswith("agterm.app/Contents/MacOS/agterm"):
+            return str(Path(line).parent / "agtermctl")
+    return ""
+
+
+def repo_root(cwd: str) -> Path:
+    """repo_root returns the repo the session sits in, or its cwd when that is not a repo.
+
+    The chord can fire from any subdirectory, and docs/backlog lives at the root.
+    """
+    try:
+        res = subprocess.run(["git", "rev-parse", "--show-toplevel"], cwd=cwd, capture_output=True,
+                             text=True, timeout=10, check=False)
+    except (OSError, subprocess.SubprocessError):
+        return Path(cwd)
+    return Path(res.stdout.strip()) if res.returncode == 0 and res.stdout.strip() else Path(cwd)
+
+
+def fail(message: str, agt: Agt | None = None) -> Any:
+    """fail reports through the only channels a keybinding has, then exits."""
+    log(message)
+    print(f"backlog-picker: {message}", file=sys.stderr)
+    if agt:
+        agt.notify(message)
+    sys.exit(1)
+
+
+def command_for(slug: str, running: bool) -> str:
+    """command_for is what gets typed: a slash command into a live claude, else one that starts it.
+
+    The quotes matter only in the shell case - the slash command is one argument there, while the TUI
+    takes the line as typed.
+    """
+    return f"/backlog {slug}" if running else f'{CLAUDE_CMD} "/backlog {slug}"'
+
+
+def main(argv: list[str]) -> int:
+    cwd = os.environ.get("AGT_SESSION_PWD") or os.getcwd()
+    pane = os.environ.get("AGT_PANE", "left")
+    root = repo_root(cwd)
+    items = load_items(root)
+
+    if "--list" in argv:
+        today = local_today()
+        for item in items:
+            print(f"{item.slug:46} {item.worth:6} {age_label(item.added, today):6} {item.where}")
+        print(f"{len(items)} items in {root / BACKLOG_DIR}")
+        return 0
+
+    agt = Agt()
+    if not agt.bin:
+        fail("no agtermctl with pick support found (the one on PATH is too old)")
+    if not items:
+        fail(f"no backlog items in {root / BACKLOG_DIR}", agt)
+
+    chosen = agt.pick(items_of(items, local_today()))
+    if not chosen:
+        return 0
+    if chosen not in {i.slug for i in items}:
+        fail(f"picker returned an unknown item: {chosen}", agt)
+
+    running = any(FG_MATCH.search(part) for part in agt.foreground(pane))
+    agt.type_line(command_for(chosen, running), pane)
+    return 0
+
+
+class Tests(unittest.TestCase):
+    ITEM = ("---\n"
+            "worth: later\n"
+            "where: internal/store/reopen.go:537\n"
+            "added: 2026-08-05\n"
+            "---\n"
+            "# reopen fallback ignores which window was last frontmost\n"
+            "\n"
+            "Body prose that is not the title.\n")
+
+    def test_parse_item(self) -> None:
+        item = parse_item(Path("/x/reopen-fallback.md"), self.ITEM, 1.0)
+        self.assertEqual(item.slug, "reopen-fallback")
+        self.assertEqual(item.title, "reopen fallback ignores which window was last frontmost")
+        self.assertEqual(item.worth, "later")
+        self.assertEqual(item.where, "internal/store/reopen.go:537")
+        self.assertEqual(item.added, "2026-08-05")
+
+    def test_parse_item_tolerates_missing_pieces(self) -> None:
+        cases = [
+            ("no frontmatter", "# just a title\n", "just a title", "", ""),
+            ("no h1", "---\nworth: no\n---\nbody\n", "slug", "no", ""),
+            ("unanchored", "---\nworth: yes\nadded: 2026-01-02\n---\n# t\n", "t", "yes", ""),
+        ]
+        for name, text, title, worth, where in cases:
+            with self.subTest(name):
+                item = parse_item(Path("/x/slug.md"), text, 1.0)
+                self.assertEqual((item.title, item.worth, item.where), (title, worth, where))
+
+    def test_age_label(self) -> None:
+        today = date(2026, 8, 5)
+        for added, want in [("2026-08-05", "today"), ("2026-08-04", "1d"), ("2026-07-06", "30d"),
+                            ("2026-06-01", "2mo"), ("2025-01-01", "1y"), ("", ""), ("nonsense", "")]:
+            with self.subTest(added):
+                self.assertEqual(age_label(added, today), want)
+
+    def test_command_for(self) -> None:
+        self.assertEqual(command_for("some-slug", running=True), "/backlog some-slug")
+        self.assertEqual(command_for("some-slug", running=False), 'claude "/backlog some-slug"')
+
+    def test_items_of(self) -> None:
+        today = date(2026, 8, 5)
+        rows = items_of([Item("a", "title a", "yes", "f.go:1", "2026-08-05", 1.0),
+                         Item("b", "title b", "later", "", "2026-01-01", 2.0),
+                         Item("c", "title c", "", "", "", 3.0),
+                         Item("d", "title d", "no", "", "2026-08-05", 4.0),
+                         Item("e", "title e", "maybe", "", "2026-08-05", 5.0)], today)
+        self.assertEqual(rows, [
+            {"id": "a", "label": "title a", "subtitle": "worth fixing · today · f.go:1"},
+            {"id": "b", "label": "title b", "subtitle": "worth fixing later · 6mo"},
+            {"id": "c", "label": "title c", "subtitle": ""},
+            {"id": "d", "label": "title d", "subtitle": "not worth fixing · today"},
+            {"id": "e", "label": "title e", "subtitle": "maybe · today"},
+        ])
+
+    def test_load_items_is_newest_first(self) -> None:
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp) / BACKLOG_DIR
+            directory.mkdir(parents=True)
+            for slug, added in [("old", "2026-01-01"), ("new", "2026-08-05"), ("mid", "2026-05-05")]:
+                (directory / f"{slug}.md").write_text(f"---\nworth: yes\nadded: {added}\n---\n# {slug}\n")
+            # two items added the same day fall back to mtime, which a day's granularity cannot split
+            (directory / "same-day.md").write_text("---\nworth: yes\nadded: 2026-08-05\n---\n# same\n")
+            os.utime(directory / "same-day.md", (0, 0))
+            self.assertEqual([i.slug for i in load_items(Path(tmp))], ["new", "same-day", "mid", "old"])
+
+    def test_load_items_missing_dir(self) -> None:
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(load_items(Path(tmp)), [])
+
+
+if __name__ == "__main__":
+    if "--test" in sys.argv:
+        sys.argv.remove("--test")
+        unittest.main()
+    try:
+        sys.exit(main(sys.argv[1:]))
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/cookbook/backlog-picker/backlog-picker.py
+++ b/cookbook/backlog-picker/backlog-picker.py
@@ -14,7 +14,7 @@ Whether claude is running here is read from the pane's live foreground argv, so 
 long as BACKLOG_FG_MATCH matches it.
 
 Environment:
-    AGTERMCTL           agtermctl to use, when the one on PATH is not the right one
+    AGTERMCTL           agtermctl to use, taken as given, when the one on PATH is not the right one
     BACKLOG_DIR         item directory relative to the repo root (default docs/backlog)
     BACKLOG_CLAUDE_CMD  launcher typed at a bare prompt (default claude)
     BACKLOG_FG_MATCH    argv pattern that means "claude runs here" (default (^|/)claude$)
@@ -30,6 +30,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -61,7 +62,7 @@ class Item(NamedTuple):
     title: str
     worth: str
     where: str
-    added: str   # the frontmatter date verbatim, "" when absent or unparseable
+    added: str   # the frontmatter's ISO date, "" when absent or unparseable
     mtime: float
 
 
@@ -77,20 +78,30 @@ def log(message: str) -> None:
 def parse_item(path: Path, text: str, mtime: float) -> Item:
     """parse_item reads one item file; a missing field costs that field, never the item.
 
-    The backlog format writes its three fields once and never rewrites them, so a file that predates
-    a field or omits `where` for an unanchored item is normal input, not an error. A plain markdown
-    note with no frontmatter at all still lists, under its H1 or its file name.
+    The backlog format writes its three fields once and rewrites them only when a later sighting
+    changes the call, so a file that predates a field or omits `where` for an unanchored item is
+    normal input, not an error. A plain markdown note with no frontmatter at all still lists, under
+    its H1 or its file name.
+
+    An `added` that is not an ISO date is dropped rather than kept verbatim, because it is the
+    primary sort key: `2026-8-5` compares above every well-formed `2026-...` and would park a typo
+    at the top of a newest-first list, with no age in its subtitle to explain why.
     """
     fields: dict[str, str] = {}
     front = FRONTMATTER_RE.match(text)
     if front:
         fields = {m.group(1): m.group(2).strip() for m in FIELD_RE.finditer(front.group(1))}
     title = H1_RE.search(text)
+    added = fields.get("added", "")
+    try:
+        date.fromisoformat(added)
+    except ValueError:
+        added = ""
     return Item(slug=path.stem,
                 title=title.group(1) if title else path.stem,
                 worth=fields.get("worth", ""),
                 where=fields.get("where", ""),
-                added=fields.get("added", ""),
+                added=added,
                 mtime=mtime)
 
 
@@ -124,14 +135,18 @@ def load_items(root: Path) -> list[Item]:
 
     Sorted by the `added` date and then by mtime, because a day's granularity cannot separate two
     items written in one session and the newest is what the user is coming back to.
+
+    A file name carrying a control character is refused: the slug is typed into the pane, and a
+    newline in it would submit a second line of its own to whatever is running there. `glob` needs
+    no guard of its own - it reports a missing, unreadable or non-directory path as no matches, which
+    ends in the same "no backlog items" as an empty directory.
     """
     directory = root / BACKLOG_DIR
     items: list[Item] = []
-    try:
-        paths = sorted(directory.glob("*.md"))
-    except OSError as err:
-        fail(f"cannot read {directory}: {err}")
-    for path in paths:
+    for path in sorted(directory.glob("*.md")):
+        if any(ch < " " or ch == "\x7f" for ch in path.stem):
+            log(f"skipped {path!r}: control character in the file name")
+            continue
         try:
             items.append(parse_item(path, path.read_text(errors="replace"), path.stat().st_mtime))
         except OSError as err:
@@ -166,9 +181,14 @@ class Agt:
         "Install Command Line Tool..." symlink pointing at an app that is not the one holding the
         socket. So the running app's own bundle is asked first and the rest are probed for the
         subcommand rather than trusted by version, since two builds can report the same version and
-        differ in what they carry. Set AGTERMCTL to skip all of it.
+        differ in what they carry. AGTERMCTL skips all of it and is taken as given: the probe reads a
+        help layout a wrapper script does not reproduce, so probing the reader's explicit choice would
+        discard exactly the binary the override exists to name.
         """
-        candidates = [os.environ.get("AGTERMCTL", ""), running_app_ctl(),
+        override = os.environ.get("AGTERMCTL", "")
+        if override:
+            return override if os.access(override, os.X_OK) else ""
+        candidates = [running_app_ctl(),
                       f"{os.environ.get('GHOSTTY_BIN_DIR', '')}/agtermctl",
                       "/usr/local/bin/agtermctl",
                       "/Applications/agterm.app/Contents/MacOS/agtermctl",
@@ -193,8 +213,9 @@ class Agt:
         if not field or not self.sid:
             return []
         try:
-            tree = json.loads(self.run("tree", "--json").stdout)["result"]["tree"]
-        except (ValueError, KeyError):
+            tree = json.loads(self.run("tree", "--json", "--window", self.window).stdout)["result"]["tree"]
+        except (ValueError, KeyError) as err:
+            log(f"tree read failed, so the pane reads as a shell: {err}")
             return []
         for workspace in tree.get("workspaces", []):
             for session in workspace.get("sessions", []):
@@ -215,9 +236,15 @@ class Agt:
             return ""
         return str(choice.get("id", "")) if choice.get("result") == "picked" else ""
 
-    def type_line(self, line: str, pane: str) -> None:
-        """type_line sends the command into the pane the chord fired from, Return included."""
-        self.run("session", "type", line + "\n", "--target", self.sid or "active", "--pane", pane)
+    def type_line(self, line: str, pane: str) -> subprocess.CompletedProcess[str]:
+        """type_line sends the command into the pane the chord fired from, Return included.
+
+        The caller reports a nonzero exit. The pane can be gone by the time an item is picked - the
+        split closed while the picker was open - and a dropped result is the one failure on the
+        recipe's own path that would otherwise reach no channel at all.
+        """
+        return self.run("session", "type", line + "\n", "--target", self.sid or "active",
+                        "--pane", pane)
 
     def notify(self, message: str) -> None:
         """notify is the only channel a keybinding has: its stdout goes to /dev/null."""
@@ -275,10 +302,12 @@ def fail(message: str, agt: Agt | None = None) -> Any:
 def command_for(slug: str, running: bool) -> str:
     """command_for is what gets typed: a slash command into a live claude, else one that starts it.
 
-    The quotes matter only in the shell case - the slash command is one argument there, while the TUI
-    takes the line as typed.
+    The shell case is quoted with shlex, not by hand: the slug is a file name from the repo the
+    session sits in, so a cloned tree can carry `a"; id; :"b.md`, and double quotes leave `$(...)`,
+    backticks and a closing quote live. The TUI case needs no quoting - it is typed as text - and is
+    safe from the same file name only because load_items refuses a slug carrying a newline.
     """
-    return f"/backlog {slug}" if running else f'{CLAUDE_CMD} "/backlog {slug}"'
+    return f"/backlog {slug}" if running else f"{CLAUDE_CMD} {shlex.quote(f'/backlog {slug}')}"
 
 
 def main(argv: list[str]) -> int:
@@ -296,7 +325,8 @@ def main(argv: list[str]) -> int:
 
     agt = Agt()
     if not agt.bin:
-        fail("no agtermctl with pick support found (the one on PATH is too old)")
+        fail(f"AGTERMCTL is not executable: {os.environ['AGTERMCTL']}" if os.environ.get("AGTERMCTL")
+             else "no agtermctl with pick support found (the one on PATH is too old)")
     if not items:
         fail(f"no backlog items in {root / BACKLOG_DIR}", agt)
 
@@ -307,7 +337,9 @@ def main(argv: list[str]) -> int:
         fail(f"picker returned an unknown item: {chosen}", agt)
 
     running = any(FG_MATCH.search(part) for part in agt.foreground(pane))
-    agt.type_line(command_for(chosen, running), pane)
+    res = agt.type_line(command_for(chosen, running), pane)
+    if res.returncode != 0:
+        fail(f"could not type into the {pane} pane: {res.stderr.strip() or f'exit {res.returncode}'}", agt)
     return 0
 
 
@@ -340,6 +372,14 @@ class Tests(unittest.TestCase):
                 item = parse_item(Path("/x/slug.md"), text, 1.0)
                 self.assertEqual((item.title, item.worth, item.where), (title, worth, where))
 
+    def test_parse_item_drops_an_unusable_added(self) -> None:
+        for added in ["2026-8-5", "nonsense", "", "2026-13-01"]:
+            with self.subTest(added):
+                item = parse_item(Path("/x/slug.md"), f"---\nadded: {added}\n---\n# t\n", 1.0)
+                self.assertEqual(item.added, "")
+        item = parse_item(Path("/x/slug.md"), "---\nadded: 2026-08-05\n---\n# t\n", 1.0)
+        self.assertEqual(item.added, "2026-08-05")
+
     def test_age_label(self) -> None:
         today = date(2026, 8, 5)
         for added, want in [("2026-08-05", "today"), ("2026-08-04", "1d"), ("2026-07-06", "30d"),
@@ -349,7 +389,14 @@ class Tests(unittest.TestCase):
 
     def test_command_for(self) -> None:
         self.assertEqual(command_for("some-slug", running=True), "/backlog some-slug")
-        self.assertEqual(command_for("some-slug", running=False), 'claude "/backlog some-slug"')
+        self.assertEqual(command_for("some-slug", running=False), "claude '/backlog some-slug'")
+
+    def test_command_for_quotes_a_hostile_slug(self) -> None:
+        # a file name is attacker-authored in a cloned repo; the shell must see one argument
+        for slug in ['a"; id; :"b', "x$(id)", "y`id`", "z'q"]:
+            with self.subTest(slug):
+                line = command_for(slug, running=False)
+                self.assertEqual(shlex.split(line), ["claude", f"/backlog {slug}"])
 
     def test_items_of(self) -> None:
         today = date(2026, 8, 5)
@@ -378,10 +425,31 @@ class Tests(unittest.TestCase):
             os.utime(directory / "same-day.md", (0, 0))
             self.assertEqual([i.slug for i in load_items(Path(tmp))], ["new", "same-day", "mid", "old"])
 
+    def test_resolve_bin_takes_the_override_as_given(self) -> None:
+        import tempfile
+        from unittest import mock
+        with tempfile.TemporaryDirectory() as tmp:
+            wrapper = Path(tmp) / "agtermctl-wrapper"
+            wrapper.write_text("#!/bin/sh\nexec true\n")   # no `pick` in its --help, so the probe would drop it
+            wrapper.chmod(0o755)
+            with mock.patch.dict(os.environ, {"AGTERMCTL": str(wrapper)}):
+                self.assertEqual(Agt.resolve_bin(), str(wrapper))
+            with mock.patch.dict(os.environ, {"AGTERMCTL": str(Path(tmp) / "not-there")}):
+                self.assertEqual(Agt.resolve_bin(), "")
+
     def test_load_items_missing_dir(self) -> None:
         import tempfile
         with tempfile.TemporaryDirectory() as tmp:
             self.assertEqual(load_items(Path(tmp)), [])
+
+    def test_load_items_refuses_a_control_character_in_the_name(self) -> None:
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp) / BACKLOG_DIR
+            directory.mkdir(parents=True)
+            (directory / "ok.md").write_text("# ok\n")
+            (directory / "bad\nrm -rf x.md").write_text("# bad\n")
+            self.assertEqual([i.slug for i in load_items(Path(tmp))], ["ok"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
one chord lists the repo's `docs/backlog/*.md` items in the native picker and types `/backlog <slug>` into the pane's Claude Code run, or `claude '/backlog <slug>'` at a bare shell prompt. Rows carry the triage call, the item's age and where it lives, newest first. The repo is whichever one the session sits in, so the same chord in another tab lists that project's backlog.

it ships the `backlog` skill that makes the slash command mean anything, as `SKILL.md` beside the script. `cookbook/CONTRIBUTING.md`'s layout rule now allows that for a recipe handing work to an agent, kept to what the recipe needs rather than a whole configuration.

port of a script I run daily, scrubbed of the wrapper name in the foreground match, the cross-repo glob, and the private skill named in the skill's issue-filing step.

the file name is treated as hostile, since in a cloned repo it is someone else's. The bare-prompt line is quoted with `shlex` so `a"; id; :"b.md` stays one argument, and a name carrying a control character is refused before it can submit a line of its own. `AGTERMCTL` is taken as given rather than probed, so a wrapper adding a default `--socket` is not silently dropped for whatever the fallback chain finds. An `added` value that is not an ISO date is dropped rather than sorted above every real one.

**needs** agterm 0.20.2 or later, python3, Claude Code. `pick` shipped in 0.19.0, but 0.20.0 is where a caller-supplied picker stopped re-sorting an empty query alphabetically and stopped matching typed text against subtitles, and 0.20.2 is where `tree --json` began reporting `foreground` for a pane started with `session new --command`.
