### PR TITLE
fix: reject a NUL in session.type and quick.type text

### DIFF
--- a/.claude/rules/control-api.md
+++ b/.claude/rules/control-api.md
@@ -234,6 +234,9 @@ side, and reads `lastAppliedIsDark` when bare. Refuse it outside XCUITest; provi
 - `session.type` ok means the keystrokes were queued to the pty, not that the shell read or ran them (#350).
   Nothing is lost in between: libghostty's write mailbox blocks instead of dropping, messages queued before
   the io thread starts are drained once the subprocess is up, and no code path flushes pending tty input.
+  A NUL never reaches that path: `ghostty_input_key_s.text` is NUL-terminated and libghostty slices at the
+  first zero, so `session.type`/`quick.type` reject text carrying one with `text must not contain a NUL
+  byte` rather than typing the run up to it, sending its Return, and answering ok (#455).
   A caller needing execution polls `session.text`, which is what the e2e marker idiom does.
   `ghostty_surface_key`'s bool reports consumption, not delivery, so checking it would add no readiness.
 - `inject` emits Ghostty key events and Return keycode 36 for newline/CR/CRLF. Never replace it with

--- a/agtermCore/Sources/agtermCore/ControlDispatcher.swift
+++ b/agtermCore/Sources/agtermCore/ControlDispatcher.swift
@@ -468,6 +468,13 @@ public struct ControlDispatcher {
         case rejected(ControlResponse)
     }
 
+    /// Non-nil when `text` carries a NUL: libghostty's key-text field is NUL-terminated and slices at the
+    /// first zero, dropping the run's tail while the Return after it still submits the shortened line (#455).
+    private func nulRejection(_ text: String) -> ControlResponse? {
+        guard text.unicodeScalars.contains(where: { $0.value == 0 }) else { return nil }
+        return ControlResponse(ok: false, error: "text must not contain a NUL byte")
+    }
+
     /// The shared `--pane` selector: nil when absent, the parsed pane when `parse` accepts it, and `error`
     /// as the pinned rejection otherwise. No live session needed either way.
     private func parsePane<Pane>(_ raw: String?, error: String,
@@ -597,6 +604,7 @@ public struct ControlDispatcher {
             guard let text = request.args?.text else {
                 return ControlResponse(ok: false, error: "session.type requires text")
             }
+            if let rejection = nulRejection(text) { return rejection }
             return await actions.typeSession(request.target, window: request.args?.window,
                                              options: ControlSessionTypeOptions(
                                                 text: text,
@@ -743,6 +751,7 @@ public struct ControlDispatcher {
             guard let text = request.args?.text else {
                 return ControlResponse(ok: false, error: "quick.type requires text")
             }
+            if let rejection = nulRejection(text) { return rejection }
             return await actions.typeQuick(text: text)
         case .quickText:
             let all = request.args?.all ?? false

--- a/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ControlDispatcherTests.swift
@@ -1236,6 +1236,20 @@ struct ControlDispatcherTests {
         #expect(actions.calls.isEmpty)
     }
 
+    @Test func sessionTypeRejectsNulBeforeCallingActions() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .sessionType, target: "session",
+            args: ControlArgs(text: "safe\u{0}danger\n")
+        ))
+
+        #expect(response == ControlResponse(ok: false, error: "text must not contain a NUL byte"))
+        // no action call is what pins #455: the pre-fix path typed "safe" and still sent the Return.
+        #expect(actions.calls.isEmpty)
+    }
+
     @Test func sessionTypeRoutesParsedOptionsAndEchoesActionResponse() async {
         let actions = MockControlActions()
         let dispatcher = ControlDispatcher(actions: actions)
@@ -1501,6 +1515,18 @@ struct ControlDispatcherTests {
         let response = await dispatcher.dispatch(ControlRequest(cmd: .quickType))
 
         #expect(response == ControlResponse(ok: false, error: "quick.type requires text"))
+        #expect(actions.calls.isEmpty)
+    }
+
+    @Test func quickTypeRejectsNulBeforeCallingActions() async {
+        let actions = MockControlActions()
+        let dispatcher = ControlDispatcher(actions: actions)
+
+        let response = await dispatcher.dispatch(ControlRequest(
+            cmd: .quickType, args: ControlArgs(text: "safe\u{0}danger\n")
+        ))
+
+        #expect(response == ControlResponse(ok: false, error: "text must not contain a NUL byte"))
         #expect(actions.calls.isEmpty)
     }
 

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -395,6 +395,8 @@ error keeps those names for compatibility.
   surface, so `session new --no-select` followed straight away by `session type` does not race the mount.
   `--select` selects the session first, and only when its surface is not ready — a realized session is typed
   into without moving the user's selection. A surface that never comes up → `session not realized`.
+  Text carrying a NUL is rejected with `text must not contain a NUL byte`, since libghostty's key-text
+  field is NUL-terminated and could only deliver the run up to it.
   `--pane left` types into the main pane (the default when omitted), `--pane right` into the split pane
   (errors with `session has no split pane` when the session has no split), `--pane scratch` into the
   session's scratch terminal even while it is hidden (`session has no scratch terminal` when none opened);
@@ -1214,6 +1216,7 @@ CLI rejects the same value locally with `mode must be one of: on, off, toggle, a
 locally with `mode must be on, off, or toggle`),
 `no open window` (quick/sidebar/workspace filter), `quick terminal not open` / `quick terminal not realized` (quick type) /
 `failed to read surface buffer` (quick text / session text),
+`text must not contain a NUL byte` (session type / quick type),
 `invalid restore mode` / `session.restore set requires a command` / `command must not contain control characters` /
 `command too long (max 1024 bytes)` / `the scratch terminal is never restored` / `unknown pane id` /
 `failed to save the restore override, the previous value is still in effect` (session

--- a/site/commands.html
+++ b/site/commands.html
@@ -1011,7 +1011,8 @@
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--select</span>, including one created moments ago: the main
                 pane waits briefly for its surface, so creating and typing back to back does not race.
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace">--select</span> selects the session first, and only when its
-                surface is not ready yet.
+                surface is not ready yet. Text carrying a NUL is rejected with
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace">text must not contain a NUL byte</span>.
               </p>
               <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">--pane left</span> is the main pane (the default),
@@ -2255,7 +2256,8 @@
               <p style="font-size: 13.5px; line-height: 1.6; color: #949ba4; margin: 8px 0 0">
                 Errors: <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">quick terminal not open</span> (never shown),
                 <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">quick terminal not realized</span>,
-                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">no open window</span>.
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">no open window</span>,
+                <span style="font-family: &quot;JetBrains Mono&quot;, monospace; white-space: nowrap">text must not contain a NUL byte</span>.
               </p>
             </div>
 


### PR DESCRIPTION
a NUL in a `session.type` payload silently truncated the injected text, and the command still answered `{"ok":true}`.

`ghostty_input_key_s.text` is a NUL-terminated `const char*`, and libghostty's embedded apprt converts it with `std.mem.sliceTo(ptr, 0)` (`src/apprt/embedded.zig:1287` at the pinned `GHOSTTY_REV`), so the byte is structurally undeliverable and everything past the first NUL is dropped inside the library. `inject` returned true regardless, so the caller got an ok for text that was never typed. It is worse than the report says: `KeystrokeSegments.split` emits the run and its Return as separate segments, so the shortened line still got its Return and executed. `quick.type` shares the path, and `agtermctl --stdin` carries a NUL fine since it is valid UTF-8.

rejected at the dispatcher, beside the existing `session.restore set` control-character guard, with `text must not contain a NUL byte`. Not stripped, because stripping would silently run a third command matching neither reading. Not in `KeystrokeSegments.split` as the issue suggested, because `inject`'s Bool already means "surface not realized", so a NUL there would spin the realize poll and then answer a false `session not realized`.

scope is NUL only. ESC, DEL and Ctrl-U survive `sliceTo` and reach the core key handler intact, so they are not a delivery defect, and rejecting them would be a new policy about what callers may type rather than a repair of this bug.

one rejection test per command asserts no action call at all, which is what pins the defect: it proves the truncated line's Return never escapes.

Fix #455
