### PR TITLE
cookbook: add copilot-agent-status recipe

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -40,6 +40,7 @@ its *needs* column, so searching this page for `claude` or `kiro` finds those di
 | [claude-conversation-picker](claude-conversation-picker/) | pick a past Claude Code conversation by what it was about and resume it in the pane | 0.21.0, python3, Claude Code |
 | [claude-recap](claude-recap/) | one key lists what the Claude Code run in a session was working on | 0.10.0, zsh, jq, Claude Code |
 | [container-agent-status](container-agent-status/) | a containerized agent reports status onto its sidebar row via a TCP notification to the host | 0.7.1, nc, timeout, Claude Code |
+| [copilot-agent-status](copilot-agent-status/) | Copilot CLI sessions report active, blocked, and completed onto their sidebar row | 0.7.1, Copilot CLI |
 | [kimi-agent-status](kimi-agent-status/) | Kimi Code sessions report agent status onto their sidebar row | 0.3.1, Kimi Code |
 | [kiro-agent-status](kiro-agent-status/) | Kiro CLI sessions report active, blocked, and completed onto their sidebar row | 0.7.1, Kiro CLI |
 | [status-announcer](status-announcer/) | demo: speak agent status changes from a dedicated session | 0.16.0, jq |

--- a/cookbook/copilot-agent-status/README.md
+++ b/cookbook/copilot-agent-status/README.md
@@ -1,0 +1,44 @@
+# Copilot CLI agent status
+
+Copilot CLI sessions report active, blocked, and completed onto their sidebar row via the bundled agent-status hooks package and Copilot CLI's native hook support.
+
+## What it does
+
+Gives GitHub Copilot CLI the same per-session sidebar glyph behavior the installer already wires up for Claude Code: the row pulses active while Copilot works, goes blocked while it is waiting on a permission prompt, and flashes completed at the end of the turn, clearing when you visit the session. This recipe adds that mapping through Copilot CLI's own `hooks/*.json` support; agterm itself needs no code change, and the bundled installer does not currently set Copilot hooks up for you.
+
+## Requirements
+
+- agterm 0.7.1 or later, with the agent-status hooks package installed via Help ▸ Install Agent Status Hooks… . That installs `~/.config/agterm/agent-status/agterm-agent-status.sh`, which this recipe calls directly, and the shipped wrapper forwards the injected pane markers so a split or scratch pane's status lands on the right pane. This recipe does not touch that package's shell integration or its Claude/Codex-specific files.
+- GitHub Copilot CLI with hook support. This recipe was checked against the published hooks reference in August 2026; if a later Copilot CLI release renames the events, update the JSON keys to match.
+
+## Setup
+
+Run Help ▸ Install Agent Status Hooks… once if you have not already; it is idempotent, and this recipe only depends on the wrapper it installs at `~/.config/agterm/agent-status/agterm-agent-status.sh`.
+
+Install the hook file user-wide:
+
+```sh
+mkdir -p ~/.copilot/hooks
+cp copilot-status-hooks.json ~/.copilot/hooks/
+```
+
+You can symlink it there instead of copying it if you prefer. For a repo-scoped install, put the same file in `.github/hooks/` in a trusted repository instead of `~/.copilot/hooks/`.
+
+Copilot CLI loads hook configuration when `copilot` starts, not live while it is running, so start or restart `copilot` after copying the file.
+
+## Usage
+
+Run `copilot` inside agterm as usual. The sidebar glyph pulses active while Copilot works and after each tool call, goes blocked when Copilot is waiting on a permission prompt, and flashes completed at the end of each turn, clearing when you visit the session.
+
+## How it works
+
+This is pure Copilot-CLI-side configuration: a single `hooks.json` file points Copilot's native hooks at the stock `agterm-agent-status.sh` wrapper, with no agterm code change and no custom shell wrapper of its own. Unlike the Kiro recipe's shell-function poller, Copilot maps directly onto the same four states the installer already wires up for Claude Code.
+
+The mapping mirrors Claude's bundled hook set exactly: `userPromptSubmitted` and `postToolUse` set `active --blink`, `agentStop` sets `completed --auto-reset`, and `notification` with `matcher: "permission_prompt"` sets `blocked`. Copilot CLI exposes a native event for each of those transitions, so the recipe is only data. Hook configuration is loaded once at CLI startup, not hot-reloaded, so editing the JSON means restarting `copilot`.
+
+## Limits
+
+Nothing destructive: this recipe only calls the existing status-setting wrapper. It never closes sessions, deletes workspaces, or kills shells.
+
+- Like the Claude Code mapping it mirrors, this is turn-level rather than exact real-time state. A very long single tool call will not refresh the glyph again until that tool finishes.
+- If a future Copilot CLI release renames or restructures its hook events or payloads, this recipe's JSON keys will need matching updates before the status changes fire again.

--- a/cookbook/copilot-agent-status/copilot-status-hooks.json
+++ b/cookbook/copilot-agent-status/copilot-status-hooks.json
@@ -1,0 +1,34 @@
+{
+  "version": 1,
+  "hooks": {
+    "userPromptSubmitted": [
+      {
+        "type": "command",
+        "bash": "$HOME/.config/agterm/agent-status/agterm-agent-status.sh active --blink",
+        "timeoutSec": 5
+      }
+    ],
+    "postToolUse": [
+      {
+        "type": "command",
+        "bash": "$HOME/.config/agterm/agent-status/agterm-agent-status.sh active --blink",
+        "timeoutSec": 5
+      }
+    ],
+    "agentStop": [
+      {
+        "type": "command",
+        "bash": "$HOME/.config/agterm/agent-status/agterm-agent-status.sh completed --auto-reset",
+        "timeoutSec": 5
+      }
+    ],
+    "notification": [
+      {
+        "matcher": "permission_prompt",
+        "type": "command",
+        "bash": "$HOME/.config/agterm/agent-status/agterm-agent-status.sh blocked",
+        "timeoutSec": 5
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add a cookbook recipe wiring GitHub Copilot CLI's native hooks to the bundled agent-status wrapper, giving Copilot CLI sessions the same active/blocked/completed sidebar glyph the installer already provides for Claude Code, Codex, Pi, and OpenCode. Co-authored-by: Copilot