### PR TITLE
feat(split): add horizontal split support

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -148,8 +148,10 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   between-row surface. `active` resolves through `currentWorkspaceID` — a foreground-created workspace
   first, then the selected session's, then `workspaces.last` — so repeated moves may target a different
   workspace; use an ID to keep one target.
-- `session.split` drives the addressed session, not active-only `AppActions.toggleSplit`. Off hides and
-  retains the shell; `session.split.close` and the split shell's own exit are what tear it down.
+- `session.split` drives the addressed session, not active-only `AppActions.toggleSplit`. `--axis
+  vertical|horizontal` selects left/right or top/bottom; omitting it preserves an existing split's axis
+  and defaults a new split to left/right. Off hides and retains the shell; `session.split.close` and the
+  split shell's own exit are what tear it down.
   `split` reports SHOWN, so a hidden split reads false;
   `hasSplit` reports the pane existing at all and is present exactly when `splitRatio`/`splitFocused`
   can be. Callers asking "does this session have a split" read `hasSplit`, and `agtermctl tree` tags the
@@ -161,12 +163,12 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
 - `session.scratch` is a third, nonpersisted login shell with on/off/toggle. It spawns lazily, survives
   hiding, recreates after exit, and renders as a full translucent cover below overlay. It has no session
   PWD/title link but a weak watermark link. GUI surfaces are Command-J, titlebar, View, and palette.
-- `session.focus --pane left|right|other` requires an existing split and works shown or hidden.
-  Read `splitFocused`.
-- `session.resize` accepts exactly one absolute ratio or relative grow-left/grow-right delta, defaulting
-  an unset ratio to 0.5. Require a split, clamp through store limits, persist, then post the object-scoped
-  live-divider notification. Hidden split stores for next show. Return clamped ratio as `%.3f`; read
-  `splitRatio`.
+- `session.focus primary|split|left|right|top|bottom|other` requires an existing split and works shown or
+  hidden. The pane is positional; read `splitFocused`.
+- `session.resize` accepts exactly one absolute ratio or one relative
+  `--grow-left|right|primary|split|top|bottom` delta, defaulting an unset ratio to 0.5. Require a split,
+  clamp through store limits, persist, then post the object-scoped live-divider notification. Hidden split
+  stores for next show. Return clamped ratio as `%.3f`; read `splitRatio`.
 - `session.go --to next|prev|first|last|next-attention|prev-attention` operates on current selection in
   the placement store, wraps within filtered scope, and returns selected ID. It has no target.
 - `notify` requires body, defaults title and session, skips OSC focus suppression, increments unseen, and
@@ -491,7 +493,7 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
 ## Tree and window read-back
 
 - Session nodes include foreground/split foreground argv, background spec, overlay size, pane overlays,
-  split ratio, split focus, status fields, flag, unseen, restore pins, surfaces, and `realized`.
+  split axis, split ratio, split focus, status fields, flag, unseen, restore pins, surfaces, and `realized`.
 - `realized` reports the MAIN pane's `TerminalSurface.isRealized`, populated host-free in
   `AppStore.controlTree` (no app closure — `isRealized` is on the protocol) and false for an empty slot, so
   only a server predating the field omits it. It exists because `session.new` answers `ok` for a model

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -199,7 +199,9 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
 
 ## Surface input, output, and search
 
-- `session.type --pane left|right|scratch` defaults to main for compatibility, not focused/on-screen.
+- `session.type --pane` accepts `primary|left|top`, `split|right|bottom`, or `scratch`; omission defaults
+  to primary for compatibility, not focused/on-screen. Read-back and the stable invalid-value error use
+  canonical `left|right|scratch` names.
   Hidden live scratch is addressable; missing panes error. Main alone bounded-polls (12 × 30ms) a newly
   unrealized session, with or without `select`, so `session.new --no-select` plus an immediate type does
   not race the mount+layout gap (#349). The probe precedes every sleep, so a realized session pays nothing

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -390,8 +390,8 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   no IDs/MRU/font; open needs IDs or MRU; fixed size must be finite positive.
 - A split expands to primary and split `DashboardMember`s, unless the id carries a `:left`/`:right` suffix
   (#331) selecting one pane. Host-free `DashboardTarget` owns that grammar: split on the FIRST colon,
-  accept only `left`/`right` case-insensitively, reject everything else including `primary`/`split`,
-  `scratch`/`overlay`, and a pasted `surface:<id>:<pane>`. The dispatcher rejects bad grammar outright; a
+  accept `primary`/`left`/`top` and `split`/`right`/`bottom` case-insensitively while readback stays
+  `left`/`right`; reject `scratch`/`overlay` and a pasted `surface:<id>:<pane>`. The dispatcher rejects bad grammar outright; a
   well-formed ref naming no pane (`:right` without a split) is a soft miss joining `unresolved`.
 - Resolve targets in order and deduplicate by session+pane, then cap panes app-side at
   `DashboardLayout.maxCells` 9. Append dropped-pane text to unresolved text with `;`. Guard emptiness on the
@@ -402,7 +402,7 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   `promoteSplitMember` rewrites that session's `.split` cell to `.primary` from `agtermApp.handlePaneExit`.
   Reconcile cannot do this: `closeSplit` and `closePrimaryPane` leave identical `hasSplit == false` state,
   and only the exit path knows which happened.
-- Dashboard is per-window and view-only; GUI Command-Shift-D/menu/palette toggles MRU auto-size.
+- Dashboard is per-window and view-only; GUI Command-Shift-G/menu/palette toggles MRU auto-size.
   Arrows navigate ragged `ceil(sqrt(n))` grid, Enter closes then selects/focuses exact pane, Esc closes.
   It is reciprocal with zoom. Read live `dashboardMembers`, highlighted member, applied font size, and
   `auto|fixed|untouched` mode. See [[libghostty]] for reparent, input gates, and transient font.

--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -48,7 +48,7 @@ paths:
   alternative, `alternative skipped`/`alternative dropped` with more), pinned by
   `KeymapTests.pipeFreeKeymapParsesExactlyAsItDidBeforeAlternatives`.
 - Pure types live in `Keybind.swift`, `KeybindMatcher`, `CustomCommand`/`CommandContext`,
-  `BuiltinAction` (42 cases, pinned by `BuiltinActionTests`), `Keymap`, and `ConfigPaths`.
+  `BuiltinAction` (43 cases, pinned by `BuiltinActionTests`), `Keymap`, and `ConfigPaths`.
   `CommandContext` owns the shared expansion/environment token table.
 - Built-ins use AppKit menu key equivalents from `keymap.equivalent(for:)`; apply only non-nil
   `KeyboardShortcut`s. SwiftUI rebuilds menu shortcuts on the next activation, not immediately after

--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -177,11 +177,14 @@ paths:
   own chords joined by `>` so a run cannot read as one chord (`⌘T ⌃␣>S`),
   returns the alternatives alone for an unbound action, and nil when there is neither.
 - The starter file's `map` and `command` examples are literal chords that rot when a new built-in claims
-  one, as `dashboard` did to the shipped `cmd+shift+d` (issue #405). Keep
+  one, as `dashboard` previously did to the shipped `cmd+shift+d` (issue #405). Keep
   `ConfigPathsTests.starterKeymapExamplesApplyWhenUncommented`, which uncomments every example, requires
   it to parse clean, and counts the chords that survive.
   Both verbs rot: `validateBindings` clears a custom shortcut a built-in has claimed just as
   `resolveBuiltinOverrides` drops the colliding `map`.
+- New shipped defaults must not break a valid existing keymap. `parseKeymap` vacates the new horizontal
+  split default when an old file explicitly uses `cmd+shift+d`, and vacates Dashboard's new default when
+  an old file explicitly uses `cmd+shift+g`. An explicit map for the new action opts into its new chord.
 - **`{AGT_X}` interpolation is intentionally raw and unquoted.** Selection, OSC title, OSC 7 pwd, and the
   session/workspace/window names and `--cwd` a caller supplies over control or the GUI can all inject
   visible shell metacharacters. `TerminalText.sanitized` strips control characters, not `;`,

--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -135,9 +135,10 @@ paths:
   Do not use SwiftUI mask/clipping because it reflows and loses the terminal's top row; do not use an
   opaque cover because it breaks translucency. Key each `HSplitView`/`VSplitView` identity by session and
   keep the terminal surface identities stable when changing axis.
-- Sidebar icon follows `hasSplit`. The titlebar's four-state icon is outline with none,
-  `rectangle.split.2x1.fill` while shown, left-half filled for hidden primary, and right-half filled for
-  hidden split.
+- Sidebar icon follows `hasSplit` and `splitAxis`. The titlebar has seven accessibility states: `none`,
+  `both`, `left`, and `right` for the left/right symbols, plus `both-horizontal`, `top`, and `bottom` for
+  the top/bottom symbols. A shown split fills both halves; a hidden split fills the visible primary or
+  split half on its current axis.
 
 ## Close and reselection
 

--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -74,7 +74,7 @@ paths:
   stepping, pane focus, and Dashboard. File UI tests against the menu that owns the item.
 - Workspace focus controls are mode-agnostic because membership applies when tree mode returns.
   Expand/Collapse Workspaces alone are disabled outside tree mode, in both menu and palette.
-- Dashboard uses Command-Shift-D, `BuiltinAction.dashboard`, and `toggleDashboard`; it toggles an MRU,
+- Dashboard uses Command-Shift-G, `BuiltinAction.dashboard`, and `toggleDashboard`; it toggles an MRU,
   auto-sized grid unless terminal zoom is active. Share `dashboardMembers` with control.
 - The View menu carries no fullscreen item of agterm's own, and `toggle_fullscreen` rides the key monitor
   rather than a menu shortcut; see [[windows]]. It remains rebindable and control-drivable.
@@ -104,8 +104,9 @@ paths:
 
 ## Split panes
 
-- `isSplit` means shown side-by-side, `hasSplit` means the second shell exists, and `splitFocused` chooses
-  focus. Split title/cwd feed focus-aware display name and focused cwd based on `splitFocused`, even hidden.
+- `isSplit` means both panes are shown, `hasSplit` means the second shell exists, `splitAxis` chooses
+  left/right or top/bottom, and `splitFocused` chooses focus. Split title/cwd feed focus-aware display name
+  and focused cwd based on `splitFocused`, even hidden.
   `effectiveCwd` remains primary for new panes and `AGTERM_SESSION_PWD`; `activeSurface` follows focus.
 - Creating a split focuses right. Hiding retains both shells and shows the focused pane maximized;
   reshown splits preserve focus. `closePrimaryPane` promotes right into primary with cwd/title/foreground
@@ -114,8 +115,8 @@ paths:
 - Pane focus actions, menu/palette, and `session.focus` gate on `hasSplit`, not `isSplit`, so they also swap
   the maximized hidden pane. Ctrl-1/Ctrl-2 use an app-wide event monitor and always consume these reserved
   keys, even when no split exists.
-- Persist each pane cwd and the 0...1 left-pane `splitRatio`. `SplitRatioAccessor` is an unconditional
-  background representable on primary, introspects `NSSplitView`, retries until width exists, observes
+- Persist each pane cwd and the 0...1 primary-pane `splitRatio`. `SplitRatioAccessor` is an unconditional
+  background representable on primary, introspects `NSSplitView`, retries until its axis extent exists, observes
   `didResizeSubviews`, and debounces save by about 0.4 seconds. Regular saves and quit flush also persist it.
 - Double-clicking the divider restores `splitRatioDefault` through the same `applyRatio` path as
   `session.resize`, persisting immediately rather than through the drag debounce. AppKit offers no hook:
@@ -132,7 +133,8 @@ paths:
   padding lies inside the safe-area band and AppKit expands `NSSplitView` full height; normal 48px mode is
   already bounded. Compute the live overrun and apply a CALayer mask, removing it at zero.
   Do not use SwiftUI mask/clipping because it reflows and loses the terminal's top row; do not use an
-  opaque cover because it breaks translucency. Key `HSplitView` identity by session.
+  opaque cover because it breaks translucency. Key each `HSplitView`/`VSplitView` identity by session and
+  keep the terminal surface identities stable when changing axis.
 - Sidebar icon follows `hasSplit`. The titlebar's four-state icon is outline with none,
   `rectangle.split.2x1.fill` while shown, left-half filled for hidden primary, and right-half filled for
   hidden split.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ What it does:
 
 - **Workspaces.** Sessions are grouped under named workspaces like "work" and "personal", which keeps a screen of concurrent sessions organized. You reach a session by name, by recency, or from the keyboard.
 - **Control API and CLI.** A bundled tool, `agtermctl`, drives almost everything over a local socket: create sessions, type into them, run a program in an overlay and read its exit status, move and resize windows, or post a notification tied to a specific session. A script or an agent can set up and drive its own layout, and send you a notification from the session it was working in.
-- **Splits, scratch, and overlays.** Split a session into two shells, open a scratch terminal over it, or run a program in a full or floating overlay without disturbing the shell underneath.
+- **Splits, scratch, and overlays.** Split a session into two shells side by side or top and bottom, open a scratch terminal over it, or run a program in a full or floating overlay without disturbing the shell underneath.
 - **Agent skill.** An installable skill (Help ▸ Install Agent Skill…) teaches Claude Code or Codex the control model and the `agtermctl` commands, so an agent running inside agterm can build its own layout, run overlays, manage windows, and show images inline without you explaining the API.
 - **Agent status.** A coding agent reports its state (active, blocked, or completed) onto its session's row, so you can see which of many running agents needs you. Status hooks for Claude Code, Codex, Pi, OpenCode, and other agents install from Help ▸ Install Agent Status Hooks….
 
@@ -48,7 +48,7 @@ A split session, two panes side by side on different color themes:
 - **Window.** A top-level bundle of workspaces and sessions in its own macOS window, with its own sidebar tree.
 - **Workspace.** A named group of sessions for one project or context.
 - **Session.** One running shell with a name, a working directory, and its own scrollback. It is the row you see in the sidebar, and it keeps running while you work in another one.
-- **Split and scratch.** A session can split into two shells side by side, both sharing the one sidebar row, and it can open a scratch terminal over itself for a quick aside.
+- **Split and scratch.** A session can split into two shells side by side or top and bottom, both sharing the one sidebar row, and it can open a scratch terminal over itself for a quick aside.
 - **Overlay.** One program running in a temporary terminal over a session. It disappears when the program exits and leaves the shell underneath unchanged.
 
 ## Install
@@ -90,6 +90,7 @@ Install the skill by one route or the other, never both: two copies leave it und
 ```sh
 ws=$(agtermctl workspace new demo)                        # capture the new workspace's id
 sid=$(agtermctl session new --workspace "$ws" --cwd "$PWD" --no-select)
+agtermctl session split on --axis horizontal --target "$sid" # add a top-and-bottom shell
 agtermctl session type $'pwd\n' --target "$sid"           # drive a session you are not looking at
 agtermctl session text --target "$sid" --lines 10         # read its terminal back
 agtermctl session status blocked --target "$sid"          # set the sidebar status glyph

--- a/agterm/AppActions+Palette.swift
+++ b/agterm/AppActions+Palette.swift
@@ -30,6 +30,7 @@ extension AppActions {
             hasMarkedWorkspaces: activeStore?.focusedWorkspaceIDs.isEmpty == false,
             activeWorkspaceMarked: activeStore?.isCurrentWorkspaceFocusMember == true,
             activeSessionHasSplit: activeStore?.activeSession?.hasSplit == true,
+            activeSplitAxis: activeStore?.activeSession?.splitAxis,
             hasPendingClose: activeStore?.pendingCloseSummary != nil,
             hasRecentClosed: !library.recentClosedItems.isEmpty,
             hasActiveSession: activeStore?.activeSession != nil,
@@ -80,6 +81,7 @@ extension AppActions {
         case .lastSession: selectLastSession()
         case .showAttention: openAttentionPalette()
         case .toggleSplit: toggleSplit()
+        case .toggleHorizontalSplit: toggleHorizontalSplit()
         case .closeSplit: closeSplit()
         case .toggleScratch: toggleScratch()
         case .toggleTerminalZoom: toggleTerminalZoom()

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -670,7 +670,7 @@ final class AppActions {
 
     // MARK: - Split
 
-    /// Toggle the active session's split. A NEW split shows both panes and focuses the new (right) one;
+    /// Toggle the active session's vertical split. A NEW split shows both panes and focuses the new one;
     /// closing only HIDES it (both shells stay alive) and maximizes the focused pane, so reopening restores
     /// both in their original positions with the SAME pane focused — focus follows `splitFocused`, which
     /// `AppStore.toggleSplit` moves only for a genuinely new split.
@@ -681,12 +681,27 @@ final class AppActions {
     /// scratch shell survives. A full overlay runs a caller's program that must not be closed under it, so
     /// the press is inert. Control's `session.split` keeps acting on the deck behind either cover.
     func toggleSplit() {
+        toggleSplit(axis: .leftRight)
+    }
+
+    /// Toggle the active session's horizontal split, or transpose a shown vertical split in place.
+    func toggleHorizontalSplit() {
+        toggleSplit(axis: .topBottom)
+    }
+
+    /// Preserve the current axis. Used by the titlebar's stateful split button rather than either
+    /// orientation-specific menu/keymap action.
+    func toggleCurrentSplit() {
+        toggleSplit(axis: nil)
+    }
+
+    private func toggleSplit(axis: SplitAxis?) {
         guard uiActionsEnabled else { return }
         guard let store, let session = store.activeSession else { return }
         guard !session.fullOverlayActive else { return }
         // the deck's `scratchActive` onChange reclaims first responder for the pane, as it does for ⌘J.
         if session.scratchActive { store.toggleScratch(session.id); return }
-        store.toggleSplit(session.id)
+        store.toggleSplit(session.id, axis: axis)
         focusSplitPane(session, wantSplit: session.splitFocused)
     }
 
@@ -756,7 +771,7 @@ final class AppActions {
         frontmostTerminalZoom?.toggle()
     }
 
-    /// Toggle the frontmost window's dashboard — the ⌘⇧D / Navigate ▸ Dashboard MRU grid, equivalent to
+    /// Toggle the frontmost window's dashboard, the ⌘⇧G / Navigate ▸ Dashboard MRU grid, equivalent to
     /// `agtermctl dashboard --mru --auto-size`. Inert while terminal zoom or a pending picker is up, but NOT
     /// while the dashboard itself is open, so the grid stays its own escape hatch. Open → close and refocus;
     /// closed → open over the window's most-recently-used sessions, auto-sized; no-op with none.

--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -249,14 +249,15 @@ extension ControlServer: ControlActions {
         }
     }
 
-    /// Drive the split on the target's OWN store, not active-only `AppActions.toggleSplit()`. `on|off|toggle`
-    /// is computed against `isSplit`, so both are idempotent. Always `AppStore.toggleSplit` — a ⌘D-style
-    /// keep-alive hide/show that never tears the hidden pane's surface down; `session.split.close` is the
-    /// verb that does.
+    /// Compatibility entry point. An omitted axis preserves an existing split's axis and defaults a new
+    /// split to left/right.
     func splitSession(_ target: String?, window: String?, mode: String?) -> ControlResponse {
         splitSession(target, window: window, mode: mode, axis: nil)
     }
 
+    /// Drive the split on the target's own store. An explicit axis creates or transposes; `nil` preserves
+    /// the current axis. `on|off|toggle` is computed against `isSplit` and keeps a hidden pane alive;
+    /// `session.split.close` is the teardown verb.
     func splitSession(_ target: String?, window: String?, mode: String?, axis: SplitAxis?) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
             guard let session = store.session(withID: id) else {

--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -254,6 +254,10 @@ extension ControlServer: ControlActions {
     /// keep-alive hide/show that never tears the hidden pane's surface down; `session.split.close` is the
     /// verb that does.
     func splitSession(_ target: String?, window: String?, mode: String?) -> ControlResponse {
+        splitSession(target, window: window, mode: mode, axis: nil)
+    }
+
+    func splitSession(_ target: String?, window: String?, mode: String?, axis: SplitAxis?) -> ControlResponse {
         return resolver.resolveSession(target, window: window) { store, id in
             guard let session = store.session(withID: id) else {
                 return ControlResponse(ok: false, error: "no such session: \(target ?? "active")")
@@ -261,9 +265,13 @@ extension ControlServer: ControlActions {
             guard let parsedMode = ControlToggleMode.parse(mode) else {
                 return ControlResponse(ok: false, error: "invalid split mode: \(mode ?? "toggle")")
             }
-            let want = parsedMode.desiredValue(current: session.isSplit)
-            if want != session.isSplit {
-                store.toggleSplit(id)
+            switch parsedMode {
+            case .on:
+                store.setSplitVisibility(id, shown: true, axis: axis)
+            case .off:
+                store.setSplitVisibility(id, shown: false)
+            case .toggle:
+                store.toggleSplit(id, axis: axis)
             }
             actions.focusSplitPane(session, wantSplit: session.splitFocused)
             return ControlResponse(ok: true, result: ControlResult(id: id.uuidString))
@@ -337,8 +345,8 @@ extension ControlServer: ControlActions {
     }
 
     /// Resize a split's divider (control-native — the GUI only drags it, or double-clicks it for an even
-    /// split). `ratio` is an absolute left-pane
-    /// fraction, `delta` a signed nudge (positive grows the left pane) on the current fraction (0.5 when
+    /// split). `ratio` is an absolute primary-pane
+    /// fraction, `delta` a signed nudge (positive grows the primary pane) on the current fraction (0.5 when
     /// never moved); exactly one must be set. `applySplitRatio` clamps + persists, then
     /// `.agtermApplySplitRatio` pokes the session's `SplitProbeView` to move the live divider — a no-op
     /// while the split is hidden, where the stored value applies on next show. Errors without a split, and

--- a/agterm/Views/DashboardView.swift
+++ b/agterm/Views/DashboardView.swift
@@ -193,10 +193,10 @@ struct DashboardView: View {
         .allowsHitTesting(false)
     }
 
-    /// The caption's pane marker follows the session axis: right/left arrows or bottom/top arrows.
-    /// session, nothing for a non-split session. It marks which pane the cell hosts, not that its sibling
-    /// is on the grid — a `<id>:left` request puts a lone `◀` cell up, which still says the session has
-    /// another pane you are not watching.
+    /// The caption's pane marker follows the session axis: right/left arrows or bottom/top arrows, and
+    /// nothing for a non-split session. It marks which pane the cell hosts, not that its sibling is on the
+    /// grid: a `<id>:left` request puts a lone `◀` cell up, which still says the session has another pane
+    /// you are not watching.
     private func paneIndicator(for member: DashboardMember, session: Session) -> String {
         if member.surface == .split { return session.splitAxis == .topBottom ? " ▼" : " ▶" }
         guard session.hasSplit else { return "" }

--- a/agterm/Views/DashboardView.swift
+++ b/agterm/Views/DashboardView.swift
@@ -193,13 +193,14 @@ struct DashboardView: View {
         .allowsHitTesting(false)
     }
 
-    /// The caption's pane marker: `▶` for a split (right) cell, `◀` for the primary (left) cell of a SPLIT
+    /// The caption's pane marker follows the session axis: right/left arrows or bottom/top arrows.
     /// session, nothing for a non-split session. It marks which pane the cell hosts, not that its sibling
     /// is on the grid — a `<id>:left` request puts a lone `◀` cell up, which still says the session has
     /// another pane you are not watching.
     private func paneIndicator(for member: DashboardMember, session: Session) -> String {
-        if member.surface == .split { return " ▶" }
-        return session.hasSplit ? " ◀" : ""
+        if member.surface == .split { return session.splitAxis == .topBottom ? " ▼" : " ▶" }
+        guard session.hasSplit else { return "" }
+        return session.splitAxis == .topBottom ? " ▲" : " ◀"
     }
 
     private func handleKey(_ key: DashboardKey) {

--- a/agterm/Views/SplitRatioAccessor.swift
+++ b/agterm/Views/SplitRatioAccessor.swift
@@ -15,14 +15,14 @@ extension NSView {
     }
 }
 
-/// Bridges to the AppKit `NSSplitView` under SwiftUI's `HSplitView` to (1) persist and restore the split
+/// Bridges to the AppKit `NSSplitView` under SwiftUI's `HSplitView`/`VSplitView` to (1) persist and restore the split
 /// divider ratio — no public SwiftUI API exposes the divider position — (2) clip the split's divider out
 /// of the titlebar strip, (3) paint the divider's own resize cursor, which nothing else writes, and
 /// (4) restore an even split on a divider double-click. Attached as a `.background` on the primary pane so
 /// its `NSView` lives inside the split's view tree without becoming a third arranged pane.
 ///
-/// (1) Once the split has a real width it restores `session.splitRatio` via `setPosition`; on each divider
-/// resize it writes the current left-pane fraction back to the session, which the next `save()` (or the
+/// (1) Once the split has a real axis extent it restores `session.splitRatio` via `setPosition`; on each divider
+/// resize it writes the current primary-pane fraction back to the session, which the next `save()` (or the
 /// quit-flush) persists, like a live cwd change.
 ///
 /// (2) In COMPACT mode the SwiftUI `.padding(.top, titlebarHeight)` (30px) lands inside the window's
@@ -89,8 +89,8 @@ struct SplitRatioAccessor: NSViewRepresentable {
         private var dividerClipMask: CALayer?
         private var dividerTracking: NSTrackingArea?
         private var restored = false
-        /// Left-pane width at the previous in-band press, nil when that press missed the band.
-        private var lastPressLeftWidth: CGFloat?
+        /// Primary-pane extent at the previous in-band press, nil when that press missed the band.
+        private var lastPressPrimaryExtent: CGFloat?
         /// A press was swallowed and its release is still to come.
         private var swallowedPress = false
 
@@ -109,9 +109,7 @@ struct SplitRatioAccessor: NSViewRepresentable {
             super.viewWillMove(toWindow: newWindow)
             guard newWindow == nil else { return }
             Self.dropClaimant(self)
-            guard let dividerTracking else { return }
-            splitView?.removeTrackingArea(dividerTracking)
-            self.dividerTracking = nil
+            detach()
         }
 
         override func layout() {
@@ -123,8 +121,8 @@ struct SplitRatioAccessor: NSViewRepresentable {
             guard !suspended else { return }
             guard !restored, let split = splitView else { return }
             if let ratio = session.splitRatio {
-                let total = split.bounds.width
-                guard total > 1 else { return } // wait for a real width; retried on each layout pass
+                let total = axisLength(of: split)
+                guard total > 1 else { return } // wait for a real extent; retried on each layout pass
                 split.setPosition(total * CGFloat(ratio), ofDividerAt: 0)
             }
             restored = true
@@ -132,7 +130,9 @@ struct SplitRatioAccessor: NSViewRepresentable {
 
         /// Find the enclosing `NSSplitView` once it's in the tree, then observe divider moves.
         private func attachIfNeeded() {
-            guard splitView == nil, let split = enclosingSplitView() else { return }
+            let enclosing = enclosingSplitView()
+            if splitView !== enclosing { detach() }
+            guard splitView == nil, let split = enclosing else { return }
             splitView = split
             resizeObserver = NotificationCenter.default.addObserver(
                 forName: NSSplitView.didResizeSubviewsNotification, object: split, queue: .main) { [weak self] _ in
@@ -147,6 +147,28 @@ struct SplitRatioAccessor: NSViewRepresentable {
                 forName: .agtermApplySplitRatio, object: session, queue: .main) { [weak self] _ in
                 MainActor.assumeIsolated { self?.applyRatio() }
             }
+        }
+
+        private func detach() {
+            if let dividerTracking { splitView?.removeTrackingArea(dividerTracking) }
+            dividerTracking = nil
+            if let resizeObserver { NotificationCenter.default.removeObserver(resizeObserver) }
+            if let applyObserver { NotificationCenter.default.removeObserver(applyObserver) }
+            resizeObserver = nil
+            applyObserver = nil
+            if let split = splitView, dividerClipMask != nil { split.layer?.mask = nil }
+            dividerClipMask = nil
+            splitView = nil
+            restored = false
+        }
+
+        private func axisLength(of split: NSSplitView) -> CGFloat {
+            split.isVertical ? split.bounds.width : split.bounds.height
+        }
+
+        private func primaryExtent(in split: NSSplitView) -> CGFloat {
+            guard let first = split.arrangedSubviews.first else { return 0 }
+            return split.isVertical ? first.frame.width : first.frame.height
         }
 
         /// Arm the split for `mouseMoved`/`cursorUpdate`. `.inVisibleRect` keeps it sized across divider and
@@ -168,11 +190,12 @@ struct SplitRatioAccessor: NSViewRepresentable {
 
         private func paintDividerCursor(at pointInWindow: NSPoint) {
             guard dividerOwns(pointInWindow) else { return }
-            NSCursor.resizeLeftRight.set()
+            let cursor = splitView?.isVertical == false ? NSCursor.resizeUpDown : NSCursor.resizeLeftRight
+            cursor.set()
             DispatchQueue.main.async { [weak self] in
                 guard let self, let window, window.isKeyWindow,
                       dividerOwns(window.mouseLocationOutsideOfEventStream) else { return }
-                NSCursor.resizeLeftRight.set()
+                cursor.set()
             }
         }
 
@@ -231,10 +254,10 @@ struct SplitRatioAccessor: NSViewRepresentable {
             }
             guard split.arrangedSubviews.count == 2 else { return false }
             let onDivider = dividerOwns(event.locationInWindow)
-            let leftWidth = split.arrangedSubviews[0].frame.width
-            defer { lastPressLeftWidth = onDivider ? leftWidth : nil }
+            let primaryExtent = primaryExtent(in: split)
+            defer { lastPressPrimaryExtent = onDivider ? primaryExtent : nil }
             guard onDivider, event.clickCount == 2,
-                  let previous = lastPressLeftWidth, abs(previous - leftWidth) < 1 else { return false }
+                  let previous = lastPressPrimaryExtent, abs(previous - primaryExtent) < 1 else { return false }
             resetToEvenSplit()
             swallowedPress = true
             return true
@@ -256,8 +279,8 @@ struct SplitRatioAccessor: NSViewRepresentable {
         private func applyRatio() {
             guard !suspended else { restored = false; return }
             guard let split = splitView, let ratio = session.splitRatio else { return }
-            let total = split.bounds.width
-            // no real width yet (mid-relayout): re-arm the one-shot `layout()` restore so it applies the
+            let total = axisLength(of: split)
+            // no real extent yet (mid-relayout): re-arm the one-shot `layout()` restore so it applies the
             // new fraction on the next pass instead of leaving the model ahead of the divider.
             guard total > 1 else { restored = false; return }
             split.setPosition(total * CGFloat(ratio), ofDividerAt: 0)
@@ -270,6 +293,10 @@ struct SplitRatioAccessor: NSViewRepresentable {
         /// a fixed strip would eat real terminal rows). A layer mask, not a frame change, so panes never reflow.
         private func updateDividerClip() {
             guard let split = splitView, let contentH = split.window?.contentView?.bounds.height else { return }
+            guard split.isVertical else {
+                if dividerClipMask != nil { split.layer?.mask = nil; dividerClipMask = nil }
+                return
+            }
             split.wantsLayer = true
             // split's top edge measured in points DOWN from the content top (window base coords, AppKit
             // origin bottom-left, so the top edge is maxY); then how far it rises above the titlebar boundary.
@@ -299,14 +326,15 @@ struct SplitRatioAccessor: NSViewRepresentable {
             split.layer?.mask = mask // re-assert (SwiftUI may rebuild the split's layer)
         }
 
-        /// Record the current left-pane fraction onto the session, skipping no-op and degenerate values so
+        /// Record the current primary-pane fraction onto the session, skipping no-op and degenerate values so
         /// a window resize that keeps the ratio doesn't churn it.
         private func capture() {
             guard !suspended else { return }
             guard restored, let split = splitView, let first = split.arrangedSubviews.first else { return }
-            let total = split.bounds.width
+            let total = axisLength(of: split)
             guard total > 1 else { return }
-            let ratio = Double(first.frame.width / total)
+            let extent = split.isVertical ? first.frame.width : first.frame.height
+            let ratio = Double(extent / total)
             guard ratio > AppStore.splitRatioMin, ratio < AppStore.splitRatioMax else { return }
             if let current = session.splitRatio, abs(current - ratio) < 0.004 { return }
             session.splitRatio = ratio

--- a/agterm/Views/WindowContentView+Dashboard.swift
+++ b/agterm/Views/WindowContentView+Dashboard.swift
@@ -119,7 +119,7 @@ extension WindowContentView {
     }
 
     /// Title-bar opener for the view-only grid — the frontmost window's most-recently-used sessions,
-    /// auto-sized (the `AppActions.toggleDashboard` / ⌘⇧D / Navigate ▸ Dashboard path). A single glyph,
+    /// auto-sized (the `AppActions.toggleDashboard` / ⌘⇧G / Navigate ▸ Dashboard path). A single glyph,
     /// never a 2-state toggle: an open dashboard swaps the whole titlebar for `dashboardTitlebar`, so this
     /// renders only while closed. Disabled with no sessions; non-private so `titlebarRow` can place it.
     var dashboardButton: some View {

--- a/agterm/Views/WindowContentView+Detail.swift
+++ b/agterm/Views/WindowContentView+Detail.swift
@@ -24,7 +24,7 @@ extension WindowContentView {
         }
     }
 
-    /// One session's terminal content: the primary pane, a side-by-side split (`HSplitView`), or the
+    /// One session's terminal content: the primary pane, an axis-aware split, or the
     /// maximized hidden-split pane, plus any overlay. `isActive` gates which pane auto-grabs focus — the
     /// visible deck entry, and within a split the focused pane.
     ///
@@ -62,22 +62,7 @@ extension WindowContentView {
             // hides them (opacity 0) so its translucency reveals the window backing, not the session.
             Group {
                 if session.isSplit {
-                    HSplitView {
-                        deckPane(session, pane: .left, focused: !session.splitFocused, gates: gates)
-                            // persists/restores the divider ratio and clips the NSSplitView out of the
-                            // titlebar strip; a background on the stable pane wrapper (not a third pane, not
-                            // inside its swapped content), so ONE probe survives zoom and suspend/resume.
-                            .background {
-                                SplitRatioAccessor(session: session, titlebarHeight: titlebarHeight,
-                                                   suspended: !deckInteractive,
-                                                   deckVisible: gates.visible && !gates.overlaid,
-                                                   onPersist: { store.save() })
-                            }
-                        deckPane(session, pane: .right, focused: session.splitFocused, gates: gates)
-                    }
-                    // per-session identity: without it SwiftUI reuses one NSSplitView across session
-                    // switches and the divider (and arranged subviews) leak between sessions.
-                    .id("\(session.id.uuidString)-hsplit")
+                    shownSplit(session, gates: gates, deckInteractive: deckInteractive)
                 } else if session.splitFocused, session.splitSurface != nil {
                     // split hidden while the right pane had focus: show that pane maximized.
                     deckPane(session, pane: .right, focused: true, gates: gates)
@@ -141,6 +126,37 @@ extension WindowContentView {
             guard after.count < before.count, deckInteractive, isActive, !quickTerminal.isVisible else { return }
             (session.topmostSurface as? GhosttySurfaceView)?.focusAfterReparent()
         }
+    }
+
+    /// The terminal hosts keep their pane roles and surface identity when the split axis changes. Only the
+    /// AppKit split container is replaced, transposing the existing primary/split pair in place.
+    @ViewBuilder private func shownSplit(_ session: Session, gates: DeckPaneGates,
+                                         deckInteractive: Bool) -> some View {
+        if session.splitAxis == .topBottom {
+            VSplitView {
+                splitPrimaryPane(session, gates: gates, deckInteractive: deckInteractive)
+                deckPane(session, pane: .right, focused: session.splitFocused, gates: gates)
+            }
+            .id("\(session.id.uuidString)-vsplit")
+        } else {
+            HSplitView {
+                splitPrimaryPane(session, gates: gates, deckInteractive: deckInteractive)
+                deckPane(session, pane: .right, focused: session.splitFocused, gates: gates)
+            }
+            .id("\(session.id.uuidString)-hsplit")
+        }
+    }
+
+    /// The ratio probe belongs to the stable primary pane wrapper, never a third arranged subview.
+    private func splitPrimaryPane(_ session: Session, gates: DeckPaneGates,
+                                  deckInteractive: Bool) -> some View {
+        deckPane(session, pane: .left, focused: !session.splitFocused, gates: gates)
+            .background {
+                SplitRatioAccessor(session: session, titlebarHeight: titlebarHeight,
+                                   suspended: !deckInteractive,
+                                   deckVisible: gates.visible && !gates.overlaid,
+                                   onPersist: { store.save() })
+            }
     }
 
     /// ONE pane of a session's deck entry: its terminal — or the `Color.clear` placeholder while zoom or the

--- a/agterm/Views/WindowContentView+Titlebar.swift
+++ b/agterm/Views/WindowContentView+Titlebar.swift
@@ -177,9 +177,9 @@ extension WindowContentView {
         let axis = store.activeSession?.splitAxis ?? .leftRight
         let shortcutAction: BuiltinAction = axis == .topBottom ? .toggleHorizontalSplit : .toggleSplit
         // filled = pane visible, outline = hidden: no split is an empty two-pane outline, a shown split fills
-        // both, a collapsed one (hasSplit, not shown) fills only the visible half — left for the primary, right
-        // for the split (`splitFocused` is the shown pane when hidden) — naming the pane up and the one parked.
-        // `a11y` mirrors the four states for XCUITest, which can't read the symbol name.
+        // both, and a collapsed one fills the visible leading or trailing half on the current axis.
+        // `splitFocused` identifies that visible pane. `a11y` mirrors all seven states for XCUITest, which
+        // cannot read the symbol name: none, both, both-horizontal, left, right, top, and bottom.
         let symbol: String
         let a11y: String
         if !hasSplit {

--- a/agterm/Views/WindowContentView+Titlebar.swift
+++ b/agterm/Views/WindowContentView+Titlebar.swift
@@ -174,6 +174,8 @@ extension WindowContentView {
         let isSplit = store.activeSession?.isSplit ?? false
         let hasSplit = store.activeSession?.hasSplit ?? false
         let splitFocused = store.activeSession?.splitFocused ?? false
+        let axis = store.activeSession?.splitAxis ?? .leftRight
+        let shortcutAction: BuiltinAction = axis == .topBottom ? .toggleHorizontalSplit : .toggleSplit
         // filled = pane visible, outline = hidden: no split is an empty two-pane outline, a shown split fills
         // both, a collapsed one (hasSplit, not shown) fills only the visible half — left for the primary, right
         // for the split (`splitFocused` is the shown pane when hidden) — naming the pane up and the one parked.
@@ -183,19 +185,22 @@ extension WindowContentView {
         if !hasSplit {
             symbol = "rectangle.split.2x1"; a11y = "none"
         } else if isSplit {
-            symbol = "rectangle.split.2x1.fill"; a11y = "both"
+            symbol = axis == .topBottom ? "rectangle.split.1x2.fill" : "rectangle.split.2x1.fill"
+            a11y = axis == .topBottom ? "both-horizontal" : "both"
         } else if splitFocused {
-            symbol = "rectangle.righthalf.filled"; a11y = "right"
+            symbol = axis == .topBottom ? "rectangle.bottomhalf.filled" : "rectangle.righthalf.filled"
+            a11y = axis == .topBottom ? "bottom" : "right"
         } else {
-            symbol = "rectangle.lefthalf.filled"; a11y = "left"
+            symbol = axis == .topBottom ? "rectangle.tophalf.filled" : "rectangle.lefthalf.filled"
+            a11y = axis == .topBottom ? "top" : "left"
         }
         return Button {
-            actions.toggleSplit()
+            actions.toggleCurrentSplit()
         } label: {
             // a Label (icon + title) so the toolbar's "Icon and Text" mode has text; hidden in icon-only mode.
             Label("Split", systemImage: symbol)
         }
-        .help(helpHint(isSplit ? "Hide split" : (hasSplit ? "Show split" : "Split right"), .toggleSplit))
+        .help(helpHint(isSplit ? "Hide split" : (hasSplit ? "Show split" : "Split right"), shortcutAction))
         .disabled(store.activeSession == nil)
         .accessibilityValue(a11y)
         .accessibilityIdentifier("split-toggle")

--- a/agterm/Views/WorkspaceSidebar+RowRendering.swift
+++ b/agterm/Views/WorkspaceSidebar+RowRendering.swift
@@ -72,7 +72,8 @@ extension WorkspaceSidebar.Coordinator {
             // so the fill would be noise.
             let showSplitIcon = session?.hasSplit == true
             let flagged = store.sidebarMode == .tree && session?.flagged == true
-            cell.imageView?.image = iconForSession(split: showSplitIcon, flagged: flagged)
+            cell.imageView?.image = iconForSession(split: showSplitIcon, axis: session?.splitAxis ?? .leftRight,
+                                                   flagged: flagged)
             cell.imageView?.setAccessibilityIdentifier("session-icon")
         }
         // text/icon colors track the terminal theme; a selected row uses the selection foreground.
@@ -94,12 +95,14 @@ extension WorkspaceSidebar.Coordinator {
 
     /// The leading session-row icon: split-rectangle when split, else plain terminal, each swapped to its
     /// filled variant when `flagged` — tree mode only, the flat flagged view passes `flagged: false`.
-    private func iconForSession(split: Bool, flagged: Bool) -> NSImage? {
-        switch (split, flagged) {
-        case (true, true): return flaggedSplitSessionIcon
-        case (true, false): return splitSessionIcon
-        case (false, true): return flaggedSessionIcon
-        case (false, false): return sessionIcon
+    private func iconForSession(split: Bool, axis: SplitAxis, flagged: Bool) -> NSImage? {
+        switch (split, axis, flagged) {
+        case (true, .topBottom, true): return flaggedHorizontalSplitSessionIcon
+        case (true, .topBottom, false): return horizontalSplitSessionIcon
+        case (true, .leftRight, true): return flaggedSplitSessionIcon
+        case (true, .leftRight, false): return splitSessionIcon
+        case (false, _, true): return flaggedSessionIcon
+        case (false, _, false): return sessionIcon
         }
     }
 

--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -98,7 +98,7 @@ struct WorkspaceSidebar: NSViewRepresentable {
         // reload; a touch inside viewFor wouldn't register it. The badge-visibility toggle
         // (GhosttyApp.notificationBadgeEnabled) is NOT observable and drives a re-reconcile via
         // .agtermAppearanceChanged, like toolbarMode.
-        _ = store.workspaces.map { ($0.id, $0.name, $0.unseenCount, $0.sessions.map { ($0.id, $0.displayName, $0.hasSplit, $0.unseenCount, $0.agentIndicator, $0.flagged) }) }
+        _ = store.workspaces.map { ($0.id, $0.name, $0.unseenCount, $0.sessions.map { ($0.id, $0.displayName, $0.hasSplit, $0.splitAxis, $0.unseenCount, $0.agentIndicator, $0.flagged) }) }
         _ = store.selectedSessionID
         _ = store.sidebarSelectionIDs
         // sidebarMode flips the whole data source (tree ↔ flat flagged list), so a mode change must rebuild.
@@ -343,6 +343,7 @@ struct WorkspaceSidebar: NSViewRepresentable {
         private struct RowContent: Equatable {
             let label: String
             let hasSplit: Bool
+            let splitAxis: SplitAxis
             let unseen: Int
             let indicator: AgentIndicator
             /// Whether the session is flagged (tree-mode filled-icon variant). A change re-badges just this
@@ -430,7 +431,8 @@ struct WorkspaceSidebar: NSViewRepresentable {
         /// The visible content of a workspace row. One builder shared by `reloadChangedContentRows` and
         /// `snapshotRowContent` so the snapshot and the diff can't drift.
         private func rowContent(forWorkspace workspace: Workspace) -> RowContent {
-            RowContent(label: workspace.name, hasSplit: false, unseen: effectiveUnseen(workspace.unseenCount),
+            RowContent(label: workspace.name, hasSplit: false, splitAxis: .leftRight,
+                       unseen: effectiveUnseen(workspace.unseenCount),
                        indicator: AgentIndicator(), flagged: false,
                        focusMember: store.focusedWorkspaceIDs.contains(workspace.id))
         }
@@ -440,6 +442,7 @@ struct WorkspaceSidebar: NSViewRepresentable {
         /// `workspaceName` in, so the label needs no per-session lookup and the reconcile stays linear.
         private func rowContent(forSession session: Session, workspaceName: String) -> RowContent {
             RowContent(label: rowLabel(for: session, workspaceName: workspaceName), hasSplit: session.hasSplit,
+                       splitAxis: session.splitAxis,
                        unseen: effectiveUnseen(session.unseenCount),
                        indicator: effectiveIndicator(forSession: session.id), flagged: session.flagged,
                        focusMember: false)
@@ -730,9 +733,11 @@ struct WorkspaceSidebar: NSViewRepresentable {
         lazy var workspaceIcon = Self.rowIcon("square.grid.2x2")
         lazy var focusedWorkspaceIcon = Self.rowIcon("square.grid.2x2", weight: .black)
         lazy var splitSessionIcon = Self.rowIcon("rectangle.split.2x1")
+        lazy var horizontalSplitSessionIcon = Self.rowIcon("rectangle.split.1x2")
         lazy var sessionIcon = Self.rowIcon("terminal")
         lazy var flaggedSessionIcon = Self.rowIcon("terminal.fill")
         lazy var flaggedSplitSessionIcon = Self.rowIcon("rectangle.split.2x1.fill")
+        lazy var flaggedHorizontalSplitSessionIcon = Self.rowIcon("rectangle.split.1x2.fill")
 
         private static func rowIcon(_ symbolName: String, weight: NSFont.Weight = .regular) -> NSImage? {
             let config = NSImage.SymbolConfiguration(pointSize: 13, weight: weight)

--- a/agterm/agtermApp+Menus.swift
+++ b/agterm/agtermApp+Menus.swift
@@ -268,10 +268,15 @@ extension agtermApp {
                 Button { actions.clearFocus() } label: { Label("Clear Focus", systemImage: "scope") }
                     .disabled(!PaletteCommand.clearFocus.isEnabled(in: context))
                 Button { actions.toggleSplit() } label: {
-                    Label(library.activeStore?.activeSession?.isSplit == true ? "Hide Split" : "Split Right", systemImage: "rectangle.split.2x1")
+                    Label("Toggle Vertical Split", systemImage: "rectangle.split.2x1")
                 }
                 .keyboardShortcut(shortcut(for: .toggleSplit))
                 .disabled(!PaletteCommand.toggleSplit.isEnabled(in: context))
+                Button { actions.toggleHorizontalSplit() } label: {
+                    Label("Toggle Horizontal Split", systemImage: "rectangle.split.1x2")
+                }
+                .keyboardShortcut(shortcut(for: .toggleHorizontalSplit))
+                .disabled(!PaletteCommand.toggleHorizontalSplit.isEnabled(in: context))
                 let scratchShown = library.activeStore?.activeSession?.scratchActive == true
                 Button { actions.toggleScratch() } label: {
                     // static neutral icon like the Split menu item above; state is shown by the label text.
@@ -320,7 +325,7 @@ extension agtermApp {
                     .disabled(!PaletteCommand.showAttention.isEnabled(in: context))
                 Button { actions.toggleDashboard() } label: { Label("Dashboard", systemImage: "rectangle.split.2x2") }
                     .keyboardShortcut(shortcut(for: .dashboard))
-                    // the predicate spares this one the dashboard's own term: ⌘⇧D stays the open grid's
+                    // the predicate spares this one the dashboard's own term: its shortcut stays the open grid's
                     // close escape hatch, while zoom and a topmost native picker still block the toggle.
                     .disabled(!PaletteCommand.dashboard.isEnabled(in: context))
                 Divider()
@@ -348,13 +353,16 @@ extension agtermApp {
                     .keyboardShortcut(shortcut(for: .lastSession))
                     .disabled(!PaletteCommand.lastSession.isEnabled(in: context))
                 Divider()
+                let topBottom = library.activeStore?.activeSession?.splitAxis == .topBottom
                 Button { actions.focusPane(.main) } label: {
-                    Label("Focus Left Pane", systemImage: "rectangle.lefthalf.filled")
+                    Label(topBottom ? "Focus Top Pane" : "Focus Left Pane",
+                          systemImage: topBottom ? "rectangle.tophalf.filled" : "rectangle.lefthalf.filled")
                 }
                 .keyboardShortcut(shortcut(for: .focusLeftPane))
                 .disabled(!PaletteCommand.focusLeftPane.isEnabled(in: context))
                 Button { actions.focusPane(.split) } label: {
-                    Label("Focus Right Pane", systemImage: "rectangle.righthalf.filled")
+                    Label(topBottom ? "Focus Bottom Pane" : "Focus Right Pane",
+                          systemImage: topBottom ? "rectangle.bottomhalf.filled" : "rectangle.righthalf.filled")
                 }
                 .keyboardShortcut(shortcut(for: .focusRightPane))
                 .disabled(!PaletteCommand.focusRightPane.isEnabled(in: context))

--- a/agtermCore/Sources/agtermCore/AgentStatus.swift
+++ b/agtermCore/Sources/agtermCore/AgentStatus.swift
@@ -60,6 +60,17 @@ public enum AgentStatus: String, Codable, Sendable, CaseIterable {
 /// navigation read it off `AgentIndicator` to know which surface blocked.
 public enum StatusPane: String, Codable, Sendable, CaseIterable {
     case left, right, scratch
+
+    /// Parses every accepted positional or role spelling while keeping `rawValue` stable for read-back and
+    /// the `AGTERM_PANE` environment (`left|right|scratch`).
+    public init?(controlName: String) {
+        switch controlName {
+        case "left", "top", "primary": self = .left
+        case "right", "bottom", "split": self = .right
+        case "scratch": self = .scratch
+        default: return nil
+        }
+    }
 }
 
 /// StatusShape is the silhouette a status glyph draws, so shape carries the state alongside the tint. Every

--- a/agtermCore/Sources/agtermCore/AppStore+Panes.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Panes.swift
@@ -11,11 +11,31 @@ public enum PaneOverlayOpenFailure: Equatable, Sendable {
 }
 
 extension AppStore {
-    /// Toggles the one-level split. The second pane's surface is created lazily by the detail pane and kept
-    /// alive when hidden, so this only flips the persisted flag.
-    public func toggleSplit(_ sessionID: UUID) {
+    /// Toggles the one-level split. With no axis this is the legacy preserve-axis hide/show operation. With
+    /// an axis it is the axis-specific UI command: the same shown axis hides, another shown axis transposes,
+    /// and a hidden or absent split is shown in the requested arrangement.
+    public func toggleSplit(_ sessionID: UUID, axis: SplitAxis? = nil) {
         guard let session = session(withID: sessionID) else { return }
-        session.isSplit.toggle()
+        let show: Bool
+        if let axis {
+            show = !session.isSplit || session.splitAxis != axis
+            if show { session.splitAxis = axis }
+        } else {
+            show = !session.isSplit
+        }
+        setSplitVisibility(session, shown: show)
+    }
+
+    /// Idempotently shows or hides a split, optionally selecting its arrangement when showing. Hiding never
+    /// changes the stored axis, so generic hide/show and a later same-axis command preserve the layout.
+    public func setSplitVisibility(_ sessionID: UUID, shown: Bool, axis: SplitAxis? = nil) {
+        guard let session = session(withID: sessionID) else { return }
+        if shown, let axis { session.splitAxis = axis }
+        setSplitVisibility(session, shown: shown)
+    }
+
+    private func setSplitVisibility(_ session: Session, shown: Bool) {
+        session.isSplit = shown
         // a NEW split focuses the new (right) pane; RE-showing a hidden one keeps the pane focused before
         // hiding, so a hide/show round-trip (the tmux-style zoom script) doesn't jerk focus right. hiding
         // leaves `hasSplit`/`splitFocused` set — indicators persist, the focused pane shows maximized — and
@@ -31,7 +51,7 @@ extension AppStore {
         save()
     }
 
-    /// Sets a session's split-divider left-pane fraction, clamped and persisted; returns the applied
+    /// Sets a session's split-divider primary-pane fraction, clamped and persisted; returns the applied
     /// fraction, nil for an unknown id. Moving the LIVE divider is the caller's job (`session.resize` posts
     /// `.agtermApplySplitRatio` to the pane view): control-native, no GUI path through `AppActions`.
     @discardableResult
@@ -61,6 +81,7 @@ extension AppStore {
         session.isSplit = false
         session.hasSplit = false
         session.splitFocused = false
+        session.splitAxis = .leftRight
         session.splitSurface?.teardown()
         session.splitSurface = nil
         session.splitCwd = nil
@@ -103,6 +124,7 @@ extension AppStore {
         session.isSplit = false
         session.hasSplit = false
         session.splitFocused = false
+        session.splitAxis = .leftRight
         session.splitRatio = nil // promoted to a single pane; a later split should open even, not stale
         // the promoted survivor is a plain shell: drop the creation command and its held-open flag together,
         // or a restart resurrects the exited command and a snapshot persists commandWait with no initialCommand.

--- a/agtermCore/Sources/agtermCore/AppStore+Snapshot.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Snapshot.swift
@@ -29,7 +29,8 @@ extension AppStore {
 
     func sessionSnapshot(_ session: Session) -> SessionSnapshot {
         SessionSnapshot(id: session.id, customName: session.customName, cwd: session.currentCwd ?? session.initialCwd,
-                        isSplit: session.isSplit, fontSize: session.fontSize,
+                        isSplit: session.isSplit, splitAxis: session.isSplit ? session.splitAxis : nil,
+                        fontSize: session.fontSize,
                         splitCwd: session.splitCwd ?? session.initialSplitCwd, splitRatio: session.splitRatio,
                         flagged: session.flagged,
                         foregroundCommand: session.foregroundCommand,
@@ -63,6 +64,7 @@ extension AppStore {
         let session = Session(id: snapshot.id, initialCwd: snapshot.cwd, customName: snapshot.customName)
         session.isSplit = snapshot.isSplit ?? false
         session.hasSplit = session.isSplit
+        session.splitAxis = session.isSplit ? (snapshot.splitAxis ?? .leftRight) : .leftRight
         session.fontSize = snapshot.fontSize
         session.initialSplitCwd = snapshot.splitCwd
         session.splitRatio = snapshot.splitRatio.map { min(AppStore.splitRatioMax, max(AppStore.splitRatioMin, $0)) }

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -79,15 +79,15 @@ public final class AppStore {
     public static let sidebarWidthMin: Double = 160
     public static let sidebarWidthMax: Double = 560
 
-    /// The persisted split-divider left-pane fraction bounds: live capture skips degenerate extremes outside
+    /// The persisted split-divider primary-pane fraction bounds: live capture skips degenerate extremes outside
     /// this range and `restore()` clamps to it, so the on-disk ratio is always within bounds.
     public static let splitRatioMin: Double = 0.05
     public static let splitRatioMax: Double = 0.95
-    /// The even split a never-moved divider renders at (the `HSplitView` default); the base for a relative
+    /// The even split a never-moved divider renders at; the base for a relative
     /// `session.resize` while `Session.splitRatio` is nil.
     public static let splitRatioDefault: Double = 0.5
 
-    /// Clamp a left-pane split fraction to `splitRatioMin...splitRatioMax`.
+    /// Clamp a primary-pane split fraction to `splitRatioMin...splitRatioMax`.
     public static func clampSplitRatio(_ ratio: Double) -> Double {
         min(splitRatioMax, max(splitRatioMin, ratio))
     }
@@ -261,6 +261,7 @@ public final class AppStore {
                                           active: session.id == activeID,
                                           split: session.isSplit,
                                           hasSplit: session.hasSplit ? true : nil,
+                                          splitAxis: session.hasSplit ? session.splitAxis.rawValue : nil,
                                           splitRatio: session.hasSplit ? session.splitRatio : nil,
                                           splitFocused: session.hasSplit ? session.splitFocused : nil,
                                           overlay: session.programOverlayActive,

--- a/agtermCore/Sources/agtermCore/BuiltinAction.swift
+++ b/agtermCore/Sources/agtermCore/BuiltinAction.swift
@@ -9,7 +9,8 @@ public enum BuiltinAction: String, CaseIterable, Sendable {
     case duplicateSession = "duplicate_session"
     case closeSession = "close_session", reopenRecent = "reopen_recent", undoClose = "undo_close", clearStatus = "clear_status"
     case increaseFontSize = "increase_font_size", decreaseFontSize = "decrease_font_size", resetFontSize = "reset_font_size"
-    case toggleSplit = "toggle_split", toggleScratch = "toggle_scratch", toggleTerminalZoom = "toggle_terminal_zoom"
+    case toggleSplit = "toggle_split", toggleHorizontalSplit = "toggle_horizontal_split"
+    case toggleScratch = "toggle_scratch", toggleTerminalZoom = "toggle_terminal_zoom"
     case toggleSearch = "toggle_search"
     case toggleSidebar = "toggle_sidebar", selectTheme = "select_theme", toggleFullscreen = "toggle_fullscreen"
     case toggleFlaggedView = "toggle_flagged_view", toggleFlag = "toggle_flag", focusWorkspace = "focus_workspace"
@@ -39,6 +40,7 @@ public enum BuiltinAction: String, CaseIterable, Sendable {
         case .decreaseFontSize: return Chord(mods: [.command], key: "-")
         case .resetFontSize: return Chord(mods: [.command], key: "0")
         case .toggleSplit: return Chord(mods: [.command], key: "d")
+        case .toggleHorizontalSplit: return Chord(mods: [.command, .shift], key: "d")
         case .toggleScratch: return Chord(mods: [.command], key: "j")
         case .toggleTerminalZoom: return Chord(mods: [.command, .shift], key: "return")
         case .toggleSearch: return Chord(mods: [.command], key: "f")
@@ -50,7 +52,7 @@ public enum BuiltinAction: String, CaseIterable, Sendable {
         case .commandPalette: return Chord(mods: [.control, .shift], key: "p")
         case .customCommandPalette: return Chord(mods: [.control, .shift], key: "o")
         case .showAttention: return Chord(mods: [.control, .shift], key: "i")
-        case .dashboard: return Chord(mods: [.command, .shift], key: "d")
+        case .dashboard: return Chord(mods: [.command, .shift], key: "g")
         case .focusLeftPane: return Chord(mods: [.command, .option], key: "left")
         case .focusRightPane: return Chord(mods: [.command, .option], key: "right")
         case .previousSession: return Chord(mods: [.command, .option], key: "up")

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -36,7 +36,10 @@ public protocol ControlActions {
     /// unresolvable `paneID` given without an explicit `pane`).
     func setSessionRestore(_ target: String?, window: String?,
                            update: ControlSessionRestoreUpdate) -> ControlResponse
+    /// Original axis-agnostic entry point, retained so existing conformers and callers keep compiling.
     func splitSession(_ target: String?, window: String?, mode: String?) -> ControlResponse
+    /// Axis-aware entry point. The default implementation below delegates to the original method.
+    func splitSession(_ target: String?, window: String?, mode: String?, axis: SplitAxis?) -> ControlResponse
     /// Tear the split pane down rather than hide it, the write side `splitSession`'s `on|off|toggle` cannot
     /// express: the surface dies and `hasSplit`/`splitRatio`/`splitFocused` go nil in `tree`.
     func closeSessionSplit(_ target: String?, window: String?) -> ControlResponse
@@ -100,6 +103,12 @@ public protocol ControlActions {
     /// Cancel a native picker. The host owns window resolution, registry lookup, and dismissal.
     func cancelPick(_ target: String, window: String?) -> ControlResponse
     func clearRestoreCommands() -> ControlResponse
+}
+
+public extension ControlActions {
+    func splitSession(_ target: String?, window: String?, mode: String?, axis _: SplitAxis?) -> ControlResponse {
+        splitSession(target, window: window, mode: mode)
+    }
 }
 
 public struct ControlSessionTypeOptions: Equatable, Sendable {
@@ -438,7 +447,7 @@ public struct ControlDispatcher {
 
     /// The role selector (`session.status`, `session.restore`), spelled `left|right|scratch`.
     private func parsePane(_ raw: String?) -> PaneSelection<StatusPane> {
-        parsePane(raw, error: "--pane must be left, right, or scratch") { StatusPane(rawValue: $0) }
+        parsePane(raw, error: "--pane must be left, right, or scratch") { StatusPane(controlName: $0) }
     }
 
     /// The `session.overlay.open`/`.close`/`.result` selector: absent keeps the session-wide overlay,
@@ -509,7 +518,17 @@ public struct ControlDispatcher {
     private func dispatchSessionSurfaceCommand(_ request: ControlRequest) async -> ControlResponse {
         switch request.cmd {
         case .sessionSplit:
-            return actions.splitSession(request.target, window: request.args?.window, mode: request.args?.mode)
+            let axis: SplitAxis?
+            if let raw = request.args?.axis {
+                guard let parsed = SplitAxis(rawValue: raw) else {
+                    return ControlResponse(ok: false, error: "invalid split axis: \(raw) (vertical|horizontal)")
+                }
+                axis = parsed
+            } else {
+                axis = nil
+            }
+            return actions.splitSession(request.target, window: request.args?.window,
+                                        mode: request.args?.mode, axis: axis)
         case .sessionSplitClose:
             return actions.closeSessionSplit(request.target, window: request.args?.window)
         case .sessionScratch:

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -446,7 +446,8 @@ public struct ControlDispatcher {
         return .pane(parsed)
     }
 
-    /// The role selector (`session.status`, `session.restore`), spelled `left|right|scratch`.
+    /// The role selector (`session.status`, `session.restore`). It accepts role and position aliases; the
+    /// stable rejection names the canonical `left|right|scratch` read-back values.
     private func parsePane(_ raw: String?) -> PaneSelection<StatusPane> {
         parsePane(raw, error: "--pane must be left, right, or scratch") { StatusPane(controlName: $0) }
     }

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -36,9 +36,10 @@ public protocol ControlActions {
     /// unresolvable `paneID` given without an explicit `pane`).
     func setSessionRestore(_ target: String?, window: String?,
                            update: ControlSessionRestoreUpdate) -> ControlResponse
-    /// Original axis-agnostic entry point, retained so existing conformers and callers keep compiling.
+    /// Source-compatible axis-agnostic entry point retained for existing conformers and callers.
     func splitSession(_ target: String?, window: String?, mode: String?) -> ControlResponse
-    /// Axis-aware entry point. The default implementation below delegates to the original method.
+    /// Axis-aware entry point. Its default delegates to the original method so an existing conformer does
+    /// not have to implement the new requirement until it needs axis support.
     func splitSession(_ target: String?, window: String?, mode: String?, axis: SplitAxis?) -> ControlResponse
     /// Tear the split pane down rather than hide it, the write side `splitSession`'s `on|off|toggle` cannot
     /// express: the surface dies and `hasSplit`/`splitRatio`/`splitFocused` go nil in `tree`.

--- a/agtermCore/Sources/agtermCore/ControlModes.swift
+++ b/agtermCore/Sources/agtermCore/ControlModes.swift
@@ -43,8 +43,8 @@ public enum ControlPaneFocusMode: Equatable, Sendable {
 
     public static func parse(_ pane: String?) -> ControlPaneFocusMode? {
         switch pane ?? "other" {
-        case "left", "primary": return .primary
-        case "right", "split": return .split
+        case "left", "top", "primary": return .primary
+        case "right", "bottom", "split": return .split
         case "other", "toggle": return .toggle
         default: return nil
         }

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -127,6 +127,9 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     /// `session.background` (`image|text|color|clear`), and `session.restore` (`set|none|clear` — pin
     /// `command`, pin nothing, or drop the pin).
     public var mode: String?
+    /// Optional divider direction for `session.split`: `vertical` (left/right) or `horizontal` (top/bottom).
+    /// Omitted preserves the original axis-agnostic show/hide behavior.
+    public var axis: String?
     /// The image file path for `session.background` mode `image` (PNG or JPEG).
     public var path: String?
     /// The `#rrggbb` color for `session.background`: the mode-`text` tint (nil = terminal foreground) or the
@@ -179,11 +182,11 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     /// `session.restore` diverges: an unresolvable token with NO explicit `pane` errors there rather than
     /// silently using `left`, since a wrong restore pin persists. See `Session.paneRole(forToken:)`, #199.
     public var paneID: String?
-    /// Absolute left-pane split fraction (0...1) for `session.resize`, clamped server-side to
+    /// Absolute primary-pane split fraction (0...1) for `session.resize`, clamped server-side to
     /// `AppStore.splitRatioMin...splitRatioMax`. Mutually exclusive with `ratioDelta`.
     public var ratio: Double?
-    /// Signed relative split-divider nudge for `session.resize`: a positive fraction grows the LEFT
-    /// pane, negative grows the right (the CLI's `--grow-left`/`--grow-right`). Applied to the session's
+    /// Signed relative split-divider nudge for `session.resize`: a positive fraction grows the PRIMARY
+    /// pane, negative grows the split pane. Applied to the session's
     /// current fraction (0.5 when never moved). Mutually exclusive with `ratio`.
     public var ratioDelta: Double?
     /// For `session.text` / `quick.text`: read the full screen + scrollback instead of just the visible screen.
@@ -298,7 +301,7 @@ public struct ControlArgs: Codable, Sendable, Equatable {
                 workspace: String? = nil, workspaceName: String? = nil,
                 createWorkspace: Bool? = nil, collapsed: Bool? = nil, minimized: Bool? = nil,
                 noSelect: Bool? = nil,
-                text: String? = nil, select: Bool? = nil, mode: String? = nil,
+                text: String? = nil, select: Bool? = nil, mode: String? = nil, axis: String? = nil,
                 command: String? = nil, wait: Bool? = nil, sizePercent: Int? = nil, full: Bool? = nil,
                 follow: Bool? = nil, message: String? = nil, detail: String? = nil, spinner: String? = nil,
                 items: [ControlPickItem]? = nil, prompt: String? = nil,
@@ -327,6 +330,7 @@ public struct ControlArgs: Codable, Sendable, Equatable {
         self.text = text
         self.select = select
         self.mode = mode
+        self.axis = axis
         self.command = command
         self.wait = wait
         self.sizePercent = sizePercent
@@ -488,7 +492,9 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
     /// second-guessing `split`. The sidebar icon, the dashboard's second cell and Focus Left/Right Pane all
     /// follow this, not `split`.
     public let hasSplit: Bool?
-    /// The left-pane fraction (0.05...0.95) of a session that HAS a split (shown or hidden); nil with no
+    /// Divider direction for a live split (`vertical`=left/right, `horizontal`=top/bottom); nil without one.
+    public let splitAxis: String?
+    /// The primary-pane fraction (0.05...0.95) of a session that HAS a split (shown or hidden); nil with no
     /// split OR when the ratio was never explicitly set (via `session.resize` or a divider drag), the divider
     /// then sitting at the default 0.5. The read side of `session.resize`, otherwise echoed only on that call.
     public let splitRatio: Double?
@@ -579,7 +585,8 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
     public let realized: Bool?
 
     public init(id: String, name: String, cwd: String, title: String? = nil, active: Bool, split: Bool,
-                hasSplit: Bool? = nil, splitRatio: Double? = nil, splitFocused: Bool? = nil,
+                hasSplit: Bool? = nil, splitAxis: String? = nil,
+                splitRatio: Double? = nil, splitFocused: Bool? = nil,
                 overlay: Bool = false, overlaySizePercent: Int? = nil, paneOverlays: [String]? = nil,
                 hud: ControlHudNode? = nil, scratch: Bool = false, flagged: Bool = false,
                 commandWait: Bool? = nil,
@@ -597,6 +604,7 @@ public struct ControlSessionNode: Codable, Sendable, Equatable {
         self.active = active
         self.split = split
         self.hasSplit = hasSplit
+        self.splitAxis = splitAxis
         self.splitRatio = splitRatio
         self.splitFocused = splitFocused
         self.overlay = overlay
@@ -829,7 +837,7 @@ public struct ControlResult: Codable, Sendable, Equatable {
     public var theme: String?
     /// The available bundled theme names for `theme.list`.
     public var themes: [String]?
-    /// The applied left-pane split fraction echoed by `session.resize`, after clamping / a relative nudge.
+    /// The applied primary-pane split fraction echoed by `session.resize`, after clamping / a relative nudge.
     public var ratio: Double?
     /// The light/dark syncing state for `theme.set`/`theme.list`, from the stored theme: `sync` = whether it
     /// is ghostty's dual `light:,dark:` form (the terminal tracks the macOS appearance), `light`/`dark` its
@@ -899,7 +907,7 @@ public enum OverlayHudError {
 public enum PaneOverlayError {
     public static let alreadyOpen = "pane overlay already open"
     public static let paneNotVisible = "pane not visible"
-    /// Names the canonical spellings only; `OverlayPane.init?(controlName:)` also takes `primary`/`split`.
+    /// Names the canonical spellings only; `OverlayPane.init?(controlName:)` also takes role/axis aliases.
     public static let invalidPane = "session.overlay: --pane must be left or right"
     public static let sizePercentConflict = "session.overlay.open: --pane is mutually exclusive with --size-percent"
     public static let resizeUnsupported = "session.overlay.resize: --pane is not supported (pane overlays are always full)"

--- a/agtermCore/Sources/agtermCore/DashboardTarget.swift
+++ b/agtermCore/Sources/agtermCore/DashboardTarget.swift
@@ -22,9 +22,8 @@ public struct DashboardTarget: Equatable, Sendable {
     /// accepts only `active`, a full UUID, or a UUID prefix. So `surface:<uuid>:left` (the `surface.zoom`
     /// form) fails here instead of half-resolving to a head of `surface`.
     ///
-    /// Only `left`/`right` are accepted, case-insensitively. `primary`/`split` parse as
-    /// `TerminalZoomSurface` but are refused: the `dashboardMembers` read-back emits `left`/`right`, and
-    /// one spelling per pane keeps the write form identical to the read form.
+    /// Positional and role aliases are accepted case-insensitively. Read-back remains `left`/`right`, so
+    /// adding aliases does not change the wire representation existing callers consume.
     public init?(rawValue: String) {
         guard let colon = rawValue.firstIndex(of: ":") else {
             guard !rawValue.isEmpty else { return nil }
@@ -35,8 +34,8 @@ public struct DashboardTarget: Equatable, Sendable {
         let suffix = String(rawValue[rawValue.index(after: colon)...]).lowercased()
         guard !head.isEmpty else { return nil }
         switch suffix {
-        case "left": self.init(head: head, pane: .primary)
-        case "right": self.init(head: head, pane: .split)
+        case "left", "top", "primary": self.init(head: head, pane: .primary)
+        case "right", "bottom", "split": self.init(head: head, pane: .split)
         default: return nil
         }
     }

--- a/agtermCore/Sources/agtermCore/Keymap.swift
+++ b/agtermCore/Sources/agtermCore/Keymap.swift
@@ -129,13 +129,43 @@ public func parseKeymap(_ text: String) -> (keymap: Keymap, diagnostics: [Keymap
 
     // a final pass, not incremental: the cross-section validation below needs the same resolved chord set.
     let resolved = resolveMapLines(mapLines)
-    let builtinOverrides = resolveBuiltinOverrides(resolved.overrides, unbound: resolved.unbound,
+    // Cmd-Shift-D belonged to Dashboard before horizontal split existed. Any valid old configuration that
+    // explicitly used that chord keeps it: vacate the new action's default unless the file maps that action.
+    var compatibilityUnbound = resolved.unbound
+    let horizontalMapped = resolved.overrides.contains { $0.action == .toggleHorizontalSplit }
+        || resolved.alternatives[.toggleHorizontalSplit] != nil
+        || resolved.unbound.contains(.toggleHorizontalSplit)
+    let oldDashboardChord = Chord(mods: [.command, .shift], key: "d")
+    let oldConfigUsesHorizontalChord = resolved.overrides.contains {
+        $0.action != .toggleHorizontalSplit && $0.chord == oldDashboardChord
+    } || resolved.alternatives.contains { action, entry in
+        action != .toggleHorizontalSplit && entry.alternatives.contains { $0.keybind.first == oldDashboardChord }
+    } || commandLines.contains { line in
+        line.alternatives.contains { $0.keybind.first == oldDashboardChord }
+    }
+    if !horizontalMapped, oldConfigUsesHorizontalChord {
+        compatibilityUnbound.insert(.toggleHorizontalSplit)
+    }
+    // Cmd-Shift-G was previously free. An existing explicit binding on it keeps working; Dashboard becomes
+    // keyless until the user maps it, instead of a new shipped default invalidating their configuration.
+    let newDashboardChord = Chord(mods: [.command, .shift], key: "g")
+    let dashboardMapped = resolved.overrides.contains { $0.action == .dashboard }
+        || resolved.alternatives[.dashboard] != nil || resolved.unbound.contains(.dashboard)
+    let oldConfigUsesNewDashboardChord = resolved.overrides.contains {
+        $0.action != .dashboard && $0.chord == newDashboardChord
+    } || resolved.alternatives.contains { action, entry in
+        action != .dashboard && entry.alternatives.contains { $0.keybind.first == newDashboardChord }
+    } || commandLines.contains { line in
+        line.alternatives.contains { $0.keybind.first == newDashboardChord }
+    }
+    if !dashboardMapped, oldConfigUsesNewDashboardChord { compatibilityUnbound.insert(.dashboard) }
+    let builtinOverrides = resolveBuiltinOverrides(resolved.overrides, unbound: compatibilityUnbound,
                                                    alternatives: resolved.alternatives, diagnostics: &diagnostics)
 
     // likewise final: a custom line parsed before a later keyless-built-in `map` must still be validated
     // against the override that `map` installs.
     let menuChords = Set(BuiltinAction.allCases.compactMap {
-        resolvedMenuChord($0, overrides: builtinOverrides, unbound: resolved.unbound)
+        resolvedMenuChord($0, overrides: builtinOverrides, unbound: compatibilityUnbound)
     })
     let survivors = validateBindings(monitorAlternatives(commandLines: commandLines,
                                                          mapAlternatives: resolved.alternatives),
@@ -144,7 +174,7 @@ public func parseKeymap(_ text: String) -> (keymap: Keymap, diagnostics: [Keymap
     return (Keymap(builtinOverrides: builtinOverrides,
                    commands: applySurvivingShortcuts(to: commandLines, survivors: survivors),
                    builtinSequences: survivingAlternatives(survivors),
-                   builtinUnbound: unboundAfterRestoringStrandedDefaults(resolved.unbound,
+                   builtinUnbound: unboundAfterRestoringStrandedDefaults(compatibilityUnbound,
                                                                          overrides: builtinOverrides,
                                                                          survivors: survivors)),
             diagnostics)

--- a/agtermCore/Sources/agtermCore/PaletteCatalog.swift
+++ b/agtermCore/Sources/agtermCore/PaletteCatalog.swift
@@ -14,6 +14,7 @@ public struct PaletteContext: Sendable, Equatable {
     /// The ONLY term that entry keys on, matching the View-menu twin — marking is offered in either mode.
     public let activeWorkspaceMarked: Bool
     public let activeSessionHasSplit: Bool
+    public let activeSplitAxis: SplitAxis?
     public let hasPendingClose: Bool
     public let hasRecentClosed: Bool
     /// Whether the frontmost window has an active session at all.
@@ -37,6 +38,7 @@ public struct PaletteContext: Sendable, Equatable {
                 hasMarkedWorkspaces: Bool = false,
                 activeWorkspaceMarked: Bool = false,
                 activeSessionHasSplit: Bool = false,
+                activeSplitAxis: SplitAxis? = nil,
                 hasPendingClose: Bool = false,
                 hasRecentClosed: Bool = false,
                 hasActiveSession: Bool = false,
@@ -52,6 +54,7 @@ public struct PaletteContext: Sendable, Equatable {
         self.hasMarkedWorkspaces = hasMarkedWorkspaces
         self.activeWorkspaceMarked = activeWorkspaceMarked
         self.activeSessionHasSplit = activeSessionHasSplit
+        self.activeSplitAxis = activeSplitAxis
         self.hasPendingClose = hasPendingClose
         self.hasRecentClosed = hasRecentClosed
         self.hasActiveSession = hasActiveSession
@@ -68,7 +71,8 @@ public enum PaletteCommand: String, CaseIterable, Sendable {
     case renameSession, duplicateSession, renameWorkspace, closeSession, reopenRecent, undoClose, clearStatus
     case previousSession, nextSession, previousAttentionSession, nextAttentionSession
     case firstSession, lastSession, showAttention
-    case toggleSplit, closeSplit, toggleScratch, toggleTerminalZoom, toggleSidebar, toggleFlag, focusWorkspace
+    case toggleSplit, toggleHorizontalSplit, closeSplit, toggleScratch, toggleTerminalZoom
+    case toggleSidebar, toggleFlag, focusWorkspace
     case find, quickTerminal, dashboard, toggleFullscreen
     case increaseFontSize, decreaseFontSize, resetFontSize, selectTheme
     case editKeymap, reloadKeymap, editGhosttyConfig, reloadConfig
@@ -83,7 +87,8 @@ public enum PaletteCommand: String, CaseIterable, Sendable {
     public func isEnabled(in context: PaletteContext) -> Bool {
         guard isVisible(in: context), !isCoveredByModal(context) else { return false }
         switch self {
-        case .renameSession, .duplicateSession, .clearStatus, .toggleFlag, .toggleSplit, .toggleScratch,
+        case .renameSession, .duplicateSession, .clearStatus, .toggleFlag, .toggleSplit,
+             .toggleHorizontalSplit, .toggleScratch,
              .find, .previousSession, .nextSession, .previousAttentionSession, .nextAttentionSession,
              .firstSession, .lastSession:
             return context.hasActiveSession
@@ -170,7 +175,8 @@ public enum PaletteCommand: String, CaseIterable, Sendable {
         case .firstSession: return "First Session"
         case .lastSession: return "Last Session"
         case .showAttention: return "Show Attention"
-        case .toggleSplit: return "Toggle Split"
+        case .toggleSplit: return "Toggle Vertical Split"
+        case .toggleHorizontalSplit: return "Toggle Horizontal Split"
         case .closeSplit: return "Close Split"
         case .toggleScratch: return "Toggle Scratch"
         case .toggleTerminalZoom: return "Toggle Terminal Zoom"
@@ -197,8 +203,8 @@ public enum PaletteCommand: String, CaseIterable, Sendable {
         case .toggleWorkspaceFilter: return "Toggle Workspace Filter"
         case .expandWorkspaces: return "Expand Workspaces"
         case .collapseWorkspaces: return "Collapse Workspaces"
-        case .focusLeftPane: return "Focus Left Pane"
-        case .focusRightPane: return "Focus Right Pane"
+        case .focusLeftPane: return context.activeSplitAxis == .topBottom ? "Focus Top Pane" : "Focus Left Pane"
+        case .focusRightPane: return context.activeSplitAxis == .topBottom ? "Focus Bottom Pane" : "Focus Right Pane"
         }
     }
 
@@ -222,6 +228,7 @@ public enum PaletteCommand: String, CaseIterable, Sendable {
         case .lastSession: return .lastSession
         case .showAttention: return .showAttention
         case .toggleSplit: return .toggleSplit
+        case .toggleHorizontalSplit: return .toggleHorizontalSplit
         case .toggleScratch: return .toggleScratch
         case .toggleTerminalZoom: return .toggleTerminalZoom
         case .toggleSidebar: return .toggleSidebar

--- a/agtermCore/Sources/agtermCore/Session.swift
+++ b/agtermCore/Sources/agtermCore/Session.swift
@@ -8,13 +8,13 @@ public enum OverlayPane: String, CaseIterable, Codable, Sendable {
     case right
 
     /// Accepts the same pane spellings as `TerminalZoomSurface`, minus `scratch`: a pane overlay covers a
-    /// split pane only. `primary`/`split` are accepted as aliases, so the rejection message naming only
+    /// split pane only. Role and axis names are accepted as aliases, so the rejection message naming only
     /// `left or right` is guidance, not the full accepted set.
     public init?(controlName: String) {
         switch controlName {
-        case "left", "primary":
+        case "left", "top", "primary":
             self = .left
-        case "right", "split":
+        case "right", "bottom", "split":
             self = .right
         default:
             return nil
@@ -131,18 +131,22 @@ public final class Session: Identifiable {
         }
     }
 
-    /// Whether the session is SHOWN as a one-level vertical split; the detail pane shows/hides the second pane.
+    /// Whether the session is SHOWN as a one-level split; the detail pane shows/hides the second pane.
     public var isSplit: Bool = false
 
     /// Whether the session HAS a split pane at all, shown or hidden/maximized, unlike `isSplit`. Stays true
     /// across a hide, cleared only by `closeSplit`, so the sidebar + title-bar indicators persist while hidden.
     public var hasSplit: Bool = false
 
+    /// The split's physical arrangement. A fresh or legacy session starts left/right; changing this while
+    /// both panes exist transposes their layout without replacing either terminal surface.
+    public var splitAxis: SplitAxis = .leftRight
+
     /// While split, whether the second pane holds focus rather than the primary; the detail pane dims the
     /// inactive one. Meaningless when not split.
     public var splitFocused: Bool = false
 
-    /// The split divider's left-pane fraction, captured from the live `NSSplitView` and persisted, so it
+    /// The split divider's primary-pane fraction, captured from the live `NSSplitView` and persisted, so it
     /// survives a hide/show and a relaunch. Within `AppStore.splitRatioMin...splitRatioMax` (~0.05...0.95):
     /// capture skips degenerate extremes, restore clamps and seeds. nil = even; never read by a SwiftUI view.
     @ObservationIgnored public var splitRatio: Double?

--- a/agtermCore/Sources/agtermCore/Snapshot.swift
+++ b/agtermCore/Sources/agtermCore/Snapshot.swift
@@ -139,15 +139,17 @@ public struct SessionSnapshot: Codable, Equatable, Sendable {
     public var id: UUID
     public var customName: String?
     public var cwd: String
-    /// Whether the session was shown as a vertical split; nil = not split. On restore the split pane
+    /// Whether the session was shown as a split; nil = not split. On restore the split pane
     /// re-spawns a fresh shell, like the primary.
     public var isSplit: Bool?
+    /// The shown split's divider direction; nil/missing restores the legacy left/right arrangement.
+    public var splitAxis: SplitAxis?
     /// The terminal font size in points; nil = the ghostty config default.
     public var fontSize: Double?
     /// The split (right) pane's working directory, so each pane restores to its OWN cwd. The live
     /// `splitCwd`, or its restore seed before the split reports a PWD; nil when there is no split.
     public var splitCwd: String?
-    /// The split divider's left-pane fraction. Within `AppStore.splitRatioMin...splitRatioMax`
+    /// The split divider's primary-pane fraction. Within `AppStore.splitRatioMin...splitRatioMax`
     /// (~0.05...0.95) — capture skips degenerate extremes, restore clamps; nil restores the even default.
     public var splitRatio: Double?
     /// Whether the session is in the flagged working-set; nil = not flagged.
@@ -174,7 +176,8 @@ public struct SessionSnapshot: Codable, Equatable, Sendable {
     /// The split (right) pane's restore-command override, the split analogue of `restoreCommand`.
     public var splitRestoreCommand: String?
 
-    public init(id: UUID, customName: String?, cwd: String, isSplit: Bool? = nil, fontSize: Double? = nil,
+    public init(id: UUID, customName: String?, cwd: String, isSplit: Bool? = nil,
+                splitAxis: SplitAxis? = nil, fontSize: Double? = nil,
                 splitCwd: String? = nil, splitRatio: Double? = nil, flagged: Bool? = nil,
                 foregroundCommand: [String]? = nil, splitForegroundCommand: [String]? = nil,
                 initialCommand: String? = nil, commandWait: Bool? = nil,
@@ -184,6 +187,7 @@ public struct SessionSnapshot: Codable, Equatable, Sendable {
         self.customName = customName
         self.cwd = cwd
         self.isSplit = isSplit
+        self.splitAxis = splitAxis
         self.fontSize = fontSize
         self.splitCwd = splitCwd
         self.splitRatio = splitRatio
@@ -198,7 +202,7 @@ public struct SessionSnapshot: Codable, Equatable, Sendable {
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, customName, cwd, isSplit, fontSize, splitCwd, splitRatio, flagged
+        case id, customName, cwd, isSplit, splitAxis, fontSize, splitCwd, splitRatio, flagged
         case foregroundCommand, splitForegroundCommand, initialCommand, commandWait, backgroundWatermark
         case restoreCommand, splitRestoreCommand
     }
@@ -216,6 +220,7 @@ public struct SessionSnapshot: Codable, Equatable, Sendable {
         customName = (try? c.decodeIfPresent(String.self, forKey: .customName)) ?? nil
         cwd = try c.decode(String.self, forKey: .cwd)
         isSplit = (try? c.decodeIfPresent(Bool.self, forKey: .isSplit)) ?? nil
+        splitAxis = (try? c.decodeIfPresent(SplitAxis.self, forKey: .splitAxis)) ?? nil
         fontSize = (try? c.decodeIfPresent(Double.self, forKey: .fontSize)) ?? nil
         splitCwd = (try? c.decodeIfPresent(String.self, forKey: .splitCwd)) ?? nil
         splitRatio = (try? c.decodeIfPresent(Double.self, forKey: .splitRatio)) ?? nil

--- a/agtermCore/Sources/agtermCore/SplitAxis.swift
+++ b/agtermCore/Sources/agtermCore/SplitAxis.swift
@@ -1,0 +1,6 @@
+/// The physical arrangement of a session's two panes. Raw values use the user-facing divider direction:
+/// a vertical divider produces left/right panes, while a horizontal divider produces top/bottom panes.
+public enum SplitAxis: String, Codable, CaseIterable, Equatable, Sendable {
+    case leftRight = "vertical"
+    case topBottom = "horizontal"
+}

--- a/agtermCore/Sources/agtermCore/TerminalZoom.swift
+++ b/agtermCore/Sources/agtermCore/TerminalZoom.swift
@@ -11,9 +11,9 @@ public enum TerminalZoomSurface: String, CaseIterable, Codable, Equatable, Senda
 
     public init?(controlName: String) {
         switch controlName {
-        case "left", "primary":
+        case "left", "top", "primary":
             self = .primary
-        case "right", "split":
+        case "right", "bottom", "split":
             self = .split
         case "scratch":
             self = .scratch

--- a/agtermCore/Sources/agtermctlKit/MiscCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/MiscCommands.swift
@@ -564,9 +564,9 @@ struct Font: ParsableCommand {
         subcommands: [Inc.self, Dec.self, Reset.self]
     )
 
-    /// Help for the shared `--pane` option, reusing the `left|right|scratch` vocabulary of `session type`.
+    /// Help for the shared `--pane` option; role and axis-position aliases resolve to the same stable slots.
     static let paneHelp = "Which pane's font to change: left (main), right (split), or scratch (the "
-        + "session's scratch terminal, even when hidden). Defaults to the left pane."
+        + "session's scratch terminal, even when hidden). primary/left/top and split/right/bottom are aliases. Defaults to the left pane."
 
     struct Inc: RequestCommand {
         static let configuration = CommandConfiguration(abstract: "Increase font size.")

--- a/agtermCore/Sources/agtermctlKit/SessionCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/SessionCommands.swift
@@ -2,10 +2,8 @@ import ArgumentParser
 import Foundation
 import agtermCore
 
-/// Shared `--pane` validation for the commands accepting `left|right|scratch` (session type, text, status,
-/// font). Rejects anything else with a clean usage error before the socket round-trip, matching the
-/// server-side switch, which still catches a raw socket client. They reuse `StatusPane`'s value set as the
-/// shared pane-addressing vocabulary — named for agent status, but its cases are the pane names.
+/// Shared `--pane` validation for session type, text, status, restore, and font. Accepts role and position
+/// aliases through `StatusPane`; the stable rejection names the canonical read-back values.
 func validatePaneArgument(_ pane: String?) throws {
     if let pane, StatusPane(controlName: pane) == nil {
         throw ValidationError("--pane must be left, right, or scratch")

--- a/agtermCore/Sources/agtermctlKit/SessionCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/SessionCommands.swift
@@ -7,7 +7,7 @@ import agtermCore
 /// server-side switch, which still catches a raw socket client. They reuse `StatusPane`'s value set as the
 /// shared pane-addressing vocabulary — named for agent status, but its cases are the pane names.
 func validatePaneArgument(_ pane: String?) throws {
-    if let pane, StatusPane(rawValue: pane) == nil {
+    if let pane, StatusPane(controlName: pane) == nil {
         throw ValidationError("--pane must be left, right, or scratch")
     }
 }
@@ -192,7 +192,7 @@ struct Session: ParsableCommand {
         @Argument(help: "Text to inject (omit with --stdin).") var text: String?
         @Flag(name: .long, help: "Read the text from stdin instead of an argument.") var stdin = false
         @Flag(name: .long, help: "Select the session first if its surface is not ready (main pane only; a split pane must already exist).") var select = false
-        @Option(name: .long, help: "Which pane to type into: left (main), right (split), or scratch (the session's scratch terminal, even when hidden). Defaults to the left pane.") var pane: String?
+        @Option(name: .long, help: "Which pane to type into: primary/left/top, split/right/bottom, or scratch (even when hidden). Defaults to primary.") var pane: String?
         @OptionGroup var target: TargetOptions
         @OptionGroup var options: ClientOptions
 
@@ -227,11 +227,19 @@ struct Session: ParsableCommand {
             static let configuration = CommandConfiguration(commandName: "visibility",
                                                            abstract: "Show or hide a session split (on|off|toggle).")
             @Argument(help: "Mode: on (show), off (hide), or toggle (default). Hidden panes stay alive.") var mode: String = "toggle"
+            @Option(name: .long, help: "Divider direction: vertical (left/right) or horizontal (top/bottom).") var axis: String?
             @OptionGroup var target: TargetOptions
             @OptionGroup var options: ClientOptions
 
+            func validate() throws {
+                if let axis, SplitAxis(rawValue: axis) == nil {
+                    throw ValidationError("--axis must be vertical or horizontal")
+                }
+            }
+
             func makeRequest() throws -> ControlRequest {
-                ControlRequest(cmd: .sessionSplit, target: target.target, args: options.withWindow(ControlArgs(mode: mode)))
+                ControlRequest(cmd: .sessionSplit, target: target.target,
+                               args: options.withWindow(ControlArgs(mode: mode, axis: axis)))
             }
         }
 
@@ -260,8 +268,8 @@ struct Session: ParsableCommand {
     }
 
     struct Focus: RequestCommand {
-        static let configuration = CommandConfiguration(abstract: "Focus a split session's pane (left|right|other).")
-        @Argument(help: "Pane: left, right, or other (toggle, default).") var pane: String = "other"
+        static let configuration = CommandConfiguration(abstract: "Focus a split session's pane by position or role.")
+        @Argument(help: "Pane: primary/left/top, split/right/bottom, or other (toggle, default).") var pane: String = "other"
         @OptionGroup var target: TargetOptions
         @OptionGroup var options: ClientOptions
 
@@ -272,19 +280,23 @@ struct Session: ParsableCommand {
 
     struct Resize: RequestCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Resize a split session's divider (set or nudge the left-pane fraction).")
-        @Option(name: .customLong("split-ratio"), help: "Absolute left-pane fraction 0..1 (e.g. 0.7). Clamped to 0.05..0.95.") var splitRatio: Double?
+            abstract: "Resize a split session's divider (set or nudge the primary-pane fraction).")
+        @Option(name: .customLong("split-ratio"), help: "Absolute primary-pane fraction 0..1 (left or top; e.g. 0.7). Clamped to 0.05..0.95.") var splitRatio: Double?
         @Option(name: .customLong("grow-left"), help: "Grow the left pane by this fraction (e.g. 0.05); shrinks the right.") var growLeft: Double?
         @Option(name: .customLong("grow-right"), help: "Grow the right pane by this fraction (e.g. 0.05); shrinks the left.") var growRight: Double?
+        @Option(name: .customLong("grow-primary"), help: "Grow the primary pane by this fraction.") var growPrimary: Double?
+        @Option(name: .customLong("grow-split"), help: "Grow the split pane by this fraction.") var growSplit: Double?
+        @Option(name: .customLong("grow-top"), help: "Alias for --grow-primary in a horizontal split.") var growTop: Double?
+        @Option(name: .customLong("grow-bottom"), help: "Alias for --grow-split in a horizontal split.") var growBottom: Double?
         @OptionGroup var target: TargetOptions
         @OptionGroup var options: ClientOptions
 
         // exactly one of the three forms must be set; reject neither/multiple at parse time so it's a clean
         // usage error, unit-testable without a socket. Prints the applied (clamped) fraction.
         func validate() throws {
-            let values = [splitRatio, growLeft, growRight].compactMap { $0 }
+            let values = [splitRatio, growLeft, growRight, growPrimary, growSplit, growTop, growBottom].compactMap { $0 }
             guard values.count == 1 else {
-                throw ValidationError("provide exactly one of --split-ratio, --grow-left, or --grow-right")
+                throw ValidationError("provide exactly one split ratio or grow option")
             }
             // nan/inf parse as Double but fail to JSON-encode (a generic error after the socket opens), so
             // reject non-finite input here with a clean usage error.
@@ -294,14 +306,14 @@ struct Session: ParsableCommand {
         }
 
         func makeRequest() throws -> ControlRequest {
-            // grow-left/grow-right map to a signed wire delta (+ grows the left pane); split-ratio is absolute.
+            // legacy left/right and role/axis aliases map to the same signed primary-pane delta.
             let args: ControlArgs
             if let splitRatio {
                 args = ControlArgs(ratio: splitRatio)
-            } else if let growLeft {
-                args = ControlArgs(ratioDelta: growLeft)
+            } else if let grow = growLeft ?? growPrimary ?? growTop {
+                args = ControlArgs(ratioDelta: grow)
             } else {
-                args = ControlArgs(ratioDelta: -(growRight ?? 0))
+                args = ControlArgs(ratioDelta: -(growRight ?? growSplit ?? growBottom ?? 0))
             }
             return ControlRequest(cmd: .sessionResize, target: target.target, args: options.withWindow(args))
         }
@@ -342,7 +354,7 @@ struct Session: ParsableCommand {
         static let configuration = CommandConfiguration(abstract: "Print a session's terminal buffer as plain text (does not touch the system clipboard).")
         @Flag(name: .long, help: "Read the full screen + scrollback instead of just the visible screen.") var all = false
         @Option(name: .long, help: "Keep only the last N lines of the full buffer.") var lines: Int?
-        @Option(name: .long, help: "Which pane to read: left (main), right (split), or scratch (the session's scratch terminal, even when hidden). Defaults to the on-screen pane.") var pane: String?
+        @Option(name: .long, help: "Which pane to read: primary/left/top, split/right/bottom, or scratch (even when hidden). Defaults to the on-screen pane.") var pane: String?
         @OptionGroup var target: TargetOptions
         @OptionGroup var options: ClientOptions
 
@@ -381,7 +393,11 @@ struct Session: ParsableCommand {
             reverts on the next status set without it.
             """)
         var shape: String?
-        @Option(name: .long, help: "Which pane set this status: left (main), right (split), or scratch. Records the blocked pane so nav lands on it. Defaults to the left pane.") var pane: String?
+        @Option(name: .long, help: """
+            Which pane set this status: primary/left/top, split/right/bottom, or scratch. Records the blocked \
+            pane so navigation reaches it. Defaults to primary.
+            """)
+        var pane: String?
         @Option(name: .customLong("pane-id"), help: """
             A surface's stable token (the shell's $AGTERM_PANE_ID) — the agent-status hook forwards it so a \
             status set from a promoted-then-re-split pane lands on the pane's current slot. Overrides --pane \
@@ -434,7 +450,7 @@ struct Session: ParsableCommand {
         @Argument(help: "Shell line to run on the next launch (omit with --none or --clear).") var command: String?
         @Flag(name: .long, help: "Pin the pane to nothing: it restores a plain shell, suppressing the captured command.") var none = false
         @Flag(name: .long, help: "Drop the override so the pane goes back to restoring its captured foreground command.") var clear = false
-        @Option(name: .long, help: "Which pane to pin: left (main), right (split), or scratch (rejected — the scratch is never restored). Defaults to the left pane.") var pane: String?
+        @Option(name: .long, help: "Which pane to pin: primary/left/top or split/right/bottom; scratch is rejected. Defaults to primary.") var pane: String?
         @Option(name: .customLong("pane-id"), help: """
             A surface's stable token (the shell's $AGTERM_PANE_ID) — resolves to the pane's CURRENT slot, \
             so a hook in a promoted-then-re-split pane still pins the right one. Unlike `session status`, \
@@ -625,7 +641,7 @@ struct Session: ParsableCommand {
             subcommands: [Open.self, Close.self, Resize.self, Result.self]
         )
 
-        /// `--pane` validation for the overlay commands: `left|right` only, deliberately NOT the shared
+        /// `--pane` validation for the overlay commands: the two pane roles only, deliberately NOT the shared
         /// `validatePaneArgument`, which also accepts `scratch` — there is no scratch pane to cover, and
         /// reusing it would send `scratch` to the socket instead of failing as a usage error.
         static func validatePane(_ pane: String?) throws {
@@ -644,7 +660,7 @@ struct Session: ParsableCommand {
             @Option(name: .long, help: "Render a floating, framed panel at PERCENT (1-100) of the pane instead of full-size.") var sizePercent: Int?
             @Option(name: .long, help: "Solid background color (#rrggbb) for the overlay pane, independent of the session's own.") var backgroundColor: String?
             @Option(name: .long, help: """
-                Scope the overlay to ONE split pane (left or right), leaving the sibling pane live and \
+                Scope the overlay to ONE split pane (primary/left/top or split/right/bottom), leaving the sibling pane live and \
                 visible; omit for the session-wide overlay. A pane overlay is always full-pane, so this \
                 cannot be combined with --size-percent.
                 """)
@@ -714,7 +730,7 @@ struct Session: ParsableCommand {
 
         struct Close: RequestCommand {
             static let configuration = CommandConfiguration(abstract: "Close the overlay terminal (destroys it).")
-            @Option(name: .long, help: "Close that split pane's overlay (left or right); omit for the session-wide overlay.")
+            @Option(name: .long, help: "Close that split pane's overlay (primary/left/top or split/right/bottom); omit for the session-wide overlay.")
             var pane: String?
             @OptionGroup var target: TargetOptions
             @OptionGroup var options: ClientOptions
@@ -752,7 +768,7 @@ struct Session: ParsableCommand {
 
         struct Result: RequestCommand {
             static let configuration = CommandConfiguration(abstract: "Print the overlay program's exit status (errors if it is still running or never ran).")
-            @Option(name: .long, help: "Read that split pane's overlay status (left or right); omit for the session-wide overlay.")
+            @Option(name: .long, help: "Read that split pane's overlay status (primary/left/top or split/right/bottom); omit for the session-wide overlay.")
             var pane: String?
             @OptionGroup var target: TargetOptions
             @OptionGroup var options: ClientOptions

--- a/agtermCore/Sources/agtermctlKit/SocketClient.swift
+++ b/agtermCore/Sources/agtermctlKit/SocketClient.swift
@@ -207,7 +207,7 @@ struct SocketClient {
             return count == 0 ? "ok" : "\(count) diagnostic(s)"
         }
         if let ratio = response.result?.ratio {
-            // session.resize echoes the applied (clamped) left-pane fraction, scriptable as a bare number.
+            // session.resize echoes the applied (clamped) primary-pane fraction, scriptable as a bare number.
             return String(format: "%.3f", ratio)
         }
         if echoID, let id = response.result?.id {

--- a/agtermCore/Tests/agtermCoreTests/AgentStatusTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AgentStatusTests.swift
@@ -64,6 +64,17 @@ struct AgentStatusTests {
         #expect(StatusPane.allCases == [.left, .right, .scratch])
     }
 
+    @Test func statusPaneControlAliasesPreserveCanonicalReadback() {
+        for alias in ["left", "top", "primary"] {
+            #expect(StatusPane(controlName: alias) == .left)
+            #expect(StatusPane(controlName: alias)?.rawValue == "left")
+        }
+        for alias in ["right", "bottom", "split"] {
+            #expect(StatusPane(controlName: alias) == .right)
+            #expect(StatusPane(controlName: alias)?.rawValue == "right")
+        }
+    }
+
     @Test func indicatorCarriesStatusPane() {
         let indicator = AgentIndicator(status: .blocked, statusPane: .right)
         #expect(indicator.status == .blocked)

--- a/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStorePaneTests.swift
@@ -62,6 +62,47 @@ struct AppStorePaneTests {
         #expect(session.splitFocused == false)  // regression guard: no jerk back to the right pane
     }
 
+    @Test func axisSpecificSplitFollowsCreateHideTransposeAndReshowMatrix() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+
+        store.toggleSplit(session.id, axis: .topBottom)
+        #expect(session.isSplit && session.hasSplit)
+        #expect(session.splitAxis == .topBottom)
+        #expect(session.splitFocused)
+
+        session.splitFocused = false
+        store.toggleSplit(session.id, axis: .leftRight)
+        #expect(session.isSplit)
+        #expect(session.splitAxis == .leftRight)
+        #expect(!session.splitFocused, "transposition preserves the focused pane")
+
+        store.toggleSplit(session.id, axis: .leftRight)
+        #expect(!session.isSplit)
+        #expect(session.hasSplit)
+        #expect(session.splitAxis == .leftRight)
+
+        store.toggleSplit(session.id, axis: .topBottom)
+        #expect(session.isSplit)
+        #expect(session.splitAxis == .topBottom)
+        #expect(!session.splitFocused, "reshowing a hidden split preserves the focused pane")
+    }
+
+    @Test func genericSplitPreservesLegacyBehaviorAndCurrentAxis() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        session.splitAxis = .topBottom
+
+        store.toggleSplit(session.id)
+        #expect(session.isSplit)
+        #expect(session.splitAxis == .topBottom)
+        store.toggleSplit(session.id)
+        #expect(!session.isSplit)
+        #expect(session.splitAxis == .topBottom)
+    }
+
     @Test func closeSplitHidesAndTearsDownSurface() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
@@ -73,6 +114,7 @@ struct AppStorePaneTests {
         session.splitSurface = split
         session.splitCwd = "/var/log"
         session.splitRatio = 0.7
+        session.splitAxis = .topBottom
         store.closeSplit(session.id)
         #expect(session.isSplit == false)
         #expect(session.hasSplit == false)
@@ -81,6 +123,7 @@ struct AppStorePaneTests {
         #expect(session.splitCwd == nil)
         #expect(session.initialSplitCwd == nil)
         #expect(session.splitRatio == nil) // teardown clears geometry too, so a fresh re-split opens even
+        #expect(session.splitAxis == .leftRight)
         #expect(split.teardownCount == 1)
     }
 

--- a/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreTests.swift
@@ -1465,7 +1465,7 @@ struct AppStoreTests {
         #expect(tree.workspaces[1].sessions == [
             ControlSessionNode(id: b.id.uuidString, name: "remote:~/b", cwd: "/live/b",
                                title: "remote:~/b", active: true, split: true,
-                               hasSplit: true, splitFocused: false,
+                               hasSplit: true, splitAxis: "vertical", splitFocused: false,
                                overlay: true, scratch: true, flagged: true,
                                status: "blocked", statusPane: "right",
                                background: BackgroundWatermark(kind: .text, text: "PROD"),

--- a/agtermCore/Tests/agtermCoreTests/BuiltinActionTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/BuiltinActionTests.swift
@@ -12,6 +12,7 @@ struct BuiltinActionTests {
     @Test func rawNamesAreTheKittyStyleNames() {
         #expect(BuiltinAction.newWindow.rawValue == "new_window")
         #expect(BuiltinAction.toggleSplit.rawValue == "toggle_split")
+        #expect(BuiltinAction.toggleHorizontalSplit.rawValue == "toggle_horizontal_split")
         #expect(BuiltinAction.toggleTerminalZoom.rawValue == "toggle_terminal_zoom")
         #expect(BuiltinAction.toggleSearch.rawValue == "toggle_search")
         #expect(BuiltinAction.commandPalette.rawValue == "command_palette")
@@ -29,7 +30,7 @@ struct BuiltinActionTests {
         #expect(BuiltinAction.toggleFullscreen.rawValue == "toggle_fullscreen")
         #expect(BuiltinAction.dashboard.rawValue == "dashboard")
         #expect(BuiltinAction.duplicateSession.rawValue == "duplicate_session")
-        #expect(BuiltinAction.allCases.count == 42)
+        #expect(BuiltinAction.allCases.count == 43)
     }
 
     @Test func rejectsUnknownName() {
@@ -91,6 +92,7 @@ struct BuiltinActionTests {
             .decreaseFontSize: Chord(mods: [.command], key: "-"),
             .resetFontSize: Chord(mods: [.command], key: "0"),
             .toggleSplit: Chord(mods: [.command], key: "d"),
+            .toggleHorizontalSplit: Chord(mods: [.command, .shift], key: "d"),
             .toggleScratch: Chord(mods: [.command], key: "j"),
             .toggleTerminalZoom: Chord(mods: [.command, .shift], key: "return"),
             .toggleSearch: Chord(mods: [.command], key: "f"),
@@ -114,7 +116,7 @@ struct BuiltinActionTests {
             .commandPalette: Chord(mods: [.control, .shift], key: "p"),
             .customCommandPalette: Chord(mods: [.control, .shift], key: "o"),
             .showAttention: Chord(mods: [.control, .shift], key: "i"),
-            .dashboard: Chord(mods: [.command, .shift], key: "d"),
+            .dashboard: Chord(mods: [.command, .shift], key: "g"),
         ]
         #expect(expected.count == BuiltinAction.allCases.count)
         for action in BuiltinAction.allCases {

--- a/agtermCore/Tests/agtermCoreTests/ConfigPathsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ConfigPathsTests.swift
@@ -80,7 +80,7 @@ struct ConfigPathsTests {
         #expect(parsed.diagnostics.isEmpty)
     }
 
-    // issue #405: the shipped example was `map cmd+shift+d toggle_split`, a chord `dashboard` later took,
+    // issue #405: a shipped map example once used a chord a later built-in default took,
     // so uncommenting the starter's own suggestion silently bound nothing. A `command` example rots the
     // same way, `validateCommands` dropping a custom shortcut a built-in has since claimed.
     @Test func starterKeymapExamplesApplyWhenUncommented() {

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherDashboardTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherDashboardTests.swift
@@ -56,7 +56,7 @@ struct ControlDispatcherDashboardTests {
         ])
     }
 
-    @Test(arguments: ["a:lft", "a:primary", "a:split", "a:scratch", "a:overlay", "a:", ":left",
+    @Test(arguments: ["a:lft", "a:scratch", "a:overlay", "a:", ":left",
                       "surface:9F3CAAAA-0000-0000-0000-000000000001:left"])
     func malformedPaneRefIsRejected(_ target: String) async {
         let actions = MockControlActions()

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -965,7 +965,7 @@ struct ControlDispatcherTests {
         let split = await dispatcher.dispatch(ControlRequest(
             cmd: .sessionSplit,
             target: "session",
-            args: ControlArgs(mode: "off", window: "win")
+            args: ControlArgs(mode: "off", axis: "horizontal", window: "win")
         ))
         let splitClose = await dispatcher.dispatch(ControlRequest(
             cmd: .sessionSplitClose,
@@ -994,12 +994,21 @@ struct ControlDispatcherTests {
         #expect(focus == ControlResponse(ok: true))
         #expect(resize == ControlResponse(ok: true))
         #expect(actions.calls == [
-            .sessionSplit(target: "session", window: "win", "off"),
+            .sessionSplit(target: "session", window: "win", "off", .topBottom),
             .sessionSplitClose(target: "session", window: "win"),
             .sessionScratch(target: "session", window: nil, "on", command: "htop"),
             .sessionFocus(target: "session", window: nil, "right"),
             .sessionResize(target: "session", window: "win", .delta(-0.1))
         ])
+    }
+
+    @Test func splitRejectsAnUnknownAxisBeforeDispatch() async {
+        let actions = MockControlActions()
+        let response = await ControlDispatcher(actions: actions).dispatch(ControlRequest(
+            cmd: .sessionSplit, args: ControlArgs(mode: "toggle", axis: "diagonal")))
+        #expect(response == ControlResponse(ok: false,
+                                           error: "invalid split axis: diagonal (vertical|horizontal)"))
+        #expect(actions.calls.isEmpty)
     }
 
     @Test func resizeRejectsInvalidInputs() async {

--- a/agtermCore/Tests/agtermCoreTests/ControlModesTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlModesTests.swift
@@ -40,8 +40,10 @@ struct ControlModesTests {
 
     @Test func paneFocusModeParsesAliases() {
         #expect(ControlPaneFocusMode.parse("left") == .primary)
+        #expect(ControlPaneFocusMode.parse("top") == .primary)
         #expect(ControlPaneFocusMode.parse("primary") == .primary)
         #expect(ControlPaneFocusMode.parse("right") == .split)
+        #expect(ControlPaneFocusMode.parse("bottom") == .split)
         #expect(ControlPaneFocusMode.parse("split") == .split)
         #expect(ControlPaneFocusMode.parse("other") == .toggle)
         #expect(ControlPaneFocusMode.parse("toggle") == .toggle)

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -416,7 +416,8 @@ struct ControlProtocolTests {
 
     @Test func modeBearingCommandsRoundTrip() throws {
         let cases: [ControlRequest] = [
-            ControlRequest(cmd: .sessionSplit, target: "active", args: ControlArgs(mode: "toggle")),
+            ControlRequest(cmd: .sessionSplit, target: "active",
+                           args: ControlArgs(mode: "toggle", axis: "horizontal")),
             ControlRequest(cmd: .sessionScratch, target: "active", args: ControlArgs(mode: "toggle")),
             ControlRequest(cmd: .sessionScratch, target: "9f3c", args: ControlArgs(mode: "on")),
             ControlRequest(cmd: .sessionScratch, target: "active", args: ControlArgs(mode: "on", command: "htop")),

--- a/agtermCore/Tests/agtermCoreTests/DashboardTargetTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/DashboardTargetTests.swift
@@ -59,10 +59,13 @@ struct DashboardTargetTests {
         #expect(DashboardTarget(rawValue: "\(uuid):lft") == nil)
     }
 
-    // primary/split parse as TerminalZoomSurface but are not the spelling dashboardMembers emits
-    @Test(arguments: ["primary", "split"])
-    func enumAliasSpellingsAreRejected(_ suffix: String) {
-        #expect(DashboardTarget(rawValue: "\(uuid):\(suffix)") == nil)
+    @Test func roleAndAxisAliasesResolveWithoutChangingReadbackRoles() {
+        for suffix in ["primary", "left", "top"] {
+            #expect(DashboardTarget(rawValue: "\(uuid):\(suffix)")?.pane == .primary)
+        }
+        for suffix in ["split", "right", "bottom"] {
+            #expect(DashboardTarget(rawValue: "\(uuid):\(suffix)")?.pane == .split)
+        }
     }
 
     @Test(arguments: ["scratch", "overlay"])

--- a/agtermCore/Tests/agtermCoreTests/KeymapTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/KeymapTests.swift
@@ -1106,6 +1106,47 @@ struct KeymapTests {
         }
     }
 
+    @Test func splitAndDashboardShipTheirNewDistinctDefaults() {
+        let keymap = parseKeymap("").keymap
+        #expect(keymap.equivalent(for: .toggleSplit) == Chord(mods: [.command], key: "d"))
+        #expect(keymap.equivalent(for: .toggleHorizontalSplit) == Chord(mods: [.command, .shift], key: "d"))
+        #expect(keymap.equivalent(for: .dashboard) == Chord(mods: [.command, .shift], key: "g"))
+    }
+
+    @Test func legacyExplicitDashboardBindingKeepsCmdShiftD() {
+        let (keymap, diagnostics) = parseKeymap("map cmd+shift+d dashboard")
+        #expect(diagnostics.isEmpty)
+        #expect(keymap.equivalent(for: .dashboard) == Chord(mods: [.command, .shift], key: "d"))
+        #expect(keymap.equivalent(for: .toggleHorizontalSplit) == nil)
+        #expect(keymap.builtinUnbound.contains(.toggleHorizontalSplit))
+    }
+
+    @Test func existingCmdShiftDCustomCommandIsNotBrokenByHorizontalSplitDefault() {
+        let (keymap, diagnostics) = parseKeymap("""
+        map ctrl+shift+y dashboard
+        command "Old binding" cmd+shift+d echo ok
+        """)
+        #expect(diagnostics.isEmpty)
+        #expect(keymap.commands.first?.shortcut == "cmd+shift+d")
+        #expect(keymap.equivalent(for: .toggleHorizontalSplit) == nil)
+        #expect(keymap.builtinUnbound.contains(.toggleHorizontalSplit))
+    }
+
+    @Test func existingCmdShiftGBuiltinBindingIsNotBrokenByDashboardDefault() {
+        let (keymap, diagnostics) = parseKeymap("map cmd+shift+g toggle_workspace_filter")
+        #expect(diagnostics.isEmpty)
+        #expect(keymap.equivalent(for: .toggleWorkspaceFilter) == Chord(mods: [.command, .shift], key: "g"))
+        #expect(keymap.equivalent(for: .dashboard) == nil)
+        #expect(keymap.builtinUnbound.contains(.dashboard))
+    }
+
+    @Test func existingCmdShiftGCustomCommandIsNotBrokenByDashboardDefault() {
+        let (keymap, diagnostics) = parseKeymap("command \"Old binding\" cmd+shift+g echo ok")
+        #expect(diagnostics.isEmpty)
+        #expect(keymap.commands.first?.shortcut == "cmd+shift+g")
+        #expect(keymap.equivalent(for: .dashboard) == nil)
+    }
+
     @Test func keymapStoreLoadsFileAndRecoversWhenMissing() throws {
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent("agterm-keymap-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)

--- a/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
+++ b/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
@@ -33,7 +33,7 @@ final class MockControlActions: ControlActions {
         case markSessionSeen(target: String?, window: String?)
         case sessionStatus(target: String?, window: String?, ControlSessionStatusUpdate)
         case sessionRestore(target: String?, window: String?, ControlSessionRestoreUpdate)
-        case sessionSplit(target: String?, window: String?, String?)
+        case sessionSplit(target: String?, window: String?, String?, SplitAxis?)
         case sessionSplitClose(target: String?, window: String?)
         case sessionScratch(target: String?, window: String?, String?, command: String?)
         case sessionFocus(target: String?, window: String?, String?)
@@ -280,7 +280,11 @@ final class MockControlActions: ControlActions {
     }
 
     func splitSession(_ target: String?, window: String?, mode: String?) -> ControlResponse {
-        calls.append(.sessionSplit(target: target, window: window, mode))
+        splitSession(target, window: window, mode: mode, axis: nil)
+    }
+
+    func splitSession(_ target: String?, window: String?, mode: String?, axis: SplitAxis?) -> ControlResponse {
+        calls.append(.sessionSplit(target: target, window: window, mode, axis))
         return ControlResponse(ok: true)
     }
 

--- a/agtermCore/Tests/agtermCoreTests/PaletteCatalogTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/PaletteCatalogTests.swift
@@ -21,7 +21,8 @@ struct PaletteCatalogTests {
             "First Session",
             "Last Session",
             "Show Attention",
-            "Toggle Split",
+            "Toggle Vertical Split",
+            "Toggle Horizontal Split",
             "Close Split",
             "Toggle Scratch",
             "Toggle Terminal Zoom",
@@ -54,7 +55,7 @@ struct PaletteCatalogTests {
     }
 
     @Test func catalogHasTheExpectedStaticCommandCount() {
-        #expect(PaletteCommand.allCases.count == 46)
+        #expect(PaletteCommand.allCases.count == 47)
     }
 
     @Test func idsRoundTripThroughRawValue() {
@@ -68,6 +69,8 @@ struct PaletteCatalogTests {
         #expect(PaletteCommand.toggleFlag.title(in: PaletteContext(activeSessionFlagged: true)) == "Unflag Session")
         #expect(PaletteCommand.toggleFlaggedView.title(in: PaletteContext(sidebarShowsFlaggedOnly: false)) == "Show Flagged Sessions")
         #expect(PaletteCommand.toggleFlaggedView.title(in: PaletteContext(sidebarShowsFlaggedOnly: true)) == "Show All Sessions")
+        #expect(PaletteCommand.focusLeftPane.title(in: PaletteContext(activeSplitAxis: .topBottom)) == "Focus Top Pane")
+        #expect(PaletteCommand.focusRightPane.title(in: PaletteContext(activeSplitAxis: .topBottom)) == "Focus Bottom Pane")
     }
 
     @Test func clearFlaggedVisibleOnlyWhenSomethingIsFlagged() {
@@ -138,7 +141,8 @@ struct PaletteCatalogTests {
     ]
 
     private static let needSession: Set<PaletteCommand> = [
-        .renameSession, .duplicateSession, .clearStatus, .toggleFlag, .toggleSplit, .toggleScratch, .find,
+        .renameSession, .duplicateSession, .clearStatus, .toggleFlag, .toggleSplit, .toggleHorizontalSplit,
+        .toggleScratch, .find,
         .previousSession, .nextSession, .previousAttentionSession, .nextAttentionSession,
         .firstSession, .lastSession,
     ]

--- a/agtermCore/Tests/agtermCoreTests/SnapshotRoundTripTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SnapshotRoundTripTests.swift
@@ -163,6 +163,44 @@ struct SnapshotRoundTripTests {
         #expect(restored.workspaces[0].sessions[0].splitRatio == 0.63)
     }
 
+    @Test func splitAxisRoundTripsAndLegacyOrUnknownValuesDefaultLeftRight() throws {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        session.isSplit = true
+        session.hasSplit = true
+        session.splitAxis = .topBottom
+
+        let snapshot = store.snapshot()
+        #expect(snapshot.workspaces[0].sessions[0].splitAxis == .topBottom)
+        let restored = makeStore()
+        restored.restore(from: snapshot)
+        #expect(restored.workspaces[0].sessions[0].splitAxis == .topBottom)
+
+        let legacy = #"{"id":"00000000-0000-0000-0000-000000000001","cwd":"/tmp","isSplit":true}"#
+        let legacySession = try JSONDecoder().decode(SessionSnapshot.self, from: Data(legacy.utf8))
+        #expect(legacySession.splitAxis == nil)
+        let legacyStore = makeStore()
+        legacyStore.restore(from: Snapshot(workspaces: [
+            WorkspaceSnapshot(id: UUID(), name: "legacy", sessions: [legacySession]),
+        ]))
+        #expect(legacyStore.workspaces[0].sessions[0].splitAxis == .leftRight)
+
+        let unknown = #"{"id":"00000000-0000-0000-0000-000000000002","cwd":"/tmp","isSplit":true,"splitAxis":"diagonal"}"#
+        let unknownSession = try JSONDecoder().decode(SessionSnapshot.self, from: Data(unknown.utf8))
+        #expect(unknownSession.splitAxis == nil)
+    }
+
+    @Test func hiddenSplitDoesNotPersistAnUnrestorableAxis() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        session.hasSplit = true
+        session.isSplit = false
+        session.splitAxis = .topBottom
+        #expect(store.snapshot().workspaces[0].sessions[0].splitAxis == nil)
+    }
+
     @Test func restoreCommandRoundTripsThroughSnapshot() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermCoreTests/TerminalZoomTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/TerminalZoomTests.swift
@@ -4,6 +4,15 @@ import Testing
 
 @MainActor
 struct TerminalZoomTests {
+    @Test func controlAliasesPreserveCanonicalSurfaceRoles() {
+        for alias in ["left", "top", "primary"] {
+            #expect(TerminalZoomSurface(controlName: alias) == .primary)
+        }
+        for alias in ["right", "bottom", "split"] {
+            #expect(TerminalZoomSurface(controlName: alias) == .split)
+        }
+    }
+
     @Test func resolveTargetPrioritizesQuickThenSessionCoversThenFocusedPane() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -358,6 +358,14 @@ struct CommandsTests {
         #expect(try request(["session", "split", "off", "--target", "s1", "--window", "w1"]) == expected)
     }
 
+    @Test func sessionSplitAcceptsAnOptionalAxis() throws {
+        let expected = ControlRequest(cmd: .sessionSplit, target: "active",
+                                      args: ControlArgs(mode: "toggle", axis: "horizontal"))
+        #expect(try request(["session", "split", "--axis", "horizontal"]) == expected)
+        #expect(validationMessage(["session", "split", "--axis", "diagonal"])
+            == "--axis must be vertical or horizontal")
+    }
+
     @Test func sessionSplitClose() throws {
         #expect(try request(["session", "split", "close"]) == ControlRequest(cmd: .sessionSplitClose, target: "active"))
     }
@@ -387,6 +395,12 @@ struct CommandsTests {
         #expect(try request(["session", "focus", "right"]) == expected)
     }
 
+    @Test func sessionFocusAcceptsRoleAndAxisAliasesVerbatim() throws {
+        for pane in ["primary", "left", "top", "split", "right", "bottom"] {
+            #expect(try request(["session", "focus", pane]).args?.pane == pane)
+        }
+    }
+
     @Test func sessionResizeAbsolute() throws {
         let expected = ControlRequest(cmd: .sessionResize, target: "active", args: ControlArgs(ratio: 0.7))
         #expect(try request(["session", "resize", "--split-ratio", "0.7"]) == expected)
@@ -400,6 +414,15 @@ struct CommandsTests {
     @Test func sessionResizeGrowRightIsNegativeDelta() throws {
         let expected = ControlRequest(cmd: .sessionResize, target: "active", args: ControlArgs(ratioDelta: -0.05))
         #expect(try request(["session", "resize", "--grow-right", "0.05"]) == expected)
+    }
+
+    @Test func sessionResizeRoleAndAxisAliasesKeepThePrimaryFractionConvention() throws {
+        for option in ["--grow-primary", "--grow-top"] {
+            #expect(try request(["session", "resize", option, "0.05"]).args?.ratioDelta == 0.05)
+        }
+        for option in ["--grow-split", "--grow-bottom"] {
+            #expect(try request(["session", "resize", option, "0.05"]).args?.ratioDelta == -0.05)
+        }
     }
 
     @Test func sessionResizeRequiresExactlyOneForm() {
@@ -848,6 +871,10 @@ struct CommandsTests {
         let right = ControlRequest(cmd: .sessionOverlayOpen, target: "9f3c",
                                    args: ControlArgs(command: "htop", pane: "right"))
         #expect(try request(["session", "overlay", "open", "htop", "--pane", "right", "--target", "9f3c"]) == right)
+        #expect(try request(["session", "overlay", "open", "revdiff", "--pane", "top"]).args?.pane == "top")
+        #expect(try request(["session", "overlay", "open", "revdiff", "--pane", "bottom"]).args?.pane == "bottom")
+        #expect(try request(["session", "overlay", "open", "revdiff", "--pane", "primary"]).args?.pane == "primary")
+        #expect(try request(["session", "overlay", "open", "revdiff", "--pane", "split"]).args?.pane == "split")
     }
 
     @Test func sessionOverlayOpenPaneWithTheOtherFlags() throws {

--- a/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
@@ -249,6 +249,7 @@ struct SocketClientTests {
             decrease_font_size          cmd+-
             reset_font_size             cmd+0
           * toggle_split                cmd+shift+e
+            toggle_horizontal_split     cmd+shift+d
             toggle_scratch              cmd+j
             toggle_terminal_zoom        cmd+shift+return
             toggle_search               cmd+f
@@ -272,7 +273,7 @@ struct SocketClientTests {
             command_palette             ctrl+shift+p
             custom_command_palette      ctrl+shift+o
             show_attention              ctrl+shift+i
-            dashboard                   cmd+shift+d
+            dashboard                   cmd+shift+g
 
         commands:
             Deploy  cmd+shift+y

--- a/agtermTests/ControlServerSessionActionsTests.swift
+++ b/agtermTests/ControlServerSessionActionsTests.swift
@@ -511,6 +511,42 @@ final class ControlServerSessionActionsTests: XCTestCase {
         return (store, session)
     }
 
+    func testSplitVisibilityDefaultsLeftRightAndAcceptsHorizontalAxis() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let owner = try XCTUnwrap(store.currentWorkspaceID)
+        let session = try XCTUnwrap(store.addSession(toWorkspace: owner, cwd: NSHomeDirectory()))
+
+        XCTAssertTrue(server.splitSession(session.id.uuidString, window: nil, mode: "on", axis: nil).ok)
+        XCTAssertTrue(session.isSplit)
+        XCTAssertEqual(session.splitAxis, .leftRight)
+
+        XCTAssertTrue(server.splitSession(session.id.uuidString, window: nil, mode: "on", axis: .topBottom).ok)
+        XCTAssertTrue(session.isSplit, "on with another axis transposes rather than hides")
+        XCTAssertEqual(session.splitAxis, .topBottom)
+    }
+
+    func testAxisSpecificControlToggleUsesTheSameHideTransposeMatrixAsTheGui() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let owner = try XCTUnwrap(store.currentWorkspaceID)
+        let session = try XCTUnwrap(store.addSession(toWorkspace: owner, cwd: NSHomeDirectory()))
+
+        XCTAssertTrue(server.splitSession(session.id.uuidString, window: nil,
+                                          mode: "toggle", axis: .topBottom).ok)
+        XCTAssertTrue(session.isSplit)
+        XCTAssertEqual(session.splitAxis, .topBottom)
+
+        XCTAssertTrue(server.splitSession(session.id.uuidString, window: nil,
+                                          mode: "toggle", axis: .leftRight).ok)
+        XCTAssertTrue(session.isSplit)
+        XCTAssertEqual(session.splitAxis, .leftRight)
+
+        XCTAssertTrue(server.splitSession(session.id.uuidString, window: nil,
+                                          mode: "toggle", axis: .leftRight).ok)
+        XCTAssertFalse(session.isSplit)
+        XCTAssertTrue(session.hasSplit)
+        XCTAssertEqual(session.splitAxis, .leftRight)
+    }
+
     func testSplitCloseTearsThePaneDown() throws {
         let (_, session) = try splitSession()
         session.splitRatio = 0.7

--- a/agtermTests/SplitRatioAccessorTests.swift
+++ b/agtermTests/SplitRatioAccessorTests.swift
@@ -82,6 +82,31 @@ final class SplitRatioAccessorTests: XCTestCase {
         XCTAssertEqual(NSCursor.current, NSCursor.resizeLeftRight)
     }
 
+    func testHorizontalDividerUsesHeightRatioAndUpDownCursor() throws {
+        probe.removeFromSuperview()
+        split.isVertical = false
+        split.arrangedSubviews[0].addSubview(probe)
+        session.splitRatio = 0.75
+        probe.layout()
+        split.layoutSubtreeIfNeeded()
+
+        XCTAssertEqual(split.arrangedSubviews[0].frame.height, 150, accuracy: 1)
+        let pointInSplit = NSPoint(x: split.bounds.midX,
+                                   y: split.arrangedSubviews[0].frame.maxY + split.dividerThickness / 2)
+        let pointInWindow = split.convert(pointInSplit, to: nil)
+        let pointInParent = try XCTUnwrap(split.superview).convert(pointInWindow, from: nil)
+        XCTAssertTrue(split.hitTest(pointInParent) === split,
+                      "the probe point must land on the horizontal divider; frames: \(split.arrangedSubviews.map(\.frame))")
+        let event = try XCTUnwrap(NSEvent.mouseEvent(with: .mouseMoved,
+                                                     location: pointInWindow,
+                                                     modifierFlags: [], timestamp: 0,
+                                                     windowNumber: window.windowNumber, context: nil,
+                                                     eventNumber: 0, clickCount: 0, pressure: 0))
+        NSCursor.arrow.set()
+        probe.mouseMoved(with: event)
+        XCTAssertEqual(NSCursor.current, NSCursor.resizeUpDown)
+    }
+
     /// The tracking area covers the whole split, not the band, so every move over a pane arrives here too.
     func testLeavesTheCursorAloneOverAPane() throws {
         probe.layout()

--- a/agtermTests/SplitToggleCoverTests.swift
+++ b/agtermTests/SplitToggleCoverTests.swift
@@ -45,6 +45,48 @@ final class SplitToggleCoverTests: XCTestCase {
 
         XCTAssertTrue(session.isSplit, "the cover rung must not disarm the ordinary split toggle")
         XCTAssertTrue(session.hasSplit)
+        XCTAssertEqual(session.splitAxis, .leftRight)
+    }
+
+    func testHorizontalActionCreatesAndTogglesAHorizontalSplit() throws {
+        let session = try activeSession()
+
+        actions.toggleHorizontalSplit()
+        XCTAssertTrue(session.isSplit)
+        XCTAssertEqual(session.splitAxis, .topBottom)
+
+        actions.toggleHorizontalSplit()
+        XCTAssertFalse(session.isSplit)
+        XCTAssertTrue(session.hasSplit)
+        XCTAssertEqual(session.splitAxis, .topBottom)
+    }
+
+    func testOrientationActionsTransposeAShownSplitWithoutChangingItsState() throws {
+        let session = try activeSession()
+        actions.toggleSplit()
+        session.splitRatio = 0.7
+        let focused = session.splitFocused
+
+        actions.toggleHorizontalSplit()
+
+        XCTAssertTrue(session.isSplit)
+        XCTAssertEqual(session.splitAxis, .topBottom)
+        XCTAssertEqual(session.splitRatio, 0.7)
+        XCTAssertEqual(session.splitFocused, focused)
+        XCTAssertTrue(session.hasSplit)
+    }
+
+    func testTitlebarStyleTogglePreservesTheCurrentAxis() throws {
+        let session = try activeSession()
+        actions.toggleHorizontalSplit()
+
+        actions.toggleCurrentSplit()
+        XCTAssertFalse(session.isSplit)
+        XCTAssertEqual(session.splitAxis, .topBottom)
+
+        actions.toggleCurrentSplit()
+        XCTAssertTrue(session.isSplit)
+        XCTAssertEqual(session.splitAxis, .topBottom)
     }
 
     func testShownScratchIsDismissedInsteadOfSplitting() throws {

--- a/agtermUITests/DashboardUITests.swift
+++ b/agtermUITests/DashboardUITests.swift
@@ -343,7 +343,7 @@ final class DashboardUITests: ControlAPITestCase {
                           + "so the click hit the dashboard, not the terminal beneath")
     }
 
-    // the title-bar Dashboard button opens the MRU dashboard grid — the GUI opener alongside ⌘⇧D / Navigate ▸
+    // the title-bar Dashboard button opens the MRU dashboard grid, the GUI opener alongside ⌘⇧G / Navigate ▸
     // Dashboard. It lives in the trailing action cluster in its own separator group (before the quick-terminal
     // button). Disabled with no sessions, so this seeds one first.
     func testTitlebarDashboardButtonOpensDashboard() throws {
@@ -426,7 +426,7 @@ final class DashboardUITests: ControlAPITestCase {
         XCTAssertTrue(dashboardOverlay.waitForNonExistence(timeout: 10), "close removes the overlay after the resize")
     }
 
-    // the Navigate ▸ Dashboard menu item (⌘⇧D) is the GUI opener for the MRU dashboard grid — it TOGGLES:
+    // the Navigate ▸ Dashboard menu item (⌘⇧G) is the GUI opener for the MRU dashboard grid. It TOGGLES:
     // opening the window's most-recently-used sessions when closed, closing when open. Seeds a known recency
     // via explicit selects, opens via the menu item, asserts the overlay renders one cell per recent session
     // (the mru members), then toggles it closed via the same menu item and asserts the overlay is gone.
@@ -457,7 +457,7 @@ final class DashboardUITests: ControlAPITestCase {
     // way terminal zoom gates them. ⌘N (new_session) routes through the menu (performKeyEquivalent, PAST the
     // grid's keyDown-only key-catcher), but the New Session item is .disabled while the dashboard is open AND
     // AppActions.newSession guards on uiActionsEnabled, so it neither creates a session nor dismisses the grid.
-    // The Dashboard toggle stays enabled so ⌘⇧D still closes the grid — the user is never trapped.
+    // The Dashboard toggle stays enabled so ⌘⇧G still closes the grid, and the user is never trapped.
     func testDashboardGatesSessionShortcutsWhileOpen() throws {
         let ids = try prepareSessions(extra: 1) // [seeded, new1] → two sessions
         XCTAssertEqual(ids.count, 2)
@@ -474,9 +474,9 @@ final class DashboardUITests: ControlAPITestCase {
         XCTAssertEqual(dashMembers()?.count, 2, "the gated shortcut leaves the dashboard members unchanged")
         XCTAssertFalse(pollSessionCount(3, timeout: 3), "⌘N must not create a session while the dashboard is open")
 
-        // the Dashboard toggle stays enabled (the escape hatch): ⌘⇧D closes the grid cleanly.
-        app.typeKey("d", modifierFlags: [.command, .shift])
-        XCTAssertTrue(dashboardOverlay.waitForNonExistence(timeout: 10), "⌘⇧D closes the open dashboard")
+        // the Dashboard toggle stays enabled (the escape hatch): ⌘⇧G closes the grid cleanly.
+        app.typeKey("g", modifierFlags: [.command, .shift])
+        XCTAssertTrue(dashboardOverlay.waitForNonExistence(timeout: 10), "⌘⇧G closes the open dashboard")
         XCTAssertNil(dashMembers(), "the dashboard read-backs clear on the toggle-close")
         XCTAssertTrue(pollSessionCount(2, timeout: 5), "the session set is unchanged after gating + close")
     }

--- a/agtermUITests/SplitUITests.swift
+++ b/agtermUITests/SplitUITests.swift
@@ -63,6 +63,42 @@ final class SplitUITests: XCTestCase {
         XCTAssertEqual(collapsedTTY, rightTTY, "closing the split keeps the focused (right) pane, not the primary")
     }
 
+    func testHorizontalShortcutCreatesTransposesAndTogglesWithoutReplacingPanes() throws {
+        let row = app.staticTexts["session-row"]
+        XCTAssertTrue(row.waitForExistence(timeout: 20), "seeded session should exist")
+        row.click()
+        usleep(800_000)
+
+        let primaryTTY = ttyAfterCommand(named: "horizontal-primary")
+        XCTAssertNotNil(primaryTTY)
+        let splitButton = app.buttons["split-toggle"]
+        XCTAssertTrue(splitButton.waitForExistence(timeout: 5))
+
+        app.typeKey("d", modifierFlags: [.command, .shift])
+        XCTAssertTrue(waitSplitValue(splitButton, "both-horizontal"), "⌘⇧D creates a top/bottom split")
+        let splitTTY = ttyAfterCommand(named: "horizontal-split")
+        XCTAssertNotNil(splitTTY)
+        XCTAssertNotEqual(splitTTY, primaryTTY)
+
+        app.typeKey("1", modifierFlags: .control)
+        XCTAssertEqual(ttyAfterCommand(named: "horizontal-primary-before-transpose"), primaryTTY)
+        app.typeKey("d", modifierFlags: .command)
+        XCTAssertTrue(waitSplitValue(splitButton, "both"), "⌘D transposes the shown split to left/right")
+        XCTAssertEqual(ttyAfterCommand(named: "horizontal-primary-after-transpose"), primaryTTY,
+                       "transposing preserves the focused primary terminal")
+
+        app.typeKey("d", modifierFlags: [.command, .shift])
+        XCTAssertTrue(waitSplitValue(splitButton, "both-horizontal"), "⌘⇧D transposes it back to top/bottom")
+        app.typeKey("2", modifierFlags: .control)
+        XCTAssertEqual(ttyAfterCommand(named: "horizontal-split-after-transpose"), splitTTY,
+                       "transposing preserves the split terminal")
+
+        app.typeKey("d", modifierFlags: [.command, .shift])
+        XCTAssertTrue(waitSplitValue(splitButton, "bottom"), "same-axis shortcut hides onto the focused bottom pane")
+        app.typeKey("d", modifierFlags: [.command, .shift])
+        XCTAssertTrue(waitSplitValue(splitButton, "both-horizontal"), "same-axis shortcut re-shows top/bottom")
+    }
+
     func testCtrlNumberFocusesPaneDirectly() throws {
         let row = app.staticTexts["session-row"]
         XCTAssertTrue(row.waitForExistence(timeout: 20), "seeded session should exist")
@@ -366,7 +402,7 @@ final class SplitUITests: XCTestCase {
         return nil
     }
 
-    /// Polls the split button's accessibilityValue (none/both/left/right) until it equals `value`,
+    /// Polls the split button's accessibilityValue (none/both/left/right/both-horizontal/top/bottom),
     /// covering the observation lag between a state change and the title-bar re-render.
     private func waitSplitValue(_ button: XCUIElement, _ value: String, timeout: TimeInterval = 8) -> Bool {
         let deadline = Date().addingTimeInterval(timeout)

--- a/cookbook/flagged-dashboard/README.md
+++ b/cookbook/flagged-dashboard/README.md
@@ -10,7 +10,7 @@ The unit is a pane, not a session, which is what makes the filter worth having. 
 
 Pressing the chord while the grid already shows that same set closes it, so the key both opens and dismisses. Start something in another flagged pane first and the same press reopens the grid with it included.
 
-⌘⇧D already grids a window's most-recently-used sessions, which is a different question. Recency is what you touched last, not what is working: a build you started twenty minutes ago and have not typed in since is exactly the thing that falls off the recent list while still being the thing you want on screen.
+⌘⇧G already grids a window's most-recently-used sessions, which is a different question. Recency is what you touched last, not what is working: a build you started twenty minutes ago and have not typed in since is exactly the thing that falls off the recent list while still being the thing you want on screen.
 
 ## Requirements
 
@@ -61,7 +61,7 @@ The toggle is a set comparison against the tree's top-level `dashboardMembers`, 
 
 A full grid needs a second rule. The grid holds nine cells and drops the rest, so once the set overflows, what is on screen can never equal what the script would open, and a plain equality test would leave the chord unable to ever close it. A grid holding nine cells that are all cells the script wants therefore counts as a match too. Unflagging something that is on screen still fails that test, which is what keeps the refresh working.
 
-`--auto-size` sizes the cells relative to your Settings font, shrinking them as the grid grows. It is what ⌘⇧D uses, so a flagged grid and a recent-sessions grid look alike. Swap in `--font-size N` for an absolute size in points if you would rather the cells stay put whatever the count.
+`--auto-size` sizes the cells relative to your Settings font, shrinking them as the grid grows. It is what ⌘⇧G uses, so a flagged grid and a recent-sessions grid look alike. Swap in `--font-size N` for an absolute size in points if you would rather the cells stay put whatever the count.
 
 ## Limits
 
@@ -75,6 +75,6 @@ The grid holds nine cells. Past that the extra panes are dropped, the script rep
 
 Everything is scoped to the frontmost window. The script reads `tree` and calls `dashboard` without a window selector, so flagged sessions in another window are not part of the set and need a run in that window.
 
-The toggle recognises the set, not who opened it. A ⌘⇧D recent-sessions grid that happens to hold exactly these panes will be closed by the chord rather than reopened.
+The toggle recognises the set, not who opened it. A ⌘⇧G recent-sessions grid that happens to hold exactly these panes will be closed by the chord rather than reopened.
 
 The grid is view-only, so no cell takes keyboard input. Opening and closing it does resize each pane's pty to its cell, so a full-screen program may redraw as the grid appears and again as it goes.

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -188,11 +188,12 @@ created by a scheduled job overnight stays unrealized until the displays wake an
 Poll this after an unattended create),
 `hasSplit` (whether a second pane exists at all, shown or hidden; omitted when there is none — read this
 rather than `split`, which is false for a split hidden with ⌘D even though its pane is still alive),
-`splitRatio` (the left-pane divider fraction 0.05–0.95 of a
+`splitAxis` (`vertical` for left/right or `horizontal` for top/bottom; omitted without a split),
+`splitRatio` (the primary-pane divider fraction 0.05-0.95 of a
 session that has a split — shown or hidden; omitted when there's no split or the ratio was never set (at
 the default 0.5) —
 the read side of `session resize`, record it to restore the exact divider), `splitFocused`
-(which pane holds focus in a session that has a split — `true` = split/right, `false` = main/left; omitted
+(which pane holds focus in a session that has a split: `true` = split/right/bottom, `false` = primary/left/top; omitted
 when there's no split; the read side of `session focus`, record it to restore focus), and `surfaces`
 (`id`, `kind`, `active`, `visible`) for `surface zoom`. The tree top level carries `zoomedSurface`
 (the control id of the currently zoomed surface, omitted when nothing is zoomed — the read side of
@@ -277,18 +278,22 @@ omitted when expanded).
   is the visible screen of the focused pane; `--pane scratch` reads the scratch terminal even while hidden;
   `--all` adds scrollback; `--lines N` keeps the last N lines.
 - `search [needle] [--next|--prev|--close]` — search the terminal scrollback; prints the "N of M" counter.
-- `split [on|off|toggle]` · `split close` — side-by-side second shell. Hide keeps it alive; `close`
-  destroys the pane and whatever runs in it (a nested shell, ssh, an agent), hidden or shown.
+- `split [on|off|toggle] [--axis vertical|horizontal]` · `split close` - second shell, left/right by
+  default or top/bottom with `--axis horizontal`. Omitting `--axis` preserves the current axis and the
+  legacy left/right behavior. The GUI actions are ⌘D for vertical and ⌘⇧D for horizontal; either
+  transposes a shown split of the other orientation. Hide keeps it alive; `close` destroys the pane and
+  whatever runs in it.
 - `scratch [on|off|toggle] [--command CMD]` — full-coverage third shell (hide keeps it alive; `exit`
   recreates). `--command` (when showing) runs a program instead of a shell, run-once like `session new
   --command` (respawns the scratch if one is open). Target your own session with
   `--target "$AGTERM_SESSION_ID"` (see Addressing).
-- `focus [left|right|other]` — move focus between split panes.
-- `resize --split-ratio R | --grow-left D | --grow-right D` — move the split divider (the GUI only drags
+- `focus [primary|split|left|right|top|bottom|other]` - move focus between split panes. Role and position
+  aliases select the same two live terminals; readback remains `left`/`right`.
+- `resize --split-ratio R | --grow-left D | --grow-right D | --grow-primary D | --grow-split D | --grow-top D | --grow-bottom D` - move the split divider (the GUI only drags
   it, or double-clicks it for an even split; bind any other fraction via a
   `command "agtermctl session resize …"` custom action). `--split-ratio` sets
-  the absolute left-pane fraction (0..1, clamped to 0.05..0.95); `--grow-left`/`--grow-right` nudge it by
-  a fraction. Prints the applied (clamped) fraction.
+  the absolute primary-pane fraction (left or top; 0..1, clamped to 0.05..0.95). The grow options are
+  aliases for growing the primary or split pane. Prints the applied fraction.
 - `status <idle|active|completed|blocked> [--blink] [--auto-reset] [--sound NAME] [--color #rrggbb] [--shape SHAPE] [--pane left|right|scratch] [--pane-id TOKEN]` — set the sidebar agent glyph (`--sound default` or a system sound name plays a one-shot sound; `--color` tints the glyph for this call only, reverting on the next status set without it; `--shape` (`circle`, `square`, `triangle`, `diamond`, `capsule`, `star`) picks its silhouette for this call only and reverts the same way, read back as the tree `statusShape` field; `--pane` records which pane set it — `left`=main, `right`=split, `scratch` — so foreground typing in another pane won't clear it and any user-initiated GUI selection (auto-follow, attention-nav ⌃⌥↑/↓, plain session nav, the command palettes, a Dock-menu session, a sidebar row click) reveals that pane when the status needs attention (`blocked`/`completed`); `active` preserves the existing pane selection; the pane reads back as the tree `statusPane` field; the socket `session go next-attention` only steps the selection, it does not itself reveal the pane; `--pane-id` is the hook-forwarded stable surface token (`$AGTERM_PANE_ID`) that resolves the pane's live slot and overrides a stale `--pane` after a promote + re-split — scripts set `--pane` directly and leave `--pane-id` to the hook).
 - `flag [on|off|toggle|clear]` — flag a session for the flagged working-set view (`clear` unflags all).
 - `seen [--target] [--window W]` — clear the session's unseen-notification badge WITHOUT changing the
@@ -407,7 +412,7 @@ composes with the font flags. Read the state back from the tree's top-level `das
 (pane refs `<id>:left`/`<id>:right`, in grid order) / `dashboardHighlighted` (a pane ref) /
 `dashboardFontSize`/`dashboardFontMode`. Zoom and the dashboard are mutually exclusive: opening one CLOSES
 the other. Opening/closing resizes each pane's pty to its cell, so programs may redraw — view-only
-means no input, not no process effect. The most-recently-used grid also has a GUI opener: **⌘⇧D** (the
+means no input, not no process effect. The most-recently-used grid also has a GUI opener: **⌘⇧G** (the
 `dashboard` built-in action), **Navigate ▸ Dashboard**, and the command palette's **Dashboard** entry
 TOGGLE the frontmost window's MRU dashboard auto-sized (identical to `dashboard --mru --auto-size`); no new
 control command, the socket `dashboard` command is unchanged.

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -265,6 +265,9 @@ omitted when expanded).
   workspace, so this relocates + positions in one shot, even cross-workspace). For workspace and
   after/before placement, repeat `--target` to move several sessions as one ordered block. Do not repeat
   `--target` with `--to up|down|top|bottom`.
+- Shared pane selectors accept `primary`/`left`/`top` for the primary pane and
+  `split`/`right`/`bottom` for the split pane. Commands supporting scratch also accept `scratch`.
+  Syntax and read-back use canonical `left`/`right`/`scratch`; the invalid-value error keeps those names.
 - `type <text> [--stdin] [--select] [--pane left|right|scratch]` — inject keystrokes (real typing, Enter
   included) into the main pane, the split pane with `--pane right`, or the scratch terminal (even hidden)
   with `--pane scratch`. Pass `--target "$AGTERM_SESSION_ID"` to type into YOUR session, not the user's

--- a/plugins/agterm/skills/agterm/examples.md
+++ b/plugins/agterm/skills/agterm/examples.md
@@ -140,8 +140,8 @@ the pane you duplicated from.
 ws=$(agtermctl workspace new "build" --json | jq -r '.result.id')
 a=$(agtermctl session new --workspace "$ws" --cwd "$HOME/proj" --json | jq -r '.result.id')
 agtermctl session rename "server" --target "$a"
-agtermctl session split on --target "$a"          # second shell side by side
-agtermctl session resize --split-ratio 0.7 --target "$a"   # left pane gets 70% (prints 0.700)
+agtermctl session split on --axis horizontal --target "$a" # second shell below the primary
+agtermctl session resize --split-ratio 0.7 --target "$a"   # top pane gets 70% (prints 0.700)
 b=$(agtermctl session new --workspace "$ws" --json | jq -r '.result.id')
 agtermctl session rename "logs" --target "$b"
 ```
@@ -669,7 +669,7 @@ suffix, capped at 9 cells total. No cell takes input:
 the keyboard navigates a highlight (arrows), Enter jumps into the highlighted session AND focuses that
 exact pane then closes, Esc closes. Open it over the socket with explicit session ids, or with `--mru` to
 pull the window's most-recently-used sessions automatically. The most-recently-used grid also has a built-in
-opener — **⌘⇧D** (the `dashboard` action), **Navigate ▸ Dashboard**, or the command palette's **Dashboard**
+opener: **⌘⇧G** (the `dashboard` action), **Navigate ▸ Dashboard**, or the command palette's **Dashboard**
 toggle it auto-sized (the `dashboard --mru --auto-size` equivalent), so the recent-sessions view needs no
 script for the common case.
 
@@ -707,7 +707,7 @@ agtermctl tree --json | jq '.result.tree | {dashboardMembers, dashboardHighlight
 agtermctl dashboard --close
 ```
 
-The MRU grid is already on **⌘⇧D** (the built-in `dashboard` action) — rebind that chord in `keymap.conf`
+The MRU grid is already on **⌘⇧G** (the built-in `dashboard` action). Rebind that chord in `keymap.conf`
 with `map <chord> dashboard`. To dashboard a FIXED set of explicit ids instead, bind a `keymap.conf` custom
 action (then `agtermctl keymap reload`):
 

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -371,6 +371,12 @@ All twelve are read-only projections of GUI state.
   move as one ordered block after all sources are removed. Repeated `--target` is rejected with
   `--to up|down|top|bottom` because relative reorder is per-session. Batch moves return `result.affected`,
   counting only sessions whose position/workspace changed.
+
+Shared pane selectors accept `primary`/`left`/`top` for the primary pane and
+`split`/`right`/`bottom` for the split pane. Commands supporting scratch also accept `scratch`.
+The signatures and read-back below use canonical `left`/`right`/`scratch`; the stable invalid-value
+error keeps those names for compatibility.
+
 - `session type <text> [--stdin] [--select] [--pane left|right|scratch] [--target] [--window W]` — inject text
   as real keystrokes (printable runs plus Return for each newline; no bracketed-paste markers).
   `--stdin` reads the text from stdin instead of the argument. Any session is typable without `--select`,
@@ -466,7 +472,7 @@ All twelve are read-only projections of GUI state.
   `statusColor`), and rides the `status` control event's `shape` payload field so an `events` consumer can
   explain a shape-only change.
   A `--shape` on `idle` is accepted and ignored, since an idle session draws no glyph.
-  `--pane` (`left`|`right`|`scratch`, `left`=main, `right`=split; defaults to `left` when omitted) records
+  `--pane` (canonical `left`|`right`|`scratch`; role and position aliases above are also accepted) records
   which pane set the status. It has two effects: (1) keystroke-clear becomes pane-scoped — a status set
   from a background pane survives typing in a DIFFERENT pane (so a `right`- or `scratch`-tagged block is
   no longer wiped by foreground typing in the main pane, and only a keystroke in the OWNING pane clears
@@ -479,7 +485,7 @@ All twelve are read-only projections of GUI state.
   only STEPS the selection to attention sessions; it does not itself move focus into the tagged pane — the
   reveal is a GUI/auto-follow concern.) An agent that runs in a split or scratch should set its own pane so
   the user lands on it. The value is read back on `tree` as the session node's `statusPane`. An invalid
-  value errors (`--pane must be left, right, or scratch`).
+  value errors with the stable canonical-name message (`--pane must be left, right, or scratch`).
   `--pane-id` is the surface's stable spawn token (the shell's `$AGTERM_PANE_ID`) — the agent-status hook
   forwards it automatically. When it resolves against the session's LIVE surfaces it OVERRIDES `--pane`, so
   a status from a pane whose baked role went stale (a split survivor promoted into the main pane, then a
@@ -1158,6 +1164,8 @@ restore; a `session restore --pane right` on a session with no split also return
 `invalid shape: <value> (circle|square|triangle|diamond|capsule|star)` (session status --shape over the
 raw socket; the `agtermctl` CLI rejects the same value locally with
 `shape must be one of: circle, square, triangle, diamond, capsule, star`),
-`--pane must be left, right, or scratch` (the `--pane` value check — the `agtermctl` CLI rejects a bad pane
-with this for session status/type/text, and over the raw socket `session.status` returns this same string;
+`--pane must be left, right, or scratch` (the `--pane` value check; the message intentionally lists the
+canonical read-back names while the role and position aliases documented above are accepted. The
+`agtermctl` CLI rejects a bad pane with this for session status/type/text, and over the raw socket
+`session.status` returns this same string;
 `session.type`/`session.text` over the raw socket instead return `invalid pane: <value>`). Unknown commands fail to decode and return a structured error, never a crash.

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -120,7 +120,7 @@ default 0.5) — the read side
 of `session resize`, record it to restore the exact divider position),
 `splitFocused` (which pane holds focus in a session that HAS a split: `true` = the split/right/bottom pane,
 `false` = the primary/left/top pane; omitted when there's no split; the read side of `session focus`, record it
-to restore focus via `session focus --pane left|right`),
+to restore focus via `session focus left|right`),
 `commandWait` (whether a `--command` session was created with `--wait` to hold open after the command
 exits — the read side of `session new --wait`; omitted for a plain or non-holding session),
 `overlay` (overlay shown),

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -113,12 +113,13 @@ session unattended; `agtermctl tree` also tags the row `(not realized)`),
 `hasSplit` (whether a second pane exists at all, shown or hidden with ⌘D; omitted when there is none —
 read THIS to decide whether a session has a split, because a hidden split reports `split: false` while
 its pane stays alive, and it is present exactly when `splitRatio`/`splitFocused` can be),
-`splitRatio` (the left-pane fraction 0.05–0.95 of a session that HAS a split —
+`splitAxis` (`vertical` for left/right or `horizontal` for top/bottom; omitted when there is no split),
+`splitRatio` (the primary-pane fraction 0.05-0.95, left or top, of a session that HAS a split,
 shown or hidden; omitted when there's no split or the ratio was never explicitly set (divider at the
 default 0.5) — the read side
 of `session resize`, record it to restore the exact divider position),
-`splitFocused` (which pane holds focus in a session that HAS a split — `true` = the split/right pane,
-`false` = the main/left pane; omitted when there's no split; the read side of `session focus`, record it
+`splitFocused` (which pane holds focus in a session that HAS a split: `true` = the split/right/bottom pane,
+`false` = the primary/left/top pane; omitted when there's no split; the read side of `session focus`, record it
 to restore focus via `session focus --pane left|right`),
 `commandWait` (whether a `--command` session was created with `--wait` to hold open after the command
 exits — the read side of `session new --wait`; omitted for a plain or non-holding session),
@@ -414,9 +415,10 @@ All twelve are read-only projections of GUI state.
   matches) and `result.text` (the counter string: "N of M", "M matches", or "no matches"); the count
   settles asynchronously, so the command waits briefly for it. Without `--json` it prints `result.text`
   (or `ok` on close / an empty bar).
-- `session split [on|off|toggle] [--target] [--window W]` — side-by-side second shell. `off` HIDES it
-  but keeps the shell alive (mirrors ⌘D); tearing the pane down takes `session split close` or the
-  shell's own exit. Unknown mode errors.
+- `session split [on|off|toggle] [--axis vertical|horizontal] [--target] [--window W]` - second shell.
+  `vertical` means left/right and `horizontal` means top/bottom. Omitting `--axis` preserves the current
+  axis and keeps the legacy left/right default for a new split. `off` hides but keeps the shell alive;
+  tearing it down takes `session split close` or the shell's own exit. Unknown modes and axes error.
 - `session split close [--target] [--window W]` — tear the split pane down: the surface dies, whatever it
   runs dies with it, and `hasSplit`/`splitRatio`/`splitFocused` drop out of `tree`. Reaches a HIDDEN pane
   too, which is what `session type --pane right $'exit\n'` cannot do once the pane is past a prompt
@@ -430,15 +432,15 @@ All twelve are read-only projections of GUI state.
   absolute path) and RUN-ONCE like `session new --command` (after it exits, the next `on` is a plain
   shell). A scratch is expendable, so passing `--command` while one is already open respawns it. Not
   persisted. Unknown mode errors. The tree's `scratch` flag tracks visibility.
-- `session focus [left|right|other] [--target] [--window W]` — move keyboard focus between the two
+- `session focus [primary|split|left|right|top|bottom|other] [--target] [--window W]` - move keyboard focus between the two
   split panes (`other` toggles, the default). Errors when the session has no split. Works whether the
-  split is shown side-by-side or hidden (maximized) — when hidden, focusing a pane swaps which one shows.
-- `session resize (--split-ratio R | --grow-left D | --grow-right D) [--target] [--window W]` — move the
+  split is shown in either orientation or hidden (maximized). When hidden, focusing a pane swaps which one shows.
+- `session resize (--split-ratio R | --grow-left D | --grow-right D | --grow-primary D | --grow-split D | --grow-top D | --grow-bottom D) [--target] [--window W]` - move the
   split DIVIDER (the divider is otherwise mouse-only: drag it, or double-click it for an even split. No
   GUI/menu/keymap action reaches any other fraction, so bind a key by mapping a
   `command "agtermctl session resize …"` custom action). Provide exactly one form:
-  `--split-ratio` sets the absolute left-pane fraction (`0..1`); `--grow-left D` / `--grow-right D` nudge
-  it by the fraction `D` (grow-left shrinks the right pane and vice-versa). The result is clamped to
+  `--split-ratio` sets the absolute primary-pane fraction (`0..1`, left or top). The grow options are
+  equivalent role/position aliases: primary/left/top versus split/right/bottom. The result is clamped to
   `0.05..0.95` and persisted, and the applied (clamped) fraction is printed (and returned as `result.ratio`
   under `--json`). Errors when the session has no split. Resizing a hidden split updates the stored
   fraction; it takes effect when the split is next shown.
@@ -769,8 +771,9 @@ positional ids are session addresses (id / unique prefix / `active`), each of wh
 `:left`/`:right` pane suffix to place THAT PANE ALONE — the same form `dashboardMembers` reports back, so
 `dashboard <a>:left <b>:right` grids one pane per session while a bare id still takes every pane of its
 session. The suffix composes with any head, so `active:left` and `<prefix>:right` both work, and it is
-case-insensitive. Only `left`/`right` are accepted: any other suffix (`:scratch`, `:overlay`, `:primary`,
-`:split`, a typo like `:lft`, or a pasted `surface:<id>:left` zoom address) is REJECTED and fails the whole
+case-insensitive. `:primary`/`:top` alias `:left`, and `:split`/`:bottom` alias `:right`; readback remains
+`:left`/`:right`. Other suffixes (`:scratch`, `:overlay`, a typo like `:lft`, or a pasted
+`surface:<id>:left` zoom address) are rejected and fail the whole
 command. Unresolved ids are dropped — including `:right` on a session with no split, which parses fine but
 names no pane — and cells are deduped by session+pane, so a bare id beside a pane ref for the same session
 collapses instead of double-hosting a surface. A grid that expands to no cells at all is an error and
@@ -786,7 +789,7 @@ A cell placed by a `:right` ref FOLLOWS its pane through promotion: when a split
 exits, agterm promotes the survivor into the primary slot, and the grid rewrites that cell to `<id>:left`
 rather than dropping it, so a dashboard built to watch an agent in the split pane keeps watching it.
 
-The most-recently-used grid also has a GUI opener — **⌘⇧D** (the `dashboard` built-in action, rebindable
+The most-recently-used grid also has a GUI opener: **⌘⇧G** (the `dashboard` built-in action, rebindable
 in `keymap.conf`), **Navigate ▸ Dashboard**, and the command palette's **Dashboard** entry all TOGGLE the
 frontmost window's dashboard: open it over the window's most-recently-used sessions auto-sized (identical to
 `dashboard --mru --auto-size`) when closed, close it when open. It is a no-op while terminal zoom is active.
@@ -1039,7 +1042,7 @@ so `{AGT_SESSION_NAME}` and `{AGT_SESSION_PWD}` are as untrusted as `{AGT_SELECT
 
 Built-in action names for `map` include: `new_window`, `new_workspace`, `new_session`,
 `open_directory`, `rename_session`, `duplicate_session`, `close_session`, `reopen_recent`, `undo_close`, `clear_status`, `increase_font_size`,
-`decrease_font_size`, `reset_font_size`, `toggle_split`, `toggle_scratch`, `toggle_sidebar`,
+`decrease_font_size`, `reset_font_size`, `toggle_split`, `toggle_horizontal_split`, `toggle_scratch`, `toggle_sidebar`,
 `focus_workspace`, `toggle_workspace_filter`, `quick_terminal`,
 `session_palette`, `command_palette`, `custom_command_palette`, `dashboard`, and the navigation actions (`previous_session`, `next_session`,
 `first_session`, `last_session`, `previous_attention_session`, `next_attention_session`,

--- a/site/commands.html
+++ b/site/commands.html
@@ -433,7 +433,7 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">cwd</span>,
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">title</span> (raw OSC terminal title, omitted when
                 none), <span style="font-family: &quot;JetBrains Mono&quot;, monospace">active</span>,
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">split</span> (the split is SHOWN side by side),
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">split</span> (both split panes are SHOWN),
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">realized</span> (the session's main pane has a live
                 terminal; <span style="font-family: &quot;JetBrains Mono&quot;, monospace">false</span> means no shell was spawned and
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">session type</span>/<span style="font-family: &quot;JetBrains Mono&quot;, monospace">session text</span>
@@ -443,6 +443,7 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">hasSplit</span> (a second pane exists at all, shown or
                 hidden, omitted when there is none — read this rather than
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">split</span> to tell whether a session has a split),
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">splitAxis</span> (<span style="font-family: &quot;JetBrains Mono&quot;, monospace">vertical</span> for left/right or <span style="font-family: &quot;JetBrains Mono&quot;, monospace">horizontal</span> for top/bottom),
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">splitRatio</span>,
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">splitFocused</span>,
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">overlay</span>,
@@ -1097,15 +1098,16 @@
 
             <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
-                agtermctl session split [on|off|toggle] [--target T] [--window W]
+                agtermctl session split [on|off|toggle] [--axis vertical|horizontal] [--target T] [--window W]
               </div>
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">session.split</div>
               <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
-                A side-by-side second shell in the same session.
+                A second shell in the same session. Vertical gives left/right panes; horizontal gives top/bottom.
+                Omitting <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--axis</span> preserves the current axis and the legacy left/right default.
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">off</span> <em>hides</em> it but keeps the shell alive
                 (mirroring ⌘D); tearing the pane down takes
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">session split close</span> or the shell's own exit.
-                Idempotent; an unknown mode errors.
+                Idempotent; an unknown mode or axis errors.
                 Read back via the session node's <span style="font-family: &quot;JetBrains Mono&quot;, monospace">split</span> (shown) and
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">hasSplit</span> (exists at all); a hidden split reads
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">split: false</span> with the pane still alive, and
@@ -1155,13 +1157,13 @@
 
             <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
-                agtermctl session focus [left|right|other] [--target T] [--window W]
+                agtermctl session focus [primary|split|left|right|top|bottom|other] [--target T] [--window W]
               </div>
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">session.focus</div>
               <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
                 Move keyboard focus between the two split panes;
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">other</span> toggles and is the default. Errors when
-                the session has no split. It works whether the split is shown side-by-side or hidden — when hidden, focusing a pane
+                the session has no split. It works whether the split is shown in either orientation or hidden. When hidden, focusing a pane
                 swaps which one shows maximized. Read back via the session node's
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">splitFocused</span>.
               </p>
@@ -1169,14 +1171,13 @@
 
             <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
-                agtermctl session resize (--split-ratio R | --grow-left D | --grow-right D) [--target T] [--window W]
+                agtermctl session resize (--split-ratio R | --grow-primary D | --grow-split D | --grow-left D | --grow-right D | --grow-top D | --grow-bottom D) [--target T] [--window W]
               </div>
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">session.resize</div>
               <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
                 Move the split divider. Provide exactly one form:
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--split-ratio</span> sets the absolute left-pane
-                fraction (0–1); <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">--grow-left D</span> /
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">--grow-right D</span> nudge it by the fraction D. The
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--split-ratio</span> sets the absolute primary-pane
+                fraction (left or top, 0-1); the grow options are role and position aliases that nudge it by the fraction D. The
                 result is clamped to 0.05–0.95 and persisted.
                 <strong style="color: #bfbab0">Returns</strong> the applied fraction as
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">result.ratio</span>. Errors when the session has no
@@ -1943,7 +1944,7 @@
                 pane's own font untouched.
               </p>
               <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
-                The GUI openers — ⌘⇧D, Navigate ▸ Dashboard, and the command palette's Dashboard entry — toggle the frontmost
+                The GUI openers, ⌘⇧G, Navigate ▸ Dashboard, and the command palette's Dashboard entry, toggle the frontmost
                 window's most-recently-used grid auto-sized (the
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">dashboard --mru --auto-size</span> equivalent; no separate
                 control command). Read back from the tree's top-level

--- a/site/docs.html
+++ b/site/docs.html
@@ -811,7 +811,7 @@
                   <code style="color: #e6e1d7">tree --json</code> reports in <code style="color: #e6e1d7">dashboardMembers</code> — so
                   <code style="color: #e6e1d7">agtermctl dashboard "$a:left" "$b:right"</code> keeps the panes you did not ask for
                   out of the nine-cell budget. The most-recently-used grid also has a built-in opener —
-                  <strong>⌘⇧D</strong> (or <strong>Navigate ▸ Dashboard</strong>, the command palette's Dashboard, or the
+                  <strong>⌘⇧G</strong> (or <strong>Navigate ▸ Dashboard</strong>, the command palette's Dashboard, or the
                   title-bar grid button) opens it auto-sized. Cell fonts size absolutely
                   (<code style="color: #e6e1d7">--font-size</code>) or scale to the grid
                   (<code style="color: #e6e1d7">--auto-size</code>). Mutually exclusive with terminal zoom.
@@ -1483,9 +1483,9 @@
                 color: #e6e1d7;
               "
             >
-              agtermctl session split toggle<br />agtermctl session split close
-              <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;# tear the pane down; hide keeps its shell alive</span><br />agtermctl session resize --split-ratio 0.7
-              <span style="color: #6b727a">&nbsp;# or --grow-left/--grow-right D</span><br />agtermctl session scratch toggle
+              agtermctl session split toggle --axis horizontal<br />agtermctl session split close
+              <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;# vertical=left/right; horizontal=top/bottom</span><br />agtermctl session resize --split-ratio 0.7
+              <span style="color: #6b727a">&nbsp;# primary fraction; grow role/position aliases also work</span><br />agtermctl session scratch toggle
               <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;&nbsp;# on|off|toggle</span><br />agtermctl session flag on
               <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;# on|off|toggle|clear</span><br />agtermctl session seen --target 9f3c
               <span style="color: #6b727a">&nbsp;# clear the unseen badge, focus-free</span><br />agtermctl

--- a/site/docs.html
+++ b/site/docs.html
@@ -703,14 +703,15 @@
                 <div
                   style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 14px; color: #6d82f3; margin-bottom: 8px"
                 >
-                  Split panes <span style="color: #6b727a">⌘D</span>
+                  Split panes <span style="color: #6b727a">⌘D / ⌘⇧D</span>
                 </div>
                 <p style="font-size: 15px; line-height: 1.6; color: #949ba4; margin: 0">
-                  A session can split into two shells side by side. Both panes share one sidebar row — a split is one session with
-                  two terminals, not two sessions. One pane is focused at a time and the divider position is remembered —
-                  drag the divider to resize the panes, double-click it to snap back to an even split. ⌘D hides a split rather
-                  than closing it, keeping the second shell alive; <strong style="color: #bfbab0">Close Split</strong> in the
-                  action palette tears the pane down whatever it is running.
+                  A session can split into two shells side by side with ⌘D or top and bottom with ⌘⇧D. Both panes share one
+                  sidebar row: a split is one session with two terminals, not two sessions. Using the other shortcut transposes
+                  a shown split; using its current shortcut hides it without closing the second shell. The divider follows the
+                  current axis and remembers its position; drag it to resize the panes or double-click it to return to an even
+                  split. <strong style="color: #bfbab0">Close Split</strong> in the action palette tears the pane down whatever
+                  it is running.
                 </p>
               </div>
               <div
@@ -1949,7 +1950,7 @@
                 color: #cbc6bc;
               "
             >
-              new_window&nbsp;&nbsp;&nbsp;rename_window&nbsp;&nbsp;&nbsp;delete_window<br />new_workspace&nbsp;&nbsp;&nbsp;rename_workspace&nbsp;&nbsp;&nbsp;delete_workspace<br />new_session&nbsp;&nbsp;&nbsp;open_directory&nbsp;&nbsp;&nbsp;rename_session&nbsp;&nbsp;&nbsp;duplicate_session<br />close_session&nbsp;&nbsp;&nbsp;reopen_recent&nbsp;&nbsp;&nbsp;undo_close&nbsp;&nbsp;&nbsp;clear_status<br />increase_font_size&nbsp;&nbsp;&nbsp;decrease_font_size&nbsp;&nbsp;&nbsp;reset_font_size<br />toggle_split&nbsp;&nbsp;&nbsp;toggle_scratch&nbsp;&nbsp;&nbsp;toggle_search<br />toggle_sidebar&nbsp;&nbsp;&nbsp;toggle_flag&nbsp;&nbsp;&nbsp;toggle_flagged_view<br />focus_left_pane&nbsp;&nbsp;&nbsp;focus_right_pane&nbsp;&nbsp;&nbsp;focus_workspace&nbsp;&nbsp;&nbsp;toggle_workspace_filter<br />previous_session&nbsp;&nbsp;&nbsp;next_session&nbsp;&nbsp;&nbsp;first_session&nbsp;&nbsp;&nbsp;last_session<br />previous_attention_session&nbsp;&nbsp;&nbsp;next_attention_session<br />quick_terminal&nbsp;&nbsp;&nbsp;session_palette&nbsp;&nbsp;&nbsp;command_palette<br />custom_command_palette&nbsp;&nbsp;&nbsp;show_attention<br />select_theme&nbsp;&nbsp;&nbsp;toggle_fullscreen&nbsp;&nbsp;&nbsp;toggle_terminal_zoom<br />dashboard
+              new_window&nbsp;&nbsp;&nbsp;rename_window&nbsp;&nbsp;&nbsp;delete_window<br />new_workspace&nbsp;&nbsp;&nbsp;rename_workspace&nbsp;&nbsp;&nbsp;delete_workspace<br />new_session&nbsp;&nbsp;&nbsp;open_directory&nbsp;&nbsp;&nbsp;rename_session&nbsp;&nbsp;&nbsp;duplicate_session<br />close_session&nbsp;&nbsp;&nbsp;reopen_recent&nbsp;&nbsp;&nbsp;undo_close&nbsp;&nbsp;&nbsp;clear_status<br />increase_font_size&nbsp;&nbsp;&nbsp;decrease_font_size&nbsp;&nbsp;&nbsp;reset_font_size<br />toggle_split&nbsp;&nbsp;&nbsp;toggle_horizontal_split&nbsp;&nbsp;&nbsp;toggle_scratch&nbsp;&nbsp;&nbsp;toggle_search<br />toggle_sidebar&nbsp;&nbsp;&nbsp;toggle_flag&nbsp;&nbsp;&nbsp;toggle_flagged_view<br />focus_left_pane&nbsp;&nbsp;&nbsp;focus_right_pane&nbsp;&nbsp;&nbsp;focus_workspace&nbsp;&nbsp;&nbsp;toggle_workspace_filter<br />previous_session&nbsp;&nbsp;&nbsp;next_session&nbsp;&nbsp;&nbsp;first_session&nbsp;&nbsp;&nbsp;last_session<br />previous_attention_session&nbsp;&nbsp;&nbsp;next_attention_session<br />quick_terminal&nbsp;&nbsp;&nbsp;session_palette&nbsp;&nbsp;&nbsp;command_palette<br />custom_command_palette&nbsp;&nbsp;&nbsp;show_attention<br />select_theme&nbsp;&nbsp;&nbsp;toggle_fullscreen&nbsp;&nbsp;&nbsp;toggle_terminal_zoom<br />dashboard
             </div>
             <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">toggle_fullscreen</span> is the one

--- a/site/index.html
+++ b/site/index.html
@@ -620,8 +620,8 @@
               </h3>
             </div>
             <p style="font-size: 14.5px; line-height: 1.6; color: #949ba4; margin: 0">
-              Two shells side by side in one session — run the agent left, watch logs right. The inactive pane dims toward the
-              background so the focused one is always obvious.
+              Two shells side by side or top and bottom in one session. Run the agent in one pane and watch logs in the other;
+              the inactive pane dims toward the background so the focused one is always obvious.
             </p>
           </div>
 
@@ -1094,7 +1094,7 @@
                   Splits, search &amp; scratch
                 </div>
                 <p style="font-size: 13.5px; line-height: 1.55; color: #949ba4; margin: 0">
-                  Two shells side by side, in-terminal find, and a scratch overlay on any session.
+                  Two shells side by side or top and bottom, in-terminal find, and a scratch overlay on any session.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
adds top/bottom splits and lets a live split switch orientation without recreating either terminal.

- adds distinct icons and matching menu/palette actions for both orientations
- binds `⌘⇧D` to top/bottom and keeps `⌘D` for left/right; each action creates, reveals, hides, or transposes as needed
- moves Dashboard to `⌘⇧G`
- adds optional `vertical`/`horizontal` axis input to the control API and `agtermctl`
- accepts `top`/`bottom` pane aliases while preserving existing left/right behavior and readback
- persists the axis in snapshots while keeping older snapshots valid

related to [Discussion #268](https://github.com/umputun/agterm/discussions/268).
