### PR TITLE
fix: refuse to restore a captured command that cannot be replayed faithfully

### DIFF
--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -152,7 +152,13 @@ paths:
   mid-run reopen, and `recoverOrphanedWindows` drops captures while the sticky override still arms
   (a corrupt index must not re-execute a closed window's last command).
 - Restore only when the toggle is on and basename is absent from user
-  `restore-denylist.conf`, seeded with `tmux`, `screen`, and `zellij`. Feed captured argv once through
+  `restore-denylist.conf`, seeded with `tmux`, `screen`, and `zellij`. A control character anywhere in the
+  argv also refuses, matching what `session.restore set` rejects a pin for: the line is typed, so the line
+  editor reads the byte before the shell parser and quoting cannot protect it. U+FFFD refuses with it,
+  since `parseProcArgs` decodes lossily and replaying it would run a different argument. Both refuse at
+  RENDER, keeping `hadForeground` true so a stale `initialCommand` stays preempted. A pin loaded from a
+  snapshot never passed the dispatcher's check, so `restoreInput` applies it again at the sink; both share
+  `CommandRestore.hasControlCharacter`. Feed captured argv once through
   shell-quoted `config.initial_input` so exit returns to the shell, then nil it. Only one foreground
   process from a typed pipeline/compound command can be captured.
 - `session.new --command` persists durable `initialCommand` and restores through shell-replacing

--- a/agterm/agtermApp.swift
+++ b/agterm/agtermApp.swift
@@ -302,8 +302,9 @@ struct agtermApp: App {
     }
 
     /// The `initial_input` for a restored pane: the captured foreground argv re-rendered as a shell command
-    /// line + newline, or nil when the restore-running-command flag is off or the basename is in the user's
-    /// `restore-denylist.conf` (→ plain shell), parsed at launch into `GhosttyApp.shared.restoreDenylist`.
+    /// line + newline, or nil when the restore-running-command flag is off or `shouldRestore` refuses the
+    /// argv — a denylisted basename, a control character, or a lossily-decoded byte (→ plain shell). The
+    /// denylist is the user's `restore-denylist.conf`, parsed at launch into `GhosttyApp.shared.restoreDenylist`.
     @MainActor
     private static func restoreInitialInput(_ argv: [String]?) -> String? {
         guard GhosttyApp.shared.restoreRunningCommand, let argv,

--- a/agtermCore/Sources/agtermCore/CommandRestore.swift
+++ b/agtermCore/Sources/agtermCore/CommandRestore.swift
@@ -78,12 +78,26 @@ public enum CommandRestore {
         return others.filter { $0.ppid == pgid }.map(\.pid).sorted()
     }
 
-    /// Whether a captured argv should be re-run on restore: false for an empty argv or one whose
-    /// `argv[0]` basename is in `denylist`, true otherwise. The denylist is the user-editable
-    /// `restore-denylist.conf` (no built-in entries) — `parseDenylist` builds it.
+    /// Whether a captured argv should be re-run on restore: false for an empty argv, one whose `argv[0]`
+    /// basename is in the user-editable `restore-denylist.conf` (`parseDenylist` builds it, no built-in
+    /// entries), or one carrying an `isUnreplayable` scalar. Refusing HERE rather than at capture keeps
+    /// `hadForeground` true, so `restorePlan` still preempts a stale `initialCommand`.
     public static func shouldRestore(argv: [String], denylist: Set<String>) -> Bool {
         guard let first = argv.first, !first.isEmpty else { return false }
+        if argv.contains(where: { $0.unicodeScalars.contains(where: isUnreplayable) }) { return false }
         return !denylist.contains(basename(first))
+    }
+
+    /// Two unrelated reasons, one predicate because both end at the same plain shell: a control character
+    /// the line editor acts on, and the U+FFFD `parseProcArgs` leaves where the bytes were not valid
+    /// UTF-8. A genuine U+FFFD is refused with it, the two being indistinguishable once decoded.
+    private static func isUnreplayable(_ scalar: Unicode.Scalar) -> Bool {
+        isControlCharacter(scalar) || scalar.value == 0xFFFD
+    }
+
+    /// C0 and DEL — what a line editor reads as an editing command rather than as text.
+    private static func isControlCharacter(_ scalar: Unicode.Scalar) -> Bool {
+        scalar.value < 0x20 || scalar.value == 0x7F
     }
 
     /// The mutually-exclusive surface seed a pane restores/creates with. `command` != nil → the exec path
@@ -135,8 +149,15 @@ public enum CommandRestore {
     public static func restoreInput(restoreEnabled: Bool, restoreOverride: String?,
                                     capturedInput: String?) -> String? {
         guard let restoreOverride else { return capturedInput }
-        guard restoreEnabled, !restoreOverride.isEmpty else { return nil }
+        guard restoreEnabled, !restoreOverride.isEmpty, !hasControlCharacter(restoreOverride) else { return nil }
         return restoreOverride + "\n"
+    }
+
+    /// Whether `value` carries a character the line editor would read as an editing command. `session.restore
+    /// set` rejects these on WRITE, but a pin reaching `restoreInput` from a snapshot never passed through
+    /// that check, so the sink the dispatcher's own reasoning names is guarded here too.
+    static func hasControlCharacter(_ value: String) -> Bool {
+        value.unicodeScalars.contains(where: isControlCharacter)
     }
 
     /// Decide a pane's seed on create/restore. Pure, so the gate + precedence is unit-tested off the C
@@ -170,8 +191,8 @@ public enum CommandRestore {
     }
 
     /// Render an argv into one POSIX shell command line, single-quoting each argument (so spaces, `$`,
-    /// globs and quotes survive intact) and space-joining. The inverse of capture; fed to a restored login
-    /// shell via `initial_input`.
+    /// globs and quotes survive intact) and space-joining; fed to a restored login shell via
+    /// `initial_input`. Quoting is a PARSER escape, so it inverts capture only for what `shouldRestore` accepted.
     public static func shellQuotedLine(_ argv: [String]) -> String {
         argv.map(shellQuote).joined(separator: " ")
     }

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -435,7 +435,7 @@ public struct ControlDispatcher {
             }
             // a control character would smuggle an extra line (or an escape sequence) into the shell the
             // override is typed into, so the whole class is rejected — tab included.
-            guard !command.unicodeScalars.contains(where: { $0.value < 0x20 || $0.value == 0x7f }) else {
+            guard !CommandRestore.hasControlCharacter(command) else {
                 return ControlResponse(ok: false, error: "command must not contain control characters")
             }
             guard command.utf8.count <= ControlRestoreOverride.maxCommandBytes else {

--- a/agtermCore/Tests/agtermCoreTests/CommandRestoreTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/CommandRestoreTests.swift
@@ -103,6 +103,57 @@ struct CommandRestoreTests {
         #expect(!CommandRestore.shouldRestore(argv: [""], denylist: denylist))
     }
 
+    @Test func shouldRestoreRefusesControlCharacters() {
+        // #454: the rendered line is typed, so a control byte reaches the line editor as an editing
+        // command — 0x15 kills the line and runs whatever follows it.
+        #expect(!CommandRestore.shouldRestore(argv: ["sed", "s/\u{1B}//"], denylist: []))
+        #expect(!CommandRestore.shouldRestore(argv: ["awk", "-F", "\u{09}", "{print $2}"], denylist: []))
+        #expect(!CommandRestore.shouldRestore(argv: ["grep", "a\u{15}b"], denylist: []))
+        #expect(!CommandRestore.shouldRestore(argv: ["grep", "a\u{0A}rm -rf x"], denylist: []))
+        #expect(!CommandRestore.shouldRestore(argv: ["less", "note\u{7F}.txt"], denylist: []))
+        // argv[0] carries the byte, so the basename check alone would let it through.
+        #expect(!CommandRestore.shouldRestore(argv: ["od\u{1B}d"], denylist: []))
+        // the boundary: 0x20 and printable high scalars are ordinary argument bytes.
+        #expect(CommandRestore.shouldRestore(argv: ["echo", "a b"], denylist: []))
+        #expect(CommandRestore.shouldRestore(argv: ["echo", "naïve — ✓"], denylist: []))
+    }
+
+    @Test func shouldRestoreRefusesLossilyDecodedArguments() {
+        // the argument bytes must be RAW, not a Swift literal: "\u{FFFD}" encodes as valid UTF-8, which
+        // would pin the genuine-U+FFFD case while proving nothing about lossy decoding.
+        var raw = withUnsafeBytes(of: Int32(2)) { Data($0) }
+        raw.append(Data("/usr/bin/grep".utf8)); raw.append(0)
+        raw.append(Data("grep".utf8)); raw.append(0)
+        raw.append(Data([0x63, 0x61, 0x66, 0xE9])); raw.append(0) // "caf" + a lone Latin-1 é
+        let argv = CommandRestore.parseProcArgs(raw)
+        #expect(argv == ["grep", "caf\u{FFFD}"])
+        #expect(!CommandRestore.shouldRestore(argv: argv ?? [], denylist: []))
+        // a genuine U+FFFD is refused with it, indistinguishable once decoded.
+        #expect(!CommandRestore.shouldRestore(argv: ["grep", "caf\u{FFFD}"], denylist: []))
+        #expect(!CommandRestore.shouldRestore(argv: ["\u{FFFD}bin", "x"], denylist: []))
+    }
+
+    @Test func lossyArgvStillPreemptsStaleInitialCommand() {
+        // the refusal is at render, not capture, so hadForeground stays true and a --command session
+        // comes back a plain shell rather than re-running its creation command.
+        let inputs = CommandRestore.RestoreInputs(wasRestored: true, restoreEnabled: true, hadForeground: true,
+                                                  foregroundInput: nil, initialCommand: "ssh prod",
+                                                  restoreOverride: nil)
+        let plan = CommandRestore.restorePlan(inputs)
+        #expect(plan.command == nil)
+        #expect(plan.initialInput == nil)
+    }
+
+    @Test func restoreInputRefusesOverrideCarryingControlCharacters() {
+        // the dispatcher rejects these on write, but a pin loaded from a snapshot never passed that check.
+        #expect(CommandRestore.restoreInput(restoreEnabled: true, restoreOverride: "tail -f\u{1B}x",
+                                            capturedInput: "'top'\n") == nil)
+        #expect(CommandRestore.restoreInput(restoreEnabled: true, restoreOverride: "a\u{0A}rm -rf x",
+                                            capturedInput: nil) == nil)
+        #expect(CommandRestore.restoreInput(restoreEnabled: true, restoreOverride: "cd x && claude",
+                                            capturedInput: nil) == "cd x && claude\n")
+    }
+
     @Test func parseDenylistReadsBasenamesIgnoringCommentsAndBlanks() {
         let text = """
         # programs not to restore

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -1176,7 +1176,11 @@ command at a clean quit and re-runs it on relaunch; `restore clear` wipes those 
 
 Which programs are NOT re-run is controlled by `restore-denylist.conf` in the config directory (one
 command name per line, seeded with the terminal multiplexers `tmux`/`screen`/`zellij`). It is a plain
-user-edited file read at launch — there is no control command for it.
+user-edited file read at launch — there is no control command for it. Two more things are skipped
+whatever the denylist says, and the pane starts a plain shell. A control character in the command's
+name or any argument: the restored line is typed, so the line editor reads that byte as an editing key
+rather than as text. A byte sequence that was not valid UTF-8: it is captured lossily, so replaying it
+would run an argument the process never had.
 
 For a PER-SESSION, per-pane override that pins (or suppresses) what a pane restores, use
 `session restore` (in the session section above): it wins over the captured foreground, bypasses the

--- a/site/docs.html
+++ b/site/docs.html
@@ -2734,7 +2734,10 @@ command = "'/Users/you/.config/agterm/agent-status/agterm-codex-status.sh' stop"
                 re-spawns a fresh login shell in its saved directory. The optional
                 <strong style="color: #e6e1d7">Restore running commands on restart</strong> toggle (General settings, off by
                 default) re-runs the command each pane had in the foreground at the last clean quit — a re-run, not a reattach.
-                Only a single-process command restores faithfully; a force-quit or crash captures nothing, and a capture replays
+                Only a single-process command restores faithfully; a command whose name or arguments carry a control character
+                starts a plain shell instead, since the restored line is typed and the line editor would read that byte as an
+                editing key rather than text, and so does one carrying bytes that were not valid UTF-8, which are captured
+                lossily and would replay a different argument; a force-quit or crash captures nothing, and a capture replays
                 exactly once, since the launch that arms it clears it from the state file; and the multiplexers in
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">restore-denylist.conf</span>
                 (seeded with tmux/screen/zellij) start fresh. That file is yours to edit: agterm writes a commented starter at


### PR DESCRIPTION
a captured argv keeps its bytes as the process had them, and `shellQuotedLine` single-quotes each one. That guards the shell parser, but the restored line is typed into the pane through `initial_input`, so the line editor sees it first and reads a C0 byte as an editing command. 0x15 kills the line and runs whatever follows it, 0x1b starts a meta sequence, 0x09 fires completion, 0x0a submits early. The pane comes back wedged at a `quote>` prompt, or silently running a different command.

`shouldRestore` now refuses the C0+DEL class, and U+FFFD with it: `parseProcArgs` decodes argv with `String(decoding:as:)`, so any byte sequence that was not valid UTF-8 is already a replacement character by then, and typing it back would run an argument the process never had. That is the same objection that rules out stripping. A genuine U+FFFD is refused too, the two being indistinguishable after decoding.

Both refuse at render rather than at capture, which is what keeps `hadForeground` true so `restorePlan` still preempts a stale `initialCommand`. Refusing at capture would let a `--command` session re-run its creation command instead of coming back a plain shell.

**why refuse instead of escaping.** `$'...'` is a bash/zsh extension. Of the eight login shells `knownShells` names, fish, csh and tcsh reject it outright, dash takes it literally, and ksh93 reads `\xNN` greedily over following hex digits, so `sed 's/<ESC>b//'` corrupts silently. The current single-quote renderer is correct in all eight and stays that way. Measured on this box, not recalled.

**second sink, same class.** `session.restore set` rejects control characters on write, but a pin loaded from a snapshot never passed through that check: `AppStore+Snapshot.swift:83` copies the persisted value straight into the pending override and `restoreInput` types it verbatim. The dispatcher justifies its check by the sink it is typed into, so `restoreInput` now applies it at that sink. A refused pin is still present, so it preempts capture and `initialCommand` and yields a plain shell. Both callers share one `hasControlCharacter` instead of spelling the predicate twice.

reported severity is understated in the issue: 0x15 does not wedge, it kills the line and runs what follows. The realistic trigger is not an exotic `$'...'` invocation either, it is a control byte in a filename reaching `less`/`tail -f`/`vim`, none of which are in the seeded denylist.

reviewed with revmux and vetted with codex, which caught that the first version of the lossy-decode test did not exercise lossy decoding: `blob(args:)` takes `[String]` and encodes via `Data(a.utf8)`, so a `"\u{FFFD}"` literal became valid UTF-8. The test now assembles the blob byte by byte with a lone `0xE9`.

Fix #454
