### PR TITLE
feat: advance libghostty to upstream main and fix the surface-teardown use-after-free

### DIFF
--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -30,7 +30,7 @@ paths:
   `selection-*` keys, even when set, so `resolveSelectionColors` parses the same last-wins config sources
   and named bundled theme file. Selected rows use selection background/foreground, with black/white
   luminance fallback. Tint borderless New Session through `.tint`; its label ignores foreground style.
-- Pass `theme = light:X,dark:Y` raw. Pinned libghostty `4dcb09ada` supports conditional themes, but
+- Pass `theme = light:X,dark:Y` raw. The pinned libghostty supports conditional themes, but
   `set_color_scheme` only changes conditional state and emits an unhandled soft reload. agterm must set
   app and surface schemes, then call `update_config`.
 - A dark launch must re-side the app config through `update_config` BEFORE the first surface exists;
@@ -162,7 +162,7 @@ paths:
 - Handle background `GHOSTTY_ACTION_COLOR_CHANGE` per pane. Under zero surface opacity, apply a surface
   config overlay containing only `background-opacity = windowOpacity`; never include `background`.
   Preserve and reassert the latch through reload, opacity, and dashboard font changes.
-- A live OSC 11 override masks config defaults in pinned libghostty `4dcb09ada`. No embedding API clears
+- A live OSC 11 override masks config defaults in the pinned libghostty. No embedding API clears
   it: RIS leaves colors, PTY writes bypass the parser, and COLOR_CHANGE is outbound-only.
   `session.background color` changes only the default and cannot override live OSC.
 - OSC 111 copies current default into override. Per-surface update also reseeds default from a

--- a/.claude/rules/libghostty.md
+++ b/.claude/rules/libghostty.md
@@ -20,6 +20,17 @@ paths:
   producer of `GHOSTTY_ACTION_RENDER`. The action is therefore unreachable on the embedded apprt and the
   `action` switch drops it to `default`. If `GHOSTTY_REV` ever advances onto a libghostty that declares
   that constant, panes stop painting until a RENDER arm calling `ghostty_surface_draw` comes back.
+- The render thread is not the only painter: libghostty installs its own `CALayer` subclass as the surface
+  view's layer, and its `display` calls a callback holding a raw `*Renderer`, so CoreAnimation draws on the
+  main thread too. Before upstream `4b4a5b241109` nothing cleared that callback — `Metal.deinit` dropped
+  only ghostty's retain while the view kept the layer alive — so after `ghostty_surface_free` the layer
+  pointed into a freed renderer and the next display aborted on
+  `BUG IN CLIENT OF LIBPLATFORM: os_unfair_lock is corrupt` (#443). Reproduced deterministically only under
+  `MallocScribble=1`; on unrecycled memory the same sequence survives, which is why one report over 46
+  hours was the expected shape rather than a weak signal.
+- `destroySurface` swaps in a plain layer anyway, carrying the last frame's contents, and must do it AFTER
+  the free, which is what joins the render thread. The current pin carries the upstream fix, so this is
+  defence against building on a libghostty that does not — keep it even though it looks redundant.
 - The render thread returns early on `!self.flags.visible`, so `ghostty_surface_set_occlusion` is a real
   lever over what hidden panes cost. `docs/backlog/hidden-panes-keep-drawing.md` owns whether agterm
   pulls it and what that is worth.

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 GhosttyKit.xcframework
 agterm/Resources/ghostty
 agterm/Resources/terminfo
+.ghostty-build-stamp
 *.tar.gz
 
 # build artifacts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,9 +76,10 @@ C-boundary concurrency before changing the bridge.
 
 - Fetch `origin master` before creating a native Claude worktree so it forks the current remote tip.
   Do not manually `git worktree add`.
-- Fresh worktrees lack ignored `GhosttyKit.xcframework` and
-  `agterm/Resources/{ghostty,terminfo}`. Symlink all three from the main checkout instead of rebuilding;
-  use absolute targets for resources. They remain untracked and disappear with worktree removal.
+- Fresh worktrees lack ignored `GhosttyKit.xcframework`, `agterm/Resources/{ghostty,terminfo}` and
+  `.ghostty-build-stamp`. Symlink all four from the main checkout instead of rebuilding; use absolute
+  targets for resources. The stamp is what makes the other three count as current — without it `setup.sh`
+  rebuilds libghostty in every new worktree. They remain untracked and disappear with worktree removal.
 - After merge, verify the PR merge commit on fetched `origin/master`, then remove the worktree without
   changing the main checkout's branch. Squash/rebase makes removal report unmerged commits; after
   verification, discard the worktree safely. Native removal may leave a renamed branch, which must be
@@ -133,8 +134,14 @@ C-boundary concurrency before changing the bridge.
 
 - `scripts/setup.sh` builds upstream `ghostty-org/ghostty` at `GHOSTTY_REV` using
   `zig build -Demit-xcframework=true -Dxcframework-target=native`. No fork or disposable daily build is used.
-- The pin stays at or before `4dcb09ada` (2026-04-30) because later renderer builds blank scrollback on
-  font-size increase; decrease works and no app-side fix exists. Re-test increase before advancing.
+- `GHOSTTY_REV` is `0ba6250` (2026-08-16), a plain reproducibility pin with no workaround attached.
+  It sat at `4dcb09ada` (2026-04-30) from June while later builds blanked scrollback on a font-size
+  increase; upstream fixed that and the case was re-verified by hand before the bump. Re-test the
+  font-increase case when moving it, and check `minimum_zig_version` in `build.zig.zon` against
+  `ZIG_FORMULA` — the 0.15 to 0.16 jump came with this bump.
+- `.ghostty-build-stamp` records the rev the staged artifacts came from and is what decides a rebuild.
+  Presence alone would serve an xcframework built from a different rev silently, so a `GHOSTTY_REV`
+  change costs everyone exactly one libghostty rebuild and nobody keeps a stale core by accident.
 - Setup stages the xcframework and `zig-out/share/{ghostty,terminfo}`. All are ignored build artifacts.
 - Link the xcframework with `embed: false`; embedding breaks non-Developer-ID signatures.
 

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -715,10 +715,11 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         focusObservers = []
         if let surface { ghostty_surface_free(surface) }
         surface = nil
-        // libghostty's own CALayer stays as this view's layer, still holding a display callback into the
-        // renderer freed above — Metal declares no `loopExit` to clear it — so the next CoreAnimation
-        // display locks a mutex in freed memory (#443). Must follow the free, which joins the render
-        // thread: dropping the layer while it still paints trades one use-after-free for another.
+        // release the custom layer libghostty installed and this view still retains. The current pin clears
+        // its display callback in `IOSurfaceLayer.release`, so this defends builds predating that fix, where
+        // the callback kept pointing at the freed renderer and the next CoreAnimation display locked a mutex
+        // in freed memory (#443). Must follow the free, which joins the render thread: dropping the layer
+        // while it still paints trades one use-after-free for another.
         dropGhosttyLayer()
         // the other end of the `surface != nil` term: this element just left the a11y tree, and a client
         // holding it needs to re-resolve rather than keep writing into a closed session's pane.

--- a/agterm/Ghostty/GhosttySurfaceView.swift
+++ b/agterm/Ghostty/GhosttySurfaceView.swift
@@ -715,6 +715,11 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         focusObservers = []
         if let surface { ghostty_surface_free(surface) }
         surface = nil
+        // libghostty's own CALayer stays as this view's layer, still holding a display callback into the
+        // renderer freed above — Metal declares no `loopExit` to clear it — so the next CoreAnimation
+        // display locks a mutex in freed memory (#443). Must follow the free, which joins the render
+        // thread: dropping the layer while it still paints trades one use-after-free for another.
+        dropGhosttyLayer()
         // the other end of the `surface != nil` term: this element just left the a11y tree, and a client
         // holding it needs to re-resolve rather than keep writing into a closed session's pane.
         postAccessibilityExposureChange()
@@ -757,6 +762,20 @@ final class GhosttySurfaceView: NSView, TerminalSurface {
         onSearchEnd = nil
         onSearchTotal = nil
         onSearchSelected = nil
+    }
+
+    /// Swaps libghostty's `CALayer` subclass out for a plain one, keeping the last painted frame as its
+    /// contents so a pane about to be unmounted does not blank for a frame first. The contents are an
+    /// `IOSurface` the layer retains, so carrying the reference over outlives the freed renderer.
+    private func dropGhosttyLayer() {
+        let plain = CALayer()
+        if let stale = layer {
+            plain.frame = stale.frame
+            plain.contentsScale = stale.contentsScale
+            plain.contentsGravity = stale.contentsGravity
+            plain.contents = stale.contents
+        }
+        layer = plain
     }
 
     /// `TerminalSurface` conformance: the model calls this when the owning session is closed.

--- a/agtermTests/GhosttySurfaceViewTrackingTests.swift
+++ b/agtermTests/GhosttySurfaceViewTrackingTests.swift
@@ -151,4 +151,18 @@ final class GhosttySurfaceViewTrackingTests: XCTestCase {
                        "a torn-down hud surface must not leave its painter a file to keep reading")
         XCTAssertNil(view.hudBodyFile)
     }
+
+    /// #443: libghostty's layer holds a display callback into the renderer `destroySurface` frees, so the
+    /// next CoreAnimation display of that layer aborts the process on a corrupt lock.
+    func testTeardownDropsTheLayerLibghosttyInstalled() {
+        let view = GhosttySurfaceView(workingDirectory: NSTemporaryDirectory())
+        let stale = CALayer()
+        stale.contentsScale = 3
+        view.layer = stale
+
+        view.destroySurface()
+
+        XCTAssertFalse(view.layer === stale, "a torn-down surface must not keep the layer libghostty installed")
+        XCTAssertEqual(view.layer?.contentsScale, 3, "the replacement carries the last frame, so nothing blanks")
+    }
 }

--- a/agtermUITests/ControlSurfaceZoomUITests.swift
+++ b/agtermUITests/ControlSurfaceZoomUITests.swift
@@ -108,23 +108,27 @@ final class ControlSurfaceZoomUITests: ControlAPITestCase {
         XCTAssertEqual(rehide["ok"] as? Bool, true, "explicit-target hide should be idempotent: \(rehide)")
     }
 
-    func testQuickZoomEmitsAndAcceptsQuickTargetId() throws {
+    /// #441 detached the quick terminal into one per-app panel, so a bare zoom resolves inside the WINDOW
+    /// and can no longer pick it; `quick` stays reachable as an explicit target. `TerminalZoomTests` pins
+    /// the same split host-free.
+    func testQuickIsZoomableOnlyAsAnExplicitTarget() throws {
+        let leftSurface = try activeSurfaceID(kind: "left")
         XCTAssertEqual(try sendCommand(#"{"cmd":"quick","args":{"mode":"show"}}"#)["ok"] as? Bool, true,
                        "quick show should succeed")
 
         let zoom = try sendCommand(#"{"cmd":"surface.zoom","args":{"mode":"show"}}"#)
         XCTAssertEqual(zoom["ok"] as? Bool, true, "surface zoom show should succeed: \(zoom)")
-        XCTAssertEqual((zoom["result"] as? [String: Any])?["id"] as? String, "quick",
-                       "zooming with the quick terminal visible should target it: \(zoom)")
+        XCTAssertEqual((zoom["result"] as? [String: Any])?["id"] as? String, leftSurface,
+                       "a bare zoom must resolve within the window, never the detached quick panel: \(zoom)")
+        XCTAssertEqual(try sendCommand(#"{"cmd":"surface.zoom","args":{"mode":"hide"}}"#)["ok"] as? Bool, true,
+                       "zoom hide should succeed")
 
-        let hide = try sendCommand(#"{"cmd":"surface.zoom","target":"quick","args":{"mode":"hide"}}"#)
+        let hide = try sendCommand(#"{"cmd":"surface.zoom","target":"quick","args":{"mode":"show"}}"#)
         XCTAssertEqual(hide["ok"] as? Bool, true,
-                       "the id surface.zoom emitted must be accepted back as a target: \(hide)")
+                       "quick must still be accepted as an explicit zoom target: \(hide)")
 
         // `quick hide` must stay unconditional for scripts — a zoomed quick terminal exits its zoom
         // first, never an error.
-        XCTAssertEqual(try sendCommand(#"{"cmd":"surface.zoom","args":{"mode":"show"}}"#)["ok"] as? Bool, true,
-                       "re-zooming the quick terminal should succeed")
         let quickHide = try sendCommand(#"{"cmd":"quick","args":{"mode":"hide"}}"#)
         XCTAssertEqual(quickHide["ok"] as? Bool, true,
                        "quick hide must succeed while the quick terminal is zoomed: \(quickHide)")

--- a/agtermUITests/EventSubscriptionUITests.swift
+++ b/agtermUITests/EventSubscriptionUITests.swift
@@ -49,11 +49,10 @@ final class EventSubscriptionUITests: ControlAPITestCase {
         XCTAssertTrue(close.waitForExistence(timeout: 2))
         XCTAssertTrue(close.isEnabled)
         close.click()
-        app.menuBars.menuBarItems["File"].click()
-        let reopen = app.menuItems["Reopen Closed Item"]
-        XCTAssertTrue(reopen.waitForExistence(timeout: 2))
-        XCTAssertTrue(reopen.isEnabled)
-        reopen.click()
+        // ⌘Z, not File ▸ Reopen Closed Item: the undo record lives for
+        // `AppStore.pendingCloseGraceInterval` (3s) and a second menu round-trip costs more than that, so
+        // the record hard-finalizes before the click lands and the menu item is stale-enabled by then.
+        app.typeKey("z", modifierFlags: .command)
         let lifecycle = try pollEvents(anchor: lifecycleAnchor,
                                        kinds: ["session.created", "session.closed"], minimum: 3)
         try lifecycle.items.forEach(assertCommonEnvelope)

--- a/agtermUITests/KeymapUITests.swift
+++ b/agtermUITests/KeymapUITests.swift
@@ -35,8 +35,14 @@ final class KeymapUITests: XCTestCase {
         openPalette("Command Palette")
         typeIntoPalette("Touch File")
 
-        let badge = app.descendants(matching: .any).matching(identifier: "palette-badge").firstMatch
-        XCTAssertTrue(badge.waitForExistence(timeout: 5), "the custom command should show the `custom` badge in the palette")
+        // #316 put `palette-item-<id>` on the row container and SwiftUI propagates a container identifier
+        // onto its descendant Texts, so the badge stopped answering to `palette-badge`; its accessibility
+        // VALUE still carries the label, which is what identifies it now.
+        let rows = app.descendants(matching: .staticText)
+            .matching(NSPredicate(format: "identifier BEGINSWITH 'palette-item-'"))
+        XCTAssertTrue(rows.firstMatch.waitForExistence(timeout: 5), "the filtered palette should show the custom command")
+        XCTAssertTrue(poll { rows.allElementsBoundByIndex.contains { ($0.value as? String) == "custom" } },
+                      "the custom command should show the `custom` badge in the palette")
 
         app.typeKey(.return, modifierFlags: [])
         XCTAssertTrue(poll { FileManager.default.fileExists(atPath: marker.path) },

--- a/agtermUITests/KeymapUITests.swift
+++ b/agtermUITests/KeymapUITests.swift
@@ -61,7 +61,11 @@ final class KeymapUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Touch File"].waitForExistence(timeout: 5),
                       "the custom command should appear in the Custom Commands palette")
         XCTAssertFalse(app.staticTexts["New Session"].exists, "built-in actions must not appear in the Custom Commands palette")
-        XCTAssertFalse(app.descendants(matching: .any).matching(identifier: "palette-badge").firstMatch.exists,
+        // through the row identifier for the same reason as the positive lookup above: querying
+        // `palette-badge` here would find nothing whether or not a badge renders, so it could not fail.
+        let customRows = app.descendants(matching: .staticText)
+            .matching(NSPredicate(format: "identifier BEGINSWITH 'palette-item-'"))
+        XCTAssertFalse(customRows.allElementsBoundByIndex.contains { ($0.value as? String) == "custom" },
                        "the Custom Commands palette should not show the `custom` badge")
 
         typeIntoPalette("Touch File")

--- a/agtermUITests/SessionSubtitleUITests.swift
+++ b/agtermUITests/SessionSubtitleUITests.swift
@@ -91,9 +91,15 @@ final class SessionSubtitleUITests: XCTestCase {
         let item = app.menuItems["Go to Session"]
         guard item.waitForExistence(timeout: 5) else { return "" }
         item.click()
-        let subtitle = app.staticTexts["palette-subtitle"].firstMatch
-        guard subtitle.waitForExistence(timeout: 5) else { return "" }
-        return subtitle.value as? String ?? ""
+        let rows = app.descendants(matching: .staticText)
+            .matching(NSPredicate(format: "identifier BEGINSWITH 'palette-item-'"))
+        guard rows.firstMatch.waitForExistence(timeout: 5) else { return "" }
+        // #316 put `palette-item-<id>` on the row container and SwiftUI propagates a container identifier
+        // onto its descendant Texts, so the subtitle stopped answering to `palette-subtitle`. It is still
+        // the only row text carrying the `workspace · detail` separator, which is what finds it now.
+        return rows.allElementsBoundByIndex
+            .compactMap { $0.value as? String }
+            .first { $0.contains(" · ") } ?? ""
     }
 
     private func closePalette() {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -40,8 +40,8 @@ need_res=true
 [[ -d "$XCFRAMEWORK_DIR" ]] && need_xc=false
 [[ -d "$RESOURCES_MARKER" ]] && need_res=false
 
-# a stale stamp restages BOTH: they come out of one build, and the artifact that carries the patch
-# cannot be told apart from the one that does not.
+# a stale stamp restages BOTH: they come out of one build, and an artifact built from another revision
+# cannot be told apart from a current one.
 if [[ ! -f "$STAMP_FILE" || "$(cat "$STAMP_FILE")" != "$GHOSTTY_REV" ]]; then
   need_xc=true
   need_res=true

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -19,7 +19,11 @@ cd "$(dirname "$0")/.."
 
 GHOSTTY_REPO="https://github.com/ghostty-org/ghostty"
 GHOSTTY_REV="0ba6250388641f52135414b38c4259aa682c489b"  # 2026-08-16
-ZIG_FORMULA="zig"  # ghostty pins minimum_zig_version 0.16.0; resolved by prefix, so an unlinked keg works
+# ghostty pins minimum_zig_version 0.16.0. Name the MINOR LINE, not `zig`: that one rolls, so a fresh
+# build once 0.17 is current would compile a fixed GHOSTTY_REV with a compiler it never supported. Today
+# `zig@0.16` is still an alias for `zig`, so this buys nothing yet — it claims the name Homebrew uses when
+# it cuts the real versioned formula, as it already has for zig@0.15 and zig@0.14.
+ZIG_FORMULA="zig@0.16"  # resolved by prefix, so an unlinked keg works
 XCFRAMEWORK_DIR="GhosttyKit.xcframework"
 # terminfo/ is the marker: it must extract as a SIBLING of ghostty/ so libghostty's
 # TERMINFO=dirname(GHOSTTY_RESOURCES_DIR)/terminfo derivation resolves xterm-ghostty.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,25 +2,29 @@
 # Build libghostty (GhosttyKit.xcframework) and ghostty resources from upstream ghostty source.
 #
 # We build from source rather than downloading a prebuilt artifact so the toolchain is fully
-# self-owned: the only inputs are upstream ghostty-org/ghostty at a pinned SHA, zig 0.15.2, and
-# Xcode's Metal Toolchain. No third-party fork, no daily-build release that can be pruned.
+# self-owned: the only inputs are upstream ghostty-org/ghostty at a pinned SHA, zig, and Xcode's
+# Metal Toolchain. No third-party fork, no daily-build release that can be pruned.
 #
-# The pin is DELIBERATELY a pre-regression commit: a libghostty renderer regression introduced on
-# main after this SHA blanks the terminal scrollback on a font-size increase.
-# Bump GHOSTTY_REV deliberately once upstream fixes that, re-testing the font-increase case.
+# GHOSTTY_REV is a plain pin for reproducibility, not a workaround. It was held at a 2026-04-30
+# pre-regression commit while later builds blanked the scrollback on a font-size increase; that is
+# fixed upstream and re-verified by hand before this bump. Re-test the font-increase case when moving
+# it, and check `minimum_zig_version` in build.zig.zon against ZIG_FORMULA.
 #
 # One-time cost: the build (a few minutes, plus a Metal Toolchain download on first run) is skipped
-# whenever GhosttyKit.xcframework and the resources are already present.
+# whenever the staged artifacts match the current rev. Presence alone is not enough — an xcframework
+# built from a different rev is indistinguishable from a current one, so the stamp, not the directory,
+# is what says a rebuild can be skipped.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
 GHOSTTY_REPO="https://github.com/ghostty-org/ghostty"
-GHOSTTY_REV="4dcb09ada0c0909717d92547623b26eafa50ca8a"  # 2026-04-30, last pre-regression build we verified
-ZIG_FORMULA="zig@0.15"  # ghostty pins minimum_zig_version 0.15.2; keg-only so it won't shadow system zig
+GHOSTTY_REV="0ba6250388641f52135414b38c4259aa682c489b"  # 2026-08-16
+ZIG_FORMULA="zig"  # ghostty pins minimum_zig_version 0.16.0; resolved by prefix, so an unlinked keg works
 XCFRAMEWORK_DIR="GhosttyKit.xcframework"
 # terminfo/ is the marker: it must extract as a SIBLING of ghostty/ so libghostty's
 # TERMINFO=dirname(GHOSTTY_RESOURCES_DIR)/terminfo derivation resolves xterm-ghostty.
 RESOURCES_MARKER="agterm/Resources/terminfo"
+STAMP_FILE=".ghostty-build-stamp"
 
 # stage agterm's own bundled theme(s) from the committed source into the (gitignored,
 # setup-regenerated) ghostty themes dir. idempotent and called on both the cached and the
@@ -36,16 +40,24 @@ need_res=true
 [[ -d "$XCFRAMEWORK_DIR" ]] && need_xc=false
 [[ -d "$RESOURCES_MARKER" ]] && need_res=false
 
+# a stale stamp restages BOTH: they come out of one build, and the artifact that carries the patch
+# cannot be told apart from the one that does not.
+if [[ ! -f "$STAMP_FILE" || "$(cat "$STAMP_FILE")" != "$GHOSTTY_REV" ]]; then
+  need_xc=true
+  need_res=true
+fi
+
 if ! $need_xc && ! $need_res; then
   echo "GhosttyKit and resources already present"
   stage_custom_themes
   exit 0
 fi
 
-# zig 0.15.2 (keg-only formula, so it doesn't shadow a newer system zig)
+# resolved through the keg prefix rather than PATH, so a machine still linking an older zig for another
+# project builds with the right one and keeps its own `zig` untouched.
 ZIG="$(brew --prefix "$ZIG_FORMULA" 2>/dev/null || true)/bin/zig"
 if [[ ! -x "$ZIG" ]]; then
-  echo "installing $ZIG_FORMULA (zig 0.15.2)..."
+  echo "installing $ZIG_FORMULA..."
   brew install "$ZIG_FORMULA"
   ZIG="$(brew --prefix "$ZIG_FORMULA")/bin/zig"
 fi
@@ -65,7 +77,7 @@ git -C "$BUILD_DIR" remote add origin "$GHOSTTY_REPO"
 git -C "$BUILD_DIR" fetch -q --depth 1 origin "$GHOSTTY_REV"
 git -C "$BUILD_DIR" -c advice.detachedHead=false checkout -q FETCH_HEAD
 
-echo "building GhosttyKit.xcframework with zig 0.15.2 (a few minutes)..."
+echo "building GhosttyKit.xcframework with zig (a few minutes)..."
 ( cd "$BUILD_DIR" && "$ZIG" build -Doptimize=ReleaseFast -Demit-xcframework=true -Dxcframework-target=native -Demit-macos-app=false )
 
 if $need_xc; then
@@ -84,4 +96,5 @@ if $need_res; then
 fi
 
 stage_custom_themes
+printf '%s\n' "$GHOSTTY_REV" > "$STAMP_FILE"
 echo "setup complete"


### PR DESCRIPTION
advances `GHOSTTY_REV` from `4dcb09ada` (2026-04-30) to upstream main `0ba6250`, fixes the crash in #443, and repairs four XCUITests that had drifted out of sync with the code.

**the pin**

it was held at a pre-regression commit because later renderer builds blanked the scrollback on a font-size increase. That is fixed upstream and re-verified by hand: a dev build of `0ba6250` with 400 lines of scrollback survived the increase. The June conclusion was stale, it predated ghostty-org/ghostty#13048 by two days, and that was the last of the three candidate fixes it had been tested against.

the jump carries a toolchain change. Upstream main needs Zig 0.16.0 as of `e8525c0fd9`, so `ZIG_FORMULA` names `zig@0.16` rather than the rolling `zig`, resolved through the keg prefix so a machine linking an older zig for another project is left alone. `zig@0.16` is still an alias for `zig` today, so it changes nothing about what gets installed; it claims the name Homebrew uses when it cuts the real versioned formula, as it already did for `zig@0.15` and `zig@0.14`.

`.ghostty-build-stamp` records the revision the staged artifacts came from and is what decides a rebuild. Presence alone would keep serving an xcframework built from a different revision with no error, which would have made this bump a no-op for anyone holding a cached one. Worktrees symlink it as a fourth artifact or they rebuild.

**#443**

libghostty installs its own `CALayer` subclass as the surface view's layer, holding a raw `*Renderer` as a display callback. `Metal.deinit` released only ghostty's retain, leaving the host view owning a layer whose callback pointed into the renderer `ghostty_surface_free` had destroyed. The next CoreAnimation display called `drawFrame`, whose first statement locks an `os_unfair_lock` inside freed memory. agterm reaches this on every close path: `dismantleNSView` is a no-op, so the view outlives SwiftUI churn.

reproduced with a throwaway control command that tears a surface down and forces a display. It survives on unrecycled memory and dies under `MallocScribble` with the reported stack, abort cause `0x55555554`. `destroySurface` now swaps in a plain `CALayer` after the free, carrying the last frame's contents so a closing pane does not blank. Order matters: the free is what joins the render thread.

upstream fixed the same defect in ghostty-org/ghostty@4b4a5b241109 and the new pin carries it, so the swap defends builds predating that fix.

**the four test repairs**

none was caused by this branch. All four fail the same way on master `b2351ca` with the old pin. They piled up because `ci.yml` runs `scripts/test-app.sh` only, so the UI suite has never been watched.

- #441 took `quick` out of bare-zoom resolution and updated the host-free tests, leaving `ControlSurfaceZoomUITests` asserting the old contract.
- #316 put `palette-item-<id>` on the palette row container. SwiftUI pushes a container identifier onto descendant `Text`s, which masks `palette-subtitle` and `palette-badge`. Two tests written a month earlier queried them. A third checked that a badge was absent, which the same masking made unable to fail.
- `EventSubscriptionUITests` raced the 3s undo grace with two File-menu round-trips and lost at 3.4s. It now uses the chord bound to the same action.

**validation**

`swiftlint --strict` clean, 2561 agtermCore tests and 247 hosted tests on the final tree. XCUITest: a 41-of-44 class sweep against the new pin before the repairs, plus targeted reruns of the three formerly failing classes after them, `SessionSubtitle` 2/2, `Keymap` 13/13, `EventSubscription` passing in 32s. The full 44-class suite has not been rerun end to end since the repairs.

Fix #443
