### PR TITLE
docs: note what the session.closed stream cannot distinguish

### DIFF
--- a/docs/backlog/troubleshooting-log-categories-are-wrong.md
+++ b/docs/backlog/troubleshooting-log-categories-are-wrong.md
@@ -1,0 +1,27 @@
+---
+worth: now
+where: docs/troubleshooting.md:31
+added: 2026-08-15
+---
+# The documented log categories list one that does not exist and omits three that do
+
+`docs/troubleshooting.md:31` tells users the categories are `CustomCommandRunner`, `SettingsModel`,
+`GhosttyApp`, `NotificationManager`, and `ControlServer`, right under a `log show` example that filters on
+`subsystem == "com.umputun.agterm" && category == "<name>"`.
+
+`ControlServer` is not one of them. `ControlServer.log` is `NSLog("agterm: %@", …)`
+(`agterm/Control/ControlServer.swift:659-660`), not a `Logger(subsystem:category:)`, so it carries neither
+the subsystem nor a category. A user following the page to debug the control socket - the most likely
+reason to reach for these instructions at all - gets an empty result and no indication why.
+
+The seven real categories are `GhosttyApp`, `GhosttySurfaceView`, `WatermarkRenderer`,
+`NotificationManager`, `SettingsView`, `SettingsModel`, and `CustomCommandRunner`. The page names four of
+them and omits `GhosttySurfaceView`, `WatermarkRenderer`, and `SettingsView`.
+
+Two ways to close it, and they are not equivalent: correct the list to the seven that exist and drop
+`ControlServer`, or convert `ControlServer.log` to a real `Logger` so the documented filter starts working.
+The second is the better outcome for anyone debugging the socket, since it is currently the one subsystem
+with no queryable output, but it is a behavior change rather than a doc fix.
+
+Surfaced while investigating discussion #439 (close provenance), which asked for close logging and led
+through every logging call site in the app.

--- a/plugins/agterm/skills/agterm/examples.md
+++ b/plugins/agterm/skills/agterm/examples.md
@@ -614,6 +614,11 @@ agtermctl events --json --kind session.closed |
   done
 ```
 
+The stream does not say what closed a session: a closed row, another client's `session.close`, and a
+`--command` exit are identical in it. `--wait` removes the third, parking the row on the exit prompt
+rather than closing it, so a `session.closed` under `--wait` is always a person or a client. App quit
+emits no `session.closed` at all, since window teardown is skipped while terminating.
+
 For resumable consumers, save the `run` and `next` fields from raw `events.read` batch responses and
 restart with `agtermctl events --run "$run" --after "$next" --json`. The streaming JSON lines are bare
 events and do not include the run id. If the command reports `event run changed`, `event cursor

--- a/plugins/agterm/skills/agterm/examples.md
+++ b/plugins/agterm/skills/agterm/examples.md
@@ -614,9 +614,10 @@ agtermctl events --json --kind session.closed |
   done
 ```
 
-The stream does not say what closed a session: a closed row, another client's `session.close`, and a
-`--command` exit are identical in it. `--wait` removes the third, parking the row on the exit prompt
-rather than closing it, so a `session.closed` under `--wait` is always a person or a client. App quit
+The stream does not say what closed a session: a closed row, another client's `session.close`, and the
+exit of a `session.new --command` process are identical in it. Creating that session with `--wait`
+removes the third, parking the row on the exit prompt rather than closing it, so a `session.closed`
+under `--wait` is always a person or a client. App quit
 emits no `session.closed` at all, since window teardown is skipped while terminating.
 
 For resumable consumers, save the `run` and `next` fields from raw `events.read` batch responses and


### PR DESCRIPTION
discussion #439 asked for close provenance: a supervising client cannot tell a user close from another client's `session.close` from a `--command` exit, because all three produce the same `session.closed` event and nothing is logged.

the clean-up recipe in the bundled skill showed that event stream without saying any of this. It now names the ambiguity, points at `--wait` as the flag that removes the `--command` case (the row parks on the exit prompt instead of closing, so a `session.closed` under it is always a person or a client), and records that app quit emits no `session.closed` at all, since `WindowLibrary.closeWindow` returns early while terminating.

also adds a backlog item for a separate defect found while tracing the logging call sites: `docs/troubleshooting.md` documents a `ControlServer` log category that does not exist, so the filter it gives users matches nothing, and it omits three categories that do.

Related to #439
