### PR TITLE
docs(cookbook): add container-agent-status recipe

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -39,7 +39,7 @@ its *needs* column, so searching this page for `claude` or `kiro` finds those di
 | [claude-clear](claude-clear/) | one chord sends /clear to the pane's Claude Code run, and nothing when it is not running | 0.13.0, python3, Claude Code |
 | [claude-conversation-picker](claude-conversation-picker/) | pick a past Claude Code conversation by what it was about and resume it in the pane | 0.21.0, python3, Claude Code |
 | [claude-recap](claude-recap/) | one key lists what the Claude Code run in a session was working on | 0.10.0, zsh, jq, Claude Code |
-| [container-agent-status](container-agent-status/) | a containerized agent reports status onto its sidebar row via a TCP notification to the host | 0.7.1, nc, Claude Code |
+| [container-agent-status](container-agent-status/) | a containerized agent reports status onto its sidebar row via a TCP notification to the host | 0.7.1, nc, timeout, Claude Code |
 | [kimi-agent-status](kimi-agent-status/) | Kimi Code sessions report agent status onto their sidebar row | 0.3.1, Kimi Code |
 | [kiro-agent-status](kiro-agent-status/) | Kiro CLI sessions report active, blocked, and completed onto their sidebar row | 0.7.1, Kiro CLI |
 | [status-announcer](status-announcer/) | demo: speak agent status changes from a dedicated session | 0.16.0, jq |

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -39,6 +39,7 @@ its *needs* column, so searching this page for `claude` or `kiro` finds those di
 | [claude-clear](claude-clear/) | one chord sends /clear to the pane's Claude Code run, and nothing when it is not running | 0.13.0, python3, Claude Code |
 | [claude-conversation-picker](claude-conversation-picker/) | pick a past Claude Code conversation by what it was about and resume it in the pane | 0.21.0, python3, Claude Code |
 | [claude-recap](claude-recap/) | one key lists what the Claude Code run in a session was working on | 0.10.0, zsh, jq, Claude Code |
+| [container-agent-status](container-agent-status/) | a containerized agent reports status onto its sidebar row via a TCP notification to the host | 0.7.1, nc, Claude Code |
 | [kimi-agent-status](kimi-agent-status/) | Kimi Code sessions report agent status onto their sidebar row | 0.3.1, Kimi Code |
 | [kiro-agent-status](kiro-agent-status/) | Kiro CLI sessions report active, blocked, and completed onto their sidebar row | 0.7.1, Kiro CLI |
 | [status-announcer](status-announcer/) | demo: speak agent status changes from a dedicated session | 0.16.0, jq |

--- a/cookbook/container-agent-status/README.md
+++ b/cookbook/container-agent-status/README.md
@@ -1,0 +1,105 @@
+# Container agent status
+
+Report a Claude Code (or any hook-driven agent) session's status onto its sidebar row when that agent runs inside a container instead of on the host.
+
+## What it does
+
+The installer's `Help ▸ Install Agent Status Hooks…` wires an agent's lifecycle hooks straight to `agtermctl` over the local control socket, which only works when the agent and agterm share an OS — the socket does not exist inside a Linux container. This recipe replaces that one hop with two: a small script inside the container turns each hook event into a JSON line and sends it over TCP to the host, and a listener on the host turns each line back into the same `agtermctl session status` call the installer's hooks would have made directly. The row pulses active while the agent works, goes blocked on a real permission prompt, and flashes completed at the end of a turn — the same behavior as a native session, one network hop removed.
+
+## Requirements
+
+- agterm 0.7.1 or later — `AGTERM_PANE` starts being injected into the session environment in that release (#130), which this recipe forwards so the row updates on the pane the container's shell actually runs in.
+- `nc` (netcat) on both the host and inside the container.
+- A container runtime that can pass environment variables through to the container (Docker, Podman, Apple's `container`, etc.) and reach the host over TCP — a bridge network or `host.containers.internal`-style hostname is enough; no port needs to be published to the outside world.
+- Claude Code (tested) or another agent with the same four hook events used by `Help ▸ Install Agent Status Hooks…` — see that installer's hooks for the exact event/state pairing this recipe mirrors.
+
+Tested end to end on macOS with Apple's own `container` CLI (`container machine run`, not Docker) running a Linux Claude Code container — see the Apple `container` note under Setup for what that runtime gets you for free.
+
+## Setup
+
+Variables used below: `HOST_IP` is the host's address as seen from inside the container, and `PORT` is the TCP port the two scripts agree on (9998 in the examples).
+
+### On the host
+
+```sh
+mkdir -p ~/bin
+cp agterm-remote-receiver.sh ~/bin/
+chmod +x ~/bin/agterm-remote-receiver.sh
+
+~/bin/agterm-remote-receiver.sh --port PORT --log-file ~/Library/Logs/agterm-remote.log &
+```
+
+`--socket` defaults to `$HOME/Library/Application Support/agterm/agterm.sock`; pass it explicitly if agterm's socket lives somewhere else. This process has to be running whenever you want statuses to show — it is a plain background job here, not a launchd service, so it does not survive a reboot or logout on its own; wrap it in a LaunchAgent if you want that.
+
+### Passing identity into the container
+
+Whatever starts the container needs to forward the session's own `AGTERM_*` variables plus where to send status. `AGTERM_SESSION_ID`, `AGTERM_WINDOW_ID`, `AGTERM_WORKSPACE_ID`, and `AGTERM_PANE` are already exported by agterm into any shell it spawns on the host — a session that opens a Claude Code pane runs that shell with these already set, so a wrapper function only has to pass them through; only `AGTERM_REMOTE_HOST` is new, and it is what tells the container script to use this recipe's TCP path instead of a control socket it does not have.
+
+For example, a `claude` shell function that launches an Apple `container machine` container running Claude Code, with the current session's identity forwarded in (replace `CONTAINER_CLAUDE_BIN_DIR` with wherever the container image installs the `claude` binary, and `HOST_IP:PORT` with the receiver's address):
+
+```sh
+claude() {
+  container machine run -it \
+    -e PATH="CONTAINER_CLAUDE_BIN_DIR:$PATH" \
+    -e AGTERM_SESSION_ID="${AGTERM_SESSION_ID:-}" \
+    -e AGTERM_WINDOW_ID="${AGTERM_WINDOW_ID:-}" \
+    -e AGTERM_WORKSPACE_ID="${AGTERM_WORKSPACE_ID:-}" \
+    -e AGTERM_PANE="${AGTERM_PANE:-}" \
+    -e AGTERM_REMOTE_HOST="${AGTERM_REMOTE_HOST:-HOST_IP:PORT}" \
+    claude
+}
+```
+
+Set `AGTERM_REMOTE_HOST` once in the shell that runs this function (e.g. in `~/.zshrc`, above the function) rather than hardcoding it here, so the same function keeps working if the receiver's port ever changes. The same `-e NAME="${NAME:-}"` shape works for any container runtime with an env-passthrough flag (Docker's and Podman's `-e NAME=$NAME` do the same thing).
+
+#### A note on Apple's `container` runtime
+
+This was built and tested against Apple's own `container` CLI, not Docker — and two things about how it handles networking are what make this recipe simpler than it would be otherwise. First, a container started with `container machine run` already has outbound access to every port on the host by default; nothing has to be published or bridged for the container's `nc` to reach the receiver listening on the host. Second, the reverse direction — the host seeing the container as if it were another local process — needs no container recreation or restart: if the container itself ever opens a listening port, the host can already reach it without any `-p`/`--publish` step or container rebuild. Neither of these is guaranteed on other runtimes; Docker and Podman need an explicit network mode or `--add-host`/`host.docker.internal` for the container→host leg this recipe relies on.
+
+### Inside the container
+
+```sh
+mkdir -p ~/.config/agterm/agent-status
+cp container-status-notify.sh ~/.config/agterm/agent-status/
+chmod +x ~/.config/agterm/agent-status/container-status-notify.sh
+```
+
+Merge these four hooks into `~/.claude/settings.json` inside the container (the same event/state pairing the installer uses natively, pointed at this recipe's script instead):
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      { "hooks": [{ "type": "command", "command": "~/.config/agterm/agent-status/container-status-notify.sh active --blink" }] }
+    ],
+    "PostToolUse": [
+      { "hooks": [{ "type": "command", "command": "~/.config/agterm/agent-status/container-status-notify.sh active --blink" }] }
+    ],
+    "Stop": [
+      { "hooks": [{ "type": "command", "command": "~/.config/agterm/agent-status/container-status-notify.sh completed --auto-reset" }] }
+    ],
+    "Notification": [
+      { "matcher": "permission_prompt", "hooks": [{ "type": "command", "command": "~/.config/agterm/agent-status/container-status-notify.sh blocked" }] }
+    ]
+  }
+}
+```
+
+## Usage
+
+Start Claude Code inside the container as usual. The row goes active (pulsing) on your prompt, re-asserts active on every tool call — which is what returns it from blocked to active after you answer a permission prompt, since Claude Code has no "permission answered" event of its own — goes blocked while a permission dialog is up, and flashes completed with `--auto-reset` at the end of a turn, clearing when you visit the session.
+
+## How it works
+
+`container-status-notify.sh` builds the same flat JSON shape a native install's control-socket call would carry (`cmd`, `state`, `session_id`, optionally `pane`, plus any extra flags as an `args` array) and writes it as one line to `nc "$remote_host" "$remote_port"` with a two-second timeout, then always exits 0 — a hook that blocks the agent's turn on a network hiccup is worse than a missed status update. `agterm-remote-receiver.sh` on the host runs `nc -l` in a loop (one TCP connection per event; the loop is there because each event closes its connection), greps the four fields it needs out of the JSON without a `jq` dependency, and calls `agtermctl session status <state> --target <session_id> [--pane <pane>] --socket <path>` — precisely the call the installer's own hooks make, just issued from the host instead of from inside the container.
+
+The gotcha: the two scripts' JSON shape has to agree exactly, because the receiver's parser only recognizes `"cmd":"session-status"` and silently drops anything else — a mismatched or nested payload (e.g. wrapping the state in a nested `args` object) produces no error, no status, and no clue why, since the container side reports success as soon as `nc` delivers the bytes.
+
+## Limits
+
+Nothing destructive: this only posts status for the container's own session, the same as a native install.
+
+- `agterm-remote-receiver.sh` trusts anything that reaches its port — any process able to open a TCP connection to the host can post an arbitrary status for any `session_id`. Fine on a private bridge network between a host and its own container; do not expose the port beyond that.
+- The receiver is a foreground loop started by hand in the example above; if it dies (host sleep, terminal closed, crash) statuses silently stop arriving and the sidebar row freezes at its last state until you notice and restart it.
+- `nc -l` handles one connection at a time; two events that land in the same instant can race, and the loop briefly drops connections while it restarts between them. In practice this only shows up as a very rare missed event, never a wrong one — the JSON stays a single complete line per connection.
+- Like the kimi recipe's `PermissionRequest`, this depends on the agent's own hook firing exactly when — and only when — a real approval prompt is on screen; an agent whose hook set does not distinguish that from ordinary tool use will not track blocked accurately.

--- a/cookbook/container-agent-status/README.md
+++ b/cookbook/container-agent-status/README.md
@@ -9,7 +9,7 @@ The installer's `Help ▸ Install Agent Status Hooks…` wires an agent's lifecy
 ## Requirements
 
 - agterm 0.7.1 or later — `AGTERM_PANE` starts being injected into the session environment in that release (#130), which this recipe forwards so the row updates on the pane the container's shell actually runs in.
-- `nc` (netcat) on both the host and inside the container.
+- `nc` (netcat) on the host and inside the container, plus `timeout` inside the container.
 - A container runtime that can pass environment variables through to the container (Docker, Podman, Apple's `container`, etc.) and reach the host over TCP — a bridge network or `host.containers.internal`-style hostname is enough; no port needs to be published to the outside world.
 - Claude Code (tested) or another agent with the same four hook events used by `Help ▸ Install Agent Status Hooks…` — see that installer's hooks for the exact event/state pairing this recipe mirrors.
 
@@ -33,7 +33,7 @@ chmod +x ~/bin/agterm-remote-receiver.sh
 
 ### Passing identity into the container
 
-Whatever starts the container needs to forward the session's own `AGTERM_*` variables plus where to send status. `AGTERM_SESSION_ID`, `AGTERM_WINDOW_ID`, `AGTERM_WORKSPACE_ID`, and `AGTERM_PANE` are already exported by agterm into any shell it spawns on the host — a session that opens a Claude Code pane runs that shell with these already set, so a wrapper function only has to pass them through; only `AGTERM_REMOTE_HOST` is new, and it is what tells the container script to use this recipe's TCP path instead of a control socket it does not have.
+Whatever starts the container needs to forward the session's own `AGTERM_*` variables plus where to send status. `AGTERM_SESSION_ID`, `AGTERM_WINDOW_ID`, `AGTERM_WORKSPACE_ID`, `AGTERM_PANE`, and `AGTERM_PANE_ID` are already exported by agterm into any shell it spawns on the host — a session that opens a Claude Code pane runs that shell with these already set, so a wrapper function only has to pass them through; `AGTERM_PANE_ID` only on releases newer than the floor above, where forwarding an unset variable costs nothing; only `AGTERM_REMOTE_HOST` is new, and it is what tells the container script to use this recipe's TCP path instead of a control socket it does not have.
 
 For example, a `claude` shell function that launches an Apple `container machine` container running Claude Code, with the current session's identity forwarded in (replace `CONTAINER_CLAUDE_BIN_DIR` with wherever the container image installs the `claude` binary, and `HOST_IP:PORT` with the receiver's address):
 
@@ -45,6 +45,7 @@ claude() {
     -e AGTERM_WINDOW_ID="${AGTERM_WINDOW_ID:-}" \
     -e AGTERM_WORKSPACE_ID="${AGTERM_WORKSPACE_ID:-}" \
     -e AGTERM_PANE="${AGTERM_PANE:-}" \
+    -e AGTERM_PANE_ID="${AGTERM_PANE_ID:-}" \
     -e AGTERM_REMOTE_HOST="${AGTERM_REMOTE_HOST:-HOST_IP:PORT}" \
     claude
 }
@@ -91,7 +92,7 @@ Start Claude Code inside the container as usual. The row goes active (pulsing) o
 
 ## How it works
 
-`container-status-notify.sh` builds the same flat JSON shape a native install's control-socket call would carry (`cmd`, `state`, `session_id`, optionally `pane`, plus any extra flags as an `args` array) and writes it as one line to `nc "$remote_host" "$remote_port"` with a two-second timeout, then always exits 0 — a hook that blocks the agent's turn on a network hiccup is worse than a missed status update. `agterm-remote-receiver.sh` on the host runs `nc -l` in a loop (one TCP connection per event; the loop is there because each event closes its connection), greps the four fields it needs out of the JSON without a `jq` dependency, and calls `agtermctl session status <state> --target <session_id> [--pane <pane>] --socket <path>` — precisely the call the installer's own hooks make, just issued from the host instead of from inside the container.
+`container-status-notify.sh` builds the same flat JSON shape a native install's control-socket call would carry (`cmd`, `state`, `session_id`, optionally `pane`, plus any extra flags as an `args` array) and writes it as one line to `nc "$remote_host" "$remote_port"` with a two-second timeout, then always exits 0 — a hook that blocks the agent's turn on a network hiccup is worse than a missed status update. `agterm-remote-receiver.sh` on the host runs a single `nc -k -l` (one TCP connection per event, with `-k` keeping the port bound between them so nothing is lost while a connection turns over), greps the fields it needs out of the JSON without a `jq` dependency, and calls `agtermctl session status <state> --target <session_id> [--pane <pane>] [--pane-id <pane_id>] [--blink] [--auto-reset] --socket <path>` — precisely the call the installer's own hooks make, just issued from the host instead of from inside the container. The two flags come from the sender's `args` array but are allowlisted, not forwarded, so a line off the socket cannot choose `agtermctl`'s arguments.
 
 The gotcha: the two scripts' JSON shape has to agree exactly, because the receiver's parser only recognizes `"cmd":"session-status"` and silently drops anything else — a mismatched or nested payload (e.g. wrapping the state in a nested `args` object) produces no error, no status, and no clue why, since the container side reports success as soon as `nc` delivers the bytes.
 
@@ -99,7 +100,7 @@ The gotcha: the two scripts' JSON shape has to agree exactly, because the receiv
 
 Nothing destructive: this only posts status for the container's own session, the same as a native install.
 
-- `agterm-remote-receiver.sh` trusts anything that reaches its port — any process able to open a TCP connection to the host can post an arbitrary status for any `session_id`. Fine on a private bridge network between a host and its own container; do not expose the port beyond that.
+- `agterm-remote-receiver.sh` trusts anything that reaches its port — any process able to open a TCP connection to the host can post an arbitrary status for any `session_id`. Fine on a private bridge network between a host and its own container; do not expose the port beyond that. Note that `nc -l` binds every interface by default, so on a shared or untrusted network the port is only as closed as your firewall makes it: pass `--bind 127.0.0.1` (or whichever address the container reaches the host on) to narrow it.
 - The receiver is a foreground loop started by hand in the example above; if it dies (host sleep, terminal closed, crash) statuses silently stop arriving and the sidebar row freezes at its last state until you notice and restart it.
-- `nc -l` handles one connection at a time; two events that land in the same instant can race, and the loop briefly drops connections while it restarts between them. In practice this only shows up as a very rare missed event, never a wrong one — the JSON stays a single complete line per connection.
+- `nc -k -l` handles one connection at a time; two events landing in the same instant serialize, and a sender whose two-second `timeout` expires while it waits gives up silently. The JSON stays a single complete line per connection, so a lost event leaves the row on its previous state rather than a wrong one — but a lost `completed` or `blocked` does leave it asserting something no longer true until the next event.
 - Like the kimi recipe's `PermissionRequest`, this depends on the agent's own hook firing exactly when — and only when — a real approval prompt is on screen; an agent whose hook set does not distinguish that from ordinary tool use will not track blocked accurately.

--- a/cookbook/container-agent-status/agterm-remote-receiver.sh
+++ b/cookbook/container-agent-status/agterm-remote-receiver.sh
@@ -7,14 +7,16 @@ set -u
 AGTERMCTL=${AGTERMCTL:-agtermctl}
 
 PORT=9998
+BIND=""
 LOG_FILE=""
 VERBOSE=false
 TARGET_SOCKET="$HOME/Library/Application Support/agterm/agterm.sock"
 
 usage() {
-  echo "Usage: $0 [--port PORT] [--log-file FILE] [--socket PATH] [--verbose]"
+  echo "Usage: $0 [--port PORT] [--bind ADDR] [--log-file FILE] [--socket PATH] [--verbose]"
   echo ""
   echo "  --port PORT       TCP port to listen on (default 9998)"
+  echo "  --bind ADDR       Address to bind (default: every interface)"
   echo "  --log-file FILE   Append logs here instead of stdout"
   echo "  --socket PATH     agterm control socket to forward status to"
   echo "                    (default: \$HOME/Library/Application Support/agterm/agterm.sock)"
@@ -25,6 +27,10 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --port)
       PORT=$2
+      shift 2
+      ;;
+    --bind)
+      BIND=$2
       shift 2
       ;;
     --log-file)
@@ -54,7 +60,10 @@ done
 log() {
   level=$1
   shift
-  line="[$(date '+%Y-%m-%d %H:%M:%S')] [$level] $*"
+  # socket bytes reach the log verbatim, so strip control characters here: an
+  # OSC 52 sequence in a logged line would rewrite the clipboard of whoever
+  # has this output on screen, and --log-file replays it on every later cat.
+  line="[$(date '+%Y-%m-%d %H:%M:%S')] [$level] $(printf '%s' "$*" | tr -d '[:cntrl:]')"
   if [ -n "$LOG_FILE" ]; then
     echo "$line" >>"$LOG_FILE"
   else
@@ -76,6 +85,7 @@ process_event() {
   state=$(printf '%s' "$json" | grep -o '"state":"[^"]*"' | head -1 | cut -d'"' -f4)
   session_id=$(printf '%s' "$json" | grep -o '"session_id":"[^"]*"' | head -1 | cut -d'"' -f4)
   pane=$(printf '%s' "$json" | grep -o '"pane":"[^"]*"' | head -1 | cut -d'"' -f4)
+  pane_id=$(printf '%s' "$json" | grep -o '"pane_id":"[^"]*"' | head -1 | cut -d'"' -f4)
 
   log "INFO" "event: cmd=$cmd state=$state session_id=$session_id"
 
@@ -87,6 +97,18 @@ process_event() {
   if [ -n "$pane" ]; then
     args+=("--pane" "$pane")
   fi
+  if [ -n "$pane_id" ]; then
+    args+=("--pane-id" "$pane_id")
+  fi
+
+  # the sender's "args" array carries the hook's own flags; allowlist rather
+  # than forward, so a line off the socket cannot pick agtermctl's arguments.
+  sent_args=$(printf '%s' "$json" | grep -o '"args":\[[^]]*\]' | head -1)
+  for flag in --blink --auto-reset; do
+    case "$sent_args" in
+      *"\"$flag\""*) args+=("$flag") ;;
+    esac
+  done
 
   if [ "$VERBOSE" = true ]; then
     log "DEBUG" "forwarding: $AGTERMCTL ${args[*]}"
@@ -100,16 +122,20 @@ if ! command -v nc >/dev/null 2>&1; then
   exit 1
 fi
 
-log "INFO" "listening on port $PORT"
+log "INFO" "listening on ${BIND:-*}:$PORT"
 
-while true; do
-  nc -l "$PORT" 2>/dev/null | while IFS= read -r json_line; do
-    [ -z "$json_line" ] && continue
-    case "$json_line" in
-      "{"*) process_event "$json_line" ;;
-      *) log "WARN" "ignoring non-JSON line: $json_line" ;;
-    esac
-  done
-  log "WARN" "connection closed, relistening..."
-  sleep 1
+# -k keeps the port bound across connections; a relisten loop would leave it
+# closed between events, and a status arriving in that gap is lost silently.
+if [ -n "$BIND" ]; then
+  nc -k -l "$BIND" "$PORT" 2>/dev/null
+else
+  nc -k -l "$PORT" 2>/dev/null
+fi | while IFS= read -r json_line; do
+  [ -z "$json_line" ] && continue
+  case "$json_line" in
+    "{"*) process_event "$json_line" ;;
+    *) log "WARN" "ignoring non-JSON line: $json_line" ;;
+  esac
 done
+
+log "ERROR" "listener exited"

--- a/cookbook/container-agent-status/agterm-remote-receiver.sh
+++ b/cookbook/container-agent-status/agterm-remote-receiver.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Runs on the HOST. Listens on a TCP port for status events sent by
+# container-status-notify.sh (inside a container that has no access to the
+# host's agterm control socket) and forwards each one to agtermctl.
+set -u
+
+AGTERMCTL=${AGTERMCTL:-agtermctl}
+
+PORT=9998
+LOG_FILE=""
+VERBOSE=false
+TARGET_SOCKET="$HOME/Library/Application Support/agterm/agterm.sock"
+
+usage() {
+  echo "Usage: $0 [--port PORT] [--log-file FILE] [--socket PATH] [--verbose]"
+  echo ""
+  echo "  --port PORT       TCP port to listen on (default 9998)"
+  echo "  --log-file FILE   Append logs here instead of stdout"
+  echo "  --socket PATH     agterm control socket to forward status to"
+  echo "                    (default: \$HOME/Library/Application Support/agterm/agterm.sock)"
+  echo "  --verbose         Also log the raw JSON received"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --port)
+      PORT=$2
+      shift 2
+      ;;
+    --log-file)
+      LOG_FILE=$2
+      shift 2
+      ;;
+    --socket)
+      TARGET_SOCKET=$2
+      shift 2
+      ;;
+    --verbose)
+      VERBOSE=true
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+log() {
+  level=$1
+  shift
+  line="[$(date '+%Y-%m-%d %H:%M:%S')] [$level] $*"
+  if [ -n "$LOG_FILE" ]; then
+    echo "$line" >>"$LOG_FILE"
+  else
+    echo "$line"
+  fi
+}
+
+# Forward one session-status event to agtermctl. Every field but state and
+# session_id is optional, so a hand-rolled grep-based parse (no jq
+# dependency) is enough for this fixed, single-level shape.
+process_event() {
+  json=$1
+
+  if [ "$VERBOSE" = true ]; then
+    log "DEBUG" "received: $json"
+  fi
+
+  cmd=$(printf '%s' "$json" | grep -o '"cmd":"[^"]*"' | head -1 | cut -d'"' -f4)
+  state=$(printf '%s' "$json" | grep -o '"state":"[^"]*"' | head -1 | cut -d'"' -f4)
+  session_id=$(printf '%s' "$json" | grep -o '"session_id":"[^"]*"' | head -1 | cut -d'"' -f4)
+  pane=$(printf '%s' "$json" | grep -o '"pane":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+  log "INFO" "event: cmd=$cmd state=$state session_id=$session_id"
+
+  if [ "$cmd" != "session-status" ] || [ -z "$state" ] || [ -z "$session_id" ]; then
+    return
+  fi
+
+  args=("session" "status" "$state" "--target" "$session_id" "--socket" "$TARGET_SOCKET")
+  if [ -n "$pane" ]; then
+    args+=("--pane" "$pane")
+  fi
+
+  if [ "$VERBOSE" = true ]; then
+    log "DEBUG" "forwarding: $AGTERMCTL ${args[*]}"
+  fi
+
+  "$AGTERMCTL" "${args[@]}" >/dev/null 2>&1 || true
+}
+
+if ! command -v nc >/dev/null 2>&1; then
+  log "ERROR" "nc (netcat) not found"
+  exit 1
+fi
+
+log "INFO" "listening on port $PORT"
+
+while true; do
+  nc -l "$PORT" 2>/dev/null | while IFS= read -r json_line; do
+    [ -z "$json_line" ] && continue
+    case "$json_line" in
+      "{"*) process_event "$json_line" ;;
+      *) log "WARN" "ignoring non-JSON line: $json_line" ;;
+    esac
+  done
+  log "WARN" "connection closed, relistening..."
+  sleep 1
+done

--- a/cookbook/container-agent-status/container-status-notify.sh
+++ b/cookbook/container-agent-status/container-status-notify.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Runs INSIDE the container. Claude Code's hooks call this in place of the
+# installer's agterm-agent-status.sh, which only knows how to reach a
+# control socket that does not exist in here. Sends the same state agterm's
+# own hooks would set, as JSON over TCP to agterm-remote-receiver.sh on the
+# host instead of calling agtermctl directly.
+#
+# Usage: container-status-notify.sh <active|blocked|completed|idle> [--blink] [--auto-reset]
+#
+# Requires AGTERM_SESSION_ID and AGTERM_REMOTE_HOST (host:port) in the
+# environment; a silent no-op without either, so it is safe to wire into a
+# hook that also runs outside this setup.
+set -u
+
+[ -n "${AGTERM_SESSION_ID:-}" ] || exit 0
+[ -n "${AGTERM_REMOTE_HOST:-}" ] || exit 0
+
+state=$1
+shift
+
+remote_host=${AGTERM_REMOTE_HOST%:*}
+remote_port=${AGTERM_REMOTE_HOST##*:}
+
+json="{\"cmd\":\"session-status\",\"state\":\"$state\",\"session_id\":\"$AGTERM_SESSION_ID\""
+[ -n "${AGTERM_PANE:-}" ] && json="$json,\"pane\":\"$AGTERM_PANE\""
+
+if [ $# -gt 0 ]; then
+  args_json=""
+  for arg in "$@"; do
+    [ -n "$args_json" ] && args_json="$args_json,"
+    args_json="$args_json\"$arg\""
+  done
+  json="$json,\"args\":[$args_json]"
+fi
+json="$json}"
+
+printf '%s\n' "$json" | timeout 2 nc "$remote_host" "$remote_port" >/dev/null 2>&1 || true
+exit 0

--- a/cookbook/container-agent-status/container-status-notify.sh
+++ b/cookbook/container-agent-status/container-status-notify.sh
@@ -18,11 +18,17 @@ set -u
 state=$1
 shift
 
+case "$AGTERM_REMOTE_HOST" in
+  *:*) ;;
+  *) exit 0 ;; # without a port the split below silently yields host == port
+esac
+
 remote_host=${AGTERM_REMOTE_HOST%:*}
 remote_port=${AGTERM_REMOTE_HOST##*:}
 
 json="{\"cmd\":\"session-status\",\"state\":\"$state\",\"session_id\":\"$AGTERM_SESSION_ID\""
 [ -n "${AGTERM_PANE:-}" ] && json="$json,\"pane\":\"$AGTERM_PANE\""
+[ -n "${AGTERM_PANE_ID:-}" ] && json="$json,\"pane_id\":\"$AGTERM_PANE_ID\""
 
 if [ $# -gt 0 ]; then
   args_json=""


### PR DESCRIPTION
## Summary
  - Adds `container-agent-status`, a recipe for reporting a hook-driven agent's
  status onto its sidebar row when the agent runs inside a container instead of on
  the host — the installer's own hooks can't reach the local control socket from in
  there.
  - A small script inside the container (`container-status-notify.sh`) turns each
  Claude Code hook event into a flat JSON line and sends it to the host over TCP; a
  listener on the host (`agterm-remote-receiver.sh`) turns each line back into the
  same `agtermctl session status` call the installer's own hooks would make
  directly.
  - Zero extra dependencies: the whole path runs on plain `nc` on both ends — no
  `jq`, no `socat`, nothing to `brew install`. macOS ships `nc`, and so does most
  Linux base imagery a Claude Code container would use, so there is usually nothing
  to install at all.
  - Tested end to end on macOS with Apple's `container` CLI (`container machine
  run`) running a Linux Claude Code container — see the README's note on why that
  runtime's networking (host ports reachable from the container by default, no
  publish/rebuild needed for the reverse direction) makes the recipe simpler than
  on Docker/Podman.
  - Adds the index row to `cookbook/README.md` under **Agent status and
  workflows**.

## Test plan
  - [x] `bash -n` on both scripts
  - [x] Manual end-to-end run: container script → `nc` → receiver on host →
  `agtermctl session status`, confirmed in the receiver's log and the sidebar row
  - [x] README carries all six required headings (What it does / Requirements /
  Setup / Usage / How it works / Limits)
  - [x] Index row in `cookbook/README.md` matches the directory name
  - [x] No absolute home-directory paths, hostnames, IPs, or other personal data in
  the scripts or README (checked with a full grep pass)