### PR TITLE
fix: keep the agent-hooks install alert on screen

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -50,6 +50,14 @@ paths:
 - TOML merging refreshes managed markers while preserving trust tables. Leave foreign markers, existing
   user hooks, and invalid TOML untouched; show manual instructions for the last two. Require `/hooks`
   review for command-hook changes.
+- Every install-result alert line stays ONE LINE and embeds no generated block; two or three sentences on
+  that line are fine, and `AgentHooksInstallerTests` pins exactly that. `NSAlert` sizes itself to fit
+  `informativeText` with no scroll and no height cap, so embedding the hooks block grew the window past the
+  bottom of the screen (#430) — the block's long `command =` lines wrap several times each in that narrow
+  column. The two manual-merge cases open `site/docs.html#codex-hooks-manual` through a second button
+  instead, `informativeText` being plain unselectable text that renders no link. Keep the button second so
+  OK stays the default and Return still dismisses. That docs section carries a copy of `codexHooksBlock`
+  and drifts from it silently.
 - Install Pi only when `~/.pi/agent` exists. Start is active; settle only after retries, compaction, and
   queued continuations. Pi exposes no reliable blocked event, so never infer it from prose.
 - Install OpenCode only when its config exists and export only `AgtermStatusPlugin`; the legacy loader

--- a/agterm/AgentHooksInstaller.swift
+++ b/agterm/AgentHooksInstaller.swift
@@ -7,7 +7,7 @@ import agtermCore
 /// hooks merged into `~/.claude/settings.json`, the six Codex lifecycle hooks into `~/.codex/config.toml`,
 /// and — when each is configured — Pi's lifecycle extension into `~/.pi/agent/extensions/` and OpenCode's
 /// plugin into `~/.config/opencode/plugins/`. Claude/Codex configs get a `.bak` first; the Codex step parses
-/// TOML and surfaces a manual block instead when that file already has hooks or does not parse. The
+/// TOML and points at the docs for a manual merge when that file already has hooks or does not parse. The
 /// host-free string/JSON/TOML transforms and the Pi/OpenCode ownership policy live in
 /// `agtermCore.AgentHooksInstall`; this type owns the AppKit filesystem glue. Idempotent: a re-run refreshes
 /// the baked `agtermctl` path (healing a moved bundle) and no-ops on already-present entries.
@@ -30,7 +30,7 @@ enum AgentHooksInstaller {
     }
 
     // the outcome of the Codex config.toml merge, decided by parsing the existing file.
-    private enum CodexResult {
+    enum CodexResult {
         case merged, alreadyConfigured, hooksExist, unparseable, unreadable, noCodex
 
         // warning: agterm could not auto-merge and the user must act (add the block by hand, or fix config).
@@ -38,6 +38,14 @@ enum AgentHooksInstaller {
             switch self {
             case .hooksExist, .unparseable, .unreadable: return true
             case .merged, .alreadyConfigured, .noCodex: return false
+            }
+        }
+
+        // the two outcomes whose alert text sends the user to the docs for the block to paste in by hand.
+        var needsManualMerge: Bool {
+            switch self {
+            case .hooksExist, .unparseable: return true
+            case .merged, .alreadyConfigured, .unreadable, .noCodex: return false
             }
         }
     }
@@ -85,7 +93,8 @@ enum AgentHooksInstaller {
             let outcome = try install()
             present(style: outcome.isWarning ? .warning : .informational,
                     title: outcome.isWarning ? "Agent Status Hooks Installed — with a warning" : "Agent Status Hooks Installed",
-                    text: successText(outcome))
+                    text: successText(outcome),
+                    docs: outcome.codex.needsManualMerge ? codexManualDocsURL : nil)
         } catch let error as InstallError {
             present(style: .warning, title: "Install Failed", text: error.message)
         } catch {
@@ -368,20 +377,22 @@ enum AgentHooksInstaller {
         """
     }
 
-    // the Codex portion of the alert; hooks-exist and unparseable include the block for a manual add.
-    private static func codexText(_ codex: CodexResult) -> String {
+    // the Codex portion of the alert. Every case stays one line and embeds no generated block: NSAlert sizes
+    // itself to fit `informativeText` with no scroll and no cap, so the hooks block's long `command =` lines
+    // wrapped several times each and grew the window past the bottom of a laptop screen (#430). Sentence
+    // count is not the constraint — the two manual-merge cases send the user to the docs instead.
+    static func codexText(_ codex: CodexResult) -> String {
         let approve = "Run /hooks in Codex to review and approve them before they take effect."
+        let manual = "See the Add Codex hooks by hand section of the agterm docs for the block to add, then run /hooks in Codex."
         switch codex {
         case .merged:
             return "Codex lifecycle hooks merged into ~/.codex/config.toml (any old codex-notify.sh notify line was removed). " + approve
         case .alreadyConfigured:
             return "Codex lifecycle hooks are already present in ~/.codex/config.toml. " + approve
         case .hooksExist:
-            return "Your ~/.codex/config.toml already defines its own hooks, so agterm left it untouched. "
-                + "Add these lifecycle hooks yourself, then run /hooks in Codex:\n\n" + codexBlock
+            return "Your ~/.codex/config.toml already defines its own hooks, so agterm left it untouched. " + manual
         case .unparseable:
-            return "Your ~/.codex/config.toml isn't valid TOML, so agterm left it untouched. "
-                + "Fix it, or add these lifecycle hooks yourself, then run /hooks in Codex:\n\n" + codexBlock
+            return "Your ~/.codex/config.toml isn't valid TOML, so agterm left it untouched. Fix it and run this again. " + manual
         case .unreadable:
             return "Your ~/.codex/config.toml exists but couldn't be read, so agterm left it untouched."
         case .noCodex:
@@ -427,16 +438,27 @@ enum AgentHooksInstaller {
         }
     }
 
-    // the Codex lifecycle-hooks block, for the alert's manual-add fallback cases.
-    private static var codexBlock: String {
-        AgentHooksInstall.codexHooksBlock(scriptDir: destinationFolder.path)
-    }
+    /// The docs anchor covering a manual Codex hooks merge, opened by the alert's second button. An NSAlert
+    /// renders `informativeText` as plain, unselectable text, so a printed URL would have to be retyped.
+    static let codexManualDocsURL = URL(string: "https://agterm.com/docs#codex-hooks-manual")
 
-    private static func present(style: NSAlert.Style, title: String, text: String) {
+    /// The result alert, with a second button when `docs` is set. Split out of `present()` so a hosted test
+    /// can check the buttons without running a modal.
+    static func makeAlert(style: NSAlert.Style, title: String, text: String, docs: URL?) -> NSAlert {
         let alert = NSAlert()
         alert.alertStyle = style
         alert.messageText = title
         alert.informativeText = text
-        alert.runModal()
+        if docs != nil {
+            alert.addButton(withTitle: "OK")
+            alert.addButton(withTitle: "Open Docs")
+        }
+        return alert
+    }
+
+    private static func present(style: NSAlert.Style, title: String, text: String, docs: URL? = nil) {
+        let alert = makeAlert(style: style, title: title, text: text, docs: docs)
+        guard alert.runModal() == .alertSecondButtonReturn, let docs else { return }
+        NSWorkspace.shared.open(docs)
     }
 }

--- a/agtermCore/Sources/agtermCore/AgentHooksInstall.swift
+++ b/agtermCore/Sources/agtermCore/AgentHooksInstall.swift
@@ -157,9 +157,9 @@ public enum AgentHooksInstall {
         /// The file already carries the current agterm hooks block — nothing to do.
         case unchanged
         /// The file already defines its OWN `hooks` — appending ours would duplicate (array-of-tables form) or
-        /// break (compact form) them, so the merge is skipped; surface `codexHooksBlock` for a manual merge.
+        /// break (compact form) them, so the merge is skipped; point the user at the docs for a manual merge.
         case hooksExist
-        /// The existing file is not valid TOML — leave it untouched and surface the block for a manual add.
+        /// The existing file is not valid TOML — leave it untouched and point at the docs for a manual add.
         case unparseable
     }
 
@@ -294,8 +294,9 @@ public enum AgentHooksInstall {
         scriptDir + "/" + codexWrapperName
     }
 
-    /// render the `~/.codex/config.toml` `[[hooks.*]]` block the installer merges in (or surfaces for a manual
-    /// add when the file already has hooks or doesn't parse), wiring Codex's lifecycle events to the indicator.
+    /// render the `~/.codex/config.toml` `[[hooks.*]]` block the installer merges in, wiring Codex's lifecycle
+    /// events to the indicator. `site/docs.html#codex-hooks-manual` reproduces this block for the cases the
+    /// merge declines, and nothing checks the two against each other.
     /// The wrapper's absolute path is baked into each command — shell-quoted (so a path with spaces stays one
     /// token) inside a TOML basic string — so the hook fires without the CLI on PATH.
     public static func codexHooksBlock(scriptDir: String) -> String {

--- a/agtermTests/AgentHooksInstallerTests.swift
+++ b/agtermTests/AgentHooksInstallerTests.swift
@@ -1,0 +1,50 @@
+import AppKit
+import XCTest
+@testable import agterm
+
+/// NSAlert sizes itself to fit `informativeText`, with no scroll and no height cap, so any text long enough
+/// pushes the buttons off the bottom of the screen. Issue #430: the Codex manual-merge cases embedded the
+/// whole 29-line hooks block and did exactly that.
+@MainActor
+final class AgentHooksInstallerTests: XCTestCase {
+    private let allCodexResults: [AgentHooksInstaller.CodexResult] =
+        [.merged, .alreadyConfigured, .hooksExist, .unparseable, .unreadable, .noCodex]
+
+    func testNoCodexOutcomeEmbedsTheHooksBlock() {
+        for result in allCodexResults {
+            let text = AgentHooksInstaller.codexText(result)
+            XCTAssertFalse(text.contains("[[hooks."), "\(result) should point at the docs, not inline the block")
+            XCTAssertFalse(text.contains("\n"), "\(result) should stay a single line")
+        }
+    }
+
+    func testOnlyTheManualMergeOutcomesOfferTheDocsButton() {
+        for result in allCodexResults {
+            let expected = result == .hooksExist || result == .unparseable
+            XCTAssertEqual(result.needsManualMerge, expected, "\(result) offers the docs button: \(expected)")
+        }
+    }
+
+    func testManualMergeTextNamesTheDocsSection() {
+        for result in allCodexResults where result.needsManualMerge {
+            XCTAssertTrue(AgentHooksInstaller.codexText(result).contains("Add Codex hooks by hand"),
+                          "\(result) should name the docs section the button opens")
+        }
+    }
+
+    func testDocsButtonIsSecondSoTheDefaultStaysOK() {
+        let alert = AgentHooksInstaller.makeAlert(style: .warning, title: "t", text: "x",
+                                                  docs: AgentHooksInstaller.codexManualDocsURL)
+        XCTAssertEqual(alert.buttons.map(\.title), ["OK", "Open Docs"])
+    }
+
+    func testAlertWithoutDocsKeepsTheSingleDefaultButton() {
+        let alert = AgentHooksInstaller.makeAlert(style: .informational, title: "t", text: "x", docs: nil)
+        XCTAssertEqual(alert.buttons.map(\.title), ["OK"])
+    }
+
+    func testDocsURLPointsAtTheManualMergeAnchor() throws {
+        let url = try XCTUnwrap(AgentHooksInstaller.codexManualDocsURL)
+        XCTAssertEqual(url.absoluteString, "https://agterm.com/docs#codex-hooks-manual")
+    }
+}

--- a/site/docs.html
+++ b/site/docs.html
@@ -2569,6 +2569,98 @@
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">session.status</span>.
               Restart OpenCode after installing it.
             </p>
+
+            <h3
+              id="codex-hooks-manual"
+              style="
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-weight: 600;
+                font-size: 17px;
+                color: #e6e1d7;
+                margin: 28px 0 12px;
+                scroll-margin-top: 88px;
+              "
+            >
+              Add Codex hooks by hand
+            </h3>
+            <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 0 0 14px">
+              The installer never rewrites a
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">~/.codex/config.toml</span>
+              it does not own. If that file already defines its own
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">[hooks…]</span>
+              entries, or is not valid TOML, it is left untouched and the install alert sends you here. Add the
+              six blocks below yourself, replacing
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">/Users/you</span>
+              with your own home directory — the path has to be absolute, since Codex runs the hook without
+              your shell's PATH.
+            </p>
+            <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 0 0 14px">
+              Check the shape of your existing hooks first, because that is the reason the installer declined to
+              do this for you. If every one of them is written as an
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">[[hooks.…]]</span>
+              array-of-tables entry, appending is safe, including for events you already hook — a repeated
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">[[…]]</span>
+              header adds an element rather than redefining a key, so both your hook and agterm's run. If
+              instead you have an inline
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">hooks = { … }</span>
+              table or a plain
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">[hooks.SessionStart]</span>
+              table, appending makes the file stop parsing, since TOML allows neither extending a closed inline
+              table nor overwriting a defined value. Convert those entries to the array-of-tables form first,
+              then append. Do not add a second
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">command</span>
+              line inside an existing entry — a repeated key in one table breaks the file just as surely.
+            </p>
+            <div
+              style="
+                background: #15191c;
+                border: 1px solid rgba(255, 255, 255, 0.1);
+                border-radius: 10px;
+                padding: 16px 18px;
+                font-family: &quot;JetBrains Mono&quot;, monospace;
+                font-size: 13px;
+                line-height: 1.6;
+                color: #e6e1d7;
+                overflow-x: auto;
+                white-space: pre;
+              "
+            >[[hooks.SessionStart]]
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = "'/Users/you/.config/agterm/agent-status/agterm-codex-status.sh' session-start"
+
+[[hooks.UserPromptSubmit]]
+[[hooks.UserPromptSubmit.hooks]]
+type = "command"
+command = "'/Users/you/.config/agterm/agent-status/agterm-codex-status.sh' user-prompt-submit"
+
+[[hooks.PreToolUse]]
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "'/Users/you/.config/agterm/agent-status/agterm-codex-status.sh' pre-tool-use"
+
+[[hooks.PostToolUse]]
+[[hooks.PostToolUse.hooks]]
+type = "command"
+command = "'/Users/you/.config/agterm/agent-status/agterm-codex-status.sh' post-tool-use"
+
+[[hooks.PermissionRequest]]
+[[hooks.PermissionRequest.hooks]]
+type = "command"
+command = "'/Users/you/.config/agterm/agent-status/agterm-codex-status.sh' permission-request"
+
+[[hooks.Stop]]
+[[hooks.Stop.hooks]]
+type = "command"
+command = "'/Users/you/.config/agterm/agent-status/agterm-codex-status.sh' stop"</div>
+            <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 14px 0 0">
+              The adapter script itself is already in place — the installer copies it to
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">~/.config/agterm/agent-status/</span>
+              on every run, whether or not the config merge succeeded. Once the blocks are added, run
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">/hooks</span>
+              in Codex and approve them; command hooks stay inert until you do. For the unparseable case, fixing
+              the TOML and re-running the installer is the easier route — it will merge the blocks for you.
+            </p>
           </section>
 
           <!-- RESTORE -->


### PR DESCRIPTION
`NSAlert` sizes itself to fit `informativeText`, which has no scroll and no height cap. The `.hooksExist` and `.unparseable` Codex cases embedded the full generated hooks block - 6 events x 4 lines, and each `command = "'/Users/…/agterm-codex-status.sh' pre-tool-use"` wraps 3-4 times in the alert's narrow text column.

Measured, same alert, only the home directory differs:

| home path length | before | after |
|---|---|---|
| 14 chars | 952pt | 392pt |
| 20 chars | 968pt | 408pt |

A 13" MacBook Air has 956pt of usable height. The absolute wrapper path is baked into all six `command =` lines, so a few extra characters in the home path adds a wrapped line per hook and takes it over. Whether it overflows depends on how long your home path is, which is why it reproduces for some and not others - the old alert was four points under the limit on a short path, not comfortably inside it.

Every Codex outcome is now one line with no embedded block. The two manual-merge cases point at a new docs section instead, opened by an "Open Docs" second button - `informativeText` is plain unselectable text and renders no link, so a printed URL would have to be retyped. OK stays first, so Return still dismisses.

`site/docs.html` gets an "Add Codex hooks by hand" section under `#status`, anchored `#codex-hooks-manual`, carrying all six blocks. It also says which config shapes accept a plain append: repeating an `[[hooks.Event]]` header adds an element and is safe even for an already-hooked event, while an inline `hooks = { … }` table or a plain `[hooks.Event]` table breaks on append, which is why the installer declines to touch them. Checked against a real TOML parser rather than assumed.

`agtermTests/AgentHooksInstallerTests.swift` pins the defect: no Codex case may contain `[[hooks.` or a newline, and the docs button appears for exactly the two manual-merge outcomes.

Two notes. The report says the only way out is Force Quit - `present` adds no buttons, so AppKit synthesizes a single OK with a Return key equivalent, which still dismisses it. And the button's anchor only resolves once this is on master and Pages redeploys; before that it opens the docs page at the top.

Fix #430
