### PR TITLE
drop the Debug-only hardened-runtime exceptions from the shipped app

### DIFF
--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -28,9 +28,10 @@ paths:
   Use `codesign -d --entitlements -`; the `:-` spelling is deprecated and warns.
 - The second pins the app's own Release set to the seven TCC keys, so neither a Debug-only hardened-runtime
   exception nor a dropped TCC key can ship. It ignores `com.apple.security.get-task-allow`, which the
-  ad-hoc "Sign to Run Locally" identity adds and the Developer ID re-sign drops. It compares
-  `key=value`, not key names: a key set to `<false/>` is not granted and macOS treats it as absent, so a
-  name-only match would pass that through. Changing the set means editing that list in the same commit.
+  ad-hoc "Sign to Run Locally" identity adds and the Developer ID re-sign drops. It compares `key=value`
+  through `jq ... tojson`, not key names: a key set to `<false/>` is not granted and macOS treats it as
+  absent, and codesign accepts `<string>true</string>`, which is not a Boolean and renders identically to
+  one without `tojson`. Changing the set means editing that list in the same commit.
 - The third reads the two entitlements files rather than a build, and derives Debug's expected content
   from the shipping file: Debug must be the shipping set plus exactly the three exceptions. Without it a
   TCC key added to the shipping file and missed in the Debug one leaves every job green, and Debug

--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -21,10 +21,28 @@ paths:
   `setup.sh` rebuilds libghostty. Keep both app builds: Release exercises the whole-module optimizer and
   its SIL-deserializer failure; Debug provides `ENABLE_TESTABILITY` for
   `DockMenuTests`'s `@testable import agterm`. Do not enable testability in the notarized Release app.
-- The entitlement assertion guards issue #396: `--deep` with `--entitlements` stamps the app's TCC
-  entitlements onto the bundled CLI on the user's PATH, and the build stays green. `scripts/release.sh`
-  repeats it after its Developer ID re-sign, which runs after CI's copy and is not covered by it.
+- Three entitlement assertions run, all because a wrong entitlement set stays green. The first two read
+  the built Release app. The first guards issue #396: `--deep` with `--entitlements` stamps the app's TCC
+  entitlements onto the bundled CLI on the user's PATH. `scripts/release.sh` repeats it after its
+  Developer ID re-sign, which runs after CI's copy and is not covered by it.
   Use `codesign -d --entitlements -`; the `:-` spelling is deprecated and warns.
+- The second pins the app's own Release set to the seven TCC keys, so neither a Debug-only hardened-runtime
+  exception nor a dropped TCC key can ship. It ignores `com.apple.security.get-task-allow`, which the
+  ad-hoc "Sign to Run Locally" identity adds and the Developer ID re-sign drops. It compares
+  `key=value`, not key names: a key set to `<false/>` is not granted and macOS treats it as absent, so a
+  name-only match would pass that through. Changing the set means editing that list in the same commit.
+- The third reads the two entitlements files rather than a build, and derives Debug's expected content
+  from the shipping file: Debug must be the shipping set plus exactly the three exceptions. Without it a
+  TCC key added to the shipping file and missed in the Debug one leaves every job green, and Debug
+  silently unable to prompt for that permission.
+- Debug and Release sign from different entitlements files. `agterm/agterm-debug.entitlements` adds
+  `disable-library-validation`, `allow-jit` and `allow-unsigned-executable-memory`: Debug is ad-hoc signed
+  and split into a stub plus `agterm.debug.dylib`, and `agtermTests` loads an ad-hoc `.xctest` into that
+  app, so library validation would reject both on a Team-ID mismatch. The Release bundle holds no dylib
+  and JIT-links nothing, so `agterm/agterm.entitlements` carries none of the three. The re-sign in
+  `project.yml` reads `$CODE_SIGN_ENTITLEMENTS` rather than a literal path, so it follows the
+  configuration. Restoring a literal path there would re-sign Debug from the shipping file, stripping the
+  three exceptions and breaking the ad-hoc `.xctest` load in `make test-app`.
 - A separate `cookbook: ["cookbook/**"]` filter gates the Linux `cookbook` job. Recipe-only changes run
   no macOS jobs. Keep `.github/workflows/ci.yml` in both filters: the inline cookbook checks must run when
   changed; its Swift membership also runs macOS jobs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,8 +149,9 @@ jobs:
         run: |
           app=build/DerivedData/Build/Products/Release/agterm.app
           [ -d "$app" ] || { echo "app not found at $app" >&2; exit 1; }
-          # values, not just names: a key present but set to <false/> is not granted, and macOS treats
-          # it exactly like a missing one, so comparing key names alone would pass that through.
+          # values and their types, not just names. A key set to <false/> is not granted and macOS treats
+          # it exactly like a missing one, so a name-only compare would pass that through; and codesign
+          # accepts <string>true</string>, which renders as bare true without the tojson below.
           expected=$(printf '%s=true\n' \
             com.apple.security.automation.apple-events \
             com.apple.security.device.audio-input \
@@ -164,7 +165,7 @@ jobs:
           actual=$(codesign -d --entitlements - --xml "$app" 2>/dev/null \
             | plutil -convert json -o - -- - \
             | jq -r 'to_entries[] | select(.key != "com.apple.security.get-task-allow")
-                     | "\(.key)=\(.value)"' | sort)
+                     | "\(.key)=\(.value|tojson)"' | sort)
           if [ "$actual" != "$expected" ]; then
             echo "Release entitlements changed. expected:" >&2; echo "$expected" >&2
             echo "actual:" >&2; echo "$actual" >&2
@@ -177,7 +178,7 @@ jobs:
       - name: Verify the Debug entitlements are the shipping set plus the exceptions
         shell: bash
         run: |
-          keys() { plutil -convert json -o - -- "$1" | jq -r 'to_entries[] | "\(.key)=\(.value)"' | sort; }
+          keys() { plutil -convert json -o - -- "$1" | jq -r 'to_entries[] | "\(.key)=\(.value|tojson)"' | sort; }
           release=$(keys agterm/agterm.entitlements)
           debug=$(keys agterm/agterm-debug.entitlements)
           exceptions=$(printf '%s=true\n' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,56 @@ jobs:
             echo "agtermctl carries entitlements: the app re-seal must not pass --entitlements to a --deep sign" >&2
             exit 1
           fi
+      # the Debug-only hardened-runtime exceptions (allow-jit, allow-unsigned-executable-memory,
+      # disable-library-validation) must never reach a shipped build, and the TCC set must not shrink
+      # either — losing one silently removes the user's only path to granting that permission (#396).
+      # Pin the exact Release set; adding or dropping a key is a deliberate act that edits this list.
+      - name: Verify the app's Release entitlements
+        shell: bash
+        run: |
+          app=build/DerivedData/Build/Products/Release/agterm.app
+          [ -d "$app" ] || { echo "app not found at $app" >&2; exit 1; }
+          # values, not just names: a key present but set to <false/> is not granted, and macOS treats
+          # it exactly like a missing one, so comparing key names alone would pass that through.
+          expected=$(printf '%s=true\n' \
+            com.apple.security.automation.apple-events \
+            com.apple.security.device.audio-input \
+            com.apple.security.device.camera \
+            com.apple.security.personal-information.addressbook \
+            com.apple.security.personal-information.calendars \
+            com.apple.security.personal-information.location \
+            com.apple.security.personal-information.photos-library)
+          # get-task-allow is added by the ad-hoc "Sign to Run Locally" identity this job builds with,
+          # and never survives the Developer ID re-sign in scripts/release.sh. Drop it, then match exactly.
+          actual=$(codesign -d --entitlements - --xml "$app" 2>/dev/null \
+            | plutil -convert json -o - -- - \
+            | jq -r 'to_entries[] | select(.key != "com.apple.security.get-task-allow")
+                     | "\(.key)=\(.value)"' | sort)
+          if [ "$actual" != "$expected" ]; then
+            echo "Release entitlements changed. expected:" >&2; echo "$expected" >&2
+            echo "actual:" >&2; echo "$actual" >&2
+            exit 1
+          fi
+      # the split states the shipping set twice, and only the Release copy is pinned above. A TCC key
+      # added to the shipping file and missed here leaves Debug unable to prompt for it, with every job
+      # green — the failure surfaces only when someone verifies the new permission by hand in a Debug
+      # instance. Derive Debug's expected content from the shipping file so the two cannot drift.
+      - name: Verify the Debug entitlements are the shipping set plus the exceptions
+        shell: bash
+        run: |
+          keys() { plutil -convert json -o - -- "$1" | jq -r 'to_entries[] | "\(.key)=\(.value)"' | sort; }
+          release=$(keys agterm/agterm.entitlements)
+          debug=$(keys agterm/agterm-debug.entitlements)
+          exceptions=$(printf '%s=true\n' \
+            com.apple.security.cs.allow-jit \
+            com.apple.security.cs.allow-unsigned-executable-memory \
+            com.apple.security.cs.disable-library-validation | sort)
+          expected=$(printf '%s\n%s\n' "$release" "$exceptions" | sort)
+          if [ "$debug" != "$expected" ]; then
+            echo "agterm-debug.entitlements is not the shipping set plus the three exceptions." >&2
+            diff <(echo "$expected") <(echo "$debug") >&2 || true
+            exit 1
+          fi
       - name: Application-hosted unit tests
         run: scripts/test-app.sh
 

--- a/agterm/agterm-debug.entitlements
+++ b/agterm/agterm-debug.entitlements
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Debug only: the shipping set from agterm.entitlements plus three hardened-runtime exceptions the
+     Debug layout needs. Debug builds are ad-hoc signed and split into a stub plus agterm.debug.dylib,
+     and the hosted tests load an ad-hoc .xctest into that app, so library validation would reject both
+     on a Team-ID mismatch. allow-jit and allow-unsigned-executable-memory serve Xcode's preview
+     executor, which JIT-links in process. The Release bundle has no dylib and no JIT, so it carries
+     none of the three. -->
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+	<key>com.apple.security.personal-information.addressbook</key>
+	<true/>
+	<key>com.apple.security.personal-information.calendars</key>
+	<true/>
+	<key>com.apple.security.personal-information.location</key>
+	<true/>
+	<key>com.apple.security.personal-information.photos-library</key>
+	<true/>
+</dict>
+</plist>

--- a/agterm/agterm-debug.entitlements
+++ b/agterm/agterm-debug.entitlements
@@ -5,7 +5,11 @@
      and the hosted tests load an ad-hoc .xctest into that app, so library validation would reject both
      on a Team-ID mismatch. allow-jit and allow-unsigned-executable-memory serve Xcode's preview
      executor, which JIT-links in process. The Release bundle has no dylib and no JIT, so it carries
-     none of the three. -->
+     none of the three.
+
+     They date from the scaffold, which set hardened runtime with CODE_SIGN_IDENTITY "-", so every build
+     was ad-hoc and every build needed them. Developer ID signing arrived six days later (13afe65) and
+     narrowed that to Debug alone; the file was not revisited until issue #448. -->
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.cs.disable-library-validation</key>

--- a/agterm/agterm.entitlements
+++ b/agterm/agterm.entitlements
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Shipping set. Every key is a TCC resource-access entitlement: agterm is the responsible process
+     for the programs it spawns, so without one macOS refuses to even prompt and records nothing
+     (issue #396). Debug adds three hardened-runtime exceptions it cannot build without; they are in
+     agterm-debug.entitlements and must never reach a release. -->
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.cs.disable-library-validation</key>
-	<true/>
-	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-	<true/>
-	<key>com.apple.security.cs.allow-jit</key>
-	<true/>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
 	<key>com.apple.security.device.audio-input</key>

--- a/docs/backlog/no-gate-covers-the-signed-release-app.md
+++ b/docs/backlog/no-gate-covers-the-signed-release-app.md
@@ -16,10 +16,14 @@ now: the Release set dropped `allow-jit`, `allow-unsigned-executable-memory` and
 measurement. A missing hardened-runtime exception fails at dyld or on the exec page, so the failure is
 loud, but it lands on users rather than on CI.
 
-Before the next release, launch the notarized build by hand once and exercise: first surface render
-(libghostty compiles its Metal shaders at runtime), a font-size or theme change forcing a pipeline
-rebuild, window translucency (the `dlopen(nil)`/`dlsym` path in `agterm/Views/WindowAppearance.swift`), a
-session spawning and driving heavy scrollback, and `agtermctl` from inside a session.
+Before the next release, launch the notarized build by hand once and exercise: first surface render, a
+font-size or theme change forcing a pipeline rebuild, window translucency (the `dlopen(nil)`/`dlsym` path
+in `agterm/Views/WindowAppearance.swift`), a session spawning and driving heavy scrollback, and
+`agtermctl` from inside a session. First render loads the metallib compiled into libghostty at build time
+and embedded in the binary, reached through `newLibraryWithData:`; only an optional custom shader
+compiles from source at runtime via `newLibraryWithSource:`, and that produces GPU code rather than
+CPU-executable pages. So a custom shader is worth including in the pass, but neither path is a reason to
+keep an executable-memory exception.
 
 Worth considering as a standing release step rather than a one-off, since no automated gate can replace
 it. Surfaced by issue #448 and the entitlements split that answered it.

--- a/docs/backlog/no-gate-covers-the-signed-release-app.md
+++ b/docs/backlog/no-gate-covers-the-signed-release-app.md
@@ -1,0 +1,25 @@
+---
+worth: next release
+where: .github/workflows/ci.yml, scripts/release.sh
+added: 2026-08-17
+---
+# nothing exercises a Developer ID signed Release app before it ships
+
+CI builds Release, but signs it with the ad-hoc "Sign to Run Locally" identity and never launches it.
+The hardened-runtime entitlements only take effect under a real Developer ID signature, so every gate the
+project has is blind to whether the shipped app starts. `scripts/release.sh` is the sole place that signs,
+notarizes and staples, and it runs on the maintainer's Mac with no launch step of its own.
+
+This did not matter while the entitlements file had carried the same keys since the first commit. It does
+now: the Release set dropped `allow-jit`, `allow-unsigned-executable-memory` and
+`disable-library-validation`, and the static evidence that Release needs none of them is strong but not a
+measurement. A missing hardened-runtime exception fails at dyld or on the exec page, so the failure is
+loud, but it lands on users rather than on CI.
+
+Before the next release, launch the notarized build by hand once and exercise: first surface render
+(libghostty compiles its Metal shaders at runtime), a font-size or theme change forcing a pipeline
+rebuild, window translucency (the `dlopen(nil)`/`dlsym` path in `agterm/Views/WindowAppearance.swift`), a
+session spawning and driving heavy scrollback, and `agtermctl` from inside a session.
+
+Worth considering as a standing release step rather than a one-off, since no automated gate can replace
+it. Surfaced by issue #448 and the entitlements split that answered it.

--- a/docs/backlog/no-gate-covers-the-signed-release-app.md
+++ b/docs/backlog/no-gate-covers-the-signed-release-app.md
@@ -25,5 +25,11 @@ compiles from source at runtime via `newLibraryWithSource:`, and that produces G
 CPU-executable pages. So a custom shader is worth including in the pass, but neither path is a reason to
 keep an executable-memory exception.
 
-Worth considering as a standing release step rather than a one-off, since no automated gate can replace
-it. Surfaced by issue #448 and the entitlements split that answered it.
+Worth making a standing release step rather than a one-off, since no automated gate can replace it. The
+boundary that matters: a PR merges on its own CI, but publication should stop until the signed artifact
+has started and been exercised. Static analysis decides which entitlements belong in the signature; it
+says nothing about whether the signed artifact runs, and the production path changes the signing identity
+and then notarizes and publishes without ever launching. Whether that becomes a blocking step in
+`scripts/release.sh` is a call for the maintainer, not something to add on the way past.
+
+Surfaced by issue #448 and the entitlements split that answered it.

--- a/project.yml
+++ b/project.yml
@@ -48,6 +48,7 @@ targets:
         excludes:
           - "Info.plist"
           - "agterm.entitlements"
+          - "agterm-debug.entitlements"
           - "Resources/ghostty"
           - "Resources/terminfo"
           - "Resources/agent-status"
@@ -122,6 +123,8 @@ targets:
         # set AGTERM_STATE_DIR to avoid touching the real app-support state.)
         Debug:
           PRODUCT_BUNDLE_IDENTIFIER: com.umputun.agterm.debug
+          # Debug alone needs the three hardened-runtime exceptions; see the header of the file.
+          CODE_SIGN_ENTITLEMENTS: agterm/agterm-debug.entitlements
     postBuildScripts:
       # build the agtermctl CLI and bundle it at Contents/MacOS/agtermctl so the
       # in-app "Install Command Line Tool" can symlink it into PATH. Runs before
@@ -153,7 +156,8 @@ targets:
           # SECOND pass instead: --deep applies them to every nested binary, and agtermctl is a
           # standalone CLI on the user's PATH, not a library.
           codesign --force --deep --options runtime --sign - "$CODESIGNING_FOLDER_PATH"
-          codesign --force --options runtime --entitlements "$SRCROOT/agterm/agterm.entitlements" --sign - "$CODESIGNING_FOLDER_PATH"
+          # CODE_SIGN_ENTITLEMENTS, not a literal path: Debug and Release use different files.
+          codesign --force --options runtime --entitlements "$SRCROOT/$CODE_SIGN_ENTITLEMENTS" --sign - "$CODESIGNING_FOLDER_PATH"
     dependencies:
       - framework: GhosttyKit.xcframework
         embed: false


### PR DESCRIPTION
splits code-signing entitlements per build configuration so the shipped app stops carrying three hardened-runtime exceptions it does not use.

`allow-jit`, `allow-unsigned-executable-memory` and `disable-library-validation` have been in the entitlements file since the first scaffold commit. The reason turns out to be real but expired: `3b75fc7` set `ENABLE_HARDENED_RUNTIME: YES` together with `CODE_SIGN_IDENTITY: "-"`, so every build was ad-hoc, and an ad-hoc signature has no Team ID for library validation to match. Developer ID signing arrived six days later in `13afe65` and narrowed that to Debug alone. Nobody revisited the file.

Release needs none of them. GhosttyKit links as a static archive (`libghostty-internal-fat.a`), the bundle holds no dylib beyond `agterm` and `agtermctl` under the same Developer ID, and the binary imports no JIT or `mprotect` symbol. Upstream Ghostty runs the same renderer under hardened runtime carrying none of the three.

Debug still needs them, so it signs from `agterm/agterm-debug.entitlements`. Debug is ad-hoc signed and split into a stub plus `agterm.debug.dylib`, and `agtermTests` loads an ad-hoc `.xctest` into that app, so library validation would reject both on a Team-ID mismatch. The post-build re-sign in `project.yml` now reads `$CODE_SIGN_ENTITLEMENTS` instead of a literal path, so it follows the configuration.

The seven TCC entitlements stay exactly as they are. agterm is the responsible process for the programs it spawns, so each one is what lets macOS prompt at all, and dropping one leaves no path to consent (#396).

CI gains two assertions, both because a wrong entitlement set otherwise stays green:

- the Release set must be exactly the seven TCC keys, compared as `key=value` so a key set to `<false/>` cannot pass as granted
- `agterm-debug.entitlements` must be that same set plus exactly the three exceptions, derived from the shipping file so the two copies cannot drift

**Verified**

Release signature carries none of the three, Debug carries all three, 247 hosted tests, 2569 `agtermCore` tests, SwiftLint strict clean. Both new assertions were negative-tested: they reject a `false` value, a stray exception, a dropped TCC key and Debug drift, and accept the real files.

**Needs a hand check before the next release.** No CI job signs with Developer ID or launches the app, so the shipped configuration is not covered by any gate. Worth one manual launch of the notarized build exercising first surface render, a font-size or theme change, window translucency, heavy scrollback and `agtermctl`. Written up in `docs/backlog/no-gate-covers-the-signed-release-app.md`.

Fix #448
