### PR TITLE
feat(settings): make the quick terminal panel size configurable

### DIFF
--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -20,7 +20,11 @@ paths:
   by `GlobalHotkey`, never with `KeybindMatcher`, so it is deliberately OUTSIDE the conflict model below —
   it may share a chord with a menu item — but the OS hotkey WINS and CONSUMES the key, agterm frontmost
   included, so the menu binding then never fires. Say that rather than "whichever app is in front decides",
-  which is the precise inversion. `parseGlobalHotkeyLine` diagnoses a base key no physical position produces,
+  which is the precise inversion. Ship NO default: registering takes the chord from every other application
+  on the machine, a cost nobody who never summons the panel from outside agterm should pay. Binding it to
+  `quick_terminal`'s own `ctrl+grave` is the supported way to get one chord everywhere, and both user-facing
+  surfaces (`site/docs.html`, the `ConfigPaths` keymap starter) must say so.
+  `parseGlobalHotkeyLine` diagnoses a base key no physical position produces,
   since the verb has no read-back anywhere and a silent drop at registration would be the user's only signal.
   `keyCode(forChordKey:)` resolves it
   by physical position, inverting `namedKey`/`latinKey` rather than adding a third table, so it survives a

--- a/.claude/rules/keymap.md
+++ b/.claude/rules/keymap.md
@@ -22,7 +22,7 @@ paths:
   included, so the menu binding then never fires. Say that rather than "whichever app is in front decides",
   which is the precise inversion. Ship NO default: registering takes the chord from every other application
   on the machine, a cost nobody who never summons the panel from outside agterm should pay. Binding it to
-  `quick_terminal`'s own `ctrl+grave` is the supported way to get one chord everywhere, and both user-facing
+  `quick_terminal`'s own ``ctrl+` `` is the supported way to get one chord everywhere, and both user-facing
   surfaces (`site/docs.html`, the `ConfigPaths` keymap starter) must say so.
   `parseGlobalHotkeyLine` diagnoses a base key no physical position produces,
   since the verb has no read-back anywhere and a silent drop at registration would be the user's only signal.

--- a/.claude/rules/settings.md
+++ b/.claude/rules/settings.md
@@ -6,6 +6,7 @@ paths:
   - "agterm/Views/WindowAppearance.swift"
   - "agterm/NSColor+AgtermHex.swift"
   - "agtermCore/Sources/agtermCore/AppSettings.swift"
+  - "agtermCore/Sources/agtermCore/QuickTerminalMetrics.swift"
   - "agtermCore/Sources/agtermCore/SettingsStore.swift"
   - "agtermUITests/SettingsUITests.swift"
 ---
@@ -53,6 +54,10 @@ paths:
 - Non-Ghostty settings update app mirrors and `.agtermAppearanceChanged`, not surfaces. The mute wash
   fades text toward terminal color; with transparency it also tints the see-through area. Sidebar tint
   composes over opaque or blurred backgrounds; AppKit must leave the sidebar unfilled.
+- `quickTerminalSizePercent` is the quick-terminal panel's share of its screen, nil for the built-in size.
+  `QuickTerminalMetrics` owns the arithmetic, the offered choices and the clamp; [[windows]] owns why a set
+  percentage replaces the points cap instead of raising it. Mirrored to `GhosttyApp` like `toolbarMode`,
+  and read when the panel is framed, so no appearance broadcast is involved.
 - `inactivePaneMuteStrength` drives the inactive split pane and the backdrop behind a floating overlay and
   the quick terminal, so its label names both. [[libghostty]] owns how those washes render.
 - Status colors default to active `#DBD9E6`, system amber, and system green. Shapes are raw
@@ -78,9 +83,11 @@ paths:
   `terminalColor`, quick-terminal backing, title/window appearance, and non-observable chrome mirrors.
 - Settings is a 540x640 six-tab SwiftUI scene with explicit selection defaulting General, preventing
   `com_apple_SwiftUI_Settings_selectedTabIndex` persistence. General holds Mouse, Sessions, and Ghostty
-  Config. Appearance holds Terminal and Window. Interface groups `InterfaceElement`s two per row plus
-  Multiple Windows. Notifications holds banner/badge/attention/bounce/sound. Agent Status holds
-  colors/shapes, sound, auto-follow, and Reset. Key Mapping holds config directory, diagnostics, and Reload.
+  Config. Appearance holds Terminal and Window. Interface groups `InterfaceElement`s two per row, plus
+  Multiple Windows and the quick terminal's panel size, which sits there rather than under Appearance's
+  Window because the panel belongs to no window.
+  Notifications holds banner/badge/attention/bounce/sound. Agent Status holds colors/shapes, sound,
+  auto-follow, and Reset. Key Mapping holds config directory, diagnostics, and Reload.
 - Keep titlebar construction in `WindowContentView+Titlebar.swift` so `WindowContentView.swift` remains
   below the 1000-line limit.
 - Keep Agent Status shape pickers in a trailing-aligned 80-point column wider than the 64.5...68-point

--- a/.claude/rules/windows.md
+++ b/.claude/rules/windows.md
@@ -99,9 +99,13 @@ session drag are out of scope.
   `reshowSuppression` is dropped — AppKit makes a clicked window key BEFORE delivering its button action, so
   the toolbar and Dock toggles would otherwise re-show the panel the same click dismissed. This is AppKit
   key-window behavior, so it is manually verified, not unit-tested.
-- The frame is 90% of the focused screen capped at `maxNormalSize` (1100x700). The in-window overlay needed
-  no cap because a window is already modest; 90% of a large display is a wall of terminal, not a quick
-  aside.
+- `QuickTerminalMetrics.panelSize` owns the frame. Unset, it is 90% of the focused screen capped at
+  1100x700: the in-window overlay needed no cap because a window is already modest, and 90% of a large
+  display is a wall of terminal, not a quick aside. `quickTerminalSizePercent` REPLACES both terms with a
+  plain share of the screen rather than raising the cap, a cap in points being what ages badly across
+  displays. nil keeps its own path because no single percentage reproduces the pair: the cap binds above
+  roughly 1222x780 points and the share below it. The panel re-frames on every show, so a Settings change
+  lands on the next summon and needs no notification.
 - While the quick terminal OWNS THE KEYBOARD, no deck surface may be active. Gate main, split, maximized
   split, scratch, and overlay with `deckInteractive && isActive && !quickTerminal.holdsKey`. Read `holdsKey`,
   never `isVisible`: the predicate is app-level, so it inerts EVERY window, and a PINNED panel (a control

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,9 +184,11 @@ C-boundary concurrency before changing the bridge.
 - `site/docs.html` is the canonical user guide and `site/commands.html` the canonical command reference.
   `README.md` is the product synopsis: pitch, install, the model, and the control-API demo.
   `site/llms.txt` is the crawler-oriented summary and discovery index.
-  These four facts stay synchronized across every surface that states them: the command count, the install
-  commands, the minimum macOS version, and the positioning claim
+  These three facts stay synchronized across every surface that states them: the install commands, the
+  minimum macOS version, and the positioning claim
   (`a simply good terminal with a full control API`).
+  The command count is NOT one of them and must not become one: no surface states a total, which is what
+  keeps a new command off every page that merely mentions the catalog. `control-api.md` owns that rule.
   The positioning claim must stay consistent in substance, not byte-identical: `site/index.html`'s title and
   social tags insert `macOS` for search intent, and `site/llms.txt` carries a libghostty-based variant.
 - `site/index.html` reflects major features and current `softwareVersion`; `site/commands.html` mirrors

--- a/agterm/Ghostty/GhosttyApp.swift
+++ b/agterm/Ghostty/GhosttyApp.swift
@@ -88,6 +88,9 @@ final class GhosttyApp {
     /// The sizes the palette/picker and session switcher derive from the separate `interfaceFontSize`,
     /// resolved once per settings change rather than per row.
     private(set) var interfaceMetrics = InterfaceMetrics(fontSize: AppSettings.defaultInterfaceFontSize)
+    /// The share of the focused screen the quick-terminal panel takes, as a percentage; nil = the built-in
+    /// size. `QuickTerminalController` reads it when it frames the panel; settings-mirrored like `toolbarMode`.
+    private(set) var quickTerminalSizePercent: Int?
     /// The base terminal font size in points (the Settings default; nil → the ghostty built-in). The renderer
     /// never reads it — it is the size a session with a nil `session.fontSize` reverts to, which the dashboard
     /// font-override clear needs to recognize its own async CELL_SIZE report (`pendingFontRestore`).
@@ -234,6 +237,11 @@ final class GhosttyApp {
     /// `InterfaceMetrics` clamps its own input, so a hand-edited out-of-range value lands in range here too.
     func setInterfaceFontSize(_ size: Double) {
         interfaceMetrics = InterfaceMetrics(fontSize: size)
+    }
+
+    /// `QuickTerminalMetrics.panelSize` clamps what it is given, so the raw setting is stored as-is.
+    func setQuickTerminalSizePercent(_ percent: Int?) {
+        quickTerminalSizePercent = percent
     }
 
     /// Set the agent-status glyph colors from the user's hex settings; nil or malformed → the system default.

--- a/agterm/SettingsModel.swift
+++ b/agterm/SettingsModel.swift
@@ -63,6 +63,7 @@ final class SettingsModel {
         applySidebarBackgroundShift()
         applySidebarFontSize()
         applyInterfaceFontSize()
+        applyQuickTerminalSizePercent()
         applyBaseFontSize()
         applyAgentStatusColors()
         applyAgentStatusShapes()
@@ -209,6 +210,10 @@ final class SettingsModel {
     func setSidebarBackgroundShift(_ value: Int?) { settings.sidebarBackgroundShift = value; persistAndApply() }
     func setSidebarFontSize(_ value: Double?) { settings.sidebarFontSize = value; persistAndApply() }
     func setInterfaceFontSize(_ value: Double?) { settings.interfaceFontSize = value; persistAndApply() }
+    func setQuickTerminalSizePercent(_ value: Int?) {
+        settings.quickTerminalSizePercent = value
+        persistAndApply()
+    }
     // not a ghostty key, so persistAndApply()'s writeGhosttyConfig() no-ops and no surface reload fires.
     func setRestoreRunningCommand(_ value: Bool?) { settings.restoreRunningCommand = value; persistAndApply() }
     // chrome flag, not a ghostty key: persistAndApply() no-ops the config but rides .agtermAppearanceChanged.
@@ -600,6 +605,7 @@ final class SettingsModel {
         applySidebarBackgroundShift()
         applySidebarFontSize()
         applyInterfaceFontSize()
+        applyQuickTerminalSizePercent()
         applyBaseFontSize()
         applyAgentStatusColors()
         applyAgentStatusShapes()
@@ -689,6 +695,10 @@ final class SettingsModel {
 
     private func applyInterfaceFontSize() {
         GhosttyApp.shared.setInterfaceFontSize(settings.effectiveInterfaceFontSize)
+    }
+
+    private func applyQuickTerminalSizePercent() {
+        GhosttyApp.shared.setQuickTerminalSizePercent(settings.quickTerminalSizePercent)
     }
 
     private func applyBaseFontSize() {

--- a/agterm/SettingsModel.swift
+++ b/agterm/SettingsModel.swift
@@ -698,7 +698,7 @@ final class SettingsModel {
     }
 
     private func applyQuickTerminalSizePercent() {
-        GhosttyApp.shared.setQuickTerminalSizePercent(settings.quickTerminalSizePercent)
+        GhosttyApp.shared.setQuickTerminalSizePercent(settings.effectiveQuickTerminalSizePercent)
     }
 
     private func applyBaseFontSize() {

--- a/agterm/Views/QuickTerminal.swift
+++ b/agterm/Views/QuickTerminal.swift
@@ -220,19 +220,17 @@ final class QuickTerminalController {
         surfaceView = nil
     }
 
-    /// The panel's comfortable maximum. The in-window overlay took 90% of its host and needed no cap, a
-    /// window already being a modest size; 90% of a large display is not a quick aside but a wall of
-    /// terminal, so the share is a floor-to-ceiling that stops growing past a readable width.
-    private static let maxNormalSize = NSSize(width: 1100, height: 700)
-
-    /// Centered on the focused screen at 90% of it or `maxNormalSize`, whichever is smaller, and its whole
-    /// visible frame while zoomed. The panel follows the POINTER's screen, not the app's: it is summoned
-    /// from another application, where agterm's own key window is no guide to where the user is looking.
+    /// Centered on the focused screen at whatever `QuickTerminalMetrics` sizes it to, and its whole visible
+    /// frame while zoomed. The panel follows the POINTER's screen, not the app's: it is summoned from
+    /// another application, where agterm's own key window is no guide to where the user is looking. The
+    /// user's size is read here rather than cached because the frame is recomputed on every show, so a
+    /// Settings change lands on the next summon with nothing to notify.
     private static func targetFrame(zoomed: Bool) -> NSRect {
         let visible = activeScreen().visibleFrame
         guard !zoomed else { return visible }
-        let size = NSSize(width: min(visible.width * 0.9, maxNormalSize.width),
-                          height: min(visible.height * 0.9, maxNormalSize.height))
+        let size = QuickTerminalMetrics.panelSize(
+            visible: WindowGeometry.Size(width: visible.width, height: visible.height),
+            sizePercent: GhosttyApp.shared.quickTerminalSizePercent)
         return NSRect(x: visible.midX - size.width / 2, y: visible.midY - size.height / 2,
                       width: size.width, height: size.height)
     }

--- a/agterm/Views/QuickTerminal.swift
+++ b/agterm/Views/QuickTerminal.swift
@@ -24,7 +24,7 @@ final class QuickTerminalController {
     /// responder in every window and leave the user unable to type outside the panel's own frame.
     private(set) var holdsKey = false
 
-    /// Whether the panel fills its screen instead of taking the inset 90% frame — the re-homed
+    /// Whether the panel fills its screen instead of the inset frame `QuickTerminalMetrics` sizes — the re-homed
     /// `surface.zoom --target quick`, which used to be a per-window `TerminalZoomTarget`. Cleared on hide,
     /// so a dismissed panel never reports a stale zoom.
     private(set) var isZoomed = false

--- a/agterm/Views/SettingsView.swift
+++ b/agterm/Views/SettingsView.swift
@@ -432,7 +432,7 @@ private struct InterfaceSettingsView: View {
 
     /// The quick-terminal panel's share of the screen; nil is the built-in size, not a percentage.
     private var quickTerminalSizePercent: Binding<Int?> {
-        Binding(get: { model.settings.quickTerminalSizePercent },
+        Binding(get: { model.settings.effectiveQuickTerminalSizePercent },
                 set: { model.setQuickTerminalSizePercent($0) })
     }
 

--- a/agterm/Views/SettingsView.swift
+++ b/agterm/Views/SettingsView.swift
@@ -395,7 +395,8 @@ private struct AppearanceSettingsView: View {
 }
 
 /// Interface tab: per-element title-bar and sidebar chrome visibility, grouped by surface, two toggles per
-/// row so the tab keeps fitting the fixed 540×640 window as the element set grows. Everything shows by
+/// row so the tab keeps fitting the fixed 540×640 window as the element set grows, plus the quick terminal's
+/// panel size — that panel belongs to no window, so it is not a Window setting. Everything shows by
 /// default; a toggle off adds it to `AppSettings.hiddenInterfaceElements` and live-applies — title-bar and
 /// footer elements re-gate in open windows on `.agtermAppearanceChanged`, the add-session "+" on hover.
 private struct InterfaceSettingsView: View {
@@ -409,6 +410,15 @@ private struct InterfaceSettingsView: View {
                 Toggle("Show sidebar only in the active window", isOn: autoHideSidebarInactiveWindows)
                     .accessibilityIdentifier("settings-auto-hide-inactive-sidebars")
             }
+            Section("Quick Terminal") {
+                Picker("Size", selection: quickTerminalSizePercent) {
+                    Text("Default").tag(Int?.none)
+                    ForEach(QuickTerminalMetrics.sizePercentChoices, id: \.self) { percent in
+                        Text("\(percent)% of screen").tag(Int?.some(percent))
+                    }
+                }
+                .accessibilityIdentifier("settings-quick-terminal-size")
+            }
         }
         .formStyle(.grouped)
         .padding()
@@ -418,6 +428,12 @@ private struct InterfaceSettingsView: View {
     private var autoHideSidebarInactiveWindows: Binding<Bool> {
         Binding(get: { model.settings.autoHideSidebarInactiveWindows ?? false },
                 set: { model.setAutoHideSidebarInactiveWindows($0 ? true : nil) })
+    }
+
+    /// The quick-terminal panel's share of the screen; nil is the built-in size, not a percentage.
+    private var quickTerminalSizePercent: Binding<Int?> {
+        Binding(get: { model.settings.quickTerminalSizePercent },
+                set: { model.setQuickTerminalSizePercent($0) })
     }
 
     /// A section whose toggles lay out TWO per row, each filling half the row around a centered `Divider` so

--- a/agtermCore/Sources/agtermCore/AppSettings.swift
+++ b/agtermCore/Sources/agtermCore/AppSettings.swift
@@ -413,6 +413,17 @@ public struct AppSettings: Codable, Equatable, Sendable {
         min(interfaceFontSizeRange.upperBound, max(interfaceFontSizeRange.lowerBound, size))
     }
 
+    /// The resolved quick-terminal share, or nil for the built-in size. The single read point, and the one
+    /// the Settings picker binds: a stored value outside `QuickTerminalMetrics.sizePercentChoices` — hand
+    /// edited, or written by a later version offering more of them — resolves to nil rather than being
+    /// applied, so the picker can never show blank while the panel uses a size it has no row for.
+    /// `panelSize` clamps its own argument as well; that guards a direct caller, this owns the setting.
+    public var effectiveQuickTerminalSizePercent: Int? {
+        guard let quickTerminalSizePercent,
+              QuickTerminalMetrics.sizePercentChoices.contains(quickTerminalSizePercent) else { return nil }
+        return quickTerminalSizePercent
+    }
+
     /// The resolved sidebar row-text size, clamped. The single read point.
     public var effectiveSidebarFontSize: Double {
         Self.clampSidebarFontSize(sidebarFontSize ?? Self.defaultSidebarFontSize)

--- a/agtermCore/Sources/agtermCore/AppSettings.swift
+++ b/agtermCore/Sources/agtermCore/AppSettings.swift
@@ -257,6 +257,9 @@ public struct AppSettings: Codable, Equatable, Sendable {
     /// The palette, picker and session-switcher text point size, nil for `defaultInterfaceFontSize`.
     /// Panel widths scale with it (`InterfaceMetrics`). Independent of `sidebarFontSize`.
     public var interfaceFontSize: Double?
+    /// The share of the focused screen the quick-terminal panel takes, as a percentage; nil keeps the
+    /// built-in size. `QuickTerminalMetrics.panelSize` resolves and clamps it.
+    public var quickTerminalSizePercent: Int?
     /// Raw names of the chrome elements the user has HIDDEN (see `InterfaceElement`); nil/empty shows
     /// everything. Unknown names are dropped by `resolvedHiddenInterfaceElements`.
     public var hiddenInterfaceElements: [String]?
@@ -286,7 +289,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
                 confirmCloseSession: Bool? = nil, closeGraceUndoEnabled: Bool? = nil,
                 autoFollowAttention: String? = nil,
                 autoFollowStayOnActive: Bool? = nil, sidebarFontSize: Double? = nil,
-                interfaceFontSize: Double? = nil,
+                interfaceFontSize: Double? = nil, quickTerminalSizePercent: Int? = nil,
                 hiddenInterfaceElements: [String]? = nil,
                 autoHideSidebarInactiveWindows: Bool? = nil, welcomeShown: Bool? = nil) {
         self.fontFamily = fontFamily
@@ -326,6 +329,7 @@ public struct AppSettings: Codable, Equatable, Sendable {
         self.autoFollowStayOnActive = autoFollowStayOnActive
         self.sidebarFontSize = sidebarFontSize
         self.interfaceFontSize = interfaceFontSize
+        self.quickTerminalSizePercent = quickTerminalSizePercent
         self.hiddenInterfaceElements = hiddenInterfaceElements
         self.autoHideSidebarInactiveWindows = autoHideSidebarInactiveWindows
         self.welcomeShown = welcomeShown

--- a/agtermCore/Sources/agtermCore/ConfigPaths.swift
+++ b/agtermCore/Sources/agtermCore/ConfigPaths.swift
@@ -93,7 +93,7 @@ public enum ConfigPaths {
         #       Examples:
         #
         #           global-hotkey ctrl+opt+space
-        #           global-hotkey ctrl+grave        # same chord as the in-app quick_terminal binding
+        #           global-hotkey ctrl+`            # same chord as the in-app quick_terminal binding
         #
         # Built-in actions (raw name → shipped default chord):
         #

--- a/agtermCore/Sources/agtermCore/ConfigPaths.swift
+++ b/agtermCore/Sources/agtermCore/ConfigPaths.swift
@@ -85,9 +85,15 @@ public enum ConfigPaths {
         #       physical key position, so it keeps working on a non-Latin layout. Because the system
         #       owns it rather than agterm, it takes no part in the collision rules above. Note the
         #       precedence: the system hotkey WINS, agterm frontmost included, so a chord shared with a
-        #       menu action fires this and the menu binding never sees it. Example:
+        #       menu action fires this and the menu binding never sees it. There is no default because
+        #       registering a chord takes it from every other application on your Mac, which is not a
+        #       cost to impose on someone who never summons the panel from outside agterm. Spending it
+        #       on the chord the in-app binding already uses is allowed, and is how to get ONE shortcut
+        #       that works everywhere — at the price of that chord no longer reaching anything else.
+        #       Examples:
         #
         #           global-hotkey ctrl+opt+space
+        #           global-hotkey ctrl+grave        # same chord as the in-app quick_terminal binding
         #
         # Built-in actions (raw name → shipped default chord):
         #

--- a/agtermCore/Sources/agtermCore/QuickTerminalMetrics.swift
+++ b/agtermCore/Sources/agtermCore/QuickTerminalMetrics.swift
@@ -1,0 +1,45 @@
+/// The quick-terminal panel's size on the screen it is summoned onto. Host-free so the arithmetic is
+/// testable: `QuickTerminalController` owns the `NSScreen` and the `NSPanel` and converts at the call
+/// site. Uses `WindowGeometry.Size` for the same reason it exists — see that file on why these are
+/// Double-backed rather than `CGSize`.
+public enum QuickTerminalMetrics {
+    /// The share of the screen the panel takes when the user has set no size of his own.
+    public static let defaultShare: Double = 0.9
+
+    /// Where the default share stops growing, in points. The in-window overlay this replaced needed no
+    /// ceiling, a window already being a modest size; 90% of a large display is a wall of terminal rather
+    /// than a quick aside.
+    public static let defaultMaxSize = WindowGeometry.Size(width: 1100, height: 700)
+
+    /// The sizes offered in Settings. Discrete rather than a slider: the panel is summoned and dismissed,
+    /// so the choice is which of a few shapes it should have, not a value worth tuning by the point.
+    public static let sizePercentChoices = [40, 50, 60, 70, 80, 90]
+
+    /// Bounds for a user-set percentage. The ceiling is `defaultShare`, which is as large as the panel was
+    /// ever meant to get; the floor is roughly what `defaultMaxSize` already yields on a large display, so
+    /// every offered value is a real choice rather than a smaller version of what the default gives.
+    public static let sizePercentRange: ClosedRange<Int> = 40 ... 90
+
+    /// Bounds a raw percentage to `sizePercentRange`, so a hand-edited `settings.json` cannot produce a
+    /// panel too small to read or one covering the screen.
+    public static func clampSizePercent(_ percent: Int) -> Int {
+        min(sizePercentRange.upperBound, max(sizePercentRange.lowerBound, percent))
+    }
+
+    /// The panel's size on a screen whose visible frame measures `visible`. The single read point, and it
+    /// clamps, so callers pass the stored value straight through.
+    ///
+    /// A set percentage REPLACES both the default share and its points ceiling rather than raising the
+    /// ceiling: a size in points is what ages badly across displays in the first place, so configuring one
+    /// would move the same problem to the next screen size instead of removing it. `nil` keeps the built-in
+    /// pair exactly, which no single percentage can reproduce — the ceiling binds above roughly 1222x780
+    /// points and the share binds below it, so the two yield different fractions of different screens.
+    public static func panelSize(visible: WindowGeometry.Size, sizePercent: Int?) -> WindowGeometry.Size {
+        guard let sizePercent else {
+            return WindowGeometry.Size(width: min(visible.width * defaultShare, defaultMaxSize.width),
+                                       height: min(visible.height * defaultShare, defaultMaxSize.height))
+        }
+        let share = Double(clampSizePercent(sizePercent)) / 100
+        return WindowGeometry.Size(width: visible.width * share, height: visible.height * share)
+    }
+}

--- a/agtermCore/Tests/agtermCoreTests/AppSettingsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppSettingsTests.swift
@@ -385,6 +385,16 @@ struct AppSettingsTests {
         #expect(!json.contains("interfaceFontSize"))
     }
 
+    @Test func quickTerminalSizePercentRoundTripsAndDefaultsNil() throws {
+        #expect(AppSettings().quickTerminalSizePercent == nil)
+        let json = String(decoding: try JSONEncoder().encode(AppSettings()), as: UTF8.self)
+        #expect(!json.contains("quickTerminalSizePercent"))
+        let original = AppSettings(quickTerminalSizePercent: 70)
+        let decoded = try JSONDecoder().decode(AppSettings.self, from: JSONEncoder().encode(original))
+        #expect(decoded.quickTerminalSizePercent == 70)
+        #expect(original.ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
+    }
+
     @Test func sidebarAndInterfaceFontSizesAreIndependent() throws {
         let sidebarOnly = try JSONDecoder().decode(AppSettings.self, from: Data(#"{ "sidebarFontSize": 17 }"#.utf8))
         #expect(sidebarOnly.effectiveSidebarFontSize == 17)

--- a/agtermCore/Tests/agtermCoreTests/AppSettingsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/AppSettingsTests.swift
@@ -395,6 +395,22 @@ struct AppSettingsTests {
         #expect(original.ghosttyConfigLines() == ["mouse-scroll-multiplier = 3", "right-click-action = paste"])
     }
 
+    @Test func quickTerminalSizePercentResolvesOffGridValuesToTheDefault() {
+        #expect(AppSettings(quickTerminalSizePercent: 70).effectiveQuickTerminalSizePercent == 70)
+        // hand-edited or written by a version offering more choices: applied as neither 75% nor a snapped
+        // neighbour, so the picker and the panel cannot disagree about the size in use.
+        #expect(AppSettings(quickTerminalSizePercent: 75).effectiveQuickTerminalSizePercent == nil)
+        #expect(AppSettings(quickTerminalSizePercent: 400).effectiveQuickTerminalSizePercent == nil)
+        #expect(AppSettings(quickTerminalSizePercent: 0).effectiveQuickTerminalSizePercent == nil)
+        #expect(AppSettings().effectiveQuickTerminalSizePercent == nil)
+    }
+
+    @Test func everyOfferedQuickTerminalChoiceSurvivesResolution() {
+        for percent in QuickTerminalMetrics.sizePercentChoices {
+            #expect(AppSettings(quickTerminalSizePercent: percent).effectiveQuickTerminalSizePercent == percent)
+        }
+    }
+
     @Test func sidebarAndInterfaceFontSizesAreIndependent() throws {
         let sidebarOnly = try JSONDecoder().decode(AppSettings.self, from: Data(#"{ "sidebarFontSize": 17 }"#.utf8))
         #expect(sidebarOnly.effectiveSidebarFontSize == 17)

--- a/agtermCore/Tests/agtermCoreTests/ConfigPathsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/ConfigPathsTests.swift
@@ -82,17 +82,20 @@ struct ConfigPathsTests {
 
     // issue #405: a shipped map example once used a chord a later built-in default took,
     // so uncommenting the starter's own suggestion silently bound nothing. A `command` example rots the
-    // same way, `validateCommands` dropping a custom shortcut a built-in has since claimed.
+    // same way, `validateCommands` dropping a custom shortcut a built-in has since claimed, and a
+    // `global-hotkey` example is rejected outright when its base key is not one `parseChord` spells.
     @Test func starterKeymapExamplesApplyWhenUncommented() {
         let examples = ConfigPaths.starterKeymapConf().split(separator: "\n").compactMap { line -> String? in
             let text = line.drop { $0 == "#" || $0.isWhitespace }
             let verb = text.prefix { !$0.isWhitespace }
             // `<` skips the two verb-syntax lines, which state a grammar rather than an example.
-            guard verb == "map" || verb == "command", !text.contains("<") else { return nil }
+            guard verb == "map" || verb == "command" || verb == "global-hotkey",
+                  !text.contains("<") else { return nil }
             return String(text)
         }
-        // an example silently dropped from the guard must fail here: three `map` lines and three `command`.
-        #expect(examples.count == 6)
+        // an example silently dropped from the guard must fail here: three `map`, three `command`, three
+        // `global-hotkey`.
+        #expect(examples.count == 9)
         var bound = 0
         for example in examples {
             let (keymap, diagnostics) = parseKeymap(example)
@@ -101,10 +104,12 @@ struct ConfigPathsTests {
             // shortcuts that survived rather than the commands that parsed.
             bound += keymap.builtinOverrides.count + keymap.commands.filter { !$0.shortcut.isEmpty }.count
                 + keymap.builtinSequences.values.reduce(0) { $0 + $1.count }
+                + (keymap.globalHotkey == nil ? 0 : 1)
         }
         // all three `map` examples and the two chorded `command` ones; `Deploy` is palette-only by design.
-        // the alternatives example counts twice, its menu chord and its monitor-bound half.
-        #expect(bound == 6)
+        // the alternatives example counts twice, its menu chord and its monitor-bound half. Then the three
+        // `global-hotkey` examples, each of which must yield a chord rather than a diagnostic.
+        #expect(bound == 9)
     }
 
     @Test func ghosttyConfigPathIsGhosttyConfInDir() {

--- a/agtermCore/Tests/agtermCoreTests/QuickTerminalMetricsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/QuickTerminalMetricsTests.swift
@@ -44,10 +44,13 @@ struct QuickTerminalMetricsTests {
         #expect(choicesMatchingTheDefault(on: large).isEmpty)
     }
 
+    /// Both axes, since the claim is that the whole size matches: on a screen where one axis is share-bound
+    /// and the other cap-bound, a percentage can reproduce the default width while missing its height.
     private func choicesMatchingTheDefault(on visible: WindowGeometry.Size) -> [Int] {
-        QuickTerminalMetrics.sizePercentChoices.filter {
-            QuickTerminalMetrics.panelSize(visible: visible, sizePercent: $0).width
-                == QuickTerminalMetrics.panelSize(visible: visible, sizePercent: nil).width
+        let byDefault = QuickTerminalMetrics.panelSize(visible: visible, sizePercent: nil)
+        return QuickTerminalMetrics.sizePercentChoices.filter {
+            let sized = QuickTerminalMetrics.panelSize(visible: visible, sizePercent: $0)
+            return abs(sized.width - byDefault.width) < 0.001 && abs(sized.height - byDefault.height) < 0.001
         }
     }
 

--- a/agtermCore/Tests/agtermCoreTests/QuickTerminalMetricsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/QuickTerminalMetricsTests.swift
@@ -12,16 +12,16 @@ struct QuickTerminalMetricsTests {
 
     /// A 32" 4K display in points, the case from the report that motivated the setting.
     private let large = WindowGeometry.Size(width: 2560, height: 1440)
-    /// A built-in Retina panel in points, small enough that the default share still binds.
-    private let small = WindowGeometry.Size(width: 1470, height: 860)
+    /// A small external display in points, under the roughly 1222x780 where the built-in maximum takes
+    /// over, so the default share binds on both axes. Every current built-in panel is above that.
+    private let small = WindowGeometry.Size(width: 1200, height: 760)
 
     @Test func defaultCapsALargeScreenAtTheBuiltInMaximum() {
         expectSize(QuickTerminalMetrics.panelSize(visible: large, sizePercent: nil), 1100, 700)
     }
 
     @Test func defaultTakesTheShareWhenItFallsUnderTheMaximum() {
-        let visible = WindowGeometry.Size(width: 1000, height: 600)
-        expectSize(QuickTerminalMetrics.panelSize(visible: visible, sizePercent: nil), 900, 540)
+        expectSize(QuickTerminalMetrics.panelSize(visible: small, sizePercent: nil), 1080, 684)
     }
 
     @Test func defaultMixesShareAndMaximumPerAxis() {
@@ -34,20 +34,21 @@ struct QuickTerminalMetricsTests {
     }
 
     @Test func setPercentageAppliesToASmallScreenToo() {
-        expectSize(QuickTerminalMetrics.panelSize(visible: small, sizePercent: 50), 735, 430)
+        expectSize(QuickTerminalMetrics.panelSize(visible: small, sizePercent: 50), 600, 380)
     }
 
-    /// No single percentage reproduces the default on both screen sizes, which is why nil keeps its own path.
+    /// Why nil keeps its own path: the two regimes disagree. Where the share binds, 90% IS the default;
+    /// where the maximum binds, no offered percentage reproduces it, so no single choice serves both.
     @Test func noPercentageReproducesTheDefaultOnBothScreens() {
-        let matchingLarge = QuickTerminalMetrics.sizePercentChoices.filter {
-            QuickTerminalMetrics.panelSize(visible: large, sizePercent: $0).width
-                == QuickTerminalMetrics.panelSize(visible: large, sizePercent: nil).width
+        #expect(choicesMatchingTheDefault(on: small) == [90])
+        #expect(choicesMatchingTheDefault(on: large).isEmpty)
+    }
+
+    private func choicesMatchingTheDefault(on visible: WindowGeometry.Size) -> [Int] {
+        QuickTerminalMetrics.sizePercentChoices.filter {
+            QuickTerminalMetrics.panelSize(visible: visible, sizePercent: $0).width
+                == QuickTerminalMetrics.panelSize(visible: visible, sizePercent: nil).width
         }
-        let matchingSmall = QuickTerminalMetrics.sizePercentChoices.filter {
-            QuickTerminalMetrics.panelSize(visible: small, sizePercent: $0).width
-                == QuickTerminalMetrics.panelSize(visible: small, sizePercent: nil).width
-        }
-        #expect(Set(matchingLarge).isDisjoint(with: Set(matchingSmall)))
     }
 
     @Test func percentageAboveTheRangeClampsToTheCeiling() {

--- a/agtermCore/Tests/agtermCoreTests/QuickTerminalMetricsTests.swift
+++ b/agtermCore/Tests/agtermCoreTests/QuickTerminalMetricsTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Testing
+@testable import agtermCore
+
+struct QuickTerminalMetricsTests {
+    /// Compared with a tolerance: a share of a screen is a floating-point product, so 70% of 1440 lands on
+    /// 1007.9999999999999. The panel is framed in fractional points either way, as it was before the setting.
+    private func expectSize(_ size: WindowGeometry.Size, _ width: Double, _ height: Double) {
+        #expect(abs(size.width - width) < 0.001)
+        #expect(abs(size.height - height) < 0.001)
+    }
+
+    /// A 32" 4K display in points, the case from the report that motivated the setting.
+    private let large = WindowGeometry.Size(width: 2560, height: 1440)
+    /// A built-in Retina panel in points, small enough that the default share still binds.
+    private let small = WindowGeometry.Size(width: 1470, height: 860)
+
+    @Test func defaultCapsALargeScreenAtTheBuiltInMaximum() {
+        expectSize(QuickTerminalMetrics.panelSize(visible: large, sizePercent: nil), 1100, 700)
+    }
+
+    @Test func defaultTakesTheShareWhenItFallsUnderTheMaximum() {
+        let visible = WindowGeometry.Size(width: 1000, height: 600)
+        expectSize(QuickTerminalMetrics.panelSize(visible: visible, sizePercent: nil), 900, 540)
+    }
+
+    @Test func defaultMixesShareAndMaximumPerAxis() {
+        let visible = WindowGeometry.Size(width: 2000, height: 600)
+        expectSize(QuickTerminalMetrics.panelSize(visible: visible, sizePercent: nil), 1100, 540)
+    }
+
+    @Test func setPercentageReplacesTheMaximumInsteadOfRaisingIt() {
+        expectSize(QuickTerminalMetrics.panelSize(visible: large, sizePercent: 70), 1792, 1008)
+    }
+
+    @Test func setPercentageAppliesToASmallScreenToo() {
+        expectSize(QuickTerminalMetrics.panelSize(visible: small, sizePercent: 50), 735, 430)
+    }
+
+    /// No single percentage reproduces the default on both screen sizes, which is why nil keeps its own path.
+    @Test func noPercentageReproducesTheDefaultOnBothScreens() {
+        let matchingLarge = QuickTerminalMetrics.sizePercentChoices.filter {
+            QuickTerminalMetrics.panelSize(visible: large, sizePercent: $0).width
+                == QuickTerminalMetrics.panelSize(visible: large, sizePercent: nil).width
+        }
+        let matchingSmall = QuickTerminalMetrics.sizePercentChoices.filter {
+            QuickTerminalMetrics.panelSize(visible: small, sizePercent: $0).width
+                == QuickTerminalMetrics.panelSize(visible: small, sizePercent: nil).width
+        }
+        #expect(Set(matchingLarge).isDisjoint(with: Set(matchingSmall)))
+    }
+
+    @Test func percentageAboveTheRangeClampsToTheCeiling() {
+        expectSize(QuickTerminalMetrics.panelSize(visible: large, sizePercent: 400),
+                   QuickTerminalMetrics.panelSize(visible: large, sizePercent: 90).width,
+                   QuickTerminalMetrics.panelSize(visible: large, sizePercent: 90).height)
+    }
+
+    @Test func percentageBelowTheRangeClampsToTheFloor() {
+        expectSize(QuickTerminalMetrics.panelSize(visible: large, sizePercent: 0),
+                   QuickTerminalMetrics.panelSize(visible: large, sizePercent: 40).width,
+                   QuickTerminalMetrics.panelSize(visible: large, sizePercent: 40).height)
+    }
+
+    @Test func clampSizePercentBoundsBothEnds() {
+        #expect(QuickTerminalMetrics.clampSizePercent(-5) == QuickTerminalMetrics.sizePercentRange.lowerBound)
+        #expect(QuickTerminalMetrics.clampSizePercent(1000) == QuickTerminalMetrics.sizePercentRange.upperBound)
+        #expect(QuickTerminalMetrics.clampSizePercent(70) == 70)
+    }
+
+    @Test func everyOfferedChoiceIsInRange() {
+        for percent in QuickTerminalMetrics.sizePercentChoices {
+            #expect(QuickTerminalMetrics.clampSizePercent(percent) == percent)
+        }
+    }
+
+    @Test func percentageIsMonotonicAcrossTheOfferedChoices() {
+        let widths = QuickTerminalMetrics.sizePercentChoices.map {
+            QuickTerminalMetrics.panelSize(visible: large, sizePercent: $0).width
+        }
+        #expect(widths == widths.sorted())
+        #expect(Set(widths).count == widths.count)
+    }
+}

--- a/agtermUITests/SettingsUITests.swift
+++ b/agtermUITests/SettingsUITests.swift
@@ -209,6 +209,24 @@ final class SettingsUITests: XCTestCase {
                       "selecting Normal should persist toolbarMode=normal to settings.json")
     }
 
+    func testQuickTerminalSizePickerPersists() throws {
+        let picker = settingsControl(tab: "Interface", control: "settings-quick-terminal-size")
+
+        picker.click()
+        let seventy = app.menuItems["70% of screen"]
+        XCTAssertTrue(seventy.waitForExistence(timeout: 5), "the size dropdown should offer a 70% item")
+        seventy.click()
+        XCTAssertTrue(poll { self.settingsDouble("quickTerminalSizePercent") == 70 },
+                      "selecting 70% should persist quickTerminalSizePercent=70 to settings.json")
+
+        picker.click()
+        let byDefault = app.menuItems["Default"]
+        XCTAssertTrue(byDefault.waitForExistence(timeout: 5), "the size dropdown should offer a Default item")
+        byDefault.click()
+        XCTAssertTrue(poll { self.settingsObject()?["quickTerminalSizePercent"] == nil },
+                      "selecting Default should remove the quickTerminalSizePercent key from settings.json")
+    }
+
     func testRestoreRunningCommandTogglePersists() throws {
         let toggle = settingsControl(tab: "General", control: "settings-restore-running-command")
         toggle.click() // turn it on (default off)

--- a/plugins/agterm/skills/agterm/SKILL.md
+++ b/plugins/agterm/skills/agterm/SKILL.md
@@ -92,8 +92,8 @@ An overlay covers the whole session, or with `--pane left|right` exactly one spl
 sibling pane visible and usable. The same session-wide slot also holds a **HUD** (`session hud`), a small
 passive panel carrying a message instead of a program: the session keeps focus and stays typable under it.
 One slot, so a session shows either a HUD or a program overlay, never both. Separately, the app has one
-**quick terminal** (a scratch shell in a floating panel at 90% of the focused screen, not part of the tree
-and not owned by a window).
+**quick terminal** (a scratch shell in a floating panel at 90% of the focused screen capped at 1100x700,
+or whatever share Settings sets instead; not part of the tree and not owned by a window).
 
 Inspect the live tree any time with `agtermctl tree --json` (workspaces → sessions, each with
 `id`, `name`, `cwd`, `title`, `active`, `split`, `overlay`, `hud`, `scratch`, `status`, `background`, `surfaces`). `title` is the raw OSC

--- a/plugins/agterm/skills/agterm/reference.md
+++ b/plugins/agterm/skills/agterm/reference.md
@@ -932,7 +932,8 @@ it waited for. Results age out oldest-first: the 8 most recent per open window, 
 ## quick
 
 `agtermctl quick [show|hide|toggle]` — the app's one quick terminal (a single scratch terminal in a
-floating panel at 90% of the focused screen up to 1100x700, not in the tree and owned by no window; its
+floating panel at 90% of the focused screen up to 1100x700 unless Settings > Interface sets a share of its
+own, not in the tree and owned by no window; its
 shell stays alive across hides). Errors with `no open window` when none is open, and with `pick pending`
 while a picker is up. Read its visibility back from the tree's top-level `quickVisible`.
 A panel YOU open with `show` stays up when agterm loses focus — including when it was already visible

--- a/site/commands.html
+++ b/site/commands.html
@@ -2216,7 +2216,7 @@
             </h2>
             <p style="font-size: 16px; line-height: 1.7; color: #cbc6bc; margin: 0 0 16px">
               The quick terminal — one scratch terminal for the whole app, shown in a floating panel at 90% of whichever screen
-              has focus, capped at 1100x700, rather than inside a window; not in the tree, and its shell stays alive across hides. A panel the user
+              has focus, capped at 1100x700 unless Settings sets a share of its own, rather than inside a window; not in the tree, and its shell stays alive across hides. A panel the user
               summoned closes when it loses keyboard focus; one opened by
               <span style="font-family: &quot;JetBrains Mono&quot;, monospace">quick show</span> stays up until something hides it,
               so a following <span style="font-family: &quot;JetBrains Mono&quot;, monospace">quick type</span> or

--- a/site/docs.html
+++ b/site/docs.html
@@ -1947,7 +1947,7 @@
               from every other application on the Mac, and that is not a cost to impose on someone who may never summon
               the panel from outside agterm. Spending it on the chord the in-app binding already uses is allowed and is
               the way to get one shortcut that works everywhere —
-              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">global-hotkey ctrl+grave</span>
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">global-hotkey ctrl+`</span>
               makes <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">⌃`</span> summon the panel
               from any application, at the price of that chord no longer reaching anything else.
             </p>

--- a/site/docs.html
+++ b/site/docs.html
@@ -1943,7 +1943,13 @@
               first. macOS registers it by physical key position, so it keeps firing on a non-Latin layout. Because the system owns
               it rather than agterm, it takes no part in the collision rules below. Note which side wins: the system-wide chord
               takes the key even while agterm is in front, so binding one a menu item already uses means that menu shortcut stops
-              firing. It is unset unless you add the line.
+              firing. It is unset unless you add the line: agterm ships no default because registering a chord takes it
+              from every other application on the Mac, and that is not a cost to impose on someone who may never summon
+              the panel from outside agterm. Spending it on the chord the in-app binding already uses is allowed and is
+              the way to get one shortcut that works everywhere —
+              <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">global-hotkey ctrl+grave</span>
+              makes <span style="font-family: &quot;JetBrains Mono&quot;, monospace; color: #cbc6bc">⌃`</span> summon the panel
+              from any application, at the price of that chord no longer reaching anything else.
             </p>
             <p style="font-size: 15px; line-height: 1.65; color: #949ba4; margin: 16px 0 0">
               One binding can offer several <strong style="color: #e6e1d7">alternatives</strong>, joined by

--- a/site/docs.html
+++ b/site/docs.html
@@ -725,7 +725,9 @@
                 <p style="font-size: 15px; line-height: 1.6; color: #949ba4; margin: 0">
                   A single throwaway shell for the whole app, not tied to any session or window. It appears in a floating panel at
                   90% of whichever screen has focus, on the Space you are currently on, and opens in the active session's
-                  directory, sized to 90% of that screen up to a comfortable maximum. Bind a system-wide chord with
+                  directory, sized to 90% of that screen up to a comfortable maximum. Settings &#9656; Interface sets that
+                  size as a plain share of the screen instead, which is worth doing on a large display where the
+                  built-in maximum is the smaller of the two. Bind a system-wide chord with
                   <code style="color: #e6e1d7">global-hotkey</code> in <code style="color: #e6e1d7">keymap.conf</code> and it
                   summons agterm from any application. Press the key again, or click away, to dismiss it; hiding keeps its shell
                   alive. A panel opened by <code style="color: #e6e1d7">agtermctl quick show</code> stays put instead of closing


### PR DESCRIPTION
The quick terminal panel was sized `min(90% of screen, 1100x700 points)`, so past roughly 1222x780 the cap is the only term that acts. On a 2560x1440-point display that is about 21% of the screen area where the 90% share intends 81%, which is what discussion #453 reported: reading a wide `git diff` in it means scrolling sideways with empty space around the panel.

Settings ▸ Interface now takes a share of the screen instead. Unset it is exactly the old size, so nobody's panel changes without them asking.

**Why a share replaces the cap rather than raising it**

A ceiling in points is what ages badly across displays, so making the ceiling configurable only moves the same problem to the next screen size. A set percentage drops both the 90% share and the 1100x700 pair and takes that share of whatever screen the panel opens on.

`nil` keeps its own path because no single percentage reproduces the old behavior everywhere: the cap binds above roughly 1222x780 and the share below it, so the two yield different fractions of different screens. `QuickTerminalMetricsTests.noPercentageReproducesTheDefaultOnBothScreens` pins that.

**Where it lives**

Interface rather than Appearance ▸ Window, because the panel belongs to no window. The choices are Default plus 40% to 90% in tens, discrete rather than a slider: the panel is summoned and dismissed, so the choice is which of a few shapes it should have. 90 is the ceiling because that is the share #441 documented, and 100% already means zoom.

A stored value outside those choices resolves to the default at `effectiveQuickTerminalSizePercent`, which both the picker and the `GhosttyApp` mirror read, so a hand-edited `75` cannot leave the picker blank while the panel uses a size it has no row for. That matches how `toolbarMode`, `dockBounce` and `newSessionDirectory` already resolve.

The frame arithmetic moves into `agtermCore` as `QuickTerminalMetrics`, which makes it testable without AppKit. No control command: `.claude/rules/settings.md` ends with settings being GUI-only unless the catalog says otherwise, and no comparable appearance preference has one.

**Two documentation fixes carried along**

Both were found while working on this and are unrelated to the size setting.

`global-hotkey` documented what it does but never why it ships unbound: registering a chord takes it from every other application on the Mac. Both surfaces also stated the precedence over a menu binding only as a hazard, when it is equally the recipe for one shortcut that works everywhere, so ``global-hotkey ctrl+` `` is now an example. The first version of that example used `ctrl+grave`, which does not parse, and no test caught it because `starterKeymapExamplesApplyWhenUncommented` kept only `map` and `command` lines. That guard now covers the third verb too, which is the same gap issue #405 records for the verbs it did cover.

`CLAUDE.md` required the command count to stay synchronized across surfaces while `control-api.md` says no surface states a total and none should be reintroduced. No surface states one, so the rule that named it was the stale half.

**Checks**

`swift test` 2590 passing, `make test-app` 247, `SettingsUITests` 16 including a new `testQuickTerminalSizePickerPersists`, `make lint` clean.

Two revmux rounds over the branch: the first found four minor issues, all fixed in 186504c, the second came back with nothing. A separate codex pass then found the raw picker binding that both rounds let through, fixed in e5a5134.

Asked for in discussion #453.
