### PR TITLE
fix: read the quit reason with kAEQuitReason, not a keyword built from a string

### DIFF
--- a/.claude/rules/windows.md
+++ b/.claude/rules/windows.md
@@ -67,8 +67,10 @@ session drag are out of scope.
   `Debouncer`; structural mutations save synchronously and cancel pending saves.
 - Quit uses `applicationShouldTerminate` and a warning alert with host-free `openCounts` and
   `QuitPrompt.message`. Skip it for system shutdown/restart/logout, no open windows, XCUITest, or an
-  unwired library during the first roughly four seconds. The GUI-only prompt is keep-in-sync exempt and
-  manually verified.
+  unwired library during the first roughly four seconds. The system-quit half is host-free in
+  `QuitReason.isSystemQuit`, which reads `kAEQuitReason` off the current Apple event, so the read itself
+  is under test: a keyword built as `AEKeyword("why?")` is `UInt32.init?(String)` and always nil. The
+  GUI-only prompt is keep-in-sync exempt and manually verified.
 - App-side `WindowRegistry` maps IDs to `NSWindow`. Register/unregister through `TitleProbeView`;
   `raise` deminiaturizes and fronts, and `close` uses `performClose` so standard teardown runs.
 

--- a/agterm/AppDelegate.swift
+++ b/agterm/AppDelegate.swift
@@ -293,12 +293,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// restart, logout, XCUITest, auto-quit after the last window closes, or an unwired library.
     func applicationShouldTerminate(_: NSApplication) -> NSApplication.TerminateReply {
         guard !ContentView.isUITestLaunch, let library else { return .terminateNow }
-        if let event = NSAppleEventManager.shared().currentAppleEvent,
-           let keyword = AEKeyword("why?"),
-           let reason = event.attributeDescriptor(forKeyword: keyword),
-           QuitReason.skipsConfirmation(typeCode: reason.typeCodeValue) {
-            return .terminateNow
-        }
+        if QuitReason.isSystemQuit(NSAppleEventManager.shared().currentAppleEvent) { return .terminateNow }
         let counts = library.openCounts()
         guard counts.windows > 0 else { return .terminateNow }
         let alert = NSAlert()

--- a/agtermCore/Sources/agtermCore/QuitReason.swift
+++ b/agtermCore/Sources/agtermCore/QuitReason.swift
@@ -1,7 +1,21 @@
+import Foundation
+
 public enum QuitReason {
     private static let shutDown = fourCharacterCode("shut")
     private static let restart = fourCharacterCode("rest")
     private static let reallyLogOut = fourCharacterCode("rlgo")
+
+    /// Whether a quit came from the system (shutdown, restart, logout) rather than from the user, read
+    /// off the quit event's `kAEQuitReason` attribute. A nil event, an event with no reason attribute,
+    /// and a scripted quit all answer false, so the caller keeps its confirmation.
+    ///
+    /// The read lives here rather than in the app target so the whole seam is testable, and because
+    /// building the keyword by hand hides a trap: `AEKeyword` is `FourCharCode`, which is `UInt32`, so
+    /// `AEKeyword("why?")` resolves to `UInt32.init?(String)`, the decimal parser, and is always nil.
+    public static func isSystemQuit(_ event: NSAppleEventDescriptor?) -> Bool {
+        guard let reason = event?.attributeDescriptor(forKeyword: AEKeyword(kAEQuitReason)) else { return false }
+        return skipsConfirmation(typeCode: reason.typeCodeValue)
+    }
 
     public static func skipsConfirmation(typeCode: UInt32) -> Bool {
         typeCode == shutDown || typeCode == restart || typeCode == reallyLogOut

--- a/agtermCore/Tests/agtermCoreTests/QuitReasonTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/QuitReasonTests.swift
@@ -1,7 +1,43 @@
+import Foundation
 import Testing
 @testable import agtermCore
 
 struct QuitReasonTests {
+    /// The quit event AppKit hands `applicationShouldTerminate`, carrying `reason` under
+    /// `kAEQuitReason`, or no reason attribute at all when `reason` is nil.
+    private func quitEvent(reason: String?) -> NSAppleEventDescriptor {
+        let event = NSAppleEventDescriptor.appleEvent(
+            withEventClass: AEEventClass(kCoreEventClass),
+            eventID: AEEventID(kAEQuitApplication),
+            targetDescriptor: nil,
+            returnID: AEReturnID(kAutoGenerateReturnID),
+            transactionID: AETransactionID(kAnyTransactionID))
+        if let reason {
+            let code = reason.utf8.reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }
+            event.setAttribute(NSAppleEventDescriptor(typeCode: code), forKeyword: AEKeyword(kAEQuitReason))
+        }
+        return event
+    }
+
+    /// Reads the reason off a real event, which is what a keyword built from a string cannot do:
+    /// `AEKeyword("why?")` is `UInt32.init?(String)` and always nil, so the check it guarded never ran.
+    @Test(arguments: ["shut", "rest", "rlgo"])
+    func systemQuitEventSkipsConfirmation(reason: String) {
+        #expect(QuitReason.isSystemQuit(quitEvent(reason: reason)))
+    }
+
+    @Test func scriptedQuitEventKeepsConfirmation() {
+        #expect(!QuitReason.isSystemQuit(quitEvent(reason: "quia")))
+    }
+
+    @Test func anEventWithoutAReasonKeepsConfirmation() {
+        #expect(!QuitReason.isSystemQuit(quitEvent(reason: nil)))
+    }
+
+    @Test func noEventKeepsConfirmation() {
+        #expect(!QuitReason.isSystemQuit(nil))
+    }
+
     @Test(arguments: ["shut", "rest", "rlgo"])
     func systemQuitSkipsConfirmation(reason: String) {
         let typeCode = reason.utf8.reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }


### PR DESCRIPTION
Thanks for turning #445 around within the hour. The shape of #446 is right, and it does not go far enough: as merged, the check cannot fire.

`AEKeyword` is `FourCharCode`, which is `UInt32`, so `AEKeyword("why?")` resolves to `UInt32.init?(String)`, the decimal parser, and is always nil. The `if let` chain stops on its second condition, the alert is built anyway, and an unattended restart still loses every captured command.

So this does not read as a claim, here is a throwaway test in this repo's own suite, not part of this diff:

```
✘ Test theKeywordTheAppBuildsResolves() recorded an issue at QuitReasonTests.swift:10:9:
  Expectation failed: (AEKeyword("why?") → nil) != nil
```

Nothing in the suite could have caught it, which is worth saying out loud: the read sat inline in the app target, out of reach of the host-free tests, and the hosted suite returns `.terminateNow` under XCUITest before the check. `QuitReasonTests` was green because the classifier is fine. It is the keyword that never resolved.

**The fix.** The read moves into `agtermCore` as `QuitReason.isSystemQuit`, which is what makes the seam testable, and the keyword comes from `kAEQuitReason`, which Foundation exposes: 0x7768793F, the same number your string algorithm produces. `AppDelegate` keeps one line, and the three codes stay exactly as you built them.

The tests build the quit event AppKit delivers and assert through the code under test: shut, rest and rlgo skip the prompt, a scripted quia keeps it, an event with no reason attribute or no event keeps it too. A keyword that fails to resolve fails all three positive cases.

`make test` 2569 tests green, `make lint` clean, `make build` succeeds. The manual check is unchanged from #446: whether macOS delivers the event before `applicationShouldTerminate` on a real restart.

Two notes, neither touched here. The trap is an easy one to hit and not yours alone: ghostty carries the same dead guard in `macos/Sources/App/AppDelegate.swift`, so the implementation we both read never reached its switch either. And `kAELogOut` (logo, 1819240303) is still outside the set, only rlgo is in it: I have not established which of the two macOS sends for an ordinary logout, so I left the set alone.

Follows #446, reported in #445.
