### PR TITLE
report a surface's cursor column over the control API

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -126,7 +126,7 @@ renumbering. Do not reintroduce a count anywhere.
   `.scratch`, `.focus`, `.resize`, `.go`, `.copy`, `.paste`, `.selectall`, `.text`, `.search`, `.status`,
   `.flag`, `.seen`, `.restore`, `.background`, `.overlay.open`, `.overlay.close`, `.overlay.resize`,
   `.overlay.result`, `.overlay.copy`, `.overlay.text`, `.hud.open`, `.hud.update`, `.hud.close`
-- `surface.zoom`, `dashboard`, `pick.open`, `pick.result`, `pick.cancel`
+- `surface.zoom`, `surface.cursor`, `dashboard`, `pick.open`, `pick.result`, `pick.cancel`
 - `quick`, `quick.type`, `quick.text`
 - `sidebar`, `sidebar.mode`, `sidebar.expand`, `sidebar.collapse`, `notify`
 - `font.inc`, `font.dec`, `font.reset`
@@ -425,6 +425,25 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
   then scratch, then the focused pane's own overlay, then that pane. Those
   predicates are mutually exclusive and total, resting on `Session.focusedPane`, so widening one without
   narrowing its neighbour silently picks the wrong surface.
+- `surface.cursor` reports a zero-based COLUMN and nothing else, nested as `result.cursor.column` so a `row`
+  could join it additively; the human form is the bare integer and must stay one value. libghostty exports no
+  cursor accessor, so the column is solved for: `ghostty_surface_ime_point` gives the cell midpoint including
+  an unknown padding term, and reading the viewport's top-left cell MEASURES that term as
+  `ghostty_text_s.tl_px_x`, which cancels. Verified exact under asymmetric `window-padding-*` with
+  `window-padding-balance`, across font sizes, on both split panes and on a hidden background session.
+  There is NO row, and the vertical twin is not a near miss to be finished later: `tl_px_y` is the text
+  BASELINE against an IME point at the cell bottom, and `adjust-font-baseline = 30` was measured reporting
+  row 5 for a caret on row 4 while the column stayed right — a silent off-by-one, so a row waits for a real
+  accessor. Use `TerminalZoomSurface.surface(in:)`, never a second inline switch over the six slots.
+- It shares `surface.zoom`'s target vocabulary AND its gates, which is not cosmetic: `active` must consult
+  the window's `TerminalZoomRegistry` target BEFORE the store's focused pane, or zooming a nonfocused pane
+  reads the hidden one; and both paths must pass `TerminalZoomController.isTargetValid`, or a guessed
+  `surface:<id>:overlay` reads a HUD the tree omits and zoom rejects. `quick` gates on
+  `QuickTerminalController.isVisible`, not on `currentSurface()`, which `hide()` deliberately keeps alive.
+  All three shipped as bugs once; `ControlSurfaceCursorUITests` pins each.
+- It is a pure read that adds NO tree field, a deliberate exception to the state-command read-back rule
+  (it sets no state) and to the temptation to project it: `ghostty_surface_read_text` allocates and takes the
+  renderer lock, so paying it per live and hidden surface on every tree poll is the wrong trade.
 - `quick` is the one target that names no window surface: it grows the quick-terminal PANEL to fill its
   screen. `setSurfaceZoom` routes it before resolving a window, so it takes no `--window` and never reaches
   `resolveSurfaceZoom`; it is refused `surface not available: quick` while the panel is hidden, and an

--- a/agterm/Control/ControlServer+SessionActions.swift
+++ b/agterm/Control/ControlServer+SessionActions.swift
@@ -741,7 +741,7 @@ extension ControlServer: ControlActions {
         }
     }
 
-    private func resolveOpenWindow(_ window: String?) -> ControlTargetResolver.Resolution<(WindowInfo.ID, AppStore)> {
+    func resolveOpenWindow(_ window: String?) -> ControlTargetResolver.Resolution<(WindowInfo.ID, AppStore)> {
         guard let window = trimmed(window) else {
             guard let windowID = library.activeWindowID, let store = library.store(for: windowID) else {
                 return .failure(ControlResponse(ok: false, error: "no open window"))
@@ -759,7 +759,7 @@ extension ControlServer: ControlActions {
         }
     }
 
-    private func resolveSurfaceOwner(_ surfaceID: TerminalSurfaceID, window: String?)
+    func resolveSurfaceOwner(_ surfaceID: TerminalSurfaceID, window: String?)
         -> ControlTargetResolver.Resolution<(WindowInfo.ID, AppStore)> {
         if trimmed(window) != nil {
             switch resolveOpenWindow(window) {

--- a/agterm/Control/ControlServer+SurfaceIO.swift
+++ b/agterm/Control/ControlServer+SurfaceIO.swift
@@ -268,6 +268,74 @@ extension ControlServer {
         }
     }
 
+    /// Returns the addressed surface's zero-based cursor column. Takes `surface.zoom`'s target vocabulary —
+    /// `surface:<session-id>:<kind>` ids from `tree`, `quick`, or `active` for the frontmost (or `--window`)
+    /// window's active surface — so both `surface.*` commands address the same set. Unlike zoom it changes
+    /// nothing, so it neither selects nor realizes the target: an unrealized surface is reported, not waited
+    /// for. `GhosttySurfaceView.readCursorColumn` owns how the column is derived and when it declines.
+    func readSurfaceCursor(_ target: String?, window: String?) -> ControlResponse {
+        let rawTarget = trimmed(target) ?? "active"
+        if rawTarget == "quick" {
+            // `hide()` deliberately keeps the panel's surface alive, so visibility is the gate, not the
+            // surface existing — otherwise a panel shown once stays readable forever. Same test `setZoom` makes.
+            guard QuickTerminalController.shared.isVisible,
+                  let surface = QuickTerminalController.shared.currentSurface() else {
+                return ControlResponse(ok: false, error: "surface not available: quick")
+            }
+            return cursorResponse(surface, controlID: "quick")
+        }
+        let resolved: (store: AppStore, target: TerminalZoomTarget)
+        if rawTarget == "active" {
+            switch resolveOpenWindow(window) {
+            case .failure(let response):
+                return response
+            case .success(let (windowID, store)):
+                // a live zoom IS the active surface, and `surface.zoom active` resolves it the same way: the
+                // controller's target wins over the store's focused pane, which zooming a NONFOCUSED pane
+                // never moves.
+                guard let zoomTarget = TerminalZoomRegistry.shared.controller(for: windowID)?.target
+                        ?? TerminalZoomController.resolveTarget(store: store) else {
+                    return ControlResponse(ok: false, error: "no active surface")
+                }
+                resolved = (store, zoomTarget)
+            }
+        } else {
+            guard let surfaceID = TerminalSurfaceID(rawValue: rawTarget) else {
+                return ControlResponse(ok: false, error: "invalid surface: \(rawTarget)")
+            }
+            switch resolveSurfaceOwner(surfaceID, window: window) {
+            case .failure(let response):
+                return response
+            case .success(let (_, store)):
+                resolved = (store, .session(surfaceID.sessionID, surfaceID.surface))
+            }
+        }
+        // the same validity gate `surface.zoom` applies, so an explicit id cannot reach an occupant the tree
+        // refuses to address: a HUD fills `overlaySurface` while `.overlay` reads unavailable, and without
+        // this a guessed `surface:<id>:overlay` would report the app's own message painter's cursor.
+        guard case let .session(sessionID, kind) = resolved.target,
+              let session = resolved.store.session(withID: sessionID),
+              TerminalZoomController.isTargetValid(resolved.target, in: resolved.store) else {
+            return ControlResponse(ok: false, error: "surface not available: \(resolved.target.controlID)")
+        }
+        return cursorResponse(kind.surface(in: session) as? GhosttySurfaceView, controlID: resolved.target.controlID)
+    }
+
+    private func cursorResponse(_ surface: GhosttySurfaceView?, controlID: String) -> ControlResponse {
+        guard let surface else {
+            return ControlResponse(ok: false, error: "surface not available: \(controlID)")
+        }
+        // an occupied slot proves nothing about a running terminal — the deck parks the view before
+        // `createSurface`, which the display being asleep refuses outright (#416).
+        guard surface.isRealized else {
+            return ControlResponse(ok: false, error: "surface not realized")
+        }
+        guard let column = surface.readCursorColumn() else {
+            return ControlResponse(ok: false, error: "failed to read cursor position")
+        }
+        return ControlResponse(ok: true, result: ControlResult(id: controlID, cursor: ControlCursor(column: column)))
+    }
+
     /// Drives in-terminal search on session `id`, mirroring the GUI bar. `close` exits without selecting;
     /// open/needle/navigate select the target, open search on the focused pane if not already active, then
     /// set the needle and step on `to == next|prev` — all on the PINNED `searchSurface`, so a split focus

--- a/agterm/Control/ControlServer.swift
+++ b/agterm/Control/ControlServer.swift
@@ -422,6 +422,7 @@ final class ControlServer {
                 .workspaceFocus,
                 .workspaceFilter, .workspaceCollapse, .workspaceExpand,
                 .sessionSplit, .sessionSplitClose, .sessionScratch, .sessionFocus, .sessionResize, .surfaceZoom,
+                .surfaceCursor,
                 .sessionStatus, .sessionFlag, .sessionSeen, .sessionRestore, .notify,
                 .fontInc, .fontDec, .fontReset, .keymapReload, .keymapList, .configReload, .themeSet, .themeList,
                 .sidebar, .sidebarMode, .sidebarExpand, .sidebarCollapse, .sessionType, .sessionCopy,

--- a/agterm/Ghostty/GhosttySurfaceView+IO.swift
+++ b/agterm/Ghostty/GhosttySurfaceView+IO.swift
@@ -96,6 +96,57 @@ extension GhosttySurfaceView {
         return rows.suffix(n).joined(separator: "\n")
     }
 
+    /// This surface's zero-based cursor COLUMN (`surface.cursor`), nil when the surface is not created or
+    /// the geometry cannot be trusted. Row is deliberately absent: see the type comment on `ControlCursor`.
+    ///
+    /// libghostty exports no cursor accessor, so the column is solved for. `ghostty_surface_ime_point`
+    /// reports the cursor cell's horizontal MIDPOINT as
+    /// `(column * cellWidth + paddingLeft + cellWidth / 2) / contentScale`, and the padding term is the
+    /// unknown — `ghostty_surface_size` carries no padding, agterm's default comes from
+    /// `Resources/ghostty-defaults.conf`, and a user `ghostty.conf` may override it untracked (the same
+    /// hazard `Hud.swift` documents for its own column math). Reading the viewport's top-left cell MEASURES
+    /// it instead: `ghostty_text_s.tl_px_x` is `(column * cellWidth + paddingLeft) / contentScale` for the
+    /// selected cell, so at column zero it is exactly the padding term in the same units, and subtracting
+    /// leaves `column + 0.5` cells. That holds under asymmetric padding and every padding-balance mode
+    /// because neither side is derived.
+    ///
+    /// The libghostty calls each take the renderer lock separately, so geometry changing between them —
+    /// a font-size change or a resize — would mix two coordinate systems. The grid is re-read afterwards and
+    /// a change abandons the reading. Padding is not re-checked because it cannot move under a live surface:
+    /// libghostty derives it at first layout only, which is why `window-padding-*` needs a new pane. This is
+    /// still an instantaneous sample, not a lock over the three calls.
+    func readCursorColumn() -> Int? {
+        guard let surface else { return nil }
+        var sel = ghostty_selection_s()
+        let origin = ghostty_point_s(tag: GHOSTTY_POINT_VIEWPORT, coord: GHOSTTY_POINT_COORD_EXACT, x: 0, y: 0)
+        sel.top_left = origin
+        sel.bottom_right = origin
+        sel.rectangle = false
+        var probe = ghostty_text_s()
+        guard ghostty_surface_read_text(surface, sel, &probe) else { return nil }
+        let columnZeroX = probe.tl_px_x
+        ghostty_surface_free_text(surface, &probe)
+        // libghostty reports -1 for a cell it could not place; the viewport's own top-left should always
+        // resolve, so treat it as a failed calibration rather than clamping to a padding of zero.
+        guard columnZeroX >= 0 else { return nil }
+
+        let size = ghostty_surface_size(surface)
+        // both readings are pre-divided by the content scale agterm gave libghostty, which is the WINDOW's
+        // (`updateMetalLayerSize`). Never substitute a screen's for a detached view: that answers 2x for a
+        // surface last driven at 1x, an in-range wrong column.
+        guard let scale = window?.backingScaleFactor, scale > 0 else { return nil }
+        guard size.cell_width_px > 0, size.columns > 0 else { return nil }
+        let cellWidth = Double(size.cell_width_px) / Double(scale)
+
+        var x = 0.0, y = 0.0, w = 0.0, h = 0.0
+        ghostty_surface_ime_point(surface, &x, &y, &w, &h)
+        let after = ghostty_surface_size(surface)
+        guard after.cell_width_px == size.cell_width_px, after.columns == size.columns else { return nil }
+        let column = Int(((x - columnZeroX) / cellWidth).rounded(.down))
+        guard column >= 0, column < Int(size.columns) else { return nil }
+        return column
+    }
+
     /// This surface's foreground process pid (`ghostty_surface_foreground_pid`), nil when the surface is not
     /// created or the call returns 0. Read at quit by the restore-running-command capture; not focus-dependent.
     func foregroundPid() -> pid_t? {

--- a/agterm/Views/WindowContentView+Zoom.swift
+++ b/agterm/Views/WindowContentView+Zoom.swift
@@ -176,15 +176,7 @@ extension WindowContentView {
         guard pick.pending == nil else { return }
         let expectedTarget = TerminalZoomTarget.session(session.id, surface)
         guard terminalZoom.target == expectedTarget else { return }
-        let target: (any TerminalSurface)? = switch surface {
-        case .primary: session.surface
-        case .split: session.splitSurface
-        case .scratch: session.scratchSurface
-        case .overlay: session.overlaySurface
-        case .overlayLeft: session.leftOverlaySurface
-        case .overlayRight: session.rightOverlaySurface
-        }
-        if let view = target as? GhosttySurfaceView {
+        if let view = surface.surface(in: session) as? GhosttySurfaceView {
             // suppress the focus report BEFORE the first grab: this runs from the target onChange, which can
             // land before the zoom layer's TerminalView has mounted and flipped the flag, and an unsuppressed
             // makeFirstResponder on the still-deck-hosted surface fires onFocusChange(true) and mutates

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -52,6 +52,9 @@ public protocol ControlActions {
     func focusSessionPane(_ target: String?, window: String?, pane: String?) -> ControlResponse
     func resizeSplit(_ target: String?, window: String?, resize: ControlSplitResize) -> ControlResponse
     func setSurfaceZoom(_ target: String?, window: String?, mode: ControlToggleMode) -> ControlResponse
+    /// The addressed surface's cursor column. Takes `surface.zoom`'s target vocabulary, `quick` included,
+    /// because it addresses the same set of surfaces; unlike zoom it is a pure read and changes nothing.
+    func readSurfaceCursor(_ target: String?, window: String?) -> ControlResponse
     func setDashboard(targets: [String], window: String?, close: Bool,
                       fontMode: DashboardFontMode, mru: Bool) -> ControlResponse
     func font(_ target: String?, window: String?, pane: String?, action: String) -> ControlResponse
@@ -214,7 +217,7 @@ public struct ControlDispatcher {
                 .sessionReveal, .sessionMove, .sessionFlag, .sessionSeen, .sessionStatus, .sessionRestore:
             return dispatchSessionCommand(request)
         case .sessionSplit, .sessionSplitClose, .sessionScratch, .sessionFocus, .sessionResize,
-                .surfaceZoom, .sessionType,
+                .surfaceZoom, .surfaceCursor, .sessionType,
                 .sessionCopy, .sessionPaste, .sessionSelectAll, .sessionSearch, .sessionOverlayOpen,
                 .sessionOverlayClose, .sessionOverlayResize, .sessionOverlayResult, .sessionOverlayCopy,
                 .sessionOverlayText, .sessionBackground,
@@ -588,6 +591,8 @@ public struct ControlDispatcher {
                 return ControlResponse(ok: false, error: "invalid surface zoom mode: \(request.args?.mode ?? "toggle")")
             }
             return actions.setSurfaceZoom(request.target, window: request.args?.window, mode: mode)
+        case .surfaceCursor:
+            return actions.readSurfaceCursor(request.target, window: request.args?.window)
         case .sessionType:
             guard let text = request.args?.text else {
                 return ControlResponse(ok: false, error: "session.type requires text")

--- a/agtermCore/Sources/agtermCore/ControlProtocol.swift
+++ b/agtermCore/Sources/agtermCore/ControlProtocol.swift
@@ -33,6 +33,7 @@ public enum Command: String, Codable, Sendable {
     case sessionFocus = "session.focus"
     case sessionResize = "session.resize"
     case surfaceZoom = "surface.zoom"
+    case surfaceCursor = "surface.cursor"
     case dashboard
     case sessionCopy = "session.copy"
     case sessionPaste = "session.paste"
@@ -858,6 +859,8 @@ public struct ControlResult: Codable, Sendable, Equatable {
     public var keymap: ControlKeymap?
     /// The current or terminal picker outcome for `pick.result`.
     public var pick: ControlPickResult?
+    /// The addressed surface's cursor position for `surface.cursor`.
+    public var cursor: ControlCursor?
 
     public init(id: String? = nil, tree: ControlTree? = nil, text: String? = nil,
                 windows: [ControlWindowNode]? = nil, exitCode: Int? = nil, count: Int? = nil,
@@ -865,7 +868,7 @@ public struct ControlResult: Codable, Sendable, Equatable {
                 theme: String? = nil, themes: [String]? = nil, ratio: Double? = nil,
                 sync: Bool? = nil, light: String? = nil, dark: String? = nil,
                 events: ControlEventBatch? = nil, keymap: ControlKeymap? = nil,
-                pick: ControlPickResult? = nil) {
+                pick: ControlPickResult? = nil, cursor: ControlCursor? = nil) {
         self.id = id
         self.tree = tree
         self.text = text
@@ -882,6 +885,24 @@ public struct ControlResult: Codable, Sendable, Equatable {
         self.events = events
         self.keymap = keymap
         self.pick = pick
+        self.cursor = cursor
+    }
+}
+
+/// `surface.cursor`'s payload, nested so a `row` could join it additively rather than by a rename.
+///
+/// There is no row: `tl_px_y` is the text BASELINE against an IME point at the cell bottom, leaving a term
+/// no probe separates from the row, and `adjust-font-baseline = 30` was measured reporting row 5 for a caret
+/// on row 4. `GhosttySurfaceView.readCursorColumn` owns why the horizontal twin is exact.
+///
+/// A column is a signal, not an assertion about content: past the prompt it proves the line is not empty,
+/// AT the prompt it proves nothing, the caret having possibly moved back over text.
+public struct ControlCursor: Codable, Sendable, Equatable {
+    /// Zero-based, counted from the left edge of the grid.
+    public let column: Int
+
+    public init(column: Int) {
+        self.column = column
     }
 }
 

--- a/agtermCore/Sources/agtermCore/TerminalZoom.swift
+++ b/agtermCore/Sources/agtermCore/TerminalZoom.swift
@@ -28,6 +28,20 @@ public enum TerminalZoomSurface: String, CaseIterable, Codable, Equatable, Senda
         }
     }
 
+    /// The live surface occupying this slot, nil when nothing has been created there. Availability is a
+    /// separate question — `isAvailable` answers whether the slot is ADDRESSABLE, which a session can be
+    /// while its surface has yet to come up.
+    @MainActor public func surface(in session: Session) -> (any TerminalSurface)? {
+        switch self {
+        case .primary: return session.surface
+        case .split: return session.splitSurface
+        case .scratch: return session.scratchSurface
+        case .overlay: return session.overlaySurface
+        case .overlayLeft: return session.leftOverlaySurface
+        case .overlayRight: return session.rightOverlaySurface
+        }
+    }
+
     @MainActor public func isAvailable(in session: Session) -> Bool {
         switch self {
         case .primary:

--- a/agtermCore/Sources/agtermctlKit/MiscCommands.swift
+++ b/agtermCore/Sources/agtermctlKit/MiscCommands.swift
@@ -192,8 +192,28 @@ struct Quick: ParsableCommand {
 struct Surface: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Terminal surface commands.",
-        subcommands: [Zoom.self]
+        subcommands: [Zoom.self, Cursor.self]
     )
+
+    struct Cursor: RequestCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Report a terminal surface's zero-based cursor column.",
+            discussion: """
+            Prints the column alone, so it drops straight into a command substitution. Row is not \
+            reported: the pinned libghostty exposes no cursor accessor and the vertical metrics it does \
+            export cannot recover a row that survives a custom `adjust-font-baseline`.
+
+            A column is a signal, not proof about the line's content. Past the prompt it establishes the \
+            line is not empty; AT the prompt it establishes nothing, since the caret may have been moved \
+            back over text that is still there.
+            """)
+        @OptionGroup var target: SurfaceTargetOptions
+        @OptionGroup var options: ClientOptions
+
+        func makeRequest() throws -> ControlRequest {
+            ControlRequest(cmd: .surfaceCursor, target: target.target, args: options.withWindow(ControlArgs()))
+        }
+    }
 
     struct Zoom: RequestCommand {
         static let configuration = CommandConfiguration(abstract: "Zoom a terminal surface (show|hide|toggle).")

--- a/agtermCore/Sources/agtermctlKit/SocketClient.swift
+++ b/agtermCore/Sources/agtermctlKit/SocketClient.swift
@@ -206,6 +206,11 @@ struct SocketClient {
             // keymap.reload reports its parse-diagnostic count; 0 reads as a clean reload.
             return count == 0 ? "ok" : "\(count) diagnostic(s)"
         }
+        if let cursor = response.result?.cursor {
+            // the bare column, scriptable as a command substitution. This stays one value even if the
+            // payload ever gains a row: a second field belongs under --json, not in a format callers parse.
+            return "\(cursor.column)"
+        }
         if let ratio = response.result?.ratio {
             // session.resize echoes the applied (clamped) primary-pane fraction, scriptable as a bare number.
             return String(format: "%.3f", ratio)

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -1584,6 +1584,34 @@ struct ControlDispatcherTests {
         #expect(actions.calls.isEmpty)
     }
 
+    @Test func surfaceCursorRoutesTargetAndWindow() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+        actions.nextSurfaceCursorResponse = ControlResponse(
+            ok: true, result: ControlResult(id: "surface:s1:right", cursor: ControlCursor(column: 7))
+        )
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .surfaceCursor,
+            target: "surface:s1:right",
+            args: ControlArgs(window: "win")
+        ))
+
+        #expect(response == ControlResponse(
+            ok: true, result: ControlResult(id: "surface:s1:right", cursor: ControlCursor(column: 7))
+        ))
+        #expect(actions.calls == [.surfaceCursor(target: "surface:s1:right", window: "win")])
+    }
+
+    @Test func surfaceCursorDefaultsTargetAndWindowToNil() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        _ = await dispatcher.dispatch(ControlRequest(cmd: .surfaceCursor))
+
+        #expect(actions.calls == [.surfaceCursor(target: nil, window: nil)])
+    }
+
     @Test func dashboardOpenRoutesTargetsWindowAndFixedFontMode() async {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)

--- a/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlProtocolTests.swift
@@ -61,6 +61,16 @@ struct ControlProtocolTests {
         #expect(try JSONDecoder().decode(ControlResult.self, from: Data(json.utf8)).pick == nil)
     }
 
+    @Test func controlResultCursorRoundTripsAndOmitsWhenNil() throws {
+        let carried = ControlResponse(ok: true, result: ControlResult(id: "surface:s1:left",
+                                                                     cursor: ControlCursor(column: 12)))
+        #expect(try roundTrip(carried) == carried)
+
+        let json = String(decoding: try JSONEncoder().encode(ControlResult(id: "surface:s1:left")), as: UTF8.self)
+        #expect(!json.contains("\"cursor\""), "a nil cursor must be omitted from the JSON; got \(json)")
+        #expect(try JSONDecoder().decode(ControlResult.self, from: Data(json.utf8)).cursor == nil)
+    }
+
     @Test func controlTreePickPendingOmitsWhenNil() throws {
         let tree = ControlTree(workspaces: [])
         let json = String(decoding: try JSONEncoder().encode(tree), as: UTF8.self)
@@ -140,6 +150,8 @@ struct ControlProtocolTests {
             ControlRequest(cmd: .sessionOverlayText, target: "9f3c", args: ControlArgs(lines: 20)),
             ControlRequest(cmd: .surfaceZoom, target: "surface:5E5B1C5B-75C5-49E6-8806-2C61D8D6BBA9:right",
                            args: ControlArgs(mode: "show", window: "win")),
+            ControlRequest(cmd: .surfaceCursor, target: "surface:5E5B1C5B-75C5-49E6-8806-2C61D8D6BBA9:left",
+                           args: ControlArgs(window: "win")),
         ]
         for request in cases {
             #expect(try roundTrip(request) == request)

--- a/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
+++ b/agtermCore/Tests/agtermCoreTests/MockControlActions.swift
@@ -40,6 +40,7 @@ final class MockControlActions: ControlActions {
         case sessionFocus(target: String?, window: String?, String?)
         case sessionResize(target: String?, window: String?, ControlSplitResize)
         case surfaceZoom(target: String?, window: String?, ControlToggleMode)
+        case surfaceCursor(target: String?, window: String?)
         case dashboard(targets: [String], window: String?, close: Bool, fontMode: DashboardFontMode, mru: Bool)
         case font(target: String?, window: String?, pane: String?, String)
         case keymapReload
@@ -135,6 +136,7 @@ final class MockControlActions: ControlActions {
     var nextSessionBackgroundResponse = ControlResponse(ok: true)
     var nextSessionTextResponse = ControlResponse(ok: true)
     var nextSurfaceZoomResponse = ControlResponse(ok: true)
+    var nextSurfaceCursorResponse = ControlResponse(ok: true, result: ControlResult(cursor: ControlCursor(column: 0)))
     var nextDashboardResponse = ControlResponse(ok: true)
     var nextWindowNewResponse = ControlResponse(ok: true)
     var nextWindowListResponse = ControlResponse(ok: true)
@@ -322,6 +324,11 @@ final class MockControlActions: ControlActions {
     func setSurfaceZoom(_ target: String?, window: String?, mode: ControlToggleMode) -> ControlResponse {
         calls.append(.surfaceZoom(target: target, window: window, mode))
         return nextSurfaceZoomResponse
+    }
+
+    func readSurfaceCursor(_ target: String?, window: String?) -> ControlResponse {
+        calls.append(.surfaceCursor(target: target, window: window))
+        return nextSurfaceCursorResponse
     }
 
     func setDashboard(targets: [String], window: String?, close: Bool,

--- a/agtermCore/Tests/agtermCoreTests/TerminalZoomTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/TerminalZoomTests.swift
@@ -13,6 +13,29 @@ struct TerminalZoomTests {
         }
     }
 
+    @Test func surfaceInSessionReturnsEachSlotsOwnSurface() {
+        let store = makeStore()
+        let ws = store.addWorkspace(name: "work")
+        let session = store.addSession(toWorkspace: ws.id, cwd: "/a")!
+        let slots: [(TerminalZoomSurface, ReferenceWritableKeyPath<Session, (any TerminalSurface)?>)] = [
+            (.primary, \.surface), (.split, \.splitSurface), (.scratch, \.scratchSurface),
+            (.overlay, \.overlaySurface),
+            (.overlayLeft, \.leftOverlaySurface), (.overlayRight, \.rightOverlaySurface),
+        ]
+
+        for (kind, slot) in slots {
+            #expect(kind.surface(in: session) == nil)
+            let surface = SpySurface()
+            session[keyPath: slot] = surface
+            #expect(kind.surface(in: session) === surface)
+            // every other slot must stay empty, or a transposed case would still read as a hit
+            for (other, _) in slots where other != kind {
+                #expect(other.surface(in: session) == nil)
+            }
+            session[keyPath: slot] = nil
+        }
+    }
+
     @Test func resolveTargetPrioritizesSessionCoversThenFocusedPane() {
         let store = makeStore()
         let ws = store.addWorkspace(name: "work")

--- a/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/CommandsTests.swift
@@ -1210,6 +1210,18 @@ struct CommandsTests {
             ControlRequest(cmd: .surfaceZoom, target: "active", args: ControlArgs(mode: "hide", window: "win")))
     }
 
+    @Test func surfaceCursorDefaultsToActive() throws {
+        #expect(try request(["surface", "cursor"]) ==
+            ControlRequest(cmd: .surfaceCursor, target: "active", args: ControlArgs()))
+    }
+
+    @Test func surfaceCursorTargetsSurfaceIDAndWindow() throws {
+        let id = "surface:5E5B1C5B-75C5-49E6-8806-2C61D8D6BBA9:right"
+
+        #expect(try request(["surface", "cursor", "--target", id, "--window", "win"]) ==
+            ControlRequest(cmd: .surfaceCursor, target: id, args: ControlArgs(window: "win")))
+    }
+
     // MARK: - pick
 
     @Test func pickDefaultsToOpen() throws {

--- a/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
+++ b/agtermCore/Tests/agtermctlKitTests/SocketClientTests.swift
@@ -758,6 +758,13 @@ struct SocketClientTests {
         #expect(SocketClient.formatResponse(response, json: false) == "selected\nlines")
     }
 
+    @Test(arguments: [0, 42])
+    func formatResponseCursorPrintsTheBareColumn(_ column: Int) {
+        let response = ControlResponse(ok: true, result: ControlResult(id: "surface:s1:left",
+                                                                      cursor: ControlCursor(column: column)))
+        #expect(SocketClient.formatResponse(response, json: false) == "\(column)")
+    }
+
     @Test func formatResponseZeroCountIsOk() {
         // keymap.reload reports a parse-diagnostic count; 0 reads as a clean reload.
         let response = ControlResponse(ok: true, result: ControlResult(count: 0))

--- a/agtermUITests/ControlSurfaceCursorUITests.swift
+++ b/agtermUITests/ControlSurfaceCursorUITests.swift
@@ -1,0 +1,160 @@
+import XCTest
+
+@MainActor
+final class ControlSurfaceCursorUITests: ControlAPITestCase {
+    // differential, not absolute: the host's prompt, font size and padding are unknown here
+    func testSurfaceCursorColumnAdvancesByTheTypedTextLength() throws {
+        let sessionID = try activeSessionID()
+        try waitForPrompt(sessionID, marker: "cursor-ready")
+
+        let atPrompt = try XCTUnwrap(settledCursorColumn(timeout: 10), "the column should settle at the prompt")
+        let probe = "abcdefg"
+        // no trailing newline: the payload must sit on the prompt line, not run
+        XCTAssertEqual(try sendCommand(typeRequest(text: probe, target: sessionID, select: false))["ok"] as? Bool,
+                       true, "typing the probe payload should succeed")
+        XCTAssertTrue(pollCursorColumn(atPrompt + probe.count, timeout: 10),
+                      "the column should advance by the payload length from \(atPrompt); got \(String(describing: cursorColumnOrNil()))")
+    }
+
+    func testSurfaceCursorReadsAnExplicitSplitPaneAndRejectsUnknownTargets() throws {
+        let sessionID = try activeSessionID()
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.split","args":{"mode":"on"}}"#)["ok"] as? Bool, true,
+                       "split on should succeed")
+        try waitForPrompt(sessionID, marker: "cursor-split-ready", pane: "right")
+
+        let response = try sendCommand(#"{"cmd":"surface.cursor","target":"surface:\#(sessionID):right"}"#)
+        XCTAssertEqual(response["ok"] as? Bool, true, "reading the split pane's cursor should succeed: \(response)")
+        let result = try XCTUnwrap(response["result"] as? [String: Any], "a cursor read should carry a result")
+        XCTAssertEqual(result["id"] as? String, "surface:\(sessionID):right",
+                       "the result should echo the surface it read")
+        // pins the nested shape: a future row joins `cursor`, never a second top-level key
+        let cursor = try XCTUnwrap(result["cursor"] as? [String: Any], "the result should nest a cursor object")
+        XCTAssertNotNil(cursor["column"] as? Int, "the cursor should carry an Int column: \(cursor)")
+        XCTAssertNil(cursor["row"], "row is deliberately absent, the pinned libghostty cannot recover it")
+
+        let unknown = try sendCommand(#"{"cmd":"surface.cursor","target":"not-a-surface"}"#)
+        XCTAssertEqual(unknown["ok"] as? Bool, false, "an unparsable target should be refused: \(unknown)")
+        XCTAssertEqual(unknown["error"] as? String, "invalid surface: not-a-surface")
+
+        let empty = try sendCommand(#"{"cmd":"surface.cursor","target":"surface:\#(sessionID):scratch"}"#)
+        XCTAssertEqual(empty["ok"] as? Bool, false, "an empty slot should be refused: \(empty)")
+        XCTAssertEqual(empty["error"] as? String, "surface not available: surface:\(sessionID):scratch")
+    }
+
+    // zooming a NONFOCUSED pane leaves `splitFocused` alone, so resolving `active` from the store's focus
+    // instead of the window's zoom controller silently read the hidden pane.
+    func testSurfaceCursorActiveFollowsAnExplicitZoomOfTheNonFocusedPane() throws {
+        let sessionID = try activeSessionID()
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.split","args":{"mode":"on"}}"#)["ok"] as? Bool, true,
+                       "split on should succeed")
+        try waitForPrompt(sessionID, marker: "zoom-left-ready", pane: "left")
+        try waitForPrompt(sessionID, marker: "zoom-right-ready", pane: "right")
+
+        // distinct payloads so the two panes' columns cannot coincide
+        try type("ab", into: sessionID, pane: "left")
+        try type("abcdefghij", into: sessionID, pane: "right")
+        let left = try XCTUnwrap(settledCursorColumn(target: "surface:\(sessionID):left", timeout: 10))
+        let right = try XCTUnwrap(settledCursorColumn(target: "surface:\(sessionID):right", timeout: 10))
+        XCTAssertNotEqual(left, right, "the panes must differ for `active` to be a real discriminator")
+
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.focus","args":{"pane":"left"}}"#)["ok"] as? Bool, true,
+                       "focusing the left pane should succeed")
+        XCTAssertTrue(pollCursorColumn(left, timeout: 10), "unzoomed, `active` should read the focused left pane")
+
+        let zoom = try sendCommand(#"{"cmd":"surface.zoom","target":"surface:\#(sessionID):right","args":{"mode":"show"}}"#)
+        XCTAssertEqual(zoom["ok"] as? Bool, true, "zooming the right pane should succeed: \(zoom)")
+        XCTAssertTrue(pollCursorColumn(right, timeout: 10),
+                      "`active` should follow the zoom to the right pane, not stay on the focused left one")
+
+        XCTAssertEqual(try sendCommand(#"{"cmd":"surface.zoom","target":"surface:\#(sessionID):right","args":{"mode":"hide"}}"#)["ok"] as? Bool,
+                       true, "unzooming should succeed")
+        XCTAssertTrue(pollCursorColumn(left, timeout: 10), "`active` should return to the focused pane after unzoom")
+    }
+
+    // `QuickTerminalController.hide()` keeps its surface alive, so a panel shown once stayed readable —
+    // the never-shown case is the false green here.
+    func testSurfaceCursorRefusesAHiddenQuickTerminalAfterItHasBeenShown() throws {
+        let before = try sendCommand(#"{"cmd":"surface.cursor","target":"quick"}"#)
+        XCTAssertEqual(before["ok"] as? Bool, false, "a never-shown quick terminal should be refused: \(before)")
+
+        XCTAssertEqual(try sendCommand(#"{"cmd":"quick","args":{"mode":"show"}}"#)["ok"] as? Bool, true,
+                       "showing the quick terminal should succeed")
+        XCTAssertNotNil(settledCursorColumn(target: "quick", timeout: 10),
+                        "a shown quick terminal should report a column")
+
+        XCTAssertEqual(try sendCommand(#"{"cmd":"quick","args":{"mode":"hide"}}"#)["ok"] as? Bool, true,
+                       "hiding the quick terminal should succeed")
+        let after = try sendCommand(#"{"cmd":"surface.cursor","target":"quick"}"#)
+        XCTAssertEqual(after["ok"] as? Bool, false, "a hidden quick terminal should be refused again: \(after)")
+        XCTAssertEqual(after["error"] as? String, "surface not available: quick")
+    }
+
+    // a HUD fills `overlaySurface` while `tree` omits the overlay surface and zoom rejects it, so a guessed
+    // id read the app's own message painter. The program overlay proves the refusal is the gate, not a dead path.
+    func testSurfaceCursorRefusesAHudInTheOverlaySlotButReadsAProgramOverlay() throws {
+        let sessionID = try activeSessionID()
+        let overlayID = "surface:\(sessionID):overlay"
+
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.hud.open","args":{"message":"cursor hud"}}"#)["ok"] as? Bool,
+                       true, "opening a hud should succeed")
+        let hud = try sendCommand(#"{"cmd":"surface.cursor","target":"\#(overlayID)"}"#)
+        XCTAssertEqual(hud["ok"] as? Bool, false, "a hud must not be readable through the overlay id: \(hud)")
+        XCTAssertEqual(hud["error"] as? String, "surface not available: \(overlayID)")
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.hud.close"}"#)["ok"] as? Bool, true,
+                       "closing the hud should succeed")
+
+        XCTAssertEqual(try sendCommand(#"{"cmd":"session.overlay.open","args":{"command":"sleep 300"}}"#)["ok"] as? Bool,
+                       true, "opening a program overlay should succeed")
+        XCTAssertNotNil(settledCursorColumn(target: overlayID, timeout: 15),
+                        "a program overlay in the same slot should report a column")
+    }
+
+    // MARK: - Helpers
+
+    /// A single cursor read, nil on any refusal. Silent because the pollers below run it while a surface is
+    /// still coming up: `quick show` and `overlay.open` both answer `surface not realized` for a moment, the
+    /// same readiness gap `quick.type`/`quick.text` poll through.
+    private func cursorColumnOrNil(target: String? = nil) -> Int? {
+        let response = try? sendCommand(target.map { #"{"cmd":"surface.cursor","target":"\#($0)"}"# }
+            ?? #"{"cmd":"surface.cursor"}"#)
+        guard let result = response?["result"] as? [String: Any],
+              let cursor = result["cursor"] as? [String: Any] else { return nil }
+        return cursor["column"] as? Int
+    }
+
+    /// A column read twice in a row with the same value. The marker file proves the command RAN, not that the
+    /// shell has finished redrawing its next prompt, so a bare single read can sample the executing command's
+    /// caret and every later expectation is then off by the prompt width.
+    private func settledCursorColumn(target: String? = nil, timeout: TimeInterval) -> Int? {
+        let deadline = Date().addingTimeInterval(timeout)
+        var previous: Int?
+        while Date() < deadline {
+            let current = cursorColumnOrNil(target: target)
+            if let current, current == previous { return current }
+            previous = current
+            RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+        }
+        return nil
+    }
+
+    private func pollCursorColumn(_ expected: Int, target: String? = nil, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if cursorColumnOrNil(target: target) == expected { return true }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        }
+        return false
+    }
+
+    private func waitForPrompt(_ sessionID: String, marker: String, pane: String? = nil) throws {
+        let file = markerDir.appendingPathComponent(marker)
+        let value = try typeUntilMarker("printf READY > '\(file.path)'\n",
+                                        target: sessionID, file: file, select: false, pane: pane)
+        XCTAssertEqual(value, "READY", "the \(pane ?? "left") pane's shell should be reading commands")
+    }
+
+    private func type(_ text: String, into sessionID: String, pane: String?) throws {
+        XCTAssertEqual(try sendCommand(typeRequest(text: text, target: sessionID, select: false, pane: pane))["ok"] as? Bool,
+                       true, "typing into the \(pane ?? "left") pane should succeed")
+    }
+}

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -17,7 +17,7 @@ description: >
   feature request / question as a GitHub Discussion.
 when_to_use: >
   Trigger on: agterm, agtermctl, agterm control socket, session.new, session.close, session.type,
-  session.split, session.split.close, session.scratch, session.focus, session.resize, surface.zoom, dashboard, pick, pick.open, pick.result, pick.cancel, native picker, session.go, session.copy, session.paste, session.selectall, session.text, session.search, session.status,
+  session.split, session.split.close, session.scratch, session.focus, session.resize, surface.zoom, surface.cursor, cursor column, dashboard, pick, pick.open, pick.result, pick.cancel, native picker, session.go, session.copy, session.paste, session.selectall, session.text, session.search, session.status,
   session.flag, session.seen, session.reveal, session.duplicate, session.background, session.overlay,
   session.hud, hud panel, show a message over a session, workspace.new, workspace.select, workspace.go, workspace.move, workspace.focus, workspace.filter, window.new, window.list,
   window.select, window.resize, window.move, window.zoom, window.fullscreen, window.minimize, quick terminal, sidebar, sidebar.mode, sidebar.expand, sidebar.collapse, flagged, notify, font.inc, keymap.reload, keymap.list, config.reload,
@@ -99,8 +99,8 @@ Inspect the live tree any time with `agtermctl tree --json` (workspaces → sess
 `id`, `name`, `cwd`, `title`, `active`, `split`, `overlay`, `hud`, `scratch`, `status`, `background`, `surfaces`). `title` is the raw OSC
 terminal title (e.g. a remote host over SSH), omitted when none was reported — read it when a
 session's local `cwd` is stale because it's connected to a remote. `surfaces[].id` is the
-control address for `surface zoom` (`left`, `right`, `scratch`, `overlay`, `overlay-left`, or
-`overlay-right`), including hidden-but-alive split/scratch surfaces. The tree object also carries five
+control address for `surface zoom` and `surface cursor` (`left`, `right`, `scratch`, `overlay`,
+`overlay-left`, or `overlay-right`), including hidden-but-alive split/scratch surfaces. The tree object also carries five
 read-only top-level fields: `idleMs` (ms since the last user input in the window), `autoFollowMs`
 (the Auto-follow timeout in ms, omitted when Disabled), `sidebarVisible` (whether the window's
 sidebar is currently shown — the read side of the write-only `sidebar` command), `sidebarMode`
@@ -198,7 +198,7 @@ the default 0.5) —
 the read side of `session resize`, record it to restore the exact divider), `splitFocused`
 (which pane holds focus in a session that has a split: `true` = split/right/bottom, `false` = primary/left/top; omitted
 when there's no split; the read side of `session focus`, record it to restore focus), and `surfaces`
-(`id`, `kind`, `active`, `visible`) for `surface zoom`. The tree top level carries `zoomedSurface`
+(`id`, `kind`, `active`, `visible`) for `surface zoom` and `surface cursor`. The tree top level carries `zoomedSurface`
 (the control id of the currently zoomed surface, omitted when nothing is zoomed — the read side of
 `surface zoom`, so a script can check the zoom state and record-then-restore). It also carries the read
 side of the `dashboard` command (all omitted when no dashboard is open): `dashboardMembers` (the pane refs

--- a/plugins/agterm/skills/agterm/examples.md
+++ b/plugins/agterm/skills/agterm/examples.md
@@ -693,6 +693,25 @@ agtermctl tree --json | jq -r '.result.tree.zoomedSurface'
 `surface zoom` is not `window zoom`: it does not move/resize the macOS window and must not change split
 ratios, sidebar state, focus, or split/scratch visibility. Surface ids come from `tree --json`.
 
+## Read a surface's cursor column
+
+```bash
+# The active surface's zero-based column, as a plain number.
+col=$(agtermctl surface cursor)
+
+# Any addressable surface, including a pane that is not on screen.
+agtermctl surface cursor --target "surface:${AGTERM_SESSION_ID:?}:right"
+
+# Under --json it is nested, so a future row would not move it.
+agtermctl surface cursor --json | jq -r '.result.cursor.column'
+```
+
+Use it as a ONE-WAY signal about the line the caret is on. A column past the prompt proves the line is not
+empty. A column AT the prompt proves nothing — the caret may have been moved back over text that is still
+there — so never read it as "the input is empty". There is no row: the pinned libghostty exposes no cursor
+accessor, and the vertical metrics it does export cannot recover a row that survives a custom
+`adjust-font-baseline`. The command reports no field in `tree`, so poll it when you need it.
+
 ## Watch several sessions at once in a dashboard grid
 
 The dashboard shows several sessions' live output in one view-only grid — for watching several agents or

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -802,6 +802,19 @@ opens on the zoomed session still spawn their shells behind the zoom layer. A no
 click exits zoom before revealing its session. Use `surface zoom` when the user/agent needs a pane
 fullscreen inside agterm; use `window zoom` only to maximize the whole window on screen.
 
+`agtermctl surface cursor [--target SURFACE_ID|active|quick] [--window W]` — the surface's zero-based
+cursor column, counted from the left edge of the grid. Plain output is the bare number, so
+`col=$(agtermctl surface cursor)` works; under `--json` it is `.result.cursor.column`. The target
+vocabulary and its refusals are `surface zoom`'s, so an explicit `SURFACE_ID` reads a hidden pane or a
+background session as readily as the visible one. It is a pure read: it neither selects nor realizes the
+target, and it reports no field in `tree`, so poll it when you need it.
+
+There is no row. The pinned libghostty exposes no cursor accessor and the vertical metrics it does export
+cannot recover a row that survives a custom `adjust-font-baseline`; a `row` would join the same `cursor`
+object if that ever changes. Treat the column as a one-way signal about the line: past the prompt it
+proves the line is NOT empty, at the prompt it proves nothing, because the caret may have been moved back
+over text that is still there. Never read "column equals the prompt" as "the composer is empty".
+
 ## dashboard
 
 `agtermctl dashboard <ids…> [--font-size N | --auto-size] [--window W]` opens a per-window, view-only

--- a/site/commands.html
+++ b/site/commands.html
@@ -192,7 +192,7 @@
             <a href="#overlay" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">session overlay</a>
             <a href="#hud" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">session hud</a>
             <a href="#window" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">window</a>
-            <a href="#surface" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">surface zoom</a>
+            <a href="#surface" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">surface</a>
             <a href="#dashboard" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">dashboard</a>
             <a href="#pick" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">pick</a>
             <a href="#quick" style="color: #bfbab0; padding: 7px 12px; border-radius: 7px" class="hv9">quick</a>
@@ -1932,11 +1932,12 @@
                 border-bottom: 1px solid rgba(255, 255, 255, 0.08);
               "
             >
-              surface zoom
+              surface
             </h2>
             <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 16px">
-              A view mode that fills the window with one terminal surface. It never touches the macOS window frame —
-              distinct from <span style="font-family: &quot;JetBrains Mono&quot;, monospace">window zoom</span>.
+              Commands addressing one terminal surface rather than a session: a view mode that fills the window with a
+              single surface, and a read of that surface's cursor column. Both take the same
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--target</span> vocabulary.
             </p>
 
             <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
@@ -1978,6 +1979,39 @@
                 The panel's zoom is app-level and independent of any window's, and it takes precedence: while it is zoomed the
                 field reads <span style="font-family: &quot;JetBrains Mono&quot;, monospace">quick</span> even if that window's own
                 session zoom is armed. Record the value before zooming the panel, not after.
+              </p>
+            </div>
+
+            <div style="background: #22272b; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 11px; padding: 18px 20px; margin-bottom: 12px">
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 13.5px; color: #6d82f3; line-height: 1.6; word-break: break-word">
+                agtermctl surface cursor [--target surface:&lt;id&gt;:right | active | quick] [--window W]
+              </div>
+              <div style="font-family: &quot;JetBrains Mono&quot;, monospace; font-size: 11.5px; color: #6b727a; margin-top: 6px">surface.cursor</div>
+              <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
+                Report the surface's zero-based cursor column, counted from the left edge of the grid. Human output is the
+                bare number, so it drops straight into a command substitution; under
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--json</span> it is
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">result.cursor.column</span>. The target vocabulary is
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">surface zoom</span>'s, so an explicit
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">surface:&lt;session-id&gt;:&lt;kind&gt;</span>
+                id reads a hidden pane or a background session just as well as the visible one. This is a pure read: it neither
+                selects nor realizes the target, so an unrealized surface is reported rather than waited for.
+              </p>
+              <p style="font-size: 15px; line-height: 1.65; color: #cbc6bc; margin: 10px 0 0">
+                There is no row. The pinned libghostty exposes no cursor accessor, and the vertical metrics it does export
+                cannot recover a row that survives a custom
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">adjust-font-baseline</span> — a wrong row is worse
+                than an absent one. If libghostty ever exports the position directly, a
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">row</span> joins the same
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">cursor</span> object under
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--json</span>; the plain output stays one number.
+              </p>
+              <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
+                A column is a signal, not a claim about the line's contents. Past the prompt it establishes the line is not
+                empty; at the prompt it establishes nothing, because the caret may have been moved back over text that is
+                still there. It is poll-only and reports no read-back field in
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">tree</span>: the read is expensive enough that
+                paying it for every live and hidden surface on every poll would be the wrong trade.
               </p>
             </div>
           </section>


### PR DESCRIPTION
Adds `surface.cursor`, a read that reports a terminal surface's zero-based cursor column.

```
$ agtermctl surface cursor
18
$ agtermctl surface cursor --target surface:<id>:right --json
{"result":{"id":"surface:<id>:right","cursor":{"column":18}},"ok":true}
```

Plain output is the bare number so it drops into a command substitution. It takes `surface.zoom`'s target
vocabulary, so an explicit id reads a hidden pane or a background session as readily as the visible one.

**How the column is derived.** libghostty exposes no cursor accessor. `ghostty_surface_ime_point` reports the
cursor cell's midpoint as `(column * cellWidth + paddingLeft + cellWidth / 2) / contentScale`, and the padding
is the unknown: `ghostty_surface_size` does not carry it, and a user `ghostty.conf` can override agterm's
default without agterm tracking it. Reading the viewport's top-left cell measures it instead, since
`ghostty_text_s.tl_px_x` is `(column * cellWidth + paddingLeft) / contentScale` for whichever cell was asked
for, so at column zero it is the padding term itself. Subtracting leaves `column + 0.5` cells with nothing
derived on either side.

Checked against parked carets on a live instance rather than reasoned about: exact at columns 0, 1, 14 and 40,
at the right edge where the terminal clamps to its own grid, under `window-padding-x = 37,3` with
`window-padding-y = 11,2` and `window-padding-balance` on, across font sizes, on both split panes, and on a
session that had never been on screen.

**No row, deliberately.** `tl_px_y` is the text baseline while the IME point is the cell bottom, which leaves a
term no probe separates from the row. It cancels for ordinary fonts, but under `adjust-font-baseline = 30` a
caret parked on row 4 reported row 5 while its column stayed correct. A wrong row with no error is worse than
an absent one, so the payload is nested and a `row` can join the same `cursor` object if libghostty ever
exports the position directly.

**What a column does and does not prove.** Past the prompt it establishes the line is not empty. At the prompt
it establishes nothing, because the caret may have been moved back over text that is still there. It is a
one-way signal, documented as such in the skill and the command reference.

The command shares `surface.zoom`'s gates as well as its vocabulary. `active` reads the window's zoom target
before the store's focused pane, or zooming a pane that does not hold focus reads the hidden one. Both paths
pass `TerminalZoomController.isTargetValid`, so a guessed `surface:<id>:overlay` cannot reach a HUD that `tree`
omits and zoom rejects. `quick` gates on visibility rather than on the surface `hide()` keeps alive. All three
were real bugs during review and each has its own regression test; the zoom one was confirmed by removing the
fix and watching that test fail.

No `tree` field: `ghostty_surface_read_text` allocates and takes the renderer lock, so paying it per live and
hidden surface on every poll is the wrong trade.

`TerminalZoomSurface.surface(in:)` replaces the six-case switch `WindowContentView+Zoom.swift` spelled inline,
so the slot mapping has one home.

Docs updated in `site/commands.html`, the bundled skill (`SKILL.md`, `reference.md`, `examples.md`) and
`.claude/rules/control-api.md`, which records the measured padding cancellation and the baseline off-by-one so
the row question does not get reopened as a near miss.
