### PR TITLE
fix: skip the quit confirmation for a system-initiated quit

### DIFF
--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -131,7 +131,8 @@ paths:
   Capture no hidden split.
   Strip login `-` before shell recognition; a known shell with only flags is idle and omitted, while
   scripts/payload args remain, including `/bin/sh <script>`.
-  Force quit preserves snapshots/cwd but skips capture.
+  System shutdown, restart, and logout skip quit confirmation so `applicationWillTerminate` can capture
+  commands and flush stores. Force quit preserves earlier snapshots/cwd but skips this exit path.
   Replay arms ONLY on a launch restore: `session(from:launchRestore:)` copies
   `foregroundCommand`/`splitForegroundCommand` (like the pending override) under `launchRestore` alone,
   so a mid-run window reopen or Reopen Closed Item comes back a plain shell.

--- a/.claude/rules/windows.md
+++ b/.claude/rules/windows.md
@@ -66,8 +66,9 @@ session drag are out of scope.
   live cwd changes, which structural saves may not capture. Selection and font use a roughly 0.3-second
   `Debouncer`; structural mutations save synchronously and cancel pending saves.
 - Quit uses `applicationShouldTerminate` and a warning alert with host-free `openCounts` and
-  `QuitPrompt.message`. Skip it for no open windows, XCUITest, or an unwired library during the first
-  roughly four seconds. The GUI-only prompt is keep-in-sync exempt and manually verified.
+  `QuitPrompt.message`. Skip it for system shutdown/restart/logout, no open windows, XCUITest, or an
+  unwired library during the first roughly four seconds. The GUI-only prompt is keep-in-sync exempt and
+  manually verified.
 - App-side `WindowRegistry` maps IDs to `NSWindow`. Register/unregister through `TitleProbeView`;
   `raise` deminiaturizes and fronts, and `close` uses `performClose` so standard teardown runs.
 

--- a/agterm/AppDelegate.swift
+++ b/agterm/AppDelegate.swift
@@ -289,11 +289,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// Confirm a quit (menu Quit / ⌘Q) before the app tears down its windows — that ends every session's
-    /// shell with no undo. Reports the open-window and session counts; skips the prompt with nothing open
-    /// (the auto-quit after the last window closed) or under XCUITest, where a modal would hang terminate.
+    /// Confirm a user-initiated quit (menu Quit / ⌘Q) when windows are open. Skip system shutdown,
+    /// restart, logout, XCUITest, auto-quit after the last window closes, or an unwired library.
     func applicationShouldTerminate(_: NSApplication) -> NSApplication.TerminateReply {
         guard !ContentView.isUITestLaunch, let library else { return .terminateNow }
+        if let event = NSAppleEventManager.shared().currentAppleEvent,
+           let keyword = AEKeyword("why?"),
+           let reason = event.attributeDescriptor(forKeyword: keyword),
+           QuitReason.skipsConfirmation(typeCode: reason.typeCodeValue) {
+            return .terminateNow
+        }
         let counts = library.openCounts()
         guard counts.windows > 0 else { return .terminateNow }
         let alert = NSAlert()

--- a/agtermCore/Sources/agtermCore/QuitReason.swift
+++ b/agtermCore/Sources/agtermCore/QuitReason.swift
@@ -1,0 +1,14 @@
+public enum QuitReason {
+    private static let shutDown = fourCharacterCode("shut")
+    private static let restart = fourCharacterCode("rest")
+    private static let reallyLogOut = fourCharacterCode("rlgo")
+
+    public static func skipsConfirmation(typeCode: UInt32) -> Bool {
+        typeCode == shutDown || typeCode == restart || typeCode == reallyLogOut
+    }
+
+    private static func fourCharacterCode(_ value: String) -> UInt32 {
+        precondition(value.utf8.count == 4)
+        return value.utf8.reduce(0) { ($0 << 8) | UInt32($1) }
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/QuitReasonTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/QuitReasonTests.swift
@@ -1,0 +1,15 @@
+import Testing
+@testable import agtermCore
+
+struct QuitReasonTests {
+    @Test(arguments: ["shut", "rest", "rlgo"])
+    func systemQuitSkipsConfirmation(reason: String) {
+        let typeCode = reason.utf8.reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }
+        #expect(QuitReason.skipsConfirmation(typeCode: typeCode))
+    }
+
+    @Test func scriptedQuitKeepsConfirmation() {
+        let quitAll = "quia".utf8.reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }
+        #expect(!QuitReason.skipsConfirmation(typeCode: quitAll))
+    }
+}


### PR DESCRIPTION
`applicationShouldTerminate` put up the quit confirmation on every quit path, with nothing to tell a ⌘Q from a shutdown, restart or logout. On an unattended restart nobody answers it, macOS kills the app at the shutdown timeout, and `applicationWillTerminate` never runs. That is the only quit-time caller of `captureForegroundCommands`, and also of `saveAllOpen`, `saveIndex` and `flushPendingSaves`, so sessions and window names come back while running commands do not, live cwd is whatever the last structural save wrote, and debounced settings writes are gone.

the quit event's `why?` attribute (`kAEQuitReason`) is now read before the alert is built, and `kAEShutDown`, `kAERestart` and `kAEReallyLogOut` return `.terminateNow`. `kAEQuitAll` is deliberately not in that set, so a scripted quit still gets the prompt. `currentAppleEvent` is nil for a ⌘Q out of the Cmd-Tab view, so the read is guarded.

the classifier is host-free in `agtermCore/QuitReason.swift` with its own tests, codes built from `shut`/`rest`/`rlgo` rather than hex literals. It cannot be reached from the hosted suite: `AppDelegate.swift:296` returns `.terminateNow` under XCUITest before any of this, so a UI test would pass with or without the change. Whether macOS delivers the event before `applicationShouldTerminate` on a real restart stays a manual check.

reported by @ssgreg with a measurement on 0.22.0 and a pointer to ghostty's own implementation.

Fix #445
