### PR TITLE
feat: add keyboard workspace navigation and a per-workspace collapse action

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -132,7 +132,7 @@ There are 76 public commands:
   `.fullscreen`, `.minimize`
 - `keymap.reload`, `keymap.list`, `config.reload`, `theme.set`, `theme.list`, `restore.clear`
 
-`debug.appearance` is a private 76th `Command` case used only by `AppearanceFlipUITests`.
+`debug.appearance` is a private 77th `Command` case used only by `AppearanceFlipUITests`.
 It accepts light/dark, sets `NSApp.appearance`, posts `.agtermSystemAppearanceChanged`, echoes the effective
 side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provide no CLI or skill entry.
 

--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -115,10 +115,10 @@ paths:
 
 ## Public catalog
 
-There are 75 public commands:
+There are 76 public commands:
 
 - `tree`, `events.read`
-- `workspace.new`, `.rename`, `.delete`, `.select`, `.move`, `.focus`, `.filter`, `.collapse`, `.expand`
+- `workspace.new`, `.rename`, `.delete`, `.select`, `.go`, `.move`, `.focus`, `.filter`, `.collapse`, `.expand`
 - `session.new`, `.duplicate`, `.close`, `.select`, `.rename`, `.reveal`, `.move`, `.type`, `.split`,
   `.split.close`,
   `.scratch`, `.focus`, `.resize`, `.go`, `.copy`, `.paste`, `.selectall`, `.text`, `.search`, `.status`,
@@ -156,6 +156,13 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   between-row surface. `active` resolves through `currentWorkspaceID` — a foreground-created workspace
   first, then the selected session's, then `workspaces.last` — so repeated moves may target a different
   workspace; use an ID to keep one target.
+- `workspace.go --to next|prev` steps the CURRENT workspace through `visibleWorkspaces`, wrapping, and
+  routes through `selectWorkspace`, so it lands on the target's FIRST session and inherits the
+  empty-workspace reveal. Relative like `session.go`, so it takes no target; `workspace.move` is the
+  neighbouring verb that reorders instead. Returns the workspace id it landed on. Collapse state is NOT a
+  term — a folded workspace is stepped into like any other, and issue #435 assumed otherwise. Errors with
+  `no other workspace to navigate to` where there is nowhere to step: flagged mode, or one visible
+  workspace. Read back through `tree` selection; the GUI twins are `previous_workspace`/`next_workspace`.
 - `session.split` drives the addressed session, not active-only `AppActions.toggleSplit`. `--axis
   vertical|horizontal` selects left/right or top/bottom; omitting it preserves an existing split's axis
   and defaults a new split to left/right. Off hides and retains the shell; `session.split.close` and the

--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -48,7 +48,7 @@ paths:
   alternative, `alternative skipped`/`alternative dropped` with more), pinned by
   `KeymapTests.pipeFreeKeymapParsesExactlyAsItDidBeforeAlternatives`.
 - Pure types live in `Keybind.swift`, `KeybindMatcher`, `CustomCommand`/`CommandContext`,
-  `BuiltinAction` (43 cases, pinned by `BuiltinActionTests`), `Keymap`, and `ConfigPaths`.
+  `BuiltinAction` (46 cases, pinned by `BuiltinActionTests`), `Keymap`, and `ConfigPaths`.
   `CommandContext` owns the shared expansion/environment token table.
 - Built-ins use AppKit menu key equivalents from `keymap.equivalent(for:)`; apply only non-nil
   `KeyboardShortcut`s. SwiftUI rebuilds menu shortcuts on the next activation, not immediately after

--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -179,6 +179,12 @@ paths:
   Option-Command-Left/Right remains pane focus.
 - `navigateSession` uses `navigableSessions`, wraps previous/next, selects ends for first/last, chooses
   first on nil/invalid selection, and no-ops when empty. Menu, palette, and `session.go` share it.
+- Previous/Next Workspace are the level above: `navigateWorkspace` steps `currentWorkspaceID` through
+  `visibleWorkspaces` and lands on the target's FIRST session, so the keybind, the palette row and
+  `workspace.go` mean one thing. Keyless, tree mode only, and it reveals a landed pane off the step's
+  captured indicator exactly as plain session nav does. **Collapse is not a navigation filter** —
+  `navigableSessions` and `navigateWorkspace` both ignore `isExpanded`, and adding a term to either would
+  silently rewrite where every existing keystroke, `session.go` call and Ctrl-Tab candidate lands.
 - When selection moves, GUI callers reveal a captured blocked/completed pane; unchanged plain navigation
   only refocuses, preventing a one-item wrap from resetting split focus. Modal focus guards still apply.
 - Attention navigation defaults to Control-Option-Up/Down, includes blocked/completed only, wraps, and

--- a/.claude/rules/sidebar.md
+++ b/.claude/rules/sidebar.md
@@ -164,7 +164,9 @@ paths:
   leave the data source, so expand/collapse delegate callbacks and `expandAll` update the set and
   `rebuildAndReload` reapplies it after flagged-mode round trips.
 - Expand Workspaces opens all. Collapse Workspaces closes all except the active workspace and scrolls it
-  visible. Scope notifications by the target `AppStore` object so only that window's Coordinator acts.
+  visible. Collapse/Expand Workspace (singular, `toggle_workspace_collapse`) folds the active one alone,
+  which is the row those two never fold; it routes through `AppActions.setWorkspaceExpanded(_:expanded:in:)`,
+  the same persist-then-notify path as `workspace.collapse`/`.expand`. Scope notifications by the target `AppStore` object so only that window's Coordinator acts.
   Both no-op in flagged mode. Menus/palette target frontmost; `sidebar.expand`/`sidebar.collapse` resolve
   `--window` and can target background windows.
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ agtermctl tree --json                                     # dump the whole model
 
 `session type` returns once the keystrokes are queued, so a following `session text` races the shell, and `pick` blocks until someone chooses.
 
-The same interface covers windows, splits, overlays, dashboards, HUDs, notifications, events, themes, and restoration. All 75 commands are at [agterm.com/commands](https://agterm.com/commands).
+The same interface covers windows, splits, overlays, dashboards, HUDs, notifications, events, themes, and restoration. All 76 commands are at [agterm.com/commands](https://agterm.com/commands).
 
 ## Documentation
 

--- a/agterm/AppActions+Palette.swift
+++ b/agterm/AppActions+Palette.swift
@@ -30,6 +30,7 @@ extension AppActions {
             hasMarkedWorkspaces: activeStore?.focusedWorkspaceIDs.isEmpty == false,
             activeWorkspaceMarked: activeStore?.isCurrentWorkspaceFocusMember == true,
             activeWorkspaceCollapsed: activeStore?.isCurrentWorkspaceCollapsed == true,
+            canStepWorkspaces: (activeStore?.visibleWorkspaces.count ?? 0) > 1,
             activeSessionHasSplit: activeStore?.activeSession?.hasSplit == true,
             activeSplitAxis: activeStore?.activeSession?.splitAxis,
             hasPendingClose: activeStore?.pendingCloseSummary != nil,

--- a/agterm/AppActions+Palette.swift
+++ b/agterm/AppActions+Palette.swift
@@ -29,6 +29,7 @@ extension AppActions {
             activeSessionFlagged: activeStore?.activeSession?.flagged == true,
             hasMarkedWorkspaces: activeStore?.focusedWorkspaceIDs.isEmpty == false,
             activeWorkspaceMarked: activeStore?.isCurrentWorkspaceFocusMember == true,
+            activeWorkspaceCollapsed: activeStore?.isCurrentWorkspaceCollapsed == true,
             activeSessionHasSplit: activeStore?.activeSession?.hasSplit == true,
             activeSplitAxis: activeStore?.activeSession?.splitAxis,
             hasPendingClose: activeStore?.pendingCloseSummary != nil,
@@ -77,6 +78,8 @@ extension AppActions {
         case .nextSession: selectNextSession()
         case .previousAttentionSession: selectPreviousAttentionSession()
         case .nextAttentionSession: selectNextAttentionSession()
+        case .previousWorkspace: selectPreviousWorkspace()
+        case .nextWorkspace: selectNextWorkspace()
         case .firstSession: selectFirstSession()
         case .lastSession: selectLastSession()
         case .showAttention: openAttentionPalette()
@@ -108,6 +111,7 @@ extension AppActions {
         case .toggleWorkspaceFilter: toggleFocusFilter()
         case .expandWorkspaces: expandAllWorkspaces()
         case .collapseWorkspaces: collapseOtherWorkspaces()
+        case .toggleWorkspaceCollapse: toggleActiveWorkspaceCollapse()
         case .focusLeftPane: focusPane(.main)
         case .focusRightPane: focusPane(.split)
         }

--- a/agterm/AppActions+Palette.swift
+++ b/agterm/AppActions+Palette.swift
@@ -30,7 +30,7 @@ extension AppActions {
             hasMarkedWorkspaces: activeStore?.focusedWorkspaceIDs.isEmpty == false,
             activeWorkspaceMarked: activeStore?.isCurrentWorkspaceFocusMember == true,
             activeWorkspaceCollapsed: activeStore?.isCurrentWorkspaceCollapsed == true,
-            canStepWorkspaces: (activeStore?.visibleWorkspaces.count ?? 0) > 1,
+            canStepWorkspaces: activeStore?.canStepWorkspaces == true,
             activeSessionHasSplit: activeStore?.activeSession?.hasSplit == true,
             activeSplitAxis: activeStore?.activeSession?.splitAxis,
             hasPendingClose: activeStore?.pendingCloseSummary != nil,

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -546,15 +546,19 @@ final class AppActions {
     /// Fold or unfold the CURRENT workspace alone, for the keyless `toggle_workspace_collapse`, its View-menu
     /// item and its palette row. The per-workspace counterpart of Expand / Collapse Workspaces, which act on
     /// every row and deliberately keep this one open — so before this there was no built-in way to fold the
-    /// workspace you are in. Tree mode only, matching those two and the rows it acts on.
+    /// workspace you are in. Tree mode only, matching those two and the rows it acts on. Targets what the row
+    /// SHOWS (`isCurrentWorkspaceCollapsed`), not what is persisted: a reveal routinely leaves this workspace
+    /// open on screen while its stored flag still says collapsed, and toggling the stored flag there costs the
+    /// user a keystroke that changes nothing he can see.
     func toggleActiveWorkspaceCollapse() {
         guard uiActionsEnabled else { return }
         guard let store, store.sidebarMode == .tree, let id = store.currentWorkspaceID else { return }
         setWorkspaceExpanded(id, expanded: store.isCurrentWorkspaceCollapsed, in: store)
     }
 
-    /// Collapse/expand a SINGLE workspace in `store`'s window sidebar — the `workspace.collapse`/`.expand`
-    /// control path and its only caller (a GUI row click drives the outline directly). Persists
+    /// Collapse/expand a SINGLE workspace in `store`'s window sidebar — the shared path for
+    /// `workspace.collapse`/`.expand` and for `toggleActiveWorkspaceCollapse` above (a GUI row click drives
+    /// the outline directly instead). Persists
     /// `Workspace.isExpanded` DIRECTLY on the store (source of truth for the `collapsed` read-back,
     /// delta-guarded so it's idempotent), THEN posts a store-scoped notification so that window's Coordinator
     /// syncs the live outline row and its tracked expansion set. The persist must NOT ride the notification:

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -423,6 +423,21 @@ final class AppActions {
     func selectFirstSession() { navigatePlain(.first) }
     func selectLastSession() { navigatePlain(.last) }
 
+    /// Step the CURRENT workspace prev/next through the sidebar's visible order and select its first session,
+    /// through shared `navigateWorkspace` so the menu, the palette and `workspace.go` can't drift. Notes the
+    /// step as user activity like session nav, then routes pane reveal off the step's captured indicator —
+    /// the same treatment plain session nav gives, so where focus lands does not depend on which keystroke
+    /// got you there. A step with nowhere to go (flagged mode, one visible workspace) leaves focus alone.
+    private func navigateWorkspace(_ direction: WorkspaceNavigation) {
+        guard uiActionsEnabled else { return }
+        store?.noteUserActivity()
+        guard let step = store?.navigateWorkspace(direction) else { return }
+        revealActiveBlockedPane(captured: step.indicator)
+    }
+
+    func selectNextWorkspace() { navigateWorkspace(.next) }
+    func selectPreviousWorkspace() { navigateWorkspace(.previous) }
+
     /// Step to the next/previous session needing attention (`blocked`/`completed`), wrapping and skipping
     /// idle/active, through `navigateSession` shared with the palette and `session.go next-attention|prev-attention`.
     /// Notes user activity like plain nav, then `revealActiveBlockedPane` focuses the split/scratch pane that
@@ -526,6 +541,16 @@ final class AppActions {
     /// and how `sidebar.collapse` targets a specific (default frontmost) window.
     func collapseOtherWorkspaces(in store: AppStore) {
         NotificationCenter.default.post(name: .agtermCollapseWorkspaces, object: store)
+    }
+
+    /// Fold or unfold the CURRENT workspace alone, for the keyless `toggle_workspace_collapse`, its View-menu
+    /// item and its palette row. The per-workspace counterpart of Expand / Collapse Workspaces, which act on
+    /// every row and deliberately keep this one open — so before this there was no built-in way to fold the
+    /// workspace you are in. Tree mode only, matching those two and the rows it acts on.
+    func toggleActiveWorkspaceCollapse() {
+        guard uiActionsEnabled else { return }
+        guard let store, store.sidebarMode == .tree, let id = store.currentWorkspaceID else { return }
+        setWorkspaceExpanded(id, expanded: store.isCurrentWorkspaceCollapsed, in: store)
     }
 
     /// Collapse/expand a SINGLE workspace in `store`'s window sidebar — the `workspace.collapse`/`.expand`

--- a/agterm/Control/ControlServer+WorkspaceCommands.swift
+++ b/agterm/Control/ControlServer+WorkspaceCommands.swift
@@ -28,6 +28,16 @@ extension ControlServer {
         }
     }
 
+    func goWorkspace(window: String?, direction: WorkspaceNavigation) -> ControlResponse {
+        // relative nav acts on the store's current workspace: no target, just the frontmost/`--window` store.
+        resolver.resolvePlacementStore(window) { store in
+            guard let step = store.navigateWorkspace(direction) else {
+                return ControlResponse(ok: false, error: "no other workspace to navigate to")
+            }
+            return ControlResponse(ok: true, result: ControlResult(id: step.workspaceID.uuidString))
+        }
+    }
+
     func renameWorkspace(_ target: String?, window: String?, name: String) -> ControlResponse {
         resolver.resolveWorkspace(target, window: window) { store, id in
             store.renameWorkspace(id, to: name)

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -415,7 +415,8 @@ final class ControlServer {
         switch request.cmd {
         case .tree, .eventsRead, .sessionNew, .sessionDuplicate, .sessionSelect, .sessionGo, .sessionClose, .sessionRename,
                 .sessionReveal, .sessionMove,
-                .workspaceNew, .workspaceSelect, .workspaceRename, .workspaceDelete, .workspaceMove, .workspaceFocus,
+                .workspaceNew, .workspaceSelect, .workspaceGo, .workspaceRename, .workspaceDelete, .workspaceMove,
+                .workspaceFocus,
                 .workspaceFilter, .workspaceCollapse, .workspaceExpand,
                 .sessionSplit, .sessionSplitClose, .sessionScratch, .sessionFocus, .sessionResize, .surfaceZoom,
                 .sessionStatus, .sessionFlag, .sessionSeen, .sessionRestore, .notify,

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -576,7 +576,8 @@ final class ControlServer {
     }
 
     /// Project a window's workspace tree into the wire `ControlTree`, marking the active session and the
-    /// active workspace (the one owning the selected session).
+    /// active workspace (`currentWorkspaceID`, what `--target active` resolves to — not necessarily the
+    /// selected session's owner, since an empty or foreground-created workspace becomes current on its own).
     func buildTree(in store: AppStore) -> ControlTree {
         let shellBasename = ProcessInfo.processInfo.environment["SHELL"].map(CommandRestore.basename)
         // the projected window owns its quick terminal; find its id by store identity to read the live

--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -137,15 +137,16 @@ struct WorkspaceSidebar: NSViewRepresentable {
         /// Workspace ids the user has expanded, tracked via the expand/collapse callbacks. The source of
         /// truth for restoring expansion on rebuild: NSOutlineView discards its own expansion state for
         /// items it no longer renders, and the flagged-mode reload drops every workspace node.
-        /// Mirrored into the store on every change — a suppressed reveal opens a row without touching
+        /// Mirrored into the store on every assignment — a suppressed reveal opens a row without touching
         /// `Workspace.isExpanded`, so the persisted flag alone cannot answer "is this row open right now",
         /// which is what Collapse/Expand Workspace has to fold. One `didSet` rather than a push beside each
-        /// of the seven mutation sites, because a missed site desynchronizes silently.
+        /// of the seven mutation sites, because a missed site desynchronizes silently. Deliberately NOT
+        /// delta-guarded: a fresh Coordinator starts empty, so seeding an all-collapsed tree assigns empty
+        /// over empty and a guard would skip the push, leaving the PREVIOUS mount's ids in the store while
+        /// the outline shows every row folded. The store field is `@ObservationIgnored`, so a redundant
+        /// push costs one set copy and invalidates nothing.
         private var expandedWorkspaceIDs = Set<UUID>() {
-            didSet {
-                guard expandedWorkspaceIDs != oldValue else { return }
-                store.noteSidebarExpansion(expandedWorkspaceIDs)
-            }
+            didSet { store.noteSidebarExpansion(expandedWorkspaceIDs) }
         }
         /// Set true around PROGRAMMATIC `expandItem`/`collapseItem` (the launch/rebuild re-apply, the
         /// `syncSelection` reveal, the focus force-expand): the didExpand/DidCollapse callbacks still update
@@ -320,7 +321,8 @@ struct WorkspaceSidebar: NSViewRepresentable {
             collapseOthers()
         }
 
-        /// Sync the sidebar to a SINGLE workspace's collapse/expand (`workspace.collapse`/`.expand`).
+        /// Sync the sidebar to a SINGLE workspace's collapse/expand — `workspace.collapse`/`.expand` and the
+        /// GUI's own Collapse/Expand Workspace, which share `AppActions.setWorkspaceExpanded`.
         /// `AppActions.setWorkspaceExpanded` has ALREADY persisted `Workspace.isExpanded` — the source of
         /// truth, independent of this Coordinator — so this handler only keeps the tracked
         /// `expandedWorkspaceIDs` in step (letting the intent survive a flagged-mode or focused-away row and
@@ -809,8 +811,9 @@ extension Notification.Name {
     /// one, with the frontmost window's `AppStore` as the object so only that window's sidebar reacts.
     static let agtermExpandWorkspaces = Notification.Name("agterm.expandWorkspaces")
     static let agtermCollapseWorkspaces = Notification.Name("agterm.collapseWorkspaces")
-    /// Posted by the `workspace.collapse`/`workspace.expand` control arm for a SINGLE workspace, with the
-    /// target window's `AppStore` as the object and the workspace id + desired state in `userInfo`.
+    /// Posted for a SINGLE workspace by the `workspace.collapse`/`workspace.expand` control arm and by the
+    /// GUI's Collapse/Expand Workspace, with the target window's `AppStore` as the object and the workspace
+    /// id + desired state in `userInfo`.
     static let agtermSetWorkspaceExpanded = Notification.Name("agterm.setWorkspaceExpanded")
     /// Posted by the `session.resize` control arm after storing a new split-divider fraction, with the
     /// target `Session` as the object so only that session's `SplitProbeView` (in `ContentView`) moves its

--- a/agterm/Views/WorkspaceSidebar.swift
+++ b/agterm/Views/WorkspaceSidebar.swift
@@ -137,7 +137,16 @@ struct WorkspaceSidebar: NSViewRepresentable {
         /// Workspace ids the user has expanded, tracked via the expand/collapse callbacks. The source of
         /// truth for restoring expansion on rebuild: NSOutlineView discards its own expansion state for
         /// items it no longer renders, and the flagged-mode reload drops every workspace node.
-        private var expandedWorkspaceIDs = Set<UUID>()
+        /// Mirrored into the store on every change — a suppressed reveal opens a row without touching
+        /// `Workspace.isExpanded`, so the persisted flag alone cannot answer "is this row open right now",
+        /// which is what Collapse/Expand Workspace has to fold. One `didSet` rather than a push beside each
+        /// of the seven mutation sites, because a missed site desynchronizes silently.
+        private var expandedWorkspaceIDs = Set<UUID>() {
+            didSet {
+                guard expandedWorkspaceIDs != oldValue else { return }
+                store.noteSidebarExpansion(expandedWorkspaceIDs)
+            }
+        }
         /// Set true around PROGRAMMATIC `expandItem`/`collapseItem` (the launch/rebuild re-apply, the
         /// `syncSelection` reveal, the focus force-expand): the didExpand/DidCollapse callbacks still update
         /// the visual `expandedWorkspaceIDs` but SKIP the persist write-back, so a view-only reveal never

--- a/agterm/agtermApp+Menus.swift
+++ b/agterm/agtermApp+Menus.swift
@@ -221,6 +221,15 @@ extension agtermApp {
                     .disabled(!PaletteCommand.expandWorkspaces.isEnabled(in: context))
                 Button { actions.collapseOtherWorkspaces() } label: { Label("Collapse Workspaces", systemImage: "chevron.right") }
                     .disabled(!PaletteCommand.collapseWorkspaces.isEnabled(in: context))
+                // fold the current workspace alone — the one row the two items above never fold, since
+                // Collapse Workspaces keeps it open. keyless, rebindable via toggle_workspace_collapse;
+                // control workspace.collapse/.expand. the label tracks the toggle.
+                Button { actions.toggleActiveWorkspaceCollapse() } label: {
+                    Label(PaletteCommand.toggleWorkspaceCollapse.title(in: context),
+                          systemImage: context.activeWorkspaceCollapsed ? "chevron.down.square" : "chevron.right.square")
+                }
+                .keyboardShortcut(shortcut(for: .toggleWorkspaceCollapse))
+                .disabled(!PaletteCommand.toggleWorkspaceCollapse.isEnabled(in: context))
                 // flip the sidebar between the workspace tree and the flat flagged working-set list. one
                 // 2-state item, keyless by default (rebindable via toggle_flagged_view); control sidebar.mode.
                 // Disabled with nothing to show (tree mode + no flags), live in flagged mode so it can
@@ -352,6 +361,19 @@ extension agtermApp {
                 Button { actions.selectLastSession() } label: { Label("Last Session", systemImage: "arrow.down.to.line") }
                     .keyboardShortcut(shortcut(for: .lastSession))
                     .disabled(!PaletteCommand.lastSession.isEnabled(in: context))
+                // step between WORKSPACES, landing on each one's first session. keyless, rebindable via
+                // previous_workspace/next_workspace; control workspace.go. tree mode only, like the
+                // expansion items in View — flagged mode renders no workspace rows to step through.
+                Button { actions.selectPreviousWorkspace() } label: {
+                    Label("Previous Workspace", systemImage: "chevron.up.2")
+                }
+                .keyboardShortcut(shortcut(for: .previousWorkspace))
+                .disabled(!PaletteCommand.previousWorkspace.isEnabled(in: context))
+                Button { actions.selectNextWorkspace() } label: {
+                    Label("Next Workspace", systemImage: "chevron.down.2")
+                }
+                .keyboardShortcut(shortcut(for: .nextWorkspace))
+                .disabled(!PaletteCommand.nextWorkspace.isEnabled(in: context))
                 Divider()
                 let topBottom = library.activeStore?.activeSession?.splitAxis == .topBottom
                 Button { actions.focusPane(.main) } label: {

--- a/agtermCore/Sources/agtermCore/AppStore+Focus.swift
+++ b/agtermCore/Sources/agtermCore/AppStore+Focus.swift
@@ -169,6 +169,19 @@ extension AppStore {
         return visible.isEmpty ? workspaces : visible
     }
 
+    /// Whether a workspace step has anywhere to go. The predicate `navigateWorkspace` itself turns on, and
+    /// what `PaletteCommand.isEnabled` reads, so the menu item and the mapped key cannot claim to do
+    /// something the action then declines. A lone visible workspace is a dead end only while it is ALREADY
+    /// current: when the current one is filtered out, entering the sole survivor is the whole point of the
+    /// step. Flagged mode renders no workspace rows at all.
+    public var canStepWorkspaces: Bool {
+        guard sidebarMode == .tree else { return false }
+        let ids = visibleWorkspaces.map(\.id)
+        guard !ids.isEmpty else { return false }
+        guard let current = currentWorkspaceID, ids.contains(current) else { return true }
+        return ids.count > 1
+    }
+
     /// The session set navigation operates over — the VISIBLE/FILTERED set, not the whole tree: flagged
     /// sessions in `.flagged` mode, the marked workspaces' sessions while the filter is on, else all. Computed
     /// live, so clearing the flag/filter restores the full set. `navigateSession` next/prev WRAP within it,

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -23,7 +23,7 @@ extension SessionNavigation {
 }
 
 /// A relative step through the visible workspace list. Only `next`/`previous`: a workspace carries no
-/// attention state, and the tree ends are already reachable by wrapping.
+/// attention state, and wrapping already reaches both ends.
 public enum WorkspaceNavigation: Sendable { case next, previous }
 
 /// What one workspace step landed on. The indicator is the selected session's, captured BEFORE an
@@ -35,8 +35,7 @@ public struct WorkspaceStep: Sendable {
 }
 
 extension WorkspaceNavigation {
-    /// Maps a control-channel direction string to a case, nil for an unknown one. Accepts both spellings of
-    /// previous, like `SessionNavigation`.
+    /// Maps a control-channel direction string to a case, nil for unknown. Both spellings of previous.
     public init?(wire: String) {
         switch wire {
         case "next": self = .next
@@ -268,7 +267,9 @@ public final class AppStore {
                             dashboardFontSize: () -> Double? = { nil },
                             dashboardFontMode: () -> String? = { nil }) -> ControlTree {
         let activeID = selectedSessionID
-        let activeWorkspaceID = activeID.flatMap { workspace(forSession: $0)?.id }
+        // `currentWorkspaceID`, not the selected session's owner: an EMPTY destination selects nothing, so
+        // deriving this from the selection alone made `tree` name the workspace `workspace.go` just left.
+        let activeWorkspaceID = currentWorkspaceID
         let nodes = workspaces.map { workspace in
             let sessions = workspace.sessions.map { session in
                 let idle = session.agentIndicator.status == .idle
@@ -659,12 +660,11 @@ public final class AppStore {
         return selectSession(target)
     }
 
-    /// Steps the CURRENT workspace one place through `visibleWorkspaces`, WRAPPING, via `selectWorkspace`.
-    /// Scoped to the set `navigableSessions` uses, so a focus filter confines it as it does session nav.
-    /// Collapse state is deliberately NOT a term: skipping a folded workspace would let the sidebar's fold
-    /// silently rewrite where a keystroke lands. Nil when there is nowhere to step — flagged mode renders no
-    /// workspace rows, and a lone workspace would only reselect itself, yanking the selection to its first
-    /// session. Backs `next_workspace`/`previous_workspace` and `workspace.go`.
+    /// Steps the CURRENT workspace one place through `visibleWorkspaces`, WRAPPING, via `selectWorkspace`, so
+    /// a focus filter confines it as it does session nav. Collapse state is deliberately NOT a term: skipping
+    /// a folded workspace would let the sidebar's fold silently rewrite where a keystroke lands. Nil with
+    /// nowhere to step — flagged mode renders no workspace rows, and a lone workspace would only reselect
+    /// itself. Backs `next_workspace`/`previous_workspace` and `workspace.go`.
     @discardableResult
     public func navigateWorkspace(_ direction: WorkspaceNavigation) -> WorkspaceStep? {
         guard sidebarMode == .tree else { return nil }
@@ -760,20 +760,20 @@ public final class AppStore {
 
     /// The workspace rows the sidebar renders OPEN, mirrored from its outline. View state: not persisted, not
     /// in `snapshot()`, and deliberately at odds with `Workspace.isExpanded` wherever a reveal opened a row
-    /// collapsed on disk. `@ObservationIgnored` because the mirror is written from inside the outline's own
-    /// update pass, where an observed write would feed back into the rebuild that caused it.
+    /// collapsed on disk. `@ObservationIgnored` — the mirror is written from inside the outline's own update
+    /// pass, where an observed write would feed back into the rebuild that caused it.
     @ObservationIgnored public private(set) var sidebarExpandedWorkspaceIDs = Set<UUID>()
 
-    /// Records what the sidebar outline now shows expanded. Called by its coordinator alone.
+    /// Records what the outline now shows expanded. Called by the sidebar coordinator alone.
     public func noteSidebarExpansion(_ ids: Set<UUID>) {
         sidebarExpandedWorkspaceIDs = ids
     }
 
     /// Whether the CURRENT workspace is folded ON SCREEN — what Collapse/Expand Workspace acts on, NOT the
-    /// persisted `!isExpanded` the `collapsed` read-back reports. The two diverge constantly here: a reveal
-    /// opens the owner of a newly selected session without persisting, and the current workspace is by
-    /// definition the one holding the selection, so the persisted flag would call a visibly open row collapsed
-    /// and spend the keystroke re-persisting instead of folding. With no sidebar there are no rows to read.
+    /// persisted `!isExpanded` the `collapsed` read-back reports. The two diverge constantly here, since a
+    /// reveal opens the owner of a newly selected session without persisting and this workspace is by
+    /// definition the selection's owner: the persisted flag would call a visibly open row collapsed and spend
+    /// the keystroke re-persisting. With no sidebar there are no rows to read.
     public var isCurrentWorkspaceCollapsed: Bool {
         guard let id = currentWorkspaceID else { return false }
         guard sidebarVisible else { return workspaces.first(where: { $0.id == id })?.isExpanded == false }

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -26,10 +26,9 @@ extension SessionNavigation {
 /// attention state, and the tree ends are already reachable by wrapping.
 public enum WorkspaceNavigation: Sendable { case next, previous }
 
-/// What one workspace step landed on: the workspace now current, and the indicator of the session it
-/// selected, captured BEFORE an `autoReset` status cleared. Both halves are needed — `workspace.go` reports
-/// the workspace, while the GUI needs the indicator to route pane reveal exactly as session nav does
-/// (`AppActions.revealActiveBlockedPane`). An empty workspace carries no indicator.
+/// What one workspace step landed on. The indicator is the selected session's, captured BEFORE an
+/// `autoReset` status cleared, which is what lets the GUI route pane reveal exactly as session nav does
+/// (`AppActions.revealActiveBlockedPane`); nil for an empty workspace.
 public struct WorkspaceStep: Sendable {
     public let workspaceID: UUID
     public let indicator: AgentIndicator?
@@ -209,9 +208,8 @@ public final class AppStore {
     /// Makes `workspaceID` the current one and selects its first session when it has one. Both halves are
     /// needed: the first session may already BE the selection, and a same-value write leaves the target
     /// alone; an empty workspace has nothing to select at all, and reporting success while targeting
-    /// somewhere else is what made `workspace.select --target <empty>` a lie. Nil for an unknown id, which
-    /// is the only failure. Backs `workspace.select` and `navigateWorkspace`; the returned step carries the
-    /// pre-auto-reset indicator the GUI needs for pane reveal, nil for an empty workspace.
+    /// somewhere else is what made `workspace.select --target <empty>` a lie. Nil for an unknown id, the only
+    /// failure. Backs `workspace.select` and `navigateWorkspace`.
     @discardableResult
     public func selectWorkspace(_ workspaceID: UUID) -> WorkspaceStep? {
         guard let workspace = workspaces.first(where: { $0.id == workspaceID }) else { return nil }
@@ -661,15 +659,12 @@ public final class AppStore {
         return selectSession(target)
     }
 
-    /// Steps the CURRENT workspace one place through `visibleWorkspaces` and makes it current, WRAPPING at
-    /// both ends. Scoped to the same filtered set `navigableSessions` uses, so a focus filter confines
-    /// workspace traversal exactly as it confines session navigation. Collapse state is deliberately not a
-    /// term: a collapsed workspace is a display state, and skipping it here would make the sidebar's fold
-    /// silently rewrite where a keystroke lands. Routes through `selectWorkspace`, inheriting its
-    /// first-session selection and its empty-workspace reveal. Returns what it landed on, nil when there is
-    /// nowhere to step: flagged mode renders no workspace rows, and a lone visible workspace would only
-    /// reselect itself, yanking the selection to its first session. Backs `next_workspace`/
-    /// `previous_workspace` and `workspace.go`.
+    /// Steps the CURRENT workspace one place through `visibleWorkspaces`, WRAPPING, via `selectWorkspace`.
+    /// Scoped to the set `navigableSessions` uses, so a focus filter confines it as it does session nav.
+    /// Collapse state is deliberately NOT a term: skipping a folded workspace would let the sidebar's fold
+    /// silently rewrite where a keystroke lands. Nil when there is nowhere to step — flagged mode renders no
+    /// workspace rows, and a lone workspace would only reselect itself, yanking the selection to its first
+    /// session. Backs `next_workspace`/`previous_workspace` and `workspace.go`.
     @discardableResult
     public func navigateWorkspace(_ direction: WorkspaceNavigation) -> WorkspaceStep? {
         guard sidebarMode == .tree else { return nil }
@@ -763,12 +758,26 @@ public final class AppStore {
         save()
     }
 
-    /// Whether the CURRENT workspace's subtree is folded — the persisted `!isExpanded`, matching the `collapsed`
-    /// tree read-back rather than the sidebar's transient reveal. Names the Collapse/Expand Workspace row and
-    /// picks the value its keystroke writes. False with no current workspace, so the toggle folds it.
+    /// The workspace rows the sidebar renders OPEN, mirrored from its outline. View state: not persisted, not
+    /// in `snapshot()`, and deliberately at odds with `Workspace.isExpanded` wherever a reveal opened a row
+    /// collapsed on disk. `@ObservationIgnored` because the mirror is written from inside the outline's own
+    /// update pass, where an observed write would feed back into the rebuild that caused it.
+    @ObservationIgnored public private(set) var sidebarExpandedWorkspaceIDs = Set<UUID>()
+
+    /// Records what the sidebar outline now shows expanded. Called by its coordinator alone.
+    public func noteSidebarExpansion(_ ids: Set<UUID>) {
+        sidebarExpandedWorkspaceIDs = ids
+    }
+
+    /// Whether the CURRENT workspace is folded ON SCREEN — what Collapse/Expand Workspace acts on, NOT the
+    /// persisted `!isExpanded` the `collapsed` read-back reports. The two diverge constantly here: a reveal
+    /// opens the owner of a newly selected session without persisting, and the current workspace is by
+    /// definition the one holding the selection, so the persisted flag would call a visibly open row collapsed
+    /// and spend the keystroke re-persisting instead of folding. With no sidebar there are no rows to read.
     public var isCurrentWorkspaceCollapsed: Bool {
         guard let id = currentWorkspaceID else { return false }
-        return workspaces.first(where: { $0.id == id })?.isExpanded == false
+        guard sidebarVisible else { return workspaces.first(where: { $0.id == id })?.isExpanded == false }
+        return !sidebarExpandedWorkspaceIDs.contains(id)
     }
 
     /// Marks each workspace expanded iff its id is in `expandedIDs`, one `save()` for the whole diff and no

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -22,6 +22,31 @@ extension SessionNavigation {
     }
 }
 
+/// A relative step through the visible workspace list. Only `next`/`previous`: a workspace carries no
+/// attention state, and the tree ends are already reachable by wrapping.
+public enum WorkspaceNavigation: Sendable { case next, previous }
+
+/// What one workspace step landed on: the workspace now current, and the indicator of the session it
+/// selected, captured BEFORE an `autoReset` status cleared. Both halves are needed — `workspace.go` reports
+/// the workspace, while the GUI needs the indicator to route pane reveal exactly as session nav does
+/// (`AppActions.revealActiveBlockedPane`). An empty workspace carries no indicator.
+public struct WorkspaceStep: Sendable {
+    public let workspaceID: UUID
+    public let indicator: AgentIndicator?
+}
+
+extension WorkspaceNavigation {
+    /// Maps a control-channel direction string to a case, nil for an unknown one. Accepts both spellings of
+    /// previous, like `SessionNavigation`.
+    public init?(wire: String) {
+        switch wire {
+        case "next": self = .next
+        case "prev", "previous": self = .previous
+        default: return nil
+        }
+    }
+}
+
 /// The whole app state: the workspace tree and the current selection. `@Observable @MainActor` so views
 /// observe mutations and all model access is main-actor isolated (implicitly `Sendable` via isolation).
 /// Selection is one `Session.ID?` — workspace rows are non-selectable headers, so the workspace is derived.
@@ -184,14 +209,16 @@ public final class AppStore {
     /// Makes `workspaceID` the current one and selects its first session when it has one. Both halves are
     /// needed: the first session may already BE the selection, and a same-value write leaves the target
     /// alone; an empty workspace has nothing to select at all, and reporting success while targeting
-    /// somewhere else is what made `workspace.select --target <empty>` a lie. Backs `workspace.select`.
+    /// somewhere else is what made `workspace.select --target <empty>` a lie. Nil for an unknown id, which
+    /// is the only failure. Backs `workspace.select` and `navigateWorkspace`; the returned step carries the
+    /// pre-auto-reset indicator the GUI needs for pane reveal, nil for an empty workspace.
     @discardableResult
-    public func selectWorkspace(_ workspaceID: UUID) -> Bool {
-        guard let workspace = workspaces.first(where: { $0.id == workspaceID }) else { return false }
+    public func selectWorkspace(_ workspaceID: UUID) -> WorkspaceStep? {
+        guard let workspace = workspaces.first(where: { $0.id == workspaceID }) else { return nil }
         if let first = workspace.sessions.first {
-            selectSession(first.id)
+            let indicator = selectSession(first.id)
             freshWorkspaceID = nil
-            return true
+            return WorkspaceStep(workspaceID: workspaceID, indicator: indicator)
         }
         // an empty workspace the filter hides would be a target with no row: reveal it, the same
         // auto-reveal `addWorkspace` performs, so what is current is always on screen. the target itself
@@ -200,7 +227,7 @@ public final class AppStore {
         revealNewFocusMember(workspaceID)
         freshWorkspaceID = workspaceID
         if focusedWorkspaceIDs != marked { save() }
-        return true
+        return WorkspaceStep(workspaceID: workspaceID, indicator: nil)
     }
 
     /// Drops the target when the focus filter has hidden it, so turning the filter off later cannot make it
@@ -634,6 +661,32 @@ public final class AppStore {
         return selectSession(target)
     }
 
+    /// Steps the CURRENT workspace one place through `visibleWorkspaces` and makes it current, WRAPPING at
+    /// both ends. Scoped to the same filtered set `navigableSessions` uses, so a focus filter confines
+    /// workspace traversal exactly as it confines session navigation. Collapse state is deliberately not a
+    /// term: a collapsed workspace is a display state, and skipping it here would make the sidebar's fold
+    /// silently rewrite where a keystroke lands. Routes through `selectWorkspace`, inheriting its
+    /// first-session selection and its empty-workspace reveal. Returns what it landed on, nil when there is
+    /// nowhere to step: flagged mode renders no workspace rows, and a lone visible workspace would only
+    /// reselect itself, yanking the selection to its first session. Backs `next_workspace`/
+    /// `previous_workspace` and `workspace.go`.
+    @discardableResult
+    public func navigateWorkspace(_ direction: WorkspaceNavigation) -> WorkspaceStep? {
+        guard sidebarMode == .tree else { return nil }
+        let ids = visibleWorkspaces.map(\.id)
+        guard ids.count > 1 else { return nil }
+        let target: UUID
+        if let current = currentWorkspaceID, let i = ids.firstIndex(of: current) {
+            let step = direction == .next ? 1 : -1
+            target = ids[((i + step) % ids.count + ids.count) % ids.count]
+        } else {
+            // current sits outside the visible set: land on the end the step comes from, so the first
+            // keystroke enters the set rather than no-opping, mirroring `navigateSession`'s fallback.
+            target = direction == .next ? ids[0] : ids[ids.count - 1]
+        }
+        return selectWorkspace(target)
+    }
+
     /// The next/previous session needing attention (`blocked`/`completed`) in the flattened order, scanning
     /// from the current selection and WRAPPING; the current session is excluded, so repeated steps cycle
     /// through the others. With no/invalid selection the scan starts from the tree end opposite the
@@ -708,6 +761,14 @@ public final class AppStore {
         guard let index = workspaces.firstIndex(where: { $0.id == id }), workspaces[index].isExpanded != expanded else { return }
         workspaces[index].isExpanded = expanded
         save()
+    }
+
+    /// Whether the CURRENT workspace's subtree is folded — the persisted `!isExpanded`, matching the `collapsed`
+    /// tree read-back rather than the sidebar's transient reveal. Names the Collapse/Expand Workspace row and
+    /// picks the value its keystroke writes. False with no current workspace, so the toggle folds it.
+    public var isCurrentWorkspaceCollapsed: Bool {
+        guard let id = currentWorkspaceID else { return false }
+        return workspaces.first(where: { $0.id == id })?.isExpanded == false
     }
 
     /// Marks each workspace expanded iff its id is in `expandedIDs`, one `save()` for the whole diff and no

--- a/agtermCore/Sources/agtermCore/AppStore.swift
+++ b/agtermCore/Sources/agtermCore/AppStore.swift
@@ -667,9 +667,8 @@ public final class AppStore {
     /// itself. Backs `next_workspace`/`previous_workspace` and `workspace.go`.
     @discardableResult
     public func navigateWorkspace(_ direction: WorkspaceNavigation) -> WorkspaceStep? {
-        guard sidebarMode == .tree else { return nil }
+        guard canStepWorkspaces else { return nil }
         let ids = visibleWorkspaces.map(\.id)
-        guard ids.count > 1 else { return nil }
         let target: UUID
         if let current = currentWorkspaceID, let i = ids.firstIndex(of: current) {
             let step = direction == .next ? 1 : -1

--- a/agtermCore/Sources/agtermCore/BuiltinAction.swift
+++ b/agtermCore/Sources/agtermCore/BuiltinAction.swift
@@ -15,6 +15,8 @@ public enum BuiltinAction: String, CaseIterable, Sendable {
     case toggleSidebar = "toggle_sidebar", selectTheme = "select_theme", toggleFullscreen = "toggle_fullscreen"
     case toggleFlaggedView = "toggle_flagged_view", toggleFlag = "toggle_flag", focusWorkspace = "focus_workspace"
     case toggleWorkspaceFilter = "toggle_workspace_filter"
+    case previousWorkspace = "previous_workspace", nextWorkspace = "next_workspace"
+    case toggleWorkspaceCollapse = "toggle_workspace_collapse"
     case focusLeftPane = "focus_left_pane", focusRightPane = "focus_right_pane"
     case previousSession = "previous_session", nextSession = "next_session"
     case previousAttentionSession = "previous_attention_session", nextAttentionSession = "next_attention_session"
@@ -61,7 +63,7 @@ public enum BuiltinAction: String, CaseIterable, Sendable {
         case .nextAttentionSession: return Chord(mods: [.control, .option], key: "down")
         case .renameWindow, .deleteWindow, .renameWorkspace, .deleteWorkspace, .renameSession, .duplicateSession,
              .clearStatus, .firstSession, .lastSession, .selectTheme, .toggleFlaggedView, .focusWorkspace,
-             .toggleWorkspaceFilter:
+             .toggleWorkspaceFilter, .previousWorkspace, .nextWorkspace, .toggleWorkspaceCollapse:
             return nil
         }
     }

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -17,8 +17,9 @@ public protocol ControlActions {
     func revealSession(_ target: String?, window: String?) -> ControlResponse
     func createWorkspace(window: String?, name: String?, collapsed: Bool) -> ControlResponse
     func selectWorkspace(_ target: String?, window: String?) -> ControlResponse
-    /// Step the placement store's CURRENT workspace one place through the sidebar's visible order and select
-    /// its first session. Relative, so it takes no target — the counterpart of `session.go` one level up.
+    /// Step the placement store's CURRENT workspace one place through the sidebar's visible order, selecting
+    /// the destination's first session when it has one — an EMPTY destination becomes current with the
+    /// selection left where it was. Relative, so no target: the counterpart of `session.go` one level up.
     func goWorkspace(window: String?, direction: WorkspaceNavigation) -> ControlResponse
     func renameWorkspace(_ target: String?, window: String?, name: String) -> ControlResponse
     func deleteWorkspace(_ target: String?, window: String?) -> ControlResponse

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -17,6 +17,9 @@ public protocol ControlActions {
     func revealSession(_ target: String?, window: String?) -> ControlResponse
     func createWorkspace(window: String?, name: String?, collapsed: Bool) -> ControlResponse
     func selectWorkspace(_ target: String?, window: String?) -> ControlResponse
+    /// Step the placement store's CURRENT workspace one place through the sidebar's visible order and select
+    /// its first session. Relative, so it takes no target — the counterpart of `session.go` one level up.
+    func goWorkspace(window: String?, direction: WorkspaceNavigation) -> ControlResponse
     func renameWorkspace(_ target: String?, window: String?, name: String) -> ControlResponse
     func deleteWorkspace(_ target: String?, window: String?) -> ControlResponse
     func moveSession(_ target: String?, window: String?, move: ControlSessionMove) -> ControlResponse
@@ -192,7 +195,7 @@ public struct ControlDispatcher {
                 .sessionOverlayClose, .sessionOverlayResize, .sessionOverlayResult, .sessionBackground,
                 .sessionText:
             return await dispatchSessionSurfaceCommand(request)
-        case .workspaceNew, .workspaceSelect, .workspaceRename, .workspaceDelete,
+        case .workspaceNew, .workspaceSelect, .workspaceGo, .workspaceRename, .workspaceDelete,
                 .workspaceMove, .workspaceFocus, .workspaceFilter, .workspaceCollapse, .workspaceExpand:
             return dispatchWorkspaceCommand(request)
         case .quick, .fontInc, .fontDec, .fontReset, .keymapReload, .keymapList,
@@ -476,6 +479,11 @@ public struct ControlDispatcher {
                                            collapsed: request.args?.collapsed ?? false)
         case .workspaceSelect:
             return actions.selectWorkspace(request.target, window: request.args?.window)
+        case .workspaceGo:
+            guard let dir = (request.args?.to).flatMap(WorkspaceNavigation.init(wire:)) else {
+                return ControlResponse(ok: false, error: "workspace.go requires --to next|prev")
+            }
+            return actions.goWorkspace(window: request.args?.window, direction: dir)
         case .workspaceRename:
             guard let name = request.args?.name?.trimmedOrNil else {
                 return ControlResponse(ok: false, error: "workspace.rename requires a name")

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -194,9 +194,10 @@ public struct ControlArgs: Codable, Sendable, Equatable {
     public var all: Bool?
     /// For `session.text` / `quick.text`: keep only the last N lines of the full buffer.
     public var lines: Int?
-    /// Direction for `session.go` (`next`|`prev`|`previous`|`first`|`last`), for the reorder form of
-    /// `session.move` / `workspace.move` (`up`|`down`|`top`|`bottom`), and for `session.search`
-    /// (`next`|`prev`|`close`).
+    /// Direction for `session.go` (`next`|`prev`|`previous`|`first`|`last`), for `workspace.go`
+    /// (`next`|`prev`|`previous` — a workspace has no attention state and no ends to jump to), for the
+    /// reorder form of `session.move` / `workspace.move` (`up`|`down`|`top`|`bottom`), and for
+    /// `session.search` (`next`|`prev`|`close`).
     public var to: String?
     /// Anchor session (id / unique prefix / `active`) to place a session right AFTER, for the placement form
     /// of `session.new`/`session.move`. The anchor carries its own workspace (resolved across the whole

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -642,7 +642,9 @@ public struct ControlWorkspaceNode: Codable, Sendable, Equatable {
     public let active: Bool
     /// Whether this workspace is a MEMBER of the sidebar's focus set; nil/omitted when not. Reported
     /// INDEPENDENTLY of whether the filter is applied (that flag is the tree top-level `workspaceFilter`), so
-    /// a marked-but-not-filtering set reads back. Distinct from `active` (the SELECTED workspace). The read
+    /// a marked-but-not-filtering set reads back. Distinct from `active` (the CURRENT workspace — what
+    /// `--target active` resolves to, which an empty or foreground-created destination makes current while
+    /// the selected session stays behind in another one). The read
     /// side of the write-only `workspace.focus`/`workspace.filter`.
     ///
     /// A workspace ROW is VISIBLE iff `tree.sidebarVisible && tree.sidebarMode == "tree" &&

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -7,6 +7,7 @@ public enum Command: String, Codable, Sendable {
     case workspaceRename = "workspace.rename"
     case workspaceDelete = "workspace.delete"
     case workspaceSelect = "workspace.select"
+    case workspaceGo = "workspace.go"
     case sessionNew = "session.new"
     case sessionDuplicate = "session.duplicate"
     case sessionClose = "session.close"

--- a/agtermCore/Sources/agtermCore/PaletteCatalog.swift
+++ b/agtermCore/Sources/agtermCore/PaletteCatalog.swift
@@ -14,8 +14,13 @@ public struct PaletteContext: Sendable, Equatable {
     /// The ONLY term that entry keys on, matching the View-menu twin — marking is offered in either mode.
     public let activeWorkspaceMarked: Bool
     /// Whether the CURRENT workspace's sidebar subtree is folded, so the collapse toggle can name what the
-    /// keystroke will do. Mirrors the `collapsed` tree read-back, i.e. the persisted `!isExpanded`.
+    /// keystroke will do. `AppStore.isCurrentWorkspaceCollapsed`: what the ROW shows, deliberately not the
+    /// persisted `!isExpanded` the `collapsed` tree read-back reports.
     public let activeWorkspaceCollapsed: Bool
+    /// Whether more than one workspace is visible, i.e. whether a workspace step has anywhere to go.
+    /// `navigateWorkspace` no-ops below that, so without this term the menu item and the mapped key stay
+    /// live while provably doing nothing.
+    public let canStepWorkspaces: Bool
     public let activeSessionHasSplit: Bool
     public let activeSplitAxis: SplitAxis?
     public let hasPendingClose: Bool
@@ -41,6 +46,7 @@ public struct PaletteContext: Sendable, Equatable {
                 hasMarkedWorkspaces: Bool = false,
                 activeWorkspaceMarked: Bool = false,
                 activeWorkspaceCollapsed: Bool = false,
+                canStepWorkspaces: Bool = false,
                 activeSessionHasSplit: Bool = false,
                 activeSplitAxis: SplitAxis? = nil,
                 hasPendingClose: Bool = false,
@@ -58,6 +64,7 @@ public struct PaletteContext: Sendable, Equatable {
         self.hasMarkedWorkspaces = hasMarkedWorkspaces
         self.activeWorkspaceMarked = activeWorkspaceMarked
         self.activeWorkspaceCollapsed = activeWorkspaceCollapsed
+        self.canStepWorkspaces = canStepWorkspaces
         self.activeSessionHasSplit = activeSessionHasSplit
         self.activeSplitAxis = activeSplitAxis
         self.hasPendingClose = hasPendingClose
@@ -98,9 +105,11 @@ public enum PaletteCommand: String, CaseIterable, Sendable {
              .find, .previousSession, .nextSession, .previousAttentionSession, .nextAttentionSession,
              .firstSession, .lastSession:
             return context.hasActiveSession
-        case .renameWorkspace, .focusWorkspace, .addWorkspaceToFocus,
-             .previousWorkspace, .nextWorkspace, .toggleWorkspaceCollapse:
+        case .renameWorkspace, .focusWorkspace, .addWorkspaceToFocus, .toggleWorkspaceCollapse:
             return context.hasCurrentWorkspace
+        case .previousWorkspace, .nextWorkspace:
+            // a step needs somewhere to go, so a lone visible workspace disables rather than no-ops
+            return context.hasCurrentWorkspace && context.canStepWorkspaces
         default:
             return true
         }

--- a/agtermCore/Sources/agtermCore/PaletteCatalog.swift
+++ b/agtermCore/Sources/agtermCore/PaletteCatalog.swift
@@ -13,6 +13,9 @@ public struct PaletteContext: Sendable, Equatable {
     /// offering a silent no-op (the sidebar row's item has a clicked row and flips to "Remove from Focus").
     /// The ONLY term that entry keys on, matching the View-menu twin — marking is offered in either mode.
     public let activeWorkspaceMarked: Bool
+    /// Whether the CURRENT workspace's sidebar subtree is folded, so the collapse toggle can name what the
+    /// keystroke will do. Mirrors the `collapsed` tree read-back, i.e. the persisted `!isExpanded`.
+    public let activeWorkspaceCollapsed: Bool
     public let activeSessionHasSplit: Bool
     public let activeSplitAxis: SplitAxis?
     public let hasPendingClose: Bool
@@ -37,6 +40,7 @@ public struct PaletteContext: Sendable, Equatable {
                 activeSessionFlagged: Bool = false,
                 hasMarkedWorkspaces: Bool = false,
                 activeWorkspaceMarked: Bool = false,
+                activeWorkspaceCollapsed: Bool = false,
                 activeSessionHasSplit: Bool = false,
                 activeSplitAxis: SplitAxis? = nil,
                 hasPendingClose: Bool = false,
@@ -53,6 +57,7 @@ public struct PaletteContext: Sendable, Equatable {
         self.activeSessionFlagged = activeSessionFlagged
         self.hasMarkedWorkspaces = hasMarkedWorkspaces
         self.activeWorkspaceMarked = activeWorkspaceMarked
+        self.activeWorkspaceCollapsed = activeWorkspaceCollapsed
         self.activeSessionHasSplit = activeSessionHasSplit
         self.activeSplitAxis = activeSplitAxis
         self.hasPendingClose = hasPendingClose
@@ -70,6 +75,7 @@ public enum PaletteCommand: String, CaseIterable, Sendable {
     case newSession, newWorkspace, openDirectory
     case renameSession, duplicateSession, renameWorkspace, closeSession, reopenRecent, undoClose, clearStatus
     case previousSession, nextSession, previousAttentionSession, nextAttentionSession
+    case previousWorkspace, nextWorkspace
     case firstSession, lastSession, showAttention
     case toggleSplit, toggleHorizontalSplit, closeSplit, toggleScratch, toggleTerminalZoom
     case toggleSidebar, toggleFlag, focusWorkspace
@@ -78,7 +84,7 @@ public enum PaletteCommand: String, CaseIterable, Sendable {
     case editKeymap, reloadKeymap, editGhosttyConfig, reloadConfig
     case deleteWorkspace, toggleFlaggedView, clearFlagged, clearFocus
     case addWorkspaceToFocus, toggleWorkspaceFilter
-    case expandWorkspaces, collapseWorkspaces, focusLeftPane, focusRightPane
+    case expandWorkspaces, collapseWorkspaces, toggleWorkspaceCollapse, focusLeftPane, focusRightPane
 
     /// Whether the command can RUN right now — the single owner of menu enablement, read by the menu item's
     /// `.disabled(…)`, by the palette row (which stays listed but renders inert) and by the key monitor's
@@ -92,7 +98,8 @@ public enum PaletteCommand: String, CaseIterable, Sendable {
              .find, .previousSession, .nextSession, .previousAttentionSession, .nextAttentionSession,
              .firstSession, .lastSession:
             return context.hasActiveSession
-        case .renameWorkspace, .focusWorkspace, .addWorkspaceToFocus:
+        case .renameWorkspace, .focusWorkspace, .addWorkspaceToFocus,
+             .previousWorkspace, .nextWorkspace, .toggleWorkspaceCollapse:
             return context.hasCurrentWorkspace
         default:
             return true
@@ -137,7 +144,11 @@ public enum PaletteCommand: String, CaseIterable, Sendable {
             // `workspace.focus`/`workspace.filter`. the tree-mode gate belongs to expand/collapse, whose rows
             // flagged mode never renders.
             return !context.activeWorkspaceMarked
-        case .expandWorkspaces, .collapseWorkspaces:
+        case .expandWorkspaces, .collapseWorkspaces, .toggleWorkspaceCollapse,
+             .previousWorkspace, .nextWorkspace:
+            // the tree-mode gate the sibling comment on `addWorkspaceToFocus` describes: these five act on
+            // workspace ROWS, which flagged mode's flat list does not render, and `navigateWorkspace` no-ops
+            // there for the same reason.
             return context.sidebarShowsWorkspaceTree
         case .focusLeftPane, .focusRightPane, .closeSplit:
             // `hasSplit`, not `isSplit`: a hidden pane is alive and still reported, the state Close Split
@@ -172,6 +183,8 @@ public enum PaletteCommand: String, CaseIterable, Sendable {
         case .nextSession: return "Next Session"
         case .previousAttentionSession: return "Previous Attention Session"
         case .nextAttentionSession: return "Next Attention Session"
+        case .previousWorkspace: return "Previous Workspace"
+        case .nextWorkspace: return "Next Workspace"
         case .firstSession: return "First Session"
         case .lastSession: return "Last Session"
         case .showAttention: return "Show Attention"
@@ -203,6 +216,7 @@ public enum PaletteCommand: String, CaseIterable, Sendable {
         case .toggleWorkspaceFilter: return "Toggle Workspace Filter"
         case .expandWorkspaces: return "Expand Workspaces"
         case .collapseWorkspaces: return "Collapse Workspaces"
+        case .toggleWorkspaceCollapse: return context.activeWorkspaceCollapsed ? "Expand Workspace" : "Collapse Workspace"
         case .focusLeftPane: return context.activeSplitAxis == .topBottom ? "Focus Top Pane" : "Focus Left Pane"
         case .focusRightPane: return context.activeSplitAxis == .topBottom ? "Focus Bottom Pane" : "Focus Right Pane"
         }
@@ -224,6 +238,9 @@ public enum PaletteCommand: String, CaseIterable, Sendable {
         case .nextSession: return .nextSession
         case .previousAttentionSession: return .previousAttentionSession
         case .nextAttentionSession: return .nextAttentionSession
+        case .previousWorkspace: return .previousWorkspace
+        case .nextWorkspace: return .nextWorkspace
+        case .toggleWorkspaceCollapse: return .toggleWorkspaceCollapse
         case .firstSession: return .firstSession
         case .lastSession: return .lastSession
         case .showAttention: return .showAttention

--- a/agtermCore/Sources/agtermctlKit/WorkspaceCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/WorkspaceCommands.swift
@@ -6,7 +6,7 @@ import agtermCore
 struct Workspace: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Workspace commands.",
-        subcommands: [New.self, Rename.self, Delete.self, Select.self, Move.self, Focus.self, Filter.self,
+        subcommands: [New.self, Rename.self, Delete.self, Select.self, Go.self, Move.self, Focus.self, Filter.self,
                       Collapse.self, Expand.self]
     )
 
@@ -50,6 +50,20 @@ struct Workspace: ParsableCommand {
 
         func makeRequest() throws -> ControlRequest {
             ControlRequest(cmd: .workspaceSelect, target: target.target, args: options.withWindow())
+        }
+    }
+
+    /// `agtermctl workspace go --to next|prev` — steps the CURRENT workspace and selects its first session.
+    /// Deliberately NO `--target`: it is relative to what is current, the shape `session go` takes, not the
+    /// `workspace.*` target commands. `move` is the neighbouring verb that REORDERS instead.
+    struct Go: RequestCommand {
+        static let configuration = CommandConfiguration(commandName: "go",
+            abstract: "Navigate workspaces: next|prev.")
+        @Option(name: .long, help: "Direction: next or prev.") var to: String
+        @OptionGroup var options: ClientOptions
+
+        func makeRequest() throws -> ControlRequest {
+            ControlRequest(cmd: .workspaceGo, args: options.withWindow(ControlArgs(to: to)))
         }
     }
 

--- a/agtermCore/Tests/agtermCoreTests/AppStoreCurrentWorkspaceTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreCurrentWorkspaceTests.swift
@@ -178,7 +178,7 @@ struct AppStoreCurrentWorkspaceTests {
         store.selectSession(session.id)
         store.addWorkspace(name: "fresh")
 
-        #expect(store.selectWorkspace(work.id))
+        #expect(store.selectWorkspace(work.id) != nil)
         #expect(store.selectedSessionID == session.id)
         #expect(store.currentWorkspaceID == work.id)
     }
@@ -193,7 +193,7 @@ struct AppStoreCurrentWorkspaceTests {
         store.addWorkspace(name: "fresh")
         let empty = store.addWorkspace(name: "empty", revealNewWorkspace: false)
 
-        #expect(store.selectWorkspace(empty.id))
+        #expect(store.selectWorkspace(empty.id) != nil)
         #expect(store.selectedSessionID == session.id)
         #expect(store.currentWorkspaceID == empty.id)
     }
@@ -208,7 +208,7 @@ struct AppStoreCurrentWorkspaceTests {
         store.setFocusedWorkspace(work.id)
         #expect(store.visibleWorkspaces.map(\.id) == [work.id])
 
-        #expect(store.selectWorkspace(empty.id))
+        #expect(store.selectWorkspace(empty.id) != nil)
         #expect(store.currentWorkspaceID == empty.id)
         #expect(store.visibleWorkspaces.map(\.id) == [work.id, empty.id], "the target must be on screen")
         #expect(store.focusEnabled, "the filter must widen, not switch off")
@@ -247,7 +247,7 @@ struct AppStoreCurrentWorkspaceTests {
         let store = makeStore()
         let work = store.addWorkspace(name: "work")
 
-        #expect(!store.selectWorkspace(UUID()))
+        #expect(store.selectWorkspace(UUID()) == nil)
         #expect(store.currentWorkspaceID == work.id)
     }
 

--- a/agtermCore/Tests/agtermCoreTests/AppStoreNavigationTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreNavigationTests.swift
@@ -417,4 +417,95 @@ struct AppStoreNavigationTests {
         _ = store.addSession(toWorkspace: ws.id, cwd: "/b")
         #expect(store.attentionSessions.isEmpty)
     }
+
+    /// Three workspaces (work: a, b; personal: c; scratch: d) so a step's landing session is unambiguous.
+    static func makeWorkspaceNavTree() -> (store: AppStore, workspaces: [UUID], sessions: [UUID]) {
+        let store = makeStore()
+        let work = store.addWorkspace(name: "work")
+        let personal = store.addWorkspace(name: "personal")
+        let scratch = store.addWorkspace(name: "scratch")
+        let a = store.addSession(toWorkspace: work.id, cwd: "/a")!
+        let b = store.addSession(toWorkspace: work.id, cwd: "/b")!
+        let c = store.addSession(toWorkspace: personal.id, cwd: "/c")!
+        let d = store.addSession(toWorkspace: scratch.id, cwd: "/d")!
+        return (store, [work.id, personal.id, scratch.id], [a.id, b.id, c.id, d.id])
+    }
+
+    @Test func navigateWorkspaceNextStepsForwardAndWraps() throws {
+        let (store, workspaces, sessions) = Self.makeWorkspaceNavTree()
+        store.selectSession(sessions[1]) // b, the SECOND session of work
+        #expect(try #require(store.navigateWorkspace(.next)).workspaceID == workspaces[1])
+        #expect(store.selectedSessionID == sessions[2], "lands on the target's FIRST session")
+        #expect(try #require(store.navigateWorkspace(.next)).workspaceID == workspaces[2])
+        #expect(try #require(store.navigateWorkspace(.next)).workspaceID == workspaces[0])
+        #expect(store.selectedSessionID == sessions[0])
+    }
+
+    @Test func navigateWorkspacePreviousStepsBackwardAndWraps() throws {
+        let (store, workspaces, sessions) = Self.makeWorkspaceNavTree()
+        store.selectSession(sessions[1]) // b, so previous leaves work from its middle
+        #expect(try #require(store.navigateWorkspace(.previous)).workspaceID == workspaces[2])
+        #expect(store.selectedSessionID == sessions[3])
+        #expect(try #require(store.navigateWorkspace(.previous)).workspaceID == workspaces[1])
+        #expect(store.selectedSessionID == sessions[2])
+    }
+
+    @Test func navigateWorkspaceStaysWithinTheFocusFilter() {
+        let (store, workspaces, sessions) = Self.makeWorkspaceNavTree()
+        store.selectSession(sessions[0])
+        store.setFocusedWorkspace(workspaces[0])
+        #expect(store.navigateWorkspace(.next) == nil, "a sole marked workspace has nowhere to step")
+        #expect(store.selectedSessionID == sessions[0])
+    }
+
+    @Test func navigateWorkspaceIsANoOpInFlaggedMode() {
+        let (store, _, sessions) = Self.makeWorkspaceNavTree()
+        store.selectSession(sessions[0])
+        store.setFlag(true, forSession: sessions[0])
+        store.setSidebarMode(.flagged)
+        #expect(store.navigateWorkspace(.next) == nil)
+        #expect(store.selectedSessionID == sessions[0])
+    }
+
+    @Test func navigateWorkspaceIsANoOpWithOneWorkspace() {
+        let store = makeStore()
+        let only = store.addWorkspace(name: "only")
+        let a = store.addSession(toWorkspace: only.id, cwd: "/a")!
+        let b = store.addSession(toWorkspace: only.id, cwd: "/b")!
+        store.selectSession(b.id)
+        #expect(store.navigateWorkspace(.next) == nil)
+        #expect(store.selectedSessionID == b.id, "a lone workspace must not yank the selection to its first session")
+        #expect(a.id != b.id)
+    }
+
+    // issue #435 assumed collapsing a workspace steers navigation. it does not, and must not: the fold is a
+    // display state, so a step lands the same way whether or not the target is folded
+    @Test func navigateWorkspaceIgnoresCollapseState() throws {
+        let (store, workspaces, sessions) = Self.makeWorkspaceNavTree()
+        store.selectSession(sessions[0])
+        store.setWorkspaceExpanded(workspaces[1], expanded: false)
+        #expect(try #require(store.navigateWorkspace(.next)).workspaceID == workspaces[1])
+        #expect(store.selectedSessionID == sessions[2])
+    }
+
+    // `currentWorkspaceID` falls back to the LAST workspace, which the filter can leave off screen — the
+    // step has to enter the visible set rather than no-op there
+    @Test func navigateWorkspaceEntersTheVisibleSetWhenCurrentIsOutsideIt() throws {
+        let (store, workspaces, _) = Self.makeWorkspaceNavTree()
+        store.setFocusMembership(workspaces[0], member: true)
+        store.setFocusMembership(workspaces[1], member: true)
+        store.setFocusEnabled(true)
+        store.selectSession(nil)
+        #expect(store.visibleWorkspaces.map(\.id) == [workspaces[0], workspaces[1]])
+        #expect(store.currentWorkspaceID == workspaces[2], "the fallback sits outside the visible set")
+        #expect(try #require(store.navigateWorkspace(.next)).workspaceID == workspaces[0])
+
+        let (other, otherWorkspaces, _) = Self.makeWorkspaceNavTree()
+        other.setFocusMembership(otherWorkspaces[0], member: true)
+        other.setFocusMembership(otherWorkspaces[1], member: true)
+        other.setFocusEnabled(true)
+        other.selectSession(nil)
+        #expect(try #require(other.navigateWorkspace(.previous)).workspaceID == otherWorkspaces[1],
+                "previous enters from the other end")
+    }
 }

--- a/agtermCore/Tests/agtermCoreTests/AppStoreNavigationTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreNavigationTests.swift
@@ -488,6 +488,41 @@ struct AppStoreNavigationTests {
         #expect(store.selectedSessionID == sessions[2])
     }
 
+    // the collapse toggle folds what the ROW shows, and a reveal opens a row without persisting, so reading
+    // the persisted flag there spends the keystroke re-persisting instead of folding
+    @Test func currentWorkspaceCollapseFollowsTheSidebarRowNotThePersistedFlag() {
+        let (store, workspaces, sessions) = Self.makeWorkspaceNavTree()
+        store.selectSession(sessions[0])
+        store.setWorkspaceExpanded(workspaces[0], expanded: false)
+        #expect(store.isCurrentWorkspaceCollapsed, "persisted collapsed with no row open reads collapsed")
+
+        store.noteSidebarExpansion([workspaces[0]]) // the reveal opens the row, persisting nothing
+        #expect(store.workspaces[0].isExpanded == false, "the reveal must not touch the persisted flag")
+        #expect(!store.isCurrentWorkspaceCollapsed, "an open row reads expanded, so the toggle folds it")
+
+        store.noteSidebarExpansion([])
+        #expect(store.isCurrentWorkspaceCollapsed)
+    }
+
+    // with no sidebar mounted there is no row to read, so the persisted intent is the only state there is
+    @Test func currentWorkspaceCollapseFallsBackToThePersistedFlagWithNoSidebar() {
+        let (store, workspaces, sessions) = Self.makeWorkspaceNavTree()
+        store.selectSession(sessions[0])
+        store.noteSidebarExpansion([workspaces[0]])
+        store.setSidebarVisible(false)
+        store.setWorkspaceExpanded(workspaces[0], expanded: false)
+        #expect(store.isCurrentWorkspaceCollapsed, "a stale live set must not outvote the persisted flag")
+
+        store.setWorkspaceExpanded(workspaces[0], expanded: true)
+        #expect(!store.isCurrentWorkspaceCollapsed)
+    }
+
+    @Test func currentWorkspaceCollapseIsFalseWithNoCurrentWorkspace() {
+        let store = makeStore()
+        #expect(store.currentWorkspaceID == nil)
+        #expect(!store.isCurrentWorkspaceCollapsed)
+    }
+
     // `currentWorkspaceID` falls back to the LAST workspace, which the filter can leave off screen — the
     // step has to enter the visible set rather than no-op there
     @Test func navigateWorkspaceEntersTheVisibleSetWhenCurrentIsOutsideIt() throws {

--- a/agtermCore/Tests/agtermCoreTests/AppStoreNavigationTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreNavigationTests.swift
@@ -517,6 +517,23 @@ struct AppStoreNavigationTests {
         #expect(!store.isCurrentWorkspaceCollapsed)
     }
 
+    // an empty destination has no session to select, so the selection stays behind and only the current
+    // workspace moves — `tree` has to name the workspace `workspace.go` reported, not the one it left
+    @Test func treeReportsTheEmptyWorkspaceAStepLandedOnAsActive() throws {
+        let (store, workspaces, sessions) = Self.makeWorkspaceNavTree()
+        let empty = store.addWorkspace(name: "empty", revealNewWorkspace: false)
+        store.selectSession(sessions[0])
+
+        let step = try #require(store.selectWorkspace(empty.id))
+        #expect(step.workspaceID == empty.id)
+        #expect(step.indicator == nil, "an empty workspace selects nothing, so it carries no indicator")
+        #expect(store.selectedSessionID == sessions[0], "the selection stays where it was")
+
+        let tree = store.controlTree()
+        #expect(tree.workspaces.first(where: { $0.active })?.id == empty.id.uuidString)
+        #expect(tree.workspaces.first(where: { $0.id == workspaces[0].uuidString })?.active == false)
+    }
+
     @Test func currentWorkspaceCollapseIsFalseWithNoCurrentWorkspace() {
         let store = makeStore()
         #expect(store.currentWorkspaceID == nil)

--- a/agtermCore/Tests/agtermCoreTests/AppStoreNavigationTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppStoreNavigationTests.swift
@@ -467,6 +467,21 @@ struct AppStoreNavigationTests {
         #expect(store.selectedSessionID == sessions[0])
     }
 
+    // a lone visible workspace is a dead end only while it is ALREADY current — when the filter hid the
+    // current one, entering the sole survivor is the whole point of the step
+    @Test func navigateWorkspaceEntersTheSoleVisibleWorkspaceWhenCurrentIsHidden() throws {
+        let (store, workspaces, _) = Self.makeWorkspaceNavTree()
+        store.setFocusMembership(workspaces[0], member: true)
+        store.setFocusEnabled(true)
+        store.selectSession(nil)
+        #expect(store.visibleWorkspaces.map(\.id) == [workspaces[0]])
+        #expect(store.currentWorkspaceID == workspaces[2], "the fallback sits outside the visible set")
+
+        #expect(store.canStepWorkspaces, "the menu item must not go dead on a reachable workspace")
+        #expect(try #require(store.navigateWorkspace(.next)).workspaceID == workspaces[0])
+        #expect(!store.canStepWorkspaces, "and once inside the sole workspace there is nowhere left to step")
+    }
+
     @Test func navigateWorkspaceIsANoOpWithOneWorkspace() {
         let store = makeStore()
         let only = store.addWorkspace(name: "only")

--- a/agtermCore/Tests/agtermCoreTests/BuiltinActionTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/BuiltinActionTests.swift
@@ -30,7 +30,10 @@ struct BuiltinActionTests {
         #expect(BuiltinAction.toggleFullscreen.rawValue == "toggle_fullscreen")
         #expect(BuiltinAction.dashboard.rawValue == "dashboard")
         #expect(BuiltinAction.duplicateSession.rawValue == "duplicate_session")
-        #expect(BuiltinAction.allCases.count == 43)
+        #expect(BuiltinAction.previousWorkspace.rawValue == "previous_workspace")
+        #expect(BuiltinAction.nextWorkspace.rawValue == "next_workspace")
+        #expect(BuiltinAction.toggleWorkspaceCollapse.rawValue == "toggle_workspace_collapse")
+        #expect(BuiltinAction.allCases.count == 46)
     }
 
     @Test func rejectsUnknownName() {
@@ -103,6 +106,9 @@ struct BuiltinActionTests {
             .toggleWorkspaceFilter: nil,
             .toggleFlag: Chord(mods: [.command, .shift], key: "f"),
             .focusWorkspace: nil,
+            .previousWorkspace: nil,
+            .nextWorkspace: nil,
+            .toggleWorkspaceCollapse: nil,
             .focusLeftPane: Chord(mods: [.command, .option], key: "left"),
             .focusRightPane: Chord(mods: [.command, .option], key: "right"),
             .previousSession: Chord(mods: [.command, .option], key: "up"),
@@ -173,7 +179,7 @@ struct BuiltinActionTests {
         let keyless: Set<BuiltinAction> = [
             .renameWindow, .deleteWindow, .renameWorkspace, .deleteWorkspace, .renameSession, .duplicateSession,
             .clearStatus, .firstSession, .lastSession, .selectTheme, .toggleFlaggedView, .focusWorkspace,
-            .toggleWorkspaceFilter,
+            .toggleWorkspaceFilter, .previousWorkspace, .nextWorkspace, .toggleWorkspaceCollapse,
         ]
         for action in keyless {
             #expect(action.defaultChord == nil, "expected nil default for \(action.rawValue)")

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -418,6 +418,39 @@ struct ControlDispatcherTests {
         ])
     }
 
+    @Test func workspaceGoRoutesBothDirectionsThroughActions() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let next = await dispatcher.dispatch(ControlRequest(cmd: .workspaceGo, args: ControlArgs(window: "win", to: "next")))
+        let prev = await dispatcher.dispatch(ControlRequest(cmd: .workspaceGo, args: ControlArgs(to: "prev")))
+        let spelled = await dispatcher.dispatch(ControlRequest(cmd: .workspaceGo, args: ControlArgs(to: "previous")))
+
+        #expect(next == ControlResponse(ok: true))
+        #expect(prev == ControlResponse(ok: true))
+        #expect(spelled == ControlResponse(ok: true))
+        #expect(actions.calls == [
+            .workspaceGo(window: "win", .next),
+            .workspaceGo(window: nil, .previous),
+            .workspaceGo(window: nil, .previous)
+        ])
+    }
+
+    @Test func workspaceGoRejectsMissingOrUnknownDirectionWithoutCallingActions() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let missing = await dispatcher.dispatch(ControlRequest(cmd: .workspaceGo))
+        let unknown = await dispatcher.dispatch(ControlRequest(cmd: .workspaceGo, args: ControlArgs(to: "sideways")))
+        // session.go accepts these two, workspace.go does not — a workspace has no ends to jump to
+        let sessionOnly = await dispatcher.dispatch(ControlRequest(cmd: .workspaceGo, args: ControlArgs(to: "first")))
+
+        #expect(missing == ControlResponse(ok: false, error: "workspace.go requires --to next|prev"))
+        #expect(unknown == ControlResponse(ok: false, error: "workspace.go requires --to next|prev"))
+        #expect(sessionOnly == ControlResponse(ok: false, error: "workspace.go requires --to next|prev"))
+        #expect(actions.calls.isEmpty)
+    }
+
     @Test func workspaceRenameRejectsMissingOrBlankNameWithoutCallingActions() async {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -1314,6 +1314,24 @@ struct ControlProtocolTests {
         #expect(SessionNavigation(wire: decoded.args!.to!) == .nextAttention)
     }
 
+    @Test func workspaceGoRoundTripsWithDirection() throws {
+        let request = ControlRequest(cmd: .workspaceGo, args: ControlArgs(window: "w1", to: "prev"))
+        let decoded = try roundTrip(request)
+        #expect(decoded == request)
+        #expect(decoded.cmd == .workspaceGo)
+        #expect(decoded.args?.window == "w1")
+        #expect(WorkspaceNavigation(wire: decoded.args!.to!) == .previous)
+    }
+
+    @Test func workspaceNavigationWireMapping() {
+        #expect(WorkspaceNavigation(wire: "next") == .next)
+        #expect(WorkspaceNavigation(wire: "prev") == .previous)
+        #expect(WorkspaceNavigation(wire: "previous") == .previous)
+        #expect(WorkspaceNavigation(wire: "first") == nil)
+        #expect(WorkspaceNavigation(wire: "next-attention") == nil)
+        #expect(WorkspaceNavigation(wire: "") == nil)
+    }
+
     @Test func sessionMoveReorderRoundTripsWithDirection() throws {
         let request = ControlRequest(cmd: .sessionMove, target: "9f3c", args: ControlArgs(to: "up"))
         let decoded = try roundTrip(request)

--- a/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
+++ b/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
@@ -21,6 +21,7 @@ final class MockControlActions: ControlActions {
         case sessionReveal(target: String?, window: String?)
         case workspaceNew(window: String?, String?, collapsed: Bool)
         case workspaceSelect(target: String?, window: String?)
+        case workspaceGo(window: String?, WorkspaceNavigation)
         case workspaceRename(target: String?, window: String?, String)
         case workspaceDelete(target: String?, window: String?)
         case sessionMove(target: String?, window: String?, ControlSessionMove)
@@ -205,6 +206,11 @@ final class MockControlActions: ControlActions {
 
     func selectWorkspace(_ target: String?, window: String?) -> ControlResponse {
         calls.append(.workspaceSelect(target: target, window: window))
+        return ControlResponse(ok: true)
+    }
+
+    func goWorkspace(window: String?, direction: WorkspaceNavigation) -> ControlResponse {
+        calls.append(.workspaceGo(window: window, direction))
         return ControlResponse(ok: true)
     }
 

--- a/agtermCore/Tests/agtermCoreTests/PaletteCatalogTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/PaletteCatalogTests.swift
@@ -97,9 +97,21 @@ struct PaletteCatalogTests {
         for command in [PaletteCommand.toggleWorkspaceCollapse, .previousWorkspace, .nextWorkspace] {
             #expect(command.isVisible(in: PaletteContext(sidebarShowsWorkspaceTree: true)))
             #expect(!command.isVisible(in: PaletteContext(sidebarShowsWorkspaceTree: false)))
-            #expect(command.isEnabled(in: PaletteContext(sidebarShowsWorkspaceTree: true, hasCurrentWorkspace: true)))
             #expect(!command.isEnabled(in: PaletteContext(sidebarShowsWorkspaceTree: true, hasCurrentWorkspace: false)))
         }
+    }
+
+    // a step below two visible workspaces cannot move, and `isEnabled` is the single run-now predicate, so
+    // it has to say so rather than leaving a live item that no-ops. Folding one workspace still works.
+    @Test func workspaceStepsDisableWithNowhereToStep() {
+        let alone = PaletteContext(sidebarShowsWorkspaceTree: true, canStepWorkspaces: false, hasCurrentWorkspace: true)
+        let several = PaletteContext(sidebarShowsWorkspaceTree: true, canStepWorkspaces: true, hasCurrentWorkspace: true)
+        for command in [PaletteCommand.previousWorkspace, .nextWorkspace] {
+            #expect(!command.isEnabled(in: alone))
+            #expect(command.isEnabled(in: several))
+            #expect(command.isVisible(in: alone), "still listed, just inert")
+        }
+        #expect(PaletteCommand.toggleWorkspaceCollapse.isEnabled(in: alone))
     }
 
     @Test func workspaceAndSplitCommandsFollowTheirPredicates() {
@@ -141,6 +153,7 @@ struct PaletteCatalogTests {
     /// Everything present, nothing covering: every command's menu item is live here.
     private static let live = PaletteContext(canRemoveWorkspace: true, hasFlaggedSessions: true,
                                              sidebarShowsWorkspaceTree: true, hasMarkedWorkspaces: true,
+                                             canStepWorkspaces: true,
                                              activeSessionHasSplit: true, hasPendingClose: true,
                                              hasRecentClosed: true, hasActiveSession: true,
                                              hasCurrentWorkspace: true)
@@ -167,6 +180,7 @@ struct PaletteCatalogTests {
     @Test func sessionPresenceGatesTheSameCommandsTheMenuDoes() {
         let context = PaletteContext(canRemoveWorkspace: true, hasFlaggedSessions: true,
                                      sidebarShowsWorkspaceTree: true, hasMarkedWorkspaces: true,
+                                     canStepWorkspaces: true,
                                      activeSessionHasSplit: true, hasPendingClose: true,
                                      hasRecentClosed: true, hasActiveSession: false,
                                      hasCurrentWorkspace: true)
@@ -178,6 +192,7 @@ struct PaletteCatalogTests {
     @Test func workspacePresenceGatesTheWorkspaceEntries() {
         let context = PaletteContext(canRemoveWorkspace: true, hasFlaggedSessions: true,
                                      sidebarShowsWorkspaceTree: true, hasMarkedWorkspaces: true,
+                                     canStepWorkspaces: true,
                                      activeSessionHasSplit: true, hasPendingClose: true,
                                      hasRecentClosed: true, hasActiveSession: true,
                                      hasCurrentWorkspace: false)
@@ -191,6 +206,7 @@ struct PaletteCatalogTests {
     @Test func terminalZoomLeavesOnlyTheItemsCarryingNoModalTerm() {
         let context = PaletteContext(canRemoveWorkspace: true, hasFlaggedSessions: true,
                                      sidebarShowsWorkspaceTree: true, hasMarkedWorkspaces: true,
+                                     canStepWorkspaces: true,
                                      activeSessionHasSplit: true, hasPendingClose: true,
                                      hasRecentClosed: true, hasActiveSession: true,
                                      hasCurrentWorkspace: true, terminalZoomActive: true)
@@ -202,6 +218,7 @@ struct PaletteCatalogTests {
     @Test func aPendingPickerLeavesTheSameSet() {
         let context = PaletteContext(canRemoveWorkspace: true, hasFlaggedSessions: true,
                                      sidebarShowsWorkspaceTree: true, hasMarkedWorkspaces: true,
+                                     canStepWorkspaces: true,
                                      activeSessionHasSplit: true, hasPendingClose: true,
                                      hasRecentClosed: true, hasActiveSession: true,
                                      hasCurrentWorkspace: true, pickerActive: true)
@@ -214,6 +231,7 @@ struct PaletteCatalogTests {
     @Test func theOpenDashboardSparesItsOwnToggle() {
         let context = PaletteContext(canRemoveWorkspace: true, hasFlaggedSessions: true,
                                      sidebarShowsWorkspaceTree: true, hasMarkedWorkspaces: true,
+                                     canStepWorkspaces: true,
                                      activeSessionHasSplit: true, hasPendingClose: true,
                                      hasRecentClosed: true, hasActiveSession: true,
                                      hasCurrentWorkspace: true, dashboardOpen: true)

--- a/agtermCore/Tests/agtermCoreTests/PaletteCatalogTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/PaletteCatalogTests.swift
@@ -18,6 +18,8 @@ struct PaletteCatalogTests {
             "Next Session",
             "Previous Attention Session",
             "Next Attention Session",
+            "Previous Workspace",
+            "Next Workspace",
             "First Session",
             "Last Session",
             "Show Attention",
@@ -49,13 +51,14 @@ struct PaletteCatalogTests {
             "Toggle Workspace Filter",
             "Expand Workspaces",
             "Collapse Workspaces",
+            "Collapse Workspace",
             "Focus Left Pane",
             "Focus Right Pane",
         ])
     }
 
     @Test func catalogHasTheExpectedStaticCommandCount() {
-        #expect(PaletteCommand.allCases.count == 47)
+        #expect(PaletteCommand.allCases.count == 50)
     }
 
     @Test func idsRoundTripThroughRawValue() {
@@ -71,6 +74,8 @@ struct PaletteCatalogTests {
         #expect(PaletteCommand.toggleFlaggedView.title(in: PaletteContext(sidebarShowsFlaggedOnly: true)) == "Show All Sessions")
         #expect(PaletteCommand.focusLeftPane.title(in: PaletteContext(activeSplitAxis: .topBottom)) == "Focus Top Pane")
         #expect(PaletteCommand.focusRightPane.title(in: PaletteContext(activeSplitAxis: .topBottom)) == "Focus Bottom Pane")
+        #expect(PaletteCommand.toggleWorkspaceCollapse.title(in: PaletteContext(activeWorkspaceCollapsed: false)) == "Collapse Workspace")
+        #expect(PaletteCommand.toggleWorkspaceCollapse.title(in: PaletteContext(activeWorkspaceCollapsed: true)) == "Expand Workspace")
     }
 
     @Test func clearFlaggedVisibleOnlyWhenSomethingIsFlagged() {
@@ -89,6 +94,12 @@ struct PaletteCatalogTests {
         #expect(PaletteCommand.collapseWorkspaces.isVisible(in: PaletteContext(sidebarShowsWorkspaceTree: true)))
         #expect(!PaletteCommand.expandWorkspaces.isVisible(in: PaletteContext(sidebarShowsWorkspaceTree: false)))
         #expect(!PaletteCommand.collapseWorkspaces.isVisible(in: PaletteContext(sidebarShowsWorkspaceTree: false)))
+        for command in [PaletteCommand.toggleWorkspaceCollapse, .previousWorkspace, .nextWorkspace] {
+            #expect(command.isVisible(in: PaletteContext(sidebarShowsWorkspaceTree: true)))
+            #expect(!command.isVisible(in: PaletteContext(sidebarShowsWorkspaceTree: false)))
+            #expect(command.isEnabled(in: PaletteContext(sidebarShowsWorkspaceTree: true, hasCurrentWorkspace: true)))
+            #expect(!command.isEnabled(in: PaletteContext(sidebarShowsWorkspaceTree: true, hasCurrentWorkspace: false)))
+        }
     }
 
     @Test func workspaceAndSplitCommandsFollowTheirPredicates() {
@@ -170,7 +181,8 @@ struct PaletteCatalogTests {
                                      activeSessionHasSplit: true, hasPendingClose: true,
                                      hasRecentClosed: true, hasActiveSession: true,
                                      hasCurrentWorkspace: false)
-        let needWorkspace: Set<PaletteCommand> = [.renameWorkspace, .focusWorkspace, .addWorkspaceToFocus]
+        let needWorkspace: Set<PaletteCommand> = [.renameWorkspace, .focusWorkspace, .addWorkspaceToFocus,
+                                                  .previousWorkspace, .nextWorkspace, .toggleWorkspaceCollapse]
         for command in PaletteCommand.allCases {
             #expect(command.isEnabled(in: context) == !needWorkspace.contains(command), "\(command)")
         }

--- a/agtermCore/Tests/agtermCoreTests/SkillInstallTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SkillInstallTests.swift
@@ -23,7 +23,7 @@ struct SkillInstallTests {
         let reference = try String(contentsOf: skillDirectory.appendingPathComponent("reference.md"), encoding: .utf8)
         let examples = try String(contentsOf: skillDirectory.appendingPathComponent("examples.md"), encoding: .utf8)
 
-        #expect(skill.contains("Command summary (75 commands)"))
+        #expect(skill.contains("Command summary (76 commands)"))
         #expect(skill.contains("`keymap list`"))
         #expect(reference.contains("`agtermctl keymap list`"))
         #expect(examples.contains("agtermctl keymap list"))

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -54,6 +54,18 @@ struct CommandsTests {
         #expect(try request(["workspace", "select", "--target", "ab"]) == ControlRequest(cmd: .workspaceSelect, target: "ab"))
     }
 
+    @Test func workspaceGo() throws {
+        #expect(try request(["workspace", "go", "--to", "next"]) == ControlRequest(cmd: .workspaceGo, args: ControlArgs(to: "next")))
+        let windowed = ControlRequest(cmd: .workspaceGo, args: ControlArgs(window: "w1", to: "prev"))
+        #expect(try request(["workspace", "go", "--to", "prev", "--window", "w1"]) == windowed)
+    }
+
+    // relative to what is current, so unlike its `workspace.*` siblings it carries no target at all
+    @Test func workspaceGoTakesNoTarget() {
+        #expect(throws: (any Error).self) { try Agtermctl.parseAsRoot(["workspace", "go", "--to", "next", "--target", "ab"]) }
+        #expect(throws: (any Error).self) { try Agtermctl.parseAsRoot(["workspace", "go"]) }
+    }
+
     @Test func workspaceMove() throws {
         let expected = ControlRequest(cmd: .workspaceMove, target: "active", args: ControlArgs(to: "top"))
         #expect(try request(["workspace", "move", "--to", "top"]) == expected)

--- a/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
@@ -260,6 +260,9 @@ struct SocketClientTests {
             toggle_flag                 cmd+shift+f
             focus_workspace             -
             toggle_workspace_filter     -
+            previous_workspace          -
+            next_workspace              -
+            toggle_workspace_collapse   -
           * focus_left_pane             ctrl+cmd+left
             focus_right_pane            cmd+opt+right
             previous_session            cmd+opt+up

--- a/agtermTests/SessionNavRevealTests.swift
+++ b/agtermTests/SessionNavRevealTests.swift
@@ -72,4 +72,46 @@ final class SessionNavRevealTests: XCTestCase {
         XCTAssertFalse(second.splitFocused,
                        "a step that moved should reveal the untagged block's primary pane")
     }
+
+    // workspace nav has to route pane reveal exactly as session nav does, which is only true while
+    // `selectWorkspace` returns the destination's indicator AND `selectNextWorkspace` hands it on. Both are
+    // invisible to a test asserting selection alone: passing nil still selects the right session, and only
+    // the reveal's `.left`/nil arm clears `splitFocused`.
+    func testWorkspaceNavRunsTheRevealOnTheStepsIndicator() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let first = try XCTUnwrap(store.activeSession)
+        let second = store.addWorkspace(name: "second")
+        let away = try XCTUnwrap(store.addSession(toWorkspace: second.id, cwd: NSHomeDirectory()))
+
+        store.selectSession(first.id)
+        away.agentIndicator = AgentIndicator(status: .blocked)
+        away.splitFocused = true
+
+        actions.selectNextWorkspace()
+
+        XCTAssertEqual(store.selectedSessionID, away.id, "the step should land on the next workspace's first session")
+        XCTAssertFalse(away.splitFocused, "the step must reveal the untagged block's primary pane")
+    }
+
+    // the auto-reset case is what makes the indicator have to travel WITH the step: selecting the session
+    // clears its status, so an `AppActions` that read the indicator back off the store afterwards would see
+    // idle and skip the reveal entirely.
+    func testWorkspaceNavRevealsAnAutoResetStatusClearedByTheSelect() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let first = try XCTUnwrap(store.activeSession)
+        let second = store.addWorkspace(name: "second")
+        let away = try XCTUnwrap(store.addSession(toWorkspace: second.id, cwd: NSHomeDirectory()))
+
+        // the status goes on AFTER the selection settles: creating a session selects it, and selecting away
+        // from an auto-reset session is itself one of the two clears, so seeding it earlier would arrive idle
+        store.selectSession(first.id)
+        away.agentIndicator = AgentIndicator(status: .completed, autoReset: true)
+        away.splitFocused = true
+
+        actions.selectNextWorkspace()
+
+        XCTAssertEqual(store.selectedSessionID, away.id, "the step should land on the next workspace's first session")
+        XCTAssertEqual(away.agentIndicator.status, .idle, "selecting an auto-reset session clears its status")
+        XCTAssertFalse(away.splitFocused, "the reveal must run off the indicator captured BEFORE that clear")
+    }
 }

--- a/agtermTests/SidebarExpansionMirrorTests.swift
+++ b/agtermTests/SidebarExpansionMirrorTests.swift
@@ -1,0 +1,65 @@
+import AppKit
+import XCTest
+@testable import agterm
+import agtermCore
+
+/// Hosted coverage for the Coordinator's expansion mirror — the store-side copy of which workspace rows the
+/// outline renders open, which `AppStore.isCurrentWorkspaceCollapsed` reads so Collapse/Expand Workspace
+/// folds what the user can see rather than what was persisted. Hosted rather than host-free because the
+/// mirror is pushed from the Coordinator, and a store-only test cannot tell an unconditional push from a
+/// delta-guarded one.
+@MainActor
+final class SidebarExpansionMirrorTests: XCTestCase {
+    private var stateDir: URL!
+    private var library: WindowLibrary!
+    private var actions: AppActions!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        await MainActor.run {
+            stateDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("agterm-expansion-mirror-tests-\(UUID().uuidString)", isDirectory: true)
+            library = WindowLibrary(directory: stateDir)
+            actions = AppActions(library: library)
+        }
+    }
+
+    override func tearDown() async throws {
+        await MainActor.run {
+            actions = nil
+            library = nil
+            try? FileManager.default.removeItem(at: stateDir)
+            stateDir = nil
+        }
+        try await super.tearDown()
+    }
+
+    // a fresh Coordinator starts with an empty set, so seeding an all-collapsed tree assigns empty over
+    // empty. Re-introducing a `!= oldValue` guard on the didSet would skip that push and strand the previous
+    // mount's ids in the store, leaving Collapse Workspace reading "expanded" over a visibly folded row.
+    func testSeedingAnAllCollapsedTreeClearsAStaleMirror() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let workspace = try XCTUnwrap(store.currentWorkspaceID)
+        store.setWorkspaceExpanded(workspace, expanded: false)
+        store.noteSidebarExpansion([workspace]) // what a previous mount left behind
+        XCTAssertFalse(store.isCurrentWorkspaceCollapsed, "precondition: the stale mirror reads expanded")
+
+        WorkspaceSidebar.Coordinator(store: store, actions: actions).seedExpansionFromModel()
+
+        XCTAssertTrue(store.sidebarExpandedWorkspaceIDs.isEmpty, "a remount must publish what it actually shows")
+        XCTAssertTrue(store.isCurrentWorkspaceCollapsed, "so the toggle folds against the folded row")
+    }
+
+    // the other direction, so the test above cannot pass by the mirror being cleared unconditionally.
+    func testSeedingPublishesTheExpandedWorkspaces() throws {
+        let store = try XCTUnwrap(library.activeStore)
+        let workspace = try XCTUnwrap(store.currentWorkspaceID)
+        store.setWorkspaceExpanded(workspace, expanded: true)
+        store.noteSidebarExpansion([])
+
+        WorkspaceSidebar.Coordinator(store: store, actions: actions).seedExpansionFromModel()
+
+        XCTAssertEqual(store.sidebarExpandedWorkspaceIDs, [workspace])
+        XCTAssertFalse(store.isCurrentWorkspaceCollapsed)
+    }
+}

--- a/agtermUITests/ControlSidebarStatusUITests.swift
+++ b/agtermUITests/ControlSidebarStatusUITests.swift
@@ -408,6 +408,85 @@ final class ControlSidebarStatusUITests: ControlAPITestCase {
         XCTAssertTrue(sessionRowValueExists(containing: "hidden"), "the collapsed workspace's session should return")
     }
 
+    func testWorkspaceGoStepsBetweenWorkspacesAndWraps() throws {
+        XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 10), "seeded session row")
+
+        let tree = try sendCommand(#"{"cmd":"tree"}"#)
+        let result = try XCTUnwrap(tree["result"] as? [String: Any], "tree should carry a result")
+        let t = try XCTUnwrap(result["tree"] as? [String: Any], "result should carry a tree")
+        let firstWs = try XCTUnwrap((t["workspaces"] as? [[String: Any]])?.first, "should have a workspace")
+        let firstWsID = try XCTUnwrap(firstWs["id"] as? String, "the workspace should carry an id")
+        let seededID = try XCTUnwrap((firstWs["sessions"] as? [[String: Any]])?.first?["id"] as? String, "seeded session")
+
+        let newWs = try sendCommand(#"{"cmd":"workspace.new","args":{"name":"second"}}"#)
+        let secondWsID = try XCTUnwrap((newWs["result"] as? [String: Any])?["id"] as? String, "workspace.new returns an id")
+        let created = try sendCommand(#"{"cmd":"session.new","args":{"workspace":"\#(secondWsID)"}}"#)
+        let secondSessID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "session.new returns an id")
+
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.select","target":"\#(seededID)"}"#)["ok"] as? Bool, true,
+                       "selecting the seeded session should succeed")
+
+        let next = try sendCommand(#"{"cmd":"workspace.go","args":{"to":"next"}}"#)
+        XCTAssertEqual(next["ok"] as? Bool, true, "workspace.go next should succeed: \(next)")
+        XCTAssertEqual((next["result"] as? [String: Any])?["id"] as? String, secondWsID, "it should land on the second workspace")
+        XCTAssertTrue(pollActiveSession(secondSessID, timeout: 10), "landing selects the target's first session")
+
+        // wrapping is what makes a repeated keystroke a cycle rather than a dead end at the last workspace
+        let wrapped = try sendCommand(#"{"cmd":"workspace.go","args":{"to":"next"}}"#)
+        XCTAssertEqual((wrapped["result"] as? [String: Any])?["id"] as? String, firstWsID, "next at the end wraps to the first")
+        XCTAssertTrue(pollActiveSession(seededID, timeout: 10), "the wrap selects the first workspace's first session")
+
+        let back = try sendCommand(#"{"cmd":"workspace.go","args":{"to":"prev"}}"#)
+        XCTAssertEqual((back["result"] as? [String: Any])?["id"] as? String, secondWsID, "prev at the start wraps to the last")
+
+        let bad = try sendCommand(#"{"cmd":"workspace.go","args":{"to":"sideways"}}"#)
+        XCTAssertEqual(bad["ok"] as? Bool, false, "an unknown direction is rejected")
+        XCTAssertEqual(bad["error"] as? String, "workspace.go requires --to next|prev")
+    }
+
+    // issue #435: collapsing a workspace must not steer navigation — the fold is a display state, so the
+    // step lands on the collapsed workspace exactly as it would on an open one
+    func testWorkspaceGoStepsIntoACollapsedWorkspace() throws {
+        XCTAssertTrue(app.staticTexts["session-row"].firstMatch.waitForExistence(timeout: 10), "seeded session row")
+
+        let tree = try sendCommand(#"{"cmd":"tree"}"#)
+        let result = try XCTUnwrap(tree["result"] as? [String: Any], "tree should carry a result")
+        let t = try XCTUnwrap(result["tree"] as? [String: Any], "result should carry a tree")
+        let firstWs = try XCTUnwrap((t["workspaces"] as? [[String: Any]])?.first, "should have a workspace")
+        let seededID = try XCTUnwrap((firstWs["sessions"] as? [[String: Any]])?.first?["id"] as? String, "seeded session")
+
+        let newWs = try sendCommand(#"{"cmd":"workspace.new","args":{"name":"folded"}}"#)
+        let foldedWsID = try XCTUnwrap((newWs["result"] as? [String: Any])?["id"] as? String, "workspace.new returns an id")
+        let created = try sendCommand(#"{"cmd":"session.new","args":{"workspace":"\#(foldedWsID)"}}"#)
+        let foldedSessID = try XCTUnwrap((created["result"] as? [String: Any])?["id"] as? String, "session.new returns an id")
+
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.select","target":"\#(seededID)"}"#)["ok"] as? Bool, true,
+                       "selecting the seeded session should succeed")
+        XCTAssertEqual(try sendCommand(#"{"cmd":"workspace.collapse","target":"\#(foldedWsID)"}"#)["ok"] as? Bool, true,
+                       "collapsing the second workspace should succeed")
+
+        let next = try sendCommand(#"{"cmd":"workspace.go","args":{"to":"next"}}"#)
+        XCTAssertEqual((next["result"] as? [String: Any])?["id"] as? String, foldedWsID, "a folded workspace is still stepped into")
+        XCTAssertTrue(pollActiveSession(foldedSessID, timeout: 10), "it selects the folded workspace's first session")
+    }
+
+    /// Polls `tree` until `sessionID` reports `active`. Selection lands through the store and the outline's
+    /// row sync, so an immediate read can race the step.
+    private func pollActiveSession(_ sessionID: String, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let tree = try? sendCommand(#"{"cmd":"tree"}"#),
+               let result = tree["result"] as? [String: Any],
+               let t = result["tree"] as? [String: Any],
+               let workspaces = t["workspaces"] as? [[String: Any]] {
+                let sessions = workspaces.flatMap { ($0["sessions"] as? [[String: Any]]) ?? [] }
+                if sessions.first(where: { $0["id"] as? String == sessionID })?["active"] as? Bool == true { return true }
+            }
+            usleep(200_000)
+        }
+        return false
+    }
+
     /// Whether any `session-row` exposes `needle` in its accessibility value (the row's displayed name —
     /// `session : workspace` in flagged mode). The sidebar surfaces the row name via `value`, not `label`.
     private func sessionRowValueExists(containing needle: String) -> Bool {

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -19,7 +19,7 @@ when_to_use: >
   Trigger on: agterm, agtermctl, agterm control socket, session.new, session.close, session.type,
   session.split, session.split.close, session.scratch, session.focus, session.resize, surface.zoom, dashboard, pick, pick.open, pick.result, pick.cancel, native picker, session.go, session.copy, session.paste, session.selectall, session.text, session.search, session.status,
   session.flag, session.seen, session.reveal, session.duplicate, session.background, session.overlay,
-  session.hud, hud panel, show a message over a session, workspace.new, workspace.select, workspace.move, workspace.focus, workspace.filter, window.new, window.list,
+  session.hud, hud panel, show a message over a session, workspace.new, workspace.select, workspace.go, workspace.move, workspace.focus, workspace.filter, window.new, window.list,
   window.select, window.resize, window.move, window.zoom, window.fullscreen, window.minimize, quick terminal, sidebar, sidebar.mode, sidebar.expand, sidebar.collapse, flagged, notify, font.inc, keymap.reload, keymap.list, config.reload,
   theme.set, theme.list, events, events.read, event subscription, select theme, edit keymap, show an image, display an image inline, show-image,
   AGTERM_SESSION_ID, AGTERM_SOCKET, and asks to drive or script agterm. Also: troubleshoot agterm,
@@ -148,7 +148,7 @@ prompt concatenates with yours, and the program starts on the merged line. (`--n
 focus, but the newline and shared-buffer hazards of `type`-as-launcher remain — `--command` is still the
 rule.) After `--command`, confirm in `tree --json` that the new node's `foreground` shows your program running, not a bare shell prompt.
 
-## Command summary (75 commands)
+## Command summary (76 commands)
 
 Run `agtermctl <area> <cmd> --help` for exact flags. Full detail in **reference.md**; recipes in
 **examples.md**.
@@ -216,6 +216,9 @@ rebaselined. There is no terminal-output event stream.
 **workspace** — `new [name] [--collapsed]` (`--collapsed` creates it closed in the sidebar so you can fill
 it with `session new --no-select` without it opening, and keeps it out of the focus set; a plain create
 joins the marked set while the filter is applied, so it is visible) · `rename <name>` · `delete` · `select` ·
+`go --to next|prev` (step the CURRENT workspace one place through the sidebar's visible order, wrapping,
+and select the first session of the one it lands on — relative, so no `--target`, and unaffected by
+whether a workspace is collapsed; `move` REORDERS instead) ·
 `move --to up|down|top|bottom` ·
 `focus [on|off|toggle|add]` (mark ONE workspace in the sidebar's focus set — `on` marks it alone and
 applies the filter, `off` unmarks it, `toggle` (default) replace-toggles, and `add` marks it alongside

--- a/plugins/agterm/skills/agterm/examples.md
+++ b/plugins/agterm/skills/agterm/examples.md
@@ -832,6 +832,8 @@ a RUNNING program is refused instead: a message is replaceable, a program is not
 ```bash
 agtermctl session go --to next            # step selection to the next session
 agtermctl session go --to next-attention  # jump to the next blocked/completed session
+agtermctl workspace go --to next          # step a whole workspace, landing on its first session
+agtermctl workspace go --to prev          # wraps at both ends; no --target, it is relative
 w=$(agtermctl window new "scratch" --json | jq -r '.result.id')
 # or park one in the Dock right after creating it (it appears briefly on its way there):
 # p=$(agtermctl window new "proj-b" --minimized --json | jq -r '.result.id')

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -233,6 +233,14 @@ All twelve are read-only projections of GUI state.
 - `workspace rename <name> [--target] [--window W]`.
 - `workspace delete [--target] [--window W]` — keep-at-least-one; deleting the last workspace errors.
 - `workspace select [--target] [--window W]`.
+- `workspace go --to next|prev [--window W]` — step the CURRENT workspace one place through the
+  sidebar's visible order, wrapping at both ends, and select the workspace it lands on. Relative, so it
+  takes NO `--target`; `workspace move` is the neighbouring verb that REORDERS a workspace instead.
+  Landing selects that workspace's FIRST session, exactly as `workspace select` does. Returns the
+  workspace id. A workspace's COLLAPSED state does not affect it — a folded workspace is stepped into
+  like any other. While the focus filter is applied, stepping is confined to the marked workspaces, the
+  same scoping `session go` gets. Errors with `no other workspace to navigate to` when there is nowhere
+  to step: the flagged flat list (which renders no workspace rows), or a single visible workspace.
 - `workspace move --to up|down|top|bottom [--target] [--window W]` — reorder among siblings. Missing
   or invalid `--to` errors. Note: `--target active` resolves to the current workspace — a
   foreground-created workspace that still holds the target, else the selected session's, else

--- a/site/commands.html
+++ b/site/commands.html
@@ -6,7 +6,7 @@
     <title>Command reference — agterm | agtermctl control API</title>
     <meta
       name="description"
-      content="Complete agtermctl reference: all 75 control commands for agterm, including sessions, workspaces, windows, overlays, the native picker, the quick terminal, sidebar, agent status, themes, and keymaps, with arguments and return values."
+      content="Complete agtermctl reference: all 76 control commands for agterm, including sessions, workspaces, windows, overlays, the native picker, the quick terminal, sidebar, agent status, themes, and keymaps, with arguments and return values."
     />
     <meta
       name="keywords"
@@ -18,7 +18,7 @@
     <meta property="og:title" content="Command reference — agterm" />
     <meta
       property="og:description"
-      content="All 75 agtermctl control commands with arguments, return values, and errors."
+      content="All 76 agtermctl control commands with arguments, return values, and errors."
     />
     <meta property="og:url" content="https://agterm.com/commands" />
     <meta property="og:image" content="https://agterm.com/assets/agterm-og.png" />
@@ -30,7 +30,7 @@
     <meta name="twitter:title" content="Command reference — agterm" />
     <meta
       name="twitter:description"
-      content="All 75 agtermctl control commands with arguments, return values, and errors."
+      content="All 76 agtermctl control commands with arguments, return values, and errors."
     />
     <meta name="twitter:image" content="https://agterm.com/assets/agterm-og.png" />
     <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
@@ -237,7 +237,7 @@
             Command reference
           </h1>
           <p style="font-size: 19px; line-height: 1.6; color: #bfbab0; margin: 0 0 8px">
-            All 75 commands of the agterm control API, with arguments and return values. Every one is reachable from the
+            All 76 commands of the agterm control API, with arguments and return values. Every one is reachable from the
             <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">agtermctl</span> CLI and from the local
             control socket.
           </p>
@@ -646,6 +646,27 @@
               </div>
               <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">workspace.select</div>
               <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">Select the target workspace.</p>
+            </div>
+
+            <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
+                agtermctl workspace go --to next|prev [--window W]
+              </div>
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">workspace.go</div>
+              <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
+                Step the current workspace one place through the sidebar's visible order, wrapping at both ends, and select the
+                first session of the workspace it lands on. Relative, so it takes no
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--target</span> —
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">workspace move</span> is the verb that reorders instead.
+                Returns the workspace id.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                Whether a workspace is collapsed makes no difference — a folded workspace is stepped into like any other. While the
+                workspace focus filter is applied, stepping stays inside the marked workspaces, the same scoping
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">session go</span> gets. With nowhere to step — the flagged
+                flat list, or a single visible workspace — it errors with
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">no other workspace to navigate to</span>.
+              </p>
             </div>
 
             <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">

--- a/site/docs.html
+++ b/site/docs.html
@@ -1248,7 +1248,7 @@
               "
             >
               <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 0">
-                Looking for the full list? All 75 commands, with every argument, return value, and error, live on the
+                Looking for the full list? All 76 commands, with every argument, return value, and error, live on the
                 <a href="/commands" style="color: #6d82f3; font-weight: 500">Command reference →</a>
               </p>
             </div>
@@ -1405,6 +1405,8 @@
               <span style="color: #6b727a">&nbsp;&nbsp;# move a batch as one ordered block</span
               ><br />agtermctl session close --target 9f3c --target abcd
               <span style="color: #6b727a">&nbsp;&nbsp;# one grace-period undo for the batch</span
+              ><br />agtermctl workspace go --to next
+              <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;# step to the next workspace and select its first session</span
               ><br />agtermctl workspace move --to top
               <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;# reorder a workspace</span><br />agtermctl workspace new work --collapsed
               <span style="color: #6b727a">&nbsp;&nbsp;&nbsp;# create a workspace closed in the sidebar (fill with session new --no-select)</span
@@ -1950,7 +1952,7 @@
                 color: #cbc6bc;
               "
             >
-              new_window&nbsp;&nbsp;&nbsp;rename_window&nbsp;&nbsp;&nbsp;delete_window<br />new_workspace&nbsp;&nbsp;&nbsp;rename_workspace&nbsp;&nbsp;&nbsp;delete_workspace<br />new_session&nbsp;&nbsp;&nbsp;open_directory&nbsp;&nbsp;&nbsp;rename_session&nbsp;&nbsp;&nbsp;duplicate_session<br />close_session&nbsp;&nbsp;&nbsp;reopen_recent&nbsp;&nbsp;&nbsp;undo_close&nbsp;&nbsp;&nbsp;clear_status<br />increase_font_size&nbsp;&nbsp;&nbsp;decrease_font_size&nbsp;&nbsp;&nbsp;reset_font_size<br />toggle_split&nbsp;&nbsp;&nbsp;toggle_horizontal_split&nbsp;&nbsp;&nbsp;toggle_scratch&nbsp;&nbsp;&nbsp;toggle_search<br />toggle_sidebar&nbsp;&nbsp;&nbsp;toggle_flag&nbsp;&nbsp;&nbsp;toggle_flagged_view<br />focus_left_pane&nbsp;&nbsp;&nbsp;focus_right_pane&nbsp;&nbsp;&nbsp;focus_workspace&nbsp;&nbsp;&nbsp;toggle_workspace_filter<br />previous_session&nbsp;&nbsp;&nbsp;next_session&nbsp;&nbsp;&nbsp;first_session&nbsp;&nbsp;&nbsp;last_session<br />previous_attention_session&nbsp;&nbsp;&nbsp;next_attention_session<br />quick_terminal&nbsp;&nbsp;&nbsp;session_palette&nbsp;&nbsp;&nbsp;command_palette<br />custom_command_palette&nbsp;&nbsp;&nbsp;show_attention<br />select_theme&nbsp;&nbsp;&nbsp;toggle_fullscreen&nbsp;&nbsp;&nbsp;toggle_terminal_zoom<br />dashboard
+              new_window&nbsp;&nbsp;&nbsp;rename_window&nbsp;&nbsp;&nbsp;delete_window<br />new_workspace&nbsp;&nbsp;&nbsp;rename_workspace&nbsp;&nbsp;&nbsp;delete_workspace<br />new_session&nbsp;&nbsp;&nbsp;open_directory&nbsp;&nbsp;&nbsp;rename_session&nbsp;&nbsp;&nbsp;duplicate_session<br />close_session&nbsp;&nbsp;&nbsp;reopen_recent&nbsp;&nbsp;&nbsp;undo_close&nbsp;&nbsp;&nbsp;clear_status<br />increase_font_size&nbsp;&nbsp;&nbsp;decrease_font_size&nbsp;&nbsp;&nbsp;reset_font_size<br />toggle_split&nbsp;&nbsp;&nbsp;toggle_horizontal_split&nbsp;&nbsp;&nbsp;toggle_scratch&nbsp;&nbsp;&nbsp;toggle_search<br />toggle_sidebar&nbsp;&nbsp;&nbsp;toggle_flag&nbsp;&nbsp;&nbsp;toggle_flagged_view<br />focus_left_pane&nbsp;&nbsp;&nbsp;focus_right_pane&nbsp;&nbsp;&nbsp;focus_workspace&nbsp;&nbsp;&nbsp;toggle_workspace_filter<br />toggle_workspace_collapse<br />previous_session&nbsp;&nbsp;&nbsp;next_session&nbsp;&nbsp;&nbsp;first_session&nbsp;&nbsp;&nbsp;last_session<br />previous_workspace&nbsp;&nbsp;&nbsp;next_workspace<br />previous_attention_session&nbsp;&nbsp;&nbsp;next_attention_session<br />quick_terminal&nbsp;&nbsp;&nbsp;session_palette&nbsp;&nbsp;&nbsp;command_palette<br />custom_command_palette&nbsp;&nbsp;&nbsp;show_attention<br />select_theme&nbsp;&nbsp;&nbsp;toggle_fullscreen&nbsp;&nbsp;&nbsp;toggle_terminal_zoom<br />dashboard
             </div>
             <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">toggle_fullscreen</span> is the one


### PR DESCRIPTION
adds keyboard navigation between workspaces, and a way to fold the one you are in.

**what's new**

- `previous_workspace` / `next_workspace` builtins and `workspace.go --to next|prev`. Steps the current workspace through the sidebar's visible order, wrapping, and selects the destination's first session through the existing `selectWorkspace`. The focus filter scopes it exactly as it scopes session nav. Collapse state is deliberately not a term, so a folded workspace is stepped into like any other.
- `toggle_workspace_collapse` folds the current workspace alone. That is the one row Expand/Collapse Workspaces never folds, since `collapseOthers` keeps the active workspace open by design, so mouse or control socket were the only ways to fold it.
- all three ship keyless. Nothing collides with an existing binding.

**how it works**

`AppStore.selectWorkspace` returns `WorkspaceStep?` instead of `Bool`. The step carries the destination's pre-auto-reset indicator, which is what lets workspace nav route pane reveal the same way session nav does; `AppActions+Focus.swift` states that as an invariant.

the collapse toggle reads what the sidebar row shows, not the persisted flag. The two diverge constantly for this particular workspace: a reveal opens the row without persisting, and the current workspace is by definition the one holding the selection. `WorkspaceSidebar.Coordinator` mirrors its live expansion into the store from one `didSet`, and that push is not delta-guarded on purpose, or a fresh Coordinator seeding an all-collapsed tree would assign empty over empty and strand the previous mount's ids.

`tree`'s workspace `active` flag now reads `currentWorkspaceID` rather than the selected session's owner. An empty destination has no session to select, so `workspace.go` reported that workspace while `tree` still marked the one the caller left.

`Previous`/`Next Workspace` disable when a step has nowhere to go, through `AppStore.canStepWorkspaces`, which `navigateWorkspace` also guards on so the menu item cannot offer what the action declines. A lone visible workspace blocks only while it is already current, since entering the sole survivor is the point when the filter hid the current one.

**also**

command count 75 -> 76 and `BuiltinAction` 43 -> 46 across README, `site/commands.html`, `site/docs.html`, the bundled agent skill and the rules files.

tests: host-free store/dispatcher/protocol/CLI coverage for `workspace.go` and the collapse predicate, hosted coverage for the pane reveal and the expansion mirror's remount, plus e2e for stepping, wrapping and stepping into a collapsed workspace.

Fix #435
