### PR TITLE
feat: detach the quick terminal into a floating panel with a global hotkey

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -412,15 +412,21 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   arrives because the pty's session leader is the surviving `login`. Without it every crash, `kill -9` and
   XCUITest `terminate()` leaves a 2-10 Hz repaint loop running forever.
 - `surface.zoom show|hide|toggle` reparents exactly one surface below a slim titlebar. Explicit IDs are
-  `surface:<session-id>:<left|right|scratch|overlay|overlay-left|overlay-right>` or `quick`, including
-  hidden live panes. The active target is the single case `TerminalZoomSurface.isActive` accepts: quick,
-  then the session overlay, then scratch, then the focused pane's own overlay, then that pane. Those
+  `surface:<session-id>:<left|right|scratch|overlay|overlay-left|overlay-right>`, including hidden live
+  panes. The active target is the single case `TerminalZoomSurface.isActive` accepts: the session overlay,
+  then scratch, then the focused pane's own overlay, then that pane. Those
   predicates are mutually exclusive and total, resting on `Session.focusedPane`, so widening one without
   narrowing its neighbour silently picks the wrong surface.
+- `quick` is the one target that names no window surface: it grows the quick-terminal PANEL to fill its
+  screen. `setSurfaceZoom` routes it before resolving a window, so it takes no `--window` and never reaches
+  `resolveSurfaceZoom`; it is refused `surface not available: quick` while the panel is hidden, and an
+  omitted `--target` never resolves to it. See [[windows]].
 - Host-free `TerminalZoomController` owns mode/state. Zoom must not change ratios, focus, sidebar, or pane
-  visibility; deck slots remain constant and focus reporting is suppressed. Opening closes palette/search
-  and conflicting quick terminal; banner reveal and Command-W exit. Font remains live. Reject quick show
-  and search-open while zoomed, but keep hides idempotent even if the target vanished. Read
+  visibility; deck slots remain constant and focus reporting is suppressed. Opening closes palette/search;
+  banner reveal and Command-W exit. Font remains live. Reject search-open while zoomed, but keep hides
+  idempotent even if the target vanished. Zoom neither closes nor blocks the quick terminal any more — the
+  panel floats above every window instead of being hosted by one, so `quick show` is no longer refused with
+  `terminal zoom active`. Read
   top-level live `zoomedSurface`; surface node active/visible describes pane state, not zoom.
 - `dashboard` opens explicit IDs or `--mru`, or closes. Font-size and auto-size are exclusive; close accepts
   no IDs/MRU/font; open needs IDs or MRU; fixed size must be finite positive.
@@ -546,6 +552,8 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   which preempts `initialCommand` in `restorePlan` and would drop the exec path.
 - Top-level tree includes idle/auto-follow, live sidebar visibility/mode, workspace filter, quick
   visibility, zoom, dashboard, and picker state. Prefer live tree sidebar state over cached window list.
+  `quickVisible` and a `quick` `zoomedSurface` are APP-level, so every projected window reports the same
+  value for them; the rest stay per-window.
 - Window nodes include open/active, open-store sidebar/auto-follow, geometry, fullscreen, zoomed, minimized.
   Closed live fields are omitted. Geometry is top-left display-relative y-down and round-trips move/resize.
 - Window list is cached. Refresh after commands and frontmost/sidebar/attachment/move/resize/fullscreen/

--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -18,7 +18,11 @@ paths:
 - `global-hotkey <chord>` is the third verb: ONE chord, modifier required, no `|` alternatives and no
   leader sequence (`RegisterEventHotKey` expresses neither), last line wins. It is registered with the OS
   by `GlobalHotkey`, never with `KeybindMatcher`, so it is deliberately OUTSIDE the conflict model below —
-  it may share a chord with a menu item and neither loses its binding. `keyCode(forChordKey:)` resolves it
+  it may share a chord with a menu item — but the OS hotkey WINS and CONSUMES the key, agterm frontmost
+  included, so the menu binding then never fires. Say that rather than "whichever app is in front decides",
+  which is the precise inversion. `parseGlobalHotkeyLine` diagnoses a base key no physical position produces,
+  since the verb has no read-back anywhere and a silent drop at registration would be the user's only signal.
+  `keyCode(forChordKey:)` resolves it
   by physical position, inverting `namedKey`/`latinKey` rather than adding a third table, so it survives a
   layout switch. It summons the quick terminal; see [[windows]] for the panel.
 - `parseKeymap` never throws. `map <chord> <action>` takes one whitespace-delimited chord token.

--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -15,6 +15,12 @@ paths:
 - `<configDir>/keymap.conf` (default `~/.config/agterm`) rebinds built-in menu shortcuts and defines
   custom shell commands, which appear in the action palette as `custom`. One parsed `Keymap` drives the
   menu, custom-command monitor, and palette; host-free logic lives in `agtermCore`.
+- `global-hotkey <chord>` is the third verb: ONE chord, modifier required, no `|` alternatives and no
+  leader sequence (`RegisterEventHotKey` expresses neither), last line wins. It is registered with the OS
+  by `GlobalHotkey`, never with `KeybindMatcher`, so it is deliberately OUTSIDE the conflict model below —
+  it may share a chord with a menu item and neither loses its binding. `keyCode(forChordKey:)` resolves it
+  by physical position, inverting `namedKey`/`latinKey` rather than adding a third table, so it survives a
+  layout switch. It summons the quick terminal; see [[windows]] for the panel.
 - `parseKeymap` never throws. `map <chord> <action>` takes one whitespace-delimited chord token.
   `command "<name>" [chord] <shell...>` treats the token after the quoted name as a shortcut only when
   `parseKeybinds` accepts it with a modifier; a bare key is diagnosed and the command stays palette-only.

--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -119,18 +119,21 @@ paths:
   `paneDim` — in `WindowContentView+Detail.swift` so `WindowContentView.swift` remains below the
   1000-line limit. `sessionDetail` owns the constant-shape statement; every other site cross-references it.
   One `deckPane` renders each pane, so the split's two arranged subviews are the same view type.
-- Window-level quick terminal, palettes, switcher, and dashboard live in `windowOverlayLayer`, inset by
-  `titlebarHeight` below `customTitlebar`. A body overlay's 0.2-opacity black scrim darkens the transparent
-  tall titlebar.
+- Palettes, switcher, and dashboard live in `windowOverlayLayer`, inset by
+  `titlebarHeight` below `customTitlebar`. The quick terminal is NOT among them: it is a detached
+  `QuickTerminalPanel` above every window, so it needs no inset and paints its own frame ([[windows]]).
+  A body overlay's 0.2-opacity black scrim darkens the transparent tall titlebar.
   The seam appears in 48px normal mode; 30px compact remains inside the native band.
   Keep the empty overlay layer free of Color/contentShape so it cannot intercept hits. Do not add an opaque
   titlebar background; it breaks translucent chrome.
 - With translucency, every surface has zero background opacity. A full overlay has no opaque SwiftUI
-  backing, so hide panes and scratch beneath it and remove their drop eligibility. Floating overlay and
-  quick terminal have opaque terminal-color panels.
-- Because those two leave a live terminal around the panel, their tap-catcher also paints the
+  backing, so hide panes and scratch beneath it and remove their drop eligibility. A floating overlay has
+  an opaque terminal-color panel; the quick terminal takes the same backing from its own panel's content,
+  through `WindowContentView.resolvedTerminalColor`.
+- Because a floating overlay leaves a live terminal around its panel, its tap-catcher also paints the
   `inactivePaneMuteStrength` wash. Fill the existing catcher; never add a sibling scrim. Suppress `paneDim`
-  while a backdrop wash is up or the covered inactive pane takes both.
+  while a backdrop wash is up or the covered inactive pane takes both. The quick terminal no longer takes
+  part: its panel is a separate window, so there is no in-window margin left to catch a tap or wash.
 - Anything that HIDES a pane in place takes the wash with it, so the cover must carry `paneDim` itself:
   `paneOverlayPanel` washes an overlay opened on the unfocused pane, or split focus stops reading.
   Wash a cover against ITS OWN background, not `washColor(for:)`. An overlay surface is sessionless and

--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -142,15 +142,21 @@ paths:
 
 ## Close and reselection
 
-- Command-W first dismisses the frontmost cover: quick terminal, then overlay, then scratch, then the
+- Command-W first dismisses the frontmost cover: the quick-terminal panel (un-zoom, then hide), then
+  overlay, then scratch, then the
   FOCUSED pane's own overlay (`focusedOverlayPane`; one on the sibling pane is not in front of the user and
   does not intercept). Only then close the active session. If no cover or session exists, the menu performs
   window close. Keep the cover check inside `closeActiveSession`, since a sessionless window can still show
   quick terminal.
+- The panel's two rungs read `holdsKey`, not `isVisible`. A PINNED panel (a control `quick show`) stays on
+  screen without owning the keyboard, and Command-W in a terminal window must then close that session
+  rather than reach past it to the panel.
 - The menu item diverts to a plain `performClose` when the key window is not an agterm terminal window —
   Settings, the About panel, an open/save panel — because `applyCloseSessionChord` takes ⌘W off the stock
   File ▸ Close item and nothing else would close them (issue #401). `WindowRegistry.contains` is the
-  predicate, as in `CustomCommandRunner`. A `nil` key window still runs the deck sequence: with every
+  predicate, as in `CustomCommandRunner`, EXCEPT for `QuickTerminalPanel`: it is unregistered too but it is
+  a cover, not an auxiliary window, and being borderless it has no close button, so `performClose` would
+  only beep and the ladder's own panel rungs would never run. A `nil` key window still runs the deck sequence: with every
   window minimized the equivalent still dispatches, and `performClose` on nothing would make ⌘W silently
   no-op. The divert is gated on `close_session` still holding ⌘W, the same condition
   `applyCloseSessionChord` splits on: rebound off it, the stock item takes the chord back and the

--- a/.claude/rules/menu-actions.md
+++ b/.claude/rules/menu-actions.md
@@ -42,8 +42,8 @@ paths:
   and `runIfEnabled()` asks it again at the keystroke, returning whether it ran — which is the only thing
   that dismisses the palette, so an inert row cannot close it on a keystroke that did nothing.
 - `toggleQuickTerminal` gates on all `uiActionsEnabled`, including terminal zoom and dashboard.
-  Control drives `QuickTerminalRegistry` directly. The titlebar button is replaced by dashboard chrome,
-  which hides an open quick terminal before showing the grid.
+  Control drives `QuickTerminalController.shared` directly, there being one panel per app. The titlebar
+  button is replaced by dashboard chrome, which hides an open quick terminal before showing the grid.
 - Every new action must satisfy the control contract in [[control-api]]: protocol, dispatch, CLI, and
   protocol/end-to-end tests. Do not restate per-action audits here.
 

--- a/.claude/rules/windows.md
+++ b/.claude/rules/windows.md
@@ -82,10 +82,16 @@ session drag are out of scope.
   `openIDs`.
 - Losing key hides a HUMAN-summoned panel (hotkey, ⌃`, toolbar, Dock), which is what makes it
   summon-and-dismiss rather than window chrome. A control-driven `quick show` passes
-  `dismissOnFocusLoss: false` and pins it instead: `show` calls `NSApp.activate`, so the caller's NEXT
-  command runs while the previous application is coming back to the front, and a blur-dismissing panel is
-  already gone by the time `quick.type` or `surface.zoom --target quick` arrives — measured, not theorised.
-  `hide` clears the pin. This is AppKit key-window behavior, so it is manually verified, not unit-tested.
+  `dismissOnFocusLoss: false` and pins it instead, because the caller's NEXT command runs while focus is
+  still settling and a blur-dismissing panel is already gone by the time `quick.type` or
+  `surface.zoom --target quick` arrives — measured, not theorised. `show` applies that pin even when the
+  panel is ALREADY visible, which is the case a script hits over a hotkey-summoned panel; `hide` and a shell
+  exit clear it. `NSApp.activate` is never called: activating raises agterm's own windows over the
+  application the panel was summoned from, so `.nonactivatingPanel` plus `orderFrontRegardless` is what lets
+  it take the keyboard while agterm stays inactive. A resign-driven hide records its time, and a show within
+  `reshowSuppression` is dropped — AppKit makes a clicked window key BEFORE delivering its button action, so
+  the toolbar and Dock toggles would otherwise re-show the panel the same click dismissed. This is AppKit
+  key-window behavior, so it is manually verified, not unit-tested.
 - The frame is 90% of the focused screen capped at `maxNormalSize` (1100x700). The in-window overlay needed
   no cap because a window is already modest; 90% of a large display is a wall of terminal, not a quick
   aside.

--- a/.claude/rules/windows.md
+++ b/.claude/rules/windows.md
@@ -73,12 +73,32 @@ session drag are out of scope.
 
 ## Quick terminal, notifications, and environment
 
-- `QuickTerminalController` is per-window state registered by ID, never a singleton. Providers bind to
-  that window; frontmost calls use `activeWindowID`, control reports `no open window`, and settings
-  broadcast to all controllers.
+- `QuickTerminalController` is an app-level singleton hosting one `QuickTerminalPanel`, a borderless
+  non-activating `NSPanel` on `.canJoinAllSpaces` that lands on the POINTER's screen — it is summoned from
+  another application, where agterm's own key window is no guide to where the user is looking. Providers
+  resolve through `activeStore` at call time rather than capturing a window, `agtermApp.wireQuickTerminal`
+  binding them once after the socket binds. `canShow` refuses with no open window, agterm terminating on an
+  empty open set; the panel is not a library window, so it neither keeps the app alive nor appears in
+  `openIDs`.
+- Losing key hides a HUMAN-summoned panel (hotkey, ⌃`, toolbar, Dock), which is what makes it
+  summon-and-dismiss rather than window chrome. A control-driven `quick show` passes
+  `dismissOnFocusLoss: false` and pins it instead: `show` calls `NSApp.activate`, so the caller's NEXT
+  command runs while the previous application is coming back to the front, and a blur-dismissing panel is
+  already gone by the time `quick.type` or `surface.zoom --target quick` arrives — measured, not theorised.
+  `hide` clears the pin. This is AppKit key-window behavior, so it is manually verified, not unit-tested.
+- The frame is 90% of the focused screen capped at `maxNormalSize` (1100x700). The in-window overlay needed
+  no cap because a window is already modest; 90% of a large display is a wall of terminal, not a quick
+  aside.
 - While quick terminal is visible, no deck surface may be active. Gate main, split, maximized split,
-  scratch, and overlay with `deckInteractive && isActive && !quickTerminal.isVisible`; the overlay shares
-  the containing window's first responder.
+  scratch, and overlay with `deckInteractive && isActive && !quickTerminal.isVisible`. The predicate is now
+  app-level, so a visible panel makes EVERY window's deck inert, which is correct — the panel holds key.
+- The panel is not a window surface, so no window's `TerminalZoomController` can hold `.quick`;
+  `QuickTerminalController.isZoomed` owns it and `surface.zoom --target quick` grows the panel to fill its
+  screen. `resolveTarget` never returns `.quick` and `isTargetValid` always rejects it, so a stale value
+  clears. `zoomedSurface` reports `quick` from the app-level flag ahead of the window's own target.
+- `GlobalHotkey` registers the `keymap.conf` `global-hotkey` chord through Carbon `RegisterEventHotKey`,
+  which needs no Accessibility grant and CONSUMES the key, unlike an `NSEvent` global monitor. It is
+  re-registered on `.agtermKeymapChanged`. See [[keymap]] for the verb's grammar.
 - Notification identity is `"<windowID>:<sessionID>:<paneRole>"`. Capture resolves the owning window.
   Reveal reopens a closed window through raise or enqueue/open, polls until its store loads, then selects
   and focuses the pane. Unknown window/session only activates. This internal route is keep-in-sync exempt.
@@ -86,7 +106,8 @@ session drag are out of scope.
   `[ghostty_env_var_s]` beside `configCStrings`, call `ghostty_surface_new` inside its mutable-buffer
   lifetime, and clear it with the strdup storage on destroy/deinit.
 - Tree surfaces inject `AGTERM_ENABLED`, window/workspace/session IDs, and `AGTERM_SOCKET`; split/overlay
-  inherit the session IDs. Quick terminal gets enabled, window, and socket only. Use
+  inherit the session IDs. Quick terminal gets enabled and socket only — it belongs to no window, so it
+  carries no window id and an untargeted `agtermctl` run from it resolves the active window. Use
   `ControlServer.boundSocketPath`, omitting the variable before bind, so overridden sockets match children.
 
 ## Window state controls

--- a/.claude/rules/windows.md
+++ b/.claude/rules/windows.md
@@ -95,9 +95,15 @@ session drag are out of scope.
 - The frame is 90% of the focused screen capped at `maxNormalSize` (1100x700). The in-window overlay needed
   no cap because a window is already modest; 90% of a large display is a wall of terminal, not a quick
   aside.
-- While quick terminal is visible, no deck surface may be active. Gate main, split, maximized split,
-  scratch, and overlay with `deckInteractive && isActive && !quickTerminal.isVisible`. The predicate is now
-  app-level, so a visible panel makes EVERY window's deck inert, which is correct — the panel holds key.
+- While the quick terminal OWNS THE KEYBOARD, no deck surface may be active. Gate main, split, maximized
+  split, scratch, and overlay with `deckInteractive && isActive && !quickTerminal.holdsKey`. Read `holdsKey`,
+  never `isVisible`: the predicate is app-level, so it inerts EVERY window, and a PINNED panel (a control
+  `quick show`) stays on screen after agterm loses key. Gating on visibility there makes
+  `TerminalView.updateNSView` revoke first responder in every window on the next SwiftUI update, so the user
+  clicks into a terminal, types, and loses the keyboard again at the next title or status change. The same
+  distinction governs `focusActiveSession`, `focusSplitPane`, the scratch's `suppressAutoFocus`,
+  `coverHidesActiveSession` and the Command-W rungs. `holdsKey` follows the panel's own
+  didBecomeKey/didResignKey, so a resign clears it whether or not the panel also hides.
 - The panel is not a window surface, so no window's `TerminalZoomController` can hold `.quick`;
   `QuickTerminalController.isZoomed` owns it and `surface.zoom --target quick` grows the panel to fill its
   screen. `resolveTarget` never returns `.quick` and `isTargetValid` always rejects it, so a stale value

--- a/agterm/AppActions+Focus.swift
+++ b/agterm/AppActions+Focus.swift
@@ -127,7 +127,7 @@ extension AppActions {
         // palette, then opens the .themes picker a tick later) keeps its field focus.
         if palette?.mode != nil { return }
         if pickActive(for: library.activeWindowID) { return }
-        if quickTerminal.isVisible { return }
+        if quickTerminal.holdsKey { return }
         if let view = store?.activeSession?.topmostSurface as? GhosttySurfaceView, let window = view.window {
             window.makeFirstResponder(view)
         }
@@ -180,7 +180,7 @@ extension AppActions {
         }
         // the quick-terminal panel owns focus above EVERY window, not just this session's; its own hide
         // restores the session.
-        if quickTerminal.isVisible { return }
+        if quickTerminal.holdsKey { return }
         if let view = session.focusTarget(wantSplit: wantSplit) as? GhosttySurfaceView, let window = view.window {
             window.makeFirstResponder(view)
         }

--- a/agterm/AppActions+Focus.swift
+++ b/agterm/AppActions+Focus.swift
@@ -67,15 +67,6 @@ extension AppActions {
         return owner.selectedSessionID == session.id
     }
 
-    /// Whether the quick terminal is showing in the window OWNING this session — the session-scoped twin of
-    /// `frontmostQuickTerminal`, window-scoped like `terminalZoomActive(for:)` since each window owns its own
-    /// controller: gating on the frontmost would both drop the focus step for a background target (leaving
-    /// its `splitFocused` and real first responder disagreeing) and miss a cover actually showing there.
-    private func quickTerminalActive(for session: Session) -> Bool {
-        guard let windowID = library.windowID(forSession: session.id) else { return false }
-        return QuickTerminalRegistry.shared.controller(for: windowID)?.isVisible == true
-    }
-
     // MARK: - Reveal & focus
 
     /// Reveal and focus the active session's blocked pane, reading its agent-status pane tag so navigation
@@ -136,7 +127,7 @@ extension AppActions {
         // palette, then opens the .themes picker a tick later) keeps its field focus.
         if palette?.mode != nil { return }
         if pickActive(for: library.activeWindowID) { return }
-        if frontmostQuickTerminal?.isVisible == true { return }
+        if quickTerminal.isVisible { return }
         if let view = store?.activeSession?.topmostSurface as? GhosttySurfaceView, let window = view.window {
             window.makeFirstResponder(view)
         }
@@ -187,8 +178,9 @@ extension AppActions {
             if renamePending { return }
             if palette?.mode != nil { return }
         }
-        // the quick terminal is a window-level cover that owns focus; its own hide restores the session.
-        if quickTerminalActive(for: session) { return }
+        // the quick-terminal panel owns focus above EVERY window, not just this session's; its own hide
+        // restores the session.
+        if quickTerminal.isVisible { return }
         if let view = session.focusTarget(wantSplit: wantSplit) as? GhosttySurfaceView, let window = view.window {
             window.makeFirstResponder(view)
         }

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -797,10 +797,20 @@ final class AppActions {
         quickTerminal.toggle()
     }
 
-    /// Toggle the frontmost window's full-window terminal zoom. Core resolves which surface is active
-    /// (quick, overlay, scratch, split, or primary); the owning window renders it above all chrome.
+    /// Toggle terminal zoom for whatever the user is actually looking at: the quick-terminal panel when it
+    /// owns the keyboard, else the frontmost window's active surface (core resolves overlay, scratch, split
+    /// or primary; the owning window renders it above all chrome).
+    ///
+    /// The panel rung is not optional. The chord still reaches agterm while the panel is key, but the panel
+    /// is no longer a `TerminalZoomTarget` a window can hold — so without it the keystroke would arm zoom on
+    /// a window BEHIND the panel, changing nothing on screen and leaving a window the user may not even have
+    /// visible zoomed with its sidebar gone. Same rule as `closeActiveSession`: never mutate covered state.
     func toggleTerminalZoom() {
         guard !pickActive(for: library.activeWindowID) else { return }
+        if quickTerminal.holdsKey {
+            quickTerminal.setZoom(.toggle)
+            return
+        }
         frontmostTerminalZoom?.toggle()
     }
 

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -223,8 +223,8 @@ final class AppActions {
         // rungs below read state the panel is covering, and clearing a zoom the user cannot see is a silent
         // mutation of state they never touched. Stepwise like zoom: a zoomed panel un-zooms first, the next
         // ⌘W hides it. Its zoom is app-level (`isZoomed`), NOT a window's `TerminalZoomTarget`.
-        if quickTerminal.isZoomed { quickTerminal.setZoom(.off); return true }
-        if quickTerminal.isVisible { quickTerminal.hide(); return true }
+        if quickTerminal.holdsKey, quickTerminal.isZoomed { quickTerminal.setZoom(.off); return true }
+        if quickTerminal.holdsKey { quickTerminal.hide(); return true }
         // zoom is the topmost cover inside the window: ⌘W dismisses it, never mutating hidden session/window
         // state behind it. the dashboard grid is the
         // other modal cover (mutually exclusive with zoom) — close and refocus, don't close the session.
@@ -871,7 +871,7 @@ final class AppActions {
     /// overlay is NOT a term here — `searchTarget` owns that rung, in the one order that gets the
     /// scratch-above-a-pane-overlay case right; duplicating it here would block ⌘F on the searchable scratch.
     private var coverHidesActiveSession: Bool {
-        if quickTerminal.isVisible { return true }
+        if quickTerminal.holdsKey { return true }
         guard let session = store?.activeSession else { return false }
         // a FLOATING overlay leaves the session visible, so only a FULL overlay hides it (and is not searchable).
         return session.fullOverlayActive

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -15,10 +15,9 @@ final class AppActions {
     /// closed (quitting), where callers no-op.
     var store: AppStore? { library.activeStore }
 
-    /// The frontmost window's quick-terminal controller (one per window). Nil when no window is open.
-    var frontmostQuickTerminal: QuickTerminalController? {
-        QuickTerminalRegistry.shared.controller(for: library.activeWindowID)
-    }
+    /// The app's one quick terminal, which lives in a detached panel rather than in a window — so unlike the
+    /// zoom/dashboard/pick controllers beside it there is nothing to resolve and nothing to be nil.
+    var quickTerminal: QuickTerminalController { .shared }
 
     /// The frontmost window's zoom controller; `WindowContentView` renders its target above the chrome.
     private var frontmostTerminalZoom: TerminalZoomController? {
@@ -225,7 +224,7 @@ final class AppActions {
         // other modal cover (mutually exclusive with zoom) — close and refocus, don't close the session.
         if terminalZoomActive { frontmostTerminalZoom?.clear(); return true }
         if let dashboard = frontmostDashboard, dashboard.isOpen { dashboard.close(); focusActiveSession(); return true }
-        if let quick = frontmostQuickTerminal, quick.isVisible { quick.hide(); return true }
+        if quickTerminal.isVisible { quickTerminal.hide(); return true }
         guard let store, let session = store.activeSession else { return false }
         if session.overlayActive { store.closeOverlay(session.id); return true }
         if session.scratchActive { store.toggleScratch(session.id); return true }
@@ -790,7 +789,7 @@ final class AppActions {
     /// item's own key equivalent), the palette's `runPaletteCommand`, and the Dock item's invocation check.
     func toggleQuickTerminal() {
         guard uiActionsEnabled else { return }
-        frontmostQuickTerminal?.toggle()
+        quickTerminal.toggle()
     }
 
     /// Toggle the frontmost window's full-window terminal zoom. Core resolves which surface is active
@@ -867,7 +866,7 @@ final class AppActions {
     /// overlay is NOT a term here — `searchTarget` owns that rung, in the one order that gets the
     /// scratch-above-a-pane-overlay case right; duplicating it here would block ⌘F on the searchable scratch.
     private var coverHidesActiveSession: Bool {
-        if frontmostQuickTerminal?.isVisible == true { return true }
+        if quickTerminal.isVisible { return true }
         guard let session = store?.activeSession else { return false }
         // a FLOATING overlay leaves the session visible, so only a FULL overlay hides it (and is not searchable).
         return session.fullOverlayActive

--- a/agterm/AppActions.swift
+++ b/agterm/AppActions.swift
@@ -219,12 +219,17 @@ final class AppActions {
         // a pick is an external caller waiting on an answer: the first ⌘W layer even behind a zoomed terminal,
         // and resolved rather than hidden so the caller can finish.
         if cancelPendingPick(for: library.activeWindowID) { return true }
-        // zoom is the topmost cover: ⌘W dismisses it stepwise (a zoomed quick terminal un-zooms first, the
-        // next ⌘W hides it), never mutating hidden session/window state behind it. the dashboard grid is the
+        // the quick-terminal panel floats above every window, so it outranks anything inside one — the window
+        // rungs below read state the panel is covering, and clearing a zoom the user cannot see is a silent
+        // mutation of state they never touched. Stepwise like zoom: a zoomed panel un-zooms first, the next
+        // ⌘W hides it. Its zoom is app-level (`isZoomed`), NOT a window's `TerminalZoomTarget`.
+        if quickTerminal.isZoomed { quickTerminal.setZoom(.off); return true }
+        if quickTerminal.isVisible { quickTerminal.hide(); return true }
+        // zoom is the topmost cover inside the window: ⌘W dismisses it, never mutating hidden session/window
+        // state behind it. the dashboard grid is the
         // other modal cover (mutually exclusive with zoom) — close and refocus, don't close the session.
         if terminalZoomActive { frontmostTerminalZoom?.clear(); return true }
         if let dashboard = frontmostDashboard, dashboard.isOpen { dashboard.close(); focusActiveSession(); return true }
-        if quickTerminal.isVisible { quickTerminal.hide(); return true }
         guard let store, let session = store.activeSession else { return false }
         if session.overlayActive { store.closeOverlay(session.id); return true }
         if session.scratchActive { store.toggleScratch(session.id); return true }

--- a/agterm/AppDelegate+DockMenu.swift
+++ b/agterm/AppDelegate+DockMenu.swift
@@ -82,15 +82,15 @@ extension AppDelegate {
             actions?.newWindow(ignoringModals: true)
         }
 
-        let quickTerminal = windowID.flatMap { QuickTerminalRegistry.shared.controller(for: $0) }
+        // the quick terminal is app-level, so unlike its neighbours here there is no per-window controller to
+        // find; the captured window still has to come forward, the panel spawning in its active session's cwd.
         addDockMenuItem(
             "Quick Terminal",
-            enabled: actionsEnabled && quickTerminal != nil,
+            enabled: actionsEnabled,
             to: menu
         ) { [weak self, weak store] in
             guard let self, let store, let windowID,
                   actions?.uiActionsEnabled(for: windowID) == true,
-                  QuickTerminalRegistry.shared.controller(for: windowID) != nil,
                   activate(windowID: windowID, store: store)
             else { return }
             actions?.toggleQuickTerminal()

--- a/agterm/Commands/GlobalHotkey.swift
+++ b/agterm/Commands/GlobalHotkey.swift
@@ -44,7 +44,9 @@ final class GlobalHotkey {
                                            MemoryLayout<EventHotKeyID>.size, nil, &firedID)
             guard status == noErr, firedID.id == GlobalHotkey.hotKeyID.id else { return OSStatus(eventNotHandledErr) }
             DispatchQueue.main.async {
-                QuickTerminalController.shared.toggle()
+                // a keypress from another application causes no blur of its own, so it must not be
+                // coalesced with one the user's own click just caused.
+                QuickTerminalController.shared.toggle(fromGlobalHotkey: true)
             }
             return noErr
         }, 1, &eventType, nil, &handlerRef)

--- a/agterm/Commands/GlobalHotkey.swift
+++ b/agterm/Commands/GlobalHotkey.swift
@@ -1,0 +1,94 @@
+import agtermCore
+import AppKit
+import Carbon.HIToolbox
+
+/// The system-wide chord that summons the quick terminal, registered with the OS through Carbon's
+/// `RegisterEventHotKey` so it fires while another application is frontmost — which the app's own
+/// `NSEvent.addLocalMonitorForEvents` monitor, gated on agterm's key window, structurally cannot do.
+///
+/// Carbon rather than `NSEvent.addGlobalMonitorForEvents`: the global monitor needs an Accessibility grant,
+/// fails silently when it is missing or revoked, and observes rather than consumes, so the chord would also
+/// reach whatever application is in front. `RegisterEventHotKey` needs no TCC grant and takes the key.
+///
+/// The chord is registered by physical key POSITION, `keyCode(forChordKey:)` resolving it, so it keeps
+/// firing when the user switches to a non-Latin layout — the same choice `CustomCommandRunner` makes for
+/// non-ASCII layouts.
+@MainActor
+final class GlobalHotkey {
+    private let settings: SettingsModel
+
+    private var hotKeyRef: EventHotKeyRef?
+    private var handlerRef: EventHandlerRef?
+    private var keymapObserver: NSObjectProtocol?
+
+    /// The `RegisterEventHotKey` id this app uses. Only one hotkey is ever registered, so the signature and
+    /// id are constants rather than a counter.
+    private static let hotKeyID = EventHotKeyID(signature: OSType(0x4147_544D), id: 1) // 'AGTM'
+
+    init(settings: SettingsModel) {
+        self.settings = settings
+    }
+
+    /// Install the Carbon handler and register the current keymap's chord (idempotent), then re-register on
+    /// `.agtermKeymapChanged` so `keymap.reload` moves the hotkey like it moves every other binding.
+    func start() {
+        guard handlerRef == nil else { return }
+        var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard),
+                                      eventKind: UInt32(kEventHotKeyPressed))
+        // the callback captures nothing and reaches the shared controller, like the libghostty C callbacks:
+        // a Carbon handler is a plain C function pointer with no context of its own beyond `userData`.
+        InstallEventHandler(GetApplicationEventTarget(), { _, event, _ -> OSStatus in
+            var firedID = EventHotKeyID()
+            let status = GetEventParameter(event, EventParamName(kEventParamDirectObject),
+                                           EventParamType(typeEventHotKeyID), nil,
+                                           MemoryLayout<EventHotKeyID>.size, nil, &firedID)
+            guard status == noErr, firedID.id == GlobalHotkey.hotKeyID.id else { return OSStatus(eventNotHandledErr) }
+            DispatchQueue.main.async {
+                QuickTerminalController.shared.toggle()
+            }
+            return noErr
+        }, 1, &eventType, nil, &handlerRef)
+        register(settings.keymap.globalHotkey)
+        keymapObserver = NotificationCenter.default.addObserver(
+            forName: .agtermKeymapChanged, object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.register(self.settings.keymap.globalHotkey)
+            }
+        }
+    }
+
+    /// Unregister the chord, the Carbon handler, and the keymap observer.
+    func stop() {
+        unregister()
+        if let handlerRef { RemoveEventHandler(handlerRef) }
+        handlerRef = nil
+        if let keymapObserver { NotificationCenter.default.removeObserver(keymapObserver) }
+        keymapObserver = nil
+    }
+
+    /// Replace the registered chord. A nil chord, or one whose base key names no physical position, leaves
+    /// the app with no global hotkey — the file's own diagnostics report the second case, so this is silent.
+    private func register(_ chord: Chord?) {
+        unregister()
+        guard let chord, let code = keyCode(forChordKey: chord.key) else { return }
+        RegisterEventHotKey(UInt32(code), Self.carbonModifiers(chord.mods), Self.hotKeyID,
+                            GetApplicationEventTarget(), 0, &hotKeyRef)
+    }
+
+    private func unregister() {
+        if let hotKeyRef { UnregisterEventHotKey(hotKeyRef) }
+        hotKeyRef = nil
+    }
+
+    /// agterm's own modifier set as Carbon's, the only spelling `RegisterEventHotKey` takes.
+    private static func carbonModifiers(_ mods: Modifier) -> UInt32 {
+        var carbon: UInt32 = 0
+        if mods.contains(.command) { carbon |= UInt32(cmdKey) }
+        if mods.contains(.option) { carbon |= UInt32(optionKey) }
+        if mods.contains(.control) { carbon |= UInt32(controlKey) }
+        if mods.contains(.shift) { carbon |= UInt32(shiftKey) }
+        return carbon
+    }
+}

--- a/agterm/ContentView.swift
+++ b/agterm/ContentView.swift
@@ -19,9 +19,6 @@ struct ContentView: View {
     /// `left`/`right` the pane-scoped one covering that split pane.
     let makeOverlaySurface: (Session, AppStore, OverlayPane?) -> GhosttySurfaceView
     let makeScratchSurface: (Session, AppStore) -> GhosttySurfaceView
-    /// The `AGTERM_*` environment a window's quick terminal exposes (ENABLED + WINDOW_ID + SOCKET), per
-    /// window id. Threaded down so `WindowContentView` binds its quick terminal's `envProvider` with its own id.
-    let quickTerminalEnv: (WindowInfo.ID) -> [String: String]
     let actions: AppActions
     let palette: PaletteController
     let sessionSwitcher: SessionSwitcher
@@ -66,7 +63,6 @@ struct ContentView: View {
                     makeSplitSurface: { makeSplitSurface($0, store) },
                     makeOverlaySurface: { makeOverlaySurface($0, store, $1) },
                     makeScratchSurface: { makeScratchSurface($0, store) },
-                    quickTerminalEnv: quickTerminalEnv,
                     actions: actions,
                     palette: palette,
                     sessionSwitcher: sessionSwitcher

--- a/agterm/Control/ControlServer+AppCommands.swift
+++ b/agterm/Control/ControlServer+AppCommands.swift
@@ -4,7 +4,7 @@ import agtermCore
 
 /// `ControlServer` APP-GLOBAL action adapter arms — no session/workspace target, acting on a whole window or
 /// the app: the `tree` projection, sidebar visibility/view-mode and expand/collapse, keymap + ghostty-config
-/// reload, theme slots, per-window quick terminal. Split out of the session-, workspace- and surface-scoped
+/// reload, theme slots, the app-wide quick terminal. Split out of the session-, workspace- and surface-scoped
 /// `ControlServer+SessionActions.swift` for the file size limit.
 extension ControlServer {
     func controlTree(window: String?) -> ControlResponse {
@@ -222,16 +222,18 @@ extension ControlServer {
            PickRegistry.shared.controller(for: library.activeWindowID)?.pending != nil {
             return ControlResponse(ok: false, error: "pick pending")
         }
-        if want != controller.isVisible {
-            // pinned: a control show activates agterm, so the caller's next command runs while the previous
-            // application is coming back to the front. A blur-dismissing panel would be gone before
-            // `quick type` or `surface zoom --target quick` arrived.
-            if want { controller.show(dismissOnFocusLoss: false) } else { controller.hide() }
+        // `show` runs even when the panel is ALREADY visible, which `hide` has no equivalent of: it is what
+        // pins a panel the user summoned by hotkey. Skipping it there would answer ok and leave the caller's
+        // next command racing the blur the promise says it will not — see `show(dismissOnFocusLoss:)`.
+        if want {
+            controller.show(dismissOnFocusLoss: false)
+        } else if controller.isVisible {
+            controller.hide()
         }
         return ControlResponse(ok: true)
     }
 
-    /// Inject `text` as literal keystrokes into the frontmost window's quick terminal, the twin of
+    /// Inject `text` as literal keystrokes into the app's one quick terminal, the twin of
     /// `session.type`. `quick show` flips `isVisible` before SwiftUI mounts + libghostty realizes the surface,
     /// so this polls briefly rather than racing a back-to-back `quick show; quick type`. Fails fast with `quick
     /// terminal not open` when never shown (no surface AND not visible), else `quick terminal not realized`.
@@ -260,7 +262,7 @@ extension ControlServer {
         return ControlResponse(ok: false, error: "quick terminal not realized")
     }
 
-    /// Read the frontmost window's quick-terminal screen as plain text, the twin of `session.text` and the
+    /// Read the quick-terminal screen as plain text, the twin of `session.text` and the
     /// read-back for `quick.type`. `all` adds scrollback, `lines` keeps the last N; one surface, so no `--pane`.
     /// Polls for mount + realization like `typeQuick`; a never-shown quick errors, an unrealized one gives
     /// `failed to read surface buffer`.

--- a/agterm/Control/ControlServer+AppCommands.swift
+++ b/agterm/Control/ControlServer+AppCommands.swift
@@ -218,8 +218,9 @@ extension ControlServer {
             return ControlResponse(ok: false, error: "invalid quick mode: \(mode ?? "toggle")")
         }
         let want = parsedMode.desiredValue(current: controller.isVisible)
-        if want, !controller.isVisible,
-           PickRegistry.shared.controller(for: library.activeWindowID)?.pending != nil {
+        // NOT gated on the panel being hidden: `show` also carries the pin, and `canShow` refuses under a
+        // pending pick, so an already-visible panel would answer ok with the pin silently not applied.
+        if want, PickRegistry.shared.controller(for: library.activeWindowID)?.pending != nil {
             return ControlResponse(ok: false, error: "pick pending")
         }
         // `show` runs even when the panel is ALREADY visible, which `hide` has no equivalent of: it is what

--- a/agterm/Control/ControlServer+AppCommands.swift
+++ b/agterm/Control/ControlServer+AppCommands.swift
@@ -203,10 +203,15 @@ extension ControlServer {
 
     // MARK: - Quick terminal
 
-    /// Show / hide / toggle the frontmost window's quick terminal (each window owns one), flipping only when the
-    /// state differs from `isVisible`. Unknown mode and no open window are errors.
+    /// Show / hide / toggle the app's one quick terminal, flipping only when the state differs from
+    /// `isVisible`. Unknown mode and no open window are errors — the panel is not window chrome, but it is
+    /// still refused with no window open, agterm terminating on an empty open set.
+    ///
+    /// A window's terminal zoom is no longer a term: the panel floats above every window rather than being
+    /// hosted by one, so a zoom layer can neither replace nor strand it.
     func setQuickTerminal(mode: String?) -> ControlResponse {
-        guard let controller = QuickTerminalRegistry.shared.controller(for: library.activeWindowID) else {
+        let controller = QuickTerminalController.shared
+        guard !library.openIDs().isEmpty else {
             return ControlResponse(ok: false, error: "no open window")
         }
         guard let parsedMode = ControlToggleMode.parse(mode, on: "show", off: "hide") else {
@@ -217,19 +222,11 @@ extension ControlServer {
            PickRegistry.shared.controller(for: library.activeWindowID)?.pending != nil {
             return ControlResponse(ok: false, error: "pick pending")
         }
-        if let zoom = TerminalZoomRegistry.shared.controller(for: library.activeWindowID), zoom.target != nil {
-            // a script must always be able to DISMISS the quick terminal (cleanup relies on hide being a
-            // guaranteed-ok idempotent no-op), so hiding un-zooms a zoomed one first. Only SHOWING one under the
-            // zoom layer stays blocked — that would strand an unmounted-but-visible cover.
-            guard !want else {
-                return ControlResponse(ok: false, error: "terminal zoom active")
-            }
-            if zoom.target == .quick { zoom.clear() }
-            if controller.isVisible { controller.hide() }
-            return ControlResponse(ok: true)
-        }
         if want != controller.isVisible {
-            if want { controller.show() } else { controller.hide() }
+            // pinned: a control show activates agterm, so the caller's next command runs while the previous
+            // application is coming back to the front. A blur-dismissing panel would be gone before
+            // `quick type` or `surface zoom --target quick` arrived.
+            if want { controller.show(dismissOnFocusLoss: false) } else { controller.hide() }
         }
         return ControlResponse(ok: true)
     }
@@ -239,7 +236,8 @@ extension ControlServer {
     /// so this polls briefly rather than racing a back-to-back `quick show; quick type`. Fails fast with `quick
     /// terminal not open` when never shown (no surface AND not visible), else `quick terminal not realized`.
     func typeQuick(text: String) async -> ControlResponse {
-        guard let controller = QuickTerminalRegistry.shared.controller(for: library.activeWindowID) else {
+        let controller = QuickTerminalController.shared
+        guard !library.openIDs().isEmpty else {
             return ControlResponse(ok: false, error: "no open window")
         }
         // probe first, then sleep-then-probe up to 12 more times — a probe follows every sleep, so the full
@@ -267,7 +265,8 @@ extension ControlServer {
     /// Polls for mount + realization like `typeQuick`; a never-shown quick errors, an unrealized one gives
     /// `failed to read surface buffer`.
     func readQuickText(all: Bool, lines: Int?) async -> ControlResponse {
-        guard let controller = QuickTerminalRegistry.shared.controller(for: library.activeWindowID) else {
+        let controller = QuickTerminalController.shared
+        guard !library.openIDs().isEmpty else {
             return ControlResponse(ok: false, error: "no open window")
         }
         // same probe-then-sleep poll shape as `typeQuick`.

--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -650,6 +650,14 @@ extension ControlServer: ControlActions {
         if rawTarget == "active" {
             return setActiveSurfaceZoom(window: window, mode: mode)
         }
+        // `quick` names the detached panel, which no window's zoom controller can hold — it fills its own
+        // screen instead of a window. It takes no `--window` for the same reason.
+        if rawTarget == "quick" {
+            guard QuickTerminalController.shared.setZoom(mode) else {
+                return ControlResponse(ok: false, error: "surface not available: quick")
+            }
+            return ControlResponse(ok: true, result: ControlResult(id: "quick"))
+        }
         switch resolveSurfaceZoom(rawTarget, window: window) {
         case .failure(let response):
             return response
@@ -666,8 +674,7 @@ extension ControlServer: ControlActions {
             // vanished (an exited overlay auto-clears the zoom) while the end state holds; `set(.off, …)`
             // on a non-matching target is a no-op.
             if mode != .off {
-                guard TerminalZoomController.isTargetValid(resolved.target, in: resolved.store,
-                                                           quickTerminalVisible: quickVisible(in: resolved.windowID)) else {
+                guard TerminalZoomController.isTargetValid(resolved.target, in: resolved.store) else {
                     return ControlResponse(ok: false, error: "surface not available: \(resolved.controlID)")
                 }
             }
@@ -698,12 +705,10 @@ extension ControlServer: ControlActions {
                 guard mode != .off else {
                     return ControlResponse(ok: true)
                 }
-                let quickVisible = quickVisible(in: windowID)
-                guard let zoomTarget = TerminalZoomController.resolveTarget(store: store,
-                                                                            quickTerminalVisible: quickVisible) else {
+                guard let zoomTarget = TerminalZoomController.resolveTarget(store: store) else {
                     return ControlResponse(ok: false, error: "no active surface")
                 }
-                guard TerminalZoomController.isTargetValid(zoomTarget, in: store, quickTerminalVisible: quickVisible) else {
+                guard TerminalZoomController.isTargetValid(zoomTarget, in: store) else {
                     return ControlResponse(ok: false, error: "surface not available: \(zoomTarget.controlID)")
                 }
                 effectiveTarget = zoomTarget
@@ -722,17 +727,7 @@ extension ControlServer: ControlActions {
 
     private func resolveSurfaceZoom(_ target: String, window: String?)
         -> ControlTargetResolver.Resolution<SurfaceZoomResolution> {
-        // `quick` is the control id this command emits for a quick-terminal zoom, so it must be accepted
-        // back as a target; visibility is checked by the caller's shared `isTargetValid` gate.
-        if target == "quick" {
-            switch resolveOpenWindow(window) {
-            case .failure(let response):
-                return .failure(response)
-            case .success(let (windowID, store)):
-                return .success(SurfaceZoomResolution(windowID: windowID, store: store,
-                                                      target: .quick, controlID: "quick"))
-            }
-        }
+        // `quick` never arrives here — `setSurfaceZoom` routes it to the panel before resolving a window.
         guard let surfaceID = TerminalSurfaceID(rawValue: target) else {
             return .failure(ControlResponse(ok: false, error: "invalid surface: \(target)"))
         }
@@ -784,7 +779,4 @@ extension ControlServer: ControlActions {
         return .success((windowID, store))
     }
 
-    private func quickVisible(in windowID: WindowInfo.ID) -> Bool {
-        QuickTerminalRegistry.shared.controller(for: windowID)?.isVisible ?? false
-    }
 }

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -601,8 +601,13 @@ final class ControlServer {
             fontSize: { ($0.addressableSurface as? GhosttySurfaceView)?.currentFontSize() },
             splitFontSize: { ($0.splitSurface as? GhosttySurfaceView)?.currentFontSize() },
             scratchFontSize: { ($0.scratchSurface as? GhosttySurfaceView)?.currentFontSize() },
-            quickVisible: { windowID.flatMap { QuickTerminalRegistry.shared.controller(for: $0)?.isVisible } ?? false },
-            zoomedSurface: { windowID.flatMap { TerminalZoomRegistry.shared.controller(for: $0)?.target?.controlID } },
+            // both are app-level facts now that the quick terminal is one detached panel, so every projected
+            // window reports the same value for them rather than one of its own.
+            quickVisible: { QuickTerminalController.shared.isVisible },
+            zoomedSurface: {
+                if QuickTerminalController.shared.isZoomed { return TerminalZoomTarget.quick.controlID }
+                return windowID.flatMap { TerminalZoomRegistry.shared.controller(for: $0)?.target?.controlID }
+            },
             // resolved through the projected window's registry entry on every tree build, and tree-only:
             // window.list is cache-backed, so mirroring a GUI-resolved pick there would go stale.
             pickPending: { windowID.flatMap { PickRegistry.shared.controller(for: $0)?.pending?.id } },

--- a/agterm/SettingsModel.swift
+++ b/agterm/SettingsModel.swift
@@ -728,7 +728,7 @@ final class SettingsModel {
             .flatMap(\.sessions)
             .flatMap { [$0.surface, $0.splitSurface, $0.scratchSurface] }
             .compactMap { $0 as? GhosttySurfaceView }
-        views += QuickTerminalRegistry.shared.allControllers().compactMap { $0.currentSurface() }
+        views += [QuickTerminalController.shared.currentSurface()].compactMap { $0 }
         return views
     }
 }

--- a/agterm/Views/QuickTerminal.swift
+++ b/agterm/Views/QuickTerminal.swift
@@ -30,6 +30,10 @@ final class QuickTerminalController {
 
     @ObservationIgnored private var panel: QuickTerminalPanel?
 
+    /// The panel's content host, retained so a show can re-read the terminal color into it without
+    /// rebuilding the panel (which would remount the surface).
+    @ObservationIgnored private var hostingView: NSHostingView<QuickTerminalPanelContent>?
+
     /// Whether losing key dismisses the panel. A HUMAN summon (hotkey, ⌃`, toolbar, Dock) is
     /// dismiss-on-blur, which is what makes it summon-and-return. A control-driven show pins it instead:
     /// `show` activates agterm, so a script's very next command runs while some other application is coming
@@ -56,29 +60,52 @@ final class QuickTerminalController {
     @ObservationIgnored var focusAllowed: () -> Bool = { true }
 
     /// Whether a show may proceed at all — false with no open window, where a panel would be the only thing
-    /// on screen for an app that is about to terminate.
+    /// on screen for an app that is about to terminate, and false while a control picker is pending, which
+    /// owns the keyboard. The pick term is here rather than on each caller because the global hotkey reaches
+    /// the controller directly, with none of the `uiActionsEnabled` gating every in-app path has.
     @ObservationIgnored var canShow: () -> Bool = { true }
 
     /// The opaque backing the panel paints behind the surface, which draws transparent under
-    /// `background-opacity = 0`. Re-read on every show so a theme change lands without rebuilding the panel.
+    /// `background-opacity = 0`. Re-read on every show, so a theme change lands on the next summon.
     @ObservationIgnored var terminalColorProvider: () -> Color = { .black }
+
+    /// When a resign-driven hide last fired, and how long a show is suppressed afterwards. AppKit makes the
+    /// clicked window key BEFORE delivering the button action, so a click on the Quick Terminal toolbar
+    /// button or Dock item first blurs the panel — and without this the toggle would then see
+    /// `isVisible == false` and re-show the panel that same click just dismissed.
+    @ObservationIgnored private var autoHiddenAt: Date?
+    private static let reshowSuppression: TimeInterval = 0.3
 
     private init() {}
 
     /// Toolbar-button / hotkey / menu action: show if hidden, hide if visible. Always the human path, so the
     /// panel it shows dismisses on blur.
     func toggle() {
-        if isVisible { hide() } else { show() }
+        if isVisible {
+            hide()
+            return
+        }
+        if let autoHiddenAt, Date().timeIntervalSince(autoHiddenAt) < Self.reshowSuppression {
+            self.autoHiddenAt = nil
+            return
+        }
+        show()
     }
 
     /// Show the panel. `dismissOnFocusLoss` false is the control path — see the property of that name.
+    /// Idempotent, and deliberately still applies the pin when the panel is ALREADY up: a script running
+    /// `quick show` over a panel the user summoned by hotkey is promised a panel that survives its next
+    /// command, and returning early would leave that promise to a blur.
     func show(dismissOnFocusLoss: Bool = true) {
         guard canShow() else { return }
         // a control show over a user-summoned panel still pins it: the caller is a script either way.
         dismissesOnFocusLoss = dismissesOnFocusLoss && dismissOnFocusLoss
+        autoHiddenAt = nil
         guard !isVisible else { return }
         isVisible = true
         let panel = ensurePanel()
+        hostingView?.rootView = QuickTerminalPanelContent(controller: self,
+                                                          terminalColor: terminalColorProvider())
         panel.setFrame(Self.targetFrame(zoomed: isZoomed), display: true)
         // NEVER `NSApp.activate()` here. Activating agterm raises ITS WINDOWS too, so summoning the panel
         // from another application buries that application behind the whole terminal, and dismissing leaves
@@ -100,8 +127,9 @@ final class QuickTerminalController {
 
     /// The panel lost key. Only a human-summoned panel dismisses itself here.
     private func handleResignKey() {
-        guard dismissesOnFocusLoss else { return }
+        guard dismissesOnFocusLoss, isVisible else { return }
         hide()
+        autoHiddenAt = Date()
     }
 
     /// Apply `surface.zoom --target quick`. Returns false when the panel is not up, which is what makes the
@@ -148,9 +176,11 @@ final class QuickTerminalController {
     private func ensurePanel() -> QuickTerminalPanel {
         if let panel { return panel }
         let panel = QuickTerminalPanel(onResignKey: { [weak self] in self?.handleResignKey() })
-        panel.contentView = NSHostingView(rootView: QuickTerminalPanelContent(
+        let host = NSHostingView(rootView: QuickTerminalPanelContent(
             controller: self, terminalColor: terminalColorProvider()
         ))
+        panel.contentView = host
+        hostingView = host
         self.panel = panel
         return panel
     }
@@ -160,9 +190,14 @@ final class QuickTerminalController {
     private func handleShellExit() {
         isVisible = false
         isZoomed = false
+        // the next summon is a fresh panel and a fresh shell, so it starts from the default policy — a pin
+        // left standing here would silently outlive the control show that set it.
+        dismissesOnFocusLoss = true
+        autoHiddenAt = nil
         panel?.orderOut(nil)
         panel?.contentView = nil
         panel = nil
+        hostingView = nil
         surfaceView?.onUserInput = nil
         surfaceView?.teardown()
         surfaceView = nil

--- a/agterm/Views/QuickTerminal.swift
+++ b/agterm/Views/QuickTerminal.swift
@@ -2,57 +2,126 @@ import agtermCore
 import AppKit
 import SwiftUI
 
-/// The in-app quick terminal: a single scratch terminal shown as a centered overlay at 90% of the window,
-/// over the sidebar and terminal. A toolbar button toggles it, and clicking the dimmed margin hides it;
-/// hiding keeps the shell alive, since the surface is owned here rather than by the overlay view, so it
-/// survives the view being removed. Not persisted (fresh each launch).
+/// The quick terminal: one scratch terminal per app, hosted in a detached floating panel on whichever screen
+/// has focus rather than inside a window. A toolbar button, ⌃`, the control socket and the global hotkey all
+/// summon the same panel; losing key hides it, which is what makes it a summon-and-dismiss surface rather
+/// than window chrome. Hiding keeps the shell alive, since the surface is owned here rather than by the
+/// panel's content view, so it survives the view being removed. Not persisted (fresh each launch).
 ///
-/// Per window: each `WindowContentView` owns one and registers it in `QuickTerminalRegistry` under its window
-/// id, so the frontmost-window call sites (menu/keybind, `AppActions`, `ControlServer`) reach the controller
-/// of the window the user is looking at. The owner binds `cwdProvider`, so a freshly-spawned quick terminal
-/// opens in that window's active session's directory (home when nothing is selected).
+/// App-level, not per-window: the panel belongs to no window, so `AGTERM_WINDOW_ID` is absent from its
+/// environment and the surface carries only enabled + socket. `canShow` is what keeps it from outliving the
+/// last window, agterm terminating on an empty open set (see `AppDelegate.applicationShouldTerminate…`).
 @MainActor @Observable
 final class QuickTerminalController {
-    /// Whether the overlay is shown. Observed, so `WindowContentView` shows/hides the overlay.
+    static let shared = QuickTerminalController()
+
+    /// Whether the panel is on screen. Observed, so the deck's gates and the control read-back follow it.
     private(set) var isVisible = false
 
+    /// Whether the panel fills its screen instead of taking the inset 90% frame — the re-homed
+    /// `surface.zoom --target quick`, which used to be a per-window `TerminalZoomTarget`. Cleared on hide,
+    /// so a dismissed panel never reports a stale zoom.
+    private(set) var isZoomed = false
+
     /// The long-lived quick-terminal surface, created lazily on first show and kept across hide/show so the
-    /// shell survives. The overlay pulls it imperatively, like a session owns its surface; nothing in
+    /// shell survives. The panel's content pulls it imperatively, like a session owns its surface; nothing in
     /// SwiftUI observes the view itself.
     @ObservationIgnored private var surfaceView: GhosttySurfaceView?
+
+    @ObservationIgnored private var panel: QuickTerminalPanel?
+
+    /// Whether losing key dismisses the panel. A HUMAN summon (hotkey, ⌃`, toolbar, Dock) is
+    /// dismiss-on-blur, which is what makes it summon-and-return. A control-driven show pins it instead:
+    /// `show` activates agterm, so a script's very next command runs while some other application is coming
+    /// back to the front, and a blur-dismissing panel would be gone before `quick type` or
+    /// `surface zoom --target quick` could reach it.
+    @ObservationIgnored private var dismissesOnFocusLoss = true
 
     /// The directory a freshly-created quick terminal spawns its shell in. Read once, at surface creation,
     /// so the quick terminal keeps its own working directory afterwards.
     @ObservationIgnored var cwdProvider: () -> String = { FileManager.default.homeDirectoryForCurrentUser.path }
 
-    /// The `AGTERM_*` environment a freshly-created quick terminal exposes to its shell (ENABLED + WINDOW_ID
-    /// + SOCKET — scratch, so no workspace/session ids). Read once, at surface creation. Set by the owning
-    /// `WindowContentView`, so the var carries this window's id.
+    /// The `AGTERM_*` environment a freshly-created quick terminal exposes to its shell (ENABLED + SOCKET —
+    /// scratch and window-less, so no window/workspace/session ids). Read once, at surface creation.
     @ObservationIgnored var envProvider: () -> [String: String] = { [:] }
 
-    /// Notes a keystroke as user activity on the owning window's `AppStore`, so typing here resets that
-    /// window's auto-follow idle timer (an idle fire must NOT change the selection behind the overlay while
-    /// the user types). The controller is store-less, so `WindowContentView` supplies this; `surface()`
-    /// forwards it to the surface's `onUserInput`, as the overlay/scratch factories do, and `destroySurface`
-    /// nils it on teardown.
+    /// Notes a keystroke as user activity on the active window's `AppStore`, so typing here resets that
+    /// window's auto-follow idle timer (an idle fire must NOT change a selection while the user types).
+    /// The controller is store-less, so the app supplies this; `surface()` forwards it to the surface's
+    /// `onUserInput`, as the overlay/scratch factories do, and `handleShellExit` nils it on teardown.
     @ObservationIgnored var onUserInput: (() -> Void)?
 
-    /// Whether this cover may claim keyboard focus. The owning window disables it while a control picker
-    /// is above the quick terminal, stopping an in-flight show retry from stealing the picker's field.
+    /// Whether this cover may claim keyboard focus. The app disables it while a control picker is up,
+    /// stopping an in-flight show retry from stealing the picker's field.
     @ObservationIgnored var focusAllowed: () -> Bool = { true }
 
-    /// Toolbar-button action: show if hidden, hide if visible.
-    func toggle() { isVisible.toggle() }
+    /// Whether a show may proceed at all — false with no open window, where a panel would be the only thing
+    /// on screen for an app that is about to terminate.
+    @ObservationIgnored var canShow: () -> Bool = { true }
 
-    func show() { isVisible = true }
+    /// The opaque backing the panel paints behind the surface, which draws transparent under
+    /// `background-opacity = 0`. Re-read on every show so a theme change lands without rebuilding the panel.
+    @ObservationIgnored var terminalColorProvider: () -> Color = { .black }
 
-    func hide() { isVisible = false }
+    private init() {}
+
+    /// Toolbar-button / hotkey / menu action: show if hidden, hide if visible. Always the human path, so the
+    /// panel it shows dismisses on blur.
+    func toggle() {
+        if isVisible { hide() } else { show() }
+    }
+
+    /// Show the panel. `dismissOnFocusLoss` false is the control path — see the property of that name.
+    func show(dismissOnFocusLoss: Bool = true) {
+        guard canShow() else { return }
+        // a control show over a user-summoned panel still pins it: the caller is a script either way.
+        dismissesOnFocusLoss = dismissesOnFocusLoss && dismissOnFocusLoss
+        guard !isVisible else { return }
+        isVisible = true
+        let panel = ensurePanel()
+        panel.setFrame(Self.targetFrame(zoomed: isZoomed), display: true)
+        // NEVER `NSApp.activate()` here. Activating agterm raises ITS WINDOWS too, so summoning the panel
+        // from another application buries that application behind the whole terminal, and dismissing leaves
+        // the user in agterm instead of where they were. That round trip is the entire point of the feature.
+        // `.nonactivatingPanel` exists for exactly this: the panel takes keyboard input while agterm stays
+        // inactive, so hiding it returns the keyboard to whatever was in front, with nothing to restore.
+        panel.orderFrontRegardless()
+        panel.makeKey()
+        focus()
+    }
+
+    func hide() {
+        guard isVisible else { return }
+        isVisible = false
+        isZoomed = false
+        dismissesOnFocusLoss = true
+        panel?.orderOut(nil)
+    }
+
+    /// The panel lost key. Only a human-summoned panel dismisses itself here.
+    private func handleResignKey() {
+        guard dismissesOnFocusLoss else { return }
+        hide()
+    }
+
+    /// Apply `surface.zoom --target quick`. Returns false when the panel is not up, which is what makes the
+    /// control command answer `surface not available` rather than silently arming a zoom nothing renders.
+    @discardableResult
+    func setZoom(_ mode: ControlToggleMode) -> Bool {
+        guard isVisible else { return false }
+        let want = mode.desiredValue(current: isZoomed)
+        guard want != isZoomed else { return true }
+        isZoomed = want
+        panel?.setFrame(Self.targetFrame(zoomed: want), display: true)
+        focus()
+        return true
+    }
 
     /// The existing quick-terminal surface, or nil — does NOT create one (unlike `surface()`), so a settings
     /// broadcast can reach it without spawning a shell.
     func currentSurface() -> GhosttySurfaceView? { surfaceView }
 
-    /// The surface to render in the overlay, created on first use in the active cwd and reused afterwards.
+    /// The surface to render in the panel, created on first use in the active cwd and reused afterwards.
     /// Recreated after the shell exits.
     func surface() -> GhosttySurfaceView {
         if let surfaceView { return surfaceView }
@@ -63,8 +132,8 @@ final class QuickTerminalController {
         return view
     }
 
-    /// Re-assert first responder on the surface for a short window so focus lands once the overlay is
-    /// on-window (a one-shot would race the overlay's layout).
+    /// Re-assert first responder on the surface for a short window so focus lands once the panel is
+    /// on-screen (a one-shot would race the panel's layout).
     func focus(attempt: Int = 0) {
         guard focusAllowed() else { return }
         if let surfaceView, let window = surfaceView.window {
@@ -76,18 +145,111 @@ final class QuickTerminalController {
         }
     }
 
-    /// The quick-terminal shell exited: hide the overlay and tear down the surface so the next show spawns a
-    /// fresh shell (the surface, not the overlay, owns the shell).
+    private func ensurePanel() -> QuickTerminalPanel {
+        if let panel { return panel }
+        let panel = QuickTerminalPanel(onResignKey: { [weak self] in self?.handleResignKey() })
+        panel.contentView = NSHostingView(rootView: QuickTerminalPanelContent(
+            controller: self, terminalColor: terminalColorProvider()
+        ))
+        self.panel = panel
+        return panel
+    }
+
+    /// The quick-terminal shell exited: drop the panel with the surface it hosted so the next show spawns a
+    /// fresh shell (the surface, not the panel, owns the shell).
     private func handleShellExit() {
         isVisible = false
+        isZoomed = false
+        panel?.orderOut(nil)
+        panel?.contentView = nil
+        panel = nil
+        surfaceView?.onUserInput = nil
         surfaceView?.teardown()
         surfaceView = nil
     }
+
+    /// The panel's comfortable maximum. The in-window overlay took 90% of its host and needed no cap, a
+    /// window already being a modest size; 90% of a large display is not a quick aside but a wall of
+    /// terminal, so the share is a floor-to-ceiling that stops growing past a readable width.
+    private static let maxNormalSize = NSSize(width: 1100, height: 700)
+
+    /// Centered on the focused screen at 90% of it or `maxNormalSize`, whichever is smaller, and its whole
+    /// visible frame while zoomed. The panel follows the POINTER's screen, not the app's: it is summoned
+    /// from another application, where agterm's own key window is no guide to where the user is looking.
+    private static func targetFrame(zoomed: Bool) -> NSRect {
+        let visible = activeScreen().visibleFrame
+        guard !zoomed else { return visible }
+        let size = NSSize(width: min(visible.width * 0.9, maxNormalSize.width),
+                          height: min(visible.height * 0.9, maxNormalSize.height))
+        return NSRect(x: visible.midX - size.width / 2, y: visible.midY - size.height / 2,
+                      width: size.width, height: size.height)
+    }
+
+    private static func activeScreen() -> NSScreen {
+        let mouse = NSEvent.mouseLocation
+        if let under = NSScreen.screens.first(where: { $0.frame.contains(mouse) }) { return under }
+        return NSApp.keyWindow?.screen ?? NSScreen.main ?? NSScreen.screens[0]
+    }
 }
 
-/// Hosts the quick-terminal surface in the overlay. Like `TerminalView`, it pulls the long-lived surface
-/// from its owner (the per-window controller) rather than creating one, and never frees it on dismantle —
-/// hiding the overlay must keep the shell alive.
+/// The floating host. Borderless and non-activating so summoning it from another app is one deliberate
+/// `NSApp.activate`, and joining all spaces so it lands on whichever Space the user is on instead of pulling
+/// them back to agterm's. `canBecomeKey` is overridden because a borderless panel refuses key by default,
+/// which would leave the terminal unable to take a keystroke.
+@MainActor
+final class QuickTerminalPanel: NSPanel {
+    private let onResignKey: () -> Void
+
+    init(onResignKey: @escaping () -> Void) {
+        self.onResignKey = onResignKey
+        super.init(contentRect: .zero,
+                   styleMask: [.borderless, .nonactivatingPanel],
+                   backing: .buffered, defer: false)
+        isOpaque = false
+        backgroundColor = .clear
+        hasShadow = true
+        // above every application's normal windows, since it is summoned over whatever the user is in.
+        level = .floating
+        // a panel defaults to hiding when its app deactivates, and agterm is deliberately never activated
+        // for this, so the default would pull the panel away the moment it appeared.
+        hidesOnDeactivate = false
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        isReleasedWhenClosed = false
+        // the panel is transient chrome, never part of the saved window set AppKit would try to bring back.
+        isRestorable = false
+        NotificationCenter.default.addObserver(self, selector: #selector(handleResignKey),
+                                               name: NSWindow.didResignKeyNotification, object: self)
+    }
+
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+
+    @objc private func handleResignKey() {
+        onResignKey()
+    }
+}
+
+/// The panel's content: the surface plus the frame the in-window overlay used to draw, libghostty rendering
+/// only the terminal. The solid backing keeps the quick terminal opaque even where the app is translucent.
+private struct QuickTerminalPanelContent: View {
+    let controller: QuickTerminalController
+    let terminalColor: Color
+
+    var body: some View {
+        QuickTerminalPane(controller: controller)
+            .background(terminalColor)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(Color.white.opacity(0.18), lineWidth: 1)
+            )
+            .accessibilityIdentifier("quick-terminal")
+    }
+}
+
+/// Hosts the quick-terminal surface in the panel. Like `TerminalView`, it pulls the long-lived surface from
+/// its owner (the app-level controller) rather than creating one, and never frees it on dismantle — hiding
+/// the panel must keep the shell alive.
 struct QuickTerminalPane: NSViewRepresentable {
     let controller: QuickTerminalController
 
@@ -101,36 +263,5 @@ struct QuickTerminalPane: NSViewRepresentable {
 
     static func dismantleNSView(_: GhosttySurfaceView, coordinator _: ()) {
         // no-op: the controller owns the surface so it survives hide/show.
-    }
-}
-
-/// App-side bridge mapping a `WindowInfo.ID` to its window's `QuickTerminalController`, a per-window instance
-/// owned by `WindowContentView` (which registers/unregisters on appear/close). Frontmost-window call sites
-/// resolve the controller to act on through `controller(for: library.activeWindowID)`.
-@MainActor
-final class QuickTerminalRegistry {
-    static let shared = QuickTerminalRegistry()
-    private var controllers: [WindowInfo.ID: QuickTerminalController] = [:]
-
-    private init() {}
-
-    func register(_ id: WindowInfo.ID, controller: QuickTerminalController) {
-        controllers[id] = controller
-    }
-
-    func unregister(_ id: WindowInfo.ID) {
-        controllers[id] = nil
-    }
-
-    /// The quick-terminal controller for `id`, or nil when the window is closed/unknown.
-    func controller(for id: WindowInfo.ID?) -> QuickTerminalController? {
-        guard let id else { return nil }
-        return controllers[id]
-    }
-
-    /// Every registered (open-window) controller — used by the settings broadcast to reach each window's
-    /// quick-terminal surface.
-    func allControllers() -> [QuickTerminalController] {
-        Array(controllers.values)
     }
 }

--- a/agterm/Views/QuickTerminal.swift
+++ b/agterm/Views/QuickTerminal.swift
@@ -18,6 +18,12 @@ final class QuickTerminalController {
     /// Whether the panel is on screen. Observed, so the deck's gates and the control read-back follow it.
     private(set) var isVisible = false
 
+    /// Whether the panel currently owns the keyboard. Distinct from `isVisible`, and it is this — not mere
+    /// visibility — that every deck gate and focus guard reads: a PINNED panel (a control `quick show`) stays
+    /// on screen after agterm loses key, and treating that as "a cover owns focus" would revoke first
+    /// responder in every window and leave the user unable to type outside the panel's own frame.
+    private(set) var holdsKey = false
+
     /// Whether the panel fills its screen instead of taking the inset 90% frame — the re-homed
     /// `surface.zoom --target quick`, which used to be a per-window `TerminalZoomTarget`. Cleared on hide,
     /// so a dismissed panel never reports a stale zoom.
@@ -80,12 +86,17 @@ final class QuickTerminalController {
 
     /// Toolbar-button / hotkey / menu action: show if hidden, hide if visible. Always the human path, so the
     /// panel it shows dismisses on blur.
-    func toggle() {
+    ///
+    /// `fromGlobalHotkey` bypasses the re-show suppression. That window exists because a CLICK on the
+    /// toolbar button blurs the panel before its action arrives, and a keypress from another application
+    /// causes no such blur — so suppressing it there would swallow a deliberate summon made within 300ms of
+    /// the user clicking away.
+    func toggle(fromGlobalHotkey: Bool = false) {
         if isVisible {
             hide()
             return
         }
-        if let autoHiddenAt, Date().timeIntervalSince(autoHiddenAt) < Self.reshowSuppression {
+        if !fromGlobalHotkey, let autoHiddenAt, Date().timeIntervalSince(autoHiddenAt) < Self.reshowSuppression {
             self.autoHiddenAt = nil
             return
         }
@@ -121,12 +132,16 @@ final class QuickTerminalController {
         guard isVisible else { return }
         isVisible = false
         isZoomed = false
+        holdsKey = false
         dismissesOnFocusLoss = true
         panel?.orderOut(nil)
     }
 
-    /// The panel lost key. Only a human-summoned panel dismisses itself here.
+    /// The panel lost key. `holdsKey` drops either way — a PINNED panel stays on screen without owning the
+    /// keyboard, and that is exactly the state the deck gates must not read as a cover. Only a human-summoned
+    /// panel dismisses itself.
     private func handleResignKey() {
+        holdsKey = false
         guard dismissesOnFocusLoss, isVisible else { return }
         hide()
         autoHiddenAt = Date()
@@ -175,7 +190,8 @@ final class QuickTerminalController {
 
     private func ensurePanel() -> QuickTerminalPanel {
         if let panel { return panel }
-        let panel = QuickTerminalPanel(onResignKey: { [weak self] in self?.handleResignKey() })
+        let panel = QuickTerminalPanel(onBecomeKey: { [weak self] in self?.holdsKey = true },
+                                       onResignKey: { [weak self] in self?.handleResignKey() })
         let host = NSHostingView(rootView: QuickTerminalPanelContent(
             controller: self, terminalColor: terminalColorProvider()
         ))
@@ -194,6 +210,7 @@ final class QuickTerminalController {
         // left standing here would silently outlive the control show that set it.
         dismissesOnFocusLoss = true
         autoHiddenAt = nil
+        holdsKey = false
         panel?.orderOut(nil)
         panel?.contentView = nil
         panel = nil
@@ -233,9 +250,11 @@ final class QuickTerminalController {
 /// which would leave the terminal unable to take a keystroke.
 @MainActor
 final class QuickTerminalPanel: NSPanel {
+    private let onBecomeKey: () -> Void
     private let onResignKey: () -> Void
 
-    init(onResignKey: @escaping () -> Void) {
+    init(onBecomeKey: @escaping () -> Void, onResignKey: @escaping () -> Void) {
+        self.onBecomeKey = onBecomeKey
         self.onResignKey = onResignKey
         super.init(contentRect: .zero,
                    styleMask: [.borderless, .nonactivatingPanel],
@@ -252,12 +271,18 @@ final class QuickTerminalPanel: NSPanel {
         isReleasedWhenClosed = false
         // the panel is transient chrome, never part of the saved window set AppKit would try to bring back.
         isRestorable = false
+        NotificationCenter.default.addObserver(self, selector: #selector(handleBecomeKey),
+                                               name: NSWindow.didBecomeKeyNotification, object: self)
         NotificationCenter.default.addObserver(self, selector: #selector(handleResignKey),
                                                name: NSWindow.didResignKeyNotification, object: self)
     }
 
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { false }
+
+    @objc private func handleBecomeKey() {
+        onBecomeKey()
+    }
 
     @objc private func handleResignKey() {
         onResignKey()

--- a/agterm/Views/WindowAccessor.swift
+++ b/agterm/Views/WindowAccessor.swift
@@ -165,6 +165,11 @@ struct WindowAccessor: NSViewRepresentable {
                         session.discardHudBody() // an unrealized HUD has no teardown to delete its body file
                     }
                     library.closeWindow(windowID)
+                    // the quick-terminal panel belongs to no window, so nothing above tore it down. Usually
+                    // moot — an empty open set terminates the app — but a cancelled quit prompt leaves agterm
+                    // running with no window, where `canShow` refuses a NEW show while a panel already up
+                    // would linger as the only thing on screen.
+                    if library.openIDs().isEmpty { QuickTerminalController.shared.hide() }
                     // closing a window drops its (unobserved) store, so the Dock badge's observation won't
                     // fire — refresh explicitly. guarded on isTerminating: at quit willClose fires after
                     // applicationWillTerminate's clear() and closeWindow no-ops (stores stay loaded), so the

--- a/agterm/Views/WindowContentView+Detail.swift
+++ b/agterm/Views/WindowContentView+Detail.swift
@@ -308,9 +308,11 @@ extension WindowContentView {
 
     /// Whether a floating panel is washing the whole backdrop of this session's detail pane. Reads the same
     /// `backdrop` flag `overlayPanel` paints from, so the wash and its `paneDim` suppression cannot disagree
-    /// about a HUD, which paints none.
+    /// about a HUD, which paints none. The quick terminal is NOT a term: it is a separate window now, with no
+    /// in-window margin to wash, so counting it would suppress `paneDim` in every open window and put nothing
+    /// in its place — split focus would stop reading behind the panel.
     private func backdropWashActive(session: Session) -> Bool {
-        quickTerminal.isVisible || OverlayPanelStyle.resolve(session).backdrop
+        OverlayPanelStyle.resolve(session).backdrop
     }
 }
 

--- a/agterm/Views/WindowContentView+Detail.swift
+++ b/agterm/Views/WindowContentView+Detail.swift
@@ -50,11 +50,11 @@ extension WindowContentView {
         // Shared by BOTH split panes (unlike focus-gated `isActive`), it gates drag-type (un)registration and
         // mouse-cursor tracking (the `deckVisible` note in libghostty.md). Without the quick-terminal term a
         // covered pane races it for the cursor and fans mouse-motion into the covered TUI (issue #225).
-        let visible = deckInteractive && isActive && !hideForOverlay && !quickTerminal.isVisible
+        let visible = deckInteractive && isActive && !hideForOverlay && !quickTerminal.holdsKey
         // focus gate: a visible quick terminal OWNS first responder, so no deck surface may be `isActive`
         // behind it — `updateNSView` would grab focus and send keystrokes to a covered session. Every
         // automatic reselection (`reselectIfSelectionHidden`, auto-follow) reaches this, not just a click.
-        let focusable = deckInteractive && isActive && !quickTerminal.isVisible
+        let focusable = deckInteractive && isActive && !quickTerminal.holdsKey
         let gates = DeckPaneGates(focusable: focusable, overlaid: DeckPaneGates.coverActive(session),
                                   visible: visible)
         ZStack {
@@ -84,7 +84,7 @@ extension WindowContentView {
                 // makeScratchSurface's autoFocus suppression); `deckVisible` keeps drops to an on-screen one.
                 TerminalView(session: session, surfaceKeyPath: \.scratchSurface, makeSurface: makeScratchSurface,
                              isActive: focusable && !session.programOverlayActive,
-                             deckVisible: deckInteractive && isActive && !fullOverlay && !quickTerminal.isVisible)
+                             deckVisible: deckInteractive && isActive && !fullOverlay && !quickTerminal.holdsKey)
                     .opacity(fullOverlay ? 0 : 1)
                     .allowsHitTesting(!fullOverlay)
                     .id("\(session.id.uuidString)-scratch")
@@ -104,14 +104,14 @@ extension WindowContentView {
         // it on the HUD's close would instead YANK focus out of whatever holds it — an open ⌘F search field,
         // an in-progress sidebar rename — and `retryReparentFocus` re-grabs for ~0.36s.
         .onChange(of: session.programOverlayActive) { _, isOpen in
-            if !isOpen, deckInteractive, isActive, !quickTerminal.isVisible {
+            if !isOpen, deckInteractive, isActive, !quickTerminal.holdsKey {
                 (session.topmostSurface as? GhosttySurfaceView)?.focusAfterReparent()
             }
         }
         // the scratch needs the same retry on SHOW too: its surface is kept alive across hides, so a re-show
         // remounts it and `autoFocus`'s one-shot latch won't re-fire.
         .onChange(of: session.scratchActive) { _, _ in
-            guard deckInteractive, isActive, !quickTerminal.isVisible else { return }
+            guard deckInteractive, isActive, !quickTerminal.holdsKey else { return }
             (session.topmostSurface as? GhosttySurfaceView)?.focusAfterReparent()
         }
         // the deck is the authority on which panes it lays out, so it also retires a pane overlay whose pane
@@ -123,7 +123,7 @@ extension WindowContentView {
         .onChange(of: terminalZoom.target) { _, _ in session.dropUnrealizedPaneOverlays() }
         // a closing pane overlay un-hides its pane and loses the same race.
         .onChange(of: session.openPaneOverlays) { before, after in
-            guard after.count < before.count, deckInteractive, isActive, !quickTerminal.isVisible else { return }
+            guard after.count < before.count, deckInteractive, isActive, !quickTerminal.holdsKey else { return }
             (session.topmostSurface as? GhosttySurfaceView)?.focusAfterReparent()
         }
     }

--- a/agterm/Views/WindowContentView+Zoom.swift
+++ b/agterm/Views/WindowContentView+Zoom.swift
@@ -10,18 +10,11 @@ extension WindowContentView {
             dashboard.requestFocus()
             return
         }
-        if let target = terminalZoom.target {
-            switch target {
-            case .quick:
-                quickTerminal.focus()
-            case let .session(sessionID, surface):
-                guard let session = store.session(withID: sessionID) else { return }
-                focusZoomedSessionSurface(session: session, surface: surface)
-            }
-            return
-        }
-        if quickTerminal.isVisible {
-            quickTerminal.focus()
+        // the quick terminal is a panel of its own, so a picker in THIS window never covered it and it
+        // reclaims its own key; only this window's own covers are restored here.
+        if case let .session(sessionID, surface) = terminalZoom.target {
+            guard let session = store.session(withID: sessionID) else { return }
+            focusZoomedSessionSurface(session: session, surface: surface)
             return
         }
         actions.focusActiveSession()
@@ -70,10 +63,10 @@ extension WindowContentView {
     /// closes the window's transient chrome and focuses the zoomed surface; exiting returns focus.
     func handleZoomTargetChange(old: TerminalZoomTarget?, new: TerminalZoomTarget?) {
         if let new {
-            // zoom closes this window's transient chrome: the palette, an open ⌘F search (else libghostty
-            // stays in search mode with stale full-window highlights and no visible bar), and — for a
-            // session-surface zoom — a visible quick terminal (the zoom layer replaces its host, stranding
-            // `isVisible` true with nothing on screen); a `.quick` zoom keeps it, the zoom layer hosting it.
+            // zoom closes this window's transient chrome: the palette and an open ⌘F search (else libghostty
+            // stays in search mode with stale full-window highlights and no visible bar). The quick terminal
+            // is NOT closed — it is a panel above every window, so a zoom inside one neither hosts nor hides
+            // it; taking key back from the panel is what dismisses it.
             // The palette is app-global and renders in the FRONTMOST window, so only that window's zoom may
             // close it — a control-driven zoom of a background window must not kill the user's palette.
             if library.activeWindowID == windowID { palette.close() }
@@ -81,7 +74,6 @@ extension WindowContentView {
                 (session.searchSurface as? GhosttySurfaceView)?.endSearch()
             }
             if case let .session(sessionID, surface) = new {
-                if quickTerminal.isVisible { quickTerminal.hide() }
                 if let session = store.session(withID: sessionID) {
                     // an explicit control target can zoom a BACKGROUND session's surface without
                     // selecting it: end THAT session's search too (the active-session clear above
@@ -96,18 +88,11 @@ extension WindowContentView {
                 }
             }
         }
-        if let old, new == nil {
-            switch old {
-            case .quick:
-                // `quick hide` un-zooms then hides, so refocus only while it is still on screen — its own
-                // isVisible onChange handles the focus return otherwise.
-                if quickTerminal.isVisible { quickTerminal.focus() }
-            case .session:
-                // scoped to THIS window, like the palette close above: `focusActiveSession` targets the
-                // FRONTMOST window, so a background window's zoom exit must not grab first responder there
-                // — e.g. out of an open ⌘F search field the user is typing into.
-                if library.activeWindowID == windowID { actions.focusActiveSession() }
-            }
+        if let old, new == nil, case .session = old {
+            // scoped to THIS window, like the palette close above: `focusActiveSession` targets the
+            // FRONTMOST window, so a background window's zoom exit must not grab first responder there
+            // — e.g. out of an open ⌘F search field the user is typing into.
+            if library.activeWindowID == windowID { actions.focusActiveSession() }
         }
     }
 
@@ -123,22 +108,14 @@ extension WindowContentView {
     }
 
     @ViewBuilder func terminalZoomLayer(_ target: TerminalZoomTarget) -> some View {
-        if TerminalZoomController.isTargetValid(target, in: store, quickTerminalVisible: quickTerminal.isVisible) {
-            switch target {
-            case .quick:
-                zoomTerminalHost {
-                    QuickTerminalPane(controller: quickTerminal)
-                }
-            case let .session(sessionID, surface):
-                // focus is driven by the body's `.onChange(of: terminalZoom.target)` — see
-                // `handleZoomTargetChange` for why no `.onAppear` here.
-                if let session = store.session(withID: sessionID) {
-                    zoomTerminalHost {
-                        zoomedSessionTerminal(session: session, surface: surface)
-                    }
-                } else {
-                    Color.clear.onAppear { terminalZoom.clear() }
-                }
+        // `.quick` is never a window's target (the panel is app-level), so `isTargetValid` rejects it and the
+        // stale value clears here rather than needing a case of its own.
+        if TerminalZoomController.isTargetValid(target, in: store),
+           case let .session(sessionID, surface) = target, let session = store.session(withID: sessionID) {
+            // focus is driven by the body's `.onChange(of: terminalZoom.target)` — see
+            // `handleZoomTargetChange` for why no `.onAppear` here.
+            zoomTerminalHost {
+                zoomedSessionTerminal(session: session, surface: surface)
             }
         } else {
             Color.clear.onAppear { terminalZoom.clear() }

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -187,7 +187,11 @@ struct WindowContentView: View {
         .onChange(of: pick.pending?.id) { old, new in
             if old == nil, new != nil, !pickSuppressesAutoFollow {
                 // a socket-driven picker may arrive with either title-bar popover already open; dismiss
-                // both so no second interactive surface remains above the modal picker.
+                // both so no second interactive surface remains above the modal picker. The quick-terminal
+                // panel is now exactly that surface and the worst of them: it floats above every window and
+                // holds key, so the picker would open under it with neither the screen nor the keyboard.
+                // `canShow` stops the reverse order; this is the same class from the other direction.
+                QuickTerminalController.shared.hide()
                 recentSessionsShown = false
                 attentionPopoverShown = false
                 store.suppressAutoFollow()

--- a/agterm/Views/WindowContentView.swift
+++ b/agterm/Views/WindowContentView.swift
@@ -30,17 +30,17 @@ struct WindowContentView: View {
     /// nil builds the session-wide overlay surface, `left`/`right` the pane-scoped one reading that pane's slot.
     let makeOverlaySurface: (Session, OverlayPane?) -> GhosttySurfaceView
     let makeScratchSurface: (Session) -> GhosttySurfaceView
-    let quickTerminalEnv: (WindowInfo.ID) -> [String: String]
     let actions: AppActions
     let palette: PaletteController
     let sessionSwitcher: SessionSwitcher
     /// Mirrors `WindowAppearance`'s other opaque-forcing condition; SwiftUI keeps it current by itself.
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
-    /// One quick terminal per window, registered in `QuickTerminalRegistry` on appear so the
-    /// frontmost-window call sites reach it; its `cwdProvider` binds to this window's active session.
-    @State var quickTerminal = QuickTerminalController()
-    /// Window-level zoom: rehosts the visible terminal surface above the sidebar, titlebar, quick terminal
-    /// frame, palettes and switcher until toggled off.
+    /// The app's one quick terminal, which lives in its own detached panel rather than in any window. Read
+    /// here so the deck's gates still follow its visibility — a panel with key steals it from every window,
+    /// not just this one. `agtermApp` owns its providers.
+    var quickTerminal: QuickTerminalController { .shared }
+    /// Window-level zoom: rehosts the visible terminal surface above the sidebar, titlebar,
+    /// palettes and switcher until toggled off.
     @State var terminalZoom = TerminalZoomController()
     /// View-only grid of reparented member surfaces, registered in `DashboardControllerRegistry` on appear so
     /// the socket drives it; `+Dashboard` owns the overlay branch, deck yield, font override and lifecycle.
@@ -146,11 +146,12 @@ struct WindowContentView: View {
                 dividerDragging = false
             }
         }
-        // on quick-terminal hide refocus the active session, unless this window's zoom owns focus: zoom-enter
-        // hides it, and `actions` targets the FRONTMOST window, so a background hide must not move focus.
+        // on quick-terminal hide refocus the active session, unless this window's zoom owns focus. The panel
+        // is app-level so every open window sees the change; `actions` targets the FRONTMOST window, so the
+        // frontmost check keeps a background window from moving focus on its behalf.
         .onChange(of: quickTerminal.isVisible) { _, visible in
-            if !visible, terminalZoom.target == .quick { terminalZoom.clear() }
-            if !visible, terminalZoom.target == nil { actions.focusActiveSession() }
+            guard !visible, isFrontmost, terminalZoom.target == nil else { return }
+            actions.focusActiveSession()
         }
         .onChange(of: terminalZoom.target) { old, new in
             handleZoomTargetChange(old: old, new: new)
@@ -217,25 +218,14 @@ struct WindowContentView: View {
         // un-minimized on launch. the title token re-runs the blend in updateNSView on a session switch.
         .background(WindowAccessor(titleToken: windowTitle, windowID: windowID, library: library, store: store))
         .onAppear {
-            quickTerminal.cwdProvider = { [store] in
-                store.activeSession?.effectiveCwd ?? FileManager.default.homeDirectoryForCurrentUser.path
-            }
-            // the quick terminal's shell sees this window's AGTERM_* env (scratch: ENABLED + WINDOW_ID + SOCKET).
-            quickTerminal.envProvider = { [quickTerminalEnv, windowID] in quickTerminalEnv(windowID) }
-            // typing counts as activity, so an idle auto-follow fire can't change this window's selected
-            // session behind the overlay while the user types (mirrors the overlay/scratch).
-            quickTerminal.onUserInput = { [store] in store.noteUserActivity() }
-            quickTerminal.focusAllowed = { [pick] in pick.pending == nil }
-            QuickTerminalRegistry.shared.register(windowID, controller: quickTerminal)
-            terminalZoom.targetResolver = { [store, quickTerminal] in
-                TerminalZoomController.resolveTarget(store: store, quickTerminalVisible: quickTerminal.isVisible)
+            terminalZoom.targetResolver = { [store] in
+                TerminalZoomController.resolveTarget(store: store)
             }
             TerminalZoomRegistry.shared.register(windowID, controller: terminalZoom)
             registerDashboard()
             PickRegistry.shared.register(windowID, controller: pick)
         }
         .onDisappear {
-            QuickTerminalRegistry.shared.unregister(windowID)
             TerminalZoomRegistry.shared.unregister(windowID)
             tearDownDashboard()
             if pickSuppressesAutoFollow {
@@ -475,7 +465,9 @@ struct WindowContentView: View {
     }
 
     /// The terminal background color from the ghostty config, with a dark fallback if libghostty has none.
-    private static func resolvedTerminalColor() -> Color {
+    /// Not private: the quick-terminal panel paints the same backing, its surface drawing transparent under
+    /// `background-opacity = 0` exactly as a window's does.
+    static func resolvedTerminalColor() -> Color {
         Color(nsColor: GhosttyApp.shared.terminalBackgroundColor
             ?? NSColor(srgbRed: 0.157, green: 0.173, blue: 0.204, alpha: 1))
     }
@@ -523,58 +515,19 @@ struct WindowContentView: View {
         return "\(base) (\(glyph))"
     }
 
-    /// The window-level overlays (quick terminal, palettes, Ctrl-Tab switcher) as one ZStack sibling INSIDE
+    /// The window-level overlays (palettes, Ctrl-Tab switcher) as one ZStack sibling INSIDE
     /// the body's root ZStack, not body-level `.overlay`s, so it can be inset below the titlebar and ordered
     /// BELOW `customTitlebar`. Every child is conditional, so an empty layer is not hit-testable and the
-    /// terminal below stays interactive. Order here = z-order (switcher over palette over quick terminal).
+    /// terminal below stays interactive. Order here = z-order (switcher over palette). The quick terminal is
+    /// NOT here — it is a detached panel, above every window rather than inside one.
     private var windowOverlayLayer: some View {
         ZStack {
-            quickTerminalOverlay
             commandPaletteOverlay
             sessionSwitcherOverlay
             // opening the dashboard closes the three above, so ordering only settles the empty case.
             dashboardOverlay
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-
-    /// The scratch terminal centered at 90% of the window, framed by a hairline border and shadow so it reads
-    /// as a distinct floating window over the content — libghostty renders only the terminal, so the frame is
-    /// drawn here. The margin is a tap-catcher that dismisses on click and carries the same backdrop mute as
-    /// a floating overlay. A dark scrim was rejected here and stays rejected: this layer is inset below the
-    /// AppKit title bar, so anything painted over the body raises its opacity against unchanged chrome. The
-    /// mute wash is neutral at full window opacity and `muteWashOpacity` scales it down under translucency,
-    /// which shrinks the seam without closing it. The controller owns the surface, so hiding keeps the shell
-    /// alive.
-    @ViewBuilder private var quickTerminalOverlay: some View {
-        if quickTerminal.isVisible {
-            GeometryReader { geo in
-                ZStack {
-                    // the tap-catcher carries the `quick-terminal` accessibility id, so tests query this
-                    // one. It spans the sidebar too, unlike the overlay's pane-scoped backdrop.
-                    // `QuickTerminalPane` is in the a11y tree as well: it takes the default
-                    // `deckVisible`/`viewOnly`, so the dictation bridge exposes its on-screen surface as a
-                    // "Terminal" text area. Do NOT set `deckVisible = false` here, that would drop it.
-                    (store.activeSession.map { washColor(for: $0) } ?? terminalColor).opacity(muteWashOpacity)
-                        .contentShape(Rectangle())
-                        .onTapGesture { quickTerminal.hide() }
-                        .accessibilityElement()
-                        .accessibilityIdentifier("quick-terminal")
-                    QuickTerminalPane(controller: quickTerminal)
-                        .frame(width: geo.size.width * 0.9, height: geo.size.height * 0.9)
-                        // solid backing so the quick terminal stays opaque even when the main window
-                        // is translucent (its ghostty surface draws transparent under background-opacity=0).
-                        .background(terminalColor)
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12)
-                                .strokeBorder(Color.white.opacity(0.18), lineWidth: 1)
-                        )
-                        .shadow(radius: 24)
-                }
-                .frame(width: geo.size.width, height: geo.size.height)
-            }
-        }
     }
 
     /// True only for the frontmost window: the palette and switcher are app-global singles on the frontmost

--- a/agterm/agtermApp+Menus.swift
+++ b/agterm/agtermApp+Menus.swift
@@ -157,7 +157,11 @@ extension agtermApp {
                     // `CustomCommandRunner`'s no-surface gate. A nil key window keeps the deck behavior.
                     // Gated on close_session still holding ⌘W: rebound off it, the stock item takes the chord
                     // back and an auxiliary window closes itself, so the new chord means only what it says.
-                    if closeSessionOwnsCommandW, let key = NSApp.keyWindow, !WindowRegistry.shared.contains(key) {
+                    // the quick-terminal panel is the one unregistered key window that is NOT auxiliary: it is
+                    // a cover, and `closeActiveSession`'s top two rungs exist to un-zoom then hide it. It also
+                    // has no close button (borderless), so `performClose` would only beep.
+                    if closeSessionOwnsCommandW, let key = NSApp.keyWindow, !WindowRegistry.shared.contains(key),
+                       !(key is QuickTerminalPanel) {
                         key.performClose(nil)
                         return
                     }

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -15,6 +15,7 @@ struct agtermApp: App {
     @State private var sessionSwitcher: SessionSwitcher
     @State private var paneShortcuts: PaneShortcuts
     @State private var undoCloseShortcut: UndoCloseShortcut
+    @State private var globalHotkey: GlobalHotkey
     @State var settingsModel: SettingsModel
     @State private var controlServer: ControlServer
     @State private var customCommandRunner: CustomCommandRunner
@@ -62,6 +63,7 @@ struct agtermApp: App {
         _sessionSwitcher = State(initialValue: SessionSwitcher(library: library, canSwitch: { actions.uiActionsEnabled }))
         _paneShortcuts = State(initialValue: PaneShortcuts(library: library, actions: actions))
         _undoCloseShortcut = State(initialValue: UndoCloseShortcut(actions: actions))
+        _globalHotkey = State(initialValue: GlobalHotkey(settings: settingsModel))
         // built last: needs the keymap (settings), the action hub for built-in monitor binds, and the control
         // server's bound socket path for `{AGT_SOCKET}`.
         _customCommandRunner = State(initialValue: CustomCommandRunner(
@@ -99,17 +101,15 @@ struct agtermApp: App {
                         Self.makeOverlaySurface(for: $0, store: $1, pane: $2, env: surfaceEnv(for: $0))
                     },
                     makeScratchSurface: { session, store in
-                        // suppress the scratch's creation autoFocus when a caller's program overlay or this
-                        // window's quick terminal is up — each renders above it and owns focus. A HUD renders
+                        // suppress the scratch's creation autoFocus when a caller's program overlay or the
+                        // quick terminal is up — each renders above it and owns focus. A HUD renders
                         // above it too but owns nothing, so it must not hold focus off a scratch just shown.
-                        let qtVisible = library.windowID(forSession: session.id)
-                            .flatMap { QuickTerminalRegistry.shared.controller(for: $0) }?.isVisible ?? false
+                        let qtVisible = QuickTerminalController.shared.isVisible
                         return Self.makeScratchSurface(for: session, store: store,
                                                        env: surfaceEnv(for: session, pane: .scratch),
                                                        suppressAutoFocus: session.programOverlayActive || qtVisible,
                                                        library: library)
                     },
-                    quickTerminalEnv: { quickTerminalEnv(for: $0) },
                     actions: actions,
                     palette: palette,
                     sessionSwitcher: sessionSwitcher
@@ -129,12 +129,18 @@ struct agtermApp: App {
                         // socket on terminate.
                         appDelegate.controlServer = controlServer
                         controlServer.start()
+                        // bind the app-level quick terminal (idempotent); its env needs the bound socket, so
+                        // this follows `start()` like the surface environment does.
+                        wireQuickTerminal(library: library)
                         // Ctrl-Tab session-switcher key monitors (idempotent).
                         sessionSwitcher.start()
                         // Ctrl-1/Ctrl-2 direct pane-focus key monitor (idempotent).
                         paneShortcuts.start()
                         // undo-close shortcut (idempotent); passes through text fields so native undo wins there.
                         undoCloseShortcut.start()
+                        // the OS-registered quick-terminal chord (idempotent), re-registered on keymap reload.
+                        // Must follow `wireQuickTerminal`, the hotkey being able to summon the panel at once.
+                        globalHotkey.start()
                         // custom-command key monitor (idempotent): rebuilds its matcher from the keymap on
                         // `.agtermKeymapChanged`, removed on terminate via the delegate reference.
                         appDelegate.customCommandRunner = customCommandRunner
@@ -337,13 +343,11 @@ struct agtermApp: App {
             // refocus ONLY while this is still the selected session and no cover is up: `session.search --close
             // --target <background>` would otherwise make a hidden, opacity-0 surface first responder and steal
             // input from the visible session (hidden views CAN), and a cover owns focus. `topmostSurface` catches
-            // the in-deck overlay/scratch (overlay > scratch > active pane) but not the window-level quick
-            // terminal, so bail while that is up — it refocuses on hide; the retry outlasts the SwiftUI teardown.
+            // the in-deck overlay/scratch (overlay > scratch > active pane) but not the quick-terminal panel,
+            // so bail while that is up — it refocuses on hide; the retry outlasts the SwiftUI teardown.
             guard store.selectedSessionID == sessionID else { return }
             let windowID = library.windowID(forSession: sessionID)
-            let quickTerminalVisible = windowID
-                .flatMap { QuickTerminalRegistry.shared.controller(for: $0) }?.isVisible ?? false
-            guard !quickTerminalVisible else { return }
+            guard !QuickTerminalController.shared.isVisible else { return }
             // terminal zoom owns focus above the deck and zoom-enter ends an open search; this END lands a tick
             // later, so refocusing would steal first responder back from the zoomed terminal.
             guard windowID.flatMap({ TerminalZoomRegistry.shared.controller(for: $0) })?.target == nil else { return }
@@ -560,11 +564,32 @@ struct agtermApp: App {
                                           pane: pane, paneToken: pane == nil ? nil : UUID().uuidString)
     }
 
-    /// The environment a window's quick terminal exposes — scratch, not in the tree, so its `AGTERM_*`
-    /// values carry only enabled, window, and socket facts (no workspace/session ids), plus app identity.
+    /// The environment the quick terminal exposes — scratch, not in the tree and owned by no window, so its
+    /// `AGTERM_*` values carry only enabled and socket facts, plus app identity.
     @MainActor
-    func quickTerminalEnv(for windowID: WindowInfo.ID) -> [String: String] {
-        SurfaceEnvironment.quickTerminal(windowID: windowID, socketPath: controlServer.resolvedSocketPath,
+    func quickTerminalEnv() -> [String: String] {
+        SurfaceEnvironment.quickTerminal(socketPath: controlServer.resolvedSocketPath,
                                          programVersion: Self.terminalProgramVersion)
+    }
+
+    /// Bind the app's one quick terminal to the library. Every provider resolves through `activeStore` at
+    /// call time rather than capturing a window, the panel outliving any particular one; `canShow` is what
+    /// keeps it from being summoned into an app with no window left to return to.
+    @MainActor
+    func wireQuickTerminal(library: WindowLibrary) {
+        let controller = QuickTerminalController.shared
+        controller.cwdProvider = { [weak library] in
+            library?.activeStore?.activeSession?.effectiveCwd
+                ?? FileManager.default.homeDirectoryForCurrentUser.path
+        }
+        controller.envProvider = { [self] in quickTerminalEnv() }
+        // typing counts as activity, so an idle auto-follow fire can't reshuffle the active window's
+        // selection behind the panel while the user types (mirrors the overlay/scratch).
+        controller.onUserInput = { [weak library] in library?.activeStore?.noteUserActivity() }
+        controller.focusAllowed = { [weak library] in
+            PickRegistry.shared.controller(for: library?.activeWindowID)?.pending == nil
+        }
+        controller.canShow = { [weak library] in !(library?.openIDs().isEmpty ?? true) }
+        controller.terminalColorProvider = { WindowContentView.resolvedTerminalColor() }
     }
 }

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -589,7 +589,13 @@ struct agtermApp: App {
         controller.focusAllowed = { [weak library] in
             PickRegistry.shared.controller(for: library?.activeWindowID)?.pending == nil
         }
-        controller.canShow = { [weak library] in !(library?.openIDs().isEmpty ?? true) }
+        // the global hotkey reaches the controller directly, with none of the `uiActionsEnabled` gating every
+        // in-app path has, so the pick term belongs here. Only that term: refusing a system-wide summon
+        // because some BACKGROUND window has a dashboard open would defeat the point of the chord.
+        controller.canShow = { [weak library] in
+            guard let library, !library.openIDs().isEmpty else { return false }
+            return PickRegistry.shared.controller(for: library.activeWindowID)?.pending == nil
+        }
         controller.terminalColorProvider = { WindowContentView.resolvedTerminalColor() }
     }
 }

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -104,7 +104,7 @@ struct agtermApp: App {
                         // suppress the scratch's creation autoFocus when a caller's program overlay or the
                         // quick terminal is up — each renders above it and owns focus. A HUD renders
                         // above it too but owns nothing, so it must not hold focus off a scratch just shown.
-                        let qtVisible = QuickTerminalController.shared.isVisible
+                        let qtVisible = QuickTerminalController.shared.holdsKey
                         return Self.makeScratchSurface(for: session, store: store,
                                                        env: surfaceEnv(for: session, pane: .scratch),
                                                        suppressAutoFocus: session.programOverlayActive || qtVisible,
@@ -347,7 +347,7 @@ struct agtermApp: App {
             // so bail while that is up — it refocuses on hide; the retry outlasts the SwiftUI teardown.
             guard store.selectedSessionID == sessionID else { return }
             let windowID = library.windowID(forSession: sessionID)
-            guard !QuickTerminalController.shared.isVisible else { return }
+            guard !QuickTerminalController.shared.holdsKey else { return }
             // terminal zoom owns focus above the deck and zoom-enter ends an open search; this END lands a tick
             // later, so refocusing would steal first responder back from the zoomed terminal.
             guard windowID.flatMap({ TerminalZoomRegistry.shared.controller(for: $0) })?.target == nil else { return }

--- a/agtermCore/Sources/agtermCore/ConfigPaths.swift
+++ b/agtermCore/Sources/agtermCore/ConfigPaths.swift
@@ -42,7 +42,7 @@ public enum ConfigPaths {
         # reload`) to apply. Blank lines and lines starting with `#` are ignored. A line that is
         # rejected or skipped is reported in Settings ▸ Key Mapping and by `agtermctl keymap list`.
         #
-        # Two verbs:
+        # Three verbs:
         #
         #   map <chord> <action>
         #       Rebind a built-in action. Chords use kitty syntax: mods joined by `+`, e.g.
@@ -77,6 +77,17 @@ public enum ConfigPaths {
         #           command "Lazygit"      ctrl+a>g     agtermctl session overlay open 'zsh -lc lazygit' --socket "$AGT_SOCKET"
         #           command "Deploy"                    ./deploy.sh
         #
+        #   global-hotkey <chord>
+        #       Bind ONE system-wide chord that summons the quick terminal while any application is
+        #       frontmost — the only binding here that fires when agterm does not have the keyboard.
+        #       Exactly one chord: no `|` alternatives, no leader sequence, and it must carry a
+        #       modifier. A second global-hotkey line replaces the first. macOS registers it by
+        #       physical key position, so it keeps working on a non-Latin layout. Because the system
+        #       owns it rather than agterm, it takes no part in the collision rules above: it may
+        #       share a chord with a menu item, and whichever app is frontmost gets the key. Example:
+        #
+        #           global-hotkey ctrl+opt+space
+        #
         # Built-in actions (raw name → shipped default chord):
         #
         \(actionLines)
@@ -93,6 +104,7 @@ public enum ConfigPaths {
         #
         # Uncomment and edit a line below to start.
         # map cmd+shift+l toggle_split
+        # global-hotkey ctrl+opt+space
 
         """
     }

--- a/agtermCore/Sources/agtermCore/ConfigPaths.swift
+++ b/agtermCore/Sources/agtermCore/ConfigPaths.swift
@@ -83,8 +83,9 @@ public enum ConfigPaths {
         #       Exactly one chord: no `|` alternatives, no leader sequence, and it must carry a
         #       modifier. A second global-hotkey line replaces the first. macOS registers it by
         #       physical key position, so it keeps working on a non-Latin layout. Because the system
-        #       owns it rather than agterm, it takes no part in the collision rules above: it may
-        #       share a chord with a menu item, and whichever app is frontmost gets the key. Example:
+        #       owns it rather than agterm, it takes no part in the collision rules above. Note the
+        #       precedence: the system hotkey WINS, agterm frontmost included, so a chord shared with a
+        #       menu action fires this and the menu binding never sees it. Example:
         #
         #           global-hotkey ctrl+opt+space
         #

--- a/agtermCore/Sources/agtermCore/Keybind.swift
+++ b/agtermCore/Sources/agtermCore/Keybind.swift
@@ -108,6 +108,19 @@ func latinKey(forKeyCode keyCode: UInt16) -> String? {
     }
 }
 
+/// The macOS virtual key code that produces a chord's base key, or nil when no ANSI position does.
+///
+/// The inverse of `namedKey(forKeyCode:)`/`latinKey(forKeyCode:)`, derived by scanning them rather than
+/// spelled as a third table, so a name or position added to either is reachable here with no second edit.
+/// `RegisterEventHotKey` is the caller: a system-wide hotkey is registered by physical position, never by
+/// produced character, so it keeps firing when the user switches to a non-Latin layout.
+public func keyCode(forChordKey key: String) -> UInt16? {
+    // named keys first: their codes are outside the ANSI table, and neither map claims the same code.
+    for code in UInt16(0)...127 where namedKey(forKeyCode: code) == key { return code }
+    for code in UInt16(0)...127 where latinKey(forKeyCode: code) == key { return code }
+    return nil
+}
+
 /// The base key for a key press. `produced` is the character the ACTIVE layout puts on that key with no
 /// modifiers applied, `layoutIsASCIICapable` whether that layout can type ASCII at all.
 ///

--- a/agtermCore/Sources/agtermCore/Keymap.swift
+++ b/agtermCore/Sources/agtermCore/Keymap.swift
@@ -12,14 +12,22 @@ public struct Keymap: Equatable, Sendable {
     /// Actions whose `map` line offered no menu-bindable alternative. Distinct from ABSENT, which means
     /// "keep the shipped default": without this, `map ctrl+space>s toggle_split` would leave ⌘D live.
     public let builtinUnbound: Set<BuiltinAction>
+    /// The system-wide chord that summons the quick terminal, nil when the file binds none. Registered with
+    /// the OS rather than the app's local monitor, so it deliberately takes NO part in the conflict model:
+    /// it never reaches `KeybindMatcher`, and a chord it shares with a menu item resolves by which app is
+    /// frontmost. One chord only — no alternatives, no leader sequence, since neither is expressible to
+    /// `RegisterEventHotKey`.
+    public let globalHotkey: Chord?
 
     public init(builtinOverrides: [BuiltinAction: Chord], commands: [CustomCommand],
                 builtinSequences: [BuiltinAction: [Keybind]] = [:],
-                builtinUnbound: Set<BuiltinAction> = []) {
+                builtinUnbound: Set<BuiltinAction> = [],
+                globalHotkey: Chord? = nil) {
         self.builtinOverrides = builtinOverrides
         self.commands = commands
         self.builtinSequences = builtinSequences
         self.builtinUnbound = builtinUnbound
+        self.globalHotkey = globalHotkey
     }
 
     /// The active menu chord for a built-in: the user override, else the shipped `defaultChord` — `nil` for
@@ -104,6 +112,9 @@ public func parseKeymap(_ text: String) -> (keymap: Keymap, diagnostics: [Keymap
     var mapLines: [ParsedMapLine] = []
     var commandLines: [ParsedCommandLine] = []
     var diagnostics: [KeymapDiagnostic] = []
+    // last-wins like `map`, but with no cross-line resolution to run afterwards: an OS-registered chord
+    // collides with nothing agterm owns.
+    var globalHotkey: Chord?
 
     // normalize line endings: a CRLF leaves a trailing `\r` that .whitespaces won't strip (so
     // `toggle_split\r` reads as an unknown action) and a lone-CR file would collapse into one line.
@@ -122,6 +133,8 @@ public func parseKeymap(_ text: String) -> (keymap: Keymap, diagnostics: [Keymap
             parseMapLine(rest, line: lineNumber, mapLines: &mapLines, diagnostics: &diagnostics)
         case "command":
             parseCommandLine(rest, line: lineNumber, commandLines: &commandLines, diagnostics: &diagnostics)
+        case "global-hotkey":
+            parseGlobalHotkeyLine(rest, line: lineNumber, hotkey: &globalHotkey, diagnostics: &diagnostics)
         default:
             diagnostics.append(KeymapDiagnostic(line: lineNumber, message: "unknown verb '\(verb)'"))
         }
@@ -176,8 +189,37 @@ public func parseKeymap(_ text: String) -> (keymap: Keymap, diagnostics: [Keymap
                    builtinSequences: survivingAlternatives(survivors),
                    builtinUnbound: unboundAfterRestoringStrandedDefaults(compatibilityUnbound,
                                                                          overrides: builtinOverrides,
-                                                                         survivors: survivors)),
+                                                                         survivors: survivors),
+                   globalHotkey: globalHotkey),
             diagnostics)
+}
+
+/// Parse the remainder of a `global-hotkey` line: one chord token and nothing else. Rejects a bare key
+/// outright — a system-wide binding with no modifier would take that key from every other application —
+/// and a leader sequence, which `RegisterEventHotKey` cannot express. Repeats are last-wins.
+private func parseGlobalHotkeyLine(_ rest: String, line: Int, hotkey: inout Chord?,
+                                   diagnostics: inout [KeymapDiagnostic]) {
+    let token = String(rest.prefix(while: { !$0.isWhitespace }))
+    guard !token.isEmpty else {
+        diagnostics.append(KeymapDiagnostic(line: line, message: "global-hotkey needs a chord"))
+        return
+    }
+    let trailing = String(rest.dropFirst(token.count)).trimmingCharacters(in: .whitespaces)
+    guard trailing.isEmpty else {
+        diagnostics.append(KeymapDiagnostic(line: line,
+                                            message: "global-hotkey takes one chord, found '\(rest)'"))
+        return
+    }
+    guard let keybind = parseKeybind(token), keybind.count == 1, let chord = keybind.first else {
+        diagnostics.append(KeymapDiagnostic(line: line, message: "invalid global-hotkey chord '\(token)'"))
+        return
+    }
+    guard !chord.mods.isEmpty else {
+        diagnostics.append(KeymapDiagnostic(line: line,
+                                            message: "global-hotkey '\(token)' must include a modifier"))
+        return
+    }
+    hotkey = chord
 }
 
 /// Whether a diagnostic is about a binding as a whole or about one alternative of several. The ONLY thing

--- a/agtermCore/Sources/agtermCore/Keymap.swift
+++ b/agtermCore/Sources/agtermCore/Keymap.swift
@@ -219,6 +219,16 @@ private func parseGlobalHotkeyLine(_ rest: String, line: Int, hotkey: inout Chor
                                             message: "global-hotkey '\(token)' must include a modifier"))
         return
     }
+    // `parseChord` takes any single character, but the OS registers a PHYSICAL key position, so a base key
+    // no ANSI position produces cannot be registered. Diagnose here: this line has no read-back anywhere —
+    // `keymap list` does not carry it — so a silent drop at registration leaves the user no signal at all.
+    guard keyCode(forChordKey: chord.key) != nil else {
+        diagnostics.append(KeymapDiagnostic(
+            line: line,
+            message: "global-hotkey '\(token)' names no key position; write a shifted symbol as shift+<base>"
+        ))
+        return
+    }
     hotkey = chord
 }
 

--- a/agtermCore/Sources/agtermCore/SurfaceEnvironment.swift
+++ b/agtermCore/Sources/agtermCore/SurfaceEnvironment.swift
@@ -35,12 +35,12 @@ public enum SurfaceEnvironment {
         return env
     }
 
-    /// Environment for a window's quick terminal, which is not part of the session tree.
-    public static func quickTerminal(windowID: UUID, socketPath: String,
-                                     programVersion: String) -> [String: String] {
+    /// Environment for the quick terminal, which is neither part of the session tree nor owned by a window —
+    /// it is one detached panel per app, so it carries no window id and an untargeted `agtermctl` run from it
+    /// resolves the active window like any other caller.
+    public static func quickTerminal(socketPath: String, programVersion: String) -> [String: String] {
         terminalIdentity(programVersion: programVersion).merging([
             "AGTERM_ENABLED": "1",
-            "AGTERM_WINDOW_ID": windowID.uuidString,
             "AGTERM_SOCKET": socketPath,
         ]) { _, agtermValue in agtermValue }
     }

--- a/agtermCore/Sources/agtermCore/TerminalZoom.swift
+++ b/agtermCore/Sources/agtermCore/TerminalZoom.swift
@@ -190,8 +190,10 @@ public final class TerminalZoomController {
         target = nil
     }
 
-    public static func resolveTarget(store: AppStore, quickTerminalVisible: Bool) -> TerminalZoomTarget? {
-        if quickTerminalVisible { return .quick }
+    /// The surface a bare zoom toggle fills THIS window with. The quick terminal is deliberately absent: it
+    /// is one detached panel per app, so it is not a surface any window can zoom, and `.quick` is instead
+    /// owned by `QuickTerminalController.isZoomed`.
+    public static func resolveTarget(store: AppStore) -> TerminalZoomTarget? {
         guard let session = store.activeSession else { return nil }
         // one source of truth for the active-surface precedence: `isActive(in:)` defines mutually
         // exclusive predicates per case, so the first (only) active one is the zoom target. The
@@ -200,10 +202,12 @@ public final class TerminalZoomController {
         return .session(session.id, surface)
     }
 
-    public static func isTargetValid(_ target: TerminalZoomTarget, in store: AppStore, quickTerminalVisible: Bool) -> Bool {
+    /// Whether a WINDOW's zoom target still exists. `.quick` never reaches a window controller (see
+    /// `resolveTarget`), so it can only be a stale value and is always invalid here.
+    public static func isTargetValid(_ target: TerminalZoomTarget, in store: AppStore) -> Bool {
         switch target {
         case .quick:
-            return quickTerminalVisible
+            return false
         case let .session(sessionID, surface):
             guard let session = store.session(withID: sessionID) else { return false }
             return surface.isAvailable(in: session)

--- a/agtermCore/Tests/agtermCoreTests/KeybindTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/KeybindTests.swift
@@ -29,6 +29,31 @@ struct KeybindTests {
         #expect(namedKey(forKeyEquivalent: "ab") == nil, "only a single scalar can be a named key")
     }
 
+    /// The reverse lookup must round-trip both tables it scans, or a chord that parses cannot be registered
+    /// as a system-wide hotkey.
+    @Test func keyCodeForChordKeyInvertsBothKeyTables() {
+        for code in UInt16(0)...127 {
+            if let named = namedKey(forKeyCode: code) {
+                #expect(keyCode(forChordKey: named) == code)
+            }
+            if let latin = latinKey(forKeyCode: code) {
+                #expect(keyCode(forChordKey: latin) == code)
+            }
+        }
+    }
+
+    @Test func keyCodeForChordKeyCoversEveryBindableNamedKey() {
+        for key in bindableNamedKeys {
+            #expect(keyCode(forChordKey: key) != nil)
+        }
+    }
+
+    @Test func keyCodeForChordKeyRejectsUnproducibleKeys() {
+        #expect(keyCode(forChordKey: "f1") == nil)
+        #expect(keyCode(forChordKey: "esc") == nil)
+        #expect(keyCode(forChordKey: "") == nil)
+    }
+
     @Test func parseSimpleChord() {
         let kb = parseKeybind("cmd+shift+e")
         #expect(kb == [Chord(mods: [.command, .shift], key: "e")])

--- a/agtermCore/Tests/agtermCoreTests/KeymapTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/KeymapTests.swift
@@ -55,6 +55,83 @@ struct KeymapTests {
         #expect(keymap.commands.isEmpty)
     }
 
+    // MARK: global-hotkey — the OS-registered chord that summons the quick terminal
+
+    @Test func parseGlobalHotkeyHappyPath() {
+        let (keymap, diagnostics) = parseKeymap("global-hotkey ctrl+opt+space")
+        #expect(diagnostics.isEmpty)
+        #expect(keymap.globalHotkey == Chord(mods: [.control, .option], key: "space"))
+        #expect(keymap.builtinOverrides.isEmpty)
+        #expect(keymap.commands.isEmpty)
+    }
+
+    @Test func absentGlobalHotkeyIsNil() {
+        let (keymap, diagnostics) = parseKeymap("map cmd+shift+e toggle_split")
+        #expect(diagnostics.isEmpty)
+        #expect(keymap.globalHotkey == nil)
+    }
+
+    @Test func lastGlobalHotkeyLineWins() {
+        let (keymap, diagnostics) = parseKeymap("""
+        global-hotkey ctrl+opt+space
+        global-hotkey cmd+shift+j
+        """)
+        #expect(diagnostics.isEmpty)
+        #expect(keymap.globalHotkey == Chord(mods: [.command, .shift], key: "j"))
+    }
+
+    /// A system-wide binding with no modifier would take that key from every other application.
+    @Test func bareGlobalHotkeyChordIsRejected() {
+        let (keymap, diagnostics) = parseKeymap("global-hotkey j")
+        #expect(keymap.globalHotkey == nil)
+        #expect(diagnostics.count == 1)
+        #expect(diagnostics[0].line == 1)
+        #expect(diagnostics[0].message.contains("must include a modifier"))
+    }
+
+    /// `RegisterEventHotKey` takes one chord, so a leader sequence has nothing to register.
+    @Test func globalHotkeySequenceIsRejected() {
+        let (keymap, diagnostics) = parseKeymap("global-hotkey ctrl+a>j")
+        #expect(keymap.globalHotkey == nil)
+        #expect(diagnostics.count == 1)
+        #expect(diagnostics[0].message.contains("invalid global-hotkey chord"))
+    }
+
+    @Test func globalHotkeyRejectsMissingAndExtraTokens() {
+        let (missing, missingDiagnostics) = parseKeymap("global-hotkey")
+        #expect(missing.globalHotkey == nil)
+        #expect(missingDiagnostics.count == 1)
+        #expect(missingDiagnostics[0].message.contains("needs a chord"))
+
+        let (extra, extraDiagnostics) = parseKeymap("global-hotkey ctrl+opt+space quick_terminal")
+        #expect(extra.globalHotkey == nil)
+        #expect(extraDiagnostics.count == 1)
+        #expect(extraDiagnostics[0].message.contains("takes one chord"))
+    }
+
+    /// The chord is registered with the OS, never with `KeybindMatcher`, so it is deliberately outside the
+    /// conflict model: sharing a chord with a menu item costs neither of them its binding.
+    @Test func globalHotkeyDoesNotCollideWithABuiltinMenuChord() {
+        let (keymap, diagnostics) = parseKeymap("""
+        map cmd+shift+j toggle_split
+        global-hotkey cmd+shift+j
+        """)
+        #expect(diagnostics.isEmpty)
+        #expect(keymap.globalHotkey == Chord(mods: [.command, .shift], key: "j"))
+        #expect(keymap.builtinOverrides == [.toggleSplit: Chord(mods: [.command, .shift], key: "j")])
+    }
+
+    @Test func aBadGlobalHotkeyLineDoesNotDiscardTheRestOfTheFile() {
+        let (keymap, diagnostics) = parseKeymap("""
+        global-hotkey j
+        map cmd+shift+e toggle_split
+        """)
+        #expect(keymap.globalHotkey == nil)
+        #expect(keymap.builtinOverrides == [.toggleSplit: Chord(mods: [.command, .shift], key: "e")])
+        #expect(diagnostics.count == 1)
+        #expect(diagnostics[0].line == 1)
+    }
+
     // MARK: glyphHint — the shortcut shown in the palette and toolbar tooltips
 
     @Test func glyphHintRendersDefaultChordAsGlyphs() {

--- a/agtermCore/Tests/agtermCoreTests/KeymapTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/KeymapTests.swift
@@ -97,6 +97,25 @@ struct KeymapTests {
         #expect(diagnostics[0].message.contains("invalid global-hotkey chord"))
     }
 
+    /// The OS registers a physical key position, so a base key no ANSI position produces cannot be bound.
+    /// It has no read-back anywhere, so the diagnostic is the user's only signal.
+    @Test func globalHotkeyRejectsAChordWithNoKeyPosition() {
+        for token in ["ctrl+opt+é", "ctrl+opt+!", "cmd+ю"] {
+            let (keymap, diagnostics) = parseKeymap("global-hotkey \(token)")
+            #expect(keymap.globalHotkey == nil, "\(token) should not bind")
+            #expect(diagnostics.count == 1)
+            #expect(diagnostics[0].message.contains("names no key position"))
+        }
+    }
+
+    @Test func globalHotkeyAcceptsEveryBindableNamedKey() {
+        for key in bindableNamedKeys {
+            let (keymap, diagnostics) = parseKeymap("global-hotkey ctrl+opt+\(key)")
+            #expect(diagnostics.isEmpty, "\(key) should parse clean")
+            #expect(keymap.globalHotkey == Chord(mods: [.control, .option], key: key))
+        }
+    }
+
     @Test func globalHotkeyRejectsMissingAndExtraTokens() {
         let (missing, missingDiagnostics) = parseKeymap("global-hotkey")
         #expect(missing.globalHotkey == nil)

--- a/agtermCore/Tests/agtermCoreTests/SurfaceEnvironmentTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/SurfaceEnvironmentTests.swift
@@ -15,7 +15,6 @@ struct SurfaceEnvironmentTests {
             programVersion: "0.12.0"
         )
         let quickEnv = SurfaceEnvironment.quickTerminal(
-            windowID: windowID,
             socketPath: "/tmp/agterm.sock",
             programVersion: "0.12.0"
         )
@@ -153,24 +152,23 @@ struct SurfaceEnvironmentTests {
         #expect(env["AGTERM_PANE_ID"] == nil)
     }
 
-    @Test func quickTerminalEnvironmentOmitsSessionAndWorkspaceIdentifiers() {
-        let windowID = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
-
+    /// The panel is one per app and belongs to no window, so it carries no window id either — an untargeted
+    /// `agtermctl` run from it resolves the active window like any other caller.
+    @Test func quickTerminalEnvironmentOmitsSessionWorkspaceAndWindowIdentifiers() {
         let env = SurfaceEnvironment.quickTerminal(
-            windowID: windowID,
             socketPath: "/tmp/agterm.sock",
             programVersion: "0.12.0"
         )
 
         #expect(env == [
             "AGTERM_ENABLED": "1",
-            "AGTERM_WINDOW_ID": "22222222-2222-2222-2222-222222222222",
             "AGTERM_SOCKET": "/tmp/agterm.sock",
             "TERM_PROGRAM": "agterm",
             "TERM_PROGRAM_VERSION": "0.12.0",
         ])
         #expect(env["AGTERM_SESSION_ID"] == nil)
         #expect(env["AGTERM_WORKSPACE_ID"] == nil)
+        #expect(env["AGTERM_WINDOW_ID"] == nil)
     }
 
     @Test func emptySocketPathIsStillEmitted() {
@@ -202,7 +200,6 @@ struct SurfaceEnvironmentTests {
             programVersion: "0.12.0"
         )
         let quickEnv = SurfaceEnvironment.quickTerminal(
-            windowID: windowID,
             socketPath: unavailable,
             programVersion: "0.12.0"
         )

--- a/agtermCore/Tests/agtermCoreTests/TerminalZoomTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/TerminalZoomTests.swift
@@ -13,41 +13,49 @@ struct TerminalZoomTests {
         }
     }
 
-    @Test func resolveTargetPrioritizesQuickThenSessionCoversThenFocusedPane() {
+    @Test func resolveTargetPrioritizesSessionCoversThenFocusedPane() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
 
-        #expect(TerminalZoomController.resolveTarget(store: store, quickTerminalVisible: true) == .quick)
-        #expect(TerminalZoomController.resolveTarget(store: store, quickTerminalVisible: false) == .session(session.id, .primary))
+        #expect(TerminalZoomController.resolveTarget(store: store) == .session(session.id, .primary))
 
         // `splitFocused` alone describes no pane: with neither a shown split nor a split surface the focused
         // pane is still the primary, matching `rendersPane`/`focusedOverlayPane` and `.split`'s isAvailable.
         session.splitFocused = true
-        #expect(TerminalZoomController.resolveTarget(store: store, quickTerminalVisible: false) == .session(session.id, .primary))
+        #expect(TerminalZoomController.resolveTarget(store: store) == .session(session.id, .primary))
 
         store.toggleSplit(session.id)
         session.splitSurface = SpySurface()
-        #expect(TerminalZoomController.resolveTarget(store: store, quickTerminalVisible: false) == .session(session.id, .split))
+        #expect(TerminalZoomController.resolveTarget(store: store) == .session(session.id, .split))
 
         session.scratchActive = true
-        #expect(TerminalZoomController.resolveTarget(store: store, quickTerminalVisible: false) == .session(session.id, .scratch))
+        #expect(TerminalZoomController.resolveTarget(store: store) == .session(session.id, .scratch))
 
         session.overlayActive = true
-        #expect(TerminalZoomController.resolveTarget(store: store, quickTerminalVisible: false) == .session(session.id, .overlay))
+        #expect(TerminalZoomController.resolveTarget(store: store) == .session(session.id, .overlay))
     }
 
-    @Test func targetValidityTracksQuickVisibilityAndSessionLifetime() {
+    /// The quick terminal is one detached panel per app, so no WINDOW's zoom can hold it: `.quick` is neither
+    /// resolved here nor valid here, and `QuickTerminalController.isZoomed` owns it instead.
+    @Test func windowZoomNeverTakesTheQuickTerminal() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
 
-        #expect(TerminalZoomController.isTargetValid(.quick, in: store, quickTerminalVisible: true))
-        #expect(!TerminalZoomController.isTargetValid(.quick, in: store, quickTerminalVisible: false))
-        #expect(TerminalZoomController.isTargetValid(.session(session.id, .primary), in: store, quickTerminalVisible: false))
+        #expect(TerminalZoomController.resolveTarget(store: store) == .session(session.id, .primary))
+        #expect(!TerminalZoomController.isTargetValid(.quick, in: store))
+    }
+
+    @Test func targetValidityTracksSessionLifetime() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+
+        #expect(TerminalZoomController.isTargetValid(.session(session.id, .primary), in: store))
 
         store.closeSession(session.id)
-        #expect(!TerminalZoomController.isTargetValid(.session(session.id, .primary), in: store, quickTerminalVisible: false))
+        #expect(!TerminalZoomController.isTargetValid(.session(session.id, .primary), in: store))
     }
 
     @Test func splitTargetStaysValidWhenHiddenAndClearsWhenPromotedOrClosed() {
@@ -56,12 +64,12 @@ struct TerminalZoomTests {
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
 
         store.toggleSplit(session.id)
-        #expect(TerminalZoomController.isTargetValid(.session(session.id, .split), in: store, quickTerminalVisible: false))
+        #expect(TerminalZoomController.isTargetValid(.session(session.id, .split), in: store))
 
         store.toggleSplit(session.id)
         #expect(session.isSplit == false)
         #expect(session.hasSplit == true)
-        #expect(TerminalZoomController.isTargetValid(.session(session.id, .split), in: store, quickTerminalVisible: false))
+        #expect(TerminalZoomController.isTargetValid(.session(session.id, .split), in: store))
 
         // the primary exiting PROMOTES the survivor into the main slot, leaving no right pane to zoom.
         session.surface = SpySurface()
@@ -69,12 +77,12 @@ struct TerminalZoomTests {
         store.closePrimaryPane(session.id)
         #expect(session.hasSplit == false)
         #expect(session.splitSurface == nil)
-        #expect(!TerminalZoomController.isTargetValid(.session(session.id, .split), in: store, quickTerminalVisible: false))
+        #expect(!TerminalZoomController.isTargetValid(.session(session.id, .split), in: store))
 
         store.toggleSplit(session.id)
-        #expect(TerminalZoomController.isTargetValid(.session(session.id, .split), in: store, quickTerminalVisible: false))
+        #expect(TerminalZoomController.isTargetValid(.session(session.id, .split), in: store))
         store.closeSplit(session.id)
-        #expect(!TerminalZoomController.isTargetValid(.session(session.id, .split), in: store, quickTerminalVisible: false))
+        #expect(!TerminalZoomController.isTargetValid(.session(session.id, .split), in: store))
     }
 
     @Test func primaryTargetStaysValidWhenPrimaryExitsAndSplitIsPromoted() {
@@ -82,7 +90,7 @@ struct TerminalZoomTests {
         let ws = store.addWorkspace(name: "work")
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
 
-        #expect(TerminalZoomController.isTargetValid(.session(session.id, .primary), in: store, quickTerminalVisible: false))
+        #expect(TerminalZoomController.isTargetValid(.session(session.id, .primary), in: store))
 
         let survivor = SpySurface()
         session.surface = SpySurface()
@@ -94,8 +102,8 @@ struct TerminalZoomTests {
         #expect(session.surface === survivor)
         #expect(session.splitSurface == nil)
         #expect(session.splitFocused == false)
-        #expect(TerminalZoomController.isTargetValid(.session(session.id, .primary), in: store, quickTerminalVisible: false))
-        #expect(!TerminalZoomController.isTargetValid(.session(session.id, .split), in: store, quickTerminalVisible: false))
+        #expect(TerminalZoomController.isTargetValid(.session(session.id, .primary), in: store))
+        #expect(!TerminalZoomController.isTargetValid(.session(session.id, .split), in: store))
     }
 
     @Test func scratchAndOverlayTargetsFollowActiveFlags() {
@@ -104,18 +112,18 @@ struct TerminalZoomTests {
         let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
 
         store.toggleScratch(session.id)
-        #expect(TerminalZoomController.isTargetValid(.session(session.id, .scratch), in: store, quickTerminalVisible: false))
+        #expect(TerminalZoomController.isTargetValid(.session(session.id, .scratch), in: store))
         store.toggleScratch(session.id)
-        #expect(!TerminalZoomController.isTargetValid(.session(session.id, .scratch), in: store, quickTerminalVisible: false))
+        #expect(!TerminalZoomController.isTargetValid(.session(session.id, .scratch), in: store))
         session.scratchSurface = SpySurface()
-        #expect(TerminalZoomController.isTargetValid(.session(session.id, .scratch), in: store, quickTerminalVisible: false))
+        #expect(TerminalZoomController.isTargetValid(.session(session.id, .scratch), in: store))
         store.closeScratch(session.id)
-        #expect(!TerminalZoomController.isTargetValid(.session(session.id, .scratch), in: store, quickTerminalVisible: false))
+        #expect(!TerminalZoomController.isTargetValid(.session(session.id, .scratch), in: store))
 
         #expect(store.openOverlay(session.id, command: "top"))
-        #expect(TerminalZoomController.isTargetValid(.session(session.id, .overlay), in: store, quickTerminalVisible: false))
+        #expect(TerminalZoomController.isTargetValid(.session(session.id, .overlay), in: store))
         #expect(store.closeOverlay(session.id))
-        #expect(!TerminalZoomController.isTargetValid(.session(session.id, .overlay), in: store, quickTerminalVisible: false))
+        #expect(!TerminalZoomController.isTargetValid(.session(session.id, .overlay), in: store))
     }
 
     @Test func paneOverlayTargetsFollowTheirSlotAndFocusedPane() {
@@ -128,19 +136,19 @@ struct TerminalZoomTests {
         session.splitFocused = false
 
         #expect(store.openPaneOverlay(session.id, pane: .left, command: "top") == nil)
-        #expect(TerminalZoomController.resolveTarget(store: store, quickTerminalVisible: false) == .session(session.id, .overlayLeft))
-        #expect(TerminalZoomController.isTargetValid(.session(session.id, .overlayLeft), in: store, quickTerminalVisible: false))
-        #expect(!TerminalZoomController.isTargetValid(.session(session.id, .overlayRight), in: store, quickTerminalVisible: false))
+        #expect(TerminalZoomController.resolveTarget(store: store) == .session(session.id, .overlayLeft))
+        #expect(TerminalZoomController.isTargetValid(.session(session.id, .overlayLeft), in: store))
+        #expect(!TerminalZoomController.isTargetValid(.session(session.id, .overlayRight), in: store))
 
         session.splitFocused = true
-        #expect(TerminalZoomController.resolveTarget(store: store, quickTerminalVisible: false) == .session(session.id, .split))
+        #expect(TerminalZoomController.resolveTarget(store: store) == .session(session.id, .split))
 
         #expect(store.openPaneOverlay(session.id, pane: .right, command: "top") == nil)
-        #expect(TerminalZoomController.resolveTarget(store: store, quickTerminalVisible: false) == .session(session.id, .overlayRight))
+        #expect(TerminalZoomController.resolveTarget(store: store) == .session(session.id, .overlayRight))
 
         #expect(store.closePaneOverlay(session.id, pane: .right))
-        #expect(!TerminalZoomController.isTargetValid(.session(session.id, .overlayRight), in: store, quickTerminalVisible: false))
-        #expect(TerminalZoomController.resolveTarget(store: store, quickTerminalVisible: false) == .session(session.id, .split))
+        #expect(!TerminalZoomController.isTargetValid(.session(session.id, .overlayRight), in: store))
+        #expect(TerminalZoomController.resolveTarget(store: store) == .session(session.id, .split))
     }
 
     @Test func paneOverlayTakesItsPanesVisibilityAndSessionCoversHideBoth() {
@@ -206,7 +214,7 @@ struct TerminalZoomTests {
             let active = TerminalZoomSurface.allCases.filter { $0.isActive(in: session) }
             let shape = names.indices.filter { on($0) }.map { names[$0] }.joined(separator: "+")
             #expect(active == [expected], "[\(shape.isEmpty ? "bare" : shape)] resolved to \(active)")
-            #expect(TerminalZoomController.resolveTarget(store: store, quickTerminalVisible: false)
+            #expect(TerminalZoomController.resolveTarget(store: store)
                 == .session(session.id, expected), "[\(shape.isEmpty ? "bare" : shape)] wrong zoom target")
             // a pane overlay is only ever the active target while its own pane is the one on screen.
             if expected == .overlayLeft || expected == .overlayRight {
@@ -226,20 +234,18 @@ struct TerminalZoomTests {
 
         #expect(TerminalZoomSurface.allCases.filter { $0.isActive(in: session) } == [.primary])
         #expect(TerminalZoomSurface.primary.isVisible(in: session))
-        #expect(TerminalZoomController.resolveTarget(store: store, quickTerminalVisible: false)
+        #expect(TerminalZoomController.resolveTarget(store: store)
             == .session(session.id, .primary))
 
         #expect(!TerminalZoomSurface.overlay.isAvailable(in: session))
         #expect(!TerminalZoomSurface.overlay.isVisible(in: session))
-        #expect(!TerminalZoomController.isTargetValid(.session(session.id, .overlay), in: store,
-                                                     quickTerminalVisible: false))
+        #expect(!TerminalZoomController.isTargetValid(.session(session.id, .overlay), in: store))
 
         // the refusal is about the HUD, not the slot: a program taking the same slot is addressable again.
         #expect(store.openOverlay(session.id, command: "top"))
         #expect(TerminalZoomSurface.overlay.isAvailable(in: session))
         #expect(TerminalZoomSurface.allCases.filter { $0.isActive(in: session) } == [.overlay])
-        #expect(TerminalZoomController.isTargetValid(.session(session.id, .overlay), in: store,
-                                                    quickTerminalVisible: false))
+        #expect(TerminalZoomController.isTargetValid(.session(session.id, .overlay), in: store))
     }
 
     @Test func aHudLeavesTheScratchAndPaneOverlayTargetsIntact() {
@@ -254,14 +260,14 @@ struct TerminalZoomTests {
         store.toggleScratch(session.id)
         #expect(TerminalZoomSurface.allCases.filter { $0.isActive(in: session) } == [.scratch])
         #expect(TerminalZoomSurface.scratch.isVisible(in: session))
-        #expect(TerminalZoomController.resolveTarget(store: store, quickTerminalVisible: false)
+        #expect(TerminalZoomController.resolveTarget(store: store)
             == .session(session.id, .scratch))
         store.toggleScratch(session.id)
 
         #expect(store.openPaneOverlay(session.id, pane: .left, command: "top") == nil)
         #expect(TerminalZoomSurface.allCases.filter { $0.isActive(in: session) } == [.overlayLeft])
         #expect(TerminalZoomSurface.overlayLeft.isVisible(in: session))
-        #expect(TerminalZoomController.resolveTarget(store: store, quickTerminalVisible: false)
+        #expect(TerminalZoomController.resolveTarget(store: store)
             == .session(session.id, .overlayLeft))
     }
 

--- a/agtermTests/ControlServerPickTests.swift
+++ b/agtermTests/ControlServerPickTests.swift
@@ -14,7 +14,6 @@ final class ControlServerPickTests: XCTestCase {
     private var registeredPickIDs: Set<WindowInfo.ID> = []
     private var registeredWindows: [WindowInfo.ID: NSWindow] = [:]
     private var registeredZoomIDs: Set<WindowInfo.ID> = []
-    private var registeredQuickIDs: Set<WindowInfo.ID> = []
     private var registeredDashboardIDs: Set<WindowInfo.ID> = []
 
     override func setUp() async throws {
@@ -45,9 +44,6 @@ final class ControlServerPickTests: XCTestCase {
             for id in registeredZoomIDs {
                 TerminalZoomRegistry.shared.unregister(id)
             }
-            for id in registeredQuickIDs {
-                QuickTerminalRegistry.shared.unregister(id)
-            }
             for id in registeredDashboardIDs {
                 DashboardControllerRegistry.shared.unregister(id)
             }
@@ -57,7 +53,6 @@ final class ControlServerPickTests: XCTestCase {
             }
             registeredPickIDs.removeAll()
             registeredZoomIDs.removeAll()
-            registeredQuickIDs.removeAll()
             registeredDashboardIDs.removeAll()
             registeredWindows.removeAll()
             server = nil
@@ -222,9 +217,6 @@ final class ControlServerPickTests: XCTestCase {
         let pick = registerPick(windowID)
         XCTAssertTrue(pick.open(makePick("modal-owner")))
 
-        let quick = QuickTerminalController()
-        QuickTerminalRegistry.shared.register(windowID, controller: quick)
-        registeredQuickIDs.insert(windowID)
         let zoom = TerminalZoomController()
         TerminalZoomRegistry.shared.register(windowID, controller: zoom)
         registeredZoomIDs.insert(windowID)

--- a/agtermTests/DockMenuTests.swift
+++ b/agtermTests/DockMenuTests.swift
@@ -19,7 +19,6 @@ final class DockMenuTests: XCTestCase {
     private struct CapturedTopLevelActions {
         let store: AppStore
         let current: Session
-        let quick: QuickTerminalController
         let dashboard: DashboardController
         let zoom: TerminalZoomController
         let menu: NSMenu
@@ -49,7 +48,6 @@ final class DockMenuTests: XCTestCase {
         await MainActor.run {
             delegate.dockMenuActionTargets.removeAll()
             for id in registeredWindowIDs {
-                QuickTerminalRegistry.shared.unregister(id)
                 DashboardControllerRegistry.shared.unregister(id)
                 TerminalZoomRegistry.shared.unregister(id)
             }
@@ -93,8 +91,8 @@ final class DockMenuTests: XCTestCase {
             "Recent Sessions", "Sessions Needing Attention",
         ])
         XCTAssertTrue(try item("New Session", in: menu).isEnabled)
-        XCTAssertFalse(try item("Quick Terminal", in: menu).isEnabled,
-                       "quick terminal requires the captured window's registered controller")
+        XCTAssertTrue(try item("Quick Terminal", in: menu).isEnabled,
+                      "the quick terminal is app-level, so it needs no registered per-window controller")
         XCTAssertFalse(try item("Dashboard", in: menu).isEnabled,
                        "dashboard requires the captured window's registered controller")
         XCTAssertEqual(try submenu("Recent Sessions", in: menu).items.map(\.title), ["No Recent Sessions"])
@@ -103,10 +101,9 @@ final class DockMenuTests: XCTestCase {
                        ["No Sessions Need Attention"])
         XCTAssertFalse(try submenu("Sessions Needing Attention", in: menu).items[0].isEnabled)
 
-        let quick = QuickTerminalController()
         let dashboard = DashboardController()
         let zoom = TerminalZoomController()
-        register(windowID, quick: quick, dashboard: dashboard, zoom: zoom)
+        register(windowID, dashboard: dashboard, zoom: zoom)
 
         menu = try dockMenu()
         XCTAssertTrue(try item("Quick Terminal", in: menu).isEnabled)
@@ -138,10 +135,9 @@ final class DockMenuTests: XCTestCase {
     // state that makes them inert. Discussion #313.
     func testNewWindowStaysEnabledUnderModalsAndOpensAWindow() throws {
         let windowID = try activeWindowID()
-        let quick = QuickTerminalController()
         let dashboard = DashboardController()
         let zoom = TerminalZoomController()
-        register(windowID, quick: quick, dashboard: dashboard, zoom: zoom)
+        register(windowID, dashboard: dashboard, zoom: zoom)
         let current = try XCTUnwrap(library.activeStore?.activeSession)
 
         zoom.set(.on, target: .session(current.id, .primary))
@@ -308,12 +304,10 @@ final class DockMenuTests: XCTestCase {
         let storeA = try activeStore()
         let windowB = library.newWindow(name: "window B").id
         let storeB = try XCTUnwrap(library.store(for: windowB))
-        let quickA = QuickTerminalController()
-        let quickB = QuickTerminalController()
         let dashboardA = DashboardController()
         let dashboardB = DashboardController()
-        register(windowA, quick: quickA, dashboard: dashboardA, zoom: TerminalZoomController())
-        register(windowB, quick: quickB, dashboard: dashboardB, zoom: TerminalZoomController())
+        register(windowA, dashboard: dashboardA, zoom: TerminalZoomController())
+        register(windowB, dashboard: dashboardB, zoom: TerminalZoomController())
 
         library.frontmostWindowID = windowA
         let capturedMenu = try dockMenu()
@@ -329,11 +323,9 @@ final class DockMenuTests: XCTestCase {
         XCTAssertEqual(storeB.workspaces.flatMap(\.sessions).count, sessionCountB)
         XCTAssertEqual(library.frontmostWindowID, windowA)
 
-        library.frontmostWindowID = windowB
-        try invokeWithNilSender(try item("Quick Terminal", in: capturedMenu))
-        XCTAssertTrue(quickA.isVisible)
-        XCTAssertFalse(quickB.isVisible)
-        XCTAssertEqual(library.frontmostWindowID, windowA)
+        // Quick Terminal is deliberately absent from this scoping check: there is one panel per app, so it
+        // has no per-window state for a captured item to hold on to. Invoking it here would summon the panel
+        // and spawn its shell; the modal-gate tests above cover that its item stays inert when it should.
 
         library.frontmostWindowID = windowB
         try invokeWithNilSender(try item("Dashboard", in: capturedMenu))
@@ -358,7 +350,7 @@ final class DockMenuTests: XCTestCase {
         }
 
         XCTAssertEqual(context.store.workspaces.flatMap(\.sessions).count, context.sessionCount)
-        XCTAssertFalse(context.quick.isVisible)
+        XCTAssertFalse(QuickTerminalController.shared.isVisible)
         XCTAssertTrue(context.dashboard.isOpen,
                       "a Dashboard item built while closed must not close a post-build dashboard")
     }
@@ -378,7 +370,7 @@ final class DockMenuTests: XCTestCase {
         }
 
         XCTAssertEqual(context.store.workspaces.flatMap(\.sessions).count, context.sessionCount)
-        XCTAssertFalse(context.quick.isVisible)
+        XCTAssertFalse(QuickTerminalController.shared.isVisible)
         XCTAssertFalse(context.dashboard.isOpen)
         XCTAssertEqual(context.zoom.target, target)
     }
@@ -595,9 +587,8 @@ final class DockMenuTests: XCTestCase {
         ))
         let windowB = library.newWindow(name: "window B").id
         let windowBSession = try XCTUnwrap(library.store(for: windowB)?.activeSession?.id)
-        let quick = QuickTerminalController()
         let dashboard = DashboardController()
-        register(windowA, quick: quick, dashboard: dashboard, zoom: TerminalZoomController())
+        register(windowA, dashboard: dashboard, zoom: TerminalZoomController())
         library.frontmostWindowID = windowA
 
         let menu = try dockMenu()
@@ -613,7 +604,7 @@ final class DockMenuTests: XCTestCase {
             try invokeWithNilSender(try item(title, in: menu))
         }
         XCTAssertEqual(retainedStore?.workspaces.flatMap(\.sessions).count, sessionCount)
-        XCTAssertFalse(quick.isVisible)
+        XCTAssertFalse(QuickTerminalController.shared.isVisible)
         XCTAssertFalse(dashboard.isOpen)
         XCTAssertEqual(library.frontmostWindowID, windowB)
 
@@ -668,10 +659,9 @@ final class DockMenuTests: XCTestCase {
         let windowID = try activeWindowID()
         let store = try activeStore()
         let current = try XCTUnwrap(store.activeSession)
-        let quick = QuickTerminalController()
         let dashboard = DashboardController()
         let zoom = TerminalZoomController()
-        register(windowID, quick: quick, dashboard: dashboard, zoom: zoom)
+        register(windowID, dashboard: dashboard, zoom: zoom)
         let menu = try dockMenu()
         for title in ["New Session", "Quick Terminal", "Dashboard"] {
             XCTAssertTrue(try item(title, in: menu).isEnabled)
@@ -679,7 +669,6 @@ final class DockMenuTests: XCTestCase {
         return CapturedTopLevelActions(
             store: store,
             current: current,
-            quick: quick,
             dashboard: dashboard,
             zoom: zoom,
             menu: menu,
@@ -712,12 +701,10 @@ final class DockMenuTests: XCTestCase {
 
     private func register(
         _ windowID: UUID,
-        quick: QuickTerminalController? = nil,
         dashboard: DashboardController? = nil,
         zoom: TerminalZoomController? = nil
     ) {
         registeredWindowIDs.insert(windowID)
-        if let quick { QuickTerminalRegistry.shared.register(windowID, controller: quick) }
         if let dashboard { DashboardControllerRegistry.shared.register(windowID, controller: dashboard) }
         if let zoom { TerminalZoomRegistry.shared.register(windowID, controller: zoom) }
     }

--- a/agtermUITests/MultiWindowUITests.swift
+++ b/agtermUITests/MultiWindowUITests.swift
@@ -376,7 +376,10 @@ final class MultiWindowUITests: XCTestCase {
         XCTAssertTrue(settled, "win-a should be marked closed and win-b open, got \(String(describing: indexOpenState()))")
     }
 
-    func testQuickTerminalIsPerWindow() throws {
+    /// One panel for the whole app, not one per window: showing it with two windows open yields a single
+    /// surface, and it stays up and addressable when the other window becomes frontmost — the contract that
+    /// replaced the per-window registry.
+    func testQuickTerminalIsOnePanelForTheApp() throws {
         try seedTwoWindows()
         launch()
 
@@ -391,8 +394,15 @@ final class MultiWindowUITests: XCTestCase {
 
         let shown = try sendCommand(#"{"cmd":"quick","args":{"mode":"show"}}"#)
         XCTAssertEqual(shown["ok"] as? Bool, true, "quick show should succeed: \(shown)")
-        XCTAssertTrue(quick.firstMatch.waitForExistence(timeout: 10), "the frontmost quick terminal should appear")
-        XCTAssertEqual(quick.count, 1, "only the frontmost window's quick terminal should show, got \(quick.count)")
+        XCTAssertTrue(quick.firstMatch.waitForExistence(timeout: 10), "the quick-terminal panel should appear")
+        XCTAssertEqual(quick.count, 1, "one panel for the whole app, got \(quick.count)")
+
+        // the panel belongs to no window, so selecting the other one neither hides it nor mints a second.
+        for id in [windowBID, windowAID] {
+            let selected = try sendCommand(#"{"cmd":"window.select","args":{"target":"\#(id.uuidString)"}}"#)
+            XCTAssertEqual(selected["ok"] as? Bool, true, "window.select should succeed: \(selected)")
+            XCTAssertEqual(quick.count, 1, "the panel should survive a frontmost change, got \(quick.count)")
+        }
 
         let hidden = try sendCommand(#"{"cmd":"quick","args":{"mode":"hide"}}"#)
         XCTAssertEqual(hidden["ok"] as? Bool, true, "quick hide should succeed: \(hidden)")

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -51,8 +51,9 @@ the control channel is available:
   per-surface token; the agent-status hook forwards them as `session status --pane` / `--pane-id`. The
   token resolves the pane's LIVE slot, so a promoted-then-re-split agent still tags the right pane.
 
-The quick terminal is scratch (not in the tree), so it only gets `AGTERM_ENABLED`, `AGTERM_WINDOW_ID`,
-and `AGTERM_SOCKET` (no session/workspace ids).
+The quick terminal is scratch (not in the tree) and belongs to no window, so it only gets
+`AGTERM_ENABLED` and `AGTERM_SOCKET` (no session/workspace/window ids). An untargeted `agtermctl` run
+from it therefore resolves the active window like any other caller.
 
 These variables are inherited by every process the session's shell spawns — including long-lived
 daemons that outlive the shell. A tmux/screen server, a session manager (agent-deck and the like), or
@@ -90,8 +91,9 @@ shell, toggled like the split), and an ephemeral **overlay** (runs one program o
 An overlay covers the whole session, or with `--pane left|right` exactly one split pane, leaving the
 sibling pane visible and usable. The same session-wide slot also holds a **HUD** (`session hud`), a small
 passive panel carrying a message instead of a program: the session keeps focus and stays typable under it.
-One slot, so a session shows either a HUD or a program overlay, never both. Separately, each window has one
-**quick terminal** (a scratch overlay at 90% of the window, not part of the tree).
+One slot, so a session shows either a HUD or a program overlay, never both. Separately, the app has one
+**quick terminal** (a scratch shell in a floating panel at 90% of the focused screen, not part of the tree
+and not owned by a window).
 
 Inspect the live tree any time with `agtermctl tree --json` (workspaces → sessions, each with
 `id`, `name`, `cwd`, `title`, `active`, `split`, `overlay`, `hud`, `scratch`, `status`, `background`, `surfaces`). `title` is the raw OSC
@@ -102,8 +104,9 @@ control address for `surface zoom` (`left`, `right`, `scratch`, `overlay`, `over
 read-only top-level fields: `idleMs` (ms since the last user input in the window), `autoFollowMs`
 (the Auto-follow timeout in ms, omitted when Disabled), `sidebarVisible` (whether the window's
 sidebar is currently shown — the read side of the write-only `sidebar` command), `sidebarMode`
-(`tree` or `flagged` — the read side of `sidebar mode`), and `quickVisible` (whether the window's quick
-terminal is shown — the read side of the write-only `quick` command). List windows with
+(`tree` or `flagged` — the read side of `sidebar mode`), and `quickVisible` (whether the quick terminal is
+shown — the read side of the write-only `quick` command; app-level, so every window reports the same
+value). List windows with
 `agtermctl window list --json`; each window also reports `autoFollowMs`, `sidebarVisible`, `geometry`
 (the live frame `{x, y, width, height, display}` in the units `window move`/`window resize` take — the
 read side, so record it then restore the exact frame), and `fullscreen`/`zoomed`/`minimized` (the read side
@@ -405,7 +408,9 @@ window; read back as `minimized` on `window list`).
 — zoom a terminal surface to fill the window (sidebar hidden; a slim title-bar strip with an exit
 button remains). Omit `--target` to use the active surface;
 copy an explicit surface id from `tree --json` to address a hidden split/scratch or a background
-session (`quick` is the id returned for a quick-terminal zoom). `hide` exits zoom; `toggle`
+session. `quick` is the one target that is not a window surface: it grows the quick-terminal panel to
+fill its screen, takes no `--window`, is refused while the panel is hidden, and is never what an omitted
+`--target` resolves to. `hide` exits zoom; `toggle`
 enters/exits only this zoom mode, not macOS window zoom.
 
 **dashboard** — `dashboard <ids…> [--font-size N | --auto-size] [--window W]` opens a view-only grid
@@ -445,10 +450,12 @@ result. `--no-block` prints the picker id instead;
 Only one picker may be pending per window. It opens without raising a background target unless
 `--follow` is set. Read the live picker id from the tree's top-level `pickPending` field.
 
-**quick** — `[show|hide|toggle]` (visibility; read back from the tree's `quickVisible`) ·
-`type TEXT` (or `--stdin`) inject keystrokes into the frontmost window's quick terminal ·
-`text [--all] [--lines N]` read its screen back — the twins of `session type`/`session text`,
-frontmost-window-only (no `--target`/`--window`/`--pane`).
+**quick** — `[show|hide|toggle]` (visibility; read back from the tree's `quickVisible`; a panel YOU open
+with `quick show` stays up when agterm loses focus, unlike one the user summoned by hotkey, so a following
+`quick type` / `quick text` / `surface zoom --target quick` still finds it) ·
+`type TEXT` (or `--stdin`) inject keystrokes into the quick terminal ·
+`text [--all] [--lines N]` read its screen back — the twins of `session type`/`session text`. There is one
+per app, so none of them take `--target`/`--window`/`--pane`; all three still need an open window.
 
 **sidebar** — `[show|hide|toggle]` (visibility; read back from the tree's `sidebarVisible`) ·
 `mode [tree|flagged|toggle]` (flip between the workspace tree and the flat flagged working-set list; read

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -207,7 +207,9 @@ every window reports the same value), `zoomedSurface`
 (the control id of the surface terminal zoom currently fills the window with —
 `surface:<session-id>:<kind>` or `quick`; omitted when nothing is zoomed — the read side of the
 write-only `surface zoom` command, so a script can check "is it already zoomed" and
-record-then-restore), and the four read sides of the write-only `dashboard` command (all omitted when
+record-then-restore. `quick` is app-level and independent of any window's zoom, and it WINS: with the
+panel zoomed this reports `quick` even while that window's own session zoom is armed and rendering, so
+record-then-restore must read it BEFORE zooming the panel, not after), and the four read sides of the write-only `dashboard` command (all omitted when
 no dashboard is open): `dashboardMembers` (the pane refs the open dashboard shows, in grid order —
 `<session-id>:left` for a primary pane, `<session-id>:right` for a split pane, so a split session appears
 as both), `dashboardHighlighted` (the highlighted cell's pane ref — the one Enter jumps into, focusing

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -201,8 +201,9 @@ visible before), `sidebarMode` (`tree` or `flagged` — the sidebar view mode, t
 `sidebar mode`), `workspaceFilter` (whether the window's workspace focus filter is currently APPLIED —
 the flag half of the focus set, whose member half is each workspace node's `focused`; the read side of
 `workspace filter`, so a script can record the filter state, restore it, or make the toggle idempotent),
-`quickVisible` (whether the window's quick terminal is currently shown — the read
-side of the write-only `quick` command, so a script can make the toggle idempotent), `zoomedSurface`
+`quickVisible` (whether the quick terminal is currently shown — the read
+side of the write-only `quick` command, so a script can make the toggle idempotent; it is app-level, so
+every window reports the same value), `zoomedSurface`
 (the control id of the surface terminal zoom currently fills the window with —
 `surface:<session-id>:<kind>` or `quick`; omitted when nothing is zoomed — the read side of the
 write-only `surface zoom` command, so a script can check "is it already zoomed" and
@@ -774,8 +775,10 @@ lights and an exit button remains). `SURFACE_ID` comes from
 `agtermctl tree --json` at `.result.tree.workspaces[].sessions[].surfaces[].id`, for example
 `surface:<session-id>:right` for the split pane or `surface:<session-id>:overlay-right` for a pane
 overlay covering it. Omit `--target` (or pass `active`) to act on the active surface in the
-frontmost or `--window` window; `quick` addresses a quick-terminal zoom (the id the command itself
-returns when the quick terminal is the zoom target). A HUD is not a zoom target: while one is up the
+frontmost or `--window` window. `quick` is the one target that is not a window surface: it grows the
+quick-terminal panel to fill its screen instead, takes no `--window`, is refused with `surface not
+available: quick` while the panel is hidden, and is never what an omitted `--target` resolves to.
+A HUD is not a zoom target: while one is up the
 session lists no overlay surface and `surface:<session-id>:overlay` is refused with `surface not
 available`, the same answer an empty slot gives.
 
@@ -786,8 +789,8 @@ back from the tree's top-level `zoomedSurface` (the zoomed surface's control id,
 is zoomed). This is NOT
 `window zoom`: it does not change the macOS window frame and it must not mutate split ratios, focus,
 sidebar state, or split/scratch visibility. Entering zoom does close the window's transient chrome —
-an open command palette, an active in-terminal search, and (for a session-surface zoom) a visible
-quick terminal. While zoomed, the hidden deck keeps running: `session.split`/`session.scratch`/overlay
+an open command palette and an active in-terminal search. The quick terminal is NOT closed: it is a panel
+above every window rather than a surface inside one. While zoomed, the hidden deck keeps running: `session.split`/`session.scratch`/overlay
 opens on the zoomed session still spawn their shells behind the zoom layer. A notification-banner
 click exits zoom before revealing its session. Use `surface zoom` when the user/agent needs a pane
 fullscreen inside agterm; use `window zoom` only to maximize the whole window on screen.
@@ -1031,13 +1034,19 @@ line can express — such an item is AppKit's own and never matches an action.
 ### keymap.conf format
 
 The file lives at `<config dir>/keymap.conf` (default `~/.config/agterm`; the dir is set in Settings ▸
-Key Mapping). Two verbs, line-based; blank lines and `#` comments ignored:
+Key Mapping). Three verbs, line-based; blank lines and `#` comments ignored:
 
 - `map <chord> <action>` — rebind a built-in menu action.
 - `command "<name>" [chord] <shell...>` — define a custom shell command, listed in the action palette
   marked `custom`. The quoted name may contain spaces. The post-name token is the chord only if it
   parses AND carries a modifier (a bare modifier-less key is rejected). A custom chord may be a leader
   sequence (chords joined by `>`, e.g. `ctrl+a>g`). No chord → palette-only.
+- `global-hotkey <chord>` — bind ONE system-wide chord that summons the quick terminal while any
+  application is frontmost. Unset unless the line is present. Exactly one chord: no alternatives, no
+  leader sequence, and it must carry a modifier. A second line replaces the first. macOS registers it
+  by physical key position, so it survives a layout switch. It is registered with the OS rather than
+  agterm's own monitor, so it takes NO part in the collision rules below — it may share a chord with a
+  menu item, and whichever application is frontmost decides who gets the key.
 
 Either verb's chord token may hold **alternatives** joined by `|`, with no spaces around it (everything
 after the first token is the shell line): `map cmd+t|ctrl+space>s toggle_split` fires the action from

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -911,11 +911,14 @@ it waited for. Results age out oldest-first: the 8 most recent per open window, 
 
 ## quick
 
-`agtermctl quick [show|hide|toggle]` — the frontmost window's quick terminal (a single scratch
-terminal at 90% of the window, not in the tree; its shell stays alive across hides). Errors with
-`no open window` when none is open. Read its visibility back from the tree's top-level `quickVisible`.
-While terminal zoom is active, `show` errors with `terminal zoom active`; `hide` always succeeds (a
-zoomed quick terminal exits its zoom first), so cleanup scripts can dismiss it unconditionally.
+`agtermctl quick [show|hide|toggle]` — the app's one quick terminal (a single scratch terminal in a
+floating panel at 90% of the focused screen up to 1100x700, not in the tree and owned by no window; its
+shell stays alive across hides). Errors with `no open window` when none is open, and with `pick pending`
+while a picker is up. Read its visibility back from the tree's top-level `quickVisible`.
+A panel YOU open with `show` stays up when agterm loses focus — including when it was already visible
+because the user had summoned it by hotkey — so a following `quick type` / `quick text` /
+`surface zoom --target quick` still finds it. A window's terminal zoom is not a term either way: the panel
+floats above every window, so `show` is never refused for it.
 
 `agtermctl quick type TEXT` (or `--stdin`) — inject `TEXT` as literal keystrokes into the frontmost
 window's quick terminal, the quick-terminal twin of `session type`. There is no `--target`/`--window`
@@ -1053,7 +1056,9 @@ after the first token is the shell line): `map cmd+t|ctrl+space>s toggle_split` 
 either. A built-in's first single-chord alternative the menu can carry becomes its menu shortcut (one that
 names a reserved chord or a bare arrow is diagnosed and dropped, and the next single chord takes the slot);
 every other alternative, and every alternative of a `command`, is delivered by a key monitor and so must
-carry a modifier on its first chord. A `map` line with no single-chord alternative
+carry a modifier on its first chord. `global-hotkey` is outside all of this: the OS owns it, and it WINS —
+agterm frontmost included — so a chord it shares with a menu action fires the panel and the menu binding
+never sees it. A `map` line with no single-chord alternative
 (`map ctrl+a>s toggle_split`) leaves the action with NO menu shortcut — its shipped default is gone, not
 kept. A malformed alternative rejects the whole line; one that merely breaks a rule or collides with
 another binding drops by itself and its siblings keep working. A line left binding nothing at all leaves

--- a/site/commands.html
+++ b/site/commands.html
@@ -1939,13 +1939,20 @@
                 Fill the window with one terminal surface, hiding the sidebar and collapsing the title bar to a slim strip
                 (traffic lights plus an exit button). Omit
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--target</span> (or pass
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">active</span>) to zoom the active surface — the quick
-                terminal if shown, else the active session's overlay, scratch, the focused pane's own overlay, or that pane. An explicit
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">active</span>) to zoom the active surface — the active
+                session's overlay, scratch, the focused pane's own overlay, or that pane. An explicit
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">surface:&lt;session-id&gt;:&lt;left|right|scratch|overlay|overlay-left|overlay-right&gt;</span>
                 id (from <span style="font-family: &quot;JetBrains Mono&quot;, monospace">tree</span>'s
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">surfaces[].id</span>) zooms that exact surface, including a
-                hidden-but-alive split or scratch; <span style="font-family: &quot;JetBrains Mono&quot;, monospace">quick</span> addresses a
-                quick-terminal zoom.
+                hidden-but-alive split or scratch.
+              </p>
+              <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">quick</span> is the one target that is not a window's
+                surface: it grows the quick-terminal panel to fill its screen instead. It takes no
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--window</span>, is refused with
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">surface not available: quick</span> while the panel is
+                hidden, and is never what an omitted <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--target</span>
+                resolves to.
               </p>
               <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">show</span> is idempotent;
@@ -2162,11 +2169,17 @@
               quick
             </h2>
             <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 16px">
-              The frontmost window's quick terminal — a single scratch terminal at 90% of the window, not in the tree, whose shell
-              stays alive across hides. All three are frontmost-window-only: no
+              The quick terminal — one scratch terminal for the whole app, shown in a floating panel at 90% of whichever screen
+              has focus rather than inside a window, not in the tree, whose shell stays alive across hides. A panel the user
+              summoned closes when it loses keyboard focus; one opened by
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">quick show</span> stays up until something hides it,
+              so a following <span style="font-family: &quot;JetBrains Mono&quot;, monospace">quick type</span> or
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">surface zoom --target quick</span> still finds it.
+              All three take no
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--target</span>,
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--window</span>, or
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--pane</span>.
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--pane</span>: there is only one. They still need an open
+              window, agterm quitting when the last one closes.
             </p>
 
             <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">

--- a/site/commands.html
+++ b/site/commands.html
@@ -1966,6 +1966,9 @@
                 Read the current zoom back from the tree's top-level
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">zoomedSurface</span> (the zoomed surface's control id, or
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">quick</span>; omitted when nothing is zoomed).
+                The panel's zoom is app-level and independent of any window's, and it takes precedence: while it is zoomed the
+                field reads <span style="font-family: &quot;JetBrains Mono&quot;, monospace">quick</span> even if that window's own
+                session zoom is armed. Record the value before zooming the panel, not after.
               </p>
             </div>
           </section>

--- a/site/commands.html
+++ b/site/commands.html
@@ -2170,7 +2170,7 @@
             </h2>
             <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 16px">
               The quick terminal — one scratch terminal for the whole app, shown in a floating panel at 90% of whichever screen
-              has focus rather than inside a window, not in the tree, whose shell stays alive across hides. A panel the user
+              has focus, capped at 1100x700, rather than inside a window; not in the tree, and its shell stays alive across hides. A panel the user
               summoned closes when it loses keyboard focus; one opened by
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace">quick show</span> stays up until something hides it,
               so a following <span style="font-family: &quot;JetBrains Mono&quot;, monospace">quick type</span> or

--- a/site/docs.html
+++ b/site/docs.html
@@ -1939,8 +1939,9 @@
               must carry a modifier, takes no alternatives and no leader sequence, and a second
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">global-hotkey</span> line replaces the
               first. macOS registers it by physical key position, so it keeps firing on a non-Latin layout. Because the system owns
-              it rather than agterm, it takes no part in the collision rules below — it may share a chord with a menu item, and
-              whichever application is in front decides who receives it. It is unset unless you add the line.
+              it rather than agterm, it takes no part in the collision rules below. Note which side wins: the system-wide chord
+              takes the key even while agterm is in front, so binding one a menu item already uses means that menu shortcut stops
+              firing. It is unset unless you add the line.
             </p>
             <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
               One binding can offer several <strong style="color: #e6e1d7">alternatives</strong>, joined by

--- a/site/docs.html
+++ b/site/docs.html
@@ -723,9 +723,13 @@
                   Quick terminal <span style="color: #6b727a">⌃`</span>
                 </div>
                 <p style="font-size: 15px; line-height: 1.6; color: #949ba4; margin: 0">
-                  A single throwaway shell per window, not tied to any session, overlaid at 90% of the window and opening in the
-                  active session's directory. Click again or the surrounding margin to dismiss; hiding keeps its shell alive. Not
-                  restored across launches.
+                  A single throwaway shell for the whole app, not tied to any session or window. It appears in a floating panel at
+                  90% of whichever screen has focus, on the Space you are currently on, and opens in the active session's
+                  directory, sized to 90% of that screen up to a comfortable maximum. Bind a system-wide chord with
+                  <code style="color: #e6e1d7">global-hotkey</code> in <code style="color: #e6e1d7">keymap.conf</code> and it
+                  summons agterm from any application. Press the key again, or click away, to dismiss it; hiding keeps its shell
+                  alive. A panel opened by <code style="color: #e6e1d7">agtermctl quick show</code> stays put instead of closing
+                  on click-away, so a script can drive it. Not restored across launches.
                 </p>
               </div>
               <div
@@ -781,7 +785,7 @@
                   Terminal zoom <span style="color: #6b727a">⇧⌘↩</span>
                 </div>
                 <p style="font-size: 15px; line-height: 1.6; color: #949ba4; margin: 0">
-                  Fills the whole window with one terminal surface — a pane, the scratch, an overlay, or the quick terminal —
+                  Fills the whole window with one terminal surface — a pane, the scratch, or an overlay —
                   hiding the sidebar and collapsing the title bar to a slim strip with the traffic lights, the window title, and an exit button
                   (⌘W leaves zoom too). A view mode, not a layout change: exiting
                   restores split ratios, focus, and visibility exactly as they were, and everything else keeps running behind it.
@@ -1860,7 +1864,7 @@
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #e6e1d7">~/.config/agterm/keymap.conf</span
               >. It rebinds built-in menu shortcuts and defines custom shell commands bound to keys (and listed in the action
               palette). The file is optional — a commented starter is written on first launch, and the directory can be changed in
-              <strong style="color: #e6e1d7">Settings ▸ Key Mapping</strong>. Two verbs; blank lines and
+              <strong style="color: #e6e1d7">Settings ▸ Key Mapping</strong>. Three verbs; blank lines and
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">#</span> comments are ignored.
             </p>
             <div
@@ -1894,7 +1898,10 @@
               <span style="color: #f2b45c">"Lazygit"</span
               >&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ctrl+a&gt;g&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;agtermctl session overlay open 'zsh -lc lazygit'
               --socket {AGT_SOCKET}<br /><span style="color: #5ea1f2">command</span>
-              <span style="color: #f2b45c">"Deploy"</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;./deploy.sh
+              <span style="color: #f2b45c">"Deploy"</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;./deploy.sh<br /><br /><span
+                style="color: #6b727a"
+                ># one system-wide chord that summons the quick terminal from any application</span
+              ><br /><span style="color: #5ea1f2">global-hotkey</span> ctrl+opt+space
             </div>
             <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
               A chord is modifier words (<span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc"
@@ -1924,6 +1931,16 @@
               shifted symbol. Custom commands may also use a leader sequence
               (<span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">ctrl+a&gt;g</span>), and their chord
               must include a modifier — a bare key can't shadow a plain terminal key.
+            </p>
+            <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">global-hotkey</span> takes exactly one
+              chord and binds it <strong style="color: #e6e1d7">system-wide</strong>: it summons the quick terminal while any
+              application is frontmost, which no other binding here can do — the rest only fire while agterm has the keyboard. It
+              must carry a modifier, takes no alternatives and no leader sequence, and a second
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">global-hotkey</span> line replaces the
+              first. macOS registers it by physical key position, so it keeps firing on a non-Latin layout. Because the system owns
+              it rather than agterm, it takes no part in the collision rules below — it may share a chord with a menu item, and
+              whichever application is in front decides who receives it. It is unset unless you add the line.
             </p>
             <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
               One binding can offer several <strong style="color: #e6e1d7">alternatives</strong>, joined by

--- a/site/index.html
+++ b/site/index.html
@@ -684,8 +684,9 @@
               </h3>
             </div>
             <p style="font-size: 14.5px; line-height: 1.6; color: #949ba4; margin: 0">
-              One window-wide scratch, overlaid at 90% and shared across the window. It opens in the active session's directory
-              for a fast aside — dismiss it with the same key or a click on the margin.
+              One scratch shell for the whole app, in a floating panel at 90% of whichever screen has focus. Give it a
+              system-wide hotkey and it drops onto the Space you are on from any application, opening in the active session's
+              directory — dismiss it with the same key or by clicking away.
             </p>
           </div>
 

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -10,7 +10,7 @@ agterm is a native macOS terminal, built on libghostty (Ghostty's engine), with 
 - Agent-status glyphs on sidebar rows: active, blocked, completed, idle — auto-wired for Claude Code, Codex, Pi, and OpenCode
 - agtermctl control CLI over a local unix-domain socket: create, rename, move, and type into sessions, run overlays, move windows, capture output, post notifications tied to a session
 - Installable agent skill that teaches Claude Code and Codex the control model and the full agtermctl command set
-- Surfaces per session: split panes (two shells), a per-session scratch terminal, a window-wide quick terminal, and floating/full overlays
+- Surfaces per session: split panes (two shells), a per-session scratch terminal, and floating/full overlays; plus one app-wide quick terminal in a floating panel, summonable by a system-wide hotkey
 - Multi-window: a library of windows (e.g. "work" and "personal"), one per screen, restored on next launch
 - 512 bundled themes with a live-preview picker, fully rebindable kitty-flavored keymap.conf, and full session persistence
 - In-terminal search, fuzzy command palettes, and a Ctrl-Tab MRU session switcher


### PR DESCRIPTION
Detaches the quick terminal from the window and gives it a system-wide hotkey, so it can be summoned over whatever you are working in and dismissed back to it. Asked for in discussion #438.

**What changed**

The quick terminal was a per-window SwiftUI overlay, reachable only while agterm already had the keyboard. It is now one panel for the whole app, in its own floating `NSPanel` that drops onto whichever screen and Space has focus.

It never calls `NSApp.activate`. Activating raises every agterm window over the application you summoned it from, so dismissing would leave you in agterm rather than back where you were, which defeats the point. `.nonactivatingPanel` is what lets it take the keyboard while agterm stays inactive, so hiding returns focus with nothing to restore.

`keymap.conf` gains a third verb:

```
global-hotkey ctrl+opt+space
```

One chord, modifier required, no alternatives and no leader sequence. It goes through Carbon `RegisterEventHotKey`, which needs no Accessibility grant and registers by physical key position, so it survives a layout switch. The OS owns it, so it takes no part in the chord conflict model - and it wins, agterm frontmost included, so a chord shared with a menu item takes that item's shortcut away.

Size is 90% of the focused screen capped at 1100x700. The old 90%-of-a-window needed no cap; 90% of a large display is a wall of terminal.

**Behavior worth knowing**

- A panel you summon dismisses when it loses focus. A panel `agtermctl quick show` opens stays up, so a script's next command does not race the blur.
- `surface.zoom --target quick` is re-homed onto the panel and grows it to fill its screen. No window's `TerminalZoomController` can hold `.quick` any more, and `tree.zoomedSurface` reports it from app-level state, ahead of a window's own target.
- The panel's shell carries no `AGTERM_WINDOW_ID`, belonging to no window. An untargeted `agtermctl` run from it resolves the active window like any other caller.
- Deck gates, focus guards and the Command-W ladder read whether the panel owns the keyboard, not whether it is visible - a pinned panel must leave every window usable.

**Breaking**

`AGTERM_WINDOW_ID` is gone from the quick terminal's environment. Nothing else changes shape.

**Checks**

`swift test` 2561 passing, `make test-app`, `make lint` clean, plus `MultiWindowUITests/testQuickTerminalIsOnePanelForTheApp` re-pointed at the app-level contract and run.

Four review rounds over the branch; gating findings went 3, 3, 1, 0 with no finding recurring. The panel's key-window behavior is checked by hand rather than by test, the way AppKit window behavior is handled elsewhere in this repo.
