### PR TITLE
docs(cookbook): add sqlite-browser recipe

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -52,6 +52,7 @@ its *needs* column, so searching this page for `claude` or `kiro` finds those di
 | [native-dir-picker](native-dir-picker/) | pick a directory in the native picker and type it into the shell | 0.19.0, fd, jq |
 | [overlay-and-split](overlay-and-split/) | keymap lines: a stateful split toggle and TUI overlays | 0.10.0, jq |
 | [same-dir](same-dir/) | sync working directory to target split pane | 0.10.0, jq, zsh |
+| [sqlite-browser](sqlite-browser/) | pick one of the repo's SQLite databases and browse it in an overlay | 0.22.0, python3, tabiew |
 
 Most recipes need `agtermctl` on your PATH; **Help ▸ Install Command Line Tool…** puts it there. Three of the four session-resume recipes are shell functions that read the environment agterm gives a session and never call the CLI; the Kimi one is a lifecycle hook that pins its tab's restore command through `agtermctl`. Some recipes also need `jq`, `fzf`, or a particular shell, and each recipe's *Requirements* section says which, along with the minimum agterm version it needs. Recipes are snapshots rather than a maintained surface: the control API grows by addition, so they rarely break, and one that does gets fixed when it is reported.
 

--- a/cookbook/sqlite-browser/README.md
+++ b/cookbook/sqlite-browser/README.md
@@ -26,7 +26,7 @@ The repo is whichever one the session sits in, so the same chord in another tab 
 - Python 3.9 or later, which macOS ships as `/usr/bin/python3`
 - [tabiew](https://github.com/shshemi/tabiew) (`brew install tabiew`), or another viewer you point `SQLITE_VIEWER` at.
 
-Set `AGTERMCTL` if your binary is somewhere unusual; the script otherwise tries the usual install directories and then `PATH`.
+Set `AGTERMCTL` if your binary is somewhere unusual; the script otherwise takes the `agtermctl` on `PATH`, which the chord's own widened `PATH` provides. The viewer is looked up differently, in the usual install directories before `PATH`, because it has to reach the overlay as an absolute path.
 
 ## Setup
 

--- a/cookbook/sqlite-browser/README.md
+++ b/cookbook/sqlite-browser/README.md
@@ -1,0 +1,99 @@
+# SQLite browser
+
+Pick one of the repo's SQLite databases in the native picker and browse it in a TUI viewer, in an overlay over the session you pressed the chord in.
+
+## What it does
+
+Plenty of projects carry a SQLite database or two — the application's store, a test fixture, a cache — and opening one up is the quickest way to see what the code actually wrote.
+
+One chord does that, in a proper TUI rather than a `sqlite3` prompt. The picker lists this repo's databases newest first, each row showing how big it is and how long ago it was written:
+
+```
+internal/store/data.db
+2.4M · just now
+
+testdata/fixture.sqlite3
+48K · 3d ago
+```
+
+Choosing one opens the viewer in a 90% overlay over the session. Escape closes the overlay and the session is where it was.
+
+The repo is whichever one the session sits in, so the same chord in another tab lists that project's databases.
+
+## Requirements
+
+- agterm 0.22.0 or later. `pick` itself shipped in 0.19.0; 0.20.0 is where a caller-supplied picker stopped re-sorting an empty query alphabetically and stopped matching typed text against subtitles, both of which this recipe depends on — newest-first is the order it hands over, and typing `2.4M` must not filter the list by another row's size. 0.22.0 is where `session hud --position` took the nine anchors of a 3x3 grid, which is what puts the "nothing found" panel at the top of the session instead of over the middle of the text.
+- Python 3.9 or later, which macOS ships as `/usr/bin/python3`
+- [tabiew](https://github.com/shshemi/tabiew) (`brew install tabiew`), or another viewer you point `SQLITE_VIEWER` at.
+
+Set `AGTERMCTL` if your binary is somewhere unusual; the script otherwise tries the usual install directories and then `PATH`.
+
+## Setup
+
+Copy the script somewhere on your machine, say `~/bin/`, and make it executable:
+
+```sh
+mkdir -p ~/bin && cp sqlite-browser.py ~/bin/ && chmod +x ~/bin/sqlite-browser.py
+```
+
+Add an entry to `~/.config/agterm/keymap.conf` and apply it with File ▸ Reload Keymap or `agtermctl keymap reload`:
+
+```
+command "SQLite ›" ctrl+a>d ~/bin/sqlite-browser.py
+```
+
+`ctrl+a>d` is a leader sequence: press ⌃A, release, then press D. Any chord carrying a modifier works as the leader, and leaving the chord out entirely makes the entry palette-only. The name ends in `›` so the palette shows it opens something rather than doing something.
+
+To use a viewer other than tabiew, set the two variables on the same line. `SQLITE_VIEWER` is the command and `SQLITE_VIEWER_ARGS` is what goes before the path, so a viewer that needs no flags takes an empty string:
+
+```
+command "SQLite ›" ctrl+a>d SQLITE_VIEWER=litecli SQLITE_VIEWER_ARGS= ~/bin/sqlite-browser.py
+```
+
+`SQLITE_OVERLAY_PERCENT` sizes the overlay, default `90`. `SQLITE_HUD_BG`, `SQLITE_HUD_FG`, `SQLITE_HUD_WIDTH` and `SQLITE_HUD_SECONDS` style the panel that reports an empty-handed run, and `SQLITE_BROWSER_LOG` moves the run log off `/tmp/sqlite-browser.log`.
+
+## Usage
+
+Press the chord in any session sitting in a repo. Type to filter, Return to pick, Escape to cancel — cancelling opens nothing. In the viewer, Escape (or whatever your viewer quits with) closes the overlay.
+
+Check what the picker will show without opening it:
+
+```sh
+./sqlite-browser.py --list
+```
+
+It prints one line per database, path first, then the size and age, then the count and the root it read. This is the first thing to run when the picker says there are none and you know there are: the path it prints is the repo root it resolved.
+
+The script carries its own tests, which is what to run after editing the scan:
+
+```sh
+./sqlite-browser.py --test
+```
+
+A run that finds nothing to do — no databases under the root, or a viewer that is not installed — posts a panel over the session saying which, and takes it down after three seconds. Real failures exit nonzero, which agterm banners by itself as `SQLite › (exit 1)`, and post a notification naming what went wrong. Files skipped during the scan are in the log and nowhere else.
+
+## How it works
+
+The scan is two filters, and the order is the whole point. The extension is checked first, against `.db`, `.db3`, `.sqlite`, `.sqlite3` and `.sqlitedb`, because it is free; then the first sixteen bytes are read and compared against `SQLite format 3\0`, because the extension proves nothing. A `.db` that is really a Berkeley DB, a text file, or a `-wal` sidecar never reaches the picker. The cost of that ordering is a database stored under a name nobody would guess, which is not found at all.
+
+What the scan skips matters more than what it keeps. `node_modules`, `vendor`, `venv`, `__pycache__`, `site-packages`, `target` and `Pods` are pruned, and so is every hidden directory — as a rule rather than a list, because `.mypy_cache` alone put 32 of its own SQLite files ahead of every real one in the first repo this ran in, and `.pytest_cache`, `.tox` and `.venv` are the same shape. Symlinked directories are not followed: a checkout carrying a link back to a parent would otherwise turn the scan into an unbounded walk of the filesystem.
+
+Rows are sorted by mtime, newest first, on the assumption that the database just written is the one being debugged. That order is handed to `agtermctl pick` on stdin as JSON and shown as-is.
+
+The file name is treated as hostile, because in a repo you cloned it is someone else's. The viewer's command line is quoted with `shlex`, so `a"; id; :"b.db` reaches `zsh -c` as one argument rather than as a second statement, and a name carrying a control character is refused outright and logged.
+
+PATH is the gotcha, and it bites at both ends. This script runs from a keybinding, so it gets launchd's PATH rather than a login shell's; the overlay it opens gets the app's, which is a different minimal one. Neither carries `/opt/homebrew/bin`. So the viewer is resolved to an absolute path here and passed as one to the overlay, rather than named and hoped for — a viewer named bare works when you test it in a shell and fails from the chord.
+
+The overlay is opened without `--follow`. It belongs to this session, and pulling focus to it would move the selection out from under whatever you are doing in another one.
+
+Everything the script needs about where it is comes from the environment agterm exports to a custom command: `AGT_SESSION_PWD` for the repo, `AGT_SESSION_ID` for which session gets the overlay, `AGT_WINDOW_ID` for which window shows the picker, and `AGT_SOCKET` for the instance to talk to. The repo root itself is `git rev-parse --show-toplevel` from that directory, so the chord works from a subdirectory. A session that is not in a repo falls back to its own working directory, which for a home directory means a long scan.
+
+## Limits
+
+The viewer opens the database read-write, whatever that viewer's defaults are. Nothing here makes it read-only, and tabiew's `:` commands run SQL against the file you picked.
+
+The overlay takes the session's overlay slot, so a chord pressed while a program overlay is already up is refused rather than replacing it.
+
+The scan walks the whole repo on every press. On a large checkout with a cold page cache that is a visible pause before the picker appears, with no progress shown.
+
+Databases are found by extension, so one stored under a name that is not on the list is invisible to the recipe, however valid its header.

--- a/cookbook/sqlite-browser/README.md
+++ b/cookbook/sqlite-browser/README.md
@@ -16,7 +16,7 @@ testdata/fixture.sqlite3
 48K · 3d ago
 ```
 
-Choosing one opens the viewer in a 90% overlay over the session. Escape closes the overlay and the session is where it was.
+Choosing one opens the viewer in a 90% overlay over the session. The overlay closes when the viewer exits — `q` in tabiew — and the session is where it was.
 
 The repo is whichever one the session sits in, so the same chord in another tab lists that project's databases.
 
@@ -82,11 +82,17 @@ Rows are sorted by mtime, newest first, on the assumption that the database just
 
 The file name is treated as hostile, because in a repo you cloned it is someone else's. The viewer's command line is quoted with `shlex`, so `a"; id; :"b.db` reaches `zsh -c` as one argument rather than as a second statement, and a name carrying a control character is refused outright and logged.
 
-PATH is the gotcha, and it bites at both ends. This script runs from a keybinding, so it gets launchd's PATH rather than a login shell's; the overlay it opens gets the app's, which is a different minimal one. Neither carries `/opt/homebrew/bin`. So the viewer is resolved to an absolute path here and passed as one to the overlay, rather than named and hoped for — a viewer named bare works when you test it in a shell and fails from the chord.
+PATH is the gotcha, and the two halves of it are not the same. A custom command's own PATH is widened by the runner from 0.22.0 on, with the CLI install directory and Homebrew's prefix, so a bare `agtermctl` resolves from the chord. The overlay it opens is a different matter: nothing widens that one, it is the app's own, and a bare viewer name exits 127 there with the overlay flashing open and vanishing. So the viewer is resolved to an absolute path here and passed as one — which is also why the recipe reports "not installed" up front rather than letting the overlay fail silently.
 
 The overlay is opened without `--follow`. It belongs to this session, and pulling focus to it would move the selection out from under whatever you are doing in another one.
 
-Everything the script needs about where it is comes from the environment agterm exports to a custom command: `AGT_SESSION_PWD` for the repo, `AGT_SESSION_ID` for which session gets the overlay, `AGT_WINDOW_ID` for which window shows the picker, and `AGT_SOCKET` for the instance to talk to. The repo root itself is `git rev-parse --show-toplevel` from that directory, so the chord works from a subdirectory. A session that is not in a repo falls back to its own working directory, which for a home directory means a long scan.
+Everything the script needs about where it is comes from the environment agterm exports to a custom command: `AGT_SESSION_PWD` for the repo, `AGT_SESSION_ID` for which session gets the overlay, `AGT_WINDOW_ID` for which window shows the picker, and `AGT_SOCKET` for the instance to talk to. The repo root itself is `git rev-parse --show-toplevel` from that directory, so the chord works from a subdirectory.
+
+`AGT_SESSION_PWD` has three states and they are three different situations, which is worth knowing if you port this pattern. Unset means nobody is passing one — a plain shell run, so the shell's own directory is the subject. A real path is a session. **Set but empty is the trap**: agterm exports every `AGT_` token whether or not it resolved, and a chord fired in a window holding no session gets an empty one while the process is left in the app's own working directory, `/` for a Dock-launched bundle. Read that as "no value, use the cwd" and one keypress walks the entire filesystem, raising a macOS permission prompt for every protected folder on the way. The recipe tests the variable rather than its truthiness, and refuses.
+
+Refusing is easy; saying so is not. With no session there is no target, so the panel and the desktop notification both resolve `active` to nothing and neither arrives — which is the same absence that sent the chord down this path. What is left is the exit code: agterm banners a custom command's nonzero exit by itself, as `SQLite › (exit 1)`, and that is what the reader actually sees.
+
+The other end of the same problem is a session in a directory git does not recognise as a repo, where the scan root is that directory verbatim. A subdirectory is fine and is a normal place to keep a database. The home directory is not: `~/Library` alone holds hundreds of application databases, and reaching `~/Documents` and `~/Desktop` costs a macOS permission prompt each. That one and the filesystem root are refused by name.
 
 ## Limits
 
@@ -97,3 +103,9 @@ The overlay takes the session's overlay slot, so a chord pressed while a program
 The scan walks the whole repo on every press. On a large checkout with a cold page cache that is a visible pause before the picker appears, with no progress shown.
 
 Databases are found by extension, so one stored under a name that is not on the list is invisible to the recipe, however valid its header.
+
+The picker takes at most 1000 rows, which is agterm's own cap. Past that the list is cut to the 1000 newest and the prompt says so.
+
+The chord does nothing in the home directory, at the filesystem root, or in a window with no session. Those are refusals rather than failures — see *How it works* for why.
+
+A file symlink is followed. A cloned repo can carry `cache.db` as a link to a database outside the checkout, and it appears under its repo-relative name.

--- a/cookbook/sqlite-browser/sqlite-browser.py
+++ b/cookbook/sqlite-browser/sqlite-browser.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""Pick a SQLite database from THIS session's repo and open it in a TUI viewer, in an overlay.
+
+Runs as an agterm keymap custom command, so the runner exports $AGT_* and the app spawns it with
+launchd's PATH and stdout on /dev/null.
+
+Candidates are files under the repo root carrying a database extension AND starting with the SQLite
+magic header, so a `.db` that is really a Berkeley DB or a text file never reaches the picker. The
+extension is a speed filter only - reading 16 bytes of every file in a large tree is what it avoids -
+so a database stored under an unusual name is not found. Newest first: the one just written is the
+one being debugged.
+
+Usage: sqlite-browser.py [--list] [--test]
+    --list  print the databases found and exit, without opening the picker
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import time
+import unittest
+from pathlib import Path
+from typing import Any, NamedTuple
+
+MAGIC = b"SQLite format 3\x00"
+EXTS = {".db", ".db3", ".sqlite", ".sqlite3", ".sqlitedb"}
+# a checkout carries whole dependency trees with their own fixtures; those are never the database the
+# session is working on, and walking them is most of the scan. Hidden directories go too, as a rule
+# rather than a list: .mypy_cache alone put 32 of its own sqlite files ahead of every real one in a
+# repo tried during development, and .pytest_cache, .tox and .venv are the same shape.
+PRUNE = {"node_modules", "vendor", "venv", "__pycache__", "site-packages", "target", "Pods"}
+# tabiew: it opens ON the data - every table of the database becomes a tab, H/L cycles them, `:schema`
+# lists them with column stats. The SQL clients tried first (lazysql, harlequin, rainfrog, dblab) all
+# open on an empty editor or a logo instead. The format is passed rather than inferred: tabiew maps
+# only .db and .sqlite by extension, and this picker also finds .db3, .sqlite3 and .sqlitedb.
+VIEWER = os.environ.get("SQLITE_VIEWER", "tw")
+VIEWER_ARGS = shlex.split(os.environ.get("SQLITE_VIEWER_ARGS", "-f sqlite"))
+OVERLAY_PERCENT = os.environ.get("SQLITE_OVERLAY_PERCENT", "90")
+LOG = Path(os.environ.get("SQLITE_BROWSER_LOG", "/tmp/sqlite-browser.log"))
+HUD_SECONDS = float(os.environ.get("SQLITE_HUD_SECONDS", "3"))
+HUD_BG = os.environ.get("SQLITE_HUD_BG", "#4a3c12")
+HUD_FG = os.environ.get("SQLITE_HUD_FG", "#f0d890")
+HUD_WIDTH = os.environ.get("SQLITE_HUD_WIDTH", "40")
+
+
+class Db(NamedTuple):
+    """Db is one SQLite file found under the repo root."""
+
+    rel: str      # path relative to the root, which is what the picker shows and returns
+    path: Path
+    size: int
+    mtime: float
+
+
+def log(message: str) -> None:
+    """log appends a line to the run log; a keybinding has no stdout anyone reads."""
+    try:
+        with LOG.open("a") as fh:
+            fh.write(f"{time.strftime('%F %T')}  {message}\n")
+    except OSError:
+        pass
+
+
+def is_sqlite(path: Path) -> bool:
+    """is_sqlite reads the file header; the extension alone proves nothing about the format."""
+    try:
+        with path.open("rb") as fh:
+            return fh.read(len(MAGIC)) == MAGIC
+    except OSError:
+        return False
+
+
+def find_dbs(root: Path) -> list[Db]:
+    """find_dbs walks the repo for SQLite files, newest first.
+
+    Symlinked directories are not followed: a checkout carrying a link back to a parent (or to a home
+    directory) would otherwise turn the scan into an unbounded walk of the filesystem. A database
+    inside a hidden or dependency directory is not offered - see PRUNE.
+
+    A name carrying a control character is refused. The path reaches a shell command line, and a
+    newline in it would start a line of its own.
+    """
+    found: list[Db] = []
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        dirnames[:] = [d for d in dirnames if d not in PRUNE and not d.startswith(".")]
+        for name in filenames:
+            path = Path(dirpath) / name
+            if path.suffix.lower() not in EXTS or not is_sqlite(path):
+                continue
+            rel = str(path.relative_to(root))
+            if any(ch < " " or ch == "\x7f" for ch in rel):
+                log(f"skipped {path!r}: control character in the path")
+                continue
+            try:
+                stat = path.stat()
+            except OSError as err:
+                log(f"skipped {path}: {err}")
+                continue
+            found.append(Db(rel=rel, path=path, size=stat.st_size, mtime=stat.st_mtime))
+    return sorted(found, key=lambda d: d.mtime, reverse=True)
+
+
+def human_size(size: int) -> str:
+    """human_size renders a byte count for a one-line subtitle."""
+    for unit in ("B", "K", "M", "G"):
+        if size < 1024 or unit == "G":
+            return f"{size:.0f}{unit}" if unit == "B" or size >= 10 else f"{size:.1f}{unit}"
+        size /= 1024.0  # type: ignore[assignment]
+    return f"{size}B"
+
+
+def age_label(mtime: float, now: float) -> str:
+    """age_label says how long ago the file was written; a live database is the one being worked on."""
+    seconds = max(0.0, now - mtime)
+    if seconds < 90:
+        return "just now"
+    for limit, div, unit in ((3600, 60, "m"), (86400, 3600, "h"), (86400 * 31, 86400, "d")):
+        if seconds < limit:
+            return f"{int(seconds // div)}{unit} ago"
+    return f"{int(seconds // (86400 * 31))}mo ago"
+
+
+def rows_of(dbs: list[Db], now: float) -> list[dict[str, str]]:
+    """rows_of renders the picker rows: the path, then its size and how fresh it is."""
+    return [{"id": db.rel, "label": db.rel, "subtitle": f"{human_size(db.size)} · {age_label(db.mtime, now)}"}
+            for db in dbs]
+
+
+def viewer_command(path: Path, viewer: str) -> str:
+    """viewer_command is the shell line the overlay runs.
+
+    The viewer is spelled absolutely and the path is quoted: the overlay is spawned with the app's GUI
+    PATH, which holds neither /opt/homebrew/bin nor the repo, and a checked-out file name can carry
+    `$(...)`, a backtick or a quote.
+    """
+    return " ".join(shlex.quote(part) for part in (viewer, *VIEWER_ARGS, str(path)))
+
+
+class Agt:
+    """Agt is the agterm control channel: agtermctl plus this session's addressing."""
+
+    def __init__(self) -> None:
+        self.bin = self.resolve_bin()
+        self.socket = os.environ.get("AGT_SOCKET", "")
+        self.sid = os.environ.get("AGT_SESSION_ID", "")
+        self.window = os.environ.get("AGT_WINDOW_ID", "active")
+
+    @staticmethod
+    def resolve_bin() -> str:
+        """resolve_bin returns the agtermctl to drive, "" when there is none to run.
+
+        A keybinding runs with launchd's PATH rather than a login shell's, so the usual install
+        directories are tried by hand before falling back to a lookup.
+        """
+        override = os.environ.get("AGTERMCTL", "")
+        if override:
+            return override if os.access(override, os.X_OK) else ""
+        for directory in ("/usr/local/bin", os.environ.get("GHOSTTY_BIN_DIR", ""), "/opt/homebrew/bin"):
+            candidate = os.path.join(directory, "agtermctl") if directory else ""
+            if candidate and os.access(candidate, os.X_OK):
+                return candidate
+        return shutil.which("agtermctl") or ""
+
+    def run(self, *args: str, stdin: str | None = None) -> subprocess.CompletedProcess[str]:
+        """run invokes agtermctl with the socket appended, never raising on a nonzero exit."""
+        cmd = [self.bin, *args]
+        if self.socket:
+            cmd += ["--socket", self.socket]
+        return subprocess.run(cmd, input=stdin, capture_output=True, text=True, check=False)
+
+    def pick(self, rows: list[dict[str, str]]) -> str:
+        """pick opens the native picker and returns the chosen path, "" when cancelled."""
+        res = self.run("pick", "--prompt", "sqlite", "--window", self.window, stdin=json.dumps(rows))
+        if res.returncode == 2:
+            return ""
+        if res.returncode != 0:
+            fail(f"picker failed (exit {res.returncode})", self)
+        try:
+            choice = json.loads(res.stdout)
+        except ValueError:
+            return ""
+        return str(choice.get("id", "")) if choice.get("result") == "picked" else ""
+
+    def overlay(self, command: str) -> subprocess.CompletedProcess[str]:
+        """overlay runs the viewer on top of the session the chord fired from.
+
+        No --follow: the overlay belongs to this session, and pulling the user to it would move the
+        selection out from under whatever he is doing elsewhere.
+        """
+        return self.run("session", "overlay", "open", f"zsh -c {shlex.quote(command)}",
+                        "--size-percent", OVERLAY_PERCENT, "--target", self.sid or "active")
+
+    def notify(self, message: str) -> None:
+        """notify is the fallback channel: a keybinding's stdout goes to /dev/null."""
+        if self.bin:
+            self.run("notify", message, "--title", "SQLite")
+
+    def hud(self, message: str, seconds: float, detail: str = "") -> bool:
+        """hud posts a passive panel at the top of the session, then takes it down.
+
+        Preferred over a desktop notification for a state the chord itself produced: the panel appears
+        over the session the key was pressed in, leaves it focused and typable, and needs no visit to
+        Notification Center. False when the panel could not be posted at all.
+        """
+        target = self.sid or "active"
+        args = ["session", "hud", "open", message, "--position", "top-center", "--target", target,
+                "--background-color", HUD_BG, "--text-color", HUD_FG,
+                "--size-percent", HUD_WIDTH]
+        if detail:
+            args += ["--detail", detail]
+        if self.run(*args).returncode != 0:
+            return False
+        time.sleep(seconds)
+        self.run("session", "hud", "close", "--target", target)
+        return True
+
+
+def resolve_viewer() -> str:
+    """resolve_viewer returns the viewer's absolute path, "" when it is not installed.
+
+    PATH cannot be trusted at either end: this script runs with launchd's PATH, and the overlay it
+    opens gets the app's, so /opt/homebrew/bin is missing from both.
+    """
+    if os.path.isabs(VIEWER):
+        return VIEWER if os.access(VIEWER, os.X_OK) else ""
+    for directory in ("/opt/homebrew/bin", "/usr/local/bin", str(Path.home() / "bin"), "/usr/bin"):
+        candidate = os.path.join(directory, VIEWER)
+        if os.access(candidate, os.X_OK):
+            return candidate
+    return shutil.which(VIEWER) or ""
+
+
+def repo_root(cwd: str) -> Path:
+    """repo_root returns the repo the session sits in, or its cwd when that is not a repo.
+
+    The chord can fire from any subdirectory, and a database can sit anywhere under the root.
+    """
+    try:
+        res = subprocess.run(["git", "rev-parse", "--show-toplevel"], cwd=cwd, capture_output=True,
+                             text=True, timeout=10, check=False)
+    except (OSError, subprocess.SubprocessError):
+        return Path(cwd)
+    return Path(res.stdout.strip()) if res.returncode == 0 and res.stdout.strip() else Path(cwd)
+
+
+def fail(message: str, agt: Agt | None = None) -> Any:
+    """fail reports through the only channels a keybinding has, then exits."""
+    log(message)
+    print(f"sqlite-browser: {message}", file=sys.stderr)
+    if agt:
+        agt.notify(message)
+    sys.exit(1)
+
+
+def announce(agt: Agt, message: str, detail: str) -> None:
+    """announce says a normal empty-handed outcome over the session, falling back to a notification."""
+    log(f"{message}: {detail}")
+    if not agt.hud(f"ⓘ  {message}", HUD_SECONDS, detail=detail):
+        agt.notify(f"{message}: {detail}")
+
+
+def main(argv: list[str]) -> int:
+    cwd = os.environ.get("AGT_SESSION_PWD") or os.getcwd()
+    root = repo_root(cwd)
+    dbs = find_dbs(root)
+
+    if "--list" in argv:
+        now = time.time()
+        for db in dbs:
+            print(f"{db.rel:60} {human_size(db.size):>7}  {age_label(db.mtime, now)}")
+        print(f"{len(dbs)} databases under {root}")
+        return 0
+
+    agt = Agt()
+    if not agt.bin:
+        fail(f"AGTERMCTL is not executable: {os.environ['AGTERMCTL']}" if os.environ.get("AGTERMCTL")
+             else "no agtermctl found; install the command line tool or set AGTERMCTL")
+
+    viewer = resolve_viewer()
+    if not viewer:
+        announce(agt, f"{VIEWER} is not installed", f"brew install {VIEWER}")
+        return 0
+    if not dbs:
+        announce(agt, "no sqlite databases", str(root))
+        return 0
+
+    chosen = agt.pick(rows_of(dbs, time.time()))
+    if not chosen:
+        return 0
+    picked = next((db for db in dbs if db.rel == chosen), None)
+    if not picked:
+        fail(f"picker returned an unknown database: {chosen}", agt)
+
+    res = agt.overlay(viewer_command(picked.path, viewer))
+    if res.returncode != 0:
+        fail(f"could not open the overlay: {res.stderr.strip() or f'exit {res.returncode}'}", agt)
+    return 0
+
+
+class Tests(unittest.TestCase):
+    def db_tree(self, tmp: str) -> Path:
+        root = Path(tmp)
+        (root / "sub").mkdir()
+        (root / "node_modules" / "pkg").mkdir(parents=True)
+        (root / "app.db").write_bytes(MAGIC + b"rest")
+        (root / "sub" / "cache.sqlite3").write_bytes(MAGIC + b"rest")
+        (root / "notes.db").write_bytes(b"this is a text file pretending")   # right name, wrong format
+        (root / "app.db-wal").write_bytes(MAGIC + b"rest")                   # sidecar, not a database
+        (root / "readme.md").write_bytes(MAGIC + b"rest")                    # magic, wrong extension
+        (root / "node_modules" / "pkg" / "fixture.db").write_bytes(MAGIC + b"rest")
+        (root / ".mypy_cache").mkdir()
+        (root / ".mypy_cache" / "cache.db").write_bytes(MAGIC + b"rest")   # a tool cache, not the repo's data
+        return root
+
+    def test_find_dbs_takes_only_real_databases(self) -> None:
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self.db_tree(tmp)
+            os.utime(root / "app.db", (0, 0))   # older, so the sort has something to order
+            self.assertEqual([db.rel for db in find_dbs(root)], ["sub/cache.sqlite3", "app.db"])
+
+    def test_find_dbs_does_not_follow_a_directory_symlink(self) -> None:
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            (root / "inner").mkdir(parents=True)
+            (root / "inner" / "real.db").write_bytes(MAGIC)
+            (root / "loop").symlink_to(root)   # a walk that followed this would never finish
+            self.assertEqual([db.rel for db in find_dbs(root)], ["inner/real.db"])
+
+    def test_find_dbs_refuses_a_control_character(self) -> None:
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "ok.db").write_bytes(MAGIC)
+            (root / "bad\nrm -rf x.db").write_bytes(MAGIC)
+            self.assertEqual([db.rel for db in find_dbs(root)], ["ok.db"])
+
+    def test_human_size(self) -> None:
+        for size, want in [(0, "0B"), (512, "512B"), (1536, "1.5K"), (20480, "20K"),
+                           (5 * 1024 * 1024, "5.0M"), (3 * 1024**3, "3.0G")]:
+            with self.subTest(size):
+                self.assertEqual(human_size(size), want)
+
+    def test_age_label(self) -> None:
+        now = 1_000_000.0
+        for delta, want in [(0, "just now"), (60, "just now"), (600, "10m ago"), (7200, "2h ago"),
+                            (86400 * 3, "3d ago"), (86400 * 90, "2mo ago")]:
+            with self.subTest(delta):
+                self.assertEqual(age_label(now - delta, now), want)
+
+    def test_rows_of(self) -> None:
+        now = 1_000_000.0
+        rows = rows_of([Db("app.db", Path("/r/app.db"), 1536, now - 600)], now)
+        self.assertEqual(rows, [{"id": "app.db", "label": "app.db", "subtitle": "1.5K · 10m ago"}])
+
+    def test_viewer_command_quotes_a_hostile_path(self) -> None:
+        # a checked-out file name is attacker-authored; zsh -c must see one argument
+        for name in ['a"; id; :"b.db', "x$(id).db", "y`id`.db", "z'q.db"]:
+            with self.subTest(name):
+                line = viewer_command(Path("/r") / name, "/opt/homebrew/bin/tw")
+                self.assertEqual(shlex.split(line),
+                                 ["/opt/homebrew/bin/tw", *VIEWER_ARGS, f"/r/{name}"])
+
+    def test_resolve_viewer_takes_an_absolute_override_as_given(self) -> None:
+        import tempfile
+        from unittest import mock
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "myviewer"
+            binary.write_text("#!/bin/sh\n")
+            binary.chmod(0o755)
+            with mock.patch.object(sys.modules[__name__], "VIEWER", str(binary)):
+                self.assertEqual(resolve_viewer(), str(binary))
+            with mock.patch.object(sys.modules[__name__], "VIEWER", str(Path(tmp) / "gone")):
+                self.assertEqual(resolve_viewer(), "")
+
+    def test_resolve_bin_takes_an_executable_override_as_given(self) -> None:
+        import tempfile
+        from unittest import mock
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "agtermctl"
+            binary.write_text("#!/bin/sh\n")
+            binary.chmod(0o755)
+            with mock.patch.dict(os.environ, {"AGTERMCTL": str(binary)}):
+                self.assertEqual(Agt.resolve_bin(), str(binary))
+            with mock.patch.dict(os.environ, {"AGTERMCTL": str(Path(tmp) / "gone")}):
+                self.assertEqual(Agt.resolve_bin(), "")
+
+    def test_overlay_targets_this_session(self) -> None:
+        from unittest import mock
+        agt = Agt.__new__(Agt)
+        agt.bin, agt.socket, agt.sid, agt.window = "/x/agtermctl", "", "sid-1", "active"
+        calls = []
+        with mock.patch.object(Agt, "run", lambda self, *a, **kw: calls.append(a) or
+                               subprocess.CompletedProcess(a, 0, "", "")):
+            agt.overlay("/opt/homebrew/bin/tw -f sqlite /r/app.db")
+        self.assertEqual(calls, [("session", "overlay", "open",
+                                  "zsh -c '/opt/homebrew/bin/tw -f sqlite /r/app.db'",
+                                  "--size-percent", OVERLAY_PERCENT, "--target", "sid-1")])
+
+
+if __name__ == "__main__":
+    if "--test" in sys.argv:
+        sys.argv.remove("--test")
+        unittest.main()
+    try:
+        sys.exit(main(sys.argv[1:]))
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/cookbook/sqlite-browser/sqlite-browser.py
+++ b/cookbook/sqlite-browser/sqlite-browser.py
@@ -99,7 +99,9 @@ def find_dbs(root: Path) -> list[Db]:
         dirnames[:] = [d for d in dirnames if d not in PRUNE and not d.startswith(".")]
         for name in filenames:
             path = Path(dirpath) / name
-            if path.suffix.lower() not in EXTS or not is_sqlite(path):
+            # is_file before is_sqlite, and both follow the link: opening a FIFO read-only blocks until
+            # something writes to it, and a chord whose stdout is /dev/null would hang with no sign of it.
+            if path.suffix.lower() not in EXTS or not path.is_file() or not is_sqlite(path):
                 continue
             rel = str(path.relative_to(root))
             if any(ch < " " or ch == "\x7f" for ch in rel):
@@ -189,10 +191,12 @@ class Agt:
             return ""
         if res.returncode != 0:
             fail(f"picker failed: {res.stderr.strip() or f'exit {res.returncode}'}", self)
+        # not a quiet "" here: a cancel is exit 2 and was handled above, so exit 0 owes us the result
+        # JSON, and treating a body we cannot read as a cancel would turn the failure into a dead key.
         try:
             choice = json.loads(res.stdout)
         except ValueError:
-            return ""
+            fail(f"picker returned no readable result: {res.stdout.strip()[:120]!r}", self)
         return str(choice.get("id", "")) if choice.get("result") == "picked" else ""
 
     def overlay(self, command: str) -> subprocess.CompletedProcess[str]:
@@ -386,6 +390,14 @@ class Tests(unittest.TestCase):
             (root / "inner" / "real.db").write_bytes(MAGIC)
             (root / "loop").symlink_to(root)   # a walk that followed this would never finish
             self.assertEqual([db.rel for db in find_dbs(root)], ["inner/real.db"])
+
+    def test_find_dbs_skips_a_fifo(self) -> None:
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "real.db").write_bytes(MAGIC)
+            os.mkfifo(root / "pipe.db")   # reading this one would block until something writes to it
+            self.assertEqual([db.rel for db in find_dbs(root)], ["real.db"])
 
     def test_find_dbs_refuses_a_control_character(self) -> None:
         import tempfile

--- a/cookbook/sqlite-browser/sqlite-browser.py
+++ b/cookbook/sqlite-browser/sqlite-browser.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Pick a SQLite database from THIS session's repo and open it in a TUI viewer, in an overlay.
 
-Runs as an agterm keymap custom command, so the runner exports $AGT_* and the app spawns it with
-launchd's PATH and stdout on /dev/null.
+Runs as an agterm keymap custom command, so the runner exports $AGT_*, widens PATH with the CLI and
+Homebrew directories, and pins stdout to /dev/null.
 
 Candidates are files under the repo root carrying a database extension AND starting with the SQLite
 magic header, so a `.db` that is really a Berkeley DB or a text file never reaches the picker. The
@@ -34,6 +34,10 @@ EXTS = {".db", ".db3", ".sqlite", ".sqlite3", ".sqlitedb"}
 # rather than a list: .mypy_cache alone put 32 of its own sqlite files ahead of every real one in a
 # repo tried during development, and .pytest_cache, .tox and .venv are the same shape.
 PRUNE = {"node_modules", "vendor", "venv", "__pycache__", "site-packages", "target", "Pods"}
+# agterm's picker refuses a longer list outright (ControlPickItem.maxItems) rather than truncating it,
+# so a tree with more databases than this would open no picker at all. Rows are newest-first, so the
+# cut falls on the least interesting end.
+MAX_ROWS = 1000
 # tabiew: it opens ON the data - every table of the database becomes a tab, H/L cycles them, `:schema`
 # lists them with column stats. The SQL clients tried first (lazysql, harlequin, rainfrog, dblab) all
 # open on an empty editor or a logo instead. The format is passed rather than inferred: tabiew maps
@@ -67,11 +71,16 @@ def log(message: str) -> None:
 
 
 def is_sqlite(path: Path) -> bool:
-    """is_sqlite reads the file header; the extension alone proves nothing about the format."""
+    """is_sqlite reads the file header; the extension alone proves nothing about the format.
+
+    An unreadable file is logged rather than dropped quietly: it looks identical to a wrong-format one
+    in the result, and a permission error is the whole explanation for a database that never appears.
+    """
     try:
         with path.open("rb") as fh:
             return fh.read(len(MAGIC)) == MAGIC
-    except OSError:
+    except OSError as err:
+        log(f"skipped {path}: {err}")
         return False
 
 
@@ -154,16 +163,12 @@ class Agt:
     def resolve_bin() -> str:
         """resolve_bin returns the agtermctl to drive, "" when there is none to run.
 
-        A keybinding runs with launchd's PATH rather than a login shell's, so the usual install
-        directories are tried by hand before falling back to a lookup.
+        A plain PATH lookup is enough from 0.22.0 on: the custom-command runner widens the child's PATH
+        with the CLI install directory and Homebrew's prefix before spawning it.
         """
         override = os.environ.get("AGTERMCTL", "")
         if override:
             return override if os.access(override, os.X_OK) else ""
-        for directory in ("/usr/local/bin", os.environ.get("GHOSTTY_BIN_DIR", ""), "/opt/homebrew/bin"):
-            candidate = os.path.join(directory, "agtermctl") if directory else ""
-            if candidate and os.access(candidate, os.X_OK):
-                return candidate
         return shutil.which("agtermctl") or ""
 
     def run(self, *args: str, stdin: str | None = None) -> subprocess.CompletedProcess[str]:
@@ -173,13 +178,17 @@ class Agt:
             cmd += ["--socket", self.socket]
         return subprocess.run(cmd, input=stdin, capture_output=True, text=True, check=False)
 
-    def pick(self, rows: list[dict[str, str]]) -> str:
-        """pick opens the native picker and returns the chosen path, "" when cancelled."""
-        res = self.run("pick", "--prompt", "sqlite", "--window", self.window, stdin=json.dumps(rows))
+    def pick(self, rows: list[dict[str, str]], dropped: int = 0) -> str:
+        """pick opens the native picker and returns the chosen path, "" when cancelled.
+
+        The prompt says when the list was cut, since a truncation nothing names reads as the whole tree.
+        """
+        prompt = f"sqlite (newest {len(rows)} of {len(rows) + dropped})" if dropped else "sqlite"
+        res = self.run("pick", "--prompt", prompt, "--window", self.window, stdin=json.dumps(rows))
         if res.returncode == 2:
             return ""
         if res.returncode != 0:
-            fail(f"picker failed (exit {res.returncode})", self)
+            fail(f"picker failed: {res.stderr.strip() or f'exit {res.returncode}'}", self)
         try:
             choice = json.loads(res.stdout)
         except ValueError:
@@ -223,8 +232,9 @@ class Agt:
 def resolve_viewer() -> str:
     """resolve_viewer returns the viewer's absolute path, "" when it is not installed.
 
-    PATH cannot be trusted at either end: this script runs with launchd's PATH, and the overlay it
-    opens gets the app's, so /opt/homebrew/bin is missing from both.
+    Absolute because of where the name is going, not where it is resolved: the OVERLAY is spawned with
+    the app's own PATH, which no runner widens, so a bare viewer name exits 127 there. The directory
+    ladder runs ahead of the lookup for a PATH that reaches this script without Homebrew's prefix.
     """
     if os.path.isabs(VIEWER):
         return VIEWER if os.access(VIEWER, os.X_OK) else ""
@@ -248,6 +258,37 @@ def repo_root(cwd: str) -> Path:
     return Path(res.stdout.strip()) if res.returncode == 0 and res.stdout.strip() else Path(cwd)
 
 
+def scan_root() -> Path | None:
+    """scan_root resolves the tree to walk, None when there is no session behind the chord.
+
+    The three states of AGT_SESSION_PWD are three different situations and only the variable tells them
+    apart. UNSET is a plain shell run, so the shell's own cwd is the subject. SET AND EMPTY is the chord
+    firing in a window holding no session: agterm exports every token whether or not it resolved, and
+    leaves the child in the APP's working directory, which is / for a Dock-launched bundle. Reading that
+    as "no value, use the cwd" is what turns one keypress into a walk of the whole filesystem, a TCC
+    prompt per protected folder, and a picker listing personal databases.
+    """
+    pwd = os.environ.get("AGT_SESSION_PWD")
+    if pwd is None:
+        return repo_root(os.getcwd())
+    return repo_root(pwd) if pwd else None
+
+
+def too_broad(root: Path) -> str:
+    """too_broad names what the root would drag in, "" when it is safe to walk.
+
+    Only reachable when git found no repo, since a repo root is neither of these. The home directory is
+    the one that actually happens: a shell opened there scans ~/Library's hundreds of application
+    databases and raises a macOS permission prompt for every protected folder on the way. A non-repo
+    subdirectory is left alone — that is a normal place to keep a database.
+    """
+    if root == Path(root.root):
+        return "the whole filesystem"
+    if root == Path.home():
+        return "the whole home directory"
+    return ""
+
+
 def fail(message: str, agt: Agt | None = None) -> Any:
     """fail reports through the only channels a keybinding has, then exits."""
     log(message)
@@ -265,12 +306,11 @@ def announce(agt: Agt, message: str, detail: str) -> None:
 
 
 def main(argv: list[str]) -> int:
-    cwd = os.environ.get("AGT_SESSION_PWD") or os.getcwd()
-    root = repo_root(cwd)
-    dbs = find_dbs(root)
+    root = scan_root()
 
     if "--list" in argv:
-        now = time.time()
+        root = root or repo_root(os.getcwd())
+        dbs, now = find_dbs(root), time.time()
         for db in dbs:
             print(f"{db.rel:60} {human_size(db.size):>7}  {age_label(db.mtime, now)}")
         print(f"{len(dbs)} databases under {root}")
@@ -281,18 +321,32 @@ def main(argv: list[str]) -> int:
         fail(f"AGTERMCTL is not executable: {os.environ['AGTERMCTL']}" if os.environ.get("AGTERMCTL")
              else "no agtermctl found; install the command line tool or set AGTERMCTL")
 
+    if root is None:
+        # not announce: with no session there is no target, so the hud and the notification both
+        # resolve `active` to nothing. A nonzero exit is the one channel left — agterm banners it.
+        fail("no session here: the chord needs a session to take its directory from", agt)
+    if reason := too_broad(root):
+        announce(agt, f"refusing to scan {reason}", f"this session's directory is {root}")
+        return 0
+
     viewer = resolve_viewer()
     if not viewer:
         announce(agt, f"{VIEWER} is not installed", f"brew install {VIEWER}")
         return 0
+
+    dbs = find_dbs(root)
     if not dbs:
         announce(agt, "no sqlite databases", str(root))
         return 0
 
-    chosen = agt.pick(rows_of(dbs, time.time()))
+    shown, dropped = dbs[:MAX_ROWS], max(0, len(dbs) - MAX_ROWS)
+    if dropped:
+        log(f"{dropped} databases past the picker's {MAX_ROWS}-item cap were not offered")
+
+    chosen = agt.pick(rows_of(shown, time.time()), dropped)
     if not chosen:
         return 0
-    picked = next((db for db in dbs if db.rel == chosen), None)
+    picked = next((db for db in shown if db.rel == chosen), None)
     if not picked:
         fail(f"picker returned an unknown database: {chosen}", agt)
 
@@ -390,6 +444,60 @@ class Tests(unittest.TestCase):
                 self.assertEqual(Agt.resolve_bin(), str(binary))
             with mock.patch.dict(os.environ, {"AGTERMCTL": str(Path(tmp) / "gone")}):
                 self.assertEqual(Agt.resolve_bin(), "")
+
+    def test_scan_root_tells_the_three_pwd_states_apart(self) -> None:
+        import tempfile
+        from unittest import mock
+        with tempfile.TemporaryDirectory() as tmp:
+            session = Path(tmp) / "session"
+            session.mkdir()
+            with mock.patch.object(sys.modules[__name__], "repo_root", Path):
+                with mock.patch.dict(os.environ):
+                    os.environ.pop("AGT_SESSION_PWD", None)
+                    self.assertEqual(scan_root(), Path(os.getcwd()))
+                with mock.patch.dict(os.environ, {"AGT_SESSION_PWD": ""}):
+                    self.assertIsNone(scan_root())
+                with mock.patch.dict(os.environ, {"AGT_SESSION_PWD": str(session)}):
+                    self.assertEqual(scan_root(), session)
+
+    def test_too_broad_refuses_the_root_and_the_home_directory(self) -> None:
+        self.assertEqual(too_broad(Path("/")), "the whole filesystem")
+        self.assertEqual(too_broad(Path.home()), "the whole home directory")
+        self.assertEqual(too_broad(Path.home() / "dev" / "project"), "")
+        self.assertEqual(too_broad(Path("/opt/data")), "")
+
+    def test_pick_prompt_names_a_truncated_list(self) -> None:
+        from unittest import mock
+        for dropped, want in ((0, "sqlite"), (5, "sqlite (newest 2 of 7)")):
+            with self.subTest(dropped=dropped):
+                agt = Agt.__new__(Agt)
+                agt.bin, agt.socket, agt.sid, agt.window = "/x/agtermctl", "", "sid-1", "active"
+                calls: list[tuple[str, ...]] = []
+                with mock.patch.object(Agt, "run", lambda self, *a, _c=calls, **kw: _c.append(a) or
+                                       subprocess.CompletedProcess(a, 2, "", "")):
+                    agt.pick([{"id": "a"}, {"id": "b"}], dropped)
+                self.assertEqual(calls[0][2], want)
+
+    def test_pick_failure_carries_the_server_reason(self) -> None:
+        import tempfile
+        from unittest import mock
+        agt = Agt.__new__(Agt)
+        agt.bin, agt.socket, agt.sid, agt.window = "/x/agtermctl", "", "sid-1", "active"
+        said = []
+
+        def fake_run(self: Agt, *args: str, **kwargs: object) -> subprocess.CompletedProcess[str]:
+            if args[0] == "notify":
+                said.append(args[1])
+                return subprocess.CompletedProcess(args, 0, "", "")
+            return subprocess.CompletedProcess(args, 1, "", "too many items (max 1000)\n")
+
+        with tempfile.TemporaryDirectory() as tmp, open(os.devnull, "w") as quiet, \
+             mock.patch.object(sys.modules[__name__], "LOG", Path(tmp) / "log"), \
+             mock.patch.object(Agt, "run", fake_run), \
+             mock.patch.object(sys, "stderr", quiet), \
+             self.assertRaises(SystemExit):
+            agt.pick([{"id": "a"}])
+        self.assertEqual(said, ["picker failed: too many items (max 1000)"])
 
     def test_overlay_targets_this_session(self) -> None:
         from unittest import mock


### PR DESCRIPTION
new cookbook recipe: press a chord and agterm's native picker lists the SQLite databases in this session's repo, newest first with size and age; pick one and it opens in tabiew in a 90% overlay.

**How the scan works**

extension first, because it is free, then the first 16 bytes against the SQLite magic header, because the extension proves nothing. A `.db` that is really a Berkeley DB, a text file or a `-wal` sidecar never reaches the picker. Dependency and hidden directories are pruned as a rule rather than a list: `.mypy_cache` alone put 32 of its own SQLite files ahead of every real one in the first repo it ran in. Directory symlinks are not followed.

**Two refusals worth calling out**

`AGT_SESSION_PWD` has three states and only reading the variable itself tells them apart. Unset is a plain shell run. A path is a session. Set but empty is a chord fired in a window holding no session, where the runner leaves the child in the app's own cwd, `/` for a Dock-launched bundle. Reading that as "no value, use the cwd" walks the whole filesystem and raises a permission prompt per protected folder, so it is refused. Saying so takes the exit code rather than a panel: with no session there is no target, so the hud and the notification both resolve `active` to nothing, while agterm banners a nonzero exit by itself.

The same walk is reachable with a session, from a directory git does not call a repo, so the home directory and the filesystem root are refused by name. A non-repo subdirectory still scans, which is a normal place to keep a database.

**Also**

the list is cut to the picker's own 1000-item cap rather than having the call refused outright, and the prompt says when it was cut. A failed pick carries the server's error text. `resolve_bin` is a plain PATH lookup, since the custom-command runner has widened a command's PATH with the CLI and Homebrew directories since 0.22.0, which is the recipe's stated minimum.

Requires agterm 0.22.0 or later, python3 and tabiew; `SQLITE_VIEWER` points it at another viewer. Index row added under Panes, pickers and input.
